### PR TITLE
perf(anti-drift): stop the claim-drift walker doing its work four times over, and stop the typecheck selftest asking one question twice

### DIFF
--- a/scripts/ci/typecheck-gate-selftest.sh
+++ b/scripts/ci/typecheck-gate-selftest.sh
@@ -14,6 +14,7 @@
 #   2. RATCHET BITES      new file with a type error       → exit 1, names the file
 #   3. COVERAGE BITES     new tracked file no project loads→ exit 1, "NO typecheck project loads"
 #   4. STALE EXCEPTION    bogus entry in the uncovered list→ exit 1, "Stale entries"
+#                         (3 and 4 share ONE gate run — see the section itself)
 #   5. DEDUP KEY          one error rendered two ways      → counted ONCE
 #   5m. …AND ITS MUTANT   the same fixture under the OLD full-line key → counted TWICE
 #   6. WITHIN-FILE SWAP   one error traded for another of a different TS
@@ -34,8 +35,30 @@
 # refuses to run on a dirty tree so it can never destroy uncommitted work, and
 # its cleanup trap fires on every exit path.
 #
-# Runtime: ~3 min (scenarios 3 and 4 fail in the cheap coverage phase; 5 and 5m
-# do not compile at all).
+# ── WHAT THIS COSTS CI, AND WHAT IS AND IS NOT SHAREABLE ─────────────────────
+# The gate builds one tsc program per project per phase: two `--listFilesOnly`
+# programs in phase 1, two full checks in phase 2 (PROJECTS is a 2-element array
+# and each phase is one `for` loop containing one `npx tsc`). So a gate run that
+# reaches phase 2 costs 4 program builds, and one that fails in phase 1 costs 2.
+#
+# That made this script 20 program builds across 6 gate runs — 4+4+2+2+4+4 — of
+# which the two newest scenarios (6 and 7) were 8. Merging 3 and 4, whose
+# COMPILER input is identical, takes it to 18.
+#
+# THE REMAINING REDUNDANCY IS REAL AND IS NOT REMOVABLE HERE. Scenarios 1, 6 and
+# 7 also present the compiler with an identical input — a clean tree; they differ
+# only in a baseline artefact the gate reads AFTER compiling — so 12 of the 18
+# builds compile the same tree three times. They cannot share a run because their
+# expected VERDICTS are mutually exclusive: 1 must PASS with the added-diagnostic
+# notice SILENT, 6 must FAIL, and 7 must PASS with that same notice FIRING. No
+# ordering or combination of mutations produces all three from one output.
+# Collapsing them would need the gate to accept a captured diagnostic set the way
+# `--dedup-filter` already accepts a captured diagnostic list — a change to the
+# GATE, which is the thing under test here, and therefore its own reviewed piece
+# of work rather than a side effect of a cost fix.
+#
+# Runtime: dominated by those 18 builds (scenarios 3+4 fail in the cheap coverage
+# phase; 5 and 5m do not compile at all).
 
 set -uo pipefail
 
@@ -167,34 +190,48 @@ expect "the failure names the offending file" nonzero "$BAD_SRC"
 rm -rf "$(dirname "$BAD_SRC")"
 echo
 
-# ── 3. COVERAGE BITES ────────────────────────────────────────────────────────
-# A tracked TypeScript file that no project loads. `archive/` is excluded from
-# tsconfig.tooling.json and its existing files are listed one-by-one in the
-# exception list, so a NEW file there is genuinely invisible to the compiler —
-# and must therefore fail. `git add -N` makes it visible to `git ls-files`
-# (which is how the gate derives the source set) without staging its content.
-echo "3/7  coverage bites on a tracked file NO project loads"
+# ── 3 + 4. THE TWO COVERAGE FAILURES, IN ONE GATE RUN ────────────────────────
+# 3. A tracked TypeScript file that no project loads. `archive/` is excluded from
+#    tsconfig.tooling.json and its existing files are listed one-by-one in the
+#    exception list, so a NEW file there is genuinely invisible to the compiler —
+#    and must therefore fail. `git add -N` makes it visible to `git ls-files`
+#    (which is how the gate derives the source set) without staging its content.
+# 4. The exception list is the one hand-maintained artefact left, so it gets the
+#    bidirectional treatment: an entry that no longer describes reality must fail
+#    too, or the list would rot into a green lie exactly like the include list did.
+#
+# WHY ONE RUN. These two scenarios present the COMPILER with an identical input:
+# the invisible file lives in `archive/`, which no project loads, and the stale
+# entry is a line in a text file the compiler never sees. So both runs were
+# building the same two `--listFilesOnly` programs and diffing them against
+# different git/exception sets — 4 tsc program builds where 2 answer both
+# questions. The gate collects the two coverage failures independently
+# (`COVERAGE_FAIL` is set by each block, and neither short-circuits the other),
+# so both messages appear in one output.
+#
+# WHAT THIS COSTS, stated rather than glossed. Each detector is still asserted on
+# its OWN message and its OWN filename, so a broken detector still reddens this
+# scenario — that half is unchanged. What is no longer directly OBSERVED is
+# "this mutation, alone, produces a non-zero exit"; with both present, the
+# non-zero exit is attributable to either. That claim now rests on reading the
+# gate (each block sets COVERAGE_FAIL, and the exit is unconditional on it)
+# rather than on watching it, which is a weaker kind of evidence and is why it
+# is written down here.
+echo "3+4/7  coverage bites on an invisible tracked file AND a stale exception entry"
 mkdir -p "$(dirname "$INVISIBLE")"
 cat >"$INVISIBLE" <<'TS'
 // Self-test fixture, written and deleted by scripts/ci/typecheck-gate-selftest.sh.
 export const neverChecked = 1;
 TS
 git add -N -- "$INVISIBLE" >/dev/null
+printf 'archive/this-file-does-not-exist.selftest.ts\n' >>"$UNCOVERED"
 run_gate
 expect "invisible tracked file fails coverage" nonzero "NO typecheck project loads"
 expect "the failure names the invisible file" nonzero "$INVISIBLE"
+expect "stale exception entry fails coverage" nonzero "Stale entries"
+expect "the failure names the stale entry" nonzero "archive/this-file-does-not-exist.selftest.ts"
 git rm --cached -q --ignore-unmatch -- "$INVISIBLE" >/dev/null
 rm -rf "$(dirname "$INVISIBLE")"
-echo
-
-# ── 4. STALE EXCEPTION ───────────────────────────────────────────────────────
-# The exception list is the one hand-maintained artefact left, so it gets the
-# bidirectional treatment: an entry that no longer describes reality must fail
-# too, or the list would rot into a green lie exactly like the include list did.
-echo "4/7  stale entry in the exception list fails"
-printf 'archive/this-file-does-not-exist.selftest.ts\n' >>"$UNCOVERED"
-run_gate
-expect "stale exception entry fails coverage" nonzero "Stale entries"
 git checkout -q -- "$UNCOVERED"
 echo
 
@@ -279,7 +316,7 @@ echo "═══ self-test: $PASS passed, $FAIL failed ═══"
 # A run that dies in the middle prints "0 failed" for every scenario it never
 # reached — the harness's own version of the invisibility this gate exists to
 # stop. Assert the arithmetic instead of trusting that the script got here.
-EXPECTED_ASSERTIONS=17
+EXPECTED_ASSERTIONS=18
 if [[ $((PASS + FAIL)) -ne "$EXPECTED_ASSERTIONS" ]]; then
   echo "::error::Self-test ran $((PASS + FAIL)) assertions, expected $EXPECTED_ASSERTIONS — it exited early, so this result means nothing."
   echo "::error::If you added or removed an assertion, update EXPECTED_ASSERTIONS in $0."

--- a/src/test/__tests__/claim-ownership.drift.spec.ts
+++ b/src/test/__tests__/claim-ownership.drift.spec.ts
@@ -40,6 +40,7 @@ import {
   aggregateItems,
   compareIdentities,
   compareToBaseline,
+  createSourceCache,
   crossCheckArtefacts,
   discoverFamilies,
   findReads,
@@ -63,6 +64,24 @@ describe('claim-ownership drift', () => {
   const all = trackedSourceFiles()
   const prod = productionFiles(all)
 
+  // ONE scan of the tree for the whole file, shared by discovery and the walk.
+  // Discovery reads every tracked file; the walk reads the production subset, so
+  // without this the same bytes are read repeatedly. Measured at 6d474415, the
+  // four `discoverFamilies` calls below cost 11,008 of the run's 13,890
+  // `readFileSync` calls — the same 2,752 files, four times, for an answer that
+  // cannot differ between them inside one spec run.
+  const sources = createSourceCache()
+
+  // LAZY, not eager. Building the promise here in the describe body would create
+  // it at COLLECTION time, and a discovery failure — which this instrument goes
+  // out of its way to make loud — would surface as an unhandled rejection with
+  // no test attached to it. Created on first use instead, so the rejection always
+  // has an awaiter and every test that asks for the families still fails with the
+  // real message, exactly as when each called `discoverFamilies` itself.
+  let familiesOnce: Promise<Family[]> | null = null
+  const discoveredFamilies = (): Promise<Family[]> =>
+    (familiesOnce ??= discoverFamilies(all, sources))
+
   // ── ANTI-VACUITY CONTROLS ─────────────────────────────────────────────────
   // These must fail if the instrument stops seeing anything, rather than the
   // suite passing because it generated nothing to check.
@@ -74,7 +93,7 @@ describe('claim-ownership drift', () => {
   })
 
   it('control 2: the scan is not vacuous — at least one family is registered', async () => {
-    const families = await discoverFamilies(all)
+    const families = await discoveredFamilies()
     expect(
       families.length,
       'ZERO claim families discovered. With passWithNoTests:true a walker that ' +
@@ -84,7 +103,7 @@ describe('claim-ownership drift', () => {
   })
 
   it('control 3a: every registered raw field has EXACTLY ONE owner', async () => {
-    const families = await discoverFamilies(all)
+    const families = await discoveredFamilies()
     const fieldOwner = new Map<string, string>()
     const familyOwner = new Map<string, string>()
     const clashes: string[] = []
@@ -113,7 +132,7 @@ describe('claim-ownership drift', () => {
     // share a name, so the naive alias fix punishes exactly the sites a migration
     // just made compliant. The owner’s output surface is DERIVED here (by
     // calling the selector), never declared, so this cannot rot.
-    const families = await discoverFamilies(all)
+    const families = await discoveredFamilies()
     const collisions: string[] = []
     for (const f of families) {
       for (const field of f.rawFields) {
@@ -382,7 +401,7 @@ describe('claim-ownership drift', () => {
   // ── THE WALK ──────────────────────────────────────────────────────────────
 
   it('no production file re-derives an owned claim beyond the baseline', async () => {
-    const families = await discoverFamilies(all)
+    const families = await discoveredFamilies()
 
     // Per-family floor. A family whose fields vanish from the tree entirely is
     // either fully migrated (regenerate: the stale rows will say so) or the
@@ -404,7 +423,7 @@ describe('claim-ownership drift', () => {
 
     const baseline = parseBaseline(readFileSync(BASELINE_PATH, 'utf8'))
     const identities = parseIdentities(readFileSync(IDENTITIES_PATH, 'utf8'))
-    const { rows, detail, items } = walk(families, prod)
+    const { rows, detail, items } = walk(families, prod, sources)
 
     // The pair must agree before either is trusted. A skew means one artefact
     // was hand-edited or a generator half-ran, and a baseline that disagrees

--- a/src/test/claimDrift/claimDriftWalker.ts
+++ b/src/test/claimDrift/claimDriftWalker.ts
@@ -143,6 +143,62 @@ export interface Family {
   outputFields: readonly string[]
 }
 
+/**
+ * Read-once-per-path source access, shared by discovery and the walk.
+ *
+ * ⚠ THIS IS A PERFORMANCE STRUCTURE ONLY. Every method returns exactly what a
+ * bare `readFileSync` / `stripComments` would return for the same path; nothing
+ * here may change a verdict. The reason it exists is that the two phases read
+ * overlapping file sets — discovery scans all tracked files, the walk scans the
+ * production subset — and before this the same bytes were read, and the same
+ * source re-tokenised, several times per run (measured at 6d474415: 13,890
+ * `readFileSync` calls / 117.8 MB for a tree of 2,752 files).
+ *
+ * It is a CALLER-SCOPED object with a fresh default, deliberately, not a
+ * module-level memo. A module-level cache would be a hidden global that goes
+ * stale the moment anything writes to the tree between two calls — and an
+ * instrument that reports a file it can no longer see is worse than a slow one.
+ * A caller that wants the sharing asks for it by passing one in; a caller that
+ * says nothing gets today's exact behaviour, one fresh cache per call.
+ *
+ * IT TRADES MEMORY FOR TIME, and the price is measured, not waved at: holding
+ * one run's sources took peak footprint from 146 MB to 191 MB in a bare-node
+ * replay of the spec's call sequence, for 750 ms → 267 ms. It is transient — the
+ * cache dies with the describe block that made it — but a reviewer weighing a
+ * vitest worker's budget should have the number rather than a reassurance.
+ */
+export interface SourceCache {
+  /** Raw file text. Read at most once per path for the life of this cache. */
+  read(rel: string): string
+  /** Comment-stripped source, split to lines. Tokenised at most once per path. */
+  strippedLines(rel: string): string[]
+}
+
+/** A fresh, empty cache. The default argument of both phases. */
+export function createSourceCache(): SourceCache {
+  const raw = new Map<string, string>()
+  const stripped = new Map<string, string[]>()
+  const read = (rel: string): string => {
+    let s = raw.get(rel)
+    if (s === undefined) {
+      s = readFileSync(join(REPO_ROOT, rel), 'utf8')
+      raw.set(rel, s)
+    }
+    return s
+  }
+  return {
+    read,
+    strippedLines(rel: string): string[] {
+      let lines = stripped.get(rel)
+      if (lines === undefined) {
+        lines = stripComments(read(rel), rel).split('\n')
+        stripped.set(rel, lines)
+      }
+      return lines
+    },
+  }
+}
+
 /** Tracked TS/TSX under src/. The house standard for an absence claim. */
 export function trackedSourceFiles(): string[] {
   const out = execFileSync('git', ['ls-files', '--', 'src/*.ts', 'src/*.tsx'], {
@@ -171,9 +227,12 @@ export function productionFiles(all: string[]): string[] {
  * FAILURE, never a silent skip: an owner the walker cannot read is an owner it
  * is not policing, and that must be loud.
  */
-export async function discoverFamilies(all: string[]): Promise<Family[]> {
+export async function discoverFamilies(
+  all: string[],
+  cache: SourceCache = createSourceCache(),
+): Promise<Family[]> {
   const candidates = all.filter((rel) =>
-    /export\s+const\s+CLAIM_OWNERSHIP\b/.test(readFileSync(join(REPO_ROOT, rel), 'utf8')),
+    /export\s+const\s+CLAIM_OWNERSHIP\b/.test(cache.read(rel)),
   )
 
   const families: Family[] = []
@@ -330,13 +389,40 @@ export function patternsFor(fields: readonly string[]): {
  * compliant chain to sanction.
  */
 export function isSanctioned(lines: string[], i: number, at: number, fam: Family): boolean {
+  return sanctionedWith(lines, i, at, fam, sanctionTrailRe(fam))
+}
+
+/**
+ * The trailing-`??`-chain probe of `isSanctioned`, compiled ONCE PER FAMILY
+ * instead of once per candidate LINE. It depends on nothing but
+ * `fam.callInstead`, so hoisting it out of the line loop cannot change which
+ * lines it matches. `null` for a family with no chooser, which sanctions
+ * nothing and therefore never reaches this probe.
+ *
+ * The pattern carries no `g` flag, so it holds no `lastIndex` state and a single
+ * instance is safe to reuse across every line and every file.
+ */
+function sanctionTrailRe(fam: Family): RegExp | null {
+  return fam.callInstead === null
+    ? null
+    : new RegExp(`${escapeRe(fam.callInstead)}[^]*\\?\\?\\s*$`)
+}
+
+/** `isSanctioned` with its per-family regex supplied. Same predicate, same order. */
+function sanctionedWith(
+  lines: string[],
+  i: number,
+  at: number,
+  fam: Family,
+  trailRe: RegExp | null,
+): boolean {
   if (fam.callInstead === null) return false
   const before = lines[i].slice(0, at)
   if (before.includes(fam.callInstead)) return true
   // A presence probe is not a decision (same exemption the ESLint rule takes).
   if (/typeof\s+$/.test(before)) return true
   const prev = i > 0 ? lines[i - 1] : ''
-  return new RegExp(`${escapeRe(fam.callInstead)}[^]*\\?\\?\\s*$`).test(prev.trimEnd())
+  return (trailRe as RegExp).test(prev.trimEnd())
 }
 
 /**
@@ -396,12 +482,40 @@ export function renderHit(h: Hit): string {
  * not close it for a second read of the SAME field on the same line.
  */
 export function findReads(src: string, rel: string, fam: Family): Hit[] {
-  const p = patternsFor(fam.rawFields)
-  const stripped = stripComments(src, rel).split('\n')
-  const rawLines = src.split('\n')
+  return findReadsIn(
+    src.split('\n'),
+    stripComments(src, rel).split('\n'),
+    fam,
+    patternsFor(fam.rawFields),
+    sanctionTrailRe(fam),
+  )
+}
+
+/**
+ * The scan itself, with everything it does not derive from the SOURCE supplied
+ * by the caller: the split lines, the family's four patterns, and its sanction
+ * probe. This is the split `walk()` needs and `findReads()` does not — the walk
+ * has many files per family, so building those four patterns per (family, file)
+ * and stripping the same file once per family is pure repetition; a caller
+ * holding one source string has nothing to reuse.
+ *
+ * ⚠ IT IS NOT KEYED ON `rel`. Memoising the strip inside `findReads` on the path
+ * would be wrong, not merely different: the detector-contract tests call it with
+ * the SAME synthetic path `'x.ts'` and ten DIFFERENT code strings, so a
+ * path-keyed memo would serve the first fixture's tokens to all ten and every
+ * one of them would pass on the wrong input. Caching belongs where paths are
+ * real and unique — `SourceCache`, driven by the walk.
+ */
+function findReadsIn(
+  rawLines: string[],
+  strippedLines: string[],
+  fam: Family,
+  p: ReturnType<typeof patternsFor>,
+  trailRe: RegExp | null,
+): Hit[] {
   const hits: Hit[] = []
-  for (let i = 0; i < stripped.length; i++) {
-    const line = stripped[i]
+  for (let i = 0; i < strippedLines.length; i++) {
+    const line = strippedLines[i]
     const at = (field: string): Hit => ({
       line: i + 1,
       field,
@@ -409,7 +523,7 @@ export function findReads(src: string, rel: string, fam: Family): Hit[] {
       raw: rawLines[i].trim(),
     })
     const m = p.member.exec(line)
-    if (m && !isSanctioned(stripped, i, m.index, fam)) {
+    if (m && !sanctionedWith(strippedLines, i, m.index, fam, trailRe)) {
       hits.push(at(m[1]))
       continue
     }
@@ -487,24 +601,66 @@ export interface WalkResult {
   items: Item[]
 }
 
-/** Walk every production file for every discovered family. */
-export function walk(families: Family[], prod: string[]): WalkResult {
+/**
+ * Walk every production file for every discovered family.
+ *
+ * FILES OUTER, FAMILIES INNER — and that order is load-bearing for cost, not for
+ * meaning. The pair (family, file) visited is identical either way, and each
+ * pair is visited exactly once; what changes is that a file is now read and
+ * comment-stripped ONCE however many families ask about it, instead of once PER
+ * family. The old order was O(families x files) reads and grew linearly with
+ * every family that registered — measured at 6d474415: 2,882 reads for two
+ * families over 1,442 production files, where 1,442 suffice.
+ *
+ * WHY THE OUTPUT IS UNMOVED BY THE REORDER, stated rather than assumed:
+ *   * `rows` is sorted before return on (family, rel), and each (family, rel)
+ *     yields at most one row, so the sort is TOTAL and the pre-sort push order
+ *     cannot survive into the result.
+ *   * `items` is only ever consumed through `aggregateItems`, which merges
+ *     equal identities and sorts on the whole tuple — order-independent by
+ *     construction, and pinned as such by the "byte-stable under input order"
+ *     control in the spec.
+ *   * `detail` is a Map that is only ever `get`-ed by key. Nothing iterates it,
+ *     so its insertion order is not observable.
+ * The equivalence proof for the restructure is the bytes of both artefacts plus
+ * the flattened detail map, not this paragraph — but the paragraph says which
+ * property each one is resting on.
+ */
+export function walk(
+  families: Family[],
+  prod: string[],
+  cache: SourceCache = createSourceCache(),
+): WalkResult {
   const rows: Row[] = []
   const detail = new Map<string, string[]>()
   const items: Item[] = []
 
-  for (const fam of families) {
-    const fieldRe = new RegExp(fam.rawFields.map(escapeRe).join('|'))
-    for (const rel of prod) {
-      if (rel === fam.ownerRel) continue
-      const src = readFileSync(join(REPO_ROOT, rel), 'utf8')
-      if (!fieldRe.test(src)) continue // cheap prefilter
-      const hits = findReads(src, rel, fam)
-      const exempt = producerAttestation(src, fam.family) !== null
+  // Everything a family carries into the scan, built ONCE per family. Before
+  // this, `patternsFor` constructed its four RegExps per (family, FILE) and
+  // `isSanctioned` constructed one per candidate LINE. None of them depends on
+  // the file or the line, so none of them belonged there. All are flagless, so
+  // they hold no `lastIndex` state and are safe to share across the whole walk.
+  const matchers = families.map((fam) => ({
+    fam,
+    fieldRe: new RegExp(fam.rawFields.map(escapeRe).join('|')),
+    patterns: patternsFor(fam.rawFields),
+    trailRe: sanctionTrailRe(fam),
+  }))
+
+  for (const rel of prod) {
+    let src: string | null = null
+    let rawLines: string[] | null = null
+    for (const m of matchers) {
+      if (rel === m.fam.ownerRel) continue
+      if (src === null) src = cache.read(rel)
+      if (!m.fieldRe.test(src)) continue // cheap prefilter
+      if (rawLines === null) rawLines = src.split('\n')
+      const hits = findReadsIn(rawLines, cache.strippedLines(rel), m.fam, m.patterns, m.trailRe)
+      const exempt = producerAttestation(src, m.fam.family) !== null
       if (hits.length === 0 && !exempt) continue
-      rows.push({ family: fam.family, rel, count: hits.length, exempt })
-      if (hits.length > 0) detail.set(`${fam.family}\t${rel}`, hits.map(renderHit))
-      for (const h of hits) items.push({ family: fam.family, rel, field: h.field, text: h.text })
+      rows.push({ family: m.fam.family, rel, count: hits.length, exempt })
+      if (hits.length > 0) detail.set(`${m.fam.family}\t${rel}`, hits.map(renderHit))
+      for (const h of hits) items.push({ family: m.fam.family, rel, field: h.field, text: h.text })
     }
   }
 


### PR DESCRIPTION
Two measured CI-cost fixes. Both are refactors of INSTRUMENTS, so the bar is not
"faster" — it is **the same verdict, proven, and still biting**. Every artefact
this repo generates from the claim-drift walker is byte-identical before and
after, and the walker's discrimination is re-proven against eight mutants rather
than asserted.

No baseline, no exception list and no generated artefact is touched by this PR.
The typecheck ratchet is unmoved at 2545.

---

## Fix 1 — the claim-drift walker did its work four times over

`src/test/__tests__/claim-ownership.drift.spec.ts` called `discoverFamilies()`
**four times**, and each call re-read **every tracked file in the repo**. The walk
then read each production file **once per registered family** and re-tokenised it
once per family on top. Measured at `6d474415` with a plain-node replay driving
the same module through the same Vite SSR path the generator uses:

| | before | after |
|---|---|---|
| `readFileSync` calls | **13,890** | **2,752** (−80%) |
| bytes read | 117.8 MB | 23.6 MB |
| engine wall-clock | **738–757 ms** | **266–267 ms** (−64%, 2.8×) |
| ↳ discovery | 468–480 ms (×4) | 123–124 ms (×1) |
| ↳ walk | 257–263 ms | 130–131 ms |
| spec (`vitest` "tests" time) | ~4.05 s | ~2.08 s |
| peak footprint | 146 MB | 191 MB |

(A/B interleaved, 8 alternating pairs, so a machine that got busier mid-run
cannot be mistaken for a speed-up in whichever arm ran second. A repeat under a
much heavier load reproduced the same direction at ~2.2×.)

**The memory number is the honest cost of the fix and is stated in the code, not
smoothed over.** Holding one run's sources costs ~45 MB of transient peak; the
cache dies with the describe block that made it.

### What changed

* **`discoverFamilies` is memoised once per spec run**, LAZILY. Building the
  promise eagerly in the describe body would create it at *collection* time, and
  a discovery failure — which this instrument goes out of its way to make loud —
  would surface as an unhandled rejection with no test attached. Created on first
  use instead, so the rejection always has an awaiter and every test that asks
  for the families still fails with the real message.
* **`walk()` is inverted to files-outer / families-inner.** The same (family,
  file) pairs are visited, each exactly once; a file is now read and stripped
  once however many families ask. The old order was O(families × files) reads and
  grew linearly with every family that registered.
* **A `SourceCache` shared by discovery and the walk**, as an optional parameter
  with a **fresh default** — not a module-level memo, which would be a hidden
  global that goes stale the moment anything writes to the tree between two
  calls. Callers that say nothing (the baseline generator) get exactly today's
  behaviour.
* **The four per-(family, file) RegExps in `patternsFor`, and the per-LINE RegExp
  in `isSanctioned`, are built once per family.** None of them depends on the
  file or the line. All are flagless, so they carry no `lastIndex` state and are
  safe to share across the walk.
* `findReads()` keeps its exact signature and semantics; the scan moved into an
  internal `findReadsIn()` that takes the prepared inputs. **It is deliberately
  NOT keyed on `rel`**: the detector-contract tests call `findReads` with the same
  synthetic path `'x.ts'` and ten different code strings, so a path-keyed memo
  inside it would serve the first fixture's tokens to all ten and every one of
  them would pass on the wrong input.

The `stripComments` tokeniser itself is untouched — its `split('')` cost is real
and out of scope here.

### Equivalence proof

The walker re-run at `HEAD` and on this branch produces **byte-identical**:

| artefact | sha256 |
|---|---|
| `claim-drift-baseline.tsv` | `3349f47b…1ad7d6` |
| `claim-drift-identities.tsv` | `ea03f522…4deaa5` |
| the flattened `detail` map (every failure message the gate prints) | `e129d948…d257064` |
| the discovered `families` array | `da6a1959…eb90f2` |

…and the first two are byte-identical to the **committed** artefacts. Shape
unchanged: 2 families, 22 rows, 85 items, 22 detail keys, 1,442 production files
of 2,752 tracked.

Second, independent check: `node tools/ci-guards/update-claim-drift-baseline.mjs
--check` — the engine's *other* consumer, which exercises the **default**
no-cache path — reports `baseline unchanged` / `item baseline unchanged`.

Why the reorder cannot move the output, stated rather than assumed: `rows` is
sorted on (family, rel) and each pair yields at most one row, so the sort is
TOTAL; `items` is only ever consumed through `aggregateItems`, which merges equal
identities and sorts the whole tuple (and the spec already pins that with its
"byte-stable under input order" control); `detail` is a Map that is only ever
`get`-ed, never iterated.

### Bite proof — the instrument still discriminates

An instrument refactor without a bite-proof is how guarantee theatre starts. Run
in a throwaway worktree **outside** the repo root, removed before the gates:

| mutant | expected | result |
|---|---|---|
| control 0 — unmutated | GREEN | 21/21 pass |
| **M1** — #509's DIFFERENT-field within-file swap in `useResultCompleteness.ts` | RED | RED: `MORE reads of one field` ×3, `STALE raw-read field` ×1 |
| **M2** — #509's SAME-field within-file swap | GREEN **+ reported** | GREEN, `⚠ WITHIN-FILE SWAP` printed |
| **M3** — every `CLAIM_OWNERSHIP` registration removed (#498 anti-vacuity) | RED | RED: `ZERO claim families discovered` |
| **M3b** — one registration removed | RED | RED: `STALE row` for every `elasticity` row |
| **M4** — a new re-derivation site in a file with no baseline row | RED | RED: `+ NEW re-derivation site` |
| **M5** — a `goal-probability` read injected into an `elasticity` file | RED, attributed to `goal-probability` | RED, correctly attributed |
| **M6a** — a genuine sanctioned `??` chain | GREEN, suppressed | GREEN, 0 new sites |
| **M6b** — byte-identical read, sanction removed | RED | RED, 3 new sites |

M3 targets the memoisation specifically: if the memo ever returned a stale or
empty set, that is the control that goes quiet. M5 targets the pattern hoist
(cross-family leakage). **M6a/M6b are a matched pair** for the hoisted
`isSanctioned` regex — M6a alone would be a vacuous absence assertion, so M6b
removes only the thing that sanctioned the read and watches it fire.

**Verdict parity, not just correctness:** M1, M2, M6a and M6b were re-run at
`6d474415`. Exit codes and signal counts are identical on both arms
(M1 `1`/3/1 ≡ `1`/3/1 · M2 `0`/1 ≡ `0`/1 · M6a `0`/0 ≡ `0`/0 · M6b `1`/3 ≡ `1`/3).

---

## Fix 2 — the selftest's gate runs, and what is honestly recoverable

`scripts/ci/typecheck-gate-selftest.sh` drove the whole gate **6×**. The gate
builds one tsc program per project per phase (`PROJECTS` is a 2-element array;
phase 1 is one loop with one `npx tsc --listFilesOnly`, phase 2 one loop with one
`npx tsc --noEmit`, with `exit 1` on `COVERAGE_FAIL` between them), so a run
reaching phase 2 costs **4** program builds and one aborting in phase 1 costs
**2**. That made the job `4+4+2+2+4+4` = **20 builds**.

**Scenarios 3 and 4 are now one gate run: 20 → 18.** They present the *compiler*
with an identical input — the invisible file lives in `archive/`, which no
project loads, and the stale entry is a line in a text file tsc never sees — so
they were building the same two programs twice to ask two different questions of
the same answer. Verified with a build counter on a throwaway copy of the gate:
the merged run performs **exactly 2** builds, exits 1, prints **all four**
discriminating strings, and never reaches phase 2.

`EXPECTED_ASSERTIONS` 17 → 18 (the merge adds an assertion naming the stale
entry). The #506 count guard stays honest.

**What the merge costs, written down rather than glossed:** each detector is
still asserted on its own message *and* its own filename, so a broken detector
still reddens. What is no longer directly *observed* is "this mutation, alone,
produces a non-zero exit" — that now rests on reading the gate (each block sets
`COVERAGE_FAIL`; the exit is unconditional on it) rather than on watching it.

### ⚠ The brief's 4–8 build target is REFUTED, and here is why

The remaining redundancy is real and larger than what was recovered: scenarios
**1, 6 and 7 also present the compiler with an identical input** — a clean tree,
differing only in a baseline artefact the gate reads *after* compiling — so 12 of
the 18 builds compile the same tree three times.

They cannot share a run, because **their expected verdicts are mutually
exclusive**: 1 must PASS with the added-diagnostic notice SILENT, 6 must FAIL,
and 7 must PASS with that same notice FIRING. No ordering or combination of the
mutations yields all three from one output, and scenario 1 is scenario 7's
negative control, so neither can be dropped. Merging 2 into 6 is also blocked:
6's mutant asserts `New file(s) with TypeScript errors` is ABSENT, which is
exactly what 2 makes present.

### Measured on CI hardware — and it reframes the follow-up

The local machine was at load 50–145 (other lanes), so the wall-clock came from
CI's own job history for `Typecheck Gate Self-Test` instead. 15 historical
samples split cleanly across #506, which added scenarios 6 and 7:

| era | builds | n | mean | range |
|---|---|---|---|---|
| pre-#506 | 12 | 8 | **178 s** | 166–187 s |
| post-#506 (incl. `6d474415`) | 20 | 7 | **335 s** | 310–357 s |
| **this PR (`268e27f6`)** | **18** | 1 | **323 s** | — |

Solving `8L+4F = 178` and `12L+8F = 335` fits **one `--listFilesOnly` build at
≈ 5.2 s and one full check at ≈ 34 s** — so a gate run reaching phase 2 costs
≈ 78 s and one aborting in phase 1 ≈ 10 s. (#506 cost +88 %, not the +50 % the
brief carried.)

**Be straight about what this PR's wall-clock saving is worth.** The two builds
removed are the *cheap* kind: predicted saving ≈ **10 s** of 335 s. Predicted
after-value 324 s, measured 323 s — a good match, but **10 s is far inside the
47 s run-to-run spread of the 20-build era, so a single sample cannot
demonstrate it.** The build-count reduction (20 → 18) is exact and verified; the
wall-clock claim is a model prediction, not an observation, and is labelled as
one.

**Which is exactly why the blocked reduction matters more than the delivered
one.** The two redundant *full* gate runs — scenarios 6 and 7 recompiling an
identical tree — are worth `2 × (2L+2F)` ≈ **157 s, 47 % of the job**. That is
the piece worth a rowed follow-up, and it is a gate-side change, not a selftest
one.

Collapsing those 12 builds needs a **gate-side** capability — letting phase 2
accept a captured diagnostic set, the way `--dedup-filter` already accepts a
captured diagnostic list. That is a change to the instrument under test, it adds
a code path CI never exercises, and it would downgrade 6 and 7 from "the gate
exits 1" to "the comparison computes the right answer". Deliberately not done
here; it is its own reviewed piece of work.

---

## Gates

* `pnpm typecheck` — **PASSED**. 3,016 / 3,034 tracked TS files loaded;
  633 files / **2545** errors against baseline **2545** (ratchet unmoved).
* `claim-ownership.drift.spec.ts` — 21/21.
* `update-claim-drift-baseline.mjs --check` — both artefacts unchanged.
* `pnpm typecheck:selftest` — **PASSED on CI** (`Typecheck Gate Self-Test`, 323 s).
* All 4 `Full Test Suite` shards, `Production Build`, `TypeScript + Lint`,
  `Security Audit`, `CEE Contract Validation` — green.

Env: `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set for every vitest run
(trap 2b — without them 7 inspector-v2 specs fail at COLLECT and the suite you
measured is not the suite you think).

## Disclosure

Midway through, my own interleaved A/B harness ran `git checkout HEAD -- <spec>
<engine>` where `HEAD` was my WIP commit, which silently reverted a later
simplification of `SourceCache`. I caught it reviewing the final diff, voided the
affected evidence, and **re-ran the entire proof set — equivalence and all eight
mutants — against the exact tree in this PR**. The simplification's own rationale
was refuted by measurement anyway (190 MB vs 191 MB peak: no difference), so the
shipped version is the one every proof actually ran against, and the code comment
now carries the measured figure instead of my estimate. Trap 9, on the lane that
was quoting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
