### PR TITLE
fix(results): stress-test fragile cards must not presuppose a recommendation on a withheld run

### DIFF
--- a/src/components/results/ChallengeSection.tsx
+++ b/src/components/results/ChallengeSection.tsx
@@ -23,6 +23,12 @@ import { CappedList } from './CappedList'
 import { GraphLink } from './GraphLink'
 import { HelpCircle, AlertTriangle, Info } from 'lucide-react'
 import { stripEncodingNotation, stripStatusQuoSuffixForDisplay } from './utils/cleanFactorLabel'
+import {
+  fragileDiscussDraft,
+  fragileEValueNote,
+  fragileEdgeConsequence,
+  fragileEdgeGroupHeader,
+} from './utils/fragileEdgeCopy'
 import type { EvidenceGapItem, DriverItem } from './types'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
 import { openAskOlumi } from './coaching/askOlumiStore'
@@ -70,6 +76,16 @@ export interface ChallengeSectionProps {
   identifiabilityTag?: string | null
   /** Expert mode: gates E-value raw numbers in fragile edge cards */
   expertMode?: boolean
+  /**
+   * ROADMAP 1.267 — `!DecisionVerdict.hasLeadingOption`, quoted from the
+   * caller, never re-derived here. Threaded straight through to
+   * `FragileEdgeGroupCard`, whose prose presupposed a recommendation.
+   *
+   * REQUIRED, not optional-defaulting-false, for the same reason
+   * `StressTestSectionProps.designationsWithheld` is: an opt-in gate is a gate
+   * every future call site can forget. The compiler names every call site.
+   */
+  designationsWithheld: boolean
 }
 
 /**
@@ -201,6 +217,7 @@ export function FragileEdgeGroupCard({
   onFocusNode,
   onSendMessage,
   expertMode,
+  designationsWithheld,
 }: {
   /**
    * Shared alt-winner label for this group (D11: grouped by alt-winner).
@@ -211,15 +228,32 @@ export function FragileEdgeGroupCard({
   onFocusNode?: (nodeId: string) => void
   onSendMessage?: (text: string) => void
   expertMode?: boolean
+  /**
+   * ROADMAP 1.267 — `!DecisionVerdict.hasLeadingOption`, quoted from the
+   * caller. This card's five sentences were UNCONDITIONAL claims about "the
+   * result" and "the recommendation"; every one of them is now a function of
+   * this boolean (see `utils/fragileEdgeCopy.ts`).
+   *
+   * The card's DATA is untouched in both states — the fragile-factor rows are
+   * producer output, and `StressTestSection` keeps them visible on a withheld
+   * run by design.
+   *
+   * REQUIRED, not optional-defaulting-false: an opt-in gate is a gate every
+   * future call site can forget.
+   */
+  designationsWithheld: boolean
 }) {
   const hasEValue = edges.some(e => e.e_value != null)
-  const multiple = edges.length > 1
 
-  const headerCopy = altWinnerLabel && multiple
-    ? <>{edges.length} {edges.length === 1 ? 'factor' : 'factors'} could flip the result to <span className={`${typography.panelHeader} text-text-body`} data-testid="fragile-alt-winner">{altWinnerLabel}</span></>
-    : altWinnerLabel
-      ? <>Result could flip to <span className={`${typography.panelHeader} text-text-body`} data-testid="fragile-alt-winner">{altWinnerLabel}</span></>
-      : hasEValue ? 'Fragile result, verify key assumptions' : 'Fragile relationship'
+  const header = fragileEdgeGroupHeader({
+    altWinnerLabel,
+    edgeCount: edges.length,
+    hasEValue,
+    designationsWithheld,
+  })
+  const headerCopy = header.kind === 'altWinner'
+    ? <>{header.lead}<span className={`${typography.panelHeader} text-text-body`} data-testid="fragile-alt-winner">{header.altWinnerLabel}</span></>
+    : header.text
 
   return (
     <div className={`relative border border-panel-border rounded-lg px-3 py-2 pr-16 space-y-1.5 ${onSendMessage ? 'pb-7' : ''}`}>
@@ -256,13 +290,13 @@ export function FragileEdgeGroupCard({
             <div className={`flex items-baseline gap-2 flex-wrap ${typography.panelMeta} text-text-light`}>
               <span>If <span className="text-text-body">{edgeSource}</span> shifts</span>
               {!altWinnerLabel && (
-                <span>the recommendation could change</span>
+                <span>{fragileEdgeConsequence({ designationsWithheld })}</span>
               )}
             </div>
             {edge.e_value != null && expertMode && (
               <ExpertBlock>
                 <p className={`${typography.panelMeta} text-text-light`}>
-                  E-value {edge.e_value.toFixed(1)}: assumptions would only need to be {edge.e_value.toFixed(1)}x wrong to flip the recommendation.
+                  {fragileEValueNote({ eValue: edge.e_value, designationsWithheld })}
                 </p>
               </ExpertBlock>
             )}
@@ -289,11 +323,13 @@ export function FragileEdgeGroupCard({
             element={{ kind: 'missing' }}
             onSend={() => openAskOlumi({
               context: 'Fragile relationships',
-              draft: altWinnerLabel && multiple
-                ? `Are these ${edges.length} relationships that could flip the result to ${altWinnerLabel} reliable?`
-                : altWinnerLabel
-                  ? `Is the relationship between ${stripEncodingNotation(edges[0].from_label)} and ${stripEncodingNotation(edges[0].to_label)} reliable?`
-                  : `Are these ${edges.length} fragile relationships in my model reliable?`,
+              draft: fragileDiscussDraft({
+                edgeCount: edges.length,
+                altWinnerLabel,
+                fromLabel: stripEncodingNotation(edges[0].from_label),
+                toLabel: stripEncodingNotation(edges[0].to_label),
+                designationsWithheld,
+              }),
               label: 'Discuss fragile relationships',
             })}
           />
@@ -346,6 +382,7 @@ export function ChallengeSection({
   fragileEdges: fragileEdgesProp,
   identifiabilityTag,
   expertMode,
+  designationsWithheld,
 }: ChallengeSectionProps) {
   // ── Model structure items ──────────────────────────────────────────────
   // Merge fragile edges with E-value data per edge, group by source node.
@@ -402,6 +439,7 @@ export function ChallengeSection({
               onFocusNode={onFocusNode}
               onSendMessage={onSendMessage}
               expertMode={expertMode}
+              designationsWithheld={designationsWithheld}
             />
           ))}
         </div>

--- a/src/components/results/StressTestSection.tsx
+++ b/src/components/results/StressTestSection.tsx
@@ -76,9 +76,17 @@ export interface StressTestSectionProps {
    * REQUIRED, not optional-defaulting-false: an opt-in gate is a gate every
    * future call site can forget. The compiler names every call site instead.
    *
-   * Scope is deliberately the two authored cards ONLY. Sensitive assumptions
-   * and fragile factors are producer data and keep rendering — suppressing
-   * the section wholesale would be the over-suppression the ruling forbids.
+   * Sensitive assumptions and fragile factors are producer data and keep
+   * rendering — suppressing the section wholesale would be the
+   * over-suppression the ruling forbids.
+   *
+   * ⚠ AMENDED (this lane): this doc used to end "Scope is deliberately the two
+   * authored cards ONLY", and that sentence was read as settling the fragile
+   * factors — it did not. It settled their VISIBILITY (they stay) and said
+   * nothing about their PROSE, which presupposed a recommendation in five
+   * strings inside `FragileEdgeGroupCard`. The card now takes this same
+   * boolean; the rows, counts, labels and E-values are unchanged. Suppression
+   * scope is still the two authored cards; CLAIM scope is the whole section.
    */
   designationsWithheld: boolean
   /** Recommended option label (winner) — drives template question phrasing. */
@@ -372,6 +380,7 @@ export const StressTestSection = memo(function StressTestSection({
                 onFocusNode={onFocusNode}
                 onSendMessage={onSendMessage}
                 expertMode={expertMode}
+                designationsWithheld={designationsWithheld}
               />
             ))}
           </div>

--- a/src/components/results/__tests__/ChallengeSection.fragileRows.spec.tsx
+++ b/src/components/results/__tests__/ChallengeSection.fragileRows.spec.tsx
@@ -36,6 +36,7 @@ describe('ChallengeSection — Brief 5.2 Task 6 fragile-row layout', () => {
   it('D11: alt-winner appears in the card header (not per-edge), stripped of "(Status Quo)"', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({ alternative_winner_label: 'Option B' })]}
@@ -54,6 +55,7 @@ describe('ChallengeSection — Brief 5.2 Task 6 fragile-row layout', () => {
   it('D11: strips "(Status Quo)" suffix from alt-winner in the card header', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({
@@ -69,6 +71,7 @@ describe('ChallengeSection — Brief 5.2 Task 6 fragile-row layout', () => {
   it('D11: no inline arrow in per-edge row — alt-winner is in header, source-shift line has no arrow', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({
@@ -89,6 +92,7 @@ describe('ChallengeSection — Brief 5.2 Task 6 fragile-row layout', () => {
   it('falls back to neutral phrase when no alternative winner is known', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({ alternative_winner_label: undefined })]}
@@ -102,6 +106,7 @@ describe('ChallengeSection — Brief 5.2 Task 6 fragile-row layout', () => {
   it('Stability pill renders at the card top-right (Brief 5.2 Task 6a)', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge()]}
@@ -121,6 +126,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     const onFocusNode = vi.fn()
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({ from_id: 'node-source-1' })]}
@@ -139,6 +145,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
   it('Review chip is hidden when onFocusNode is not wired (defensive)', () => {
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge()]}
@@ -151,6 +158,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     const onFocusNode = vi.fn()
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[makeFragileEdge({ from_label: 'Market Size', to_label: 'Revenue' })]}
@@ -175,6 +183,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     ]
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={edges}
@@ -199,6 +208,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     ]
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={edges}
@@ -222,6 +232,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     ]
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={edges}
@@ -254,6 +265,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     }
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={[edgeWithoutId]}
@@ -277,6 +289,7 @@ describe('ChallengeSection — Brief 5.2 Task 6c Review chip', () => {
     ]
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={[]}
         preMortemItems={[]}
         fragileEdges={edges}

--- a/src/components/results/__tests__/v12.2-factor-labels.spec.tsx
+++ b/src/components/results/__tests__/v12.2-factor-labels.spec.tsx
@@ -36,6 +36,7 @@ describe('Fix 3: Bias finding affected_elements shows factor labels', () => {
 
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={biasFindings}
         preMortemItems={[]}
         evidenceGaps={evidenceGaps}
@@ -72,6 +73,7 @@ describe('Fix 3: Bias finding affected_elements shows factor labels', () => {
 
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={biasFindings}
         preMortemItems={[]}
         evidenceGaps={[]}
@@ -95,6 +97,7 @@ describe('Fix 3: Bias finding affected_elements shows factor labels', () => {
 
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={biasFindings}
         preMortemItems={[]}
         evidenceGaps={[]}
@@ -130,6 +133,7 @@ describe('Fix 3: Bias finding affected_elements shows factor labels', () => {
 
     render(
       <ChallengeSection
+        designationsWithheld={false}
         biasFindings={biasFindings}
         preMortemItems={[]}
         evidenceGaps={evidenceGaps}

--- a/src/components/results/__tests__/withheldProse.spec.tsx
+++ b/src/components/results/__tests__/withheldProse.spec.tsx
@@ -355,23 +355,39 @@ describe('StressTestSection fragile factors — STRING 1: the grouped header', (
     expect(screen.getByTestId('fragile-alt-winner').textContent).toBe(HIGH_LABEL)
   })
 
-  it('WITHHELD: the header states the fragility without a flip target', () => {
+  it('WITHHELD: the header drops the presupposing verb', () => {
     const text = fragileText(true, twoEdges)
-    expect(text).toContain('2 factors could change the comparison')
+    expect(text).toContain('2 factors could shift the comparison towards')
     expect(text).not.toMatch(FRAGILE_CLAIM_RE)
   })
 
-  it('WITHHELD: the would-be leader is not named (#505 — silence without authority)', () => {
+  /**
+   * ORCHESTRATOR RULING: the presupposition is the defect; the NAME is data.
+   * `alternative_winner_label` is directional sensitivity — which option this
+   * edge's fragility points toward — and `heroCopy.flipRiskWithAlternative`
+   * (canonical for this field) keeps it on a withheld run. Dropping it here
+   * would both over-suppress and make one screen treat one producer field two
+   * ways. This case is the over-suppression control for that ruling.
+   */
+  it('WITHHELD: the alternative is still NAMED — the name is data, not a claim', () => {
     renderFragile(true, twoEdges)
-    expect(screen.queryByTestId('fragile-alt-winner')).toBeNull()
+    expect(screen.getByTestId('fragile-alt-winner').textContent).toBe(HIGH_LABEL)
     expect(screen.getByTestId('stress-test-fragile-subsection').textContent ?? '')
-      .not.toContain(HIGH_LABEL)
+      .toContain(HIGH_LABEL)
   })
 
   it('PERMITTED: the header is byte-identical to today', () => {
     expect(
       fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 2, hasEValue: false, designationsWithheld: false }),
     ).toEqual({ kind: 'altWinner', lead: '2 factors could flip the result to ', altWinnerLabel: HIGH_LABEL })
+  })
+
+  it('WITHHELD: the header keeps the altWinner SHAPE — only the lead changes', () => {
+    // Pinned as a shape, not just a substring: a fix that returned a plain
+    // sentence would drop the `fragile-alt-winner` element and the name with it.
+    expect(
+      fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 2, hasEValue: false, designationsWithheld: true }),
+    ).toEqual({ kind: 'altWinner', lead: '2 factors could shift the comparison towards ', altWinnerLabel: HIGH_LABEL })
   })
 })
 
@@ -382,17 +398,23 @@ describe('StressTestSection fragile factors — STRING 2: the singleton header',
     expect(text).toMatch(FRAGILE_CLAIM_RE)
   })
 
-  it('WITHHELD: the singleton header presupposes no result to flip', () => {
+  it('WITHHELD: the singleton header presupposes no result to flip, and still names the alternative', () => {
     const text = fragileText(true, [fragileEdge()])
-    expect(text).toContain('The comparison could change')
+    expect(text).toContain('The comparison could shift towards')
     expect(text).not.toMatch(FRAGILE_CLAIM_RE)
-    expect(screen.queryByTestId('fragile-alt-winner')).toBeNull()
+    expect(screen.getByTestId('fragile-alt-winner').textContent).toBe(HIGH_LABEL)
   })
 
   it('PERMITTED: the singleton header is byte-identical to today', () => {
     expect(
       fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 1, hasEValue: false, designationsWithheld: false }),
     ).toEqual({ kind: 'altWinner', lead: 'Result could flip to ', altWinnerLabel: HIGH_LABEL })
+  })
+
+  it('WITHHELD: the singleton header keeps the altWinner shape', () => {
+    expect(
+      fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 1, hasEValue: false, designationsWithheld: true }),
+    ).toEqual({ kind: 'altWinner', lead: 'The comparison could shift towards ', altWinnerLabel: HIGH_LABEL })
   })
 
   it('NO ALT-WINNER: both headers are byte-identical in BOTH verdict states', () => {
@@ -485,11 +507,12 @@ describe('StressTestSection fragile factors — STRING 5: the Ask-Olumi draft', 
     expect(draft).toMatch(FRAGILE_CLAIM_RE)
   })
 
-  it('WITHHELD: the grouped draft asks about the comparison instead', () => {
+  it('WITHHELD: the grouped draft asks about the comparison, still naming the alternative', () => {
     const draft = fragileDiscussDraft({ ...base, altWinnerLabel: HIGH_LABEL, designationsWithheld: true })
-    expect(draft).toBe('Are these 2 relationships that could change the comparison reliable?')
+    expect(draft).toBe(`Are these 2 relationships that could shift the comparison towards ${HIGH_LABEL} reliable?`)
     expect(draft).not.toMatch(FRAGILE_CLAIM_RE)
-    expect(draft).not.toContain(HIGH_LABEL)
+    // The user's own question carries every fact the analysis computed.
+    expect(draft).toContain(HIGH_LABEL)
   })
 
   /**
@@ -524,11 +547,11 @@ describe('StressTestSection fragile factors — STRING 5: the Ask-Olumi draft', 
     expect(draft).toMatch(FRAGILE_CLAIM_RE)
   })
 
-  it('WITHHELD: the sparkle prefills a draft that names no flip target', () => {
+  it('WITHHELD: the sparkle prefills a draft with no presupposition', () => {
     const draft = draftFromCta(true)
-    expect(draft).toBe('Are these 2 relationships that could change the comparison reliable?')
+    expect(draft).toBe(`Are these 2 relationships that could shift the comparison towards ${HIGH_LABEL} reliable?`)
     expect(draft).not.toMatch(FRAGILE_CLAIM_RE)
-    expect(draft).not.toContain(HIGH_LABEL)
+    expect(draft).toContain(HIGH_LABEL)
   })
 
   it('the two already-neutral drafts are byte-identical in BOTH verdict states', () => {

--- a/src/components/results/__tests__/withheldProse.spec.tsx
+++ b/src/components/results/__tests__/withheldProse.spec.tsx
@@ -35,16 +35,25 @@
  * visual order. Nothing here claims a visual property.
  */
 import { describe, expect, it } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { useAskOlumiStore } from '../coaching/askOlumiStore'
 import { V7EvidenceDisclosure } from '../v7/V7EvidenceDisclosure'
 import type { V7EvidenceModel } from '../v7/buildV7Lenses'
 import { V7_LENS_COPY } from '../v7/v7LensCopy'
 import { flipThresholdStatusNote } from '../utils/flipThresholdStatusNote'
 import { StressTestSection } from '../StressTestSection'
+import { FragileEdgeGroupCard, type ChallengeFragileEdge } from '../ChallengeSection'
+import {
+  fragileDiscussDraft,
+  fragileEValueNote,
+  fragileEdgeConsequence,
+  fragileEdgeGroupHeader,
+} from '../utils/fragileEdgeCopy'
 import { buildCertaintyCopy } from '../utils/certaintyCopy'
 import { NO_CLAIM_VERDICT } from '../../../lib/decisionVerdict'
 import type { DriverItem } from '../types'
 import {
+  HIGH_ID,
   HIGH_LABEL,
   MID_LABEL,
   PERMITTED_VERDICT,
@@ -261,6 +270,315 @@ describe('StressTestSection — the UI-authored thinking patterns', () => {
     renderStressTest(true)
     expect(screen.getByTestId('stress-test-sensitive-subsection').textContent ?? '')
       .toContain('Team capacity')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 6 — the stress-test FRAGILE-FACTOR cards (FragileEdgeGroupCard)
+//
+// The surface SURFACE 4 missed, one component over. #503 gated the two
+// UI-authored thinking-pattern cards on the verdict and recorded that
+// "sensitive assumptions and fragile factors are producer data and keep
+// rendering". True — and it settled their VISIBILITY, not their PROSE.
+// `FragileEdgeGroupCard` took no verdict at all, so on a withheld run its
+// header asserted "N factors could flip the result to <named option>" directly
+// beneath the panel's own "the analysis did not put an option forward".
+//
+// The line drawn here is the file's line: DATA STAYS (counts, factor labels,
+// E-values, Review chips, the stability pill — all asserted below on the
+// withheld run), CLAIMS GO.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The fragile card's own claim vocabulary.
+ *
+ * Distinct from `LEADER_PRESUPPOSITION_RE` because this card presupposes the
+ * recommendation without ever saying "leading option" or "your recommendation"
+ * — which is precisely why the #503 matcher, pointed at the same panel, could
+ * not see it. "the recommendation" (bare definite article) and "flip the
+ * result to" are the claims: both presuppose that a result/recommendation
+ * exists to be flipped.
+ */
+const FRAGILE_CLAIM_RE = /flip the result to|result could flip to|the recommendation/i
+
+const FRAGILE_FROM = 'Team capacity'
+const FRAGILE_FROM_2 = 'Delivery risk'
+
+function fragileEdge(overrides: Partial<ChallengeFragileEdge> = {}): ChallengeFragileEdge {
+  return {
+    edge_id: 'e_capacity',
+    from_id: 'fac_capacity',
+    from_label: FRAGILE_FROM,
+    to_label: 'Value delivered',
+    switch_probability: 0.48,
+    alternative_winner_id: HIGH_ID,
+    alternative_winner_label: HIGH_LABEL,
+    ...overrides,
+  }
+}
+
+/** Mount the LIVE path: ResultsBody → StressTestSection → FragileEdgeGroupCard. */
+function renderFragile(designationsWithheld: boolean, edges: ChallengeFragileEdge[]) {
+  const utils = render(
+    <StressTestSection
+      drivers={[]}
+      fragileEdges={edges}
+      winnerLabel={HIGH_LABEL}
+      alternativeLabel={MID_LABEL}
+      designationsWithheld={designationsWithheld}
+    />,
+  )
+  return { ...utils, subsection: () => screen.getByTestId('stress-test-fragile-subsection') }
+}
+
+/**
+ * Assertions read the FRAGILE SUBSECTION, never the whole container: the
+ * thinking-pattern cards above it also carry claim vocabulary and are already
+ * suppressed by #503, so a container-wide `not.toMatch` on a withheld run
+ * would pass on someone else's fix.
+ */
+function fragileText(designationsWithheld: boolean, edges: ChallengeFragileEdge[]): string {
+  const { subsection } = renderFragile(designationsWithheld, edges)
+  return subsection().textContent ?? ''
+}
+
+describe('StressTestSection fragile factors — STRING 1: the grouped header', () => {
+  const twoEdges = [
+    fragileEdge(),
+    fragileEdge({ edge_id: 'e_risk', from_id: 'fac_risk', from_label: FRAGILE_FROM_2, switch_probability: 0.31 }),
+  ]
+
+  it('ANTI-VACUITY: the PERMITTED header carries the claim the matcher hunts', () => {
+    const text = fragileText(false, twoEdges)
+    expect(text).toContain('2 factors could flip the result to')
+    expect(text).toMatch(FRAGILE_CLAIM_RE)
+    expect(screen.getByTestId('fragile-alt-winner').textContent).toBe(HIGH_LABEL)
+  })
+
+  it('WITHHELD: the header states the fragility without a flip target', () => {
+    const text = fragileText(true, twoEdges)
+    expect(text).toContain('2 factors could change the comparison')
+    expect(text).not.toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the would-be leader is not named (#505 — silence without authority)', () => {
+    renderFragile(true, twoEdges)
+    expect(screen.queryByTestId('fragile-alt-winner')).toBeNull()
+    expect(screen.getByTestId('stress-test-fragile-subsection').textContent ?? '')
+      .not.toContain(HIGH_LABEL)
+  })
+
+  it('PERMITTED: the header is byte-identical to today', () => {
+    expect(
+      fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 2, hasEValue: false, designationsWithheld: false }),
+    ).toEqual({ kind: 'altWinner', lead: '2 factors could flip the result to ', altWinnerLabel: HIGH_LABEL })
+  })
+})
+
+describe('StressTestSection fragile factors — STRING 2: the singleton header', () => {
+  it('ANTI-VACUITY: the PERMITTED singleton header carries the claim', () => {
+    const text = fragileText(false, [fragileEdge()])
+    expect(text).toContain('Result could flip to')
+    expect(text).toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the singleton header presupposes no result to flip', () => {
+    const text = fragileText(true, [fragileEdge()])
+    expect(text).toContain('The comparison could change')
+    expect(text).not.toMatch(FRAGILE_CLAIM_RE)
+    expect(screen.queryByTestId('fragile-alt-winner')).toBeNull()
+  })
+
+  it('PERMITTED: the singleton header is byte-identical to today', () => {
+    expect(
+      fragileEdgeGroupHeader({ altWinnerLabel: HIGH_LABEL, edgeCount: 1, hasEValue: false, designationsWithheld: false }),
+    ).toEqual({ kind: 'altWinner', lead: 'Result could flip to ', altWinnerLabel: HIGH_LABEL })
+  })
+
+  it('NO ALT-WINNER: both headers are byte-identical in BOTH verdict states', () => {
+    // The verdict-independent branch — a control against a fix that rewrote
+    // copy it had no reason to touch.
+    for (const designationsWithheld of [false, true]) {
+      expect(fragileEdgeGroupHeader({ altWinnerLabel: null, edgeCount: 1, hasEValue: false, designationsWithheld }))
+        .toEqual({ kind: 'plain', text: 'Fragile relationship' })
+      expect(fragileEdgeGroupHeader({ altWinnerLabel: null, edgeCount: 2, hasEValue: true, designationsWithheld }))
+        .toEqual({ kind: 'plain', text: 'Fragile result, verify key assumptions' })
+    }
+  })
+})
+
+describe('StressTestSection fragile factors — STRING 3: the per-edge consequence', () => {
+  // Rendered only when the group has NO named alt-winner.
+  const orphanEdge = [fragileEdge({ alternative_winner_id: undefined, alternative_winner_label: undefined })]
+
+  it('ANTI-VACUITY: the PERMITTED clause names the recommendation', () => {
+    const text = fragileText(false, orphanEdge)
+    expect(text).toContain('the recommendation could change')
+    expect(text).toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the clause names the comparison instead', () => {
+    const text = fragileText(true, orphanEdge)
+    expect(text).toContain('the comparison could change')
+    expect(text).not.toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('PERMITTED: the clause is byte-identical to today', () => {
+    expect(fragileEdgeConsequence({ designationsWithheld: false })).toBe('the recommendation could change')
+  })
+})
+
+describe('StressTestSection fragile factors — STRING 4: the expert E-value note', () => {
+  /**
+   * REACHABILITY, stated precisely (CLAUDE.md — name the claim type).
+   * This string is NOT reachable on the live path today: `e_value` reaches
+   * `FragileEdgeGroupCard` only from `ChallengeSection`, which merges
+   * `edgeEValues`, and `ChallengeSection` has no production call site;
+   * `StressTestSection` passes `ChallengeFragileEdge[]`, which carries no
+   * `e_value`. It is fixed and pinned here because it is the same defect in
+   * the same component and one prop away from live.
+   */
+  const eValueEdges = [{ ...fragileEdge({ alternative_winner_label: undefined }), e_value: 2.0 }]
+
+  function renderCard(designationsWithheld: boolean) {
+    return render(
+      <FragileEdgeGroupCard
+        altWinnerLabel={null}
+        edges={eValueEdges}
+        expertMode
+        designationsWithheld={designationsWithheld}
+      />,
+    )
+  }
+
+  it('ANTI-VACUITY: the PERMITTED note says "flip the recommendation"', () => {
+    const { container } = renderCard(false)
+    expect(container.textContent ?? '').toContain('2.0x wrong to flip the recommendation.')
+    expect(container.textContent ?? '').toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the note says what would change without naming a recommendation', () => {
+    const { container } = renderCard(true)
+    expect(container.textContent ?? '').toContain('2.0x wrong to change the comparison.')
+    expect(container.textContent ?? '').not.toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD DATA PRESERVED: the E-value number itself still renders', () => {
+    const { container } = renderCard(true)
+    expect(container.textContent ?? '').toContain('E-value 2.0')
+  })
+
+  it('PERMITTED: the note is byte-identical to today', () => {
+    expect(fragileEValueNote({ eValue: 2.0, designationsWithheld: false }))
+      .toBe('E-value 2.0: assumptions would only need to be 2.0x wrong to flip the recommendation.')
+  })
+})
+
+describe('StressTestSection fragile factors — STRING 5: the Ask-Olumi draft', () => {
+  // In scope for the reason #503 put the two thinking-pattern drafts in scope:
+  // a draft is prose the product hands the user to send in their own name.
+  const base = { edgeCount: 2, fromLabel: FRAGILE_FROM, toLabel: 'Value delivered' }
+
+  it('ANTI-VACUITY: the PERMITTED grouped draft names the flip target', () => {
+    const draft = fragileDiscussDraft({ ...base, altWinnerLabel: HIGH_LABEL, designationsWithheld: false })
+    expect(draft).toBe(`Are these 2 relationships that could flip the result to ${HIGH_LABEL} reliable?`)
+    expect(draft).toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the grouped draft asks about the comparison instead', () => {
+    const draft = fragileDiscussDraft({ ...base, altWinnerLabel: HIGH_LABEL, designationsWithheld: true })
+    expect(draft).toBe('Are these 2 relationships that could change the comparison reliable?')
+    expect(draft).not.toMatch(FRAGILE_CLAIM_RE)
+    expect(draft).not.toContain(HIGH_LABEL)
+  })
+
+  /**
+   * The pure-function cases above cannot go red against the pristine
+   * component (they exercise the new module directly). This one drives the
+   * LIVE path — mount, click the sparkle, read what the drawer was handed —
+   * so the draft's gate is proven the same way strings 1-4 are.
+   */
+  function draftFromCta(designationsWithheld: boolean): string {
+    useAskOlumiStore.setState({ draft: '' })
+    render(
+      <StressTestSection
+        drivers={[]}
+        fragileEdges={[
+          fragileEdge(),
+          fragileEdge({ edge_id: 'e_risk', from_id: 'fac_risk', from_label: FRAGILE_FROM_2, switch_probability: 0.31 }),
+        ]}
+        winnerLabel={HIGH_LABEL}
+        alternativeLabel={MID_LABEL}
+        designationsWithheld={designationsWithheld}
+        onSendMessage={() => {}}
+      />,
+    )
+    const subsection = screen.getByTestId('stress-test-fragile-subsection')
+    fireEvent.click(within(subsection).getByTestId('discuss-with-ai'))
+    return useAskOlumiStore.getState().draft
+  }
+
+  it('ANTI-VACUITY: the PERMITTED sparkle prefills the flip-target draft', () => {
+    const draft = draftFromCta(false)
+    expect(draft).toBe(`Are these 2 relationships that could flip the result to ${HIGH_LABEL} reliable?`)
+    expect(draft).toMatch(FRAGILE_CLAIM_RE)
+  })
+
+  it('WITHHELD: the sparkle prefills a draft that names no flip target', () => {
+    const draft = draftFromCta(true)
+    expect(draft).toBe('Are these 2 relationships that could change the comparison reliable?')
+    expect(draft).not.toMatch(FRAGILE_CLAIM_RE)
+    expect(draft).not.toContain(HIGH_LABEL)
+  })
+
+  it('the two already-neutral drafts are byte-identical in BOTH verdict states', () => {
+    for (const designationsWithheld of [false, true]) {
+      expect(fragileDiscussDraft({ ...base, edgeCount: 1, altWinnerLabel: HIGH_LABEL, designationsWithheld }))
+        .toBe(`Is the relationship between ${FRAGILE_FROM} and Value delivered reliable?`)
+      expect(fragileDiscussDraft({ ...base, altWinnerLabel: null, designationsWithheld }))
+        .toBe('Are these 2 fragile relationships in my model reliable?')
+    }
+  })
+})
+
+describe('StressTestSection fragile factors — OVER-SUPPRESSION CONTROLS', () => {
+  const twoEdges = [
+    fragileEdge(),
+    fragileEdge({ edge_id: 'e_risk', from_id: 'fac_risk', from_label: FRAGILE_FROM_2, switch_probability: 0.31 }),
+  ]
+
+  it('WITHHELD: the fragile subsection still renders, with its producer count', () => {
+    // StressTestSection.tsx:79-82 keeps fragile factors visible on a withheld
+    // run BY DESIGN. A fix that silenced the section would pass every string
+    // gate above and be a worse product than the defect.
+    renderFragile(true, twoEdges)
+    const subsection = screen.getByTestId('stress-test-fragile-subsection')
+    expect(subsection.textContent ?? '').toContain('Fragile factors (2)')
+  })
+
+  it('WITHHELD: every source factor and Review chip still renders', () => {
+    renderFragile(true, twoEdges)
+    const text = screen.getByTestId('stress-test-fragile-subsection').textContent ?? ''
+    expect(text).toContain(FRAGILE_FROM)
+    expect(text).toContain(FRAGILE_FROM_2)
+    expect(text).toContain('If')
+    expect(text).toContain('shifts')
+    expect(screen.getAllByTestId('fragile-card-stability-pill').length).toBeGreaterThan(0)
+  })
+
+  it('WITHHELD: the header count is the same number the permitted run shows', () => {
+    const { unmount } = renderFragile(false, twoEdges)
+    const permitted = screen.getByTestId('accordion-stress-test').textContent ?? ''
+    unmount()
+    renderFragile(true, twoEdges)
+    const withheld = screen.getByTestId('accordion-stress-test').textContent ?? ''
+    // #503 removes the two thinking-pattern cards (4 → 2); the two FRAGILE
+    // rows must survive both counts. Asserted on the subsection header, which
+    // counts only this subsection.
+    expect(permitted).toContain('4')
+    expect(withheld).toContain('2')
+    expect(screen.getByTestId('stress-test-fragile-subsection').textContent ?? '')
+      .toContain('Fragile factors (2)')
   })
 })
 

--- a/src/components/results/utils/fragileEdgeCopy.ts
+++ b/src/components/results/utils/fragileEdgeCopy.ts
@@ -36,21 +36,31 @@
  * DATA STAYS, in full: the edge count, every source-factor label, every
  * E-value, every Review chip, the stability pill. Only the CLAIM changes.
  *
- * The alt-winner NAME is dropped from the withheld headers (#505 doctrine —
- * silence where we lack authority). `alternative_winner_label` means "the
- * option that would take the lead if this edge flipped", so rendering it in a
- * flip sentence names a would-be leader on a run where no leader may be
- * named. The fragility FACT — that N factors could change the picture — is
- * kept whole.
+ * ## Where the defect actually is: the VERB, not the name (orchestrator ruling)
  *
- * ⚠ DOCTRINE NOTE, deliberately left visible for review: `heroCopy.ts`
- * (`flipRiskWithAlternative`) took the OTHER branch for the same producer
- * field — it KEEPS the alternative's name on a withheld run and neutralises
- * only the verb ("the comparison shifts towards {alt}"), arguing that
- * dropping producer data is itself over-suppression. This module follows the
- * #505 drop-the-name doctrine as briefed; if the programme rules the hero's
- * treatment canonical, `fragileEdgeGroupHeader`'s withheld branch is the one
- * line that changes.
+ * This module first dropped `alternative_winner_label` from the withheld
+ * headers, reading #505 ("silence where we lack authority") as reaching the
+ * name. **That was ruled wrong, and the ruling is recorded here because the
+ * distinction is the whole point of the fix:**
+ *
+ *   · **The PRESUPPOSING VERB is the defect.** "flip the result to {alt}"
+ *     asserts that a current result — a leader — exists to flip *from*. That
+ *     is the claim the verdict withholds, and it is removed.
+ *   · **The NAME is data, not a claim.** `alternative_winner_label` is
+ *     DIRECTIONAL SENSITIVITY: which option this edge's fragility points
+ *     toward. Dropping it is exactly the over-suppression the ruling forbids —
+ *     the product says everything it HAS computed.
+ *   · **One field may not be treated two ways on one screen.** `heroCopy.ts`
+ *     (`flipRiskWithAlternative`, :398-414) already keeps the name and
+ *     neutralises only the verb: "the comparison shifts towards {alt}". A
+ *     panel where the hero names the alternative and the stress-test card
+ *     hides it is the family-1 self-contradiction shape. Consistency across
+ *     surfaces on the same producer field is itself a doctrine requirement,
+ *     so the HERO'S TREATMENT IS CANONICAL and this module follows it.
+ *
+ * So the withheld headers keep `{alt}` and change only the sentence around
+ * it. Strings 3 and 4 name no option at all, so they have no name to keep —
+ * their withheld forms simply drop the presupposition.
  */
 
 /**
@@ -122,12 +132,16 @@ export function fragileEdgeGroupHeader({
   const multiple = edgeCount > 1
 
   if (designationsWithheld) {
-    // The count survives; the flip TARGET does not.
+    // The count survives AND so does the name — the alternative is directional
+    // sensitivity data. What goes is "flip the result TO", which presupposes a
+    // current result to flip from. Same shape as `heroCopy.flipRiskWithAlternative`
+    // ("the comparison shifts towards {alt}"), which is canonical for this field.
     return {
-      kind: 'plain',
-      text: multiple
-        ? `${factorCount(edgeCount)} could change ${FRAGILE_NEUTRAL_OBJECT}`
-        : `${sentenceCase(FRAGILE_NEUTRAL_OBJECT)} could change`,
+      kind: 'altWinner',
+      lead: multiple
+        ? `${factorCount(edgeCount)} could shift ${FRAGILE_NEUTRAL_OBJECT} towards `
+        : `${sentenceCase(FRAGILE_NEUTRAL_OBJECT)} could shift towards `,
+      altWinnerLabel,
     }
   }
 
@@ -169,6 +183,9 @@ export function fragileEValueNote({
  * scope: a draft is prose the product hands the user to send in their own
  * name. Only the grouped-with-alt-winner branch carries a claim; the other
  * two are already neutral and are byte-identical in both states.
+ *
+ * The withheld form keeps `{alt}` for the reason above: the user's own
+ * question should carry every fact the analysis computed.
  */
 export function fragileDiscussDraft({
   edgeCount,
@@ -187,7 +204,7 @@ export function fragileDiscussDraft({
 
   if (altWinnerLabel && multiple) {
     return designationsWithheld
-      ? `Are these ${edgeCount} relationships that could change ${FRAGILE_NEUTRAL_OBJECT} reliable?`
+      ? `Are these ${edgeCount} relationships that could shift ${FRAGILE_NEUTRAL_OBJECT} towards ${altWinnerLabel} reliable?`
       : `Are these ${edgeCount} relationships that could flip the result to ${altWinnerLabel} reliable?`
   }
 

--- a/src/components/results/utils/fragileEdgeCopy.ts
+++ b/src/components/results/utils/fragileEdgeCopy.ts
@@ -1,0 +1,204 @@
+/**
+ * fragileEdgeCopy — the stress-test fragile-factor card's prose, as pure
+ * functions of the shared verdict (ROADMAP 1.267, the #503/#505 pattern).
+ *
+ * ## Why it moved out of ChallengeSection
+ *
+ * `FragileEdgeGroupCard` is the card the stress-test "Fragile factors"
+ * subsection renders. Four of its strings named a recommendation the producer
+ * had withdrawn:
+ *
+ *   1. `N factors could flip the result to {alt}`   (grouped header)
+ *   2. `Result could flip to {alt}`                 (singleton header)
+ *   3. `the recommendation could change`            (per-edge consequence)
+ *   4. `… would only need to be Nx wrong to flip the recommendation.`
+ *   5. `Are these N relationships that could flip the result to {alt} …`
+ *      (the Ask-Olumi draft — a string the user is handed to send, and the
+ *      same defect class the #503 thinking-pattern drafts carried)
+ *
+ * None of them was a function of anything: `FragileEdgeGroupCard` took no
+ * verdict at all, so on a withheld run the card asserted a recommendation
+ * directly beneath the panel's own "the analysis did not put an option
+ * forward". `StressTestSection` deliberately keeps fragile factors VISIBLE on
+ * a withheld run (its own comment, `StressTestSection.tsx:79-82`: the factors
+ * are producer DATA and suppressing them would be the over-suppression the
+ * ruling forbids) — which is correct, and is exactly why the prose beneath
+ * them had to change instead.
+ *
+ * As inline JSX literals these five could not be unit-tested without mounting
+ * the card, which is why the leak survived #501, #503 and #505. As pure
+ * functions they are addressable directly by the withheld/permitted fixture
+ * pair, and there is ONE spelling of each sentence rather than five literals a
+ * future copy edit could update unevenly (trap 12).
+ *
+ * ## What changes on a withheld run, and what does not
+ *
+ * DATA STAYS, in full: the edge count, every source-factor label, every
+ * E-value, every Review chip, the stability pill. Only the CLAIM changes.
+ *
+ * The alt-winner NAME is dropped from the withheld headers (#505 doctrine —
+ * silence where we lack authority). `alternative_winner_label` means "the
+ * option that would take the lead if this edge flipped", so rendering it in a
+ * flip sentence names a would-be leader on a run where no leader may be
+ * named. The fragility FACT — that N factors could change the picture — is
+ * kept whole.
+ *
+ * ⚠ DOCTRINE NOTE, deliberately left visible for review: `heroCopy.ts`
+ * (`flipRiskWithAlternative`) took the OTHER branch for the same producer
+ * field — it KEEPS the alternative's name on a withheld run and neutralises
+ * only the verb ("the comparison shifts towards {alt}"), arguing that
+ * dropping producer data is itself over-suppression. This module follows the
+ * #505 drop-the-name doctrine as briefed; if the programme rules the hero's
+ * treatment canonical, `fragileEdgeGroupHeader`'s withheld branch is the one
+ * line that changes.
+ */
+
+/**
+ * The neutral object of every withheld sentence here.
+ *
+ * Quoted from `flipThresholdStatusNote.ts:62`, which resolved the same
+ * question for the "What could change the result" note. Three sanctioned
+ * spellings exist across the panel ('the comparison', 'how the options
+ * compare', 'the comparison between options'); this surface uses the shortest,
+ * and uses it for all five sentences so they cannot drift apart.
+ */
+export const FRAGILE_NEUTRAL_OBJECT = 'the comparison'
+
+/**
+ * TODO(designationsWithheld-helper): `designationsWithheld` is hand-derived in
+ * three disagreeing spellings across the panel (`ResultsBody.tsx:154`
+ * `verdict != null && !verdict.hasLeadingOption`, `ResultsBody.tsx:457`
+ * `verdict?.hasLeadingOption === false`, `useResultsSectionData.ts:1571`
+ * `!leaderVerdict.hasLeadingOption`). A shared helper is being consolidated
+ * separately; this module and its callers deliberately QUOTE the caller's
+ * boolean and never re-derive one, so the consolidation lands in one place.
+ */
+export interface FragileEdgeVerdictInput {
+  /**
+   * `!DecisionVerdict.hasLeadingOption`, quoted from the caller. Never
+   * re-derived here.
+   */
+  designationsWithheld: boolean
+}
+
+/**
+ * The card header. Two shapes, because the permitted header embeds the
+ * alt-winner in its own styled `<span data-testid="fragile-alt-winner">` and
+ * the caller must keep rendering that element unchanged on a permitted run.
+ */
+export type FragileEdgeGroupHeader =
+  /** A single plain sentence — no alt-winner element is rendered. */
+  | { kind: 'plain'; text: string }
+  /** `lead` (trailing space included) followed by the alt-winner element. */
+  | { kind: 'altWinner'; lead: string; altWinnerLabel: string }
+
+/** `N factor` / `N factors` — the count is DATA and survives withholding. */
+function factorCount(edgeCount: number): string {
+  return `${edgeCount} ${edgeCount === 1 ? 'factor' : 'factors'}`
+}
+
+export function fragileEdgeGroupHeader({
+  altWinnerLabel,
+  edgeCount,
+  hasEValue,
+  designationsWithheld,
+}: FragileEdgeVerdictInput & {
+  /** Resolved shared alt-winner for the group, or null/'' when there is none. */
+  altWinnerLabel: string | null
+  edgeCount: number
+  /** True when any edge in the group carries an E-value. */
+  hasEValue: boolean
+}): FragileEdgeGroupHeader {
+  // No alt-winner: both existing sentences are already verdict-neutral —
+  // they describe the relationship, not a designation. Byte-identical in
+  // both verdict states, on purpose.
+  if (!altWinnerLabel) {
+    return {
+      kind: 'plain',
+      text: hasEValue ? 'Fragile result, verify key assumptions' : 'Fragile relationship',
+    }
+  }
+
+  const multiple = edgeCount > 1
+
+  if (designationsWithheld) {
+    // The count survives; the flip TARGET does not.
+    return {
+      kind: 'plain',
+      text: multiple
+        ? `${factorCount(edgeCount)} could change ${FRAGILE_NEUTRAL_OBJECT}`
+        : `${sentenceCase(FRAGILE_NEUTRAL_OBJECT)} could change`,
+    }
+  }
+
+  return {
+    kind: 'altWinner',
+    lead: multiple ? `${factorCount(edgeCount)} could flip the result to ` : 'Result could flip to ',
+    altWinnerLabel,
+  }
+}
+
+/**
+ * The per-edge trailing clause, rendered beside "If {source} shifts" when the
+ * group has no named alt-winner.
+ */
+export function fragileEdgeConsequence({ designationsWithheld }: FragileEdgeVerdictInput): string {
+  return designationsWithheld
+    ? `${FRAGILE_NEUTRAL_OBJECT} could change`
+    : 'the recommendation could change'
+}
+
+/**
+ * The expert-mode E-value sentence. The NUMBER is producer data and is
+ * unchanged in both states; only the object of "flip" moves.
+ */
+export function fragileEValueNote({
+  eValue,
+  designationsWithheld,
+}: FragileEdgeVerdictInput & { eValue: number }): string {
+  const v = eValue.toFixed(1)
+  return designationsWithheld
+    ? `E-value ${v}: assumptions would only need to be ${v}x wrong to change ${FRAGILE_NEUTRAL_OBJECT}.`
+    : `E-value ${v}: assumptions would only need to be ${v}x wrong to flip the recommendation.`
+}
+
+/**
+ * The Ask-Olumi draft the sparkle CTA prefills.
+ *
+ * In scope for the same reason #503 put the two thinking-pattern drafts in
+ * scope: a draft is prose the product hands the user to send in their own
+ * name. Only the grouped-with-alt-winner branch carries a claim; the other
+ * two are already neutral and are byte-identical in both states.
+ */
+export function fragileDiscussDraft({
+  edgeCount,
+  altWinnerLabel,
+  fromLabel,
+  toLabel,
+  designationsWithheld,
+}: FragileEdgeVerdictInput & {
+  edgeCount: number
+  altWinnerLabel: string | null
+  /** First edge's cleaned endpoint labels — used by the singleton branch. */
+  fromLabel: string
+  toLabel: string
+}): string {
+  const multiple = edgeCount > 1
+
+  if (altWinnerLabel && multiple) {
+    return designationsWithheld
+      ? `Are these ${edgeCount} relationships that could change ${FRAGILE_NEUTRAL_OBJECT} reliable?`
+      : `Are these ${edgeCount} relationships that could flip the result to ${altWinnerLabel} reliable?`
+  }
+
+  if (altWinnerLabel) {
+    return `Is the relationship between ${fromLabel} and ${toLabel} reliable?`
+  }
+
+  return `Are these ${edgeCount} fragile relationships in my model reliable?`
+}
+
+/** Derived, not mirrored: the neutral object appears once as a constant. */
+function sentenceCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}


### PR DESCRIPTION
## The defect

A withheld run — one where CEE declined to put an option forward — still rendered a card that named a recommendation, inside the stress-test accordion, a few hundred pixels under the panel's own line **"the analysis did not put an option forward"**.

**Trace (verified at `13cca490`):**

```
ResultsBody.tsx:627   designationsWithheld={designationsWithheld}   ← already threaded, correctly
  → StressTestSection.tsx:236  renderThinkingPatterns = showThinkingPatterns && !designationsWithheld
  → StressTestSection.tsx:368  <FragileEdgeGroupCard … />           ← NO verdict prop existed
      → ChallengeSection.tsx:219/221/259/265                        ← five unconditional claims
```

`StressTestSection` keeps fragile factors **visible** on a withheld run by design (`StressTestSection.tsx:79-82` — they are producer DATA, and suppressing them would be the over-suppression the ruling forbids). That is correct. It is also exactly why the **prose** beneath them had to change instead: the data was honest, the sentences were not.

`#503` recorded its own scope as *"the two authored cards ONLY. Sensitive assumptions and fragile factors are producer data and keep rendering"*. True — and it settled their **visibility**, not their **prose**. That sentence has been amended in place rather than left to read as a clearance (`StressTestSection.tsx`).

### Why the existing gate could not see it

`withheldProse.spec.tsx`'s `LEADER_PRESUPPOSITION_RE` is `/leading option|likely leader|your recommendation/i`. This card says **"the recommendation"** (bare definite article) and **"flip the result to"** — it presupposes the recommendation without ever using the #503 vocabulary. A second matcher, `FRAGILE_CLAIM_RE`, is introduced for it, with anti-vacuity controls proving the permitted copy matches it.

---

## Live-path reachability — stated precisely, because it is not uniform

Derived from `useResultsSectionData.ts:3053-3113` and `types.ts:847`, not assumed:

| String | Site | Reachable on the live path today? | Why |
|---|---|---|---|
| 1 · grouped header | `:219` | **YES** | every surviving `challengeFragileEdges` entry carries an `alternative_winner_label` — the hook **drops** edges whose label cannot be resolved (`:3084 return null`) |
| 2 · singleton header | `:221` | **YES** | same |
| 3 · per-edge consequence | `:259` | **no** | renders only when `!altWinnerLabel`, which the hook's drop rule makes unreachable via `StressTestSection` |
| 4 · expert E-value note | `:265` | **no** | `e_value` reaches the card only from `ChallengeSection`, which merges `edgeEValues`; **`ChallengeSection` has no production call site** (grep: `<ChallengeSection` appears in two spec files only) |
| 5 · Ask-Olumi draft | `:293` | **YES** | prefilled by the sparkle CTA on the same grouped card |

So **three of the five are live**, not four. Strings 3 and 4 are fixed and pinned anyway: same defect, same component, one prop away from live, and `ChallengeSection` is one re-wire from being a call site again.

---

## Per-string old → new

Withheld copy reuses **one** neutral object, `'the comparison'` — quoted from `flipThresholdStatusNote.ts:62`, the shortest of the three sanctioned spellings, and used for all five sentences so they cannot drift apart.

| # | Site | PERMITTED (byte-identical to today) | WITHHELD (new) |
|---|---|---|---|
| 1 | `:219` | `{N} factors could flip the result to `**`{alt}`** | `{N} factors could shift the comparison towards `**`{alt}`** |
| 2 | `:221` | `Result could flip to `**`{alt}`** | `The comparison could shift towards `**`{alt}`** |
| 3 | `:259` | `the recommendation could change` | `the comparison could change` |
| 4 | `:265` | `E-value {v}: assumptions would only need to be {v}x wrong to flip the recommendation.` | `E-value {v}: assumptions would only need to be {v}x wrong to change the comparison.` |
| 5 | `:293` | `Are these {N} relationships that could flip the result to {alt} reliable?` | `Are these {N} relationships that could shift the comparison towards {alt} reliable?` |

Strings 1, 2 and 5 **keep `{alt}`** and the `data-testid="fragile-alt-winner"` element on a withheld run. Strings 3 and 4 name no option, so they have no name to keep.

Unchanged in **both** states (verdict-independent, and controlled for): `Fragile relationship`, `Fragile result, verify key assumptions`, `Is the relationship between {from} and {to} reliable?`, `Are these {N} fragile relationships in my model reliable?`.

String 5 is in scope for the reason #503 put the two thinking-pattern drafts in scope: a draft is prose the product hands the user to send in their own name.

### Doctrine: RULED — the hero's treatment is canonical

This PR originally **dropped** the alt-winner name on withheld, reading #505 ("silence where we lack authority") as reaching the name, and flagged the conflict with `heroCopy.ts:398-414` rather than resolving it silently. **The orchestrator ruled against that reading and the fix has been amended.** The ruling, recorded verbatim in `fragileEdgeCopy.ts`:

- **The presupposing VERB is the defect.** `"flip the result to {alt}"` asserts that a current result — a leader — exists to flip *from*. That is the claim the verdict withholds, and it is what gets removed.
- **The NAME is data, not a claim.** `alternative_winner_label` is *directional sensitivity*: which option this edge's fragility points toward. Dropping it is exactly the over-suppression the ruling forbids — the product says everything it HAS computed.
- **One producer field may not be treated two ways on one screen.** `heroCopy.flipRiskWithAlternative` already keeps the name and neutralises only the verb (`"the comparison shifts towards {alt}"`). A panel where the hero names the alternative and the stress-test card hides it is the family-1 self-contradiction shape; cross-surface consistency on one field is itself a doctrine requirement.

The withheld copy therefore follows the hero's sentence shape exactly. The `fragileEdgeCopy.ts` docstring now records the ruling and its reasoning, not the open question.

---

## RED-first evidence

Throwaway worktree at pristine `13cca490`, created **outside the repo root** (trap 9c) with only the new spec + the new copy module copied in — **components left pristine**:

```
❯ withheldProse.spec.tsx  (45 tests | 5 failed)
  × STRING 1 > WITHHELD: the header drops the presupposing verb
  × STRING 2 > WITHHELD: the singleton header presupposes no result to flip, and still names the alternative
  × STRING 3 > WITHHELD: the clause names the comparison instead
  × STRING 4 > WITHHELD: the note says what would change without naming a recommendation
  × STRING 5 > WITHHELD: the sparkle prefills a draft with no presupposition
  Tests  5 failed | 40 passed (45)
```

**Exactly one RED per string.** Re-derived at the amended bytes, in a second throwaway worktree. String 5's is a live-path test — mount, click the sparkle, read what `askOlumiStore` was handed — so its gate is proven the same way the other four are, not only against the new pure function.

The name-preservation cases (`WITHHELD: the alternative is still NAMED`) correctly **pass** against pristine: pristine also names the alternative. They are over-suppression controls for the ruling, not defect gates — and M1/M2 below prove they still bite.

## Mutation evidence (per string)

Full fix applied, then **one** withheld branch reverted at a time. The worktree was removed before any gate run.

| Mutant | Reverted | Tests that went RED |
|---|---|---|
| baseline | — | 45/45 green |
| M1 | string 1 withheld branch | 2 — STRING 1 verb case **and** its altWinner-shape pin |
| M2 | string 2 withheld branch | 2 — STRING 2 verb case **and** its altWinner-shape pin |
| M3 | string 3 withheld branch | 2 — STRING 3 withheld **and** STRING 4 withheld¹ |
| M4 | string 4 withheld branch | 1 — STRING 4 withheld |
| M5 | string 5 withheld branch | 2 — STRING 5 pure-function **and** live-CTA cases |
| restore | — | 45/45 green |

Re-run in full at the amended bytes (not just the changed strings), so the whole table is valid against what is actually on the branch.

¹ Honest cross-coverage, not vacuity: the STRING 4 fixture is an edge with no alt-winner, so it renders the string-3 clause too and its `not.toMatch(FRAGILE_CLAIM_RE)` catches it. M4 isolates string 4 on its own.

**Trap 15 disclosure, since it happened here:** the first M3/M4/M5 run reported all-green — and that green was worthless. The `perl -0pi -e "…"` scripts were double-quoted, so **bash expanded `${FRAGILE_NEUTRAL_OBJECT}` to the empty string before perl ever saw the pattern** and every replace silently no-opped. Caught by asserting the anchor count in the mutated file, not by reading the test result. All mutation runs above were redone with a driver that asserts the anchor exists exactly once, that the replace changed the text, and that the write landed on disk.

## Over-suppression controls

Every one of these asserts on the **withheld** render, and each would fail a fix that silenced the section:

- fragile subsection still renders, header still reads `Fragile factors (2)`
- both source-factor labels (`Team capacity`, `Delivery risk`) still render
- `If … shifts` trigger rows still render
- stability pill still renders
- the E-value **number** (`E-value 2.0`) still renders — only the sentence around it moved
- **the alternative's name still renders** in strings 1, 2 and 5, and the `fragile-alt-winner` element is still in the DOM — pinned as a returned *shape*, so a regression that fell back to a plain sentence would drop the element and go RED
- accordion count: permitted `4` → withheld `2`, i.e. #503 removes exactly its own two cards and **both fragile rows survive**

Plus permitted-side byte-identity pins on all five strings, and a both-states byte-identity pin on the four verdict-independent strings.

**Scope of the claim (trap 3):** jsdom proves rendered text, presence and absence. Nothing here claims layout, visibility or visual order.

## Gates (re-derived at the tip, nothing bumped)

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set for every run (trap 2b).

| Gate | Result |
|---|---|
| `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) | ✅ PASSED — phase 1 coverage **3016 / 3034** tracked files (was 3015/3033; the new module is loaded, not out-of-scope); phase 2 ratchet **633 files / 2545 errors, baseline 2545** — unchanged, no `--update-baseline` |
| `pnpm exec eslint` (6 changed files) | ✅ exit 0, no findings |
| `vitest run src/components/results` | ✅ **192 files / 3729 tests passed**, 0 failed |
| `withheldProse.spec.tsx` | 20 → **45** tests, all green |

`designationsWithheld` is made **REQUIRED** on `FragileEdgeGroupCard` and on `ChallengeSectionProps`, matching the doctrine already stated on `StressTestSectionProps` ("an opt-in gate is a gate every future call site can forget"). The compiler named all 17 `<ChallengeSection>` mounts in two spec files; they are updated in this PR rather than absorbed into a baseline (trap-2 refinement — `tsconfig.build.json`-style exclusions do not apply here, but `Typecheck Drift` would have caught them regardless).

`// TODO(designationsWithheld-helper)` is added in `fragileEdgeCopy.ts` naming the three disagreeing hand-derivations (`ResultsBody.tsx:154`, `ResultsBody.tsx:457`, `useResultsSectionData.ts:1571`). **The shared helper is deliberately NOT created here** — it is consolidating separately. Every function in this module quotes the caller's boolean and never re-derives one, so that consolidation lands in one place.

## Overlap statement

Checked against **all 26 open PRs** (`gh pr view <n> --json files` for each of the 10 non-dependabot PRs; the 16 dependabot PRs touch `package.json` / lockfile / workflows only).

- `ChallengeSection.tsx`, `StressTestSection.tsx`, `utils/fragileEdgeCopy.ts`, `withheldProse.spec.tsx`, `ChallengeSection.fragileRows.spec.tsx`, `v12.2-factor-labels.spec.tsx` — **zero open PRs touch any of these six files.**
- One adjacency: **#116** (`claude/ui-quick-wins-panels-8R8mq`) touches `ResultsBody.tsx`. This PR does **not** modify `ResultsBody.tsx` — the `designationsWithheld` derivation and the `StressTestSection` call site were already correct at `13cca490` and are untouched. No conflict.
- Sibling UI lanes in flight (`useRecommendation` hook, vitest-config/claimDrift) have no PR open and share no file with this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
