### PR TITLE
fix(hero): withheld runs may not designate in the HEADLINE or the SUBLINE either

### DIFF
--- a/src/components/results/__fixtures__/withheldDesignations.fixtures.ts
+++ b/src/components/results/__fixtures__/withheldDesignations.fixtures.ts
@@ -82,8 +82,44 @@ export const PERMITTED_REPORT: DecisionVerdictReportLike = {
   } as unknown as DecisionVerdictReportLike['decision_brief'],
 }
 
+/**
+ * WITHHELD, third shape: the producer RECOMMENDS an option that is not the
+ * win-probability argmax, and bands THAT option.
+ *
+ * This is not a contrived shape — `decisionVerdict` documents it explicitly
+ * ("PLoT may recommend an option that is not the win-probability argmax"),
+ * and it is the input that separates the two identity gates:
+ *   · `deriveDecisionVerdict` checks the band against `top1` (the win argmax,
+ *     HIGH) → does not apply → no producer signal → `separation: 'unknown'`,
+ *     `hasLeadingOption: false` → the verdict WITHHOLDS.
+ *   · `buildHeroModel` checks the same band against `headlineRow` (the
+ *     RECOMMENDED option, MID) → applies → it re-bands the leader claim the
+ *     verdict just withheld.
+ * Exactly the Authority-3 failure ROADMAP 1.223 deleted, re-entering through
+ * the hero's own local fallback.
+ */
+export const MISALIGNED_BAND_REPORT: DecisionVerdictReportLike = {
+  option_probabilities: OPTION_PROBABILITIES,
+  robustness: { recommended_option_id: MID_ID },
+  decision_brief: {
+    headline_banded: {
+      band: 'clearly_ahead',
+      leader_option_id: MID_ID,
+      robustness_gated: false,
+    },
+  } as unknown as DecisionVerdictReportLike['decision_brief'],
+}
+
+/** The hero-prop form of the same band (`DecisionResultData.headlineBanded`). */
+export const MISALIGNED_BAND = {
+  band: 'clearly_ahead' as const,
+  leaderOptionId: MID_ID,
+  robustnessGated: false,
+}
+
 export const WITHHELD_VERDICT = deriveDecisionVerdict(WITHHELD_REPORT)
 export const PERMITTED_VERDICT = deriveDecisionVerdict(PERMITTED_REPORT)
+export const MISALIGNED_BAND_VERDICT = deriveDecisionVerdict(MISALIGNED_BAND_REPORT)
 
 /** Options in CANONICAL order, as the hook now emits them on a withheld run. */
 export function withheldFixtureOptions(): OptionResult[] {
@@ -126,6 +162,68 @@ export function withheldFixtureOptions(): OptionResult[] {
     },
   ] as OptionResult[]
 }
+
+/**
+ * The SWEEP RUN's shape: every option's goal probability below the shared
+ * sub-1% floor (UI-SEM-057), so `allGoalBelowFloor` is true and the hero
+ * headlines "No option is currently on track…".
+ *
+ * This is the run the 2026-07-27 browser sweep captured on the deployed
+ * build, where the subline underneath still read
+ * "<option> has the highest expected outcome."
+ */
+export function flooredGoalFixtureOptions(): OptionResult[] {
+  return withheldFixtureOptions().map((o) => ({ ...o, goalProbability: 0.002 }))
+}
+
+/**
+ * The MISALIGNED-BAND run's shape: MID is the recommended option, and no
+ * goal crown exists (uniform goal fits tie at the max), so the banded
+ * analysis-leader headline is the branch under test.
+ */
+export function misalignedBandFixtureOptions(): OptionResult[] {
+  return withheldFixtureOptions().map((o) => ({
+    ...o,
+    isRecommended: o.id === MID_ID,
+    goalProbability: 0.4,
+  })) as OptionResult[]
+}
+
+/**
+ * The NO-RECOMMENDATION run's shape: no row is the recommended option, so
+ * the hero falls to the branch that headlines the outcome fact itself.
+ * Goal fits are uniform (tied at the max) so no goal crown intercepts.
+ */
+export function noRecommendationFixtureOptions(): OptionResult[] {
+  return withheldFixtureOptions().map((o) => ({
+    ...o,
+    isRecommended: false,
+    goalProbability: 0.4,
+  })) as OptionResult[]
+}
+
+/**
+ * Superlative/entitlement vocabulary that must not appear in HERO COPY on a
+ * withheld run, over and above the no-label rule.
+ *
+ * Separate from `DESIGNATION_RE` on purpose, and NARROWER: `DESIGNATION_RE`
+ * screens screen-reader strings, where "top option" is itself a designation.
+ * The hero's own sanctioned no-claim lines ("Compare the top options before
+ * deciding.", "The top options are close on expected outcome.") contain that
+ * phrase by design, so screening hero prose with `DESIGNATION_RE` would fail
+ * the very copy this contract prescribes. What hero prose may never do is
+ * assert a superlative or an entitlement — with or without a name.
+ *
+ * Verified inert against every neutral hero string it must tolerate:
+ *   · 'No option is currently on track to meet every target this run scored.'
+ *   · 'No option is currently on track to meet your goal and limits.'
+ *   · 'Here is how your options compare.'
+ *   · 'No option is clearly ahead.'          (a producer TIE claim, not ours)
+ *   · 'Compare the top options before deciding.'
+ *   · 'The top options are close on expected outcome.'
+ */
+export const HERO_CLAIM_RE =
+  /\b(highest|strongest|most likely|slightly ahead|leads|leading|winner|best)\b/i
 
 /**
  * Every string a screen reader can reach that is NOT ordinary body text:

--- a/src/components/results/analysis-hero/__tests__/withheldDesignations.hero.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/withheldDesignations.hero.spec.tsx
@@ -35,23 +35,39 @@ import { buildHeroModel } from '../buildHeroModel'
 import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
 import type { HeroChartModel } from '../heroTypes'
 import { makeHeroData } from '../__fixtures__/hero.fixtures'
+import type { OptionResult } from '../../types'
 import {
   CANONICAL_IDS,
   CANONICAL_LABELS,
   DESIGNATION_RE,
+  HERO_CLAIM_RE,
+  HIGH_LABEL,
+  MID_LABEL,
+  MISALIGNED_BAND,
+  MISALIGNED_BAND_VERDICT,
   PERMITTED_VERDICT,
   PROBABILITY_IDS,
   WITHHELD_VERDICT,
+  flooredGoalFixtureOptions,
+  misalignedBandFixtureOptions,
+  noRecommendationFixtureOptions,
   renderedRowIds,
   screenReaderStrings,
   withheldFixtureOptions as options,
 } from '../../__fixtures__/withheldDesignations.fixtures'
 
-function heroModel(verdict: typeof WITHHELD_VERDICT): HeroChartModel {
+function heroModel(
+  verdict: typeof WITHHELD_VERDICT,
+  overrides: { options?: OptionResult[]; recommendation?: Record<string, unknown> } = {},
+): HeroChartModel {
   return buildHeroModel(
     makeHeroData({
-      options: options(),
-      recommendation: { verdict, storyHeadlines: {} },
+      options: overrides.options ?? options(),
+      recommendation: {
+        verdict,
+        storyHeadlines: {},
+        ...overrides.recommendation,
+      } as never,
     }),
   ) as HeroChartModel
 }
@@ -160,5 +176,172 @@ describe('HeroChartModel.designationsWithheld', () => {
   it('is false when no verdict is supplied (legacy fixtures unchanged)', () => {
     const model = buildHeroModel(makeHeroData({ options: options() })) as HeroChartModel
     expect(model.designationsWithheld).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE PROSE LEG — added after the 2026-07-27 browser sweep.
+//
+// The blocks above pin the NON-PROSE designations (order, ordinals, crown,
+// sr-only cue). They passed on the deployed build while the hero's own two
+// sentences went on naming a leader: the sweep photographed
+//
+//     No option is currently on track to meet every target this run scored.
+//     Continue Current Arrangement (Status Quo) has the highest expected outcome.
+//
+// — the withheld headline with the leader claim relocated one line down, which
+// is the exact failure mode `buildHeroModel`'s state-C subline comment already
+// names and guards against. That guard was never applied to its siblings.
+//
+// Driven by RUN SHAPES rather than by branch names on purpose: a branch list
+// is the hand-maintained mirror this programme keeps being bitten by. Each
+// shape is an input a live withheld run can actually take; if a future edit
+// adds a branch, the shape that reaches it still has to satisfy the contract.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RunShape {
+  name: string
+  options: OptionResult[]
+  verdict: typeof WITHHELD_VERDICT
+  recommendation?: Record<string, unknown>
+}
+
+const WITHHELD_RUN_SHAPES: RunShape[] = [
+  {
+    // goal-fit crown: the goalProbability argmax is unique and clears the
+    // floor, so the headline crowns it and the subline agrees with it.
+    name: 'goal-fit crown',
+    options: options(),
+    verdict: WITHHELD_VERDICT,
+  },
+  {
+    // THE SWEEP RUN: no option on track, so the neutral headline is correct
+    // and the leader claim survives in the subline alone.
+    name: 'no option on track (the sweep run)',
+    options: flooredGoalFixtureOptions(),
+    verdict: WITHHELD_VERDICT,
+  },
+  {
+    // the hero's own producer-band fallback re-banding a withheld claim,
+    // because its identity gate anchors on the RECOMMENDED option while
+    // `deriveDecisionVerdict`'s anchors on the win argmax.
+    name: 'misaligned producer band',
+    options: misalignedBandFixtureOptions(),
+    verdict: MISALIGNED_BAND_VERDICT,
+    recommendation: { headlineBanded: MISALIGNED_BAND },
+  },
+  {
+    // no recommended option among the rows: the headline states the outcome
+    // fact itself, which names an option just the same.
+    name: 'no recommended option',
+    options: noRecommendationFixtureOptions(),
+    verdict: WITHHELD_VERDICT,
+    recommendation: { recommendedOption: null },
+  },
+]
+
+function heroProse(shape: RunShape): { headline: string; subline: string | null } {
+  const model = heroModel(shape.verdict, {
+    options: shape.options,
+    recommendation: shape.recommendation,
+  })
+  expect(
+    model.designationsWithheld,
+    `run shape "${shape.name}" is not withheld — the assertion below would be vacuous`,
+  ).toBe(true)
+  return { headline: model.headline, subline: model.subline }
+}
+
+describe('analysis hero — WITHHELD: the prose may not designate either', () => {
+  for (const shape of WITHHELD_RUN_SHAPES) {
+    it(`names no option in the headline or the subline — ${shape.name}`, () => {
+      const { headline, subline } = heroProse(shape)
+      for (const [surface, text] of [
+        ['headline', headline],
+        ['subline', subline ?? ''],
+      ] as const) {
+        for (const label of CANONICAL_LABELS) {
+          expect(
+            text,
+            `${surface} named an option on a withheld run: "${text}"`,
+          ).not.toContain(label)
+        }
+      }
+    })
+
+    it(`asserts no superlative in the headline or the subline — ${shape.name}`, () => {
+      const { headline, subline } = heroProse(shape)
+      expect(headline, `headline claimed a superlative: "${headline}"`).not.toMatch(
+        HERO_CLAIM_RE,
+      )
+      expect(subline ?? '', `subline claimed a superlative: "${subline}"`).not.toMatch(
+        HERO_CLAIM_RE,
+      )
+    })
+  }
+
+  /**
+   * OVER-SUPPRESSION GUARD. The sweep proved this surface renders on a
+   * withheld run, so an empty subline would be a regression of its own —
+   * the fix must SUBSTITUTE the neutral companion line, not delete the line.
+   */
+  it('still renders a non-empty subline on the sweep run', () => {
+    const { subline } = heroProse(WITHHELD_RUN_SHAPES[1])
+    expect(subline).toBeTruthy()
+    expect((subline ?? '').trim().length).toBeGreaterThan(0)
+  })
+
+  /** The neutral line is the one the guarded sibling already prescribes. */
+  it('uses the existing state-C companion line, not new copy', () => {
+    expect(heroProse(WITHHELD_RUN_SHAPES[1]).subline).toBe(
+      'Compare the top options before deciding.',
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PERMITTED — the over-suppression controls for the prose leg. Two are pinned
+// BYTE-FOR-BYTE to what the deployed build renders today, so a fix that
+// suppressed the claim on permitted runs too would fail here rather than pass
+// quietly by suppressing everything.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('analysis hero — PERMITTED prose (over-suppression controls)', () => {
+  it('goal-fit crown: headline and subline unchanged, byte-for-byte', () => {
+    const model = heroModel(PERMITTED_VERDICT)
+    expect(model.designationsWithheld).toBe(false)
+    expect(model.headline).toBe(
+      'Hire two developers is most likely to meet every target this run scored.',
+    )
+    expect(model.subline).toBe('Hire two developers also has the strongest expected outcome.')
+  })
+
+  it('no option on track: headline and subline unchanged, byte-for-byte', () => {
+    const model = heroModel(PERMITTED_VERDICT, { options: flooredGoalFixtureOptions() })
+    expect(model.designationsWithheld).toBe(false)
+    expect(model.headline).toBe(
+      'No option is currently on track to meet every target this run scored.',
+    )
+    expect(model.subline).toBe('Hire two developers has the highest expected outcome.')
+  })
+
+  it('producer band: still bands the recommended option by name', () => {
+    const model = heroModel(PERMITTED_VERDICT, {
+      options: misalignedBandFixtureOptions(),
+      recommendation: { headlineBanded: MISALIGNED_BAND },
+    })
+    expect(model.designationsWithheld).toBe(false)
+    expect(model.headline).toContain(MID_LABEL)
+    expect(model.headline).toMatch(HERO_CLAIM_RE)
+  })
+
+  it('no recommended option: still headlines the outcome leader by name', () => {
+    const model = heroModel(PERMITTED_VERDICT, {
+      options: noRecommendationFixtureOptions(),
+      recommendation: { recommendedOption: null },
+    })
+    expect(model.designationsWithheld).toBe(false)
+    expect(model.headline).toContain(HIGH_LABEL)
+    expect(model.headline).toMatch(HERO_CLAIM_RE)
   })
 })

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -472,9 +472,26 @@ export function buildHeroModel(
     sharedVerdict.leaderId === headlineRow.id
 
   const producerBand = recommendation.headlineBanded ?? null
+  // WITHHELD GATE 1 of 4 (ROADMAP 1.267, prose leg — sweep 2026-07-27).
+  //
+  // The two identity gates anchor on DIFFERENT rows, and that difference is
+  // a live leak: `deriveDecisionVerdict` applies the band only when it names
+  // the win-probability ARGMAX (`top1`), while this local fallback applies it
+  // when it names the RECOMMENDED option (`headlineRow`). PLoT is documented
+  // to recommend a non-argmax option — and on such a run the shared verdict
+  // withholds (`separation: 'unknown'`, `hasLeadingOption: false`) while this
+  // line still resolves a band and re-authors the claim as
+  // "<option> is most likely to be strongest overall."
+  //
+  // That is Authority 3 re-entering by the side door. The shared verdict is
+  // the single answer to "may we name a leader?" (2026-07-25); when it says
+  // no, the local band resolution may not say yes. The producer's own TIE
+  // call is unaffected — it arrives via `sharedVerdictApplies` above, keeps
+  // `leaderBand === 'none'`, and still earns "No option is clearly ahead."
   const producerBandApplies =
     producerBand != null &&
     headlineRow != null &&
+    !designationsWithheld &&
     producerBand.leaderOptionId === headlineRow.id
 
   // UI-SEM-060 (ROADMAP 1.223): the band comes from a PRODUCER claim or it
@@ -582,8 +599,21 @@ export function buildHeroModel(
   //     headline keeps precedence).
   // With no crown the headline falls through to the existing honest
   // branches (banded analysis-leader claim) and the goal lens shows no ring.
+  //
+  // WITHHELD GATE 2 of 4 (ROADMAP 1.267, prose leg — sweep 2026-07-27).
+  // The crown is withheld AT SOURCE on a withheld run, not just where it is
+  // read. `leaders.goal` below already nulled it for the lens ring, and that
+  // gate's own comment states the rule — "null on EVERY lens when the verdict
+  // withholds… a designation whatever it is derived from". But the SAME
+  // argmax also selects the goal-attainment HEADLINE ("<option> is most
+  // likely to meet every target this run scored.") and the `claimedRow` the
+  // subline describes, and neither was gated: the ring went dark while the
+  // sentence above it kept crowning the identical row. Gating the selection
+  // rather than one of its three readers is the single change point — and it
+  // removes the hand-maintained mirror in which each new reader has to
+  // remember to re-apply the rule.
   let goalLeaderRow: HeroRowVM | null = null
-  if (hasUserTarget && rows.every((r) => r.goal.value != null)) {
+  if (!designationsWithheld && hasUserTarget && rows.every((r) => r.goal.value != null)) {
     let best: HeroRowVM | null = null
     let bestValue = -Infinity
     let tiedAtMax = false
@@ -644,7 +674,19 @@ export function buildHeroModel(
           : leaderBand === 'none'
             ? HERO_COPY.headline.noClearLeader
             : HERO_COPY.headline.noLeader
-  } else if (outcomeAvailable && outcomeLeaderRow && !topOutcomesReadoutTied) {
+  } else if (
+    outcomeAvailable &&
+    outcomeLeaderRow &&
+    !topOutcomesReadoutTied &&
+    // WITHHELD GATE 3 of 4 (ROADMAP 1.267, prose leg — sweep 2026-07-27).
+    // "<option> has the highest expected outcome." is a superlative naming a
+    // single option; that it is derived from the outcome lens rather than
+    // from the producer's leader field does not make it less of a
+    // designation — the identical argument was made for the per-lens crown
+    // and overturned at the screenshots (row 1.306). Withheld runs fall to
+    // `noLeader` below: SILENCE, not a denial.
+    !designationsWithheld
+  ) {
     // No recommended option among the rows: headline the outcome fact
     // itself — but ONLY when the outcome lens is actually visible (centres
     // without ranges hide it, and the hero must not assert an
@@ -687,6 +729,28 @@ export function buildHeroModel(
       // diverged. A neutral plural line; naming a runner-up among tied values
       // would be arbitrary. This is the reported run: four "100" readouts.
       subline = HERO_COPY.subline.outcomesClose
+    } else if (designationsWithheld) {
+      // WITHHELD GATE 4 of 4 (ROADMAP 1.267, prose leg — sweep 2026-07-27).
+      // THIS IS THE BRANCH THE SWEEP PHOTOGRAPHED. Every remaining branch in
+      // this chain NAMES an option — `highestOutcome`, `closeOnOutcome`,
+      // `aligned` — so the gate sits once, ahead of all of them, rather than
+      // being repeated on each (a per-branch guard list is a mirror, and the
+      // next branch added would silently miss it: that is exactly how this
+      // defect happened).
+      //
+      // The state-C branch sixteen lines above ALREADY carries this rule in
+      // its comment — "on a withheld turn it simply relocates the leader
+      // claim one line down" — and takes `compareTop` for it. Its condition
+      // reaches only the no-goal-basis case, so the two paths that bypass it
+      // (`allGoalBelowFloor`, and a headlined leader) were left naming an
+      // option. On the sweep's run the headline correctly said "No option is
+      // currently on track…" and this chain answered "<option> has the
+      // highest expected outcome." directly underneath.
+      //
+      // Same neutral line as the sibling, so no new voice is introduced. It
+      // SUBSTITUTES rather than deletes: the sweep proved the surface
+      // renders, so an empty subline would be its own regression.
+      subline = HERO_COPY.subline.compareTop
     } else if (allGoalBelowFloor) {
       // No leader was claimed; the outcome fact is the one honest pointer.
       subline = HERO_COPY.subline.highestOutcome(safeLabel(outcomeLeaderRow))


### PR DESCRIPTION
## The defect

The 2026-07-27 browser sweep photographed this on the **deployed** build, on a run whose verdict was proven withheld:

> **No option is currently on track to meet every target this run scored.**
> Continue Current Arrangement (Status Quo) has the highest expected outcome.

The headline is correct. The line directly under it is the leader claim, relocated one line down — on a run where CEE declined to put an option forward.

That failure mode is **already named, in this same function**. The state-C subline branch carries it verbatim:

> `on a withheld turn it simply relocates the leader claim one line down`

…and takes the neutral `compareTop` line because of it. **That guard was never applied to its siblings.** Its condition (`bandedNoGoalClaim`) reaches only the no-goal-basis case, so the two paths that bypass it kept naming an option.

## What the branch sweep found

The brief asked for the one firing branch plus a sweep of its siblings. Probing **every** copy-producing branch of `buildHeroModel` against the withheld fixture found **four** withheld-reachable designation sites, not one — the sweep's subline, and three in the headline.

Reachability was established empirically (a throwaway probe built the model per run shape and printed the strings), not by reading conditions.

### Headline branches

| # | Condition | Copy | Designates? | Status at `5492c765` | This PR |
|---|-----------|------|-------------|----------------------|---------|
| H1 | `rows.length === 1` | `singleOption(label)` | names the sole option | no ranking exists on a one-option run — not a designation | unchanged |
| H2 | `allGoalBelowFloor` | `noneOnTrack` / `noneOnTrackWithLimits` | no | already neutral | unchanged |
| H3 | `goalLeaderRow` | `goalOnly(label)` / `goalWithLimits(label)` | **YES** | **UNGUARDED** | **FIXED — gate 2** |
| H4 | `headlineRow`, band `strong`/`ahead` | `mostLikelyStrongest` / `slightlyAhead` | **YES** | **UNGUARDED** (via the local producer-band fallback) | **FIXED — gate 1** |
| H4′ | `headlineRow`, band `none` | `noClearLeader` | a denial, and the **producer's own** | guarded by design | unchanged — **deliberately**, see below |
| H4″ | `headlineRow`, band `null` | `noLeader` | no | already the withheld path | unchanged |
| H5 | `outcomeAvailable && outcomeLeaderRow && !tie` | `outcomeLeader(label)` | **YES** | **UNGUARDED** | **FIXED — gate 3** |
| H6 | else | `noLeader` | no | neutral | unchanged |

### Subline branches

| # | Condition | Copy | Designates? | Status at `5492c765` | This PR |
|---|-----------|------|-------------|----------------------|---------|
| S1 | `bandedNoGoalClaim && band ∈ {none, null}` | `compareTop` | no | **GUARDED** — carries the comment quoted above | unchanged; **its pattern is what the fix reuses** |
| S2 | `topOutcomesReadoutTied` | `outcomesClose` | no (plural, no name) | neutral | unchanged |
| S3 | `allGoalBelowFloor` | `highestOutcome(outcomeLeaderRow)` | **YES** | **UNGUARDED — ⭐ THE BRANCH THE SWEEP PHOTOGRAPHED** | **FIXED — gate 4** |
| S4a | `claimedRow && !alignedLeaders` | `highestOutcome(outcomeLeaderRow)` | **YES** | **UNGUARDED** | **FIXED — gate 4** |
| S4b | band `ahead` + outcome gap small | `closeOnOutcome(runnerUp)` | **YES** | **UNGUARDED** | **FIXED — gate 4** |
| S4c | band `strong` | `highestOutcome(claimedRow)` | **YES** | **UNGUARDED** | **FIXED — gate 4** |
| S4d | else | `aligned(claimedRow)` | **YES** | **UNGUARDED** | **FIXED — gate 4** |
| S4e | overlap advisory (appended to S4) | `overlapAdvisory` | no | neutral; unreachable on withheld once S4 is gated | unchanged |
| S5 | falls off the chain | `null` | no | no line at all | unchanged |

**Eight of the seventeen branches assert a superlative or name an option on a run that may be withheld. All eight were unguarded, and all eight are fixed here.**

(H1's `singleOption` also names an option, but on a one-option run no ranking exists, so it is not a designation and is unchanged. H4′ `noClearLeader` is a claim we are entitled to make — see below.)

## The fix — four gates, all on the SELECTION, all reusing existing copy

No new strings were written. Every withheld path lands on copy that already exists and is already sanctioned for the no-claim case.

**Gate 1 — `producerBandApplies`.** The two identity gates anchor on **different rows**, and that difference is the leak. `deriveDecisionVerdict` applies a producer band only when it names the win-probability **argmax** (`top1`); this local fallback applies it when it names the **recommended** option (`headlineRow`). `decisionVerdict.ts` documents that PLoT may recommend a non-argmax option — and on exactly such a run the shared verdict withholds (`separation: 'unknown'`) while the hero re-bands the claim as *"X is most likely to be strongest overall."* That is **Authority 3 re-entering by the side door**, five months after ROADMAP 1.223 deleted it.

**Gate 2 — `goalLeaderRow`, at source.** `leaders.goal` already nulled the crown for the lens ring, and its own comment states the rule: *"null on EVERY lens when the verdict withholds… a designation whatever it is derived from."* But the same argmax **also** selects the goal-attainment headline and the subline's `claimedRow`, and neither was gated — the ring went dark while the sentence above it kept crowning the identical row. Gating the selection rather than one of its three readers is the single change point, and removes the mirror in which each new reader must remember to re-apply the rule.

**Gate 3 — the outcome-fact headline.** *"X has the highest expected outcome"* is a superlative naming one option. That it derives from the outcome lens rather than the producer's leader field does not make it less of a designation — the identical argument was made for the per-lens crown and overturned at the screenshots (row 1.306).

**Gate 4 — the subline chain.** Placed **once, ahead of all four naming branches**, not repeated on each. A per-branch guard list is the hand-maintained mirror this programme keeps being bitten by, and it is literally how this defect happened: S1 got the guard, its siblings did not. It **substitutes** rather than deletes — the sweep proved the surface renders, so an empty subline would be its own regression.

### What is deliberately NOT suppressed

`noClearLeader` ("No option is clearly ahead.") on a **producer tie** stays. `hasLeadingOption: false` covers two different verdicts — `'tied'` (the producer positively said the options are close) and `'unknown'` (no claim). Gate 1 only blocks the *local band fallback*; the producer's tie arrives via `sharedVerdictApplies`, keeps `leaderBand === 'none'`, and still earns its line. **Silence where we have no authority, not silence where the producer spoke.** The file's own doctrine: *"asserting it on a withheld turn would swap one unearned claim for another."*

### Behaviour delta on withheld runs

| Run shape | Before | After |
|---|---|---|
| goal-fit crown | H: *"Hire two developers is most likely to meet every target this run scored."*<br>S: *"Hire two developers also has the strongest expected outcome."* | H: *"Here is how your options compare."*<br>S: *"Compare the top options before deciding."* |
| **no option on track (the sweep run)** | H: *"No option is currently on track…"*<br>S: *"Hire two developers has the highest expected outcome."* | H: *"No option is currently on track…"* (unchanged)<br>S: *"Compare the top options before deciding."* |
| misaligned producer band | H: *"Upskill the current team is most likely to be strongest overall."* | H: *"Here is how your options compare."* |
| no recommended option | H: *"Hire two developers has the highest expected outcome."* | H: *"Here is how your options compare."* |

Every row's data is untouched — options, win probabilities, goal fits, ranges and readouts all still render. Only the claim goes.

## RED-first evidence

Tests are driven by **run shapes**, not branch names — same mirror-avoidance reason as gate 4. Each shape is an input a live withheld run can take; a future branch is still covered by whichever shape reaches it.

**Before the fix — 9 failures, each naming the exact leaked string:**

```
× names no option … — goal-fit crown
  → headline named an option on a withheld run:
    "Hire two developers is most likely to meet every target this run scored."
× names no option … — no option on track (the sweep run)
  → subline named an option on a withheld run:
    "Hire two developers has the highest expected outcome."
× names no option … — misaligned producer band
  → headline named an option on a withheld run:
    "Upskill the current team is most likely to be strongest overall."
× names no option … — no recommended option
  → headline named an option on a withheld run:
    "Hire two developers has the highest expected outcome."
  (+ the 4 paired superlative assertions, + the state-C companion-line pin)
```

**After the fix:** 27/27 in the file, 788/788 across the hero modules, **3703/3703 across `src/components/results` (192 files)**.

### Per-gate mutation check

Run in a **detached worktree outside the repo root** (trap 9c — an in-repo worktree gets globbed by the runner and manufactures false reds), removed before any gate run. One gate reverted at a time; the script asserts the anchor exists, that the write landed, and that the restore landed (trap 15).

| Gate reverted | Result | Failing test names the string |
|---|---|---|
| G1 `producerBandApplies` | **RED**, 2 tests | *"Upskill the current team is most likely to be strongest overall."* |
| G2 `goalLeaderRow` | **RED**, 2 tests | *"Hire two developers is most likely to meet every target this run scored."* |
| G3 outcome-fact headline | **RED**, 2 tests | *"Hire two developers has the highest expected outcome."* |
| G4 subline chain | **RED**, 3 tests | *"Hire two developers has the highest expected outcome."* → expected *"Compare the top options before deciding."* |

Each gate fails **only its own** run shape — the shapes discriminate rather than all tripping one assertion.

## Positive controls (over-suppression)

The permitted-run assertions were **pinned byte-for-byte before the fix existed** and pass unchanged after it, so a change that suppressed everything would fail here rather than pass quietly:

- goal-fit crown, PERMITTED: headline and subline byte-identical
- no option on track, PERMITTED: headline and subline byte-identical (subline still *"Hire two developers has the highest expected outcome."*)
- producer band, PERMITTED: still bands the recommended option **by name**
- no recommended option, PERMITTED: still headlines the outcome leader **by name**
- withheld subline is asserted **non-empty**, and pinned to the sibling's existing line — the fix substitutes, never deletes
- every run shape asserts `designationsWithheld === true` **before** its no-designation assertion, so no case can pass vacuously by not being withheld at all

`HERO_CLAIM_RE` is deliberately **narrower** than the fixture's `DESIGNATION_RE`, and the fixture documents why: `DESIGNATION_RE` bans "top option", which the hero's own sanctioned no-claim lines contain by design — screening hero prose with it would condemn the very copy this contract prescribes. It is documented as verified-inert against all six neutral hero strings.

## Relationship to the earlier prose pass

`withheldProse.hero.spec.tsx` (follow-up to #501) already removed leader **presupposition** from the hero's three flip-risk strings. It did not reach the headline or the subline. This PR closes that gap; both files coexist, with different matchers for different claim types.

## Rider — the `decisionShapeScore 2.test.ts` conflict copy

**Verified, and the brief's premise does not hold: the file is UNTRACKED.** There is nothing in the repo to delete, so it cannot be removed in this PR.

- `git ls-files | grep -i decisionShapeScore` → the canonical `decisionShapeScore.test.ts` and `decisionShapeScore.ts` only.
- `git ls-files --error-unmatch "…/decisionShapeScore 2.test.ts"` → *"did not match any file(s) known to git"*.
- `git status --porcelain -uall` → `?? "src/canvas/…/decisionShapeScore 2.test.ts"`.
- Repo-wide, **zero** tracked files match the conflict-copy pattern.

It **is** a pure duplicate, as suspected — all three local variants are byte-identical: `md5 = 538a7c78336daaf31c4eee5e1463f34f` for `decisionShapeScore 2.test.ts`, `decisionShapeScore.test 2.ts` and the canonical `decisionShapeScore.test.ts`; `diff` against the canonical is empty.

The collection behaviour is also narrower than it looked. Only the `<name> 2.test.ts` form matches the vitest `include` glob (`*.{test,spec}.?(c|m)[jt]s?(x)`); the `<name>.test 2.ts` form does **not** — the required `.` after `test` is a space. So of the eight local conflict copies in that directory, exactly the one flagged is collected. The sweep was precise.

Consequence: this is **local-filesystem hygiene in the iCloud working tree, not a repo defect** — CI checks out a clean tree and never sees it. Deliberately **not** bundled here (the change would be a `vitest.config.ts` exclude, unrelated to a copy-semantics fix). Flagged separately.

## Overlap

Files changed — all three under `src/components/results/`:

- `analysis-hero/buildHeroModel.ts`
- `analysis-hero/__tests__/withheldDesignations.hero.spec.tsx`
- `__fixtures__/withheldDesignations.fixtures.ts`

The other in-flight UI lane is scoped to `scripts/ci/**`. **Disjoint — zero overlap.** In particular `scripts/ci/typecheck-baseline.txt` is untouched by this PR.

## Gates

- **`pnpm run typecheck`** (the authoritative gate, `scripts/ci/typecheck-gate.sh`) — **PASSED**. Phase 1 coverage: 3015/3033 tracked files loaded, 18 declared out of scope. Phase 2 ratchet: **633 files / 2547 errors, exactly at baseline — NOT bumped**, no `--update-baseline`. Gate behaviour re-derived at this tip; the baseline is the one #504 regenerated (2663 → 2547), which was already merged when this lane branched.
- **`src/components/results`** — 192 files / 3703 tests, all passing.
- **hero modules + designation suites** (`analysis-hero`, `analysisHeroV17`, `strengthen`, `withheldDesignations.spec.tsx`, incl. the `inertness` / `fixtureIsolation` / `glossaryCompliance` guards) — 38 files / 788 tests, all passing.
- **ESLint** on all three touched files — clean.

Verified in a fresh blobless clone at a lane-unique path outside iCloud, `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set (trap 2b) so no spec failed at collect.

## Scope of the claim

These are string assertions over a built model. They prove **wording**; they do not prove layout (trap 3). The deployed-build symptom this fixes was captured by the sweep in a real browser; the assertions here pin the model that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
