### PR TITLE
fix(ui): terminal-notice chips actually render (2.138)

### DIFF
--- a/src/canvas/conversation/ActionChipRow.tsx
+++ b/src/canvas/conversation/ActionChipRow.tsx
@@ -10,6 +10,7 @@
  */
 
 import { memo } from 'react'
+import { isChipRenderable } from './chipDispatch'
 import type { ActionChip } from './types'
 import styles from './Conversation.module.css'
 
@@ -34,8 +35,12 @@ export const ActionChipRow = memo(function ActionChipRow({
   onChipClick,
   disabled = false,
 }: ActionChipRowProps) {
-  // Central guard: only render chips that can actually dispatch
-  const dispatchable = chips.filter(c => c.intent === 'undo' || !!c.message)
+  // Central guard: only render chips that can actually dispatch.
+  // ROADMAP 2.138 — shared with SuggestedChips and ChatThread (`chipDispatch.ts`).
+  // The guard used to be inlined here as `intent === 'undo' || !!c.message`,
+  // one of three divergent copies of the same rule; none of them knew about
+  // chips ConversationPanel routes by id, which carry no message by design.
+  const dispatchable = chips.filter(isChipRenderable)
   if (dispatchable.length === 0) return null
 
   return (

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -13,7 +13,11 @@ import { useCanvasStore, selectResultsStatus } from '../store'
 import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import type { ActionChip, GraphPatchBlock } from './types'
-import { START_NEW_DRAFT_CHIP_ID } from './useConversation'
+import {
+  RETRY_CHIP_ID,
+  START_NEW_DRAFT_CHIP_ID,
+  type LocallyRoutedChipId,
+} from './chipDispatch'
 import type { UseConversationReturn } from './useConversation'
 import { applyAutoApplyPatch, applyValidatedGraph } from './utils/applyPatch'
 import { buildAnalysisReadyPatch, applyAnalysisReadyPatch } from './utils/mirrorAnalysisReady'
@@ -134,11 +138,24 @@ export const ConversationPanel = memo(function ConversationPanel({
   // ── Chip handler ──────────────────────────────────────────────────────
   const handleChipClick = useCallback(
     async (chip: ActionChip): Promise<void> => {
-      if (chip.id === 'retry') { retryLast(); return }
-      // ROADMAP 2.122 round 2 (review F3): the unsettled-draft recovery chip.
-      // Routed to a handler that CAN deliver what its label says — `retryLast`
-      // provably cannot, because CEE declines to re-draft a committed scenario.
-      if (chip.id === START_NEW_DRAFT_CHIP_ID) { await startNewDraft(); return }
+      // Chips routed BY ID to a local handler. These never reach `sendChip`, so
+      // they carry no `message` — which is why the chip rows have to be told
+      // about them (`isChipRenderable`, ROADMAP 2.138); before that, the
+      // `start_new_draft` chip existed on every terminal notice and rendered on
+      // none of them.
+      //
+      // Typed as `Record<LocallyRoutedChipId, …>` deliberately: adding an id to
+      // that union without wiring a handler here is a TYPECHECK ERROR, not a
+      // chip that silently does nothing. (ROADMAP 2.122 round 2 / review F3:
+      // `start_new_draft` goes to a handler that CAN deliver what its label
+      // says — `retryLast` provably cannot, because CEE declines to re-draft a
+      // committed scenario.)
+      const localRoutes: Record<LocallyRoutedChipId, () => void | Promise<void>> = {
+        [RETRY_CHIP_ID]: retryLast,
+        [START_NEW_DRAFT_CHIP_ID]: startNewDraft,
+      }
+      const localRoute = (localRoutes as Record<string, (() => void | Promise<void>) | undefined>)[chip.id]
+      if (localRoute) { await localRoute(); return }
       await sendChip(chip)
 
       // Track 2: mark suggested action as taken

--- a/src/canvas/conversation/__tests__/terminalNoticeChipRender.spec.tsx
+++ b/src/canvas/conversation/__tests__/terminalNoticeChipRender.spec.tsx
@@ -1,0 +1,185 @@
+/**
+ * ROADMAP 2.138 — the terminal-notice recovery chip must RENDER, not just exist.
+ *
+ * WHY THIS FILE EXISTS AT ALL (the blindness lesson).
+ * `streamedDraftTurn.spec.ts` already pins the chip — but it pins it on the
+ * MESSAGE OBJECT (`notice.actionChips.map(c => c.id)`), and that assertion is
+ * satisfied by a chip no user can ever see. 2.134's live probe found the
+ * consequence: both terminal notices rendered with an EMPTY chip wrapper, so the
+ * copy named the remedy ("start a new draft…") and gave the user no button.
+ * Guarantee-theatre, invisible to every existing spec.
+ *
+ * So every assertion here is RENDER-LEVEL: the real ConversationPanel is
+ * rendered with the real notice text and the chip built EXACTLY as
+ * `useConversation` builds it, and the pins are "a button is in the DOM" and
+ * "clicking it reaches `startNewDraft`". Both terminal notices are covered —
+ * the stopped-draft one (Stop button / 130 s timeout) and the connection-drop
+ * one — because both mint the same chip at different sites.
+ *
+ * NEGATIVE CONTROL (kept deliberately): a message-less chip with an id NOTHING
+ * routes locally must still be dropped. Without it, "the chip renders" would
+ * also pass under a renderer that had simply stopped filtering, which is the
+ * bug in the other direction — a chip that promises an action and throws.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { ConversationPanel } from '../ConversationPanel'
+import { useCanvasStore } from '../../store'
+import { START_NEW_DRAFT_CHIP_ID } from '../useConversation'
+import {
+  STOPPED_DRAFT_NOTICE,
+  UNSETTLED_DRAFT_NOTICE,
+} from '../../components/DraftLoadingAnimation'
+import type { ActionChip, ConversationMessage } from '../types'
+import type { UseConversationReturn } from '../useConversation'
+
+// ---------------------------------------------------------------------------
+// The chip, built exactly as useConversation.ts mints it at BOTH notice sites.
+// Written out longhand rather than imported so that a change to the mint shape
+// (e.g. someone "fixing" this by bolting on a decoy `message`) shows up here as
+// a diff to reason about, not as a silently-satisfied import.
+// ---------------------------------------------------------------------------
+const START_NEW_DRAFT_CHIP: ActionChip = {
+  id: START_NEW_DRAFT_CHIP_ID,
+  label: 'Start a new draft',
+  intent: 'primary',
+}
+
+function noticeMessage(content: string, chips: ActionChip[]): ConversationMessage {
+  return {
+    id: 'notice-1',
+    role: 'assistant',
+    synthetic: true,
+    content,
+    actionChips: chips,
+    timestamp: new Date(),
+  }
+}
+
+function makeMockConversation(messages: ConversationMessage[]) {
+  const startNewDraft = vi.fn(async () => {})
+  const sendChip = vi.fn().mockResolvedValue(undefined)
+  const retryLast = vi.fn().mockResolvedValue(undefined)
+
+  const conversation: UseConversationReturn = {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    lastSendFailure: null,
+    dispatchAction: vi.fn().mockResolvedValue(undefined),
+    cancelTurn: vi.fn(),
+    startNewDraft,
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendSystemEvent: vi.fn().mockResolvedValue(undefined),
+    sendChip,
+    clearHistory: vi.fn(),
+    retryLast,
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }
+
+  return { conversation, startNewDraft, sendChip, retryLast }
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement scrollIntoView
+  Element.prototype.scrollIntoView = vi.fn()
+  useCanvasStore.setState({
+    // A stopped draft leaves STRUCTURE on the canvas — a non-empty graph is the
+    // real state this notice is shown in, and it also keeps ChatThread's
+    // EmptyState from taking over the surface.
+    nodes: [{ id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } }],
+    edges: [],
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    results: { status: 'idle' } as never,
+    _externalMutationActive: 0,
+  } as never)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// The pin, for BOTH terminal notices
+// ---------------------------------------------------------------------------
+
+describe.each([
+  ['stopped-draft notice', STOPPED_DRAFT_NOTICE],
+  ['connection-drop (unsettled) notice', UNSETTLED_DRAFT_NOTICE],
+])('2.138 — %s renders a clickable "Start a new draft" chip', (_name, notice) => {
+  it('renders the notice AND a button for its remedy', () => {
+    const { conversation } = makeMockConversation([
+      noticeMessage(notice, [START_NEW_DRAFT_CHIP]),
+    ])
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} onAttach={vi.fn()} />)
+
+    // Positive control FIRST (trap 13): prove this harness can see the bubble at
+    // all. Without it, a missing-button assertion could pass on an empty render.
+    // Matched on a distinctive clause rather than the whole string — the live
+    // chat renderer rewrites the em dash (2.134 §2c), and this test must pin the
+    // BUTTON, not punctuation.
+    expect(screen.getByText(/start a new draft to get a model with settled values/i))
+      .toBeInTheDocument()
+
+    const button = screen.getByRole('button', { name: 'Start a new draft' })
+    expect(button).toBeInTheDocument()
+    expect(button.tagName).toBe('BUTTON')
+    expect(button).not.toBeDisabled()
+    expect(button).toHaveTextContent('Start a new draft')
+  })
+
+  it('clicking the chip reaches startNewDraft — not sendChip, not retryLast', async () => {
+    const { conversation, startNewDraft, sendChip, retryLast } = makeMockConversation([
+      noticeMessage(notice, [START_NEW_DRAFT_CHIP]),
+    ])
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} onAttach={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start a new draft' }))
+
+    await waitFor(() => {
+      expect(startNewDraft).toHaveBeenCalledTimes(1)
+    })
+    // The chip carries no `message`. If it ever reached sendChip it would throw
+    // ("has no message field") — the id-route in ConversationPanel is what makes
+    // it work, and this asserts the route, not just the outcome.
+    expect(sendChip).not.toHaveBeenCalled()
+    expect(retryLast).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Negative control — the widening must stay narrow
+// ---------------------------------------------------------------------------
+
+describe('2.138 — the render guard is widened, not removed', () => {
+  it('still drops a message-less chip that no local handler routes', () => {
+    const orphan: ActionChip = { id: 'mystery_action', label: 'Do a thing', intent: 'primary' }
+    const { conversation } = makeMockConversation([
+      noticeMessage(STOPPED_DRAFT_NOTICE, [orphan]),
+    ])
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} onAttach={vi.fn()} />)
+
+    // The bubble is on screen (positive control) …
+    expect(screen.getByText(/start a new draft to get a model with settled values/i))
+      .toBeInTheDocument()
+    // … and the undispatchable chip is not.
+    expect(screen.queryByRole('button', { name: 'Do a thing' })).not.toBeInTheDocument()
+  })
+
+  it('renders the recovery chip even when an undispatchable sibling is present', () => {
+    const orphan: ActionChip = { id: 'mystery_action', label: 'Do a thing', intent: 'primary' }
+    const { conversation } = makeMockConversation([
+      noticeMessage(STOPPED_DRAFT_NOTICE, [orphan, START_NEW_DRAFT_CHIP]),
+    ])
+    render(<ConversationPanel conversation={conversation} onCollapse={vi.fn()} onAttach={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Start a new draft' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Do a thing' })).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/conversation/chipDispatch.ts
+++ b/src/canvas/conversation/chipDispatch.ts
@@ -1,0 +1,91 @@
+/**
+ * Chip dispatchability — ONE predicate, for every chip row.
+ *
+ * ─── The defect this module exists to close (ROADMAP 2.138) ────────────────
+ * A chip row must not render a chip nothing can act on: `sendChip` throws on a
+ * chip with no `message`/`prompt`, so an unfiltered row would promise an action
+ * and deliver an error. Both rows therefore filtered — and both filtered with
+ * their OWN hand-written copy of the rule:
+ *
+ *     ActionChipRow.tsx   c.intent === 'undo' || !!c.message
+ *     SuggestedChips.tsx  !!(c.message || c.prompt)
+ *     ChatThread.tsx      !!c.message              (the hide-inline-chips mirror)
+ *
+ * Three copies, none agreeing, and none of them knowing about the THIRD class of
+ * chip: the ones `ConversationPanel.handleChipClick` routes BY ID to a local
+ * handler and which therefore never reach `sendChip` at all. Those chips carry
+ * no `message` BY DESIGN — there is no message to send — so every copy of the
+ * rule silently dropped them.
+ *
+ * 2.134's live probe caught the consequence: the stopped-draft and
+ * connection-drop notices both say "start a new draft to get a model with
+ * settled values" and both rendered with an EMPTY chip wrapper. The user was
+ * told the remedy and given no button; the handler (`startNewDraft`) existed,
+ * was correct, and had no reachable caller.
+ *
+ * ─── Why the fix is here and not at the mint site ──────────────────────────
+ * The other available "fix" was to give the chip a `message` so it satisfies the
+ * filters. That would be a decoy: `message` is documented as "Message sent to
+ * orchestrator when chip is tapped", and this chip's click NEVER sends it —
+ * `startNewDraft` sends `lastUserInputRef`, on a fresh scenario. The field would
+ * exist purely to fool a guard, and it would arm a live regression: if the
+ * id-route below were ever renamed or removed, the chip would stop failing
+ * loudly and start quietly POSTing that decoy to CEE as a chat turn. The filter
+ * was over-narrow; the chip's shape was right.
+ */
+
+import type { ActionChip } from './types'
+
+/**
+ * Chips `ConversationPanel.handleChipClick` routes by id to a local handler.
+ * They never reach `sendChip`, so they carry no `message`.
+ *
+ * The union is load-bearing: `ConversationPanel` builds its router as a
+ * `Record<LocallyRoutedChipId, …>`, so adding an id here without wiring a
+ * handler is a TYPECHECK ERROR rather than a silently dead chip.
+ */
+export const RETRY_CHIP_ID = 'retry'
+export const START_NEW_DRAFT_CHIP_ID = 'start_new_draft'
+export type LocallyRoutedChipId = typeof RETRY_CHIP_ID | typeof START_NEW_DRAFT_CHIP_ID
+
+/**
+ * Of the locally-routed chips, the ones a chip row must RENDER.
+ *
+ * `retry` is deliberately absent, and the omission is a product decision, not an
+ * oversight — recorded here so it cannot be mistaken for one again:
+ *
+ *   - `retry` is minted at NINE sites in `useConversation.ts` (transport failure,
+ *     typed error, stuck-stream recovery, timeout, decline…), and every one of
+ *     those bubbles ALREADY carries a retry affordance: `MessageActions` renders
+ *     a hover/focus-revealed Retry on assistant messages (`ChatMessage.tsx`), and
+ *     the failed-send path additionally renders "Not delivered → Retry" on the
+ *     user's own bubble (`MessageBubble.tsx`), both wired to the same `retryLast`.
+ *     Rendering the chip too is a change to nine error surfaces with its own copy
+ *     and duplicate-affordance questions — a product slice, not this defect.
+ *   - `start_new_draft` has NO alternative affordance anywhere. Resetting the
+ *     canvas AND minting a fresh scenario is not something the user can do from
+ *     any other control, and the notice's copy explicitly instructs them to do it.
+ *
+ * So: this set is what the ROWS show; the union above is what the ROUTER handles.
+ * They are allowed to differ, but only on purpose and only in writing.
+ */
+const RENDERABLE_LOCAL_CHIP_IDS: ReadonlySet<string> = new Set<LocallyRoutedChipId>([
+  START_NEW_DRAFT_CHIP_ID,
+])
+
+/**
+ * Can this chip's click reach a handler that does something?
+ *
+ * The three routes, in the order the click takes them:
+ *   1. id-routed local handler   (`ConversationPanel.handleChipClick`)
+ *   2. `intent === 'undo'`       (`sendChip` → `undoDraft`, no message needed)
+ *   3. `message` / `prompt`      (`sendChip` → `dispatchAction`, the normal path)
+ *
+ * Anything else would land in `sendChip`'s final branch and throw, so it must
+ * not be rendered.
+ */
+export function isChipRenderable(chip: ActionChip): boolean {
+  if (RENDERABLE_LOCAL_CHIP_IDS.has(chip.id)) return true
+  if (chip.intent === 'undo') return true
+  return !!(chip.message || chip.prompt)
+}

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -55,6 +55,7 @@ import {
 // recordDroppedContent never throws and never changes composition output.
 import { recordDroppedContent } from '../../lib/droppedContentCounter'
 import { buildChipMeta, toLegacyChipMetadata, type ChipMeta } from './chipMeta'
+import { START_NEW_DRAFT_CHIP_ID } from './chipDispatch'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 import { extractAnswerShapeSidecar } from './answerShape'
@@ -345,8 +346,14 @@ export function inferLoadingHint(message: string, _nodeCount: number, turnType?:
  * Once a scenario has a committed turn, the ONLY thing that can produce settled
  * numbers is a draft on a FRESH scenario. That is what `startNewDraft` does, and
  * it is what the copy now promises.
+ *
+ * ROADMAP 2.138: the id now lives in `chipDispatch.ts`, beside the render
+ * predicate that has to know about it — the chip carries no `message` (there is
+ * nothing to send; `startNewDraft` sends `lastUserInputRef` on a fresh scenario),
+ * so every chip row filtered it out and the notice named a remedy it gave no
+ * button for. Re-exported here so existing importers are unaffected.
  */
-export const START_NEW_DRAFT_CHIP_ID = 'start_new_draft'
+export { START_NEW_DRAFT_CHIP_ID, RETRY_CHIP_ID } from './chipDispatch'
 
 export interface StreamedDraftEligibility {
   turnType: TurnType

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -15,6 +15,7 @@ import { ChatMessage } from './ChatMessage'
 import { SessionDivider } from '../primitives/SessionDivider'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { SuggestedChips } from './SuggestedChips'
+import { isChipRenderable } from '../chipDispatch'
 import type { ConversationMessage, ActionChip, GraphPatchBlock } from '../types'
 import type { PatchBlockState, PatchRejectionInfo } from '../useConversation'
 
@@ -120,9 +121,11 @@ export const ChatThread = memo(function ChatThread({
   // Get suggested chips from last assistant message
   const suggestedChips = lastAssistantMsg?.actionChips ?? []
   // Only hide inline chips when SuggestedChips will actually render something.
-  // SuggestedChips filters out chips without a message field (e.g. retry chips),
-  // so hideChips must mirror that filter — otherwise retry chips vanish entirely.
-  const suggestedChipsWillRender = suggestedChips.some(c => !!c.message)
+  // ROADMAP 2.138: this used to be a THIRD hand-written copy of the render rule
+  // (`!!c.message`) that had already drifted from SuggestedChips' own copy
+  // (`message || prompt`). It now calls the same predicate the row calls, so the
+  // mirror cannot drift again.
+  const suggestedChipsWillRender = suggestedChips.some(isChipRenderable)
 
   return (
     <div

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -24,6 +24,7 @@ import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
 import { useCanvasStore } from '../../store'
 import { type FreshnessDisplaySemantic } from '../../store/analysisFreshness'
 import { useAnalysisTrust } from '../../hooks/useAnalysisTrust'
+import { isChipRenderable } from '../chipDispatch'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
@@ -264,7 +265,12 @@ export function SuggestedChips({
   // Ruled doctrine D-K (closed 15 Jul): 0-3 suggested action chips — render
   // up to 3 when offered, none when none offered (no filler). Supersedes the
   // DS v5 §21.4 "max 2" cap; the DS doc amendment is owned by the DS-1 lane.
-  const visible = polished.filter(c => !!(c.message || c.prompt)).slice(0, 3)
+  //
+  // ROADMAP 2.138: the dispatchability guard is `isChipRenderable`, shared with
+  // ActionChipRow and ChatThread. It used to be an inline `!!(message || prompt)`
+  // here, which dropped the terminal notices' `start_new_draft` chip — a chip
+  // ConversationPanel routes by id and which therefore carries no message.
+  const visible = polished.filter(isChipRenderable).slice(0, 3)
   if (visible.length === 0) return null
 
   const disabled = isThinking || isHistorical


### PR DESCRIPTION
Closes ROADMAP **2.138**. **DO NOT MERGE** — awaiting review.

Both terminal draft notices (`STOPPED_DRAFT_NOTICE`, `UNSETTLED_DRAFT_NOTICE`) carried a `Start a new draft` chip in their message object and rendered **no button**. The notice named the remedy and gave the user nothing that performs it. Found by 2.134's live probe (§6): the chip wrapper rendered **empty**. Newly one-click-reachable since #527 mounted Stop on the live composer.

Full evidence: `PHASE0-EVIDENCE-2026-07-28/fix-2138-chip.md`.

## Root cause — one rule, three hand-written copies, none aware of a third chip class

A chip row must not render a chip nothing can act on (`sendChip` throws on a message-less chip). Correct in principle. But the predicate existed **three times over**, each different:

| site | its copy of the rule | knows `undo`? | knows `prompt`? | knows id-routed? |
|---|---|---|---|---|
| `SuggestedChips.tsx:267` — **the live row** | `!!(c.message \|\| c.prompt)` | ✗ | ✓ | ✗ |
| `ActionChipRow.tsx:38` | `c.intent === 'undo' \|\| !!c.message` | ✓ | ✗ | ✗ |
| `ChatThread.tsx:123` — hide-inline mirror | `!!c.message` | ✗ | ✗ | ✗ |

A click has **three** routes and the filters knew two. The third is `ConversationPanel.handleChipClick`'s **id-route to a local handler**, taken *before* `sendChip` is reached. Those chips carry **no `message` by design** — there is nothing to send; `startNewDraft` resets the canvas, mints a fresh scenario, and sends `lastUserInputRef`. Class 3 was invisible to every copy of the rule: a hand-maintained mirror of a contract that grew a branch upstream (traps 12 + 16).

## Layer verdict: the FILTER was over-narrow. The chip's shape was right.

**Rejected — bolt a `message` onto the chip.** `ActionChip.message` is documented as *"Message sent to orchestrator when chip is tapped"* and this chip never sends it (`startNewDraft` calls `sendTurn`, not `dispatchAction`). The field would exist only to fool a guard — and it would make the failure mode *quieter*: today a lost id-route makes the chip **throw loudly** in `sendChip`; with a decoy `message` it would silently POST that text as a continuation turn on the committed scenario, which is **exactly the F3 defect #525 removed the `retry` chip for**.

**Derived from the working chips.** CEE-sent chips carry `message`/`prompt` because `sendChip` dispatches them — shape follows the handler. The `undo` chip carries **no** message and renders anyway, because `sendChip` handles it locally, and `ActionChipRow`'s filter already carried a bespoke `c.intent === 'undo' ||` exception for it. **So the codebase's own contract is: widen the filter for locally-handled classes.** `undo` is the precedent; the id-routed class is the one nobody widened for.

## The fix

- New `chipDispatch.ts` — the ids, the renderable set, and one `isChipRenderable` predicate, adjacent so the mirror has a single copy.
- All three former copies call it.
- `handleChipClick`'s id-router is now typed `Record<LocallyRoutedChipId, () => void | Promise<void>>`, so **adding an id without wiring a handler is a typecheck error** rather than a silently dead chip — which is how this chip got here. Mutation-proven (M3 below).

### Scope: `retry` is locally routed but deliberately NOT renderable yet

Minted at **nine** sites, and every one of those bubbles already has a retry affordance — `MessageActions`' hover/focus `Retry` (`ChatMessage.tsx:99`), plus "Not delivered → Retry" on the failed-send path (`MessageBubble.tsx:171`), both wired to the same `retryLast`. Rendering it is a nine-surface product slice with duplicate-affordance questions, not this defect. `start_new_draft` has **no** alternative affordance anywhere and its copy instructs the user to use it. Consequence, and the signal the scoping is deliberate: the two existing specs pinning the retry drop stay **green**, and **no existing spec was edited**.

## The pin — render-level, both notices

New `terminalNoticeChipRender.spec.tsx` (6 tests). Why a new file: `streamedDraftTurn.spec.ts:980` pins the chip on the **message object**, which a chip nobody can see satisfies perfectly — and `narrationHonesty.invariant.spec.ts:392` has a test named *"neither notice promises an action the handler cannot perform (F3)"* whose body only asserts the **copy** matches `/start a new draft/i`. **The suite that exists to prevent this defect is itself an instance of it.**

So: the real `ConversationPanel`, the real notice constants, both notices via `describe.each`, asserting the button is in the DOM and that clicking it reaches `startNewDraft` and **not** `sendChip` (pinning the route, not just the outcome), each preceded by a trap-13 positive control that the bubble is visible at all. Plus two negative controls so the widening cannot decay into "render everything".

**RED first:** `5 failed | 1 passed` — the one pass is the negative control, which is the right RED shape: it proves the failures were the product, not a broken assertion. **GREEN after:** `6 passed`.

## Mutation-check — four mutants, all bite

| # | mutant | measured |
|---|---|---|
| M1 | re-narrow the **live** row back to `!!(c.message \|\| c.prompt)` | **5 RED** — identical to the pre-fix RED |
| M2 | strip `START_NEW_DRAFT_CHIP_ID` from the renderable set | **5 RED** |
| M3 | add an unhandled id to `LocallyRoutedChipId` | **`ConversationPanel.tsx(153,13): TS2741`** — absent from the unmutated run |
| M4 | delete the guard (`isChipRenderable → true`) | **2 RED** — exactly the two negative controls |

M4 matters as much as M1: without it, "the chip renders" would also pass under a renderer that had simply stopped filtering.

## Gates

- **`pnpm run typecheck` PASSED** — phase 1: 3056/3096 tracked files loaded; phase 2: **within baseline, 622 files / 2510 errors, no `--update-baseline`**. The first attempt correctly **REDded** on 5 new errors, all in the new spec (missing `onAttach`, an over-narrow `Mock` annotation); production files contributed **zero**. Fixed at source.
- **164 affected spec files / 2307 tests green, 0 failed** — the complete `ConversationPanel`/`ChatThread`/`SuggestedChips`/`ActionChipRow`/`START_NEW_DRAFT` consumer set, including `streamedDraftTurn`, `narrationHonesty.invariant` and `AIInputBar.stopControl`.
- **eslint: 0 errors** on changed files (15 pre-existing warnings, none on new lines).

## ⚠ Correction to 2.134 §6, for the reviewer

2.134 named "both chip renderers". Both predicates do drop the chip — but **`ActionChipRow` has ZERO production render sites**. Complete manifest of every non-test read of `message.actionChips` (evidence §2): exactly **one** render path, `ChatThread.tsx:122 → SuggestedChips`. `ActionChipRow` is imported by two spec files and nothing else; `MessageBubble` still declares `hideChips` and never uses it. **A fix applied only where 2.134 pointed first would have changed nothing a user sees.** Its deadness is reported, not resolved (deleting it also deletes two spec files) — worth a hygiene row.

## Not established

- **No live proof.** jsdom cannot prove visibility (trap 3) — this is a DOM-presence + wiring pin. A staging probe on the stopped-draft path has not been run.
- `startNewDraft`'s own behaviour is unchanged and re-verified nowhere here; #525 round 2 pins it. This PR makes it *reachable*.
- The nine `retry` mint sites still render no chip — scoped out on purpose.
- **ROADMAP 2.133 left rowed.** (a) The stale-brief premise — *"a later chat message becomes the redraft brief if an OLDER chip is clicked"* — **could not be reproduced on the live render path**: `ChatThread` sources chips from `lastAssistantMsg` only, so a superseded notice's chip unmounts, and while a newer turn is in flight the row is `disabled = isThinking`. Its premise should be re-derived before sizing (it may be partly withdrawable), and note it would *not* hold if `ActionChipRow` were re-mounted. (b) The "the structure is still here" wording preceding a `resetCanvas()` **is** real and this PR makes it reachable for the first time, so it should be prioritised — but it is pinned as a literal in the honesty suite and the row sequences the reword *after* (a). Evidence §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
