### PR TITLE
feat(ui): Compare tab hydrates from persisted analysis runs (2.113a slice 1)

### DIFF
--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -9,6 +9,7 @@ import { useCanvasStore } from '../store'
 import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import { AnalysisRunStateCover } from '../components/AnalysisRunStateCover'
 import { useAnalysisSnapshotStore, selectSnapshots } from '../stores/analysisSnapshotStore'
+import { useCompareHistoryHydration } from './useCompareHistoryHydration'
 import { useUIStore } from '../../stores/uiStore'
 import { deriveCompareState } from './deriveCompareState'
 import { deriveTransitions, buildCumulativeTransition } from './deriveTransitions'
@@ -28,6 +29,14 @@ interface CompareTabBodyProps {
 const EXPERT_STORAGE_KEY = 'feature.compareExpert'
 
 export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
+  // ROADMAP 2.113a slice 1: seed the journey from PERSISTED `run_analysis`
+  // facts. The session capture gate (canvas/store.ts `resultsComplete`)
+  // requires a `rawV2Response`, and the deployed V5 results-hydration path
+  // passes null for it — so before this hook the tab had no data source on
+  // the live wire at all, reload or no reload. Everything below is unchanged:
+  // this fills the same store the tab already read.
+  useCompareHistoryHydration()
+
   // Snapshot data
   const snapshots = useAnalysisSnapshotStore(selectSnapshots)
   // One trust surface (F10/F11): staleness AND run state both come from the

--- a/src/canvas/compare-tab/EmptyState.tsx
+++ b/src/canvas/compare-tab/EmptyState.tsx
@@ -7,7 +7,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ onViewResults }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center px-6 py-10 text-center">
+    <div className="flex flex-col items-center px-6 py-10 text-center" data-testid="compare-empty-state">
       <TrendingUp size={36} className="text-panel-border" />
       <div className={`${typography.panelHeader} text-text-body mt-3 mb-1.5`}>
         Refine your model and run the analysis again

--- a/src/canvas/compare-tab/HealthIndicators.tsx
+++ b/src/canvas/compare-tab/HealthIndicators.tsx
@@ -19,7 +19,15 @@ function stabilityImproving(from: string | null, to: string | null): boolean {
   return order.indexOf(to) > order.indexOf(from)
 }
 
-function coverageImproving(from: string, to: string): boolean {
+/**
+ * T2b, same rule as `stabilityImproving` above: coverage that was never
+ * measured at one end cannot be "improving". A run rebuilt from a persisted
+ * `run_analysis` fact has no graph, so it has no coverage — and `parseInt`
+ * over a null (or the "0/0" a fabricating factory would have produced) would
+ * manufacture a rise out of that absence.
+ */
+function coverageImproving(from: string | null, to: string | null): boolean {
+  if (from == null || to == null) return false
   // "3/5" format — compare numerators
   const fromNum = parseInt(from.split('/')[0], 10) || 0
   const toNum = parseInt(to.split('/')[0], 10) || 0
@@ -38,8 +46,11 @@ export function HealthIndicators({ first, latest }: HealthIndicatorsProps) {
     },
     {
       label: 'Evidence coverage',
-      from: first.evidenceCoverage,
-      to: latest.evidenceCoverage,
+      // T2b: null means the run carries no graph to count factor evidence
+      // over (a run rebuilt from a persisted analysis fact). Say so, exactly
+      // as the stability row above does.
+      from: first.evidenceCoverage ?? 'Not assessed',
+      to: latest.evidenceCoverage ?? 'Not assessed',
       up: coverageImproving(first.evidenceCoverage, latest.evidenceCoverage),
     },
     {

--- a/src/canvas/compare-tab/TrajectorySection.tsx
+++ b/src/canvas/compare-tab/TrajectorySection.tsx
@@ -48,7 +48,7 @@ function ExpertTable({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
                 s.recommendationStability != null
                   ? `${Math.round(s.recommendationStability * 100)}%`
                   : NOT_ASSESSED,
-                s.evidenceCoverage,
+                s.evidenceCoverage ?? NOT_ASSESSED,
                 `${s.influenceConcentration}%`,
                 s.rankFlipRate.toFixed(2),
                 s.fragileEdgeCount ?? NOT_ASSESSED,

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
@@ -1,0 +1,204 @@
+/**
+ * ROADMAP 2.113a slice 1 — the Compare tab populates from PERSISTED analysis
+ * runs, and survives a reload.
+ *
+ * WHY THIS SPEC EXISTS (the defect it pins).
+ * ------------------------------------------------------------------
+ * The Compare tab's only data source was `analysisSnapshotStore`, seeded
+ * exclusively by the capture gate at `canvas/store.ts` `resultsComplete`:
+ *
+ *     if (isCompareTabEnabled() && rawV2Response && report) { … }
+ *
+ * The DEPLOYED analyse path is the CEE turn, and its results-hydration
+ * applicator calls that same setter with `rawV2Response: null` — explicitly,
+ * with the comment "V5 carries no V2 envelope" (`v5/applyV5State.ts:1023`).
+ * So on the live wire the gate NEVER opened: the tab showed its empty state
+ * even within one session. This is not "compare loses its history on reload"
+ * — it is "compare never had a history to lose".
+ *
+ * RLS CONTROL, BOTH DIRECTIONS (CLAUDE.md trap 13 — an absence assertion must
+ * first prove it can see a presence). The owner case asserts positive CONTENT
+ * (the journey renders, with the winner's label and a run count), never
+ * merely "no error"; the guest and empty-owner cases then assert the empty
+ * state. Without the positive half, a mock wired to the wrong module would
+ * make every case render the empty state and all of them would "pass".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { makePersistedRunFactRow } from './__fixtures__/persistedRunFact'
+
+// --- seams ----------------------------------------------------------------
+
+const listPersistedAnalysisRuns = vi.fn()
+const getSessionIdentity = vi.fn()
+
+vi.mock('../../../services/analysisRunHistoryService', () => ({
+  listPersistedAnalysisRuns: (...args: unknown[]) => listPersistedAnalysisRuns(...args),
+  MAX_PERSISTED_RUNS: 20,
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getSessionIdentity: () => getSessionIdentity(),
+  supabase: {},
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockCanvasState: any
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (selector: (s: any) => unknown) => selector({ activeOutputTab: 'compare' }),
+    { getState: () => ({ setActiveOutputTab: vi.fn() }) },
+  ),
+}))
+
+vi.mock('../../hooks/useAnalysisTrust', () => ({
+  useAnalysisTrust: () => ({ semantic: 'fresh', isRunning: false, runStartedAt: null }),
+}))
+
+// Heavy children stubbed the same way CompareTabBody.freshness.spec does —
+// except Hero, which echoes the content we assert on, and EmptyState /
+// RunSelector, which ARE the surfaces under test.
+vi.mock('../Hero', () => ({
+  Hero: ({ snapshots }: { snapshots: Array<{ winnerLabel: string }> }) => (
+    <div data-testid="compare-hero">
+      {snapshots.length} runs · {snapshots[snapshots.length - 1]?.winnerLabel}
+    </div>
+  ),
+}))
+vi.mock('../TrajectorySection', () => ({ TrajectorySection: () => null }))
+vi.mock('../TransitionsSection', () => ({ TransitionsSection: () => null }))
+vi.mock('../CompareFooter', () => ({ CompareFooter: () => null }))
+vi.mock('../TabHeader', () => ({ TabHeader: () => null }))
+
+import { CompareTabBody } from '../CompareTabBody'
+import { useAnalysisSnapshotStore } from '../../stores/analysisSnapshotStore'
+
+const emptyState = () => screen.queryByTestId('compare-empty-state')
+
+beforeEach(() => {
+  mockCanvasState = {
+    currentScenarioId: 'scenario-owned-1',
+    currentScenarioLastResultHash: 'resp-hash-2',
+    selection: { nodeIds: new Set<string>() },
+    _hydratedEvents: [],
+  }
+  useAnalysisSnapshotStore.getState().clearSnapshots()
+  listPersistedAnalysisRuns.mockReset()
+  getSessionIdentity.mockReset()
+  getSessionIdentity.mockResolvedValue({ userId: 'user-1', accessToken: 'tok' })
+})
+
+afterEach(() => cleanup())
+
+describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', () => {
+  it('renders the Refinement Journey from persisted run_analysis facts — the live V5 path captured nothing', async () => {
+    listPersistedAnalysisRuns.mockResolvedValue([
+      makePersistedRunFactRow({
+        id: 'fact-1',
+        createdAt: '2026-07-20T10:00:00.000Z',
+        responseHash: 'resp-hash-1',
+        graphHashAtRun: 'aag-1',
+        winner: { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.62 },
+        runnerUp: { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.38 },
+      }),
+      makePersistedRunFactRow({
+        id: 'fact-2',
+        createdAt: '2026-07-20T11:00:00.000Z',
+        responseHash: 'resp-hash-2',
+        graphHashAtRun: 'aag-2',
+        winner: { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.74 },
+        runnerUp: { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.26 },
+      }),
+    ])
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    // POSITIVE CONTROL: real content, from rows, not "no error".
+    expect(await screen.findByTestId('compare-hero')).toBeTruthy()
+    expect(screen.getByTestId('compare-hero').textContent).toContain('2 runs')
+    expect(screen.getByTestId('compare-hero').textContent).toContain('Option A')
+    // The run selector only renders past the 2-snapshot gate.
+    expect(screen.getByText('Latest vs previous')).toBeTruthy()
+    expect(emptyState()).toBeNull()
+
+    expect(listPersistedAnalysisRuns).toHaveBeenCalledWith('scenario-owned-1', 20)
+    const stored = useAnalysisSnapshotStore.getState().snapshots
+    expect(stored).toHaveLength(2)
+    expect(stored.map(s => s.source)).toEqual(['persisted', 'persisted'])
+    // Durable identity: the fact row id, so a re-hydration is idempotent.
+    expect(stored.map(s => s.runId)).toEqual(['fact-1', 'fact-2'])
+  })
+
+  it('survives reload: a fresh mount over an EMPTY session store still renders the journey', async () => {
+    // A reload is exactly this — zero session snapshots, same scenario id.
+    expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(0)
+
+    listPersistedAnalysisRuns.mockResolvedValue([
+      makePersistedRunFactRow({ id: 'f1', createdAt: '2026-07-20T10:00:00.000Z', responseHash: 'h1' }),
+      makePersistedRunFactRow({ id: 'f2', createdAt: '2026-07-20T11:00:00.000Z', responseHash: 'h2' }),
+      makePersistedRunFactRow({ id: 'f3', createdAt: '2026-07-20T12:00:00.000Z', responseHash: 'h3' }),
+    ])
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(3)
+    })
+    expect(emptyState()).toBeNull()
+    expect(useAnalysisSnapshotStore.getState().snapshots.map(s => s.runNumber)).toEqual([1, 2, 3])
+    expect(screen.getByTestId('compare-hero').textContent).toContain('3 runs')
+  })
+
+  it('GUEST UNCHANGED: no signed-in session ⇒ no read attempted, existing empty state, never an error', async () => {
+    getSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    await waitFor(() => expect(getSessionIdentity).toHaveBeenCalled())
+    expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()
+    expect(emptyState()).toBeTruthy()
+    expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(0)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('an owner whose scenario has no persisted runs sees the SAME empty state', async () => {
+    listPersistedAnalysisRuns.mockResolvedValue([])
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    await waitFor(() => expect(listPersistedAnalysisRuns).toHaveBeenCalled())
+    expect(emptyState()).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('a failing read (e.g. a revoked grant) degrades to the empty state, never to an error surface', async () => {
+    listPersistedAnalysisRuns.mockRejectedValue(
+      new Error('permission denied for table v5_handler_facts'),
+    )
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    await waitFor(() => expect(listPersistedAnalysisRuns).toHaveBeenCalled())
+    expect(emptyState()).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('a guest scenario id of null makes no read at all', async () => {
+    mockCanvasState.currentScenarioId = null
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+
+    await waitFor(() => expect(emptyState()).toBeTruthy())
+    expect(getSessionIdentity).not.toHaveBeenCalled()
+    expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
@@ -24,6 +24,7 @@
  * make every case render the empty state and all of them would "pass".
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { StrictMode } from 'react'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { makePersistedRunFactRow } from './__fixtures__/persistedRunFact'
 
@@ -190,6 +191,32 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
     await waitFor(() => expect(listPersistedAnalysisRuns).toHaveBeenCalled())
     expect(emptyState()).toBeTruthy()
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('MOUNT/UNMOUNT/REMOUNT WITHOUT A DEP CHANGE STILL HYDRATES (StrictMode double-invoke)', async () => {
+    // The trap this pins: a dedupe key marked when the read STARTS. React can
+    // mount, tear down and re-mount an effect with unchanged deps — exactly
+    // what StrictMode does in development. The first pass would claim the key,
+    // its cleanup would cancel the in-flight read, and the second pass would
+    // see the key claimed and do nothing: a tab permanently empty, with no
+    // error anywhere. Marking the key on COMPLETION cannot produce that.
+    // (StrictMode is not enabled in src/main.tsx today; this keeps enabling it
+    // from silently switching the feature off.)
+    listPersistedAnalysisRuns.mockResolvedValue([
+      makePersistedRunFactRow({ id: 'f1', createdAt: '2026-07-20T10:00:00.000Z', responseHash: 'h1' }),
+      makePersistedRunFactRow({ id: 'f2', createdAt: '2026-07-20T11:00:00.000Z', responseHash: 'h2' }),
+    ])
+
+    render(
+      <StrictMode>
+        <CompareTabBody onRunAnalysis={vi.fn()} />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(2)
+    })
+    expect(emptyState()).toBeNull()
   })
 
   it('a guest scenario id of null makes no read at all', async () => {

--- a/src/canvas/compare-tab/__tests__/TrajectorySection.absence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/TrajectorySection.absence.spec.tsx
@@ -23,6 +23,7 @@ function snapshot(overrides: Partial<AnalysisSnapshot> = {}): AnalysisSnapshot {
     runId: 'run-1',
     runNumber: 1,
     timestamp: '2026-02-20T10:00:00Z',
+    source: 'session',
     graphHash: 'hash-1',
     nodeCount: 2,
     edgeCount: 1,

--- a/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
@@ -1,0 +1,143 @@
+/**
+ * Fixtures shaped like the REAL persisted `run_analysis` fact.
+ *
+ * Field placement here is byte-derived from staging Supabase
+ * (`v5_handler_facts`, 773 non-noop `run_analysis` rows, probed read-only
+ * 2026-07-29 — see PHASE0-EVIDENCE-2026-07-28/compare-slice1.md §0):
+ *
+ *   • `payload` = `{ fact_type, fact_version, result }` — `noop` lives on its
+ *     own COLUMN, never inside the payload (CEE `mapFactsForRpc` splits them).
+ *   • `result.enrichment` is the PLoT envelope byte-for-byte.
+ *   • ⚠ `conditional_winners` / `edge_e_values` / `inference_warnings` are
+ *     enrichment-ROOT siblings of `robustness` — 773/773 at the root, 0/773
+ *     under `robustness`. The design doc's mapping table said
+ *     `enrichment.robustness.*`; it is wrong at the bytes, and a fixture that
+ *     copied the doc would have made the mapper's three empty arrays look
+ *     correct.
+ *   • `recommendation_stability` is present in only 347/773 runs, so it is
+ *     OPT-IN here — the default fixture omits it, which is the majority case.
+ */
+import type { PersistedAnalysisRunRow } from '../../../../services/analysisRunHistoryService'
+
+interface OptionSpec {
+  option_id: string
+  option_label: string
+  win_probability: number
+  probability_of_joint_goal?: number
+}
+
+export interface PersistedRunFactFixtureOptions {
+  id?: string
+  createdAt?: string
+  computedAt?: string | null
+  responseHash?: string
+  graphHashAtRun?: string | null
+  winner?: OptionSpec
+  runnerUp?: OptionSpec | null
+  /** Present in only 45% of live runs — omit to exercise the honest-absence path. */
+  recommendationStability?: number
+  fragileEdges?: unknown[] | null
+  factorSensitivity?: Array<Record<string, unknown>>
+  inferenceWarnings?: unknown[]
+  conditionalWinners?: Array<Record<string, unknown>>
+  edgeEValues?: Array<Record<string, unknown>>
+  seedUsed?: unknown
+  /** Escape hatch for malformed-row tests. */
+  payloadOverride?: unknown
+}
+
+export function makePersistedRunFactRow(
+  opts: PersistedRunFactFixtureOptions = {},
+): PersistedAnalysisRunRow {
+  const {
+    id = 'fact-1',
+    createdAt = '2026-07-20T10:00:00.000Z',
+    computedAt = createdAt,
+    responseHash = 'resp-hash-1',
+    graphHashAtRun = 'aag-hash-1',
+    winner = { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.62 },
+    runnerUp = { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.38 },
+    recommendationStability,
+    fragileEdges = [],
+    factorSensitivity = [
+      {
+        factor_id: 'factor-1',
+        factor_label: 'Factor One',
+        elasticity: 0.42,
+        rank_flip_rate: 0.11,
+        attribution_stability: 'stable',
+      },
+      {
+        factor_id: 'factor-2',
+        factor_label: 'Factor Two',
+        elasticity: 0.18,
+        rank_flip_rate: 0.05,
+        attribution_stability: 'unstable',
+      },
+    ],
+    inferenceWarnings = [],
+    conditionalWinners = [],
+    edgeEValues = [],
+    seedUsed = 4242,
+    payloadOverride,
+  } = opts
+
+  if (payloadOverride !== undefined) {
+    return { id, createdAt, payload: payloadOverride, turnId: 'turn-1' }
+  }
+
+  const optionComparison = [winner, ...(runnerUp ? [runnerUp] : [])]
+
+  return {
+    id,
+    createdAt,
+    turnId: 'turn-1',
+    payload: {
+      fact_type: 'run_analysis',
+      fact_version: 1,
+      result: {
+        scenario_id: 'scenario-owned-1',
+        leading_option_id: winner.option_id,
+        summary: 'A persisted analysis summary.',
+        ...(computedAt != null ? { computed_at: computedAt } : {}),
+        ...(graphHashAtRun != null ? { graph_hash_at_run: graphHashAtRun } : {}),
+        constraint_verdict: {
+          may_name_leading_option: true,
+          constraint_verdict_state: 'no_constraints',
+        },
+        enrichment: {
+          analysis_status: 'computed',
+          option_comparison_status: 'computed',
+          robustness_status: 'computed',
+          drivers_status: 'computed',
+          response_hash: responseHash,
+          option_comparison: optionComparison,
+          factor_sensitivity: factorSensitivity,
+          robustness: {
+            level: 'moderate',
+            is_robust: true,
+            near_tie: false,
+            confidence: 0.7,
+            robust_edges: [],
+            ...(fragileEdges != null ? { fragile_edges: fragileEdges } : {}),
+            ...(recommendationStability != null
+              ? { recommendation_stability: recommendationStability }
+              : {}),
+            recommended_option_id: winner.option_id,
+            recommended_option_label: winner.option_label,
+          },
+          // ⚠ ROOT-level siblings of `robustness` — this is where the live
+          // bytes put them.
+          inference_warnings: inferenceWarnings,
+          conditional_winners: conditionalWinners,
+          edge_e_values: edgeEValues,
+          meta: {
+            seed_used: seedUsed,
+            computed_at: computedAt,
+            n_samples: 5000,
+          },
+        },
+      },
+    },
+  }
+}

--- a/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
@@ -34,6 +34,14 @@ export interface PersistedRunFactFixtureOptions {
   graphHashAtRun?: string | null
   winner?: OptionSpec
   runnerUp?: OptionSpec | null
+  /**
+   * Replaces the `winner`/`runnerUp`-derived array outright. Exists for the
+   * producer-shape holes the adversarial review of #523 found: a fact with a
+   * present `enrichment` but an EMPTY `option_comparison` must be dropped, not
+   * rendered as a 0% run with an empty winner label. 0/773 live rows are
+   * shaped this way today — the guard is against producer drift.
+   */
+  optionComparison?: Array<Record<string, unknown>>
   /** Present in only 45% of live runs — omit to exercise the honest-absence path. */
   recommendationStability?: number
   fragileEdges?: unknown[] | null
@@ -57,6 +65,7 @@ export function makePersistedRunFactRow(
     graphHashAtRun = 'aag-hash-1',
     winner = { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.62 },
     runnerUp = { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.38 },
+    optionComparison,
     recommendationStability,
     fragileEdges = [],
     factorSensitivity = [
@@ -86,7 +95,8 @@ export function makePersistedRunFactRow(
     return { id, createdAt, payload: payloadOverride, turnId: 'turn-1' }
   }
 
-  const optionComparison = [winner, ...(runnerUp ? [runnerUp] : [])]
+  const options: unknown[] =
+    optionComparison ?? [winner, ...(runnerUp ? [runnerUp] : [])]
 
   return {
     id,
@@ -111,7 +121,7 @@ export function makePersistedRunFactRow(
           robustness_status: 'computed',
           drivers_status: 'computed',
           response_hash: responseHash,
-          option_comparison: optionComparison,
+          option_comparison: options,
           factor_sensitivity: factorSensitivity,
           robustness: {
             level: 'moderate',

--- a/src/canvas/compare-tab/__tests__/analysisSnapshotStore.spec.ts
+++ b/src/canvas/compare-tab/__tests__/analysisSnapshotStore.spec.ts
@@ -11,6 +11,7 @@ function makeSnapshot(runNumber: number, overrides?: Partial<AnalysisSnapshot>):
     runId: `run-${runNumber}`,
     runNumber,
     timestamp: new Date().toISOString(),
+    source: 'session',
     graphHash: 'hash-default',
     nodeCount: 5,
     edgeCount: 4,
@@ -135,6 +136,105 @@ describe('useAnalysisSnapshotStore', () => {
       store.clearSnapshots()
       expect(store.getRunCount()).toBe(0)
       expect(store.getLatest()).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // ROADMAP 2.113a slice 1 — hydration from persisted runs
+  // -------------------------------------------------------------------------
+
+  describe('hydrateFromPersisted', () => {
+    const persisted = (n: number, overrides?: Partial<AnalysisSnapshot>): AnalysisSnapshot =>
+      makeSnapshot(n, {
+        runId: `fact-${n}`,
+        source: 'persisted',
+        graphHash: `aag-${n}`,
+        nodeCount: null,
+        edgeCount: null,
+        evidenceCoverage: null,
+        responseHash: `rh-${n}`,
+        timestamp: `2026-07-20T1${n}:00:00.000Z`,
+        ...overrides,
+      })
+
+    it('seeds an EMPTY store — the reload case, and the live-V5 case where nothing was ever captured', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.hydrateFromPersisted([persisted(1), persisted(2)])
+      const out = useAnalysisSnapshotStore.getState().snapshots
+      expect(out.map(s => s.runId)).toEqual(['fact-1', 'fact-2'])
+      expect(out.map(s => s.runNumber)).toEqual([1, 2])
+      expect(out.every(s => s.source === 'persisted')).toBe(true)
+    })
+
+    it('is IDEMPOTENT — re-hydrating the same history does not duplicate runs', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.hydrateFromPersisted([persisted(1), persisted(2)])
+      store.hydrateFromPersisted([persisted(1), persisted(2)])
+      expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(2)
+    })
+
+    it('LAYERS a session run the persisted set does not contain, and renumbers by timestamp', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.addSnapshot(
+        makeSnapshot(1, {
+          runId: 'session-new',
+          responseHash: 'rh-9',
+          timestamp: '2026-07-20T19:00:00.000Z',
+        }),
+      )
+      store.hydrateFromPersisted([persisted(1), persisted(2)])
+      const out = useAnalysisSnapshotStore.getState().snapshots
+      expect(out.map(s => s.runId)).toEqual(['fact-1', 'fact-2', 'session-new'])
+      expect(out.map(s => s.runNumber)).toEqual([1, 2, 3])
+      expect(out.map(s => s.source)).toEqual(['persisted', 'persisted', 'session'])
+    })
+
+    it('DEDUPES by run identity (responseHash) and prefers the PERSISTED copy', () => {
+      // Same run seen twice: captured in session by a direct run, then read
+      // back from the DB. Keeping both would show the user a phantom rerun
+      // with every delta zero.
+      const store = useAnalysisSnapshotStore.getState()
+      store.addSnapshot(
+        makeSnapshot(1, {
+          runId: 'session-dupe',
+          responseHash: 'rh-2',
+          timestamp: '2026-07-20T12:00:00.000Z',
+        }),
+      )
+      store.hydrateFromPersisted([persisted(1), persisted(2)])
+      const out = useAnalysisSnapshotStore.getState().snapshots
+      expect(out).toHaveLength(2)
+      expect(out.map(s => s.runId)).toEqual(['fact-1', 'fact-2'])
+      expect(out.some(s => s.runId === 'session-dupe')).toBe(false)
+    })
+
+    it('a session run with NO responseHash is never merged into another run', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.addSnapshot(
+        makeSnapshot(1, { runId: 'session-nohash', responseHash: '', timestamp: '2026-07-20T19:00:00.000Z' }),
+      )
+      store.hydrateFromPersisted([persisted(1, { responseHash: '' })])
+      const out = useAnalysisSnapshotStore.getState().snapshots
+      expect(out.map(s => s.runId)).toEqual(['fact-1', 'session-nohash'])
+    })
+
+    it('a second hydration REPLACES the persisted portion but keeps session-only runs', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.addSnapshot(
+        makeSnapshot(1, { runId: 'session-keep', responseHash: 'rh-keep', timestamp: '2026-07-20T19:00:00.000Z' }),
+      )
+      store.hydrateFromPersisted([persisted(1)])
+      store.hydrateFromPersisted([persisted(1), persisted(2), persisted(3)])
+      const out = useAnalysisSnapshotStore.getState().snapshots
+      expect(out.map(s => s.runId)).toEqual(['fact-1', 'fact-2', 'fact-3', 'session-keep'])
+    })
+
+    it('hydrating with an empty list clears the persisted portion and keeps session runs', () => {
+      const store = useAnalysisSnapshotStore.getState()
+      store.addSnapshot(makeSnapshot(1, { runId: 'session-only', responseHash: 'rh-s' }))
+      store.hydrateFromPersisted([persisted(1)])
+      store.hydrateFromPersisted([])
+      expect(useAnalysisSnapshotStore.getState().snapshots.map(s => s.runId)).toEqual(['session-only'])
     })
   })
 

--- a/src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts
@@ -11,6 +11,7 @@ function makeSnapshot(overrides: Partial<AnalysisSnapshot> & { runNumber: number
     runId: `run-${overrides.runNumber}`,
     runNumber: overrides.runNumber,
     timestamp: new Date().toISOString(),
+    source: 'session',
     graphHash: 'hash-default',
     nodeCount: 5,
     edgeCount: 4,

--- a/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
@@ -21,6 +21,7 @@ function makeSnapshot(overrides: Partial<AnalysisSnapshot> & { runNumber: number
     runId: `run-${overrides.runNumber}`,
     runNumber: overrides.runNumber,
     timestamp: new Date().toISOString(),
+    source: 'session',
     graphHash: 'hash-default',
     nodeCount: 5,
     edgeCount: 4,
@@ -195,6 +196,54 @@ describe('deriveTransitions', () => {
         makeSnapshot({ runNumber: 2 }),
       ]
       expect(deriveTransitions(snapshots)[0].structureChanged).toBe(false)
+    })
+
+    // ⚠ HASH REGIMES NEVER COMPARE (ROADMAP 2.113a slice 1).
+    // A session snapshot's graphHash is the UI's generateGraphHash; a
+    // persisted run's is CEE's analysis-affecting aag_v1. They are ALWAYS
+    // unequal, so an unguarded `!==` would assert "structure changed" on
+    // every transition across the provenance boundary — a claim about the
+    // user's model manufactured out of where the data was read from.
+    it('does NOT claim a structure change across two different hash regimes', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag_v1_abc' }),
+        makeSnapshot({ runNumber: 2, source: 'session', graphHash: 'ui_hash_xyz' }),
+      ]
+      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(false)
+    })
+
+    it('DOES compare hashes within one regime (the guard is not a blanket off-switch)', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
+        makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2' }),
+      ]
+      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(true)
+    })
+
+    it('an absent hash at either end is no evidence, not a change', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: null }),
+        makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2' }),
+      ]
+      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(false)
+    })
+
+    it('null node/edge counts are no evidence, not a change (persisted runs carry no graph)', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1', nodeCount: null, edgeCount: null }),
+        makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-1', nodeCount: null, edgeCount: null }),
+      ]
+      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(false)
+    })
+
+    it('cumulative caveat: no cross-regime "Structure changed during this period"', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
+        makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-1' }),
+        makeSnapshot({ runNumber: 3, source: 'session', graphHash: 'ui-hash' }),
+      ]
+      const cumulative = buildCumulativeTransition(snapshots)!
+      expect(cumulative.cumulativeCaveats).not.toContain('Structure changed during this period')
     })
   })
 

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -95,12 +95,37 @@ function deriveDeterministicAnchor(
 // Structure change detection
 // ---------------------------------------------------------------------------
 
-function detectStructureChange(from: AnalysisSnapshot, to: AnalysisSnapshot): boolean {
+/**
+ * Can these two snapshots' `graphHash` values be compared at all?
+ *
+ * ⚠ HASH REGIMES NEVER COMPARE. A session snapshot's hash is the UI's
+ * `generateGraphHash(nodes, edges)`; a persisted run's is CEE's
+ * analysis-affecting `aag_v1` (`result.graph_hash_at_run`). Two hashes from
+ * different regimes are ALWAYS unequal, so an unguarded `!==` would assert
+ * "structure changed" on every transition from a rebuilt run into a
+ * session-captured one — a claim about the user's model manufactured entirely
+ * out of a provenance boundary. Absence is likewise not evidence: 55 of the
+ * 773 live persisted runs carry no hash at all.
+ */
+function hashesAreComparable(from: AnalysisSnapshot, to: AnalysisSnapshot): boolean {
   return (
-    from.graphHash !== to.graphHash ||
-    from.nodeCount !== to.nodeCount ||
-    from.edgeCount !== to.edgeCount
+    from.graphHash != null &&
+    to.graphHash != null &&
+    from.source === to.source
   )
+}
+
+/**
+ * T2b: a structure CHANGE is only claimable from a signal that was actually
+ * measured at BOTH ends. Where no comparable signal exists the answer is
+ * "no evidence of a change" — the same posture `robustnessChanged` already
+ * takes — not "changed".
+ */
+function detectStructureChange(from: AnalysisSnapshot, to: AnalysisSnapshot): boolean {
+  if (hashesAreComparable(from, to) && from.graphHash !== to.graphHash) return true
+  if (from.nodeCount != null && to.nodeCount != null && from.nodeCount !== to.nodeCount) return true
+  if (from.edgeCount != null && to.edgeCount != null && from.edgeCount !== to.edgeCount) return true
+  return false
 }
 
 // ---------------------------------------------------------------------------
@@ -242,9 +267,10 @@ export function buildCumulativeTransition(snapshots: AnalysisSnapshot[]): Transi
     caveats.push(`Result flipped ${flipCount === 1 ? 'once' : `${flipCount} times`}`)
   }
 
-  // Check for any structure changes
+  // Check for any structure changes. Same regime guard as the pairwise case —
+  // a cross-source or absent-ended hash pair is no evidence, not a change.
   const structureChanged = snapshots.slice(1).some((s, i) =>
-    s.graphHash !== snapshots[i].graphHash
+    hashesAreComparable(snapshots[i], s) && s.graphHash !== snapshots[i].graphHash
   )
   if (structureChanged) {
     caveats.push('Structure changed during this period')

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -19,17 +19,59 @@ export interface FactorSensitivitySummary {
   attributionStability: string
 }
 
+/**
+ * Where a snapshot came from, and — inseparably — which HASH REGIME its
+ * `graphHash` belongs to. The two are one fact, so they are one field:
+ * a second `graphHashFamily` field would be a hand-maintained mirror of this
+ * one (CLAUDE.md trap 12).
+ *
+ *   • 'session'   captured in this browser session at `resultsComplete` from
+ *                 the live canvas. `graphHash` is the UI's own
+ *                 `generateGraphHash(nodes, edges)`.
+ *   • 'persisted' rebuilt from a `v5_handler_facts` `run_analysis` row.
+ *                 `graphHash` is CEE's ANALYSIS-AFFECTING hash (`aag_v1`)
+ *                 as stored in `result.graph_hash_at_run`.
+ *
+ * ⚠ THE REGIMES NEVER COMPARE. Three different hashes over "the graph" exist
+ * in this estate (UI `generateGraphHash`, CEE identity, CEE `aag_v1`); the
+ * `model_versions` and `decision_records` DDL both say so explicitly. Any
+ * code comparing two `graphHash` values MUST first check that both snapshots
+ * share a `source` — see `detectStructureChange` in deriveTransitions.ts.
+ */
+export type SnapshotSource = 'session' | 'persisted'
+
 export interface AnalysisSnapshot {
   runId: string
   /** Sequential, 1-indexed */
   runNumber: number
   /** ISO 8601 */
   timestamp: string
-  /** From generateGraphHash(nodes, edges) */
-  graphHash: string
-  /** For structure-change detection alongside graphHash */
-  nodeCount: number
-  edgeCount: number
+  /**
+   * Provenance AND hash regime. See {@link SnapshotSource} — comparing
+   * `graphHash` across two different sources is meaningless.
+   */
+  source: SnapshotSource
+  /**
+   * 'session': `generateGraphHash(nodes, edges)`.
+   * 'persisted': `result.graph_hash_at_run` (`aag_v1`).
+   *
+   * T2b absence-preserving: null when the run carries no hash at all. 55 of
+   * the 773 live persisted runs have no `graph_hash_at_run`; a fabricated ''
+   * would make two such runs compare EQUAL and silently assert "structure
+   * unchanged" about two runs nobody measured.
+   */
+  graphHash: string | null
+  /**
+   * For structure-change detection alongside graphHash.
+   *
+   * T2b absence-preserving: null when the graph the run was computed over is
+   * not available. A run rebuilt from a persisted fact has no graph — the
+   * fact stores the analysis, not the model — so these are null there. A
+   * fabricated 0 would report "the model lost every node" on the first
+   * transition into a session snapshot.
+   */
+  nodeCount: number | null
+  edgeCount: number | null
 
   // Winner/runner-up (from option_comparison sorted by win_probability desc)
   winnerId: string
@@ -54,8 +96,17 @@ export interface AnalysisSnapshot {
   fragileEdgeCount: number | null
 
   // Evidence
-  /** "3/5" format */
-  evidenceCoverage: string
+  /**
+   * "3/5" format — factor nodes carrying observed data, over all factor nodes.
+   *
+   * T2b absence-preserving: null when the run was rebuilt from a persisted
+   * fact, because the quantity is derived from the GRAPH and the fact stores
+   * only the analysis. "0/0" would be a fabricated verdict ("no evidence
+   * anywhere"), and `coverageImproving` would then read a rise out of it.
+   * Renders as "Not assessed", the same treatment `recommendationStability`
+   * and `fragileEdgeCount` already get.
+   */
+  evidenceCoverage: string | null
 
   // Factor sensitivity — top 5 for transition derivation
   topFactors: FactorSensitivitySummary[]

--- a/src/canvas/compare-tab/useCompareHistoryHydration.ts
+++ b/src/canvas/compare-tab/useCompareHistoryHydration.ts
@@ -43,26 +43,46 @@ export function useCompareHistoryHydration(): void {
   const scenarioId = useCanvasStore(s => s.currentScenarioId)
   const lastResultHash = useCanvasStore(s => s.currentScenarioLastResultHash)
 
-  // One in-flight read at a time, and never a setState after unmount.
-  const activeKeyRef = useRef<string | null>(null)
+  /**
+   * The (scenario, result-hash) pair whose read has ALREADY COMPLETED.
+   *
+   * ⚠ It is set on COMPLETION, never on start — and that ordering is the whole
+   * point. Marking it on start looks like the same dedupe and is a trap: React
+   * may mount, tear down and re-mount an effect without the deps changing
+   * (StrictMode's development double-invoke is the common case). The first
+   * pass would then claim the key, its cleanup would cancel the in-flight
+   * read, and the second pass would see the key already claimed and do
+   * nothing — leaving the tab permanently empty with no error anywhere. That
+   * is this programme's dominant defect class: machinery that reads as a
+   * guarantee and never executes. Marking on completion cannot produce it;
+   * the worst case is one redundant read of a read-only, idempotent query.
+   *
+   * (StrictMode is NOT enabled in `src/main.tsx` today. The guard is written
+   * this way so that enabling it can never silently switch this feature off.)
+   */
+  const completedKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!scenarioId) return
 
     const key = `${scenarioId}::${lastResultHash ?? ''}`
-    if (activeKeyRef.current === key) return
-    activeKeyRef.current = key
+    if (completedKeyRef.current === key) return
 
     let cancelled = false
 
     void (async () => {
       try {
         // Guest / signed-out: no read, no error, existing empty state.
+        // Deliberately NOT marked complete — a user who signs in mid-session
+        // must get their history without a scenario switch to unlatch it.
         const { userId } = await getSessionIdentity()
         if (cancelled || !userId) return
 
         const rows = await listPersistedAnalysisRuns(scenarioId, MAX_PERSISTED_RUNS)
-        if (cancelled || rows.length === 0) return
+        if (cancelled) return
+        // A completed read that found nothing is still a completed read.
+        completedKeyRef.current = key
+        if (rows.length === 0) return
 
         // Events come from the scenario row the canvas already hydrated —
         // read at USE time, not captured in the effect's dependency list, so
@@ -73,9 +93,9 @@ export function useCompareHistoryHydration(): void {
 
         useAnalysisSnapshotStore.getState().hydrateFromPersisted(snapshots)
       } catch (err) {
-        // Degrade to the tab's existing empty state. Reset the key so a later
-        // render can retry rather than latching the failure forever.
-        activeKeyRef.current = null
+        // Degrade to the tab's existing empty state, and leave the key
+        // UNMARKED so a later mount retries rather than latching the failure
+        // forever.
         if (import.meta.env.DEV) {
           console.warn('[useCompareHistoryHydration] persisted run read failed', err)
         }

--- a/src/canvas/compare-tab/useCompareHistoryHydration.ts
+++ b/src/canvas/compare-tab/useCompareHistoryHydration.ts
@@ -1,0 +1,89 @@
+/**
+ * useCompareHistoryHydration — seed the Compare tab from persisted runs.
+ *
+ * ROADMAP 2.113a slice 1. This hook is the whole data-source swap: no new UI
+ * surface, no change to the tab's state machine, no change to what any
+ * component renders. The existing render tree (RunSelector, Hero,
+ * TrajectorySection, TransitionsSection, CompareFooter) is driven by
+ * `analysisSnapshotStore` exactly as before — this fills that store.
+ *
+ * WHERE IT RUNS. Inside `CompareTabBody`, which `OutputsDock` mounts ONLY
+ * while the Compare tab is the active tab. So the read costs nothing until
+ * the user opens the tab, and "open Compare" is the moment the history is
+ * wanted.
+ *
+ * WHEN IT RE-READS. On scenario change, and whenever
+ * `currentScenarioLastResultHash` moves — which `canvas/store.ts`
+ * `resultsComplete` sets on EVERY completion including the V5 path
+ * (store.ts:3068). A completed analysis has already been persisted by CEE
+ * inside the turn that produced it, so by the time that hash changes the new
+ * fact is readable.
+ *
+ * GUESTS ARE UNCHANGED, AND DELIBERATELY SO. Versions and facts exist only
+ * for signed-in-owned scenarios (`v5_handler_facts.user_id` is NULL for guest
+ * rows, and `auth.uid() = NULL` is NULL, so RLS returns a guest nothing). The
+ * hook checks for a session FIRST and skips the read entirely rather than
+ * firing a request that is guaranteed to come back empty. The tab then shows
+ * its existing empty/explainer state — never an error.
+ *
+ * EVERY FAILURE DEGRADES TO THAT SAME EMPTY STATE. A missing grant, an
+ * offline client, a malformed row: the Compare tab is a passive, read-only
+ * retrospective, and there is no honest error for it to show that the user
+ * could act on.
+ */
+import { useEffect, useRef } from 'react'
+import { useCanvasStore } from '../store'
+import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
+import { buildSnapshotsFromPersistedRuns } from '../stores/persistedRunSnapshotFactory'
+import { listPersistedAnalysisRuns, MAX_PERSISTED_RUNS } from '../../services/analysisRunHistoryService'
+import { getSessionIdentity } from '../../lib/supabase'
+import type { ScenarioEvent } from '../../types/scenario'
+
+export function useCompareHistoryHydration(): void {
+  const scenarioId = useCanvasStore(s => s.currentScenarioId)
+  const lastResultHash = useCanvasStore(s => s.currentScenarioLastResultHash)
+
+  // One in-flight read at a time, and never a setState after unmount.
+  const activeKeyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!scenarioId) return
+
+    const key = `${scenarioId}::${lastResultHash ?? ''}`
+    if (activeKeyRef.current === key) return
+    activeKeyRef.current = key
+
+    let cancelled = false
+
+    void (async () => {
+      try {
+        // Guest / signed-out: no read, no error, existing empty state.
+        const { userId } = await getSessionIdentity()
+        if (cancelled || !userId) return
+
+        const rows = await listPersistedAnalysisRuns(scenarioId, MAX_PERSISTED_RUNS)
+        if (cancelled || rows.length === 0) return
+
+        // Events come from the scenario row the canvas already hydrated —
+        // read at USE time, not captured in the effect's dependency list, so
+        // a late events hydration cannot re-trigger the network read.
+        const events = (useCanvasStore.getState()._hydratedEvents ?? []) as ScenarioEvent[]
+        const snapshots = buildSnapshotsFromPersistedRuns(rows, events)
+        if (cancelled || snapshots.length === 0) return
+
+        useAnalysisSnapshotStore.getState().hydrateFromPersisted(snapshots)
+      } catch (err) {
+        // Degrade to the tab's existing empty state. Reset the key so a later
+        // render can retry rather than latching the failure forever.
+        activeKeyRef.current = null
+        if (import.meta.env.DEV) {
+          console.warn('[useCompareHistoryHydration] persisted run read failed', err)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [scenarioId, lastResultHash])
+}

--- a/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
+++ b/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
@@ -169,6 +169,84 @@ describe('persistedRunSnapshotFactory — unreadable rows are DROPPED, never def
     ).toBeNull()
   })
 
+  // -------------------------------------------------------------------------
+  // Adversarial review of PR #523, finding 1 (MODERATE, fabrication-class).
+  //
+  // `parseRunFact` accepted any row with {object, fact_type, result,
+  // enrichment}, and `toV2ResponseShape` then DEFAULTED an empty/absent
+  // `option_comparison` to []. The factory's pre-existing
+  // `winner?.win_probability ?? 0` turned that into a renderable snapshot.
+  // The reviewer's probe output, verbatim:
+  //
+  //   RESULT: {"winnerId":"","winnerLabel":"","winnerProbability":0,
+  //            "goalProbability":null,"runnerUpProbability":null}
+  //
+  // A run plotted at 0% with an empty winner label — absent rendered as zero,
+  // on the exact path this module claims is "dropped, never defaulted". The
+  // three original drop tests covered {non-object payload, wrong fact_type, no
+  // enrichment} and could not see this shape.
+  //
+  // Live incidence 0/773 (both arrays non-empty in every live fact, twice
+  // confirmed), so this is producer-drift class, not an exploit. The write
+  // surface is service-role-only. The guard makes drift LOUD-by-omission
+  // instead of silently fabricating a 0% run.
+  // -------------------------------------------------------------------------
+
+  it('drops a fact whose enrichment carries an EMPTY option_comparison (no 0% phantom run)', () => {
+    const row = makePersistedRunFactRow({ optionComparison: [] })
+    expect(build(row)).toBeNull()
+  })
+
+  it('drops a fact whose enrichment has NO option_comparison key at all', () => {
+    const row = makePersistedRunFactRow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (row.payload as any).result.enrichment.option_comparison
+    expect(build(row)).toBeNull()
+  })
+
+  it('drops a fact whose option_comparison is present but not an array', () => {
+    const row = makePersistedRunFactRow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(row.payload as any).result.enrichment.option_comparison = { opt: 1 }
+    expect(build(row)).toBeNull()
+  })
+
+  it('drops a fact whose enrichment carries an EMPTY factor_sensitivity (no measured-looking 0s)', () => {
+    // Same hole, second array: empty factors yield topElasticity 0,
+    // rankFlipRate 0, influenceConcentration 0 and topCalibrationFactor '',
+    // which the hero prints as "Calibrate " / "0% influence" — three
+    // fabricated measurements in one sentence.
+    expect(build(makePersistedRunFactRow({ factorSensitivity: [] }))).toBeNull()
+  })
+
+  it('drops a fact whose factor_sensitivity is absent or not an array', () => {
+    const noKey = makePersistedRunFactRow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (noKey.payload as any).result.enrichment.factor_sensitivity
+    expect(build(noKey)).toBeNull()
+
+    const notArray = makePersistedRunFactRow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(notArray.payload as any).result.enrichment.factor_sensitivity = 'nope'
+    expect(build(notArray)).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: the guard drops ONLY the degenerate shapes — a one-option, one-factor run still builds', () => {
+    // Without this, tightening the guard until everything is dropped would
+    // "pass" every test above. 773/773 live facts carry both arrays non-empty,
+    // so the guard must cost nothing on real data.
+    const s = build(
+      makePersistedRunFactRow({
+        runnerUp: null,
+        factorSensitivity: [{ factor_id: 'f1', factor_label: 'F1', elasticity: 0.5 }],
+      }),
+    )
+    expect(s).not.toBeNull()
+    expect(s!.winnerId).toBe('opt-a')
+    expect(s!.runnerUpId).toBeNull()
+    expect(s!.topFactors).toHaveLength(1)
+  })
+
   it('drops a row with no result.enrichment', () => {
     expect(
       build(

--- a/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
+++ b/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * persistedRunSnapshotFactory — the field mapping, and the two honest
+ * degradations. ROADMAP 2.113a slice 1.
+ *
+ * Fixtures are byte-shaped from the live staging table (773 non-noop
+ * `run_analysis` facts, probed read-only 2026-07-29) — see the fixture
+ * module's header for the placement evidence.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildSnapshotFromPersistedRun,
+  buildSnapshotsFromPersistedRuns,
+} from '../persistedRunSnapshotFactory'
+import { makePersistedRunFactRow } from '../../compare-tab/__tests__/__fixtures__/persistedRunFact'
+import type { ScenarioEvent } from '../../../types/scenario'
+
+const build = (row = makePersistedRunFactRow(), events: ScenarioEvent[] = []) =>
+  buildSnapshotFromPersistedRun({ row, runNumber: 1, events, previousSnapshotTimestamp: null })
+
+describe('persistedRunSnapshotFactory — field mapping', () => {
+  it('maps the winner and runner-up from enrichment.option_comparison, sorted by win_probability', () => {
+    const s = build(
+      makePersistedRunFactRow({
+        winner: { option_id: 'opt-low', option_label: 'Low', win_probability: 0.3 },
+        runnerUp: { option_id: 'opt-high', option_label: 'High', win_probability: 0.7 },
+      }),
+    )!
+    expect(s.winnerId).toBe('opt-high')
+    expect(s.winnerLabel).toBe('High')
+    expect(s.winnerProbability).toBe(70)
+    expect(s.runnerUpId).toBe('opt-low')
+    expect(s.runnerUpProbability).toBe(30)
+  })
+
+  it('takes runId from the fact row id and timestamp from result.computed_at', () => {
+    const s = build(
+      makePersistedRunFactRow({
+        id: 'fact-abc',
+        createdAt: '2026-07-20T10:00:05.000Z',
+        computedAt: '2026-07-20T10:00:00.000Z',
+      }),
+    )!
+    expect(s.runId).toBe('fact-abc')
+    // computed_at (when the analysis ran), not created_at (when it was written)
+    expect(s.timestamp).toBe('2026-07-20T10:00:00.000Z')
+  })
+
+  it('falls back to the row created_at when computed_at is absent', () => {
+    const s = build(makePersistedRunFactRow({ createdAt: '2026-07-20T09:00:00.000Z', computedAt: null }))!
+    expect(s.timestamp).toBe('2026-07-20T09:00:00.000Z')
+  })
+
+  it('carries graph_hash_at_run as the graphHash, tagged source "persisted" (aag_v1 regime)', () => {
+    const s = build(makePersistedRunFactRow({ graphHashAtRun: 'aag_v1_deadbeef' }))!
+    expect(s.graphHash).toBe('aag_v1_deadbeef')
+    expect(s.source).toBe('persisted')
+  })
+
+  it('reads seed and responseHash from the persisted envelope', () => {
+    const s = build(makePersistedRunFactRow({ seedUsed: 777, responseHash: 'rh-9' }))!
+    expect(s.seedUsed).toBe(777)
+    expect(s.responseHash).toBe('rh-9')
+  })
+
+  it('maps factor sensitivity into topFactors', () => {
+    const s = build()!
+    expect(s.topFactors.map(f => f.id)).toEqual(['factor-1', 'factor-2'])
+    expect(s.topCalibrationFactor).toBe('Factor One')
+    expect(s.topElasticity).toBe(42)
+  })
+
+  // -------------------------------------------------------------------------
+  // DECLARED DEVIATION FROM THE DESIGN DOC — the three root-level fields
+  // -------------------------------------------------------------------------
+
+  it('reads inference_warnings / conditional_winners / edge_e_values from the ENRICHMENT ROOT', () => {
+    // The design doc's §2 table maps these to `enrichment.robustness.*`.
+    // Live bytes: 773/773 at the root, 0/773 under robustness. Implementing
+    // the doc verbatim would leave all three permanently empty, silently.
+    const s = build(
+      makePersistedRunFactRow({
+        inferenceWarnings: [{ message: 'Low sample coverage' }],
+        conditionalWinners: [
+          {
+            factor_id: 'factor-1',
+            factor_label: 'Factor One',
+            split_value: 12,
+            high_bucket: { winner_label: 'Option B' },
+          },
+        ],
+        edgeEValues: [{ edge_id: 'factor-1->goal', e_value: 1.8 }],
+      }),
+    )!
+    expect(s.inferenceWarnings).toEqual(['Low sample coverage'])
+    expect(s.conditionalWinners).toHaveLength(1)
+    expect(s.conditionalWinners[0].factorId).toBe('factor-1')
+    expect(s.edgeEValues).toEqual([
+      { edgeId: 'factor-1->goal', edgeLabel: 'factor-1 → goal', eValue: 1.8 },
+    ])
+  })
+
+  it('MUTATION GUARD for that deviation: values nested under robustness are still read (forward-compat)', () => {
+    const row = makePersistedRunFactRow()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const enrichment = (row.payload as any).result.enrichment
+    delete enrichment.inference_warnings
+    enrichment.robustness.inference_warnings = ['nested warning']
+    expect(build(row)!.inferenceWarnings).toEqual(['nested warning'])
+  })
+
+  // -------------------------------------------------------------------------
+  // The two named gaps — degradations, never fabrications
+  // -------------------------------------------------------------------------
+
+  it('GAP 1 — node/edge counts are null, not 0 (the fact stores the analysis, not the model)', () => {
+    const s = build()!
+    expect(s.nodeCount).toBeNull()
+    expect(s.edgeCount).toBeNull()
+  })
+
+  it('GAP 2 — evidenceCoverage is null, not "0/0"', () => {
+    expect(build()!.evidenceCoverage).toBeNull()
+  })
+
+  it('absent graph_hash_at_run degrades to null, never to an empty string', () => {
+    // 55 of 773 live rows carry no hash. '' would make two such runs compare
+    // EQUAL and assert "structure unchanged" about runs nobody measured.
+    expect(build(makePersistedRunFactRow({ graphHashAtRun: null }))!.graphHash).toBeNull()
+  })
+
+  it('absent recommendation_stability stays null → "Not assessed", never "fragile"', () => {
+    // Present in only 347/773 live runs. deriveStabilityLabel(0) === 'fragile',
+    // so a fabricated 0 would make the tab ASSERT a verdict about 55% of runs.
+    const s = build()!
+    expect(s.recommendationStability).toBeNull()
+    expect(s.stabilityLabel).toBeNull()
+  })
+
+  it('present recommendation_stability is carried through', () => {
+    const s = build(makePersistedRunFactRow({ recommendationStability: 0.82 }))!
+    expect(s.recommendationStability).toBe(0.82)
+    expect(s.stabilityLabel).toBe('stable')
+  })
+
+  it('absent fragile_edges stays null; an honest empty array reports 0', () => {
+    expect(build(makePersistedRunFactRow({ fragileEdges: null }))!.fragileEdgeCount).toBeNull()
+    expect(build(makePersistedRunFactRow({ fragileEdges: [] }))!.fragileEdgeCount).toBe(0)
+  })
+
+  it('a malformed seed does not become NaN or a fabricated 0', () => {
+    expect(build(makePersistedRunFactRow({ seedUsed: 'not-a-seed' }))!.seedUsed).toBeNull()
+    expect(build(makePersistedRunFactRow({ seedUsed: null }))!.seedUsed).toBeNull()
+  })
+
+  it('no goal probability on the wire ⇒ null, never 0 (live: 0/2784 items carry one)', () => {
+    expect(build()!.goalProbability).toBeNull()
+  })
+})
+
+describe('persistedRunSnapshotFactory — unreadable rows are DROPPED, never defaulted', () => {
+  it('drops a row whose payload is not an object', () => {
+    expect(build(makePersistedRunFactRow({ payloadOverride: 'nonsense' }))).toBeNull()
+    expect(build(makePersistedRunFactRow({ payloadOverride: null }))).toBeNull()
+  })
+
+  it('drops a row with the wrong fact_type', () => {
+    expect(
+      build(makePersistedRunFactRow({ payloadOverride: { fact_type: 'edit_graph', result: {} } })),
+    ).toBeNull()
+  })
+
+  it('drops a row with no result.enrichment', () => {
+    expect(
+      build(
+        makePersistedRunFactRow({
+          payloadOverride: { fact_type: 'run_analysis', fact_version: 1, result: { summary: 'x' } },
+        }),
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('buildSnapshotsFromPersistedRuns — journey assembly', () => {
+  it('numbers the SURVIVORS contiguously when a row in the middle is unreadable', () => {
+    const snapshots = buildSnapshotsFromPersistedRuns(
+      [
+        makePersistedRunFactRow({ id: 'a', responseHash: 'h-a', createdAt: '2026-07-20T10:00:00.000Z' }),
+        makePersistedRunFactRow({ id: 'bad', payloadOverride: { fact_type: 'run_analysis' } }),
+        makePersistedRunFactRow({ id: 'c', responseHash: 'h-c', createdAt: '2026-07-20T12:00:00.000Z' }),
+      ],
+      [],
+    )
+    expect(snapshots.map(s => s.runId)).toEqual(['a', 'c'])
+    expect(snapshots.map(s => s.runNumber)).toEqual([1, 2])
+  })
+
+  it('the first run is "Initial analysis" and a later rerun with no edits says so', () => {
+    const snapshots = buildSnapshotsFromPersistedRuns(
+      [
+        makePersistedRunFactRow({ id: 'a', responseHash: 'h-a', createdAt: '2026-07-20T10:00:00.000Z' }),
+        makePersistedRunFactRow({ id: 'b', responseHash: 'h-b', createdAt: '2026-07-20T11:00:00.000Z' }),
+      ],
+      [],
+    )
+    expect(snapshots[0].editSummary).toBe('Initial analysis')
+    expect(snapshots[1].editSummary).toBe('Rerun (no edits)')
+  })
+
+  it('derives the between-runs edit summary from scenario events', () => {
+    const events = [
+      { event_type: 'direct_edit', timestamp: '2026-07-20T10:30:00.000Z', details: {} },
+    ] as unknown as ScenarioEvent[]
+    const snapshots = buildSnapshotsFromPersistedRuns(
+      [
+        makePersistedRunFactRow({ id: 'a', responseHash: 'h-a', createdAt: '2026-07-20T10:00:00.000Z' }),
+        makePersistedRunFactRow({ id: 'b', responseHash: 'h-b', createdAt: '2026-07-20T11:00:00.000Z' }),
+      ],
+      events,
+    )
+    expect(snapshots[1].editSummary).toBe('Edited model')
+  })
+})

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -20,9 +20,27 @@ import {
 
 export interface BuildSnapshotParams {
   rawV2Response: V2RunResponse
-  report: ReportV1
-  nodes: Node[]
-  edges: Edge[]
+  /**
+   * Unused by this factory (kept in the signature only because every live
+   * caller already holds it and dropping it from the call sites would be
+   * churn). Optional so a caller rebuilding a PAST run from a persisted fact
+   * — which has no ReportV1 — is not forced to invent one.
+   */
+  report?: ReportV1 | null
+  /**
+   * The graph the analysis was computed over.
+   *
+   * `null` when the caller does not HAVE it — the persisted-run rebuild path
+   * (`persistedRunSnapshotFactory`): a `run_analysis` fact stores the
+   * analysis, not the model. Passing `[]` instead would be a fabrication with
+   * three separate consequences, all silent: `generateGraphHash([], [])` is a
+   * real hash of an empty graph (so two rebuilt runs would compare EQUAL and
+   * assert "structure unchanged"), `nodeCount`/`edgeCount` would read 0, and
+   * `evidenceCoverage` would read "0/0" — a verdict of "no evidence anywhere"
+   * that nobody measured. Absence is preserved as null instead (T2b).
+   */
+  nodes: Node[] | null
+  edges: Edge[] | null
   runNumber: number
   events: ScenarioEvent[]
   previousSnapshotTimestamp: string | null
@@ -112,15 +130,17 @@ function extractConditionalWinners(
 
 function extractEdgeEValues(
   robustness: V2RunResponse['robustness'],
-  nodes: Node[],
-  _edges: Edge[],
+  nodes: Node[] | null,
+  _edges: Edge[] | null,
 ): AnalysisSnapshot['edgeEValues'] {
   const raw = (robustness as Record<string, unknown> | undefined)?.edge_e_values
   if (!Array.isArray(raw)) return []
 
-  // Build node label lookup
+  // Build node label lookup. Absent nodes (persisted-run rebuild) degrade to
+  // the raw edge ids below — the same fallback an unlabelled node already
+  // takes, so no branch is added and no label is invented.
   const nodeLabels = new Map<string, string>()
-  for (const n of nodes) {
+  for (const n of nodes ?? []) {
     const data = n.data as Record<string, unknown> | undefined
     if (data?.label) nodeLabels.set(n.id, String(data.label))
   }
@@ -295,9 +315,13 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     runId: crypto.randomUUID(),
     runNumber,
     timestamp: new Date().toISOString(),
-    graphHash: generateGraphHash(nodes, edges),
-    nodeCount: nodes.length,
-    edgeCount: edges.length,
+    // The graph-derived block. All four fields stand or fall together with
+    // `nodes`/`edges`: they are facts ABOUT THE MODEL, and a caller rebuilding
+    // a past ANALYSIS does not have the model. See BuildSnapshotParams.nodes.
+    source: 'session',
+    graphHash: nodes != null && edges != null ? generateGraphHash(nodes, edges) : null,
+    nodeCount: nodes != null ? nodes.length : null,
+    edgeCount: edges != null ? edges.length : null,
 
     winnerId: winner?.option_id ?? '',
     winnerLabel: winner?.option_label ?? '',
@@ -319,7 +343,7 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
       ? robustness.fragile_edges.length
       : null,
 
-    evidenceCoverage: computeEvidenceCoverage(nodes),
+    evidenceCoverage: nodes != null ? computeEvidenceCoverage(nodes) : null,
 
     topFactors,
     influenceConcentration: computeInfluenceConcentration(factors),

--- a/src/canvas/stores/analysisSnapshotStore.ts
+++ b/src/canvas/stores/analysisSnapshotStore.ts
@@ -1,11 +1,17 @@
 /**
  * Analysis Snapshot Store
  *
- * Session-scoped Zustand store that persists lightweight snapshots
- * after each analysis run. Used by the Compare tab's Refinement Journey
- * to track recommendation and model quality evolution.
+ * Zustand store holding the runs the Compare tab's Refinement Journey is
+ * built from.
  *
- * Not persisted to localStorage or Supabase — session-scoped only.
+ * ROADMAP 2.113a slice 1 changed WHERE those runs come from. The store itself
+ * is still in-memory — it is not written to localStorage or Supabase — but it
+ * is now SEEDED from Supabase (`hydrateFromPersisted`), which is what makes
+ * the journey survive a reload and, on the deployed V5 path, exist at all:
+ * the session capture gate at `canvas/store.ts` `resultsComplete` requires a
+ * `rawV2Response`, and the live results-hydration applicator passes null for
+ * it (`v5/applyV5State.ts:1023`, "V5 carries no V2 envelope"), so that gate
+ * never opened on the real wire.
  */
 import { create } from 'zustand'
 import type { AnalysisSnapshot } from '../compare-tab/types'
@@ -16,11 +22,31 @@ export interface AnalysisSnapshotStoreState {
 
 export interface AnalysisSnapshotActions {
   addSnapshot: (snapshot: AnalysisSnapshot) => void
+  hydrateFromPersisted: (persisted: AnalysisSnapshot[]) => void
   getLatest: () => AnalysisSnapshot | null
   getPrevious: () => AnalysisSnapshot | null
   getFirst: () => AnalysisSnapshot | null
   getRunCount: () => number
   clearSnapshots: () => void
+}
+
+/**
+ * Run identity for dedupe across the two sources.
+ *
+ * `responseHash` is the analysis response's own hash — the identity the V5
+ * hydration path ALREADY uses to decide whether an incoming
+ * `analysis_result` is a new run (`applyV5State.ts:1014`, `hash !== prevHash`).
+ * Reusing it means the Compare tab and the results panel agree on what "the
+ * same run" means instead of each inventing an answer.
+ *
+ * Falls back to `runId` when a run carries no response hash, so an unhashed
+ * run is never silently merged into another one. (Live: 773/773 persisted
+ * runs carry `enrichment.response_hash`; the fallback is for malformed rows.)
+ */
+function runIdentity(snapshot: AnalysisSnapshot): string {
+  return snapshot.responseHash && snapshot.responseHash.length > 0
+    ? `hash:${snapshot.responseHash}`
+    : `run:${snapshot.runId}`
 }
 
 export const useAnalysisSnapshotStore = create<AnalysisSnapshotStoreState & AnalysisSnapshotActions>(
@@ -32,6 +58,50 @@ export const useAnalysisSnapshotStore = create<AnalysisSnapshotStoreState & Anal
         // Enforce sequential 1-indexed runNumber regardless of caller
         const enforced = { ...snapshot, runNumber: state.snapshots.length + 1 }
         return { snapshots: [...state.snapshots, enforced] }
+      })
+    },
+
+    /**
+     * Seed the journey from persisted `run_analysis` facts, keeping any
+     * session-captured run the persisted set does not already contain.
+     *
+     * MERGE RULES, and why each one is what it is:
+     *
+     * 1. PERSISTED WINS ON A COLLISION. When a session snapshot and a
+     *    persisted row describe the same run (same `responseHash`), the
+     *    persisted one is kept. It carries the durable `runId` and the
+     *    `aag_v1` hash, so the list stays internally consistent across
+     *    re-hydrations; the session copy's only advantage is its graph-derived
+     *    fields, and preferring it would make the SAME run change identity
+     *    between a fresh load and a reload.
+     *
+     * 2. SESSION SNAPSHOTS ARE LAYERED ON TOP, NOT DISCARDED. A direct-run
+     *    path still captures them, and a run that has not reached the DB yet
+     *    must not vanish from the tab.
+     *
+     * 3. THE LIST IS SORTED BY TIMESTAMP, then renumbered 1..N. Sorting is
+     *    what lets rule 2 hold without assuming session runs are always the
+     *    newest.
+     *
+     * 4. ⚠ NO HASH FAMILY IS MIXED INTO A COMPARISON. The merged list can
+     *    legitimately hold both sources, whose `graphHash` values come from
+     *    DIFFERENT regimes and are not comparable. That is handled where the
+     *    comparison happens — `detectStructureChange` refuses a cross-source
+     *    hash comparison — NOT by refusing to merge. See types.ts
+     *    `SnapshotSource`.
+     */
+    hydrateFromPersisted: (persisted) => {
+      set(state => {
+        const seen = new Set(persisted.map(runIdentity))
+        const sessionOnly = state.snapshots.filter(
+          s => s.source === 'session' && !seen.has(runIdentity(s)),
+        )
+        const merged = [...persisted, ...sessionOnly].sort((a, b) =>
+          a.timestamp === b.timestamp ? 0 : a.timestamp < b.timestamp ? -1 : 1,
+        )
+        return {
+          snapshots: merged.map((s, i) => ({ ...s, runNumber: i + 1 })),
+        }
       })
     },
 

--- a/src/canvas/stores/persistedRunSnapshotFactory.ts
+++ b/src/canvas/stores/persistedRunSnapshotFactory.ts
@@ -58,10 +58,9 @@ interface ParsedRunFact {
   enrichment: Record<string, unknown>
   /**
    * The two arrays every DECIDING snapshot field comes from, carried out of the
-   * parser already proven non-empty. They are surfaced here rather than re-read
-   * downstream so that `toV2ResponseShape` has no `?? []` arm to reach for —
-   * the defaulting path finding 1 exploited cannot be written back in without
-   * deleting a field from this type.
+   * parser already proven non-empty, so `toV2ResponseShape` has no `?? []` arm
+   * that reads like sanctioned defaulting. Readability only — see that
+   * function's header for why this is NOT a second line of defence.
    */
   optionComparison: unknown[]
   factorSensitivity: unknown[]
@@ -159,12 +158,20 @@ function composeRobustness(enrichment: Record<string, unknown>): V2RunResponse['
  * value is invented: absent producer fields stay absent, and the factory's own
  * absence-preserving branches then fire.
  *
- * ⚠ It takes the PARSED fact, not the raw enrichment, and that is the fix for
- * finding 1 rather than a refactor. The two deciding arrays arrive already
- * proven non-empty by `parseRunFact`, so there is no `Array.isArray(...) ?? []`
- * arm here to silently manufacture an empty comparison — which is exactly what
- * turned a shape-broken fact into a 0%-winner run on the trajectory. Restoring
- * a default would now require deleting a field from `ParsedRunFact`.
+ * It takes the PARSED fact rather than the raw enrichment so that the two
+ * deciding arrays arrive already proven non-empty and this function has no
+ * `Array.isArray(...) : []` arm that READS like sanctioned defaulting.
+ *
+ * ⚠ BE CLEAR ABOUT WHAT THIS IS NOT. It is **not** a second line of defence,
+ * and the earlier draft of this comment implied it was. `buildAnalysisSnapshot`
+ * has its own `rawV2Response.option_comparison ?? []` and
+ * `factor_sensitivity ?? []` (analysisSnapshotFactory.ts:250,257), so deleting
+ * the `parseRunFact` guards would re-create finding 1 exactly, whatever this
+ * function passes through. Mutation-checked: restoring the defaulting arm here
+ * with the guards intact REDs nothing (28/28 green — M13), while deleting
+ * either guard REDs immediately (M10/M11). **The guards in `parseRunFact` are
+ * the whole fix; this is readability, and it must not be mistaken for a
+ * guarantee.**
  */
 function toV2ResponseShape(fact: ParsedRunFact): V2RunResponse {
   return {

--- a/src/canvas/stores/persistedRunSnapshotFactory.ts
+++ b/src/canvas/stores/persistedRunSnapshotFactory.ts
@@ -45,6 +45,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
+function isNonEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length > 0
+}
+
 /**
  * The CEE-owned half of the fact, plus the PLoT envelope it wraps.
  * Everything here is untrusted JSONB — `null` means "this row cannot be read
@@ -52,6 +56,15 @@ function asRecord(value: unknown): Record<string, unknown> | null {
  */
 interface ParsedRunFact {
   enrichment: Record<string, unknown>
+  /**
+   * The two arrays every DECIDING snapshot field comes from, carried out of the
+   * parser already proven non-empty. They are surfaced here rather than re-read
+   * downstream so that `toV2ResponseShape` has no `?? []` arm to reach for —
+   * the defaulting path finding 1 exploited cannot be written back in without
+   * deleting a field from this type.
+   */
+  optionComparison: unknown[]
+  factorSensitivity: unknown[]
   computedAt: string | null
   graphHashAtRun: string | null
 }
@@ -72,8 +85,47 @@ function parseRunFact(payload: unknown): ParsedRunFact | null {
   // from the journey, not to render a run with every field blank.
   if (!enrichment) return null
 
+  // ⚠ A PRESENT ENVELOPE IS NOT A READABLE RUN. Found by the adversarial
+  // review of PR #523 (finding 1) and closed here pre-merge.
+  //
+  // Until this guard existed, `parseRunFact` accepted any row with
+  // {object, fact_type, result, enrichment} and `toV2ResponseShape` DEFAULTED a
+  // missing or empty `option_comparison` to `[]`. `buildAnalysisSnapshot`'s
+  // pre-existing `winner?.win_probability ?? 0` then produced a fully
+  // renderable snapshot. The reviewer's probe, reproduced verbatim here before
+  // the fix:
+  //
+  //   RESULT:  {"winnerId":"","winnerLabel":"","winnerProbability":0,
+  //             "goalProbability":null,"runnerUpProbability":null}
+  //   FACTORS: {"topElasticity":0,"rankFlipRate":0,
+  //             "influenceConcentration":0,"topCalibrationFactor":""}
+  //
+  // i.e. a run plotted on the trajectory at 0% with an empty winner label, and
+  // a hero inviting the user to "Calibrate " at "0% influence" — three
+  // fabricated measurements in one sentence. That is the absent≠zero class, on
+  // the very path this module documents as "dropped, never defaulted": the
+  // original three drop tests (non-object payload / wrong fact_type / no
+  // enrichment) could not see this shape.
+  //
+  // Both arrays are non-empty in 773/773 live facts, so this costs nothing on
+  // real data — it is a guard against PRODUCER DRIFT, and it makes that drift
+  // loud by omission (a run vanishes from the journey) instead of silently
+  // publishing zeros the engine never measured. The write surface is
+  // service-role-only, so this was never reachable by a client.
+  //
+  // These are the two arrays the snapshot's DECIDING fields come from —
+  // `option_comparison` for winner/runner-up/probabilities/goal, and
+  // `factor_sensitivity` for the whole top-factor and calibration block. Every
+  // OTHER producer field stays absence-preserving rather than drop-worthy
+  // (`recommendation_stability` is legitimately absent in 426/773 runs and must
+  // render "Not assessed", not delete the run).
+  if (!isNonEmptyArray(enrichment.option_comparison)) return null
+  if (!isNonEmptyArray(enrichment.factor_sensitivity)) return null
+
   return {
     enrichment,
+    optionComparison: enrichment.option_comparison,
+    factorSensitivity: enrichment.factor_sensitivity,
     computedAt: typeof result.computed_at === 'string' ? result.computed_at : null,
     graphHashAtRun:
       typeof result.graph_hash_at_run === 'string' && result.graph_hash_at_run.length > 0
@@ -103,20 +155,23 @@ function composeRobustness(enrichment: Record<string, unknown>): V2RunResponse['
 }
 
 /**
- * Shape the persisted envelope into the `V2RunResponse` slot the factory
- * consumes. No value is invented: absent producer fields stay absent, and the
- * factory's own absence-preserving branches then fire.
+ * Shape the parsed fact into the `V2RunResponse` slot the factory consumes. No
+ * value is invented: absent producer fields stay absent, and the factory's own
+ * absence-preserving branches then fire.
+ *
+ * ⚠ It takes the PARSED fact, not the raw enrichment, and that is the fix for
+ * finding 1 rather than a refactor. The two deciding arrays arrive already
+ * proven non-empty by `parseRunFact`, so there is no `Array.isArray(...) ?? []`
+ * arm here to silently manufacture an empty comparison — which is exactly what
+ * turned a shape-broken fact into a 0%-winner run on the trajectory. Restoring
+ * a default would now require deleting a field from `ParsedRunFact`.
  */
-function toV2ResponseShape(enrichment: Record<string, unknown>): V2RunResponse {
+function toV2ResponseShape(fact: ParsedRunFact): V2RunResponse {
   return {
-    ...enrichment,
-    option_comparison: Array.isArray(enrichment.option_comparison)
-      ? enrichment.option_comparison
-      : [],
-    factor_sensitivity: Array.isArray(enrichment.factor_sensitivity)
-      ? enrichment.factor_sensitivity
-      : [],
-    robustness: composeRobustness(enrichment),
+    ...fact.enrichment,
+    option_comparison: fact.optionComparison,
+    factor_sensitivity: fact.factorSensitivity,
+    robustness: composeRobustness(fact.enrichment),
   } as unknown as V2RunResponse
 }
 
@@ -141,7 +196,7 @@ export function buildSnapshotFromPersistedRun(
   if (!fact) return null
 
   const base = buildAnalysisSnapshot({
-    rawV2Response: toV2ResponseShape(fact.enrichment),
+    rawV2Response: toV2ResponseShape(fact),
     // No graph-at-run in a run_analysis fact. Passing null (not []) is what
     // makes graphHash / nodeCount / edgeCount / evidenceCoverage report
     // honest absence instead of a fabricated empty graph.

--- a/src/canvas/stores/persistedRunSnapshotFactory.ts
+++ b/src/canvas/stores/persistedRunSnapshotFactory.ts
@@ -1,0 +1,194 @@
+/**
+ * Persisted-run snapshot factory — rebuild an `AnalysisSnapshot` from a
+ * `v5_handler_facts` `run_analysis` row.
+ *
+ * ROADMAP 2.113a slice 1. Design of record:
+ * `docs-designs/COMPARE-BRIDGE-DESIGN-2026-07-29.md` §2 (field mapping).
+ *
+ * ⚠ THIS MODULE DOES NOT RE-DERIVE ANYTHING. It reshapes the persisted PLoT
+ * envelope into the `V2RunResponse` slot `buildAnalysisSnapshot` already
+ * consumes, then hands it to that ONE factory. A second snapshot builder
+ * would be a mirror of the first (CLAUDE.md trap 12), and the thing it would
+ * mirror is precisely the estate's hard-won absence-preserving logic: the
+ * T2b null for `recommendation_stability`, the null for absent
+ * `fragile_edges`, the NaN-safe seed parse, `selectGoalProbability` as the
+ * single registered owner of the goal-probability claim, and
+ * `topCalibrationFactor` as max |elasticity| rather than the refuted EVPI
+ * quantity. Every one of those is a defect this estate already paid for.
+ *
+ * ⚠⚠ DECLARED DEVIATION FROM THE DESIGN DOC (§2 mapping table, three rows).
+ * The doc maps `inferenceWarnings` / `conditionalWinners` / `edgeEValues` to
+ * `enrichment.robustness.*`. Measured over all 773 live non-noop
+ * `run_analysis` facts on staging (2026-07-29, read-only):
+ *
+ *     conditional_winners   root 773/773   robustness 0/773
+ *     edge_e_values         root 773/773   robustness 0/773
+ *     inference_warnings    root 773/773   robustness 0/773
+ *
+ * They are enrichment-ROOT siblings of `robustness`, never members of it.
+ * `buildAnalysisSnapshot` reads all three off the object handed to it in the
+ * `robustness` slot, so this module FOLDS the root-level values into that
+ * object — root wins, an existing nested value is preserved as a fallback so
+ * a future producer that moves them cannot silently blank the fields. Had the
+ * doc been implemented verbatim, all three would render permanently empty
+ * with no error to notice.
+ */
+import type { V2RunResponse } from '../../adapters/plot/v2/types'
+import type { ScenarioEvent } from '../../types/scenario'
+import type { AnalysisSnapshot } from '../compare-tab/types'
+import type { PersistedAnalysisRunRow } from '../../services/analysisRunHistoryService'
+import { buildAnalysisSnapshot } from './analysisSnapshotFactory'
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * The CEE-owned half of the fact, plus the PLoT envelope it wraps.
+ * Everything here is untrusted JSONB — `null` means "this row cannot be read
+ * as a completed analysis", and the caller DROPS it rather than defaulting it.
+ */
+interface ParsedRunFact {
+  enrichment: Record<string, unknown>
+  computedAt: string | null
+  graphHashAtRun: string | null
+}
+
+function parseRunFact(payload: unknown): ParsedRunFact | null {
+  const root = asRecord(payload)
+  if (!root) return null
+  // `noop` is a COLUMN, not a payload key (CEE splits the wire shape on
+  // write), so it is filtered in SQL — see analysisRunHistoryService.
+  if (root.fact_type !== 'run_analysis') return null
+
+  const result = asRecord(root.result)
+  if (!result) return null
+
+  const enrichment = asRecord(result.enrichment)
+  // No envelope ⇒ nothing to render. 773/773 live rows carry one; a row that
+  // does not is a producer change, and the honest response is to omit the run
+  // from the journey, not to render a run with every field blank.
+  if (!enrichment) return null
+
+  return {
+    enrichment,
+    computedAt: typeof result.computed_at === 'string' ? result.computed_at : null,
+    graphHashAtRun:
+      typeof result.graph_hash_at_run === 'string' && result.graph_hash_at_run.length > 0
+        ? result.graph_hash_at_run
+        : null,
+  }
+}
+
+/**
+ * Fold the enrichment-ROOT robustness siblings into the `robustness` object,
+ * because that is the slot `buildAnalysisSnapshot`'s three extractors read.
+ * Root wins; a nested value is kept as a fallback (forward-compatible if a
+ * future PLoT build ever nests them).
+ */
+function composeRobustness(enrichment: Record<string, unknown>): V2RunResponse['robustness'] {
+  const nested = asRecord(enrichment.robustness) ?? {}
+  const folded: Record<string, unknown> = { ...nested }
+  for (const key of ['inference_warnings', 'conditional_winners', 'edge_e_values'] as const) {
+    if (Array.isArray(enrichment[key])) folded[key] = enrichment[key]
+  }
+  // Double cast, deliberately: the folded object is untrusted JSONB, not a
+  // validated V2RobustnessActual. The factory's extractors already re-read
+  // every field off it defensively (`as Record<string, unknown>` + type
+  // guards), so widening through `unknown` is honest about what is known —
+  // asserting the nominal type directly would claim a validation nobody did.
+  return folded as unknown as V2RunResponse['robustness']
+}
+
+/**
+ * Shape the persisted envelope into the `V2RunResponse` slot the factory
+ * consumes. No value is invented: absent producer fields stay absent, and the
+ * factory's own absence-preserving branches then fire.
+ */
+function toV2ResponseShape(enrichment: Record<string, unknown>): V2RunResponse {
+  return {
+    ...enrichment,
+    option_comparison: Array.isArray(enrichment.option_comparison)
+      ? enrichment.option_comparison
+      : [],
+    factor_sensitivity: Array.isArray(enrichment.factor_sensitivity)
+      ? enrichment.factor_sensitivity
+      : [],
+    robustness: composeRobustness(enrichment),
+  } as unknown as V2RunResponse
+}
+
+export interface BuildPersistedSnapshotParams {
+  row: PersistedAnalysisRunRow
+  runNumber: number
+  /** Scenario events, for the between-runs edit summary. */
+  events: ScenarioEvent[]
+  previousSnapshotTimestamp: string | null
+}
+
+/**
+ * Rebuild one snapshot. Returns null when the row cannot be read as a
+ * completed analysis — the caller omits it from the journey.
+ */
+export function buildSnapshotFromPersistedRun(
+  params: BuildPersistedSnapshotParams,
+): AnalysisSnapshot | null {
+  const { row, runNumber, events, previousSnapshotTimestamp } = params
+
+  const fact = parseRunFact(row.payload)
+  if (!fact) return null
+
+  const base = buildAnalysisSnapshot({
+    rawV2Response: toV2ResponseShape(fact.enrichment),
+    // No graph-at-run in a run_analysis fact. Passing null (not []) is what
+    // makes graphHash / nodeCount / edgeCount / evidenceCoverage report
+    // honest absence instead of a fabricated empty graph.
+    nodes: null,
+    edges: null,
+    runNumber,
+    events,
+    previousSnapshotTimestamp,
+  })
+
+  return {
+    ...base,
+    // Durable identity: the fact row id, not a fresh uuid. Two hydrations of
+    // the same history must produce the same runId, or React keys churn and
+    // dedupe against session snapshots becomes impossible.
+    runId: row.id,
+    // `computed_at` is the moment the ANALYSIS was computed; the row's
+    // `created_at` is when it was written. They differ by the persistence
+    // round-trip only, but the former is the one the trajectory is about.
+    timestamp: fact.computedAt ?? row.createdAt,
+    source: 'persisted',
+    // CEE's ANALYSIS-AFFECTING hash (`aag_v1`) — a DIFFERENT regime from the
+    // UI's `generateGraphHash`. `source: 'persisted'` is what stops
+    // `detectStructureChange` comparing it against a session snapshot's.
+    graphHash: fact.graphHashAtRun,
+  }
+}
+
+/**
+ * Rebuild a whole journey, oldest-first. Rows that cannot be read are
+ * dropped, and `runNumber` is stamped over the SURVIVORS so the numbering the
+ * user sees is contiguous and matches what is actually rendered.
+ */
+export function buildSnapshotsFromPersistedRuns(
+  rows: readonly PersistedAnalysisRunRow[],
+  events: ScenarioEvent[],
+): AnalysisSnapshot[] {
+  const snapshots: AnalysisSnapshot[] = []
+  for (const row of rows) {
+    const previous = snapshots[snapshots.length - 1] ?? null
+    const snapshot = buildSnapshotFromPersistedRun({
+      row,
+      runNumber: snapshots.length + 1,
+      events,
+      previousSnapshotTimestamp: previous?.timestamp ?? null,
+    })
+    if (snapshot) snapshots.push(snapshot)
+  }
+  return snapshots
+}

--- a/src/services/__tests__/analysisRunHistoryService.spec.ts
+++ b/src/services/__tests__/analysisRunHistoryService.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * analysisRunHistoryService — the RLS read seam. ROADMAP 2.113a slice 1.
+ *
+ * The mock is at the SUPABASE CLIENT seam, so these tests pin the QUERY this
+ * module actually issues. Ownership itself is enforced by Postgres RLS
+ * (`USING (auth.uid() = user_id)`) and is NOT re-implemented here — the
+ * `owner filter` test below asserts that absence deliberately: a client-side
+ * `.eq('user_id', …)` would be a second, drift-prone copy of an invariant the
+ * DB already owns.
+ *
+ * Grant + policy were derived at the live staging DB on 2026-07-29
+ * (`has_table_privilege('authenticated','public.v5_handler_facts','SELECT')`
+ * → true; policy present). Evidence:
+ * PHASE0-EVIDENCE-2026-07-28/compare-slice1.md §0.1.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+interface Recorded {
+  table: string
+  select: string
+  eq: Array<[string, unknown]>
+  order: Array<[string, unknown]>
+  limit: number | null
+}
+
+let recorded: Recorded
+let response: { data: unknown; error: { message: string } | null }
+
+vi.mock('../../lib/supabase', () => {
+  const builder: Record<string, unknown> = {}
+  const chain = {
+    select(cols: string) { recorded.select = cols; return chain },
+    eq(col: string, val: unknown) { recorded.eq.push([col, val]); return chain },
+    order(col: string, opts: unknown) { recorded.order.push([col, opts]); return chain },
+    limit(n: number) { recorded.limit = n; return Promise.resolve(response) },
+  }
+  builder.from = (table: string) => { recorded.table = table; return chain }
+  return { supabase: builder }
+})
+
+import { listPersistedAnalysisRuns, MAX_PERSISTED_RUNS } from '../analysisRunHistoryService'
+
+beforeEach(() => {
+  recorded = { table: '', select: '', eq: [], order: [], limit: null }
+  response = { data: [], error: null }
+})
+
+describe('listPersistedAnalysisRuns — the query', () => {
+  it('reads non-noop run_analysis facts for one scenario, newest-first, capped', async () => {
+    await listPersistedAnalysisRuns('scenario-1')
+    expect(recorded.table).toBe('v5_handler_facts')
+    expect(recorded.select).toBe('id, created_at, payload, v5_conversation_turn_id')
+    expect(recorded.eq).toEqual([
+      ['scenario_id', 'scenario-1'],
+      ['handler_id', 'run_analysis'],
+      // `noop` is a real COLUMN, not a payload key — a noop fact carries no
+      // enrichment and must be filtered in SQL, not silently dropped later.
+      ['noop', false],
+    ])
+    expect(recorded.order).toEqual([['created_at', { ascending: false }]])
+    expect(recorded.limit).toBe(MAX_PERSISTED_RUNS)
+  })
+
+  it('does NOT filter by user_id — RLS is the authorisation boundary, not a client copy of it', async () => {
+    await listPersistedAnalysisRuns('scenario-1')
+    expect(recorded.eq.map(([col]) => col)).not.toContain('user_id')
+    expect(recorded.eq.map(([col]) => col)).not.toContain('owner_user_id')
+  })
+
+  it('makes no query at all for an empty scenario id', async () => {
+    expect(await listPersistedAnalysisRuns('')).toEqual([])
+    expect(recorded.table).toBe('')
+  })
+})
+
+describe('listPersistedAnalysisRuns — the result', () => {
+  it('returns rows OLDEST-first (every Compare derivation walks chronologically)', async () => {
+    response = {
+      data: [
+        { id: 'c', created_at: '2026-07-20T12:00:00.000Z', payload: { n: 3 }, v5_conversation_turn_id: 't3' },
+        { id: 'b', created_at: '2026-07-20T11:00:00.000Z', payload: { n: 2 }, v5_conversation_turn_id: 't2' },
+        { id: 'a', created_at: '2026-07-20T10:00:00.000Z', payload: { n: 1 }, v5_conversation_turn_id: 't1' },
+      ],
+      error: null,
+    }
+    const rows = await listPersistedAnalysisRuns('scenario-1')
+    expect(rows.map(r => r.id)).toEqual(['a', 'b', 'c'])
+    expect(rows[0].turnId).toBe('t1')
+  })
+
+  it('an owner with no runs, and a guest (RLS returns nothing), both get []', async () => {
+    response = { data: [], error: null }
+    expect(await listPersistedAnalysisRuns('scenario-1')).toEqual([])
+    response = { data: null, error: null }
+    expect(await listPersistedAnalysisRuns('scenario-1')).toEqual([])
+  })
+
+  it('THROWS on a read error so the caller decides how to degrade — never returns [] for a failure', async () => {
+    // Returning [] here would make a revoked grant indistinguishable from
+    // "this scenario has no history" — the tab would state the second while
+    // the first was true.
+    response = { data: null, error: { message: 'permission denied for table v5_handler_facts' } }
+    await expect(listPersistedAnalysisRuns('scenario-1')).rejects.toThrow(/permission denied/)
+  })
+
+  it('drops a row with no usable id or timestamp rather than defaulting one', async () => {
+    response = {
+      data: [
+        { id: 'ok', created_at: '2026-07-20T10:00:00.000Z', payload: {}, v5_conversation_turn_id: 't' },
+        { id: null, created_at: '2026-07-20T11:00:00.000Z', payload: {} },
+        { id: 'no-ts', created_at: null, payload: {} },
+      ],
+      error: null,
+    }
+    const rows = await listPersistedAnalysisRuns('scenario-1')
+    expect(rows.map(r => r.id)).toEqual(['ok'])
+  })
+
+  it('honours an explicit limit', async () => {
+    await listPersistedAnalysisRuns('scenario-1', 5)
+    expect(recorded.limit).toBe(5)
+  })
+})

--- a/src/services/analysisRunHistoryService.ts
+++ b/src/services/analysisRunHistoryService.ts
@@ -1,0 +1,123 @@
+/**
+ * Analysis run history — the persisted `run_analysis` facts for a scenario.
+ *
+ * ROADMAP 2.113a slice 1. This is the read seam that gives the Compare tab a
+ * data source at all. Design of record:
+ * `docs-designs/COMPARE-BRIDGE-DESIGN-2026-07-29.md` §3, option (b).
+ *
+ * WHY A DIRECT SUPABASE READ, AND WHY THAT IS NOT A DOCTRINE BREACH
+ * -----------------------------------------------------------------
+ * "CEE owns the compute-orchestration seam" is a statement about the
+ * ANALYSE path: the UI must not commission a computation, and it does not
+ * here. These rows were requested by CEE, computed by PLoT/ISL, and persisted
+ * by CEE under CEE-authored RLS. Reading them back is the same relationship
+ * the UI already has with `scenarios` (10 direct `.from('scenarios')` call
+ * sites in `scenarioService.ts`). Slice 1 therefore ships with zero CEE
+ * deploy, and the DATABASE is the authorisation boundary.
+ *
+ * THE AUTHORISATION BOUNDARY — derived at the live DB, not assumed
+ * -----------------------------------------------------------------
+ * Verified read-only against staging on 2026-07-29
+ * (`has_table_privilege` + `pg_policies`; evidence in
+ * PHASE0-EVIDENCE-2026-07-28/compare-slice1.md §0.1):
+ *
+ *   • `GRANT SELECT ON v5_handler_facts TO authenticated` — present.
+ *   • POLICY "Users can read own v5 handler facts" FOR SELECT
+ *     USING (auth.uid() = user_id) — present, RLS enabled.
+ *
+ * So this query CANNOT return another user's rows, and this module therefore
+ * does NOT filter by `user_id` — re-implementing the check client-side would
+ * be a second, drift-prone copy of an invariant the DB already enforces
+ * (CLAUDE.md trap 12: derive, don't mirror).
+ *
+ * GUESTS. `v5_handler_facts.user_id` is NULLABLE (guest mode, CEE migration
+ * 20260422000000). For a guest row `auth.uid() = user_id` evaluates to NULL,
+ * not TRUE — so a guest reads exactly zero rows BY CONSTRUCTION. 643 of the
+ * 773 live non-noop run_analysis facts are guest rows and are invisible to
+ * this query for that reason. Callers must render their normal empty state
+ * for that case, never an error.
+ *
+ * SHAPE TRUST. The row is read OUTSIDE the `@talchain/schemas` contract, so
+ * nothing here asserts a shape. This module returns the raw `payload` and
+ * lets `persistedRunSnapshotFactory` parse it tolerantly; a row it cannot
+ * read is dropped, never defaulted.
+ */
+import { supabase } from '../lib/supabase'
+
+/** The CEE handler whose facts carry a completed analysis. */
+const RUN_ANALYSIS_HANDLER_ID = 'run_analysis'
+
+/**
+ * How many past runs the Compare tab hydrates. The tab's trajectory chart and
+ * transition list are both read top-down by a human; beyond ~20 the journey
+ * stops being legible and the payload stops being cheap. Live maximum per
+ * owned scenario at the time of writing is 8.
+ */
+export const MAX_PERSISTED_RUNS = 20
+
+export interface PersistedAnalysisRunRow {
+  /** `v5_handler_facts.id` — the durable identity of this run. */
+  id: string
+  /** `v5_handler_facts.created_at`, ISO 8601. */
+  createdAt: string
+  /** `v5_handler_facts.payload` — `{ fact_type, fact_version, result }`, untrusted. */
+  payload: unknown
+  /** Parent `v5_conversation_turns.id`; null only if the column were ever absent. */
+  turnId: string | null
+}
+
+interface RawFactRow {
+  id?: unknown
+  created_at?: unknown
+  payload?: unknown
+  v5_conversation_turn_id?: unknown
+}
+
+/**
+ * Read this scenario's completed analysis runs, oldest-first.
+ *
+ * Ordering note: the QUERY orders newest-first so the `limit` keeps the most
+ * RECENT runs (a `limit` on an ascending order would keep the oldest and drop
+ * the ones the user just produced). The result is reversed before returning,
+ * because every Compare derivation — trajectory, transitions, cumulative
+ * card — walks the list chronologically.
+ *
+ * Throws on a read error. Callers decide how to degrade; the Compare
+ * hydration hook degrades to the tab's existing empty state.
+ */
+export async function listPersistedAnalysisRuns(
+  scenarioId: string,
+  limit: number = MAX_PERSISTED_RUNS,
+): Promise<PersistedAnalysisRunRow[]> {
+  if (!scenarioId) return []
+
+  const { data, error } = await supabase
+    .from('v5_handler_facts')
+    .select('id, created_at, payload, v5_conversation_turn_id')
+    .eq('scenario_id', scenarioId)
+    .eq('handler_id', RUN_ANALYSIS_HANDLER_ID)
+    // `noop` is a real COLUMN, not a payload field (CEE splits the wire shape
+    // on write). A noop run_analysis fact carries no `result.enrichment` and
+    // would map to nothing — filter it in SQL rather than dropping it later.
+    .eq('noop', false)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    throw new Error(`Failed to read persisted analysis runs: ${error.message}`)
+  }
+
+  const rows = (data ?? []) as RawFactRow[]
+  const mapped: PersistedAnalysisRunRow[] = []
+  for (const row of rows) {
+    if (typeof row?.id !== 'string' || typeof row?.created_at !== 'string') continue
+    mapped.push({
+      id: row.id,
+      createdAt: row.created_at,
+      payload: row.payload,
+      turnId: typeof row.v5_conversation_turn_id === 'string' ? row.v5_conversation_turn_id : null,
+    })
+  }
+
+  return mapped.reverse()
+}


### PR DESCRIPTION
## What this is

**ROADMAP 2.113a slice 1** (POC-DONE step 6). Design of record:
`docs-designs/COMPARE-BRIDGE-DESIGN-2026-07-29.md`, slice 1 exactly.

**DO NOT MERGE — adversarial review follows.**

## The defect: the Compare tab had no data source on the deployed wire

Its only seed was the capture gate at `canvas/store.ts` `resultsComplete`:

```ts
if (isCompareTabEnabled() && rawV2Response && report) { … }
```

and the live V5 results-hydration applicator calls that same setter with
`rawV2Response: null` — explicitly, with the comment *"V5 carries no V2 envelope"*
(`src/v5/applyV5State.ts:1023`). Only the direct-run paths supply a non-null envelope,
and the deployed analyse path is the CEE turn.

So this is **not** "Compare loses its history on reload". **Compare never had a history
to lose** — the tab shipped its empty state to every user in every session.

## What changed

The **data source**, and nothing else. The whole existing render tree survives unchanged
— RunSelector, Hero, TrajectorySection, TransitionsSection, CompareFooter, the state
machine (`deriveCompareState`), the transition derivation. **No new UI surface, no new
flag, no CEE deploy, no schema change, no `@talchain/schemas` import.**

`useCompareHistoryHydration` (called from the existing `CompareTabBody`) reads the
scenario's non-noop `run_analysis` facts from `v5_handler_facts` under RLS and seeds the
store the tab already read. Each fact's `result.enrichment` is the validated PLoT
envelope byte-for-byte, so every field the state machine and hero decide on reconstructs
1:1 from what CEE already persisted. Nothing new is written.

### Authorisation is the database — derived, not assumed

Verified read-only at the live staging DB (2026-07-29):

| check | result |
|---|---|
| `has_table_privilege('authenticated','public.v5_handler_facts','SELECT')` | **true** |
| POLICY `Users can read own v5 handler facts` FOR SELECT `USING (auth.uid() = user_id)` | **present**, RLS enabled |

This closes the design doc §3 caveat ("policy-implied but not byte-verified"). The
service therefore does **not** filter by `user_id` — a client-side copy of an invariant
the DB owns is the drift-prone mirror this estate keeps paying for.

**Live non-owner proof, with a positive control** (anon key from the deployed bundle,
`role=anon`, never printed):

| probe | result |
|---|---|
| `GET /rest/v1/v5_handler_facts?select=id&limit=1` (non-owner) | **200 `[]`** |
| `GET /rest/v1/model_versions…` — anon has **no** grant | **401 `42501` permission denied** |
| `GET /rest/v1/v5_handler_facts?select=no_such_column` | **400 `42703` column does not exist** |

The last two are the controls: the probe **can** see a permission denial and the request
**did** reach the table, so the `200 []` is genuine RLS filtering rather than a swallowed
error (CLAUDE.md trap 13).

**The owner half of the live proof is NOT in this PR** — see "Live-proof scope" below.

### Guests are unchanged by construction

`v5_handler_facts.user_id` is nullable for guest rows, and `auth.uid() = NULL` is `NULL`,
not `TRUE` — so RLS returns a guest zero rows. 643 of the 773 live non-noop
`run_analysis` facts are guest rows and are invisible to this query for exactly that
reason. The hook checks for a session **first** and skips the read entirely. The tab
renders its existing empty/explainer state — never an error — and so does every failure
path (revoked grant, offline, malformed row).

## Declared deviation from the design of record

**§2 mapping table, three rows.** The doc maps `inferenceWarnings` /
`conditionalWinners` / `edgeEValues` to `enrichment.robustness.*`. Measured over **all
773** live non-noop `run_analysis` facts:

| field | at `enrichment.<field>` | at `enrichment.robustness.<field>` |
|---|---|---|
| `conditional_winners` | **773 / 773** | **0 / 773** |
| `edge_e_values` | **773 / 773** | **0 / 773** |
| `inference_warnings` | **773 / 773** | **0 / 773** |

They are enrichment-**root** siblings of `robustness`, never members. The doc implemented
verbatim would have produced three permanently-empty arrays with nothing to notice. The
mapper folds the root values into the slot the factory reads, keeps a nested value as a
forward-compatible fallback, and a test pins **both** directions.

## The two named gaps degrade — they do not fabricate

A `run_analysis` fact stores the **analysis**, not the model, so a rebuilt run has no
graph. `nodeCount` / `edgeCount` / `evidenceCoverage` are widened to nullable and report
absence; `graphHash` likewise (55 of 773 live rows carry no `graph_hash_at_run`).

Passing `nodes: []` would have been three silent fabrications at once:
`generateGraphHash([], [])` is a **real hash of an empty graph**, so two rebuilt runs
would compare EQUAL and assert *"structure unchanged"*; counts would read 0; and coverage
would read `"0/0"` — a measured-sounding verdict of *"no evidence anywhere"*. Absence
renders as **"Not assessed"**, the treatment `recommendationStability` and
`fragileEdgeCount` already get.

Also honest by inheritance: `recommendation_stability` is present in only **347/773**
runs, and `deriveStabilityLabel(0) === 'fragile'` — so a fabricated 0 would make the tab
**assert "Model fragile"** about 55% of runs. The existing T2b null carries through
because this slice reuses the one factory rather than mirroring it.

## Hash regimes never compare

A session snapshot's `graphHash` is the UI's `generateGraphHash`; a persisted run's is
CEE's analysis-affecting `aag_v1`. `AnalysisSnapshot.source` carries that provenance as
**one** field (a separate `graphHashFamily` would mirror it), and `detectStructureChange`
refuses a cross-source or absent-ended hash comparison — otherwise every transition
across the provenance boundary would manufacture *"structure changed"* out of where the
data was read from. Pinned both ways, including that the guard is not a blanket
off-switch.

## Gates

| gate | result |
|---|---|
| `pnpm typecheck` | **PASS** — 624 files / 2513 errors, **+0**; coverage 3019/3059 with all four new files loaded |
| `src/canvas` + `src/services` + `src/components/results` | **924 files, 14,212 passed, 59 skipped, 0 failed** |
| mutation check (throwaway worktree **outside** the clone) | **9/9 mutants bite; control green** |

Mutants: drop the hydration call · drop the guest guard · read the three fields from
`robustness` (the doc as written) · pass `nodes: []` · disable the regime guard · drop
the run-identity dedupe · swallow a read error into `[]` · drop the oldest-first
reversal · mark the dedupe key on start (see the self-review section below).

One mutant's first attempt (M5) was a **false RED** — the edit left the file unparseable, so it failed at COLLECTION rather than on behaviour. Redone as a valid mutant; the recorded RED is the second run. Both mutation worktrees lived outside the clone and were removed before any gate run.

## Live-proof scope — stated honestly

`playwright.staging.config.ts` targets only `e2e/smoke/v5-proxy-reachability.spec.ts`
(HTTP-only) and carries **no signed-in credentials**; a grep across `e2e/` for
`storageState` / `signInWithPassword` / `TEST_*EMAIL` / `*PASSWORD` finds none. I cannot
create an account (house rule). So:

- **Non-owner half — DONE live** (table above, with controls).
- **Grant + policy — DONE at the DB** (`has_table_privilege` + `pg_policies`).
- **Owner half — NOT DONE, and it is A1's to run**: sign in as the demo user, open a
  scenario with ≥2 past analyses, confirm the Refinement Journey renders and survives a
  reload. **41 owned staging scenarios qualify**; the largest carries 8 runs
  (`0acc0716-0002-4001-8001-000000000002`).

I have not faked this step and no claim in this PR depends on it.

## A defect I introduced and caught in self-review (commit `495e5310`)

Disclosed rather than quietly squashed. `useCompareHistoryHydration` originally claimed
its `(scenarioId, resultHash)` dedupe key the moment the read **started**. React can
mount, tear down and re-mount an effect **without the deps changing** — StrictMode's
development double-invoke is the ordinary case. Under that sequence: pass 1 claims the
key, its cleanup cancels the in-flight read, pass 2 sees the key claimed and does
nothing. **The tab would have sat permanently empty, with no error anywhere** — the
dominant defect class here, machinery that reads as a guarantee and never executes,
reintroduced by the guard written to keep the read cheap.

`src/main.tsx` does **not** enable StrictMode today (grep at `994fba64`: zero hits), so
nothing shipped broken. The point is that enabling it must not silently switch the
feature off.

The key is now set after the read **resolves** — including a completed read that found no
rows, which is still a completed read. A failure leaves it unmarked so a later mount
retries instead of latching; the guest branch leaves it unmarked so a user who signs in
mid-session gets their history without a scenario switch to unlatch it. Worst case is one
redundant read of a read-only, idempotent query. Pinned by a test rendering
`CompareTabBody` inside `<StrictMode>`; mutant **M9** (mark-on-start) REDs exactly that
test.

## Other declared deviations

- **The read fires on TAB OPEN, not on canvas load.** Design §4 says *"on canvas load
  (and after `resultsComplete`)"*. The hook lives in `CompareTabBody`, which `OutputsDock`
  mounts only while Compare is active (`OutputsDock.tsx:2472`), so the read costs nothing
  until the tab is opened — the only moment its result is observable. The *"after
  `resultsComplete`"* half is satisfied without a second call site: the effect keys on
  `currentScenarioLastResultHash`, which `resultsComplete` writes on every completion
  including V5 (`store.ts:3068`). **Honest cost:** one async tick on first open during
  which the empty state shows. If you prefer the eager trigger, moving the hook into
  `useScenario.loadScenario` is a one-line change and no test depends on its location.
- **"RLS positive-control probe as its first commit"** — the probe is a read-only DB/HTTP
  step, not code, so there was nothing to commit. The tables above are its record.
- **`deriveTransitions` was modified.** The constraint was that the tab's *state machine*
  keep its decision logic: `deriveCompareState.ts` is **byte-identical** (`git diff`
  against `staging` is empty). The one change to `deriveTransitions` is a refusal to
  claim, not a new claim.

## Post-review: finding 1 closed pre-merge (`3c6765b5`, `1a4b2f6c`)

The adversarial review returned **MERGE-SAFE** with one moderate, fabrication-class
finding, ruled pre-merge. Both fixes are on the branch.

**The defect.** `parseRunFact` accepted any row shaped `{object, fact_type:
'run_analysis', result, enrichment}`; `toV2ResponseShape` DEFAULTED an empty/absent
`option_comparison` to `[]`; and `buildAnalysisSnapshot`'s pre-existing
`winner?.win_probability ?? 0` made that renderable. Reproduced in my tree at
`495e5310`, byte-identical to the reviewer's probe:

```
RESULT:  {"winnerId":"","winnerLabel":"","winnerProbability":0,
          "goalProbability":null,"runnerUpProbability":null}
FACTORS: {"topElasticity":0,"rankFlipRate":0,
          "influenceConcentration":0,"topCalibrationFactor":""}
```

A run plotted at **0% with an empty winner label**, and a hero inviting the user to
**"Calibrate " at "0% influence"** — three fabricated measurements in one sentence, on the
exact path this module documents as *"dropped, never defaulted"*. The three original drop
tests couldn't see the shape.

**The fix.** `parseRunFact` requires `option_comparison` **and** `factor_sensitivity` to be
non-empty arrays; a fact failing either is dropped. Those two and no more: they are the
arrays every *deciding* field comes from. Everything else stays absence-preserving —
`recommendation_stability` is legitimately absent in 426/773 live runs and must render "Not
assessed", not delete the run. **Live cost zero:** both arrays are non-empty in 773/773
facts, so this is producer-drift insurance on a service-role-only write surface, and it
makes drift loud by omission instead of publishing zeros ISL never measured.

**RED-first:** 5 of the 6 new specs fail on the unfixed tree (`expected { Object (runId,
runNumber, ...) } to be null`); 28/28 after. The sixth is a positive control (one option,
one factor still builds) so tightening the guard until everything drops can't pass.

**Mutation check** (throwaway worktree outside the clone):

| Mutant | Result |
|---|---|
| M10 remove the `option_comparison` guard | **RED** 3/28 |
| M11 remove the `factor_sensitivity` guard | **RED** 2/28 |
| M12 weaken `isNonEmptyArray` to bare `Array.isArray` | **RED** 2/28 |
| M13 restore the `: []` arm, guards intact | ⚪ **GREEN — does not bite** |
| CONTROL unmutated | GREEN 28/28 |

**M13 is reported because it refuted a sentence of mine** (`1a4b2f6c`). I had written that
threading the validated arrays through `ParsedRunFact` meant a default "would require
deleting a field from this type" — implying a second line of defence. It isn't one:
`buildAnalysisSnapshot` has its own `?? []` (`analysisSnapshotFactory.ts:250,257`), so
deleting the guards re-creates the defect regardless. The guards are the whole fix; the
threading is readability. The comment now says so.

**Gates at head:** typecheck **PASS at baseline +0**; compare-tab + stores + services
**26 files / 390 tests green**. CI at `495e5310` was fully green including all four shards;
the run for `1a4b2f6c` is yours to read.

Findings 3 and 4 (INFO) are disclosed boundaries, not defects, and are not actioned in
slice 1.

## Evidence

`PHASE0-EVIDENCE-2026-07-28/compare-slice1.md`
