### PR TITLE
docs(sequential): record useSequentialAnalysis as dead and its endpoint as deleted

### DIFF
--- a/docs/ISL_CALL_AUDIT.md
+++ b/docs/ISL_CALL_AUDIT.md
@@ -168,7 +168,33 @@ These hooks were audited but do NOT call ISL directly:
 |------|-----------------|-------|
 | `useISLSynthesis` | `/bff/cee/isl-synthesis` | Calls CEE, not ISL |
 | `useConditionalRecommendations` | `/bff/engine/v1/analysis/conditional-recommend` | Calls PLoT |
-| `useSequentialAnalysis` | `/bff/engine/v1/analysis/sequential` | Calls PLoT |
+| `useSequentialAnalysis` | `/bff/engine/v1/analysis/sequential` — **route DELETED 26 Jul 2026** | **DEAD CODE — calls nothing.** See the note below. |
+
+> **⚠ `useSequentialAnalysis` is dead, and its endpoint no longer exists (recorded 28 Jul 2026).**
+>
+> This row previously read *"Calls PLoT"* with no qualification, which described a
+> live call. It is not one, on either side of the wire:
+>
+> - **The endpoint is gone.** PLoT deleted `POST /v1/analysis/sequential` (and
+>   `/v1/analysis/policy-tree`) on 26 Jul 2026 as vacuous — ISL owns the real
+>   sequential capability. Live-probed 28 Jul 2026 at PLoT staging tip `05529e42`:
+>   `GET`+`POST /v1/analysis/sequential` → **404**, against positive control
+>   `POST /v1/run` → 401 and negative control `POST /v1/does-not-exist-xyz` → 404.
+> - **Nothing reaches the call anyway.** `useSequentialAnalysis` has exactly one
+>   importer, `src/canvas/components/SequentialView/index.tsx`, and `SequentialView`
+>   has **zero** importers outside its own directory — no JSX renderer, no barrel
+>   re-export, no `lazy()`/dynamic import, and no registry or lookup-table mount.
+>   The pair is a closed, orphaned loop.
+> - **Confirmed against the deployed bundle**, not just the source: all 70 JS chunks
+>   of `staging--olumi.netlify.app` were crawled (5.4 MB, zero fetch failures);
+>   `analysis/sequential` and the hook's own `[useSequentialAnalysis]` log tag appear
+>   in **0** chunks, while positive controls `pre-analysis-sensitivity`,
+>   `graph-readiness`, `v1/templates` and `bff/engine` were all found. The absence is
+>   measured, not assumed.
+>
+> **Consequence: there is no user-visible breakage and nothing to fix urgently.**
+> Disposition (archive under the repo's `archive/dead-*-<YYYY-MM>/` precedent, or
+> delete) is rowed as separate work and deliberately NOT done here.
 
 ---
 

--- a/src/canvas/hooks/useSequentialAnalysis.ts
+++ b/src/canvas/hooks/useSequentialAnalysis.ts
@@ -1,13 +1,47 @@
 /**
  * useSequentialAnalysis Hook
  *
+ * ## ⚠ DEAD CODE — NOT MOUNTED, AND STEP 2 BELOW CALLS A DELETED ENDPOINT
+ * ## (recorded 28 Jul 2026 — read this before trusting anything under "Flow")
+ *
+ * This hook is not reachable from any live path, and its primary request would
+ * 404 if it ever ran. Both halves were measured, not assumed:
+ *
+ * - **No mount.** Complete importer manifest at UI tip `4facd4a7`: the sole
+ *   importer is `src/canvas/components/SequentialView/index.tsx`, and
+ *   `SequentialView` itself has ZERO importers outside its own directory — no
+ *   JSX renderer, no barrel re-export, no `lazy()`/dynamic import, and no
+ *   registry or lookup-table mount. The two files form a closed, orphaned loop.
+ * - **Not in the shipped bundle.** All 70 JS chunks of
+ *   `staging--olumi.netlify.app` were crawled (5.4 MB, zero fetch failures):
+ *   `analysis/sequential` and the `[useSequentialAnalysis]` log tag below appear
+ *   in 0 chunks, while positive controls (`pre-analysis-sensitivity`,
+ *   `graph-readiness`, `v1/templates`, `bff/engine`) were all present — so the
+ *   absence is a real measurement, not a grep that could see nothing.
+ * - **The endpoint is gone.** PLoT deleted `POST /v1/analysis/sequential` on
+ *   26 Jul 2026 as vacuous (ISL owns the real sequential capability). Probed
+ *   28 Jul 2026 at PLoT staging tip `05529e42`: 404, against positive control
+ *   `POST /v1/run` → 401 and negative control `POST /v1/does-not-exist-xyz` → 404.
+ *
+ * Because nothing mounts it, there is no user-visible breakage. Disposition
+ * (archive under the `archive/dead-*-<YYYY-MM>/` precedent, or delete) is rowed
+ * as separate work. **Do not wire this hook up again without first restoring or
+ * replacing the endpoint** — mounting it as-is ships a guaranteed 404.
+ *
+ * ## ⚠ The service attributions in the original Flow were also wrong
+ *
+ * Steps 2 and 3 named ISL and CEE. Both actually resolve to **PLoT**:
+ * `netlify.toml` redirects `/bff/engine/*` →
+ * `https://plot-lite-service-staging.onrender.com/:splat`, and `BFF_BASE_URL`
+ * below defaults to `/bff/engine`. Corrected inline.
+ *
  * Detects sequential graphs and fetches stage-by-stage analysis.
  * Provides policy recommendations for multi-stage decisions.
  *
  * Flow:
  * 1. Detect if graph has sequential metadata
- * 2. Fetch sequential analysis from ISL /analysis/sequential
- * 3. Get policy explanation from CEE /explain/policy
+ * 2. Fetch sequential analysis from PLoT /v1/analysis/sequential — DELETED, 404s
+ * 3. Get policy explanation from PLoT /v1/explain/policy — this route still exists
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'


### PR DESCRIPTION
## Verdict: **DEAD** — there is no live call to the deleted endpoint

No user-visible breakage, and nothing to fix urgently. The *record* asserted otherwise, and that is what this PR fixes. **No deletion here** — disposition is rowed separately.

`docs/ISL_CALL_AUDIT.md:171` read `useSequentialAnalysis` → `/bff/engine/v1/analysis/sequential` | *"Calls PLoT"*, describing a live call. Neither side of that wire holds.

### 1. No mount — static, complete manifest at UI tip `4facd4a7`

| Link in the chain | Finding |
|---|---|
| `useSequentialAnalysis` importers | **1** — `src/canvas/components/SequentialView/index.tsx` |
| `SequentialView` importers outside its own dir | **0** |
| JSX renderers / barrel re-exports | none |
| `lazy()` / dynamic `import()` | none |
| registry or lookup-table mount (string-key) | none — every remaining `sequential` string literal in `src/` is unrelated test prose |

The two files form a closed, orphaned loop. Only non-source references are CI baselines (`ds-compliance-baseline.json`, `typecheck-baseline*.txt` — which already record `TS6133 declared but never read` in both files) and the doc corrected here.

### 2. Not in the deployed bundle — artefact evidence, not just source

All **70** JS chunks of `staging--olumi.netlify.app` crawled (5.4 MB, **zero** fetch failures):

| String | Chunks | Role |
|---|---|---|
| `analysis/sequential` | **0** | target |
| `[useSequentialAnalysis]` (hook log tag) | **0** | target |
| `pre-analysis-sensitivity` | 1 | ✅ positive control |
| `graph-readiness` | 1 | ✅ positive control |
| `v1/templates` | 1 | ✅ positive control |
| `bff/engine` | 4 | ✅ positive control |
| `zzz-not-a-real-string-xyz` | 0 | ✅ negative control |

The positive controls prove the grep **can see a presence**, so the absence is measured, not vacuous. (My first crawl was wrong and I caught it: Vite lists chunks in `__vite__mapDeps` as `"assets/…"` *without* a leading slash, so a `/assets/` regex found 1 chunk instead of 70. Fixed before drawing any conclusion.)

### 3. The endpoint is deleted

PLoT removed `POST /v1/analysis/sequential` on 26 Jul 2026 as vacuous (ISL owns the real sequential capability). Probed 28 Jul 2026 at PLoT staging tip `05529e42`: **404**, against positive control `POST /v1/run` → 401 and negative control `POST /v1/does-not-exist-xyz` → 404.

### Also corrected: the hook misattributed both services

Its header credited step 2 to **ISL** and step 3 to **CEE**. Both resolve to **PLoT** — `netlify.toml:195` redirects `/bff/engine/*` → `plot-lite-service-staging.onrender.com/:splat`, and `BFF_BASE_URL` defaults to `/bff/engine`. The sibling call at `:250`, `/v1/explain/policy`, **does still exist** and is auth-gated — not to be conflated with the deleted route.

## Disposition (rowed, deliberately NOT done here)

Archive `useSequentialAnalysis.ts` + `SequentialView/` under the repo’s existing `archive/dead-*-2026-07/` precedent (which already holds `MultiGoalParetoPanel.tsx` et al. with a README), or delete. That is a multi-file removal touching two CI baselines and belongs in its own reviewed change.

## Evidence

- **`pnpm typecheck`: PASSED** — ratchet **HELD at 2516** (baseline 2516), coverage 3005/3045 files
- `tools/ci-guards/check-ds-compliance.mjs`: **exit 0**
- **Comment/doc-only** — the TS diff contains **zero** non-comment lines (mechanically checked); block comment balanced
- No test suite references either changed file; claim-drift baseline does not cover them
- Run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set (trap 2b)

Held for orchestrator review.

Generated with [Claude Code](https://claude.com/claude-code)