### PR TITLE
fix(ui): the draft wait must not claim a phase it cannot see (M1-L2 — blocked, see body)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -149,7 +149,7 @@ export const AIInputBar = memo(
     // Empty canvas + isThinking === a model-generation turn is in flight.
     // The composer freezes and shows a gently-pulsing, time-escalating status
     // line where the placeholder normally sits. Tick once a second so the
-    // message advances through PROGRESSIVE_STAGES (0/15/30/45/60s).
+    // message advances through PROGRESSIVE_STAGES (0/20/45s).
     const isGenerating = isThinking && nodeCount === 0
     // Store the resolved MESSAGE (not raw seconds): the 1s tick then only
     // triggers a re-render when the stage actually advances — React bails on an

--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -1,28 +1,71 @@
 /**
  * DraftLoadingAnimation
  *
- * Time-based progressive loading indicator for AI draft generation.
- * Status message escalates based on elapsed wall-clock time so users
- * understand the system is still working on complex briefs.
+ * Time-based loading indicator for AI draft generation. Elapsed wall-clock
+ * time is the ONLY input this component has, and the copy now says only what
+ * elapsed time licenses.
  *
  * Stages:
- *   0–15 s  "Generating your decision model…"
- *  15–30 s  "Mapping factors and causal relationships…"
- *  30–45 s  "Assessing options, risks and potential outcomes"
- *  45–60 s  "This is a complex decision - building a thorough model…"
- *  60 s+    "Still working - complex briefs can take up to two minutes."
+ *   0–20 s  "Drafting your decision model…"
+ *  20–45 s  "Still drafting your decision model…"
+ *  45 s+    "Still drafting — complex decisions can take a while…"
+ *
+ * ── ROADMAP 1.204 M1-L2: this table used to be a wall-clock fiction ───────
+ * It previously claimed internal pipeline phases off a timer ("Mapping
+ * factors and causal relationships…" at 15 s, "Assessing options, risks and
+ * potential outcomes" at 30 s) and asserted a property of the user's own
+ * input ("This is a complex decision") purely because the server was slow. A
+ * two-word brief on a slow afternoon was told its decision was complex.
+ *
+ * None of it was derivable. Verified at CEE `95e1a2f8`: the V5 turn's draft
+ * tool (`src/orchestrator/tools/draft-graph.ts:190`) calls
+ * `runUnifiedPipeline(...)` WITHOUT the `onStage` emitter — that emitter is
+ * passed only by `assist.v1.draft-graph-staged.ts:486`, a route the product
+ * path does not call. The client therefore receives ZERO stage signal during
+ * a draft, so every phase word here was a guess dressed as knowledge. The
+ * measured truth is also not what the old copy implied: on the 28 Jul live
+ * probe the graph was finished and validated at ~33 s and the remaining ~20 s
+ * was a coaching pass — i.e. at 30–45 s, when the old table said "Assessing
+ * options", the options had been settled for over ten seconds.
+ *
+ * ── The bar, and where it comes from ──────────────────────────────────────
+ * This is not new copy doctrine. `AnalysisRunningBanner.NARRATION_STAGES`
+ * (the analysis wait) already carries it, reasoned out over two review
+ * rounds: no claim of a pipeline stage, count or completion proximity the
+ * client cannot know; every line must stay TRUE from its own threshold until
+ * the wait ends, including a wait that dies at the timeout. That review also
+ * killed the comparative family ("longer than usual", "usually takes about a
+ * minute") — the client holds no distribution of past draft durations, so it
+ * has no baseline to compare against and must not invent one. The doctrine
+ * was never analysis-specific; it had simply only ever been enforced on one
+ * surface. `__tests__/narrationHonesty.invariant.spec.ts` now enforces it
+ * over BOTH tables, so the two cannot drift apart again.
+ *
+ * ⚠ This table is an HONEST INTERIM, not the destination. M1's real cure is
+ * server-driven narration: once CEE-2 ships the staged turn route
+ * (`POST /orchestrate/v2/turn/stream`), this file should be driven by real
+ * GRAPH_READY / COACHING_READY frames and the elapsed-time table deleted
+ * outright. Until that route exists the client has nothing real to narrate,
+ * and the correct behaviour is to claim less — not to guess more.
  */
 
 import { useEffect, useState, useRef } from 'react'
 import { typography } from '../../styles/typography'
 
-/** Progressive message stages keyed by elapsed-second threshold */
+/**
+ * Message stages keyed by elapsed-second threshold.
+ *
+ * Every line must be true by construction of elapsed time alone AND stay
+ * true from its threshold until the draft ends — a line that becomes false
+ * while it is still on screen is the "progress bar stuck at 95%" defect.
+ * Thresholds sit at 0/20/45 s against a measured typical draft of ~53 s
+ * (28 Jul live probe), so the user sees the acknowledgement escalate twice
+ * during an ordinary wait without any line ever over-promising.
+ */
 export const PROGRESSIVE_STAGES = [
-  { afterSeconds: 0,  message: 'Generating your decision model…' },
-  { afterSeconds: 15, message: 'Mapping factors and causal relationships…' },
-  { afterSeconds: 30, message: 'Assessing options, risks and potential outcomes' },
-  { afterSeconds: 45, message: 'This is a complex decision - building a thorough model…' },
-  { afterSeconds: 60, message: 'Still working - complex briefs can take up to two minutes.' },
+  { afterSeconds: 0,  message: 'Drafting your decision model…' },
+  { afterSeconds: 20, message: 'Still drafting your decision model…' },
+  { afterSeconds: 45, message: 'Still drafting — complex decisions can take a while…' },
 ] as const
 
 /** Resolve the current message for a given elapsed time (seconds) */

--- a/src/canvas/components/__tests__/DraftLoadingAnimation.spec.ts
+++ b/src/canvas/components/__tests__/DraftLoadingAnimation.spec.ts
@@ -1,61 +1,65 @@
 /**
- * Tests for DraftLoadingAnimation progressive status messaging.
+ * Tests for DraftLoadingAnimation status messaging.
  *
- * Tests the pure `messageForElapsed` function that resolves
- * time-based status messages without needing React rendering.
+ * Tests the pure `messageForElapsed` function that resolves time-based
+ * status messages without needing React rendering.
+ *
+ * The HONESTY properties of this copy (no pipeline-phase claim, no claim
+ * about the user's decision, no comparative/forecast, no completion
+ * proximity) are pinned separately and CROSS-SURFACE in
+ * `narrationHonesty.invariant.spec.ts`, which holds this table and the
+ * analysis banner's table to the same bar. This file pins resolution
+ * mechanics and the exact strings.
  */
 
 import { describe, it, expect } from 'vitest'
 import { messageForElapsed, PROGRESSIVE_STAGES } from '../DraftLoadingAnimation'
 
+const STAGE_1 = 'Drafting your decision model…'
+const STAGE_2 = 'Still drafting your decision model…'
+const STAGE_3 = 'Still drafting — complex decisions can take a while…'
+
 describe('messageForElapsed', () => {
   it('returns stage 1 message at 0 seconds', () => {
-    expect(messageForElapsed(0)).toBe('Generating your decision model…')
+    expect(messageForElapsed(0)).toBe(STAGE_1)
   })
 
-  it('returns stage 1 message at 14 seconds', () => {
-    expect(messageForElapsed(14)).toBe('Generating your decision model…')
+  it('returns stage 1 message at 19 seconds', () => {
+    expect(messageForElapsed(19)).toBe(STAGE_1)
   })
 
-  it('returns stage 2 message at 15 seconds', () => {
-    expect(messageForElapsed(15)).toBe('Mapping factors and causal relationships…')
+  it('returns stage 2 message at 20 seconds', () => {
+    expect(messageForElapsed(20)).toBe(STAGE_2)
   })
 
-  it('returns stage 2 message at 29 seconds', () => {
-    expect(messageForElapsed(29)).toBe('Mapping factors and causal relationships…')
+  it('returns stage 2 message at 44 seconds', () => {
+    expect(messageForElapsed(44)).toBe(STAGE_2)
   })
 
-  it('returns stage 3 message at 30 and 44 seconds', () => {
-    expect(messageForElapsed(30)).toBe('Assessing options, risks and potential outcomes')
-    expect(messageForElapsed(44)).toBe('Assessing options, risks and potential outcomes')
+  it('returns stage 3 message at 45 seconds', () => {
+    expect(messageForElapsed(45)).toBe(STAGE_3)
   })
 
-  it('returns stage 4 message at 45 and 59 seconds', () => {
-    expect(messageForElapsed(45)).toBe(
-      'This is a complex decision - building a thorough model…'
-    )
-    expect(messageForElapsed(59)).toBe(
-      'This is a complex decision - building a thorough model…'
-    )
-  })
-
-  it('returns stage 5 message at 60 and 120 seconds', () => {
-    expect(messageForElapsed(60)).toBe(
-      'Still working - complex briefs can take up to two minutes.'
-    )
-    expect(messageForElapsed(120)).toBe(
-      'Still working - complex briefs can take up to two minutes.'
-    )
+  /**
+   * The last line has to hold all the way to the client timeout — it is the
+   * one the user stares at on a bad draft, and it must still be true there.
+   */
+  it('holds the final message indefinitely, including past the client timeout', () => {
+    expect(messageForElapsed(60)).toBe(STAGE_3)
+    expect(messageForElapsed(120)).toBe(STAGE_3)
+    expect(messageForElapsed(130)).toBe(STAGE_3)
+    expect(messageForElapsed(600)).toBe(STAGE_3)
   })
 
   it('handles negative elapsed time gracefully', () => {
-    expect(messageForElapsed(-1)).toBe('Generating your decision model…')
+    expect(messageForElapsed(-1)).toBe(STAGE_1)
   })
 })
 
 describe('PROGRESSIVE_STAGES', () => {
-  it('has exactly 5 stages', () => {
-    expect(PROGRESSIVE_STAGES).toHaveLength(5)
+  it('exposes exactly the three honest stages, in order', () => {
+    expect(PROGRESSIVE_STAGES.map((s) => s.message)).toEqual([STAGE_1, STAGE_2, STAGE_3])
+    expect(PROGRESSIVE_STAGES.map((s) => s.afterSeconds)).toEqual([0, 20, 45])
   })
 
   it('stages are in ascending order by afterSeconds', () => {

--- a/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
+++ b/src/canvas/components/__tests__/aiPanelV2.polish.spec.tsx
@@ -131,7 +131,7 @@ describe('Item 4 — AIInputBar generating state (isThinking + empty canvas)', (
     // The placeholder is cleared so the pulsing status overlay owns the text
     // box; the first-stage message renders in that status line instead.
     expect(textarea.placeholder).toBe('')
-    expect(screen.getByTestId('gen-generating')).toHaveTextContent('Generating your decision model…')
+    expect(screen.getByTestId('gen-generating')).toHaveTextContent('Drafting your decision model…')
     expect(textarea).toBeDisabled()
     expect(textarea).toHaveAttribute('aria-disabled', 'true')
     // Cog + send must also lock during generation so the user can't open
@@ -150,15 +150,14 @@ describe('Item 4 — AIInputBar generating state (isThinking + empty canvas)', (
       conversationMockState.isThinking = true
       render(<AIInputBar variant="first-use" hideChevron testId="gen" onCogClick={() => {}} />, { wrapper: Wrapper })
       const status = screen.getByTestId('gen-generating')
-      expect(status).toHaveTextContent('Generating your decision model…')
-      act(() => { vi.advanceTimersByTime(15_000) })
-      expect(status).toHaveTextContent('Mapping factors and causal relationships…')
-      act(() => { vi.advanceTimersByTime(15_000) })
-      expect(status).toHaveTextContent('Assessing options, risks and potential outcomes')
-      act(() => { vi.advanceTimersByTime(15_000) })
-      expect(status).toHaveTextContent('This is a complex decision - building a thorough model…')
-      act(() => { vi.advanceTimersByTime(15_000) })
-      expect(status).toHaveTextContent('Still working - complex briefs can take up to two minutes.')
+      expect(status).toHaveTextContent('Drafting your decision model…')
+      act(() => { vi.advanceTimersByTime(20_000) })
+      expect(status).toHaveTextContent('Still drafting your decision model…')
+      act(() => { vi.advanceTimersByTime(25_000) })
+      expect(status).toHaveTextContent('Still drafting — complex decisions can take a while…')
+      // The final line holds — it must still be true at the client timeout.
+      act(() => { vi.advanceTimersByTime(60_000) })
+      expect(status).toHaveTextContent('Still drafting — complex decisions can take a while…')
     } finally {
       vi.useRealTimers()
     }

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * CROSS-SURFACE narration-honesty invariant (ROADMAP 1.204 M1-L2).
+ *
+ * There are two wait-narration surfaces in this app, and until this spec they
+ * were governed by two different standards:
+ *
+ *   - `AnalysisRunningBanner.NARRATION_STAGES` (the analysis wait) carries a
+ *     RATIFIED honesty doctrine, reasoned out over two review rounds in its
+ *     own header: "no claim of a pipeline stage, count or completion
+ *     proximity the client cannot know", elapsed time is the ONLY input, and
+ *     every line must stay true from its own threshold until the run ends.
+ *     That review explicitly killed the "almost there" family AND the
+ *     comparative family ("than usual" — the client holds no distribution of
+ *     past durations, so it has no baseline to compare against).
+ *
+ *   - `DraftLoadingAnimation.PROGRESSIVE_STAGES` (the draft wait) never got
+ *     it. It claimed internal pipeline phases off a wall clock ("Mapping
+ *     factors and causal relationships…" at 15 s) and asserted a property of
+ *     the user's own input ("This is a complex decision") purely because the
+ *     server was slow.
+ *
+ * The doctrine was never surface-specific — it just only ever got enforced on
+ * one surface. This spec applies it to BOTH, so a future line added to either
+ * table is held to the same bar. Testing each table in isolation is what let
+ * them diverge in the first place.
+ *
+ * ── WHY THE DRAFT WAIT CANNOT NAME A PHASE (derived, not assumed) ──────────
+ * The client receives no stage signal on the product draft path. Verified at
+ * CEE `95e1a2f8`: the V5 turn's draft tool (`src/orchestrator/tools/
+ * draft-graph.ts:190`) calls `runUnifiedPipeline(...)` WITHOUT the `onStage`
+ * emitter, which is passed only by `assist.v1.draft-graph-staged.ts:486` — a
+ * route the UI's product path does not call. So every phase word in the old
+ * table was a guess dressed as knowledge.
+ *
+ * ── HONEST LIMIT OF THIS GUARD (trap 12) ──────────────────────────────────
+ * The rule set below is a HAND-LISTED VOCABULARY. It cannot prove the absence
+ * of every possible fabrication — a novel phase word would pass. What it DOES
+ * guarantee is that the retired lines and their close relatives cannot come
+ * back, and that the two surfaces are held to one standard. It is a
+ * regression pin plus a shared bar, NOT a general claim-safety proof, and it
+ * is deliberately not described as one.
+ *
+ * ── POSITIVE CONTROL (trap 13) ────────────────────────────────────────────
+ * An absence assertion that has never seen a presence is vacuous. Every rule
+ * is proved to FIRE on a string that violates it, and the retired draft table
+ * — pinned here BY VALUE, permanently, as a historical artefact rather than a
+ * pointer at whatever is current (trap 12b) — is proved to fail the suite.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { NARRATION_STAGES } from '../AnalysisRunningBanner'
+import { PROGRESSIVE_STAGES } from '../DraftLoadingAnimation'
+
+interface Stage {
+  readonly afterSeconds: number
+  readonly message: string
+}
+
+/**
+ * The draft table EXACTLY as it stood at `0b65ada1`, immediately before this
+ * lane. Frozen by value on purpose: a control pinned to "whatever is current"
+ * decays into a tautology the first time current changes (trap 12b). This
+ * array must never be updated to track the live table.
+ */
+const RETIRED_DRAFT_STAGES_2026_07_28: readonly Stage[] = [
+  { afterSeconds: 0, message: 'Generating your decision model…' },
+  { afterSeconds: 15, message: 'Mapping factors and causal relationships…' },
+  { afterSeconds: 30, message: 'Assessing options, risks and potential outcomes' },
+  { afterSeconds: 45, message: 'This is a complex decision - building a thorough model…' },
+  { afterSeconds: 60, message: 'Still working - complex briefs can take up to two minutes.' },
+] as const
+
+interface Rule {
+  readonly name: string
+  readonly pattern: RegExp
+  /** A string known to violate this rule — the rule's own positive control. */
+  readonly control: string
+}
+
+const RULES: readonly Rule[] = [
+  {
+    name: 'no internal-pipeline-phase claim',
+    pattern: /\b(mapping|assessing|shaping|extracting|validating|scoring|simulating|parsing|repairing)\b/i,
+    control: 'Mapping factors and causal relationships…',
+  },
+  {
+    name: 'no claim about THIS decision or brief',
+    pattern: /\bthis (is|was|looks|seems)\b|\byour (decision|brief) (is|looks|seems)\b/i,
+    control: 'This is a complex decision - building a thorough model…',
+  },
+  {
+    name: 'no comparative, baseline or duration forecast',
+    pattern: /\b(than usual|usually|typically|on average|normally|up to (a|an|one|two|three|four|five|\d)|takes? about)\b/i,
+    control: 'Still working - complex briefs can take up to two minutes.',
+  },
+  {
+    name: 'no completion-proximity claim',
+    pattern: /\b(almost|nearly|any (moment|second)|finishing|wrapping up|final(ising|izing))\b/i,
+    control: 'Almost there — shaping the results…',
+  },
+  {
+    name: 'no fabricated progress number',
+    pattern: /\d+\s*%|\bstep \d+\b|\b\d+\s*of\s*\d+\b/i,
+    control: 'Step 2 of 4 — 60% complete',
+  },
+]
+
+function violations(message: string): string[] {
+  return RULES.filter((r) => r.pattern.test(message)).map((r) => r.name)
+}
+
+/**
+ * Both live tables. The analysis table doubles as a NEGATIVE control on the
+ * rules themselves: it is the already-ratified copy, so if a rule ever flags
+ * it, the rule is over-strict rather than the copy being dishonest.
+ */
+const LIVE_TABLES: ReadonlyArray<readonly [string, readonly Stage[]]> = [
+  ['AnalysisRunningBanner.NARRATION_STAGES', NARRATION_STAGES],
+  ['DraftLoadingAnimation.PROGRESSIVE_STAGES', PROGRESSIVE_STAGES],
+]
+
+describe('narration honesty — one bar for every wait surface', () => {
+  describe.each(LIVE_TABLES)('%s', (_label, stages) => {
+    it('asserts nothing the client cannot know from elapsed time alone', () => {
+      const offenders = stages
+        .map((s) => ({ message: s.message, broke: violations(s.message) }))
+        .filter((r) => r.broke.length > 0)
+
+      expect(offenders).toEqual([])
+    })
+
+    it('starts at zero and escalates strictly', () => {
+      expect(stages.length).toBeGreaterThan(0)
+      expect(stages[0].afterSeconds).toBe(0)
+      for (let i = 1; i < stages.length; i++) {
+        expect(stages[i].afterSeconds).toBeGreaterThan(stages[i - 1].afterSeconds)
+      }
+    })
+
+    it('never renders an empty line', () => {
+      for (const s of stages) {
+        expect(s.message.trim().length).toBeGreaterThan(0)
+      }
+    })
+  })
+})
+
+describe('positive control — the guard can SEE a violation', () => {
+  it.each(RULES.map((r) => [r.name, r] as const))('%s fires on its control string', (_name, rule) => {
+    expect(rule.pattern.test(rule.control)).toBe(true)
+    expect(violations(rule.control)).toContain(rule.name)
+  })
+
+  it('an honest line trips no rule', () => {
+    expect(violations('Still drafting your decision model…')).toEqual([])
+  })
+
+  it('the retired draft table FAILS this suite (the defect this lane fixes)', () => {
+    const offenders = RETIRED_DRAFT_STAGES_2026_07_28
+      .map((s) => ({ message: s.message, broke: violations(s.message) }))
+      .filter((r) => r.broke.length > 0)
+
+    // Three of the five retired lines were fabrications; naming them keeps the
+    // control specific, so a rule that silently stops matching is visible.
+    expect(offenders).toEqual([
+      {
+        message: 'Mapping factors and causal relationships…',
+        broke: ['no internal-pipeline-phase claim'],
+      },
+      {
+        message: 'Assessing options, risks and potential outcomes',
+        broke: ['no internal-pipeline-phase claim'],
+      },
+      {
+        message: 'This is a complex decision - building a thorough model…',
+        broke: ['no claim about THIS decision or brief'],
+      },
+      {
+        message: 'Still working - complex briefs can take up to two minutes.',
+        broke: ['no comparative, baseline or duration forecast'],
+      },
+    ])
+  })
+
+  it('none of the retired messages survives verbatim in either live table', () => {
+    const liveMessages = LIVE_TABLES.flatMap(([, stages]) => stages.map((s) => s.message))
+    const retiredFabrications = RETIRED_DRAFT_STAGES_2026_07_28
+      .filter((s) => violations(s.message).length > 0)
+      .map((s) => s.message)
+
+    for (const fabricated of retiredFabrications) {
+      expect(liveMessages).not.toContain(fabricated)
+    }
+  })
+})


### PR DESCRIPTION
**ROADMAP 1.204 M1 — UI lane.** Design of record: `docs-designs/ASYNC-DRAFTING-DESIGN-2026-07-28.md`.
Evidence: `PHASE0-EVIDENCE-2026-07-28/m1l2-draft-consumer.md`.

## ⚠ READ FIRST — the lane I was dispatched to build is BLOCKED, and this PR is not it

I was dispatched to build the UI consumer for CEE #745's staged draft frames — "first content on canvas in seconds". **That is not buildable today, and I did not fake it.** What follows is the derivation, because the dispatch brief states the server half is done and it is done only for a route the product does not call.

### The product cold draft is a V5 TURN. #745 staged an ASSIST route.

| | |
|---|---|
| UI's live cold draft | `DraftChat.tsx:252-262` → `conversation.sendMessage(brief, { turnType: 'explicit_generate' })` → `v5Adapter.ts:31-35,:73` → **`POST /bff/orchestrate/v2/turn`**, `Accept: application/json` |
| What #745 built | **`POST /assist/v1/draft-graph/staged`** — `assist.v1.draft-graph-staged.ts:270` parses `DraftGraphInput`, calls `runUnifiedPipeline` directly |

Complete route-file manifest at CEE `95e1a2f8`, `src/routes/`, filtered for draft/stream/turn: `assist.draft-graph.ts`, `assist.v1.draft-graph.ts`, `assist.v1.draft-graph-stream.ts`, `assist.v1.draft-graph-staged.ts`, `proxy-v5-turn.ts`. **There is no `/orchestrate/v2/turn/stream`.** `server.ts:1179` logs only `V5 orchestrator registered (POST /orchestrate/v2/turn)`.

**The turn emits no frames, by construction.** `src/orchestrator/tools/draft-graph.ts:190` calls `runUnifiedPipeline(input, { brief }, request, opts)` **without `onStage`**. Complete `onStage`-passing manifest in CEE `src/`: exactly one call site, `assist.v1.draft-graph-staged.ts:486`. #745's own PR body says so — *"The turn-level sibling (`/orchestrate/v2/turn/stream`) is CEE lane 2, not this PR."* The design agrees: Q3 scopes **UI-1 as re-pointing the consumer at CEE-2's route**.

### And re-pointing the draft at the assist route would break analysis

The staged route has **zero** scenario/session concept (one `scenario|session|persist` hit in the whole file, a comment about the out-of-scope M3 store). The V5 turn commits the graph to the scenario store (`turn-executor.ts:9229`, `edit-graph-dispatch.ts:2905`), and `run_analysis` reads it back — with an explicit NULL-graph branch returning a typed `analysis_not_ready` "draft a model first" (`config/index.ts:1133`).

So drafting over the assist route would leave `scenarios.graph` NULL and make **the very next thing the user does — Run analysis — honestly refuse.** That trades a 53 s wait for a broken product. I did not do it, and I did not build an unreachable consumer module either: a typed SSE client with no reachable server route is the guarantee-theatre defect class this programme exists to hunt.

**M1-L2 is blocked on CEE-2. Time-to-first-content is UNCHANGED at ~53–60 s by this PR.**

---

## What this PR actually does: kills a live fabrication in the draft wait

While deriving the above I verified the copy the user stares at for those 53 s. It was a wall-clock fiction — and worse than the design recorded.

| elapsed | old copy | truth |
|---|---|---|
| 15–30 s | "Mapping factors and causal relationships…" | a guess; the client receives **zero** stage signal (derived above) |
| 30–45 s | "Assessing options, risks and potential outcomes" | on the 28 Jul live probe the graph was **validated at ~33 s**; at 30–45 s the options had been settled for over ten seconds and the server was doing a coaching pass |
| 45–60 s | **"This is a complex decision - building a thorough model…"** | asserts a property of the **user's own input** because the server was slow. A two-word brief on a slow afternoon is told its decision is complex. |
| 60 s+ | "Still working - complex briefs can take up to two minutes." | a duration forecast the client cannot make |

Live on the product path: `AIInputBar.tsx:152-166` renders `messageForElapsed` whenever `isThinking && nodeCount === 0`, and `DraftChat.tsx:1187` renders the animation.

### The bar is not my invention — it was already ratified, on the other surface

`AnalysisRunningBanner.NARRATION_STAGES` carries a doctrine reasoned out over two review rounds in its own header: *no claim of a pipeline stage, count or completion proximity the client cannot know*; elapsed time is the ONLY input; every line must stay true from its threshold **until the wait ends, including one that dies at the timeout**. That review explicitly killed the "almost there" family **and the comparative family** — "the client holds no distribution of past run durations, so it has no baseline to compare against".

That doctrine was never analysis-specific. It had only ever been *enforced* on one surface. This PR applies it to the draft wait:

```
0–20 s   Drafting your decision model…
20–45 s  Still drafting your decision model…
45 s+    Still drafting — complex decisions can take a while…
```

Note the surviving line says complex decisions *can* take a while — a general statement — where the retired line asserted *this* decision was complex. That distinction is the one the analysis review already adjudicated.

**I deliberately did NOT write "this usually takes about a minute"**, which was my first instinct and which the ratified doctrine forbids for exactly the right reason.

## The test is CROSS-SURFACE, because testing each table alone is what let them diverge

`narrationHonesty.invariant.spec.ts` runs one rule set over **both** tables.

- The **analysis table is a negative control on the rules**: it is already-ratified copy, so if a rule ever flags it, the rule is over-strict rather than the copy dishonest. It passed unmodified.
- The **retired draft table is pinned BY VALUE, permanently** (`RETIRED_DRAFT_STAGES_2026_07_28`) as a historical artefact — not a pointer at whatever is current, which decays into a tautology the first time current changes.
- **Every rule is proved to fire** on a string that violates it. An absence assertion that has never seen a presence is vacuous.

**Honest limit, stated in the spec rather than glossed:** the rule set is a **hand-listed vocabulary**. It cannot prove the absence of every fabrication — a novel phase word would pass. It is a regression pin plus a shared bar, **not a general claim-safety proof**, and it is not described as one.

### Mutation battery — throwaway worktree OUTSIDE the clone, removed before every gate run

| # | mutation | verdict |
|---|---|---|
| M1 | draft table re-claims a pipeline phase | **RED** |
| M2 | draft table re-asserts the user's decision is complex | **RED** |
| M3 | draft table adds a comparative/baseline claim | **RED** |
| M4 | **the ANALYSIS table adds a fabrication** (proves the cross-surface claim is real, not decorative) | **RED** |
| M5 | **the pipeline-phase rule is neutered** (proves the guard cannot be silently hollowed) | **RED** |

**Survivors: 0.** Baseline unmutated run: GREEN.

RED-first: the invariant spec was written before the fix and failed on the draft table while passing on the analysis table.

## Gates

- `pnpm typecheck` — **PASSED**. Coverage 3016/3056 tracked files (40 declared out of scope); ratchet **2516 errors, exactly the baseline** — zero new.
- `npx vitest run src/canvas/components` — **243 files, 3374 tests passed, 0 failed** (2 files / 37 tests skipped, pre-existing).
- `npx eslint` on all five touched files — clean, exit 0.
- Run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set (collect-time trap).

## Scope

- **No flags.** Copy + a pure function. Rollback = revert.
- **This is an HONEST INTERIM, not M1's cure**, and both the component header and the commit say so. When CEE-2 ships, this table should be **deleted** and the component driven by real `GRAPH_READY` / `COACHING_READY` frames. Until that route exists the client has nothing real to narrate, and the correct move is to claim less, not to guess more.

## Deviation from dispatch, declared

- The dispatch specified the title *"feat(ui): consume staged draft frames — first content in seconds (M1-L2)"*. **That title would have been false** — nothing in this PR consumes a frame. Retitled to what it is.
- The dispatch required *"ONE test that asserts the early-frame graph and the COMPLETE-frame graph agree on identity"*. **Not applicable and not written** — there is no frame consumer to test. It remains the right requirement for the real M1-L2 and is recorded for that lane.
- The adjacent-trap instruction (ROADMAP 2.110, the `?schema=v2` double transform) was to STOP and report if my path hit it. **My path does not reach it**: the UI's only caller of the 2-frame stream route is `useDraftModel`, which has **zero callers** in `src/` (complete grep, non-test). Separately confirmed dead: `streamOrchestratorTurn` still targets `/orchestrate/v1/turn/stream`, deleted by CEE on 21 Jul.

## Rowed, not fixed here

1. **CEE-2 is the blocker for M1-L2** — `POST /orchestrate/v2/turn/stream`. Until it exists there is no UI path to first-content-in-seconds.
2. **`useDraftModel` is dead code** carrying a live SSE draft consumer aimed at the 2-frame route (the ROADMAP 2.110 defect). Zero callers. Retire or wire.
3. **`src/adapters/assistants/http.ts` + the `/bff/cee/*` redirect** point at `olumi-assistants-service.onrender.com` (not `cee-staging`), on a legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
