### PR TITLE
chore(ui): window-readiness pair — one PostHog key, login smoke spec (2.111 + 2.126b)

### DIFF
--- a/e2e/smoke/required-login-window-gate.spec.ts
+++ b/e2e/smoke/required-login-window-gate.spec.ts
@@ -1,0 +1,535 @@
+// e2e/smoke/required-login-window-gate.spec.ts
+// =============================================================================
+// ROADMAP 2.126(b) — the required-login smoke that GATES the user-testing window.
+// Spec source: TESTER-READINESS-PACK-2026-07-29.md §3 (charter-ratified 28 Jul).
+// =============================================================================
+//
+// ⚠ THIS SPEC HAS NEVER BEEN EXECUTED AGAINST A LIVE ENVIRONMENT, DELIBERATELY.
+//
+// Required-login is NOT flipped on staging: `VITE_REQUIRE_LOGIN` exists in the
+// UI (src/lib/poc.ts + src/flags.ts `isRequireLoginEnabled`) but the deployed
+// build still serves guest mode, so every assertion below would be asserting
+// against the wrong posture today. Flipping it is a Netlify env + redeploy
+// decision that is Paul's window-posture call. **Live execution is deferred to
+// the flip day.** What lands here is the gate itself, written and reviewed in
+// advance so that on flip day the only remaining work is `pnpm e2e:staging:v5`
+// with the env below set.
+//
+// Nothing in this file creates an account, sends a request, or touches staging
+// unless an operator explicitly opts in via env (see GATING). A default run —
+// local, CI, or otherwise — is SKIPPED and inert.
+//
+// -----------------------------------------------------------------------------
+// TEST-ACCOUNT CREDENTIALS — THE TWO ENV VAR NAMES (never hardcode either)
+// -----------------------------------------------------------------------------
+//   SMOKE_EMAIL
+//       The disposable smoke account's address. NEVER a real tester's address —
+//       this account's rows are the deletion-runbook rehearsal (pack §2/§1.115).
+//
+//   SMOKE_SUPABASE_SERVICE_ROLE_KEY
+//       Supabase service-role key for the staging project, used for exactly two
+//       calls: provision the smoke account if absent, and mint its sign-in link.
+//       Never logged, never asserted on, never written to a trace.
+//
+// ⚠ THE PACK PROPOSED `SMOKE_EMAIL` + `SMOKE_PASSWORD`. `SMOKE_PASSWORD` IS
+//   UNIMPLEMENTABLE AND WAS NOT USED — verified at the bytes on staging tip
+//   fe11ef9e:
+//     · There is NO password auth in this UI. `LoginPage.tsx` offers exactly a
+//       magic-link email field and Google OAuth. `AuthContext`'s `signIn`/`signUp`
+//       are declared legacy no-ops that return
+//       `new Error('Password auth removed — use magic link')`.
+//     · Self-signup is IMPOSSIBLE: `signInWithMagicLink` calls
+//       `supabase.auth.signInWithOtp({ …, options: { shouldCreateUser: false } })`,
+//       and Google OAuth is gated by a dashboard "Before User Created" allowlist
+//       hook. An unknown email gets the enumeration-safe "if this email is
+//       registered…" state and NO account.
+//   Naming an env var for a mechanism that does not exist is the false-label
+//   defect (CLAUDE.md trap 14), so the pair above replaces it, and the account
+//   is provisioned through the Supabase Admin API instead — which is the same
+//   key and the same project the pack's §2 deletion runbook already uses.
+//
+//   ⚠⚠ CONSEQUENCE FOR THE WINDOW ITSELF, beyond this spec: the pilot-kit
+//   invitation text ("each participant creates a free account at the start")
+//   and pack §3 step 2 ("Create account") are NOT achievable through the
+//   product. The 4 tester accounts MUST be pre-provisioned before the session.
+//   Pack §4 already recommended pre-provisioning to dodge the built-in-SMTP
+//   confirmation-email throttle; the real reason is harder than that — without
+//   pre-provisioning, testers simply cannot get in at all.
+//
+// -----------------------------------------------------------------------------
+// ENVIRONMENT
+// -----------------------------------------------------------------------------
+//   RUN_STAGING_E2E=1                 opt-in switch shared with the other staging gates
+//   STAGING_UI_URL                    deployed UI origin, e.g. https://staging--olumi.netlify.app
+//   STAGING_SUPABASE_URL              staging Supabase project URL
+//   SMOKE_EMAIL                       (above)
+//   SMOKE_SUPABASE_SERVICE_ROLE_KEY   (above)
+//   REQUIRE_LOGIN_EXPECTED=1          OPTIONAL. Gate-day switch — see SKIP CONDITION.
+//
+// -----------------------------------------------------------------------------
+// SKIP CONDITION (why this suite is runnable-but-skipped by default)
+// -----------------------------------------------------------------------------
+// A red suite on an environment that was never flipped is a BROKEN ALARM
+// (CLAUDE.md trap 7): everyone learns to ignore it, and it is then worthless on
+// the one morning it matters. So the suite skips in two distinct ways, and the
+// distinction is the whole design:
+//
+//   (1) ENV ABSENT — module-scope `test.skip`. No browser, no network, no
+//       account, no credential read. This is the default everywhere.
+//
+//   (2) ENV PRESENT BUT THE FLAG IS OFF — a POSTURE PROBE runs first, in a
+//       fresh unauthenticated context with NO credentials, and opens
+//       `/#/canvas`:
+//         · login surface  → `VITE_REQUIRE_LOGIN` is ON  → the suite RUNS.
+//         · canvas/guest   → `VITE_REQUIRE_LOGIN` is OFF → every remaining test
+//                            SKIPS with that reason, and NO ACCOUNT IS CREATED
+//                            (provisioning happens only inside the first
+//                            running test, never in the probe).
+//         · probe error    → HARD FAIL. The operator opted in explicitly; an
+//                            unreachable deployed UI is a real red, not noise.
+//
+//   (3) `REQUIRE_LOGIN_EXPECTED=1` INVERTS case (2): a guest canvas becomes a
+//       LOUD FAILURE instead of a skip. This is what pack §3 step 1 demands on
+//       gate day — "if a guest canvas appears, the flag is OFF and the window is
+//       NOT gated: fail loudly, don't skip". Set it on every gate run, from the
+//       flip onward. It is deliberately NOT the default, because before the flip
+//       the honest verdict is "not applicable", not "broken".
+//
+// GATE RULE (pack §3): GREEN on the morning of each session day, against the
+// deployed staging build, before the team arrives, with REQUIRE_LOGIN_EXPECTED=1.
+// Any RED and the window does not open that day. Keep the trace.
+//
+// -----------------------------------------------------------------------------
+// WHAT THIS SPEC DOES NOT DO
+// -----------------------------------------------------------------------------
+// It does NOT delete anything. Teardown signs out and PRINTS the smoke account's
+// user id and the scenario id it created, so an operator can run the pack §2
+// deletion runbook against them. §2 executes only on Paul's explicit word, and a
+// test that hard-deletes staging rows on its own would take that decision away.
+//
+// -----------------------------------------------------------------------------
+// SELECTOR PROVENANCE (all derived at staging tip fe11ef9e — RE-CHECK ON FLIP DAY)
+// -----------------------------------------------------------------------------
+//   login email input      #login-email                      LoginPage.tsx
+//   login submit           button "Send magic link"          LoginPage.tsx
+//   first-use composer     [data-testid="first-use-composer"] FirstUseComposer.tsx:262
+//   composer textarea      aria-label "Describe your decision" FirstUseComposer.tsx:314
+//   send                   button[aria-label="Send"]          AIInputBar.tsx:516
+//   graph nodes            .react-flow__node                  ReactFlowGraph
+//   run analysis           [data-testid="btn-run-analysis"]    CanvasToolbar.tsx:347
+//   results surface        [data-testid="outputs-dock"]        OutputsDock.tsx:1812
+//   honest can't-confirm   [data-testid="results-tab-cannot-confirm-icon"] OutputsDock.tsx:1892
+//   error banner           [data-testid="outputs-error-banner"] OutputsDock.tsx:2022,2120
+//   routing                HashRouter; /canvas and / sit inside <AuthGuard>    AppPoC.tsx:909
+// =============================================================================
+
+import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test'
+
+// ---------------------------------------------------------------------------
+// Gating (case 1) — module scope, evaluated before any fixture is created
+// ---------------------------------------------------------------------------
+
+const RUN_STAGING_E2E = process.env.RUN_STAGING_E2E === '1'
+const STAGING_UI_URL = process.env.STAGING_UI_URL
+const STAGING_SUPABASE_URL = process.env.STAGING_SUPABASE_URL
+const SMOKE_EMAIL = process.env.SMOKE_EMAIL
+const SMOKE_SUPABASE_SERVICE_ROLE_KEY = process.env.SMOKE_SUPABASE_SERVICE_ROLE_KEY
+const REQUIRE_LOGIN_EXPECTED = process.env.REQUIRE_LOGIN_EXPECTED === '1'
+
+const SHOULD_RUN =
+  RUN_STAGING_E2E &&
+  !!STAGING_UI_URL &&
+  !!STAGING_SUPABASE_URL &&
+  !!SMOKE_EMAIL &&
+  !!SMOKE_SUPABASE_SERVICE_ROLE_KEY
+
+test.skip(
+  !SHOULD_RUN,
+  'required-login window gate disabled (set RUN_STAGING_E2E=1 + STAGING_UI_URL + ' +
+    'STAGING_SUPABASE_URL + SMOKE_EMAIL + SMOKE_SUPABASE_SERVICE_ROLE_KEY). ' +
+    'No browser opened, no account created.',
+)
+
+// ---------------------------------------------------------------------------
+// Budgets — a real V5 draft is 40–60 s; analysis is slower again.
+// ---------------------------------------------------------------------------
+
+const PROBE_TIMEOUT_MS = 45_000
+const DRAFT_TIMEOUT_MS = 110_000
+const ANALYSIS_TIMEOUT_MS = 150_000
+
+/** Three sentences, deliberately messy, no PII — mirrors the pilot brief shape. */
+const FIXTURE_BRIEF =
+  'We run a 12-person consultancy and we are deciding whether to open a second office ' +
+  'in Manchester next year or stay remote-first and spend the money on senior hires. ' +
+  'We are worried about culture, our lease costs, and whether clients actually care.'
+
+const uiUrl = (hashPath: string): string =>
+  `${STAGING_UI_URL!.replace(/\/$/, '')}/#${hashPath}`
+
+/** Bounded, non-leaky host token for triage logs. */
+function hostFor(url: string | undefined): string {
+  try {
+    return new URL(url!).host
+  } catch {
+    return '<invalid-url>'
+  }
+}
+
+/** Redact an email for logs: keep the domain, drop the local part. */
+function redactEmail(email: string): string {
+  const at = email.lastIndexOf('@')
+  return at < 0 ? '<redacted>' : `<redacted>${email.slice(at)}`
+}
+
+// ---------------------------------------------------------------------------
+// Supabase Admin API — the ONLY two privileged calls this spec makes
+// ---------------------------------------------------------------------------
+
+function adminHeaders(): Record<string, string> {
+  return {
+    apikey: SMOKE_SUPABASE_SERVICE_ROLE_KEY!,
+    Authorization: `Bearer ${SMOKE_SUPABASE_SERVICE_ROLE_KEY!}`,
+    'Content-Type': 'application/json',
+  }
+}
+
+/**
+ * Provision the smoke account if it does not already exist, and return its id.
+ *
+ * This IS the "fresh account signup" step, performed by the test — adapted to
+ * the fact that the product itself cannot create accounts (shouldCreateUser:
+ * false + invite-only OAuth hook). Idempotent, so a re-run on the same morning
+ * signs into the account the first run made rather than failing.
+ *
+ * Called ONLY from inside a running test, never from the posture probe.
+ */
+async function provisionSmokeAccount(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<string> {
+  const base = STAGING_SUPABASE_URL!.replace(/\/$/, '')
+
+  const lookup = await request.get(
+    `${base}/auth/v1/admin/users?filter=${encodeURIComponent(SMOKE_EMAIL!)}`,
+    { headers: adminHeaders(), timeout: 20_000 },
+  )
+  expect(lookup.ok(), `admin user lookup failed with ${lookup.status()}`).toBe(true)
+  const existing = (await lookup.json()) as { users?: Array<{ id: string; email: string }> }
+  const found = (existing.users ?? []).find(
+    (u) => u.email?.toLowerCase() === SMOKE_EMAIL!.toLowerCase(),
+  )
+  if (found) return found.id
+
+  const created = await request.post(`${base}/auth/v1/admin/users`, {
+    headers: adminHeaders(),
+    data: { email: SMOKE_EMAIL, email_confirm: true },
+    timeout: 20_000,
+  })
+  expect(
+    created.ok(),
+    `admin user create failed with ${created.status()} — cannot provision the smoke account`,
+  ).toBe(true)
+  const body = (await created.json()) as { id?: string }
+  expect(body.id, 'admin user create returned no id').toBeTruthy()
+  return body.id!
+}
+
+/**
+ * Mint a single-use sign-in link for the smoke account.
+ *
+ * This is the headless substitute for opening the magic-link email — the same
+ * link Supabase would have mailed. It does not bypass the auth surface: the
+ * link lands on `/auth/callback`, which is exactly where a tester's emailed
+ * link lands, and the UI establishes the session by the same code path.
+ */
+async function mintSignInLink(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<string> {
+  const base = STAGING_SUPABASE_URL!.replace(/\/$/, '')
+  const response = await request.post(`${base}/auth/v1/admin/generate_link`, {
+    headers: adminHeaders(),
+    data: {
+      type: 'magiclink',
+      email: SMOKE_EMAIL,
+      options: { redirect_to: uiUrl('/auth/callback') },
+    },
+    timeout: 20_000,
+  })
+  expect(
+    response.ok(),
+    `admin generate_link failed with ${response.status()} — cannot sign the smoke account in`,
+  ).toBe(true)
+  const body = (await response.json()) as {
+    action_link?: string
+    properties?: { action_link?: string }
+  }
+  const link = body.action_link ?? body.properties?.action_link
+  expect(link, 'generate_link returned no action_link').toBeTruthy()
+  return link!
+}
+
+// ---------------------------------------------------------------------------
+// Posture probe (case 2) — unauthenticated, credential-free, account-free
+// ---------------------------------------------------------------------------
+
+type Posture = 'required-login-on' | 'guest-mode'
+
+async function probePosture(browser: Browser): Promise<Posture> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  try {
+    await page.goto(uiUrl('/canvas'), { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+
+    const loginSurface = page.locator('#login-email')
+    const guestSurface = page.locator(
+      '[data-testid="first-use-composer"], .react-flow, [data-testid="outputs-dock"]',
+    )
+
+    await expect(loginSurface.or(guestSurface).first()).toBeVisible({
+      timeout: PROBE_TIMEOUT_MS,
+    })
+
+    return (await loginSurface.isVisible()) ? 'required-login-on' : 'guest-mode'
+  } finally {
+    await context.close()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('required-login window gate (ROADMAP 2.126b)', () => {
+  let posture: Posture
+  let context: BrowserContext
+  let page: Page
+  let smokeUserId = '<not provisioned>'
+  let scenarioUrl = '<none>'
+
+  const OFF_REASON =
+    'VITE_REQUIRE_LOGIN is OFF on the deployed build — the window is not gated yet, ' +
+    'so this suite would assert against the wrong posture. Not a failure: flip the ' +
+    'flag (Netlify env + redeploy, Paul-gated) and re-run with REQUIRE_LOGIN_EXPECTED=1.'
+
+  test.beforeAll(async ({ browser }) => {
+    // Belt-and-braces: the module-scope `test.skip` already marks every test
+    // skipped without env, but hook-execution semantics are a runner detail and
+    // this hook makes a NETWORK CALL. Depending on the runner to skip it would
+    // make the inert default state depend on something this file does not own —
+    // and with STAGING_UI_URL unset the probe would navigate to `undefined/#/canvas`
+    // and red the suite for everyone. Explicit guard, no inference.
+    if (!SHOULD_RUN) return
+    posture = await probePosture(browser)
+    // eslint-disable-next-line no-console
+    console.log(
+      `[required-login-gate] host=${hostFor(STAGING_UI_URL)} posture=${posture} ` +
+        `expected_on=${REQUIRE_LOGIN_EXPECTED} account=${redactEmail(SMOKE_EMAIL!)}`,
+    )
+    if (posture === 'required-login-on') {
+      context = await browser.newContext()
+      page = await context.newPage()
+    }
+  })
+
+  test.afterAll(async () => {
+    if (context) await context.close()
+  })
+
+  // ── Step 1 — the posture itself (pack §3 step 1) ──────────────────────────
+  test('1 · unauthenticated /#/canvas lands on the login surface, never a guest canvas', async ({
+    browser,
+  }) => {
+    // Case (3): on gate day this is the loud failure the pack demands. Written
+    // as an explicit branch, not a conditional expectation — a `toBe(cond ? a :
+    // posture)` would compare the value with itself in the off branch and pass
+    // by asserting nothing (trap 12b: a control pinned to "current" is vacuous).
+    if (REQUIRE_LOGIN_EXPECTED) {
+      expect(
+        posture,
+        'REQUIRE_LOGIN_EXPECTED=1 but the deployed build served a GUEST CANVAS to an ' +
+          'unauthenticated visitor. The required-login posture is NOT in force and the ' +
+          'user-testing window is NOT gated. Do not open the window.',
+      ).toBe('required-login-on')
+    }
+    // Case (2): before the flip, skip rather than red.
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+
+    const fresh = await browser.newContext()
+    const freshPage = await fresh.newPage()
+    try {
+      await freshPage.goto(uiUrl('/canvas'), { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+      await expect(freshPage.locator('#login-email')).toBeVisible({ timeout: PROBE_TIMEOUT_MS })
+      await expect(freshPage.locator('.react-flow__node')).toHaveCount(0)
+      // No guest session was minted — the guest branch sets a synthetic user.
+      const storage = await fresh.storageState()
+      expect(
+        JSON.stringify(storage).includes('guest@poc'),
+        'a guest session was minted despite the login surface being shown',
+      ).toBe(false)
+    } finally {
+      await fresh.close()
+    }
+  })
+
+  // ── Step 2 — the real login surface + sign-in (pack §3 step 2) ────────────
+  test('2 · the real login surface accepts the smoke account and a session is established', async ({
+    request,
+  }) => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+    test.setTimeout(PROBE_TIMEOUT_MS * 3)
+
+    // Provisioning happens HERE — inside a running test — never in the probe,
+    // so a skipped run creates nothing.
+    smokeUserId = await provisionSmokeAccount(request)
+
+    // Drive the real surface first: this is the affordance a tester will use.
+    await page.goto(uiUrl('/login'), { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+    await page.locator('#login-email').fill(SMOKE_EMAIL!)
+    await page.getByRole('button', { name: 'Send magic link' }).click()
+    // Apostrophe-agnostic on purpose: the copy is "…you'll receive a sign-in
+    // link shortly", and a curly-vs-straight apostrophe swap in the copy must
+    // not red the window gate.
+    await expect(
+      page.getByText(/receive a sign-in link/i),
+      'the login form did not reach its link-sent state',
+    ).toBeVisible({ timeout: PROBE_TIMEOUT_MS })
+
+    // Then complete the journey headlessly with the equivalent link.
+    const actionLink = await mintSignInLink(request)
+    await page.goto(actionLink, { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+
+    // AuthCallback redirects to the hub on SIGNED_IN; AuthGuard must let us past.
+    await expect(page.locator('#login-email')).toHaveCount(0, { timeout: PROBE_TIMEOUT_MS })
+    const sessionPresent = await page.evaluate(() =>
+      Object.keys(window.localStorage).some((k) => /^sb-.*-auth-token$/.test(k)),
+    )
+    expect(sessionPresent, 'no Supabase session token after the sign-in link').toBe(true)
+  })
+
+  // ── Step 3 — canvas mounts (pack §3 step 3) ──────────────────────────────
+  test('3 · the canvas mounts with the first-use composer', async () => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+
+    await page.goto(uiUrl('/canvas'), { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+    await expect(page.locator('[data-testid="first-use-composer"]')).toBeVisible({
+      timeout: PROBE_TIMEOUT_MS,
+    })
+    await expect(page.getByLabel('Describe your decision').first()).toBeVisible()
+  })
+
+  // ── Steps 4+5 — draft, and the authenticated wire contract (pack §3 4–5) ─
+  test('4 · the draft turn carries an Authorization: Bearer header and returns a graph', async () => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+    test.setTimeout(DRAFT_TIMEOUT_MS + 30_000)
+
+    // Capture the request BEFORE sending, so the assertion cannot race the turn.
+    const turnRequest = page.waitForRequest(
+      (r) => r.url().includes('/proxy/v5/turn') && r.method() === 'POST',
+      { timeout: DRAFT_TIMEOUT_MS },
+    )
+    const turnResponse = page.waitForResponse(
+      (r) => r.url().includes('/proxy/v5/turn') && r.request().method() === 'POST',
+      { timeout: DRAFT_TIMEOUT_MS },
+    )
+
+    await page.getByLabel('Describe your decision').first().fill(FIXTURE_BRIEF)
+    await page.locator('button[aria-label="Send"]').click()
+
+    const req = await turnRequest
+    const authHeader = (await req.headerValue('authorization')) ?? ''
+    expect(
+      /^Bearer\s+\S+/.test(authHeader),
+      'the turn went to CEE WITHOUT an Authorization: Bearer header — the required-login ' +
+        'wire contract is not in force even though the UI showed a login surface ' +
+        '(see src/v5/turnAuthHeaders.ts and CEE extractJwtCandidate)',
+    ).toBe(true)
+    // The header must never be logged; only its shape is asserted.
+
+    const res = await turnResponse
+    expect(res.status(), 'CEE turn did not return 200').toBe(200)
+
+    // Draft lands on the canvas.
+    await expect
+      .poll(async () => page.locator('.react-flow__node').count(), {
+        timeout: DRAFT_TIMEOUT_MS,
+        message: 'the draft never produced a graph on the canvas',
+      })
+      .toBeGreaterThanOrEqual(5)
+
+    await expect(page.locator('[data-testid="outputs-error-banner"]')).toHaveCount(0)
+    scenarioUrl = page.url()
+  })
+
+  // ── Step 6 — run the analysis (pack §3 step 6) ───────────────────────────
+  test('6 · the analysis runs, or says honestly that it cannot recommend', async () => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+    test.setTimeout(ANALYSIS_TIMEOUT_MS + 30_000)
+
+    const runButton = page.locator('[data-testid="btn-run-analysis"]')
+    await expect(runButton, 'no run control on the canvas after a draft').toBeVisible({
+      timeout: PROBE_TIMEOUT_MS,
+    })
+    await runButton.click()
+
+    // EITHER outcome passes. What fails is a silent stall: the pass condition is
+    // that the product reaches a stated verdict — a result, or a typed honest
+    // "can't recommend, because…". An empty dock after the budget is the FAIL.
+    const results = page.locator('[data-testid="outputs-dock"]')
+    const cannotConfirm = page.locator('[data-testid="results-tab-cannot-confirm-icon"]')
+    const errorBanner = page.locator('[data-testid="outputs-error-banner"]')
+
+    await expect(results.or(cannotConfirm).or(errorBanner).first()).toBeVisible({
+      timeout: ANALYSIS_TIMEOUT_MS,
+    })
+    // The analysis must have finished, not merely started.
+    await expect(page.locator('[data-testid="cancel-analysis-button"]')).toHaveCount(0, {
+      timeout: ANALYSIS_TIMEOUT_MS,
+    })
+  })
+
+  // ── Step 7 — the session and the work survive a reload (pack §3 step 7) ──
+  test('7 · reload keeps the session and re-loads the same scenario', async () => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+    test.setTimeout(DRAFT_TIMEOUT_MS)
+
+    await page.reload({ waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+    await expect(
+      page.locator('#login-email'),
+      'the reload bounced back to the login surface — the session did not survive',
+    ).toHaveCount(0, { timeout: PROBE_TIMEOUT_MS })
+    await expect
+      .poll(async () => page.locator('.react-flow__node').count(), {
+        timeout: DRAFT_TIMEOUT_MS,
+        message: 'the scenario did not re-load after a reload',
+      })
+      .toBeGreaterThanOrEqual(5)
+  })
+
+  // ── Step 8 — teardown (pack §3 step 8, deletion deliberately NOT automated) ─
+  test('8 · sign out, and report what the deletion runbook must clean up', async () => {
+    test.skip(posture !== 'required-login-on', OFF_REASON)
+
+    await page.evaluate(async () => {
+      const keys = Object.keys(window.localStorage).filter((k) => /^sb-.*-auth-token$/.test(k))
+      for (const k of keys) window.localStorage.removeItem(k)
+    })
+    await page.goto(uiUrl('/canvas'), { waitUntil: 'commit', timeout: PROBE_TIMEOUT_MS })
+    await expect(
+      page.locator('#login-email'),
+      'signing out did not return the visitor to the login surface',
+    ).toBeVisible({ timeout: PROBE_TIMEOUT_MS })
+
+    // Deletion is Paul-gated (pack §2). Report, do not execute.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[required-login-gate] TEARDOWN — deletion runbook (pack §2) input:\n` +
+        `    smoke account uid : ${smokeUserId}\n` +
+        `    account email     : ${redactEmail(SMOKE_EMAIL!)} (full value is in SMOKE_EMAIL)\n` +
+        `    scenario url      : ${scenarioUrl}\n` +
+        `    This spec deleted NOTHING. Run pack §2 against the uid above on Paul's word;\n` +
+        `    that run doubles as the deletion-runbook rehearsal (ROADMAP 1.115).`,
+    )
+  })
+})

--- a/playwright.staging.config.ts
+++ b/playwright.staging.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig, devices } from '@playwright/test'
 
 /**
- * Playwright config for HTTP-only staging gates.
+ * Playwright config for staging gates.
  *
- * Used by `pnpm e2e:staging:v5`. Targets specs that hit a deployed staging
- * host directly via Playwright's `request` fixture and therefore need no
- * local dev server.
+ * Used by `pnpm e2e:staging:v5`. Targets specs that run against a DEPLOYED
+ * staging host and therefore need no local dev server. Two shapes live here:
+ *   - HTTP-only gates using the `request` fixture (v5-proxy-reachability)
+ *   - real-browser journey gates against the deployed UI
+ *     (required-login-window-gate — ROADMAP 2.126b)
  *
  * Differences from `playwright.config.ts`:
  *   - no `webServer` (does not launch `npm run dev`)
@@ -14,10 +16,16 @@ import { defineConfig, devices } from '@playwright/test'
  *
  * Specs targeted here are individually self-skipping when their staging
  * env vars are absent, so this config is also safe to invoke without env.
+ * `required-login-window-gate` additionally self-skips when the deployed build
+ * has not had `VITE_REQUIRE_LOGIN` flipped on — see that file's header; a red
+ * suite on an unflipped environment would be a broken alarm.
  */
 export default defineConfig({
   testDir: 'e2e',
-  testMatch: ['**/smoke/v5-proxy-reachability.spec.ts'],
+  testMatch: [
+    '**/smoke/v5-proxy-reachability.spec.ts',
+    '**/smoke/required-login-window-gate.spec.ts',
+  ],
   fullyParallel: false,
   workers: 1,
   retries: process.env.CI ? 1 : 0,

--- a/scripts/ci/bundle-env-allowlist.json
+++ b/scripts/ci/bundle-env-allowlist.json
@@ -81,9 +81,8 @@
     },
     "VITE_ACCESS_CODES": "Credential-shaped name read by src/lib/auth/accessValidation.ts. Not present in the measured build (unset), so not currently exposed \u2014 listed here so that setting it is a loud event rather than a silent one.",
     "VITE_ACCESS_SALT": "As above \u2014 a salt in a client bundle provides no secrecy. Review before this is ever set.",
-    "VITE_POSTHOG_API_KEY": "PostHog project keys are write-only and intended to be public, but the name is credential-shaped; kept visible here deliberately.",
-    "VITE_POSTHOG_KEY": "As above.",
-    "VITE_POSTHOG_HOST": "Public endpoint; grouped with the PostHog pair for review.",
+    "VITE_POSTHOG_KEY": "PostHog project keys are write-only and intended to be public, but the name is credential-shaped; kept visible here deliberately. ROADMAP 2.111: this is now the ONLY PostHog key name in the repo — the former second name VITE_POSTHOG_API_KEY was removed (not aliased) so activation cannot leave one consumer dark.",
+    "VITE_POSTHOG_HOST": "Public endpoint; grouped with the PostHog key for review.",
     "VITE_STORAGE_KEY": "Read by src/lib/secureStorage.ts. A client-side encryption key in the bundle is not a secret from the user; review what it is protecting.",
     "VITE_OPENAI_API_KEY": "Was baked as the literal \"placeholder\" before this change and is no longer in the bundle. If a REAL key is ever set here it would be published to every visitor; the guard will red on it."
   }

--- a/src/lib/__tests__/posthogKeyUnify.spec.ts
+++ b/src/lib/__tests__/posthogKeyUnify.spec.ts
@@ -1,0 +1,301 @@
+// src/lib/__tests__/posthogKeyUnify.spec.ts
+// =============================================================================
+// ROADMAP 2.111 — ONE PostHog key name. The activation-day split-brain pin.
+// =============================================================================
+//
+// THE DEFECT THIS EXISTS TO PREVENT
+// --------------------------------
+// Before this pin the repo read TWO different env names for the same PostHog
+// project key:
+//
+//   src/lib/posthog.ts:10        VITE_POSTHOG_KEY       ← gates posthog.init()
+//   src/lib/config.ts:98,104     VITE_POSTHOG_API_KEY   ← observability.*
+//   src/observability/metrics.ts VITE_POSTHOG_API_KEY   ← isEnabled()
+//
+// On activation day exactly one of those names would be set in Netlify, and
+// whichever it was, the other consumer stayed DARK — silently, with no error,
+// no warning, and a green build. That is the failure mode ROADMAP 1.68's
+// collaboration-signal baseline cannot survive: it is measured once, during the
+// user-testing window, and an unrecoverable half-dark telemetry path destroys
+// the baseline rather than delaying it.
+//
+// The fix REMOVES the losing name rather than aliasing it. An alias
+// (`VITE_POSTHOG_KEY ?? VITE_POSTHOG_API_KEY`) is a hand-maintained mirror: it
+// makes both names work today and lets the divergence creep back the next time
+// someone copies a read. Removal makes re-divergence a visible edit.
+//
+// WHY `VITE_POSTHOG_KEY` WON
+// --------------------------
+// Neither name had any deployment footprint (absent from netlify.toml,
+// .env.example, docs/, and the flags:check guard), so the tie was broken on
+// call-graph footprint: `VITE_POSTHOG_KEY` is the name read by the ONLY module
+// that actually initialises the SDK (src/lib/posthog.ts → posthog.init), and
+// that module is imported by ten live product modules. Both
+// `VITE_POSTHOG_API_KEY` readers had ZERO importers repo-wide.
+//
+// WHAT EACH TEST BELOW CLAIMS — the claim types differ, deliberately
+// -----------------------------------------------------------------
+//   1. BEHAVIOURAL (runtime): with only the chosen name set, BOTH runtime
+//      consumers light up; with only the retired name set, BOTH stay dark.
+//      Never one-lit-one-dark. This is the split-brain assertion itself.
+//   2. DERIVED SOURCE INVARIANT: the set of PostHog env names read anywhere in
+//      src/ is exactly {VITE_POSTHOG_KEY, VITE_POSTHOG_HOST}. This is NOT a
+//      hand-maintained list of consumers — it is derived by walking src/, so a
+//      future third consumer that re-diverges reds this without anyone
+//      remembering to add it. It also covers src/observability/metrics.ts,
+//      whose isEnabled() short-circuits on MODE === 'test' and therefore cannot
+//      be exercised behaviourally from vitest.
+//   3. NAMED PER-CONSUMER PINS, so a mutation in either specific file bites by
+//      name and the failure message says which file regressed.
+//
+// Every absence assertion here carries a POSITIVE CONTROL (CLAUDE.md trap 13):
+// the source scan proves it can SEE a presence before it is allowed to report
+// an absence.
+// =============================================================================
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+// Reused, not reinvented: the bundle-env guard already owns a comment stripper
+// and a repo-root resolver, and already has its own anti-vacuity spec
+// (tests/ci-guards/bundle-env-allowlist.spec.ts). A second copy of either here
+// would be a second thing to keep correct. `import.meta.url` is NOT usable for
+// this from a vitest-transformed spec — it is not a file: URL there.
+import { stripComments, ROOT } from '../../../scripts/ci/assert-bundle-env-allowlist.mjs'
+
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  },
+}))
+
+import posthog from 'posthog-js'
+
+/** The single sanctioned PostHog key name. */
+const CHOSEN = 'VITE_POSTHOG_KEY'
+/** The name retired by 2.111. Must appear NOWHERE in src/ as a read. */
+const RETIRED = 'VITE_POSTHOG_API_KEY'
+/** Shared by both sides; never diverged, asserted so it stays that way. */
+const HOST = 'VITE_POSTHOG_HOST'
+
+const REPO_ROOT = ROOT
+const SRC_DIR = path.join(REPO_ROOT, 'src')
+
+// ---------------------------------------------------------------------------
+// Synthetic-env helpers
+// ---------------------------------------------------------------------------
+// `import.meta.env` is a live object under vitest (no static replacement — the
+// reads under test all use `import.meta.env?.X`, which Vite cannot narrow), so
+// assigning to it is how the existing suite already drives these code paths
+// (see src/telemetry/__tests__/guidanceEvents.spec.tsx).
+
+const env = import.meta.env as unknown as Record<string, unknown>
+const MANAGED = [CHOSEN, RETIRED, HOST] as const
+let saved: Record<string, unknown> = {}
+
+function applyEnv(patch: Partial<Record<(typeof MANAGED)[number], string>>): void {
+  for (const name of MANAGED) {
+    const value = patch[name]
+    if (value === undefined) delete env[name]
+    else env[name] = value
+  }
+}
+
+beforeEach(() => {
+  saved = {}
+  for (const name of MANAGED) {
+    if (name in env) saved[name] = env[name]
+  }
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  for (const name of MANAGED) {
+    if (name in saved) env[name] = saved[name]
+    else delete env[name]
+  }
+})
+
+/**
+ * Load both runtime consumers FRESH under the current synthetic env.
+ * `src/lib/config.ts` evaluates its `observability` object at module scope, so
+ * it must be re-imported after every env change — a stale module would make
+ * this whole spec pass by testing the wrong snapshot.
+ */
+async function loadConsumers(): Promise<{
+  initPostHog: () => void
+  observability: { postHogKey: string; hasPostHog: boolean }
+}> {
+  const posthogModule = await import('../posthog')
+  const configModule = await import('../config')
+  return {
+    initPostHog: posthogModule.initPostHog,
+    observability: configModule.observability as { postHogKey: string; hasPostHog: boolean },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. BEHAVIOURAL — both consumers resolve the SAME env var
+// ---------------------------------------------------------------------------
+
+describe('2.111 · both runtime consumers resolve the same env var', () => {
+  it('ONLY the chosen name set → BOTH consumers are configured', async () => {
+    applyEnv({ [CHOSEN]: 'phc_chosen_key', [HOST]: 'https://posthog.example.test' })
+
+    const { initPostHog, observability } = await loadConsumers()
+    initPostHog()
+
+    // Consumer A — the SDK actually initialises.
+    expect(
+      posthog.init,
+      `posthog.init was not called with only ${CHOSEN} set — src/lib/posthog.ts is dark`,
+    ).toHaveBeenCalledTimes(1)
+    expect(posthog.init).toHaveBeenCalledWith('phc_chosen_key', expect.anything())
+
+    // Consumer B — config.observability agrees.
+    expect(
+      observability.hasPostHog,
+      `config.observability.hasPostHog is false with only ${CHOSEN} set — split-brain: ` +
+        'src/lib/config.ts is reading a different env name',
+    ).toBe(true)
+    expect(observability.postHogKey).toBe('phc_chosen_key')
+  })
+
+  it('ONLY the retired name set → BOTH consumers are dark (never one-lit-one-dark)', async () => {
+    applyEnv({ [RETIRED]: 'phc_retired_key', [HOST]: 'https://posthog.example.test' })
+
+    const { initPostHog, observability } = await loadConsumers()
+    initPostHog()
+
+    expect(
+      posthog.init,
+      `posthog.init ran off ${RETIRED} — the retired name is still wired somewhere`,
+    ).not.toHaveBeenCalled()
+    expect(
+      observability.hasPostHog,
+      `config.observability lit up from ${RETIRED} while posthog.ts stayed dark — ` +
+        'this is exactly the activation-day split-brain 2.111 removes',
+    ).toBe(false)
+    expect(observability.postHogKey).toBe('')
+  })
+
+  it('BOTH names set → still exactly one source of truth, and it is the chosen name', async () => {
+    applyEnv({
+      [CHOSEN]: 'phc_chosen_key',
+      [RETIRED]: 'phc_retired_key',
+      [HOST]: 'https://posthog.example.test',
+    })
+
+    const { initPostHog, observability } = await loadConsumers()
+    initPostHog()
+
+    expect(posthog.init).toHaveBeenCalledWith('phc_chosen_key', expect.anything())
+    expect(observability.postHogKey).toBe('phc_chosen_key')
+  })
+
+  it('neither name set → both dark (the pre-activation state today)', async () => {
+    applyEnv({ [HOST]: 'https://posthog.example.test' })
+
+    const { initPostHog, observability } = await loadConsumers()
+    initPostHog()
+
+    expect(posthog.init).not.toHaveBeenCalled()
+    expect(observability.hasPostHog).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. DERIVED SOURCE INVARIANT — covers every consumer, including untestable ones
+// ---------------------------------------------------------------------------
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx'])
+
+/** Walk src/, skipping test trees (a spec is allowed to NAME the retired var). */
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'tests' || entry === '__fixtures__') continue
+      collectSourceFiles(full, out)
+      continue
+    }
+    if (/\.(test|spec)\.[cm]?tsx?$/.test(entry)) continue
+    if (SOURCE_EXTENSIONS.has(path.extname(entry))) out.push(full)
+  }
+  return out
+}
+
+describe('2.111 · derived invariant: exactly one PostHog key name exists in src/', () => {
+  const files = collectSourceFiles(SRC_DIR)
+  const hits: Array<{ file: string; name: string }> = []
+  for (const file of files) {
+    // Comments stripped: the files below deliberately NAME the retired variable
+    // in prose to explain why it was removed. A prose mention is not a read,
+    // and counting it would make this invariant impossible to document.
+    const text = stripComments(readFileSync(file, 'utf8'))
+    for (const match of text.matchAll(/VITE_POSTHOG[A-Z0-9_]*/g)) {
+      hits.push({ file: path.relative(REPO_ROOT, file), name: match[0] })
+    }
+  }
+
+  it('POSITIVE CONTROL — the scan can see a presence before it reports an absence', () => {
+    // Trap 13: without these floors, a broken walker (wrong root, wrong
+    // extension filter) would report "zero occurrences of the retired name"
+    // by scanning nothing at all, and every assertion below would pass vacuously.
+    expect(files.length, 'source walk collected suspiciously few files').toBeGreaterThan(300)
+    expect(
+      hits.filter((h) => h.name === CHOSEN).length,
+      `scan found no ${CHOSEN} occurrences — the walker is not seeing the real source`,
+    ).toBeGreaterThanOrEqual(3)
+  })
+
+  it(`the retired name ${RETIRED} appears NOWHERE in non-test src/`, () => {
+    const offenders = hits.filter((h) => h.name === RETIRED)
+    expect(
+      offenders.map((h) => h.file),
+      `${RETIRED} was re-introduced. 2.111 removed it deliberately: two names for one ` +
+        'key means whichever is set on activation day leaves the other consumer dark. ' +
+        `Use ${CHOSEN}.`,
+    ).toEqual([])
+  })
+
+  it('the complete set of PostHog env names read in src/ is exactly {key, host}', () => {
+    const distinct = [...new Set(hits.map((h) => h.name))].sort()
+    expect(distinct).toEqual([HOST, CHOSEN].sort())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. NAMED PER-CONSUMER PINS — so a mutation names the file that regressed
+// ---------------------------------------------------------------------------
+
+describe('2.111 · per-consumer pins', () => {
+  const CONSUMERS = [
+    'src/lib/posthog.ts',
+    'src/lib/config.ts',
+    'src/observability/metrics.ts',
+  ] as const
+
+  for (const relative of CONSUMERS) {
+    it(`${relative} reads ${CHOSEN} and not ${RETIRED}`, () => {
+      const text = readFileSync(path.join(REPO_ROOT, relative), 'utf8')
+      // The comment blocks in these files NAME the retired variable on purpose
+      // (they explain why it went). Only a READ counts as a regression, so
+      // match the read shape — `import.meta.env.X` or `import.meta.env?.X`.
+      const retiredRead = new RegExp(String.raw`import\.meta\.env\??\.${RETIRED}`)
+      const chosenRead = new RegExp(String.raw`import\.meta\.env\??\.${CHOSEN}`)
+      expect(
+        retiredRead.test(text),
+        `${relative} still READS ${RETIRED} — activation-day split-brain reintroduced`,
+      ).toBe(false)
+      expect(
+        chosenRead.test(text),
+        `${relative} no longer reads ${CHOSEN} — it will be dark on activation day`,
+      ).toBe(true)
+    })
+  }
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -94,14 +94,23 @@ export const plotProxyBase = import.meta.env?.VITE_PLOT_PROXY_BASE || '/bff/engi
  * Observability service configuration
  */
 export const observability = {
-  /** PostHog API key for analytics (empty = disabled) */
-  postHogKey: import.meta.env?.VITE_POSTHOG_API_KEY || '',
+  /**
+   * PostHog project key for analytics (empty = disabled).
+   *
+   * ROADMAP 2.111 — ONE key name across the whole repo: `VITE_POSTHOG_KEY`.
+   * This used to read `VITE_POSTHOG_API_KEY` while `src/lib/posthog.ts` (the
+   * only module that actually calls `posthog.init`) read `VITE_POSTHOG_KEY`,
+   * so whichever name got set on activation day left the other consumer dark.
+   * The retired name is REMOVED, not aliased — an alias is a hand-maintained
+   * mirror. Pinned by `src/lib/__tests__/posthogKeyUnify.spec.ts`.
+   */
+  postHogKey: import.meta.env?.VITE_POSTHOG_KEY || '',
 
   /** Sentry DSN for error tracking (empty = disabled) */
   sentryDsn: import.meta.env?.VITE_SENTRY_DSN || '',
 
-  /** Whether PostHog is configured */
-  hasPostHog: Boolean(import.meta.env?.VITE_POSTHOG_API_KEY),
+  /** Whether PostHog is configured (same single key name — see postHogKey above) */
+  hasPostHog: Boolean(import.meta.env?.VITE_POSTHOG_KEY),
 
   /** Whether Sentry is configured */
   hasSentry: Boolean(import.meta.env?.VITE_SENTRY_DSN),

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -90,8 +90,13 @@ function isEnabled(): boolean {
   // Dev: console only
   if (import.meta.env.DEV) return true
 
-  // Staging/Prod: require API keys
-  const hasPostHog = Boolean(import.meta.env?.VITE_POSTHOG_API_KEY)
+  // Staging/Prod: require API keys.
+  // ROADMAP 2.111: ONE PostHog key name repo-wide — `VITE_POSTHOG_KEY`, the
+  // name `src/lib/posthog.ts` gates `posthog.init` on. This previously read
+  // `VITE_POSTHOG_API_KEY`, so setting either name on activation day left one
+  // consumer dark. Retired name removed, not aliased. Pinned by
+  // `src/lib/__tests__/posthogKeyUnify.spec.ts`.
+  const hasPostHog = Boolean(import.meta.env?.VITE_POSTHOG_KEY)
   const hasSentry = Boolean(import.meta.env?.VITE_SENTRY_DSN)
 
   return hasPostHog || hasSentry

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -78,7 +78,9 @@ interface ImportMetaEnv {
 
   // --- Observability ---
   readonly VITE_SENTRY_DSN?: string
-  readonly VITE_POSTHOG_API_KEY?: string
+  // ROADMAP 2.111 — ONE PostHog key name. `VITE_POSTHOG_API_KEY` was deleted
+  // from this declaration deliberately: with `strict` env typing, re-introducing
+  // the divergent read becomes a compile error rather than a silent split-brain.
   readonly VITE_POSTHOG_HOST?: string
   readonly VITE_POSTHOG_KEY?: string
   readonly VITE_HOTJAR_ID?: string


### PR DESCRIPTION
Two small window-gating items, one lane. Both advance POC-DONE tester readiness. **Do not merge yet — review first.**

Base tip: staging `fe11ef9e`. Fresh blobless clone at a unique `/private/tmp` path; dummy `VITE_SUPABASE_*` on every test run (trap 2b). Evidence: `PHASE0-EVIDENCE-2026-07-28/window-readiness-pair.md`.

---

## ROADMAP 2.111 — the PostHog key-name divergence

The repo read **two** env names for one PostHog project key, so whichever name got set on activation day would have left the other consumer silently dark:

| File | Read |
|---|---|
| `src/lib/posthog.ts` | `VITE_POSTHOG_KEY` ← gates `posthog.init()` |
| `src/lib/config.ts` | `VITE_POSTHOG_API_KEY` ← `observability.postHogKey` / `.hasPostHog` |
| `src/observability/metrics.ts` | `VITE_POSTHOG_API_KEY` ← `isEnabled()` |

**Unified on `VITE_POSTHOG_KEY`; the losing name is removed, not aliased** (an alias is a hand-maintained mirror that lets the divergence creep back). The declaration is deleted from `src/vite-env.d.ts` too, so re-introducing the read is a compile error rather than a silent split-brain.

**Why that name won.** The brief asked me to pick the name with existing footprint. Derived, not assumed: **neither** name appears in `netlify.toml`, `.env.example`, `docs/`, or the `flags:check` guard — deployment footprint is empty for both, so that tie-break does not exist. The tie was broken on **call-graph footprint** instead: `VITE_POSTHOG_KEY` is read by the only module that actually initialises the SDK, and that module is imported by ten live product modules. Both `VITE_POSTHOG_API_KEY` readers have **zero importers repo-wide** — `src/observability/metrics.ts` is imported nowhere, and `config.ts`'s `observability` export is imported nowhere. Unifying the other way would have left the only live path dark on activation day. This gates ROADMAP 1.68, whose collaboration-signal baseline is measured once and is unrecoverable if half the telemetry is dark during the window.

**The pin** — `src/lib/__tests__/posthogKeyUnify.spec.ts` (10 tests), three claim types kept deliberately distinct:
1. **Behavioural** — only the chosen name set → both runtime consumers configured; only the retired name set → **both dark**, never one-lit-one-dark. That is the split-brain assertion itself.
2. **Derived source invariant** over `src/` — the set of PostHog env names read is exactly `{VITE_POSTHOG_KEY, VITE_POSTHOG_HOST}`. Not a hand-maintained consumer list: it is derived by walking `src/`, so a future third consumer that re-diverges reds without anyone remembering. This is what covers `metrics.ts`, whose `isEnabled()` short-circuits on `MODE === 'test'` and cannot be exercised behaviourally from vitest.
3. **Per-file pins**, so a mutation names the file that regressed.

The absence assertion carries a positive control (trap 13); it fired correctly during the RED-first run.

**RED-first + mutation** (one file at a time, throwaway private clone — traps 9/9c):

| State | Result |
|---|---|
| all three files at pre-fix `HEAD` (RED-first) | **8 failed / 2 passed** |
| only `src/lib/config.ts` reverted | 6 failed / 4 passed |
| only `src/observability/metrics.ts` reverted | 3 failed / 7 passed |
| only `src/vite-env.d.ts` reverted | 2 failed / 8 passed |
| fix in place | **10 passed** |

**A second activation-day trap, checked and cleared at the bytes.** The PostHog names sit in the allowlist's `knownExposed` bucket but not in `allowed`, and `allowed` is what the guard's `undeclared` check uses — so setting the key could have redded the required build gate. Probed: `pnpm run build` with `VITE_POSTHOG_KEY` set bakes the **value** (once, narrowed, in the `AppPoC` chunk) but **not the name** — `grep -ro 'VITE_POSTHOG[A-Z_]*' dist/assets/*.js` returns zero. So `undeclared` cannot trip and **no `allowed` change is needed**. Scope stated honestly: that was a local build with only four `VITE_*` set, not a full-env Netlify build.

---

## ROADMAP 2.126(b) — the required-login window smoke

New `e2e/smoke/required-login-window-gate.spec.ts` implements pack §3 (sign-up → canvas → draft → run → reload → teardown), reusing `playwright.staging.config.ts`, which gains one `testMatch` entry and nothing else.

**It is runnable but SKIPPED by default and has never been executed live, on purpose.** Required-login is not flipped on staging — that is Paul's window-posture call — and a permanently-red suite on an unflipped environment is a broken alarm (trap 7). Three-way gating:

- **env absent** → module-scope skip. No browser, no network, no account. *(Proven by an actual run: 9 skipped, 0 failed, no browser launched — chromium is not even installed in the clone.)*
- **flag OFF** → a credential-free, unauthenticated **posture probe** classifies the deployed build and every test skips **with that reason**. No account is created: provisioning lives inside the first *running* test, never in the probe. A defensive `if (!SHOULD_RUN) return` guards `beforeAll` too, because that hook makes a network call and the inert default must not depend on runner hook semantics.
- **`REQUIRE_LOGIN_EXPECTED=1`** inverts that: a guest canvas becomes a **loud failure**. Set it on gate day — that is pack §3 step 1's "fail loudly, don't skip".

**Two findings from the tip that CHANGE the pack's spec** — both verified at the bytes, both documented in the file header:

1. **There is no password auth in this UI.** `LoginPage` offers magic link + Google only; `AuthContext`'s `signIn`/`signUp` are legacy no-ops returning `Password auth removed`. The pack's proposed `SMOKE_PASSWORD` is unimplementable, and naming an env var for a mechanism that does not exist is the false-label defect (trap 14). **The two account env vars are `SMOKE_EMAIL` and `SMOKE_SUPABASE_SERVICE_ROLE_KEY`** — the same key and project the pack's §2 deletion runbook already uses. Nothing is hardcoded.
2. **⚠ Self-signup is IMPOSSIBLE.** `signInWithMagicLink` passes `shouldCreateUser: false`, and Google OAuth is gated by a dashboard Before-User-Created allowlist hook. So the pilot kit's *"each participant creates a free account at the start"* is **not achievable through the product** — the 4 tester accounts **must** be pre-provisioned. Pack §4 recommended pre-provisioning to dodge the SMTP throttle; the real reason is harder than that. **This is the item worth acting on independently of this PR.**

**Teardown deletes nothing.** It signs out and prints the smoke account's uid + scenario for an operator to run pack §2 against — that runbook executes only on Paul's explicit word, and a test that hard-deletes staging rows would take that decision away.

---

## Gates

- **`pnpm run typecheck`** (the authoritative gate, read at this tip rather than trusted from a note): **PASSED**. Coverage **3056/3096** after staging the new files — `+2`, exactly the two new TS files, so both are *inside* the gate — and the ratchet is unchanged at **2510** errors / 622 files.
- Touched + adjacent suites (`src/lib`, `src/observability`, `src/telemetry`, `tests/ci-guards`, `src/components/auth`): **136 files / 1655 tests passed**.
- `playwright.staging.config.ts` with no env: **9 skipped, 0 failed**.
- `eslint` on every touched file: **0 errors** (two pre-existing `no-console` warnings in `metrics.ts`, untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
