### PR TITLE
feat(ui): consume the streamed draft — graph on canvas at ~36s (M1-L2)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -23,7 +23,8 @@ import {
   type AddOptionCanvasTargets,
   type AddOptionChange,
 } from '../conversation/addOptionRequest'
-import { messageForElapsed } from './DraftLoadingAnimation'
+import { messageForElapsed, messageForSettling } from './DraftLoadingAnimation'
+import { useDraftStore } from '../stores/draftStore'
 
 export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use' | 'welcome'
 
@@ -150,23 +151,46 @@ export const AIInputBar = memo(
     // The composer freezes and shows a gently-pulsing, time-escalating status
     // line where the placeholder normally sits. Tick once a second so the
     // message advances through PROGRESSIVE_STAGES (0/20/45s).
-    const isGenerating = isThinking && nodeCount === 0
+    //
+    // ── ROADMAP 2.122: `nodeCount === 0` ALONE IS NOW A 25-SECOND SILENCE ────
+    // On the streamed draft path the graph lands on the canvas at ~36 s
+    // (GRAPH_READY) while the turn keeps running to ~61 s (coaching). The
+    // original gate goes false the instant those nodes appear — so the composer
+    // would stay FROZEN (`isThinking` is still true) with no status line at all
+    // for the remaining ~25 s. That is a worse wait than the one this lane
+    // exists to shorten, so the gate widens to include the settling phase, and
+    // the copy switches to the frame-licensed table for it.
+    //
+    // The two tables are licensed differently and must not be interchanged:
+    // before GRAPH_READY the client holds only a clock (PROGRESS frames are
+    // measured-ABSENT on the wire), after it the client holds a frame that says
+    // the graph exists and its numbers are `in_progress`. See
+    // DraftLoadingAnimation's SETTLING_STAGES docstring.
+    const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
+    const isSettling = draftStreamPhase === 'settling'
+    const isGenerating = isThinking && (nodeCount === 0 || isSettling)
     // Store the resolved MESSAGE (not raw seconds): the 1s tick then only
     // triggers a re-render when the stage actually advances — React bails on an
     // unchanged string — instead of re-rendering the composer every second for
     // up to two minutes.
     const [generatingMessage, setGeneratingMessage] = useState(() => messageForElapsed(0))
     useEffect(() => {
+      // `isSettling` is in the dep list so the clock RESTARTS when the graph
+      // lands: the settling table's thresholds are measured from the render, not
+      // from the start of the turn. Sharing the turn's clock would put the
+      // escalated settling line up immediately on every single draft.
+      const resolve = isSettling ? messageForSettling : messageForElapsed
       if (!isGenerating) {
-        setGeneratingMessage(messageForElapsed(0))
+        setGeneratingMessage(resolve(0))
         return
       }
+      setGeneratingMessage(resolve(0))
       const start = Date.now()
       const id = window.setInterval(() => {
-        setGeneratingMessage(messageForElapsed(Math.floor((Date.now() - start) / 1000)))
+        setGeneratingMessage(resolve(Math.floor((Date.now() - start) / 1000)))
       }, 1000)
       return () => window.clearInterval(id)
-    }, [isGenerating])
+    }, [isGenerating, isSettling])
 
     useImperativeHandle(
       ref,

--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -121,15 +121,41 @@ export const SETTLING_STAGES = [
 ] as const
 
 /**
- * The terminal honest line for a draft whose values will NOT settle in this
- * session (`draftStreamPhase === 'unsettled'`): the stream died after
- * GRAPH_READY and the buffered fallback found the turn already committed, so
- * CEE declined to re-draft and there is no second copy of the settled numbers
- * to fetch. Saying the model is ready would be a fabrication; saying nothing
- * would leave a silently-blocked Run button unexplained.
+ * The terminal honest lines for a draft whose values will NOT settle in this
+ * session (`draftStreamPhase === 'unsettled'`). Two, because there are two
+ * genuinely different causes and one sentence cannot state both truthfully.
+ *
+ * ── WHY THE OFFER CHANGED (adversarial review F3) ────────────────────────
+ * These used to say *"Draft again to get its final numbers"* and shipped a
+ * "Draft again" chip wired to `retryLast()`. **The chip could not do it on any
+ * auth tier.** `retryLast` re-sends the same message on the same scenario, whose
+ * canvas is now non-empty, so it is a BUFFERED turn — and CEE's continuation
+ * guard, live-proven to key on the scenario's committed state, DECLINES to
+ * re-draft (prose, no `draft_graph`). Each click removed the notice, re-sent,
+ * received "already drafted with four options…", and left the gate shut. The
+ * Supabase re-fetch branch cannot rescue it either: it additionally requires
+ * `stage:analyse` in the applied set, which a decline's prose does not produce.
+ *
+ * So the copy now promises the action that genuinely works — a NEW draft, on a
+ * fresh scenario, which is the only thing that can produce settled numbers once
+ * the old scenario has a committed turn — and the chip is wired to a handler that
+ * actually does that (`startNewDraft`). No promise the handler cannot keep.
  */
+// ⚠ My first wording of BOTH notices ended "…to get the finished model", and the
+// honesty suite rejected it on the model-is-finished rule. Third time this guard
+// has caught its own author; rewording rather than loosening the rule.
 export const UNSETTLED_DRAFT_NOTICE =
-  'Your model is on the canvas, but the connection dropped before its values arrived. Draft again to get its final numbers.'
+  'Your model is on the canvas, but the connection dropped before its values arrived, so they are not final. Start a new draft to get a model with settled values.'
+
+/**
+ * The same terminal state, reached because drafting was STOPPED rather than
+ * because the connection failed — the Stop button, or the 130 s client timeout
+ * (review F1). Worded to be true of both without asserting which: "drafting
+ * ended" covers a user stop, a timeout and a preempt, where "you stopped it"
+ * would be false for two of the three.
+ */
+export const STOPPED_DRAFT_NOTICE =
+  'Drafting ended before your model\u2019s values arrived, so they are not final. The structure is still here \u2014 start a new draft to get a model with settled values.'
 
 /**
  * Every narration table this module owns, keyed by name.

--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -41,12 +41,28 @@
  * surface. `__tests__/narrationHonesty.invariant.spec.ts` now enforces it
  * over BOTH tables, so the two cannot drift apart again.
  *
- * ⚠ This table is an HONEST INTERIM, not the destination. M1's real cure is
- * server-driven narration: once CEE-2 ships the staged turn route
- * (`POST /orchestrate/v2/turn/stream`), this file should be driven by real
+ * ⚠ AMENDED 29 Jul (ROADMAP 2.122) — CEE-2 LANDED, AND THE TABLE STILL CANNOT
+ * BE DELETED. The note here used to say this file "should be driven by real
  * GRAPH_READY / COACHING_READY frames and the elapsed-time table deleted
- * outright. Until that route exists the client has nothing real to narrate,
- * and the correct behaviour is to claim less — not to guess more.
+ * outright" once the streamed turn route existed. That route now exists (#751,
+ * `POST /proxy/v5/turn/stream`) and the UI consumes it — and the deletion would
+ * be a REGRESSION, for a measured reason:
+ *
+ *   the wire carries **no PROGRESS frames at all**. Zero observed across three
+ *   live runs on deployed staging (`PHASE0-EVIDENCE-2026-07-28/
+ *   cee2-live-latency.md` honest note 4 — "the route emits the frame class;
+ *   nothing feeds it"; it needs the Anthropic streaming adapter, #745's
+ *   inherited LOW and #751's rowed item 5).
+ *
+ * So between DRAFTING (271 ms) and GRAPH_READY (35.8 s median, 39.9 s on the
+ * cold run) the client holds ONE frame and a clock. Deleting this table would
+ * convert 36 seconds of honest escalating acknowledgement into 36 seconds of
+ * silence. It stays until PROGRESS frames actually arrive — see the 2.122
+ * PROGRESS row.
+ *
+ * What DID change: there is now a second table, `SETTLING_STAGES`, for the
+ * window after GRAPH_READY. It is licensed differently and that difference is
+ * the point — see its own docstring.
  */
 
 import { useEffect, useState, useRef } from 'react'
@@ -68,15 +84,90 @@ export const PROGRESSIVE_STAGES = [
   { afterSeconds: 45, message: 'Still drafting — complex decisions can take a while…' },
 ] as const
 
+/**
+ * The post-GRAPH_READY table (ROADMAP 2.122). Shown only when the client HOLDS
+ * a GRAPH_READY frame, i.e. the graph is on the canvas and the turn is still
+ * running (live: a ~25 s window, 35.8 s → 60.9 s).
+ *
+ * ── WHY THIS TABLE IS ALLOWED TO SAY MORE ────────────────────────────────
+ * `PROGRESSIVE_STAGES` above is licensed by ELAPSED TIME ALONE, which is why it
+ * cannot name a phase. This table is licensed by A FRAME THE CLIENT IS HOLDING:
+ *
+ *   - "your model is on the canvas" — the client rendered it; it can see it.
+ *   - "values are still settling"   — the frame is stamped `status:
+ *     "in_progress"`, and the route's contract states that
+ *     `graph-data-integrity` refines the numeric values after the transform.
+ *     Saying so is reading the frame, not guessing at a pipeline.
+ *   - "coaching is still arriving"  — COACHING_READY is a distinct later frame
+ *     (live: 59.2 s) which has not arrived.
+ *
+ * Every rule that governs the elapsed-time table still applies here (no
+ * comparative, no duration forecast, no completion-proximity, no claim about
+ * the user's decision, no fabricated number) AND one more that is specific to
+ * this phase, because this is the phase where a graph is visible and the
+ * temptation to say something ABOUT it is highest: **no claim the frame does
+ * not license** — no verdict, no leader, no win probability, no freshness, no
+ * recommendation. Enforced by `narrationHonesty.invariant.spec.ts`.
+ *
+ * Thresholds are 0/12 s against the measured ~25 s settling window.
+ */
+export const SETTLING_STAGES = [
+  { afterSeconds: 0, message: 'Your model is on the canvas. Values and coaching are still arriving…' },
+  // ⚠ My first draft of this line read "Still finishing the values and
+  // coaching…" and the honesty suite REJECTED it on the completion-proximity
+  // rule — correctly: "finishing" tells the user the wait is nearly over, and
+  // the client has no frame that says so. The guard caught its author.
+  { afterSeconds: 12, message: 'Still waiting on the values and coaching…' },
+] as const
+
+/**
+ * The terminal honest line for a draft whose values will NOT settle in this
+ * session (`draftStreamPhase === 'unsettled'`): the stream died after
+ * GRAPH_READY and the buffered fallback found the turn already committed, so
+ * CEE declined to re-draft and there is no second copy of the settled numbers
+ * to fetch. Saying the model is ready would be a fabrication; saying nothing
+ * would leave a silently-blocked Run button unexplained.
+ */
+export const UNSETTLED_DRAFT_NOTICE =
+  'Your model is on the canvas, but the connection dropped before its values arrived. Draft again to get its final numbers.'
+
+/**
+ * Every narration table this module owns, keyed by name.
+ *
+ * DERIVED, so the cross-surface honesty suite cannot miss one. The suite used
+ * to consume a HAND-LISTED array of tables — which is trap 12: adding a table
+ * without also adding it to the list would leave the new copy ungoverned, and
+ * the omission would read as green. It now iterates this record instead.
+ */
+export const NARRATION_TABLES = {
+  'DraftLoadingAnimation.PROGRESSIVE_STAGES': PROGRESSIVE_STAGES,
+  'DraftLoadingAnimation.SETTLING_STAGES': SETTLING_STAGES,
+} as const
+
+function resolveStage(
+  stages: readonly { readonly afterSeconds: number; readonly message: string }[],
+  elapsedSeconds: number,
+): string {
+  // Walk stages in reverse to find the highest threshold that applies
+  for (let i = stages.length - 1; i >= 0; i--) {
+    if (elapsedSeconds >= stages[i].afterSeconds) return stages[i].message
+  }
+  return stages[0].message
+}
+
 /** Resolve the current message for a given elapsed time (seconds) */
 export function messageForElapsed(elapsedSeconds: number): string {
-  // Walk stages in reverse to find the highest threshold that applies
-  for (let i = PROGRESSIVE_STAGES.length - 1; i >= 0; i--) {
-    if (elapsedSeconds >= PROGRESSIVE_STAGES[i].afterSeconds) {
-      return PROGRESSIVE_STAGES[i].message
-    }
-  }
-  return PROGRESSIVE_STAGES[0].message
+  return resolveStage(PROGRESSIVE_STAGES, elapsedSeconds)
+}
+
+/**
+ * Resolve the post-GRAPH_READY message. `elapsedSeconds` is measured from the
+ * moment the graph landed, not from the start of the turn — the client knows
+ * when it rendered, and re-using the turn's clock here would put the escalated
+ * line up immediately on every draft.
+ */
+export function messageForSettling(elapsedSeconds: number): string {
+  return resolveStage(SETTLING_STAGES, elapsedSeconds)
 }
 
 export function DraftLoadingAnimation() {

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -101,6 +101,7 @@ import type { TornadoRow } from '../../components/results/TornadoChart'
 import { useCanvasResultsSync } from '../../components/results/useCanvasResultsSync'
 import { ResultsBody } from '../../components/results/ResultsBody'
 import { useGuidanceStore } from '../stores/guidanceStore'
+import { useDraftStore } from '../stores/draftStore'
 import { executeAutoFix, determineFixType, type AutoFixParams } from '../utils/autoFix'
 import { getStrengthCorrections } from '../../adapters/plot/v2/adapter'
 // P0.6: User-friendly error messages
@@ -844,6 +845,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     return selectOptionsNeedingValues(ceeAnalysisReadyForCopy, labelById)
   }, [ceeAnalysisReadyForCopy, nodes])
 
+  // ROADMAP 2.122 — the run gate must stay shut while a streamed draft's
+  // structure is on the canvas but its numbers have not settled. The PHASE is
+  // handed to the gate unexamined: which phases count as unsettled is
+  // `canRunAnalysis`'s decision to make, in one tested place, not a two-clause
+  // expression re-derived at every call site. (A mutant that dropped one clause
+  // from an earlier version of that expression, right here, survived the
+  // battery — nothing tested this component's copy of the rule.)
+  const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
+
   const runGateResult = canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
@@ -851,6 +861,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     nodeCount: nodes.length,
     isRunning,
     ceeCannotSeeModel: computeCeeCannotSeeModel(nodes),
+    draftStreamPhase,
     optionsNeedingValues,
   })
   const canRunAnalysis = runGateResult.allowed

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -101,7 +101,7 @@ import type { TornadoRow } from '../../components/results/TornadoChart'
 import { useCanvasResultsSync } from '../../components/results/useCanvasResultsSync'
 import { ResultsBody } from '../../components/results/ResultsBody'
 import { useGuidanceStore } from '../stores/guidanceStore'
-import { useDraftStore } from '../stores/draftStore'
+import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
 import { executeAutoFix, determineFixType, type AutoFixParams } from '../utils/autoFix'
 import { getStrengthCorrections } from '../../adapters/plot/v2/adapter'
 // P0.6: User-friendly error messages
@@ -852,7 +852,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // expression re-derived at every call site. (A mutant that dropped one clause
   // from an earlier version of that expression, right here, survived the
   // battery — nothing tested this component's copy of the rule.)
-  const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
+  // Review F2: scoped to the OPEN scenario — an unsettled draft on another
+  // scenario must not reach this gate at all. `draftStreamPhaseFor` owns that
+  // decision; re-deriving it here is what M15/M16 punished.
+  const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, overviewScenarioId))
 
   const runGateResult = canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,

--- a/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
@@ -1,0 +1,157 @@
+/**
+ * The composer's wait narration across the STREAMED draft's two phases
+ * (ROADMAP 2.122).
+ *
+ * ── WHY THIS SPEC EXISTS ─────────────────────────────────────────────────
+ * `AIInputBar` is the ONLY live narration surface on the V5 draft path
+ * (complete manifest in `PHASE0-EVIDENCE-2026-07-28/m1l2-consumer.md` F0-3;
+ * `DraftChat`'s `DraftLoadingAnimation` hangs off `useCEEDraft`, the legacy
+ * `/bff/cee/draft-graph` hook the orchestrator path returns before reaching).
+ *
+ * Its gate was `isThinking && nodeCount === 0`. On the streamed path the graph
+ * lands at ~36 s and the turn runs on to ~61 s — so that gate goes FALSE while
+ * `isThinking` stays true, and the composer would sit frozen with no status
+ * line for ~25 s. The streamed render CREATES that silence, so the widened gate
+ * is part of the feature, not decoration, and it needs a pin: without one, a
+ * mutant that reverts the gate is invisible.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { PROGRESSIVE_STAGES, SETTLING_STAGES } from '../DraftLoadingAnimation'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+  },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+const canvasMockState: { nodes: Array<{ id: string }> } = { nodes: [] }
+vi.mock('../../store', () => ({
+  useCanvasStore: (selector: (s: unknown) => unknown) => selector(canvasMockState),
+}))
+
+const draftMockState: { draftStreamPhase: string } = { draftStreamPhase: 'idle' }
+vi.mock('../../stores/draftStore', () => ({
+  useDraftStore: (selector: (s: unknown) => unknown) => selector(draftMockState),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask about this model…',
+}))
+vi.mock('../../hooks/useSelectionContext', () => ({ useSelectionContext: () => null }))
+
+const conversationMockState = { messages: [] as unknown[], isThinking: false }
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      const [sendSystemEvent] = useState(() => vi.fn())
+      const [sendChip] = useState(() => vi.fn())
+      const [retryLast] = useState(() => vi.fn())
+      const [setPatchBlockState] = useState(() => vi.fn())
+      const [setPatchRejection] = useState(() => vi.fn())
+      return {
+        messages: conversationMockState.messages,
+        isThinking: conversationMockState.isThinking,
+        longRunningHint: null,
+        sendMessage,
+        sendSystemEvent,
+        sendChip,
+        retryLast,
+        patchBlockStates: new Map(),
+        setPatchBlockState,
+        patchRejections: new Map(),
+        setPatchRejection,
+      }
+    },
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { AIInputBar } from '../AIInputBar'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+const DRAFTING_LINE = PROGRESSIVE_STAGES[0].message
+const SETTLING_LINE = SETTLING_STAGES[0].message
+
+beforeEach(() => {
+  canvasMockState.nodes = []
+  draftMockState.draftStreamPhase = 'idle'
+  conversationMockState.isThinking = false
+  conversationMockState.messages = []
+})
+
+function renderBar() {
+  render(<AIInputBar variant="first-use" hideChevron testId="gen" onCogClick={() => {}} />, {
+    wrapper: Wrapper,
+  })
+}
+
+describe('phase 1 — before GRAPH_READY (empty canvas)', () => {
+  it('shows the elapsed-time line', () => {
+    conversationMockState.isThinking = true
+    draftMockState.draftStreamPhase = 'drafting'
+    renderBar()
+    expect(screen.getByText(DRAFTING_LINE)).toBeInTheDocument()
+    expect(screen.queryByText(SETTLING_LINE)).toBeNull()
+  })
+})
+
+describe('phase 2 — after GRAPH_READY, graph on canvas, turn still running', () => {
+  it('KEEPS narrating, and switches to the frame-licensed line', () => {
+    // This is the regression the streamed render would otherwise introduce:
+    // nodes exist, so the old gate is false, and the frozen composer would
+    // explain nothing for ~25 s.
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = [{ id: 'g1' }, { id: 'opt_a' }]
+    draftMockState.draftStreamPhase = 'settling'
+    renderBar()
+    expect(screen.getByText(SETTLING_LINE)).toBeInTheDocument()
+    // And it must NOT still be claiming a draft is being built — the client now
+    // holds a frame saying the graph exists.
+    expect(screen.queryByText(DRAFTING_LINE)).toBeNull()
+  })
+
+  it('freezes the composer for the whole turn, not just the first phase', () => {
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = [{ id: 'g1' }]
+    draftMockState.draftStreamPhase = 'settling'
+    renderBar()
+    expect(screen.getByTestId('gen').querySelector('textarea')).toBeDisabled()
+  })
+})
+
+describe('the gate stays shut everywhere else', () => {
+  it('says nothing once the turn ends', () => {
+    canvasMockState.nodes = [{ id: 'g1' }]
+    draftMockState.draftStreamPhase = 'idle'
+    conversationMockState.isThinking = false
+    renderBar()
+    expect(screen.queryByText(SETTLING_LINE)).toBeNull()
+    expect(screen.queryByText(DRAFTING_LINE)).toBeNull()
+  })
+
+  it('says nothing on an ordinary continuation turn over a populated canvas', () => {
+    // NEGATIVE CONTROL on the widening: a normal follow-up question on a
+    // non-empty canvas must not start narrating a draft. If the widened gate
+    // had been `isThinking` alone, this would fail.
+    canvasMockState.nodes = [{ id: 'g1' }]
+    draftMockState.draftStreamPhase = 'idle'
+    conversationMockState.isThinking = true
+    renderBar()
+    expect(screen.queryByText(SETTLING_LINE)).toBeNull()
+    expect(screen.queryByText(DRAFTING_LINE)).toBeNull()
+  })
+})

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -50,13 +50,18 @@
 import { describe, it, expect } from 'vitest'
 
 import { NARRATION_STAGES } from '../AnalysisRunningBanner'
+import * as narration from '../DraftLoadingAnimation'
 import {
   NARRATION_TABLES,
   PROGRESSIVE_STAGES,
   SETTLING_STAGES,
   UNSETTLED_DRAFT_NOTICE,
+  STOPPED_DRAFT_NOTICE,
 } from '../DraftLoadingAnimation'
-import { DRAFT_VALUES_SETTLING_REFUSAL } from '../../utils/canRunAnalysis'
+import {
+  DRAFT_VALUES_SETTLING_REFUSAL,
+  DRAFT_VALUES_UNSETTLED_REFUSAL,
+} from '../../utils/canRunAnalysis'
 
 interface Stage {
   readonly afterSeconds: number
@@ -276,7 +281,9 @@ function frameLicenceViolations(message: string): string[] {
 const FRAME_LICENSED_STRINGS: ReadonlyArray<readonly [string, string]> = [
   ...SETTLING_STAGES.map((s) => [`SETTLING_STAGES@${s.afterSeconds}s`, s.message] as const),
   ['UNSETTLED_DRAFT_NOTICE', UNSETTLED_DRAFT_NOTICE],
+  ['STOPPED_DRAFT_NOTICE', STOPPED_DRAFT_NOTICE],
   ['DRAFT_VALUES_SETTLING_REFUSAL', DRAFT_VALUES_SETTLING_REFUSAL],
+  ['DRAFT_VALUES_UNSETTLED_REFUSAL', DRAFT_VALUES_UNSETTLED_REFUSAL],
 ]
 
 describe('frame-licensed narration — may say the graph exists, may not judge it', () => {
@@ -337,5 +344,56 @@ describe('the derived table registry cannot silently miss a surface (trap 12)', 
     ])
     expect(NARRATION_TABLES['DraftLoadingAnimation.PROGRESSIVE_STAGES']).toBe(PROGRESSIVE_STAGES)
     expect(NARRATION_TABLES['DraftLoadingAnimation.SETTLING_STAGES']).toBe(SETTLING_STAGES)
+  })
+})
+
+describe('every notice this module exports is governed (trap 12, round 2)', () => {
+  /**
+   * `FRAME_LICENSED_STRINGS` is hand-listed, which is the shape that let a table
+   * escape the guard once already. Round 2 added TWO more notices
+   * (`STOPPED_DRAFT_NOTICE` for the abort path, and a second refusal string), so
+   * this DERIVES the completeness check: every `*_NOTICE` export of the narration
+   * module must be under the frame-licence rules.
+   *
+   * Scoped to that module on purpose. The gate module also exports
+   * `CEE_DRAFT_FIRST_REFUSAL`, which is CEE's own words quoted verbatim and
+   * predates this lane — holding someone else's copy to this lane's licence model
+   * would be the wrong claim, so the two refusals this lane owns are listed
+   * explicitly above and asserted here by name.
+   */
+  it('covers every *_NOTICE the narration module exports', () => {
+    const exportedNotices = Object.keys(narration).filter((k) => k.endsWith('_NOTICE'))
+    // Trap 13: if this finds nothing the loop below is vacuous.
+    expect(exportedNotices.length).toBeGreaterThan(0)
+    const governed = FRAME_LICENSED_STRINGS.map(([label]) => label)
+    for (const name of exportedNotices) {
+      expect(governed).toContain(name)
+    }
+    // And the manifest is named, so a reviewer sees what was actually covered.
+    expect(exportedNotices.sort()).toEqual(['STOPPED_DRAFT_NOTICE', 'UNSETTLED_DRAFT_NOTICE'])
+  })
+
+  it('covers both refusal strings this lane owns', () => {
+    const governed = FRAME_LICENSED_STRINGS.map(([label]) => label)
+    expect(governed).toContain('DRAFT_VALUES_SETTLING_REFUSAL')
+    expect(governed).toContain('DRAFT_VALUES_UNSETTLED_REFUSAL')
+  })
+
+  it('the two notices differ — one cause cannot describe both truthfully', () => {
+    // A dead connection and a user pressing Stop are different facts. One
+    // sentence asserting "the connection dropped" would be false for the Stop and
+    // timeout paths (review F1).
+    expect(UNSETTLED_DRAFT_NOTICE).not.toBe(STOPPED_DRAFT_NOTICE)
+    expect(UNSETTLED_DRAFT_NOTICE).toMatch(/connection dropped/i)
+    expect(STOPPED_DRAFT_NOTICE).not.toMatch(/connection dropped/i)
+  })
+
+  it('neither notice promises an action the handler cannot perform (F3)', () => {
+    // Both used to say "Draft again", wired to `retryLast`, which CEE declines on
+    // a committed scenario. The copy now names the action that works.
+    for (const notice of [UNSETTLED_DRAFT_NOTICE, STOPPED_DRAFT_NOTICE]) {
+      expect(notice).toMatch(/start a new draft/i)
+      expect(notice).not.toMatch(/draft again/i)
+    }
   })
 })

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -50,7 +50,13 @@
 import { describe, it, expect } from 'vitest'
 
 import { NARRATION_STAGES } from '../AnalysisRunningBanner'
-import { PROGRESSIVE_STAGES } from '../DraftLoadingAnimation'
+import {
+  NARRATION_TABLES,
+  PROGRESSIVE_STAGES,
+  SETTLING_STAGES,
+  UNSETTLED_DRAFT_NOTICE,
+} from '../DraftLoadingAnimation'
+import { DRAFT_VALUES_SETTLING_REFUSAL } from '../../utils/canRunAnalysis'
 
 interface Stage {
   readonly afterSeconds: number
@@ -111,18 +117,36 @@ function violations(message: string): string[] {
 }
 
 /**
- * Both live tables. The analysis table doubles as a NEGATIVE control on the
+ * Every live table. The analysis table doubles as a NEGATIVE control on the
  * rules themselves: it is the already-ratified copy, so if a rule ever flags
  * it, the rule is over-strict rather than the copy being dishonest.
+ *
+ * ⚠ AMENDED 29 Jul (ROADMAP 2.122). This used to be a HAND-LISTED array, and
+ * that was trap 12 sitting inside the guard written to prevent trap 12: adding
+ * a narration table without also adding it here would leave the new copy
+ * completely ungoverned, and the omission would read as GREEN. The draft-side
+ * entries are now DERIVED from `DraftLoadingAnimation.NARRATION_TABLES`, so a
+ * table added to that module is governed the moment it exists. The analysis
+ * banner stays named explicitly because it lives in a different module and
+ * exports exactly one table.
  */
 const LIVE_TABLES: ReadonlyArray<readonly [string, readonly Stage[]]> = [
   ['AnalysisRunningBanner.NARRATION_STAGES', NARRATION_STAGES],
-  ['DraftLoadingAnimation.PROGRESSIVE_STAGES', PROGRESSIVE_STAGES],
+  ...(Object.entries(NARRATION_TABLES) as Array<[string, readonly Stage[]]>),
 ]
 
 describe('narration honesty — one bar for every wait surface', () => {
   describe.each(LIVE_TABLES)('%s', (_label, stages) => {
-    it('asserts nothing the client cannot know from elapsed time alone', () => {
+    // ⚠ RENAMED 29 Jul (ROADMAP 2.122). This test used to be titled "asserts
+    // nothing the client cannot know from elapsed time alone", which was exactly
+    // right while every table was elapsed-time-licensed — and became an
+    // OVERCLAIM the moment `SETTLING_STAGES` joined, because that table is
+    // licensed by a held GRAPH_READY frame and legitimately says the graph
+    // exists. What this test actually checks, and all it ever checked, is that
+    // no table reproduces one of the retired fabrication CLASSES. The
+    // per-surface licence is asserted separately below. Correcting the title
+    // rather than the assertion, because the assertion was never the problem.
+    it('reproduces none of the retired fabrication classes', () => {
       const offenders = stages
         .map((s) => ({ message: s.message, broke: violations(s.message) }))
         .filter((r) => r.broke.length > 0)
@@ -192,5 +216,126 @@ describe('positive control — the guard can SEE a violation', () => {
     for (const fabricated of retiredFabrications) {
       expect(liveMessages).not.toContain(fabricated)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.122 — the FRAME-LICENSED surfaces
+// ---------------------------------------------------------------------------
+//
+// `PROGRESSIVE_STAGES` is licensed by elapsed time alone, so it cannot name a
+// phase. `SETTLING_STAGES` (and the two standing notices) are licensed by a
+// GRAPH_READY frame the client is HOLDING — so they may say the graph exists
+// and that its values are still in flight, because the frame is stamped
+// `status: "in_progress"` and its contract says the numbers get refined.
+//
+// That extra licence is exactly where a fabrication would slip in, so it comes
+// with an extra rule set. The claim these surfaces may NOT make is any claim
+// ABOUT the graph now visible: a verdict, a leader, a probability, a freshness
+// judgement, a recommendation. Those are what the dispatch's honesty
+// constraint forbids, and this is where they would be written.
+
+const FRAME_LICENCE_RULES: readonly Rule[] = [
+  {
+    name: 'no analysis verdict or recommendation',
+    pattern:
+      /\b(recommend|recommended|recommendation|best option|optimal|you should|we suggest|verdict|conclusion)\b/i,
+    control: 'Your model is ready — we recommend the build option.',
+  },
+  {
+    name: 'no leader or ranking language',
+    pattern: /\b(lead(s|ing)?|ahead|winner|winning|wins|front[- ]runner|top option|ranked)\b/i,
+    control: 'Build in-house is leading so far…',
+  },
+  {
+    name: 'no probability or confidence claim',
+    pattern: /\b(probability|likelihood|confidence|\d+\s*%\s*(chance|likely)|odds)\b/i,
+    control: 'Build in-house has a 62% probability of winning…',
+  },
+  {
+    name: 'no freshness or up-to-date verdict',
+    pattern: /\b(up to date|current results|fresh|stale|reflects the current model)\b/i,
+    control: 'Results are fresh and reflect the current model.',
+  },
+  {
+    name: 'no claim the model is finished',
+    pattern: /\b(ready to run|analysis ready|complete|finished|done)\b/i,
+    control: 'Your model is complete and ready to run.',
+  },
+]
+
+function frameLicenceViolations(message: string): string[] {
+  return FRAME_LICENCE_RULES.filter((r) => r.pattern.test(message)).map((r) => r.name)
+}
+
+/**
+ * Every string shown while a GRAPH_READY preview is on the canvas. Includes the
+ * run-gate refusal, because a blocked Run button whose tooltip made a claim
+ * would be exactly as dishonest as a status line that did.
+ */
+const FRAME_LICENSED_STRINGS: ReadonlyArray<readonly [string, string]> = [
+  ...SETTLING_STAGES.map((s) => [`SETTLING_STAGES@${s.afterSeconds}s`, s.message] as const),
+  ['UNSETTLED_DRAFT_NOTICE', UNSETTLED_DRAFT_NOTICE],
+  ['DRAFT_VALUES_SETTLING_REFUSAL', DRAFT_VALUES_SETTLING_REFUSAL],
+]
+
+describe('frame-licensed narration — may say the graph exists, may not judge it', () => {
+  it.each(FRAME_LICENSED_STRINGS)('%s makes no claim the frame does not license', (_label, message) => {
+    expect(frameLicenceViolations(message)).toEqual([])
+  })
+
+  it.each(FRAME_LICENSED_STRINGS)('%s also obeys every elapsed-time-table rule', (_label, message) => {
+    // The extra licence is additive, not a waiver: a settling line still may not
+    // forecast a duration, compare against a baseline, or claim proximity.
+    expect(violations(message)).toEqual([])
+  })
+
+  it('the settling table is non-empty, starts at 0 and escalates strictly', () => {
+    expect(SETTLING_STAGES.length).toBeGreaterThan(0)
+    expect(SETTLING_STAGES[0].afterSeconds).toBe(0)
+    for (let i = 1; i < SETTLING_STAGES.length; i++) {
+      expect(SETTLING_STAGES[i].afterSeconds).toBeGreaterThan(SETTLING_STAGES[i - 1].afterSeconds)
+    }
+  })
+})
+
+describe('positive control — the frame-licence rules can SEE a violation', () => {
+  it.each(FRAME_LICENCE_RULES.map((r) => [r.name, r] as const))(
+    '%s fires on its control string',
+    (_name, rule) => {
+      expect(rule.pattern.test(rule.control)).toBe(true)
+      expect(frameLicenceViolations(rule.control)).toContain(rule.name)
+    },
+  )
+
+  it('an honest settling line trips no frame-licence rule', () => {
+    expect(frameLicenceViolations('Still finishing the values and coaching…')).toEqual([])
+  })
+
+  it('the elapsed-time table would FAIL the frame-licence rules if shown post-GRAPH_READY', () => {
+    // Not a defect — it proves the two rule sets are genuinely different and
+    // that the frame-licence set is the STRICTER one. "Still drafting your
+    // decision model…" is true before GRAPH_READY and misleading after it, so
+    // the phase switch in AIInputBar is load-bearing rather than cosmetic.
+    const escalated = PROGRESSIVE_STAGES[PROGRESSIVE_STAGES.length - 1].message
+    expect(violations(escalated)).toEqual([])
+    expect(FRAME_LICENSED_STRINGS.map(([, m]) => m)).not.toContain(escalated)
+  })
+})
+
+describe('the derived table registry cannot silently miss a surface (trap 12)', () => {
+  it('governs every table DraftLoadingAnimation exports, without a hand-listed copy', () => {
+    const governed = LIVE_TABLES.map(([label]) => label)
+    for (const label of Object.keys(NARRATION_TABLES)) {
+      expect(governed).toContain(label)
+    }
+    // And the registry really does carry both draft tables — a registry that
+    // had quietly lost one would make the loop above vacuous.
+    expect(Object.keys(NARRATION_TABLES)).toEqual([
+      'DraftLoadingAnimation.PROGRESSIVE_STAGES',
+      'DraftLoadingAnimation.SETTLING_STAGES',
+    ])
+    expect(NARRATION_TABLES['DraftLoadingAnimation.PROGRESSIVE_STAGES']).toBe(PROGRESSIVE_STAGES)
+    expect(NARRATION_TABLES['DraftLoadingAnimation.SETTLING_STAGES']).toBe(SETTLING_STAGES)
   })
 })

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useRef, useState, useEffect, useCallback, useMemo, memo } from 'react'
 import { useCanvasStore, selectResultsStatus } from '../store'
+import { useDraftStore } from '../stores/draftStore'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import type { ActionChip, GraphPatchBlock } from './types'
 import type { UseConversationReturn } from './useConversation'
@@ -459,6 +460,14 @@ export const ConversationPanel = memo(function ConversationPanel({
   // flip. Same honest gate as OutputsDock — without it this surface's run
   // button re-created the exact panel-vs-engine contradiction #343 fixed.
   const ceeCannotSeeModel = useCanvasStore((s) => computeCeeCannotSeeModel(s.nodes))
+  // ROADMAP 2.122 — this surface is a run affordance too, so it needs the
+  // streamed-draft honesty rung for the same reason OutputsDock does: between
+  // GRAPH_READY (~36 s) and COMPLETE (~61 s) the canvas holds a graph whose
+  // numbers are the frame's `in_progress` ones and whose scenario commit has not
+  // landed. Missing it here would have re-created, on a second surface, exactly
+  // the panel-vs-engine contradiction the comment above records #343 fixing.
+  // Found by a surviving mutant, not by me.
+  const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
   const runGateResult = useMemo(() => canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
@@ -466,7 +475,8 @@ export const ConversationPanel = memo(function ConversationPanel({
     nodeCount,
     isRunning: isAnalysisRunning,
     ceeCannotSeeModel,
-  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel])
+    draftStreamPhase,
+  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel, draftStreamPhase])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -10,9 +10,10 @@
 
 import { useRef, useState, useEffect, useCallback, useMemo, memo } from 'react'
 import { useCanvasStore, selectResultsStatus } from '../store'
-import { useDraftStore } from '../stores/draftStore'
+import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import type { ActionChip, GraphPatchBlock } from './types'
+import { START_NEW_DRAFT_CHIP_ID } from './useConversation'
 import type { UseConversationReturn } from './useConversation'
 import { applyAutoApplyPatch, applyValidatedGraph } from './utils/applyPatch'
 import { buildAnalysisReadyPatch, applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
@@ -108,7 +109,7 @@ export const ConversationPanel = memo(function ConversationPanel({
 }: ConversationPanelProps) {
   const {
     messages, isThinking, longRunningHint,
-    sendMessage, sendSystemEvent, sendChip, dispatchAction, retryLast,
+    sendMessage, sendSystemEvent, sendChip, dispatchAction, retryLast, startNewDraft,
     patchBlockStates, setPatchBlockState,
     patchRejections, setPatchRejection,
   } = conversation
@@ -134,6 +135,10 @@ export const ConversationPanel = memo(function ConversationPanel({
   const handleChipClick = useCallback(
     async (chip: ActionChip): Promise<void> => {
       if (chip.id === 'retry') { retryLast(); return }
+      // ROADMAP 2.122 round 2 (review F3): the unsettled-draft recovery chip.
+      // Routed to a handler that CAN deliver what its label says — `retryLast`
+      // provably cannot, because CEE declines to re-draft a committed scenario.
+      if (chip.id === START_NEW_DRAFT_CHIP_ID) { await startNewDraft(); return }
       await sendChip(chip)
 
       // Track 2: mark suggested action as taken
@@ -145,7 +150,7 @@ export const ConversationPanel = memo(function ConversationPanel({
         onChipTaken(lastAssistant.id, chip.id)
       }
     },
-    [sendChip, retryLast, messages, onChipTaken],
+    [sendChip, retryLast, startNewDraft, messages, onChipTaken],
   )
 
   // ── Artefact action handler ─────────────────────────────────────────
@@ -467,7 +472,10 @@ export const ConversationPanel = memo(function ConversationPanel({
   // landed. Missing it here would have re-created, on a second surface, exactly
   // the panel-vs-engine contradiction the comment above records #343 fixing.
   // Found by a surviving mutant, not by me.
-  const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
+  // Review F2: scoped to the OPEN scenario. An unsettled draft on scenario A used
+  // to block Run on every other scenario with a false reason. `draftStreamPhaseFor`
+  // is the one place that decides ownership — never re-derived at a call site.
+  const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, scenarioId))
   const runGateResult = useMemo(() => canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,

--- a/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
+++ b/src/canvas/conversation/__tests__/conversationPanel.systemEventFailure.spec.tsx
@@ -101,6 +101,8 @@ function makeMockConversation(
     lastSendFailure: null,
     dispatchAction: vi.fn().mockResolvedValue(undefined),
     cancelTurn: vi.fn(),
+    // ROADMAP 2.122 round 2 (review F3): the unsettled-draft recovery handler.
+    startNewDraft: vi.fn(async () => {}),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     // `vi.fn()` is `Mock<any[], unknown>`, which does not structurally satisfy
     // the typed `sendSystemEvent` signature (and drifted again when its `opts`

--- a/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
+++ b/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
@@ -154,6 +154,8 @@ function makeMockConversation(): {
     lastSendFailure: null,
     dispatchAction: vi.fn().mockResolvedValue(undefined),
     cancelTurn: vi.fn(),
+    // ROADMAP 2.122 round 2 (review F3): the unsettled-draft recovery handler.
+    startNewDraft: vi.fn(async () => {}),
     sendMessage,
     sendSystemEvent: vi.fn().mockResolvedValue(undefined),
     sendChip: vi.fn().mockResolvedValue(undefined),

--- a/src/canvas/conversation/__tests__/patchAcceptLogic.spec.tsx
+++ b/src/canvas/conversation/__tests__/patchAcceptLogic.spec.tsx
@@ -86,6 +86,8 @@ function makeMockConversation(messages: ConversationMessage[]): {
     lastSendFailure: null,
     dispatchAction: vi.fn().mockResolvedValue(undefined),
     cancelTurn: vi.fn(),
+    // ROADMAP 2.122 round 2 (review F3): the unsettled-draft recovery handler.
+    startNewDraft: vi.fn(async () => {}),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     sendSystemEvent,
     sendChip: vi.fn().mockResolvedValue(undefined),

--- a/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
+++ b/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
@@ -1028,3 +1028,118 @@ describe('F3 — the recovery affordance can actually deliver what it promises',
     expect(useDraftStore.getState().draftStreamPhase).not.toBe('unsettled')
   })
 })
+
+// ===========================================================================
+// ROUND-2 RE-REVIEW — R2-F1: abort of the FALLBACK, not of the stream
+// ===========================================================================
+//
+// The round-2 review found F1's fix covered abort-of-the-STREAM and not
+// abort-of-the-FALLBACK, and reproduced the ORIGINAL F1 end state one level
+// deeper (preview standing, phase `idle`, gate OPEN, nothing said).
+//
+// Why the round-1 battery could not see it: N1 mutates the stream-abort branch
+// only, and every fallback test resolves `callV5Turn`. Nothing ever aborted a
+// turn while the buffered fallback was in flight.
+//
+// ⚠ The timeout variant needs NO USER ACTION. The stream dies late (any blip in
+// the ~25 s window), the fallback issues a ~55 s buffered turn, and the 130 s
+// wall-clock budget kills it mid-flight — guaranteed for any stream death at
+// ≥75 s. On that path the round-2 timeout-copy suppression fires correctly and
+// makes the outcome MORE silent, not less: no timeout copy, no stopped notice,
+// no phase, open gate.
+describe('R2-F1 — the turn is aborted while the buffered fallback is in flight', () => {
+  /** `callV5Turn` that hangs until the turn's own signal aborts, then rejects as the real one does. */
+  function hangingUntilAbort() {
+    mockCallV5Turn.mockImplementation(
+      (_payload: unknown, opts: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal?.addEventListener('abort', () => {
+            const e = new Error('The operation was aborted')
+            e.name = 'AbortError'
+            reject(e)
+          })
+        }),
+    )
+  }
+
+  async function streamDiesThenAbort(
+    result: { current: ReturnType<typeof useConversation> },
+    abort: () => void,
+  ) {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    hangingUntilAbort()
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('settling')
+    // A genuine transport blip in the settling window — the fallback fires.
+    await stream.fail()
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    // …and the turn is killed while that buffered request is still open.
+    await act(async () => {
+      abort()
+    })
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+  }
+
+  it('Stop during the fallback does not resurrect the original fabrication', async () => {
+    const { result } = renderHook(() => useConversation())
+    await streamDiesThenAbort(result, () => result.current.cancelTurn())
+
+    // The exact end state R2-P4 found: preview standing, phase idle, gate open,
+    // silence. Every one of these must now be the honest counterpart.
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    expect(runGate().allowed).toBe(false)
+    expect(runGate().reason).toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+    expect(result.current.messages.map((m) => m.content)).toContain(STOPPED_DRAFT_NOTICE)
+  })
+
+  it('the 130 s timeout during the fallback does the same — and this one needs no user action', async () => {
+    // Driven through the same abort seam the timeout uses (`controller.abort()`),
+    // because the alternative is a 130-second wall clock in a jsdom test. The
+    // timeout's OWN copy-suppression is pinned separately at
+    // `streamedPreviewStandingFor`; what is under test here is that the abort
+    // arriving mid-fallback still reaches the honest path.
+    const { result } = renderHook(() => useConversation())
+    await streamDiesThenAbort(result, () => result.current.cancelTurn())
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    expect(runGate().allowed).toBe(false)
+  })
+
+  it('does not fire a SECOND buffered turn — the abort is honoured, not worked around', async () => {
+    const { result } = renderHook(() => useConversation())
+    await streamDiesThenAbort(result, () => result.current.cancelTurn())
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+  })
+
+  it('an abort mid-fallback with NO preview stays silent — nothing to mark', async () => {
+    // Negative control, matching the stream-abort branch's own: the fallback can
+    // also be in flight after a failure that preceded GRAPH_READY, and there the
+    // canvas holds nothing. Inventing a notice would be its own fabrication.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    hangingUntilAbort()
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING)
+    await stream.fail()
+    await act(async () => {
+      result.current.cancelTurn()
+    })
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(result.current.messages.map((m) => m.content)).not.toContain(STOPPED_DRAFT_NOTICE)
+  })
+})

--- a/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
+++ b/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
@@ -1,0 +1,658 @@
+/**
+ * The streamed cold draft, end to end through `useConversation` (ROADMAP 2.122
+ * / 1.204 M1, POC-DONE step 1).
+ *
+ * This is the seam the lane could have failed SILENTLY at, so it gets pinned at
+ * the level where the failure would have been invisible:
+ *
+ *   - the graph must be on the canvas BEFORE the terminal frame arrives (the
+ *     entire point — a consumer that buffered every frame and applied at the end
+ *     would pass every content assertion while deleting the whole benefit);
+ *   - the terminal ingest must take the FRESH-DRAFT branch, not the
+ *     applied-edit-receipt branch. Reconcile gets the nodes right and performs
+ *     none of `applyDraftResult`'s side-effects, so coaching and the run
+ *     affordance would never unlock and the canvas would look perfect;
+ *   - the run affordance must stay SHUT while values are settling;
+ *   - a dead stream must never be a dead end, and never a double-commit.
+ *
+ * The stream is driven by a real `ReadableStream` through the real
+ * `streamStageFrames`, so the SSE parse, the chunk boundaries and the frame
+ * ordering are exercised rather than stubbed. Only the two network calls
+ * (`openV5TurnStream`, `callV5Turn`) are mocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useConversation, streamedDraftEligible } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useDraftStore } from '../../stores/draftStore'
+import { canRunAnalysis, DRAFT_VALUES_SETTLING_REFUSAL } from '../../utils/canRunAnalysis'
+import { UNSETTLED_DRAFT_NOTICE } from '../../components/DraftLoadingAnimation'
+import wireFixture from './fixtures/cee-draft-goal-constraints-wire.json'
+
+// ---------------------------------------------------------------------------
+// Network seam — the only thing mocked
+// ---------------------------------------------------------------------------
+
+const mockOpenStream = vi.fn()
+const mockCallV5Turn = vi.fn()
+
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: (...args: unknown[]) => mockOpenStream(...args),
+  }
+})
+
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/v5Adapter')>()
+  return {
+    ...actual,
+    callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+    getV5Endpoint: () => 'https://cee.test/proxy/v5/turn',
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return { ...actual, isV5Eligible: () => ({ eligible: true }) }
+})
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({ loadScenario: async () => null }))
+
+// ---------------------------------------------------------------------------
+// Fixtures — the live 29 Jul wire shape, reduced
+// ---------------------------------------------------------------------------
+
+/**
+ * The terminal body is a REAL CEE wire capture
+ * (`fixtures/cee-draft-goal-constraints-wire.json`, already in the repo and
+ * already used by `draftGoalConstraints.wire.spec.ts`), not a hand-written
+ * object. That matters: the terminal frame goes through the real
+ * `parseV5Response`, which validates against the strict `OlumiResponse` schema
+ * — a plausible-looking invented body is rejected as `parse_error` and the
+ * whole ingest silently never happens. My first version of this spec did
+ * exactly that and every downstream assertion failed for the wrong reason.
+ */
+const TERMINAL_BODY = wireFixture as unknown as Record<string, unknown>
+const TERMINAL_GRAPH = (TERMINAL_BODY.draft_graph as {
+  nodes: Array<Record<string, unknown>>
+  edges: Array<Record<string, unknown>>
+})
+
+/**
+ * The GRAPH_READY frame's graph: the SAME node and edge identities as the
+ * terminal graph, with the numeric values zeroed — which is precisely the
+ * contract ("identity is stable, values settle") and precisely why the frame is
+ * stamped `in_progress`. Derived from the terminal graph rather than typed out
+ * twice, so the two cannot drift apart and make the identity pin vacuous.
+ */
+const READY_GRAPH = {
+  nodes: TERMINAL_GRAPH.nodes.map((n) => ({ id: n.id, kind: n.kind, label: n.label })),
+  edges: TERMINAL_GRAPH.edges.map((e) => ({ from: e.from, to: e.to, strength: { mean: 0 } })),
+}
+const TERMINAL_NODE_IDS = TERMINAL_GRAPH.nodes.map((n) => String(n.id)).sort()
+
+function frame(obj: Record<string, unknown>): string {
+  return `event: stage\ndata: ${JSON.stringify(obj)}\n\n`
+}
+
+const F_DRAFTING = frame({ stage: 'DRAFTING', seq: 0, status: 'in_progress' })
+const F_GRAPH_READY = frame({
+  stage: 'GRAPH_READY',
+  seq: 2,
+  status: 'in_progress',
+  schema_version: 'v3',
+  elapsed_ms: 35_834,
+  graph: READY_GRAPH,
+})
+const F_COACHING = frame({
+  stage: 'COACHING_READY',
+  seq: 3,
+  status: 'in_progress',
+  coaching_status: 'partial',
+})
+const fComplete = (statusCode = 200, payload: unknown = TERMINAL_BODY) =>
+  frame({ stage: 'COMPLETE', seq: 4, status: 'complete', status_code: statusCode, payload })
+
+/**
+ * A `Response` whose body the TEST drives, so state can be inspected while the
+ * stream is still open. `push` enqueues; `close` ends; `fail` errors the socket.
+ */
+function controllableStream() {
+  const encoder = new TextEncoder()
+  let ctrl!: ReadableStreamDefaultController<Uint8Array>
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      ctrl = c
+    },
+  })
+  const res = new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+  // The path from `enqueue` to a rendered node crosses several awaits (reader
+  // read -> decode -> SSE parse -> generator yield -> consumer -> React commit),
+  // so a single microtask flush is not enough. Two macrotask turns drain it.
+  const settle = () =>
+    act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+  let closed = false
+  return {
+    response: res,
+    async push(text: string) {
+      if (!closed) ctrl.enqueue(encoder.encode(text))
+      await settle()
+    },
+    async close() {
+      // The generator cancels the reader as soon as it sees the terminal frame,
+      // which closes the controller for us — closing again would throw.
+      if (!closed) {
+        closed = true
+        try {
+          ctrl.close()
+        } catch {
+          /* already closed by the consumer's own cancel */
+        }
+      }
+      await settle()
+    },
+    async fail() {
+      if (!closed) {
+        closed = true
+        try {
+          ctrl.error(new Error('socket hung up'))
+        } catch {
+          /* already closed */
+        }
+      }
+      await settle()
+    },
+  }
+}
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const BRIEF = 'Should we build or buy a billing system for our new SaaS product?'
+
+/**
+ * The run gate exactly as `OutputsDock` calls it: the raw phase goes in and the
+ * gate decides. Nothing here re-derives "is it settling" — an earlier version of
+ * this helper did, and that let a mutation of `OutputsDock`'s own copy of the
+ * rule SURVIVE the mutation battery.
+ */
+function runGate() {
+  return canRunAnalysis({
+    graphHealth: null,
+    readiness: null,
+    hasBlockers: false,
+    nodeCount: useCanvasStore.getState().nodes.length,
+    draftStreamPhase: useDraftStore.getState().draftStreamPhase,
+  })
+}
+
+beforeEach(() => {
+  mockOpenStream.mockReset()
+  mockCallV5Turn.mockReset()
+  useDraftStore.getState().resetDraft()
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [],
+    edges: [],
+    // Reset the history slice AND its dedupe memo. `pushToHistory` skips a push
+    // when the pre-apply hash equals `_internal.lastHistoryHash`, so a memo left
+    // behind by a previous test silently swallows the next test's history push
+    // and the undo-depth pin below would read the wrong number.
+    history: { past: [], future: [] },
+    _internal: { ...(useCanvasStore.getState() as unknown as { _internal: object })._internal, lastHistoryHash: null },
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    results: { status: 'idle' } as never,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('streamedDraftEligible — narrow, and narrow towards doing nothing', () => {
+  const base = {
+    turnType: 'explicit_generate' as never,
+    derivedStage: 'frame',
+    isSystemEvent: false,
+    nodeCountAtDispatch: 0,
+  }
+
+  it('accepts an explicit_generate turn on an empty canvas', () => {
+    expect(streamedDraftEligible(base)).toBe(true)
+  })
+
+  it('accepts a frame-stage composer turn on an empty canvas', () => {
+    expect(streamedDraftEligible({ ...base, turnType: 'conversation' as never })).toBe(true)
+  })
+
+  it('REFUSES a populated canvas — a continuation turn has no graph frame to give', () => {
+    expect(streamedDraftEligible({ ...base, nodeCountAtDispatch: 7 })).toBe(false)
+  })
+
+  it('REFUSES a system event — graph edits must keep the buffered path byte for byte', () => {
+    expect(streamedDraftEligible({ ...base, isSystemEvent: true })).toBe(false)
+  })
+
+  it('REFUSES an ordinary conversation turn at a non-frame stage', () => {
+    expect(
+      streamedDraftEligible({ ...base, turnType: 'conversation' as never, derivedStage: 'analyse' }),
+    ).toBe(false)
+  })
+
+  it('REFUSES a run_analysis turn even on an empty canvas', () => {
+    // ⚠ The regression this predicate actually had. `deriveV5Stage` returns
+    // 'frame' for ANY turn on an empty canvas, so an eligibility rule of
+    // "explicit_generate OR stage === frame" routed a Run click into the draft
+    // stream. Caught by `useConversation.hook.spec.ts`'s preempt test, not by
+    // this suite — so it is pinned here, at the predicate, where it belongs.
+    expect(streamedDraftEligible({ ...base, turnType: 'run_analysis' as never })).toBe(false)
+  })
+
+  it('REFUSES every other turn type on an empty canvas — the rule is fail-closed', () => {
+    for (const turnType of ['explain', 'patch_followup', 'clarification_response'] as const) {
+      expect(streamedDraftEligible({ ...base, turnType: turnType as never })).toBe(false)
+    }
+  })
+})
+
+describe('the happy path — graph at GRAPH_READY, full ingest at COMPLETE', () => {
+  it('puts the graph on the canvas BEFORE the terminal frame arrives', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+
+    await stream.push(F_DRAFTING)
+    // Nothing rendered yet — DRAFTING carries no graph. This is the 36 s wait.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('drafting')
+
+    await stream.push(F_GRAPH_READY)
+    // ⭐ THE LANE'S WHOLE POINT: the graph is on the canvas and the turn is
+    // still open. A buffered-then-applied consumer would show 0 here.
+    expect(useCanvasStore.getState().nodes.map((n) => n.id).sort()).toEqual(TERMINAL_NODE_IDS)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('settling')
+
+    await stream.push(F_COACHING)
+    await stream.push(fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+
+  it('runs the FRESH-DRAFT ingest at COMPLETE, not the applied-edit reconcile', async () => {
+    // The silent-failure pin. `ceeAnalysisReady` is written ONLY by
+    // applyDraftResult's `hasAnalysisReady` branch; `reconcileAppliedGraph`
+    // never touches it. If the terminal graph took the reconcile branch the
+    // node ids would still be perfect and this would be null — the canvas would
+    // look right while coaching and the run gate never unlocked.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useCanvasStore.getState().ceeAnalysisReady).toBeNull()
+
+    await stream.push(F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    expect(useCanvasStore.getState().ceeAnalysisReady).toMatchObject({
+      status: 'needs_user_input',
+    })
+  })
+
+  it('leaves the undo stack exactly as deep as a buffered draft leaves it', async () => {
+    // Two applies, ONE history entry. Without `skipHistory` on the terminal
+    // apply, undo would step to the intermediate preview graph first.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    const historyDepth = () =>
+      (useCanvasStore.getState() as unknown as { history: { past: unknown[] } }).history.past.length
+    const historyBefore = historyDepth()
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    const historyAfterPreview = historyDepth()
+    await stream.push(F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    const historyAfterComplete = historyDepth()
+
+    expect(historyAfterPreview).toBe(historyBefore + 1)
+    expect(historyAfterComplete).toBe(historyAfterPreview)
+  })
+
+  it('never fires the buffered turn when the stream completes', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY + F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    expect(mockCallV5Turn).not.toHaveBeenCalled()
+  })
+})
+
+describe('HONESTY while the values settle', () => {
+  it('keeps the run affordance SHUT between GRAPH_READY and COMPLETE, with a true reason', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    // A graph with three nodes is on screen. Without the settling rung the gate
+    // would be driven by nodeCount alone and hand the tester a live Run button
+    // over values CEE is about to change, on a scenario CEE has not committed.
+    const settling = runGate()
+    expect(settling.allowed).toBe(false)
+    expect(settling.reason).toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+
+    await stream.push(F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    // Positive control on the rung: the same graph, same gate inputs, and now
+    // it is no longer the settling rung doing the blocking. Without this, the
+    // assertion above could be passing because SOMETHING always blocks.
+    expect(runGate().reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+  })
+
+  it('writes no freshness verdict and no analysis fact from the GRAPH_READY frame', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+
+    const s = useCanvasStore.getState() as unknown as Record<string, unknown>
+    expect(s.ceeAnalysisReady).toBeNull()
+    expect(s.v5AnalysisFact ?? null).toBeNull()
+    expect((s.results as { status?: string } | undefined)?.status).not.toBe('complete')
+
+    await stream.push(fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+  })
+})
+
+describe('FAILURE HONESTY — never a dead end, never a double-commit', () => {
+  it('falls back to ONE buffered turn on the SAME payload when the stream dies early', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    mockCallV5Turn.mockResolvedValue({ kind: 'response', response: TERMINAL_BODY })
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING)
+    await stream.fail()
+    await act(async () => {
+      await sent
+    })
+
+    // Exactly one buffered turn — a re-entered turn, which CEE's continuation
+    // guard resolves. No second stream, no new scenario, so no double-commit.
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    const streamPayload = mockOpenStream.mock.calls[0][0]
+    const bufferedPayload = mockCallV5Turn.mock.calls[0][0]
+    expect(bufferedPayload).toEqual(streamPayload)
+    expect((bufferedPayload as { scenario_id: string }).scenario_id).toBe(SCENARIO)
+
+    // And the user still gets their model.
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+
+  it('falls back when the stream cannot even be opened', async () => {
+    mockOpenStream.mockRejectedValue(new TypeError('Failed to fetch'))
+    mockCallV5Turn.mockResolvedValue({ kind: 'response', response: TERMINAL_BODY })
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' })
+    })
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+  })
+
+  it('states the truth when the stream died AFTER commit and CEE declines to re-draft', async () => {
+    // The one genuinely awkward case, and the reason this branch is written by
+    // hand rather than inherited. The turn committed server-side (proven
+    // behaviour: the route lets the turn finish when the client hangs up), so
+    // the buffered re-entry returns prose with NO draft_graph. The structure on
+    // screen is real; its numbers are the frame's in-progress ones and no
+    // settled copy will reach this session.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    mockCallV5Turn.mockResolvedValue({
+      kind: 'response',
+      response: {
+        response_version: 2,
+        assistant_text: 'Your billing system decision model is already drafted with four options.',
+        blocks: [],
+      },
+    })
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    await stream.fail()
+    await act(async () => {
+      await sent
+    })
+
+    // The graph is KEPT — throwing away a correct structure would be worse.
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+    // The phase is terminal-unsettled, so the run gate stays shut …
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    expect(runGate().reason).toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    // … and the transcript says why, rather than leaving a silently dead button.
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(UNSETTLED_DRAFT_NOTICE)
+    // Still exactly one buffered turn.
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT go unsettled when the fallback redrafts — the ordinary recovery', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    mockCallV5Turn.mockResolvedValue({ kind: 'response', response: TERMINAL_BODY })
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    await stream.fail()
+    await act(async () => {
+      await sent
+    })
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(result.current.messages.map((m) => m.content)).not.toContain(UNSETTLED_DRAFT_NOTICE)
+  })
+
+  it('removes the preview when the terminal frame is an error', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+
+    await stream.push(fComplete(422, { error: 'INGRESS_CONTRACT_VIOLATION' }))
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    // A graph rendered on the promise of a turn that then failed must not stay.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+})
+
+describe('a scenario switch mid-draft must not write to the new scenario', () => {
+  it('renders NO preview, and the terminal ingest does not treat one as present', async () => {
+    // ⚠ Added because a mutant SURVIVED: making the scenario guard `return`
+    // silently instead of throwing stayed GREEN. That difference is not
+    // cosmetic. `consumeStreamedDraftTurn` records `renderedGraph` unless the
+    // callback THROWS, so a silent return leaves it believing a preview is on
+    // screen — and the terminal ingest would then take the
+    // "resolve my own preview" branch (skipping history, treating a foreign
+    // canvas as empty) for a preview that was never drawn.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING)
+
+    // The user switches scenario while the draft is in flight.
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: 'b1b1b1b1-c2c2-4d3d-8e4e-f5f5f5f5f5f5' } as never)
+    })
+    await stream.push(F_GRAPH_READY)
+
+    // Nothing was drawn onto the new scenario's canvas.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    // And the phase never advanced to `settling`, so the run gate for the NEW
+    // scenario is not blocked by a draft that does not belong to it.
+    expect(useDraftStore.getState().draftStreamPhase).not.toBe('settling')
+
+    await stream.push(F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    // The terminal ingest is also scenario-guarded, so the switched-away canvas
+    // stays empty rather than receiving the other scenario's model.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    // History untouched: no preview push, no terminal push.
+    expect(
+      (useCanvasStore.getState() as unknown as { history: { past: unknown[] } }).history.past,
+    ).toHaveLength(0)
+  })
+
+  it('a REJECTED preview is not later "discarded" out of the scenario the user moved to', async () => {
+    // ⚠ The pin that makes the render callback's THROW load-bearing rather than
+    // decorative. `consumeStreamedDraftTurn` records `renderedGraph` unless the
+    // callback throws, and the error path uses `renderedGraph` to strip the
+    // preview's own element ids off the canvas. So a guard that returned
+    // SILENTLY would have the error path reach into the scenario the user
+    // switched TO and clear its authoritative-graph identity — cross-scenario
+    // contamination from a draft that was never drawn.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING)
+
+    // The user moves to another scenario that has its OWN acknowledged graph.
+    const otherAuthoritative = { nodeIds: ['other_1'], edgePairs: [] }
+    await act(async () => {
+      useCanvasStore.setState({
+        currentScenarioId: 'b1b1b1b1-c2c2-4d3d-8e4e-f5f5f5f5f5f5',
+        lastAuthoritativeGraph: otherAuthoritative,
+      } as never)
+    })
+    await stream.push(F_GRAPH_READY)
+    // …and the turn then fails at the boundary, which is the path that discards.
+    await stream.push(fComplete(422, { error: 'INGRESS_CONTRACT_VIOLATION' }))
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    expect(
+      (useCanvasStore.getState() as unknown as { lastAuthoritativeGraph: unknown })
+        .lastAuthoritativeGraph,
+    ).toEqual(otherAuthoritative)
+  })
+})
+
+describe('the buffered path is untouched for everything else', () => {
+  it('a continuation turn on a populated canvas never opens a stream', async () => {
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }],
+    } as never)
+    mockCallV5Turn.mockResolvedValue({
+      kind: 'response',
+      response: { response_version: 2, assistant_text: 'ok', blocks: [] },
+    })
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('what about timeline risk?')
+    })
+    expect(mockOpenStream).not.toHaveBeenCalled()
+    expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+})

--- a/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
+++ b/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
@@ -23,11 +23,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-import { useConversation, streamedDraftEligible } from '../useConversation'
+import { useConversation, streamedDraftEligible, START_NEW_DRAFT_CHIP_ID } from '../useConversation'
 import { useCanvasStore } from '../../store'
 import { useDraftStore } from '../../stores/draftStore'
-import { canRunAnalysis, DRAFT_VALUES_SETTLING_REFUSAL } from '../../utils/canRunAnalysis'
-import { UNSETTLED_DRAFT_NOTICE } from '../../components/DraftLoadingAnimation'
+import {
+  canRunAnalysis,
+  DRAFT_VALUES_SETTLING_REFUSAL,
+  DRAFT_VALUES_UNSETTLED_REFUSAL,
+} from '../../utils/canRunAnalysis'
+import { shouldPersistGraphForScenario, draftStreamPhaseFor } from '../../stores/draftStore'
+import {
+  UNSETTLED_DRAFT_NOTICE,
+  STOPPED_DRAFT_NOTICE,
+} from '../../components/DraftLoadingAnimation'
+import * as scenariosModule from '../../store/scenarios'
 import wireFixture from './fixtures/cee-draft-goal-constraints-wire.json'
 
 // ---------------------------------------------------------------------------
@@ -189,12 +198,15 @@ const BRIEF = 'Should we build or buy a billing system for our new SaaS product?
  * rule SURVIVE the mutation battery.
  */
 function runGate() {
+  const currentScenarioId = useCanvasStore.getState().currentScenarioId
   return canRunAnalysis({
     graphHealth: null,
     readiness: null,
     hasBlockers: false,
     nodeCount: useCanvasStore.getState().nodes.length,
-    draftStreamPhase: useDraftStore.getState().draftStreamPhase,
+    // Scoped exactly as both live call sites scope it (F2): a phase belonging to
+    // another scenario must not reach this gate at all.
+    draftStreamPhase: draftStreamPhaseFor(useDraftStore.getState(), currentScenarioId),
   })
 }
 
@@ -500,9 +512,11 @@ describe('FAILURE HONESTY — never a dead end, never a double-commit', () => {
 
     // The graph is KEPT — throwing away a correct structure would be worse.
     expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
-    // The phase is terminal-unsettled, so the run gate stays shut …
+    // The phase is terminal-unsettled, so the run gate stays shut — with the
+    // TERMINAL refusal, not the settling one (review F5: the settling string
+    // forecasts a finish that will never come in this state).
     expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
-    expect(runGate().reason).toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    expect(runGate().reason).toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
     // … and the transcript says why, rather than leaving a silently dead button.
     const contents = result.current.messages.map((m) => m.content)
     expect(contents).toContain(UNSETTLED_DRAFT_NOTICE)
@@ -654,5 +668,363 @@ describe('the buffered path is untouched for everything else', () => {
     expect(mockOpenStream).not.toHaveBeenCalled()
     expect(mockCallV5Turn).toHaveBeenCalledTimes(1)
     expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+})
+
+// ===========================================================================
+// ADVERSARIAL REVIEW OF PR #525 — the reviewer's probes, adopted verbatim in
+// intent (ROADMAP 2.122, round 2)
+// ===========================================================================
+//
+// The review returned BLOCKED on two findings, both in the phase machine's
+// BOUNDARY states, both proven executable at `bb0338e9`, neither covered by the
+// 24-mutant battery. The core construction survived every attack — which is
+// exactly why these matter: an "honest no-claim window" is either true at every
+// edge or it is not a guarantee.
+//
+// Each probe below is written as the reviewer executed it, and each went RED
+// before the fix.
+
+describe('F1 — abort after GRAPH_READY (Stop button / 130 s timeout)', () => {
+  /**
+   * The reviewer's probe, verbatim in intent: after GRAPH_READY + Stop, the head
+   * left the canvas holding every preview node, `draftStreamPhase === 'idle'`,
+   * `canRunAnalysis(...).allowed === true` with NO reason, and no notice in the
+   * transcript — an unsettled draft presented as a finished model with a live
+   * Run affordance, one click away from the fabrication M4/M7 exist to prevent.
+   *
+   * The Stop button is rendered for the whole settling window (`isThinking`), and
+   * the natural tester is the one who sees the graph land at 36 s and concludes
+   * the spinner is vestigial.
+   */
+  it('does NOT present the unsettled preview as a finished model', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('settling')
+
+    // The user presses Stop.
+    await act(async () => {
+      result.current.cancelTurn()
+    })
+    await stream.fail()
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+
+    // The structure is REAL and is kept — deleting it would assert something
+    // false ("you have no model") about a graph CEE actually validated.
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+    // …but it is MARKED, so the run gate stays shut with the honest reason.
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    expect(runGate().allowed).toBe(false)
+    expect(runGate().reason).toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+    // …and the transcript says what happened rather than leaving a silently
+    // dead Run button next to a "values are still arriving" line.
+    expect(result.current.messages.map((m) => m.content)).toContain(STOPPED_DRAFT_NOTICE)
+  })
+
+  it('never issues a second network request after an explicit Stop', async () => {
+    // The abort must NOT reuse the died-stream fallback: Stop is a user
+    // instruction not to continue, and preempt means a newer turn owns the
+    // canvas. Firing a fresh ~55 s buffered turn would contradict the user's own
+    // click. See the F1 design note in the evidence file.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    await act(async () => {
+      result.current.cancelTurn()
+    })
+    await stream.fail()
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+    expect(mockCallV5Turn).not.toHaveBeenCalled()
+  })
+
+  it('an abort BEFORE GRAPH_READY stays silent — no notice, no phase, nothing to mark', async () => {
+    // Negative control on the fix: without it, "abort ⇒ unsettled" would fire on
+    // every cancelled draft and invent a marker for a canvas that holds nothing.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING)
+    await act(async () => {
+      result.current.cancelTurn()
+    })
+    await stream.fail()
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(result.current.messages.map((m) => m.content)).not.toContain(STOPPED_DRAFT_NOTICE)
+  })
+})
+
+describe('F1 — the autosave bound: the UI never persists a graph it knows is unsettled', () => {
+  /**
+   * The reviewer VOIDED rowed item 9's premise for the abort path: with no
+   * terminal ingest the unsettled values persist indefinitely, and the next
+   * canvas edit's debounced echo save (which re-reads the store at fire time)
+   * writes the unsettled graph back OVER CEE's settled commit.
+   *
+   * The fix is stronger than the bound the row claimed: the write is suppressed
+   * for BOTH in-progress phases at the single shared write choke point, so an
+   * unsettled row is never written in the first place — not merely bounded.
+   */
+  it('suppresses the Supabase graph write while values are settling or unsettled', () => {
+    for (const phase of ['settling', 'unsettled'] as const) {
+      useDraftStore.getState().setDraftStreamPhase(phase, 'turn-1', SCENARIO)
+      expect(shouldPersistGraphForScenario(SCENARIO)).toBe(false)
+    }
+  })
+
+  it('permits it again the moment the draft settles — the suppression is not a one-way door', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 'turn-1', SCENARIO)
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(false)
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(true)
+  })
+
+  it('does not suppress writes for a DIFFERENT scenario', () => {
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 'turn-1', SCENARIO)
+    expect(shouldPersistGraphForScenario('other-scenario-id')).toBe(true)
+  })
+
+  it('the GRAPH_READY preview does not write the local autosave either', async () => {
+    // A guest tab-close during the window otherwise restores the unsettled graph
+    // on reload with no marker and an OPEN gate — the same dishonest state with
+    // no Stop click needed (the reviewer's second F1 vector).
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    const autosaveSpy = vi.spyOn(scenariosModule, 'saveAutosave')
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(autosaveSpy).not.toHaveBeenCalled()
+
+    // …and the terminal apply DOES autosave, so the settled graph is preserved.
+    await stream.push(F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    expect(autosaveSpy).toHaveBeenCalled()
+    autosaveSpy.mockRestore()
+  })
+})
+
+describe('F2 — the phase is scoped to its own scenario', () => {
+  /**
+   * Reviewer probe: drive scenario A to `unsettled`, switch to scenario B with a
+   * populated settled canvas → the gate returned blocked with
+   * "Your model is still being drafted…" about a model that was never streamed.
+   * The phase was global, deliberately never cleared, and nothing reset it at any
+   * scenario boundary; recovery was a new streamed draft (needs an empty canvas)
+   * or a page reload.
+   */
+  it('does not block a DIFFERENT scenario with another scenario\'s unsettled draft', () => {
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 'turn-A', SCENARIO)
+    // Scenario B, its own settled canvas.
+    useCanvasStore.setState({
+      currentScenarioId: 'b1b1b1b1-c2c2-4d3d-8e4e-f5f5f5f5f5f5',
+      nodes: [{ id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }],
+    } as never)
+    const gate = runGate()
+    expect(gate.reason).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+    expect(gate.reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+  })
+
+  it('still blocks the OWNING scenario — the scoping is not a blanket release', () => {
+    // Positive control. Without it the test above could pass because the rung
+    // stopped firing at all.
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 'turn-A', SCENARIO)
+    useCanvasStore.setState({
+      currentScenarioId: SCENARIO,
+      nodes: [{ id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }],
+    } as never)
+    expect(runGate().reason).toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+  })
+
+  it('a settled draft landing on the owning scenario clears the unsettled state', async () => {
+    // The other half of the recovery: an `unsettled` phase must not outlive a
+    // draft that actually completed for that scenario.
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 'turn-A', SCENARIO)
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    useCanvasStore.setState({ currentScenarioId: SCENARIO, nodes: [] } as never)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY + F_COACHING + fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(runGate().reason).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+  })
+})
+
+describe('F4 — a 200 COMPLETE with no draft_graph after GRAPH_READY is the FAILURE path', () => {
+  /**
+   * Reviewer probe: GRAPH_READY, then a 200 terminal carrying valid prose,
+   * `blocks: []` and no graph → the preview nodes stayed, phase `idle`, gate
+   * OPEN, no notice. Not purely a malice shape: it is the client shadow of the
+   * ROWED server salvage gap — a truncation-salvaged turn is precisely a 200
+   * whose graph may be absent or reduced. Node-level divergence was handled well
+   * (wholesale replace); graph-ABSENT divergence was the unhandled rung.
+   */
+  it('never leaves a phantom preview standing with an open gate', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+
+    await stream.push(
+      fComplete(200, {
+        response_version: 2,
+        assistant_text: 'I could not finish assembling the model. Try again.',
+        blocks: [],
+      }),
+    )
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    // Either state is honest; a standing graph with an OPEN gate is not.
+    expect(runGate().allowed).toBe(false)
+    expect(useDraftStore.getState().draftStreamPhase).not.toBe('idle')
+    expect(result.current.messages.map((m) => m.content)).toContain(UNSETTLED_DRAFT_NOTICE)
+  })
+})
+
+describe('F5 — the two in-progress phases do not share one refusal string', () => {
+  it('says something DIFFERENT, and true, for settling vs unsettled', () => {
+    // `settling` legitimately forecasts a finish ("once drafting finishes").
+    // `unsettled` must not: its own docstring says the values will not settle in
+    // this session, so the same sentence there forecasts a finish that will never
+    // come — contradicting the transcript notice sitting beside it.
+    expect(DRAFT_VALUES_SETTLING_REFUSAL).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+    expect(DRAFT_VALUES_SETTLING_REFUSAL).toMatch(/once drafting finishes/i)
+    expect(DRAFT_VALUES_UNSETTLED_REFUSAL).not.toMatch(/once drafting finishes|finishes|will finish/i)
+  })
+})
+
+describe('F3 — the recovery affordance can actually deliver what it promises', () => {
+  /**
+   * The review: chip id `retry` → `retryLast()` → re-sends the SAME message on the
+   * SAME scenario, whose canvas is now non-empty → BUFFERED turn → CEE's
+   * continuation guard DECLINES to re-draft (prose, no `draft_graph`). Each click
+   * removed the notice, re-sent, got "already drafted with four options…", kept the
+   * phase `unsettled` and kept the gate shut. The Supabase re-fetch branch cannot
+   * rescue it either — it additionally requires `stage:analyse` in the applied set,
+   * which a decline's prose does not produce. The notice promised final numbers the
+   * chip could not obtain on any auth tier.
+   */
+  async function driveToUnsettled(result: { current: ReturnType<typeof useConversation> }) {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    mockCallV5Turn.mockResolvedValue({
+      kind: 'response',
+      response: {
+        response_version: 2,
+        assistant_text: 'Your billing system decision model is already drafted with four options.',
+        blocks: [],
+      },
+    })
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    await stream.fail()
+    await act(async () => {
+      await sent.catch(() => {})
+    })
+  }
+
+  it('offers the new-draft chip, NOT the retry chip that CEE declines', async () => {
+    const { result } = renderHook(() => useConversation())
+    await driveToUnsettled(result)
+    const notice = result.current.messages.find((m) => m.content === UNSETTLED_DRAFT_NOTICE)
+    expect(notice).toBeDefined()
+    expect(notice!.actionChips?.map((c) => c.id)).toEqual([START_NEW_DRAFT_CHIP_ID])
+    expect(notice!.actionChips?.map((c) => c.id)).not.toContain('retry')
+  })
+
+  it('startNewDraft clears the canvas, mints a FRESH scenario, and drafts', async () => {
+    const { result } = renderHook(() => useConversation())
+    await driveToUnsettled(result)
+    const staleScenario = useCanvasStore.getState().currentScenarioId
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+
+    // The chip's handler. A second stream is offered for the fresh draft.
+    const fresh = controllableStream()
+    mockOpenStream.mockResolvedValue(fresh.response)
+    let restarted!: Promise<void>
+    await act(async () => {
+      restarted = result.current.startNewDraft()
+    })
+
+    // A NEW scenario — the only condition under which CEE will draft again, since
+    // the old one now has a committed turn.
+    const newScenario = useCanvasStore.getState().currentScenarioId
+    expect(newScenario).not.toBe(staleScenario)
+    expect(newScenario).toBeTruthy()
+    // …and it really is dispatched to the draft stream, not silently dropped.
+    expect(mockOpenStream).toHaveBeenCalledTimes(2)
+
+    await fresh.push(F_DRAFTING + F_GRAPH_READY + F_COACHING + fComplete())
+    await fresh.close()
+    await act(async () => {
+      await restarted
+    })
+
+    // The recovery completed: settled values, phase released, gate open again.
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(runGate().reason).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+  })
+
+  it('releases the stale scenario\'s unsettled gate immediately, not only on success', async () => {
+    // Otherwise the fresh scenario would inherit the old one's blocked gate for the
+    // moment before its own `drafting` write lands.
+    const { result } = renderHook(() => useConversation())
+    await driveToUnsettled(result)
+    const stalled = controllableStream()
+    mockOpenStream.mockResolvedValue(stalled.response)
+    await act(async () => {
+      void result.current.startNewDraft()
+    })
+    expect(useDraftStore.getState().draftStreamPhase).not.toBe('unsettled')
   })
 })

--- a/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.hook.spec.ts
@@ -104,6 +104,26 @@ const mockGetUserId = vi.fn<[], Promise<string | null>>()
 // exercise the Bearer path set .value; everything else runs token-less.
 const mockAccessToken = { value: null as string | null }
 
+// ROADMAP 2.122 — `sendMessage` on an EMPTY canvas is now dispatched to the
+// STREAMED turn sibling first (`<endpoint>/stream`, CEE #751), with a
+// transparent fallback to the buffered turn on any stream failure.
+//
+// This spec's subject is the BUFFERED chain, so the streamed sibling is stubbed
+// unreachable — which is not an artificial construction: it is exactly the state
+// of a deployment where the streamed route is absent or refusing, and the
+// fallback it triggers is the behaviour under test elsewhere
+// (`streamedDraftTurn.spec.ts`). With the sibling unreachable the buffered path
+// runs exactly once, which is what this spec's request-count pins measure.
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: async () => {
+      throw new TypeError('Failed to fetch')
+    },
+  }
+})
+
 vi.mock('../../../lib/supabase', () => ({
   getUserId: (...args: unknown[]) => mockGetUserId(...args as []),
   // Login 3.4: useConversation resolves identity via getSessionIdentity

--- a/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
@@ -50,6 +50,26 @@ vi.mock('../turnService', () => ({
   },
 }))
 
+// ROADMAP 2.122 — `sendMessage` on an EMPTY canvas is now dispatched to the
+// STREAMED turn sibling first (`<endpoint>/stream`, CEE #751), with a
+// transparent fallback to the buffered turn on any stream failure.
+//
+// This spec's subject is the BUFFERED chain, so the streamed sibling is stubbed
+// unreachable — which is not an artificial construction: it is exactly the state
+// of a deployment where the streamed route is absent or refusing, and the
+// fallback it triggers is the behaviour under test elsewhere
+// (`streamedDraftTurn.spec.ts`). With the sibling unreachable the buffered path
+// runs exactly once, which is what this spec's request-count pins measure.
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: async () => {
+      throw new TypeError('Failed to fetch')
+    },
+  }
+})
+
 vi.mock('../../../lib/supabase', () => ({
   getUserId: async () => null,
   getSessionIdentity: async () => ({ userId: null, accessToken: null }),

--- a/src/canvas/conversation/turnService.ts
+++ b/src/canvas/conversation/turnService.ts
@@ -59,6 +59,7 @@ import { validateEnvelopeShape, validateStreamEventShape } from './validateRespo
 import { computePayloadHash } from '../../lib/canonical-hash'
 import { recordRequest, recordResponse } from '../../lib/debug-state'
 import { recordRequestPayload, recordResponsePayload } from '../../lib/payload-trace-store'
+import { parseSSELines } from '../../lib/sse/parseSSELines'
 import { isUUID, stripTurnType, validateTurnRequestBoundary, type TurnRequestPayload } from '../../services/turn-request-builder'
 
 // In production/staging, route through Netlify edge function proxy at /bff/orchestrate
@@ -332,62 +333,15 @@ interface StreamTelemetry {
 }
 
 /**
- * Parse a raw SSE text chunk into structured events.
+ * Re-exported from the app's single SSE line parser (`lib/sse/parseSSELines`).
  *
- * Handles multi-line `data:` fields per the SSE spec (consecutive data lines
- * joined with `\n`) and `:` comment lines as heartbeat signals.
- *
- * @returns An array of parsed events and a boolean indicating heartbeat activity
+ * ROADMAP 2.122: the staged V5 turn consumer (`v5/streamedDraftFrames`) needs
+ * the same parser, and writing a second one would be trap 12 with a silent
+ * failure mode (a drift on multi-line `data:` or CRLF would read as green in
+ * both suites). The body moved; this name stays so
+ * `__tests__/streamEventParsing.spec.ts` keeps covering it unchanged.
  */
-export function parseSSELines(
-  lines: string[],
-  /** When true, flush any buffered event at the end even without a trailing
-   *  blank line. Only set this when processing the final chunk of a stream. */
-  flush = false,
-): { events: Array<{ eventType: string; data: string }>; hadActivity: boolean } {
-  const events: Array<{ eventType: string; data: string }> = []
-  let currentEventType = ''
-  let dataLines: string[] = []
-  let hadActivity = false
-
-  for (const rawLine of lines) {
-    // Normalise CRLF / bare CR — servers may use \r\n line endings
-    const line = rawLine.replace(/\r$/, '')
-
-    if (line === '') {
-      // Empty line = event boundary per SSE spec
-      if (dataLines.length > 0) {
-        events.push({ eventType: currentEventType, data: dataLines.join('\n') })
-        dataLines = []
-        currentEventType = ''
-      }
-      continue
-    }
-    if (line.startsWith(':')) {
-      // Comment line = heartbeat signal
-      hadActivity = true
-      continue
-    }
-    if (line.startsWith('event: ')) {
-      currentEventType = line.slice(7).trim()
-      hadActivity = true
-    } else if (line.startsWith('data: ')) {
-      dataLines.push(line.slice(6))
-      hadActivity = true
-    } else if (line.startsWith('data:')) {
-      // `data:` with no space — still valid per SSE spec
-      dataLines.push(line.slice(5))
-      hadActivity = true
-    }
-  }
-
-  // Flush trailing buffered event on EOF (stream ended without final blank line)
-  if (flush && dataLines.length > 0) {
-    events.push({ eventType: currentEventType, data: dataLines.join('\n') })
-  }
-
-  return { events, hadActivity }
-}
+export { parseSSELines }
 
 /**
  * Stream an orchestrator turn via SSE (POST /orchestrate/v1/turn/stream).

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -9,7 +9,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { useCanvasStore } from '../store'
 import { setCurrentScenarioId } from '../store/scenarios'
-import { useDraftStore } from '../stores/draftStore'
+import { useDraftStore, streamedPreviewStandingFor } from '../stores/draftStore'
 import { generateGraphHash } from '../utils/graphHash'
 import { callOrchestratorTurn, streamOrchestratorTurn, OrchestratorError } from './turnService'
 import {
@@ -107,7 +107,7 @@ import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPa
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb, storeAnalysis } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
-import { UNSETTLED_DRAFT_NOTICE } from '../components/DraftLoadingAnimation'
+import { UNSETTLED_DRAFT_NOTICE, STOPPED_DRAFT_NOTICE } from '../components/DraftLoadingAnimation'
 import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
@@ -330,6 +330,24 @@ export function inferLoadingHint(message: string, _nodeCount: number, turnType?:
 // ROADMAP 2.122 / 1.204 M1 \u2014 the streamed cold draft
 // ---------------------------------------------------------------------------
 
+/**
+ * The recovery chip on the two unsettled-draft notices (adversarial review F3).
+ *
+ * Deliberately NOT `retry`. `retryLast` re-sends the same message onto the SAME
+ * scenario, whose canvas is now non-empty — so it is a buffered turn, and CEE's
+ * continuation guard (live-proven to key on the scenario's committed state)
+ * DECLINES to re-draft it: prose, no `draft_graph`. Each click removed the
+ * notice, re-sent, received "already drafted with four options…" and left the gate
+ * shut. The Supabase re-fetch branch cannot rescue it either — it additionally
+ * requires `stage:analyse` in the applied set, which a decline's prose does not
+ * produce, so signed-in users were no better off than guests.
+ *
+ * Once a scenario has a committed turn, the ONLY thing that can produce settled
+ * numbers is a draft on a FRESH scenario. That is what `startNewDraft` does, and
+ * it is what the copy now promises.
+ */
+export const START_NEW_DRAFT_CHIP_ID = 'start_new_draft'
+
 export interface StreamedDraftEligibility {
   turnType: TurnType
   derivedStage: string
@@ -376,6 +394,22 @@ export function streamedDraftEligible(p: StreamedDraftEligibility): boolean {
 
 /** Thrown inside `onGraphReady` when the user has switched scenario mid-draft. */
 class PreviewNotApplicableError extends Error {}
+
+/**
+ * Thrown when a streamed draft is ABORTED (Stop button, 130 s client timeout, or
+ * a preempting turn) after GRAPH_READY had already put a preview on the canvas
+ * — adversarial review F1.
+ *
+ * `name` is deliberately `'AbortError'` so every existing abort handler in
+ * `sendTurn` keeps treating it as the abort it is (silent, no transport-failure
+ * bubble, no `deliveryState: 'failed'` on a message that genuinely reached the
+ * server). The marker property is what lets the catch add the ONE thing the abort
+ * path was missing: an honest notice about the graph now sitting on the canvas.
+ */
+class StreamedDraftAbortedWithPreviewError extends Error {
+  readonly name = 'AbortError'
+  readonly abortedWithPreview = true
+}
 
 /** Does a parsed turn result carry a draft graph with anything in it? */
 function resultCarriesDraftGraph(result: V5CallResult): boolean {
@@ -474,7 +508,7 @@ async function runStreamedDraftTurn(args: {
   signal: AbortSignal
 }): Promise<StreamedDraftTurnResult> {
   const { payload, turnClientId, scenarioIdAtDispatch, headers, signal } = args
-  useDraftStore.getState().setDraftStreamPhase('drafting', turnClientId)
+  useDraftStore.getState().setDraftStreamPhase('drafting', turnClientId, scenarioIdAtDispatch)
 
   // ⚠ THERE IS DELIBERATELY NO LOCAL `previewRendered` FLAG.
   //
@@ -498,18 +532,20 @@ async function runStreamedDraftTurn(args: {
     if (drafted) {
       // Outcome 1. The buffered body carries the whole graph, so the terminal
       // ingest replaces whatever the preview put up.
-      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      useDraftStore.getState().setDraftStreamPhase('idle', null, null)
       return { result, previewOwnsCanvas: previewOnCanvas, unsettled: false }
     }
     if (previewOnCanvas) {
       // Outcome 2 — the honest failure. Phase stays non-idle so the run gate
       // stays shut; `previewOwnsCanvas` is false because there is no graph in
       // this response to apply over the preview.
-      useDraftStore.getState().setDraftStreamPhase('unsettled', turnClientId)
+      useDraftStore
+        .getState()
+        .setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
       return { result, previewOwnsCanvas: false, unsettled: true }
     }
     // Outcome 3.
-    useDraftStore.getState().setDraftStreamPhase('idle', null)
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
     return { result, previewOwnsCanvas: false, unsettled: false }
   }
 
@@ -519,7 +555,7 @@ async function runStreamedDraftTurn(args: {
   } catch (e) {
     // The stream never opened, so nothing ran server-side and nothing committed.
     if ((e as Error)?.name === 'AbortError' || signal.aborted) {
-      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      useDraftStore.getState().setDraftStreamPhase('idle', null, null)
       throw e
     }
     // Nothing streamed, so no preview can exist.
@@ -540,14 +576,60 @@ async function runStreamedDraftTurn(args: {
       // `hasAnalysisReady` gate skips every analysis side-effect: no readiness,
       // no freshness verdict, no coaching, no quality, no interventions. The
       // honesty constraint holds by construction of a gate that already existed.
-      applyDraftResult({ nodes: graph.nodes ?? [], edges: graph.edges ?? [] } as never)
-      useDraftStore.getState().setDraftStreamPhase('settling', turnClientId)
+      // `skipAutosave` (review F1): the preview must not reach localStorage. The
+      // phase that marks it unsettled is in-memory and does not survive a reload,
+      // so a persisted preview would come back unmarked with an open gate.
+      applyDraftResult({ nodes: graph.nodes ?? [], edges: graph.edges ?? [] } as never, {
+        skipAutosave: true,
+      })
+      useDraftStore
+        .getState()
+        .setDraftStreamPhase('settling', turnClientId, scenarioIdAtDispatch)
     },
   })
 
   if (outcome.kind === 'abandoned') {
     if (outcome.reason === 'aborted' || signal.aborted) {
-      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      // ═══ ADVERSARIAL REVIEW F1 — the abort hole ═══════════════════════════
+      //
+      // This branch used to set the phase to `idle` and rethrow, and the outer
+      // catch is silent for aborts by design. So a Stop click after GRAPH_READY
+      // left every preview node on the canvas with the run gate OPEN, the phase
+      // `idle` and no notice — an unsettled draft presented as a finished model,
+      // one click from the exact fabrication M4/M7 exist to prevent, on an
+      // affordance rendered for the whole settling window.
+      //
+      // The fix is `unsettled`, and the two alternatives were both rejected on
+      // evidence rather than taste (full reasoning in the evidence file):
+      //
+      //   · re-using the DIED-STREAM FALLBACK is wrong for the dominant abort
+      //     causes. Stop is a user instruction not to continue and preempt means
+      //     a newer turn owns the canvas — issuing a fresh ~55 s buffered request
+      //     in either case contradicts the user's own action or races the newer
+      //     turn. It would also require minting a new AbortController to defeat
+      //     the very abort that was requested.
+      //   · DISCARDING the preview can destroy a committed model. Per #751 the
+      //     server turn runs to completion and commits at ~61 s, so on the 130 s
+      //     timeout path a discard's echo save would write an EMPTY graph AFTER
+      //     that commit — trading a fabrication for data loss. It also asserts
+      //     something false to the user ("you have no model") about a graph CEE
+      //     genuinely validated.
+      //
+      // `unsettled` says exactly what happened: the structure is real, its
+      // numbers are the frame's in-progress ones, they will not settle in this
+      // session, and the gate is shut until a new draft. The stranded-row half of
+      // the review's finding is answered separately and more strongly, at
+      // `shouldPersistGraphForScenario` — the UI never writes an unsettled graph
+      // to either store, so there is no row to strand.
+      if (outcome.renderedGraph !== null) {
+        useDraftStore
+          .getState()
+          .setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
+        throw new StreamedDraftAbortedWithPreviewError('streamed draft aborted after GRAPH_READY')
+      }
+      // Nothing was rendered, so there is nothing to mark and nothing to say.
+      // Inventing a marker here would be its own fabrication.
+      useDraftStore.getState().setDraftStreamPhase('idle', null, null)
       const abort = new Error('streamed draft aborted')
       abort.name = 'AbortError'
       throw abort
@@ -576,7 +658,27 @@ async function runStreamedDraftTurn(args: {
   const result = await parseV5Response(
     streamTransport.terminalPayloadToResponse(outcome.terminalPayload, outcome.statusCode),
   )
-  useDraftStore.getState().setDraftStreamPhase('idle', null)
+
+  // ═══ ADVERSARIAL REVIEW F4 ══════════════════════════════════════════════
+  // A 200 terminal frame that carries NO extractable `draft_graph` while a
+  // preview is standing is the FAILURE path, not a success. `discardPreview`
+  // only fires on `status_code >= 400`, so this used to leave a phantom preview
+  // on the canvas with the gate OPEN, the phase `idle` and no notice.
+  //
+  // It is not a malice-only shape: it is the client shadow of the ROWED server
+  // salvage gap — a truncation-salvaged turn is precisely a 200 whose graph may
+  // be absent or reduced. Node-level divergence was already handled well
+  // (wholesale replace); graph-ABSENT divergence was the unhandled rung.
+  //
+  // Treated as `unsettled` rather than discarded, for the same reason as F1: the
+  // rendered structure came from a validated GRAPH_READY frame and is real, so
+  // deleting it asserts something false while marking it states the truth.
+  if (previewOwnsCanvas && !resultCarriesDraftGraph(result)) {
+    useDraftStore.getState().setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
+    return { result, previewOwnsCanvas: false, unsettled: true }
+  }
+
+  useDraftStore.getState().setDraftStreamPhase('idle', null, null)
   return { result, previewOwnsCanvas, unsettled: false }
 }
 
@@ -2070,6 +2172,11 @@ export interface UseConversationReturn {
    * accept, reject, or mutate any patch state.
    */
   cancelTurn: () => void
+  /**
+   * Start a fresh draft on a fresh scenario — the recovery affordance for an
+   * unsettled streamed draft (review F3). See `START_NEW_DRAFT_CHIP_ID`.
+   */
+  startNewDraft: () => Promise<void>
   /** GraphPatchBlock state map (keyed by `${turnId}:${patchId}`) */
   patchBlockStates: Map<string, PatchBlockState>
   setPatchBlockState: (key: string, state: PatchBlockState) => void
@@ -3913,7 +4020,20 @@ export function useConversation(): UseConversationReturn {
           setIsThinking(false)
           useDraftStore.getState().setIsGenerating(false)
           setLongRunningHint(null)
-          if (mode === 'user' && !hidden) {
+          // ROADMAP 2.122 round 2 (review F1, adjacent) — a streamed draft that
+          // already put a graph on the canvas must NOT be told "your message has
+          // not gone through". It did go through: the server produced and
+          // validated a graph, and per #751 the turn continues and commits. The
+          // generic timeout copy, the `deliveryState: 'failed'` marker and the
+          // timeout send-failure would all be false here, and would contradict
+          // the honest notice the abort path is about to add. Derived from the
+          // store, so it cannot disagree with the phase machine.
+          const streamedPreviewStanding = streamedPreviewStandingFor(
+            useDraftStore.getState(),
+            turnClientId,
+            currentScenarioId,
+          )
+          if (mode === 'user' && !hidden && !streamedPreviewStanding) {
             // Transcript honesty: we stopped waiting — the turn produced no
             // response, so the bubble must not read as delivered.
             if (userBubbleIdForTurn) {
@@ -4489,16 +4609,6 @@ export function useConversation(): UseConversationReturn {
             // dropped before the values arrived, drafting again gets them. No
             // duration forecast, no verdict — held to the same bar as the wait
             // narration and pinned by `narrationHonesty.invariant.spec.ts`.
-            if (streamedUnsettled) {
-              addMessage({
-                id: crypto.randomUUID(),
-                role: 'assistant',
-                synthetic: true,
-                content: UNSETTLED_DRAFT_NOTICE,
-                actionChips: [{ id: 'retry', label: 'Draft again', intent: 'primary' }],
-                timestamp: new Date(),
-              })
-            }
           } else if (target.kind === 'empty') {
             // Blank-response guard: no text, no blocks, no chips from CEE.
             addMessage({
@@ -4611,9 +4721,65 @@ export function useConversation(): UseConversationReturn {
               )
             }
           }
+
+          // ═══ ROADMAP 2.122 round 2 — the unsettled-draft notice ═══════════
+          //
+          // Emitted for EVERY response class, deliberately outside the
+          // `target.kind` chain. It was inside the text_only/blocks branch, and
+          // review F4 exposed why that is wrong: a terminal frame that fails
+          // strict validation routes to `typed_error`, so the canvas kept a
+          // standing preview and a shut gate with NOTHING said — the same
+          // silently-blocked Run button F1 is about. The notice is a statement
+          // about the CANVAS, not about the response's shape, so it belongs where
+          // every branch reaches it.
+          //
+          // Says only what is known: the structure is visible, drafting ended
+          // before its values arrived, a new draft gets the finished model. No
+          // duration forecast, no verdict — held to the same bar as the wait
+          // narration and pinned by `narrationHonesty.invariant.spec.ts`.
+          if (streamedUnsettled && mode === 'user' && !hidden) {
+            addMessage({
+              id: crypto.randomUUID(),
+              role: 'assistant',
+              synthetic: true,
+              content: UNSETTLED_DRAFT_NOTICE,
+              // F3: NOT `retry`. `retryLast` re-sends onto the SAME scenario,
+              // whose canvas is now non-empty, so it is a buffered turn CEE's
+              // continuation guard DECLINES — the old chip could not deliver the
+              // numbers its own copy promised, on any auth tier.
+              actionChips: [
+                { id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' },
+              ],
+              timestamp: new Date(),
+            })
+          }
         } catch (err) {
           clearLifecycleTimers()
           const isAbort = (err as Error).name === 'AbortError'
+
+          // ═══ ADVERSARIAL REVIEW F1 ════════════════════════════════════════
+          // An abort that left a GRAPH_READY preview standing is the ONE abort
+          // that must not be silent: the canvas now holds real structure whose
+          // numbers are not final, and without a word the user reads it as a
+          // finished model beside a Run button. `runStreamedDraftTurn` has already
+          // moved the phase to `unsettled` (so the gate is shut); this adds the
+          // sentence, and the affordance that can actually deliver on it (F3 —
+          // `retryLast` provably cannot, because CEE's continuation guard declines
+          // to re-draft a committed scenario).
+          if (
+            (err as { abortedWithPreview?: boolean })?.abortedWithPreview &&
+            mode === 'user' &&
+            !hidden
+          ) {
+            addMessage({
+              id: crypto.randomUUID(),
+              role: 'assistant',
+              synthetic: true,
+              content: STOPPED_DRAFT_NOTICE,
+              actionChips: [{ id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' }],
+              timestamp: new Date(),
+            })
+          }
           // Timeout-triggered aborts render their own bubble (above). User
           // stops and concurrent cancellations are silent by design.
           if (!isAbort && mode === 'user' && !hidden) {
@@ -4668,7 +4834,7 @@ export function useConversation(): UseConversationReturn {
               draftState.draftStreamTurnId === turnClientId &&
               draftState.draftStreamPhase !== 'unsettled'
             ) {
-              draftState.setDraftStreamPhase('idle', null)
+              draftState.setDraftStreamPhase('idle', null, null)
             }
           }
           releaseInFlightLockIfOwned()
@@ -5529,6 +5695,47 @@ export function useConversation(): UseConversationReturn {
     }
   }, [sendTurn])
 
+  /**
+   * ROADMAP 2.122 round 2 (adversarial review F3) — start a genuinely FRESH
+   * draft, on a fresh scenario.
+   *
+   * The recovery affordance on an unsettled draft. `retryLast` cannot serve this
+   * role: the old scenario has a committed turn, so CEE's continuation guard
+   * declines to re-draft it no matter how many times it is asked. `resetCanvas`
+   * clears the graph AND `currentScenarioId` (`store.ts` →
+   * `scenarios.clearCurrentScenarioId()`), so `sendTurn` mints a fresh UUID and
+   * CEE sees a scenario with no prior turns — the one condition under which it
+   * will draft.
+   *
+   * The phase is released explicitly rather than left to the new turn: the new
+   * scenario must not inherit the old one's `unsettled` gate even for the moment
+   * before its own `drafting` write lands.
+   */
+  const startNewDraft = useCallback(async () => {
+    const last = lastUserInputRef.current
+    if (!last.message) return
+    recordUserAction({
+      actionType: 'clicked chip',
+      payloadSummary: { raw_message: last.message, chip_id: START_NEW_DRAFT_CHIP_ID },
+    })
+    // Drop the notice bubble the chip came from (same rule as retryLast).
+    setMessages((prev) => {
+      const tail = prev[prev.length - 1]
+      const next = tail?.synthetic ? prev.slice(0, -1) : prev
+      messagesRef.current = next
+      return next
+    })
+    useCanvasStore.getState().resetCanvas()
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    await sendTurn({
+      message: last.message,
+      mode: 'user',
+      skipUserBubble: true,
+      turnType: 'explicit_generate',
+      source: 'retry',
+    })
+  }, [sendTurn])
+
   const clearHistory = useCallback(() => {
     messagesRef.current = []
     sessionStateRef.current = null
@@ -5616,6 +5823,7 @@ export function useConversation(): UseConversationReturn {
     clearHistory,
     retryLast,
     cancelTurn,
+    startNewDraft,
     patchBlockStates,
     setPatchBlockState,
     patchRejections,

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -396,9 +396,16 @@ export function streamedDraftEligible(p: StreamedDraftEligibility): boolean {
 class PreviewNotApplicableError extends Error {}
 
 /**
- * Thrown when a streamed draft is ABORTED (Stop button, 130 s client timeout, or
- * a preempting turn) after GRAPH_READY had already put a preview on the canvas
- * — adversarial review F1.
+ * Thrown when a streamed draft ENDS WITHOUT A TERMINAL INGEST while a
+ * GRAPH_READY preview is standing on the canvas — adversarial review F1, and its
+ * round-2 residual R2-F1.
+ *
+ * Two entry points, one meaning:
+ *   · the STREAM is aborted after GRAPH_READY (Stop button, the 130 s client
+ *     timeout, or a preempting turn);
+ *   · the buffered FALLBACK is aborted or fails after the stream already
+ *     rendered — the residual the round-2 review found, whose dominant trigger
+ *     (the 130 s budget killing a ~55 s fallback) needs no user action at all.
  *
  * `name` is deliberately `'AbortError'` so every existing abort handler in
  * `sendTurn` keeps treating it as the abort it is (silent, no transport-failure
@@ -527,7 +534,52 @@ async function runStreamedDraftTurn(args: {
     if (import.meta.env.DEV) {
       console.warn(`[sendTurn V5] streamed draft abandoned (${reason}); falling back to the buffered turn`)
     }
-    const result = await callV5Turn(payload, { signal, headers })
+
+    // ═══ ROUND-2 RE-REVIEW, R2-F1 ═══════════════════════════════════════════
+    // The fallback itself can be killed, and until this branch existed that
+    // resurrected the ORIGINAL F1 fabrication one level deeper.
+    //
+    // Sequence: the stream dies post-GRAPH_READY on any transport blip in the
+    // ~25 s window → this fallback issues a ~55 s buffered turn → the turn is
+    // aborted mid-flight. The AbortError propagated PLAIN, so
+    // `abortedWithPreview` was never set, the outer catch stayed silent by
+    // design, and the finally's ownership guard saw phase `settling` (not
+    // `unsettled`) and actively cleared it to `idle` — preview standing, gate
+    // OPEN, nothing said.
+    //
+    // ⚠ AND THE DOMINANT TRIGGER NEEDS NO USER ACTION: the 130 s wall-clock
+    // budget kills the fallback by itself whenever the stream dies at ≥75 s,
+    // because a ~55 s buffered turn cannot fit in what is left. On that path the
+    // round-2 timeout-copy suppression fires correctly and makes the outcome
+    // MORE silent, not less — no timeout copy, no notice, no phase.
+    //
+    // Routed to the SAME `unsettled` + notice path the stream-abort branch takes,
+    // for the same reason: the structure on the canvas is real, its values never
+    // arrived, and that is true whichever of the two aborts killed the fallback.
+    //
+    // The catch is deliberately not narrowed to `AbortError`. `callV5Turn`
+    // converts network failures into a `parse_error` RESULT rather than a throw,
+    // so a non-abort throw here is near-unreachable — but if one ever occurs the
+    // honest statement is identical (drafting ended, values never arrived), and
+    // an unmarked standing preview would be the very defect this branch exists
+    // to close. Fail-closed toward honesty.
+    let result: V5CallResult
+    try {
+      result = await callV5Turn(payload, { signal, headers })
+    } catch (e) {
+      if (previewOnCanvas) {
+        useDraftStore
+          .getState()
+          .setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
+        throw new StreamedDraftAbortedWithPreviewError(
+          `buffered fallback ended without a terminal ingest: ${(e as Error)?.message ?? 'unknown'}`,
+        )
+      }
+      // Nothing rendered, so there is nothing to mark and nothing to say.
+      useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+      throw e
+    }
+
     const drafted = resultCarriesDraftGraph(result)
     if (drafted) {
       // Outcome 1. The buffered body carries the whole graph, so the terminal

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -19,7 +19,11 @@ import {
   isDisplaySafeReason,
 } from './ceeRecovery'
 import { buildTransportFailureCopy, isTransportFailure } from './transportFailure'
-import { callV5Turn, getV5Endpoint } from '../../v5/v5Adapter'
+import { callV5Turn, getV5Endpoint, type V5CallResult } from '../../v5/v5Adapter'
+import { parseV5Response } from '../../v5/responseParser'
+import { openV5TurnStream, __streamInternals as streamTransport } from '../../v5/streamedTurnTransport'
+import { streamStageFrames } from '../../v5/streamedDraftFrames'
+import { consumeStreamedDraftTurn } from '../../v5/consumeStreamedDraftTurn'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
 import { isV5Eligible } from '../../v5/eligibility'
@@ -103,6 +107,7 @@ import { applyAutoApplyPatch, synthesiseCeeAnalysisReady } from './utils/applyPa
 import { applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
 import { loadScenario as loadScenarioFromDb, storeAnalysis } from '../../services/scenarioService'
 import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/applyDraftResult'
+import { UNSETTLED_DRAFT_NOTICE } from '../components/DraftLoadingAnimation'
 import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
@@ -319,6 +324,260 @@ export function inferLoadingHint(message: string, _nodeCount: number, turnType?:
   if (lower.includes('explain') || lower.includes('why')) return 'Preparing explanation\u2026'
   if (turnType === 'explicit_generate') return 'Building your decision model\u2026'
   return 'Thinking\u2026'
+}
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.122 / 1.204 M1 \u2014 the streamed cold draft
+// ---------------------------------------------------------------------------
+
+export interface StreamedDraftEligibility {
+  turnType: TurnType
+  derivedStage: string
+  isSystemEvent: boolean
+  /** Canvas node count read BEFORE the request, not after. */
+  nodeCountAtDispatch: number
+}
+
+/**
+ * Is this the ONE turn shape the streamed sibling exists for \u2014 a cold draft?
+ *
+ * FAIL-CLOSED, deliberately: anything that does not match keeps today's buffered
+ * turn, unchanged. The cost of a false negative is one draft that is 20 s slower;
+ * the cost of a false positive is a non-draft turn on a route built for drafts.
+ *
+ *   - **`explicit_generate`** \u2014 the Draft/Generate affordances' own turn type.
+ *   - **a plain `conversation` turn at stage `frame`** \u2014 the composer's first
+ *     message on an empty canvas, which CEE dispatches `draft_graph` for.
+ *   - **The canvas must be EMPTY at dispatch.** A populated canvas means a
+ *     continuation turn, which CEE's own continuation guard refuses to draft for
+ *     \u2014 so there would be no GRAPH_READY frame to consume and nothing to gain,
+ *     while the streamed route's measured ~5.5 s completion overhead would still
+ *     be paid.
+ *   - **Never a system event.** Graph edits, patch accepts and factor-value
+ *     writes are not drafts; they must keep the buffered path byte for byte.
+ *
+ * \u26a0 THE `turnType === 'conversation'` CONJUNCT IS LOAD-BEARING, AND MY FIRST
+ * VERSION OMITTED IT. The predicate read `explicit_generate || stage === 'frame'`,
+ * which looked right \u2014 `getTimeoutMs` grants its extended budget on exactly that
+ * disjunction \u2014 and was wrong, because **`deriveV5Stage` returns `'frame'` for
+ * ANY turn on an empty canvas**, including `run_analysis`. So a Run click on an
+ * empty canvas was being dispatched to the draft stream. Caught by an existing
+ * spec (`useConversation.hook.spec.ts`'s preempt test), not by me: I had reused
+ * a disjunction from a function whose purpose (choose a timeout) tolerates being
+ * over-broad, in a function whose purpose (choose a route) does not. Pinned now
+ * by `streamedDraftTurn.spec.ts`.
+ */
+export function streamedDraftEligible(p: StreamedDraftEligibility): boolean {
+  if (p.isSystemEvent) return false
+  if (p.nodeCountAtDispatch !== 0) return false
+  if (p.turnType === 'explicit_generate') return true
+  return p.turnType === 'conversation' && p.derivedStage === 'frame'
+}
+
+/** Thrown inside `onGraphReady` when the user has switched scenario mid-draft. */
+class PreviewNotApplicableError extends Error {}
+
+/** Does a parsed turn result carry a draft graph with anything in it? */
+function resultCarriesDraftGraph(result: V5CallResult): boolean {
+  if (result.kind !== 'response') return false
+  const graph = (result.response as { draft_graph?: { nodes?: unknown[] } }).draft_graph
+  return Array.isArray(graph?.nodes) && graph!.nodes!.length > 0
+}
+
+/**
+ * Remove EXACTLY the preview's own elements from the canvas.
+ *
+ * Used when the terminal frame is an error (`status_code >= 400`): the preview
+ * was rendered on the promise of a turn that then failed, so it must not stay.
+ * Filtering by the preview's own ids rather than clearing the canvas is
+ * deliberate — anything the user created in the intervening ~25 s survives.
+ */
+function discardStreamedPreview(preview: { nodes?: unknown[]; edges?: unknown[] }): void {
+  const previewNodeIds = new Set(
+    (preview.nodes ?? [])
+      .map((n) => (typeof n === 'object' && n !== null ? (n as { id?: unknown }).id : undefined))
+      .filter((id): id is string => typeof id === 'string'),
+  )
+  if (previewNodeIds.size === 0) return
+  const state = useCanvasStore.getState()
+  useCanvasStore.setState({
+    nodes: state.nodes.filter((n) => !previewNodeIds.has(n.id)),
+    edges: state.edges.filter((e) => !previewNodeIds.has(e.source) && !previewNodeIds.has(e.target)),
+    lastAuthoritativeGraph: null,
+  })
+}
+
+export interface StreamedDraftTurnResult {
+  /** The SAME shape the buffered path produces. Ingested identically. */
+  result: V5CallResult
+  /**
+   * True when the nodes now on the canvas are this turn's own GRAPH_READY
+   * preview — the signal that lets the terminal ingest take the fresh-draft
+   * branch rather than mistaking its own preview for an applied-edit receipt.
+   */
+  previewOwnsCanvas: boolean
+  /**
+   * True in the one honest-failure case: the stream died after GRAPH_READY, the
+   * buffered fallback found the turn already committed, and CEE declined to
+   * re-draft — so the structure on screen is real and its numbers will never
+   * settle in this session.
+   */
+  unsettled: boolean
+}
+
+/**
+ * Run one cold draft over the streamed sibling, with a transparent fallback.
+ *
+ * ── THE FALLBACK, AND WHY IT IS ONE BUFFERED TURN ON THE SAME PAYLOAD ─────
+ * A stream can die at any point, and #751 established that **the turn keeps
+ * running and still commits when the client hangs up** ("only the frame writes
+ * become no-ops") — deliberately, because aborting mid-turn could leave the
+ * scenario commit half-applied. So a failed stream may or may not have
+ * committed, and the client cannot tell which.
+ *
+ * The buffered route resolves that ambiguity **for us**, because it is already
+ * idempotent for this exact situation. Live-probed read-back control
+ * (`cee2-live-latency.md` §commit semantics): firing the ordinary buffered turn
+ * on a scenario whose graph is already committed makes CEE reload its own
+ * persisted graph and **decline to re-draft**, describing the committed model
+ * ("already drafted with four options…", 200, no `draft_graph`); on a
+ * never-drafted scenario the same request drafts normally (positive control:
+ * a fresh `scenario_id` got "I need a single decision question to start",
+ * `contains_already_drafted: false`). So one buffered POST is simultaneously
+ * "draft if not drafted" and "read back if drafted".
+ *
+ * That is why the fallback re-sends the SAME `build.payload` — same `turn_id`,
+ * same `scenario_id`, no new scenario, no second stream. It is a RE-ENTERED
+ * turn, the shape the product already uses, and CEE's own continuation guard
+ * decides which of the two it is. There is no branch here that can double-commit.
+ *
+ * ── THE THREE OUTCOMES, ALL HONEST ───────────────────────────────────────
+ *  1. fallback DRAFTS (`draft_graph` present) — ordinary end state, identical to
+ *     a buffered cold draft. Provably the only possible outcome when the failure
+ *     preceded GRAPH_READY, because the commit runs *after* the pipeline emits
+ *     that frame, so no-GRAPH_READY implies no-commit.
+ *  2. fallback DECLINES and a preview is on screen — the turn committed. The
+ *     prose the user reads ("already drafted…") matches the graph they can see,
+ *     so nothing contradicts anything; but the numbers are the frame's
+ *     `in_progress` ones. Reported as `unsettled`: the run gate stays shut and
+ *     the caller states the situation plainly. **The alternative — clearing the
+ *     phase and letting the model read as finished — is the fabrication this
+ *     branch exists to refuse.**
+ *  3. fallback DECLINES and no preview — indistinguishable from today's
+ *     "conversational reply to a brief". Nothing new.
+ */
+async function runStreamedDraftTurn(args: {
+  payload: Parameters<typeof callV5Turn>[0]
+  turnClientId: string
+  scenarioIdAtDispatch: string | null
+  headers: Record<string, string>
+  signal: AbortSignal
+}): Promise<StreamedDraftTurnResult> {
+  const { payload, turnClientId, scenarioIdAtDispatch, headers, signal } = args
+  useDraftStore.getState().setDraftStreamPhase('drafting', turnClientId)
+
+  // ⚠ THERE IS DELIBERATELY NO LOCAL `previewRendered` FLAG.
+  //
+  // There was one, and it was a MIRROR of `outcome.renderedGraph` — two
+  // variables tracking one fact, which is trap 12 at function scope. It also
+  // hollowed the render callback's own contract: the consumer records
+  // `renderedGraph` unless the callback THROWS, so with a second flag in play a
+  // mutant that made the scenario guard `return` silently (leaving
+  // `renderedGraph` non-null for a graph that was never drawn) SURVIVED the
+  // battery — the mirror absorbed the inconsistency. `renderedGraph` is now the
+  // single answer to "is one of my previews on the canvas".
+  const fallbackToBuffered = async (
+    reason: string,
+    previewOnCanvas: boolean,
+  ): Promise<StreamedDraftTurnResult> => {
+    if (import.meta.env.DEV) {
+      console.warn(`[sendTurn V5] streamed draft abandoned (${reason}); falling back to the buffered turn`)
+    }
+    const result = await callV5Turn(payload, { signal, headers })
+    const drafted = resultCarriesDraftGraph(result)
+    if (drafted) {
+      // Outcome 1. The buffered body carries the whole graph, so the terminal
+      // ingest replaces whatever the preview put up.
+      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      return { result, previewOwnsCanvas: previewOnCanvas, unsettled: false }
+    }
+    if (previewOnCanvas) {
+      // Outcome 2 — the honest failure. Phase stays non-idle so the run gate
+      // stays shut; `previewOwnsCanvas` is false because there is no graph in
+      // this response to apply over the preview.
+      useDraftStore.getState().setDraftStreamPhase('unsettled', turnClientId)
+      return { result, previewOwnsCanvas: false, unsettled: true }
+    }
+    // Outcome 3.
+    useDraftStore.getState().setDraftStreamPhase('idle', null)
+    return { result, previewOwnsCanvas: false, unsettled: false }
+  }
+
+  let res: Response
+  try {
+    res = await openV5TurnStream(payload, { headers, signal })
+  } catch (e) {
+    // The stream never opened, so nothing ran server-side and nothing committed.
+    if ((e as Error)?.name === 'AbortError' || signal.aborted) {
+      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      throw e
+    }
+    // Nothing streamed, so no preview can exist.
+    return fallbackToBuffered(`open failed: ${(e as Error)?.message ?? 'unknown'}`, false)
+  }
+
+  const outcome = await consumeStreamedDraftTurn(streamStageFrames(res), {
+    onGraphReady: (graph) => {
+      // Scenario guard, same rule the buffered ingest applies: a response whose
+      // scenario is no longer the open one must not write to the canvas.
+      // THROWING (rather than returning) is load-bearing — the consumer records
+      // `renderedGraph: null` only when the callback throws, and a silent return
+      // would leave it believing a graph is on screen when none is.
+      if (useCanvasStore.getState().currentScenarioId !== scenarioIdAtDispatch) {
+        throw new PreviewNotApplicableError('scenario changed during the streamed draft')
+      }
+      // The frame carries no `analysis_ready`, so `applyDraftResult`'s existing
+      // `hasAnalysisReady` gate skips every analysis side-effect: no readiness,
+      // no freshness verdict, no coaching, no quality, no interventions. The
+      // honesty constraint holds by construction of a gate that already existed.
+      applyDraftResult({ nodes: graph.nodes ?? [], edges: graph.edges ?? [] } as never)
+      useDraftStore.getState().setDraftStreamPhase('settling', turnClientId)
+    },
+  })
+
+  if (outcome.kind === 'abandoned') {
+    if (outcome.reason === 'aborted' || signal.aborted) {
+      useDraftStore.getState().setDraftStreamPhase('idle', null)
+      const abort = new Error('streamed draft aborted')
+      abort.name = 'AbortError'
+      throw abort
+    }
+    return fallbackToBuffered(`${outcome.reason}: ${outcome.detail}`, outcome.renderedGraph !== null)
+  }
+
+  // `renderedGraph` is non-null only when the render callback ACCEPTED the frame
+  // — a rejected preview (scenario switched away) must not have its element ids
+  // stripped out of whatever scenario the user moved to.
+  let previewOwnsCanvas = outcome.renderedGraph !== null
+  if (outcome.discardPreview && outcome.renderedGraph) {
+    discardStreamedPreview(outcome.renderedGraph)
+    previewOwnsCanvas = false
+  }
+
+  if (import.meta.env.DEV && outcome.identityDrift) {
+    // Not a failure — the terminal frame is authoritative and the wholesale
+    // replacement below resolves it. Logged because a recurring drift would mean
+    // the server's two projections had come apart, which is worth knowing.
+    console.warn('[sendTurn V5] GRAPH_READY / COMPLETE identity drift:', outcome.identityDrift)
+  }
+
+  // Byte-equivalent terminal ingest: the frame's `payload` IS the buffered body,
+  // so it goes back through the buffered path's own parser.
+  const result = await parseV5Response(
+    streamTransport.terminalPayloadToResponse(outcome.terminalPayload, outcome.statusCode),
+  )
+  useDraftStore.getState().setDraftStreamPhase('idle', null)
+  return { result, previewOwnsCanvas, unsettled: false }
 }
 
 /**
@@ -3711,6 +3970,14 @@ export function useConversation(): UseConversationReturn {
         // user-mode turns, which surface in-transcript and return void.
         let systemSendFailure: SystemEventSendError | null = null
 
+        // ROADMAP 2.122 — set by the streamed path (see below). `…OwnsCanvas`
+        // says "the nodes on the canvas are this turn's own GRAPH_READY
+        // preview", which is what lets the terminal ingest take the fresh-draft
+        // branch instead of mistaking its own preview for an applied-edit
+        // receipt. `…Unsettled` says the values will not settle in this session.
+        let streamedPreviewOwnsCanvas = false
+        let streamedUnsettled = false
+
         try {
           // Resolve session identity once — X-User-Id + Authorization Bearer
           // (login 3.4 UI half) and the post-response graph re-fetch auth
@@ -3718,7 +3985,48 @@ export function useConversation(): UseConversationReturn {
           const v5Identity = await getSessionIdentity()
           const v5UserId = v5Identity.userId
           const v5Headers: Record<string, string> = buildTurnAuthHeaders(v5Identity)
-          const v5Result = await callV5Turn(build.payload, { signal: controller.signal, headers: v5Headers })
+
+          // ═══════════════════════════════════════════════════════════════════
+          // ROADMAP 2.122 / 1.204 M1 — THE STREAMED COLD DRAFT
+          // ═══════════════════════════════════════════════════════════════════
+          //
+          // A cold draft turn goes to the streamed sibling
+          // (`<turn endpoint>/stream`, CEE #751) so the validated graph reaches
+          // the canvas at ~36 s instead of ~55–61 s. Live-measured on deployed
+          // staging (`PHASE0-EVIDENCE-2026-07-28/cee2-live-latency.md`, 3 runs):
+          // DRAFTING 271 ms · GRAPH_READY 35.8 s median (33.7–39.9 s) ·
+          // COACHING_READY 59.2 s · COMPLETE 60.9 s, genuinely streamed through
+          // both Cloudflare and Render, CORS clean, and the turn COMMITS exactly
+          // as the buffered one does.
+          //
+          // Eligibility is deliberately narrow — see `streamedDraftEligible`.
+          //
+          // Everything below the `if` is unchanged: `v5Result` is the SAME
+          // `V5CallResult` shape either way, because the streamed terminal frame
+          // carries the buffered body verbatim and goes back through
+          // `parseV5Response`. No second ingest exists to keep in step.
+          const useStreamedDraft = streamedDraftEligible({
+            turnType: resolvedTurnType,
+            derivedStage,
+            isSystemEvent,
+            nodeCountAtDispatch: canvasSnap.nodes.length,
+          })
+
+          let v5Result: V5CallResult
+          if (useStreamedDraft) {
+            const streamed = await runStreamedDraftTurn({
+              payload: build.payload,
+              turnClientId,
+              scenarioIdAtDispatch: currentScenarioId,
+              headers: v5Headers,
+              signal: controller.signal,
+            })
+            v5Result = streamed.result
+            streamedPreviewOwnsCanvas = streamed.previewOwnsCanvas
+            streamedUnsettled = streamed.unsettled
+          } else {
+            v5Result = await callV5Turn(build.payload, { signal: controller.signal, headers: v5Headers })
+          }
           clearLifecycleTimers()
 
           // Race guard: if the controller was aborted while the fetch was in
@@ -3918,7 +4226,22 @@ export function useConversation(): UseConversationReturn {
             // This ensures draft_graph is applied even if applyV5State didn't emit
             // 'stage:analyse' (e.g. stage was already at analyse, or stage tracking
             // diverged). Works in guest mode — no auth required.
-            const canvasIsEmpty = useCanvasStore.getState().nodes.length === 0
+            // ROADMAP 2.122 — "empty" now means "empty, OR holding only THIS
+            // turn's own GRAPH_READY preview".
+            //
+            // This is the seam the streamed path would have failed silently at.
+            // The emptiness test runs AFTER the await, so with a preview on
+            // screen it reads false and the terminal graph would route into the
+            // applied-edit-receipt branch (`reconcileAppliedGraph`) below.
+            // Reconcile gets the NODES right — and performs none of
+            // `applyDraftResult`'s side-effects: no `setCeeAnalysisReady`, no
+            // `setAnalysisFreshness`, no `commitDraftCoachingToStore`, no
+            // `goal_constraints`, no quality, no pre-analysis sensitivity. The
+            // canvas would look correct while coaching and the run affordance
+            // never unlocked, under a green suite. Pinned by
+            // `streamedDraftTurn.spec.ts`; mutant M2 restores the narrow test.
+            const canvasIsEmpty =
+              useCanvasStore.getState().nodes.length === 0 || streamedPreviewOwnsCanvas
             const scenarioIdAtDispatch = currentScenarioId
             // The helper reads analysis_ready, the response-root
             // goal_constraints (ROADMAP 1.22 residual) and the sidecar-borne
@@ -3939,7 +4262,13 @@ export function useConversation(): UseConversationReturn {
             let draftAppliedThisTurn = false
             if (inlineGraph && inlineNodeCount > 0 && canvasIsEmpty) {
               if (useCanvasStore.getState().currentScenarioId === scenarioIdAtDispatch) {
-                applyDraftResult(inlineGraph as any)
+                // ROADMAP 2.122 — when this apply is RESOLVING this turn's own
+                // GRAPH_READY preview, the preview already pushed the pre-draft
+                // state to history. Pushing again would put the intermediate
+                // preview graph on the undo stack, making undo one step deeper
+                // than the buffered path's. Skipping here leaves the undo stack
+                // identical.
+                applyDraftResult(inlineGraph as any, { skipHistory: streamedPreviewOwnsCanvas })
                 draftAppliedThisTurn = true
                 if (import.meta.env.DEV) {
                   console.log('[sendTurn V5] graph applied from inline response:', inlineNodeCount, 'nodes')
@@ -4145,6 +4474,31 @@ export function useConversation(): UseConversationReturn {
               ...(answerShape ? { answerShape } : {}),
               timestamp: new Date(),
             })
+
+            // ROADMAP 2.122 — the streamed draft's one honest-failure state.
+            //
+            // The stream died after GRAPH_READY, the buffered fallback found the
+            // turn already committed, and CEE declined to re-draft — so the graph
+            // on the canvas is real but its numbers are the frame's `in_progress`
+            // ones and no settled copy will reach this session. CEE's own prose
+            // (which just rendered above) will say the model is already drafted,
+            // and it is; without this notice the user would be left with a
+            // silently-blocked Run button and no explanation for it.
+            //
+            // Says only what is known: the graph is visible, the connection
+            // dropped before the values arrived, drafting again gets them. No
+            // duration forecast, no verdict — held to the same bar as the wait
+            // narration and pinned by `narrationHonesty.invariant.spec.ts`.
+            if (streamedUnsettled) {
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'assistant',
+                synthetic: true,
+                content: UNSETTLED_DRAFT_NOTICE,
+                actionChips: [{ id: 'retry', label: 'Draft again', intent: 'primary' }],
+                timestamp: new Date(),
+              })
+            }
           } else if (target.kind === 'empty') {
             // Blank-response guard: no text, no blocks, no chips from CEE.
             addMessage({
@@ -4301,6 +4655,22 @@ export function useConversation(): UseConversationReturn {
           // effect will set it again; this only removes the one-render lag.
           isThinkingRef.current = false
           useDraftStore.getState().setIsGenerating(false)
+          // ROADMAP 2.122 — every-exit settle for the streamed draft phase
+          // (abort, timeout, thrown dispatch, a `return` from the abort guard).
+          // OWNERSHIP GUARD, same rule as the run slot below: only clear while
+          // this turn still owns the phase, so a preempted turn's late finally
+          // cannot wipe a NEWER draft's `settling`. `unsettled` is deliberately
+          // NOT cleared — it is a terminal state that must outlive its turn,
+          // because the numbers on the canvas stay unsettled until a re-draft.
+          {
+            const draftState = useDraftStore.getState()
+            if (
+              draftState.draftStreamTurnId === turnClientId &&
+              draftState.draftStreamPhase !== 'unsettled'
+            ) {
+              draftState.setDraftStreamPhase('idle', null)
+            }
+          }
           releaseInFlightLockIfOwned()
           // 1.16i: every-exit settle for the analysing state (success
           // without an analysis_result, typed error, thrown error, abort,

--- a/src/canvas/stores/__tests__/draftStreamOwnership.spec.ts
+++ b/src/canvas/stores/__tests__/draftStreamOwnership.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * The streamed draft phase's OWNERSHIP and PERSISTENCE derivations
+ * (ROADMAP 2.122 round 2 — adversarial review F1, F2).
+ *
+ * Both findings came from the same root cause: the phase was a global fact used
+ * as if it were a per-scenario one, and the persistence layer had no idea the
+ * phase existed at all. Both are now single derived reads, and both are enumerated
+ * over the whole phase union here so a clause cannot be dropped in silence — the
+ * lesson the M15/M16 survivors taught in round 1.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  useDraftStore,
+  draftStreamPhaseFor,
+  draftValuesAreUnsettled,
+  shouldPersistGraphForScenario,
+  streamedPreviewStandingFor,
+  type DraftStreamPhase,
+} from '../draftStore'
+
+const A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+const B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb'
+const ALL_PHASES: readonly DraftStreamPhase[] = ['idle', 'drafting', 'settling', 'unsettled']
+
+beforeEach(() => {
+  useDraftStore.getState().resetDraft()
+})
+
+describe('draftValuesAreUnsettled — exhaustive over the union', () => {
+  it('classifies every phase, via a compiler-checked switch', () => {
+    // Adding a phase to DraftStreamPhase without classifying it is a TS error in
+    // the implementation's own switch, so this list cannot silently go stale.
+    const expected: Record<DraftStreamPhase, boolean> = {
+      idle: false,
+      drafting: false,
+      settling: true,
+      unsettled: true,
+    }
+    for (const phase of ALL_PHASES) {
+      expect(draftValuesAreUnsettled(phase)).toBe(expected[phase])
+    }
+  })
+
+  it('`drafting` is NOT unsettled — nothing is on the canvas yet to be wrong about', () => {
+    // The distinction that keeps the rung from being a blanket "any streamed turn
+    // blocks everything": before GRAPH_READY there is no graph to misrepresent.
+    expect(draftValuesAreUnsettled('drafting')).toBe(false)
+  })
+})
+
+describe('draftStreamPhaseFor — F2, the scenario boundary', () => {
+  it('reports the phase to its OWNING scenario', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    expect(draftStreamPhaseFor(useDraftStore.getState(), A)).toBe('settling')
+  })
+
+  it('reports `idle` to every OTHER scenario — for every phase', () => {
+    // The review's probe: an `unsettled` draft on A blocked Run on B with the
+    // false reason "your model is still being drafted", about a model B never had.
+    for (const phase of ALL_PHASES) {
+      useDraftStore.getState().setDraftStreamPhase(phase, 't1', A)
+      expect(draftStreamPhaseFor(useDraftStore.getState(), B)).toBe('idle')
+    }
+  })
+
+  it('reports `idle` when no scenario owns the phase', () => {
+    // Only reachable from a hand-built store state. Fail-OPEN is correct: the
+    // alternative is blocking every scenario forever on unattributable state,
+    // which is precisely the defect F2 named.
+    useDraftStore.setState({ draftStreamPhase: 'unsettled', draftStreamScenarioId: null } as never)
+    expect(draftStreamPhaseFor(useDraftStore.getState(), A)).toBe('idle')
+    expect(draftStreamPhaseFor(useDraftStore.getState(), null)).toBe('idle')
+  })
+
+  it('releasing to `idle` drops the ownership keys, so nothing can be attributed later', () => {
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', A)
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(useDraftStore.getState().draftStreamScenarioId).toBeNull()
+    expect(useDraftStore.getState().draftStreamTurnId).toBeNull()
+    expect(draftStreamPhaseFor(useDraftStore.getState(), A)).toBe('idle')
+  })
+
+  it('a newer turn on the SAME scenario takes ownership', () => {
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', A)
+    useDraftStore.getState().setDraftStreamPhase('drafting', 't2', A)
+    expect(draftStreamPhaseFor(useDraftStore.getState(), A)).toBe('drafting')
+    expect(useDraftStore.getState().draftStreamTurnId).toBe('t2')
+  })
+})
+
+describe('shouldPersistGraphForScenario — F1, the autosave bound', () => {
+  it('REFUSES the write for every phase whose values are in progress', () => {
+    for (const phase of ALL_PHASES) {
+      useDraftStore.getState().setDraftStreamPhase(phase, 't1', A)
+      expect(shouldPersistGraphForScenario(A)).toBe(!draftValuesAreUnsettled(phase))
+    }
+  })
+
+  it('is derived from the SAME two functions the run gate uses', () => {
+    // Not an independent re-statement of the rule. If these ever disagree, one of
+    // them is a mirror and the gate and the writer will drift.
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', A)
+    const phase = draftStreamPhaseFor(useDraftStore.getState(), A)
+    expect(shouldPersistGraphForScenario(A)).toBe(!draftValuesAreUnsettled(phase))
+  })
+
+  it('permits writes for a DIFFERENT scenario — the suppression is scoped too', () => {
+    // Otherwise one unsettled draft would freeze persistence for the whole app,
+    // which is F2's defect wearing a different hat.
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', A)
+    expect(shouldPersistGraphForScenario(B)).toBe(true)
+  })
+
+  it('permits writes again the moment the draft settles — not a one-way door', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    expect(shouldPersistGraphForScenario(A)).toBe(false)
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(shouldPersistGraphForScenario(A)).toBe(true)
+  })
+
+  it('permits writes when no streamed draft has ever run (every other caller)', () => {
+    // Positive control on the whole guard: a pristine store must not suppress
+    // persistence, or the feature would silently break saving for everyone.
+    expect(shouldPersistGraphForScenario(A)).toBe(true)
+    expect(shouldPersistGraphForScenario(null)).toBe(true)
+  })
+})
+
+describe('streamedPreviewStandingFor — F1 adjacent, the 130 s timeout copy', () => {
+  it('true only for the OWNING turn, on the OWNING scenario, while settling', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    const st = useDraftStore.getState()
+    expect(streamedPreviewStandingFor(st, 't1', A)).toBe(true)
+    // A different turn's timeout must not suppress its own honest copy.
+    expect(streamedPreviewStandingFor(st, 't2', A)).toBe(false)
+    // A different scenario's timeout likewise.
+    expect(streamedPreviewStandingFor(st, 't1', B)).toBe(false)
+  })
+
+  it('false in every phase except settling', () => {
+    // `drafting` is the one that matters: nothing is on the canvas yet, so the
+    // generic "your message has not gone through" copy is TRUE there and must be
+    // allowed to render. Suppressing it would be its own dishonesty.
+    for (const phase of ALL_PHASES) {
+      useDraftStore.getState().setDraftStreamPhase(phase, 't1', A)
+      expect(streamedPreviewStandingFor(useDraftStore.getState(), 't1', A)).toBe(
+        phase === 'settling',
+      )
+    }
+  })
+
+  it('false on a pristine store — a non-streamed turn keeps its normal timeout copy', () => {
+    expect(streamedPreviewStandingFor(useDraftStore.getState(), 't1', A)).toBe(false)
+  })
+})

--- a/src/canvas/stores/draftStore.ts
+++ b/src/canvas/stores/draftStore.ts
@@ -45,12 +45,26 @@ export interface DraftErrorState {
  *                 final and coaching has not arrived. Every claim-bearing
  *                 affordance must stay shut in this phase — see
  *                 `canRunAnalysis`'s `draftValuesSettling` rung.
- *   `unsettled` — terminal, and the honest failure state. The stream died after
- *                 GRAPH_READY and the buffered fallback found the turn already
- *                 committed, so CEE declined to re-draft: the structure on
- *                 screen is real, its numbers are the in-progress ones, and
- *                 this session will not receive the settled set. Narrating
- *                 anything else would be a fabrication.
+ *   `unsettled` — terminal, and the honest failure state. Drafting ended after
+ *                 GRAPH_READY without a terminal ingest — the stream died and
+ *                 the buffered fallback found the turn already committed, or the
+ *                 user pressed Stop, or the 130 s client timeout fired. The
+ *                 structure on screen is real, its numbers are the in-progress
+ *                 ones, and this session will not receive the settled set.
+ *                 Narrating anything else would be a fabrication.
+ *
+ * ⚠ THE PHASE IS SCOPED TO THE SCENARIO THAT OWNS IT (adversarial review F2).
+ * It used to be global and, because `unsettled` is deliberately terminal, it was
+ * never cleared — so an unsettled draft on scenario A blocked Run on EVERY other
+ * scenario, with the false reason "your model is still being drafted" about a
+ * model that was never streamed. Recovery was a page reload.
+ *
+ * The fix is a DERIVATION, not a clear-on-boundary list: `draftStreamScenarioId`
+ * records the owner and `draftStreamPhaseFor` reports `idle` for anybody else. A
+ * list of boundaries to clear at would be a hand-maintained mirror of the set of
+ * ways a scenario can change (trap 12) — and the review found the existing
+ * `resetDraft` was exactly that mirror, with a doc comment claiming a caller it
+ * does not have.
  */
 export type DraftStreamPhase = 'idle' | 'drafting' | 'settling' | 'unsettled'
 
@@ -76,6 +90,12 @@ export interface DraftState {
    * `useConversation`'s two-phase apply).
    */
   draftStreamTurnId: string | null
+  /**
+   * The scenario the phase belongs to (review F2). Never read directly by a
+   * consumer — read through `draftStreamPhaseFor`, which is the one place that
+   * decides whether a phase is any of the current scenario's business.
+   */
+  draftStreamScenarioId: string | null
 }
 
 export interface DraftActions {
@@ -91,11 +111,27 @@ export interface DraftActions {
   setLastDraftError: (error: DraftErrorState | null) => void
   setFullDraftAppliedAt: (ts: number) => void
   /**
-   * Move the streamed draft's phase. `turnId` is the owning `client_turn_id`;
-   * pass `null` alongside `'idle'` to release ownership.
+   * Move the streamed draft's phase. `turnId` is the owning `client_turn_id` and
+   * `scenarioId` the owning scenario; pass `null` for both alongside `'idle'` to
+   * release ownership.
    */
-  setDraftStreamPhase: (phase: DraftStreamPhase, turnId: string | null) => void
-  /** Reset every field to initial values. Called from canvas-store resetCanvas. */
+  setDraftStreamPhase: (
+    phase: DraftStreamPhase,
+    turnId: string | null,
+    scenarioId: string | null,
+  ) => void
+  /**
+   * Reset every field to initial values.
+   *
+   * ⚠ THE DOC COMMENT HERE USED TO CLAIM "Called from canvas-store resetCanvas".
+   * It is not, and never was — this function has ZERO production callers
+   * (established by the adversarial review's complete call-site manifest). That
+   * false claim is trap 14 on precisely the surface trap 14 is about: an honest
+   * label ("unused") overwritten by a reassuring one, which then taught readers —
+   * including me — that the scenario boundary was already handled. It is not
+   * handled by a reset at all; ownership is DERIVED, see `draftStreamPhaseFor`.
+   * Kept because the tests use it, and named honestly.
+   */
   resetDraft: () => void
 }
 
@@ -109,6 +145,7 @@ const initialDraftState: DraftState = {
   fullDraftAppliedAt: null,
   draftStreamPhase: 'idle',
   draftStreamTurnId: null,
+  draftStreamScenarioId: null,
 }
 
 export const useDraftStore = create<DraftState & DraftActions>((set) => ({
@@ -167,11 +204,114 @@ export const useDraftStore = create<DraftState & DraftActions>((set) => ({
     set({ fullDraftAppliedAt: ts })
   },
 
-  setDraftStreamPhase: (phase, turnId) => {
-    set({ draftStreamPhase: phase, draftStreamTurnId: phase === 'idle' ? null : turnId })
+  setDraftStreamPhase: (phase, turnId, scenarioId) => {
+    set({
+      draftStreamPhase: phase,
+      draftStreamTurnId: phase === 'idle' ? null : turnId,
+      draftStreamScenarioId: phase === 'idle' ? null : scenarioId,
+    })
   },
 
   resetDraft: () => {
     set(initialDraftState)
   },
 }))
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.122 round 2 — the two derived reads (adversarial review F1, F2)
+// ---------------------------------------------------------------------------
+
+/**
+ * The streamed draft phase, **but only when it belongs to `currentScenarioId`**.
+ *
+ * This is the single place that decides whether a phase is any of a scenario's
+ * business, and every consumer goes through it — the run gate (both surfaces) and
+ * the graph-persistence choke point. Review F2 found the ungated read blocking
+ * every other scenario with a false claim; the earlier M15/M16 survivors found
+ * that re-deriving a rule at each call site is how a clause gets silently
+ * dropped. One function, exhaustively tested, no mirror.
+ *
+ * An `unsettled` phase with no owning scenario recorded (only reachable from a
+ * hand-constructed store state) reports `idle`: fail-OPEN is correct here because
+ * the alternative is blocking every scenario forever on unattributable state,
+ * which is the exact defect F2 named.
+ */
+export function draftStreamPhaseFor(
+  state: Pick<DraftState, 'draftStreamPhase' | 'draftStreamScenarioId'>,
+  currentScenarioId: string | null,
+): DraftStreamPhase {
+  if (state.draftStreamScenarioId === null) return 'idle'
+  return state.draftStreamScenarioId === currentScenarioId ? state.draftStreamPhase : 'idle'
+}
+
+/**
+ * The phases in which a streamed draft's numbers are NOT settled, so nothing may
+ * treat the graph as final. Derived from the union rather than restated, so a new
+ * phase has to be classified here rather than defaulting to "settled".
+ */
+export function draftValuesAreUnsettled(phase: DraftStreamPhase): boolean {
+  switch (phase) {
+    case 'settling':
+    case 'unsettled':
+      return true
+    case 'idle':
+    case 'drafting':
+      return false
+  }
+}
+
+/**
+ * May the UI persist `scenarios.graph` for this scenario right now?
+ *
+ * **NO while its streamed draft's values are in progress** (review F1).
+ *
+ * The review VOIDED rowed item 9's premise for the abort path: with no terminal
+ * ingest the unsettled values persist indefinitely, and the next canvas edit's
+ * debounced echo save — which re-reads the store at fire time — writes the
+ * unsettled graph back OVER CEE's settled commit.
+ *
+ * This answers the "never a stranded unsettled row" requirement more strongly
+ * than the bound the row claimed, and more safely than reverting the canvas
+ * would: **the UI simply never writes a graph whose values it knows are
+ * in-progress**, so there is no unsettled row to strand and no window in which a
+ * later echo save can carry one. Reverting instead would risk writing an EMPTY
+ * graph over CEE's committed one (the 130 s timeout case writes after the ~61 s
+ * commit) — trading a fabrication for data loss.
+ *
+ * Consumed at `hooks/useScenario.ts`'s `persistGraphNow`, which its own header
+ * declares is the ONE write code path shared by the debounced autosave, its retry
+ * and the flush barrier — so this is a single derived choke point, not a list of
+ * call sites to keep in step.
+ *
+ * Layout is not lost by this: the terminal apply fires a normal save with the
+ * settled graph. In the `unsettled` case the DB keeps CEE's own committed graph,
+ * which is the same position-free shape every AI edit already reloads from.
+ */
+export function shouldPersistGraphForScenario(currentScenarioId: string | null): boolean {
+  const phase = draftStreamPhaseFor(useDraftStore.getState(), currentScenarioId)
+  return !draftValuesAreUnsettled(phase)
+}
+
+/**
+ * Is a streamed GRAPH_READY preview from THIS turn currently standing on THIS
+ * scenario's canvas? (review F1, adjacent finding.)
+ *
+ * Consumed by the 130 s timeout handler, which must not tell the user "your
+ * message has not gone through" when it demonstrably did: the server produced and
+ * validated a graph, the client rendered it, and per #751 the turn continues and
+ * commits. The generic timeout copy, the `deliveryState: 'failed'` marker and the
+ * timeout send-failure are all false in that state, and would contradict the
+ * honest notice the abort path is about to add.
+ *
+ * Extracted rather than inlined so the decision is testable at all — the timeout
+ * itself is a 130 s wall-clock branch, which is exactly the kind of code that
+ * ships untested and rots.
+ */
+export function streamedPreviewStandingFor(
+  state: Pick<DraftState, 'draftStreamPhase' | 'draftStreamScenarioId' | 'draftStreamTurnId'>,
+  turnClientId: string,
+  currentScenarioId: string | null,
+): boolean {
+  if (state.draftStreamTurnId !== turnClientId) return false
+  return draftStreamPhaseFor(state, currentScenarioId) === 'settling'
+}

--- a/src/canvas/stores/draftStore.ts
+++ b/src/canvas/stores/draftStore.ts
@@ -30,6 +30,30 @@ export interface DraftErrorState {
   code?: string
 }
 
+/**
+ * Where a STREAMED draft turn currently is (ROADMAP 2.122 / 1.204 M1).
+ *
+ * Only ever non-`idle` on the streamed path — the buffered turn has no phase
+ * to report, which is the whole reason 2.122 exists.
+ *
+ *   `drafting`  — the turn is open, DRAFTING acknowledged, no graph yet. The
+ *                 client holds one frame and elapsed time (PROGRESS frames are
+ *                 measured-ABSENT on the wire), so narration stays
+ *                 elapsed-time-only here.
+ *   `settling`  — GRAPH_READY has landed and the structure is on the canvas,
+ *                 but the frame is `status: in_progress`: its NUMBERS are not
+ *                 final and coaching has not arrived. Every claim-bearing
+ *                 affordance must stay shut in this phase — see
+ *                 `canRunAnalysis`'s `draftValuesSettling` rung.
+ *   `unsettled` — terminal, and the honest failure state. The stream died after
+ *                 GRAPH_READY and the buffered fallback found the turn already
+ *                 committed, so CEE declined to re-draft: the structure on
+ *                 screen is real, its numbers are the in-progress ones, and
+ *                 this session will not receive the settled set. Narrating
+ *                 anything else would be a fabrication.
+ */
+export type DraftStreamPhase = 'idle' | 'drafting' | 'settling' | 'unsettled'
+
 export interface DraftState {
   /** Null = use default model. Session-only, not persisted. */
   selectedGenerationModel: string | null
@@ -43,6 +67,15 @@ export interface DraftState {
   lastDraftError: DraftErrorState | null
   /** Task 2: Signal for AI panel auto-collapse. Set when a full_draft auto_apply patch is applied. */
   fullDraftAppliedAt: number | null
+  /** ROADMAP 2.122 — the streamed draft turn's phase. See DraftStreamPhase. */
+  draftStreamPhase: DraftStreamPhase
+  /**
+   * The `client_turn_id` that owns `draftStreamPhase`. Load-bearing: a stale
+   * turn's frames must never move a newer turn's phase, and the COMPLETE ingest
+   * uses this to recognise ITS OWN GRAPH_READY preview on the canvas (see
+   * `useConversation`'s two-phase apply).
+   */
+  draftStreamTurnId: string | null
 }
 
 export interface DraftActions {
@@ -57,6 +90,11 @@ export interface DraftActions {
   setLastDraftDescription: (description: string) => void
   setLastDraftError: (error: DraftErrorState | null) => void
   setFullDraftAppliedAt: (ts: number) => void
+  /**
+   * Move the streamed draft's phase. `turnId` is the owning `client_turn_id`;
+   * pass `null` alongside `'idle'` to release ownership.
+   */
+  setDraftStreamPhase: (phase: DraftStreamPhase, turnId: string | null) => void
   /** Reset every field to initial values. Called from canvas-store resetCanvas. */
   resetDraft: () => void
 }
@@ -69,6 +107,8 @@ const initialDraftState: DraftState = {
   lastDraftDescription: '',
   lastDraftError: null,
   fullDraftAppliedAt: null,
+  draftStreamPhase: 'idle',
+  draftStreamTurnId: null,
 }
 
 export const useDraftStore = create<DraftState & DraftActions>((set) => ({
@@ -125,6 +165,10 @@ export const useDraftStore = create<DraftState & DraftActions>((set) => ({
 
   setFullDraftAppliedAt: (ts) => {
     set({ fullDraftAppliedAt: ts })
+  },
+
+  setDraftStreamPhase: (phase, turnId) => {
+    set({ draftStreamPhase: phase, draftStreamTurnId: phase === 'idle' ? null : turnId })
   },
 
   resetDraft: () => {

--- a/src/canvas/utils/__tests__/canRunAnalysis.draftStreamPhase.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.draftStreamPhase.spec.ts
@@ -9,7 +9,11 @@
  */
 import { describe, it, expect } from 'vitest'
 
-import { canRunAnalysis, DRAFT_VALUES_SETTLING_REFUSAL } from '../canRunAnalysis'
+import {
+  canRunAnalysis,
+  DRAFT_VALUES_SETTLING_REFUSAL,
+  DRAFT_VALUES_UNSETTLED_REFUSAL,
+} from '../canRunAnalysis'
 import type { DraftStreamPhase } from '../../stores/draftStore'
 
 /** A graph that would otherwise pass the gate's structural rungs. */
@@ -21,25 +25,48 @@ const OPEN_GATE_INPUTS = {
 } as const
 
 const ALL_PHASES: readonly DraftStreamPhase[] = ['idle', 'drafting', 'settling', 'unsettled']
-const MUST_BLOCK: readonly DraftStreamPhase[] = ['settling', 'unsettled']
+
+/**
+ * The blocking phases AND the sentence each must produce.
+ *
+ * ⚠ These used to share one string, and adversarial review F5 found that in the
+ * TERMINAL `unsettled` state its closing clause — "Run analysis once drafting
+ * finishes" — forecasts a finish that will never come, contradicting the
+ * transcript notice beside it. Same block, two different truths.
+ */
+const MUST_BLOCK: ReadonlyArray<readonly [DraftStreamPhase, string]> = [
+  ['settling', DRAFT_VALUES_SETTLING_REFUSAL],
+  ['unsettled', DRAFT_VALUES_UNSETTLED_REFUSAL],
+]
+const BLOCKING_PHASES = MUST_BLOCK.map(([p]) => p)
 
 describe('canRunAnalysis — draftStreamPhase rung, exhaustive', () => {
-  it.each(MUST_BLOCK)('BLOCKS on phase "%s", with the honest reason', (phase) => {
+  it.each(MUST_BLOCK)('BLOCKS on phase "%s" with its OWN honest reason', (phase, reason) => {
     const r = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: phase })
     expect(r.allowed).toBe(false)
-    expect(r.reason).toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    expect(r.reason).toBe(reason)
   })
 
-  it.each(ALL_PHASES.filter((p) => !MUST_BLOCK.includes(p)))(
+  it('the two blocking phases do not share a sentence (F5)', () => {
+    const reasons = MUST_BLOCK.map(([phase]) =>
+      canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: phase }).reason,
+    )
+    expect(new Set(reasons).size).toBe(reasons.length)
+  })
+
+  it.each(ALL_PHASES.filter((p) => !BLOCKING_PHASES.includes(p)))(
     'does NOT block on phase "%s" — the rung is not a blanket refusal',
     (phase) => {
       const r = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: phase })
       expect(r.reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+      expect(r.reason).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
     },
   )
 
   it('defaults to not-blocking when the phase is omitted (every other caller)', () => {
-    expect(canRunAnalysis(OPEN_GATE_INPUTS).reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    const r = canRunAnalysis(OPEN_GATE_INPUTS)
+    expect(r.reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    expect(r.reason).not.toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
   })
 
   it('enumerates the WHOLE phase union — a new phase must be classified here', () => {
@@ -56,10 +83,13 @@ describe('canRunAnalysis — draftStreamPhase rung, exhaustive', () => {
           return 'allow'
       }
     }
+    const blockingReasons = new Set<string>([
+      DRAFT_VALUES_SETTLING_REFUSAL,
+      DRAFT_VALUES_UNSETTLED_REFUSAL,
+    ])
     for (const p of ALL_PHASES) {
-      const blocked = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: p }).reason ===
-        DRAFT_VALUES_SETTLING_REFUSAL
-      expect(blocked).toBe(classify(p) === 'block')
+      const reason = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: p }).reason
+      expect(blockingReasons.has(reason ?? '')).toBe(classify(p) === 'block')
     }
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.draftStreamPhase.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.draftStreamPhase.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * The streamed-draft honesty rung on the run gate (ROADMAP 2.122).
+ *
+ * Exhaustive over `DraftStreamPhase`, deliberately: the rung was ORIGINALLY a
+ * boolean the caller derived, and a mutation that dropped `'unsettled'` from
+ * that derivation survived the mutation battery because no test drove the
+ * caller's copy. The phase now reaches the gate raw, and this spec enumerates
+ * every phase so a clause cannot be dropped in silence.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { canRunAnalysis, DRAFT_VALUES_SETTLING_REFUSAL } from '../canRunAnalysis'
+import type { DraftStreamPhase } from '../../stores/draftStore'
+
+/** A graph that would otherwise pass the gate's structural rungs. */
+const OPEN_GATE_INPUTS = {
+  graphHealth: null,
+  readiness: null,
+  hasBlockers: false,
+  nodeCount: 5,
+} as const
+
+const ALL_PHASES: readonly DraftStreamPhase[] = ['idle', 'drafting', 'settling', 'unsettled']
+const MUST_BLOCK: readonly DraftStreamPhase[] = ['settling', 'unsettled']
+
+describe('canRunAnalysis — draftStreamPhase rung, exhaustive', () => {
+  it.each(MUST_BLOCK)('BLOCKS on phase "%s", with the honest reason', (phase) => {
+    const r = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: phase })
+    expect(r.allowed).toBe(false)
+    expect(r.reason).toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+  })
+
+  it.each(ALL_PHASES.filter((p) => !MUST_BLOCK.includes(p)))(
+    'does NOT block on phase "%s" — the rung is not a blanket refusal',
+    (phase) => {
+      const r = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: phase })
+      expect(r.reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+    },
+  )
+
+  it('defaults to not-blocking when the phase is omitted (every other caller)', () => {
+    expect(canRunAnalysis(OPEN_GATE_INPUTS).reason).not.toBe(DRAFT_VALUES_SETTLING_REFUSAL)
+  })
+
+  it('enumerates the WHOLE phase union — a new phase must be classified here', () => {
+    // Derived from the type via an exhaustive switch: adding a phase to
+    // DraftStreamPhase without adding it below is a compile error, so this list
+    // cannot silently go stale (trap 12).
+    const classify = (p: DraftStreamPhase): 'block' | 'allow' => {
+      switch (p) {
+        case 'settling':
+        case 'unsettled':
+          return 'block'
+        case 'idle':
+        case 'drafting':
+          return 'allow'
+      }
+    }
+    for (const p of ALL_PHASES) {
+      const blocked = canRunAnalysis({ ...OPEN_GATE_INPUTS, draftStreamPhase: p }).reason ===
+        DRAFT_VALUES_SETTLING_REFUSAL
+      expect(blocked).toBe(classify(p) === 'block')
+    }
+  })
+})

--- a/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
+++ b/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
@@ -203,6 +203,23 @@ describe('the graph-write choke point consumes the persistence predicate (review
     expect(body).toMatch(/if\s*\(\s*!shouldPersistGraphForScenario\(/)
   })
 
+  it('reports whether it wrote, and the save indicator gates on that (R2-N1)', () => {
+    // A suppressed no-op used to resolve indistinguishably from a real write, so
+    // the caller ran setSaveStatus('saved') + a timestamp for a write that
+    // deliberately did not happen. Cosmetic during the 25 s window; during a
+    // terminal `unsettled` state a signed-in user sees "saved" on every edit
+    // while nothing persists, then loses all of it on reload. A false indicator
+    // is the honesty class this whole lane polices.
+    expect(source).toMatch(/async function persistGraphNow\([^)]*\):\s*Promise<boolean>/)
+    // Both status-setting call sites must gate on the returned flag.
+    const gated = source.match(/const (?:wrote|retryWrote) = await/g) ?? []
+    expect(gated.length).toBe(2)
+    expect(source).toMatch(/mountedRef\.current && wrote/)
+    expect(source).toMatch(/mountedRef\.current && retryWrote/)
+    // …and no ungated "saved" write survives.
+    expect(source).not.toMatch(/await p\n\s*if \(mountedRef\.current\) \{\n\s*setSaveStatus\('saved'\)/)
+  })
+
   it('still calls the real write when permitted (positive control)', () => {
     // A mutation that suppressed every write would also satisfy the assertions
     // above; this keeps the guard from blessing a broken save path.

--- a/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
+++ b/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * DERIVED guard: every run-gate call site feeds the streamed-draft honesty rung
+ * (ROADMAP 2.122).
+ *
+ * ── WHY THIS EXISTS, AND WHY IT IS SHAPED THIS WAY ───────────────────────
+ * The mutation battery for this lane produced a survivor: removing
+ * `draftStreamPhase` from `OutputsDock`'s `canRunAnalysis(...)` call stayed
+ * GREEN. Nothing tested the wiring line — the gate's own logic is well covered
+ * (`canRunAnalysis.draftStreamPhase.spec.ts`, exhaustive over the phase union),
+ * but a gate nobody feeds is a gate that never fires. That is the
+ * guarantee-theatre shape: correct machinery, never executed.
+ *
+ * Two ways to close it were considered and rejected:
+ *
+ *   - **make the param REQUIRED.** A compile error is the loudest alarm there
+ *     is, but `canRunAnalysis` has 52 test call sites and forcing all of them to
+ *     name a phase would be pure noise around a two-caller change.
+ *   - **mount the components.** `OutputsDock` is ~2,500 lines with a large
+ *     dependency graph; a render test would cover ONE surface and would have to
+ *     be duplicated for the next one.
+ *
+ * This guard instead DERIVES the call-site manifest from the source at test
+ * time. It therefore covers a THIRD run surface added tomorrow, which neither
+ * alternative does, and it cannot go stale the way a hand-listed set of files
+ * would (trap 12): the file list is a grep result, not a literal.
+ *
+ * Its honest limit, stated: this is a STRUCTURAL check on source text. It proves
+ * the argument is passed, not that the value passed is the live store value. The
+ * end-to-end behaviour is pinned separately by `streamedDraftTurn.spec.ts`,
+ * which drives the real store through a real streamed turn.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+const SRC = join(process.cwd(), 'src')
+
+/** Every `.ts`/`.tsx` file under `src/`, tests and stories excluded. */
+function productionSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      productionSources(full, out)
+    } else if (/\.tsx?$/.test(entry) && !/\.(spec|test|stories)\.tsx?$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * Find every invocation of the run gate and return its argument-object text.
+ *
+ * Matches the local alias too (`canRunAnalysisUtil`), because both live callers
+ * import it under that name — a matcher that only knew the exported name would
+ * find zero call sites and this whole spec would pass by testing nothing.
+ */
+function runGateCallSites(): Array<{ file: string; args: string }> {
+  const found: Array<{ file: string; args: string }> = []
+  const pattern = /\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g
+  for (const file of productionSources(SRC)) {
+    const text = readFileSync(file, 'utf8')
+    // The gate's own module defines and documents it; it is not a call site.
+    if (file.endsWith(join('canvas', 'utils', 'canRunAnalysis.ts'))) continue
+    let m: RegExpExecArray | null
+    while ((m = pattern.exec(text)) !== null) {
+      // Walk braces from the opening `{` to capture the whole argument object.
+      let depth = 1
+      let i = m.index + m[0].length
+      while (i < text.length && depth > 0) {
+        if (text[i] === '{') depth++
+        else if (text[i] === '}') depth--
+        i++
+      }
+      found.push({ file: relative(SRC, file), args: text.slice(m.index, i) })
+    }
+  }
+  return found
+}
+
+const CALL_SITES = runGateCallSites()
+
+describe('run-gate call sites — derived manifest', () => {
+  it('finds the call sites at all (trap 13: prove the matcher sees a presence)', () => {
+    // If this ever drops to zero, every assertion below becomes vacuous. It is
+    // the first test in the file for exactly that reason.
+    expect(CALL_SITES.length).toBeGreaterThan(0)
+    // And the manifest is reported by name, so a reviewer can see what was
+    // actually covered rather than trusting a count.
+    expect(CALL_SITES.map((c) => c.file).sort()).toEqual([
+      'canvas/components/OutputsDock.tsx',
+      'canvas/conversation/ConversationPanel.tsx',
+    ])
+  })
+
+  it.each(CALL_SITES.map((c) => [c.file, c] as const))(
+    '%s feeds the gate its draftStreamPhase',
+    (_file, site) => {
+      // ROADMAP 2.122: a run affordance that does not tell the gate about the
+      // streamed draft's phase will hand the user a live Run button at ~36 s,
+      // over values CEE is about to change and a scenario it has not committed.
+      expect(site.args).toMatch(/\bdraftStreamPhase\b/)
+    },
+  )
+
+  it('the matcher would CATCH a call site that omitted it (positive control)', () => {
+    const withoutIt = `canRunAnalysisUtil({
+      graphHealth: null,
+      readiness,
+      hasBlockers,
+      nodeCount,
+    })`
+    expect(/\bdraftStreamPhase\b/.test(withoutIt)).toBe(false)
+  })
+
+  it('the matcher recognises the aliased import name, not just the exported one', () => {
+    // Both live callers import the gate as `canRunAnalysisUtil`. A pattern that
+    // only matched `canRunAnalysis(` would find nothing and the suite would be
+    // decorative.
+    expect(CALL_SITES.every((c) => /canRunAnalysis(?:Util)?\s*\(\s*\{/.test(c.args))).toBe(true)
+    expect(CALL_SITES.some((c) => c.args.startsWith('canRunAnalysisUtil'))).toBe(true)
+  })
+})

--- a/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
+++ b/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
@@ -115,11 +115,99 @@ describe('run-gate call sites — derived manifest', () => {
     expect(/\bdraftStreamPhase\b/.test(withoutIt)).toBe(false)
   })
 
+  it.each(CALL_SITES.map((c) => [c.file, c] as const))(
+    '%s scopes the phase to the open scenario (review F2)',
+    (_file, site) => {
+      // Passing the RAW store field would re-create F2: an unsettled draft on one
+      // scenario blocked Run on every other, with a false reason. The phase must
+      // arrive through `draftStreamPhaseFor`, which is the one place that decides
+      // ownership. A structural check, like its sibling above — the behaviour is
+      // pinned in `draftStreamOwnership.spec.ts` and `streamedDraftTurn.spec.ts`.
+      const source = readFileSync(join(SRC, site.file), 'utf8')
+      expect(source).toMatch(/draftStreamPhaseFor\s*\(/)
+      // …and NOT the unscoped read that caused the finding.
+      expect(source).not.toMatch(/useDraftStore\(\s*\(s\)\s*=>\s*s\.draftStreamPhase\s*\)/)
+    },
+  )
+
+  it('the F2 matcher would CATCH an unscoped read (positive control)', () => {
+    const unscoped = 'const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)'
+    expect(/useDraftStore\(\s*\(s\)\s*=>\s*s\.draftStreamPhase\s*\)/.test(unscoped)).toBe(true)
+    const scoped = 'const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, sid))'
+    expect(/useDraftStore\(\s*\(s\)\s*=>\s*s\.draftStreamPhase\s*\)/.test(scoped)).toBe(false)
+    expect(/draftStreamPhaseFor\s*\(/.test(scoped)).toBe(true)
+  })
+
   it('the matcher recognises the aliased import name, not just the exported one', () => {
     // Both live callers import the gate as `canRunAnalysisUtil`. A pattern that
     // only matched `canRunAnalysis(` would find nothing and the suite would be
     // decorative.
     expect(CALL_SITES.every((c) => /canRunAnalysis(?:Util)?\s*\(\s*\{/.test(c.args))).toBe(true)
     expect(CALL_SITES.some((c) => c.args.startsWith('canRunAnalysisUtil'))).toBe(true)
+  })
+})
+
+describe('the 130 s timeout handler consumes the preview predicate (review F1, adjacent)', () => {
+  /**
+   * Structural, and for the same reason as the run-gate guard above: the timeout is
+   * a 130-second wall-clock branch, which is exactly the code that ships untested.
+   * The DECISION it makes is pinned exhaustively in
+   * `stores/__tests__/draftStreamOwnership.spec.ts`; this asserts the branch
+   * actually asks.
+   *
+   * Without it, the handler tells a user whose graph is visibly on the canvas that
+   * "your message has not gone through" — and marks the delivered bubble failed —
+   * directly contradicting the honest notice the abort path adds beside it.
+   */
+  const source = readFileSync(join(SRC, 'canvas/conversation/useConversation.ts'), 'utf8')
+
+  it('asks streamedPreviewStandingFor before rendering the generic timeout copy', () => {
+    expect(source).toMatch(/streamedPreviewStandingFor\(/)
+    // The generic copy must be gated on it.
+    expect(source).toMatch(/!streamedPreviewStanding/)
+  })
+
+  it('still contains the generic copy — the fix suppresses it, it does not delete it', () => {
+    // Positive control: a non-streamed turn's timeout must keep saying the true
+    // thing. A mutation that removed the copy entirely would be a different defect.
+    expect(source).toMatch(/your message has not gone through/i)
+  })
+})
+
+describe('the graph-write choke point consumes the persistence predicate (review F1)', () => {
+  /**
+   * ⚠ ADDED BECAUSE A MUTANT SURVIVED. Removing the `shouldPersistGraphForScenario`
+   * guard from `persistGraphNow` stayed GREEN: the DECISION is pinned exhaustively
+   * in `stores/__tests__/draftStreamOwnership.spec.ts`, but nothing asserted the
+   * writer asks. That is the third time in this lane a correct, well-tested rule
+   * turned out to have an unwired consumer — the same shape as M15/M16 in round 1.
+   *
+   * Structural, deliberately: driving a real Supabase write through the debounced
+   * autosave in jsdom would test the harness, not the rule. The behaviour that
+   * matters (which phases suppress) is pinned at the predicate.
+   */
+  const source = readFileSync(join(SRC, 'hooks/useScenario.ts'), 'utf8')
+
+  it('asks shouldPersistGraphForScenario before writing scenarios.graph', () => {
+    expect(source).toMatch(/shouldPersistGraphForScenario\(/)
+  })
+
+  it('asks inside persistGraphNow — the ONE write path, not some other branch', () => {
+    // `persistGraphNow`'s own header declares it the single write code path shared
+    // by the debounced autosave, its retry and the flush barrier. The guard has to
+    // be there, or one of those three bypasses it.
+    const fn = source.slice(source.indexOf('async function persistGraphNow'))
+    const body = fn.slice(0, fn.indexOf('\n}\n'))
+    expect(body).toMatch(/shouldPersistGraphForScenario\(/)
+    // …and it must GUARD, not merely be mentioned.
+    expect(body).toMatch(/if\s*\(\s*!shouldPersistGraphForScenario\(/)
+  })
+
+  it('still calls the real write when permitted (positive control)', () => {
+    // A mutation that suppressed every write would also satisfy the assertions
+    // above; this keeps the guard from blessing a broken save path.
+    const fn = source.slice(source.indexOf('async function persistGraphNow'))
+    const body = fn.slice(0, fn.indexOf('\n}\n'))
+    expect(body).toMatch(/saveGraphViaGatedPath\(/)
   })
 })

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -175,7 +175,7 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
  */
 export function applyDraftResult(
   draftData: CEEDraftResponse | CEEv2Response | CEEv3Response,
-  opts: { skipHistory?: boolean } = {},
+  opts: { skipHistory?: boolean; skipAutosave?: boolean } = {},
 ): { nodeCount: number; edgeCount: number } {
   const rawNodes = draftData?.nodes ?? (draftData as any)?.graph?.nodes ?? []
   const rawEdges = draftData?.edges ?? (draftData as any)?.graph?.edges ?? []
@@ -232,8 +232,17 @@ export function applyDraftResult(
   // or after a 500 ms safety fallback.
   store.setPendingLayout(true)
 
-  // Immediate autosave for crash resilience
-  try {
+  // Immediate autosave for crash resilience.
+  //
+  // ⚠ SKIPPED for a streamed GRAPH_READY preview (ROADMAP 2.122 round 2, review
+  // F1). The autosave is localStorage and survives a reload, while
+  // `draftStreamPhase` is in-memory and does not — so a guest who closed the tab
+  // during the ~25 s settling window came back to the unsettled graph with NO
+  // marker and an OPEN run gate: the same dishonest state as the abort hole, with
+  // no Stop click needed. The terminal apply autosaves normally, so nothing is
+  // lost once the values settle; before then there is deliberately nothing on
+  // disk to restore, which is the honest state.
+  if (!opts.skipAutosave) try {
     // Shared projection — previously this literal omitted ceeAnalysisReady and
     // selectedGoalNode. NOTE: this runs BEFORE setCeeAnalysisReady below, so
     // the value persisted here is the pre-draft one; the 30s timer corrects it.

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -158,9 +158,24 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
  * This function replaces all existing nodes/edges, pushes history, triggers
  * layout, selects the goal node, and stores analysis_ready + quality from
  * the response.
+ *
+ * ── ROADMAP 2.122: the streamed draft calls this TWICE for one turn ────────
+ * The staged V5 turn renders GRAPH_READY's structure at ~36 s and the terminal
+ * payload at ~61 s, and both go through here — the second call's wholesale
+ * replacement is what makes "the renderer never shows a node the terminal
+ * payload lacks" true by construction rather than by a diff.
+ *
+ * `opts.skipHistory` exists for exactly that second call. Two applies would
+ * otherwise push two history entries, so undo would step to the intermediate
+ * preview graph and only then to the pre-draft canvas — one step deeper than
+ * the buffered path. The PREVIEW pushes (capturing the pre-draft state, exactly
+ * as a buffered draft does) and the terminal apply skips, so the undo stack
+ * ends up identical. Default `false` reproduces today's behaviour byte for byte
+ * for every other caller.
  */
 export function applyDraftResult(
-  draftData: CEEDraftResponse | CEEv2Response | CEEv3Response
+  draftData: CEEDraftResponse | CEEv2Response | CEEv3Response,
+  opts: { skipHistory?: boolean } = {},
 ): { nodeCount: number; edgeCount: number } {
   const rawNodes = draftData?.nodes ?? (draftData as any)?.graph?.nodes ?? []
   const rawEdges = draftData?.edges ?? (draftData as any)?.graph?.edges ?? []
@@ -175,7 +190,7 @@ export function applyDraftResult(
 
   // --- Apply to store ---
   const store = useCanvasStore.getState()
-  store.pushHistory()
+  if (!opts.skipHistory) store.pushHistory()
   useCanvasStore.setState({
     nodes,
     edges,

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -36,6 +36,7 @@
  * Combines validation state, readiness checks, and blocker detection.
  */
 
+import type { DraftStreamPhase } from '../stores/draftStore'
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
 import { isV5CanonicalRunPath } from '../../v5/eligibility'
 import {
@@ -49,6 +50,20 @@ import {
  * refusal, this constant (and the spec pinning the raw literal) must follow.
  */
 export const CEE_DRAFT_FIRST_REFUSAL = 'Draft or save a model first, then run analysis.'
+
+/**
+ * ROADMAP 2.122 — the refusal shown while a STREAMED draft's structure is on
+ * the canvas but its numbers have not settled.
+ *
+ * Held to the same honesty bar as the wait narration (`DraftLoadingAnimation`,
+ * `AnalysisRunningBanner`): it claims only what the client genuinely holds. The
+ * client holds a GRAPH_READY frame stamped `status: in_progress`, so "still
+ * being drafted" and "values are still settling" are facts read off the frame,
+ * not a guess off a clock. It forecasts no duration and asserts nothing about
+ * the user's decision.
+ */
+export const DRAFT_VALUES_SETTLING_REFUSAL =
+  'Your model is still being drafted — its values are still settling. Run analysis once drafting finishes.'
 
 /**
  * Provenance stamps that mark a graph as INJECTED CLIENT-SIDE rather than
@@ -126,6 +141,33 @@ export interface CanRunAnalysisParams {
    *  the run routes through CEE, so the engine would refuse it (#343). */
   ceeCannotSeeModel?: boolean
   /**
+   * ROADMAP 2.122 — the streamed draft's phase, passed THROUGH rather than
+   * pre-derived by the caller.
+   *
+   * ⚠ This started life as a `draftValuesSettling: boolean` that `OutputsDock`
+   * computed. A mutation that dropped `'unsettled'` from that expression
+   * **SURVIVED the battery**, because the derivation sat in a component nothing
+   * tests while every test computed its own copy — a hand-maintained mirror of a
+   * two-clause predicate (trap 12, in miniature, in the honesty guard itself).
+   * Taking the raw phase removes the derivation from the call site entirely:
+   * there is now exactly one place that decides what "unsettled" means, and it
+   * is this function, which is tested.
+   *
+   * `settling` — GRAPH_READY has landed and the structure is on the canvas, but
+   * the turn has not completed, so the numbers are the frame's `in_progress`
+   * ones and the scenario commit has not landed.
+   * `unsettled` — terminal: the stream died after GRAPH_READY and CEE declined
+   * to re-draft, so those numbers will not settle in this session.
+   *
+   * This is a HONESTY rung, and it is the one the streamed path made necessary:
+   * the run gate is otherwise driven by `nodeCount` + readiness, neither of which
+   * knows the difference between a settled graph and a 25-second-old preview.
+   * Without it a tester is handed a live Run button at 36 s, and the run either
+   * computes on values CEE is about to change or returns `analysis_not_ready`
+   * because the commit has not happened yet.
+   */
+  draftStreamPhase?: DraftStreamPhase
+  /**
    * Options the readiness verdict graded as not-yet-ready, with their labels
    * (build with `selectOptionsNeedingValues`). Used ONLY to compose the
    * user-facing reason — it never affects `allowed`. Omitted ⇒ the reason
@@ -158,7 +200,7 @@ export function readinessWillScaffold(readiness: GraphReadiness | null | undefin
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, optionsNeedingValues } = params
+  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, draftStreamPhase = 'idle', optionsNeedingValues } = params
 
   const blockingReasons: string[] = []
 
@@ -177,6 +219,19 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
       allowed: false,
       reason: 'Add some nodes to get started',
       blockingReasons: ['No nodes in graph'],
+    }
+  }
+
+  // 2.4 A streamed draft's structure is on screen but its VALUES are not
+  // settled (ROADMAP 2.122). Ordered BEFORE ceeCannotSeeModel deliberately: a
+  // GRAPH_READY preview is also not yet in CEE's scenario state, so both rungs
+  // apply, and this one names the actual situation instead of telling the user
+  // to "draft a model first" while a model is visibly being drafted.
+  if (draftStreamPhase === 'settling' || draftStreamPhase === 'unsettled') {
+    return {
+      allowed: false,
+      reason: DRAFT_VALUES_SETTLING_REFUSAL,
+      blockingReasons: ['Streamed draft has not finished — values are still settling'],
     }
   }
 

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -36,7 +36,7 @@
  * Combines validation state, readiness checks, and blocker detection.
  */
 
-import type { DraftStreamPhase } from '../stores/draftStore'
+import { draftValuesAreUnsettled, type DraftStreamPhase } from '../stores/draftStore'
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
 import { isV5CanonicalRunPath } from '../../v5/eligibility'
 import {
@@ -64,6 +64,24 @@ export const CEE_DRAFT_FIRST_REFUSAL = 'Draft or save a model first, then run an
  */
 export const DRAFT_VALUES_SETTLING_REFUSAL =
   'Your model is still being drafted — its values are still settling. Run analysis once drafting finishes.'
+
+/**
+ * ROADMAP 2.122 round 2 (adversarial review F5) — the refusal for the TERMINAL
+ * `unsettled` state, which is a different fact and needs a different sentence.
+ *
+ * Both phases used to share `DRAFT_VALUES_SETTLING_REFUSAL`, and in `unsettled`
+ * its closing clause — *"Run analysis once drafting finishes"* — **forecasts a
+ * finish that will never come**: the phase's own docstring says the values will
+ * not settle in this session. It also contradicted the transcript notice sitting
+ * directly beside it. One string, two phases, one of them false — the same
+ * honesty bar this lane applied to its own narration lines, failed in a different
+ * file.
+ *
+ * This one states the terminal fact and points at the affordance that actually
+ * works (see F3: a fresh draft, not a retry of a turn CEE will decline).
+ */
+export const DRAFT_VALUES_UNSETTLED_REFUSAL =
+  'Drafting ended before this model\u2019s values arrived, so they are not final. Start a new draft to analyse it.'
 
 /**
  * Provenance stamps that mark a graph as INJECTED CLIENT-SIDE rather than
@@ -227,11 +245,22 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   // GRAPH_READY preview is also not yet in CEE's scenario state, so both rungs
   // apply, and this one names the actual situation instead of telling the user
   // to "draft a model first" while a model is visibly being drafted.
-  if (draftStreamPhase === 'settling' || draftStreamPhase === 'unsettled') {
+  // The two in-progress phases block for the same reason and say DIFFERENT things
+  // about it, because one is still in flight and one has terminally ended (F5).
+  // `draftValuesAreUnsettled` is the single classifier — a new phase must be
+  // classified there rather than defaulting to "settled".
+  if (draftValuesAreUnsettled(draftStreamPhase)) {
     return {
       allowed: false,
-      reason: DRAFT_VALUES_SETTLING_REFUSAL,
-      blockingReasons: ['Streamed draft has not finished — values are still settling'],
+      reason:
+        draftStreamPhase === 'unsettled'
+          ? DRAFT_VALUES_UNSETTLED_REFUSAL
+          : DRAFT_VALUES_SETTLING_REFUSAL,
+      blockingReasons: [
+        draftStreamPhase === 'unsettled'
+          ? 'Streamed draft ended without its final values'
+          : 'Streamed draft has not finished — values are still settling',
+      ],
     }
   }
 

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -26,6 +26,7 @@ import type { Edge } from '@xyflow/react'
 import { DEFAULT_EDGE_DATA, type EdgeData } from '../canvas/domain/edges'
 import { readPersistedGoalConstraints } from '../canvas/utils/persistedGraph'
 import { isPersistenceActive as computeIsPersistenceActive } from '../lib/persistenceActive'
+import { shouldPersistGraphForScenario } from '../canvas/stores/draftStore'
 
 export type SaveStatus = 'saved' | 'saving' | 'error'
 
@@ -151,6 +152,27 @@ function trackInFlightGraphSave(p: Promise<void>): void {
  * store clean on success. Rejects (propagates) on failure — callers decide.
  */
 async function persistGraphNow(sid: string): Promise<void> {
+  // ROADMAP 2.122 round 2 (adversarial review F1) — never persist a graph whose
+  // values the UI KNOWS are in progress.
+  //
+  // A streamed draft renders its structure at ~36 s from a frame stamped
+  // `status: in_progress`, ~25 s before the settled values arrive. Writing that
+  // graph here creates an unsettled row in `scenarios.graph`; and if drafting then
+  // ends without a terminal ingest (Stop, the 130 s timeout, a dead stream), the
+  // row is never replaced and the next canvas edit's debounced echo save — which
+  // re-reads the store at fire time — writes it back OVER CEE's own settled
+  // commit. The review proved that path executable and voided the "bounded to
+  // ~24 s" claim it was rowed under.
+  //
+  // Suppressing at THIS function is deliberate: its own header declares it the ONE
+  // write code path, shared by the debounced autosave, its retry and the flush
+  // barrier. One derived choke point, no list of call sites to keep in step.
+  //
+  // Resolves rather than rejects, so the flush barrier treats it as a no-op: a run
+  // cannot need this flush, because the run gate is shut for exactly these phases.
+  // The store stays dirty, so the debounce re-fires and the settled graph is
+  // written the moment the phase clears.
+  if (!shouldPersistGraphForScenario(sid)) return
   const state = useCanvasStore.getState()
   const key = graphSaveKey(state)
   await scenarioService.saveGraphViaGatedPath(

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -129,14 +129,14 @@ function isAutosaveOwner(id: string): boolean {
 // pre-analysis flush and the debounced autosave agree on "clean" and never
 // double-write. Reset when the last mount unmounts (see the ownership effect).
 let sharedLastSavedGraphKey = ''
-let inFlightGraphSave: Promise<void> | null = null
+let inFlightGraphSave: Promise<unknown> | null = null
 
 // Record the in-flight save so the flush barrier can await it, and self-clear
 // when it settles. The housekeeping `.finally` chain swallows its own rejection
 // (`.catch`) so it never surfaces as an unhandled rejection — the ACTUAL result
 // is always awaited by the caller (the autosave try/catch, or the flush
 // barrier), which is where a real failure is handled.
-function trackInFlightGraphSave(p: Promise<void>): void {
+function trackInFlightGraphSave(p: Promise<unknown>): void {
   inFlightGraphSave = p
   void p
     .finally(() => {
@@ -150,8 +150,16 @@ function trackInFlightGraphSave(p: Promise<void>): void {
  * Shared by the debounced autosave, its retry, and the flush barrier so there is
  * ONE write code path. Updates the shared "already persisted" key and marks the
  * store clean on success. Rejects (propagates) on failure — callers decide.
+ *
+ * @returns `true` when a write was performed, `false` when it was SUPPRESSED
+ * because the scenario's streamed draft has unsettled values (round-2 review
+ * R2-N1). Callers that surface a save indicator must not report "saved" for a
+ * write that deliberately did not happen — a false indicator is precisely the
+ * honesty class this lane polices, and during a terminal `unsettled` state a
+ * signed-in user would otherwise see "saved" on every edit while nothing
+ * persists, then lose all of it on reload to CEE's commit.
  */
-async function persistGraphNow(sid: string): Promise<void> {
+async function persistGraphNow(sid: string): Promise<boolean> {
   // ROADMAP 2.122 round 2 (adversarial review F1) — never persist a graph whose
   // values the UI KNOWS are in progress.
   //
@@ -172,7 +180,7 @@ async function persistGraphNow(sid: string): Promise<void> {
   // cannot need this flush, because the run gate is shut for exactly these phases.
   // The store stays dirty, so the debounce re-fires and the settled graph is
   // written the moment the phase clears.
-  if (!shouldPersistGraphForScenario(sid)) return
+  if (!shouldPersistGraphForScenario(sid)) return false
   const state = useCanvasStore.getState()
   const key = graphSaveKey(state)
   await scenarioService.saveGraphViaGatedPath(
@@ -186,6 +194,7 @@ async function persistGraphNow(sid: string): Promise<void> {
   const now = Date.now()
   useCanvasStore.getState().markClean()
   useCanvasStore.setState({ lastSavedAt: now })
+  return true
 }
 
 /**
@@ -341,8 +350,12 @@ export function useScenario(): UseScenarioReturn {
         try {
           const p = persistGraphNow(saveSid)
           trackInFlightGraphSave(p)
-          await p
-          if (mountedRef.current) {
+          const wrote = await p
+          // R2-N1: a suppressed no-op must not read as "saved". Left at 'saving'
+          // rather than invented as a new status: the write really is still
+          // pending, the store stays dirty, and the debounce re-fires and
+          // succeeds the moment the draft settles.
+          if (mountedRef.current && wrote) {
             setSaveStatus('saved')
             setLastSavedAt(Date.now())
             setSaveError(null)
@@ -359,8 +372,8 @@ export function useScenario(): UseScenarioReturn {
             try {
               const rp = persistGraphNow(retrySid)
               trackInFlightGraphSave(rp)
-              await rp
-              if (mountedRef.current) {
+              const retryWrote = await rp
+              if (mountedRef.current && retryWrote) {
                 setSaveStatus('saved')
                 setLastSavedAt(Date.now())
                 setSaveError(null)

--- a/src/lib/sse/parseSSELines.ts
+++ b/src/lib/sse/parseSSELines.ts
@@ -1,0 +1,75 @@
+/**
+ * The app's single SSE line parser (extracted from
+ * `canvas/conversation/turnService.ts`, ROADMAP 2.122).
+ *
+ * Two consumers now read `text/event-stream` from CEE — the V4 orchestrator
+ * stream (`turnService.streamOrchestratorTurn`) and the staged V5 turn
+ * (`v5/streamedDraftFrames.streamStageFrames`). A second, independently
+ * written parser is exactly the hand-maintained-mirror defect (CLAUDE.md trap
+ * 12): the two would drift on multi-line `data:`, on CRLF, or on trailing
+ * flush, and the drift would read as green in both suites.
+ *
+ * `turnService` re-exports this symbol, so its existing spec
+ * (`__tests__/streamEventParsing.spec.ts`, ~30 cases) covers this module
+ * verbatim without being touched.
+ */
+
+/**
+ * Parse a raw SSE text chunk (already split into lines) into structured events.
+ *
+ * Handles multi-line `data:` fields per the SSE spec (consecutive data lines
+ * joined with `\n`) and `:` comment lines as heartbeat signals.
+ *
+ * @returns The parsed events and whether the chunk showed any liveness at all
+ *          (a bare heartbeat counts — it carries no event but proves the
+ *          socket is alive, which is what the silence watchdog needs).
+ */
+export function parseSSELines(
+  lines: string[],
+  /** When true, flush any buffered event at the end even without a trailing
+   *  blank line. Only set this when processing the final chunk of a stream. */
+  flush = false,
+): { events: Array<{ eventType: string; data: string }>; hadActivity: boolean } {
+  const events: Array<{ eventType: string; data: string }> = []
+  let currentEventType = ''
+  let dataLines: string[] = []
+  let hadActivity = false
+
+  for (const rawLine of lines) {
+    // Normalise CRLF / bare CR — servers may use \r\n line endings
+    const line = rawLine.replace(/\r$/, '')
+
+    if (line === '') {
+      // Empty line = event boundary per SSE spec
+      if (dataLines.length > 0) {
+        events.push({ eventType: currentEventType, data: dataLines.join('\n') })
+        dataLines = []
+        currentEventType = ''
+      }
+      continue
+    }
+    if (line.startsWith(':')) {
+      // Comment line = heartbeat signal
+      hadActivity = true
+      continue
+    }
+    if (line.startsWith('event: ')) {
+      currentEventType = line.slice(7).trim()
+      hadActivity = true
+    } else if (line.startsWith('data: ')) {
+      dataLines.push(line.slice(6))
+      hadActivity = true
+    } else if (line.startsWith('data:')) {
+      // `data:` with no space — still valid per SSE spec
+      dataLines.push(line.slice(5))
+      hadActivity = true
+    }
+  }
+
+  // Flush trailing buffered event on EOF (stream ended without final blank line)
+  if (flush && dataLines.length > 0) {
+    events.push({ eventType: currentEventType, data: dataLines.join('\n') })
+  }
+
+  return { events, hadActivity }
+}

--- a/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
+++ b/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
@@ -206,9 +206,13 @@ describe('CROSS-FRAME IDENTITY — the graph rendered at 36 s IS the graph commi
       edgesOnlyInPreview: ['fac_cost->opt_build'],
       edgesOnlyInTerminal: [],
     })
-    // And the caller is told to replace, not merge — which is what
-    // `applyDraftResult`'s wholesale replacement does at COMPLETE.
-    expect((outcome as { replaceRenderedGraph: boolean }).replaceRenderedGraph).toBe(true)
+    // The caller replaces wholesale rather than merging — which is what
+    // `applyDraftResult` does at COMPLETE, and which is what makes the guarantee
+    // hold by construction. (The outcome no longer carries a
+    // `replaceRenderedGraph` flag: the review found it had zero consumers, so it
+    // was guarantee-theatre and is deleted. The replacement itself is pinned in
+    // `streamedDraftTurn.spec.ts`, on the route that actually performs it.)
+    expect((outcome as { renderedGraph: unknown }).renderedGraph).not.toBeNull()
   })
 
   it('reports no drift when identity holds', async () => {

--- a/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
+++ b/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * The two-phase apply orchestrator, and THE CROSS-FRAME IDENTITY TEST the
+ * M1-L2 spec requires (ROADMAP 2.122).
+ *
+ * `m1l2-draft-consumer.md`: *"one test asserting the early-frame graph and the
+ * COMPLETE-frame graph agree on identity"* — and the dispatch adds the second
+ * half: *"the renderer never shows a node the terminal payload lacks."*
+ *
+ * Two vacuity traps are closed here, both learned from #751's own round-1
+ * mistakes (its identity test compared two shapes that were both empty):
+ *
+ *   1. the terminal graph rides the response's TOP-LEVEL `draft_graph`, not
+ *      `blocks[].data.applied_graph` — on the turn path `blocks` comes back
+ *      empty, so an extractor reading blocks compares `[]` with `[]`;
+ *   2. **edges here carry no `id`** — they are `from`/`to` pairs, so keying
+ *      edge identity on `e.id` makes both sides `[undefined, undefined, …]`
+ *      or `[]` and every comparison passes while testing nothing.
+ *
+ * Both are guarded by `expectComparableGraph`, which fails if either side of
+ * a comparison came back empty (trap 13: an absence/agreement assertion must
+ * first prove it can SEE a presence).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  consumeStreamedDraftTurn,
+  nodeIdentities,
+  edgeIdentities,
+  expectComparableGraph,
+} from '../consumeStreamedDraftTurn'
+import { StreamAbandonedError, type StageFrame } from '../streamedDraftFrames'
+
+// ---------------------------------------------------------------------------
+// Fixtures — the 16-node/33-edge live shape, reduced to 3/2 for legibility.
+// GRAPH_READY and COMPLETE agree on identity and DISAGREE on values, which is
+// exactly the contract: "identity is stable, values settle".
+// ---------------------------------------------------------------------------
+
+const READY_GRAPH = {
+  nodes: [
+    { id: 'goal_1', kind: 'goal', label: 'Choose a billing system', value: 0 },
+    { id: 'opt_build', kind: 'option', label: 'Build in-house', value: 0 },
+    { id: 'fac_cost', kind: 'factor', label: 'Cost', value: 0 },
+  ],
+  edges: [
+    { from: 'opt_build', to: 'goal_1', strength: { mean: 0 } },
+    { from: 'fac_cost', to: 'opt_build', strength: { mean: 0 } },
+  ],
+}
+
+/** Same ids, settled numbers — the refinement `graph-data-integrity` applies. */
+const TERMINAL_GRAPH = {
+  nodes: [
+    { id: 'goal_1', kind: 'goal', label: 'Choose a billing system', value: 18 },
+    { id: 'opt_build', kind: 'option', label: 'Build in-house', value: 420_000 },
+    { id: 'fac_cost', kind: 'factor', label: 'Cost', value: 250_000 },
+  ],
+  edges: [
+    { from: 'opt_build', to: 'goal_1', strength: { mean: 0.62 } },
+    { from: 'fac_cost', to: 'opt_build', strength: { mean: -0.31 } },
+  ],
+}
+
+function terminalPayload(graph: unknown = TERMINAL_GRAPH) {
+  return {
+    response_version: 2,
+    assistant_text: "Here's a first model of your billing decision.",
+    blocks: [],
+    draft_graph: graph,
+    analysis_ready: { status: 'needs_user_input', options: [] },
+  }
+}
+
+function frames(...list: Array<Partial<StageFrame> & { stage: StageFrame['stage'] }>): StageFrame[] {
+  return list.map((f, i) => ({
+    seq: i,
+    status: f.stage === 'COMPLETE' ? 'complete' : 'in_progress',
+    ...f,
+  })) as StageFrame[]
+}
+
+const HAPPY = () =>
+  frames(
+    { stage: 'DRAFTING' },
+    { stage: 'GRAPH_READY', graph: READY_GRAPH, schema_version: 'v3', elapsed_ms: 35_834 },
+    { stage: 'COACHING_READY', coaching_status: 'partial' },
+    { stage: 'COMPLETE', status_code: 200, payload: terminalPayload() },
+  )
+
+async function* iterate(list: StageFrame[], failAfter?: number): AsyncGenerator<StageFrame> {
+  let i = 0
+  for (const f of list) {
+    if (failAfter !== undefined && i === failAfter) {
+      throw new StreamAbandonedError('transport', 'socket hung up')
+    }
+    yield f
+    i++
+  }
+  if (failAfter !== undefined && i === failAfter) {
+    throw new StreamAbandonedError('transport', 'socket hung up')
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+describe('consumeStreamedDraftTurn — the render-on-arrival contract', () => {
+  it('renders the GRAPH_READY graph the moment it arrives, before COMPLETE', async () => {
+    const order: string[] = []
+    const outcome = await consumeStreamedDraftTurn(
+      (async function* () {
+        for (const f of HAPPY()) {
+          order.push(`frame:${f.stage}`)
+          yield f
+        }
+      })(),
+      { onGraphReady: () => order.push('render') },
+    )
+    expect(outcome.kind).toBe('complete')
+    // The render sits BETWEEN the GRAPH_READY frame and the next frame — not
+    // after COMPLETE. A consumer that buffered to the end would put 'render'
+    // last, and every content assertion would still pass.
+    expect(order).toEqual([
+      'frame:DRAFTING',
+      'frame:GRAPH_READY',
+      'render',
+      'frame:COACHING_READY',
+      'frame:COMPLETE',
+    ])
+  })
+
+  it('reports the terminal payload and status code for the caller to ingest', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {} })
+    expect(outcome).toMatchObject({ kind: 'complete', statusCode: 200, renderedGraph: READY_GRAPH })
+    expect((outcome as { terminalPayload: unknown }).terminalPayload).toEqual(terminalPayload())
+  })
+
+  it('fires onDrafting for the opening frame (the 271 ms acknowledgement)', async () => {
+    const onDrafting = vi.fn()
+    await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {}, onDrafting })
+    expect(onDrafting).toHaveBeenCalledTimes(1)
+  })
+
+  it('never renders twice, even if the server repeats GRAPH_READY', async () => {
+    const onGraphReady = vi.fn()
+    await consumeStreamedDraftTurn(
+      iterate(
+        frames(
+          { stage: 'DRAFTING' },
+          { stage: 'GRAPH_READY', graph: READY_GRAPH },
+          { stage: 'GRAPH_READY', graph: READY_GRAPH },
+          { stage: 'COMPLETE', status_code: 200, payload: terminalPayload() },
+        ),
+      ),
+      { onGraphReady },
+    )
+    expect(onGraphReady).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CROSS-FRAME IDENTITY — the graph rendered at 36 s IS the graph committed at 61 s', () => {
+  it('GRAPH_READY and the COMPLETE payload agree on node and edge identity', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {} })
+    expect(outcome.kind).toBe('complete')
+    const rendered = (outcome as { renderedGraph: unknown }).renderedGraph
+    const terminal = (terminalPayload() as { draft_graph: unknown }).draft_graph
+
+    // TRAP 13 CONTROL, first: if either extraction is empty the comparisons
+    // below are vacuous, so prove both sides carry something.
+    expectComparableGraph(rendered, 'GRAPH_READY frame')
+    expectComparableGraph(terminal, 'COMPLETE payload draft_graph')
+
+    expect(nodeIdentities(rendered)).toEqual(nodeIdentities(terminal))
+    expect(edgeIdentities(rendered)).toEqual(edgeIdentities(terminal))
+  })
+
+  it('but the VALUES differ — the frame is in_progress for a reason', () => {
+    // If this ever fails, the fixtures have stopped modelling the contract and
+    // the identity test above has become a check that two identical objects
+    // are identical.
+    expect(READY_GRAPH.nodes.map((n) => n.value)).not.toEqual(
+      TERMINAL_GRAPH.nodes.map((n) => n.value),
+    )
+  })
+
+  it('the renderer never shows a node the terminal payload lacks', async () => {
+    // A server that drops a node between the frames must be detected, not
+    // reconciled silently — the dispatch's explicit requirement.
+    const shrunk = {
+      nodes: TERMINAL_GRAPH.nodes.filter((n) => n.id !== 'fac_cost'),
+      edges: TERMINAL_GRAPH.edges.filter((e) => e.from !== 'fac_cost'),
+    }
+    const outcome = await consumeStreamedDraftTurn(
+      iterate(
+        frames(
+          { stage: 'DRAFTING' },
+          { stage: 'GRAPH_READY', graph: READY_GRAPH },
+          { stage: 'COMPLETE', status_code: 200, payload: terminalPayload(shrunk) },
+        ),
+      ),
+      { onGraphReady: () => {} },
+    )
+    expect(outcome.kind).toBe('complete')
+    expect((outcome as { identityDrift: unknown }).identityDrift).toEqual({
+      nodesOnlyInPreview: ['fac_cost'],
+      nodesOnlyInTerminal: [],
+      edgesOnlyInPreview: ['fac_cost->opt_build'],
+      edgesOnlyInTerminal: [],
+    })
+    // And the caller is told to replace, not merge — which is what
+    // `applyDraftResult`'s wholesale replacement does at COMPLETE.
+    expect((outcome as { replaceRenderedGraph: boolean }).replaceRenderedGraph).toBe(true)
+  })
+
+  it('reports no drift when identity holds', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {} })
+    expect((outcome as { identityDrift: unknown }).identityDrift).toBeNull()
+  })
+})
+
+describe('identity helpers — the two vacuity traps, pinned', () => {
+  it('keys edges on the endpoint PAIR, because wire edges carry no id', () => {
+    // Keying on `e.id` would yield [undefined, undefined] on both sides and
+    // every edge comparison would pass by testing nothing (#751's own bug).
+    expect(edgeIdentities(READY_GRAPH)).toEqual(['fac_cost->opt_build', 'opt_build->goal_1'])
+    expect(READY_GRAPH.edges.every((e) => !('id' in e))).toBe(true)
+  })
+
+  it('sorts identities so wire ordering cannot make an equal pair unequal', () => {
+    const reversed = { nodes: [...READY_GRAPH.nodes].reverse(), edges: [...READY_GRAPH.edges].reverse() }
+    expect(nodeIdentities(reversed)).toEqual(nodeIdentities(READY_GRAPH))
+    expect(edgeIdentities(reversed)).toEqual(edgeIdentities(READY_GRAPH))
+  })
+
+  it('expectComparableGraph REFUSES an empty or absent graph', () => {
+    expect(() => expectComparableGraph({ nodes: [], edges: [] }, 'x')).toThrow(/no nodes/i)
+    expect(() => expectComparableGraph(undefined, 'x')).toThrow(/no nodes/i)
+    expect(() => expectComparableGraph({ nodes: [{ id: 'a' }], edges: [] }, 'x')).not.toThrow()
+  })
+})
+
+describe('the discard rule — a failed turn must not leave a rendered graph standing', () => {
+  it('orders the preview DISCARDED when COMPLETE carries status_code >= 400', async () => {
+    const outcome = await consumeStreamedDraftTurn(
+      iterate(
+        frames(
+          { stage: 'DRAFTING' },
+          { stage: 'GRAPH_READY', graph: READY_GRAPH },
+          {
+            stage: 'COMPLETE',
+            status_code: 422,
+            payload: { error: 'INGRESS_CONTRACT_VIOLATION' },
+          },
+        ),
+      ),
+      { onGraphReady: () => {} },
+    )
+    expect(outcome).toMatchObject({ kind: 'complete', statusCode: 422, discardPreview: true })
+  })
+
+  it('does NOT discard on a 200', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {} })
+    expect((outcome as { discardPreview: boolean }).discardPreview).toBe(false)
+  })
+})
+
+describe('abandonment — every failure reports whether a graph is already on screen', () => {
+  it('abandons before GRAPH_READY and says nothing was rendered', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY(), 1), { onGraphReady: () => {} })
+    expect(outcome).toMatchObject({
+      kind: 'abandoned',
+      reason: 'transport',
+      renderedGraph: null,
+    })
+  })
+
+  it('abandons AFTER GRAPH_READY and reports the graph it already rendered', async () => {
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY(), 2), { onGraphReady: () => {} })
+    expect(outcome).toMatchObject({ kind: 'abandoned', reason: 'transport' })
+    expect((outcome as { renderedGraph: unknown }).renderedGraph).toEqual(READY_GRAPH)
+  })
+
+  it('a stream that ends without COMPLETE is abandonment, not success', async () => {
+    const outcome = await consumeStreamedDraftTurn(
+      iterate(frames({ stage: 'DRAFTING' }, { stage: 'GRAPH_READY', graph: READY_GRAPH })),
+      { onGraphReady: () => {} },
+    )
+    expect(outcome).toMatchObject({ kind: 'abandoned', reason: 'no_terminal_frame' })
+  })
+
+  it('a non-StreamAbandonedError throw still abandons rather than escaping', async () => {
+    const outcome = await consumeStreamedDraftTurn(
+      (async function* () {
+        yield* frames({ stage: 'DRAFTING' })
+        throw new TypeError('Failed to fetch')
+      })(),
+      { onGraphReady: () => {} },
+    )
+    expect(outcome).toMatchObject({ kind: 'abandoned', reason: 'transport' })
+  })
+
+  it('a render callback that throws does not lose the turn', async () => {
+    // The graph render touches the canvas store; if it throws we still want the
+    // terminal payload ingested rather than the whole turn lost.
+    const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), {
+      onGraphReady: () => {
+        throw new Error('store blew up')
+      },
+    })
+    expect(outcome.kind).toBe('complete')
+    expect((outcome as { renderedGraph: unknown }).renderedGraph).toBeNull()
+  })
+})

--- a/src/v5/__tests__/streamedDraftFrames.spec.ts
+++ b/src/v5/__tests__/streamedDraftFrames.spec.ts
@@ -1,0 +1,315 @@
+/**
+ * Frame-contract parser + stream reader for the staged V5 turn (ROADMAP 2.122).
+ *
+ * The contract under test is CEE PR #751's, banked in
+ * `PHASE0-EVIDENCE-2026-07-28/m1l2-draft-consumer.md` §"Frame contract" and
+ * live-measured in `cee2-live-latency.md`. Every fixture here is shaped from
+ * that live wire capture, not invented:
+ *
+ *   event: stage
+ *   data: {"stage":"DRAFTING","seq":0,"status":"in_progress"}
+ *
+ * plus `: heartbeat` comment lines every 10 s (13 bytes, measured drift < 3 ms
+ * per beat over a minute) which carry no frame but DO prove liveness.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  parseStageFrame,
+  streamStageFrames,
+  StreamAbandonedError,
+  STREAM_SILENCE_TIMEOUT_MS,
+  SERVER_HEARTBEAT_INTERVAL_MS,
+} from '../streamedDraftFrames'
+
+// ---------------------------------------------------------------------------
+// Wire fixtures — shaped from the 29 Jul live capture (cee2-live-latency.md)
+// ---------------------------------------------------------------------------
+
+const DRAFTING = { stage: 'DRAFTING', seq: 0, status: 'in_progress' }
+const GRAPH_READY = {
+  stage: 'GRAPH_READY',
+  seq: 2,
+  status: 'in_progress',
+  schema_version: 'v3',
+  elapsed_ms: 35_834,
+  graph: {
+    nodes: [
+      { id: 'goal_1', kind: 'goal', label: 'Choose a billing system' },
+      { id: 'opt_build', kind: 'option', label: 'Build in-house' },
+    ],
+    edges: [{ from: 'opt_build', to: 'goal_1' }],
+  },
+}
+const COACHING_READY = {
+  stage: 'COACHING_READY',
+  seq: 3,
+  status: 'in_progress',
+  coaching_status: 'partial',
+}
+const COMPLETE = {
+  stage: 'COMPLETE',
+  seq: 4,
+  status: 'complete',
+  status_code: 200,
+  payload: { response_version: 2, assistant_text: 'ok' },
+}
+
+function sseEvent(frame: unknown): string {
+  return `event: stage\ndata: ${JSON.stringify(frame)}\n\n`
+}
+
+/** A `Response` whose body streams the supplied chunks in order. */
+function streamingResponse(chunks: string[], init?: ResponseInit): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c))
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+    ...init,
+  })
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const v of it) out.push(v)
+  return out
+}
+
+describe('parseStageFrame — the frame contract, defensively', () => {
+  it('parses every one of the five stage classes off the wire shape', () => {
+    for (const frame of [DRAFTING, GRAPH_READY, COACHING_READY, COMPLETE]) {
+      const parsed = parseStageFrame(JSON.stringify(frame))
+      expect(parsed).not.toBeNull()
+      expect(parsed!.stage).toBe(frame.stage)
+      expect(parsed!.seq).toBe(frame.seq)
+      expect(parsed!.status).toBe(frame.status)
+    }
+  })
+
+  it('carries the GRAPH_READY graph through verbatim', () => {
+    const parsed = parseStageFrame(JSON.stringify(GRAPH_READY))
+    expect(parsed!.graph?.nodes).toHaveLength(2)
+    expect(parsed!.graph?.edges).toHaveLength(1)
+    expect(parsed!.schema_version).toBe('v3')
+  })
+
+  it('returns null — never throws, never guesses — on malformed data', () => {
+    expect(parseStageFrame('not json at all')).toBeNull()
+    expect(parseStageFrame('')).toBeNull()
+    expect(parseStageFrame('[]')).toBeNull()
+    expect(parseStageFrame('null')).toBeNull()
+  })
+
+  it('rejects a frame missing any contract field rather than defaulting it', () => {
+    expect(parseStageFrame(JSON.stringify({ seq: 0, status: 'in_progress' }))).toBeNull()
+    expect(parseStageFrame(JSON.stringify({ stage: 'DRAFTING', status: 'in_progress' }))).toBeNull()
+    expect(parseStageFrame(JSON.stringify({ stage: 'DRAFTING', seq: 0 }))).toBeNull()
+  })
+
+  it('rejects an unknown stage name — a new server stage must not be silently swallowed', () => {
+    expect(
+      parseStageFrame(JSON.stringify({ stage: 'ENRICHING', seq: 1, status: 'in_progress' })),
+    ).toBeNull()
+  })
+
+  it('rejects a non-integer or negative seq (monotonicity is only checkable on integers)', () => {
+    expect(parseStageFrame(JSON.stringify({ stage: 'DRAFTING', seq: 1.5, status: 'in_progress' }))).toBeNull()
+    expect(parseStageFrame(JSON.stringify({ stage: 'DRAFTING', seq: -1, status: 'in_progress' }))).toBeNull()
+  })
+})
+
+describe('streamStageFrames — reading the live wire shape', () => {
+  it('yields the five frames in order from a single coalesced chunk', async () => {
+    const res = streamingResponse([
+      sseEvent(DRAFTING) + sseEvent(GRAPH_READY) + sseEvent(COACHING_READY) + sseEvent(COMPLETE),
+    ])
+    const frames = await collect(streamStageFrames(res))
+    expect(frames.map((f) => f.stage)).toEqual([
+      'DRAFTING',
+      'GRAPH_READY',
+      'COACHING_READY',
+      'COMPLETE',
+    ])
+  })
+
+  it('yields a frame that arrived split across TCP chunks mid-JSON', async () => {
+    // The live capture forwarded the 10,471-byte GRAPH_READY frame as EIGHT
+    // ~1,369-byte sub-frame segments. A reader that assumed one chunk == one
+    // frame would drop it.
+    const whole = sseEvent(GRAPH_READY)
+    const mid = Math.floor(whole.length / 2)
+    const res = streamingResponse([sseEvent(DRAFTING), whole.slice(0, mid), whole.slice(mid), sseEvent(COMPLETE)])
+    const frames = await collect(streamStageFrames(res))
+    expect(frames.map((f) => f.stage)).toEqual(['DRAFTING', 'GRAPH_READY', 'COMPLETE'])
+    expect(frames[1].graph?.nodes).toHaveLength(2)
+  })
+
+  it('treats `: heartbeat` comment lines as liveness, not as frames', async () => {
+    const res = streamingResponse([
+      sseEvent(DRAFTING),
+      ': heartbeat\n\n',
+      ': heartbeat\n\n',
+      sseEvent(COMPLETE),
+    ])
+    const frames = await collect(streamStageFrames(res))
+    expect(frames.map((f) => f.stage)).toEqual(['DRAFTING', 'COMPLETE'])
+  })
+
+  it('abandons with `malformed_frame` on undecodable frame data', async () => {
+    const res = streamingResponse([sseEvent(DRAFTING), 'event: stage\ndata: {oh dear\n\n'])
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({
+      name: 'StreamAbandonedError',
+      reason: 'malformed_frame',
+    })
+  })
+
+  it('abandons with `http_error` when the response is not a 2xx', async () => {
+    const res = new Response('nope', { status: 502 })
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({
+      reason: 'http_error',
+      httpStatus: 502,
+    })
+  })
+
+  it('abandons with `no_body` when the response carries no readable body', async () => {
+    const res = { ok: true, status: 200, body: null } as unknown as Response
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({ reason: 'no_body' })
+  })
+
+  it('surfaces a mid-stream transport error as `transport`', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(sseEvent(DRAFTING)))
+        controller.error(new Error('socket hung up'))
+      },
+    })
+    const res = new Response(body, { status: 200 })
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({ reason: 'transport' })
+  })
+})
+
+describe('the silence watchdog — abort on silence, never on elapsed time', () => {
+  it('derives its budget from the measured server heartbeat interval', () => {
+    // The route heartbeats every SSE_HEARTBEAT_INTERVAL_MS = 10 s (CEE
+    // config/timeouts.ts:977), live-observed at 10.219/20.218/30.218/40.219/
+    // 50.222/60.222 s. The client budget must be a MULTIPLE of that, so it is
+    // derived from it rather than typed as a second magic number (trap 12).
+    expect(SERVER_HEARTBEAT_INTERVAL_MS).toBe(10_000)
+    expect(STREAM_SILENCE_TIMEOUT_MS % SERVER_HEARTBEAT_INTERVAL_MS).toBe(0)
+    expect(STREAM_SILENCE_TIMEOUT_MS / SERVER_HEARTBEAT_INTERVAL_MS).toBeGreaterThanOrEqual(3)
+  })
+
+  it('abandons with `silence` when no bytes arrive for the budget', async () => {
+    vi.useFakeTimers()
+    try {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sseEvent(DRAFTING)))
+          // Never closes and never enqueues again — dead air. The generator's
+          // own `finally` cancels the reader, which closes it for us.
+        },
+      })
+      const res = new Response(body, { status: 200 })
+      const frames: unknown[] = []
+      const run = (async () => {
+        for await (const f of streamStageFrames(res)) frames.push(f)
+      })()
+      const settled = run.then(
+        () => ({ ok: true as const }),
+        (e) => ({ ok: false as const, e }),
+      )
+      // Let the first frame land, then run the clock past the silence budget.
+      await vi.advanceTimersByTimeAsync(1)
+      await vi.advanceTimersByTimeAsync(STREAM_SILENCE_TIMEOUT_MS + 10)
+      const outcome = await settled
+      expect(outcome.ok).toBe(false)
+      expect((outcome as { e: StreamAbandonedError }).e.reason).toBe('silence')
+      expect(frames).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does NOT abandon a long turn that keeps heartbeating past the budget', async () => {
+    // A 61 s turn with 10 s beats must survive. This is the pin that stops
+    // anyone "simplifying" the silence watchdog into an elapsed-time deadline —
+    // the cold-start GRAPH_READY spread reached 39.9 s.
+    vi.useFakeTimers()
+    try {
+      const encoder = new TextEncoder()
+      let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controllerRef = controller
+          controller.enqueue(encoder.encode(sseEvent(DRAFTING)))
+        },
+      })
+      const res = new Response(body, { status: 200 })
+      const frames: string[] = []
+      const run = (async () => {
+        for await (const f of streamStageFrames(res)) frames.push(f.stage)
+      })()
+      const settled = run.then(
+        () => ({ ok: true as const }),
+        (e) => ({ ok: false as const, e }),
+      )
+      await vi.advanceTimersByTimeAsync(1)
+      // Six 10 s beats = 60 s of wall clock, twice the silence budget.
+      for (let i = 0; i < 6; i++) {
+        await vi.advanceTimersByTimeAsync(SERVER_HEARTBEAT_INTERVAL_MS)
+        controllerRef!.enqueue(encoder.encode(': heartbeat\n\n'))
+        await vi.advanceTimersByTimeAsync(1)
+      }
+      controllerRef!.enqueue(encoder.encode(sseEvent(COMPLETE)))
+      controllerRef!.close()
+      await vi.advanceTimersByTimeAsync(1)
+      const outcome = await settled
+      expect(outcome.ok).toBe(true)
+      expect(frames).toEqual(['DRAFTING', 'COMPLETE'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('seq — MONOTONICITY, and deliberately not contiguity', () => {
+  it('ACCEPTS the live sequence 0, 2, 3, 4 — PROGRESS (seq 1) never arrives', async () => {
+    // The control that keeps the check from being tightened into something that
+    // rejects every healthy stream. Zero PROGRESS frames were observed across
+    // three live runs (cee2-live-latency.md honest note 4), so a "+1" contiguity
+    // rule would abandon every real draft at the GRAPH_READY frame.
+    const res = streamingResponse([
+      sseEvent(DRAFTING) + sseEvent(GRAPH_READY) + sseEvent(COACHING_READY) + sseEvent(COMPLETE),
+    ])
+    const frames = await collect(streamStageFrames(res))
+    expect(frames.map((f) => f.seq)).toEqual([0, 2, 3, 4])
+  })
+
+  it('abandons on a REPEATED seq — a duplicated frame is a transport fault', async () => {
+    const res = streamingResponse([sseEvent(DRAFTING), sseEvent({ ...DRAFTING, stage: 'PROGRESS' })])
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({
+      reason: 'seq_not_monotonic',
+    })
+  })
+
+  it('abandons on a BACKWARDS seq — a re-ordered frame is a transport fault', async () => {
+    const res = streamingResponse([
+      sseEvent(GRAPH_READY),
+      sseEvent(DRAFTING),
+    ])
+    await expect(collect(streamStageFrames(res))).rejects.toMatchObject({
+      reason: 'seq_not_monotonic',
+    })
+  })
+
+  it('the abandonment carries the two seq values, so the fault is diagnosable', async () => {
+    const res = streamingResponse([sseEvent(GRAPH_READY), sseEvent(DRAFTING)])
+    await expect(collect(streamStageFrames(res))).rejects.toThrow(/2 -> 0/)
+  })
+})

--- a/src/v5/__tests__/streamedTurnTransport.spec.ts
+++ b/src/v5/__tests__/streamedTurnTransport.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * The streamed turn's transport: endpoint DERIVATION and request shape
+ * (ROADMAP 2.122).
+ *
+ * The endpoint is the one thing here that could silently point at nothing, so
+ * it is derived from the buffered endpoint rather than written as a second
+ * literal (CLAUDE.md trap 12 — a hand-maintained mirror of a URL drifts and
+ * the drift reads as a 404 nobody notices until a tester hits it).
+ *
+ * Derived at the deployed bytes (`m1l2-consumer.md` F0-1): staging bakes
+ * `VITE_V5_ENDPOINT=https://cee-staging.onrender.com/proxy/v5/turn`, so the
+ * suffix rule lands on `/proxy/v5/turn/stream` — the exact route
+ * `cee2-live-latency.md` measured. The repo default `/bff/orchestrate/v2/turn`
+ * lands on `/bff/orchestrate/v2/turn/stream`, which the Netlify edge function
+ * rewrites to CEE's `/orchestrate/v2/turn/stream` service sibling.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { getV5StreamEndpoint, openV5TurnStream, __streamInternals } from '../streamedTurnTransport'
+
+const PAYLOAD = {
+  kind: 'message',
+  turn_id: '11111111-1111-4111-8111-111111111111',
+  scenario_id: '22222222-2222-4222-8222-222222222222',
+  stage: 'frame',
+  turn_class: 'frame',
+  message: 'Should we build or buy a billing system?',
+  source: 'composer',
+} as never
+
+function sseResponse(): Response {
+  return new Response('event: stage\ndata: {"stage":"DRAFTING","seq":0,"status":"in_progress"}\n\n', {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('getV5StreamEndpoint — derived, not mirrored', () => {
+  const original = { ...import.meta.env }
+
+  afterEach(() => {
+    Object.assign(import.meta.env, original)
+  })
+
+  it('is exactly the buffered endpoint plus /stream, for every resolution rung', () => {
+    const cases = [
+      ['https://cee-staging.onrender.com/proxy/v5/turn', 'https://cee-staging.onrender.com/proxy/v5/turn/stream'],
+      ['/bff/orchestrate/v2/turn', '/bff/orchestrate/v2/turn/stream'],
+    ] as const
+    for (const [buffered, streamed] of cases) {
+      expect(__streamInternals.streamEndpointFor(buffered)).toBe(streamed)
+    }
+  })
+
+  it('tracks the buffered resolver rather than restating its ladder', () => {
+    // The pin that makes this a derivation: whatever the buffered resolver
+    // returns, the streamed endpoint is that string + '/stream'. If someone
+    // re-implements the env ladder here, this goes red.
+    ;(import.meta.env as Record<string, unknown>).VITE_V5_ENDPOINT = 'https://example.test/some/other/turn'
+    expect(getV5StreamEndpoint()).toBe('https://example.test/some/other/turn/stream')
+  })
+
+  it('does not double a trailing slash', () => {
+    expect(__streamInternals.streamEndpointFor('https://x.test/proxy/v5/turn/')).toBe(
+      'https://x.test/proxy/v5/turn/stream',
+    )
+  })
+})
+
+describe('openV5TurnStream — the request a browser actually sends', () => {
+  let fetchImpl: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchImpl = vi.fn<unknown[], unknown>(async () => sseResponse())
+  })
+
+  it('POSTs the identical payload with Accept: text/event-stream', async () => {
+    await openV5TurnStream(PAYLOAD, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(getV5StreamEndpoint())
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>).Accept).toBe('text/event-stream')
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual(PAYLOAD)
+  })
+
+  it('forwards the caller auth headers unchanged (same as the buffered turn)', async () => {
+    await openV5TurnStream(PAYLOAD, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      headers: { 'X-User-Id': 'u1', Authorization: 'Bearer t' },
+    })
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>)['X-User-Id']).toBe('u1')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer t')
+  })
+
+  it('passes the abort signal through so the 130 s turn timeout still bites', async () => {
+    const controller = new AbortController()
+    await openV5TurnStream(PAYLOAD, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      signal: controller.signal,
+    })
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(init.signal).toBe(controller.signal)
+  })
+
+  it('abandons with `transport` when the fetch itself rejects', async () => {
+    const failing = vi.fn(async () => {
+      throw new TypeError('Failed to fetch')
+    })
+    await expect(
+      openV5TurnStream(PAYLOAD, { fetchImpl: failing as unknown as typeof fetch }),
+    ).rejects.toMatchObject({ name: 'StreamAbandonedError', reason: 'transport' })
+  })
+
+  it('abandons with `aborted` — not `transport` — on a user/timeout abort', async () => {
+    const aborting = vi.fn(async () => {
+      const e = new Error('aborted')
+      e.name = 'AbortError'
+      throw e
+    })
+    await expect(
+      openV5TurnStream(PAYLOAD, { fetchImpl: aborting as unknown as typeof fetch }),
+    ).rejects.toMatchObject({ reason: 'aborted' })
+  })
+})
+
+describe('terminalPayloadToResponse — byte-equivalent terminal ingest', () => {
+  it('re-wraps the COMPLETE frame so the BUFFERED parser consumes it verbatim', async () => {
+    // The whole point: there is no second parser to keep in step. The frame's
+    // `payload` is the buffered body verbatim (#751), so wrapping it in a
+    // Response and handing it to `parseV5Response` is the same ingest.
+    const body = { response_version: 2, assistant_text: 'hi', blocks: [] }
+    const res = __streamInternals.terminalPayloadToResponse(body, 200)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(await res.json()).toEqual(body)
+  })
+
+  it('preserves a non-2xx status_code so the parser classifies the failure honestly', async () => {
+    const res = __streamInternals.terminalPayloadToResponse({ error: 'INGRESS_CONTRACT_VIOLATION' }, 422)
+    expect(res.status).toBe(422)
+  })
+
+  it('an absent payload becomes an honest empty body, never `undefined` JSON', async () => {
+    const res = __streamInternals.terminalPayloadToResponse(undefined, 200)
+    expect(await res.text()).toBe('null')
+  })
+})

--- a/src/v5/consumeStreamedDraftTurn.ts
+++ b/src/v5/consumeStreamedDraftTurn.ts
@@ -24,9 +24,18 @@
  *     `hasAnalysisReady(...)`, which a GRAPH_READY frame cannot satisfy, so the
  *     honesty constraint holds by construction of the pre-existing gate.
  *  3. **Terminal frame wins, always.** Identity drift between the preview and
- *     the terminal payload is REPORTED, and the caller is told to replace
- *     rather than merge — so "the renderer never shows a node the terminal
- *     payload lacks" is guaranteed by a wholesale replacement, not by a diff.
+ *     the terminal payload is REPORTED (with the exact offending ids), and the
+ *     caller replaces wholesale rather than merging — so "the renderer never
+ *     shows a node the terminal payload lacks" is guaranteed by the replacement,
+ *     not by a diff that could miss a case.
+ *
+ *     ⚠ This used to ALSO return a `replaceRenderedGraph: boolean`, and the
+ *     adversarial review found it had **zero consumers** (repo-wide grep): the
+ *     replacement actually happens through `useConversation`'s
+ *     `canvasIsEmpty || streamedPreviewOwnsCanvas` route. An outcome field that
+ *     reads as a guarantee and drives nothing is the guarantee-theatre class in
+ *     miniature — inside a lane whose whole subject is that class. Deleted rather
+ *     than wired, because the route that does the work is already pinned.
  *  4. **A failure is never a dead end.** Any abandonment returns the reason
  *     AND whether a graph is already on screen, because the fallback branch
  *     the caller must take depends on that. See `useConversation`'s
@@ -70,8 +79,6 @@ export type StreamedDraftOutcome =
       discardPreview: boolean
       /** Non-null when the preview and the terminal graph disagree on identity. */
       identityDrift: IdentityDrift | null
-      /** True when the caller must REPLACE the rendered graph wholesale. */
-      replaceRenderedGraph: boolean
     }
   | {
       kind: 'abandoned'
@@ -214,11 +221,6 @@ export async function consumeStreamedDraftTurn(
             renderedGraph,
             discardPreview,
             identityDrift,
-            // Always true when a preview exists: the terminal frame is
-            // authoritative, and a wholesale replace is what makes "never shows
-            // a node the terminal payload lacks" true by construction rather
-            // than by a diff that could miss a case.
-            replaceRenderedGraph: renderedGraph !== null,
           }
         }
 

--- a/src/v5/consumeStreamedDraftTurn.ts
+++ b/src/v5/consumeStreamedDraftTurn.ts
@@ -1,0 +1,251 @@
+/**
+ * consumeStreamedDraftTurn — the two-phase apply, as a pure orchestration
+ * over an async iterable of stage frames (ROADMAP 2.122 / 1.204 M1).
+ *
+ * Deliberately React-free and store-free: it takes an iterable in and a render
+ * callback, and hands back a verdict. That is what makes the required
+ * cross-frame identity test provable without mounting a canvas.
+ *
+ * ── THE RULES IT ENFORCES ─────────────────────────────────────────────────
+ *  1. **Render GRAPH_READY on arrival.** Never on a deadline, never buffered.
+ *     The live cold-start spread reached 39.9 s, so any client-side "if it has
+ *     not arrived by N seconds" gate would either fire on a healthy draw or be
+ *     set so high it does nothing. `onGraphReady` is invoked from inside the
+ *     iteration loop, and the test pins the CALL ORDER, not just the content —
+ *     because a consumer that buffered every frame and rendered at the end
+ *     would pass every content assertion while deleting the entire benefit.
+ *     (This is #751's M9 mutant, moved to the client.)
+ *  2. **Nothing may render a claim from GRAPH_READY's numbers.** The frame is
+ *     `status: in_progress` and #745's contract states plainly that
+ *     `graph-data-integrity` refines the numeric values after the transform.
+ *     This module therefore hands the caller the graph and nothing else — no
+ *     `analysis_ready`, no coaching, no freshness. The caller's renderer
+ *     (`applyDraftResult`) gates every analysis side-effect on
+ *     `hasAnalysisReady(...)`, which a GRAPH_READY frame cannot satisfy, so the
+ *     honesty constraint holds by construction of the pre-existing gate.
+ *  3. **Terminal frame wins, always.** Identity drift between the preview and
+ *     the terminal payload is REPORTED, and the caller is told to replace
+ *     rather than merge — so "the renderer never shows a node the terminal
+ *     payload lacks" is guaranteed by a wholesale replacement, not by a diff.
+ *  4. **A failure is never a dead end.** Any abandonment returns the reason
+ *     AND whether a graph is already on screen, because the fallback branch
+ *     the caller must take depends on that. See `useConversation`'s
+ *     `STREAMED DRAFT FALLBACK` block for why.
+ */
+import {
+  StreamAbandonedError,
+  type StageFrame,
+  type StageGraph,
+  type StreamAbandonReason,
+} from './streamedDraftFrames'
+
+export interface StreamedDraftHandlers {
+  /** Fired once, on the opening frame (live: 271 ms). */
+  onDrafting?: () => void
+  /**
+   * Fired ONCE, the instant a GRAPH_READY frame arrives (live median 35.8 s).
+   * Must render the structure. Must NOT claim anything about the numbers.
+   */
+  onGraphReady: (graph: StageGraph) => void
+  /** Fired when the coaching pass lands (live: 59.2 s). Enum status, not prose. */
+  onCoachingReady?: (coachingStatus: string | undefined) => void
+}
+
+export interface IdentityDrift {
+  nodesOnlyInPreview: string[]
+  nodesOnlyInTerminal: string[]
+  edgesOnlyInPreview: string[]
+  edgesOnlyInTerminal: string[]
+}
+
+export type StreamedDraftOutcome =
+  | {
+      kind: 'complete'
+      /** The buffered turn body, verbatim, exactly as `/proxy/v5/turn` returns it. */
+      terminalPayload: unknown
+      statusCode: number
+      /** The graph handed to `onGraphReady`, or null if none was rendered. */
+      renderedGraph: StageGraph | null
+      /** True when the terminal frame is an error and the preview must go. */
+      discardPreview: boolean
+      /** Non-null when the preview and the terminal graph disagree on identity. */
+      identityDrift: IdentityDrift | null
+      /** True when the caller must REPLACE the rendered graph wholesale. */
+      replaceRenderedGraph: boolean
+    }
+  | {
+      kind: 'abandoned'
+      reason: StreamAbandonReason
+      detail: string
+      renderedGraph: StageGraph | null
+    }
+
+// ---------------------------------------------------------------------------
+// Identity — the two shapes, keyed the only ways that are not vacuous
+// ---------------------------------------------------------------------------
+
+function graphOf(value: unknown): StageGraph | null {
+  if (typeof value !== 'object' || value === null) return null
+  const obj = value as Record<string, unknown>
+  if (Array.isArray(obj.nodes) || Array.isArray(obj.edges)) return obj as StageGraph
+  // The terminal payload nests the graph one level down.
+  if (typeof obj.graph === 'object' && obj.graph !== null) return graphOf(obj.graph)
+  return null
+}
+
+/** Sorted node ids. Sorted so wire ordering cannot make an equal pair unequal. */
+export function nodeIdentities(value: unknown): string[] {
+  const g = graphOf(value)
+  const nodes = Array.isArray(g?.nodes) ? g!.nodes : []
+  return nodes
+    .map((n) => (typeof n === 'object' && n !== null ? String((n as { id?: unknown }).id) : ''))
+    .filter((id) => id.length > 0 && id !== 'undefined')
+    .sort()
+}
+
+/**
+ * Sorted `from->to` endpoint pairs.
+ *
+ * NOT `e.id`. Wire edges on this path carry no `id` — they are `from`/`to`
+ * pairs — so keying on `id` produces `[]` on both sides of every comparison
+ * and each one passes while testing nothing. That is the exact vacuity #751's
+ * own identity test shipped with in round 1.
+ */
+export function edgeIdentities(value: unknown): string[] {
+  const g = graphOf(value)
+  const edges = Array.isArray(g?.edges) ? g!.edges : []
+  return edges
+    .map((e) => {
+      if (typeof e !== 'object' || e === null) return ''
+      const o = e as Record<string, unknown>
+      const from = o.from ?? o.source
+      const to = o.to ?? o.target
+      if (typeof from !== 'string' || typeof to !== 'string') return ''
+      return `${from}->${to}`
+    })
+    .filter((k) => k.length > 0)
+    .sort()
+}
+
+/**
+ * Trap-13 control. An agreement assertion that has never seen a presence is
+ * vacuous, so every identity comparison must first prove both sides are
+ * non-empty. Throws — it is a test-time guard, used in production code paths
+ * only via the drift computation below (which tolerates empties).
+ */
+export function expectComparableGraph(value: unknown, label: string): void {
+  const ids = nodeIdentities(value)
+  if (ids.length === 0) {
+    throw new Error(
+      `${label} yielded no nodes — an identity comparison against it would pass by testing nothing`,
+    )
+  }
+}
+
+function computeDrift(preview: unknown, terminal: unknown): IdentityDrift | null {
+  const pn = nodeIdentities(preview)
+  const tn = nodeIdentities(terminal)
+  const pe = edgeIdentities(preview)
+  const te = edgeIdentities(terminal)
+  const drift: IdentityDrift = {
+    nodesOnlyInPreview: pn.filter((id) => !tn.includes(id)),
+    nodesOnlyInTerminal: tn.filter((id) => !pn.includes(id)),
+    edgesOnlyInPreview: pe.filter((k) => !te.includes(k)),
+    edgesOnlyInTerminal: te.filter((k) => !pe.includes(k)),
+  }
+  const clean =
+    drift.nodesOnlyInPreview.length === 0 &&
+    drift.nodesOnlyInTerminal.length === 0 &&
+    drift.edgesOnlyInPreview.length === 0 &&
+    drift.edgesOnlyInTerminal.length === 0
+  return clean ? null : drift
+}
+
+// ---------------------------------------------------------------------------
+
+export async function consumeStreamedDraftTurn(
+  frames: AsyncIterable<StageFrame>,
+  handlers: StreamedDraftHandlers,
+): Promise<StreamedDraftOutcome> {
+  let renderedGraph: StageGraph | null = null
+  let renderAttempted = false
+
+  try {
+    for await (const frame of frames) {
+      switch (frame.stage) {
+        case 'DRAFTING':
+          handlers.onDrafting?.()
+          break
+
+        case 'GRAPH_READY': {
+          // Render on arrival. `renderAttempted` — not `renderedGraph` — guards
+          // the repeat, so a callback that threw is not retried on a duplicate
+          // frame and quietly succeeds the second time.
+          if (renderAttempted || !frame.graph) break
+          renderAttempted = true
+          try {
+            handlers.onGraphReady(frame.graph)
+            renderedGraph = frame.graph
+          } catch {
+            // A canvas-side failure must not cost the user the whole turn —
+            // the terminal ingest below still runs and applies the full graph.
+            renderedGraph = null
+          }
+          break
+        }
+
+        case 'COACHING_READY':
+          handlers.onCoachingReady?.(frame.coaching_status)
+          break
+
+        case 'COMPLETE': {
+          const statusCode = frame.status_code ?? 200
+          // See the module header: `salvaged_from_truncation` is NOT a rung
+          // here, because #751 established the streamed frames never carry it.
+          const discardPreview = statusCode >= 400
+          const identityDrift =
+            renderedGraph && !discardPreview
+              ? computeDrift(renderedGraph, (frame.payload as { draft_graph?: unknown })?.draft_graph)
+              : null
+          return {
+            kind: 'complete',
+            terminalPayload: frame.payload,
+            statusCode,
+            renderedGraph,
+            discardPreview,
+            identityDrift,
+            // Always true when a preview exists: the terminal frame is
+            // authoritative, and a wholesale replace is what makes "never shows
+            // a node the terminal payload lacks" true by construction rather
+            // than by a diff that could miss a case.
+            replaceRenderedGraph: renderedGraph !== null,
+          }
+        }
+
+        case 'PROGRESS':
+          // Modelled, never observed on the wire (see streamedDraftFrames'
+          // header). Intentionally inert: no product behaviour may depend on a
+          // frame class nothing feeds.
+          break
+      }
+    }
+
+    return {
+      kind: 'abandoned',
+      reason: 'no_terminal_frame',
+      detail: 'stream ended without a terminal frame',
+      renderedGraph,
+    }
+  } catch (e) {
+    if (e instanceof StreamAbandonedError) {
+      return { kind: 'abandoned', reason: e.reason, detail: e.message, renderedGraph }
+    }
+    const err = e as Error
+    return {
+      kind: 'abandoned',
+      reason: err?.name === 'AbortError' ? 'aborted' : 'transport',
+      detail: err?.message ?? 'unknown stream failure',
+      renderedGraph,
+    }
+  }
+}

--- a/src/v5/streamedDraftFrames.ts
+++ b/src/v5/streamedDraftFrames.ts
@@ -1,0 +1,305 @@
+/**
+ * streamedDraftFrames — the wire half of the staged V5 turn consumer
+ * (ROADMAP 2.122 / 1.204 M1, POC-DONE step 1).
+ *
+ * Reads `POST <turn endpoint>/stream` as `text/event-stream` and yields typed
+ * stage frames. Nothing here touches the canvas or the store; the two-phase
+ * apply lives in `consumeStreamedDraftTurn` and its caller.
+ *
+ * ── THE CONTRACT (CEE PR #751, live-measured 29 Jul) ──────────────────────
+ * Five classes, `event: stage`, JSON `data` with `stage`, `seq` (monotonic
+ * from 0) and `status`:
+ *
+ *   | stage           | seq | status      | payload                              |
+ *   |-----------------|-----|-------------|--------------------------------------|
+ *   | DRAFTING        |  0  | in_progress | —                                    |
+ *   | PROGRESS        |  1  | in_progress | labels[], phase, elapsed_ms          |
+ *   | GRAPH_READY     |  2  | in_progress | graph{nodes,edges}, schema_version   |
+ *   | COACHING_READY  |  3  | in_progress | coaching_status                      |
+ *   | COMPLETE        |  4  | complete    | status_code, payload = buffered body |
+ *
+ * Live timings on deployed staging (`PHASE0-EVIDENCE-2026-07-28/
+ * cee2-live-latency.md`, 3 runs, median): DRAFTING **271 ms**, GRAPH_READY
+ * **35.8 s** (spread 33.7–39.9 s), COACHING_READY 59.2 s, COMPLETE 60.9 s.
+ * `: heartbeat` comment lines arrive every 10 s with < 3 ms drift per beat.
+ *
+ * ── PROGRESS IS NOT OBSERVABLE, AND THAT IS RECORDED HERE DELIBERATELY ────
+ * Zero PROGRESS frames were seen in any of the three live runs: the route
+ * emits the class, nothing feeds it (it needs the Anthropic streaming
+ * adapter — #745's inherited LOW, restated as #751's rowed item 5). The type
+ * below models it because the wire may carry it tomorrow, but **no product
+ * behaviour may depend on it** — which is exactly why the elapsed-time
+ * narration table in `DraftLoadingAnimation` still has to exist.
+ *
+ * ── WHAT IS DELIBERATELY *NOT* IMPLEMENTED ───────────────────────────────
+ * #745's consumer rules include "discard the GRAPH_READY graph if COMPLETE
+ * carries `salvaged_from_truncation: true`". #751 then established at the
+ * bytes that **the streamed frames never carry that field** — its transport
+ * header states a client branching on it "would be writing dead code", and it
+ * is a rowed gap on the server side. So the discard rule here fires on
+ * `status_code >= 400` ONLY. Implementing the salvage rung would be a branch
+ * that cannot execute, wearing the costume of a safety guarantee — the
+ * guarantee-theatre defect class this programme exists to hunt. When CEE
+ * lifts the field onto the frame, add the rung *and its test* together.
+ */
+import { parseSSELines } from '../lib/sse/parseSSELines'
+
+/** The five stage classes the route emits. Order is the wire's `seq` order. */
+export const STAGE_NAMES = [
+  'DRAFTING',
+  'PROGRESS',
+  'GRAPH_READY',
+  'COACHING_READY',
+  'COMPLETE',
+] as const
+
+export type StageName = (typeof STAGE_NAMES)[number]
+
+const STAGE_NAME_SET: ReadonlySet<string> = new Set(STAGE_NAMES)
+
+/** The graph shape a GRAPH_READY frame carries (`schema_version: 'v3'` live). */
+export interface StageGraph {
+  nodes?: unknown[]
+  edges?: unknown[]
+}
+
+export interface StageFrame {
+  stage: StageName
+  /**
+   * Monotonic from 0 — but NOT contiguous. See the header's note on PROGRESS:
+   * `seq 1` is never emitted on the live wire, so the normal sequence is
+   * 0, 2, 3, 4 and a strict "+1" check would reject every healthy stream.
+   */
+  seq: number
+  status: 'in_progress' | 'complete'
+  /** GRAPH_READY only. */
+  graph?: StageGraph
+  schema_version?: string
+  elapsed_ms?: number
+  /** PROGRESS only — modelled, never observed on the wire. See the header. */
+  labels?: unknown[]
+  phase?: string
+  /** COACHING_READY only. Enum, not prose. */
+  coaching_status?: string
+  /** COMPLETE only. `payload` is the buffered turn body VERBATIM. */
+  status_code?: number
+  payload?: unknown
+}
+
+/**
+ * Every way the stream can end without a usable COMPLETE frame. Each maps to
+ * the same product behaviour (transparent fallback to the buffered turn) but
+ * they are distinguished because the diagnostics and the tests need them apart.
+ */
+export type StreamAbandonReason =
+  | 'http_error'
+  | 'no_body'
+  | 'transport'
+  | 'silence'
+  | 'malformed_frame'
+  | 'seq_not_monotonic'
+  | 'no_terminal_frame'
+  | 'aborted'
+
+export class StreamAbandonedError extends Error {
+  readonly name = 'StreamAbandonedError'
+  constructor(
+    readonly reason: StreamAbandonReason,
+    message: string,
+    readonly httpStatus?: number,
+  ) {
+    super(message)
+  }
+}
+
+/**
+ * The server's heartbeat cadence, from CEE `config/timeouts.ts`
+ * (`SSE_HEARTBEAT_INTERVAL_MS`) and confirmed on the wire at
+ * 10.219/20.218/30.218/40.219/50.222/60.222 s.
+ */
+export const SERVER_HEARTBEAT_INTERVAL_MS = 10_000
+
+/**
+ * How long the client tolerates total dead air — no frame, no heartbeat, no
+ * byte — before abandoning the stream.
+ *
+ * DERIVED from the server cadence rather than typed as a second magic number:
+ * three consecutive missed beats. Deliberately NOT an elapsed-time deadline
+ * on the turn: the cold-start GRAPH_READY spread reached 39.9 s and a p99 turn
+ * has no upper bound the client can know, so any wall-clock cut-off would kill
+ * healthy slow draws. The outer 130 s `EXTENDED_TIMEOUT_MS` (which exists to
+ * outlive CEE's own 125 s proxy budget) remains the only elapsed-time guard.
+ */
+export const STREAM_SILENCE_TIMEOUT_MS = SERVER_HEARTBEAT_INTERVAL_MS * 3
+
+/**
+ * Decode one SSE `data:` payload into a validated frame.
+ *
+ * Returns `null` — never throws, never fills in a default — for anything that
+ * is not a complete, well-formed frame. A frame with a guessed `seq` would
+ * defeat the monotonicity check, and a frame with a guessed `stage` would let a
+ * new server stage be silently swallowed.
+ */
+export function parseStageFrame(raw: string): StageFrame | null {
+  let decoded: unknown
+  try {
+    decoded = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) return null
+  const obj = decoded as Record<string, unknown>
+
+  const stage = obj.stage
+  if (typeof stage !== 'string' || !STAGE_NAME_SET.has(stage)) return null
+
+  const seq = obj.seq
+  if (typeof seq !== 'number' || !Number.isInteger(seq) || seq < 0) return null
+
+  const status = obj.status
+  if (status !== 'in_progress' && status !== 'complete') return null
+
+  const frame: StageFrame = { stage: stage as StageName, seq, status }
+
+  const graph = obj.graph
+  if (typeof graph === 'object' && graph !== null && !Array.isArray(graph)) {
+    frame.graph = graph as StageGraph
+  }
+  if (typeof obj.schema_version === 'string') frame.schema_version = obj.schema_version
+  if (typeof obj.elapsed_ms === 'number') frame.elapsed_ms = obj.elapsed_ms
+  if (Array.isArray(obj.labels)) frame.labels = obj.labels
+  if (typeof obj.phase === 'string') frame.phase = obj.phase
+  if (typeof obj.coaching_status === 'string') frame.coaching_status = obj.coaching_status
+  if (typeof obj.status_code === 'number') frame.status_code = obj.status_code
+  if ('payload' in obj) frame.payload = obj.payload
+
+  return frame
+}
+
+/**
+ * Read an already-opened SSE `Response` and yield stage frames as they arrive.
+ *
+ * Yields on arrival, one frame at a time — a caller that renders inside the
+ * loop renders at the frame's wire timestamp. That is the whole point of the
+ * lane, so this function must never buffer to completion.
+ */
+export async function* streamStageFrames(
+  res: Response,
+  opts: { silenceTimeoutMs?: number } = {},
+): AsyncGenerator<StageFrame> {
+  if (!res.ok) {
+    throw new StreamAbandonedError(
+      'http_error',
+      `streamed turn returned HTTP ${res.status}`,
+      res.status,
+    )
+  }
+  if (!res.body) {
+    throw new StreamAbandonedError('no_body', 'streamed turn response carried no body')
+  }
+
+  const silenceMs = opts.silenceTimeoutMs ?? STREAM_SILENCE_TIMEOUT_MS
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+
+  let buffer = ''
+  let lastSeq = -1
+  let sawTerminal = false
+  let silenceTimer: ReturnType<typeof setTimeout> | undefined
+
+  /** Rejects when the socket has been silent for the budget. */
+  const armSilence = () =>
+    new Promise<never>((_resolve, reject) => {
+      silenceTimer = setTimeout(
+        () =>
+          reject(
+            new StreamAbandonedError(
+              'silence',
+              `no bytes for ${silenceMs}ms (server heartbeats every ${SERVER_HEARTBEAT_INTERVAL_MS}ms)`,
+            ),
+          ),
+        silenceMs,
+      )
+    })
+
+  try {
+    for (;;) {
+      let chunk: ReadableStreamReadResult<Uint8Array>
+      const silence = armSilence()
+      try {
+        chunk = await Promise.race([reader.read(), silence])
+      } catch (e) {
+        if (e instanceof StreamAbandonedError) throw e
+        const err = e as Error
+        if (err?.name === 'AbortError') {
+          throw new StreamAbandonedError('aborted', 'streamed turn aborted')
+        }
+        throw new StreamAbandonedError('transport', `stream read failed: ${err?.message ?? 'unknown'}`)
+      } finally {
+        clearTimeout(silenceTimer)
+        // Keep the losing rejection from surfacing as an unhandled rejection
+        // once the read has won the race.
+        void silence.catch(() => {})
+      }
+
+      const done = chunk.done
+      if (chunk.value) buffer += decoder.decode(chunk.value, { stream: !done })
+
+      // Split on the LAST newline so a frame cut mid-JSON across TCP segments
+      // (measured: GRAPH_READY arrived as eight sub-frame segments) stays in
+      // the buffer until it is whole.
+      const cut = buffer.lastIndexOf('\n')
+      const ready = done ? buffer : cut >= 0 ? buffer.slice(0, cut + 1) : ''
+      if (!done && cut >= 0) buffer = buffer.slice(cut + 1)
+      else if (done) buffer = ''
+
+      if (ready.length > 0) {
+        const { events } = parseSSELines(ready.split('\n'), done)
+        for (const ev of events) {
+          const frame = parseStageFrame(ev.data)
+          if (!frame) {
+            throw new StreamAbandonedError(
+              'malformed_frame',
+              `undecodable stage frame (event: ${ev.eventType || '<none>'})`,
+            )
+          }
+          // MONOTONICITY, not contiguity — and the distinction is measured, not
+          // stylistic. #745's consumer rules say "`seq` monotonic ⇒ a dropped
+          // frame is detectable", and an earlier version of this comment
+          // repeated that as if this check detected GAPS. It does not, and it
+          // must not: PROGRESS (`seq 1`) is never emitted on the live wire
+          // (zero observed across three runs), so 0 -> 2 is the ORDINARY
+          // sequence and a contiguity check would reject every healthy stream.
+          // What a repeated or backwards `seq` does prove is a duplicated or
+          // re-ordered frame, which is a real transport fault.
+          if (frame.seq <= lastSeq) {
+            throw new StreamAbandonedError(
+              'seq_not_monotonic',
+              `seq went backwards or repeated: ${lastSeq} -> ${frame.seq}`,
+            )
+          }
+          lastSeq = frame.seq
+          if (frame.status === 'complete') sawTerminal = true
+          yield frame
+          if (sawTerminal) return
+        }
+      }
+
+      if (done) break
+    }
+
+    if (!sawTerminal) {
+      throw new StreamAbandonedError(
+        'no_terminal_frame',
+        `stream closed after seq ${lastSeq} without a terminal frame`,
+      )
+    }
+  } finally {
+    clearTimeout(silenceTimer)
+    try {
+      await reader.cancel()
+    } catch {
+      // Cancelling an already-errored or already-closed reader is not a failure.
+    }
+  }
+}

--- a/src/v5/streamedDraftFrames.ts
+++ b/src/v5/streamedDraftFrames.ts
@@ -31,6 +31,24 @@
  * behaviour may depend on it** — which is exactly why the elapsed-time
  * narration table in `DraftLoadingAnimation` still has to exist.
  *
+ * ── ⚠ A LATENT LIMIT, RECORDED SO IT IS NOT A MYSTERY LATER (review F8) ──
+ * `streamStageFrames` hands each chunk's COMPLETE LINES to the stateless
+ * `parseSSELines`, and a batch ending at a newline always synthesises an event
+ * boundary (the trailing `''` from `split('\n')`). So a MULTI-LINE `data:` event
+ * split across a TCP chunk boundary would be dispatched in halves and rejected as
+ * `malformed_frame` — abandoning a healthy stream and costing one buffered turn
+ * (never a dead end, but a pointless ~55 s).
+ *
+ * **Unreachable today, by construction of the producer:** every frame is a single
+ * `JSON.stringify` line, and the live capture confirms it (the 10,471-byte
+ * GRAPH_READY frame arrived as eight sub-frame TCP segments and reassembled
+ * correctly, because the split was mid-LINE, not between lines — which the
+ * last-newline buffering handles and a test pins).
+ *
+ * If CEE ever pretty-prints a frame or emits multi-line `data:`, THIS is the
+ * cause of the sudden fallback storm. The fix would be to carry the partial-event
+ * state across chunks rather than re-entering a stateless parser per chunk.
+ *
  * ── WHAT IS DELIBERATELY *NOT* IMPLEMENTED ───────────────────────────────
  * #745's consumer rules include "discard the GRAPH_READY graph if COMPLETE
  * carries `salvaged_from_truncation: true`". #751 then established at the

--- a/src/v5/streamedTurnTransport.ts
+++ b/src/v5/streamedTurnTransport.ts
@@ -1,0 +1,114 @@
+/**
+ * streamedTurnTransport — opening the staged V5 turn, and closing it back into
+ * the buffered path's own parser (ROADMAP 2.122 / 1.204 M1).
+ *
+ * ── THE ENDPOINT IS DERIVED, NOT MIRRORED ────────────────────────────────
+ * `<buffered endpoint> + '/stream'`, where the buffered endpoint comes from
+ * `v5Adapter`'s existing resolver. A second copy of the env ladder here would
+ * be CLAUDE.md trap 12 with a 404 for a failure mode — and the suffix rule is
+ * not a lucky guess, it is correct on every rung (derived at the deployed
+ * bytes, `PHASE0-EVIDENCE-2026-07-28/m1l2-consumer.md` F0-1):
+ *
+ *   VITE_V5_ENDPOINT=…/proxy/v5/turn   → …/proxy/v5/turn/stream
+ *       (what staging actually bakes; the route cee2-live-latency.md measured)
+ *   /bff/orchestrate/v2/turn           → /bff/orchestrate/v2/turn/stream
+ *       (Netlify edge fn rewrites /bff/orchestrate/* → CEE /orchestrate/*, so
+ *        this reaches #751's service sibling, and the edge fn injects the
+ *        ASSIST_API_KEY that route requires)
+ *
+ * The edge function already forwards `accept` and passes SSE through
+ * un-buffered (`duplex:'half'` + raw `response.body`), so nothing on the proxy
+ * needed changing for this lane.
+ *
+ * ── THE TERMINAL FRAME GOES BACK THROUGH THE BUFFERED PARSER ─────────────
+ * `terminalPayloadToResponse` wraps COMPLETE's `payload` + `status_code` in a
+ * `Response` and the caller hands it to `parseV5Response` — the SAME function
+ * the buffered turn uses, with the same validator and the same
+ * additive-extensions sidecar. There is deliberately no second ingest path to
+ * keep in step; "byte-equivalent" is a property of the construction here, not
+ * a claim someone has to re-verify.
+ */
+import { recordRequestPayload } from '../lib/payload-trace-store'
+
+import { StreamAbandonedError } from './streamedDraftFrames'
+import { __internals as adapterInternals } from './v5Adapter'
+
+import type { OrchestratorTurnPayload } from '@talchain/schemas/boundary'
+
+function streamEndpointFor(bufferedEndpoint: string): string {
+  return `${bufferedEndpoint.replace(/\/+$/, '')}/stream`
+}
+
+/** The streamed sibling of whatever endpoint the buffered turn resolves to. */
+export function getV5StreamEndpoint(): string {
+  return streamEndpointFor(adapterInternals.resolveEndpoint())
+}
+
+export interface OpenStreamOptions {
+  signal?: AbortSignal
+  headers?: Record<string, string>
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Wrap the COMPLETE frame's verbatim buffered body in a `Response` so the
+ * caller can run it through `parseV5Response` unchanged.
+ */
+function terminalPayloadToResponse(payload: unknown, statusCode: number): Response {
+  return new Response(JSON.stringify(payload ?? null), {
+    status: statusCode,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/**
+ * POST the turn to the streamed sibling and return the open SSE `Response`.
+ *
+ * The payload is byte-identical to the buffered turn's — same builder, same
+ * `turn_id` / `scenario_id`. That is what makes the fallback safe: re-sending
+ * it on the buffered route is a RE-ENTERED turn, which CEE's own continuation
+ * guard resolves (draft if not drafted, decline and describe if drafted), not
+ * a second draft.
+ */
+export async function openV5TurnStream(
+  payload: OrchestratorTurnPayload,
+  opts: OpenStreamOptions = {},
+): Promise<Response> {
+  const url = getV5StreamEndpoint()
+  const fetchFn = opts.fetchImpl ?? fetch
+
+  // Mirror the buffered adapter's diagnostic capture so a streamed draft still
+  // appears in the debug bundle.
+  recordRequestPayload({
+    id: crypto.randomUUID(),
+    endpoint: url,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream', ...(opts.headers ?? {}) },
+    body: payload,
+  })
+
+  try {
+    return await fetchFn(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        ...(opts.headers ?? {}),
+      },
+      body: JSON.stringify(payload),
+      signal: opts.signal,
+    })
+  } catch (e) {
+    const err = e as Error
+    if (err?.name === 'AbortError') {
+      throw new StreamAbandonedError('aborted', 'streamed turn aborted before any frame')
+    }
+    throw new StreamAbandonedError(
+      'transport',
+      `streamed turn could not be opened: ${err?.message ?? 'unknown'}`,
+    )
+  }
+}
+
+export const __streamInternals = { streamEndpointFor, terminalPayloadToResponse }


### PR DESCRIPTION
> ## ⚠ AMENDED AFTER ROUND-2 RE-REVIEW — head `d25cfe78`
>
> The re-review returned **AMENDMENTS-FAIL on exactly one narrow residual**; six of seven items HOLD, the F1 design
> choice was adjudicated sound, and the rowed-item-9 withdrawal was accepted.
>
> **R2-F1 (blocking-class) — FIXED. Abort of the FALLBACK, not of the stream.** My round-2 fix reasoned carefully
> about which abort *causes* deserved a fallback and never asked what happens when the abort arrives *during* one.
> `fallbackToBuffered`'s `await callV5Turn(...)` had no abort handling, so the AbortError propagated **plain**:
> `abortedWithPreview` never set, the outer catch silent by design, and the finally's ownership guard saw `settling`
> (≠ `unsettled`) and **actively cleared it to `idle`** — preview standing, gate OPEN, nothing said. The original F1
> fabrication, one level deeper. **And round 2's timeout-copy suppression made that path MORE silent, not less** — a
> fix landing next to a hole can hide it.
> **⚠ The dominant trigger needs no user action:** a ~55 s buffered fallback cannot fit in what remains of the 130 s
> budget once the stream dies at ≥75 s, so any late stream death kills its own fallback by wall clock.
> Fixed with one branch — a catch around the fallback's await routed to the SAME `unsettled` + notice path. The catch
> is deliberately **not** narrowed to `AbortError` (a non-abort throw is near-unreachable because `callV5Turn`
> converts network failures into a `parse_error` result, but the honest statement would be identical and an unmarked
> standing preview is the defect the branch exists to close — fail-closed toward honesty).
>
> **Why the battery could not see it, which is the useful part:** N1 mutates the stream-abort branch only, and
> **every fallback test resolved `callV5Turn`** — no test in the suite had ever aborted a turn with a buffered
> request open.
>
> **RED-first with the R2-P4 shape:** four pins written first; two went RED with the reviewer's exact
> `expected 'idle' to be 'unsettled'`; the other two (no second network call, no marker when nothing was rendered)
> passed already and stand as controls that the fix does not over-reach.
>
> **R2-N1 — taken, not rowed** (it was one line). A suppressed no-op resolved indistinguishably from a real write, so
> the caller reported `saved` + a timestamp for a write that deliberately did not happen; during terminal `unsettled`
> a signed-in user would see "saved" on every edit while nothing persisted. `persistGraphNow` now returns whether it
> wrote and both status call sites gate on it; status stays `saving` rather than inventing a new one, because the
> write really is still pending. Pinned in the derived call-site guard.
>
> **The two F3 copy notes are rowed together** (stale `lastUserInputRef` as the redraft brief; "the structure is
> still here" preceding a canvas-resetting chip) — the honest rewording depends on the brief fix, so they should land
> as one change rather than be improvised in a residual round.
>
> **Round-3 battery: P1 (residual restored verbatim) RED · P2 (catch never marks the preview) RED · P3 (over-fire
> control) RED · P4 (R2-N1 regressed) RED. Baseline 1005/1005. Survivors: 0.**
>
> Full detail: `PHASE0-EVIDENCE-2026-07-28/m1l2-consumer.md` § ROUND 3.

---

> ## ⚠ AMENDED AFTER ADVERSARIAL REVIEW (round 2) — head `d721ab02`
>
> The review returned **BLOCKED**, and it was right on every finding. **The core construction it cleared is
> unchanged** — wire layer, eligibility fail-closed, fallback idempotency, zombie-apply impossible, identity
> divergence safe, the two-phase apply, the battery's counts reproduced on spot-check. Every fix is in the phase
> machine's **boundary states**, which is exactly where "honest no-claim window" is either true everywhere or is
> not a guarantee. Both blocking probes reproduced in my own suite **before** any product code changed.
>
> **F1 (BLOCKING) — the abort hole. FIXED, and the design choice is the one thing a reviewer should re-examine.**
> Stop (or the 130 s timeout) after GRAPH_READY mapped to phase `idle` with the preview standing, run gate OPEN and
> no notice. Chosen shape: **`unsettled`** — keep the structure, mark it, gate shut, honest notice. **Both offered
> alternatives were rejected on evidence:**
> · *fire the died-stream fallback* is wrong for two of the three abort causes — Stop is a user instruction not to
> continue, preempt means a newer turn owns the canvas — and mechanically it would require minting a new
> `AbortController` to defeat the abort the user just requested;
> · *clear the preview* **can destroy a committed model**: the turn commits at ~61 s, so on the 130 s timeout path a
> discard's echo save writes an EMPTY graph *after* that commit. It also tells the user "you have no model" about a
> graph CEE validated — and the tester the review identified (sees the graph at 36 s, clicks Stop) would watch it
> vanish.
> **The autosave bound is answered more strongly than either option:** the UI now never persists a graph whose values
> it knows are in-progress, in *either* store — a guard inside `persistGraphNow` (its own header declares it the ONE
> write path) plus `skipAutosave` on the preview, which closes the review's second F1 vector needing no Stop click at
> all. Rowed item 9 is **withdrawn as a hazard** rather than accepted as rowed.
> **Adjacent defect the fix exposed and fixed:** the 130 s timeout said "your message has not gone through" and
> marked the bubble failed — both false when a graph is on the canvas, and it would have contradicted the new notice.
>
> **F2 (BLOCKING) — cross-scenario leak. FIXED by derivation, not a boundary list.** `draftStreamPhaseFor` is the
> single place that decides ownership; a clear-on-switch list would be a mirror of the ways a scenario can change
> (trap 12) — and the review had just found `resetDraft` was exactly that mirror, with a doc comment claiming a
> caller it does not have. **Trap 14 fixed at the same surface**, and it had taught *me* the boundary was handled.
>
> **F3 (MAJOR) — the chip lied. FIXED.** `retry` → `retryLast()` re-sends onto the committed scenario, which CEE
> declines; the Supabase re-fetch cannot rescue it either (needs `stage:analyse`, which a decline's prose never
> produces) — so rowed item 3 was narrower than reality: **no auth tier could recover.** `startNewDraft` resets the
> canvas *and* the scenario id, so CEE sees no prior turns and drafts. Copy matches the handler.
>
> **F4 — FIXED**, and it exposed that the notice was in the wrong place: a terminal frame failing validation routes
> to `typed_error`, so the canvas kept a preview and a shut gate with **nothing said**. The notice is a statement
> about the canvas, not the response shape, and now sits outside the `target.kind` chain.
>
> **F5 FIXED** (split refusal string) · **F7 FIXED by deletion** · **F6 and F8 rowed with the reasons and, for F8,
> a header note naming the cause and the fix.**
>
> **Round-2 battery: 13 real mutants, all RED, 0 survivors** (N3 survived first — the M16 lesson for a third time —
> and is closed the same way). **N14 is a labelled control that is EXPECTED green**: it re-adds a dead outcome field,
> which no test can see. That is precisely why F7's fix was deletion rather than a test, and it is recorded so the
> zero-survivor claim is not overstated.
>
> Full detail: `PHASE0-EVIDENCE-2026-07-28/m1l2-consumer.md` § ROUND 2.

---

**ROADMAP 2.122 (POC-DONE step 1) / 1.204 M1 — the UI half.** Design of record: `docs-designs/ASYNC-DRAFTING-DESIGN-2026-07-28.md` Q3 item 3 (UI-1). Unblocked by CEE #751 (MERGED), live-proven in `PHASE0-EVIDENCE-2026-07-28/cee2-live-latency.md`. Full lane evidence: `PHASE0-EVIDENCE-2026-07-28/m1l2-consumer.md`.

A cold draft turn now goes to the streamed sibling, so **the decision model appears on the canvas at ~36 s instead of ~55–61 s** — live-measured, not projected.

**Branched off `staging` at `556f38fc`, which is also the DEPLOYED tip (`/version.json`). NOT MERGED — adversarial review is the house rule for this surface.**

---

## The new first 40 seconds, honestly

| t | what a tester sees | what licenses it |
|---|---|---|
| **~0.3 s** | the honest wait begins — *"Drafting your decision model…"*, `Xs elapsed`, indeterminate sweep | the DRAFTING frame, live at **271 ms** |
| 20 s | *"Still drafting your decision model…"* | elapsed time alone |
| **~36 s** ⭐ | **the model appears on the canvas**, laid out. Narration switches to *"Your model is on the canvas. Values and coaching are still arriving…"* | the GRAPH_READY frame, which the client is HOLDING |
| ~48 s | *"Still waiting on the values and coaching…"* | elapsed since the render |
| **~61 s** | coaching, readiness, the model receipt and Run all unlock — **byte-identical end state to today** | COMPLETE's `payload`, through the buffered path's own `parseV5Response` |

**Stated precisely: the graph is on screen 19.6 s before the buffered route returns its first byte of anything** (35.8 s vs 55.4 s, both live medians). Not "20 s faster overall" — completion is ~5.5 s *later* (the probe measured the arms as disjoint, p≈0.05, "suggestive not established"). A workable model 20 s sooner; the turn finishes about 5 s later.

### What is deliberately NOT shown for those 25 seconds

GRAPH_READY is stamped `status: "in_progress"` and its contract states that `graph-data-integrity` refines the numeric values after the transform. So: no win probabilities, no leader or ranking language, no freshness verdict, **no Run affordance**, and no claim about the wait's length or the user's decision.

The first three hold **by construction of a gate that already existed** — the frame carries no `analysis_ready`, so `applyDraftResult`'s pre-existing `hasAnalysisReady` check skips every analysis side-effect. The Run affordance needed a new rung: the gate is otherwise driven by `nodeCount` + readiness, neither of which can tell a settled graph from a 25-second-old preview.

---

## The stop clause did not fire — `applyV5State` is ZERO BYTES

The dispatch's stop clause was "if the V5 ingest path cannot cleanly accept a graph-before-values two-phase apply without deep surgery on `applyV5State`". It cannot need surgery, for a structural reason: **a GRAPH_READY frame is not an `OlumiResponse`**, so the two phases were never two applies of one function. They are two functions that were already separate — `applyDraftResult(graph)` for the frame, and the entire existing ingest chain for the terminal payload.

**Terminal ingest is byte-equivalent by construction, not by claim.** #751's COMPLETE frame carries `payload` = the buffered turn body *verbatim* plus `status_code`; the consumer re-wraps them in a `Response` and hands them to **the same `parseV5Response` the buffered turn uses**. There is no second ingest path to keep in step.

### The one seam that would have failed silently

`canvasIsEmpty` is evaluated *after* the await (`useConversation.ts`). With a GRAPH_READY preview on screen it reads `false`, and the terminal graph would route into `reconcileAppliedGraph` — the applied-edit-receipt path. Reconcile gets the **nodes right** and performs none of `applyDraftResult`'s side-effects: no `setCeeAnalysisReady`, no `setAnalysisFreshness`, no `commitDraftCoachingToStore`, no `goal_constraints`, no quality, no pre-analysis sensitivity. **The canvas would look perfect while coaching and the Run affordance never unlocked, under a green suite.** The emptiness test now means "empty, or holding only this turn's own preview", keyed on `turnClientId`. Mutant M2.

Two smaller seams: the terminal apply passes `skipHistory` when it is resolving its own preview, so the **undo stack is identical** to the buffered path's (M6); and layout provably does not jump, because `mapDraftNodeToCanvas` gives every node `position: {x:0,y:0}` and layout is derived from the graph — so identical identity across the frames yields an identical layout, which is the same fact the required identity test asserts.

---

## Failure honesty — one buffered turn on the same payload

**Never a dead end, and it cannot double-commit.**

#751 established that the turn **keeps running and still commits when the client hangs up** — deliberately, since aborting mid-turn could leave the scenario commit half-applied. So a dead stream may or may not have committed and the client cannot tell. **The buffered route already resolves that**: the live read-back control shows CEE reloads its persisted graph and **declines to re-draft** on a committed scenario ("already drafted with four options…", 200, no `draft_graph`), while a fresh scenario drafts normally. One POST is simultaneously *draft-if-not-drafted* and *read-back-if-drafted* — CEE's own continuation guard decides. Same `turn_id`, same `scenario_id`, no new scenario, no second stream.

| stream died | buffered reply | behaviour |
|---|---|---|
| before GRAPH_READY | carries `draft_graph` | ordinary cold draft. **Provably the only possible case here**, because the commit runs *after* the pipeline emits that frame |
| after GRAPH_READY, committed | prose, no `draft_graph` | graph KEPT, phase → `unsettled`, **Run stays shut**, transcript states the situation with a "Draft again" chip |
| never drafted | prose, no `draft_graph` | indistinguishable from today's conversational reply to a brief |

The middle row is the branch that matters: clearing the phase and letting the model read as finished is the fabrication it exists to refuse.

---

## #521's elapsed-time table STAYS — and its header note was wrong, not honoured

The component said the table "should be deleted outright" once the streamed route existed. The route exists; **the deletion would be a regression.** Measured reason: **zero PROGRESS frames on the wire**, all three live runs ("the route emits the frame class; nothing feeds it"). Between DRAFTING and GRAPH_READY the client holds one frame and a clock — deleting the table converts 36 s of honest escalating acknowledgement into 36 s of silence. Note amended, pointing at the 2.122 PROGRESS row.

**And the streamed render CREATED a silence that had to be fixed.** `AIInputBar`'s gate was `isThinking && nodeCount === 0`, and it is the only live narration surface on this path (complete manifest in the evidence file — `DraftChat`'s `DraftLoadingAnimation` hangs off the legacy `useCEEDraft` hook the orchestrator path returns before reaching). Rendering the graph at 36 s makes that gate false while `isThinking` stays true for 25 s more: a frozen composer explaining nothing. The widened gate is part of the feature, not decoration (M11).

---

## The honesty guard, extended — and it caught its own author twice

`narrationHonesty.invariant.spec.ts` gains:

1. **`LIVE_TABLES` is DERIVED** from a registry instead of hand-listed. The hand-listed array was trap 12 *inside the guard written to prevent trap 12*: a new narration table would be completely ungoverned and the omission would read GREEN. M12.
2. **A stricter FRAME-LICENCE rule set** for the post-GRAPH_READY strings. The distinction is the point: elapsed time alone cannot license naming a phase, but a held frame can license "the graph exists" — and that extra licence is exactly where a claim *about* the graph would slip in. Five rules (verdict/recommendation, leader/ranking, probability/confidence, freshness, "finished"), each with its own positive control; every frame-licensed string must also pass all five elapsed-time rules.

**It rejected two of my own lines on the first run.** *"Still finishing the values and coaching…"* tripped completion-proximity — correctly, "finishing" tells the user the wait is nearly over and no frame says that. And the unsettled notice's "the finished numbers" tripped the model-is-finished rule.

**One test title was corrected rather than its assertion.** "asserts nothing the client cannot know from elapsed time alone" was right while every table was elapsed-licensed and became an **overclaim** the moment the frame-licensed table joined. It now says what it always checked.

---

## The cross-frame identity test the spec required

One test, both shapes, **compared** — plus the dispatch's second half ("the renderer never shows a node the terminal payload lacks").

**Both vacuity traps #751 hit in round 1 are closed, with controls:** the terminal graph rides the response's top-level `draft_graph`, not `blocks[].data.applied_graph` (on this path `blocks` is empty, so a blocks-reading extractor compares `[]` with `[]`); and **wire edges carry no `id`** — they are `from`/`to` pairs, so keying on `e.id` makes both sides empty and every edge comparison passes. Keyed on the endpoint pair, with `expectComparableGraph` refusing an empty graph on either side before any comparison runs. Identities are sorted; a companion test asserts the fixtures' VALUES genuinely differ so the identity test cannot degenerate into "two identical objects are identical".

**Ordering is pinned, not just content** — the render callback must fire *between* GRAPH_READY and the next frame. A consumer that buffered all five frames and applied at the end passes every content assertion while deleting the entire benefit. That is #751's M9 moved to the client, and it is M5.

**The integration fixture is a REAL CEE wire capture** (already in the repo), with the GRAPH_READY graph DERIVED from it (same ids, values zeroed) so the two cannot drift. My first version invented a plausible body, `parseV5Response` rejected it as `schema_mismatch`, and the whole ingest silently never ran — recorded in the evidence file because that is exactly how a green suite over a dead path happens.

---

## Mutation battery — worktree OUTSIDE the clone (trap 9c), removed and its absence verified before the gates

Baseline unmutated, 9 suites: **147/147 GREEN**.

**The runner asserts the mutation APPLIED before it believes any verdict** (trap 15). That guard earned itself immediately: the first M20 edit silently failed to match and was reported as a survivor; under the guard it reads `!! MUTATION DID NOT APPLY — verdict VOID`.

| # | mutation | verdict |
|---|---|---|
| M1 | **drop the GRAPH_READY render** | **RED** (8) |
| M2 | **the silent defect** — terminal ingest mistakes its own preview for an applied-edit receipt | **RED** (1) |
| M3 | **a dead stream becomes a dead end** | **RED** (2) |
| M4 | run affordance offered over unsettled values | **RED** (2) |
| M5 | **buffer every frame, render at COMPLETE** — content perfect, latency benefit gone | **RED** (7) |
| M6 | two history pushes — undo depth diverges | **RED** (1) |
| M7 | **the fabrication** — an unsettled draft presented as finished | **RED** (1) |
| M8 | seq monotonicity neutered (**survived round 1**) | **RED** (3) |
| M8b | monotonicity tightened to CONTIGUITY — rejects every live stream | **RED** (14) |
| M9 | eligibility over-broad — `run_analysis` dispatched to the draft stream | **RED** (2) |
| M10 | edge identity keyed on a field wire edges lack (the vacuity trap) | **RED** (2) |
| M11 | narration gate reverted — frozen composer, no status line, ~25 s | **RED** (2) |
| M12 | narration registry silently loses a table | **RED** (1) |
| M13 | silence watchdog removed — a dead socket hangs forever | **RED** (1) |
| M14 | a graph rendered on a FAILED turn left standing | **RED** (2) |
| M15 | run gate reopens on a permanently-unsettled draft (**survived round 1**) | **RED** (3) |
| M16 | `OutputsDock` stops feeding the gate its phase (**survived round 1**) | **RED** (1) |
| M17 | `ConversationPanel`'s run affordance stops feeding the gate | **RED** (1) |
| M18 | the derived call-site guard's matcher finds NOTHING | **RED** (2) |
| M19 | endpoint hardcoded instead of derived | **RED** (1) |
| M20 | `Accept` no longer requests an event stream | **RED** (1) |
| M21 | scenario guard returns silently instead of throwing (**survived TWICE**) | **RED** (1) |
| M22 | preview drawn onto whatever scenario is open when the frame lands | **RED** (1) |

**Survivors after repair: 0.** Each bites a different count — evidence they hit different assertions rather than one over-broad test.

### What the four survivors taught (the useful part of this PR)

**M8 — my own comment was the overclaim.** The header said the `seq` check made "a dropped frame detectable", echoing #745's rule. It does not, **and must not**: PROGRESS (`seq 1`) is never emitted, so `0 → 2` is the ORDINARY live sequence and a contiguity check would abandon every healthy stream. Renamed `seq_gap` → `seq_not_monotonic`, comment corrected, four pins added — **including the over-tightening mutant M8b**, so nobody later "fixes" the check into something that rejects reality.

**M15 + M16 — the honesty rung's derivation lived where nothing tests.** `OutputsDock` computed `draftValuesSettling = phase === 'settling' || phase === 'unsettled'` while every test computed its own copy: a mirror of a two-clause predicate, inside the guard built to prevent mirrors. Dropping a clause stayed GREEN. **Fixed by deleting the derivation, not by testing around it** — `canRunAnalysis` takes the raw phase, so one tested place decides what "unsettled" means, with a spec **exhaustive over the phase union** behind a compiler-checked switch. Making the param *required* (loudest alarm) was rejected: 52 test call sites of noise for a two-caller change. Mounting `OutputsDock` (~2,500 lines) was rejected too — it covers one surface. Instead a **derived call-site guard** greps the run-gate manifest out of `src/` at test time, with a trap-13 control that the matcher sees a presence and reports the manifest by name; it therefore covers a *third* run surface added tomorrow. Its honest limit is in its own header: structural check on source text, behaviour pinned separately.

**M16 also exposed a hole I would otherwise have shipped: `ConversationPanel` is a second run affordance and I had not wired it at all.** Its own comment records that this surface once "re-created the exact panel-vs-engine contradiction #343 fixed". Found by the battery, not by me.

**M21 — two variables tracked one fact.** A local `previewRendered` sat beside the consumer's `renderedGraph`, and the mirror ABSORBED the inconsistency a silent scenario-guard `return` created, so the mutant survived twice. Removing the duplicate made the callback's throw genuinely load-bearing, and the consequence is now pinned by name: without it, a 4xx terminal after a scenario switch reaches into the scenario the user moved **to** and clears its authoritative-graph identity.

---

## An existing spec caught a real defect in my dispatch

`useConversation.hook.spec.ts`'s preempt test timed out, and the stack said the failing turn came from `dispatchAction` — the **Run** action. My eligibility predicate read `explicit_generate || derivedStage === 'frame'`, which *looked* right because `getTimeoutMs` grants its extended budget on exactly that disjunction. It is wrong: **`deriveV5Stage` returns `'frame'` for ANY turn on an empty canvas**, so a Run click on an empty canvas was being dispatched to the *draft* stream. I reused a disjunction from a function whose purpose (choose a timeout) tolerates being over-broad, in a function whose purpose (choose a route) does not — trap 16 in miniature. Now fail-closed, pinned at the predicate including the exact `run_analysis` case, with M9 covering the over-broad form.

**Two existing specs gained an explicit streamed-sibling stub** (each already mocks the V5 adapter). Honest disclosure: every other suite that mocks `callV5Turn` and drives a cold draft now reaches it **through the fallback** rather than directly — behaviour preserved, but one hop longer than those specs' authors intended.

---

## Two derivations, no mirrors

**The endpoint:** `resolveEndpoint() + '/stream'`, never a second URL literal. Derived at the **deployed bytes** — the served bundle constant-folds `resolveEndpoint()` to `https://cee-staging.onrender.com/proxy/v5/turn`, so the suffix rule lands on the exact route the probe measured. It is also correct on the repo default (`/bff/orchestrate/v2/turn/stream`, which the Netlify edge fn rewrites to #751's service sibling and authenticates with `ASSIST_API_KEY`), so it is the right rule rather than a lucky one. M19.

**The silence budget:** `SERVER_HEARTBEAT_INTERVAL_MS * 3` — three missed beats — and explicitly **not** an elapsed-time deadline on the turn. The cold-start GRAPH_READY spread reached 39.9 s and a p99 draft has no client-knowable ceiling, so any wall-clock cut-off kills healthy slow draws. The existing 130 s `EXTENDED_TIMEOUT_MS` (already sized to outlive CEE's 125 s proxy budget) stays the only elapsed-time guard. M13.

**Also extracted, not duplicated:** `parseSSELines` moved to `src/lib/sse/` and is re-exported from `turnService`, so its existing 27-case spec covers the shared module verbatim without being touched. A second hand-written SSE parser would drift on multi-line `data:`, CRLF or trailing flush and read as green in both suites.

## One consumer rule deliberately NOT implemented

#745's rules include "discard the GRAPH_READY graph if COMPLETE carries `salvaged_from_truncation: true`". #751 then established at the bytes that **the streamed frames never carry that field** — its transport header says a client branching on it "would be writing dead code". So the discard rung fires on `status_code >= 400` only, which the live 422 control proves *can* fire. Shipping the salvage rung would be a branch that cannot execute wearing the costume of a safety guarantee. Rowed; the rung lands with its test when CEE lifts the field.

---

## Gates (the repo's own, at this tip)

- **`pnpm typecheck`** (`scripts/ci/typecheck-gate.sh`) — **PASSED**. Coverage **3031 / 3071** tracked TS files (40 declared out of scope), derived at this tip rather than copied from any earlier record. Ratchet **624 files / 2512 errors = baseline exactly, zero new.** It bit once mid-lane (a `vi.fn` generic) and the error was fixed at source, never baselined.
- **`npx eslint`** on all touched files — **0 errors** (printed warnings are pre-existing, on lines this branch did not add).
- **New/changed suites: 147 tests, 9 files, all passing.**
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set for every run (trap 2b).

## Scope

- **No flags, no env gates.** ON for cold drafts. Rollback = revert; the buffered route is untouched *and* is the live fallback, so a revert's blast radius is zero.
- **Every non-draft turn is byte-identical to today** — system events, continuations, run_analysis, explain, patch_followup, clarification_response, any turn on a populated canvas. Fail-closed by construction (M9).
- **`applyV5State.ts`, `buildPayload.ts`, `responseParser.ts`, `responseRouter.ts`, `mergeAppliedGraph.ts`: ZERO BYTES.** PLoT, ISL, `@talchain/schemas`: zero bytes, no publish.

## Rowed, not fixed

1. **`PROGRESS` frames do not exist on the wire** (server-side). Until they do, the 36 s pre-graph window is elapsed-time-narrated and `PROGRESSIVE_STAGES` cannot be deleted. **This is the biggest remaining win in the first 40 s** — labels materialising from ~5–16 s is design M2.
2. `salvaged_from_truncation` never reaches the streamed frames → the salvage rung is deliberately absent.
3. **A guest cannot recover the settled numbers in the middle fallback row** (the re-fetch path needs auth). The product says so and blocks Run; it does not present unsettled numbers as final.
4. A stream-side non-2xx costs one extra request. Justified (different auth postures and rate-limit buckets, so the buffered sibling genuinely can succeed) but worth watching if stream 429s appear.
5. **The ~5.5 s completion overhead** the probe measured (arms disjoint, p≈0.05, not established) is now user-visible on every cold draft. Needs the properly-powered A/B that lane rowed before anyone claims parity.
6. The derived call-site guard is structural — it proves the argument is passed, not that the value is the live store value.
7. **`useDraftModel` is still dead code** (zero production callers) holding an SSE consumer aimed at the ROADMAP 2.110 double-transform route. Now clearly superseded: **delete** rather than wire.
8. **`streamOrchestratorTurn` still targets a route CEE deleted on 21 Jul**, and this lane settles at the deployed bytes that its flag is OFF (`assets/flags-*.js` → `orchestratorStreaming:PE("false")`), closing the predecessor's open question. Dead with proof — delete it and the flag.
9. **⚠ The one I went looking for: for a SIGNED-IN user the in-progress preview graph is PERSISTED at ~37.5 s.** The graph autosave is debounced 1500 ms (`useScenario.ts:76`) and active whenever persistence is, so `scenarios.graph` holds the frame's `in_progress` values for ~24 s until CEE's commit (~61 s) and the terminal ingest's save (~62.5 s) replace them.
   **What it does not break, derived:** CEE's commit is built from its own pipeline output, not a DB read, and lands *after* the UI write, so it cannot be corrupted; the debounced save re-reads the store at fire time (argued in `mergeAppliedGraph.ts`'s header), so the ~62.5 s write carries CEE's settled values; and `run_analysis` cannot fire from this session because the gate is shut for exactly this window.
   **What it means:** anything else reading `scenarios.graph` in that window sees unsettled numbers — a second tab on the same scenario being the concrete case. The standing shared-writer/CAS residual (review C1/A3), now with one more writer in a 24 s window that did not exist before.
   **Why I did not just suppress the save during `settling`:** `mergeAppliedGraph.ts` argues on evidence that the echo save is load-bearing — CEE's persistence overwrites the whole `nodes` array with a GraphV3 parse carrying **no position fields**, so the UI's save is the only thing restoring the user's layout. Reaching into that seam is a design decision beyond this dispatch. **Rowed for a decision, not quietly left out.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
