### PR TITLE
first-five-minutes: narrate the FIRST analysis run, not just reruns

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -360,7 +360,6 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const { showDebug } = useDebugShortcut()
 
   // Phase 2 Sprint 1B: Slow-run UX feedback (20s/40s thresholds)
-  const [slowRunMessage, setSlowRunMessage] = useState<string | null>(null)
   const runStartTimeRef = useRef<number | null>(null)
 
   // Transition bridge: snapshot of pre-analysis review progress captured at run time
@@ -788,15 +787,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
   const isRunning = resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
 
-  // Wave1-L2 (seam D-M): exactly ONE run-status live region. Both the
-  // slow-run message and the running banner render role=status
-  // aria-live=polite, and they used to stack from ~20s with opposing
-  // progress claims. This single decision drives both render sites.
-  const runStatus = runStatusRegion({
-    isRunning,
-    hasReport: Boolean(report),
-    slowRunMessage,
-  })
+  // Wave1-L2 (seam D-M): exactly ONE run-status region, now mounted for
+  // EVERY in-flight run rather than only when a previous report is on
+  // screen — a first run used to be silent until 20s. See
+  // analysisRunStatus.ts for why the dock's own slow-run copy was deleted
+  // rather than kept alongside it.
+  const runStatus = runStatusRegion({ isRunning })
 
   const { readiness } = useGraphReadiness()
 
@@ -1487,39 +1483,25 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     setShowComparePanel(false)
   }, [showComparePanel, setState, setShowComparePanel])
 
-  // Phase 2 Sprint 1B: Track elapsed time and show slow-run messages at 20s/40s
-  // Cleanup ensures timers are always cleared on unmount or status change
+  // Run-duration clock, kept ONLY for the `duration_ms` telemetry on the
+  // completed/failed event below.
+  //
+  // The 20s/40s slow-run MESSAGE this effect used to set is gone.
+  // AnalysisRunningBanner is now the single narration for every run (see
+  // analysisRunStatus.ts) and derives its own elapsed time from the store's
+  // true run start, so a second interval here would be a second stage table
+  // to keep in sync — exactly the drift that left the first-run copy saying
+  // "Taking longer than expected..." at 20s, a wait that is entirely typical.
   useEffect(() => {
     const isRunning = resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
 
     if (isRunning) {
-      // Start tracking time when run begins
       if (runStartTimeRef.current === null) {
         runStartTimeRef.current = Date.now()
-        setSlowRunMessage(null)
       }
-
-      // Check elapsed time every 5 seconds
-      const intervalId = setInterval(() => {
-        if (runStartTimeRef.current === null) return
-
-        const elapsedMs = Date.now() - runStartTimeRef.current
-        const elapsedSeconds = Math.floor(elapsedMs / 1000)
-
-        if (elapsedSeconds >= 40) {
-          setSlowRunMessage('Still working...')
-        } else if (elapsedSeconds >= 20) {
-          setSlowRunMessage('Taking longer than expected...')
-        }
-      }, 5000)
-
-      // Cleanup: always clear interval on unmount or status change
-      return () => clearInterval(intervalId)
     } else {
       // Clear tracking when run completes/errors/cancels/navigates away
       runStartTimeRef.current = null
-      setSlowRunMessage(null)
-      // No cleanup function needed when not running (no interval to clear)
     }
   }, [resultsStatus])
 
@@ -2185,23 +2167,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     </div>
                   )
                 )}
-                {/* Phase 2 Sprint 1B: Slow-run UX feedback. Wave1-L2: yields
-                    to the running banner, whose stage table subsumes these
-                    same 20s/40s thresholds — never both live regions at once. */}
-                {runStatus === 'slow-run' && slowRunMessage && (
-                  <div
-                    className="flex items-center gap-2 px-3 py-2 bg-panel border border-info/30 rounded text-text-header"
-                    role="status"
-                    aria-live="polite"
-                    data-testid="slow-run-message"
-                  >
-                    <Clock className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-                    <span className={`${typography.caption} text-text-header`}>{slowRunMessage}</span>
-                  </div>
-                )}
-                {/* 1.16i: visible processing while an analysis turn runs and
-                    the previous report is still on screen (the skeleton
-                    below covers the no-report case) */}
+                {/* 1.16i + first-five-minutes: visible staged processing for
+                    the WHOLE analysis turn, on every run. It renders above
+                    the retained report when there is one and above the
+                    results skeleton when there is not — a first run is no
+                    longer silent for its first 20 seconds. The skeleton
+                    below is decorative so this stays the one live region. */}
                 {runStatus === 'banner' && <AnalysisRunningBanner startedAt={resultsStartedAt} />}
                 {/* I.2b: Cancel button during active analysis — gated on the
                     V2 hook's own in-flight flag (1.16i): cancelRun only

--- a/src/canvas/components/ResultsPanelSkeleton.tsx
+++ b/src/canvas/components/ResultsPanelSkeleton.tsx
@@ -8,6 +8,19 @@
  * - Next steps section
  *
  * Rule: No blank white blocks while awaiting results.
+ *
+ * DECORATIVE BY DESIGN (first-five-minutes cluster). Every shape here is
+ * aria-hidden and none is a live region. This file used to carry SIX
+ * role=status regions plus an sr-only "Loading analysis results" line, all
+ * announcing at once on the no-report path — the stacked-narration class
+ * analysisRunStatus.ts exists to prevent, simply never counted because it
+ * lived in the skeleton rather than in the dock.
+ *
+ * AnalysisRunningBanner now mounts for every in-flight run, including the
+ * first, and is the single voice for run status. It renders directly above
+ * this skeleton at the only call site (OutputsDock, `isRunning && !report`),
+ * so nothing here needs to speak — and if it did, it would speak over the
+ * banner's staged copy with a static line.
  */
 
 interface SkeletonLineProps {
@@ -51,8 +64,7 @@ export function HeadlineResultSkeleton() {
     <div
       className="bg-paper-50 border border-sand-200 rounded-xl overflow-hidden animate-pulse"
       data-testid="headline-skeleton"
-      role="status"
-      aria-label="Loading decision summary"
+      aria-hidden="true"
     >
       {/* Main outcome area */}
       <div className="px-4 py-4 border-b border-sand-100">
@@ -107,8 +119,7 @@ export function TrustReadinessSkeleton() {
     <div
       className="bg-paper-50 border border-sand-200 rounded-xl p-4 animate-pulse"
       data-testid="trust-skeleton"
-      role="status"
-      aria-label="Loading trust indicators"
+      aria-hidden="true"
     >
       <div className="flex items-center gap-2 mb-3">
         <div className="w-4 h-4 bg-sand-200 rounded" />
@@ -136,8 +147,7 @@ export function DriversInsightSkeleton() {
     <div
       className="bg-paper-50 border border-sand-200 rounded-xl overflow-hidden animate-pulse"
       data-testid="drivers-skeleton"
-      role="status"
-      aria-label="Loading drivers"
+      aria-hidden="true"
     >
       {/* Header */}
       <div className="px-4 py-3 border-b border-sand-100">
@@ -179,8 +189,7 @@ export function KeyInsightSkeleton() {
     <div
       className="rounded-lg border border-sky-200 bg-sky-50/50 px-3 py-3 animate-pulse"
       data-testid="insight-skeleton"
-      role="status"
-      aria-label="Loading insight"
+      aria-hidden="true"
     >
       <div className="flex items-start gap-2">
         <div className="w-5 h-5 bg-sky-200 rounded flex-shrink-0" />
@@ -203,8 +212,7 @@ export function NextStepsSkeleton() {
     <div
       className="bg-paper-50 border border-sand-200 rounded-xl p-4 animate-pulse"
       data-testid="next-steps-skeleton"
-      role="status"
-      aria-label="Loading next steps"
+      aria-hidden="true"
     >
       <div className="flex items-center gap-2 mb-3">
         <div className="w-4 h-4 bg-sand-200 rounded" />
@@ -228,14 +236,12 @@ export function NextStepsSkeleton() {
  */
 export function ResultsPanelSkeleton() {
   return (
-    <div className="space-y-4 p-4" role="status" aria-label="Loading results">
+    <div className="space-y-4 p-4" data-testid="results-panel-skeleton" aria-hidden="true">
       <HeadlineResultSkeleton />
       <KeyInsightSkeleton />
       <DriversInsightSkeleton />
       <NextStepsSkeleton />
 
-      {/* Screen reader announcement */}
-      <span className="sr-only">Loading analysis results, please wait...</span>
     </div>
   )
 }

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -456,127 +456,113 @@ describe('OutputsDock DOM', () => {
 // region these very tests assert on. Wrapping them in a describe that runs the
 // same reset as every other block gives them the isolation they always
 // assumed. Grouping + setup only: no assertion touched.
-describe('OutputsDock DOM: non-blocking CEE + slow-run narration', () => {
+describe('OutputsDock DOM: non-blocking CEE + run narration', () => {
   beforeEach(resetDockEnvironment)
 
 // Phase 1 Section 3.3: Non-blocking CEE and degraded banner tests
 
-// Phase 2 Sprint 1B: Slow-run UX feedback tests
-it('shows "Taking longer than expected..." message after 20 seconds', async () => {
-  vi.useFakeTimers()
-
-  renderOutputsDock()
-
-  // Simulate a long-running analysis
+/**
+ * Phase 2 Sprint 1B shipped these as slow-run-message tests: the dock owned a
+ * 20s/40s escalation of its own, and they pinned its copy and a11y.
+ *
+ * That mechanism is gone (first-five-minutes cluster). AnalysisRunningBanner
+ * now narrates every run from second 0, so the dock no longer needs a second
+ * stage table — and the one it had said "Taking longer than expected..." at
+ * 20s, a wait that is entirely typical. The COVERAGE these cases represent is
+ * unchanged and still worth having, so they are re-pointed at the surviving
+ * mechanism rather than deleted: the dock escalates its narration over a long
+ * run, stops narrating when the run ends, and exposes the region to
+ * assistive tech correctly.
+ */
+function startLongRun() {
   const currentResults = useCanvasStore.getState().results
   act(() => {
     useCanvasStore.setState({
-      results: { ...currentResults, status: 'streaming' },
+      results: { ...currentResults, status: 'streaming', startedAt: Date.now() },
       hasCompletedFirstRun: true,
     } as any)
   })
+}
 
-  // Initially no message
-  expect(screen.queryByTestId('slow-run-message')).not.toBeInTheDocument()
+/** Advance the clock, then flush the banner's 200ms stage crossfade. */
+function advanceTo(ms: number) {
+  act(() => { vi.advanceTimersByTime(ms) })
+  act(() => { vi.advanceTimersByTime(250) })
+}
 
-  // After 20 seconds, show first message
-  act(() => {
-    vi.advanceTimersByTime(20000)
-  })
+it('escalates the narration after 20 seconds', async () => {
+  vi.useFakeTimers()
 
-  expect(screen.getByTestId('slow-run-message')).toBeInTheDocument()
-  expect(screen.getByText('Taking longer than expected...')).toBeInTheDocument()
+  renderOutputsDock()
+  startLongRun()
+
+  // Unlike the old slow-run region, the banner speaks immediately — the
+  // silence this replaced was the defect, not the baseline.
+  expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+    'Analysing your decision…',
+  )
+
+  advanceTo(20000)
+
+  expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+    'Still analysing your decision…',
+  )
 
   vi.useRealTimers()
 })
 
-it('escalates to "Still working..." message after 40 seconds', async () => {
+it('escalates again after 40 seconds', async () => {
   vi.useFakeTimers()
 
   renderOutputsDock()
+  startLongRun()
 
-  // Simulate a long-running analysis
-  const currentResults = useCanvasStore.getState().results
-  act(() => {
-    useCanvasStore.setState({
-      results: { ...currentResults, status: 'streaming' },
-      hasCompletedFirstRun: true,
-    } as any)
-  })
+  advanceTo(40000)
 
-  // After 40 seconds, show escalated message
-  act(() => {
-    vi.advanceTimersByTime(40000)
-  })
-
-  expect(screen.getByTestId('slow-run-message')).toBeInTheDocument()
-  expect(screen.getByText('Still working...')).toBeInTheDocument()
+  expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+    'Still analysing — complex decisions can take a while…',
+  )
 
   vi.useRealTimers()
 })
 
-it('clears slow-run message when analysis completes', async () => {
+it('stops narrating when analysis completes', async () => {
   vi.useFakeTimers()
 
   renderOutputsDock()
+  startLongRun()
 
-  // Simulate a long-running analysis
+  advanceTo(20000)
+  expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+
   const currentResults = useCanvasStore.getState().results
-  act(() => {
-    useCanvasStore.setState({
-      results: { ...currentResults, status: 'streaming' },
-      hasCompletedFirstRun: true,
-    } as any)
-  })
-
-  // Advance to 20s to show message
-  act(() => {
-    vi.advanceTimersByTime(20000)
-  })
-
-  expect(screen.getByTestId('slow-run-message')).toBeInTheDocument()
-  expect(screen.getByText('Taking longer than expected...')).toBeInTheDocument()
-
-  // Complete the analysis
   act(() => {
     useCanvasStore.setState({
       results: { ...currentResults, status: 'complete' },
     } as any)
   })
 
-  // Message should be cleared
-  expect(screen.queryByTestId('slow-run-message')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
 
   vi.useRealTimers()
 })
 
-it('slow-run message has proper accessibility attributes', async () => {
+it('the run-status region has proper accessibility attributes', async () => {
   vi.useFakeTimers()
 
   renderOutputsDock()
+  startLongRun()
 
-  // Simulate a long-running analysis
-  const currentResults = useCanvasStore.getState().results
-  act(() => {
-    useCanvasStore.setState({
-      results: { ...currentResults, status: 'streaming' },
-      hasCompletedFirstRun: true,
-    } as any)
-  })
+  advanceTo(20000)
 
-  // Advance to 20s to show message
-  act(() => {
-    vi.advanceTimersByTime(20000)
-  })
-
-  const message = screen.getByTestId('slow-run-message')
-  expect(message).toHaveAttribute('role', 'status')
-  expect(message).toHaveAttribute('aria-live', 'polite')
+  const region = screen.getByTestId('analysis-running-banner')
+  expect(region).toHaveAttribute('role', 'status')
+  expect(region).toHaveAttribute('aria-live', 'polite')
 
   vi.useRealTimers()
 })
 
-}) // end 'OutputsDock DOM: non-blocking CEE + slow-run narration'
+}) // end 'OutputsDock DOM: non-blocking CEE + run narration'
 
 // P0 Engine Integration: IdentifiabilityBadge in Results tab
 describe('P0 Engine: IdentifiabilityBadge', () => {
@@ -1100,6 +1086,8 @@ describe('Wave1-L2: single run-status live region', () => {
   /** The run-status live regions this dock can render. */
   function runStatusRegions() {
     return [
+      // slow-run-message is retired; kept in the enumeration so a
+      // reintroduction is COUNTED as a second region rather than ignored.
       ...screen.queryAllByTestId('slow-run-message'),
       ...screen.queryAllByTestId('analysis-running-banner'),
     ]
@@ -1198,7 +1186,7 @@ describe('Wave1-L2: single run-status live region', () => {
     vi.useRealTimers()
   })
 
-  it('keeps the standalone slow-run message when there is NO report (banner not mounted)', () => {
+  it('renders exactly ONE run-status live region at 25s when there is NO report', () => {
     vi.useFakeTimers()
     const baseResults = useCanvasStore.getState().results
 
@@ -1208,6 +1196,7 @@ describe('Wave1-L2: single run-status live region', () => {
         ...baseResults,
         status: 'streaming',
         report: null,
+        startedAt: Date.now(),
       },
     } as any)
 
@@ -1217,10 +1206,15 @@ describe('Wave1-L2: single run-status live region', () => {
       vi.advanceTimersByTime(25_000)
     })
 
-    // Skeleton case: the banner does not mount, so the pre-existing slow-run
-    // region is still the single run-status live region and must survive.
-    expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
-    expect(screen.getByTestId('slow-run-message')).toBeInTheDocument()
+    // ⚠ This case previously asserted the OPPOSITE, and in doing so pinned the
+    // first-run silence as correct: with no report the banner did not mount,
+    // and the dock's slow-run line was the only narration — arriving 20s late
+    // and claiming an ordinary wait was longer than expected. The banner now
+    // mounts on this path too, above the (decorative) results skeleton, so the
+    // single-region guarantee holds with the HONEST region rather than the
+    // stale one.
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.queryByTestId('slow-run-message')).not.toBeInTheDocument()
     expect(runStatusRegions()).toHaveLength(1)
 
     vi.useRealTimers()

--- a/src/canvas/components/__tests__/OutputsDock.firstRunNarration.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.firstRunNarration.spec.tsx
@@ -1,0 +1,223 @@
+/**
+ * First-five-minutes cluster — a FIRST analysis run must narrate too.
+ *
+ * The regression these tests exist for, precisely: `AnalysisRunningBanner`
+ * carried honest staged narration from second 0, but the dock mounted it only
+ * when a PREVIOUS report was still on screen (`hasReport`). So the narration a
+ * user got depended on whether they had run an analysis before:
+ *
+ *   - returning user → staged copy immediately;
+ *   - FIRST run      → nothing until 20s, then the dock's own slow-run line
+ *                      "Taking longer than expected..." — a comparative claim
+ *                      the banner's stage table had already dropped as
+ *                      dishonest (20-30s IS the typical wait, and the client
+ *                      holds no distribution of past runs to compare with).
+ *
+ * The honesty fix had been applied to the banner and never to the region it
+ * "subsumed", and because the subsume only fired where the banner mounted,
+ * the un-fixed copy was exactly what survived — on exactly the first run, in
+ * the session where a 60s+ wait is least explicable.
+ *
+ * Harness mirrors OutputsDock.announcerPlacement.spec.tsx (real dock, real
+ * canvas store, stubbed heavy children).
+ */
+import '@testing-library/jest-dom/vitest'
+import { render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+
+const {
+  mockIsV5CanonicalAnalysisEnabled,
+  mockIsV5Eligible,
+  mockUseV2Run,
+  mockShowToast,
+} = vi.hoisted(() => ({
+  mockIsV5CanonicalAnalysisEnabled: vi.fn(() => false),
+  mockIsV5Eligible: vi.fn((_input?: { flag: string | undefined }) => ({ eligible: false, reason: 'flag_off' })),
+  mockUseV2Run: vi.fn(() => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })),
+  mockShowToast: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => true,
+    isJourneyTabEnabled: vi.fn(() => false),
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: mockIsV5Eligible,
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useV2Run')>()
+  return { ...actual, useV2Run: () => mockUseV2Run() }
+})
+
+vi.mock('../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../ToastContext')>()
+  return { ...actual, useShowToast: () => mockShowToast, useShowToastSafe: () => mockShowToast }
+})
+
+vi.mock('../pre-analysis/hooks/usePreAnalysisData', () => ({ usePreAnalysisData: () => ({}) }))
+
+vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useGraphReadiness')>()
+  return {
+    ...actual,
+    useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }),
+  }
+})
+
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => <div data-testid="pre-analysis-stub" /> }))
+
+vi.mock('../../../components/results/ResultsBody', () => ({
+  ResultsBody: () => <div data-testid="mock-results-body" />,
+}))
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/**
+ * A FIRST run: a graph on the canvas, an analysis in flight, and — the
+ * load-bearing part — NO report, because the user has never run one.
+ * `startedAt` is the run's true start, which is what the banner's clock reads.
+ */
+function seedFirstRun(elapsedMs = 0) {
+  useCanvasStore.setState({
+    hasCompletedFirstRun: false,
+    nodes: [
+      { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+      { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    ],
+    edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    ceeAnalysisReady: { goal_node_id: 'goal-1', options: [{ id: 'opt-a', label: 'A', interventions: {} }] },
+    results: {
+      status: 'streaming',
+      progress: 10,
+      report: undefined,
+      startedAt: Date.now() - elapsedMs,
+    },
+    showDraftChat: false,
+  } as never)
+}
+
+function renderDock() {
+  return render(
+    <ConversationProvider>
+      <OutputsDock />
+    </ConversationProvider>,
+  )
+}
+
+describe('first run narration: the banner no longer depends on a previous report', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    vi.clearAllMocks()
+    mockUseV2Run.mockReturnValue({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })
+    useUIStore.setState({ activeRightPanel: null } as never)
+  })
+
+  afterEach(() => {
+    useUIStore.setState({ activeRightPanel: null } as never)
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 },
+      hasCompletedFirstRun: false,
+    } as never)
+  })
+
+  // THE pin. Before the fix this rendered nothing at all: `hasReport` was
+  // false, so runStatusRegion returned 'slow-run', and slowRunMessage was
+  // still null at second 0.
+  it('narrates from second 0 on a first run, with no report on screen', () => {
+    seedFirstRun(0)
+    renderDock()
+
+    expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent('Analysing your decision…')
+  })
+
+  it('escalates on a first run exactly as it does on a rerun (25s)', () => {
+    seedFirstRun(25_000)
+    renderDock()
+
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+      'Still analysing your decision…',
+    )
+  })
+
+  it('escalates again at 45s on a first run', () => {
+    seedFirstRun(45_000)
+    renderDock()
+
+    expect(screen.getByTestId('analysis-narration')).toHaveTextContent(
+      'Still analysing — complex decisions can take a while…',
+    )
+  })
+
+  // The honesty half of the fix: the comparative copy is not merely
+  // out-ranked, it is gone. A user 25s into their first run can no longer be
+  // told their perfectly ordinary wait is longer than expected.
+  it('never shows the comparative slow-run copy, at any elapsed time', () => {
+    for (const elapsed of [0, 25_000, 45_000]) {
+      seedFirstRun(elapsed)
+      const { unmount } = renderDock()
+
+      expect(screen.queryByTestId('slow-run-message')).not.toBeInTheDocument()
+      expect(screen.queryByText(/Taking longer than expected/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^Still working\.\.\./)).not.toBeInTheDocument()
+
+      unmount()
+    }
+  })
+
+  // The banner mounts ABOVE the skeleton on this path, so the skeleton must
+  // not speak over it. It used to carry six role=status regions plus an
+  // sr-only line — stacked narration that was never counted because it lived
+  // in the skeleton rather than in the dock.
+  it('leaves the results skeleton decorative, so the banner is the one voice', () => {
+    seedFirstRun(0)
+    renderDock()
+
+    const skeleton = screen.getByTestId('results-panel-skeleton')
+    expect(skeleton).toHaveAttribute('aria-hidden', 'true')
+    expect(within(skeleton).queryAllByRole('status')).toHaveLength(0)
+    expect(within(skeleton).queryByText(/Loading analysis results/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/__tests__/analysisRunStatus.spec.ts
+++ b/src/canvas/components/__tests__/analysisRunStatus.spec.ts
@@ -1,96 +1,67 @@
 /**
- * Wave1-L2 (seam D-M): exactly ONE run-status live region.
+ * Wave1-L2 (seam D-M): exactly ONE run-status region — now on every run.
  *
- * The dock can express run status two ways: the pre-existing slowRunMessage
- * (>=20s "Taking longer than expected...", >=40s "Still working...") and the
- * AnalysisRunningBanner narration. Both render role=status aria-live=polite.
- * Before the fix they STACKED from ~20s, making opposing progress claims in
- * exactly the window this lane targets — a screen-reader user heard both.
+ * ⚠ These tests were REWRITTEN, and one of them previously pinned the defect
+ * as correct behaviour. The old suite asserted:
  *
- * The reconciliation is expressed as a single pure decision returning ONE
- * region, so rendering two is structurally impossible rather than merely
- * untested. OutputsDock drives both render sites from this function alone.
+ *     it('narrates nothing before the first slow-run threshold with no report')
+ *       → expect(runStatusRegion({ isRunning: true, hasReport: false,
+ *                                  slowRunMessage: null })).toBe('none')
+ *
+ * That is the first-run silence, written down as a guarantee. It was an
+ * honest description of the code at the time — the suite was defending the
+ * "no regression to the pre-existing slow-run behaviour" of the stacking fix
+ * — but it meant the gap had a green test standing over it, which is why it
+ * survived. Recording that here rather than quietly deleting the case: the
+ * suite that pins a behaviour is where a future reader looks to find out
+ * whether the behaviour was intended.
+ *
+ * The contract now: while a run is in flight the banner narrates, first run
+ * or not; when it is not, nothing does. The dock's own 20s/40s slow-run copy
+ * is deleted (a second stage table for the same thresholds, and the surviving
+ * one made a comparative claim NARRATION_STAGES had already rejected), so
+ * 'slow-run' is no longer a reachable region.
  */
 
 import { describe, it, expect } from 'vitest'
 
 import { runStatusRegion, type RunStatusRegion } from '../analysisRunStatus'
 
-/** The slow-run copy the dock sets at its 20s / 40s thresholds. */
-const SLOW_RUN_20S = 'Taking longer than expected...'
-const SLOW_RUN_40S = 'Still working...'
-
-describe('runStatusRegion: exactly one live region', () => {
+describe('runStatusRegion: exactly one region', () => {
   // The whole point: a single return value cannot name two regions at once.
-  it('returns exactly one region for every reachable input combination', () => {
-    const valid: RunStatusRegion[] = ['banner', 'slow-run', 'none']
+  it('returns exactly one valid region for every reachable input', () => {
+    const valid: RunStatusRegion[] = ['banner', 'none']
 
     for (const isRunning of [true, false]) {
-      for (const hasReport of [true, false]) {
-        for (const slowRunMessage of [null, SLOW_RUN_20S, SLOW_RUN_40S]) {
-          const region = runStatusRegion({ isRunning, hasReport, slowRunMessage })
-          expect(valid).toContain(region)
-        }
-      }
+      expect(valid).toContain(runStatusRegion({ isRunning }))
     }
-  })
-
-  // P1 (three reviewers converged): at 25s with a report on screen the dock
-  // rendered slowRunMessage DIRECTLY ABOVE the banner narration.
-  it('at 25s with a report on screen, only the banner narrates (slow-run yields)', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: SLOW_RUN_20S }),
-    ).toBe('banner')
-  })
-
-  it('at 45s with a report on screen, only the banner narrates', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: SLOW_RUN_40S }),
-    ).toBe('banner')
   })
 })
 
-describe('no regression to the pre-existing slow-run behaviour', () => {
-  // The banner only mounts when a previous report is still on screen; the
-  // skeleton covers the no-report case, where slowRunMessage is still the
-  // only run-status narration and must keep working exactly as before.
-  it('keeps the standalone slow-run region at 25s when there is NO report', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: SLOW_RUN_20S }),
-    ).toBe('slow-run')
+describe('a run in flight always narrates', () => {
+  // THE regression pin. Under the old rule this input — a first run, nothing
+  // on screen yet — returned 'none', and the user watched an undifferentiated
+  // skeleton for 20 seconds.
+  it('narrates from the first moment of a run, with or without a previous report', () => {
+    expect(runStatusRegion({ isRunning: true })).toBe('banner')
   })
 
-  it('keeps the standalone slow-run region at 45s when there is NO report', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: SLOW_RUN_40S }),
-    ).toBe('slow-run')
+  // The old signature took `hasReport` and `slowRunMessage`, and the region
+  // it returned depended on both. Nothing about WHICH run this is can change
+  // the answer any more — that dependency was the bug, so its absence is
+  // what this suite defends.
+  it('depends on nothing except whether a run is in flight', () => {
+    const running = runStatusRegion({ isRunning: true })
+    const idle = runStatusRegion({ isRunning: false })
+
+    expect(running).toBe('banner')
+    expect(idle).toBe('none')
+    expect(running).not.toBe(idle)
   })
 })
 
 describe('quiet states', () => {
-  it('narrates nothing before the first slow-run threshold with no report', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: false, slowRunMessage: null }),
-    ).toBe('none')
-  })
-
-  it('narrates nothing once the run completes (slow-run message cleared)', () => {
-    expect(
-      runStatusRegion({ isRunning: false, hasReport: true, slowRunMessage: null }),
-    ).toBe('none')
-  })
-
-  // Completion/error clears slowRunMessage, but a stale value must never
-  // resurrect narration for a run that is no longer in flight.
-  it('narrates the slow-run line only while a run is in flight', () => {
-    expect(
-      runStatusRegion({ isRunning: false, hasReport: false, slowRunMessage: SLOW_RUN_20S }),
-    ).toBe('none')
-  })
-
-  it('shows the banner as soon as a run starts over an existing report', () => {
-    expect(
-      runStatusRegion({ isRunning: true, hasReport: true, slowRunMessage: null }),
-    ).toBe('banner')
+  it('narrates nothing once the run is no longer in flight', () => {
+    expect(runStatusRegion({ isRunning: false })).toBe('none')
   })
 })

--- a/src/canvas/components/analysisRunStatus.ts
+++ b/src/canvas/components/analysisRunStatus.ts
@@ -1,56 +1,68 @@
 /**
- * Wave1-L2 (seam D-M) — which run-status live region the dock narrates with.
+ * Wave1-L2 (seam D-M) — which run-status region the dock narrates with.
  *
- * The dock has two ways to speak about an in-flight run, and both render
- * role=status aria-live=polite:
+ * ⚠ REVISED (first-five-minutes cluster) — the previous reconciliation was
+ * correct about STACKING and wrong about COVERAGE, and the gap it left fell
+ * entirely on first-time users.
  *
- *  - `slowRunMessage` — the pre-existing 20s/40s escalation, the only
- *    narration available while the results skeleton is up (no report yet).
+ * The dock used to have two ways to speak about an in-flight run:
+ *
+ *  - `slowRunMessage` — a 20s/40s escalation owned by OutputsDock, the only
+ *    narration available while the results skeleton was up (no report yet).
  *  - `AnalysisRunningBanner` — the staged narration, mounted only while a
- *    PREVIOUS report is still on screen.
+ *    PREVIOUS report was still on screen.
  *
- * They used to stack: from ~20s the slow-run line rendered directly above the
- * banner, two live regions making opposing progress claims in exactly the
- * 20-30s window. A screen-reader user heard both.
+ * They used to stack from ~20s, so the first fix made the banner win wherever
+ * it mounted. But the banner's mount condition was `hasReport`, so the
+ * narration a user got depended on whether they had run an analysis BEFORE:
  *
- * Reconciliation: the banner SUBSUMES the slow-run thresholds into its own
- * stage table (see NARRATION_STAGES — same 20s/40s escalation points), so
- * whenever the banner is mounted the standalone slow-run region yields and
- * the user loses nothing. Where the banner does not mount (no report), the
- * slow-run region keeps its existing behaviour untouched.
+ *  - returning user (report on screen) → staged copy from second 0;
+ *  - FIRST run (no report) → nothing at all until 20s, then the slow-run
+ *    line — exactly inverted from what a first-time user needs, in the one
+ *    session where the 60s+ wait is least explicable.
  *
- * Expressing this as ONE decision with ONE return value makes "exactly one
- * run-status live region" structurally true rather than merely tested: the
- * dock drives both render sites from this function alone.
+ * And the copy that survived on that path was the copy the banner's own
+ * honesty doctrine had already rejected: `'Taking longer than expected...'`
+ * at 20s, when 20-30s IS the typical wait (see NARRATION_STAGES, which drops
+ * the comparative family precisely because the client holds no distribution
+ * of past run durations to compare against). The Wave1-L2 honesty fix was
+ * applied to the banner and never to the region it "subsumed" — and because
+ * the subsume only happened where the banner mounted, the un-fixed line was
+ * exactly what survived, on exactly the first run.
+ *
+ * That is the hand-maintained-mirror class: two implementations of one stage
+ * table, sharing thresholds by convention, drifting the moment one was fixed.
+ *
+ * Resolution: there is now ONE narration implementation. The banner mounts
+ * for every in-flight run, first or not, and the slow-run message, its timer
+ * and its render site are deleted rather than yielded to. Nothing is lost:
+ * the banner's stage table carries the same 20s/40s escalation points, from a
+ * strictly more honest clock (the run's true `startedAt`, durable across
+ * remounts, rather than a ref stamped when an effect happened to fire).
+ *
+ * The seam stays because the guarantee is still worth expressing structurally:
+ * ONE decision, ONE return value, ONE call site drives the render, so "exactly
+ * one run-status region" cannot regress into two by local edit.
  */
 
-/** The single run-status live region to render, if any. */
-export type RunStatusRegion = 'banner' | 'slow-run' | 'none'
+/** The single run-status region to render, if any. */
+export type RunStatusRegion = 'banner' | 'none'
 
 export interface RunStatusInput {
   /** A run is in flight (preparing | connecting | streaming). */
   isRunning: boolean
-  /** A previous report is still on screen (the banner's mount condition). */
-  hasReport: boolean
-  /** The dock's 20s/40s escalation copy, or null before the first threshold. */
-  slowRunMessage: string | null
 }
 
 /**
- * Resolve the one region that narrates run status. Order matters: the banner
- * wins wherever it mounts, because its stage table already carries the
- * long-wait acknowledgement the slow-run line would have duplicated.
+ * Resolve the one region that narrates run status.
+ *
+ * Deliberately NOT conditioned on whether a previous report is on screen: that
+ * condition is what made a first run silent. The banner renders above the
+ * results skeleton when there is no report and above the retained report when
+ * there is — the same narration either way.
  */
-export function runStatusRegion({
-  isRunning,
-  hasReport,
-  slowRunMessage,
-}: RunStatusInput): RunStatusRegion {
-  if (isRunning && hasReport) return 'banner'
-  // slowRunMessage is cleared on completion/error, but gate on isRunning too
-  // so a stale value can never narrate a run that is no longer in flight.
-  if (isRunning && slowRunMessage) return 'slow-run'
-  return 'none'
+export function runStatusRegion({ isRunning }: RunStatusInput): RunStatusRegion {
+  return isRunning ? 'banner' : 'none'
 }
 
 /**

--- a/src/canvas/components/analysisRunStatus.ts
+++ b/src/canvas/components/analysisRunStatus.ts
@@ -74,8 +74,11 @@ export function runStatusRegion({ isRunning }: RunStatusInput): RunStatusRegion 
  * furniture already speaks there:
  *
  *  - START: the running banner's narration div (role=status) mounts with
- *    "Analysing your decision…", and the no-report skeleton carries its own
- *    sr-only loading line. A dock announcement on top would be heard twice.
+ *    "Analysing your decision…". A dock announcement on top would be heard
+ *    twice. (This used to read "…and the no-report skeleton carries its own
+ *    sr-only loading line" — the yield's cover on the no-report path. That
+ *    line is gone: the skeleton is decorative now and the banner mounts on
+ *    BOTH paths, so the premise holds through one mechanism instead of two.)
  *  - SETTLE: AnalysisFreshnessNotice fires the completion toast
  *    (role=alert) on the running→complete transition, and the error banner
  *    mounts as role=alert on failure.

--- a/src/canvas/conversation/GraphVocabularyLegend.tsx
+++ b/src/canvas/conversation/GraphVocabularyLegend.tsx
@@ -21,6 +21,10 @@ const LEGEND_TERMS: ReadonlyArray<{ term: string; definition: string }> = [
   { term: 'Decision', definition: 'The choice you are weighing up.' },
   { term: 'Option', definition: 'A course of action you could take.' },
   { term: 'Factor', definition: 'Something that influences how things turn out.' },
+  // Outcome was the one canvas node kind this legend never named, while the
+  // canvas's own "How to read this" key did — so a card referring to an
+  // outcome node pointed at vocabulary the primer did not define.
+  { term: 'Outcome', definition: 'A result the options lead to.' },
   { term: 'Risk', definition: 'An uncertain event that could work against you.' },
   { term: 'Goal', definition: 'The outcome you are trying to achieve.' },
   { term: 'Constraint', definition: 'A limit the decision must respect.' },

--- a/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
@@ -201,8 +201,11 @@ describe('InlineBlocks — graph-vocabulary legend affordance (F16)', () => {
     expect(legendToggle).toHaveAttribute('aria-expanded', 'false')
     fireEvent.click(legendToggle)
     expect(legendToggle).toHaveAttribute('aria-expanded', 'true')
-    // Minimal node/edge vocabulary of the cards' target refs.
-    for (const term of ['Factor', 'Option', 'Goal', 'Risk', 'Constraint', 'Link']) {
+    // Minimal node/edge vocabulary of the cards' target refs. Every canvas
+    // node kind must appear: 'Outcome' was missing while the canvas's own
+    // "How to read this" key listed it, so a card pointing at an outcome node
+    // referred to vocabulary this primer did not define.
+    for (const term of ['Decision', 'Factor', 'Option', 'Outcome', 'Goal', 'Risk', 'Constraint', 'Link']) {
       expect(screen.getByText(term)).toBeInTheDocument()
     }
   })


### PR DESCRIPTION
## Verify-first: two of the three items were already built

This lane was dispatched to build three "first five minutes" items. Before writing anything I established at the bytes **and in a live browser** what already existed. Staging's deployed commit is `5cccae9f` — identical to this branch's base — so the live probes below test exactly this code.

| Item | Status | Evidence |
|---|---|---|
| **Coaching-card pacing** | **Already built — skipped** | `src/canvas/conversation/phase3Pacing.ts` (F16): top-3 phase-3 cards expanded, remainder behind ONE affordance at the first collapsed card's position, producer `priority_rank` order preserved, bias-signal cards exempt up to a structural cap. Live probe on a real analysis turn observed the affordance: `aria-label="Show 4 more coaching and review cards"`, sr summary `"4 more coaching and review cards collapsed"`. |
| **Graph legend** | **Already built (twice) — one word added** | `CanvasLegendPopover` — a `?` at the canvas bottom-left ("How to read this"), Esc/outside-click dismissible. Live: button box `{x:16, y:951, 28×28}`, popover `{224×387}`, contents `Decision · Option · Factor · Outcome · Risk · Goal · Outside your control · solid/dashed connections · weak/moderate/strong effect · Raises/Lowers`. Plus `GraphVocabularyLegend` ("What do these terms mean?") beside phase-3 cards; live terms `Decision, Option, Factor, Risk, Goal, Constraint, Link`. |
| **Analysis-wait narration** | **Real gap — built** | See below. |

I did not rebuild the first two. `CanvasLegendPopover` additionally carries an explicit instruction in-file that its copy is brief-approved and that new copy needs Paul, so I left it untouched.

## The gap: a first run does not narrate

`AnalysisRunningBanner` has carried honest staged narration from second 0 since Wave1-L2. But the dock mounted it only when a **previous report** was on screen (`hasReport`). So what a user saw depended on whether they had run an analysis before:

- returning user → staged copy immediately;
- **first run → nothing until 20s**, then the dock's own slow-run line.

Live first run on staging, probing the DOM every few seconds:

```
[t=2s]  {"banner":false,"narration":null,"skeleton":true,
         "statusRegions":["Loading results","Loading decision summary",
                          "Loading insight","Loading drivers","Loading next steps"]}
[t=8s]  {"banner":false,"narration":null, ... same ...}
[t=15s] {"banner":false,"narration":null, ... same ...}
```

No narration node exists at all — and the skeleton contributes **five stacked `role=status` regions**, the very stacked-narration class `analysisRunStatus.ts` exists to prevent, never counted because it lived in the skeleton rather than the dock.

And the copy that survived on that path was the copy the banner's own doctrine had already rejected: `"Taking longer than expected..."` at 20s, when 20–30s **is** the typical wait and the client holds no distribution of past runs to compare against. The Wave1-L2 honesty fix was applied to the banner and never to the region it "subsumed" — and because the subsume only fired where the banner mounted, the un-fixed line is precisely what survived, on precisely the first run. Two implementations of one stage table, drifting the moment one was fixed: the hand-maintained-mirror class.

## Changes

- `runStatusRegion` no longer takes `hasReport`/`slowRunMessage`. The banner mounts for **every** in-flight run, above the skeleton when there is no report.
- The dock's `slowRunMessage` state, its 5s interval and its render site are **deleted**, not yielded to — one stage table remains. `runStartTimeRef` stays; it still feeds `duration_ms` telemetry.
- `ResultsPanelSkeleton` is now decorative (`aria-hidden`, no live regions) so the banner is the single voice on that path.
- `GraphVocabularyLegend` gains **Outcome**, the one canvas node kind it never named while the canvas's own key did.

No new flags; the capability ships on. No wire change — this is the client-side timed narration D-M ruled acceptable. No leader/designation language anywhere.

## Live proof on this branch's build (local dev, `/private/tmp`, real Chromium)

Same starter graph (20 nodes) loaded in a real browser against the dev server running this branch; the run state is driven through the app's own canvas store (the CEE turn itself is proven separately on staging — a local dev server cannot reach a working turn without replicating staging's full flag set, and I would rather say so than dress a partial reproduction up as a full one).

```
bannerPresent      true          (was FALSE on this path before the fix)
bannerBox          {x:865, y:58, w:390, h:39}   ← real layout, not a jsdom presence check
bannerVisible      true
bannerRole         status        aria-live: polite
narration @0s      "Analysing your decision…"
narration @25s     "Still analysing your decision…"
narration @47s     "Still analysing — complex decisions can take a while…"
slowRunPresent     false         at every elapsed time
old copy on page   false         ("Taking longer than expected" / "Still working...")
skeletonAriaHidden "true"        ← decorative, and its five "Loading …" status regions are gone
bannerGone on idle true          ← unmounts cleanly when the run ends
```

Canvas legend re-checked on the same build (unchanged by this PR): button present, popover `{224×387}` at `{x:52, y:312}`, full contents intact.

## Tests, all mutation-proven

Five new dock-level cases in `OutputsDock.firstRunNarration.spec.tsx`. Reverting the fix turns them RED:

| Mutant | Result |
|---|---|
| Re-gate the banner on `report` | 3 RED |
| Restore the skeleton's live region | 1 RED |
| Re-introduce the comparative copy | 1 RED |
| Remove the `Outcome` legend row | 1 RED (existing legend spec) |

Two existing suites asserted the old behaviour and are **re-pointed rather than deleted**, since the coverage still matters. One of them contained:

```js
it('narrates nothing before the first slow-run threshold with no report')
```

— the first-run silence, written down as a guarantee. That is recorded in the rewritten file rather than quietly dropped: the suite pinning a behaviour is where a reader looks to find out whether it was intended.

## Gates

- `pnpm run typecheck` **PASSED** — ratchet held at exactly **2517** (626 files), coverage 2993/3033.
- Full `src/canvas/` suite: **710 files passed, 0 failed**, 2 skipped.
- `scripts/validate-prepush.sh`: checks 1–7 pass. **Check 8 (DS v5 drift) fails — pre-existing, not this branch.** Proven with a control worktree at the pristine base `5cccae9f`: byte-identical output (1790/289/62/45 against the same baselines, same two classes), and none of the listed violations is in a file this PR touches. This is the known broken alarm in `CLAUDE.md` trap 2b; **not** to be "fixed" by baselining.
- eslint on all changed files: 0 errors, 1 warning — pre-existing (same warning on base, line shifted by a deletion).

## Refuted along the way

- The register's "unbuilt 💡" claim was **false for all three items** — two shipped unrecorded.
- The dispatch's suggested copy (*"Checking your model's structure… · Running simulations… · Preparing results…"*) is exactly the pipeline-stage family `NARRATION_STAGES` documents as unavailable to the client. Adopting it would have been a regression; the existing honest table is reused instead.
- "60s+" overstates this wait: the live first run settled in **under 22s**, so the value sits almost entirely in the 0–20s window — the window that was silent.
- One of my own probe scripts passed Playwright's options object into the `arg` position, so a "never enabled" result came from a 30s wait, not the 240s I intended. That conclusion was discarded, not reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
