### PR TITLE
fix(2102): the post-edit "Re-run" control dispatches, and a failed re-draft no longer destroys the example

### DIFF
--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -161,7 +161,12 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
         className="flex-1 min-h-0 overflow-y-auto"
         aria-busy={trust.isRunning || undefined}
       >
-        <Hero state={compareState} snapshots={snapshots} showExpert={showExpert} />
+        <Hero
+          state={compareState}
+          snapshots={snapshots}
+          showExpert={showExpert}
+          onRunAnalysis={onRunAnalysis}
+        />
         <TrajectorySection snapshots={snapshots} showExpert={showExpert} />
         <TransitionsSection
           transitions={visibleTransitions}

--- a/src/canvas/compare-tab/Hero.tsx
+++ b/src/canvas/compare-tab/Hero.tsx
@@ -9,6 +9,17 @@ interface HeroProps {
   state: CompareState
   snapshots: AnalysisSnapshot[]
   showExpert: boolean
+  /**
+   * The canonical run, threaded from CompareTabBody (which already holds it
+   * for CompareFooter) and ultimately OutputsDock's `handleRunAnalysis`.
+   *
+   * REQUIRED, deliberately. The 'stale' hero's action reads "Rerun analysis"
+   * and until 2026-07-28 it was an inert `<span>` styled `cursor-pointer` —
+   * a control that looked live and dispatched nothing (ROADMAP 2.102). An
+   * optional prop would let a future call site re-create exactly that, and
+   * silently; a required one makes the compiler refuse.
+   */
+  onRunAnalysis: () => void
 }
 
 function getHeroCopy(
@@ -82,10 +93,17 @@ function getHeroCopy(
   }
 }
 
-export function Hero({ state, snapshots, showExpert }: HeroProps) {
+export function Hero({ state, snapshots, showExpert, onRunAnalysis }: HeroProps) {
   const latest = snapshots[snapshots.length - 1]
   const first = snapshots[0]
   const copy = getHeroCopy(state, latest, first, snapshots.length)
+
+  // 'stale' is the ONLY hero state whose action is a run rather than a
+  // navigation, so it is the only one that gets a real control here. Derived
+  // from `state` in one place rather than carried as a sixth field on every
+  // `getHeroCopy` branch — a per-branch flag is a mirror five call sites must
+  // keep in step (CLAUDE.md trap 12).
+  const actionIsRerun = state === 'stale'
 
   return (
     <div className="px-4 py-3 border-b border-panel-border">
@@ -116,6 +134,20 @@ export function Hero({ state, snapshots, showExpert }: HeroProps) {
               </span>
             </GraphLink>
           </span>
+        ) : actionIsRerun ? (
+          /* ROADMAP 2.102: this was an inert <span> carrying `cursor-pointer`
+             — "Rerun analysis", styled as a live link, dispatching nothing.
+             It is now the real control, on the SAME canonical run the footer's
+             Rerun and the composer use (threaded from OutputsDock), never a
+             second pipeline. */
+          <button
+            type="button"
+            data-testid="compare-hero-rerun"
+            onClick={onRunAnalysis}
+            className={`${typography.panelHeader} text-info hover:underline cursor-pointer bg-transparent border-none p-0`}
+          >
+            {copy.actionLink}
+          </button>
         ) : (
           <span className={`${typography.panelHeader} text-info hover:underline cursor-pointer`}>
             {copy.actionLink}

--- a/src/canvas/compare-tab/__tests__/Hero.rerunAction.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/Hero.rerunAction.spec.tsx
@@ -1,0 +1,88 @@
+/**
+ * ROADMAP 2.102 — the Compare hero's post-edit "Rerun analysis" must be a
+ * real control.
+ *
+ * THE DEFECT THIS PINS (bytes-confirmed at `03e13443`). The 'stale' hero is
+ * the post-edit state: it reads "Model edited since last analysis · Rerun to
+ * see impact" and offers "Rerun analysis". That action rendered as
+ *
+ *     <span className="… text-info hover:underline cursor-pointer">
+ *
+ * — an inert span with NO onClick, styled exactly like a live link. The
+ * sibling branch does wrap the label in a `GraphLink`, but only when
+ * `actionNodeId` is non-null, and the 'stale' branch pins `actionNodeId: null`,
+ * so the hero's rerun could only ever land in the inert branch. Clicking it
+ * dispatched nothing.
+ *
+ * Scope honesty: unlike the inspector control this one was NOT reachable in a
+ * live staging walk — the Compare tab needs 2+ analysis snapshots and stayed
+ * in its empty state. It is proven dead at the bytes and fixed under test; the
+ * live proof in this PR covers the inspector control only.
+ *
+ * WHAT THIS FILE PINS:
+ *   1. The stale action is a BUTTON and clicking it calls the run passed down
+ *      from CompareTabBody (→ OutputsDock `handleRunAnalysis`) — RED before.
+ *   2. NEGATIVE CONTROL — a non-stale hero does NOT dispatch a run. Without
+ *      it, assertion 1 is satisfiable by making every hero action a rerun,
+ *      which would fire an analysis when the user asked to review a result.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { Hero } from '../Hero'
+import type { AnalysisSnapshot } from '../types'
+
+function snapshot(runNumber: number): AnalysisSnapshot {
+  return {
+    runNumber,
+    winnerLabel: 'Adopt Segment',
+    winnerProbability: 62,
+    runnerUpLabel: 'Adopt RudderStack',
+    runnerUpProbability: 24,
+    winnerId: 'opt_segment',
+    topCalibrationFactor: 'Compliance Readiness',
+    topCalibrationFactorId: 'fac_compliance',
+    topElasticity: 41,
+    stabilityLabel: 'stable',
+  } as unknown as AnalysisSnapshot
+}
+
+const snapshots = [snapshot(1), snapshot(2)]
+
+describe('Compare hero stale action dispatches a run (ROADMAP 2.102)', () => {
+  afterEach(() => cleanup())
+
+  it('renders the stale "Rerun analysis" action as a real control that runs', () => {
+    const onRunAnalysis = vi.fn()
+    render(
+      <Hero state="stale" snapshots={snapshots} showExpert={false} onRunAnalysis={onRunAnalysis} />,
+    )
+
+    // The copy the user actually sees in the post-edit state.
+    expect(screen.getByText(/Model edited since last analysis/i)).toBeInTheDocument()
+
+    // THE assertion that was RED: an inert <span> has no role="button" and
+    // clicking it dispatched nothing.
+    const btn = screen.getByTestId('compare-hero-rerun')
+    expect(btn.tagName).toBe('BUTTON')
+    expect(btn).toHaveTextContent('Rerun analysis')
+
+    fireEvent.click(btn)
+    expect(onRunAnalysis).toHaveBeenCalledTimes(1)
+  })
+
+  it('NEGATIVE CONTROL: a converged hero exposes no rerun control and runs nothing', () => {
+    const onRunAnalysis = vi.fn()
+    render(
+      <Hero
+        state="converged"
+        snapshots={snapshots}
+        showExpert={false}
+        onRunAnalysis={onRunAnalysis}
+      />,
+    )
+
+    expect(screen.queryByTestId('compare-hero-rerun')).not.toBeInTheDocument()
+    expect(onRunAnalysis).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { BookmarkCheck, X } from 'lucide-react'
 import { useCanvasStore } from '../store'
+import { useShowToastSafe } from '../ToastContext'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { getStarter, resolveStarterId } from '../starters/loadStarter'
 import { typography } from '../../styles/typography'
@@ -32,12 +33,13 @@ import { typography } from '../../styles/typography'
 export function StarterProvenanceBanner() {
   const [dismissed, setDismissed] = useState(false)
   const { sendMessage } = useConversationContext()
+  const showToast = useShowToastSafe()
 
   // `resolveStarterId` is the single shape for this question, shared with the
   // run gate — see its docstring for why reading nodes[0] alone was wrong.
   const starterId = useCanvasStore((s) => resolveStarterId(s.nodes))
 
-  const handleRedraft = useCallback(() => {
+  const handleRedraft = useCallback(async () => {
     if (!starterId) return
     const starter = getStarter(starterId)
     if (!starter) return
@@ -46,12 +48,14 @@ export function StarterProvenanceBanner() {
     // and on the shapes these starters use it succeeds roughly 36–57% of the
     // time (STARTER-BRIEF-VALIDATION-2026-07-24.md) — so "you may not get a
     // model back" is a real outcome the user is entitled to know about first,
-    // not a surprise.
+    // not a surprise. The last line states the RECOVERY the code below now
+    // actually performs; it previously promised only the brief back.
     const confirmed = window.confirm(
       'Re-draft this example live?\n\n' +
         'Olumi will send the original brief to the model and build a fresh graph. ' +
         'This clears the saved example and replaces it with whatever the live draft returns. ' +
-        'Live drafting can fail or time out; if it does, your brief comes back in the composer so you can retry.',
+        'Live drafting can fail or time out; if it does, the saved example is put back and ' +
+        'your brief comes back in the composer so you can retry.',
     )
     if (!confirmed) return
 
@@ -62,22 +66,57 @@ export function StarterProvenanceBanner() {
     // structurally instead: `resetCanvas` empties the graph, `starterId` goes
     // null, and the early return below unmounts the banner and its button.
     {
+      // The example as it stands, captured BEFORE the reset destroys it.
+      const { nodes, edges } = useCanvasStore.getState()
+
       // Reset FIRST so the canvas is genuinely empty: the composer treats an
       // empty canvas as "draft a model" rather than "chat about this one", and
       // the first-use hero re-engages to show thinking state and — on failure —
       // the existing transport-honest failure copy with the brief restored.
       useCanvasStore.getState().resetCanvas()
 
+      // Arm the restore AFTER the reset, not before: `resetCanvas` itself sets
+      // `draftChatPreDraftSnapshot: null` (store.ts, "A.5+: Clear draft
+      // snapshot"), so a snapshot taken earlier would be wiped by the very
+      // call it exists to survive. Reusing the existing snapshot + `undoDraft`
+      // pair rather than a second restore mechanism also means the "Undo
+      // draft" chip reverts a SUCCESSFUL re-draft back to the example, which
+      // is the behaviour DraftChat already gives every other draft.
+      useCanvasStore.getState().setDraftChatPreDraftSnapshot({ nodes, edges })
+
       // The verbatim brief that produced this example, from the same generated
       // manifest as the graph. It cannot drift into a different brief than the
       // one the user was just looking at.
-      sendMessage(starter.brief, {
+      await sendMessage(starter.brief, {
         turnType: 'explicit_generate',
         debugSource: 'generate_model',
         debugSourceSurface: 'starter_redraft',
       })
+
+      // ⚠ WHY THIS TESTS THE CANVAS AND NOT AN ERROR.
+      //
+      // A failed user turn does NOT reject. `sendTurn` catches the dispatch
+      // error, renders the transport-honest failure bubble, and returns
+      // normally — `systemSendFailure` is set for `mode === 'system'` ONLY
+      // ("User turns never set it", useConversation.ts). So there is no error
+      // channel here to catch, and a `.catch()` on this await would be exactly
+      // the guarantee-theatre this programme hunts: machinery that reads as a
+      // safety net and can never fire.
+      //
+      // So the check is the OBSERVABLE OUTCOME: the reset emptied the canvas,
+      // and if the turn produced no graph it is still empty. That also makes
+      // the restore fail-SAFE — if anything DID land (a drafted graph, or a
+      // node the user added while the draft was in flight) we leave it alone
+      // rather than clobbering it with the old example.
+      if (useCanvasStore.getState().nodes.length === 0) {
+        useCanvasStore.getState().undoDraft()
+        showToast(
+          'The live re-draft didn’t return a model, so your saved example has been put back. Your brief is in the composer if you want to try again.',
+          'warning',
+        )
+      }
     }
-  }, [starterId, sendMessage])
+  }, [starterId, sendMessage, showToast])
 
   if (!starterId || dismissed) return null
   const starter = getStarter(starterId)

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.failedRedraft.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.failedRedraft.spec.tsx
@@ -1,0 +1,173 @@
+/**
+ * A FAILED live re-draft must not cost the user their saved example.
+ *
+ * THE DEFECT THIS PINS. `handleRedraft` called `resetCanvas()` — which
+ * destroys the example — and then fired `sendMessage(...)` without awaiting
+ * it. By the time the turn could fail, the example was already gone, and
+ * recovery was left entirely to the composer restoring the brief TEXT.
+ *
+ * Why that is the majority case rather than an edge case: ruling D-73
+ * pre-drafted these starters precisely BECAUSE live drafting on these briefs
+ * fails 43–64% of the time (Fisher p=0.0297; the component cites 36–57%
+ * success from STARTER-BRIEF-VALIDATION-2026-07-24.md). So the escape hatch
+ * left a first-time tester with LESS than they started with, more often than
+ * not.
+ *
+ * ⚠ THE SUBTLETY THAT DECIDES THE SHAPE OF THE FIX — and of this file.
+ * A failed USER turn does not reject. `sendTurn` catches the dispatch error,
+ * renders the transport-honest failure bubble and returns normally;
+ * `systemSendFailure` is set for `mode === 'system'` ONLY ("User turns never
+ * set it", useConversation.ts). So `sendMessage` RESOLVES on failure, and a
+ * `.catch()` would be a safety net that can never fire. These tests therefore
+ * simulate failure the way it actually presents — a resolving `sendMessage`
+ * that produces no graph — NOT a rejecting one. A spec written against a
+ * rejection would pass against a `.catch()` that is dead in production.
+ *
+ * WHAT THIS FILE PINS:
+ *   1. The example is RESTORED when the re-draft returns no model — RED before.
+ *   2. It is restored INTACT: same nodes, and the starter provenance stamp
+ *      still on them (a restore that dropped the stamp would silently turn a
+ *      saved example into something the run gate treats as a real model).
+ *   3. NEGATIVE CONTROL / fail-safe: when the re-draft SUCCEEDS, the fresh
+ *      graph is left alone. Without this, assertion 1 is satisfiable by a
+ *      restore that always runs and clobbers every successful re-draft.
+ *   4. The snapshot is armed AFTER `resetCanvas`, because `resetCanvas` itself
+ *      nulls `draftChatPreDraftSnapshot`. Arming it before is the one ordering
+ *      that silently produces no restore at all.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const sendMessageMock = vi.fn()
+vi.mock('../../conversation/ConversationContext', () => ({
+  useConversationContext: () => ({ sendMessage: sendMessageMock }),
+}))
+
+const showToast = vi.fn()
+vi.mock('../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useShowToastSafe: () => showToast }
+})
+
+import { StarterProvenanceBanner } from '../StarterProvenanceBanner'
+import { useCanvasStore } from '../../store'
+import { STARTERS } from '../../starters/loadStarter'
+
+const MARKET = STARTERS.find((s) => s.id === 'market-entry')!
+
+function seedStarterGraph(count = 3) {
+  useCanvasStore.setState({
+    nodes: Array.from({ length: count }, (_, i) => ({
+      id: `n${i}`,
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      data: { label: `n${i}`, starterId: 'market-entry', starterTitle: MARKET.title },
+    })) as never,
+    edges: [{ id: 'e0', source: 'n0', target: 'n1' }] as never,
+  })
+}
+
+describe('a failed starter re-draft restores the example (ROADMAP 2.102)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Not held in a typed local: `ReturnType<typeof vi.spyOn>` widens to
+    // MockInstance<unknown[], unknown>, which window.confirm's signature does
+    // not satisfy (TS2322). `restoreAllMocks` in afterEach undoes the spy
+    // without needing the handle.
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    seedStarterGraph()
+    // NOTE: `resetCanvas` is deliberately NOT mocked here (unlike the sibling
+    // spec). The whole defect lives in what the REAL reset destroys, so a
+    // no-op reset would make every assertion below vacuous.
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('puts the saved example back when the live draft returns no model', async () => {
+    // Failure as it actually presents: the turn resolves, no graph arrives.
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1))
+    // THE assertion that was RED: the canvas was left empty and the example
+    // was gone for good.
+    await waitFor(() => expect(useCanvasStore.getState().nodes).toHaveLength(3))
+  })
+
+  it('restores it INTACT — the starter provenance stamp survives', async () => {
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    await waitFor(() => expect(useCanvasStore.getState().nodes).toHaveLength(3))
+    const restored = useCanvasStore.getState().nodes
+    // Without the stamp the run gate stops treating it as a saved example and
+    // the disclosure banner stops rendering — a silent honesty regression.
+    expect(restored.every((n) => (n.data as Record<string, unknown>)?.starterId === 'market-entry')).toBe(true)
+    expect(useCanvasStore.getState().edges).toHaveLength(1)
+  })
+
+  it('tells the user their example came back, rather than restoring silently', async () => {
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(1))
+    expect(showToast.mock.calls[0][0]).toMatch(/saved example has been put back/i)
+  })
+
+  it('NEGATIVE CONTROL: a SUCCESSFUL re-draft is left alone, never clobbered', async () => {
+    // The turn lands a fresh graph, exactly as a real draft response would.
+    sendMessageMock.mockImplementation(async () => {
+      useCanvasStore.setState({
+        nodes: [
+          { id: 'fresh1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'fresh1' } },
+          { id: 'fresh2', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'fresh2' } },
+        ] as never,
+        edges: [] as never,
+      })
+      return undefined
+    })
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1))
+    const after = useCanvasStore.getState().nodes
+    expect(after).toHaveLength(2)
+    expect(after.map((n) => n.id)).toEqual(['fresh1', 'fresh2'])
+    // No "we put it back" claim over a re-draft that worked.
+    expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it('arms the restore AFTER resetCanvas — the ordering resetCanvas would otherwise erase', async () => {
+    // resetCanvas sets `draftChatPreDraftSnapshot: null`. If the snapshot were
+    // taken before it, this would be null at send time and no restore could
+    // happen. Observing it non-null while the turn is in flight is what proves
+    // the ordering, independently of the outcome assertions above.
+    let snapshotDuringSend: unknown = 'not-observed'
+    sendMessageMock.mockImplementation(async () => {
+      snapshotDuringSend = useCanvasStore.getState().draftChatPreDraftSnapshot
+      return undefined
+    })
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1))
+    expect(snapshotDuringSend).not.toBeNull()
+    expect((snapshotDuringSend as { nodes: unknown[] }).nodes).toHaveLength(3)
+  })
+})

--- a/src/canvas/components/model-tab/__tests__/evpiSurfacesRemoved.canvas.honesty.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/evpiSurfacesRemoved.canvas.honesty.spec.tsx
@@ -228,7 +228,7 @@ describe('compare-tab Hero — no pp claim, and the CTA still targets a factor',
 
   it('POSITIVE CONTROL: the improving hero renders its CTA and its influence figure', () => {
     const s = snapshot()
-    const { container } = render(<Hero state="improving" snapshots={[s, s]} showExpert={false} />)
+    const { container } = render(<Hero state="improving" snapshots={[s, s]} showExpert={false} onRunAnalysis={() => {}} />)
     const text = container.textContent ?? ''
     expect(text).toContain('Existing Team Experience Level')
     expect(text).toContain('67% influence')
@@ -236,7 +236,7 @@ describe('compare-tab Hero — no pp claim, and the CTA still targets a factor',
 
   it('states influence without asserting a percentage-point value for resolving it', () => {
     const s = snapshot()
-    const { container } = render(<Hero state="improving" snapshots={[s, s]} showExpert={false} />)
+    const { container } = render(<Hero state="improving" snapshots={[s, s]} showExpert={false} onRunAnalysis={() => {}} />)
     const text = container.textContent ?? ''
     expect(text).not.toMatch(/resolving could improve confidence/i)
     expect(text).not.toMatch(PP_TOKEN)

--- a/src/canvas/ui/inspector-v2/__tests__/InlineRerunPrompt.dispatchesRun.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InlineRerunPrompt.dispatchesRun.spec.tsx
@@ -1,0 +1,203 @@
+/**
+ * ROADMAP 2.102 — the post-edit "Re-run" control must DISPATCH A RUN.
+ *
+ * THE DEFECT THIS PINS (live-confirmed on staging `03e13443`, 2026-07-28).
+ * #513 made an inspector value edit a real turn; the inspector then told the
+ * user "Re-run to see how this affects the results" — and rendered no control
+ * that would do it. `InlineRerunPrompt`'s button sat behind `{onRerun && (…)}`
+ * with `onRerun` OPTIONAL, and ALL FOUR render sites (EdgePanel,
+ * FactorControllablePanel, FactorObservablePanel, RiskPanel) passed only
+ * `visible`. In the live walk the prompt text was present and
+ * `button:has-text("Re-run")` counted ZERO. Advice with no affordance.
+ *
+ * WHAT THIS FILE PINS, and why each assertion is load-bearing:
+ *
+ *   1. THE CONTROL EXISTS AND DISPATCHES — the assertion that was RED. It
+ *      goes through `executeCanonicalRun`, the SAME registry the canvas
+ *      shortcut, command palette, Actions menu and Define-success modal use,
+ *      which resolves to OutputsDock's `runCanonicalAnalysis` — the identical
+ *      pipeline the composer's rerun takes. Asserting the registered runner is
+ *      invoked is what proves convergence; a parallel fetch would pass a
+ *      "something happened" test and fail this one.
+ *   2. NO PROP TO FORGET — rendering the prompt with `visible` ALONE (exactly
+ *      what all four panels pass) still yields a live button. This is the
+ *      mutation guard on the actual defect: restore the `onRerun &&` wrapper
+ *      and this RED-s, because the panels supply no such prop.
+ *   3. IT REACHES THE WIRE THROUGH A REAL PANEL — asserted through
+ *      `FactorControllablePanel`, not just the leaf. A leaf-only test would
+ *      pass while the panel rendered a different component or dropped it.
+ *   4. NEGATIVE CONTROL — `visible={false}` renders no button. Without it,
+ *      assertion 1 is satisfiable by a control that is ALWAYS present, which
+ *      would invite a rerun over an analysis that is already current.
+ *   5. IT NEVER SWALLOWS A REFUSAL — a blocked/unavailable outcome is surfaced
+ *      as a toast carrying the runner's own reason. A rerun that silently
+ *      no-ops is the same class of defect in a new spelling.
+ *   6. IT DOES NOT RACE AN IN-FLIGHT TURN — disabled while a run is running.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+const showToast = vi.fn()
+
+// Trap 12 (the hand-maintained mirror): spread the real module rather than
+// hand-listing its exports — a `vi.mock` factory REPLACES the module.
+vi.mock('../../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useShowToastSafe: () => showToast }
+})
+
+// The panel's own emitter is out of scope here (#513 covers it); silence it so
+// this file fails only for its own reason.
+vi.mock('../../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useOptionalConversationContext: () => ({ sendSystemEvent: vi.fn() }) }
+})
+
+import { InlineRerunPrompt } from '../shared/InlineRerunPrompt'
+import { FactorControllablePanel } from '../panels/FactorControllablePanel'
+import { useCanvasStore } from '../../../store'
+import {
+  registerCanonicalRunner,
+  __resetCanonicalRunnerForTests,
+  RUNNER_UNAVAILABLE_MESSAGE,
+} from '../../../analysis/canonicalRunRegistry'
+
+const NODE_ID = 'fac_compliance_readiness'
+const CAP = 1
+const noop = () => {}
+
+function factorNode(): Node {
+  return {
+    id: NODE_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Compliance Readiness',
+      kind: 'factor',
+      factor_type: 'lever',
+      observedState: { value: 0.3, raw_value: 0.3, cap: CAP },
+    },
+  } as unknown as Node
+}
+
+/**
+ * The post-edit state the live walk produced: an analysis exists, CEE's
+ * verdict is no longer confirmable ('unknown' after a local edit), and an edit
+ * was confirmed in THIS panel. That is exactly `isStaleAfterEdit`.
+ */
+function seedPostEditState(runStatus: string = 'complete') {
+  useCanvasStore.setState(
+    {
+      nodes: [factorNode()],
+      edges: [],
+      results: { status: runStatus, report: null },
+      analysisFreshness: { freshness: 'stale', computedAt: new Date().toISOString() },
+      analysisFreshnessDirty: true,
+    } as any,
+    false,
+  )
+}
+
+describe('post-edit inline Re-run dispatches the canonical run (ROADMAP 2.102)', () => {
+  beforeEach(() => {
+    showToast.mockClear()
+    __resetCanonicalRunnerForTests()
+    seedPostEditState()
+  })
+  afterEach(() => {
+    cleanup()
+    __resetCanonicalRunnerForTests()
+  })
+
+  it('renders a live Re-run control given ONLY `visible` — the prop no call site passes', async () => {
+    const runner = vi.fn().mockResolvedValue({ status: 'dispatched' })
+    registerCanonicalRunner(runner)
+
+    // Exactly what all four inspector panels pass. Before the fix this
+    // rendered the advice and no button at all.
+    render(<InlineRerunPrompt visible />)
+
+    const btn = screen.getByTestId('inline-rerun')
+    expect(btn).toBeInTheDocument()
+
+    fireEvent.click(btn)
+    await waitFor(() => expect(runner).toHaveBeenCalledTimes(1))
+  })
+
+  it('dispatches through the CANONICAL registry, not a parallel path', async () => {
+    const runner = vi.fn().mockResolvedValue({ status: 'dispatched' })
+    registerCanonicalRunner(runner)
+
+    render(<InlineRerunPrompt visible />)
+    fireEvent.click(screen.getByTestId('inline-rerun'))
+
+    // The registered runner IS OutputsDock's `runCanonicalAnalysis` in the
+    // app; being called through it is what proves the inspector rerun and the
+    // composer/footer rerun are the same pipeline.
+    await waitFor(() => expect(runner).toHaveBeenCalledTimes(1))
+    expect(runner.mock.calls[0][0]).toMatchObject({ source: 'inspector-inline-rerun' })
+  })
+
+  it('NEGATIVE CONTROL: renders nothing when not stale-after-edit', () => {
+    registerCanonicalRunner(vi.fn().mockResolvedValue({ status: 'dispatched' }))
+    render(<InlineRerunPrompt visible={false} />)
+    expect(screen.queryByTestId('inline-rerun')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a BLOCKED refusal instead of silently no-opping', async () => {
+    const runner = vi
+      .fn()
+      .mockResolvedValue({ status: 'blocked', reason: 'Draft or save a model first, then run analysis.' })
+    registerCanonicalRunner(runner)
+
+    render(<InlineRerunPrompt visible />)
+    fireEvent.click(screen.getByTestId('inline-rerun'))
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('Draft or save a model first, then run analysis.', 'warning'),
+    )
+  })
+
+  it('surfaces the UNAVAILABLE reason when no run host is mounted', async () => {
+    // No runner registered at all — executeCanonicalRun folds this into the
+    // outcome union rather than throwing or no-opping.
+    render(<InlineRerunPrompt visible />)
+    fireEvent.click(screen.getByTestId('inline-rerun'))
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(RUNNER_UNAVAILABLE_MESSAGE, 'warning'))
+  })
+
+  it('does not race an in-flight turn: disabled while a run is streaming', () => {
+    const runner = vi.fn().mockResolvedValue({ status: 'dispatched' })
+    registerCanonicalRunner(runner)
+    seedPostEditState('streaming')
+
+    render(<InlineRerunPrompt visible />)
+    const btn = screen.getByTestId('inline-rerun')
+    expect(btn).toBeDisabled()
+
+    fireEvent.click(btn)
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('reaches the runner THROUGH a real inspector panel, not just the leaf', async () => {
+    const runner = vi.fn().mockResolvedValue({ status: 'dispatched' })
+    registerCanonicalRunner(runner)
+
+    render(
+      <FactorControllablePanel nodeId={NODE_ID} techMode={false} onClose={noop} onNavigate={noop} />,
+    )
+
+    // Commit an edit so the panel's own `lastConfirmed` gate opens — this is
+    // the #513 loop, and the prompt only shows after an edit in THIS panel.
+    const input = screen.getByPlaceholderText('Enter value') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '0.9' } })
+    fireEvent.blur(input)
+
+    const btn = await screen.findByTestId('inline-rerun')
+    fireEvent.click(btn)
+    await waitFor(() => expect(runner).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/canvas/ui/inspector-v2/shared/InlineRerunPrompt.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InlineRerunPrompt.tsx
@@ -1,16 +1,63 @@
 /**
  * InlineRerunPrompt — compact re-run nudge shown below an edited control
  * when analysis results are stale. Does not replace StaleGuardBanner.
+ *
+ * ⚠ THE DEFECT THIS FILE'S SHAPE EXISTS TO PREVENT (ROADMAP 2.102, fixed
+ * 2026-07-28). The button used to be wrapped in `{onRerun && (…)}` with
+ * `onRerun` an OPTIONAL prop — and all four render sites (EdgePanel,
+ * FactorControllablePanel, FactorObservablePanel, RiskPanel) passed only
+ * `visible`. So the prompt rendered its instruction — "Re-run to see how this
+ * affects the results" — and NEVER rendered the control that would do it.
+ * After the #513 value-edit loop landed, that made the inspector's post-edit
+ * advice unfollowable: the copy told the user to re-run and gave them nothing
+ * to click. Live-confirmed on staging `03e13443` (the prompt text visible, a
+ * `button:has-text("Re-run")` count of ZERO).
+ *
+ * That was a hand-maintained mirror (CLAUDE.md trap 12): four call sites each
+ * had to remember to pass the wiring, and all four forgot. The fix removes the
+ * mirror rather than repairing it — this component now OWNS its dispatch, so
+ * there is no prop for a call site to omit and no way to render a dead button.
+ *
+ * ONE dispatch, never a parallel path: it calls `executeCanonicalRun`, the same
+ * registry every other run affordance goes through (canvas ⌘Enter, command
+ * palette, Actions menu, Define-success modal) and which resolves to
+ * OutputsDock's `runCanonicalAnalysis` — the identical pipeline the composer's
+ * rerun uses, with the same gate, the same `flushPendingSaves` barrier and the
+ * same stored-goal_threshold re-attachment.
+ *
+ * It never no-ops silently. `executeCanonicalRun` folds every refusal into one
+ * outcome union carrying a human-readable reason; each is surfaced as a toast.
+ * A run already in flight disables the button instead of racing it.
  */
 
+import { useCallback } from 'react'
 import { typography } from '../../../../styles/typography'
+import { useShowToastSafe } from '../../../ToastContext'
+import { useAnalysisTrust } from '../../../hooks/useAnalysisTrust'
+import { executeCanonicalRun } from '../../../analysis/canonicalRunRegistry'
 
 interface InlineRerunPromptProps {
   visible: boolean
-  onRerun?: () => void
 }
 
-export function InlineRerunPrompt({ visible, onRerun }: InlineRerunPromptProps) {
+export function InlineRerunPrompt({ visible }: InlineRerunPromptProps) {
+  const showToast = useShowToastSafe()
+  // Same composed trust surface the Model tab's ReanalyseBar reads, so the two
+  // rerun affordances can never disagree about whether a run is in flight.
+  const { isRunning } = useAnalysisTrust()
+
+  const handleRerun = useCallback(async () => {
+    const outcome = await executeCanonicalRun({ source: 'inspector-inline-rerun' })
+    // 'dispatched' / 'v2' are the two success shapes. Everything else carries a
+    // reason the user is entitled to see — a rerun control that swallows its
+    // own refusal is the guarantee-theatre this lane exists to remove.
+    if (outcome.status === 'blocked' || outcome.status === 'unavailable') {
+      showToast(outcome.reason, 'warning')
+    } else if (outcome.status === 'already-running') {
+      showToast('Analysis is already running.', 'info')
+    }
+  }, [showToast])
+
   if (!visible) return null
 
   return (
@@ -18,15 +65,16 @@ export function InlineRerunPrompt({ visible, onRerun }: InlineRerunPromptProps) 
       <span className={`${typography.panelMeta} text-text-light`}>
         Re-run to see how this affects the results
       </span>
-      {onRerun && (
-        <button
-          type="button"
-          onClick={onRerun}
-          className={`${typography.panelMeta} px-2 py-0.5 rounded-full border border-primary/30 bg-transparent text-primary hover:bg-panel-hover transition-colors cursor-pointer`}
-        >
-          Re-run
-        </button>
-      )}
+      <button
+        type="button"
+        data-testid="inline-rerun"
+        onClick={handleRerun}
+        disabled={isRunning}
+        aria-label="Re-run the analysis"
+        className={`${typography.panelMeta} px-2 py-0.5 rounded-full border border-primary/30 bg-transparent text-primary hover:bg-panel-hover transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-40`}
+      >
+        {isRunning ? 'Re-running…' : 'Re-run'}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
Two dead-control defects on the core loop, plus one refutation the record should stop repeating.

---

# 1. The post-edit "Re-run" control rendered nothing to click

#513 made an inspector value edit a real turn. The inspector then told the user **"Re-run to see how this affects the results"** and rendered **no control**.

`InlineRerunPrompt`'s button sat behind `{onRerun && (…)}` with `onRerun` **optional** — and all four render sites passed only `visible`:

| render site | passes |
|---|---|
| `src/canvas/ui/inspector-v2/panels/EdgePanel.tsx:344` | `visible` only |
| `src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx:392` | `visible` only |
| `src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx:219` | `visible` only |
| `src/canvas/ui/inspector-v2/panels/RiskPanel.tsx:188` | `visible` only |

Break at `src/canvas/ui/inspector-v2/shared/InlineRerunPrompt.tsx:21`. Live-confirmed on staging `03e13443`: after editing a factor value the prompt text was present and `button:has-text("Re-run")` counted **ZERO**.

> The Analysis-tab footer "Rerun" was **fine throughout** — it dispatched a turn on click in the same walk. The dead control was the inspector's.

**The fix removes the mirror rather than repairing it.** Four call sites each had to remember the wiring and all four forgot (trap 12); threading `onRerun` from four panels would leave the trap armed for the fifth. `InlineRerunPrompt` now **owns its dispatch** — no prop to omit, no way to render a dead button.

**One dispatch, never a parallel path:** `executeCanonicalRun` → OutputsDock's `runCanonicalAnalysis` — the same registry the canvas ⌘Enter, command palette, Actions menu and Define-success modal use, and the identical pipeline the composer's rerun takes. The inspector inherits its gate, its `flushPendingSaves` barrier and its stored-`goal_threshold` re-attachment. Blocked / unavailable / already-running each surface a toast carrying the runner's own reason; a run in flight **disables** the button rather than racing it.

### Second dead control, same class

`src/canvas/compare-tab/Hero.tsx:120` rendered the `'stale'` hero's **"Rerun analysis"** — the post-edit state — as an inert `<span className="… cursor-pointer">` with no `onClick`. The sibling `GraphLink` branch is unreachable for it because the `'stale'` branch pins `actionNodeId: null`. Now a real button on the same canonical run, threaded from `CompareTabBody`. `onRunAnalysis` is **required**, so the compiler refuses a future call site that forgets it.

**Scope honesty:** this one was **not** reachable in a live walk — the Compare tab needs 2+ analysis snapshots and stayed in its empty state. Proven dead at the bytes and fixed under test only.

---

# 2. A failed live re-draft destroyed the user's saved example

`StarterProvenanceBanner.handleRedraft` called `resetCanvas()` — which destroys the example — then fired `sendMessage(...)` **unawaited**. By the time the turn could fail the example was gone, and recovery was left to the composer restoring the brief *text*.

Ruling **D-73** pre-drafted these starters precisely BECAUSE live drafting fails **43–64%** of the time (Fisher p=0.0297). So destroy-then-maybe-fail was the **majority** outcome. Measured again here: **three consecutive live re-drafts of the vendor-selection starter returned no model, 3/3.**

### Why the fix checks the canvas and not an error

A failed **user** turn does not reject. `sendTurn` catches the dispatch error, renders the transport-honest failure bubble and returns normally — `systemSendFailure` is set for `mode === 'system'` **only** ("User turns never set it"). So `sendMessage` **resolves** on failure, and a `.catch()` here would be a safety net that can never fire.

The check is the **observable outcome**: the reset emptied the canvas, so if the turn produced no graph it is still empty. That also makes the restore **fail-safe** — if anything did land (a drafted graph, or a node added mid-flight) it is left alone.

### Ordering, and the trap inside it

The reset-first ordering is deliberate and documented, and is **unchanged**. But the snapshot must be armed **after** the reset: `resetCanvas` itself sets `draftChatPreDraftSnapshot: null`, so a snapshot taken earlier is wiped by the very call it exists to survive. That ordering has its own pin and its own mutant.

Reuses the existing `draftChatPreDraftSnapshot` + `undoDraft` pair. Bonus: on success the snapshot survives, so the "Undo draft" chip reverts a successful re-draft back to the example — what DraftChat already gives every other draft. The confirm copy now states the recovery the code actually performs.

---

# 3. Refuted: the "Re-draft this live" button was never dead

Both prior lanes reported it emitting zero requests. **That was an artefact of browser automation auto-dismissing `window.confirm`.** Controlled A/B on the same build:

| confirm dialog | turns emitted |
|---|---|
| dismissed (automation default) | **0** |
| accepted (what a user does) | **1** → `POST cee-staging.onrender.com/proxy/v5/turn` |

The wiring is untouched, and `StarterProvenanceBanner.spec.tsx` already pinned both the send and the declined-confirm case (12/12 green). **The record should stop repeating that this control is dead.**

---

# Evidence

**RED-first**, throwaway worktrees outside the repo root:

| spec set | at `03e13443` |
|---|---|
| rerun controls (9 assertions) | **7 fail** — `Unable to find [data-testid="inline-rerun"]` / `[data-testid="compare-hero-rerun"]` |
| failed re-draft (5 assertions) | **4 fail** — `expected [] to have a length of 3` |

In both sets the passing remainder are the **negative controls**, which *should* be green at HEAD.

**Mutation — six mutants, all bite:**

| mutant | result |
|---|---|
| rerun dispatch → no-op, button kept | **5 fail** (guards vacuity: the tests check the *dispatch*, not the button) |
| restore the `onRerun &&` wrapper | **6 fail** |
| `actionIsRerun = false` | **1 fail** |
| remove the `undoDraft()` restore | **2 fail** |
| arm the snapshot **before** `resetCanvas` | **3 fail** (the silent-no-restore ordering trap) |
| restore **always** (drop the empty guard) | **1 fail** (negative control catches it clobbering a successful re-draft) |

Reverting each returns green — 9/9 and 17/17 (the latter including all 12 pre-existing pins).

**Live, fixed bundle served under the staging origin** (cee-staging's browser proxy rejects localhost origins):

- *Rerun:* draft → analyse → edit the factor value → click the post-edit Re-run. Control present **1** (was ZERO), exactly **1** POST to `/proxy/v5/turn`, freshness **unknown → fresh**. Reproduced across **three** runs.
- *Re-draft, RED/GREEN pair* — same walk, same forced network failure, only the bundle differs:

| bundle | nodes after | banner | toast | verdict |
|---|---|---|---|---|
| HEAD `03e13443` | **0** | gone | none | example **LOST** |
| this branch | **20** | back | shown | example **RESTORED** |

**Not claimed:**
- That the headline numbers visibly moved on rerun. They did not — option win probabilities read `1,1,1,100` before and after, because *Defer Decision (Status Quo)* dominates the drafted model. An earlier walk scraper reported `NUMBERS MOVED: true` on a run where every probability was identical (the only delta was a rank badge in a label). That was the **instrument** changing, not the product; it was corrected and the false positive discarded.
- The successful-re-draft-left-alone path, live — the live draft returned no model on all three attempts, which is the very failure rate that motivates the fix. Covered by the unit negative control and mutation-guarded.

**Not done, deliberately:** replacing `window.confirm` with the app's own dialog. It is unstyled and it blocks automated walks (it caused two lanes to report a working control as dead), but an accessible modal plus rewiring 12 confirm-spying pins is not small and does not belong here.

**Gates:** `pnpm typecheck` PASSES — ratchet **2516 = baseline 2516**, coverage **3001/3041**. The gate caught a real TS2322 in a new spec; fixed at source, **not** absorbed into a baseline. eslint clean. Suites: inspector-v2 + compare-tab + model-tab **722 tests**, StarterProvenanceBanner + starters **59 tests** — all green. Full CI was green on the first commit (12/12).

# Also found, rowed separately

- The Goal/Decision node "Run analysis" chips bypass the canonical runner — no readiness gate, no `flushPendingSaves`, no `goal_threshold`; silent no-op if no dispatcher is registered.
- `VITE_FEATURE_COMPARE_TAB` and `VITE_FEATURE_PRE_ANALYSIS_V3` are **live on staging** but absent from `netlify.toml` (dashboard-set) — the checked-in config no longer describes deployed reality.
- Hero's other four action links (`improving` / `noWinner` / `converged` / `flipped`) remain inert spans styled `cursor-pointer`. Same false-affordance class, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)