### PR TITLE
fix(ui): Model-tab edit loop — freshness on apply, revert on reject (2.129)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2513
+# count=2512
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -518,7 +518,6 @@
 3	src/canvas/conversation/__tests__/blockSchemaAlignment.spec.ts	TS2352	Conversion of type 'ConversationBlock' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/__tests__/cee-request-contracts.spec.ts	TS2345	Argument of type '{ factor_sensitivity: { factor_id: string; importance_rank: number; }[]; analysis_status: string; option_comparison_status: string; robustness_status: string; drivers_status: string; response_hash: string; ... 6 more ...; meta: { ...; }; }' is not assignable to parameter of type '{ analysis_status: string; option_comparison_status: string; robustness_status: string; drivers_status: string; response_hash: string; option_comparison: { option_id: string; option_label: string; expected_value: number; rank: number; }[]; ... 6 more ...; meta: { ...; }; }'.
 1	src/canvas/conversation/__tests__/conversation-flow.spec.ts	TS2352	Conversion of type 'ConversationBlock' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-1	src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx	TS2322	Type 'Mock<any[], unknown>' is not assignable to type '(event: WireSystemEvent, opts?: { debugSource?: string | undefined; debugVisibleText?: null | string | undefined; debugParentChainId?: null | string | undefined; debugInitiatedBy?: "user" | ... 1 more ... | undefined; debugSourceSurface?: string | undefined; } | undefined) => Promise<...>'.
 2	src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx	TS2741	Property 'onAttach' is missing in type '{ conversation: UseConversationReturn; onCollapse: Mock<[], void>; }' but required in type 'ConversationPanelProps'.
 1	src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts	TS2352	Conversion of type 'undefined' to type '{ response_hash?: string | undefined; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts	TS2493	Tuple type '[]' of length '0' has no element at index '0'.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2513
+# count=2512
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -230,7 +230,7 @@
 3	src/canvas/conversation/__tests__/blockSchemaAlignment.spec.ts
 1	src/canvas/conversation/__tests__/cee-request-contracts.spec.ts
 1	src/canvas/conversation/__tests__/conversation-flow.spec.ts
-3	src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
+2	src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
 7	src/canvas/conversation/__tests__/envelopeAnalysisPersistence.spec.ts
 8	src/canvas/conversation/__tests__/envelopeAnalysisWiring.spec.ts
 3	src/canvas/conversation/__tests__/goldenFixture.spec.ts

--- a/src/canvas/components/model-tab/FactorsSection.tsx
+++ b/src/canvas/components/model-tab/FactorsSection.tsx
@@ -20,6 +20,7 @@ import { SectionErrorBoundary } from '../GraphTextView'
 import { useNodeMutations } from '../../ui/inspector-v2/useInspectorMutations'
 import { useOptionalConversationContext } from '../../conversation/ConversationContext'
 import { buildFactorValueEditEvent } from '../../conversation/factorValueEdit'
+import { captureOptimisticFactorEdit } from '../../conversation/optimisticFactorEdit'
 import { Accordion } from '../../../components/results/Accordion'
 import { focusNodeById } from '../../utils/focusHelpers'
 import { formatSmartNumber, formatValueWithUnit, getPrimaryValue, countFactorsToVerify } from './utils'
@@ -234,6 +235,13 @@ function FactorCard({
       raw_value?: number
     }
 
+    // ROADMAP 2.129 (b) — capture the undo BEFORE the write, from the same
+    // pre-write `data` the event was built from. The optimistic write below is
+    // what makes the canvas responsive; this is what stops it becoming a lie when
+    // CEE refuses the number (out-of-cap, live-proven: canvas showed 25 months
+    // and stamped "User edited" while the engine held 3).
+    const undo = captureOptimisticFactorEdit(node.id, modelValue, data)
+
     // Local write first, in ONE update: value + raw_value + the provenance
     // stamp. `source: 'user'` is preserved from the old handlers — it is what
     // flips the pill to "User edited" and drops the factor out of the
@@ -244,11 +252,18 @@ function FactorCard({
     // never reached CEE, its graph_hash never moved, and the re-run the
     // freshness strip invited could not possibly reflect the change.
     if (!sendSystemEvent) return
-    void Promise.resolve(sendSystemEvent(event)).catch(() => {
+    void Promise.resolve(
+      // The undo travels WITH the send, not around it: the dispatcher owns the
+      // reply (and the deferral buffer, so an edit made mid-analysis is resolved
+      // by the same path). A `.then` here could not see a DEFERRED edit's reply
+      // at all — that promise resolves with SEND_DEFERRED before the turn exists.
+      sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
+    ).catch(() => {
       // Swallowed deliberately: a genuine send failure is already recorded by
       // the conversation's own failure channel (see FactorControllablePanel for
       // why this catch is NOT what protects an edit made during a running
-      // analysis — the dispatcher's deferral buffer is).
+      // analysis — the dispatcher's deferral buffer is). A server REFUSAL is not
+      // a failure and never reaches here; the dispatcher's revert handles it.
     })
   }, [node.id, data, mutations, sendSystemEvent])
 

--- a/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/ReanalyseBar.spec.tsx
@@ -58,6 +58,32 @@ describe('ReanalyseBar', () => {
     expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
   })
 
+  /**
+   * ROADMAP 2.129 (a). Live-proven FAIL: after CEE APPLIED a Model-tab edit the
+   * bar was ABSENT (15 samples / 70 s), so the tab offered NO re-analyse control
+   * at all — while a REJECTED edit did render it. The applied reply's
+   * `analysis_ready` is readiness-only (`{status, computed_at, options,
+   * goal_node_id}`), which the slice degrades to 'unknown' — and an 'unknown'
+   * that came from SILENCE, over a model the user just changed, is "changed",
+   * not "can't confirm". See store/__tests__/freshnessOnAppliedEdit.spec.ts for
+   * the store-level replay of the captured payloads.
+   */
+  it('renders the bar AND the re-run control after an applied edit (silent verdict + local edit)', () => {
+    mockFreshness = { freshness: 'unknown', freshnessReason: 'payload_carried_no_freshness_verdict' }
+    mockDirty = true
+    render(<ReanalyseBar />)
+    expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('reanalyse-button')).toBeInTheDocument()
+    expect(screen.getByText(/Model changed/)).toBeInTheDocument()
+  })
+
+  it('still renders nothing for that same silent verdict with NO local edit', () => {
+    mockFreshness = { freshness: 'unknown', freshnessReason: 'payload_carried_no_freshness_verdict' }
+    mockDirty = false
+    const { container } = render(<ReanalyseBar />)
+    expect(container.firstChild).toBeNull()
+  })
+
   it('calls onReanalyse when button is clicked', () => {
     mockFreshness = { freshness: 'stale' }
     mockDirty = false

--- a/src/canvas/components/model-tab/__tests__/modelTabEditCarriesUndo.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/modelTabEditCarriesUndo.spec.tsx
@@ -1,0 +1,101 @@
+/**
+ * ROADMAP 2.129 (b), panel half — the Model-tab commit must HAND THE DISPATCHER
+ * THE UNDO, captured from the state as it was BEFORE the optimistic write.
+ *
+ * The revert itself lives in the dispatcher (a refusal resolves, so no `.catch`
+ * at this layer can see it, and a DEFERRED edit's promise resolves before the
+ * reply exists — see conversation/__tests__/optimisticFactorEditRevert.spec.ts).
+ * What only a panel spec can prove is the half the dispatcher cannot: that the
+ * snapshot handed over is the PRE-EDIT state. A snapshot taken one line later
+ * would be the optimistic value itself, and every revert built on it would
+ * "restore" the number CEE refused — a fix that passes its own tests and changes
+ * nothing on screen.
+ *
+ * Kept OUT of the #522 parity suite deliberately: that suite pins slice 1 and
+ * stays untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+const sendSystemEvent = vi.fn()
+
+// Trap 12: spread the real module — a `vi.mock` factory REPLACES it.
+vi.mock('../../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useOptionalConversationContext: () => ({ sendSystemEvent }) }
+})
+
+import { FactorsSection } from '../FactorsSection'
+import { useCanvasStore } from '../../../store'
+
+const FACTOR_ID = 'fac_delivery_time'
+const CAP = 6
+
+beforeAll(() => { Element.prototype.scrollIntoView = vi.fn() })
+
+function factorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Estimated Delivery Time',
+      kind: 'factor',
+      category: 'controllable',
+      display_value: '3 months',
+      observedState: {
+        value: 3 / CAP,
+        raw_value: 3,
+        cap: CAP,
+        unit: 'months',
+        source: 'cee_inference',
+      },
+    },
+  } as unknown as Node
+}
+
+function commitInline(testId: string, next: string) {
+  fireEvent.click(screen.getByTestId(`${testId}-display`))
+  const input = screen.getByTestId(testId)
+  fireEvent.change(input, { target: { value: next } })
+  fireEvent.blur(input)
+}
+
+describe('a Model-tab value commit carries its own undo', () => {
+  beforeEach(() => {
+    sendSystemEvent.mockClear()
+    useCanvasStore.setState({ nodes: [factorNode()], edges: [], results: { status: 'idle', report: null } } as never, false)
+  })
+  afterEach(() => cleanup())
+
+  it('passes the PRE-EDIT observed state and display prose to the dispatcher', () => {
+    render(<FactorsSection factorNodes={[factorNode()]} />)
+    commitInline(`factor-${FACTOR_ID}-raw-value`, '25')
+
+    expect(sendSystemEvent).toHaveBeenCalledTimes(1)
+    const [, opts] = sendSystemEvent.mock.calls[0]
+    const undo = (opts as { optimisticFactorEdit?: Record<string, unknown> })?.optimisticFactorEdit
+
+    // RED before the fix: no second argument at all — the send was fire-and-
+    // forget with nothing to undo it.
+    expect(undo, 'the commit must hand over an undo').toBeTruthy()
+    expect(undo!.nodeId).toBe(FACTOR_ID)
+    // The number whose fate the reply decides — model scale, as sent.
+    expect(undo!.sentValue).toBe(25 / CAP)
+    // ...and the state to restore is the one from BEFORE the write.
+    const prev = undo!.prevObservedState as Record<string, unknown>
+    expect(prev.raw_value).toBe(3)
+    expect(prev.value).toBe(3 / CAP)
+    expect(prev.source).toBe('cee_inference')
+    expect(undo!.prevDisplayValue).toBe('3 months')
+
+    // Control: the optimistic write DID land — the undo is not a substitute for
+    // the responsive local update, it is its safety net.
+    const obs = (useCanvasStore.getState().nodes[0].data as Record<string, unknown>)
+      .observedState as Record<string, unknown>
+    expect(obs.raw_value).toBe(25)
+    expect(obs.source).toBe('user')
+  })
+})

--- a/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
+++ b/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
@@ -102,7 +102,13 @@ function makeMockConversation(
     dispatchAction: vi.fn().mockResolvedValue(undefined),
     cancelTurn: vi.fn(),
     sendMessage: vi.fn().mockResolvedValue(undefined),
-    sendSystemEvent,
+    // `vi.fn()` is `Mock<any[], unknown>`, which does not structurally satisfy
+    // the typed `sendSystemEvent` signature (and drifted again when its `opts`
+    // gained `optimisticFactorEdit` in 2.129). The double is deliberate and
+    // behaviourally complete for these tests — the cast states that, rather than
+    // leaving a standing diagnostic for the ratchet to re-render on every
+    // signature change.
+    sendSystemEvent: sendSystemEvent as unknown as UseConversationReturn['sendSystemEvent'],
     sendChip: vi.fn().mockResolvedValue(undefined),
     clearHistory: vi.fn(),
     retryLast: vi.fn().mockResolvedValue(undefined),

--- a/src/canvas/conversation/__tests__/optimisticFactorEdit.spec.ts
+++ b/src/canvas/conversation/__tests__/optimisticFactorEdit.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * ROADMAP 2.129 (b) — the pure half: the rejection predicate and the queue merge.
+ *
+ * The rejection signal is an ABSENCE (CEE's refusal reply carries `blocks: []`,
+ * not a `graph_patch` with `status: 'rejected'`), and an absence-based rule has
+ * a dangerous failure direction: a FALSE "not applied" reverts a value the
+ * server ACCEPTED, which is worse than the bug being fixed. So the predicate is
+ * asserted here in BOTH directions, with the fail-safe cases named explicitly —
+ * they are the ones no live capture would ever have shown us.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  captureOptimisticFactorEdit,
+  mergeOptimisticFactorEdit,
+  responseAppliedFactorEdit,
+} from '../optimisticFactorEdit'
+
+const TARGET = 'fac_delivery_time'
+
+describe('responseAppliedFactorEdit — did the server apply MY edit?', () => {
+  it('the captured REFUSAL reads as not-applied', () => {
+    expect(
+      responseAppliedFactorEdit(
+        { assistant_text: "…exceeds the factor's cap of 6 months. I haven't changed anything.", blocks: [] },
+        TARGET,
+      ),
+    ).toBe(false)
+  })
+
+  it('the captured APPLIED receipt reads as applied (block-level target_id)', () => {
+    expect(
+      responseAppliedFactorEdit(
+        {
+          blocks: [
+            { type: 'graph_patch', status: 'applied', operation: 'set_factor_value', target_id: TARGET },
+          ],
+        },
+        TARGET,
+      ),
+    ).toBe(true)
+  })
+
+  it('reads the operations[] shape too — both exist in the contract', () => {
+    expect(
+      responseAppliedFactorEdit(
+        { blocks: [{ type: 'graph_patch', status: 'applied', operations: [{ target_id: TARGET }] }] },
+        TARGET,
+      ),
+    ).toBe(true)
+  })
+
+  it('a patch applied to a DIFFERENT factor does not vouch for mine', () => {
+    expect(
+      responseAppliedFactorEdit(
+        { blocks: [{ type: 'graph_patch', status: 'applied', target_id: 'fac_other' }] },
+        TARGET,
+      ),
+    ).toBe(false)
+  })
+
+  it('an explicitly non-applied patch for my target reads as not-applied', () => {
+    for (const status of ['rejected', 'proposed', 'dismissed', 'failed']) {
+      expect(
+        responseAppliedFactorEdit(
+          { blocks: [{ type: 'graph_patch', status, target_id: TARGET }] },
+          TARGET,
+        ),
+        status,
+      ).toBe(false)
+    }
+  })
+
+  // ── fail-safe direction: when in doubt, DO NOT revert ──
+
+  it('an UNKNOWN status counts as applied — never revert over a receipt we cannot classify', () => {
+    expect(
+      responseAppliedFactorEdit(
+        { blocks: [{ type: 'graph_patch', status: 'partially_reconciled', target_id: TARGET }] },
+        TARGET,
+      ),
+    ).toBe(true)
+  })
+
+  it('an applied patch naming NO target counts as applied — it may well be mine', () => {
+    expect(
+      responseAppliedFactorEdit({ blocks: [{ type: 'graph_patch', status: 'applied' }] }, TARGET),
+    ).toBe(true)
+  })
+
+  it('an unattributable edit (no target id) never triggers a revert', () => {
+    expect(responseAppliedFactorEdit({ blocks: [] }, '')).toBe(true)
+  })
+
+  it('a malformed reply reads as not-applied — nothing there claims a mutation', () => {
+    expect(responseAppliedFactorEdit(null, TARGET)).toBe(false)
+    expect(responseAppliedFactorEdit({}, TARGET)).toBe(false)
+    expect(responseAppliedFactorEdit({ blocks: 'nope' }, TARGET)).toBe(false)
+  })
+})
+
+describe('mergeOptimisticFactorEdit — two queued edits to one factor', () => {
+  const nodeData = { observedState: { value: 0.5, raw_value: 3, source: 'cee_inference' }, display_value: '3 months' }
+
+  it('keeps the ORIGINAL pre-edit state and adopts the NEW value being sent', () => {
+    // 3 → 25, then 25 → 30, both still undispatched. The server has seen
+    // neither, so it still holds 3: a refusal of 30 must restore 3.
+    const first = captureOptimisticFactorEdit('fac_a', 25 / 6, nodeData)!
+    const secondData = { observedState: { value: 25 / 6, raw_value: 25, source: 'user' }, display_value: undefined }
+    const second = captureOptimisticFactorEdit('fac_a', 30 / 6, secondData)!
+
+    const merged = mergeOptimisticFactorEdit(first, second)!
+    expect(merged.sentValue).toBe(30 / 6)
+    expect((merged.prevObservedState as Record<string, unknown>).raw_value).toBe(3)
+    expect((merged.prevObservedState as Record<string, unknown>).source).toBe('cee_inference')
+    expect(merged.prevDisplayValue).toBe('3 months')
+  })
+
+  it('a different target replaces rather than merges', () => {
+    const a = captureOptimisticFactorEdit('fac_a', 1, nodeData)!
+    const b = captureOptimisticFactorEdit('fac_b', 2, nodeData)!
+    expect(mergeOptimisticFactorEdit(a, b)).toBe(b)
+  })
+
+  it('tolerates either side being absent', () => {
+    const a = captureOptimisticFactorEdit('fac_a', 1, nodeData)!
+    expect(mergeOptimisticFactorEdit(undefined, a)).toBe(a)
+    expect(mergeOptimisticFactorEdit(a, undefined)).toBe(a)
+    expect(mergeOptimisticFactorEdit(undefined, undefined)).toBeUndefined()
+  })
+})
+
+describe('captureOptimisticFactorEdit — fails closed', () => {
+  it('returns null for an unencodable edit rather than a half-snapshot', () => {
+    expect(captureOptimisticFactorEdit('', 1, {})).toBeNull()
+    expect(captureOptimisticFactorEdit('fac_a', NaN, {})).toBeNull()
+    expect(captureOptimisticFactorEdit('fac_a', Infinity, {})).toBeNull()
+  })
+
+  it('reads the snake_case observed state too', () => {
+    const snap = captureOptimisticFactorEdit('fac_a', 1, { observed_state: { value: 0.2 } })!
+    expect((snap.prevObservedState as Record<string, unknown>).value).toBe(0.2)
+  })
+})

--- a/src/canvas/conversation/__tests__/optimisticFactorEditRevert.spec.ts
+++ b/src/canvas/conversation/__tests__/optimisticFactorEditRevert.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * ROADMAP 2.129 (b) — a value CEE REFUSED must not survive on the canvas.
+ *
+ * THE DEFECT THIS PINS, live-proven on staging `98aae72e`
+ * (`PHASE0-EVIDENCE-2026-07-28/fix-2121-slice1-liveproof.md` §3 sub-finding,
+ * run 1). Typing `25` into a `months` factor capped at 6 produced a correct wire
+ * event and an honest refusal from CEE:
+ *
+ *   "Value 25 months exceeds the factor's cap of 6 months. I haven't changed
+ *    anything." — blocks: [], no analysis_ready, no graph_hash
+ *
+ * ...and the client kept the number anyway. The canvas node read `25 months`,
+ * the Model tab pill flipped to **"User edited"**, and the following re-run
+ * returned win probabilities BYTE-IDENTICAL to baseline because the engine still
+ * held 3. The user is shown a number, and a provenance claim about that number,
+ * that the engine explicitly declined.
+ *
+ * WHY THIS FILE DRIVES THE REAL DISPATCHER, not the panel.
+ * A refusal is not a FAILURE — the promise resolves, so no `catch` at any call
+ * site can see it, and a panel spec that mocks `ConversationContext` sits ABOVE
+ * the only place the reply is visible. The dispatcher is also the only layer
+ * that can serve the DEFERRED case: an edit committed while an analysis runs is
+ * queued, and the caller's promise resolved with SEND_DEFERRED long before the
+ * reply existed. Both are asserted here, against the transport.
+ *
+ * WHY THESE ASSERTIONS AND NOT OTHERS. Each `it` is either an assertion that was
+ * RED before the fix (reject → revert, on both the immediate and the deferred
+ * path; the pill reverting with the number) or a CONTROL that stops the fix being
+ * satisfied by something cheaper and wrong: the ACCEPTED reply must NOT revert
+ * (a fix that reverted unconditionally would pass every RED assertion and destroy
+ * every accepted edit), an unattributable patch receipt must NOT revert, and a
+ * value that has MOVED ON since the send must not be clobbered by a late revert.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import type { WireSystemEvent } from '../types'
+import { captureOptimisticFactorEdit } from '../optimisticFactorEdit'
+
+/** Reply bodies the transport should answer with, in order. */
+const replies: Array<Record<string, unknown>> = []
+const dispatched: Array<Record<string, unknown>> = []
+let holdFirstTurn = false
+let resolveInFlight: ((v: unknown) => void) | null = null
+
+// Mock the TRANSPORT, not the context (CLAUDE.md trap 12: `importOriginal`
+// spread, never a hand-listed factory).
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    callV5Turn: vi.fn(async (payload: Record<string, unknown>) => {
+      dispatched.push(payload)
+      if (holdFirstTurn && dispatched.length === 1) {
+        await new Promise((res) => { resolveInFlight = res })
+      }
+      const response = replies.shift() ?? { assistant_text: 'ok', blocks: [] }
+      return { ok: true, response }
+    }),
+  }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, isOrchestratorV2Enabled: () => true, isOrchestratorStreamingEnabled: () => false }
+})
+
+import { useConversation, SEND_DEFERRED } from '../useConversation'
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const FACTOR_ID = 'fac_delivery_time'
+const CAP = 6
+
+/** Pre-edit state: CEE's own estimate of 3 months (model scale 3/6 = 0.5). */
+const PRIOR_OBSERVED = {
+  value: 0.5,
+  raw_value: 3,
+  unit: 'months',
+  cap: CAP,
+  source: 'cee_inference',
+}
+
+/** The refused value: 25 months → 25/6 model scale. */
+const SENT_RAW = 25
+const SENT_MODEL = SENT_RAW / CAP
+
+function factorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Estimated Delivery Time',
+      category: 'controllable',
+      display_value: '3 months',
+      observedState: { ...PRIOR_OBSERVED },
+    },
+  } as Node
+}
+
+const edit = (value: number, raw: number): WireSystemEvent => ({
+  type: 'factor_value_edit',
+  payload: { target_id: FACTOR_ID, value, raw_value: raw, unit: 'months', field: 'value' },
+})
+
+/**
+ * CEE's REFUSAL, verbatim in shape from turn-responses.json[2]: prose, empty
+ * blocks, no analysis_ready, no graph_hash. There is no `status: 'rejected'`
+ * anywhere on the wire — the absence of an applied receipt IS the signal.
+ */
+const REFUSAL = {
+  assistant_text:
+    "Value 25 months exceeds the factor's cap of 6 months. I haven't changed anything.",
+  blocks: [],
+}
+
+/** CEE's ACCEPTANCE, verbatim in shape from turn-responses-run2.json[2]. */
+const acceptance = (model: number, raw: number) => ({
+  assistant_text: `Updated Delivery Timeline from 3 months to ${raw} months.`,
+  blocks: [
+    {
+      type: 'graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: FACTOR_ID,
+      before: { value: 0.5, raw_value: 3, unit: 'months', cap: CAP },
+      after: { value: model, raw_value: raw, unit: 'months', cap: CAP },
+    },
+  ],
+  graph_hash: 'f0719cb3b8905ef4',
+})
+
+/** The panel's optimistic write, through the same sanctioned setter it uses. */
+function writeOptimistically(model: number, raw: number) {
+  const store = useCanvasStore.getState()
+  const node = store.nodes.find((n) => n.id === FACTOR_ID)!
+  const existing = (node.data as Record<string, unknown>).observedState as Record<string, unknown>
+  store.updateNode(FACTOR_ID, {
+    data: {
+      ...(node.data as Record<string, unknown>),
+      display_value: undefined,
+      observedState: { ...existing, value: model, raw_value: raw, source: 'user', display_value: undefined },
+    },
+  } as never)
+}
+
+function observedNow() {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)
+  return ((node?.data as Record<string, unknown>)?.observedState ?? {}) as Record<string, unknown>
+}
+
+const flush = async () => {
+  for (let round = 0; round < 25; round++) {
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 1))
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  dispatched.length = 0
+  replies.length = 0
+  holdFirstTurn = false
+  resolveInFlight = null
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [factorNode()],
+    edges: [],
+    results: { status: 'idle' } as never,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    pendingEmittedEdits: 0,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+})
+afterEach(() => { vi.unstubAllEnvs() })
+
+describe('a REFUSED value edit reverts the optimistic write', () => {
+  it('restores the value, the raw magnitude AND the provenance stamp', async () => {
+    const { result } = renderHook(() => useConversation())
+    const pre = useCanvasStore.getState().nodes[0].data
+
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, SENT_MODEL, pre)!
+    writeOptimistically(SENT_MODEL, SENT_RAW)
+    // Sanity: the split-brain exists before the reply lands.
+    expect(observedNow().raw_value).toBe(SENT_RAW)
+    expect(observedNow().source).toBe('user')
+
+    replies.push(REFUSAL)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(SENT_MODEL, SENT_RAW), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    // RED before the fix: 25 / 4.1666… / 'user' all stood, and the "User edited"
+    // pill with them, over a value CEE said it had not changed.
+    expect(observedNow().raw_value).toBe(3)
+    expect(observedNow().value).toBe(0.5)
+    expect(observedNow().source).toBe('cee_inference')
+    // The server's own display prose comes back too — clearing it was part of
+    // the same optimistic update.
+    expect((useCanvasStore.getState().nodes[0].data as Record<string, unknown>).display_value)
+      .toBe('3 months')
+  })
+
+  it('reverts a DEFERRED edit refused after the in-flight lock cleared', async () => {
+    holdFirstTurn = true
+    const { result } = renderHook(() => useConversation())
+
+    // Occupy the lock with a turn that does not resolve — an analysis running.
+    act(() => { void result.current.sendMessage('run the analysis') })
+    await flush()
+    expect(dispatched.length).toBe(1)
+
+    const pre = useCanvasStore.getState().nodes[0].data
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, SENT_MODEL, pre)!
+    writeOptimistically(SENT_MODEL, SENT_RAW)
+
+    let outcome: unknown = 'not-set'
+    await act(async () => {
+      outcome = await result.current.sendSystemEvent(edit(SENT_MODEL, SENT_RAW), {
+        optimisticFactorEdit: undo,
+      })
+    })
+    expect(outcome, 'the edit is queued, not dispatched').toBe(SEND_DEFERRED)
+    // Its promise has ALREADY resolved — no caller-side await can ever see the
+    // refusal that is about to arrive. This is why the revert is central.
+    expect(observedNow().raw_value).toBe(SENT_RAW)
+
+    replies.push(REFUSAL)
+    await act(async () => { resolveInFlight?.({}); await flush() })
+
+    expect(observedNow().raw_value).toBe(3)
+    expect(observedNow().source).toBe('cee_inference')
+  })
+})
+
+describe('the deferral queue collapses two edits to one factor — the snapshot must not', () => {
+  it('restores the value the SERVER still holds, not the intermediate one it never saw', async () => {
+    holdFirstTurn = true
+    const { result } = renderHook(() => useConversation())
+    act(() => { void result.current.sendMessage('run the analysis') })
+    await flush()
+
+    // 3 → 25 (queued), then a correction 25 → 30 (replaces it, same target).
+    // The buffer keeps ONE entry, so exactly one turn will be dispatched — and
+    // the server has seen NEITHER value, so it still holds 3.
+    const pre = useCanvasStore.getState().nodes[0].data
+    const undo1 = captureOptimisticFactorEdit(FACTOR_ID, SENT_MODEL, pre)!
+    writeOptimistically(SENT_MODEL, SENT_RAW)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(SENT_MODEL, SENT_RAW), { optimisticFactorEdit: undo1 })
+    })
+
+    const mid = useCanvasStore.getState().nodes[0].data
+    const undo2 = captureOptimisticFactorEdit(FACTOR_ID, 30 / CAP, mid)!
+    writeOptimistically(30 / CAP, 30)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(30 / CAP, 30), { optimisticFactorEdit: undo2 })
+    })
+
+    replies.push(REFUSAL)
+    await act(async () => { resolveInFlight?.({}); await flush() })
+
+    // With a naive last-write-wins snapshot this reads 25 — a number CEE never
+    // held and never will, left on screen by the fix that was meant to remove
+    // exactly that class of lie.
+    expect(observedNow().raw_value).toBe(3)
+    expect(observedNow().source).toBe('cee_inference')
+  })
+})
+
+describe('controls — the revert must not fire when the server DID apply', () => {
+  it('an APPLIED patch receipt for the target leaves the new value standing', async () => {
+    const { result } = renderHook(() => useConversation())
+    const pre = useCanvasStore.getState().nodes[0].data
+    const NEW_RAW = 2
+    const NEW_MODEL = NEW_RAW / CAP
+
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, NEW_MODEL, pre)!
+    writeOptimistically(NEW_MODEL, NEW_RAW)
+
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(NEW_MODEL, NEW_RAW), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    expect(observedNow().raw_value).toBe(NEW_RAW)
+    expect(observedNow().source).toBe('user')
+  })
+
+  it('does not clobber a value the user has already changed again', async () => {
+    const { result } = renderHook(() => useConversation())
+    const pre = useCanvasStore.getState().nodes[0].data
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, SENT_MODEL, pre)!
+    writeOptimistically(SENT_MODEL, SENT_RAW)
+    // The user re-types 4 before the refusal of 25 comes back.
+    writeOptimistically(4 / CAP, 4)
+
+    replies.push(REFUSAL)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(SENT_MODEL, SENT_RAW), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    // A late revert must lose to newer truth.
+    expect(observedNow().raw_value).toBe(4)
+  })
+})

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -1,0 +1,209 @@
+/**
+ * `factor_value_edit` — resolving the OPTIMISTIC local write against the reply.
+ *
+ * ROADMAP 2.129 (b). Live-proven on staging `98aae72e`
+ * (`PHASE0-EVIDENCE-2026-07-28/fix-2121-slice1-liveproof.md` §3 sub-finding): a
+ * Model-tab value commit writes locally FIRST (so the canvas moves even if the
+ * turn is slow) and then fires the turn fire-and-forget. Nothing read the reply
+ * back. So when CEE REFUSED the edit —
+ *
+ *   "Value 25 months exceeds the factor's cap of 6 months. I haven't changed
+ *    anything." (blocks: [], no analysis_ready, no graph_hash)
+ *
+ * — the canvas kept showing `25 months`, the Model tab stamped the value
+ * **"User edited"**, and the next re-run returned byte-identical numbers because
+ * the engine still held `3`. A split-brain on a trust surface: the user is shown
+ * a number, and a provenance claim about that number, that the engine explicitly
+ * declined.
+ *
+ * WHY THE RESOLUTION IS CENTRAL AND NOT A `.catch` AT THE CALL SITE.
+ * A refusal is not a FAILURE: the promise resolves normally (there is no
+ * `SystemEventSendError`), so no `catch` can see it. And an `await` at the call
+ * site cannot work either — an edit committed while an analysis is running is
+ * queued in `useConversation`'s deferral buffer and the caller's promise has
+ * ALREADY resolved with `SEND_DEFERRED`. The snapshot therefore rides on
+ * `SendTurnOpts`, which the buffer holds verbatim, so the immediate dispatch and
+ * the deferred flush are resolved by ONE code path rather than two that have to
+ * stay in sync.
+ *
+ * WHY THE REJECTION SIGNAL IS AN ABSENCE, and what that forces.
+ * There is no positive rejection signal on the wire — the refusal reply carries
+ * `blocks: []`, not a `graph_patch` with `status: 'rejected'`. The only
+ * machine-readable evidence is that the reply to a `factor_value_edit` turn
+ * contains no APPLIED `graph_patch` receipt for the target the turn named
+ * (contrast the accepted reply:
+ * `{type:'graph_patch',status:'applied',operation:'set_factor_value',target_id:'fac_delivery_time',before:{…},after:{…}}`).
+ * An absence-based rule must fail SAFE, because a FALSE revert would discard a
+ * value the server DID accept — strictly worse than the bug being fixed. So:
+ * anything that could be an applied patch for this target, including an applied
+ * patch whose targets cannot be attributed at all, counts as APPLIED.
+ */
+
+import { useCanvasStore } from '../store'
+
+/**
+ * Everything needed to undo one optimistic value write, captured BEFORE it.
+ *
+ * Data, not a closure: the deferral buffer's last-write-wins replacement has to
+ * be able to KEEP THE EARLIER snapshot of two queued edits to the same factor
+ * (see `mergeOptimisticFactorEdit`), which an opaque `() => void` cannot express.
+ */
+export interface OptimisticFactorEdit {
+  /** The factor node's id — also the `target_id` the wire event names. */
+  nodeId: string
+  /**
+   * The MODEL-scale number this edit sent (`event.payload.value`). Used as the
+   * revert's own precondition: if the node no longer holds it, something newer
+   * has happened and the revert must stand down.
+   */
+  sentValue: number
+  /** The node's `observedState` as it was before the write, verbatim. */
+  prevObservedState: unknown
+  /**
+   * The node's TOP-LEVEL `display_value` before the write. CEE authors this
+   * prose ("£30k") at either level and `setObservedValue` clears both, so a
+   * revert that restored only `observedState` would leave the canvas rendering
+   * its live fallback instead of the server's own string.
+   */
+  prevDisplayValue: unknown
+}
+
+/**
+ * Read a node's observed state defensively — CEE and legacy paths write it under
+ * either casing. The RESTORE always writes the canonical `observedState`, which
+ * is the key the optimistic write (`setObservedValue`) created, so the two halves
+ * cannot end up disagreeing about which copy is live.
+ */
+function readObservedState(nodeData: unknown): unknown {
+  const d = (nodeData ?? {}) as Record<string, unknown>
+  return d.observedState ?? d.observed_state
+}
+
+/**
+ * Snapshot the pre-edit state of a factor value.
+ *
+ * MUST be called with the node data as it was BEFORE the local write — the same
+ * `nodeData` the wire event was built from, which is why both call sites build
+ * the event and the snapshot from one read.
+ */
+export function captureOptimisticFactorEdit(
+  nodeId: string,
+  sentValue: number,
+  nodeData: unknown,
+): OptimisticFactorEdit | null {
+  if (!nodeId) return null
+  if (typeof sentValue !== 'number' || !Number.isFinite(sentValue)) return null
+  const d = (nodeData ?? {}) as Record<string, unknown>
+  return {
+    nodeId,
+    sentValue,
+    prevObservedState: readObservedState(nodeData),
+    prevDisplayValue: d.display_value,
+  }
+}
+
+/**
+ * Combine an already-queued snapshot with a newer one for the SAME target.
+ *
+ * LAST-WRITE-WINS on the value, FIRST-WRITE-WINS on the snapshot. If the user
+ * commits 3→25 and then corrects it to 25→30 while both are still undispatched,
+ * the server has seen NEITHER, so it still holds 3 — and a rejection of 30 must
+ * restore 3, not the intermediate 25 the server never held.
+ */
+export function mergeOptimisticFactorEdit(
+  queued: OptimisticFactorEdit | undefined,
+  incoming: OptimisticFactorEdit | undefined,
+): OptimisticFactorEdit | undefined {
+  if (!queued) return incoming
+  if (!incoming) return queued
+  if (queued.nodeId !== incoming.nodeId) return incoming
+  // Keep the ORIGINAL pre-edit state; adopt the NEW value being sent, because
+  // that is the number whose fate the reply will decide.
+  return { ...queued, sentValue: incoming.sentValue }
+}
+
+/** Collect every target id a graph_patch block can be read to address. */
+function patchTargets(block: Record<string, unknown>): string[] {
+  const out: string[] = []
+  if (typeof block.target_id === 'string' && block.target_id) out.push(block.target_id)
+  const ops = block.operations
+  if (Array.isArray(ops)) {
+    for (const op of ops) {
+      const t = (op as Record<string, unknown>)?.target_id
+      if (typeof t === 'string' && t) out.push(t)
+    }
+  }
+  return out
+}
+
+/**
+ * Did this reply apply a graph patch for `targetId`?
+ *
+ * PURE — no store, no React. FAIL-SAFE in the applied direction:
+ *   - `status` must not be a recognised NON-applied value. An absent or unknown
+ *     status counts as applied, because a receipt we cannot classify may well be
+ *     one, and reverting over it would corrupt an accepted value.
+ *   - a patch that names NO target at all counts as applying to this target, for
+ *     the same reason. (Both shapes exist in the contract: block-level
+ *     `target_id` on the edit receipt, `operations[].target_id` on proposal
+ *     blocks.)
+ */
+export function responseAppliedFactorEdit(response: unknown, targetId: string): boolean {
+  if (!targetId) return true // unattributable edit — never revert on a guess
+  const blocks = (response as { blocks?: unknown })?.blocks
+  if (!Array.isArray(blocks)) return false
+  const NOT_APPLIED = new Set(['rejected', 'proposed', 'dismissed', 'failed', 'error', 'pending'])
+  for (const raw of blocks) {
+    const block = (raw ?? {}) as Record<string, unknown>
+    if (block.type !== 'graph_patch') continue
+    const status = typeof block.status === 'string' ? block.status.toLowerCase() : undefined
+    if (status && NOT_APPLIED.has(status)) continue
+    const targets = patchTargets(block)
+    if (targets.length === 0) return true // applied-but-unattributable → assume ours
+    if (targets.includes(targetId)) return true
+  }
+  return false
+}
+
+/** What `revertOptimisticFactorEdit` did, for tests and DEV logging. */
+export type RevertOutcome = 'reverted' | 'node_gone' | 'value_moved_on'
+
+/**
+ * Put the pre-edit value (and its provenance stamp) back.
+ *
+ * Restores the whole `observedState` object plus the top-level `display_value`,
+ * rather than patching individual keys: the write being undone set `value`,
+ * `raw_value`, `source: 'user'` and cleared TWO `display_value`s in one update,
+ * and restoring a subset would leave a different split-brain behind (a `source`
+ * stamp with no matching number). Restoring the captured object also restores
+ * the ABSENCE of keys that were absent, which no per-key setter can express.
+ *
+ * Goes through the store's `updateNode` chokepoint, so the analytical-change
+ * recognition (and with it the freshness overlay) sees the revert exactly as it
+ * saw the edit. It writes only `observedState` + `display_value` — the two
+ * fields `setObservedValue` already declares in `NODE_SETTER_FIELDS`, so the
+ * editor-written-field registry is unchanged by this path.
+ *
+ * PRECONDITION, and it is the whole safety story: the node must still hold the
+ * number we sent. A later edit to the same factor, an undo, a scenario load or
+ * a server patch that moved the value all mean this revert is stale — and a
+ * stale revert is a silent overwrite of newer truth.
+ */
+export function revertOptimisticFactorEdit(edit: OptimisticFactorEdit): RevertOutcome {
+  const store = useCanvasStore.getState()
+  const node = store.nodes.find((n) => n.id === edit.nodeId)
+  if (!node) return 'node_gone'
+
+  const obs = (readObservedState(node.data) ?? {}) as Record<string, unknown>
+  const currentValue = obs.value
+  if (currentValue !== edit.sentValue) return 'value_moved_on'
+
+  store.updateNode(edit.nodeId, {
+    data: {
+      ...(node.data as Record<string, unknown>),
+      observedState: edit.prevObservedState,
+      display_value: edit.prevDisplayValue,
+    },
+  } as never)
+  return 'reverted'
+}

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -107,6 +107,12 @@ import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
+import {
+  mergeOptimisticFactorEdit,
+  responseAppliedFactorEdit,
+  revertOptimisticFactorEdit,
+  type OptimisticFactorEdit,
+} from './optimisticFactorEdit'
 import { validateAnalysisReadyContract } from './validateAnalysisReadyContract'
 import { validateResponse, stripRepairLogLines, FALLBACK_TEXT } from './validateResponse'
 import type { CEEAnalysisReady, CEEGoalConstraint } from '../../adapters/cee/types'
@@ -1672,6 +1678,17 @@ export interface SendTurnOpts {
   chipMeta?: ChipMeta
   /** When true, render the user bubble as a compact action indicator */
   chipInitiated?: boolean
+  /**
+   * ROADMAP 2.129 (b) — how to UNDO the optimistic local write this system event
+   * announces, if the server refuses it.
+   *
+   * NOT part of the wire payload. It rides here because the deferral buffer holds
+   * a `SendTurnOpts` verbatim, so an edit queued behind a running analysis is
+   * resolved by the same code path as one dispatched immediately — a refusal of a
+   * DEFERRED edit must revert too, and the caller's promise resolved with
+   * `SEND_DEFERRED` long before the reply existed.
+   */
+  optimisticFactorEdit?: OptimisticFactorEdit
 }
 
 /** One send held back by the in-flight lock. */
@@ -1769,6 +1786,14 @@ export interface UseConversationReturn {
     debugParentChainId?: string | null
     debugInitiatedBy?: 'user' | 'automatic'
     debugSourceSurface?: string
+    /**
+     * ROADMAP 2.129 (b) — the undo for the optimistic local write that
+     * accompanies a `factor_value_edit`. The dispatcher reverts it when the
+     * reply carries no applied patch receipt for the target. Callers that write
+     * optimistically MUST pass this; without it a server refusal leaves the
+     * canvas showing a number (and a "User edited" stamp) the engine declined.
+     */
+    optimisticFactorEdit?: OptimisticFactorEdit
     // Resolves to SEND_DEFERRED when the in-flight lock queued the send instead
     // of dispatching it, so a caller can tell "queued" from "sent" — the old
     // `Promise<void>` made those two indistinguishable, which is how an
@@ -3251,6 +3276,19 @@ export function useConversation(): UseConversationReturn {
       // moving the entry to the tail would reorder edits to other factors.
       // `attempts` resets deliberately: this is a NEW value, not a retry of the
       // failed one, so it deserves a full set of attempts.
+      //
+      // ROADMAP 2.129 (b): the revert SNAPSHOT does NOT follow last-write-wins.
+      // 3→25 then 25→30, both still undispatched, means the server has seen
+      // neither and still holds 3 — so a refusal of 30 must restore 3, not the
+      // intermediate 25 the server never held. The value being sent is the new
+      // one; the state to restore is the ORIGINAL one.
+      entry.opts = {
+        ...entry.opts,
+        optimisticFactorEdit: mergeOptimisticFactorEdit(
+          deferredSystemSendsRef.current[existing].opts.optimisticFactorEdit,
+          entry.opts.optimisticFactorEdit,
+        ),
+      }
       deferredSystemSendsRef.current[existing] = entry
     } else {
       deferredSystemSendsRef.current.push(entry)
@@ -3695,6 +3733,45 @@ export function useConversation(): UseConversationReturn {
           }
 
           const target = routeV5Response(v5Result)
+
+          // ROADMAP 2.129 (b) — resolve the OPTIMISTIC value write against what
+          // the server actually did with it.
+          //
+          // A refusal is not a failure: CEE answers 200 with plain prose ("Value
+          // 25 months exceeds the factor's cap of 6 months. I haven't changed
+          // anything."), `blocks: []`, no `analysis_ready`, no `graph_hash`. The
+          // promise resolves, so no `catch` anywhere can see it — which is why
+          // the canvas kept showing 25 months, stamped "User edited", while the
+          // engine held 3 and every re-run returned byte-identical numbers.
+          //
+          // Guards, in order of what they protect:
+          //   • a response body must exist — a `typed_error` is a FAILURE, and
+          //     failures are the deferral buffer's business (it retries and, at
+          //     the attempt cap, raises an honest transcript notice). Reverting
+          //     here would race that.
+          //   • the turn must still be the active one. A response whose turn has
+          //     been superseded must not write state — the same stale-turn rule
+          //     `applyV5State` enforces, and a late revert is a silent overwrite
+          //     of newer truth.
+          //   • the revert itself stands down unless the node still holds the
+          //     number this turn sent (see `revertOptimisticFactorEdit`).
+          const optimisticEdit = opts.optimisticFactorEdit
+          if (
+            optimisticEdit &&
+            systemEvent?.type === 'factor_value_edit' &&
+            target.kind !== 'typed_error' &&
+            activeV5TurnIdRef.current === turnClientId
+          ) {
+            const applied = responseAppliedFactorEdit(target.response, optimisticEdit.nodeId)
+            if (!applied) {
+              const outcome = revertOptimisticFactorEdit(optimisticEdit)
+              if (import.meta.env.DEV) {
+                console.warn(
+                  `[sendTurn] CEE did not apply the edit to ${optimisticEdit.nodeId}; optimistic write ${outcome}`,
+                )
+              }
+            }
+          }
 
           // Transcript honesty: resolve this turn's user bubble. Any server
           // response (including an empty one) means the send was delivered;
@@ -4918,6 +4995,7 @@ export function useConversation(): UseConversationReturn {
       debugParentChainId?: string | null
       debugInitiatedBy?: 'user' | 'automatic'
       debugSourceSurface?: string
+      optimisticFactorEdit?: OptimisticFactorEdit
     }) => {
       // No-op when orchestrator V2 is OFF
       if (!isOrchestratorV2Enabled()) return
@@ -4952,6 +5030,7 @@ export function useConversation(): UseConversationReturn {
         parentChainId: opts?.debugParentChainId,
         initiatedBy: opts?.debugInitiatedBy ?? 'automatic',
         sourceSurface: opts?.debugSourceSurface,
+        optimisticFactorEdit: opts?.optimisticFactorEdit,
       })
     },
     [sendTurn],

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -21,7 +21,7 @@ import {
 } from '../components/results/utils/selectGoalProbability'
 import { trackResultsViewed, trackIssuesOpened } from './utils/sandboxTelemetry'
 import { addRun, generateGraphHash, loadRuns, type StoredRun, type RestorableRun } from './store/runHistory'
-import { RUN_COMPLETED_WITHOUT_VERDICT, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
+import { RUN_COMPLETED_WITHOUT_VERDICT, VERDICT_ABSENT_FROM_PAYLOAD, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore, analysisSnapshotFromStore } from './store/autosaveProjection'
@@ -4043,7 +4043,22 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // would affirm "reflects the current model" over a change the server has
       // never seen. Keep the verdict (it is the newest thing the server said)
       // but hold the overlay until the edit actually reaches the wire.
-      if (state.analysisFreshnessDirty && state.pendingEmittedEdits === 0) {
+      //
+      // ...OR unless the payload never mentioned freshness at all
+      // (VERDICT_ABSENT_FROM_PAYLOAD — a readiness-only `analysis_ready`, which
+      // is exactly what a `graph_patch: applied` reply carries). Same argument,
+      // weaker premise: the overlay records that the user changed the model since
+      // the last verdict, and SILENCE about freshness is not evidence the server
+      // re-verified anything. Clearing it there is what inverted the freshness
+      // strip — bar present when CEE REJECTED the edit, absent when it APPLIED
+      // it, taking the tab's only re-analyse control with it (ROADMAP 2.129 (a),
+      // live-proven on staging `98aae72e`).
+      const verdictIsSilentOnFreshness = next?.freshnessReason === VERDICT_ABSENT_FROM_PAYLOAD
+      if (
+        state.analysisFreshnessDirty &&
+        state.pendingEmittedEdits === 0 &&
+        !verdictIsSilentOnFreshness
+      ) {
         updates.analysisFreshnessDirty = false
       }
       return updates

--- a/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
+++ b/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * ROADMAP 2.129 (a) — the freshness strip was INVERTED on the applied-edit path.
+ *
+ * THE DEFECT THIS PINS, live-proven on staging `98aae72e` before the fix
+ * (`PHASE0-EVIDENCE-2026-07-28/fix-2121-slice1-liveproof.md` §4a, 11 runs):
+ *
+ *   | what CEE did with the Model-tab edit | freshness bar |
+ *   |---|---|
+ *   | REJECTED ("I haven't changed anything")            | PRESENT |
+ *   | APPLIED  ("This makes the last analysis stale")     | ABSENT (15 samples / 70 s) |
+ *
+ * The strip fired when the edit did NOT take and went silent when it did — and
+ * because the bar owns the only re-analyse control on the Model tab, an accepted
+ * edit left the tester with no way to close the loop.
+ *
+ * THE MECHANISM, from the probe's own captured bytes (turn-responses-run2.json[2],
+ * run3[2], run11[2] — all three identical in shape): a `graph_patch:applied` reply
+ * carries a readiness-ONLY `analysis_ready`
+ *
+ *     { options: [...], goal_node_id: 'goal_x', status: 'ready', computed_at: <newer> }
+ *
+ * with NO `freshness`, NO `freshness_reason` and NO hashes. The UI degraded that
+ * silence to a fabricated 'unknown' verdict, which then (i) SUPERSEDED CEE's real
+ * 'fresh' verdict and (ii) was read by `setAnalysisFreshness` as proof the server
+ * had re-verified freshness — so it CLEARED the local dirty overlay. Both inputs
+ * to "changed" were destroyed by one payload that never mentioned the subject.
+ *
+ * WHY THESE ASSERTIONS. The fixture payloads are the captured shapes verbatim, so
+ * a test that passes does so for the live reason. The rejected-edit case is a
+ * CONTROL that was GREEN before the fix (proving these tests can see BOTH sides of
+ * the inversion, not just the broken one), and the CEE-stated-'unknown' and
+ * orphan cases are controls against the fix over-reaching into
+ * cannot-confirm — the semantic the strip must never claim "you edited" over.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { classifyFreshnessForDisplay, VERDICT_ABSENT_FROM_PAYLOAD } from '../analysisFreshness'
+import { computeAnalysisTrust } from '../../hooks/useAnalysisTrust'
+
+/** The RUN's verdict, verbatim from turn-responses-run2.json[1]. */
+const RUN_VERDICT = {
+  options: [],
+  goal_node_id: 'goal_billing',
+  status: 'ready',
+  computed_at: '2026-07-29T02:10:31.421Z',
+  freshness: 'fresh',
+  freshness_reason: 'graph_hash_match',
+  graph_hash_at_run: 'c2aeb044a4bd8d6d',
+  current_graph_hash: 'c2aeb044a4bd8d6d',
+}
+
+/**
+ * The APPLIED-EDIT reply's `analysis_ready`, verbatim from
+ * turn-responses-run2.json[2]. Note the key set — this is the whole defect:
+ * readiness only, a NEWER computed_at, and total silence on freshness.
+ */
+const APPLIED_EDIT_READINESS = {
+  options: [],
+  goal_node_id: 'goal_billing',
+  status: 'ready',
+  computed_at: '2026-07-29T02:11:09.522Z',
+}
+
+function seedRunThenLocalEdit() {
+  useCanvasStore.setState({
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    pendingEmittedEdits: 0,
+  } as never)
+  // 1. the run lands CEE's real 'fresh' verdict
+  useCanvasStore.getState().setAnalysisFreshness(RUN_VERDICT)
+  // 2. the user commits a Model-tab value edit → the optimistic local write
+  //    dirties the overlay (store.updateNode → invalidateAnalysisReady)
+  useCanvasStore.getState().markAnalysisFreshnessDirty()
+}
+
+/** The composed semantic every trust surface reads (useAnalysisTrust). */
+function semanticNow() {
+  const s = useCanvasStore.getState()
+  return computeAnalysisTrust({
+    freshness: s.analysisFreshness,
+    dirty: s.analysisFreshnessDirty,
+    source: null,
+    resultsStatus: 'complete',
+  }).semantic
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    pendingEmittedEdits: 0,
+  } as never)
+})
+
+describe('the APPLIED edit — the live FAIL', () => {
+  it('keeps the dirty overlay when the reply says NOTHING about freshness', () => {
+    seedRunThenLocalEdit()
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+
+    useCanvasStore.getState().setAnalysisFreshness(APPLIED_EDIT_READINESS)
+
+    // RED before the fix: `verdictChanged` was true, so the overlay was cleared
+    // — the UI discarded a fact it knew first-hand (the user edited the model
+    // since the run) on the strength of a payload that never mentioned freshness.
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+
+  it('marks the degraded verdict as SOURCED FROM SILENCE, not as a CEE verdict', () => {
+    seedRunThenLocalEdit()
+    useCanvasStore.getState().setAnalysisFreshness(APPLIED_EDIT_READINESS)
+
+    const v = useCanvasStore.getState().analysisFreshness
+    // The 'never absence→fresh' rule is UNCHANGED — it still degrades.
+    expect(v?.freshness).toBe('unknown')
+    // What is new is the provenance: this 'unknown' is the UI's own degradation
+    // of a silent payload, NOT something CEE said. Without the distinction the
+    // two are indistinguishable at the display layer, which is what made the
+    // strip read cannot-confirm over a model the user demonstrably changed.
+    expect(v?.freshnessReason).toBe(VERDICT_ABSENT_FROM_PAYLOAD)
+  })
+
+  it('reads CHANGED — the strip must flag the analysis stale after an applied edit', () => {
+    seedRunThenLocalEdit()
+    useCanvasStore.getState().setAnalysisFreshness(APPLIED_EDIT_READINESS)
+
+    // RED before the fix: 'cannot_confirm' → ReanalyseBar returns null → no
+    // staleness copy AND no re-analyse control anywhere on the Model tab.
+    expect(semanticNow()).toBe('changed')
+  })
+})
+
+describe('the REJECTED edit — the control that was GREEN before the fix', () => {
+  it('still reads CHANGED when the reply carries no analysis_ready at all', () => {
+    seedRunThenLocalEdit()
+    // turn-responses.json[2]: blocks [], no analysis_ready, no graph_hash.
+    useCanvasStore.getState().setAnalysisFreshness(undefined)
+
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('fresh')
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    expect(semanticNow()).toBe('changed')
+  })
+})
+
+describe('controls — the fix must NOT widen "changed" beyond the silent-payload case', () => {
+  it('a CEE-STATED unknown verdict stays cannot-confirm, dirty or not', () => {
+    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, false)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, true)).toBe('cannot_confirm')
+    expect(
+      classifyFreshnessForDisplay(
+        { freshness: 'unknown', freshnessReason: 'engine_could_not_determine' },
+        true,
+      ),
+    ).toBe('cannot_confirm')
+  })
+
+  it('the orphan synthesis and the run-completion write stay cannot-confirm', () => {
+    expect(
+      classifyFreshnessForDisplay({ freshness: 'unknown', freshnessReason: 'orphaned_result' }, true),
+    ).toBe('cannot_confirm')
+    expect(
+      classifyFreshnessForDisplay(
+        { freshness: 'unknown', freshnessReason: 'run_completed_without_verdict' },
+        true,
+      ),
+    ).toBe('cannot_confirm')
+  })
+
+  it('a silent payload with NO local edit stays cannot-confirm — never "you changed it"', () => {
+    // The overlay is the only thing that licenses the factual "Model changed"
+    // claim. Silence alone must not manufacture it.
+    expect(
+      classifyFreshnessForDisplay(
+        { freshness: 'unknown', freshnessReason: VERDICT_ABSENT_FROM_PAYLOAD },
+        false,
+      ),
+    ).toBe('cannot_confirm')
+  })
+
+  it('a silent payload does not clear the overlay held by an UNDISPATCHED edit either', () => {
+    seedRunThenLocalEdit()
+    useCanvasStore.setState({ pendingEmittedEdits: 1 } as never)
+    useCanvasStore.getState().setAnalysisFreshness(APPLIED_EDIT_READINESS)
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+
+  it('a payload that DOES carry a verdict still clears the overlay (no regression)', () => {
+    seedRunThenLocalEdit()
+    // A genuine re-run: CEE speaks, hashes match the post-edit graph.
+    useCanvasStore.getState().setAnalysisFreshness({
+      ...RUN_VERDICT,
+      computed_at: '2026-07-29T02:24:37.734Z',
+      graph_hash_at_run: 'a36f4f1a643df6cd',
+      current_graph_hash: 'a36f4f1a643df6cd',
+    })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+    expect(semanticNow()).toBe('current')
+  })
+})

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -28,6 +28,37 @@ export type AnalysisFreshnessValue = 'fresh' | 'stale' | 'unknown' | 'none'
  */
 export const RUN_COMPLETED_WITHOUT_VERDICT = 'run_completed_without_verdict'
 
+/**
+ * Reason code written by THIS reducer (not by CEE): a present `analysis_ready`
+ * carried NO `freshness` field at all — readiness only. It is the provenance
+ * marker that separates the UI's own degradation-of-silence from a verdict CEE
+ * actually stated, and it exists because conflating the two shipped an inverted
+ * freshness strip (ROADMAP 2.129 (a), live-proven on staging `98aae72e`).
+ *
+ * A `graph_patch: applied` reply looks exactly like this on the wire:
+ *
+ *   { options: [...], goal_node_id: 'goal_x', status: 'ready', computed_at: <newer> }
+ *
+ * — readiness, a newer `computed_at`, and total silence on freshness. Degrading
+ * that to `'unknown'` is right (never absence→fresh). Letting the degraded value
+ * then IMPERSONATE a CEE-stated `'unknown'` was not: `'unknown'` reads as
+ * cannot-confirm, so an accepted edit stopped showing "Model changed" — and with
+ * it the Model tab's only re-analyse control — while a REJECTED edit (no
+ * `analysis_ready` at all → retain) still did. The strip fired when the edit had
+ * not taken and went silent when it had.
+ *
+ * Two rules key on this marker; both are about not over-claiming from silence:
+ *   - the store's `setAnalysisFreshness` does NOT clear the local dirty overlay
+ *     for such a payload (silence is not a re-verification — same argument the
+ *     `pendingEmittedEdits` hold already makes for an undispatched edit);
+ *   - `classifyFreshnessForDisplay` reads it WITH the dirty overlay as 'changed'
+ *     (the user demonstrably edited since CEE last spoke), and WITHOUT the
+ *     overlay as cannot-confirm (silence alone never claims "you changed it").
+ *
+ * Never user copy. Deterministic, so the echo guard's `sameVerdict` still works.
+ */
+export const VERDICT_ABSENT_FROM_PAYLOAD = 'payload_carried_no_freshness_verdict'
+
 export interface AnalysisFreshnessState {
   freshness: AnalysisFreshnessValue
   /** Technical reason code from CEE (e.g. 'graph_hash_match') — debug only, never user copy. */
@@ -95,6 +126,15 @@ export function deriveAnalysisFreshnessUpdate(
       ? (fRaw as AnalysisFreshnessValue)
       : 'unknown'
 
+  // ...but record WHY it is 'unknown' when the field was simply ABSENT. That is
+  // a different fact from CEE stating 'unknown', and from CEE sending a value we
+  // could not parse: absence means the payload said nothing about freshness at
+  // all. See VERDICT_ABSENT_FROM_PAYLOAD for what keys on the distinction and
+  // the live defect that conflating them shipped. Deliberately NOT stamped when
+  // the payload carried its own `freshness_reason` — CEE's reason is not ours to
+  // overwrite.
+  const verdictAbsent = fRaw === undefined || fRaw === null
+
   const computedAt = nonEmptyString(o.computed_at)
 
   // Order by computed_at: ignore a strictly-older (or equal) payload when both
@@ -106,7 +146,8 @@ export function deriveAnalysisFreshnessUpdate(
 
   const next: AnalysisFreshnessState = {
     freshness,
-    freshnessReason: nonEmptyString(o.freshness_reason),
+    freshnessReason:
+      nonEmptyString(o.freshness_reason) ?? (verdictAbsent ? VERDICT_ABSENT_FROM_PAYLOAD : undefined),
     graphHashAtRun: nonEmptyString(o.graph_hash_at_run),
     currentGraphHash: nonEmptyString(o.current_graph_hash),
     computedAt,
@@ -222,9 +263,26 @@ export function classifyFreshnessForDisplay(
   if (displayed === null || displayed === 'none') return 'none'
   if (displayed === 'fresh') return 'current'
   if (displayed === 'stale') return 'changed'
-  // displayed === 'unknown': only the dirty-overlay downgrade of a retained
-  // 'fresh' verdict means the user definitely changed the model since the run.
-  // A CEE-sourced 'unknown' (state.freshness === 'unknown') is cannot-confirm.
-  if (state?.freshness === 'fresh' && dirty) return 'changed'
+  // displayed === 'unknown': it means the user definitely changed the model
+  // since the run in exactly two cases, both of which require the local dirty
+  // overlay (the UI's own first-hand knowledge that an analysis-affecting edit
+  // happened) — never the verdict alone:
+  //
+  //   1. the dirty-overlay downgrade of a retained CEE 'fresh' verdict;
+  //   2. the dirty overlay over a verdict that is 'unknown' ONLY because the
+  //      payload carried no freshness field (VERDICT_ABSENT_FROM_PAYLOAD). CEE
+  //      said nothing about freshness, and the user has edited since CEE last
+  //      spoke — "Model changed. Results may be out of date." is a true claim,
+  //      and this is the state a `graph_patch: applied` reply lands the UI in
+  //      (ROADMAP 2.129 (a): treating it as cannot-confirm hid the staleness AND
+  //      the Model tab's only re-analyse control after an ACCEPTED edit).
+  //
+  // Everything else is cannot-confirm, and deliberately so: a CEE-STATED
+  // 'unknown', the orphan synthesis (ORPHANED_RESULT) and the run-completion
+  // write (RUN_COMPLETED_WITHOUT_VERDICT) must never be dressed up as a factual
+  // "you edited" claim.
+  if (dirty && (state?.freshness === 'fresh' || state?.freshnessReason === VERDICT_ABSENT_FROM_PAYLOAD)) {
+    return 'changed'
+  }
   return 'cannot_confirm'
 }

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -39,6 +39,7 @@ import { FactorControllableEditor } from '../editors/FactorControllableEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
 import { buildFactorValueEditEvent, resolveValueInputSeed } from '../../../conversation/factorValueEdit'
+import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -159,6 +160,13 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
       raw_value?: number
     }
 
+    // ROADMAP 2.129 (b) — the undo for the optimistic write, captured from the
+    // pre-write node data. The defect was live-proven on the Model tab, but this
+    // is the same fire-and-forget shape against the same endpoint: a refusal
+    // leaves the panel showing a number the engine declined. Fixing one twin and
+    // leaving the other armed is how this class keeps coming back.
+    const undo = captureOptimisticFactorEdit(nodeId ?? '', modelValue, node?.data)
+
     // Local store write first, so the canvas and the freshness overlay reflect
     // the edit immediately even if the turn is slow or fails. Note this writes
     // the MODEL-scale number into `value` — the live defect wrote the display
@@ -185,11 +193,14 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
     // buffer, which queues the send and flushes it when the lock clears (and
     // holds the freshness overlay dirty until it does). See
     // `useConversation`'s `deferredSystemSendsRef`.
-    void Promise.resolve(sendSystemEvent(event)).catch(() => {
+    void Promise.resolve(
+      sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
+    ).catch(() => {
       // Swallowed deliberately: a genuine send failure is already recorded by
       // the conversation's own failure channel. Re-throwing from a blur handler
       // would surface as an unhandled rejection and tell the user nothing they
-      // are not already being told.
+      // are not already being told. A server REFUSAL is not a failure and never
+      // reaches here — the dispatcher reverts the optimistic write instead.
     })
   }, [draftValue, inputDisplayValue, mutations, confirmEdit, sendSystemEvent, nodeId, node?.data])
 


### PR DESCRIPTION
## What this fixes

Two live defects around the now-proven Model-tab edit (ROADMAP 2.129 (a)+(b)), both found by the
2.121-slice-1 live probe on staging `98aae72e` and both traced here **against that probe's captured
wire bytes**, not against its prose. Full `file:line` traces, fix design, RED/mutation proof and
honest limits: `PHASE0-EVIDENCE-2026-07-28/fix-2129-loop.md`.

Advances **POC-DONE step 4** — edit → re-run → numbers move, truthfully. (b) is the "truthfully" half:
without it a refused edit shows the user a number the engine declined and re-runs "prove" it by
returning byte-identical results.

### (a) The freshness strip was INVERTED on the apply path

Live-measured: bar **PRESENT** when CEE *rejected* the edit, **ABSENT** when it *applied* it (15
samples / 70 s) — and because the bar owns the Model tab's only re-analyse control, an accepted edit
left no way to close the loop.

A `graph_patch: applied` reply carries a readiness-**only** `analysis_ready`:

```json
{"options":[…],"goal_node_id":"goal_billing","status":"ready","computed_at":"…T02:11:09.522Z"}
```

No `freshness`, no `freshness_reason`, no hashes — reproduced identically in three captures. The UI
degraded that silence to a fabricated `'unknown'` verdict which **(i)** superseded CEE's real
`'fresh'` verdict and **(ii)** was read by `setAnalysisFreshness` as proof the server had
re-verified freshness, so it **cleared the local dirty overlay**. One payload that never mentioned
the subject destroyed both inputs to `'changed'`. A *rejection*, whose reply carries no
`analysis_ready` at all, hits the retain path and so still rendered the bar — hence the inversion.

**Fix.** The "never absence→fresh" degrade is kept. What changes is that the degradation now carries
its **provenance** (`VERDICT_ABSENT_FROM_PAYLOAD`), so a UI degradation-of-silence can no longer
impersonate a CEE-stated verdict: a freshness-silent payload does not clear the overlay, and
dirty-over-silent classifies as `'changed'`. A **CEE-stated** `'unknown'`, the orphan synthesis
(`ORPHANED_RESULT`) and the run-completion write (`RUN_COMPLETED_WITHOUT_VERDICT`) all stay
cannot-confirm — each pinned by its own control.

*Layer check, since the reply shape is CEE's:* CEE arguably should send `freshness:'stale'` there
(its own prose says *"This makes the last analysis stale"*), and that would be good separate
hardening. But the UI defect stands alone — it fabricates a verdict from silence and then discards a
fact it knows first-hand on the strength of it. `store.ts` already carries exactly this reasoning for
the `pendingEmittedEdits` case; the verdict-less case was simply not covered. So: fixed UI-side, no
STOP.

### (b) The canvas kept a value CEE had rejected

An out-of-cap edit was refused in plain language — *"Value 25 months exceeds the factor's cap of 6
months. I haven't changed anything."* — and the canvas kept `25 months`, stamped **"User edited"**,
while the engine held `3`; the following re-run returned byte-identical win probabilities.

A refusal is **not a failure**: the promise *resolves*, so no `.catch` at any call site can see it —
and an `await` at the call site cannot serve a **deferred** edit either, whose promise resolved with
`SEND_DEFERRED` long before the reply existed.

**Fix.** The undo snapshot rides on `SendTurnOpts`, which the deferral buffer already holds verbatim,
so the immediate dispatch and the deferred flush are resolved by **one** path. Three deliberate
safety properties:

- **The rejection signal is an absence** (CEE emits no `status:'rejected'`), so the predicate fails
  **safe**: an unknown status, or an applied patch whose targets can't be attributed, both count as
  APPLIED. A false revert would discard a value the server accepted — worse than the bug.
- The revert **stands down** unless the node still holds the number this turn sent (a later edit, an
  undo or a scenario load must win over a late revert), and is turn-identity guarded.
- The queue's last-write-wins replacement **keeps the earliest snapshot**: `3→25` then `25→30` both
  undispatched means the server still holds `3`, so a refusal of `30` restores `3`, not the `25` it
  never held.

The inspector twin (`FactorControllablePanel`) is fixed alongside rather than left armed.

## Evidence

**RED-first on both**, adopting the probe's exact scenarios and its captured payloads as fixtures —
3 RED store/render assertions measured on `98aae72e`. The **rejected-edit case was green before the
fix and stays green**, as the control proving the tests can see both sides of the inversion.

**9 mutants, all bite** — run in a throwaway worktree **outside** the clone root (trap 9c) with
anchor-count assertions so a no-opped replacement can't print success (trap 15). Baseline 37/37.
They include the two that catch the *cheap wrong fixes*:

- `revert_unconditionally` → RED on the accepted-edit control (a fix that reverted always would pass
  every positive assertion and destroy every accepted edit);
- `snapshot_taken_after_the_write` → RED, proving the snapshot is the **pre-edit** state and not the
  refused value;

and the pair that separate the merge **rule** (`m8`) from its **wiring** (`m9`, fails with the exact
predicted `expected 25 to be 3`).

**Gates.** `pnpm run typecheck` **PASSED** — coverage `3031/3071`, ratchet `2512` vs baseline `2513`,
**1 diagnostic fixed, none added**. The first run flagged one new error that *was mine*; it was fixed
at the source (typed cast on a `vi.fn()` double) rather than absorbed into a baseline, and the banked
baseline diff is exactly one removed row in a file this PR touches — no attribution churn.
Regression sweep over `conversation` · `v5` · `inspector-v2` · `model-tab` · `store` · `utils`:
**381 files / 5729 passed, 0 failed**. Freshness-consumer sweep: **210 files / 3588 passed**. The
#522 parity suite is **byte-untouched** and green; #513 arc + all `inspector-v2` suites green (34
files / 377 tests). Lint: **0 errors**. Dummy `VITE_SUPABASE_*` set for every measurement.

## Honest limits — please read before approving

1. **Not live-verified.** All of the above is jsdom; jsdom cannot prove visibility (trap 3). Proven:
   the bar and its button *render* for the post-fix state. Not proven: that they are visible on
   staging. The live re-probe of applied-edit → staleness → re-run is the deploy-time check.
2. **The rejection rule keys on an absence.** Fail-safe by construction and `m5` proves that direction
   is load-bearing, but a *third* applied-patch shape (naming neither a block-level `target_id` nor
   `operations[].target_id`, *and* carrying a non-applied-looking status) would revert an accepted
   value. A CEE-side `graph_patch{status:'rejected'}` — or `freshness:'stale'` on the applied reply —
   would retire the absence rule entirely. **Worth a row against CEE.**
3. **Post-revert false alarm, unfixed by choice.** After a rejection the strip still reads "Model
   changed" over a graph now identical to the server's. False alarm, not false reassurance; clearing
   the overlay could un-dirty a *different* genuine edit. Rowed rather than guessed at.
4. **`cannot_confirm` still offers no re-run control on the Model tab** — a real gap, off the
   applied-edit path, out of this scope.
5. **A queued-then-discarded edit** (scenario switch / attempt cap) is still not reverted; it raises
   only the pre-existing transcript notice. Scope here is the dispatched-and-refused edit.

**DO NOT MERGE — review follows.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
