### PR TITLE
feat(flags): derive deployed-vs-repo flag drift from the served bundle

### DIFF
--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -197,6 +197,63 @@ jobs:
         # high/critical advisory. Moderate/low surfaced but non-blocking.
         run: pnpm run security:audit
 
+  # ── Flag deployment drift (REPORTING ONLY — never blocks) ─────────────
+  # Reads the DEPLOYED staging bundle and prints which feature flags actually
+  # resolve ON there, versus what src/flags.ts and netlify.toml claim. Netlify
+  # DASHBOARD variables override both and are invisible to this repo, which is
+  # why the repo files cannot answer "what does a tester see?" — on 2026-07-28
+  # that gap mis-scoped two dispatches, and the check found 13 divergences.
+  #
+  # ⚠ THIS JOB MUST NEVER BLOCK, and is deliberately absent from the
+  # "Staging Gate" aggregator's required-results list at the end of this file.
+  # Flipping a dashboard flag is a NORMAL operation; reddening the gate for it
+  # would turn this into the broken alarm it exists to replace — a red everyone
+  # learns to ignore (trap 7). The script exits 0 on divergences by design, and
+  # continue-on-error covers even a crash or a network blip.
+  #
+  # ⚠ SCOPE: it reports the CURRENTLY-DEPLOYED staging site. On a PR that is the
+  # PRE-MERGE state — it is NOT a prediction of what this PR will deploy.
+  flag-drift:
+    name: Flag Deployment Drift (report only)
+    needs: install
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # If staging is unreachable the script reports UNVERIFIED and names every
+      # flag it could not check. It never prints a green it has not earned.
+      - name: Compare deployed flags against repo config
+        run: |
+          pnpm run flags:check | tee flag-drift.txt
+          {
+            echo '### Flag deployment drift — deployed staging vs repo config'
+            echo ''
+            echo 'The **DEPLOYED** column is the truth. `flags.ts` / `netlify.toml` are advisory:'
+            echo 'Netlify dashboard variables override both and this repo cannot see them.'
+            echo ''
+            echo '```'
+            cat flag-drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ── Full test suite (sharded 4-way) ───────────────────────────────────
   vitest:
     name: Full Test Suite (shard ${{ matrix.shard }}/${{ strategy.job-total }})

--- a/netlify.toml
+++ b/netlify.toml
@@ -107,6 +107,47 @@
   # `[build.environment]`. See src/flags.ts `heroFixtureGallery`.
   VITE_FEATURE_HERO_FIXTURE_GALLERY = "1"
 
+  # ---------------------------------------------------------------------------
+  # Dashboard-set flags recorded 2026-07-28 (ROADMAP 2.107).
+  #
+  # These three were set through the NETLIFY DASHBOARD and appeared nowhere in
+  # this file, while all three default OFF in src/flags.ts. Any lane reading
+  # flags.ts or netlify.toml to decide what a staging tester sees therefore got
+  # the wrong answer, and the flag-off code paths looked DEAD when they were
+  # LIVE — that mis-scoped two dispatches on 2026-07-28.
+  #
+  # The values below are TRANSCRIBED FROM THE SERVED BUNDLE, not assumed:
+  # staging--olumi.netlify.app/assets/flags-BOFkajto.js (deploy of tip
+  # c86da6a4), which carries Vite's baked `import.meta.env` literal. They are
+  # byte-identical to what is already deployed, so recording them changes no
+  # behaviour — it only stops the repo lying about it.
+  #
+  # ⚠ Recording a flag here does NOT make this file authoritative. Dashboard
+  # variables still override it and remain invisible to this repo. Derive the
+  # truth instead of trusting these lines: `pnpm flags:check`.
+  # (tools/ci-guards/flag-deployment-drift.mjs — reads the deployed bundle.)
+  #
+  # That check found 13 dashboard-set divergences on 2026-07-28, not 3. The
+  # other 10 are deliberately NOT transcribed here: hand-copying them would
+  # rebuild the mirror this work exists to retire. Run `pnpm flags:check` for
+  # the current derived list.
+  #
+  # Promote any of these to production by adding to [build.environment] ONLY
+  # after sign-off.
+  # ---------------------------------------------------------------------------
+
+  # V5 canonical analysis path — routes every user-visible analysis trigger
+  # through the V5 chip-action dispatch so CEE persists a run_analysis fact.
+  # See src/flags.ts `v5CanonicalAnalysis`.
+  VITE_V5_CANONICAL_ANALYSIS = "true"
+
+  # Compare tab — renders live on staging today. See src/flags.ts `compareTab`.
+  VITE_FEATURE_COMPARE_TAB = "1"
+
+  # Pre-analysis v3 — `pre-analysis-v3-analyse` is the live pre-run CTA on
+  # staging today. See src/flags.ts `preAnalysisV3`.
+  VITE_FEATURE_PRE_ANALYSIS_V3 = "1"
+
 # =============================================================================
 # Security Headers (P0 - Enterprise Compliance)
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ci:no-console": "sh -c \"if (grep -R -n -E --exclude='*.map' --exclude='dist/assets/vendor-*.js' --exclude='dist/assets/auth-*.js' 'console\\.[A-Za-z]+\\(' dist || grep -R -n -E --exclude='*.map' '(^|[^A-Za-z])debugger(;|$)' dist); then echo 'Found console or debugger in production build'; exit 1; else echo 'OK: no console/debugger in dist'; fi\"",
     "ci:guard:sandbox": "node tools/ci-guards/check-gotosandbox.mjs",
     "ci:guard:flags": "node tools/ci-guards/check-flags-drift.mjs",
+    "flags:check": "node tools/ci-guards/flag-deployment-drift.mjs",
     "ci:guard:zustand": "node tools/ci-guards/check-zustand-selectors.mjs",
     "ci:guard:starters": "node scripts/build-starter-fixtures.mjs --check",
     "ci:guard:duplicates": "node tools/ci-guards/check-duplicates.mjs",

--- a/tests/ci-guards/flag-deployment-drift.spec.ts
+++ b/tests/ci-guards/flag-deployment-drift.spec.ts
@@ -1,0 +1,322 @@
+// tests/ci-guards/flag-deployment-drift.spec.ts
+// =============================================================================
+// Anti-vacuity spec for tools/ci-guards/flag-deployment-drift.mjs
+// =============================================================================
+//
+// This guard's whole value is that it CANNOT quietly report green. Two failure
+// modes would destroy it, and both are pinned here by tests that a mutant fails:
+//
+//   MUTANT A — `deriveDeclaredFlags` returns `[]`.
+//              An empty declared set can diverge from nothing, so every run
+//              would report "no divergences" forever. Pinned by the FLOOR
+//              assertions below.
+//
+//   MUTANT B — `extractDeployedEnv` returns `{}`.
+//              A bundle whose env could not be read would look identical to a
+//              bundle with no overrides — the exact "unreachable check reports
+//              green" defect this guard exists to close. Pinned by the THROWS
+//              assertions below.
+//
+// No network is used. The unreachable-deploy path is exercised against a closed
+// local port, so it is deterministic and offline.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import {
+  deriveDeclaredFlags,
+  parseNetlifyEnv,
+  extractDeployedEnv,
+  computeDivergences,
+  coerceFlagValue,
+  renderTable,
+  run,
+  VERDICT,
+  DeployUnreachableError,
+} from '../../tools/ci-guards/flag-deployment-drift.mjs'
+
+const ROOT = process.cwd()
+const flagsSource = readFileSync(path.join(ROOT, 'src/flags.ts'), 'utf8')
+const netlifySource = readFileSync(path.join(ROOT, 'netlify.toml'), 'utf8')
+
+// A realistic slice of what Vite bakes into the served flags chunk: the
+// `{ ...import.meta.env }` replacement, minified, with `!0`/`!1` booleans.
+const BAKED_ENV_FIXTURE =
+  'const e={BASE_URL:"/",DEV:!1,MODE:"production",PROD:!0,SSR:!1,' +
+  'VITE_APP_ENV:"staging",VITE_FEATURE_COMPARE_TAB:"1",VITE_V5_CANONICAL_ANALYSIS:"true",' +
+  'VITE_FEATURE_ORCHESTRATOR_STREAMING:"false",VITE_SOMETHING_ODD:"maybe",VITE_BOOLY:!0};' +
+  'const c={envKey:"VITE_V5_CANONICAL_ANALYSIS",storageKey:"feature.v5CanonicalAnalysis"};'
+
+describe('deriveDeclaredFlags — derived, never a hand-listed array', () => {
+  const { flags, unparseable } = deriveDeclaredFlags(flagsSource, 'src/flags.ts')
+
+  // ── MUTANT A FLOOR ────────────────────────────────────────────────────────
+  // Make the derivation return [] and these fail. Without them an empty
+  // declared set would sail through as "no divergences".
+  it('derives a NON-EMPTY declared set from the real src/flags.ts', () => {
+    expect(flags.length).toBeGreaterThan(0)
+  })
+
+  it('derives at least 50 flags — a collapsed walker cannot pass as a clean run', () => {
+    // Floor, not an exact count: adding a flag must never red this.
+    expect(flags.length).toBeGreaterThanOrEqual(50)
+  })
+
+  it('finds the three flags proven dashboard-set on staging (2026-07-28)', () => {
+    const keys = flags.map((f) => f.envKey)
+    expect(keys).toContain('VITE_V5_CANONICAL_ANALYSIS')
+    expect(keys).toContain('VITE_FEATURE_COMPARE_TAB')
+    expect(keys).toContain('VITE_FEATURE_PRE_ANALYSIS_V3')
+  })
+
+  it('reads defaultValue as a real boolean, defaulting to false', () => {
+    const v5 = flags.find((f) => f.envKey === 'VITE_V5_CANONICAL_ANALYSIS')!
+    expect(v5.defaultValue).toBe(false)
+    // At least one flag declares an explicit `defaultValue: true`, so the
+    // reader is proven to distinguish the two rather than always answering false.
+    expect(flags.some((f) => f.defaultValue === true)).toBe(true)
+  })
+
+  it('every derived flag carries a non-empty envKey', () => {
+    for (const f of flags) expect(f.envKey, `flag ${f.name}`).toMatch(/^VITE_[A-Z0-9_]+$/)
+  })
+
+  it('parses the real src/flags.ts with ZERO unparseable declarations', () => {
+    expect(unparseable).toEqual([])
+  })
+})
+
+describe('deriveDeclaredFlags — FAILS LOUD rather than silently omitting', () => {
+  it('throws when FLAGS_CONFIG is absent entirely', () => {
+    expect(() => deriveDeclaredFlags('export const nope = 1', 'x.ts')).toThrow(/FLAGS_CONFIG/)
+  })
+
+  it('throws when FLAGS_CONFIG is not an object literal', () => {
+    expect(() => deriveDeclaredFlags('const FLAGS_CONFIG = buildFlags()', 'x.ts')).toThrow(/not an object literal/)
+  })
+
+  it('reports a spread declaration as UNPARSEABLE instead of dropping it', () => {
+    const { flags, unparseable } = deriveDeclaredFlags(
+      `const FLAGS_CONFIG = { ...OTHER, a: { envKey: 'VITE_A', storageKey: 's' } } as const`, 'x.ts')
+    expect(flags.map((f) => f.envKey)).toEqual(['VITE_A'])
+    expect(unparseable).toHaveLength(1)
+    expect(unparseable[0].reason).toMatch(/unsupported property kind/)
+  })
+
+  it('reports a computed envKey as UNPARSEABLE instead of dropping it', () => {
+    const { flags, unparseable } = deriveDeclaredFlags(
+      `const FLAGS_CONFIG = { a: { envKey: PREFIX + 'A', storageKey: 's' } } as const`, 'x.ts')
+    expect(flags).toEqual([])
+    expect(unparseable).toHaveLength(1)
+    expect(unparseable[0].reason).toMatch(/envKey is .*expected a string literal/)
+  })
+
+  it('reports a non-literal defaultValue as UNPARSEABLE instead of guessing false', () => {
+    const { unparseable } = deriveDeclaredFlags(
+      `const FLAGS_CONFIG = { a: { envKey: 'VITE_A', storageKey: 's', defaultValue: isProd() } } as const`, 'x.ts')
+    expect(unparseable).toHaveLength(1)
+    expect(unparseable[0].reason).toMatch(/defaultValue is .*expected a boolean literal/)
+  })
+
+  it('unwraps `as const` so the real declaration form is readable', () => {
+    const { flags } = deriveDeclaredFlags(
+      `const FLAGS_CONFIG = { a: { envKey: 'VITE_A', storageKey: 's' } } as const`, 'x.ts')
+    expect(flags).toEqual([{ name: 'a', envKey: 'VITE_A', storageKey: 's', defaultValue: false }])
+  })
+})
+
+describe('extractDeployedEnv — MUTANT B: never returns an empty map quietly', () => {
+  it('extracts the baked VITE_* values from a Vite env object', () => {
+    const env = extractDeployedEnv(BAKED_ENV_FIXTURE)
+    expect(env.VITE_FEATURE_COMPARE_TAB).toBe('1')
+    expect(env.VITE_V5_CANONICAL_ANALYSIS).toBe('true')
+    expect(env.VITE_FEATURE_ORCHESTRATOR_STREAMING).toBe('false')
+    expect(env.VITE_BOOLY).toBe('true') // `!0` is Vite's minified `true`
+  })
+
+  it('does NOT mistake a flag CONFIG literal for a baked env value', () => {
+    // `{envKey:"VITE_V5_CANONICAL_ANALYSIS"}` must not become an env entry.
+    const env = extractDeployedEnv(BAKED_ENV_FIXTURE)
+    expect(env.envKey).toBeUndefined()
+    expect(Object.keys(env).every((k) => k.startsWith('VITE_'))).toBe(true)
+  })
+
+  // ── MUTANT B PIN ──────────────────────────────────────────────────────────
+  // Make extraction return {} and these fail. The failure mode they forbid is
+  // "read nothing, report no divergences".
+  it('THROWS when the chunk contains no Vite env object at all', () => {
+    expect(() => extractDeployedEnv('console.log("hello")', { sourceLabel: 'stub.js' }))
+      .toThrow(DeployUnreachableError)
+    expect(() => extractDeployedEnv('console.log("hello")', { sourceLabel: 'stub.js' }))
+      .toThrow(/No Vite import\.meta\.env object found/)
+  })
+
+  it('THROWS when an env object is found but carries ZERO VITE_* keys', () => {
+    expect(() => extractDeployedEnv('const e={BASE_URL:"/",MODE:"production",PROD:!0};'))
+      .toThrow(/ZERO VITE_\* keys/)
+  })
+
+  it('never returns an empty object — the only empty outcome is a throw', () => {
+    for (const input of ['', 'var x=1', '{}', 'const e={BASE_URL:"/"};']) {
+      let result: unknown = null
+      try { result = extractDeployedEnv(input) } catch { result = 'threw' }
+      expect(result === 'threw' || Object.keys(result as object).length > 0).toBe(true)
+    }
+  })
+})
+
+describe('parseNetlifyEnv — reads the real netlify.toml', () => {
+  const parsed = parseNetlifyEnv(netlifySource)
+
+  it('separates the build context from the staging context', () => {
+    expect(Object.keys(parsed.build).length).toBeGreaterThan(0)
+    expect(Object.keys(parsed.staging).length).toBeGreaterThan(0)
+    expect(parsed.staging.VITE_APP_ENV).toBe('staging')
+  })
+
+  it('ignores comments and unrelated sections', () => {
+    const t = `# lead\n[build.environment]\n  A = "1" # trailing\n[[headers]]\n  B = "2"\n[context.staging.environment]\n  C = "3"\n`
+    const p = parseNetlifyEnv(t)
+    expect(p.build).toEqual({ A: '1' })
+    expect(p.staging).toEqual({ C: '3' })
+  })
+
+  it('records the three dashboard-set flags verified on staging 2026-07-28', () => {
+    // These were set ONLY in the Netlify dashboard until this change. Pinning
+    // them here means deleting the netlify.toml record reds this spec rather
+    // than silently restoring the "repo says OFF, deploy says ON" trap.
+    expect(parsed.staging.VITE_V5_CANONICAL_ANALYSIS).toBe('true')
+    expect(parsed.staging.VITE_FEATURE_COMPARE_TAB).toBe('1')
+    expect(parsed.staging.VITE_FEATURE_PRE_ANALYSIS_V3).toBe('1')
+  })
+})
+
+describe('coerceFlagValue — mirrors flagFactory.makeFlag exactly', () => {
+  it('accepts the truthy and falsy forms flagFactory accepts', () => {
+    for (const v of ['1', 1, true, 'true']) expect(coerceFlagValue(v)).toBe(true)
+    for (const v of ['0', 0, false, 'false']) expect(coerceFlagValue(v)).toBe(false)
+  })
+  it('returns null for anything flagFactory would ignore', () => {
+    for (const v of ['yes', '', 'TRUE', 2, null, undefined]) expect(coerceFlagValue(v)).toBeNull()
+  })
+})
+
+describe('computeDivergences', () => {
+  const declared = [
+    { name: 'v5CanonicalAnalysis', envKey: 'VITE_V5_CANONICAL_ANALYSIS', storageKey: 's1', defaultValue: false },
+    { name: 'recorded', envKey: 'VITE_RECORDED', storageKey: 's2', defaultValue: false },
+    { name: 'untouched', envKey: 'VITE_UNTOUCHED', storageKey: 's3', defaultValue: false },
+    { name: 'defaultOn', envKey: 'VITE_DEFAULT_ON', storageKey: 's4', defaultValue: true },
+  ]
+
+  it('flags a dashboard-set ON flag whose repo default is OFF (the real 28 Jul defect)', () => {
+    const { divergences } = computeDivergences({
+      declared,
+      netlify: { build: {}, staging: {} },
+      deployed: { VITE_V5_CANONICAL_ANALYSIS: 'true' },
+    })
+    const d = divergences.find((r) => r.envKey === 'VITE_V5_CANONICAL_ANALYSIS')!
+    expect(d.verdict).toBe(VERDICT.DASHBOARD)
+    expect(d.repoExpected).toBe(false)
+    expect(d.deployEffective).toBe(true)
+    expect(d.dashboardOnly).toBe(true)
+  })
+
+  it('reports OK once the same value is recorded in netlify.toml', () => {
+    const { divergences } = computeDivergences({
+      declared,
+      netlify: { build: {}, staging: { VITE_V5_CANONICAL_ANALYSIS: 'true' } },
+      deployed: { VITE_V5_CANONICAL_ANALYSIS: 'true' },
+    })
+    expect(divergences.find((r) => r.envKey === 'VITE_V5_CANONICAL_ANALYSIS')).toBeUndefined()
+  })
+
+  it('catches the INVERSE too: a default-ON flag turned OFF by the dashboard', () => {
+    const { divergences } = computeDivergences({
+      declared, netlify: { build: {}, staging: {} }, deployed: { VITE_DEFAULT_ON: 'false' },
+    })
+    const d = divergences.find((r) => r.envKey === 'VITE_DEFAULT_ON')!
+    expect(d.verdict).toBe(VERDICT.DASHBOARD)
+    expect(d.repoExpected).toBe(true)
+    expect(d.deployEffective).toBe(false)
+  })
+
+  it('lets the staging context override [build.environment], as Netlify does', () => {
+    const { rows } = computeDivergences({
+      declared,
+      netlify: { build: { VITE_RECORDED: '0' }, staging: { VITE_RECORDED: '1' } },
+      deployed: { VITE_RECORDED: '1' },
+    })
+    const r = rows.find((x) => x.envKey === 'VITE_RECORDED')!
+    expect(r.repoSource).toBe('netlify.toml[staging]')
+    expect(r.verdict).toBe(VERDICT.OK)
+  })
+
+  it('treats a flag absent from the deploy as resolving to its compiled default', () => {
+    const { rows } = computeDivergences({ declared, netlify: { build: {}, staging: {} }, deployed: { VITE_OTHER: '1' } })
+    const r = rows.find((x) => x.envKey === 'VITE_UNTOUCHED')!
+    expect(r.deployedPresent).toBe(false)
+    expect(r.deployEffective).toBe(false)
+    expect(r.verdict).toBe(VERDICT.OK)
+  })
+
+  it('marks a non-boolean deployed value NON-BOOLEAN and redacts it', () => {
+    const { rows } = computeDivergences({
+      declared, netlify: { build: {}, staging: {} }, deployed: { VITE_UNTOUCHED: 'sometimes' },
+    })
+    const r = rows.find((x) => x.envKey === 'VITE_UNTOUCHED')!
+    expect(r.verdict).toBe(VERDICT.NONBOOL)
+    expect(r.deployedRaw).toBe('<non-boolean:redacted>')
+  })
+
+  it('lists undeclared deployed keys by NAME ONLY — they may be credentials', () => {
+    const { undeclaredInDeploy, rows } = computeDivergences({
+      declared, netlify: { build: {}, staging: {} },
+      deployed: { VITE_PLOT_BEARER: 'super-secret-token', VITE_UNTOUCHED: '0' },
+    })
+    expect(undeclaredInDeploy).toContain('VITE_PLOT_BEARER')
+    // The secret's VALUE must appear nowhere in the structured output.
+    expect(JSON.stringify({ undeclaredInDeploy, rows })).not.toContain('super-secret-token')
+  })
+
+  it('renderTable never prints an undeclared key\'s value', () => {
+    const { rows } = computeDivergences({
+      declared, netlify: { build: {}, staging: {} },
+      deployed: { VITE_PLOT_BEARER: 'super-secret-token', VITE_V5_CANONICAL_ANALYSIS: 'true' },
+    })
+    const table = renderTable(rows)
+    expect(table).not.toContain('super-secret-token')
+    expect(table).toContain('VITE_V5_CANONICAL_ANALYSIS')
+  })
+})
+
+describe('posture — reports, and refuses to fake a green', () => {
+  it('an UNREACHABLE deploy exits 0 but reports UNVERIFIED, never "no divergences"', async () => {
+    const out: string[] = []
+    const errOut: string[] = []
+    // Closed local port: deterministic connection refusal, no external network.
+    const code = await run(['--url=http://127.0.0.1:1'], {
+      cwd: ROOT, log: (m: string) => out.push(String(m)), err: (m: string) => errOut.push(String(m)),
+    })
+    const all = [...out, ...errOut].join('\n')
+
+    expect(code).toBe(0)                       // non-blocking posture
+    expect(all).toContain('UNVERIFIED')
+    expect(all).toMatch(/could not be read|Could not fetch/i)
+    expect(all).not.toContain('No divergences')  // the defect this closes
+    expect(all).not.toContain('✅')
+  }, 30000)
+
+  it('an unreachable deploy names every flag it could NOT verify', async () => {
+    const lines: string[] = []
+    await run(['--url=http://127.0.0.1:1', '--json'], {
+      cwd: ROOT, log: (m: string) => lines.push(String(m)), err: () => {},
+    })
+    const payload = JSON.parse(lines.join('\n'))
+    expect(payload.status).toBe('UNVERIFIED')
+    expect(payload.verifiedFlags).toEqual([])
+    expect(payload.unverifiedFlags.length).toBe(payload.declaredCount)
+    expect(payload.unverifiedFlags).toContain('VITE_V5_CANONICAL_ANALYSIS')
+  }, 30000)
+})

--- a/tools/ci-guards/flag-deployment-drift.d.mts
+++ b/tools/ci-guards/flag-deployment-drift.d.mts
@@ -1,0 +1,131 @@
+// tools/ci-guards/flag-deployment-drift.d.mts
+// Types for the flag-deployment-drift guard, so TypeScript consumers (its spec,
+// and any future caller) are checked rather than silently `any`.
+//
+// The implementation is plain .mjs deliberately: the guard must be runnable with
+// a bare `node tools/ci-guards/flag-deployment-drift.mjs` during an incident,
+// with no build step and no loader. This file gives it types without that cost.
+
+export declare const DEFAULT_DEPLOY_URL: string
+
+/** Thrown when the deployed bundle could not be reached or read. */
+export declare class DeployUnreachableError extends Error {
+  constructor(message: string, options?: { url?: string; cause?: unknown })
+  name: 'DeployUnreachableError'
+  url?: string
+  cause?: unknown
+}
+
+export interface DeclaredFlag {
+  /** Property name in `FLAGS_CONFIG`, e.g. `v5CanonicalAnalysis`. */
+  name: string
+  /** Environment variable, e.g. `VITE_V5_CANONICAL_ANALYSIS`. */
+  envKey: string
+  /** localStorage override key, e.g. `feature.v5CanonicalAnalysis`. */
+  storageKey: string | null
+  /** Compiled default when neither localStorage nor env decides. */
+  defaultValue: boolean
+}
+
+/** A declaration the AST walker could not read. Never silently dropped. */
+export interface UnparseableFlag {
+  name: string
+  reason: string
+}
+
+export interface NetlifyEnv {
+  build: Record<string, string>
+  staging: Record<string, string>
+}
+
+export declare const VERDICT: {
+  readonly OK: 'OK'
+  readonly DRIFT: 'DRIFT'
+  readonly DASHBOARD: 'DRIFT (dashboard-set)'
+  readonly NONBOOL: 'NON-BOOLEAN'
+}
+
+export type Verdict = (typeof VERDICT)[keyof typeof VERDICT]
+
+export interface DivergenceRow {
+  name: string
+  envKey: string
+  declaredDefault: boolean
+  /** Raw netlify.toml value, or null when the file does not mention the key. */
+  netlifyValue: string | null
+  repoSource: 'netlify.toml[staging]' | 'netlify.toml[build]' | 'flags.ts default'
+  /** What repo config predicts the flag resolves to. */
+  repoExpected: boolean
+  /** Deployed value, or `<non-boolean:redacted>`; null when absent from the bundle. */
+  deployedRaw: string | null
+  deployedPresent: boolean
+  /** What the flag ACTUALLY resolves to in the deploy. This is the truth. */
+  deployEffective: boolean
+  /** Present in the deploy but absent from netlify.toml => set in the dashboard. */
+  dashboardOnly: boolean
+  verdict: Verdict
+}
+
+export interface DivergenceReport {
+  rows: DivergenceRow[]
+  divergences: DivergenceRow[]
+  /** Deployed VITE_* keys with no flags.ts declaration. NAMES ONLY — may be credentials. */
+  undeclaredInDeploy: string[]
+}
+
+/**
+ * Derive every flag declared in `FLAGS_CONFIG` by walking the TypeScript AST.
+ * @throws if `FLAGS_CONFIG` is missing or is not an object literal.
+ */
+export declare function deriveDeclaredFlags(
+  sourceText: string,
+  fileName?: string,
+): { flags: DeclaredFlag[]; unparseable: UnparseableFlag[] }
+
+/** Read `[build.environment]` and `[context.staging.environment]` from netlify.toml. */
+export declare function parseNetlifyEnv(tomlText: string): NetlifyEnv
+
+/**
+ * Pull Vite's baked `import.meta.env` object out of served bundle text.
+ * @throws DeployUnreachableError rather than ever returning an empty map.
+ */
+export declare function extractDeployedEnv(
+  chunkText: string,
+  options?: { sourceLabel?: string },
+): Record<string, string>
+
+/** Mirrors `flagFactory.makeFlag`'s coercion. `null` = not boolean-ish. */
+export declare function coerceFlagValue(raw: unknown): boolean | null
+
+/**
+ * Derive the content-hashed asset chain from the served index.html and read the
+ * deployed env out of it.
+ * @throws DeployUnreachableError on any fetch or extraction failure.
+ */
+export declare function fetchDeployedEnv(
+  baseUrl?: string,
+  options?: { timeoutMs?: number; log?: (message: string) => void },
+): Promise<{ env: Record<string, string>; chain: string[] }>
+
+export declare function computeDivergences(input: {
+  declared: DeclaredFlag[]
+  netlify: NetlifyEnv
+  deployed: Record<string, string>
+}): DivergenceReport
+
+export declare function renderTable(rows: DivergenceRow[]): string
+
+/**
+ * CLI entry. Resolves to the process exit code.
+ * 0 = reported (even with divergences — reporting posture, and UNVERIFIED),
+ * 1 = divergences found AND `--fail-on-divergence` was passed,
+ * 2 = the derivation itself failed (empty or unparseable declared set).
+ */
+export declare function run(
+  argv?: string[],
+  options?: {
+    cwd?: string
+    log?: (message: string) => void
+    err?: (message: string) => void
+  },
+): Promise<number>

--- a/tools/ci-guards/flag-deployment-drift.mjs
+++ b/tools/ci-guards/flag-deployment-drift.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+// tools/ci-guards/flag-deployment-drift.mjs
+// =============================================================================
+// FLAG DEPLOYMENT DRIFT — the DEPLOYED bundle is the truth, repo config is advisory
+// =============================================================================
+//
+// WHY THIS EXISTS
+// ---------------
+// Feature flags reach the deployed staging site from THREE places:
+//   1. `src/flags.ts`      — the `defaultValue` compiled into the code
+//   2. `netlify.toml`      — `[build.environment]` / `[context.staging.environment]`
+//   3. the Netlify DASHBOARD — invisible to this repo, and it WINS
+//
+// (3) is why reading (1) or (2) to decide "what does a tester see?" gives the
+// wrong answer. Verified 2026-07-28: VITE_V5_CANONICAL_ANALYSIS is ON in the
+// deployed staging bundle, appears NOWHERE in netlify.toml, and defaults OFF in
+// flags.ts. Same for VITE_FEATURE_COMPARE_TAB and VITE_FEATURE_PRE_ANALYSIS_V3.
+// Flag-off code paths therefore look DEAD when they are LIVE — that mis-scoped
+// two dispatches in a single day.
+//
+// HOW IT DERIVES (never a hand-maintained list — that is the defect it replaces)
+// -----------------------------------------------------------------------------
+//   declared: TypeScript AST walk of the `FLAGS_CONFIG` object literal in
+//             src/flags.ts. A declaration form the walker cannot read becomes an
+//             UNPARSEABLE entry and FAILS LOUD — it is never silently omitted,
+//             because a silent omission is exactly how a mirror goes stale green.
+//   repo:     section scan of the real netlify.toml.
+//   deployed: Vite bakes `import.meta.env` into the bundle as a literal object,
+//             because src/lib/flagFactory.ts snapshots it with a LITERAL
+//             `import.meta.env` reference (`envSnapshot = { ...import.meta.env }`).
+//             So the served flags chunk carries the true deployed values. The
+//             asset filename is content-hashed and is DERIVED from the served
+//             index.html -> entry chunk -> flags chunk. Never hard-coded.
+//
+// POSTURE: REPORTING, NOT BLOCKING.
+// --------------------------------
+// Exit 0 even when divergences are found. Someone flipping a dashboard flag is
+// NORMAL — reddening CI for it would make this the broken alarm it exists to
+// replace. `--fail-on-divergence` opts in to blocking for a caller that wants it.
+//
+// If the network is unreachable the run reports UNVERIFIED and says exactly what
+// it could not check. It NEVER reports "no divergences" without having looked —
+// an unreachable check that reports green is the precise defect class this closes.
+//
+// SECRETS: the baked env object contains real credentials (VITE_PLOT_BEARER,
+// VITE_SUPABASE_ANON_KEY). This tool prints values ONLY for env keys that
+// src/flags.ts declares as feature flags, and even then only after normalising
+// them to ON/OFF; anything non-boolean prints as <non-boolean:redacted>. Env
+// keys it does not recognise are reported by NAME ONLY, never by value.
+//
+// Usage:
+//   pnpm flags:check                       # human table against staging
+//   pnpm flags:check --json                # machine-readable
+//   pnpm flags:check --url=https://…       # another deploy
+//   pnpm flags:check --fail-on-divergence  # opt-in blocking
+// =============================================================================
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import ts from 'typescript'
+
+export const DEFAULT_DEPLOY_URL = 'https://staging--olumi.netlify.app'
+
+/** Thrown when the deployed bundle could not be reached or read. Never swallowed. */
+export class DeployUnreachableError extends Error {
+  constructor(message, { url, cause } = {}) {
+    super(message)
+    this.name = 'DeployUnreachableError'
+    this.url = url
+    this.cause = cause
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. DECLARED — TypeScript AST walk of FLAGS_CONFIG in src/flags.ts
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Walk `src/flags.ts` and return every flag declaration it contains.
+ *
+ * Deliberately strict. Any property whose shape this walker cannot fully read
+ * is returned in `unparseable` rather than dropped, and callers treat a
+ * non-empty `unparseable` as a hard failure. A walker that silently skips what
+ * it does not understand is a hand-maintained mirror with extra steps.
+ *
+ * @returns {{ flags: Array<{name,envKey,storageKey,defaultValue}>, unparseable: Array<{name,reason}> }}
+ */
+export function deriveDeclaredFlags(sourceText, fileName = 'flags.ts') {
+  const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true)
+
+  let configObject = null
+  const visit = (node) => {
+    if (configObject) return
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'FLAGS_CONFIG') {
+      let init = node.initializer
+      // Unwrap `{...} as const` / `<const>{...}` / parenthesised forms.
+      while (init && (ts.isAsExpression(init) || ts.isTypeAssertionExpression(init) || ts.isParenthesizedExpression(init))) {
+        init = init.expression
+      }
+      if (init && ts.isObjectLiteralExpression(init)) configObject = init
+      else {
+        throw new Error(
+          `FLAGS_CONFIG in ${fileName} is not an object literal (got ${init ? ts.SyntaxKind[init.kind] : 'nothing'}). ` +
+          `The flag-drift walker cannot derive the declared set — fix the walker, do not fall back to a hand-listed array.`
+        )
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+
+  if (!configObject) {
+    throw new Error(
+      `Could not find a FLAGS_CONFIG declaration in ${fileName}. ` +
+      `The flag-drift walker derives the declared set from that object; without it there is nothing to compare ` +
+      `and reporting "no divergences" would be a lie.`
+    )
+  }
+
+  const flags = []
+  const unparseable = []
+
+  for (const prop of configObject.properties) {
+    // Only plain `name: { ... }` assignments are readable. Spread, shorthand,
+    // methods and computed keys are reported, never skipped.
+    if (!ts.isPropertyAssignment(prop)) {
+      unparseable.push({
+        name: prop.name && ts.isIdentifier(prop.name) ? prop.name.text : `<${ts.SyntaxKind[prop.kind]}>`,
+        reason: `unsupported property kind ${ts.SyntaxKind[prop.kind]} (spread/shorthand/method are not readable)`,
+      })
+      continue
+    }
+    if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+      unparseable.push({ name: '<computed>', reason: 'computed property name' })
+      continue
+    }
+    const name = prop.name.text
+    if (!ts.isObjectLiteralExpression(prop.initializer)) {
+      unparseable.push({ name, reason: `initializer is ${ts.SyntaxKind[prop.initializer.kind]}, expected an object literal` })
+      continue
+    }
+
+    let envKey = null
+    let storageKey = null
+    let defaultValue = false
+    let bad = null
+
+    for (const f of prop.initializer.properties) {
+      if (!ts.isPropertyAssignment(f) || !(ts.isIdentifier(f.name) || ts.isStringLiteral(f.name))) {
+        bad = `field of kind ${ts.SyntaxKind[f.kind]} is not readable`
+        break
+      }
+      const field = f.name.text
+      const v = f.initializer
+      if (field === 'envKey' || field === 'storageKey') {
+        if (!ts.isStringLiteral(v) && !ts.isNoSubstitutionTemplateLiteral(v)) {
+          bad = `${field} is ${ts.SyntaxKind[v.kind]}, expected a string literal`
+          break
+        }
+        if (field === 'envKey') envKey = v.text
+        else storageKey = v.text
+      } else if (field === 'defaultValue') {
+        if (v.kind === ts.SyntaxKind.TrueKeyword) defaultValue = true
+        else if (v.kind === ts.SyntaxKind.FalseKeyword) defaultValue = false
+        else {
+          bad = `defaultValue is ${ts.SyntaxKind[v.kind]}, expected a boolean literal`
+          break
+        }
+      }
+      // Unknown extra fields are harmless — they do not affect resolution.
+    }
+
+    if (bad) { unparseable.push({ name, reason: bad }); continue }
+    if (!envKey) { unparseable.push({ name, reason: 'no envKey string literal found' }); continue }
+
+    flags.push({ name, envKey, storageKey, defaultValue })
+  }
+
+  return { flags, unparseable }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. REPO CONFIG — scan the real netlify.toml
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract env assignments from netlify.toml's build + staging contexts.
+ * A deliberate small scanner rather than a dependency: netlify.toml env blocks
+ * are flat `KEY = "value"` lines. Comments (`#`) are ignored.
+ */
+export function parseNetlifyEnv(tomlText) {
+  const sections = { build: {}, staging: {} }
+  const SECTION_OF = {
+    '[build.environment]': 'build',
+    '[context.staging.environment]': 'staging',
+  }
+  let current = null
+  for (const rawLine of tomlText.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line.startsWith('#') || line === '') continue
+    if (line.startsWith('[')) { current = SECTION_OF[line] ?? null; continue }
+    if (!current) continue
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/)
+    if (!m) continue
+    let value = m[2].trim().replace(/\s+#.*$/, '').trim()
+    const q = value.match(/^"((?:[^"\\]|\\.)*)"$/) || value.match(/^'([^']*)'$/)
+    sections[current][m[1]] = q ? q[1] : value
+  }
+  return sections
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. DEPLOYED — extract the baked import.meta.env snapshot from a served chunk
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pull the Vite-baked env object out of bundle text.
+ *
+ * Anchors on the Vite-injected `BASE_URL:"` marker and brace-matches the object
+ * around it, so it reads the real `import.meta.env` replacement rather than any
+ * incidental `VITE_x:"y"` pair elsewhere in the file.
+ *
+ * Throws when it finds no env object at all. It must never return `{}` and let
+ * a caller print "no divergences" — see the anti-vacuity spec.
+ */
+export function extractDeployedEnv(chunkText, { sourceLabel = 'bundle' } = {}) {
+  const out = {}
+  let anchorsSeen = 0
+
+  for (const m of chunkText.matchAll(/BASE_URL\s*:\s*["']/g)) {
+    // Walk back to the object's opening brace.
+    let open = -1
+    for (let i = m.index; i >= 0; i--) {
+      if (chunkText[i] === '{') { open = i; break }
+      if (chunkText[i] === '}' || chunkText[i] === ';') break
+    }
+    if (open === -1) continue
+
+    // Brace-match forward, skipping string contents.
+    let depth = 0, close = -1, quote = null
+    for (let i = open; i < chunkText.length; i++) {
+      const c = chunkText[i]
+      if (quote) {
+        if (c === '\\') { i++; continue }
+        if (c === quote) quote = null
+        continue
+      }
+      if (c === '"' || c === "'" || c === '`') { quote = c; continue }
+      if (c === '{') depth++
+      else if (c === '}') { depth--; if (depth === 0) { close = i; break } }
+    }
+    if (close === -1) continue
+
+    anchorsSeen++
+    const slice = chunkText.slice(open, close + 1)
+    for (const p of slice.matchAll(/(VITE_[A-Z0-9_]+)\s*:\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|!0|!1|true|false|-?\d+(?:\.\d+)?)/g)) {
+      out[p[1]] = coerceBakedLiteral(p[2])
+    }
+  }
+
+  if (anchorsSeen === 0) {
+    throw new DeployUnreachableError(
+      `No Vite import.meta.env object found in the served ${sourceLabel}. ` +
+      `Either the asset chain was resolved to the wrong file, or flagFactory.ts stopped snapshotting ` +
+      `\`{ ...import.meta.env }\` with a literal reference (which is what makes the values readable). ` +
+      `Refusing to report "no divergences" from a bundle whose env could not be read.`
+    )
+  }
+  if (Object.keys(out).length === 0) {
+    throw new DeployUnreachableError(
+      `Found a Vite env object in the served ${sourceLabel} but it contained ZERO VITE_* keys. ` +
+      `That is not a green result — it means the extraction is broken or the deploy defines no flags at all.`
+    )
+  }
+  return out
+}
+
+function coerceBakedLiteral(raw) {
+  if (raw === '!0' || raw === 'true') return 'true'
+  if (raw === '!1' || raw === 'false') return 'false'
+  if (raw.startsWith('"') || raw.startsWith("'")) return raw.slice(1, -1)
+  return raw
+}
+
+/** Mirror of flagFactory.makeFlag's env coercion. Anything else is not a boolean. */
+export function coerceFlagValue(raw) {
+  if (raw === '1' || raw === 1 || raw === true || raw === 'true') return true
+  if (raw === '0' || raw === 0 || raw === false || raw === 'false') return false
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. FETCH — derive the content-hashed asset chain from the served index.html
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function getText(url, timeoutMs) {
+  const ac = new AbortController()
+  const t = setTimeout(() => ac.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { signal: ac.signal, redirect: 'follow' })
+    if (!res.ok) throw new DeployUnreachableError(`HTTP ${res.status} ${res.statusText} for ${url}`, { url })
+    return await res.text()
+  } catch (err) {
+    if (err instanceof DeployUnreachableError) throw err
+    throw new DeployUnreachableError(`Could not fetch ${url}: ${err?.message || err}`, { url, cause: err })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+/**
+ * index.html -> entry chunk -> flags chunk. Every filename is content-hashed and
+ * therefore DERIVED at each hop; nothing here is hard-coded.
+ *
+ * Both the flags chunk and the entry chunk are scanned, so this keeps working if
+ * Vite's chunking moves the env snapshot between them.
+ */
+export async function fetchDeployedEnv(baseUrl = DEFAULT_DEPLOY_URL, { timeoutMs = 20000, log = () => {} } = {}) {
+  const base = baseUrl.replace(/\/+$/, '')
+  const chain = []
+
+  const html = await getText(`${base}/`, timeoutMs)
+  chain.push(`${base}/`)
+
+  const entryPaths = [...html.matchAll(/(?:src|href)\s*=\s*"(\/assets\/[^"]+\.js)"/g)].map((m) => m[1])
+  if (entryPaths.length === 0) {
+    throw new DeployUnreachableError(`No /assets/*.js entry chunk referenced by ${base}/ — cannot derive the asset chain.`, { url: `${base}/` })
+  }
+
+  const texts = []
+  for (const p of entryPaths) {
+    const entryUrl = `${base}${p}`
+    const entryText = await getText(entryUrl, timeoutMs)
+    chain.push(entryUrl)
+    texts.push({ label: p, text: entryText })
+
+    for (const m of entryText.matchAll(/["'](?:\.\/)?(?:assets\/)?(flags-[A-Za-z0-9_-]+\.js)["']/g)) {
+      const flagsUrl = `${base}/assets/${m[1]}`
+      if (chain.includes(flagsUrl)) continue
+      const flagsText = await getText(flagsUrl, timeoutMs)
+      chain.push(flagsUrl)
+      texts.push({ label: `assets/${m[1]}`, text: flagsText })
+    }
+  }
+  log(`  asset chain: ${chain.map((u) => u.replace(base, '')).join('  ->  ')}`)
+
+  const merged = {}
+  const errors = []
+  for (const { label, text } of texts) {
+    try { Object.assign(merged, extractDeployedEnv(text, { sourceLabel: label })) } catch (e) { errors.push(`${label}: ${e.message}`) }
+  }
+  if (Object.keys(merged).length === 0) {
+    throw new DeployUnreachableError(
+      `Fetched ${texts.length} chunk(s) from ${base} but extracted ZERO VITE_* values.\n  ` + errors.join('\n  '),
+      { url: base }
+    )
+  }
+  return { env: merged, chain }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. DIVERGENCE
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const VERDICT = {
+  OK: 'OK',
+  DRIFT: 'DRIFT',
+  DASHBOARD: 'DRIFT (dashboard-set)',
+  NONBOOL: 'NON-BOOLEAN',
+}
+
+/**
+ * Compare what the repo predicts against what is actually deployed.
+ *
+ * `repoExpected` follows Netlify's own precedence: the staging context overrides
+ * [build.environment], and with neither the compiled `defaultValue` wins.
+ */
+export function computeDivergences({ declared, netlify, deployed }) {
+  const rows = declared.map((f) => {
+    const inStaging = Object.prototype.hasOwnProperty.call(netlify.staging, f.envKey)
+    const inBuild = Object.prototype.hasOwnProperty.call(netlify.build, f.envKey)
+    const repoRaw = inStaging ? netlify.staging[f.envKey] : inBuild ? netlify.build[f.envKey] : null
+    const repoSource = inStaging ? 'netlify.toml[staging]' : inBuild ? 'netlify.toml[build]' : 'flags.ts default'
+    const repoExpected = repoRaw === null ? f.defaultValue : (coerceFlagValue(repoRaw) ?? f.defaultValue)
+
+    const inDeploy = Object.prototype.hasOwnProperty.call(deployed, f.envKey)
+    const deployRaw = inDeploy ? deployed[f.envKey] : null
+    const deployCoerced = inDeploy ? coerceFlagValue(deployRaw) : null
+    // Absent from the bundle => nothing overrides the compiled default.
+    const deployEffective = inDeploy ? (deployCoerced ?? f.defaultValue) : f.defaultValue
+
+    let verdict
+    if (inDeploy && deployCoerced === null) verdict = VERDICT.NONBOOL
+    else if (deployEffective !== repoExpected) verdict = inDeploy && !inStaging && !inBuild ? VERDICT.DASHBOARD : VERDICT.DRIFT
+    else verdict = VERDICT.OK
+
+    return {
+      name: f.name,
+      envKey: f.envKey,
+      declaredDefault: f.defaultValue,
+      netlifyValue: repoRaw,
+      repoSource,
+      repoExpected,
+      deployedRaw: deployCoerced === null && inDeploy ? '<non-boolean:redacted>' : deployRaw,
+      deployedPresent: inDeploy,
+      deployEffective,
+      dashboardOnly: inDeploy && !inStaging && !inBuild,
+      verdict,
+    }
+  })
+
+  const declaredKeys = new Set(declared.map((f) => f.envKey))
+  // NAMES ONLY. These are undeclared env keys and may be credentials.
+  const undeclaredInDeploy = Object.keys(deployed).filter((k) => !declaredKeys.has(k)).sort()
+
+  return {
+    rows,
+    divergences: rows.filter((r) => r.verdict !== VERDICT.OK),
+    undeclaredInDeploy,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. RENDER
+// ─────────────────────────────────────────────────────────────────────────────
+
+const onOff = (b) => (b ? 'ON' : 'OFF')
+
+export function renderTable(rows) {
+  const head = ['FLAG', 'ENV KEY', 'flags.ts', 'netlify.toml', 'DEPLOYED', 'VERDICT']
+  const body = rows.map((r) => [
+    r.name,
+    r.envKey,
+    onOff(r.declaredDefault),
+    r.netlifyValue === null ? '—' : `"${r.netlifyValue}"`,
+    r.deployedPresent ? `${onOff(r.deployEffective)} ("${r.deployedRaw}")` : '— (absent)',
+    r.verdict,
+  ])
+  const all = [head, ...body]
+  const w = head.map((_, i) => Math.max(...all.map((r) => String(r[i]).length)))
+  const line = (cells, pad = ' ') => cells.map((c, i) => String(c).padEnd(w[i], pad)).join(pad === '-' ? '-+-' : ' | ')
+  return [line(head), line(w.map(() => ''), '-'), ...body.map((r) => line(r))].join('\n')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. CLI
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function run(argv = [], { cwd = process.cwd(), log = console.log, err = console.error } = {}) {
+  const asJson = argv.includes('--json')
+  const failOnDivergence = argv.includes('--fail-on-divergence')
+  const urlArg = argv.find((a) => a.startsWith('--url='))
+  const baseUrl = urlArg ? urlArg.slice('--url='.length) : DEFAULT_DEPLOY_URL
+  const say = asJson ? () => {} : log
+
+  const flagsSource = await fs.readFile(path.join(cwd, 'src/flags.ts'), 'utf8')
+  const { flags: declared, unparseable } = deriveDeclaredFlags(flagsSource, 'src/flags.ts')
+  const netlify = parseNetlifyEnv(await fs.readFile(path.join(cwd, 'netlify.toml'), 'utf8'))
+
+  if (declared.length === 0) {
+    err('FATAL: derived ZERO flag declarations from src/flags.ts.')
+    err('A zero-length declared set cannot diverge from anything, so this run would report a')
+    err('vacuous PASS. Treating it as a failure of the derivation, not as a clean result.')
+    return 2
+  }
+  if (unparseable.length > 0) {
+    err(`FATAL: ${unparseable.length} declaration(s) in src/flags.ts could not be parsed:`)
+    for (const u of unparseable) err(`  - ${u.name}: ${u.reason}`)
+    err('Refusing to report on a partial declared set — silently omitting these is exactly the')
+    err('hand-maintained-mirror drift this check exists to prevent. Fix the walker.')
+    return 2
+  }
+
+  say('')
+  say('='.repeat(100))
+  say('FLAG DEPLOYMENT DRIFT')
+  say('='.repeat(100))
+  say(`Declared flags derived from src/flags.ts (AST walk of FLAGS_CONFIG): ${declared.length}`)
+  say(`netlify.toml: ${Object.keys(netlify.build).length} key(s) in [build.environment], ` +
+      `${Object.keys(netlify.staging).length} in [context.staging.environment]`)
+  say(`Deploy under test: ${baseUrl}`)
+  say('')
+
+  let deployed = null
+  let chain = []
+  let unreachable = null
+  try {
+    const r = await fetchDeployedEnv(baseUrl, { log: say })
+    deployed = r.env
+    chain = r.chain
+  } catch (e) {
+    if (!(e instanceof DeployUnreachableError)) throw e
+    unreachable = e
+  }
+
+  if (unreachable) {
+    const payload = {
+      status: 'UNVERIFIED',
+      reason: unreachable.message,
+      baseUrl,
+      declaredCount: declared.length,
+      verifiedFlags: [],
+      unverifiedFlags: declared.map((f) => f.envKey),
+    }
+    if (asJson) { log(JSON.stringify(payload, null, 2)); return 0 }
+    err('')
+    err('#'.repeat(100))
+    err('## STATUS: UNVERIFIED — THE DEPLOYED BUNDLE COULD NOT BE READ')
+    err('#'.repeat(100))
+    err(`## ${unreachable.message}`)
+    err('##')
+    err(`## NOT CHECKED: all ${declared.length} declared flags. Their true deployed values are UNKNOWN.`)
+    err('## This is NOT a pass. The repo columns below cannot tell you what a tester sees, because')
+    err('## Netlify dashboard variables override them and are invisible to this repo.')
+    err('##')
+    err(`## Fix the reason above (network access, or the asset chain / extraction), or read the`)
+    err(`## baked env by hand: ${baseUrl}/assets/flags-*.js — derive the filename from index.html.`)
+    err('#'.repeat(100))
+    err('')
+    return 0
+  }
+
+  const { rows, divergences, undeclaredInDeploy } = computeDivergences({ declared, netlify, deployed })
+
+  if (asJson) {
+    log(JSON.stringify({
+      status: divergences.length ? 'DIVERGENCES' : 'ALIGNED',
+      baseUrl, assetChain: chain, declaredCount: declared.length,
+      rows, divergences, undeclaredInDeploy,
+    }, null, 2))
+    return failOnDivergence && divergences.length ? 1 : 0
+  }
+
+  log(`Deployed env keys read from the served bundle: ${Object.keys(deployed).length}`)
+  log('')
+  log('  ⚠ THE **DEPLOYED** COLUMN IS THE TRUTH.')
+  log('    `flags.ts` and `netlify.toml` are ADVISORY ONLY: Netlify dashboard variables override')
+  log('    both and are invisible to this repo. Never decide what a tester sees from the repo columns.')
+  log('')
+  log(renderTable(rows))
+  log('')
+
+  if (divergences.length === 0) {
+    log(`✅ No divergences. All ${rows.length} declared flags deploy exactly as repo config predicts.`)
+  } else {
+    log(`⚠️  ${divergences.length} DIVERGENCE(S) — repo config does not describe the deployed reality:`)
+    log('')
+    for (const d of divergences) {
+      log(`  • ${d.envKey}  (src/flags.ts \`${d.name}\`)`)
+      log(`      repo says : ${onOff(d.repoExpected)}  (via ${d.repoSource})`)
+      log(`      deployed  : ${d.deployedPresent ? `${onOff(d.deployEffective)}  ("${d.deployedRaw}")` : 'absent'}`)
+      if (d.dashboardOnly) {
+        log('      cause     : set in the NETLIFY DASHBOARD — absent from netlify.toml entirely.')
+        log('                  Record it in [context.staging.environment] so the repo stops lying.')
+      } else if (d.verdict === VERDICT.NONBOOL) {
+        log('      cause     : deployed value is not boolean-ish, so flagFactory falls through to the default.')
+      }
+      log('')
+    }
+    log('  This is REPORTED, not enforced. Flipping a dashboard flag is normal and must not red CI.')
+  }
+
+  if (undeclaredInDeploy.length > 0) {
+    log('')
+    log(`ℹ️  ${undeclaredInDeploy.length} VITE_* key(s) in the deploy are not declared in src/flags.ts`)
+    log('   (infra/env config or flags declared elsewhere, e.g. src/lib/featureFlags.ts).')
+    log('   NAMES ONLY — values withheld, since this set contains credentials:')
+    for (const k of undeclaredInDeploy) log(`     - ${k}`)
+  }
+
+  log('')
+  return failOnDivergence && divergences.length ? 1 : 0
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  run(process.argv.slice(2), { cwd: path.resolve(here, '../..') })
+    .then((code) => { process.exitCode = code })
+    .catch((e) => { console.error(`FATAL: ${e?.stack || e?.message || e}`); process.exitCode = 2 })
+}


### PR DESCRIPTION
## The problem

Repo config lies about which feature flags are live on staging.

Verified 2026-07-28 against the deployed bundle: `VITE_V5_CANONICAL_ANALYSIS` is **ON**, appears **nowhere** in `netlify.toml`, and defaults **OFF** in `src/flags.ts`. Same for `VITE_FEATURE_COMPARE_TAB` and `VITE_FEATURE_PRE_ANALYSIS_V3`. They are set through the **Netlify dashboard**, which overrides both repo sources and is invisible to this repo.

**Consequence:** any lane reading `flags.ts` or `netlify.toml` to decide what a tester sees gets the wrong answer, and flag-off code paths look **dead when they are live**. That mis-scoped two dispatches in a single day.

## What this adds

`pnpm flags:check` — `tools/ci-guards/flag-deployment-drift.mjs`. It **derives** all three inputs rather than mirroring any of them:

| input | how it is derived |
|---|---|
| **declared** | TypeScript AST walk of the `FLAGS_CONFIG` object literal in `src/flags.ts`. A declaration form the walker cannot read becomes an `UNPARSEABLE` entry and **fails loud** — never silently omitted. |
| **repo** | Section scan of the real `netlify.toml`, honouring Netlify's own precedence (staging context beats `[build.environment]` beats the compiled default). |
| **deployed** | Vite bakes `import.meta.env` into the bundle as a readable literal, because `flagFactory.ts` snapshots it with a literal reference. The content-hashed asset chain (`index.html` → entry → flags chunk) is derived at **each hop**, never hard-coded. |

## What it found: 13 divergences, not 3

Measured against the deploy of `c86da6a4` (66 declared flags, 64 deployed env keys). All 13 are dashboard-set and absent from `netlify.toml`:

| env key | flags.ts | netlify.toml | DEPLOYED |
|---|---|---|---|
| `VITE_FEATURE_SCHEMA_V2` | OFF | — | **ON** |
| `VITE_ENABLE_LEGACY_DIRECT_RUN` | **ON** | — | **OFF** ← runs the other way |
| `VITE_FEATURE_COMPARE_TAB` | OFF | — | **ON** |
| `VITE_FEATURE_BIL` | OFF | — | **ON** |
| `VITE_FEATURE_PRE_ANALYSIS_ENRICHED` | OFF | — | **ON** |
| `VITE_FEATURE_PRE_ANALYSIS_V3` | OFF | — | **ON** |
| `VITE_FEATURE_GRAPH_BADGES` | OFF | — | **ON** |
| `VITE_FEATURE_CROSS_HIGHLIGHT` | OFF | — | **ON** |
| `VITE_FEATURE_GRAPH_LENS` | OFF | — | **ON** |
| `VITE_FEATURE_ORCHESTRATOR_RENDERING_V2` | OFF | — | **ON** |
| `VITE_FEATURE_DETERMINISTIC_CEE` | OFF | — | **ON** |
| `VITE_FEATURE_ANALYSIS_HERO_V17` | OFF | — | **ON** |
| `VITE_V5_CANONICAL_ANALYSIS` | OFF | — | **ON** |

The brief named three; the derived check found thirteen. This is exactly why the mirror had to go.

## Posture: reporting, not blocking

Flipping a dashboard flag is a **normal** operation. Reddening CI for it would make this the broken alarm it exists to replace (trap 7).

- The script **exits 0** on divergences. `--fail-on-divergence` opts in to blocking.
- The new CI job is `continue-on-error: true` **and is deliberately absent** from the `Staging Gate` aggregator's required list (`needs: [tsc, typecheck-selftest, vitest, vitest-summary, build]` — unchanged).
- If staging is unreachable it reports **UNVERIFIED** and names every flag it could not check. It never prints a green it has not earned.
- Scope caveat stated in the workflow: it reports the **currently-deployed** site. On a PR that is the pre-merge state, not a prediction of what the PR will deploy.

## Secrets

The baked env carries real credentials (`VITE_PLOT_BEARER`, `VITE_SUPABASE_ANON_KEY`). Values print **only** for keys `flags.ts` declares as feature flags, normalised to ON/OFF; everything else is reported **by name only**. Two tests pin this, including one asserting a secret's value appears nowhere in the rendered table.

## Anti-vacuity — both mutants proven, in throwaway worktrees outside the repo root

| mutant | result |
|---|---|
| **A** — `deriveDeclaredFlags` → `[]` | **12 tests fail**, incl. `derives a NON-EMPTY declared set` and `derives at least 50 flags`. `run()` also exits **2** rather than reporting a vacuous clean run. |
| **B** — `extractDeployedEnv` → `{}` | **4 tests fail**, incl. `never returns an empty object — the only empty outcome is a throw`. End-to-end, the live script reports **UNVERIFIED** with **zero** green claims instead of "no divergences". |

Worktrees were created outside the repo root and removed **before** any gate run (traps 9 / 9c).

## netlify.toml

Records the three named flags in `[context.staging.environment]`, values **transcribed from the served bundle** — byte-identical to what is already deployed, so **no behaviour change**.

The other 10 are deliberately **not** transcribed: hand-copying them would rebuild the mirror this work retires. `pnpm flags:check` is the derived answer. The comment block says so explicitly.

## Gates

- `pnpm typecheck` — **PASSED**, `625 file(s) / 2516 error(s)` against baseline **2516**. No drift. The spec's 11 new errors were fixed **at source** with a `.d.mts` declaration file, **not** absorbed into the baseline.
- Coverage phase: 3003 / 3043 tracked TS files loaded; the new `.d.mts` is covered.
- `tests/ci-guards/` — 11 files / **97 passed**.
- Affected suites with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set (`netlifyCsp`, `indexHtmlHealthProbe`, `flags.v5CanonicalAnalysis`, `NodeChip.canonicalRun`) — 15 files / **120 passed**.

## Refuted / noted

Two pre-existing guards are the defect class this replaces, and **neither** was doing this job:

- `tools/ci-guards/check-flags-drift.mjs` (`ci:guard:flags`) compares a hand-maintained `docs/spec/flags-canvas.json` against a generated evidence-pack manifest. It never touches a deploy.
- `scripts/check-bundle-flags.sh` hard-codes three `REQUIRED_FLAGS` (`VITE_FEATURE_PLOT_STREAM`, `VITE_FEATURE_COMPARE_DEBUG`, `VITE_FEATURE_INSPECTOR_DEBUG`) — **none of which is declared in `FLAGS_CONFIG`**, and it greps a local `dist/`, not a deploy.

Left in place, out of scope. Flagged for a follow-up decision.

**Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)