### PR TITLE
fix(ui): mount the Stop control on the live composer (2.134)

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, ChevronUp, Settings } from 'lucide-react'
+import { ArrowUp, ChevronUp, Settings, Square } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
@@ -24,7 +24,7 @@ import {
   type AddOptionChange,
 } from '../conversation/addOptionRequest'
 import { messageForElapsed, messageForSettling } from './DraftLoadingAnimation'
-import { useDraftStore } from '../stores/draftStore'
+import { useDraftStore, draftStreamPhaseFor, draftStreamInFlight } from '../stores/draftStore'
 
 export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use' | 'welcome'
 
@@ -133,7 +133,7 @@ export const AIInputBar = memo(
     },
     ref,
   ) {
-    const { draft, setDraft, clearDraft, sendMessage, dispatchAction, isThinking } =
+    const { draft, setDraft, clearDraft, sendMessage, dispatchAction, isThinking, cancelTurn } =
       useConversationContext()
     const stagePlaceholder = useStageAwarePlaceholder()
     const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -166,9 +166,37 @@ export const AIInputBar = memo(
     // measured-ABSENT on the wire), after it the client holds a frame that says
     // the graph exists and its numbers are `in_progress`. See
     // DraftLoadingAnimation's SETTLING_STAGES docstring.
-    const draftStreamPhase = useDraftStore((s) => s.draftStreamPhase)
+    //
+    // ── THE READ IS SCOPED TO THE OPEN SCENARIO (review F2) ─────────────────
+    // This was `useDraftStore((s) => s.draftStreamPhase)` — the raw, global read
+    // the review found blocking every other scenario with one scenario's state.
+    // `draftStreamPhaseFor` is the one place that decides ownership, and it is
+    // read ONCE here: the narration gate below and the Stop control (2.134) both
+    // derive from this single value rather than each taking their own copy.
+    const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+    const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, currentScenarioId))
     const isSettling = draftStreamPhase === 'settling'
     const isGenerating = isThinking && (nodeCount === 0 || isSettling)
+
+    // ── ROADMAP 2.134: THE STOP CONTROL ─────────────────────────────────────
+    // The M1-L2 streamed-draft lane's abort machinery (PR 525) was correct,
+    // reviewed three times and mutation-pinned — and DORMANT: the only
+    // `stop-button` in the codebase lives in `ChatComposer`, whose sole host
+    // (`DraftChat`) is unmounted whenever AI Panel v2 is on — and the
+    // deployed staging build forces it on
+    // (`netlify.toml:50`). Measured: zero stop/cancel/abort controls at eight
+    // stages of the live journey, with a positive control proving the detector
+    // was not blind. Trace: PHASE0-EVIDENCE-2026-07-28/fix-2134-stop.md §1.
+    //
+    // BOTH conjuncts are load-bearing:
+    //   - `isThinking` is the canonical in-flight signal, but it is true for
+    //     EVERY turn — an analysis run included. Alone it would offer Stop over
+    //     an abort that has none of the draft's semantics and nothing to mark.
+    //   - the phase alone would leave a dead button behind if one were ever
+    //     stranded.
+    // `draftStreamInFlight` is exhaustive over the phase union in the store, so
+    // this call site does not re-derive a two-clause predicate (trap 12).
+    const showStopControl = isThinking && draftStreamInFlight(draftStreamPhase)
     // Store the resolved MESSAGE (not raw seconds): the 1s tick then only
     // triggers a re-render when the stage actually advances — React bails on an
     // unchanged string — instead of re-rendering the composer every second for
@@ -461,17 +489,36 @@ export const AIInputBar = memo(
                 <Settings className={cogIconSize} aria-hidden="true" />
               </button>
             ) : null}
-            <button
-              type="button"
-              onClick={handleSend}
-              disabled={!canSend}
-              aria-disabled={!canSend}
-              className={`inline-flex items-center justify-center ${sendBtnSize} rounded-full bg-info text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-30 disabled:hover:opacity-30`}
-              aria-label="Send"
-              data-testid={`${testId ?? `ai-input-bar-${variant}`}-send`}
-            >
-              <ArrowUp className={sendIconSize} aria-hidden="true" />
-            </button>
+            {/* Send / Stop — ONE control in this slot, never two (ROADMAP
+                2.134). Mirrors `ChatComposer`'s own swap, which is the shape
+                PR 525's abort path was written against. Send is `disabled` for
+                the whole of this window anyway (`canSend` requires
+                `!isThinking`), so the swap costs the user nothing and removes
+                the chance of reading a live Stop as a live Send. */}
+            {showStopControl ? (
+              <button
+                type="button"
+                onClick={cancelTurn}
+                className={`inline-flex items-center justify-center ${sendBtnSize} rounded-full bg-panel-hover text-text-body border border-panel-border hover:bg-panel-border focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                aria-label="Stop drafting"
+                title="Stop drafting"
+                data-testid={`${testId ?? `ai-input-bar-${variant}`}-stop`}
+              >
+                <Square className={sendIconSize} fill="currentColor" aria-hidden="true" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={!canSend}
+                aria-disabled={!canSend}
+                className={`inline-flex items-center justify-center ${sendBtnSize} rounded-full bg-info text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info disabled:opacity-30 disabled:hover:opacity-30`}
+                aria-label="Send"
+                data-testid={`${testId ?? `ai-input-bar-${variant}`}-send`}
+              >
+                <ArrowUp className={sendIconSize} aria-hidden="true" />
+              </button>
+            )}
           </div>
         </div>
         {variant === 'strip' && !hideChevron && onChevronClick ? (

--- a/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
@@ -33,15 +33,44 @@ vi.mock('../../utils/markdown', () => ({
   sanitiseMarkdown: (s: string) => s,
 }))
 
-const canvasMockState: { nodes: Array<{ id: string }> } = { nodes: [] }
+/**
+ * ROADMAP 2.134: the composer now reads the phase THROUGH `draftStreamPhaseFor`
+ * (review F2 — scoped to the open scenario) instead of the raw store field, so
+ * these two mock states carry the scenario id the real helper compares. The
+ * narration cases below all model a draft owned by the scenario that is open,
+ * which is the state they always meant.
+ */
+const SCENARIO = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+
+const canvasMockState: { nodes: Array<{ id: string }>; currentScenarioId: string | null } = {
+  nodes: [],
+  currentScenarioId: SCENARIO,
+}
 vi.mock('../../store', () => ({
   useCanvasStore: (selector: (s: unknown) => unknown) => selector(canvasMockState),
 }))
 
-const draftMockState: { draftStreamPhase: string } = { draftStreamPhase: 'idle' }
-vi.mock('../../stores/draftStore', () => ({
-  useDraftStore: (selector: (s: unknown) => unknown) => selector(draftMockState),
-}))
+const draftMockState: { draftStreamPhase: string; draftStreamScenarioId: string | null } = {
+  draftStreamPhase: 'idle',
+  draftStreamScenarioId: SCENARIO,
+}
+/**
+ * Only the HOOK is stubbed — `importOriginal` keeps every other export real.
+ *
+ * The previous factory listed `useDraftStore` alone, which REPLACES the module:
+ * the moment the component imported a second symbol from it, the spec died at
+ * render with "No draftStreamPhaseFor export is defined on the mock". That is
+ * trap 12 in a `vi.mock` factory, the same shape that once killed 51 tests here.
+ * Spreading the original also means the derived ownership rule under test is the
+ * one the component ships with, not a copy.
+ */
+vi.mock('../../stores/draftStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/draftStore')>()
+  return {
+    ...actual,
+    useDraftStore: (selector: (s: unknown) => unknown) => selector(draftMockState),
+  }
+})
 
 vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
   useStageAwarePlaceholder: () => 'Ask about this model…',
@@ -88,7 +117,9 @@ const SETTLING_LINE = SETTLING_STAGES[0].message
 
 beforeEach(() => {
   canvasMockState.nodes = []
+  canvasMockState.currentScenarioId = SCENARIO
   draftMockState.draftStreamPhase = 'idle'
+  draftMockState.draftStreamScenarioId = SCENARIO
   conversationMockState.isThinking = false
   conversationMockState.messages = []
 })

--- a/src/canvas/components/__tests__/AIInputBar.stopControl.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.stopControl.spec.tsx
@@ -1,0 +1,243 @@
+/**
+ * The Stop control on the LIVE composer (ROADMAP 2.134).
+ *
+ * ── WHY THIS SPEC EXISTS ─────────────────────────────────────────────────
+ * #525 shipped a correct, three-times-reviewed, mutation-pinned abort path for
+ * the streamed draft: abort after GRAPH_READY keeps the structure, marks the
+ * phase `unsettled`, holds the run gate shut and renders `STOPPED_DRAFT_NOTICE`.
+ * Nothing on the live path could trigger it.
+ *
+ * The final measurement proved the gap with a positive control
+ * (`PHASE0-EVIDENCE-2026-07-28/M1L2-FINAL-MEASUREMENT-2026-07-30.md` §5): zero
+ * stop/cancel/abort/halt controls at eight stages of the journey, an injected
+ * synthetic one found by the same scanner. The mount trace
+ * (`PHASE0-EVIDENCE-2026-07-28/fix-2134-stop.md` §1) then established why: the
+ * only `stop-button` in the codebase lives in `ChatComposer`, whose sole host
+ * (`DraftChat`) is unmounted whenever AI Panel v2 is on — and `netlify.toml:50`
+ * forces it on for the deployed staging build.
+ *
+ * `AIInputBar` is the composer that DOES render (strip · floating · first-use ·
+ * welcome · docked-tab), so the affordance belongs here — one edit, every live
+ * surface.
+ *
+ * ── WHAT THIS SPEC CAN AND CANNOT PROVE ──────────────────────────────────
+ * jsdom proves PRESENCE and WIRING. It cannot prove VISIBILITY — not layout, not
+ * stacking, not that the control is above the fold on a real viewport. The live
+ * proof is a post-deploy browser capture, and no claim of visibility is made
+ * here (trap 3).
+ *
+ * ── THE ABSENCE ASSERTIONS ARE NOT VACUOUS (trap 13) ─────────────────────
+ * Every negative case below uses `queryStop()` — the SAME query the positive
+ * cases use to FIND the control. A query that could not see a present Stop would
+ * fail the first three tests in this file, so the absence tests cannot pass by
+ * testing nothing.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+const { cancelTurnSpy } = vi.hoisted(() => ({ cancelTurnSpy: vi.fn() }))
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+  },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+const SCENARIO_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+const SCENARIO_B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb'
+
+const canvasMockState: { nodes: Array<{ id: string }>; currentScenarioId: string | null } = {
+  nodes: [],
+  currentScenarioId: SCENARIO_A,
+}
+vi.mock('../../store', () => ({
+  useCanvasStore: (selector: (s: unknown) => unknown) => selector(canvasMockState),
+}))
+
+/**
+ * The store HOOK is mocked; the derived helpers (`draftStreamPhaseFor`,
+ * `draftStreamInFlight`) are the REAL ones, via `importOriginal` spread.
+ *
+ * This matters twice over. (a) A `vi.mock` factory REPLACES the module, so a
+ * hand-listed factory silently drops every other export — the exact trap-12
+ * defect that once killed 51 tests in this repo. (b) If the helpers were stubbed
+ * here, this spec would be testing a copy of the ownership rule rather than the
+ * one the component ships with.
+ */
+const draftMockState: {
+  draftStreamPhase: string
+  draftStreamScenarioId: string | null
+  draftStreamTurnId: string | null
+} = { draftStreamPhase: 'idle', draftStreamScenarioId: null, draftStreamTurnId: null }
+vi.mock('../../stores/draftStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/draftStore')>()
+  return {
+    ...actual,
+    useDraftStore: (selector: (s: unknown) => unknown) => selector(draftMockState),
+  }
+})
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask about this model…',
+}))
+vi.mock('../../hooks/useSelectionContext', () => ({ useSelectionContext: () => null }))
+
+const conversationMockState = { messages: [] as unknown[], isThinking: false }
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      const [sendSystemEvent] = useState(() => vi.fn())
+      const [sendChip] = useState(() => vi.fn())
+      const [dispatchAction] = useState(() => vi.fn())
+      const [retryLast] = useState(() => vi.fn())
+      const [setPatchBlockState] = useState(() => vi.fn())
+      const [setPatchRejection] = useState(() => vi.fn())
+      return {
+        messages: conversationMockState.messages,
+        isThinking: conversationMockState.isThinking,
+        longRunningHint: null,
+        sendMessage,
+        sendSystemEvent,
+        sendChip,
+        dispatchAction,
+        retryLast,
+        cancelTurn: cancelTurnSpy,
+        patchBlockStates: new Map(),
+        setPatchBlockState,
+        patchRejections: new Map(),
+        setPatchRejection,
+      }
+    },
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { AIInputBar } from '../AIInputBar'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+beforeEach(() => {
+  canvasMockState.nodes = []
+  canvasMockState.currentScenarioId = SCENARIO_A
+  draftMockState.draftStreamPhase = 'idle'
+  draftMockState.draftStreamScenarioId = null
+  draftMockState.draftStreamTurnId = null
+  conversationMockState.isThinking = false
+  conversationMockState.messages = []
+  cancelTurnSpy.mockClear()
+})
+
+/** The ONE query. Presence tests prove it is not blind; absence tests reuse it. */
+function queryStop(): HTMLElement | null {
+  return screen.queryByTestId('gen-stop')
+}
+
+function renderBar() {
+  render(<AIInputBar variant="first-use" hideChevron testId="gen" onCogClick={() => {}} />, {
+    wrapper: Wrapper,
+  })
+}
+
+/** Put the component in "a streamed draft owned by the open scenario is live". */
+function draftInFlight(phase: 'drafting' | 'settling', owner: string | null = SCENARIO_A) {
+  conversationMockState.isThinking = true
+  draftMockState.draftStreamPhase = phase
+  draftMockState.draftStreamScenarioId = owner
+  draftMockState.draftStreamTurnId = 'turn-1'
+}
+
+describe('AIInputBar — Stop is REACHABLE while a streamed draft is in flight', () => {
+  it('renders a Stop control before GRAPH_READY (phase `drafting`)', () => {
+    draftInFlight('drafting')
+    renderBar()
+    const stop = queryStop()
+    expect(stop).not.toBeNull()
+    expect(stop).toBeEnabled()
+    // The scanner in the live measurement matched on /stop/i over innerText,
+    // aria-label, data-testid and className. Keep the accessible name in that
+    // set so the same detector finds this one post-deploy.
+    expect(stop).toHaveAttribute('aria-label', expect.stringMatching(/stop/i))
+  })
+
+  it('renders it through SETTLING — the ~25 s window after the graph lands', () => {
+    // The state a tester is MOST likely to reach for Stop in: the model is on
+    // the canvas at ~36 s and the spinner reads as vestigial, while the turn
+    // runs on to ~61 s. It is also the only window in which the abort has
+    // anything to mark.
+    draftInFlight('settling')
+    renderBar()
+    expect(queryStop()).not.toBeNull()
+  })
+
+  it('clicking it calls cancelTurn exactly once — the SAME path #525 pinned', () => {
+    // `cancelTurn` aborts `abortRef`, which is the controller
+    // `runStreamedDraftTurn` was handed (useConversation.ts:4194). Everything
+    // downstream — `unsettled`, structure kept + marked, gate shut,
+    // STOPPED_DRAFT_NOTICE — is #525's machinery, unchanged by this slice.
+    draftInFlight('settling')
+    renderBar()
+    fireEvent.click(queryStop()!)
+    expect(cancelTurnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('takes the Send slot rather than sitting beside it', () => {
+    // Mirrors ChatComposer's own `isThinking ? <stop> : <send>` swap. Send is
+    // disabled throughout this window anyway, so nothing is lost, and two
+    // circular buttons in one corner cannot be confused for one another.
+    draftInFlight('drafting')
+    renderBar()
+    expect(queryStop()).not.toBeNull()
+    expect(screen.queryByTestId('gen-send')).toBeNull()
+  })
+})
+
+describe('AIInputBar — Stop is ABSENT everywhere the abort semantics do not apply', () => {
+  it('is absent when nothing is in flight', () => {
+    renderBar()
+    expect(queryStop()).toBeNull()
+    expect(screen.queryByTestId('gen-send')).not.toBeNull()
+  })
+
+  it('is absent during a non-draft turn on a populated canvas (chat / analysis run)', () => {
+    // `isThinking` is true for EVERY turn — a Run dispatch included. Gating on
+    // it alone would hand the user a Stop over an analysis, whose abort has none
+    // of #525's semantics and nothing to mark. The phase conjunct is what makes
+    // this control draft-specific.
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = [{ id: 'n1' }, { id: 'n2' }]
+    draftMockState.draftStreamPhase = 'idle'
+    renderBar()
+    expect(queryStop()).toBeNull()
+  })
+
+  it('is absent in the terminal `unsettled` phase', () => {
+    // Drafting has already ENDED here (this is the state a Stop click produces).
+    // A Stop control over it would be a control that stops nothing.
+    conversationMockState.isThinking = true
+    draftMockState.draftStreamPhase = 'unsettled'
+    draftMockState.draftStreamScenarioId = SCENARIO_A
+    renderBar()
+    expect(queryStop()).toBeNull()
+  })
+
+  it('is absent when the in-flight draft belongs to ANOTHER scenario (review F2)', () => {
+    // The phase is a per-scenario fact. Showing Stop on scenario B for a draft
+    // owned by scenario A is the same class of error F2 found in the run gate —
+    // one scenario's state asserted over every other.
+    draftInFlight('settling', SCENARIO_B)
+    canvasMockState.currentScenarioId = SCENARIO_A
+    renderBar()
+    expect(queryStop()).toBeNull()
+  })
+})

--- a/src/canvas/stores/__tests__/draftStreamInFlight.spec.ts
+++ b/src/canvas/stores/__tests__/draftStreamInFlight.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * `draftStreamInFlight` — may the user still stop this draft? (ROADMAP 2.134)
+ *
+ * Kept in its own file so #525's `draftStreamOwnership.spec.ts` stays byte-for-
+ * byte unchanged: this slice adds a CALLER of the abort machinery, and the
+ * evidence for that is worth more if none of the machinery's own suites moved.
+ *
+ * Enumerated over the whole union for the reason the M15/M16 survivors taught:
+ * a phase predicate expressed as a two-clause boolean at a call site is a
+ * predicate no test can see, and a mutant that drops a clause survives.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { draftStreamInFlight, draftValuesAreUnsettled, type DraftStreamPhase } from '../draftStore'
+
+const ALL_PHASES: readonly DraftStreamPhase[] = ['idle', 'drafting', 'settling', 'unsettled']
+
+describe('draftStreamInFlight — exhaustive over the union', () => {
+  it('classifies every phase, via a compiler-checked switch', () => {
+    // Adding a phase to DraftStreamPhase without classifying it is a TS error in
+    // the implementation's own switch, so this table cannot silently go stale.
+    const expected: Record<DraftStreamPhase, boolean> = {
+      idle: false,
+      drafting: true,
+      settling: true,
+      unsettled: false,
+    }
+    for (const phase of ALL_PHASES) {
+      expect(draftStreamInFlight(phase)).toBe(expected[phase])
+    }
+  })
+
+  it('`settling` is in flight — the turn runs on for ~25 s after the graph lands', () => {
+    // The window the live measurement caught a tester in: the model is visible,
+    // the wait reads as vestigial, and Stop is exactly what they reach for. It is
+    // also the only window in which an abort has a structure to keep and mark.
+    expect(draftStreamInFlight('settling')).toBe(true)
+  })
+
+  it('`unsettled` is NOT in flight — it is the state a stop PRODUCES', () => {
+    // Offering Stop here would be a control over nothing: drafting has already
+    // ended, the structure is already marked, and the gate is already shut.
+    expect(draftStreamInFlight('unsettled')).toBe(false)
+  })
+
+  it('is deliberately NOT the complement of `draftValuesAreUnsettled`', () => {
+    // The two predicates answer different questions, and the table below is the
+    // whole reason neither may be expressed in terms of the other:
+    //
+    //   phase      | inFlight | valuesUnsettled
+    //   idle       |  false   |  false          ← agree
+    //   drafting   |  TRUE    |  false          ← differ
+    //   settling   |  TRUE    |  TRUE           ← agree (the load-bearing one)
+    //   unsettled  |  false   |  TRUE           ← differ
+    //
+    // `settling` is BOTH: its numbers are not final (gate shut) and its turn is
+    // still running (Stop is honest). `drafting` is in flight with nothing yet
+    // to be wrong about; `unsettled` is wrong-about-something with nothing left
+    // to stop.
+    const agree = ALL_PHASES.filter((p) => draftStreamInFlight(p) === draftValuesAreUnsettled(p))
+    expect(agree).toEqual(['idle', 'settling'])
+    const differ = ALL_PHASES.filter((p) => draftStreamInFlight(p) !== draftValuesAreUnsettled(p))
+    expect(differ).toEqual(['drafting', 'unsettled'])
+  })
+})

--- a/src/canvas/stores/draftStore.ts
+++ b/src/canvas/stores/draftStore.ts
@@ -261,6 +261,33 @@ export function draftValuesAreUnsettled(phase: DraftStreamPhase): boolean {
 }
 
 /**
+ * The phases in which a streamed draft turn is STILL RUNNING — so the user can
+ * still stop it, and a Stop affordance is honest (ROADMAP 2.134).
+ *
+ * Note this is NOT the complement of `draftValuesAreUnsettled`, and the overlap
+ * is the whole point: `settling` is both *unsettled* (its numbers are the
+ * frame's `in_progress` ones, so the run gate stays shut) and *in flight* (the
+ * turn runs on to ~61 s, so Stop still means something). `unsettled` is the
+ * terminal state a stop PRODUCES — a Stop control offered over it would be a
+ * control that stops nothing.
+ *
+ * Exhaustive over the union rather than expressed as a two-clause boolean at the
+ * call site, for the reason the M15 survivor taught: a derivation that lives in
+ * a component is a derivation no test can see, and a mutant that drops a clause
+ * from it survives. A fifth phase is a compile error here.
+ */
+export function draftStreamInFlight(phase: DraftStreamPhase): boolean {
+  switch (phase) {
+    case 'drafting':
+    case 'settling':
+      return true
+    case 'idle':
+    case 'unsettled':
+      return false
+  }
+}
+
+/**
  * May the UI persist `scenarios.graph` for this scenario right now?
  *
  * **NO while its streamed draft's values are in progress** (review F1).


### PR DESCRIPTION
## ROADMAP 2.134 — the Stop control was unreachable; this mounts it

`#525` shipped a correct, three-times-reviewed, mutation-pinned abort path for the streamed draft.
**Nothing on the live path could trigger it.** The final measurement proved the gap with a positive
control (`PHASE0-EVIDENCE-2026-07-28/M1L2-FINAL-MEASUREMENT-2026-07-30.md` §5): zero
stop/cancel/abort/halt controls at eight stages of the deployed guest journey, and an injected
synthetic one found by the same scanner. **Users cannot stop a ~60 s draft at all.**

### The mount trace — why `chat-composer` never mounts

Derived at the bytes at `efeaa609`, complete chain:

| # | fact |
|---|---|
| 1 | `data-testid="chat-composer"` has **exactly one** definition in `src/` — `ChatComposer.tsx:205` |
| 2 | `stop-button` (`:388`) and `run-analysis-chip` (`:336`) are both inside it |
| 3 | `ChatComposer` has **exactly one** production render site — `ConversationPanel.tsx:696` |
| 4 | …gated by `{!hideComposer && …}` (`:695`) |
| 5 | `ConversationPanel` has **exactly three** production hosts — `DraftChat`, `OlumiTabBody`, `FloatingOlumiPanel` |
| 6 | Two of the three pass `hideComposer` (`OlumiTabBody.tsx:110`, `FloatingOlumiPanel.tsx:1002`) |
| 7 | The only host that doesn't is `DraftChat`, mounted only when AI Panel v2 is **OFF** (`ReactFlowGraph.tsx:2244`) |
| 8 | AI Panel v2 is ON by code default since 21 May (`flags.ts:381`, `64bf2149`) **and explicitly forced on for the deployed staging build** — `netlify.toml:50`, `[context.staging.environment] VITE_FEATURE_AI_PANEL_V2 = "true"` |

**Verdict: `chat-composer` is neither dead code nor a condition that never fires. It is a
deliberately-retired legacy surface whose host is switched off by an env var in the deployed build** —
exactly as the flag's own docstring says ("the FF-off branches … are intentionally preserved as a
fallback … separate clean-up PR will move the orphaned legacy files").

For falsifiability, the exact state that WOULD mount it: `aiPanelV2` overridden false **and**
`showDraftChat === true` **and** `isOrchV2`. No user journey reaches that without a console command.

**Authoritative composer: `AIInputBar`** — the single shared composer behind strip · floating ·
first-use · welcome · docked-tab. One edit reaches every live surface.

### What this PR does

Swaps `AIInputBar`'s Send button for a **Stop** button while a streamed draft is in flight, wired to
the **same `cancelTurn`** `#525` tested (`useConversation.ts:5824` → `abortRef` → the very controller
`runStreamedDraftTurn` was handed at `:4194`).

**No machinery file is edited. `useConversation.ts` is not in this diff.** This adds a caller.

### When the control appears — and where it must not

`isThinking && draftStreamInFlight(scoped phase)`. Both conjuncts load-bearing.

| state | Stop? | why |
|---|---|---|
| `drafting` (pre-GRAPH_READY) | **yes** | the ~36 s wait |
| `settling` (post-GRAPH_READY) | **yes** | the ~25 s window where the graph is visible and the spinner reads as vestigial — where a tester actually reaches for Stop |
| `unsettled` (terminal) | no | the state a stop *produces*; a control over nothing |
| idle | no | — |
| analysis run / any non-draft turn | no | `isThinking` is true for every turn; the abort semantics are draft-specific |
| a draft owned by ANOTHER scenario | no | `draftStreamPhaseFor` scoping (review F2) |

`draftStreamInFlight` is an **exhaustive switch over the phase union** in `draftStore.ts`, beside its
siblings — so the call site doesn't re-derive a two-clause predicate (the M15-survivor lesson), and a
fifth phase is a compile error.

Also: the composer's phase read moves from the raw `s.draftStreamPhase` to `draftStreamPhaseFor`
(review F2), read **once**, with the existing narration gate and the new Stop gate both derived from
it — a read removed, not a second one added. ⚠ That is a behaviour change at the scenario boundary
beyond the literal ask; it is disclosed, pinned, and argued in the evidence file rather than buried.

### Evidence

- **RED-first:** the four presence tests failed before the fix (`expected null not to be null`;
  `Unable to fire a "click" event`); the four over-reach controls passed at RED and still pass.
- **Mutation battery, 7 mutants, 0 survivors** — unwire the button · drop the phase conjunct · count
  `unsettled` as in-flight · regress F2 to the unscoped read · drop `settling` · always-render
  over-fire control · Stop beside Send. Worktree **outside** the clone (trap 9c), removed and its
  absence verified before any gate ran.
- **`#525`'s suites pass and are UNCHANGED** — not in the diff: `streamedDraftTurn.spec.ts` 40/40 ·
  `draftStreamOwnership.spec.ts` 15/15 · `runGateCallSites.derived.spec.ts` 14/14.
- **`pnpm run typecheck` PASSED** — ratchet 622 files / 2510 errors = baseline exactly, zero new;
  coverage 3054/3094 derived at this tip.
- **`npx eslint`** on all five touched files: 0 problems. `ci:guard:zustand`, `ci:guard:duplicates`: PASS.
- **`ci:guard:ds` standing red has an EMPTY DELTA, proven with a control** — a pristine detached
  worktree at `efeaa609` produces the byte-identical NET-NEW list. No `--update-baseline` accepted.
  (One genuine net-new hit *was* introduced — the rule reads `#525` in a comment as a hex colour —
  and was **fixed by rewording, not tolerated**.)

### Honest limits

- **jsdom proves presence and wiring, never visibility** (trap 3). Nothing here shows the control is
  laid out, unoccluded or above the fold. **The live browser proof follows deploy and has not been
  taken.**
- The fast pre-push gate did **not** run — a fresh blobless clone has no `.git/hooks/pre-push`. Its
  checks were run manually instead (typecheck, lint, DS/zustand/duplicates guards); **CI is the
  authoritative full-suite run.**
- Non-streamed drafts (`streamedDraftEligible === false`) set no phase and therefore still get no
  Stop. That is deliberate: this control triggers the draft-stream abort semantics specifically.

### Rowed, not done (one concern per slice)

1. Retire `ChatComposer` + `ConversationPanel`'s `!hideComposer` branch + `DraftChat` — the clean-up
   PR the flag docstring already promises.
2. **`run-analysis-chip` is the second dormant affordance** on the same dead surface, with 6 green
   assertions in `aiPanelTranche1Hotfix.spec.tsx` standing over a control no user can reach. Note it
   is *not* a second UX gap — `OutputsDock` carries the live run affordance and feeds the same gate
   (`OutputsDock.tsx:858`) — so this is duplication-to-retire, decided together with (1).

Full write-up: `PHASE0-EVIDENCE-2026-07-28/fix-2134-stop.md`

**DO NOT MERGE** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
