### PR TITLE
feat(ui): pick-two-runs side-by-side compare (2.113a slice 2)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2512
+# count=2510
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -286,8 +286,6 @@
 1	src/canvas/analysis/assembleAnalysisInputsSummary.ts	TS2322	Type 'AnalysisInputsSummary | null' is not assignable to type 'AnalysisInputsSummary'.
 1	src/canvas/analysis/assembleAnalysisInputsSummary.ts	TS2345	Argument of type 'V2RobustnessActual | undefined' is not assignable to parameter of type 'V2RobustnessActual'.
 1	src/canvas/analysis/assembleAnalysisInputsSummary.ts	TS2352	Conversion of type 'DecisionQualityV3' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-1	src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts	TS2783	'runNumber' is specified more than once, so this usage will be overwritten.
-1	src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts	TS2783	'runNumber' is specified more than once, so this usage will be overwritten.
 2	src/canvas/compare/EdgeDiffTable.tsx	TS2322	Type '{ weight: {}; belief: {}; provenance: unknown; } | undefined' is not assignable to type '{ weight: number; belief: number; provenance?: string | undefined; } | undefined'.
 2	src/canvas/compare/EdgeDiffTable.tsx	TS2362	The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 2	src/canvas/compare/EdgeDiffTable.tsx	TS2363	The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2512
+# count=2510
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -116,8 +116,6 @@
 8	src/canvas/adapters/islRequestAdapter.ts
 10	src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.spec.ts
 3	src/canvas/analysis/assembleAnalysisInputsSummary.ts
-1	src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts
-1	src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
 6	src/canvas/compare/EdgeDiffTable.tsx
 3	src/canvas/components/AdvancedSettingsPanel.tsx
 2	src/canvas/components/BeliefInput.tsx

--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -12,15 +12,18 @@ import { useAnalysisSnapshotStore, selectSnapshots } from '../stores/analysisSna
 import { useCompareHistoryHydration } from './useCompareHistoryHydration'
 import { useUIStore } from '../../stores/uiStore'
 import { deriveCompareState } from './deriveCompareState'
-import { deriveTransitions, buildCumulativeTransition } from './deriveTransitions'
+import { deriveTransitions, buildCumulativeTransition, buildRangeTransition } from './deriveTransitions'
+import { deriveRunPairComparison } from './deriveRunPairComparison'
+import { applyRunPairChange, normaliseRunPair } from './runPairSelection'
 import { TabHeader } from './TabHeader'
 import { RunSelector } from './RunSelector'
+import { RunPairCompare } from './RunPairCompare'
 import { Hero } from './Hero'
 import { TrajectorySection } from './TrajectorySection'
 import { TransitionsSection } from './TransitionsSection'
 import { CompareFooter } from './CompareFooter'
 import { EmptyState } from './EmptyState'
-import type { RunPreset, Transition } from './types'
+import type { RunPair, RunPreset, Transition } from './types'
 
 interface CompareTabBodyProps {
   onRunAnalysis: () => void
@@ -50,6 +53,13 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
 
   // UI state
   const [preset, setPreset] = useState<RunPreset>('prev')
+  /**
+   * ROADMAP 2.113a slice 2 — the runs the user picked, BY RUN NUMBER, exactly
+   * as requested. It is deliberately NOT clamped in state: re-hydration
+   * renumbers the journey, and clamping on write would silently rewrite a
+   * choice the user could still get back. `pair` below is the resolved value.
+   */
+  const [requestedPair, setRequestedPair] = useState<RunPair | null>(null)
   const [showExpert, setShowExpert] = useState(() => {
     try { return localStorage.getItem(EXPERT_STORAGE_KEY) === '1' } catch { return false }
   })
@@ -71,8 +81,68 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
     [snapshots],
   )
 
+  // ── Pick-two-runs (slice 2) ────────────────────────────────────────────
+  const runs = useMemo(
+    () => snapshots.map(s => ({ runNumber: s.runNumber, timestamp: s.timestamp })),
+    [snapshots],
+  )
+  const pair = useMemo(
+    () => normaliseRunPair(snapshots.map(s => s.runNumber), requestedPair),
+    [snapshots, requestedPair],
+  )
+  /**
+   * Positions of the picked pair in the SAME ordered list every other
+   * derivation here reads, resolved by run number rather than assuming
+   * `runNumber - 1`. Null whenever the pair cannot be resolved to two distinct
+   * runs in forward order — and then nothing pair-shaped renders at all,
+   * rather than a comparison of a run with itself.
+   */
+  const pairIndices = useMemo(() => {
+    if (!pair) return null
+    const fromIndex = snapshots.findIndex(s => s.runNumber === pair.from)
+    const toIndex = snapshots.findIndex(s => s.runNumber === pair.to)
+    if (fromIndex < 0 || toIndex < 0 || fromIndex >= toIndex) return null
+    return { fromIndex, toIndex }
+  }, [pair, snapshots])
+  /**
+   * Derived ONLY while the pair view is the one being looked at — and this is
+   * the SINGLE gate on the pair view, deliberately.
+   *
+   * ⚠ There was a second one: the JSX below also tested `preset === 'pick'`.
+   * Mutation-checking found it inert — removing it REDs nothing, because this
+   * memo already returns null under every other preset. A redundant condition
+   * that reads like a control and cannot fail is the guarantee-theatre this
+   * estate keeps paying for, so it is gone and this one carries the whole
+   * decision: deleting it REDs both the "other presets are untouched" test and
+   * the two pre-existing CompareTabBody specs, whose deliberately-partial
+   * snapshot fixtures a comparison nobody asked for would crash on.
+   */
+  const pairComparison = useMemo(
+    () => preset === 'pick' && pairIndices
+      ? deriveRunPairComparison(snapshots[pairIndices.fromIndex], snapshots[pairIndices.toIndex])
+      : null,
+    [preset, pairIndices, snapshots],
+  )
+  const handlePairChange = useCallback(
+    (endpoint: 'from' | 'to', runNumber: number) => {
+      if (!pair) return
+      setRequestedPair(applyRunPairChange(pair, endpoint, runNumber))
+    },
+    [pair],
+  )
+
   // Visible transitions based on preset
   const visibleTransitions = useMemo((): Transition[] => {
+    if (preset === 'pick') {
+      // The narrative half of the pair view is the EXISTING TransitionsSection
+      // / TransitionCard, fed the picked pair's own transition — the design's
+      // "render the existing TransitionCard machinery for the chosen pair",
+      // with no copy of it.
+      const paired = pairIndices
+        ? buildRangeTransition(snapshots, pairIndices.fromIndex, pairIndices.toIndex)
+        : null
+      return paired ? [paired] : []
+    }
     if (preset === 'all') {
       return [...allTransitions].reverse()
     }
@@ -84,7 +154,7 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
     return allTransitions.length > 0
       ? [allTransitions[allTransitions.length - 1]]
       : []
-  }, [preset, allTransitions, snapshots])
+  }, [preset, allTransitions, snapshots, pairIndices])
 
   // Reset to 'prev' if "first" preset becomes unavailable
   useEffect(() => {
@@ -158,6 +228,9 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
         onChange={setPreset}
         runCount={snapshots.length}
         showExpert={showExpert}
+        runs={runs}
+        pair={pair}
+        onPairChange={handlePairChange}
       />
       {/* F9: run in flight over retained snapshots — banner above, content
           marked busy below, never blanked (v6 doctrine). */}
@@ -176,6 +249,7 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
           showExpert={showExpert}
           onRunAnalysis={onRunAnalysis}
         />
+        {pairComparison && <RunPairCompare comparison={pairComparison} />}
         <TrajectorySection snapshots={snapshots} showExpert={showExpert} />
         <TransitionsSection
           transitions={visibleTransitions}

--- a/src/canvas/compare-tab/RunPairCompare.tsx
+++ b/src/canvas/compare-tab/RunPairCompare.tsx
@@ -1,0 +1,270 @@
+/**
+ * Side-by-side view of two picked runs — ROADMAP 2.113a slice 2.
+ *
+ * Presentation only. Every cell renders a value `deriveRunPairComparison`
+ * produced from two persisted facts, or the estate's existing absence copy —
+ * "Not assessed" for a quantity nobody measured, "Only in run N" for an option
+ * or factor that exists on one side, "Not comparable" for a pair of models the
+ * hash regimes forbid comparing. No cell computes anything.
+ *
+ * The transition CARD for the same pair is not rendered here: `CompareTabBody`
+ * feeds the pair's `Transition` to the existing `TransitionsSection`, so the
+ * narrative half of the design's slice-2 line ("render the existing
+ * TransitionCard machinery for the chosen pair") is the untouched component,
+ * not a copy of it.
+ */
+import type { ReactNode } from 'react'
+import { typography } from '../../styles/typography'
+import { GraphLink } from '../../components/results/GraphLink'
+import { highlightNode, clearHighlight } from '../utils/highlightHelpers'
+import { runLabel } from './runLabels'
+import type { AnalysisSnapshot, LeaderClaim, RunPairComparison } from './types'
+
+interface RunPairCompareProps {
+  comparison: RunPairComparison
+}
+
+const NOT_ASSESSED = 'Not assessed'
+
+function runHeading(snapshot: AnalysisSnapshot): string {
+  return runLabel(snapshot.runNumber, snapshot.timestamp)
+}
+
+function signed(value: number, unit: string): string {
+  return `${value >= 0 ? '+' : ''}${value}${unit}`
+}
+
+function ordinal(rank: number): string {
+  const suffix = rank === 1 ? 'st' : rank === 2 ? 'nd' : rank === 3 ? 'rd' : 'th'
+  return `${rank}${suffix}`
+}
+
+/** Places gained or lost in the influence order — positive is more influential. */
+function rankMovement(delta: number): string {
+  if (delta === 0) return 'Same position'
+  const places = Math.abs(delta) === 1 ? 'place' : 'places'
+  return `${delta > 0 ? 'Up' : 'Down'} ${Math.abs(delta)} ${places}`
+}
+
+/**
+ * The producer's claim for one run, as a sentence that surface is entitled to
+ * make. `'unclaimed'` prints the estate's absence copy — never "no clear
+ * leading option", which is a SECOND claim and needs the producer's tie
+ * verdict to license it.
+ */
+function leaderText(claim: LeaderClaim): string {
+  if (claim.kind === 'named') return claim.label ?? NOT_ASSESSED
+  if (claim.kind === 'tied') return 'No clear leading option'
+  return NOT_ASSESSED
+}
+
+const STRUCTURE_TEXT: Record<RunPairComparison['structure'], string> = {
+  changed: 'Changed',
+  unchanged: 'Unchanged',
+  // ⚠ Not "unchanged". A session snapshot's hash is the UI's own
+  // `generateGraphHash`; a persisted run's is CEE's `aag_v1`. They are always
+  // unequal, and comparing them would report a structure change manufactured
+  // out of where the two runs were read from.
+  not_comparable: 'Not comparable',
+}
+
+const STRUCTURE_DETAIL: Record<RunPairComparison['structure'], string> = {
+  changed: 'The model these runs were computed over is not the same',
+  unchanged: 'Both runs were computed over the same model',
+  not_comparable: 'These two runs record their model with different, incomparable identifiers',
+}
+
+function Row({
+  label,
+  from,
+  to,
+  delta,
+  testId,
+}: {
+  label: ReactNode
+  from: ReactNode
+  to: ReactNode
+  delta: ReactNode
+  testId?: string
+}) {
+  return (
+    <div
+      className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.1fr)] gap-2 px-4 py-1.5 border-b border-panel-border/60"
+      data-testid={testId}
+    >
+      <span className={`${typography.panelBody} text-text-light min-w-0 break-words`}>{label}</span>
+      <span className={`${typography.panelBody} min-w-0 break-words`}>{from}</span>
+      <span className={`${typography.panelBody} min-w-0 break-words`}>{to}</span>
+      <span className={`${typography.panelMeta} min-w-0 break-words`}>{delta}</span>
+    </div>
+  )
+}
+
+export function RunPairCompare({ comparison }: RunPairCompareProps) {
+  const { from, to } = comparison
+
+  return (
+    <div className="border-b border-panel-border" data-testid="run-pair-compare">
+      {/* Column headings */}
+      <div className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.1fr)] gap-2 px-4 py-2 border-b border-panel-border">
+        <span className={`${typography.panelHeader}`}>Side by side</span>
+        <span className={`${typography.panelHeader}`} data-testid="run-pair-from-heading">
+          {runHeading(from)}
+        </span>
+        <span className={`${typography.panelHeader}`} data-testid="run-pair-to-heading">
+          {runHeading(to)}
+        </span>
+        <span className={`${typography.panelMeta} text-text-light`}>Change</span>
+      </div>
+
+      {/* ── Outcome: win probability per option ─────────────────────────── */}
+      <div className={`${typography.panelMeta} px-4 pt-2 pb-1 text-text-light`}>
+        Win probability by option
+      </div>
+      {comparison.options.length === 0 ? (
+        <Row label="Options" from={NOT_ASSESSED} to={NOT_ASSESSED} delta="" testId="option-row-empty" />
+      ) : (
+        comparison.options.map(row => (
+          <Row
+            key={row.optionId}
+            testId={`option-row-${row.optionId}`}
+            label={
+              <>
+                {row.label}
+                {row.previousLabel != null && (
+                  <span className={`${typography.panelMeta} text-text-light`}>
+                    {' '}(was “{row.previousLabel}”)
+                  </span>
+                )}
+              </>
+            }
+            from={row.fromProbability != null ? `${row.fromProbability}%` : '—'}
+            to={row.toProbability != null ? `${row.toProbability}%` : '—'}
+            delta={
+              row.deltaPp != null
+                ? signed(row.deltaPp, 'pp')
+                : row.presence === 'only_from'
+                  ? `Only in run ${from.runNumber}`
+                  : `Only in run ${to.runNumber}`
+            }
+          />
+        ))
+      )}
+
+      {/* ── Verdict states ───────────────────────────────────────────────── */}
+      <div className={`${typography.panelMeta} px-4 pt-2 pb-1 text-text-light`}>
+        Verdict
+      </div>
+      <Row
+        testId="leader-row"
+        label="Leading option"
+        from={leaderText(comparison.fromLeader)}
+        to={leaderText(comparison.toLeader)}
+        delta={
+          comparison.leaderChange === 'changed'
+            ? 'Leader changed'
+            : comparison.leaderChange === 'unchanged'
+              ? 'Leader unchanged'
+              : 'Not comparable'
+        }
+      />
+      <Row
+        testId="goal-row"
+        label="Goal probability"
+        from={from.goalProbability != null ? `${from.goalProbability}%` : NOT_ASSESSED}
+        to={to.goalProbability != null ? `${to.goalProbability}%` : NOT_ASSESSED}
+        delta={
+          comparison.goalProbabilityDeltaPp != null
+            ? signed(comparison.goalProbabilityDeltaPp, 'pp')
+            : ''
+        }
+      />
+      <Row
+        testId="warnings-row"
+        label="Inference warnings"
+        from={String(from.inferenceWarnings.length)}
+        to={String(to.inferenceWarnings.length)}
+        delta={
+          comparison.warningsResolved.length === 0 && comparison.warningsIntroduced.length === 0
+            ? ''
+            : [
+                comparison.warningsResolved.length > 0
+                  ? `${comparison.warningsResolved.length} resolved`
+                  : null,
+                comparison.warningsIntroduced.length > 0
+                  ? `${comparison.warningsIntroduced.length} introduced`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(' · ')
+        }
+      />
+
+      {/* ── Model ────────────────────────────────────────────────────────── */}
+      <div className={`${typography.panelMeta} px-4 pt-2 pb-1 text-text-light`}>
+        Model
+      </div>
+      {/* The two run columns hold PER-RUN values everywhere else in this
+          table, and the structure answer is a property of the PAIR — so the
+          explanation goes underneath, full width, rather than into the column
+          a reader scans for run 1's own number. */}
+      <Row
+        testId="structure-row"
+        label="Model structure"
+        from="—"
+        to="—"
+        delta={STRUCTURE_TEXT[comparison.structure]}
+      />
+      <div
+        className={`${typography.panelMeta} px-4 pb-1.5 text-text-light`}
+        data-testid="structure-detail"
+      >
+        {STRUCTURE_DETAIL[comparison.structure]}
+      </div>
+      <Row
+        testId="coverage-row"
+        label="Evidence coverage"
+        from={comparison.fromEvidenceCoverage ?? NOT_ASSESSED}
+        to={comparison.toEvidenceCoverage ?? NOT_ASSESSED}
+        delta=""
+      />
+
+      {/* ── Factors ──────────────────────────────────────────────────────── */}
+      {/* RANK, not elasticity — see FactorDelta's header: the elasticity claim
+          family has no owner selector, so new code may not add a raw read, and
+          each run's own top-factor ORDER is the already-derived value. */}
+      <div className={`${typography.panelMeta} px-4 pt-2 pb-1 text-text-light`}>
+        Influence ranking
+      </div>
+      {comparison.factors.length === 0 ? (
+        <Row label="Factors" from={NOT_ASSESSED} to={NOT_ASSESSED} delta="" testId="factor-row-empty" />
+      ) : (
+        comparison.factors.map(row => (
+          <Row
+            key={row.factorId}
+            testId={`factor-row-${row.factorId}`}
+            label={
+              (
+                <span
+                  onMouseEnter={() => highlightNode(row.factorId)}
+                  onMouseLeave={clearHighlight}
+                >
+                  <GraphLink nodeId={row.factorId} label={row.label} />
+                </span>
+              )
+            }
+            from={row.fromRank != null ? ordinal(row.fromRank) : '—'}
+            to={row.toRank != null ? ordinal(row.toRank) : '—'}
+            delta={
+              row.rankDelta != null
+                ? rankMovement(row.rankDelta)
+                : row.presence === 'only_from'
+                  ? `Only in run ${from.runNumber}`
+                  : `Only in run ${to.runNumber}`
+            }
+          />
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/canvas/compare-tab/RunSelector.tsx
+++ b/src/canvas/compare-tab/RunSelector.tsx
@@ -1,41 +1,115 @@
 import { typography } from '../../styles/typography'
-import type { RunPreset } from './types'
+import { runLabel } from './runLabels'
+import type { RunPair, RunPreset } from './types'
+
+export interface RunSelectorRun {
+  runNumber: number
+  timestamp: string
+}
 
 interface RunSelectorProps {
   preset: RunPreset
   onChange: (preset: RunPreset) => void
   runCount: number
   showExpert: boolean
+  /**
+   * ROADMAP 2.113a slice 2 — the runs the A/B pick chooses between, and the
+   * current pick. `pair` is null when the current selection cannot be resolved
+   * to two distinct runs; the selects then fall back to the extremes rather
+   * than rendering a self-comparison.
+   */
+  runs: ReadonlyArray<RunSelectorRun>
+  pair: RunPair | null
+  onPairChange: (endpoint: 'from' | 'to', runNumber: number) => void
 }
 
-export function RunSelector({ preset, onChange, runCount, showExpert }: RunSelectorProps) {
+function runOptionLabel(run: RunSelectorRun): string {
+  return runLabel(run.runNumber, run.timestamp)
+}
+
+export function RunSelector({
+  preset,
+  onChange,
+  runCount,
+  showExpert,
+  runs,
+  pair,
+  onPairChange,
+}: RunSelectorProps) {
   const presets: Array<{ id: RunPreset; label: string; hidden?: boolean }> = [
     { id: 'prev', label: 'Latest vs previous' },
     { id: 'first', label: 'Latest vs first', hidden: runCount <= 2 },
     { id: 'all', label: 'All runs' },
+    // Slice 2. Not hidden at 2 runs: "pick two" is exactly what you can do
+    // with two runs, and the pair view says more about them than the preset.
+    { id: 'pick', label: 'Pick two runs' },
   ]
 
   return (
-    <div className="flex items-center gap-1 px-4 py-1.5 border-b border-panel-border">
-      {presets.map(p =>
-        p.hidden ? null : (
-          <button
-            key={p.id}
-            onClick={() => onChange(p.id)}
-            className={`px-2.5 py-0.5 rounded-full cursor-pointer border whitespace-nowrap transition-colors ${
-              preset === p.id
-                ? 'border-info/30 bg-info/10'
-                : 'border-panel-border bg-transparent'
-            } ${typography.panelMeta} text-text-body`}
+    <div className="border-b border-panel-border">
+      <div className="flex items-center gap-1 px-4 py-1.5">
+        {presets.map(p =>
+          p.hidden ? null : (
+            <button
+              key={p.id}
+              onClick={() => onChange(p.id)}
+              className={`px-2.5 py-0.5 rounded-full cursor-pointer border whitespace-nowrap transition-colors ${
+                preset === p.id
+                  ? 'border-info/30 bg-info/10'
+                  : 'border-panel-border bg-transparent'
+              } ${typography.panelMeta} text-text-body`}
+            >
+              {p.label}
+            </button>
+          )
+        )}
+        {showExpert && (
+          <span className={`${typography.panelMeta} ml-auto text-info cursor-pointer`}>
+            Run details
+          </span>
+        )}
+      </div>
+
+      {preset === 'pick' && (
+        <div
+          className="flex items-center gap-2 px-4 pb-1.5 flex-wrap"
+          data-testid="run-pair-picker"
+        >
+          <label className={`${typography.panelMeta} text-text-light`} htmlFor="compare-pick-from">
+            Compare run
+          </label>
+          <select
+            id="compare-pick-from"
+            aria-label="Earlier run"
+            data-testid="run-pick-from"
+            value={pair?.from ?? ''}
+            onChange={e => onPairChange('from', Number(e.target.value))}
+            className={`${typography.panelMeta} px-2 py-0.5 rounded border border-panel-border bg-transparent text-text-body cursor-pointer`}
           >
-            {p.label}
-          </button>
-        )
-      )}
-      {showExpert && (
-        <span className={`${typography.panelMeta} ml-auto text-info cursor-pointer`}>
-          Run details
-        </span>
+            {runs.map(r => (
+              <option key={r.runNumber} value={r.runNumber}>
+                {runOptionLabel(r)}
+              </option>
+            ))}
+          </select>
+          <label className={`${typography.panelMeta} text-text-light`} htmlFor="compare-pick-to">
+            with
+          </label>
+          <select
+            id="compare-pick-to"
+            aria-label="Later run"
+            data-testid="run-pick-to"
+            value={pair?.to ?? ''}
+            onChange={e => onPairChange('to', Number(e.target.value))}
+            className={`${typography.panelMeta} px-2 py-0.5 rounded border border-panel-border bg-transparent text-text-body cursor-pointer`}
+          >
+            {runs.map(r => (
+              <option key={r.runNumber} value={r.runNumber}>
+                {runOptionLabel(r)}
+              </option>
+            ))}
+          </select>
+        </div>
       )}
     </div>
   )

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
@@ -1,0 +1,293 @@
+/**
+ * ROADMAP 2.113a slice 2 — a signed-in user with 2+ PERSISTED runs picks any
+ * two and sees them side by side.
+ *
+ * The whole chain is exercised on the live-shaped path: persisted
+ * `run_analysis` facts → slice-1 hydration → snapshots → picker → side-by-side
+ * table. Nothing here builds an `AnalysisSnapshot` by hand, because the point
+ * is that the PERSISTED envelope carries what the pair view renders.
+ *
+ * CONTROL IN BOTH DIRECTIONS (CLAUDE.md trap 13). The owner cases assert
+ * positive CONTENT — real probabilities in the right cells, a named leader from
+ * the producer's own verdict — before any absence case asserts a degradation.
+ * Without that half, a mock wired to the wrong module would render nothing and
+ * every "shows the degradation" test would pass by testing nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent, within } from '@testing-library/react'
+import { makePersistedRunFactRow } from './__fixtures__/persistedRunFact'
+
+// --- seams ----------------------------------------------------------------
+
+const listPersistedAnalysisRuns = vi.fn()
+const getSessionIdentity = vi.fn()
+
+vi.mock('../../../services/analysisRunHistoryService', () => ({
+  listPersistedAnalysisRuns: (...args: unknown[]) => listPersistedAnalysisRuns(...args),
+  MAX_PERSISTED_RUNS: 20,
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getSessionIdentity: () => getSessionIdentity(),
+  supabase: {},
+}))
+
+
+let mockCanvasState: any
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+     
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+     
+    (selector: (s: any) => unknown) => selector({ activeOutputTab: 'compare' }),
+    { getState: () => ({ setActiveOutputTab: vi.fn() }) },
+  ),
+}))
+
+vi.mock('../../hooks/useAnalysisTrust', () => ({
+  useAnalysisTrust: () => ({ semantic: 'fresh', isRunning: false, runStartedAt: null }),
+}))
+
+// Only the surfaces under test are real: RunSelector (the picker) and
+// RunPairCompare (the side-by-side table). Everything else is stubbed the same
+// way the slice-1 spec stubs it.
+vi.mock('../Hero', () => ({ Hero: () => null }))
+vi.mock('../TrajectorySection', () => ({ TrajectorySection: () => null }))
+vi.mock('../CompareFooter', () => ({ CompareFooter: () => null }))
+vi.mock('../TabHeader', () => ({ TabHeader: () => null }))
+vi.mock('../TransitionsSection', () => ({
+  TransitionsSection: ({ transitions }: { transitions: Array<{ fromRunNumber: number; toRunNumber: number; winnerProbDelta: number; edits: string[] }> }) => (
+    <div data-testid="transitions-stub">
+      {transitions.map(t => (
+        <span key={`${t.fromRunNumber}-${t.toRunNumber}`} data-testid="transition-pair">
+          {t.fromRunNumber}→{t.toRunNumber}:{t.winnerProbDelta}:{t.edits.length}
+        </span>
+      ))}
+    </div>
+  ),
+}))
+
+import { CompareTabBody } from '../CompareTabBody'
+import { useAnalysisSnapshotStore } from '../../stores/analysisSnapshotStore'
+
+const run = (
+  n: number,
+  hour: string,
+  winProb: number,
+  extra: Parameters<typeof makePersistedRunFactRow>[0] = {},
+) =>
+  makePersistedRunFactRow({
+    id: `fact-${n}`,
+    createdAt: `2026-07-2${n}T${hour}:00:00.000Z`,
+    responseHash: `resp-${n}`,
+    graphHashAtRun: `aag-${n}`,
+    winner: { option_id: 'opt-a', option_label: 'Option A', win_probability: winProb },
+    runnerUp: { option_id: 'opt-b', option_label: 'Option B', win_probability: 1 - winProb },
+    ...extra,
+  })
+
+async function renderWithRuns(rows: unknown[]) {
+  listPersistedAnalysisRuns.mockResolvedValue(rows)
+  render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+  await waitFor(() => {
+    expect(useAnalysisSnapshotStore.getState().snapshots.length).toBe(rows.length)
+  })
+}
+
+const openPicker = () => fireEvent.click(screen.getByText('Pick two runs'))
+
+beforeEach(() => {
+  mockCanvasState = {
+    currentScenarioId: 'scenario-owned-1',
+    currentScenarioLastResultHash: 'resp-3',
+    selection: { nodeIds: new Set<string>() },
+    _hydratedEvents: [],
+  }
+  useAnalysisSnapshotStore.getState().clearSnapshots()
+  listPersistedAnalysisRuns.mockReset()
+  getSessionIdentity.mockReset()
+  getSessionIdentity.mockResolvedValue({ userId: 'user-1', accessToken: 'tok' })
+})
+
+afterEach(() => cleanup())
+
+describe('pick-two-runs side-by-side (2.113a slice 2)', () => {
+  it('the picker appears once there are 2+ persisted runs, and defaults to first vs latest', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+
+    // Not shown until the user asks for it — the other presets are unchanged.
+    expect(screen.queryByTestId('run-pair-picker')).toBeNull()
+    openPicker()
+
+    expect(screen.getByTestId('run-pair-picker')).toBeTruthy()
+    expect((screen.getByTestId('run-pick-from') as HTMLSelectElement).value).toBe('1')
+    expect((screen.getByTestId('run-pick-to') as HTMLSelectElement).value).toBe('3')
+    expect(screen.getByTestId('run-pair-from-heading').textContent).toContain('Run 1')
+    expect(screen.getByTestId('run-pair-to-heading').textContent).toContain('Run 3')
+  })
+
+  it('POSITIVE CONTROL: the table shows each option’s win probability on both sides and a real delta', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+    openPicker()
+
+    const rowA = within(screen.getByTestId('option-row-opt-a'))
+    expect(rowA.getByText('50%')).toBeTruthy()   // run 1
+    expect(rowA.getByText('74%')).toBeTruthy()   // run 3
+    expect(rowA.getByText('+24pp')).toBeTruthy()
+
+    const rowB = within(screen.getByTestId('option-row-opt-b'))
+    expect(rowB.getByText('50%')).toBeTruthy()
+    expect(rowB.getByText('26%')).toBeTruthy()
+    expect(rowB.getByText('-24pp')).toBeTruthy()
+  })
+
+  it('picking a different pair re-derives the whole comparison', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+    openPicker()
+
+    fireEvent.change(screen.getByTestId('run-pick-to'), { target: { value: '2' } })
+
+    expect(screen.getByTestId('run-pair-to-heading').textContent).toContain('Run 2')
+    const rowA = within(screen.getByTestId('option-row-opt-a'))
+    expect(rowA.getByText('62%')).toBeTruthy()
+    expect(rowA.getByText('+12pp')).toBeTruthy()
+  })
+
+  it('picking the run already at the other end SWAPS instead of comparing a run with itself', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+    openPicker()
+
+    fireEvent.change(screen.getByTestId('run-pick-from'), { target: { value: '3' } })
+
+    const from = (screen.getByTestId('run-pick-from') as HTMLSelectElement).value
+    const to = (screen.getByTestId('run-pick-to') as HTMLSelectElement).value
+    expect(from).not.toBe(to)
+    // Still a real comparison, not a wall of +0pp.
+    expect(screen.getByTestId('run-pair-compare')).toBeTruthy()
+  })
+
+  it('the pair’s own transition card is the EXISTING machinery, fed the picked pair', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+    openPicker()
+
+    const pairs = screen.getAllByTestId('transition-pair')
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].textContent).toContain('1→3')
+  })
+
+  // ── Honest degradation ─────────────────────────────────────────────────
+  it('the LEADER row quotes each run’s own producer verdict — and stays silent when there is none', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5, { nearTie: { is_tie: false, top_option_id: 'opt-a' } }),
+      // Second run: the producer sent NO usable near-tie signal.
+      run(2, '11', 0.62, { nearTieOverride: null }),
+    ])
+    openPicker()
+
+    const leaderRow = within(screen.getByTestId('leader-row'))
+    expect(leaderRow.getByText('Option A')).toBeTruthy()      // run 1, entitled
+    expect(leaderRow.getByText('Not assessed')).toBeTruthy()  // run 2, silent
+    expect(leaderRow.getByText('Not comparable')).toBeTruthy()
+  })
+
+  it('two runs whose producer named the same leader report it UNCHANGED', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5, { nearTie: { is_tie: false, top_option_id: 'opt-a' } }),
+      run(2, '11', 0.62, { nearTie: { is_tie: false, top_option_id: 'opt-a' } }),
+    ])
+    openPicker()
+    expect(within(screen.getByTestId('leader-row')).getByText('Leader unchanged')).toBeTruthy()
+  })
+
+  it('MODEL STRUCTURE compares two persisted aag hashes, and says so honestly when they match', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5, { graphHashAtRun: 'aag-same' }),
+      run(2, '11', 0.62, { graphHashAtRun: 'aag-same' }),
+    ])
+    openPicker()
+    expect(within(screen.getByTestId('structure-row')).getByText('Unchanged')).toBeTruthy()
+    expect(screen.getByTestId('structure-detail').textContent)
+      .toContain('Both runs were computed over the same model')
+  })
+
+  it('a run with NO persisted graph hash makes the structure row NOT COMPARABLE', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5, { graphHashAtRun: null }),
+      run(2, '11', 0.62, { graphHashAtRun: 'aag-2' }),
+    ])
+    openPicker()
+    expect(within(screen.getByTestId('structure-row')).getByText('Not comparable')).toBeTruthy()
+    expect(screen.getByTestId('structure-detail').textContent).toContain('incomparable identifiers')
+  })
+
+  it('goal probability and evidence coverage render "Not assessed" on a persisted pair', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62)])
+    openPicker()
+
+    expect(within(screen.getByTestId('goal-row')).getAllByText('Not assessed')).toHaveLength(2)
+    expect(within(screen.getByTestId('coverage-row')).getAllByText('Not assessed')).toHaveLength(2)
+  })
+
+  it('an option only ONE run scored renders "Only in run N" — never a delta', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5),
+      run(2, '11', 0.62, {
+        optionComparison: [
+          { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.5 },
+          { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.3 },
+          { option_id: 'opt-c', option_label: 'Option C', win_probability: 0.2 },
+        ],
+      }),
+    ])
+    openPicker()
+
+    const rowC = within(screen.getByTestId('option-row-opt-c'))
+    expect(rowC.getByText('20%')).toBeTruthy()
+    expect(rowC.getByText('Only in run 2')).toBeTruthy()
+    expect(rowC.queryByText('+20pp')).toBeNull()
+  })
+
+  it('the factor section compares RANK and never renders a raw elasticity value', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62)])
+    openPicker()
+
+    // The default fixture's factors are elasticity 0.42 and 0.18, same order in
+    // both runs. Neither number may appear; the ordering must.
+    const row = within(screen.getByTestId('factor-row-factor-1'))
+    // Top factor in BOTH runs, so "1st" appears in each run column.
+    expect(row.getAllByText('1st')).toHaveLength(2)
+    expect(row.getByText('Same position')).toBeTruthy()
+    expect(screen.getByTestId('run-pair-compare').textContent).not.toContain('0.42')
+    expect(screen.getByTestId('run-pair-compare').textContent).not.toContain('0.18')
+  })
+
+  it('GUEST UNCHANGED: no session ⇒ no read, no picker, no side-by-side, no error', async () => {
+    getSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
+
+    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    await waitFor(() => expect(getSessionIdentity).toHaveBeenCalled())
+
+    expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()
+    expect(screen.queryByText('Pick two runs')).toBeNull()
+    expect(screen.queryByTestId('run-pair-picker')).toBeNull()
+    expect(screen.queryByTestId('run-pair-compare')).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('the other presets are untouched — "Pick two runs" is additive', async () => {
+    await renderWithRuns([run(1, '10', 0.5), run(2, '11', 0.62), run(3, '12', 0.74)])
+
+    expect(screen.getByText('Latest vs previous')).toBeTruthy()
+    expect(screen.getByText('Latest vs first')).toBeTruthy()
+    expect(screen.getByText('All runs')).toBeTruthy()
+    // Default preset still renders the latest pairwise transition, not a pair view.
+    expect(screen.queryByTestId('run-pair-compare')).toBeNull()
+    expect(screen.getAllByTestId('transition-pair')[0].textContent).toContain('2→3')
+  })
+})

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
@@ -267,6 +267,33 @@ describe('pick-two-runs side-by-side (2.113a slice 2)', () => {
     expect(screen.getByTestId('run-pair-compare').textContent).not.toContain('0.18')
   })
 
+  // ADVERSARIAL REVIEW OF #526, FINDING 1 — reproduced at the render, which is
+  // where the reviewer saw it: "Option X | 55% | 0% | -55pp".
+  it('an option the LATER run carries WITHOUT a win probability is membership, not a 0% and a -55pp fall', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.45, {
+        optionComparison: [
+          { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.45 },
+          { option_id: 'opt-x', option_label: 'Option X', win_probability: 0.55 },
+        ],
+      }),
+      run(2, '11', 0.62, {
+        optionComparison: [
+          { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.62 },
+          // Same option, producer sent no probability for it this time.
+          { option_id: 'opt-x', option_label: 'Option X' },
+        ],
+      }),
+    ])
+    openPicker()
+
+    const rowX = within(screen.getByTestId('option-row-opt-x'))
+    expect(rowX.getByText('55%')).toBeTruthy()          // run 1's real measurement
+    expect(rowX.getByText('Only in run 1')).toBeTruthy() // run 2: absence, stated
+    expect(rowX.queryByText('0%')).toBeNull()            // the fabricated baseline
+    expect(rowX.queryByText('-55pp')).toBeNull()         // the delta measured against it
+  })
+
   it('GUEST UNCHANGED: no session ⇒ no read, no picker, no side-by-side, no error', async () => {
     getSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
 

--- a/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
@@ -1,0 +1,86 @@
+/**
+ * ONE `AnalysisSnapshot` fixture builder, for every spec that needs one.
+ *
+ * ⚠ WHY THIS FILE EXISTS. Five specs each carried their own hand-written
+ * snapshot literal (`deriveTransitions`, `deriveCompareState`,
+ * `analysisSnapshotStore`, `Hero.rerunAction`, `TrajectorySection.absence`,
+ * plus one in `model-tab`). That is six copies of the same shape a human must
+ * remember to keep in step — CLAUDE.md trap 12, the hand-maintained mirror —
+ * and the failure mode is silent: a field added to the type with a plausible
+ * default in five of six copies makes five suites test a shape the product
+ * never produces. Slice 2 adds two fields, so the mirror is collapsed instead
+ * of copied a seventh time. Each spec keeps its own defaults by spreading this.
+ *
+ * DEFAULTS ARE THE PRODUCER'S HAPPY PATH, deliberately: an entitled leader
+ * verdict and a two-option comparison. Absence cases are opt-in per test, so a
+ * spec that means to exercise absence has to SAY so.
+ */
+import type { AnalysisSnapshot, SnapshotOption } from '../../types'
+import type { DecisionVerdict } from '../../../../lib/decisionVerdict'
+import { NO_CLAIM_VERDICT } from '../../../../lib/decisionVerdict'
+
+export const DEFAULT_SNAPSHOT_OPTIONS: SnapshotOption[] = [
+  { id: 'opt-a', label: 'Option A', winProbability: 65 },
+  { id: 'opt-b', label: 'Option B', winProbability: 35 },
+]
+
+/** A producer-entitled verdict naming `opt-a` — the ordinary live case. */
+export const DEFAULT_LEADER_VERDICT: DecisionVerdict = {
+  leaderId: 'opt-a',
+  separation: 'clear',
+  hasLeadingOption: true,
+  gapPp: 30,
+  source: 'producer_near_tie',
+}
+
+/** The producer's own "no clear leading option". */
+export const TIED_LEADER_VERDICT: DecisionVerdict = {
+  leaderId: 'opt-a',
+  separation: 'tied',
+  hasLeadingOption: false,
+  gapPp: 2,
+  source: 'producer_near_tie',
+}
+
+/** No applicable producer signal ⇒ silence, never a denial. */
+export const UNCLAIMED_LEADER_VERDICT: DecisionVerdict = NO_CLAIM_VERDICT
+
+export function makeAnalysisSnapshot(
+  overrides: Partial<AnalysisSnapshot> & { runNumber: number },
+): AnalysisSnapshot {
+  return {
+    runId: `run-${overrides.runNumber}`,
+    timestamp: new Date().toISOString(),
+    source: 'session',
+    graphHash: 'hash-default',
+    nodeCount: 5,
+    edgeCount: 4,
+    options: DEFAULT_SNAPSHOT_OPTIONS,
+    leaderVerdict: DEFAULT_LEADER_VERDICT,
+    winnerId: 'opt-a',
+    winnerLabel: 'Option A',
+    winnerProbability: 65,
+    runnerUpId: 'opt-b',
+    runnerUpLabel: 'Option B',
+    runnerUpProbability: 35,
+    recommendationStability: 0.7,
+    stabilityLabel: 'stable',
+    fragileEdgeCount: 0,
+    evidenceCoverage: '3/5',
+    topFactors: [],
+    influenceConcentration: 40,
+    topCalibrationFactor: 'Factor A',
+    topCalibrationFactorId: 'fac-a',
+    topElasticity: 30,
+    rankFlipRate: 0.05,
+    goalProbability: null,
+    jointGoalProbability: null,
+    inferenceWarnings: [],
+    conditionalWinners: [],
+    edgeEValues: [],
+    seedUsed: 12345,
+    responseHash: 'abc123',
+    editSummary: 'Test edit',
+    ...overrides,
+  }
+}

--- a/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/persistedRunFact.ts
@@ -44,6 +44,23 @@ export interface PersistedRunFactFixtureOptions {
   optionComparison?: Array<Record<string, unknown>>
   /** Present in only 45% of live runs — omit to exercise the honest-absence path. */
   recommendationStability?: number
+  /**
+   * ⚠ SLICE 2 CORRECTION. This fixture used to set `robustness.near_tie:
+   * false` — a BOOLEAN. Live it is an OBJECT carrying a boolean `is_tie`, in
+   * **790 / 790** non-noop `run_analysis` facts (probed read-only 2026-07-29).
+   * `readNearTie` (src/lib/decisionVerdict.ts) returns null for a boolean, so
+   * every test built on the old shape exercised the NO-PRODUCER-SIGNAL path
+   * and would have "proved" that a persisted run cannot name a leader — the
+   * exact inverse of the live truth.
+   *
+   * Default is the live shape. `nearTie: false` (the literal boolean) is still
+   * reachable via `nearTieOverride`, so the fail-closed branch stays pinned.
+   */
+  nearTie?: { is_tie: boolean; top_option_id?: string; gap?: number }
+  /** Escape hatch for malformed / legacy producer shapes. */
+  nearTieOverride?: unknown
+  /** `decision_brief.headline_banded`, present in 440/790 live facts. */
+  headlineBanded?: Record<string, unknown> | null
   fragileEdges?: unknown[] | null
   factorSensitivity?: Array<Record<string, unknown>>
   inferenceWarnings?: unknown[]
@@ -67,6 +84,9 @@ export function makePersistedRunFactRow(
     runnerUp = { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.38 },
     optionComparison,
     recommendationStability,
+    nearTie,
+    nearTieOverride,
+    headlineBanded = null,
     fragileEdges = [],
     factorSensitivity = [
       {
@@ -126,7 +146,10 @@ export function makePersistedRunFactRow(
           robustness: {
             level: 'moderate',
             is_robust: true,
-            near_tie: false,
+            // Live shape: an OBJECT with a boolean `is_tie` (790/790).
+            near_tie: nearTieOverride !== undefined
+              ? nearTieOverride
+              : (nearTie ?? { is_tie: false, top_option_id: winner.option_id, gap: 0.24 }),
             confidence: 0.7,
             robust_edges: [],
             ...(fragileEdges != null ? { fragile_edges: fragileEdges } : {}),
@@ -136,6 +159,9 @@ export function makePersistedRunFactRow(
             recommended_option_id: winner.option_id,
             recommended_option_label: winner.option_label,
           },
+          ...(headlineBanded != null
+            ? { decision_brief: { headline_banded: headlineBanded } }
+            : {}),
           // ⚠ ROOT-level siblings of `robustness` — this is where the live
           // bytes put them.
           inference_warnings: inferenceWarnings,

--- a/src/canvas/compare-tab/__tests__/analysisSnapshotStore.spec.ts
+++ b/src/canvas/compare-tab/__tests__/analysisSnapshotStore.spec.ts
@@ -1,46 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useAnalysisSnapshotStore } from '../../stores/analysisSnapshotStore'
 import type { AnalysisSnapshot } from '../types'
+import { makeAnalysisSnapshot } from './__fixtures__/analysisSnapshot'
 
 // ---------------------------------------------------------------------------
 // Fixture
 // ---------------------------------------------------------------------------
 
+// Delegates to the ONE shared snapshot fixture (trap 12 — see its header).
 function makeSnapshot(runNumber: number, overrides?: Partial<AnalysisSnapshot>): AnalysisSnapshot {
-  return {
-    runId: `run-${runNumber}`,
-    runNumber,
-    timestamp: new Date().toISOString(),
-    source: 'session',
-    graphHash: 'hash-default',
-    nodeCount: 5,
-    edgeCount: 4,
-    winnerId: 'opt-a',
-    winnerLabel: 'Option A',
-    winnerProbability: 65,
-    runnerUpId: 'opt-b',
-    runnerUpLabel: 'Option B',
-    runnerUpProbability: 35,
-    recommendationStability: 0.7,
-    stabilityLabel: 'stable',
-    fragileEdgeCount: 0,
-    evidenceCoverage: '3/5',
-    topFactors: [],
-    influenceConcentration: 40,
-    topCalibrationFactor: 'Factor A',
-    topCalibrationFactorId: 'fac-a',
-    topElasticity: 30,
-    rankFlipRate: 0.05,
-    goalProbability: null,
-    jointGoalProbability: null,
-    inferenceWarnings: [],
-    conditionalWinners: [],
-    edgeEValues: [],
-    seedUsed: 12345,
-    responseHash: 'abc123',
-    editSummary: 'Test edit',
-    ...overrides,
-  }
+  return makeAnalysisSnapshot({ runNumber, ...overrides })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveCompareState.spec.ts
@@ -1,46 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { deriveCompareState, isNarrowFlip } from '../deriveCompareState'
+import { makeAnalysisSnapshot } from './__fixtures__/analysisSnapshot'
 import type { AnalysisSnapshot } from '../types'
 
 // ---------------------------------------------------------------------------
 // Fixture factory
 // ---------------------------------------------------------------------------
 
+// Delegates to the ONE shared snapshot fixture (trap 12 — see its header).
 function makeSnapshot(overrides: Partial<AnalysisSnapshot> & { runNumber: number }): AnalysisSnapshot {
-  return {
-    runId: `run-${overrides.runNumber}`,
-    runNumber: overrides.runNumber,
-    timestamp: new Date().toISOString(),
-    source: 'session',
-    graphHash: 'hash-default',
-    nodeCount: 5,
-    edgeCount: 4,
-    winnerId: 'opt-a',
-    winnerLabel: 'Option A',
-    winnerProbability: 65,
-    runnerUpId: 'opt-b',
-    runnerUpLabel: 'Option B',
-    runnerUpProbability: 35,
-    recommendationStability: 0.7,
-    stabilityLabel: 'stable',
-    fragileEdgeCount: 0,
-    evidenceCoverage: '3/5',
-    topFactors: [],
-    influenceConcentration: 40,
-    topCalibrationFactor: 'Factor A',
-    topCalibrationFactorId: 'fac-a',
-    topElasticity: 30,
-    rankFlipRate: 0.05,
-    goalProbability: null,
-    jointGoalProbability: null,
-    inferenceWarnings: [],
-    conditionalWinners: [],
-    edgeEValues: [],
-    seedUsed: 12345,
-    responseHash: 'abc123',
-    editSummary: 'Test edit',
-    ...overrides,
-  }
+  return makeAnalysisSnapshot(overrides)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/compare-tab/__tests__/deriveRunPairComparison.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveRunPairComparison.spec.ts
@@ -1,0 +1,329 @@
+/**
+ * ROADMAP 2.113a slice 2 — the pick-two-runs derivation.
+ *
+ * WHAT THESE TESTS ARE FOR. The side-by-side view has four ways to publish a
+ * measurement nobody made, and each one is pinned here:
+ *
+ *   1. a delta against a FABRICATED BASELINE — an option or factor present on
+ *      one side only, subtracted against an implied 0;
+ *   2. a CROSS-REGIME structure claim — a session snapshot's
+ *      `generateGraphHash` compared against a persisted run's `aag_v1`, which
+ *      are always unequal and would report "changed" about a provenance
+ *      boundary;
+ *   3. an UNLICENSED LEADER claim — leader language taken from the
+ *      client-side `winnerId` argmax instead of the run's own producer verdict;
+ *   4. a MISSING quantity rendered as zero rather than as absence.
+ */
+import { describe, it, expect } from 'vitest'
+import { deriveRunPairComparison, deriveLeaderClaim } from '../deriveRunPairComparison'
+import {
+  makeAnalysisSnapshot,
+  DEFAULT_LEADER_VERDICT,
+  TIED_LEADER_VERDICT,
+  UNCLAIMED_LEADER_VERDICT,
+} from './__fixtures__/analysisSnapshot'
+import type { AnalysisSnapshot, FactorSensitivitySummary } from '../types'
+
+function factor(id: string, elasticity: number, label = id): FactorSensitivitySummary {
+  return { id, label, elasticity, rankFlipRate: 0.05, attributionStability: 'high' }
+}
+
+function persisted(overrides: Partial<AnalysisSnapshot> & { runNumber: number }): AnalysisSnapshot {
+  return makeAnalysisSnapshot({ source: 'persisted', graphHash: 'aag-x', ...overrides })
+}
+
+describe('deriveRunPairComparison — win probability by option', () => {
+  it('reports a real delta for an option BOTH runs scored', () => {
+    const from = persisted({
+      runNumber: 1,
+      options: [
+        { id: 'opt-a', label: 'Option A', winProbability: 62 },
+        { id: 'opt-b', label: 'Option B', winProbability: 38 },
+      ],
+    })
+    const to = persisted({
+      runNumber: 2,
+      options: [
+        { id: 'opt-a', label: 'Option A', winProbability: 74 },
+        { id: 'opt-b', label: 'Option B', winProbability: 26 },
+      ],
+    })
+
+    const rows = deriveRunPairComparison(from, to).options
+    const a = rows.find(r => r.optionId === 'opt-a')!
+    expect(a.presence).toBe('both')
+    expect(a.fromProbability).toBe(62)
+    expect(a.toProbability).toBe(74)
+    expect(a.deltaPp).toBe(12)
+
+    const b = rows.find(r => r.optionId === 'opt-b')!
+    expect(b.deltaPp).toBe(-12)
+  })
+
+  it('orders rows by the strongest probability seen on either side', () => {
+    const from = persisted({
+      runNumber: 1,
+      options: [
+        { id: 'opt-a', label: 'A', winProbability: 20 },
+        { id: 'opt-b', label: 'B', winProbability: 80 },
+      ],
+    })
+    const to = persisted({
+      runNumber: 2,
+      options: [
+        { id: 'opt-a', label: 'A', winProbability: 55 },
+        { id: 'opt-b', label: 'B', winProbability: 45 },
+      ],
+    })
+    expect(deriveRunPairComparison(from, to).options.map(r => r.optionId)).toEqual(['opt-b', 'opt-a'])
+  })
+
+  // ── DEFECT 1: the fabricated baseline ───────────────────────────────────
+  it('an option scored by only the LATER run gets NO delta — never a subtraction against 0', () => {
+    const from = persisted({
+      runNumber: 1,
+      options: [{ id: 'opt-a', label: 'Option A', winProbability: 100 }],
+    })
+    const to = persisted({
+      runNumber: 2,
+      options: [
+        { id: 'opt-a', label: 'Option A', winProbability: 60 },
+        { id: 'opt-c', label: 'Option C', winProbability: 40 },
+      ],
+    })
+
+    const c = deriveRunPairComparison(from, to).options.find(r => r.optionId === 'opt-c')!
+    expect(c.presence).toBe('only_to')
+    expect(c.fromProbability).toBeNull()
+    expect(c.toProbability).toBe(40)
+    // `40 - 0 = +40pp` would announce a forty-point gain for an option the
+    // earlier run never scored at all.
+    expect(c.deltaPp).toBeNull()
+  })
+
+  it('an option scored by only the EARLIER run gets NO delta either', () => {
+    const from = persisted({
+      runNumber: 1,
+      options: [
+        { id: 'opt-a', label: 'Option A', winProbability: 55 },
+        { id: 'opt-d', label: 'Option D', winProbability: 45 },
+      ],
+    })
+    const to = persisted({
+      runNumber: 2,
+      options: [{ id: 'opt-a', label: 'Option A', winProbability: 100 }],
+    })
+
+    const d = deriveRunPairComparison(from, to).options.find(r => r.optionId === 'opt-d')!
+    expect(d.presence).toBe('only_from')
+    expect(d.toProbability).toBeNull()
+    expect(d.deltaPp).toBeNull()
+  })
+
+  it('discloses a RENAME rather than silently showing only the new label', () => {
+    const from = persisted({
+      runNumber: 1,
+      options: [{ id: 'opt-a', label: 'Old name', winProbability: 62 }],
+    })
+    const to = persisted({
+      runNumber: 2,
+      options: [{ id: 'opt-a', label: 'New name', winProbability: 70 }],
+    })
+    const row = deriveRunPairComparison(from, to).options[0]
+    expect(row.label).toBe('New name')
+    expect(row.previousLabel).toBe('Old name')
+    expect(row.deltaPp).toBe(8)
+  })
+
+  it('no rename ⇒ no "was" disclosure', () => {
+    const from = persisted({ runNumber: 1, options: [{ id: 'opt-a', label: 'Same', winProbability: 62 }] })
+    const to = persisted({ runNumber: 2, options: [{ id: 'opt-a', label: 'Same', winProbability: 70 }] })
+    expect(deriveRunPairComparison(from, to).options[0].previousLabel).toBeNull()
+  })
+})
+
+describe('deriveRunPairComparison — factors (same draft-variance rule, on RANK)', () => {
+  // ⚠ Rank, not elasticity, and that is a house rule not a preference: the
+  // elasticity claim family has NO owner selector, its debt is frozen
+  // shrink-only, and a NEW raw `.elasticity` read is a hard RED in
+  // `claim-ownership.drift.spec.ts`. Each run's `topFactors` is already sorted
+  // by |elasticity| descending, so POSITION is the already-derived value the
+  // debt module tells new code to consume.
+  it('matched factors get a rank movement; unmatched ones get membership, not a number', () => {
+    const from = persisted({
+      runNumber: 1,
+      topFactors: [factor('fac-a', 0.4, 'Churn'), factor('fac-b', 0.2, 'Price')],
+    })
+    const to = persisted({
+      runNumber: 2,
+      topFactors: [factor('fac-c', 0.6, 'Latency'), factor('fac-a', 0.3, 'Churn')],
+    })
+
+    const rows = deriveRunPairComparison(from, to).factors
+    const a = rows.find(r => r.factorId === 'fac-a')!
+    expect(a.presence).toBe('both')
+    expect(a.fromRank).toBe(1)
+    expect(a.toRank).toBe(2)
+    // Positive is MORE influential, so slipping 1st → 2nd is -1.
+    expect(a.rankDelta).toBe(-1)
+
+    const b = rows.find(r => r.factorId === 'fac-b')!
+    expect(b.presence).toBe('only_from')
+    expect(b.fromRank).toBe(2)
+    expect(b.toRank).toBeNull()
+    expect(b.rankDelta).toBeNull()
+
+    const c = rows.find(r => r.factorId === 'fac-c')!
+    expect(c.presence).toBe('only_to')
+    expect(c.fromRank).toBeNull()
+    expect(c.rankDelta).toBeNull()
+  })
+
+  it('a factor that climbed reports a POSITIVE movement', () => {
+    const from = persisted({ runNumber: 1, topFactors: [factor('x', 0.5), factor('y', 0.1)] })
+    const to = persisted({ runNumber: 2, topFactors: [factor('y', 0.9), factor('x', 0.2)] })
+    const rows = deriveRunPairComparison(from, to).factors
+    expect(rows.find(r => r.factorId === 'y')!.rankDelta).toBe(1)
+    expect(rows.find(r => r.factorId === 'x')!.rankDelta).toBe(-1)
+  })
+
+  it('reads NO raw elasticity: two runs with identical order report no movement whatever the values', () => {
+    // The same ranking with wildly different elasticities is "no change in the
+    // influence order" — which is all a rank comparison is entitled to say.
+    const from = persisted({ runNumber: 1, topFactors: [factor('x', 0.9), factor('y', 0.8)] })
+    const to = persisted({ runNumber: 2, topFactors: [factor('x', 0.05), factor('y', 0.01)] })
+    expect(deriveRunPairComparison(from, to).factors.map(r => r.rankDelta)).toEqual([0, 0])
+  })
+})
+
+// ── DEFECT 2: the cross-regime structure claim ────────────────────────────
+describe('deriveRunPairComparison — model structure', () => {
+  it('two PERSISTED runs with different aag hashes: changed', () => {
+    const from = persisted({ runNumber: 1, graphHash: 'aag-1' })
+    const to = persisted({ runNumber: 2, graphHash: 'aag-2' })
+    expect(deriveRunPairComparison(from, to).structure).toBe('changed')
+  })
+
+  it('two PERSISTED runs with the same aag hash: unchanged', () => {
+    const from = persisted({ runNumber: 1, graphHash: 'aag-1' })
+    const to = persisted({ runNumber: 2, graphHash: 'aag-1' })
+    expect(deriveRunPairComparison(from, to).structure).toBe('unchanged')
+  })
+
+  it('SESSION vs PERSISTED is NOT COMPARABLE — never "changed"', () => {
+    const from = makeAnalysisSnapshot({ runNumber: 1, source: 'session', graphHash: 'ui-hash' })
+    const to = persisted({ runNumber: 2, graphHash: 'aag-1', nodeCount: null, edgeCount: null })
+    expect(deriveRunPairComparison(from, to).structure).toBe('not_comparable')
+  })
+
+  it('an absent hash at either end is NOT COMPARABLE', () => {
+    const from = persisted({ runNumber: 1, graphHash: null, nodeCount: null, edgeCount: null })
+    const to = persisted({ runNumber: 2, graphHash: 'aag-1', nodeCount: null, edgeCount: null })
+    expect(deriveRunPairComparison(from, to).structure).toBe('not_comparable')
+  })
+})
+
+// ── DEFECT 3: the unlicensed leader claim ─────────────────────────────────
+describe('deriveLeaderClaim — the run quotes its OWN producer verdict', () => {
+  it('an entitled verdict names the option, resolved against that run’s own option list', () => {
+    const snapshot = persisted({
+      runNumber: 1,
+      options: [{ id: 'opt-b', label: 'Option B', winProbability: 71 }],
+      leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-b' },
+    })
+    expect(deriveLeaderClaim(snapshot)).toEqual({ kind: 'named', optionId: 'opt-b', label: 'Option B' })
+  })
+
+  it('the producer’s TIE verdict is "tied" — the one case a denial is licensed', () => {
+    expect(deriveLeaderClaim(persisted({ runNumber: 1, leaderVerdict: TIED_LEADER_VERDICT })).kind).toBe('tied')
+  })
+
+  it('NO producer signal is "unclaimed" — silence, not a denial', () => {
+    expect(deriveLeaderClaim(persisted({ runNumber: 1, leaderVerdict: UNCLAIMED_LEADER_VERDICT })).kind)
+      .toBe('unclaimed')
+  })
+
+  it('IGNORES `winnerId`: an argmax winner does not license leader language', () => {
+    const snapshot = persisted({
+      runNumber: 1,
+      winnerId: 'opt-a',
+      winnerLabel: 'Option A',
+      winnerProbability: 88,
+      leaderVerdict: UNCLAIMED_LEADER_VERDICT,
+    })
+    const claim = deriveLeaderClaim(snapshot)
+    expect(claim.kind).toBe('unclaimed')
+    expect(claim.label).toBeNull()
+  })
+
+  it('an entitled verdict whose leader is NOT in the run’s options falls silent rather than naming a blank', () => {
+    const snapshot = persisted({
+      runNumber: 1,
+      options: [{ id: 'opt-a', label: 'Option A', winProbability: 60 }],
+      leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-ghost' },
+    })
+    expect(deriveLeaderClaim(snapshot).kind).toBe('unclaimed')
+  })
+})
+
+describe('deriveRunPairComparison — leader change', () => {
+  it('both runs named the SAME leader: unchanged', () => {
+    const from = persisted({ runNumber: 1, leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-a' } })
+    const to = persisted({ runNumber: 2, leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-a' } })
+    expect(deriveRunPairComparison(from, to).leaderChange).toBe('unchanged')
+  })
+
+  it('both runs named DIFFERENT leaders: changed', () => {
+    const from = persisted({ runNumber: 1, leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-a' } })
+    const to = persisted({ runNumber: 2, leaderVerdict: { ...DEFAULT_LEADER_VERDICT, leaderId: 'opt-b' } })
+    expect(deriveRunPairComparison(from, to).leaderChange).toBe('changed')
+  })
+
+  it('either run declined to name a leader: NOT COMPARABLE, never "unchanged"', () => {
+    const named = persisted({ runNumber: 1, leaderVerdict: DEFAULT_LEADER_VERDICT })
+    const tied = persisted({ runNumber: 2, leaderVerdict: TIED_LEADER_VERDICT })
+    const silent = persisted({ runNumber: 3, leaderVerdict: UNCLAIMED_LEADER_VERDICT })
+
+    expect(deriveRunPairComparison(named, tied).leaderChange).toBe('not_comparable')
+    expect(deriveRunPairComparison(named, silent).leaderChange).toBe('not_comparable')
+    // Two runs that BOTH said "no clear leader" have no leader to call unchanged.
+    expect(deriveRunPairComparison(tied, tied).leaderChange).toBe('not_comparable')
+  })
+})
+
+// ── DEFECT 4: absence rendered as zero ────────────────────────────────────
+describe('deriveRunPairComparison — honest degradation', () => {
+  it('goal probability absent on either side ⇒ null delta, never 0', () => {
+    const from = persisted({ runNumber: 1, goalProbability: null })
+    const to = persisted({ runNumber: 2, goalProbability: 71 })
+    expect(deriveRunPairComparison(from, to).goalProbabilityDeltaPp).toBeNull()
+  })
+
+  it('goal probability present on BOTH sides ⇒ a real delta', () => {
+    const from = persisted({ runNumber: 1, goalProbability: 40 })
+    const to = persisted({ runNumber: 2, goalProbability: 55 })
+    expect(deriveRunPairComparison(from, to).goalProbabilityDeltaPp).toBe(15)
+  })
+
+  it('evidence coverage stays null on a persisted pair — the fact stores the analysis, not the model', () => {
+    const from = persisted({ runNumber: 1, evidenceCoverage: null })
+    const to = persisted({ runNumber: 2, evidenceCoverage: null })
+    const c = deriveRunPairComparison(from, to)
+    expect(c.fromEvidenceCoverage).toBeNull()
+    expect(c.toEvidenceCoverage).toBeNull()
+  })
+
+  it('warnings are a set difference over two real lists', () => {
+    const from = persisted({ runNumber: 1, inferenceWarnings: ['w1', 'w2'] })
+    const to = persisted({ runNumber: 2, inferenceWarnings: ['w2', 'w3'] })
+    const c = deriveRunPairComparison(from, to)
+    expect(c.warningsResolved).toEqual(['w1'])
+    expect(c.warningsIntroduced).toEqual(['w3'])
+  })
+
+  it('a run with no options at all yields no option rows — not a row of zeros', () => {
+    const from = persisted({ runNumber: 1, options: [] })
+    const to = persisted({ runNumber: 2, options: [] })
+    expect(deriveRunPairComparison(from, to).options).toEqual([])
+  })
+})

--- a/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { deriveTransitions, buildCumulativeTransition } from '../deriveTransitions'
+import {
+  deriveTransitions,
+  buildCumulativeTransition,
+  buildRangeTransition,
+  compareStructure,
+} from '../deriveTransitions'
+import { makeAnalysisSnapshot } from './__fixtures__/analysisSnapshot'
 import type { AnalysisSnapshot, FactorSensitivitySummary } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -16,41 +22,14 @@ function makeFactor(overrides: Partial<FactorSensitivitySummary> & { id: string 
   }
 }
 
+// Delegates to the ONE shared snapshot fixture (see that file's header on why
+// six hand-kept copies of this literal were a trap-12 mirror). This spec's own
+// default — a single top factor — is preserved by spreading over it.
 function makeSnapshot(overrides: Partial<AnalysisSnapshot> & { runNumber: number }): AnalysisSnapshot {
-  return {
-    runId: `run-${overrides.runNumber}`,
-    runNumber: overrides.runNumber,
-    timestamp: new Date().toISOString(),
-    source: 'session',
-    graphHash: 'hash-default',
-    nodeCount: 5,
-    edgeCount: 4,
-    winnerId: 'opt-a',
-    winnerLabel: 'Option A',
-    winnerProbability: 65,
-    runnerUpId: 'opt-b',
-    runnerUpLabel: 'Option B',
-    runnerUpProbability: 35,
-    recommendationStability: 0.7,
-    stabilityLabel: 'stable',
-    fragileEdgeCount: 0,
-    evidenceCoverage: '3/5',
+  return makeAnalysisSnapshot({
     topFactors: [makeFactor({ id: 'fac-a', label: 'Churn', elasticity: 0.4 })],
-    influenceConcentration: 40,
-    topCalibrationFactor: 'Factor A',
-    topCalibrationFactorId: 'fac-a',
-    topElasticity: 30,
-    rankFlipRate: 0.05,
-    goalProbability: null,
-    jointGoalProbability: null,
-    inferenceWarnings: [],
-    conditionalWinners: [],
-    edgeEValues: [],
-    seedUsed: 12345,
-    responseHash: 'abc123',
-    editSummary: 'Test edit',
     ...overrides,
-  }
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -443,5 +422,127 @@ describe('buildCumulativeTransition', () => {
     ]
     const result = buildCumulativeTransition(snapshots)!
     expect(result.edits).toEqual(['Tightened churn', 'Added regulatory risk'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.113a slice 2 — the three-valued structure comparison
+// ---------------------------------------------------------------------------
+
+describe('compareStructure', () => {
+  it('same regime, different hash ⇒ changed', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
+      makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2' }),
+    )).toBe('changed')
+  })
+
+  it('same regime, same hash ⇒ unchanged', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
+      makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-1' }),
+    )).toBe('unchanged')
+  })
+
+  it('CROSS-REGIME ⇒ not_comparable, never "changed"', () => {
+    // A session snapshot hashes with the UI\'s generateGraphHash; a persisted
+    // run carries CEE\'s aag_v1. They are ALWAYS unequal, so an unguarded
+    // comparison manufactures a structure change out of a provenance boundary.
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, source: 'session', graphHash: 'ui-hash', nodeCount: null, edgeCount: null }),
+      makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-1', nodeCount: null, edgeCount: null }),
+    )).toBe('not_comparable')
+  })
+
+  it('an absent hash at either end ⇒ not_comparable', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, graphHash: null, nodeCount: null, edgeCount: null }),
+      makeSnapshot({ runNumber: 2, graphHash: 'h', nodeCount: null, edgeCount: null }),
+    )).toBe('not_comparable')
+  })
+
+  it('EQUAL COUNTS DO NOT LICENSE "unchanged" — a rewired graph keeps its counts', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, graphHash: null, nodeCount: 5, edgeCount: 4 }),
+      makeSnapshot({ runNumber: 2, graphHash: null, nodeCount: 5, edgeCount: 4 }),
+    )).toBe('not_comparable')
+  })
+
+  it('differing counts DO license "changed" even without a comparable hash', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, graphHash: null, nodeCount: 5, edgeCount: 4 }),
+      makeSnapshot({ runNumber: 2, graphHash: null, nodeCount: 6, edgeCount: 4 }),
+    )).toBe('changed')
+  })
+
+  it('agrees with the boolean the transition cards render — one regime rule, not two', () => {
+    const pairs: Array<[AnalysisSnapshot, AnalysisSnapshot]> = [
+      [makeSnapshot({ runNumber: 1, graphHash: 'a' }), makeSnapshot({ runNumber: 2, graphHash: 'b' })],
+      [makeSnapshot({ runNumber: 1, graphHash: 'a' }), makeSnapshot({ runNumber: 2, graphHash: 'a' })],
+      [makeSnapshot({ runNumber: 1, source: 'session', graphHash: 'a' }),
+       makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'b' })],
+    ]
+    for (const [from, to] of pairs) {
+      expect(deriveTransitions([from, to])[0].structureChanged)
+        .toBe(compareStructure(from, to) === 'changed')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.113a slice 2 — arbitrary-pair transitions
+// ---------------------------------------------------------------------------
+
+describe('buildRangeTransition', () => {
+  const four = () => [
+    makeSnapshot({ runNumber: 1, winnerProbability: 50, editSummary: 'Initial analysis' }),
+    makeSnapshot({ runNumber: 2, winnerProbability: 55, editSummary: 'Tightened churn' }),
+    makeSnapshot({ runNumber: 3, winnerProbability: 61, editSummary: 'Added risk' }),
+    makeSnapshot({ runNumber: 4, winnerProbability: 74, editSummary: 'Reweighted price' }),
+  ]
+
+  it('an ADJACENT pair is exactly the plain pairwise card', () => {
+    const result = buildRangeTransition(four(), 1, 2)!
+    expect(result.isCumulative).toBe(false)
+    expect(result.fromRunNumber).toBe(2)
+    expect(result.toRunNumber).toBe(3)
+    expect(result.winnerProbDelta).toBe(6)
+    expect(result.edits).toEqual(['Added risk'])
+  })
+
+  // ⚠ The defect this pins: `editSummary` describes the edits since the run
+  // IMMEDIATELY BEFORE. Handing buildTransition a non-adjacent pair would print
+  // run 4\'s last-leg summary under a heading claiming it covers runs 1→4 —
+  // every character true, attached to the wrong interval.
+  it('a NON-ADJACENT pair collects the edit summary of every leg inside the range', () => {
+    const result = buildRangeTransition(four(), 0, 3)!
+    expect(result.edits).toEqual(['Tightened churn', 'Added risk', 'Reweighted price'])
+    expect(result.isCumulative).toBe(true)
+    expect(result.cumulativeCaveats).toContainEqual(expect.stringContaining('2 intermediate refinements'))
+  })
+
+  it('counts flips only INSIDE the picked range', () => {
+    const snapshots = [
+      makeSnapshot({ runNumber: 1, winnerId: 'opt-a' }),
+      makeSnapshot({ runNumber: 2, winnerId: 'opt-b' }), // flip is outside 2..4
+      makeSnapshot({ runNumber: 3, winnerId: 'opt-b' }),
+      makeSnapshot({ runNumber: 4, winnerId: 'opt-b' }),
+    ]
+    expect(buildRangeTransition(snapshots, 1, 3)!.cumulativeCaveats.join(' ')).not.toContain('flipped')
+    expect(buildRangeTransition(snapshots, 0, 3)!.cumulativeCaveats.join(' ')).toContain('flipped')
+  })
+
+  it('refuses a non-forward or out-of-range pair rather than inventing one', () => {
+    const snapshots = four()
+    expect(buildRangeTransition(snapshots, 2, 2)).toBeNull()
+    expect(buildRangeTransition(snapshots, 3, 1)).toBeNull()
+    expect(buildRangeTransition(snapshots, -1, 2)).toBeNull()
+    expect(buildRangeTransition(snapshots, 0, 9)).toBeNull()
+  })
+
+  it('buildCumulativeTransition is the (first, latest) case of it — unchanged behaviour', () => {
+    const snapshots = four()
+    expect(buildCumulativeTransition(snapshots))
+      .toEqual(buildRangeTransition(snapshots, 0, snapshots.length - 1))
   })
 })

--- a/src/canvas/compare-tab/__tests__/runPairSelection.spec.ts
+++ b/src/canvas/compare-tab/__tests__/runPairSelection.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * ROADMAP 2.113a slice 2 — the A/B pick's two invariants.
+ *
+ * Both exist to stop the side-by-side view rendering a comparison that says
+ * nothing: a run against ITSELF (a column of `+0pp` deltas and "Leader
+ * unchanged", which reads exactly like a measured finding), or a pair whose
+ * delta sign convention is inverted relative to every other number in the tab.
+ */
+import { describe, it, expect } from 'vitest'
+import { applyRunPairChange, normaliseRunPair } from '../runPairSelection'
+
+describe('normaliseRunPair', () => {
+  it('defaults to first-vs-latest when nothing has been picked', () => {
+    expect(normaliseRunPair([1, 2, 3, 4], null)).toEqual({ from: 1, to: 4 })
+  })
+
+  it('returns null below two runs — there is nothing to pick between', () => {
+    expect(normaliseRunPair([], null)).toBeNull()
+    expect(normaliseRunPair([1], null)).toBeNull()
+    expect(normaliseRunPair([1], { from: 1, to: 1 })).toBeNull()
+  })
+
+  it('keeps a valid pick', () => {
+    expect(normaliseRunPair([1, 2, 3, 4], { from: 2, to: 3 })).toEqual({ from: 2, to: 3 })
+  })
+
+  it('orders the pair chronologically so every delta is later-minus-earlier', () => {
+    expect(normaliseRunPair([1, 2, 3, 4], { from: 4, to: 2 })).toEqual({ from: 2, to: 4 })
+  })
+
+  it('clamps an end that no longer exists — re-hydration renumbers the journey', () => {
+    // The user picked run 7; a scenario switch left only three runs.
+    expect(normaliseRunPair([1, 2, 3], { from: 2, to: 7 })).toEqual({ from: 2, to: 3 })
+    expect(normaliseRunPair([1, 2, 3], { from: 9, to: 2 })).toEqual({ from: 1, to: 2 })
+  })
+
+  it('NEVER returns a run compared with itself — it falls back to the extremes', () => {
+    expect(normaliseRunPair([1, 2, 3], { from: 2, to: 2 })).toEqual({ from: 1, to: 3 })
+    // Both ends stale and clamping would collapse them onto the same run.
+    expect(normaliseRunPair([1, 2, 3], { from: 8, to: 9 })).toEqual({ from: 1, to: 3 })
+  })
+})
+
+describe('applyRunPairChange', () => {
+  it('moves the picked end', () => {
+    expect(applyRunPairChange({ from: 1, to: 4 }, 'from', 2)).toEqual({ from: 2, to: 4 })
+    expect(applyRunPairChange({ from: 1, to: 4 }, 'to', 3)).toEqual({ from: 1, to: 3 })
+  })
+
+  it('SWAPS rather than collapsing when the picked run is already at the other end', () => {
+    expect(applyRunPairChange({ from: 1, to: 4 }, 'from', 4)).toEqual({ from: 1, to: 4 })
+    expect(applyRunPairChange({ from: 2, to: 5 }, 'to', 2)).toEqual({ from: 2, to: 5 })
+  })
+
+  it('re-orders when a pick crosses the other end', () => {
+    // "Compare run 6 with run 3" is the same pair as 3→6, and only one of
+    // those two readings keeps the delta sign consistent with the rest of the tab.
+    expect(applyRunPairChange({ from: 1, to: 3 }, 'from', 6)).toEqual({ from: 3, to: 6 })
+    expect(applyRunPairChange({ from: 4, to: 6 }, 'to', 1)).toEqual({ from: 1, to: 4 })
+  })
+
+  it('is total: no sequence of picks produces from === to', () => {
+    const runs = [1, 2, 3, 4, 5]
+    let pair = { from: 1, to: 5 }
+    for (const endpoint of ['from', 'to'] as const) {
+      for (const n of runs) {
+        pair = applyRunPairChange(pair, endpoint, n)
+        expect(pair.from).not.toBe(pair.to)
+        expect(pair.from).toBeLessThan(pair.to)
+      }
+    }
+  })
+})

--- a/src/canvas/compare-tab/deriveRunPairComparison.ts
+++ b/src/canvas/compare-tab/deriveRunPairComparison.ts
@@ -1,0 +1,250 @@
+/**
+ * Pick-two-runs comparison — ROADMAP 2.113a slice 2.
+ *
+ * Pure derivation over TWO `AnalysisSnapshot`s. Every value it produces comes
+ * from two persisted facts, one on each side; there is no baseline, no default
+ * and no re-derivation anywhere in this file.
+ *
+ * THE THREE RULES THIS MODULE ENFORCES
+ * ------------------------------------------------------------------
+ * 1. **A delta needs two measurements.** An option or factor present on only
+ *    one side gets `presence: 'only_from' | 'only_to'` and `delta*: null` —
+ *    never a subtraction against an implied 0. That is the draft-variance case
+ *    (ROADMAP 2.127): two runs of the same scenario may score different option
+ *    or factor sets. Measured live 2026-07-29: **0 of 83** consecutive owned
+ *    run pairs differ today, so this is producer-drift insurance rather than a
+ *    case a tester will hit — implemented and pinned because the alternative
+ *    is a fabricated baseline the moment 2.127 makes it reachable.
+ *
+ * 2. **Leader language is QUOTED, never derived.** Each side's claim comes
+ *    from that run's own `leaderVerdict` (`src/lib/decisionVerdict.ts`, the one
+ *    module entitled to produce it), not from `winnerId` — which is a
+ *    client-side argmax and exactly the "Authority 3" that module deleted. A
+ *    run whose producer sent no applicable signal is `'unclaimed'`: SILENCE,
+ *    never a denial, and never a comparison.
+ *
+ * 3. **Hash regimes never compare.** Structure goes through `compareStructure`,
+ *    the single regime rule in `deriveTransitions.ts`, which refuses a
+ *    cross-source or absent-ended pair with `'not_comparable'`.
+ */
+import type {
+  AnalysisSnapshot,
+  FactorDelta,
+  LeaderClaim,
+  OptionDelta,
+  RunPairComparison,
+} from './types'
+import { compareStructure } from './deriveTransitions'
+
+// ---------------------------------------------------------------------------
+// Leader claim — quoted from the run's own verdict
+// ---------------------------------------------------------------------------
+
+/**
+ * What THIS run's producer entitles us to say about its leading option.
+ *
+ * Note the last guard: an entitled verdict whose `leaderId` is not among the
+ * run's own options cannot be NAMED, and a leader we cannot name must not be
+ * announced. It falls to `'unclaimed'` (silence) rather than rendering a bare
+ * id or an empty label — the "Calibrate ␣" class of defect this estate has
+ * already paid for once.
+ */
+export function deriveLeaderClaim(snapshot: AnalysisSnapshot): LeaderClaim {
+  const verdict = snapshot.leaderVerdict
+
+  if (verdict.hasLeadingOption && verdict.leaderId != null) {
+    const option = snapshot.options.find(o => o.id === verdict.leaderId)
+    if (option != null && option.label.length > 0) {
+      return { kind: 'named', optionId: option.id, label: option.label }
+    }
+    return { kind: 'unclaimed', optionId: null, label: null }
+  }
+
+  // `'tied'` is the producer's own "no clear leading option". `'unknown'` is
+  // its silence — and `decisionVerdict`'s doctrine is that silence licenses no
+  // claim in EITHER direction, so it must not collapse into 'tied'.
+  if (verdict.separation === 'tied') {
+    return { kind: 'tied', optionId: null, label: null }
+  }
+  return { kind: 'unclaimed', optionId: null, label: null }
+}
+
+// ---------------------------------------------------------------------------
+// Option deltas — union, matched by option id
+// ---------------------------------------------------------------------------
+
+function deriveOptionDeltas(
+  from: AnalysisSnapshot,
+  to: AnalysisSnapshot,
+): OptionDelta[] {
+  const fromById = new Map(from.options.map(o => [o.id, o]))
+  const toById = new Map(to.options.map(o => [o.id, o]))
+
+  const ids: string[] = []
+  for (const o of to.options) ids.push(o.id)
+  for (const o of from.options) if (!toById.has(o.id)) ids.push(o.id)
+
+  const rows = ids.map((id): OptionDelta => {
+    const a = fromById.get(id) ?? null
+    const b = toById.get(id) ?? null
+
+    if (a != null && b != null) {
+      return {
+        optionId: id,
+        // The later run's label leads: the pair is presented chronologically,
+        // so the current name is the one the user is looking at now. A rename
+        // is disclosed rather than dropped.
+        label: b.label,
+        previousLabel: a.label !== b.label ? a.label : null,
+        fromProbability: a.winProbability,
+        toProbability: b.winProbability,
+        deltaPp: b.winProbability - a.winProbability,
+        presence: 'both',
+      }
+    }
+
+    const only = (a ?? b)!
+    return {
+      optionId: id,
+      label: only.label,
+      previousLabel: null,
+      fromProbability: a != null ? a.winProbability : null,
+      toProbability: b != null ? b.winProbability : null,
+      // ⚠ NEVER a number here. `b - 0` would publish the later run's whole
+      // probability as a "gain" against a run that never scored this option.
+      deltaPp: null,
+      presence: a != null ? 'only_from' : 'only_to',
+    }
+  })
+
+  // Strongest first, on whichever side measured it — an ordering, not a claim.
+  return rows.sort((x, y) => strongest(y) - strongest(x))
+}
+
+function strongest(row: OptionDelta): number {
+  return Math.max(row.toProbability ?? -Infinity, row.fromProbability ?? -Infinity)
+}
+
+// ---------------------------------------------------------------------------
+// Factor deltas — union of the two runs' TOP factors, matched by factor id
+// ---------------------------------------------------------------------------
+//
+// ⚠ THIS SECTION READS NO RAW CLAIM FIELD, DELIBERATELY. `elasticity` /
+// `sensitivity_score` are a registered claim family with NO owner selector, so
+// their debt is frozen shrink-only and a NEW raw read is a hard RED in
+// `claim-ownership.drift.spec.ts`. The first draft of this module read
+// `.elasticity` five times and the gate caught it — correctly. The compliant
+// route, quoted from `elasticityClaimDebt.ts`, is "consume an already-derived
+// value from a surface that has one": each run's `topFactors` is ALREADY sorted
+// by |elasticity| descending (`extractTopFactors`), so a factor's POSITION in
+// that list is that run's own influence ranking. Comparing two positions makes
+// no normalisation, sign or threshold choice — which is exactly what an unowned
+// family cannot sanction a consumer to make.
+
+/** 1-indexed rank of each factor within its own run's top list. */
+function rankMap(snapshot: AnalysisSnapshot): Map<string, number> {
+  return new Map(snapshot.topFactors.map((f, i) => [f.id, i + 1]))
+}
+
+function deriveFactorDeltas(
+  from: AnalysisSnapshot,
+  to: AnalysisSnapshot,
+): FactorDelta[] {
+  const fromRanks = rankMap(from)
+  const toRanks = rankMap(to)
+  const labels = new Map<string, string>()
+  for (const f of from.topFactors) labels.set(f.id, f.label)
+  for (const f of to.topFactors) labels.set(f.id, f.label)
+
+  const ids: string[] = []
+  for (const f of to.topFactors) ids.push(f.id)
+  for (const f of from.topFactors) if (!toRanks.has(f.id)) ids.push(f.id)
+
+  const rows = ids.map((id): FactorDelta => {
+    const a = fromRanks.get(id) ?? null
+    const b = toRanks.get(id) ?? null
+    const label = labels.get(id) ?? id
+
+    if (a != null && b != null) {
+      return {
+        factorId: id,
+        label,
+        fromRank: a,
+        toRank: b,
+        // Positive = moved UP the influence order (rank 3 → 1 is +2 places).
+        rankDelta: a - b,
+        presence: 'both',
+      }
+    }
+
+    return {
+      factorId: id,
+      label,
+      fromRank: a,
+      toRank: b,
+      // A factor that ENTERED or LEFT the top list has no before-or-after
+      // position to subtract. It is a MEMBERSHIP change, reported as one.
+      rankDelta: null,
+      presence: a != null ? 'only_from' : 'only_to',
+    }
+  })
+
+  return rows.sort((x, y) => bestRank(x) - bestRank(y))
+}
+
+/** Best (lowest) rank the factor reached on either side — an ordering, not a claim. */
+function bestRank(row: FactorDelta): number {
+  return Math.min(row.toRank ?? Infinity, row.fromRank ?? Infinity)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two runs. `from` is the EARLIER run and `to` the later one — the
+ * caller (`CompareTabBody`) normalises the user's pick chronologically so that
+ * every delta on the screen has the same sign convention as the rest of the
+ * tab (later minus earlier).
+ */
+export function deriveRunPairComparison(
+  from: AnalysisSnapshot,
+  to: AnalysisSnapshot,
+): RunPairComparison {
+  const fromLeader = deriveLeaderClaim(from)
+  const toLeader = deriveLeaderClaim(to)
+
+  // A leader CHANGE is only claimable when both runs named one. Two runs that
+  // both declined to name a leader have no leader to report as unchanged, and
+  // a named-vs-unclaimed pair is a change in what the PRODUCER would say, not
+  // a measured change in the model.
+  const leaderChange: RunPairComparison['leaderChange'] =
+    fromLeader.kind === 'named' && toLeader.kind === 'named'
+      ? (fromLeader.optionId === toLeader.optionId ? 'unchanged' : 'changed')
+      : 'not_comparable'
+
+  const fromWarnings = new Set(from.inferenceWarnings)
+  const toWarnings = new Set(to.inferenceWarnings)
+
+  return {
+    from,
+    to,
+    options: deriveOptionDeltas(from, to),
+    factors: deriveFactorDeltas(from, to),
+    structure: compareStructure(from, to),
+    fromLeader,
+    toLeader,
+    leaderChange,
+    // T2b: both ends or nothing. A goal probability is absent on every live
+    // persisted run measured (0 of 2,850 option entries carry one), so this is
+    // null in practice and the row renders "Not assessed" on both sides.
+    goalProbabilityDeltaPp:
+      from.goalProbability != null && to.goalProbability != null
+        ? to.goalProbability - from.goalProbability
+        : null,
+    fromEvidenceCoverage: from.evidenceCoverage,
+    toEvidenceCoverage: to.evidenceCoverage,
+    warningsResolved: from.inferenceWarnings.filter(w => !toWarnings.has(w)),
+    warningsIntroduced: to.inferenceWarnings.filter(w => !fromWarnings.has(w)),
+  }
+}

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -5,7 +5,12 @@
  * AnalysisSnapshot pairs. Handles both regular and cumulative
  * (synthetic first→latest) transitions.
  */
-import type { AnalysisSnapshot, Transition, FactorSensitivitySummary } from './types'
+import type {
+  AnalysisSnapshot,
+  Transition,
+  FactorSensitivitySummary,
+  StructureComparison,
+} from './types'
 
 // ---------------------------------------------------------------------------
 // Magnitude classification
@@ -116,16 +121,49 @@ function hashesAreComparable(from: AnalysisSnapshot, to: AnalysisSnapshot): bool
 }
 
 /**
+ * The THREE-valued structure comparison (ROADMAP 2.113a slice 2).
+ *
+ * `Transition.structureChanged` is a boolean because a transition card only
+ * ever *warns*; the side-by-side pair view has a row to fill, and "we could not
+ * compare these two models" is a different answer from "they are the same".
+ * Collapsing the two is how a provenance boundary becomes a claim about the
+ * user's graph, which is the defect the regime guard above exists to stop.
+ *
+ * WHAT LICENSES WHAT:
+ *  · `'changed'`        — a same-regime hash INEQUALITY, or a node/edge count
+ *                         that differs with both ends measured.
+ *  · `'unchanged'`      — ONLY a same-regime hash EQUALITY. Equal counts do
+ *                         NOT license it: a rewired graph keeps its counts, so
+ *                         "unchanged" from counts alone would be a claim the
+ *                         evidence cannot support.
+ *  · `'not_comparable'` — cross-regime, or a hash absent at either end
+ *                         (`graph_hash_at_run` was absent in 55 of the 773
+ *                         persisted runs measured for slice 1).
+ *
+ * `detectStructureChange` is defined as `=== 'changed'`, so the boolean the
+ * existing transition cards render is unchanged by construction — there is one
+ * regime rule in this file, not two.
+ */
+export function compareStructure(
+  from: AnalysisSnapshot,
+  to: AnalysisSnapshot,
+): StructureComparison {
+  const hashComparable = hashesAreComparable(from, to)
+  if (hashComparable && from.graphHash !== to.graphHash) return 'changed'
+  if (from.nodeCount != null && to.nodeCount != null && from.nodeCount !== to.nodeCount) return 'changed'
+  if (from.edgeCount != null && to.edgeCount != null && from.edgeCount !== to.edgeCount) return 'changed'
+  if (hashComparable) return 'unchanged'
+  return 'not_comparable'
+}
+
+/**
  * T2b: a structure CHANGE is only claimable from a signal that was actually
  * measured at BOTH ends. Where no comparable signal exists the answer is
  * "no evidence of a change" — the same posture `robustnessChanged` already
  * takes — not "changed".
  */
 function detectStructureChange(from: AnalysisSnapshot, to: AnalysisSnapshot): boolean {
-  if (hashesAreComparable(from, to) && from.graphHash !== to.graphHash) return true
-  if (from.nodeCount != null && to.nodeCount != null && from.nodeCount !== to.nodeCount) return true
-  if (from.edgeCount != null && to.edgeCount != null && from.edgeCount !== to.edgeCount) return true
-  return false
+  return compareStructure(from, to) === 'changed'
 }
 
 // ---------------------------------------------------------------------------
@@ -247,42 +285,75 @@ export function deriveTransitions(snapshots: AnalysisSnapshot[]): Transition[] {
   return transitions
 }
 
-/** Build a synthetic cumulative transition from first to latest */
-export function buildCumulativeTransition(snapshots: AnalysisSnapshot[]): Transition | null {
-  if (snapshots.length < 3) return null // meaningless at 2 runs (same as prev)
+/**
+ * Build the transition for an ARBITRARY ordered pair of runs (ROADMAP 2.113a
+ * slice 2), indices into the same ordered snapshot list the tab renders.
+ *
+ * ⚠ WHY THIS IS NOT `buildTransition(a, b)` FOR A NON-ADJACENT PAIR. A
+ * snapshot's `editSummary` describes the edits made since the run IMMEDIATELY
+ * BEFORE it — that is how `deriveEditSummary` builds it, from the scenario
+ * events between two consecutive run timestamps. Handing `buildTransition` a
+ * pair three runs apart would print run B's *last-leg* edit summary under a
+ * heading claiming it covers A→B: a true sentence attached to the wrong
+ * interval, which is a fabrication even though every character of it is real.
+ * So the edits for a span are the CONCATENATION of the per-leg summaries in
+ * `(fromIndex, toIndex]` — the derivation `buildCumulativeTransition` already
+ * used for first→latest, generalised rather than mirrored (CLAUDE.md trap 12).
+ *
+ * Returns null for an out-of-range or non-forward pair; an adjacent pair
+ * returns exactly the plain pairwise card.
+ */
+export function buildRangeTransition(
+  snapshots: AnalysisSnapshot[],
+  fromIndex: number,
+  toIndex: number,
+): Transition | null {
+  if (!Number.isInteger(fromIndex) || !Number.isInteger(toIndex)) return null
+  if (fromIndex < 0 || toIndex > snapshots.length - 1) return null
+  if (fromIndex >= toIndex) return null
 
-  const first = snapshots[0]
-  const latest = snapshots[snapshots.length - 1]
-  const base = buildTransition(first, latest)
+  const base = buildTransition(snapshots[fromIndex], snapshots[toIndex])
 
-  // Caveats from intermediate snapshots
-  const caveats: string[] = []
-  caveats.push(`Includes ${snapshots.length - 2} intermediate refinement${snapshots.length - 2 > 1 ? 's' : ''}`)
+  // Adjacent: there is nothing between the two runs, so there is no cumulative
+  // caveat to make and the card is the ordinary pairwise one.
+  const span = toIndex - fromIndex
+  if (span === 1) return base
 
-  // Check for any intermediate flips
-  const flipCount = snapshots.slice(1).filter((s, i) =>
-    s.winnerId !== snapshots[i].winnerId
+  const intermediates = span - 1
+  const caveats: string[] = [
+    `Includes ${intermediates} intermediate refinement${intermediates > 1 ? 's' : ''}`,
+  ]
+
+  // Legs strictly inside the range: each compares a snapshot with the one
+  // before it, so the window starts at fromIndex + 1.
+  const legs = snapshots.slice(fromIndex + 1, toIndex + 1)
+
+  const flipCount = legs.filter((s, i) =>
+    s.winnerId !== snapshots[fromIndex + i].winnerId
   ).length
   if (flipCount > 0) {
     caveats.push(`Result flipped ${flipCount === 1 ? 'once' : `${flipCount} times`}`)
   }
 
-  // Check for any structure changes. Same regime guard as the pairwise case —
-  // a cross-source or absent-ended hash pair is no evidence, not a change.
-  const structureChanged = snapshots.slice(1).some((s, i) =>
-    hashesAreComparable(snapshots[i], s) && s.graphHash !== snapshots[i].graphHash
+  // Same regime guard as the pairwise case — a cross-source or absent-ended
+  // hash pair is no evidence, not a change.
+  const structureChanged = legs.some((s, i) =>
+    hashesAreComparable(snapshots[fromIndex + i], s) && s.graphHash !== snapshots[fromIndex + i].graphHash
   )
   if (structureChanged) {
     caveats.push('Structure changed during this period')
   }
 
-  // Collect all edits across all transitions
-  const allEdits = snapshots.slice(1).map(s => s.editSummary).filter(Boolean)
-
   return {
     ...base,
-    edits: allEdits,
+    edits: legs.map(s => s.editSummary).filter(Boolean),
     isCumulative: true,
     cumulativeCaveats: caveats,
   }
+}
+
+/** Build a synthetic cumulative transition from first to latest */
+export function buildCumulativeTransition(snapshots: AnalysisSnapshot[]): Transition | null {
+  if (snapshots.length < 3) return null // meaningless at 2 runs (same as prev)
+  return buildRangeTransition(snapshots, 0, snapshots.length - 1)
 }

--- a/src/canvas/compare-tab/runLabels.ts
+++ b/src/canvas/compare-tab/runLabels.ts
@@ -1,0 +1,33 @@
+/**
+ * How a run is named on screen — ROADMAP 2.113a slice 2.
+ *
+ * One place, because the picker's `<option>` text and the side-by-side column
+ * heading must name the same run the same way; two formatters would drift and
+ * the drift would read as two different runs.
+ */
+
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+/**
+ * `"22 Jul"`, in UTC, or **null** when the stamp cannot be parsed.
+ *
+ * UTC and a fixed month table rather than `toLocaleDateString`, so the string a
+ * test asserts is the string a user sees regardless of the machine's timezone
+ * or ICU build. Null rather than "Invalid Date": a run whose timestamp is
+ * unreadable is named by its number alone, never by a broken date.
+ */
+export function formatRunDate(timestamp: string): string | null {
+  const t = Date.parse(timestamp)
+  if (!Number.isFinite(t)) return null
+  const d = new Date(t)
+  return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]}`
+}
+
+/** `"Run 3 · 22 Jul"`, degrading to `"Run 3"` when the stamp is unreadable. */
+export function runLabel(runNumber: number, timestamp: string): string {
+  const when = formatRunDate(timestamp)
+  return when ? `Run ${runNumber} · ${when}` : `Run ${runNumber}`
+}

--- a/src/canvas/compare-tab/runPairSelection.ts
+++ b/src/canvas/compare-tab/runPairSelection.ts
@@ -1,0 +1,72 @@
+/**
+ * The A/B pick's selection rules — ROADMAP 2.113a slice 2.
+ *
+ * Pure, so the two invariants that keep the side-by-side view honest are
+ * testable without a render:
+ *
+ *   1. **The two ends are never the same run.** A self-comparison would print
+ *      a column of `+0pp` deltas and "Leader unchanged" — a screenful of
+ *      measurements about nothing. Picking the run already at the other end
+ *      SWAPS the two rather than collapsing them, so the state is unreachable.
+ *
+ *   2. **The pair is always chronological** (`from` = earlier). Every delta in
+ *      this tab is later-minus-earlier; letting the user invert the pair would
+ *      put two opposite sign conventions on one screen.
+ *
+ * Both selects list every run, so any pair is reachable in at most two picks.
+ */
+import type { RunPair } from './types'
+
+function ordered(from: number, to: number): RunPair {
+  return from <= to ? { from, to } : { from: to, to: from }
+}
+
+/**
+ * Resolve a requested pair against the runs that actually exist right now.
+ *
+ * Re-hydration renumbers the journey (`hydrateFromPersisted` stamps 1..N), so
+ * a selection made before a scenario switch or a new run can name a run number
+ * that no longer exists. Each end is clamped independently; a pair that
+ * collapses onto one run falls back to first-vs-latest rather than rendering a
+ * comparison of a run with itself.
+ *
+ * Returns null when fewer than two runs exist — the tab does not render the
+ * journey at all below that, and there is nothing to pick between.
+ */
+export function normaliseRunPair(
+  runNumbers: readonly number[],
+  requested: RunPair | null,
+): RunPair | null {
+  if (runNumbers.length < 2) return null
+
+  const sorted = [...runNumbers].sort((a, b) => a - b)
+  const fallback: RunPair = { from: sorted[0], to: sorted[sorted.length - 1] }
+  if (requested == null) return fallback
+
+  const available = new Set(sorted)
+  const from = available.has(requested.from) ? requested.from : fallback.from
+  const to = available.has(requested.to) ? requested.to : fallback.to
+  if (from === to) return fallback
+
+  return ordered(from, to)
+}
+
+/**
+ * Apply one select's change. Choosing the run already at the OTHER end swaps
+ * the pair instead of collapsing it (invariant 1), and the result is always
+ * ordered (invariant 2).
+ */
+export function applyRunPairChange(
+  current: RunPair,
+  endpoint: 'from' | 'to',
+  runNumber: number,
+): RunPair {
+  if (endpoint === 'from') {
+    return runNumber === current.to
+      ? ordered(runNumber, current.from)
+      : ordered(runNumber, current.to)
+  }
+  return runNumber === current.from
+    ? ordered(current.to, runNumber)
+    : ordered(current.from, runNumber)
+}

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -5,6 +5,8 @@
  * and transition derivation.
  */
 
+import type { DecisionVerdict } from '../../lib/decisionVerdict'
+
 // ---------------------------------------------------------------------------
 // Snapshot types
 // ---------------------------------------------------------------------------
@@ -40,6 +42,22 @@ export interface FactorSensitivitySummary {
  */
 export type SnapshotSource = 'session' | 'persisted'
 
+/**
+ * One option as the run scored it. ROADMAP 2.113a slice 2.
+ *
+ * The snapshot already kept the top TWO options (winner / runner-up); the
+ * side-by-side compare needs every option, because "win probabilities per
+ * option" is a per-option table. No new quantity is introduced: this is the
+ * SAME `option_comparison` array `winnerId` and `runnerUpId` are already
+ * taken from, kept whole instead of truncated at two.
+ */
+export interface SnapshotOption {
+  id: string
+  label: string
+  /** 0-100, rounded — the same convention as `winnerProbability`. */
+  winProbability: number
+}
+
 export interface AnalysisSnapshot {
   runId: string
   /** Sequential, 1-indexed */
@@ -72,6 +90,29 @@ export interface AnalysisSnapshot {
    */
   nodeCount: number | null
   edgeCount: number | null
+
+  /**
+   * Every option this run scored, sorted by win probability descending.
+   * `[]` when the producer sent no option comparison at all (a persisted run
+   * in that shape is DROPPED upstream by `parseRunFact`, so `[]` here can only
+   * come from a session capture).
+   */
+  options: SnapshotOption[]
+
+  /**
+   * THIS RUN'S OWN leader verdict — `deriveDecisionVerdict` over the run's own
+   * producer signals (`robustness.near_tie`, `decision_brief.headline_banded`,
+   * `robustness.recommended_option_id`).
+   *
+   * ⚠ IT IS NOT `winnerId`. `winnerId`/`winnerLabel` below are a client-side
+   * ARGMAX over `option_comparison` — precisely the deleted "Authority 3" that
+   * `src/lib/decisionVerdict.ts` exists to prevent, kept here only because the
+   * pre-existing hero/trajectory copy is built on them. Any surface that says
+   * "leads" / "leading option" / "winner" must read THIS field and honour
+   * `hasLeadingOption`; `separation: 'unknown'` licenses silence, never a
+   * denial. See that module's header for why the two are different questions.
+   */
+  leaderVerdict: DecisionVerdict
 
   // Winner/runner-up (from option_comparison sorted by win_probability desc)
   winnerId: string
@@ -168,7 +209,128 @@ export type CompareState = 'improving' | 'noWinner' | 'converged' | 'flipped' | 
 // Run selector
 // ---------------------------------------------------------------------------
 
-export type RunPreset = 'prev' | 'first' | 'all'
+/**
+ * `'pick'` (ROADMAP 2.113a slice 2) is the explicit A/B choice: any two runs,
+ * side by side. The other three are the pre-existing presets.
+ */
+export type RunPreset = 'prev' | 'first' | 'all' | 'pick'
+
+/** The two runs a `'pick'` comparison is over, by `runNumber`, from < to. */
+export interface RunPair {
+  from: number
+  to: number
+}
+
+// ---------------------------------------------------------------------------
+// Pick-two-runs comparison (ROADMAP 2.113a slice 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a quantity was measured on BOTH sides of the pair.
+ *
+ * `'only_from'` / `'only_to'` are the draft-variance case (ROADMAP 2.127): two
+ * runs of the same scenario may score DIFFERENT option or factor sets. The one
+ * thing that must never happen there is a numeric delta — subtracting against
+ * an absent side means inventing a baseline of 0 and publishing it as a
+ * measurement. Live incidence today is 0 of 83 consecutive owned run pairs;
+ * this is producer-drift insurance, and it is pinned.
+ */
+export type PairPresence = 'both' | 'only_from' | 'only_to'
+
+export interface OptionDelta {
+  optionId: string
+  /** The later run's label when both carry the option; otherwise the only one. */
+  label: string
+  /** Set only when both runs carry the option under DIFFERENT labels. */
+  previousLabel: string | null
+  /** 0-100. null ⇒ this run did not score the option. */
+  fromProbability: number | null
+  toProbability: number | null
+  /** Percentage points. **null unless `presence === 'both'`.** */
+  deltaPp: number | null
+  presence: PairPresence
+}
+
+/**
+ * A factor's movement between two runs, expressed as its INFLUENCE RANK.
+ *
+ * ⚠ NOT its elasticity, and the reason is a house rule rather than a
+ * preference. `elasticity` / `sensitivity_score` are a registered claim family
+ * with **no owner selector** — every surface normalises, signs and thresholds
+ * them for itself — so the family's debt is FROZEN shrink-only
+ * (`src/components/results/utils/elasticityClaimDebt.ts`), and the compliant
+ * route for new code is stated there in so many words: *"do not add a raw read.
+ * Consume an already-derived value from a surface that has one."* A new
+ * `.elasticity` read here is a hard RED in `claim-ownership.drift.spec.ts`, and
+ * it was — this shape is the fix, not a workaround.
+ *
+ * Rank IS an already-derived value: `extractTopFactors` sorts each run's
+ * factors by |elasticity| descending, so a factor's position in that run's own
+ * list is that run's own answer to "how influential was this?". Comparing two
+ * positions makes no normalisation choice and introduces no threshold — which
+ * is precisely what the unowned family cannot yet sanction.
+ */
+export interface FactorDelta {
+  factorId: string
+  label: string
+  /** 1-indexed within that run's own top factors. null ⇒ not in that run's list. */
+  fromRank: number | null
+  toRank: number | null
+  /** Places gained (positive = more influential). **null unless `presence === 'both'`.** */
+  rankDelta: number | null
+  presence: PairPresence
+}
+
+/**
+ * Model-structure comparison between two runs.
+ *
+ * `'unchanged'` is only ever licensed by a SAME-REGIME hash EQUALITY. Equal
+ * node/edge counts do not license it (a rewired graph keeps its counts), and a
+ * cross-regime or absent-ended pair licenses nothing at all — see
+ * `compareStructure` in deriveTransitions.ts.
+ */
+export type StructureComparison = 'changed' | 'unchanged' | 'not_comparable'
+
+/**
+ * What one run's OWN producer verdict entitles a surface to say about a leader.
+ *
+ *   • `'named'`     — the producer said there is a leading option, and named it
+ *   • `'tied'`      — the producer said there is no clear leading option
+ *   • `'unclaimed'` — no applicable producer signal ⇒ SILENCE. Not a denial:
+ *                     `deriveDecisionVerdict` returns `separation: 'unknown'`
+ *                     precisely so no surface asserts *or* denies a leader.
+ */
+export interface LeaderClaim {
+  kind: 'named' | 'tied' | 'unclaimed'
+  optionId: string | null
+  label: string | null
+}
+
+export interface RunPairComparison {
+  from: AnalysisSnapshot
+  to: AnalysisSnapshot
+  /** Union of both runs' options, ordered by the strongest probability seen. */
+  options: OptionDelta[]
+  /** Union of both runs' top factors, ordered by the strongest |elasticity|. */
+  factors: FactorDelta[]
+  structure: StructureComparison
+  fromLeader: LeaderClaim
+  toLeader: LeaderClaim
+  /**
+   * Whether the leading option CHANGED. `'not_comparable'` unless BOTH runs
+   * named one — two runs that both declined to name a leader have no leader to
+   * report as unchanged.
+   */
+  leaderChange: 'changed' | 'unchanged' | 'not_comparable'
+  /** Percentage points; null unless both runs carry a goal probability. */
+  goalProbabilityDeltaPp: number | null
+  /** Each side's evidence coverage, null-preserving ("Not assessed"). */
+  fromEvidenceCoverage: string | null
+  toEvidenceCoverage: string | null
+  /** Inference warnings present in `from` and gone in `to`, and vice versa. */
+  warningsResolved: string[]
+  warningsIntroduced: string[]
+}
 
 // ---------------------------------------------------------------------------
 // Transition types

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.leaderVerdict.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.leaderVerdict.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * ROADMAP 2.113a slice 2 — the snapshot carries EVERY option, and the run's
+ * OWN producer leader verdict.
+ *
+ * WHY THIS IS NOT COSMETIC. `AnalysisSnapshot.winnerId` is a client-side
+ * ARGMAX over `option_comparison` (`analysisSnapshotFactory.ts`, "Sort options
+ * by win_probability descending"). `src/lib/decisionVerdict.ts` exists because
+ * sixteen surfaces were each classifying a leader that way, and its
+ * "Authority 3" — the UI banding win probabilities for itself — was DELETED
+ * after CEE #711 made producer silence meaningful: a withheld run still carries
+ * per-option win probabilities, and rebuilding a leader from them republishes
+ * the claim CEE just withheld.
+ *
+ * A side-by-side compare is exactly the surface that would have re-created it,
+ * so the snapshot quotes the module instead. These tests pin that the quoting
+ * is real — including that a run whose producer said nothing produces NO claim.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+function build(raw: Partial<V2RunResponse>) {
+  return buildAnalysisSnapshot({
+    rawV2Response: raw as V2RunResponse,
+    nodes: null,
+    edges: null,
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+const TWO_OPTIONS = [
+  { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.71 },
+  { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.29 },
+]
+
+describe('snapshot.options — every option, not just the top two', () => {
+  it('keeps all options, sorted by win probability descending, as 0-100 integers', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-b', option_label: 'B', win_probability: 0.2 },
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.5 },
+        { option_id: 'opt-c', option_label: 'C', win_probability: 0.3 },
+      ],
+    } as Partial<V2RunResponse>)
+
+    expect(snapshot.options).toEqual([
+      { id: 'opt-a', label: 'A', winProbability: 50 },
+      { id: 'opt-c', label: 'C', winProbability: 30 },
+      { id: 'opt-b', label: 'B', winProbability: 20 },
+    ])
+  })
+
+  it('drops an option with no usable id rather than keying it on the empty string', () => {
+    // Two id-less options would COLLIDE into one row in the side-by-side table
+    // and report a delta between two different options.
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.5 },
+        { option_label: 'No id', win_probability: 0.3 },
+        { option_label: 'Also no id', win_probability: 0.2 },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options.map(o => o.id)).toEqual(['opt-a'])
+  })
+
+  it('is [] when the producer sent no option comparison — not a phantom option', () => {
+    expect(build({}).options).toEqual([])
+  })
+})
+
+describe('snapshot.leaderVerdict — quoted from the producer, never derived', () => {
+  it('the producer’s near_tie "not a tie" entitles a leader', () => {
+    const snapshot = build({
+      option_comparison: TWO_OPTIONS,
+      robustness: {
+        near_tie: { is_tie: false, top_option_id: 'opt-a', gap: 0.42 },
+        recommended_option_id: 'opt-a',
+      },
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.leaderVerdict.hasLeadingOption).toBe(true)
+    expect(snapshot.leaderVerdict.leaderId).toBe('opt-a')
+    expect(snapshot.leaderVerdict.source).toBe('producer_near_tie')
+  })
+
+  it('the producer’s near_tie "IS a tie" denies one — and `winnerId` still says opt-a', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.52 },
+        { option_id: 'opt-b', option_label: 'B', win_probability: 0.48 },
+      ],
+      robustness: { near_tie: { is_tie: true, top_option_id: 'opt-a' } },
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.winnerId).toBe('opt-a')          // the argmax is unchanged…
+    expect(snapshot.leaderVerdict.hasLeadingOption).toBe(false) // …and licenses nothing
+    expect(snapshot.leaderVerdict.separation).toBe('tied')
+  })
+
+  it('the producer’s headline band refines the verdict', () => {
+    const snapshot = build({
+      option_comparison: TWO_OPTIONS,
+      robustness: { near_tie: { is_tie: false, top_option_id: 'opt-a' } },
+      decision_brief: {
+        headline_banded: { band: 'slightly_ahead', leader_option_id: 'opt-a' },
+      },
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.leaderVerdict.separation).toBe('slight')
+    expect(snapshot.leaderVerdict.source).toBe('producer_band')
+  })
+
+  // ── The fail-closed half ────────────────────────────────────────────────
+  it('NO producer signal ⇒ the NO-CLAIM verdict, even with a 88/12 split on the wire', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.88 },
+        { option_id: 'opt-b', option_label: 'B', win_probability: 0.12 },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.winnerProbability).toBe(88)
+    expect(snapshot.leaderVerdict.hasLeadingOption).toBe(false)
+    // 'unknown', NOT 'tied' — silence, never a denial (CEE #711 withheld-turn
+    // semantics; see decisionVerdict.ts).
+    expect(snapshot.leaderVerdict.separation).toBe('unknown')
+    expect(snapshot.leaderVerdict.source).toBe('none')
+  })
+
+  it('a LEGACY boolean `near_tie` is not a producer signal — it falls to no-claim', () => {
+    // The pre-slice-2 test fixture used `near_tie: false`, which does not exist
+    // on the wire (790/790 live facts carry an OBJECT with a boolean is_tie).
+    const snapshot = build({
+      option_comparison: TWO_OPTIONS,
+      robustness: { near_tie: false, recommended_option_id: 'opt-a' },
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.leaderVerdict.hasLeadingOption).toBe(false)
+    expect(snapshot.leaderVerdict.source).toBe('none')
+  })
+
+  it('a producer claim about option X is never re-pointed at option Y', () => {
+    // near_tie names opt-b as its top option, but the win-probability rank 1 is
+    // opt-a — the identity gate in decisionVerdict refuses to apply it.
+    const snapshot = build({
+      option_comparison: TWO_OPTIONS,
+      robustness: { near_tie: { is_tie: false, top_option_id: 'opt-b' } },
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.leaderVerdict.hasLeadingOption).toBe(false)
+    expect(snapshot.leaderVerdict.source).toBe('none')
+  })
+})

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.leaderVerdict.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.leaderVerdict.spec.ts
@@ -69,6 +69,102 @@ describe('snapshot.options — every option, not just the top two', () => {
   it('is [] when the producer sent no option comparison — not a phantom option', () => {
     expect(build({}).options).toEqual([])
   })
+
+  // ── ADVERSARIAL REVIEW OF #526, FINDING 1 ────────────────────────────────
+  //
+  // `parseRunFact`'s slice-1 guards require the option ARRAY to be non-empty;
+  // they say nothing about the ITEMS. So an item with an id and a label but NO
+  // `win_probability` reached this function, and `?? 0` scored it at zero.
+  // Reviewer's reproduction in the pair table, at `1a08cca9`:
+  //
+  //     ROW X RENDERS: "Option X | 55% | 0% | -55pp"
+  //
+  // — a 0% the producer never sent, AND a −55pp delta measured against it, in
+  // the table whose own header says "no baseline, no default and no
+  // re-derivation anywhere in this file". The sharp edge is that the SAME
+  // commit already handled this absence honestly twice: `extractOptions` drops
+  // an option with no usable ID, and `deriveRunLeaderVerdict` maps the missing
+  // probability to `null` so the verdict never sees a fabricated number. Only
+  // the probability on THIS line got the `?? 0`.
+  //
+  // Live incidence: 0 — 2,850/2,850 live option items carry `win_probability`.
+  // Producer-drift insurance, and the drift is now loud by OMISSION (the option
+  // disappears from the run, so the pair table reads "Only in run N") instead of
+  // publishing a zero the engine never measured.
+  it('DROPS an option with NO win_probability — a fabricated 0% is worse than an absent row', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.55 },
+        { option_id: 'opt-x', option_label: 'Option X' },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options.map(o => o.id)).toEqual(['opt-a'])
+    expect(snapshot.options.find(o => o.id === 'opt-x')).toBeUndefined()
+  })
+
+  it('DROPS a NaN / Infinity / non-numeric win_probability too', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 0.55 },
+        { option_id: 'opt-nan', option_label: 'NaN', win_probability: Number.NaN },
+        { option_id: 'opt-inf', option_label: 'Inf', win_probability: Number.POSITIVE_INFINITY },
+        { option_id: 'opt-str', option_label: 'Str', win_probability: '0.4' },
+        { option_id: 'opt-null', option_label: 'Null', win_probability: null },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options.map(o => o.id)).toEqual(['opt-a'])
+  })
+
+  it('a producer-sent ZERO is an honest measurement and is KEPT', () => {
+    // The whole point of the guard is absent ≠ zero. A real 0 must survive it,
+    // or the fix has quietly become "drop the losers".
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'A', win_probability: 1 },
+        { option_id: 'opt-z', option_label: 'Z', win_probability: 0 },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options).toEqual([
+      { id: 'opt-a', label: 'A', winProbability: 100 },
+      { id: 'opt-z', label: 'Z', winProbability: 0 },
+    ])
+  })
+
+  it('a malformed item does not CONSUME its id — well-shaped twin FIRST', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'Real', win_probability: 0.6 },
+        { option_id: 'opt-a', option_label: 'Malformed twin' },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options).toEqual([{ id: 'opt-a', label: 'Real', winProbability: 60 }])
+  })
+
+  // ⚠ THE ORDER OF THE TWO CHECKS IS LOAD-BEARING, and the test above cannot
+  // see it: with the good twin first, marking the id `seen` early or late gives
+  // the same answer. Mutant M18 (move `seen.add` above the probability check)
+  // was GREEN against that test alone — an unpinned claim in a comment.
+  //
+  // This is the ordering that separates them. The factory sorts by
+  // `(b.win_probability ?? 0) - (a.win_probability ?? 0)`, so a malformed item
+  // sorts as 0 and can only precede its twin when that twin is an honest 0 —
+  // the comparator returns 0 for the pair and `Array.prototype.sort` is stable
+  // (ES2019), so input order survives. Marking the id early would then let the
+  // MALFORMED item consume it and delete a real, producer-sent measurement.
+  it('a malformed item does not CONSUME its id — malformed FIRST, honest 0 twin second', () => {
+    const snapshot = build({
+      option_comparison: [
+        { option_id: 'opt-a', option_label: 'Malformed twin' },
+        { option_id: 'opt-a', option_label: 'Real', win_probability: 0 },
+      ],
+    } as unknown as Partial<V2RunResponse>)
+
+    expect(snapshot.options).toEqual([{ id: 'opt-a', label: 'Real', winProbability: 0 }])
+  })
 })
 
 describe('snapshot.leaderVerdict — quoted from the producer, never derived', () => {

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -10,9 +10,10 @@ import type { V2RunResponse, V2FactorSensitivity, V2OptionComparison } from '../
 import type { ReportV1 } from '../../adapters/plot/types'
 import type { ScenarioEvent, ScenarioEventType } from '../../types/scenario'
 import { SYSTEM_MARKER_EVENT_TYPES } from '../../types/scenario'
-import type { AnalysisSnapshot, FactorSensitivitySummary } from '../compare-tab/types'
+import type { AnalysisSnapshot, FactorSensitivitySummary, SnapshotOption } from '../compare-tab/types'
 import { generateGraphHash } from '../utils/graphHash'
 import { hasObservedData } from '../utils/observedStateHelpers'
+import { deriveDecisionVerdict, type DecisionVerdict } from '../../lib/decisionVerdict'
 import {
   selectGoalProbability,
   type GoalProbabilityInput,
@@ -240,6 +241,76 @@ function deriveEditSummary(
 }
 
 // ---------------------------------------------------------------------------
+// Per-option summary + the run's OWN leader verdict (ROADMAP 2.113a slice 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Every option the run scored, in the order the winner/runner-up pair is
+ * already chosen from. No new quantity: the same array, kept whole.
+ *
+ * Options with no usable id are dropped rather than keyed on `''` — two such
+ * options would collide into one row in the side-by-side table and report a
+ * delta between two different options.
+ */
+function extractOptions(sorted: readonly V2OptionComparison[]): SnapshotOption[] {
+  const out: SnapshotOption[] = []
+  const seen = new Set<string>()
+  for (const o of sorted) {
+    const id = typeof o?.option_id === 'string' ? o.option_id : ''
+    if (id.length === 0 || seen.has(id)) continue
+    seen.add(id)
+    out.push({
+      id,
+      label: typeof o.option_label === 'string' ? o.option_label : '',
+      winProbability: Math.round((o.win_probability ?? 0) * 100),
+    })
+  }
+  return out
+}
+
+/**
+ * The run's own leader verdict, from the ONE module entitled to produce it.
+ *
+ * ⚠ THIS IS NOT A SECOND WINNER DERIVATION. `deriveDecisionVerdict` reads only
+ * PRODUCER signals (`robustness.near_tie`, `decision_brief.headline_banded`,
+ * `robustness.recommended_option_id`) and returns the no-claim verdict when
+ * none applies — its whole reason for existing is that sixteen surfaces were
+ * each classifying a leader for themselves. Compare must not become the
+ * seventeenth, so it quotes this one.
+ *
+ * `option_probabilities` is the shape that module reads win probabilities out
+ * of, and the PLoT envelope does not carry it (**0 of 790 live persisted
+ * facts**, probed read-only 2026-07-29). It is RESHAPED here from
+ * `option_comparison` — the identical move `persistedRunSnapshotFactory`
+ * already makes to feed this factory — never recomputed. Options without an id
+ * are omitted, so a malformed entry cannot become the `''` key and be picked
+ * as a leader.
+ */
+function deriveRunLeaderVerdict(
+  rawV2Response: V2RunResponse,
+  sorted: readonly V2OptionComparison[],
+): DecisionVerdict {
+  const optionProbabilities: Record<string, { win_probability?: number | null }> = {}
+  for (const o of sorted) {
+    const id = typeof o?.option_id === 'string' ? o.option_id : ''
+    if (id.length === 0 || id in optionProbabilities) continue
+    optionProbabilities[id] = { win_probability: o.win_probability ?? null }
+  }
+
+  return deriveDecisionVerdict({
+    option_probabilities: optionProbabilities,
+    robustness: rawV2Response.robustness
+      ? {
+          recommended_option_id: rawV2Response.robustness.recommended_option_id ?? null,
+          near_tie: rawV2Response.robustness.near_tie,
+          nearTie: rawV2Response.robustness.nearTie,
+        }
+      : null,
+    decision_brief: rawV2Response.decision_brief ?? null,
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Main factory function
 // ---------------------------------------------------------------------------
 
@@ -322,6 +393,9 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     graphHash: nodes != null && edges != null ? generateGraphHash(nodes, edges) : null,
     nodeCount: nodes != null ? nodes.length : null,
     edgeCount: edges != null ? edges.length : null,
+
+    options: extractOptions(options as V2OptionComparison[]),
+    leaderVerdict: deriveRunLeaderVerdict(rawV2Response, options as V2OptionComparison[]),
 
     winnerId: winner?.option_id ?? '',
     winnerLabel: winner?.option_label ?? '',

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -245,12 +245,41 @@ function deriveEditSummary(
 // ---------------------------------------------------------------------------
 
 /**
- * Every option the run scored, in the order the winner/runner-up pair is
- * already chosen from. No new quantity: the same array, kept whole.
+ * Every option the run ACTUALLY SCORED, in the order the winner/runner-up pair
+ * is already chosen from. No new quantity: the same array, kept whole.
  *
- * Options with no usable id are dropped rather than keyed on `''` — two such
- * options would collide into one row in the side-by-side table and report a
- * delta between two different options.
+ * TWO DROP RULES, and they are the same rule twice.
+ *
+ * 1. **No usable id** — two id-less options would collide into one row in the
+ *    side-by-side table and report a delta between two different options.
+ *
+ * 2. **No usable `win_probability`** — ⚠ ADDED BY THE ADVERSARIAL REVIEW OF
+ *    #526 (finding 1), and it closes a live fabrication path. `parseRunFact`'s
+ *    slice-1 guards require the option ARRAY to be non-empty; they say nothing
+ *    about the ITEMS. So an item with an id and a label but no probability
+ *    reached this function and `?? 0` scored it at zero. Reproduced in the pair
+ *    table at `1a08cca9`:
+ *
+ *        ROW X RENDERS: "Option X | 55% | 0% | -55pp"
+ *
+ *    — a 0% the producer never sent, and a **−55pp delta measured against it**,
+ *    inside the table whose own header says "no baseline, no default and no
+ *    re-derivation anywhere in this file". The absence was already handled
+ *    honestly twice in this same commit — rule 1 above, and
+ *    `deriveRunLeaderVerdict` mapping the missing probability to `null` so the
+ *    verdict never sees a fabricated number. Only this line had the `?? 0`.
+ *
+ * A dropped option is not silence: it becomes a MEMBERSHIP row in the pair view
+ * ("Only in run N"), so producer drift is loud by omission instead of being
+ * published as a measurement the engine never made. Live cost is zero —
+ * 2,850/2,850 live option items carry `win_probability`.
+ *
+ * ⚠ A PRODUCER-SENT `0` IS AN HONEST MEASUREMENT AND SURVIVES. The guard is on
+ * ABSENCE (and on NaN / Infinity / non-numbers), never on the value; a control
+ * test pins that, so tightening this into "drop the losers" cannot pass.
+ *
+ * Order matters: a malformed item is skipped WITHOUT claiming its id, so a
+ * well-shaped entry carrying the same id still lands.
  */
 function extractOptions(sorted: readonly V2OptionComparison[]): SnapshotOption[] {
   const out: SnapshotOption[] = []
@@ -258,11 +287,13 @@ function extractOptions(sorted: readonly V2OptionComparison[]): SnapshotOption[]
   for (const o of sorted) {
     const id = typeof o?.option_id === 'string' ? o.option_id : ''
     if (id.length === 0 || seen.has(id)) continue
+    const win = o.win_probability
+    if (typeof win !== 'number' || !Number.isFinite(win)) continue
     seen.add(id)
     out.push({
       id,
       label: typeof o.option_label === 'string' ? o.option_label : '',
-      winProbability: Math.round((o.win_probability ?? 0) * 100),
+      winProbability: Math.round(win * 100),
     })
   }
   return out


### PR DESCRIPTION
## What this does

A signed-in user with 2+ persisted runs picks **any two** and sees them side by side.

Preset row gains a fourth chip, **"Pick two runs"**; choosing it reveals two `<select>`s over every run in the journey, defaulting to first-vs-latest. Below the hero, a four-column table (*label · earlier run · later run · change*), and below that the tab's **existing** `TransitionsSection` rendering the picked pair's own transition card.

| Section | Shows | Where every value comes from |
|---|---|---|
| Win probability by option | one row per option (union of both runs), both probabilities + `±Npp` | `enrichment.option_comparison[].win_probability` on each side |
| Verdict | **Leading option** per run, `Leader changed / unchanged / Not comparable`; goal probability; warnings resolved/introduced | `deriveDecisionVerdict` per run; `selectGoalProbability`; `inference_warnings` set difference |
| Model | structure `Changed / Unchanged / Not comparable`; evidence coverage | the same-regime hash rule; slice-1 gaps unchanged |
| Influence ranking | one row per factor (union of both top-5s), `1st → 3rd · Down 2 places` | each run's own top-factor ORDER — **not** raw elasticity, see below |

UI-only. **Zero new reads, zero CEE, zero schemas, no flag** — pure presentation over the data slice 1 (#523) already hydrates.

## The three things it refuses to say

Each is pinned by a mutant that re-creates it (full table in the evidence file).

1. **A delta against a fabricated baseline.** An option or factor present on one side only renders `Only in run N`, never a subtraction. Draft variance (2.127) makes this reachable; `b − 0` would announce a whole win probability as a "gain" against a run that never scored the option. *Live incidence today: **0 of 83** consecutive owned run pairs — this is producer-drift insurance, not something a tester will see.*
2. **A cross-regime structure claim.** A session snapshot's UI `generateGraphHash` against a persisted run's `aag_v1` reads **Not comparable**, never "Changed". Equal node/edge counts do not upgrade to "Unchanged" either — a rewired graph keeps its counts.
3. **A leader the producer did not name.** Leader language is quoted from `src/lib/decisionVerdict.ts`, never from `AnalysisSnapshot.winnerId` — which is a client-side argmax, i.e. exactly the "Authority 3" that module deleted after CEE #711 made producer silence meaningful. Producer silence renders `Not assessed`, never "no clear leading option" (a *second* claim needing the producer's own tie verdict).

## Live recon that shaped it (read-only, no values printed)

790 non-noop `run_analysis` facts on staging:

- `robustness.near_tie` with a boolean `is_tie`: **790/790** · `decision_brief.headline_banded`: 440/790 · `recommended_option_id`: 790/790 → the producer's own leader verdict is available on **every** persisted run.
- `enrichment.option_probabilities`: **0/790** → the factory reshapes `option_comparison` into that slot (the same reshape `persistedRunSnapshotFactory` already makes), never re-derives the claim.
- Option/factor **set** differences between consecutive owned runs: **0 of 83**.
- `graph_hash_at_run` null in an owned scenario: **0 of 41**; 8 of 41 scenarios show >1 distinct hash → the structure row is a real two-fact comparison on live data.

## Declared deviations from the design of record

The design's slice-2 line is one sentence and is silent on the side-by-side arrangement itself. Full list in the evidence file; the load-bearing ones:

1. **A new side-by-side table exists** (`RunPairCompare`) — the design named only the TransitionCard, which is a vertical narrative, not a side-by-side. **No render component was copied**: the narrative half is the untouched existing `TransitionsSection` / `TransitionCard`, fed the picked pair.
2. **Leader language comes from `deriveDecisionVerdict`, not `winnerId`.** `AnalysisSnapshot` gains two fields (`options`, `leaderVerdict`); `winnerId` is left untouched for the pre-existing hero/trajectory copy.
3. **A slice-1 fixture was wrong at the bytes.** `persistedRunFact` set `robustness.near_tie: false` (boolean); live it is an **object** with a boolean `is_tie` in 790/790. Left as-is, every slice-2 test would have exercised the no-producer-signal path. Corrected, with the boolean retained as an opt-in so the fail-closed branch stays pinned.
4. **Six hand-copied `AnalysisSnapshot` test literals collapsed into one shared fixture** (trap 12). This removed **two pre-existing `TS2783` errors**, which is the entire ratchet shrink below.
5. `buildCumulativeTransition` is now the `(first, latest)` case of a general `buildRangeTransition`, and `detectStructureChange` is `compareStructure(...) === 'changed'` — one regime rule in the file, not two. Both equivalences are pinned by tests.

## ⚠ A guard I added did not bite, and I deleted it rather than keep it

Separately, mutant **M13** removed the JSX condition `preset === 'pick' &&` from the pair-view render site: **GREEN, 337/337**. It could not fail — the `useMemo` above already returned null under every other preset. Two gates, one decorative. **The redundant JSX condition is deleted**; the memo is the single gate, and re-running M8 (delete the memo gate) now REDs **9** tests instead of 8 — the extra one being "the other presets are untouched", which the redundant condition had been masking.

**On RED-first, precisely:** implementation and specs were written in the same session, implementation first. I am not claiming a temporal RED-first ordering. What is claimed is the property the mutation table demonstrates: for each of twelve guards, removing it turns named tests RED; the unmutated tree is green; and M13 is reported *because* it is the case where that property failed.

## ⚠ CI caught a real violation I had not, and the fix is in the diff

The first push went green on everything except **Full Test Suite shard 1/4**: 1 failed of 5,004 —
`claim-ownership.drift.spec.ts`, *"NEW re-derivation site elasticity … (5 hits)"*.

`elasticity` / `sensitivity_score` are a **registered claim family with no owner selector**
(`elasticityClaimDebt.ts`): every surface normalises, signs and thresholds them for itself, so the
family's debt is frozen **shrink-only** and the compliant route for new code is stated there — *"do
not add a raw read; consume an already-derived value from a surface that has one"*. My first
`deriveFactorDeltas` built an elasticity delta per factor. Attesting it as a `@claim-producer` would
have been dishonest — this module consumes the field, it does not produce it.

**Fixed by comparing influence RANK instead.** `topFactors` is already sorted by |elasticity|
descending by `extractTopFactors`, so a factor's position is that run's own influence answer, and
comparing two positions makes no normalisation, sign or threshold choice — exactly the choice an
unowned family cannot sanction. The table now reads `1st → 3rd · Down 2 places`; unmatched factors
are unchanged (`Only in run N`). **`claim-drift-baseline.tsv` is untouched — this PR adds no debt.**
Two tests pin it: the render carries no raw elasticity value, and two runs with the same order but
wildly different elasticities report *no movement*.

**The process failure, plainly:** my "wide sweep" was `src/canvas src/services src/lib
src/components/results` — it **excluded `src/test`**, where the repo's cross-cutting instruments
live. The sweep was green and irrelevant to the thing that broke. I scoped by where I thought my
change lived, not by where a guard on my change might live. Suites now include `src/test`
everywhere, including in the mutation harness, and the full tree was run locally before this push.

## Post-review: finding 1 closed pre-merge (`c94d5f38`)

The adversarial review returned **MERGE-SAFE** with one fabrication-class finding, ruled pre-merge on the slice-1 precedent.

**The defect.** `parseRunFact`'s slice-1 guards require the option **array** non-empty; they say nothing about the **items**. So an option carrying an id and a label but no `win_probability` reached `extractOptions`, whose `?? 0` scored it at zero. Reproduced in **my own tree** before touching it (I re-derived the string rather than inheriting it):

```
ROW X RENDERS: "Option X55%0%-55pp"
```

— byte-identical to the reviewer's: a 0% the producer never sent, and a −55pp delta measured against it, inside the table whose own header says *"no baseline, no default and no re-derivation anywhere in this file"*. The same absence was already handled honestly twice in the same commit (`extractOptions` drops an option with no usable id; `deriveRunLeaderVerdict` maps the missing probability to `null`). Only this line had the `?? 0`.

**The fix.** `extractOptions` skips an item whose `win_probability` is not a finite number. Same probe, fixed:

```
ROW X RENDERS: "Option X55%—Only in run 1"
```

Producer drift is now loud **by omission** rather than published as a measurement. A producer-sent `0` is an honest measurement and **survives** — the guard is on absence (and NaN/Infinity/non-numbers), never on the value, pinned by a positive control so this cannot be tightened into "drop the losers". Live cost zero: 2,850/2,850 live option items carry `win_probability`, write surface service-role-only. The pre-existing `winner?.win_probability ?? 0` in the same factory is slice-1-era debt on `winnerId`, which the pair table does not read — scoped out by the reviewer, and by me.

**RED-first (genuinely, this time — specs run against the unfixed tree first):** `Tests 3 failed | 25 passed (28)`.

**Mutation check**, throwaway worktree outside the clone:

| Mutant | Result |
|---|---|
| M15 restore the `?? 0` as found | **RED 4** |
| M16 weaken to a bare `win == null` (NaN/Infinity through) | **RED 1** |
| M17 over-tighten into "drop the losers" | **RED 2** |
| M18 mark the id `seen` before the probability check | **RED 1** |
| CONTROL | **GREEN** 37 files / 613 tests |

### ⚠ M18 was GREEN on the first run — the second unpinned guard this PR has produced

My "malformed twin" test put the good item first, where marking the id early or late gives the same answer, so the ordering my code comment called load-bearing was untested. The separating case: the factory sorts by `(b.win_probability ?? 0) - (a.win_probability ?? 0)`, so a malformed item sorts as 0 and can only precede its twin when that twin is an **honest 0** (stable sort, ES2019) — marking early would then delete a real producer-sent measurement. A sixth spec pins it; M18 now REDs. Both this and M13 were found by mutating rather than reading.

### Finding 2 — coverage figure, re-derived not re-quoted

The reviewer was right and the cause matters: §7 of the evidence carried §5's numbers forward instead of re-running the derivation — trap 2's own instruction applied one row short. Re-derived at `c94d5f38` by running the gate and the manifest command myself: **coverage 3052 / 3092**, **nine** added files (my eight predated the self-review's `runLabels.ts`, and I never re-derived), none in `typecheck-uncovered.txt`, ratchet **+0**. Corrected in place in the evidence file.

Findings 3 and 4 are INFO and not actioned — both disclosed boundaries, neither a defect.

## Gates

| Gate | Result |
|---|---|
| `pnpm typecheck` (repo's own gate script) | **PASS** — coverage **3052/3092** and **nine** added files, both re-derived at `c94d5f38` (none in `typecheck-uncovered.txt`); ratchet 622 files / **2510** errors, baseline was 2512, **none added** |
| `vitest run src/canvas/compare-tab src/canvas/stores` | **25 files / 337 tests, 0 failed** |
| `vitest run` (FULL local suite, no scope filter, at `c94d5f38`) | **1364 files / 20,303 passed, 66 skipped, 0 failed** |
| `eslint` over every touched file | **0 errors** |
| Mutation check — 13 slice mutants + 4 post-review mutants (M15–M18), throwaway worktree **outside** the clone, each set re-run against its own final tree | **17 RED, control GREEN** (37 files / 613 tests) — worktree removed before every gate run |
| `tools/ci-guards/claim-drift-baseline.tsv` | **unchanged** — no claim debt added |

`--update-baseline` was run, deliberately: the shrink is **attributable at the bytes** to two `TS2783` diagnostics in the two spec files deviation #4 collapsed, and the resulting diff is exactly those two rows plus the count headers. This is not the trap-2b case (a shrink from churn in files the PR never touched).

## Not proven here

- **No signed-in browser run.** As established in slice 1, the repo's e2e config carries no signed-in credentials and I cannot create an account. The owner-side live proof (open a scenario with 2+ analyses, switch to "Pick two runs", confirm the table) is the reviewer's to run — 41 owned staging scenarios qualify.
- The full CI shards had not returned when this was opened; read them before merging.

Evidence: `PHASE0-EVIDENCE-2026-07-28/compare-slice2.md`.
Design of record: `docs-designs/COMPARE-BRIDGE-DESIGN-2026-07-29.md` §4 slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
