### PR TITLE
feat(ui): contested-edge slice 1 — edge.validation through all ingestion hops (2.146, flag off)

### DIFF
--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -17,6 +17,7 @@ import { validateNodesBatch } from '../../domain/nodes'
 import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../../domain/analyticalChange'
 import type { PatchOperation, GraphPatchBlock } from '../types'
 import type { EffectDirection, CEEAnalysisReady, CEEInterventionV3 } from '../../../adapters/cee/types'
+import type { ValidationMetadata } from '../../domain/validation'
 
 // ---------------------------------------------------------------------------
 // Operation sort order — ensures nodes exist before edges reference them,
@@ -153,8 +154,22 @@ function buildEdge(op: PatchOperation) {
   // GONE after the next `edit_graph` receipt touching the edge, with no error
   // anywhere. Kept byte-for-byte equivalent to hop 1's extraction, and pinned in
   // lockstep by src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts.
+  //
+  // The cast is a DECLARED BOUNDARY ASSUMPTION, not a validated narrowing, and it
+  // matches how every existing reader and the one existing writer of this field
+  // already treat it: the wire schema is `z.unknown().optional()` on purpose
+  // (`domain/edges.ts:270-273` — the UI deliberately does not re-declare CEE's
+  // shape), while the canvas `data` bag types it `ValidationMetadata`
+  // (`domain/edges.ts:293-296`) so consumers can read it. Every consumer
+  // null-guards before use — `StyledEdge` requires `status`, `user_action` AND a
+  // non-null `max_divergence` before it styles anything, and `RelationshipsSection`
+  // requires `status` + `user_action` — so a malformed payload degrades to "not
+  // contested" rather than throwing. Runtime-validating the shape here would be a
+  // fourth mirror of a contract that already lives in two repos.
   const validation =
-    d.validation !== undefined && d.validation !== null ? d.validation : undefined
+    d.validation !== undefined && d.validation !== null
+      ? (d.validation as ValidationMetadata)
+      : undefined
 
   return {
     id: op.target_id,

--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -146,6 +146,16 @@ function buildEdge(op: PatchOperation) {
       ? Math.max(0, Math.min(1, d.exists_probability as number))
       : undefined
 
+  // Two-pass validation metadata (ROADMAP 2.146) — HOP 2 OF 3, and the reason
+  // this line exists at all is that this function is the hand-mirrored twin of
+  // mapDraftEdgeToCanvas. Adding `validation` only there would have produced the
+  // worst kind of bug: contested markers present after a fresh draft and silently
+  // GONE after the next `edit_graph` receipt touching the edge, with no error
+  // anywhere. Kept byte-for-byte equivalent to hop 1's extraction, and pinned in
+  // lockstep by src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts.
+  const validation =
+    d.validation !== undefined && d.validation !== null ? d.validation : undefined
+
   return {
     id: op.target_id,
     source,
@@ -162,6 +172,7 @@ function buildEdge(op: PatchOperation) {
       ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
       ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
       ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      ...(validation !== undefined ? { validation } : {}),
       // Set-vs-defaulted markers — see domain/edgeValueProvenance.ts. Omitted
       // when the patch carried no value, so an operation that supplies neither
       // leaves the edge honestly marked as unset rather than claiming a

--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -179,14 +179,20 @@ function contestedStyleSignature(s: React.CSSProperties) {
   return { stroke: s.stroke, strokeDasharray: s.strokeDasharray }
 }
 
+/** The same edge data with its `validation` key removed — the control render. */
+function withoutValidation(data: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...data }
+  delete copy.validation
+  return copy
+}
+
 /**
  * Assert `data` renders IDENTICALLY to the same data with `validation` removed.
  * Returns both signatures so a caller can add a sharper assertion on top.
  */
 function expectStyledAsIfNoValidation(data: Record<string, unknown>) {
   const withValidation = contestedStyleSignature(renderEdge(data))
-  const { validation: _dropped, ...withoutValidation } = data
-  const control = contestedStyleSignature(renderEdge(withoutValidation))
+  const control = contestedStyleSignature(renderEdge(withoutValidation(data)))
   expect(withValidation).toEqual(control)
   return { withValidation, control }
 }
@@ -242,8 +248,7 @@ describe('StyledEdge — contested visual styling', () => {
       validation: makeValidation({ max_divergence: 0.6 }),
     }
     const withValidation = contestedStyleSignature(renderEdge(data))
-    const { validation: _dropped, ...bare } = data
-    const control = contestedStyleSignature(renderEdge(bare))
+    const control = contestedStyleSignature(renderEdge(withoutValidation(data)))
 
     expect(withValidation).not.toEqual(control)
     expect(withValidation.stroke).toContain('--semantic-warning')

--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -155,6 +155,42 @@ function renderEdge(data: Record<string, unknown>) {
   return capturedStyle!
 }
 
+// ── The three-way pin's negative arms (ROADMAP 2.146) ───────────────────────
+//
+// ⚠ THESE NEGATIVE ARMS USED TO BE VACUOUS, and the slice that finally fed this
+// component real data is what exposed it. Four cases below asserted
+// `expect(style.stroke).not.toContain('--semantic-info')` — but the contested
+// branch in StyledEdge emits `--semantic-warning`, never `--semantic-info`
+// (`--semantic-info` belongs to the *highlighted* branch). So those assertions
+// passed for edges that WERE styled contested: they were measuring nothing.
+// Classic broken alarm — the arm that is supposed to prove "an uncontested edge
+// looks untouched" could not fail.
+//
+// Replaced with a DIFFERENTIAL assertion instead of a second hand-written copy of
+// the component's colour/dash formula (that would be a mirror, and it would drift
+// the first time the formula is tuned): render the same edge data with and
+// without its `validation` key and require the two to be byte-identical on every
+// style channel the contested branch can touch. That is literally the brief's
+// third arm — "absent `validation` renders exactly as today" — and it fails the
+// moment contested styling leaks onto an edge that should not have it.
+
+/** Every style channel the contested branch in StyledEdge can write. */
+function contestedStyleSignature(s: React.CSSProperties) {
+  return { stroke: s.stroke, strokeDasharray: s.strokeDasharray }
+}
+
+/**
+ * Assert `data` renders IDENTICALLY to the same data with `validation` removed.
+ * Returns both signatures so a caller can add a sharper assertion on top.
+ */
+function expectStyledAsIfNoValidation(data: Record<string, unknown>) {
+  const withValidation = contestedStyleSignature(renderEdge(data))
+  const { validation: _dropped, ...withoutValidation } = data
+  const control = contestedStyleSignature(renderEdge(withoutValidation))
+  expect(withValidation).toEqual(control)
+  return { withValidation, control }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('StyledEdge — contested visual styling', () => {
@@ -197,61 +233,69 @@ describe('StyledEdge — contested visual styling', () => {
     expect(style.strokeDasharray).toBe('2.7 3')
   })
 
+  it('POSITIVE CONTROL: a contested edge does NOT render as if validation were absent', () => {
+    // Without this, every negative arm below could pass by comparing two
+    // identically-broken renders. This proves the differential helper CAN fail.
+    const data = {
+      weight: 0.5,
+      direction: 'positive',
+      validation: makeValidation({ max_divergence: 0.6 }),
+    }
+    const withValidation = contestedStyleSignature(renderEdge(data))
+    const { validation: _dropped, ...bare } = data
+    const control = contestedStyleSignature(renderEdge(bare))
+
+    expect(withValidation).not.toEqual(control)
+    expect(withValidation.stroke).toContain('--semantic-warning')
+    expect(control.stroke).not.toContain('--semantic-warning')
+  })
+
   it('resolved contested edge reverts to standard non-contested style', () => {
-    const style = renderEdge({
+    const { withValidation } = expectStyledAsIfNoValidation({
       weight: 0.5,
       direction: 'positive',
       beliefExists: 0.8,
       validation: makeValidation({ user_action: 'accepted_pass2' }),
     })
-
-    // Should NOT have info colour — falls back to direction-based stroke
-    expect(style.stroke).not.toContain('--semantic-info')
-    // Should NOT have contested dash; with beliefExists set, existenceCertainty returns null (mocked)
-    // so it falls back to visualProps.strokeDasharray (undefined)
-    expect(style.strokeDasharray).toBeUndefined()
+    // Kept from the original case: with beliefExists set, existenceCertainty
+    // returns null (mocked) so the dash falls back to visualProps (undefined).
+    expect(withValidation.strokeDasharray).toBeUndefined()
   })
 
   it('missing max_divergence on contested edge falls back to non-contested style', () => {
     const validation = makeValidation()
     delete (validation as any).max_divergence
-    const style = renderEdge({
+    expectStyledAsIfNoValidation({
       weight: 0.5,
       direction: 'positive',
       validation,
     })
-
-    // Should NOT render contested styling when max_divergence is absent
-    expect(style.stroke).not.toContain('--semantic-info')
   })
 
   it('null max_divergence on contested edge falls back to non-contested style', () => {
-    const style = renderEdge({
+    expectStyledAsIfNoValidation({
       weight: 0.5,
       direction: 'positive',
       validation: makeValidation({ max_divergence: null }),
     })
-
-    expect(style.stroke).not.toContain('--semantic-info')
   })
 
   it('absent validation renders standard style', () => {
-    const style = renderEdge({
+    // Degenerate arm of the same differential: with no `validation` key the two
+    // renders are the same input, so this pins that the component does not read
+    // anything else off the key's absence.
+    expectStyledAsIfNoValidation({
       weight: 0.5,
       direction: 'positive',
     })
-
-    expect(style.stroke).not.toContain('--semantic-info')
   })
 
   it('agreed validation status renders standard style', () => {
-    const style = renderEdge({
+    expectStyledAsIfNoValidation({
       weight: 0.5,
       direction: 'positive',
       validation: makeValidation({ status: 'agreed' }),
     })
-
-    expect(style.stroke).not.toContain('--semantic-info')
   })
 
   it('max_divergence 0 produces minimal dash width (1.5) and gap (4)', () => {

--- a/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * ROADMAP 2.146 — `edge.validation` survives ALL THREE canvas ingestion hops.
+ *
+ * The contested-edge render surface in `StyledEdge` has existed and been tested
+ * since Brief 5.7, reading `edge.data.validation`. Nothing on the DRAFT path ever
+ * populated that key: `mapDraftEdgeToCanvas` extracts wire edge fields by a
+ * hand-maintained list ("no blind spread") and `validation` was not on it. So the
+ * styling was real, its tests were real, and the field they styled never arrived.
+ *
+ * There are three hops, and they fail differently — a test covering one says
+ * nothing about the others:
+ *
+ *   1. `mapDraftEdgeToCanvas`  (applyDraftResult.ts) — full draft ingestion.
+ *   2. `buildEdge`             (conversation/utils/applyPatch.ts) — a HAND-MIRRORED
+ *      COPY of hop 1, used on `edit_graph` receipts. A field added only to hop 1
+ *      is present after a draft and VANISHES on the next patch touching the edge.
+ *      That is the drift this suite exists to catch, and it is the failure mode
+ *      nobody notices, because it needs two turns to appear.
+ *   3. `overlayEdge`           (mergeAppliedGraph.ts) — DERIVED from hop 1, so it
+ *      follows automatically. But its baseline filter deliberately UNDER-applies:
+ *      a mapped value equal to the mapper default counts as "the wire did not send
+ *      this". That makes "`validation` has NO entry in DEFAULT_EDGE_DATA" a
+ *      load-bearing property rather than an omission, and it is pinned here.
+ *
+ * Every absence assertion below is paired with the presence it denies (trap 13).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { mapDraftEdgeToCanvas } from '../applyDraftResult'
+import { DEFAULT_EDGE_DATA } from '../../domain/edges'
+
+// ── The wire shape CEE's validation pipeline emits (abridged to the fields the
+//    UI's render surface and card actually read). Not a re-declaration of the
+//    contract: this suite asserts the object arrives INTACT, by identity of
+//    content, so it never needs to know the full field list.
+const WIRE_VALIDATION = {
+  status: 'contested',
+  contested_reasons: ['strength_band_change'],
+  pass1: { strength_mean: 0.3, strength_std: 0.1, exists_probability: 0.8 },
+  pass2: {
+    strength_mean: 0.7,
+    strength_std: 0.15,
+    exists_probability: 0.9,
+    reasoning: 'The brief implies a weaker link than the draft assumed.',
+    basis: 'brief_explicit',
+    needs_user_input: false,
+  },
+  max_divergence: 0.4,
+  distance_to_goal: 1,
+  evoi_rank: null,
+  evoi_impact: null,
+  was_shown: false,
+  user_action: 'pending',
+  resolved_value: null,
+  resolved_by: 'default',
+} as const
+
+/** A V3 causal edge as CEE puts it on the wire, with validation attached. */
+const WIRE_EDGE = {
+  from: 'factor-1',
+  to: 'goal-1',
+  strength: { mean: 0.3, std: 0.1 },
+  exists_probability: 0.8,
+  effect_direction: 'positive',
+  edge_type: 'directed',
+  validation: WIRE_VALIDATION,
+}
+
+describe('edge.validation — hop 1: mapDraftEdgeToCanvas (draft ingestion)', () => {
+  it('carries validation through to edge data, intact', () => {
+    const mapped = mapDraftEdgeToCanvas({ ...WIRE_EDGE }, 0)
+    expect(mapped.data.validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('omits the key entirely when the wire carries no validation', () => {
+    // POSITIVE CONTROL for the assertion below: the same mapper DOES produce the
+    // key when the wire supplies it (previous test), so `not.toHaveProperty`
+    // here is measuring absence rather than measuring nothing.
+    const mapped = mapDraftEdgeToCanvas({ from: 'a', to: 'b', weight: 0.5 }, 0)
+    expect(mapped.data).not.toHaveProperty('validation')
+  })
+
+  it('omits the key for an explicit null (a cleared field is not a value)', () => {
+    const mapped = mapDraftEdgeToCanvas({ from: 'a', to: 'b', validation: null }, 0)
+    expect(mapped.data).not.toHaveProperty('validation')
+  })
+
+  it('DEFAULT_EDGE_DATA carries no validation default — hop 3 depends on this', () => {
+    // Not cosmetic. `overlayEdge` treats a mapped value equal to the mapper
+    // baseline as unsupplied; a non-undefined default here would silently stop
+    // validation metadata from ever overlaying onto an existing edge.
+    expect(DEFAULT_EDGE_DATA).not.toHaveProperty('validation')
+    const baseline = mapDraftEdgeToCanvas({ from: 'x', to: 'y' }, 0)
+    expect(baseline.data).not.toHaveProperty('validation')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hop 2 — the hand-mirrored patch builder. Needs the canvas store, so it is
+// driven through the public `applyAutoApplyPatch` entry point.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let storeNodes: any[] = []
+let storeEdges: any[] = []
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(vi.fn(), {
+    getState: () => ({
+      nodes: storeNodes,
+      edges: storeEdges,
+      outcomeNodeId: null,
+      ceeAnalysisReady: null,
+      applyLayout: vi.fn(() => Promise.resolve()),
+      setPendingLayout: vi.fn(),
+      setOutcomeNode: vi.fn(),
+      currentScenarioId: null,
+    }),
+    setState: vi.fn((update: any) => {
+      if (update.nodes) storeNodes = update.nodes
+      if (update.edges) storeEdges = update.edges
+    }),
+  }),
+}))
+
+vi.mock('../../store/scenarios', () => ({
+  saveAutosave: vi.fn(),
+}))
+
+const { applyAutoApplyPatch } = await import('../../conversation/utils/applyPatch')
+
+function seedPatchStore() {
+  storeNodes = [
+    { id: 'factor-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Spend' } },
+    { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Revenue' } },
+  ]
+  storeEdges = []
+}
+
+function addEdgePatch(data: Record<string, unknown>) {
+  return {
+    block_type: 'graph_patch' as const,
+    auto_apply: true,
+    operations: [{ op: 'add_edge' as const, target_id: 'e1', data }],
+  }
+}
+
+describe('edge.validation — hop 2: applyPatch buildEdge (edit_graph receipt)', () => {
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('carries validation through an add_edge receipt, intact', () => {
+    applyAutoApplyPatch(addEdgePatch({ ...WIRE_EDGE }) as any)
+    expect(storeEdges).toHaveLength(1)
+    expect(storeEdges[0].data.validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('omits the key when the receipt carries no validation', () => {
+    applyAutoApplyPatch(addEdgePatch({ from: 'factor-1', to: 'goal-1', weight: 0.5 }) as any)
+    expect(storeEdges[0].data).not.toHaveProperty('validation')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE MIRROR-DRIFT CATCHER
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('edge.validation — the two hand-mirrored mappers stay in lockstep', () => {
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('a full draft and a patch receipt of the SAME wire edge agree on validation', () => {
+    // THE PIN. Adding `validation` to one extraction list and not the other is
+    // invisible in every single-hop test, in typecheck, and in review — the field
+    // simply disappears one turn later. This is the assertion that notices.
+    //
+    // Deliberately compared through the two PUBLIC entry points rather than by
+    // reading the source: a comparison of two hand-written field lists would
+    // itself be a third mirror.
+    const drafted = mapDraftEdgeToCanvas({ ...WIRE_EDGE }, 0)
+    applyAutoApplyPatch(addEdgePatch({ ...WIRE_EDGE }) as any)
+    const patched = storeEdges[0]
+
+    expect(drafted.data.validation).toEqual(WIRE_VALIDATION)
+    expect(patched.data.validation).toEqual(WIRE_VALIDATION)
+    expect(patched.data.validation).toEqual(drafted.data.validation)
+  })
+
+  it('both hops agree on ABSENCE too (neither invents a default)', () => {
+    const bare = { from: 'factor-1', to: 'goal-1', weight: 0.5 }
+    const drafted = mapDraftEdgeToCanvas({ ...bare }, 0)
+    applyAutoApplyPatch(addEdgePatch({ ...bare }) as any)
+
+    expect('validation' in drafted.data).toBe(false)
+    expect('validation' in storeEdges[0].data).toBe(false)
+    // Same answer from both hops — a default appearing in one and not the other
+    // would be the same drift in the opposite direction.
+    expect('validation' in drafted.data).toBe('validation' in storeEdges[0].data)
+  })
+})

--- a/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
@@ -27,9 +27,18 @@
  * scenario resume** with a fully green suite. On the one journey every tester takes
  * daily.
  *
- * So this file pins the CLASS, at the four sites it can drive end-to-end, with the
- * absence arm alongside each presence arm (trap 13: an assertion that a field
- * survived must sit next to proof the harness can see it missing).
+ * So this file pins the CLASS at ALL FIVE sites — the amendment strictly required
+ * only the persistence hop, but the five share one failure mode and pinning three
+ * would have left the class open behind a spec that looks complete. Each presence
+ * arm sits next to its absence arm (trap 13: an assertion that a field SURVIVED
+ * proves nothing unless the harness can also see it missing).
+ *
+ * Mutation-proven at three distinct sites, not one: converting the wholesale spread
+ * to a named-field copy at `useScenario.ts:596`, at `store.ts:3538`, or at
+ * `store.ts:4327` each turns this file RED — and in the first case 139 pre-existing
+ * tests across 8 files (including both `useScenario` specs, which exercise that very
+ * function) stay GREEN. That green figure is the finding: the defect is invisible to
+ * every other test in the repo.
  *
  * ── NOT PINNED HERE, CLEARED WITH REASONING BY THE REVIEW ───────────────────
  * `ReactFlowGraph.tsx:1160-1191` (`insertBlueprint` → `commitTemplateGraphReplace`)

--- a/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * ROADMAP 2.146, amendment A1 (adversarial review of PR #532, §8) —
+ * `edge.validation` survives the FIVE REBUILD hops, not just the three ingestion
+ * hops.
+ *
+ * ── WHY THIS FILE EXISTS, AND WHY ITS ABSENCE WAS THE GAP ───────────────────
+ * The three ingestion hops (draft mapper, patch builder, merge overlay) are pinned
+ * in `edgeValidationMapperMirror.spec.ts` and `mergeAppliedGraph.validation.spec.ts`.
+ * But five FURTHER sites rebuild an already-existing canvas edge's `data` from
+ * scratch, and every one of them survives only because it happens to be written as
+ * a WHOLESALE SPREAD over the defaults:
+ *
+ *   { ...DEFAULT_EDGE_DATA, ...(edge.data ?? {}) }
+ *
+ * | # | site | journey |
+ * |---|---|---|
+ * | 4 | `src/hooks/useScenario.ts:596`  | Supabase scenario load / RESUME |
+ * | 5 | `src/canvas/store.ts:3538`      | store `loadScenario` rehydrate |
+ * | 6 | `src/canvas/store.ts:4272`      | `applyRepair` |
+ * | 7 | `src/canvas/store.ts:4300`      | `applyAllRepairs` |
+ * | 8 | `src/canvas/store.ts:4327`      | `applyAutoFixChanges` |
+ *
+ * There is **no live defect** — the spread carries the field today. The gap is that
+ * NOTHING PINNED IT. Convert any one of those five to a named-field copy — the
+ * exact discipline the two ingestion mappers deliberately use, and the exact defect
+ * class the hop-2 mirror test exists to catch — and contested markers **vanish on
+ * scenario resume** with a fully green suite. On the one journey every tester takes
+ * daily.
+ *
+ * So this file pins the CLASS, at the four sites it can drive end-to-end, with the
+ * absence arm alongside each presence arm (trap 13: an assertion that a field
+ * survived must sit next to proof the harness can see it missing).
+ *
+ * ── NOT PINNED HERE, CLEARED WITH REASONING BY THE REVIEW ───────────────────
+ * `ReactFlowGraph.tsx:1160-1191` (`insertBlueprint` → `commitTemplateGraphReplace`)
+ * and `:1094` (user-drawn `onConnect`) ARE allow-lists over `DEFAULT_EDGE_DATA` —
+ * but their sources are a blueprint edge and a fresh user edge, both structurally
+ * incapable of carrying `validation`, and the blueprint path REPLACES the graph
+ * rather than merging. There is nothing there to drop, so a pin would assert a
+ * vacuous truth.
+ *
+ * ── SCOPE OF THE FIVE ───────────────────────────────────────────────────────
+ * The review's list is "every rebuild hop found" over the complete
+ * `DEFAULT_EDGE_DATA` consumer set (32 non-test files) plus every named journey —
+ * NOT "provably every hop that exists"; a broader edge-construction census was
+ * still running when it was written. Anything it lands later is a follow-up row,
+ * not a hole in this file.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ── Mocks for hop 4 (the Supabase scenario-load path) ───────────────────────
+// Same harness shape as src/hooks/__tests__/useScenario.goalConstraints.lifecycle
+// .spec.ts, which pins the sibling property (goal_constraints) on this same hop.
+const mockRpc = vi.fn()
+const mockSingle = vi.fn()
+let mockRowsById: Record<string, Record<string, unknown>> = {}
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: (_col: string, id: string) => ({
+          single: () => mockSingle(id),
+        }),
+      }),
+      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+    }),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
+}))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: REAL_USER_ID }, authenticated: true }),
+}))
+
+// ── Mock for hop 5 (the store's own localStorage-backed scenario load) ──────
+// importOriginal-spread, overriding ONLY `getScenario`. A hand-written stand-in
+// for this module would replace the ~20 other functions `store.ts` calls on it
+// (`setCurrentScenarioId`, `updateScenario`, `clearAutosave`, …) — the vi.mock
+// factory REPLACES the module, which is exactly the trap-12 failure that once
+// killed 51 tests in the sibling repo.
+const mockScenariosById = new Map<string, unknown>()
+vi.mock('../../store/scenarios', async (importOriginal) => {
+  const mod = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...mod,
+    getScenario: (id: string) => mockScenariosById.get(id),
+  }
+})
+
+import { useScenario } from '../../../hooks/useScenario'
+import { useCanvasStore } from '../../store'
+import type { ValidationMetadata } from '../../domain/validation'
+import type { GraphHealth } from '../../validation/types'
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const WIRE_VALIDATION = {
+  status: 'contested',
+  contested_reasons: ['sign_flip'],
+  pass1: { strength_mean: 0.6, strength_std: 0.1, exists_probability: 0.8 },
+  pass2: {
+    strength_mean: -0.2,
+    strength_std: 0.2,
+    exists_probability: 0.6,
+    reasoning: 'Direction is not supported by the brief.',
+    basis: 'domain_prior',
+    needs_user_input: true,
+  },
+  max_divergence: 0.8,
+  distance_to_goal: 1,
+  evoi_rank: null,
+  evoi_impact: null,
+  was_shown: false,
+  user_action: 'pending',
+  resolved_value: null,
+  resolved_by: 'default',
+} as unknown as ValidationMetadata
+
+const NODES = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
+  { id: 'factor-1', type: 'factor', position: { x: 0, y: 100 }, data: { kind: 'factor', label: 'Spend' } },
+]
+
+const EDGE_ID = 'factor-1::goal-1::0'
+
+/** A persisted edge as it sits in the graph JSONB / localStorage record. */
+function persistedEdge(withValidation: boolean) {
+  return {
+    id: EDGE_ID,
+    source: 'factor-1',
+    target: 'goal-1',
+    type: 'styled',
+    data: {
+      weight: 0.7,
+      direction: 'positive',
+      ...(withValidation ? { validation: WIRE_VALIDATION } : {}),
+    },
+  }
+}
+
+function scenarioRow(id: string, edges: unknown[]): Record<string, unknown> {
+  return {
+    id,
+    graph: { nodes: NODES, edges },
+    framing: null,
+    stage: 'analyse',
+    updated_at: new Date().toISOString(),
+    analysis_status: 'none',
+    analysis: null,
+    analysis_provenance: null,
+    analysis_error: null,
+    thread: null,
+    events: null,
+  }
+}
+
+/** The rebuilt edge as it ended up in the canvas store. */
+function storeEdgeData(): Record<string, unknown> {
+  const edge = useCanvasStore.getState().edges.find((e) => e.id === EDGE_ID)
+  expect(edge, `edge ${EDGE_ID} is not in the store`).toBeDefined()
+  return (edge!.data ?? {}) as Record<string, unknown>
+}
+
+/** Seed the store as though the edge were already on the canvas. */
+function seedCanvas(withValidation: boolean) {
+  useCanvasStore.setState({
+    currentScenarioId: 'scenario-1',
+    nodes: structuredClone(NODES) as never,
+    edges: [structuredClone(persistedEdge(withValidation))] as never,
+    graphHealth: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRowsById = {}
+  mockScenariosById.clear()
+  mockSingle.mockImplementation(async (id: string) =>
+    mockRowsById[id]
+      ? { data: mockRowsById[id], error: null }
+      : { data: null, error: { code: 'PGRST116' } },
+  )
+  mockRpc.mockResolvedValue({ data: {}, error: null })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HOP 4 — Supabase scenario load / RESUME (useScenario.ts:596)
+// The journey every tester takes daily, and the one the review named as most
+// likely to expose the gap.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('hop 4 — validation survives a Supabase scenario resume', () => {
+  it('an edge persisted WITH validation still carries it after loadScenario', async () => {
+    mockRowsById['scenario-A'] = scenarioRow('scenario-A', [persistedEdge(true)])
+    const { result } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.loadScenario('scenario-A')
+    })
+
+    expect(storeEdgeData().validation).toEqual(WIRE_VALIDATION)
+    // The rebuild must not have reset the rest of the edge either.
+    expect(storeEdgeData().weight).toBeCloseTo(0.7)
+  })
+
+  it('an edge persisted WITHOUT validation gains no key (the absence arm)', async () => {
+    // POSITIVE CONTROL for the assertion below is the test above: the same code
+    // path DOES produce the key when the record carries it, so this measures a
+    // real absence rather than measuring nothing.
+    mockRowsById['scenario-B'] = scenarioRow('scenario-B', [persistedEdge(false)])
+    const { result } = renderHook(() => useScenario())
+
+    await act(async () => {
+      await result.current.loadScenario('scenario-B')
+    })
+
+    expect(storeEdgeData()).not.toHaveProperty('validation')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HOP 5 — the store's own loadScenario rehydrate (store.ts:3538)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('hop 5 — validation survives the store loadScenario rehydrate', () => {
+  it('an edge in a saved scenario still carries validation after rehydrate', () => {
+    mockScenariosById.set('local-1', {
+      id: 'local-1',
+      name: 'Saved',
+      graph: { nodes: structuredClone(NODES), edges: [persistedEdge(true)] },
+      framing: null,
+    })
+
+    expect(useCanvasStore.getState().loadScenario('local-1')).toBe(true)
+    expect(storeEdgeData().validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('an edge saved WITHOUT validation gains no key', () => {
+    mockScenariosById.set('local-2', {
+      id: 'local-2',
+      name: 'Saved',
+      graph: { nodes: structuredClone(NODES), edges: [persistedEdge(false)] },
+      framing: null,
+    })
+
+    expect(useCanvasStore.getState().loadScenario('local-2')).toBe(true)
+    expect(storeEdgeData()).not.toHaveProperty('validation')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HOPS 6–8 — the repair / auto-fix rebuilds (store.ts:4272 / :4300 / :4327)
+//
+// The repair action deliberately targets a NODE, so the validation-bearing edge
+// passes through `graphRepair` untouched and reaches the `{...DEFAULT_EDGE_DATA,
+// ...edge.data}` rebuild unchanged. That rebuild is the thing under test — not
+// the repair logic.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const NODE_ONLY_FIX: GraphHealth = {
+  status: 'warnings',
+  score: 80,
+  issues: [
+    {
+      id: 'issue-1',
+      type: 'missing_label',
+      severity: 'warning',
+      message: 'Node needs a label',
+      nodeIds: ['goal-1'],
+      suggestedFix: { type: 'update_node', targetId: 'goal-1', data: { label: 'Revenue (Q4)' } },
+    },
+  ],
+}
+
+describe('hop 6 — validation survives applyRepair', () => {
+  it('keeps validation on an edge the repair did not touch', async () => {
+    seedCanvas(true)
+    useCanvasStore.setState({ graphHealth: NODE_ONLY_FIX } as never)
+
+    await useCanvasStore.getState().applyRepair('issue-1')
+
+    expect(storeEdgeData().validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('does not invent validation on an edge that had none', async () => {
+    seedCanvas(false)
+    useCanvasStore.setState({ graphHealth: NODE_ONLY_FIX } as never)
+
+    await useCanvasStore.getState().applyRepair('issue-1')
+
+    expect(storeEdgeData()).not.toHaveProperty('validation')
+  })
+})
+
+describe('hop 7 — validation survives applyAllRepairs', () => {
+  it('keeps validation on an edge the repairs did not touch', async () => {
+    seedCanvas(true)
+    useCanvasStore.setState({ graphHealth: NODE_ONLY_FIX } as never)
+
+    await useCanvasStore.getState().applyAllRepairs()
+
+    expect(storeEdgeData().validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('does not invent validation on an edge that had none', async () => {
+    seedCanvas(false)
+    useCanvasStore.setState({ graphHealth: NODE_ONLY_FIX } as never)
+
+    await useCanvasStore.getState().applyAllRepairs()
+
+    expect(storeEdgeData()).not.toHaveProperty('validation')
+  })
+})
+
+describe('hop 8 — validation survives applyAutoFixChanges', () => {
+  it('keeps validation on an edge handed to the auto-fix', () => {
+    seedCanvas(true)
+
+    useCanvasStore.getState().applyAutoFixChanges({
+      edges: [structuredClone(persistedEdge(true))] as never,
+    })
+
+    expect(storeEdgeData().validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('does not invent validation on an edge that had none', () => {
+    seedCanvas(false)
+
+    useCanvasStore.getState().applyAutoFixChanges({
+      edges: [structuredClone(persistedEdge(false))] as never,
+    })
+
+    expect(storeEdgeData()).not.toHaveProperty('validation')
+  })
+})

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.validation.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.validation.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * ROADMAP 2.146 — hop 3 of 3: `edge.validation` overlays onto an EXISTING canvas
+ * edge through `reconcileAppliedGraph` / `overlayEdge`.
+ *
+ * Separate file from `edgeValidationMapperMirror.spec.ts` because this hop needs
+ * the REAL canvas store (that suite mocks it to drive the patch builder), and a
+ * half-mocked store would prove less than either.
+ *
+ * `overlayEdge` needs no edit for this field — it derives its behaviour from
+ * `mapDraftEdgeToCanvas`. That is exactly why it needs a test: "derived, so it
+ * follows automatically" is a claim about a filter whose whole design is to
+ * SUPPRESS mapped values that match the mapper baseline. Whether `validation`
+ * lands on the suppressed side of that filter is a fact, not a corollary.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { reconcileAppliedGraph } from '../mergeAppliedGraph'
+import { useCanvasStore } from '../../store'
+
+const WIRE_VALIDATION = {
+  status: 'contested',
+  contested_reasons: ['sign_flip'],
+  pass1: { strength_mean: 0.6, strength_std: 0.1, exists_probability: 0.8 },
+  pass2: {
+    strength_mean: -0.2,
+    strength_std: 0.2,
+    exists_probability: 0.6,
+    reasoning: 'Direction is not supported by the brief.',
+    basis: 'domain_prior',
+    needs_user_input: true,
+  },
+  max_divergence: 0.8,
+  distance_to_goal: 1,
+  evoi_rank: null,
+  evoi_impact: null,
+  was_shown: false,
+  user_action: 'pending',
+  resolved_value: null,
+  resolved_by: 'default',
+} as const
+
+const EXISTING_NODES = [
+  { id: 'goal-1', type: 'goal', position: { x: 400, y: 40 }, data: { kind: 'goal', label: 'Revenue' } },
+  { id: 'factor-1', type: 'factor', position: { x: 40, y: 200 }, data: { kind: 'factor', label: 'Spend' } },
+]
+
+/** An edge already on the canvas, carrying NO validation metadata. */
+const EXISTING_EDGES = [
+  {
+    id: 'factor-1::goal-1::0',
+    source: 'factor-1',
+    target: 'goal-1',
+    type: 'styled',
+    data: { weight: 0.7, direction: 'positive' },
+  },
+]
+
+function seedCanvas(edges = EXISTING_EDGES) {
+  useCanvasStore.setState({
+    currentScenarioId: 'scenario-1',
+    nodes: structuredClone(EXISTING_NODES) as any,
+    edges: structuredClone(edges) as any,
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    history: { past: [], future: [] },
+  } as any)
+}
+
+function receipt(edgeExtras: Record<string, unknown>) {
+  return {
+    nodes: [
+      { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+      { id: 'factor-1', kind: 'factor', label: 'Spend' },
+    ],
+    edges: [
+      { id: 'factor-1::goal-1::0', from: 'factor-1', to: 'goal-1', weight: 0.7, ...edgeExtras },
+    ],
+  } as any
+}
+
+function overlaidEdge() {
+  return useCanvasStore.getState().edges.find((e) => e.id === 'factor-1::goal-1::0') as any
+}
+
+describe('reconcileAppliedGraph — edge.validation overlay (hop 3)', () => {
+  beforeEach(() => {
+    seedCanvas()
+  })
+
+  it('overlays validation onto an existing edge that had none', () => {
+    const result = reconcileAppliedGraph(receipt({ validation: WIRE_VALIDATION }))
+
+    // The overlay is an UPDATE, not an add — the edge already existed.
+    expect(result.addedEdgeCount).toBe(0)
+    expect(result.updatedEdgeCount).toBe(1)
+    expect(overlaidEdge().data.validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('preserves the local edge state the receipt did not change', () => {
+    reconcileAppliedGraph(receipt({ validation: WIRE_VALIDATION }))
+    const edge = overlaidEdge()
+    // The overlay must add metadata, not reset the edge. Weight 0.7 is the user's
+    // (and the receipt's) value; direction is local.
+    expect(edge.data.weight).toBeCloseTo(0.7)
+    expect(edge.data.direction).toBe('positive')
+  })
+
+  it('a receipt WITHOUT validation does not clear validation already on the edge', () => {
+    // Wire absence is not "clear it" — CEE omits optional fields it has no value
+    // for, and a resolved-then-reingested edge must not silently lose its
+    // metadata. POSITIVE CONTROL: the previous tests prove the same code path
+    // DOES write the key when the wire supplies it, so this is not vacuous.
+    seedCanvas([
+      {
+        ...EXISTING_EDGES[0],
+        data: { ...EXISTING_EDGES[0].data, validation: WIRE_VALIDATION },
+      } as any,
+    ])
+
+    reconcileAppliedGraph(receipt({}))
+    expect(overlaidEdge().data.validation).toEqual(WIRE_VALIDATION)
+  })
+
+  it('a receipt carrying validation for a NEW edge adds it with the metadata', () => {
+    // The add path goes through mapDraftEdgeToCanvas directly rather than through
+    // overlayEdge's baseline filter — a different branch, so a separate case.
+    useCanvasStore.setState({ edges: [] } as any)
+    reconcileAppliedGraph(receipt({ validation: WIRE_VALIDATION }))
+    expect(overlaidEdge().data.validation).toEqual(WIRE_VALIDATION)
+  })
+})

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -120,6 +120,28 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
       ? Math.max(0, Math.min(1, e.exists_probability))
       : undefined
 
+  // Two-pass validation metadata from CEE's validation pipeline (ROADMAP 2.146).
+  //
+  // ⚠ THIS IS HOP 1 OF 3, AND THE OTHER TWO MUST STAY IN STEP. `buildEdge` in
+  // src/canvas/conversation/utils/applyPatch.ts is a HAND-MIRRORED copy of this
+  // function — a field added only here is present after a full draft and VANISHES
+  // on the next graph patch that touches the edge. `overlayEdge` in
+  // mergeAppliedGraph.ts derives its baseline FROM this function, so it follows
+  // automatically. The lockstep is pinned by
+  // src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts.
+  //
+  // Carried as an OPAQUE OBJECT on purpose. It is `z.unknown()` at the UI's edge
+  // schema boundary (domain/edges.ts:273) with a typed overlay in
+  // types/validation.ts, so field-level extraction here would be a THIRD mirror
+  // of a shape this layer has no business knowing. Consumers narrow it.
+  //
+  // Omitted (not defaulted) when absent, and deliberately given NO entry in
+  // DEFAULT_EDGE_DATA: `overlayEdge` treats a mapped value equal to the mapper
+  // baseline as "the wire did not supply this", so a non-undefined default here
+  // would silently stop validation metadata overlaying onto an existing edge.
+  const validation =
+    e.validation !== undefined && e.validation !== null ? e.validation : undefined
+
   return {
     id,
     source: e.from,
@@ -136,6 +158,7 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
       ...(edgeType !== undefined ? { edge_type: edgeType } : {}),
       ...(provenanceSource !== undefined ? { provenance_source: provenanceSource } : {}),
       ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      ...(validation !== undefined ? { validation } : {}),
       // Set-vs-defaulted markers. Derived from the resolved values themselves,
       // never from "we are in the CEE mapper so it must be CEE": when the wire
       // carried no belief at all, `beliefExists` is `undefined` here and the

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -18,6 +18,7 @@ import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
 import { hasAnalysisReady } from '../../adapters/cee/types'
 import type { CEEDraftResponse, CEEGoalConstraint, CEEv2Response, CEEv3Response, EffectDirection } from '../../adapters/cee/types'
+import type { ValidationMetadata } from '../domain/validation'
 import { commitDraftCoachingToStore, edgeProvenanceDisplayPatch } from './draftIngestion'
 import { logger } from '../../lib/logger'
 import { validateNodesBatch } from '../domain/nodes'
@@ -139,8 +140,19 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
   // DEFAULT_EDGE_DATA: `overlayEdge` treats a mapped value equal to the mapper
   // baseline as "the wire did not supply this", so a non-undefined default here
   // would silently stop validation metadata overlaying onto an existing edge.
+  //
+  // The cast is a DECLARED BOUNDARY ASSUMPTION, not a validated narrowing (see
+  // the identical note in the hop-2 twin): the wire schema is
+  // `z.unknown().optional()` on purpose while the canvas `data` bag types it
+  // `ValidationMetadata`, and every consumer null-guards. Written the same way in
+  // both mappers on purpose — the two are supposed to be byte-equivalent, and a
+  // difference here would be the first crack in the mirror this comment warns
+  // about. (This function's declared return type is `any`, so TypeScript would
+  // NOT have flagged an inconsistency; the hop-2 twin is typed and does.)
   const validation =
-    e.validation !== undefined && e.validation !== null ? e.validation : undefined
+    e.validation !== undefined && e.validation !== null
+      ? (e.validation as ValidationMetadata)
+      : undefined
 
   return {
     id,


### PR DESCRIPTION
## DO NOT MERGE — pairs with CEE `Talchain/olumi-assistants-service` #758

ROADMAP **2.146**, condition **3** of the FLIP-WITH-CONDITIONS verdict in `CONTESTED-EDGE-VERDICT-2026-07-30.md`, following the ⚠-corrected three-hop reality derived in `PHASE0-EVIDENCE-2026-07-28/derive-2154-2155.md` §(d). Useless without #758 (which makes the flip affordable and the reviewer independent); #758 is invisible without this.

Branched off `1e320e5c`, re-derived as the current `staging` tip at push time. Touches only `applyDraftResult.ts`, `applyPatch.ts`, `StyledEdge.contested.spec.tsx` and two new specs — none of the files the concurrent UI quality-fix lane is working on.

---

## ⚠ Two corrections to the design of record, both found by verifying first

### 1. The render surface the brief asked me to build ALREADY EXISTS

Condition 3 ends *"Then render the contested marker per the verdict's minimal surface (badge/tint on contested edges only)"*. **It has existed since Brief 5.7.** `src/canvas/edges/StyledEdge.tsx:278-297` computes `isContested` from `edge.data.validation` and applies, at `:669-698`:

- a **divergence-scaled dash** — width `1.5 + divergence*1.5`, gap `4 + divergence*4`, tightened to gap 3 when `pass2.needs_user_input`; and
- a **warning tint** — `var(--semantic-warning)` for `needs_user_input`, else `color-mix(… --semantic-warning 70% …)`,

with a 277-line spec beside it. **So no new marker was built.** Adding a badge would have put a second, divergent contested signal on the same edge. What the surface never had was **data** — the three mapper hops are the entire gap, and they are what this PR fixes.

### 2. That surface's three-way pin had VACUOUS negative arms

Four cases in `StyledEdge.contested.spec.tsx` proved "an uncontested edge is unstyled" with:

```ts
expect(style.stroke).not.toContain('--semantic-info')
```

**The contested branch never emits `--semantic-info`.** It emits `--semantic-warning`; `--semantic-info` belongs to the *highlighted* branch (`StyledEdge.tsx:697`). Those four assertions passed for edges that WERE styled contested — a broken alarm sitting exactly where this slice's user-visible claim rests.

Replaced with a **differential** assertion rather than a second hand-written copy of the colour/dash formula (that would be a mirror, and would drift the first time the formula is tuned): render the same edge data with and without its `validation` key and require byte-equality on every style channel the contested branch can write. That is literally the brief's third arm — *"absent `validation` renders exactly as today"*. A positive control proves the helper can fail, and the vacuity is **demonstrated** by mutation U4 below, not asserted.

---

## The change — three hops, and they fail differently

| hop | file | change |
|---|---|---|
| 1 — draft ingestion | `src/canvas/utils/applyDraftResult.ts` (`mapDraftEdgeToCanvas`) | extract `validation`; omit for `undefined`/`null` |
| 2 — patch receipt | `src/canvas/conversation/utils/applyPatch.ts` (`buildEdge`) | the same extraction, byte-equivalent, **in lockstep** |
| 3 — merge overlay | `src/canvas/utils/mergeAppliedGraph.ts` (`overlayEdge`) | **no edit** — derived from hop 1, but pinned by test |

**Hop 2 is the one that matters and the one that is easy to miss.** `buildEdge` is labelled in-file *"Edge builder — mirrors applyDraftResult.ts"* and carries the identical *"no blind spread"* comment. A field added only to hop 1 is present after a full draft and **vanishes on the next `edit_graph` receipt touching that edge** — no error, no type failure, no single-hop test failure. It needs two turns to appear. Hence one test whose whole job is to notice: the same wire edge through both public entry points must agree on `validation`, and on its absence.

**Hop 3 needs no edit but needs a test.** `overlayEdge` derives its baseline by calling `mapDraftEdgeToCanvas` on a bare edge and applies only keys whose mapped value DIFFERS from that baseline. It deliberately **under-applies**. So *"`validation` has no entry in `DEFAULT_EDGE_DATA`"* is a load-bearing property, not an omission — a non-undefined default there would silently stop validation metadata ever overlaying onto an existing edge. Pinned, and mutation-checked (U3).

The value is carried as an **opaque object**. It is `z.unknown().optional()` at the UI's edge schema boundary (`domain/edges.ts:270-273`) with a typed overlay at `:293-296`; field-level extraction in the mappers would be a third mirror of a contract that already lives in two repos. Every consumer null-guards — `StyledEdge` requires `status` + `user_action` + a non-null `max_divergence` before it styles anything, `RelationshipsSection` requires `status` + `user_action` — so a malformed payload degrades to "not contested" rather than throwing.

## Schema

**No re-vendor, no pin move**, verified at the resolved bytes: `DraftGraphBlockSchema` (`dist/boundary/blocks.js:206-221`) is `.strict()` at the block level but `edges: z.array(z.unknown())`. Note the precise form — 0.30.0 does not *declare* `edge.validation`; it **permits any edge key**. Same conclusion, but "carries it" would be a false claim if repeated.

## RED-first + mutation results

Throwaway worktree **outside** the clone root, `node_modules` symlinked from the clone so the same lockfile is measured, removed before gates.

| mutation | result |
|---|---|
| U1 — revert hop 1 only | 🔴 **4 failed** across both hop suites (hop 3 falls with it — it is derived) |
| **U2 — revert hop 2 only** | 🔴 **2 failed**, and **hop 1 + hop 3 stayed GREEN.** This is the mirror drift: without the lockstep test it passes every single-hop test, typecheck and review |
| U3 — add a `validation` default to `DEFAULT_EDGE_DATA` | 🔴 **5 failed** — the "no default" pin bites in both mappers and in the baseline probe |
| U4 — break the contested gate so styling leaks onto agreed/resolved edges | **arm A (new differential arms): 🔴 2 failed** · **arm B (the ORIGINAL `--semantic-info` arms, same mutation, spec restored from `1e320e5c`): 🟢 only 1 failed** — the four `not.toContain('--semantic-info')` arms all passed with contested styling leaking onto them. **Vacuity proven.** The fix strictly increases sensitivity: "agreed validation status renders standard style" goes from vacuous-pass to RED |
| restored | 🟢 **94 passed** (the 3 new/edited specs + the 3 pre-existing neighbours) |

## One real type error, fixed at the source — not baselined

The first gate run **failed, correctly**:

```
+ src/canvas/conversation/utils/applyPatch.ts (1 error(s))
  TS2322 … The types of 'data.validation' are incompatible between these types.
    Type '{} | undefined' is not assignable to type 'ValidationMetadata | undefined'.
Total typecheck errors increased: baseline=2510 current=2511 (+1).
```

`EdgeData` is `z.infer<EdgeDataSchema> & { validation?: ValidationMetadata }` — the Zod schema deliberately says `z.unknown()`, the TS overlay says `ValidationMetadata`. Fixed with a **documented declared boundary assumption**, matching how every existing reader and the single existing writer (`ModelTabBody.handleResolveContested`) already treat this field.

**And hop 1 did NOT error — that is itself a finding.** `mapDraftEdgeToCanvas` is declared `(e: any, i: number): any`, so TypeScript could not have flagged an inconsistency between the two mirrored mappers. Only the typed twin fails loud. Both are written identically anyway; a difference there would be the first crack in the mirror.

## Gates

| gate (Staging Gate job) | result |
|---|---|
| `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) | ✅ **PASSED** — coverage 3065/3105 tracked TS files loaded (40 declared out of scope); ratchet **622 files / 2510 errors, identical to baseline** |
| `pnpm run lint` | ✅ exit 0 (0 errors; the repo's standing 1041 warnings unchanged) |
| `pnpm run ci:guard:zustand` (React-185) | ✅ no unsafe shallow imports or bare object selectors in `src/canvas` |
| `pnpm run ci:guard:starters` | ✅ all starter fixtures + manifest match their source captures |
| `pnpm run typecheck:selftest` | ✅ **18 passed, 0 failed** (incl. every MUTANT arm) |
| full vitest suite | see the run recorded in the evidence file |

Run with `VITE_SUPABASE_URL=http://localhost` / `VITE_SUPABASE_ANON_KEY=test` — trap 2b: without them 7 inspector-v2 specs fail at COLLECT and the suite silently shrinks, so any coverage number measured without them is void.

## Slice-2 design input (reported, not built)

The complete `edge.validation` payload — all 24 leaf fields across 7 groups, with a byte-exact example produced by running CEE's real producer chain — is enumerated in `PHASE0-EVIDENCE-2026-07-28/contested-edge-slice.md` Part C, together with four findings slice 2 must design around. The two that change scope:

1. **⚠ `surfaced` is declared-but-never-sent, and a live gate reads it.** `src/types/validation.ts:91` declares `surfaced: boolean` **required**; **CEE never emits it**. The Model tab is fine (`RelationshipsSection` gates on `status` + `user_action` only), but the **pre-analysis** panel gates on it (`usePreAnalysisData.ts:887`, `:1042`) and will therefore drop **every** contested edge — that surface renders nothing even with the whole chain wired. Not fixed here (out of scope, and it is a product decision whether the cap policy belongs UI-side or producer-side). **Rowed for slice 2.** Platform hazard 1 in the flesh, and a TS-only lie: no runtime validator sees it.
2. **Six fields CEE sends that the UI's type does not declare** — `pass2_adjusted`, `bias_correction`, `sign_unstable`, `pass2_missing`, `pass2.lint_corrected`, `validation_lint_log`. They arrive and survive (`z.unknown()` + `.passthrough()`), they are just invisible to the UI's types. Notably `pass2_adjusted` is the trio the comparator actually decides on, so a slice-2 "what the reviewer thinks" number is probably that, not raw `pass2`.

**No explanation/resolve UI was built** — per the brief's scope guard.

## Not determined — declared gaps

- **No live staging verification, and none possible from this lane:** `CEE_VALIDATION_PIPELINE_ENABLED=false` on cee-staging and this lane changed no env on any service. The end-to-end claim rests on the traced hops plus unit pins.
- **jsdom cannot prove visibility** (trap 3). The render arms assert the STYLE PROPS handed to `BaseEdge`; that a contested edge is visibly distinguishable on a real canvas needs a browser and is not claimed here.
- **The decision-rule probe is NOT run** (flag on, staging, ≥5 real drafts): ~0% contested ⇒ revert as NOT-WORTH-IT; >80% ⇒ hold user exposure and retune thresholds first; the useful band ships. Post-merge, not this lane.
- **The pre-analysis contested surface stays dark** after this PR, for the `surfaced` reason above. The Model tab and the canvas edge styling do not.

Evidence: `PHASE0-EVIDENCE-2026-07-28/contested-edge-slice.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
