### PR TITLE
refactor(ui): apply the /simplify sweep findings — behaviour-preserving only [DO NOT MERGE — for review]

### DIFF
--- a/src/__fixtures__/resultsPanelV7.minimal.hook.ts
+++ b/src/__fixtures__/resultsPanelV7.minimal.hook.ts
@@ -81,8 +81,6 @@ export const minimalFixture: ResultsSectionDataReturn = {
   isError: false,
   goalLabel: 'Success metric',
   goalNodeId: 'goal-success',
-  // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-  // fixture predates the Resolve next view and asserts nothing about it.
   voiRanking: null,
 }
 

--- a/src/__fixtures__/resultsPanelV7.normalised.hook.ts
+++ b/src/__fixtures__/resultsPanelV7.normalised.hook.ts
@@ -181,8 +181,6 @@ export const normalisedFixture: ResultsSectionDataReturn = {
   isError: false,
   goalLabel: 'Revenue growth',
   goalNodeId: 'goal-revenue',
-  // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-  // fixture predates the Resolve next view and asserts nothing about it.
   voiRanking: null,
 }
 

--- a/src/__fixtures__/resultsPanelV7.rich.hook.ts
+++ b/src/__fixtures__/resultsPanelV7.rich.hook.ts
@@ -193,8 +193,6 @@ export const richFixture: ResultsSectionDataReturn = {
   isError: false,
   goalLabel: 'Annual recurring revenue',
   goalNodeId: 'goal-arr',
-  // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-  // fixture predates the Resolve next view and asserts nothing about it.
   voiRanking: null,
 }
 

--- a/src/__fixtures__/v7EvidenceModel.ts
+++ b/src/__fixtures__/v7EvidenceModel.ts
@@ -1,0 +1,27 @@
+/**
+ * Fixture: `V7EvidenceModel` builder.
+ *
+ * ONE partial-over-defaults builder for the V7 evidence disclosure's model,
+ * shared by every suite that renders `<V7EvidenceDisclosure/>`. Three specs
+ * carried byte-identical private copies (the base suite, the projection suite,
+ * the Resolve-next suite) and the copies had ALREADY started to drift within one
+ * PR — each needed the same `resolveNext: null` default added, in three places,
+ * with the same two-line rationale repeated. That is the hand-maintained mirror
+ * (trap 12) in fixture form: the next field added to `V7EvidenceModel` is a
+ * required-key compile error in N spec files instead of one.
+ *
+ * `null` for `resolveNext` is the HONEST-GATE verdict, not an empty ranking —
+ * the distinction is documented on the field declaration in `buildV7Lenses.ts`.
+ */
+
+import type { V7EvidenceModel } from '../components/results/v7/buildV7Lenses'
+
+export function v7EvidenceModel(partial: Partial<V7EvidenceModel> = {}): V7EvidenceModel {
+  return {
+    drivers: partial.drivers ?? [],
+    flipRisks: partial.flipRisks ?? [],
+    tradeOffs: partial.tradeOffs ?? [],
+    resolveNext: partial.resolveNext ?? null,
+    designationsWithheld: partial.designationsWithheld ?? false,
+  }
+}

--- a/src/components/auth/DevRoutesGuard.tsx
+++ b/src/components/auth/DevRoutesGuard.tsx
@@ -1,0 +1,46 @@
+/**
+ * TESTER-SAFE ROUTING — the developer scaffolding is behind one condition.
+ *
+ * Layout guard for the developer-surface routes in `src/poc/AppPoC.tsx`.
+ * `/plot`, `/plot-legacy`, `/plc`, `/sandbox-v1` and `/dev/hero-gallery` are
+ * developer surfaces, not product. They shipped reachable-by-URL and outside
+ * both `AuthGuard` and any flag (UI-SURFACE-CENSUS-2026-07-30, finding R1);
+ * `/dev/hero-gallery` alone self-gated inside its component. This guard puts
+ * all of them — plus `/test` and the catch-all, which render the same POC
+ * sandbox — behind the single declared `devRoutes` flag, which is OFF in every
+ * deployed build.
+ *
+ * ⚠ IT IS A PATHLESS LAYOUT ROUTE, NOT A PER-ROUTE WRAPPER, AND THAT IS THE
+ * POINT. The gating is declared ONCE, in one `<Route element={<DevRoutesGuard/>}>`
+ * whose children are the gated routes — the same shape as `AuthGuard` eight
+ * lines above it. The wrapper form it replaced required every author of every
+ * future dev route to REMEMBER to wrap it, which is the per-route memory burden
+ * that let these surfaces ship ungated in the first place.
+ *
+ * ⚠ THE REDIRECT TARGET IS `/`, NOT `/canvas`, AND THAT IS DELIBERATE.
+ * `/` is the scenario list; `/canvas` opens a blank "Untitled decision". Two
+ * reasons, in order of weight:
+ *   1. `/canvas` is a SIDE-EFFECT-PRODUCING landing. An open canvas tab is a
+ *      live writer — it is the known staging hazard where an open canvas
+ *      recreates deleted scenario rows. A mistyped URL must not start writing.
+ *   2. It matches the one in-repo precedent for this shape, which this gate is
+ *      modelled on: `HeroGallery.tsx:30` → `<Navigate to="/" replace />`.
+ * `AppPoC.routing.spec.tsx` pins the destination as `/` and asserts the canvas
+ * is NOT rendered, so a drift back to `/canvas` reds.
+ *
+ * The scaffolds are NOT deleted and NOT unmounted from the bundle: each is a
+ * `React.lazy` chunk, and building the element does not fetch it — only
+ * rendering does. Flag on, each route mounts exactly what it always mounted.
+ *
+ * Reach them in your own browser, on any environment:
+ *   localStorage.setItem('feature.devRoutes', '1')   // then reload
+ */
+
+import { Navigate, Outlet } from 'react-router-dom'
+import { isDevRoutesEnabled } from '../../flags'
+
+export default function DevRoutesGuard() {
+  // Read at RENDER time, not module load, so the localStorage override and the
+  // test suite both take effect without a module reset.
+  return isDevRoutesEnabled() ? <Outlet /> : <Navigate to="/" replace />
+}

--- a/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
@@ -135,8 +135,6 @@ function makeData(opts: FixtureOpts): ResultsSectionDataReturn {
     isLoading: false,
     isError: false,
     goalLabel: 'Maximise success',
-    // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-    // fixture predates the Resolve next view and asserts nothing about it.
     voiRanking: null,
   }
 }

--- a/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
+++ b/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
@@ -147,8 +147,6 @@ function makeData(
     isLoading: false,
     isError: false,
     goalLabel: 'Maximise success',
-    // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-    // fixture predates the Resolve next view and asserts nothing about it.
     voiRanking: null,
   }
 }

--- a/src/components/results/__tests__/buildResultsVM.spec.ts
+++ b/src/components/results/__tests__/buildResultsVM.spec.ts
@@ -127,8 +127,6 @@ function makeData(overrides: {
     isLoading: false,
     isError: false,
     goalLabel: 'Revenue',
-    // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-    // fixture predates the Resolve next view and asserts nothing about it.
     voiRanking: null,
   }
 }

--- a/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
+++ b/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
@@ -27,16 +27,20 @@ import { render, screen } from '@testing-library/react'
 import { ConfidenceSection } from '../ConfidenceSection'
 import { TriageCard } from '../../shared/TriageCard'
 import type { ConfidenceSectionData } from '../types'
+// Any "<n>pp" token, and the prose that used to carry it — ONE definition,
+// shared with `evpiSurfacesRemoved.resolveNext.honesty.spec.tsx`, which pins the
+// same absence on the NEW "Resolve next" surface. While each file held its own
+// copy, narrowing one would have left the other passing.
+import {
+  PP_TOKEN,
+  RESOLVING_CLAIM,
+  WORTH_CLAIM,
+} from './helpers/refutedEvpiClaimMatchers'
 
 vi.mock('../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
   focusByTarget: vi.fn(),
 }))
-
-/** Any "<n>pp" token, and the prose that used to carry it. */
-const PP_TOKEN = /\d+(\.\d+)?\s*pp\b/i
-const RESOLVING_CLAIM = /resolving could improve confidence/i
-const WORTH_CLAIM = /worth\s+\d+(\.\d+)?pp if resolved/i
 
 /**
  * Inject a prop the component no longer declares. The removal only means

--- a/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
+++ b/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
@@ -35,6 +35,7 @@ import {
   PP_TOKEN,
   RESOLVING_CLAIM,
   WORTH_CLAIM,
+  REFUTED_CLAIM_CONTROLS,
 } from './helpers/refutedEvpiClaimMatchers'
 
 vi.mock('../../../canvas/utils/focusHelpers', () => ({
@@ -164,9 +165,25 @@ describe('the removed prose templates appear nowhere in a rendered results surfa
     const { container } = render(<ConfidenceSection data={data} />)
     const text = container.textContent ?? ''
 
-    // Positive control on the matcher itself: it CAN fire.
-    expect('Worth 12.3pp if resolved: …').toMatch(WORTH_CLAIM)
-    expect('Resolving could improve confidence by up to 12pp').toMatch(RESOLVING_CLAIM)
+    // POSITIVE CONTROL on the matchers themselves: they CAN fire.
+    //
+    // ⚠ DRIVEN FROM THE SHARED TABLE, AND NOT HAND-LISTED, BECAUSE HAND-LISTING
+    // LEFT A HOLE HERE. Until the adversarial review of PR #533 this block named
+    // WORTH_CLAIM and RESOLVING_CLAIM only — but this file uses PP_TOKEN in three
+    // absence assertions above, and PP_TOKEN had no control at all. Once the
+    // definitions moved to a shared module (item 13 of the /simplify sweep),
+    // neutering the shared PP_TOKEN left this spec 6/6 GREEN while those three
+    // assertions silently stopped testing anything, about a REFUTED quantity.
+    // Mutation-proven both ways: neutering WORTH_CLAIM or RESOLVING_CLAIM RED-ed
+    // this file, neutering PP_TOKEN did not.
+    //
+    // Iterating the shared table closes that by construction: a pattern cannot be
+    // added to the vocabulary without acquiring a control here, and the length
+    // assertion means a SHRUNK table reds rather than quietly checking less.
+    expect(REFUTED_CLAIM_CONTROLS).toHaveLength(3)
+    for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
+      expect(re.test(original), `matcher must see: ${original}`).toBe(true)
+    }
 
     expect(text).not.toMatch(WORTH_CLAIM)
     expect(text).not.toMatch(RESOLVING_CLAIM)

--- a/src/components/results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx
+++ b/src/components/results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx
@@ -2,11 +2,14 @@
  * EVPI display surfaces — the NEW "Resolve next" view must not reopen them.
  *
  * A SIBLING of `evpiSurfacesRemoved.honesty.spec.tsx`, deliberately not an edit
- * to it. That file imports and renders the ARCHIVED `ConfidenceSection` as one
- * of its harnesses, which makes the archived component load-bearing evidence;
- * touching either is out of scope for this lane (recon
- * `PHASE0-EVIDENCE-2026-07-28/confidencesection-recon.md`). This file carries
- * the SAME THREE MATCHERS, verbatim, against the new surface.
+ * to it: that file imports and renders the ARCHIVED `ConfidenceSection` as one
+ * of its harnesses, which makes the archived component load-bearing evidence
+ * (recon `PHASE0-EVIDENCE-2026-07-28/confidencesection-recon.md`). This file
+ * asserts the SAME THREE MATCHERS against the new surface — and now imports them
+ * from `./helpers/refutedEvpiClaimMatchers.ts` rather than re-declaring them, so
+ * the banned vocabulary has ONE definition. Two copies of an absence assertion's
+ * own definition is trap 13 with a delay fuse: narrow one and the other keeps
+ * passing.
  *
  * WHY THE NEW SURFACE NEEDS ITS OWN ENTRY IN THIS FAMILY
  * ─────────────────────────────────────────────────────
@@ -33,44 +36,27 @@ import { V7EvidenceDisclosure } from '../v7/V7EvidenceDisclosure'
 import type { V7EvidenceModel } from '../v7/buildV7Lenses'
 import { buildVoiRanking } from '../voi/voiRanking'
 import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
+import {
+  PP_TOKEN,
+  RESOLVING_CLAIM,
+  WORTH_CLAIM,
+  REFUTED_CLAIM_CONTROLS,
+} from './helpers/refutedEvpiClaimMatchers'
+import { v7EvidenceModel } from '../../../__fixtures__/v7EvidenceModel'
+import {
+  voiRankingFixture,
+  openResolveNextExpanded as renderResolveNext,
+} from '../../../test/helpers/resolveNextView'
 
-/** The three matchers of `evpiSurfacesRemoved.honesty.spec.tsx`, verbatim. */
-const PP_TOKEN = /\d+(\.\d+)?\s*pp\b/i
-const RESOLVING_CLAIM = /resolving could improve confidence/i
-const WORTH_CLAIM = /worth\s+\d+(\.\d+)?pp if resolved/i
-
-function row(factorId: string, label: string) {
-  return { factorId, label, canFocus: true }
-}
-
-/** A POPULATED ranking — the honest-gate state would prove nothing here. */
+/**
+ * A POPULATED ranking — the honest-gate state would prove nothing here. Four
+ * resolved rows (so the clamp has something to hide), two below-resolution rows,
+ * and the PARTIAL disclosure on, from the shared non-degenerate fixture.
+ */
 function populated(): V7EvidenceModel {
-  return {
-    drivers: [],
-    flipRisks: [],
-    tradeOffs: [],
-    resolveNext: {
-      resolved: [
-        row('n_market', 'Market receptivity'),
-        row('n_comp', 'Competitor response'),
-        row('n_reg', 'Regulatory timeline'),
-        row('n_supply', 'Supply lead time'),
-      ],
-      belowResolution: [row('n_hiring', 'Hiring pace'), row('n_brand', 'Brand halo')],
-      someFactorsUnassessed: true,
-    },
-    designationsWithheld: false,
-  }
-}
-
-function renderResolveNext(evidence: V7EvidenceModel) {
-  render(<V7EvidenceDisclosure evidence={evidence} />)
-  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-  fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
-  // Expand, so the clamped rows are in the DOM too — a claim hiding behind
-  // "Show N more" is still a claim.
-  fireEvent.click(screen.getByTestId('v7-resolve-next-toggle'))
-  return document.body.textContent ?? ''
+  return v7EvidenceModel({
+    resolveNext: voiRankingFixture({ someFactorsUnassessed: true }),
+  })
 }
 
 describe('Resolve next — the refuted EVPI claim does not come back here', () => {
@@ -87,11 +73,12 @@ describe('Resolve next — the refuted EVPI claim does not come back here', () =
   })
 
   it('POSITIVE CONTROL: each matcher fires on the string it was written to catch', () => {
-    for (const [re, original] of [
-      [PP_TOKEN, 'Worth 12.3pp if resolved'],
-      [RESOLVING_CLAIM, 'Resolving could improve confidence by up to 10pp'],
-      [WORTH_CLAIM, 'Worth 6.6pp if resolved'],
-    ] as Array<[RegExp, string]>) {
+    // Trap 13, applied to the matchers' NEW HOME: the definitions moved out of
+    // this file, so this control also proves the import resolved to real
+    // patterns rather than to `undefined` (a bad import would otherwise make
+    // every `.not.toMatch` below throw, but an over-broad one would not).
+    expect(REFUTED_CLAIM_CONTROLS).toHaveLength(3)
+    for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
       expect(re.test(original), `matcher must see: ${original}`).toBe(true)
     }
   })
@@ -111,17 +98,7 @@ describe('Resolve next — the refuted EVPI claim does not come back here', () =
   })
 
   it('the honest-gate state is equally clean', () => {
-    render(
-      <V7EvidenceDisclosure
-        evidence={{
-          drivers: [],
-          flipRisks: [],
-          tradeOffs: [],
-          resolveNext: null,
-          designationsWithheld: false,
-        }}
-      />,
-    )
+    render(<V7EvidenceDisclosure evidence={v7EvidenceModel({ resolveNext: null })} />)
     // Nothing at all to disclose → the whole section is absent, which is itself
     // the honest outcome (never an empty shell).
     expect(screen.queryByTestId('v7-evidence-disclosure')).not.toBeInTheDocument()
@@ -130,13 +107,10 @@ describe('Resolve next — the refuted EVPI claim does not come back here', () =
   it('the gate renders clean when a sibling view has data', () => {
     render(
       <V7EvidenceDisclosure
-        evidence={{
+        evidence={v7EvidenceModel({
           drivers: [{ factorKey: 'f1', label: 'Price', direction: null, isEstimate: false }],
-          flipRisks: [],
-          tradeOffs: [],
           resolveNext: null,
-          designationsWithheld: false,
-        }}
+        })}
       />,
     )
     fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))

--- a/src/components/results/__tests__/golden-payload.spec.ts
+++ b/src/components/results/__tests__/golden-payload.spec.ts
@@ -206,8 +206,6 @@ function makeGoldenData(): ResultsSectionDataReturn {
     isLoading: false,
     isError: false,
     goalLabel: 'Revenue',
-    // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-    // fixture predates the Resolve next view and asserts nothing about it.
     voiRanking: null,
   }
 }

--- a/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
+++ b/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
@@ -1,0 +1,62 @@
+/**
+ * refutedEvpiClaimMatchers — the ONE definition of the banned
+ * value-of-information vocabulary.
+ *
+ * `evpi_percentage_points` is refuted, not merely uncalibrated (replayed live on
+ * 2026-07-25 against PLoT `1dd45b6a` → ISL `3aea011c`; the formula
+ * `voi × winProbSpread × 100` multiplies BY the top-two win-probability gap,
+ * which inverts decision theory). The sentences it wore — "Worth 12.3pp if
+ * resolved", "Resolving could improve confidence by …" — must not come back on
+ * any surface, including a surface that answers the same user question from a
+ * DIFFERENT and real estimator.
+ *
+ * WHY THESE LIVE HERE RATHER THAN IN EACH SPEC. Two suites assert the same
+ * absence: `evpiSurfacesRemoved.honesty.spec.tsx` (the removed results
+ * surfaces) and `evpiSurfacesRemoved.resolveNext.honesty.spec.tsx` (the new
+ * "Resolve next" view). While each carried its own copy, one of them could be
+ * narrowed — or a pattern added to only one — and the other would keep passing.
+ * That is trap 13 with a delay fuse: an absence assertion whose definition of
+ * the thing being absent can drift silently. One definition, two importers.
+ *
+ * ⚠ These are DEFINITIONS, not assertions. A regex that never fires proves
+ * nothing, so every importing spec pairs them with a POSITIVE CONTROL that
+ * shows each pattern still matches the string it was written to catch.
+ *
+ * ⚠ WHY THIS LIVES IN `__tests__/helpers/` AND NOT IN `src/test/helpers/`.
+ * `tests/contracts/no-evpi-display.contract.test.ts` scans every tracked
+ * `src/**` file for the removed SENTENCES, and derives its non-display exemption
+ * as `__tests__/` or `/tests/` — which `src/test/helpers/` (singular "test")
+ * matches NEITHER. Putting the banned vocabulary there turns that guard RED, and
+ * correctly so from its point of view: a non-exempt `src/` module would have
+ * just reintroduced the removed copy. Both importing specs live in
+ * `src/components/results/__tests__/`, so this sits beside them, exempt by the
+ * guard's existing derived category — the same category the two specs holding
+ * these strings today already sit in — and it follows the repo's
+ * `__tests__/helpers/` precedent (`src/lib/`, `src/v5/`).
+ *
+ * The alternative the guard's own failure message suggests — adding `src/test/`
+ * to its `NON_DISPLAY_PREFIXES` — would also work, and would close a real gap in
+ * its category derivation (as it stands, no shared test helper can mention this
+ * vocabulary from the repo's declared helpers home). That is a change to a
+ * trust-surface guard, so it is left to a reviewer rather than taken here.
+ */
+
+/** Any "<n>pp" token — the shape the refuted quantity wore on every surface. */
+export const PP_TOKEN = /\d+(\.\d+)?\s*pp\b/i
+
+/** The confidence-improvement sentence removed from the results surfaces. */
+export const RESOLVING_CLAIM = /resolving could improve confidence/i
+
+/** The per-factor "worth Npp if resolved" claim. */
+export const WORTH_CLAIM = /worth\s+\d+(\.\d+)?pp if resolved/i
+
+/**
+ * Each matcher paired with a string it MUST match — the positive-control table
+ * both honesty specs drive, so the controls cannot drift apart from the
+ * patterns they guard.
+ */
+export const REFUTED_CLAIM_CONTROLS: ReadonlyArray<readonly [RegExp, string]> = [
+  [PP_TOKEN, 'Worth 12.3pp if resolved'],
+  [RESOLVING_CLAIM, 'Resolving could improve confidence by up to 10pp'],
+  [WORTH_CLAIM, 'Worth 6.6pp if resolved'],
+] as const

--- a/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
+++ b/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
@@ -20,7 +20,26 @@
  *
  * ⚠ These are DEFINITIONS, not assertions. A regex that never fires proves
  * nothing, so every importing spec pairs them with a POSITIVE CONTROL that
- * shows each pattern still matches the string it was written to catch.
+ * shows each pattern still matches the string it was written to catch — by
+ * iterating `REFUTED_CLAIM_CONTROLS` below, never by hand-listing patterns.
+ *
+ * ⚠⚠ THAT SENTENCE WAS FALSE WHEN IT WAS FIRST WRITTEN, AND THE FALSEHOOD IS THE
+ * REASON THE RULE IS NOW "ITERATE THE TABLE". At the first commit of this
+ * extraction (PR #533), `evpiSurfacesRemoved.honesty.spec.tsx` imported the three
+ * regexes but HAND-LISTED controls for only two of them — `WORTH_CLAIM` and
+ * `RESOLVING_CLAIM`. `PP_TOKEN` had none, in a file that uses it in three
+ * absence assertions. Adversarial review proved the consequence by mutation:
+ * neutering the shared `PP_TOKEN` left that spec **6/6 GREEN**, while neutering
+ * either other pattern RED-ed it. So moving the definitions here had removed
+ * duplicate-drift and introduced a SINGLE POINT OF VACUITY about a refuted
+ * quantity — the same trap-13 class the extraction existed to close, arriving
+ * from the other direction.
+ *
+ * Both sentences flagged in that review (this one, and "the table both honesty
+ * specs drive" below) are now TRUE, and are kept rather than softened: the fix
+ * was to make the code match the claim. The history stays because a header that
+ * silently becomes true reads exactly like one that was never wrong — and
+ * "hand-listed two of three" is the mistake this file will invite again.
  *
  * ⚠ WHY THIS LIVES IN `__tests__/helpers/` AND NOT IN `src/test/helpers/`.
  * `tests/contracts/no-evpi-display.contract.test.ts` scans every tracked
@@ -52,8 +71,14 @@ export const WORTH_CLAIM = /worth\s+\d+(\.\d+)?pp if resolved/i
 
 /**
  * Each matcher paired with a string it MUST match — the positive-control table
- * both honesty specs drive, so the controls cannot drift apart from the
- * patterns they guard.
+ * both honesty specs drive, so the controls cannot drift apart from the patterns
+ * they guard.
+ *
+ * ⚠ EVERY PATTERN EXPORTED ABOVE MUST HAVE A ROW HERE. That is what makes the
+ * controls derived rather than remembered: a fourth banned pattern added above
+ * without a row here is a pattern with no control in either spec, which is how
+ * `PP_TOKEN` went uncontrolled in one of them (see the header). Both specs assert
+ * this table's LENGTH, so shrinking it reds instead of quietly checking less.
  */
 export const REFUTED_CLAIM_CONTROLS: ReadonlyArray<readonly [RegExp, string]> = [
   [PP_TOKEN, 'Worth 12.3pp if resolved'],

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -1067,6 +1067,14 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
     display_verdict?: string
     display_verdict_reason?: string
     flip_thresholds?: Array<Record<string, unknown>>
+    /**
+     * LEGACY slot for `inference_warnings`. The V4/V2 mapper nests them here
+     * (`adapters/plot/v2/responseMapper.ts`); the V5 mapper writes the ROOT key
+     * above. Measured over all 773 live non-noop `run_analysis` facts on staging
+     * (2026-07-29): root 773/773, robustness 0/773 — see
+     * `canvas/stores/persistedRunSnapshotFactory.ts`. Both are read, root first.
+     */
+    inference_warnings?: unknown[]
     _truncation?: {
       fragile_truncated: boolean
       fragile_total: number
@@ -1109,6 +1117,27 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
   downstream_calls?: unknown
   factors?: Array<Record<string, unknown>>
   factor_enrichments?: Array<Record<string, unknown>>
+  /**
+   * V7-C slice 1 (ROADMAP 2.141): the mapper's verbatim carry of
+   * `enrichment.factor_evppi` (`src/v5/mapV5AnalysisToReport.ts`).
+   *
+   * `unknown[]` ON PURPOSE — the ROW shape is validated at the one reader
+   * (`voi/voiRanking.ts`) against the pinned `EnrichmentFactorEvppiEntrySchema`,
+   * never here. What matters is that the KEY is declared: while it was absent,
+   * every read of it needed `(report as unknown as Record<string, unknown>)`,
+   * and a mistyped key inside that cast yields `undefined` — so the honest gate
+   * would render forever with nothing red anywhere. Declaring the key is what
+   * makes the typo a compile error instead of a silent permanent gate.
+   */
+  factor_evppi?: unknown[]
+  /**
+   * ISL `inference_warnings[]` — the enrichment-ROOT slot. Same reasoning as
+   * `factor_evppi`: declared so readers do not cast, entries left `unknown`
+   * because each reader validates the codes it cares about. Read it through
+   * `readInferenceWarnings()` in `useResultsSectionData.ts`, which also covers
+   * the legacy `robustness.inference_warnings` slot.
+   */
+  inference_warnings?: unknown[]
 }
 
 /**

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -1067,14 +1067,18 @@ export interface ResultsReport extends Omit<ReportV1, 'option_probabilities'> {
     display_verdict?: string
     display_verdict_reason?: string
     flip_thresholds?: Array<Record<string, unknown>>
-    /**
-     * LEGACY slot for `inference_warnings`. The V4/V2 mapper nests them here
-     * (`adapters/plot/v2/responseMapper.ts`); the V5 mapper writes the ROOT key
-     * above. Measured over all 773 live non-noop `run_analysis` facts on staging
-     * (2026-07-29): root 773/773, robustness 0/773 — see
-     * `canvas/stores/persistedRunSnapshotFactory.ts`. Both are read, root first.
-     */
-    inference_warnings?: unknown[]
+    // ⚠ `inference_warnings` is DELIBERATELY NOT DECLARED HERE, even though the
+    // V4/V2 mapper nests it in this slot. Adding a member to this INLINE object
+    // type changes the elided-member counter TypeScript prints inside four
+    // unrelated baselined diagnostics in `useResultsSectionData.ts`
+    // ("… 8 more …" → "… 9 more …"), which makes the typecheck gate emit its
+    // identity-diff notice on a clean tree — and `typecheck:selftest`'s green
+    // control asserts that notice does NOT appear on a clean tree. So declaring
+    // it here reds a required check for a purely cosmetic reason.
+    // `readInferenceWarnings()` in `useResultsSectionData.ts` reads this slot
+    // through one narrow cast instead, and it is the LEGACY slot regardless:
+    // measured 0/773 on live staging facts (root 773/773) — see
+    // `canvas/stores/persistedRunSnapshotFactory.ts`.
     _truncation?: {
       fragile_truncated: boolean
       fragile_total: number

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -531,9 +531,19 @@ function readEnrichmentFactors(report: ResultsReport): unknown[] | null {
  * wrapper rather than a bare array, so callers unwrap with `safeArray` or
  * validate for themselves. Never throws, never defaults to `[]` — an absent
  * key must stay distinguishable from an empty one.
+ *
+ * The top-level read is plain (the key is declared on `ResultsReport`). The
+ * legacy nested slot keeps ONE narrow cast, deliberately: declaring a member on
+ * `ResultsReport['robustness']` — an inline object type — changes the
+ * elided-member counter tsc prints inside four unrelated baselined diagnostics
+ * in this file, which trips `typecheck:selftest`'s clean-tree control. See the
+ * note at that slot in `types.ts`.
  */
 function readInferenceWarnings(report: ResultsReport | null | undefined): unknown {
-  return report?.inference_warnings ?? report?.robustness?.inference_warnings
+  return (
+    report?.inference_warnings ??
+    (report?.robustness as { inference_warnings?: unknown } | undefined)?.inference_warnings
+  )
 }
 
 /** Labels play no part in policy keys/metrics (getFactorKey resolves ids

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -514,6 +514,28 @@ function readEnrichmentFactors(report: ResultsReport): unknown[] | null {
   return Array.isArray(factors) ? factors : null
 }
 
+/**
+ * ISL `inference_warnings[]`, from BOTH slots a mapper may use — ROOT first,
+ * then the legacy `robustness` nesting.
+ *
+ * ONE reader because this file needed the identical dual read twice (the VOI
+ * ranking's PARTIAL disclosure and the Analysis-tab warning strip) and had it
+ * in two DIVERGENT cast styles. Two copies of a two-slot fallback is two
+ * chances for the next copy to read only one slot and render permanently empty
+ * with nothing red — which is exactly what the design doc's §2 mapping table
+ * would have caused had it been implemented verbatim (measured over all 773
+ * live non-noop `run_analysis` facts on staging, 2026-07-29: root 773/773,
+ * robustness 0/773 — see `canvas/stores/persistedRunSnapshotFactory.ts`).
+ *
+ * Returns `unknown`: payload redaction may deliver a `{__truncated, items}`
+ * wrapper rather than a bare array, so callers unwrap with `safeArray` or
+ * validate for themselves. Never throws, never defaults to `[]` — an absent
+ * key must stay distinguishable from an empty one.
+ */
+function readInferenceWarnings(report: ResultsReport | null | undefined): unknown {
+  return report?.inference_warnings ?? report?.robustness?.inference_warnings
+}
+
 /** Labels play no part in policy keys/metrics (getFactorKey resolves ids
  * before labels, and the label-map fallback needs an id anyway), so the feed
  * normalises with an empty map; the panel re-normalises with the real
@@ -1372,11 +1394,20 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
   const voiRanking = useMemo(
     () =>
       buildVoiRanking({
-        rows: (report as unknown as Record<string, unknown> | null | undefined)?.factor_evppi,
-        inferenceWarnings:
-          (report as unknown as Record<string, unknown> | null | undefined)?.inference_warnings ??
-          (report as { robustness?: { inference_warnings?: unknown } } | null | undefined)
-            ?.robustness?.inference_warnings,
+        rows: report?.factor_evppi,
+        inferenceWarnings: readInferenceWarnings(report),
+        // ⚠ THIS PRODUCER CANNOT YET EMIT `canFocus: false`, AND THAT IS AN
+        // HONEST LIMITATION, NOT A BUG. `nodeLabelMap` is built FROM the canvas
+        // nodes, so any id it resolves is by construction a node that exists and
+        // can be focused — the two outcomes here are "a focusable label" or
+        // `null` (row dropped). The field is kept rather than collapsed because
+        // it genuinely varies for the disclosure's OTHER row families (drivers
+        // and flip risks both compute `canFocus` from a target that may be
+        // absent), and because a second label source — a resolver that names a
+        // factor it cannot focus — is the case slice 2+ introduces. Until then,
+        // the `canFocus: false` branch in the reader and the view is UNEXERCISED
+        // BY THIS CALLER: it is covered only by the unit fixtures that pass
+        // `false` directly. Do not read its render-level pin as live-path proof.
         resolveLabel: (factorId) => {
           const label = nodeLabelMap.get(factorId)
           return label === undefined ? null : { label, canFocus: true }
@@ -3068,7 +3099,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         }))
       })(),
       inferenceWarnings: (() => {
-        const raw = safeArray((report as any)?.inference_warnings ?? (report as any)?.robustness?.inference_warnings)
+        const raw = safeArray(readInferenceWarnings(report))
         // Surface all inference warnings (previously gated on specific codes)
         const relevant = raw.filter((w: any) => typeof w?.code === 'string')
         if (relevant.length === 0) return undefined

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -45,11 +45,25 @@ import { V7_LENS_COPY } from './v7LensCopy'
 import { useAnalysisProjection } from '@/canvas/highlighting/useAnalysisProjection'
 
 const E = V7_LENS_COPY.evidence
-const VISIBLE_DRIVERS = 3
-/** Same clamp as Drivers — one number, one meaning, across the disclosure. */
-const VISIBLE_RESOLVE_NEXT = 3
+
+/**
+ * The row clamp — ONE number, ONE meaning, across every clamped view in this
+ * disclosure (Drivers and Resolve next today). It was two constants whose
+ * equality lived in a comment: a comment cannot fail, so the day one of them
+ * moved the two views would have silently disagreed about "top N".
+ */
+const VISIBLE_EVIDENCE_ROWS = 3
 
 type EvidenceView = 'drivers' | 'flipRisks' | 'tradeOffs' | 'resolveNext'
+
+/** The four view chips, in render order. Static — every label is a module
+ * constant, so this is built once rather than on every render. */
+const VIEWS: ReadonlyArray<{ key: EvidenceView; label: string }> = [
+  { key: 'drivers', label: E.driversTab },
+  { key: 'flipRisks', label: E.flipRisksTab },
+  { key: 'tradeOffs', label: E.tradeOffsTab },
+  { key: 'resolveNext', label: E.resolveNextTab },
+]
 
 export interface V7EvidenceDisclosureProps {
   evidence: V7EvidenceModel
@@ -69,6 +83,43 @@ function EvidenceGate({ testId, children }: { testId: string; children: React.Re
 /** The muted lead-in note above a view's rows — three identical copies. */
 function EvidenceNote({ children }: { children: React.ReactNode }) {
   return <p className={`${typography.panelMeta} text-text-light`}>{children}</p>
+}
+
+/**
+ * The row-clamp toggle — one leaf for the two verbatim copies (Drivers and
+ * Resolve next), down to the focus-ring class string.
+ *
+ * `hiddenCount` is the number of rows the clamp HIDES and does not change when
+ * the list expands, so the affordance stays mounted as "Show fewer" — the
+ * behaviour both suites pin. Renders nothing when the clamp hides nothing.
+ *
+ * ⚠ That counter is the ONLY digit-bearing string in the Resolve next view, and
+ * it is a count of HIDDEN ROWS — never a value of information. It is the string
+ * that view's no-digit assertion carves out and then pins exactly, so the
+ * carve-out cannot widen into a hole a magnitude arrives through.
+ */
+function ClampToggle({
+  testId,
+  hiddenCount,
+  expanded,
+  onToggle,
+}: {
+  testId: string
+  hiddenCount: number
+  expanded: boolean
+  onToggle: () => void
+}) {
+  if (hiddenCount <= 0) return null
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      data-testid={testId}
+      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+    >
+      {expanded ? E.showFewer : E.seeMore(hiddenCount)}
+    </button>
+  )
 }
 
 export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclosureProps) {
@@ -103,22 +154,15 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
   // Nothing to disclose at all → render nothing (never an empty shell).
   if (!hasDrivers && !hasFlipRisks && !hasTradeOffs && !hasResolveNext) return null
 
-  const views: Array<{ key: EvidenceView; label: string }> = [
-    { key: 'drivers', label: E.driversTab },
-    { key: 'flipRisks', label: E.flipRisksTab },
-    { key: 'tradeOffs', label: E.tradeOffsTab },
-    { key: 'resolveNext', label: E.resolveNextTab },
-  ]
-
-  const visibleDrivers = showAllDrivers ? evidence.drivers : evidence.drivers.slice(0, VISIBLE_DRIVERS)
-  const moreCount = evidence.drivers.length - VISIBLE_DRIVERS
+  const visibleDrivers = showAllDrivers ? evidence.drivers : evidence.drivers.slice(0, VISIBLE_EVIDENCE_ROWS)
+  const moreCount = evidence.drivers.length - VISIBLE_EVIDENCE_ROWS
 
   const resolveNext = evidence.resolveNext
   const resolvedRows = resolveNext?.resolved ?? []
   const visibleResolveNext = showAllResolveNext
     ? resolvedRows
-    : resolvedRows.slice(0, VISIBLE_RESOLVE_NEXT)
-  const resolveNextMoreCount = resolvedRows.length - VISIBLE_RESOLVE_NEXT
+    : resolvedRows.slice(0, VISIBLE_EVIDENCE_ROWS)
+  const resolveNextMoreCount = resolvedRows.length - VISIBLE_EVIDENCE_ROWS
 
   return (
     <section
@@ -144,7 +188,7 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
       {open && (
         <div className="mt-1 space-y-2 pb-2">
           <div className="flex flex-wrap gap-1" role="group" aria-label="Evidence view">
-            {views.map((v) => (
+            {VIEWS.map((v) => (
               <button
                 key={v.key}
                 type="button"
@@ -213,16 +257,12 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                       </div>
                     )
                   })}
-                  {moreCount > 0 && (
-                    <button
-                      type="button"
-                      onClick={() => setShowAllDrivers((s) => !s)}
-                      data-testid="v7-drivers-toggle"
-                      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-                    >
-                      {showAllDrivers ? E.showFewer : E.seeMore(moreCount)}
-                    </button>
-                  )}
+                  <ClampToggle
+                    testId="v7-drivers-toggle"
+                    hiddenCount={moreCount}
+                    expanded={showAllDrivers}
+                    onToggle={() => setShowAllDrivers((s) => !s)}
+                  />
                 </>
               ) : (
                 <EvidenceGate testId="v7-evidence-drivers-gate">{E.driversGate}</EvidenceGate>
@@ -367,16 +407,12 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                       })}
                     </ol>
                   )}
-                  {resolveNextMoreCount > 0 && (
-                    <button
-                      type="button"
-                      onClick={() => setShowAllResolveNext((s) => !s)}
-                      data-testid="v7-resolve-next-toggle"
-                      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-                    >
-                      {showAllResolveNext ? E.showFewer : E.seeMore(resolveNextMoreCount)}
-                    </button>
-                  )}
+                  <ClampToggle
+                    testId="v7-resolve-next-toggle"
+                    hiddenCount={resolveNextMoreCount}
+                    expanded={showAllResolveNext}
+                    onToggle={() => setShowAllResolveNext((s) => !s)}
+                  />
                   {/* Demoted, never ranked. Below-resolution means
                       indistinguishable from noise AT THIS RUN'S RESOLUTION —
                       not zero value, and not "not worth resolving". */}

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
@@ -10,20 +10,8 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
-import type { V7EvidenceModel } from '../buildV7Lenses'
 import { useCanvasStore } from '@/canvas/store'
-
-function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
-  return {
-    drivers: partial.drivers ?? [],
-    flipRisks: partial.flipRisks ?? [],
-    tradeOffs: partial.tradeOffs ?? [],
-    // V7-C slice 1 (ROADMAP 2.141): null is the honest-gate verdict — these
-    // suites predate the Resolve next view and assert nothing about it.
-    resolveNext: partial.resolveNext ?? null,
-    designationsWithheld: partial.designationsWithheld ?? false,
-  }
-}
+import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
 
 // A minimal canvas: two factors → one outcome, plus a second outgoing edge from
 // fac_price so a bare from_id would be ambiguous.

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNext.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNext.spec.tsx
@@ -4,10 +4,18 @@
  *
  * NON-DEGENERATE FIXTURE (ROADMAP 2.141 probe limit i). The live 30 Jul probe's
  * rank-order pin was VACUOUS because the run returned two zero-EVPPI factors, so
- * any order passed. This fixture therefore carries FOUR resolved rows with three
- * DISTINCT producer positions, a TIE PAIR at ranks 2-3, TWO below-resolution
- * rows, and a canvas factor deliberately absent from the wire. One pin feeds a
- * deliberately MIS-SORTED wire so accidental iteration order cannot pass.
+ * any order passed. The fixture therefore carries FOUR resolved rows with three
+ * DISTINCT producer positions, a TIE PAIR at ranks 2-3, and TWO below-resolution
+ * rows. One pin feeds a deliberately MIS-SORTED wire so accidental iteration
+ * order cannot pass.
+ *
+ * The fixture, the row builder and the open-and-switch helper live in
+ * `src/test/helpers/resolveNextView.tsx`, SHARED with
+ * `results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx`. Both
+ * suites arrived in the same PR with private copies that had already diverged
+ * (two `row()` signatures, two fixtures with different labels), so the two were
+ * asserting against subtly different surfaces while reading as if they shared
+ * one.
  *
  * CLAIM TYPE: rendered text / DOM presence within jsdom (trap 3). Nothing here
  * is a visibility or layout claim — the live check owns those.
@@ -15,53 +23,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
-import type { V7EvidenceModel } from '../buildV7Lenses'
-import type { VoiRanking } from '../../voi/voiRanking'
 import { V7_LENS_COPY } from '../v7LensCopy'
+import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
+import {
+  voiRow as row,
+  voiRankingFixture as ranking,
+  openResolveNext,
+} from '@/test/helpers/resolveNextView'
 
 const E = V7_LENS_COPY.evidence
-
-function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
-  return {
-    drivers: partial.drivers ?? [],
-    flipRisks: partial.flipRisks ?? [],
-    tradeOffs: partial.tradeOffs ?? [],
-    resolveNext: partial.resolveNext ?? null,
-    designationsWithheld: partial.designationsWithheld ?? false,
-  }
-}
-
-function row(factorId: string, label: string, canFocus = true) {
-  return { factorId, label, canFocus }
-}
-
-/**
- * Producer wire order. Ranks 2 and 3 are a TIE on the wire (identical evppi
- * upstream) — the reader keeps producer order and so must the view.
- */
-function ranking(partial: Partial<VoiRanking> = {}): VoiRanking {
-  return {
-    resolved: partial.resolved ?? [
-      row('n_market', 'Market receptivity'),
-      row('n_comp', 'Competitor response'),
-      row('n_comp_eu', 'Competitor response (Europe)'),
-      row('n_reg', 'Regulatory timeline'),
-    ],
-    belowResolution: partial.belowResolution ?? [
-      row('n_hiring', 'Hiring pace'),
-      row('n_brand', 'Brand halo'),
-    ],
-    someFactorsUnassessed: partial.someFactorsUnassessed ?? false,
-  }
-}
-
-/** Open the disclosure and switch to the Resolve next view. */
-function openResolveNext(evidence: V7EvidenceModel, onFocusNode?: (id: string) => void) {
-  const utils = render(<V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />)
-  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-  fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
-  return utils
-}
 
 describe('V7EvidenceDisclosure — Resolve next: the ranking', () => {
   it('exposes a fourth view chip beside the existing three', () => {
@@ -88,7 +58,9 @@ describe('V7EvidenceDisclosure — Resolve next: the ranking', () => {
       expect.stringContaining('Competitor response'),
       expect.stringContaining('Competitor response (Europe)'),
     ])
-    // Rank 4 is clamped until expanded (mirrors Drivers' VISIBLE_DRIVERS = 3).
+    // Rank 4 is clamped until expanded — the disclosure's shared row clamp,
+    // VISIBLE_EVIDENCE_ROWS = 3 (the SAME constant Drivers uses, which is why
+    // "mirrors Drivers'" is no longer a claim anyone has to keep true).
     expect(screen.queryByText('Regulatory timeline')).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId('v7-resolve-next-toggle'))
     expect(screen.getByText('Regulatory timeline')).toBeInTheDocument()

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
@@ -11,18 +11,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
 import type { V7EvidenceModel } from '../buildV7Lenses'
-
-function model(partial: Partial<V7EvidenceModel>): V7EvidenceModel {
-  return {
-    drivers: partial.drivers ?? [],
-    flipRisks: partial.flipRisks ?? [],
-    tradeOffs: partial.tradeOffs ?? [],
-    // V7-C slice 1 (ROADMAP 2.141): null is the honest-gate verdict — these
-    // suites predate the Resolve next view and assert nothing about it.
-    resolveNext: partial.resolveNext ?? null,
-    designationsWithheld: partial.designationsWithheld ?? false,
-  }
-}
+import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
 
 const FIVE_DRIVERS: V7EvidenceModel['drivers'] = [
   { factorKey: 'f1', label: 'Price', direction: 'negative', isEstimate: true },

--- a/src/components/results/voi/__tests__/voiRanking.spec.ts
+++ b/src/components/results/voi/__tests__/voiRanking.spec.ts
@@ -189,6 +189,68 @@ describe('buildVoiRanking — defensive row validation (drop, never coerce)', ()
     expect(m!.belowResolution.map(r => r.factorId)).toContain('n_brand')
     expect(m!.resolved.map(r => r.factorId)).not.toContain('n_brand')
   })
+
+  /**
+   * THE VALIDATION SCOPE IS DELIBERATE, AND THIS IS THE PIN THAT SAYS SO.
+   *
+   * The reader validates rows against `EnrichmentFactorEvppiEntrySchema.pick({
+   * factor_id, evppi, status })` — the three fields it READS — and not against the
+   * full entry schema. A row whose UNREAD audit legs are mistyped (`units`,
+   * `noise_floor`, `method`, `evppi_raw`, `n_samples`, the clamp booleans,
+   * `correlation_active`) therefore still ranks: those fields never reach the DOM
+   * and never affect order, so a producer typo in one of them must not cost the
+   * user the ranking.
+   *
+   * ⚠ WHY THIS TEST EXISTS AT ALL. Swapping the `.pick` for the FULL schema passed
+   * every committed test — adversarial review of PR #533 swapped it and got
+   * voiRanking 55/55, resolveNext.honesty 10/10, resolveNext.spec 25/25 all green.
+   * So the choice was held by a COMMENT, not by a test, and the fail-safe framing
+   * hid how sharp the difference is: under the full schema this row is DROPPED,
+   * and because it is rank 1, the reader's own rank-1 doctrine then collapses the
+   * WHOLE ranking to the honest gate. A user loses the entire surface to a typo in
+   * a field nobody displays.
+   *
+   * If a future lane decides that IS the right trade, this test is the place to
+   * make that decision visible — it should be changed deliberately, not discovered.
+   */
+  it('a row with a MISTYPED UNREAD audit leg still ranks (the .pick scope, pinned)', () => {
+    const m = build([
+      // Every unread audit leg wrong-typed at once, on the RANK-1 row.
+      {
+        factor_id: 'n_market',
+        evppi: 0.91,
+        status: 'resolved',
+        units: 9,
+        noise_floor: 'x',
+        method: 3,
+        evppi_raw: 'x',
+        n_samples: 'x',
+        clamped_low: 'yes',
+        clamped_high: 'no',
+        correlation_active: 'x',
+      },
+      { factor_id: 'n_comp', evppi: 0.44, status: 'resolved' },
+    ])
+    expect(m).not.toBeNull()
+    expect(m!.resolved.map(r => r.label)).toEqual(['Market receptivity', 'Competitor response'])
+    // Nothing was dropped, so nothing is disclosed as unassessed.
+    expect(m!.someFactorsUnassessed).toBe(false)
+    // …and the malformed values still reach neither the model nor a magnitude.
+    expect(JSON.stringify(m)).not.toContain('noise_floor')
+    expect(JSON.stringify(m)).not.toContain('0.91')
+  })
+
+  it('POSITIVE CONTROL: a mistyped READ field on that same row DOES drop it', () => {
+    // Without this, the test above could be passing because the reader validates
+    // nothing at all. The only difference here is that the broken field is one of
+    // the three the reader reads — and a dropped rank-1 gates the whole ranking.
+    expect(
+      build([
+        { factor_id: 'n_market', evppi: 'nope', status: 'resolved', units: 9 },
+        { factor_id: 'n_comp', evppi: 0.44, status: 'resolved' },
+      ]),
+    ).toBeNull()
+  })
 })
 
 describe('buildVoiRanking — the PARTIAL disclosure', () => {

--- a/src/components/results/voi/voiRanking.ts
+++ b/src/components/results/voi/voiRanking.ts
@@ -43,6 +43,13 @@
  * produce rows, the view says so.
  */
 
+import { EnrichmentFactorEvppiEntrySchema } from '@talchain/schemas/boundary'
+// The repo's one EXPORTED plain-object guard. `transportFailure.ts` already
+// carried a byte-identical private copy and was folded onto this one; a seventh
+// copy here would have been the same trap-12 mirror. (The six pre-existing
+// private copies in src/v5 and src/lib are a separate, rowed migration.)
+import { isRecord } from '../../../canvas/conversation/ceeRecovery'
+
 /** A canvas label resolution for a producer `factor_id`. `null` = unlabelable. */
 export interface VoiLabelResolution {
   label: string
@@ -78,15 +85,68 @@ export interface VoiRanking {
 
 const PARTIAL_WARNING_CODE = 'FACTOR_EVPPI_PARTIAL'
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v != null && typeof v === 'object' && !Array.isArray(v)
+/**
+ * THE ROW CONTRACT, DERIVED FROM THE PINNED SCHEMA — not a second copy of it.
+ *
+ * The three fields this reader actually reads, picked off
+ * `EnrichmentFactorEvppiEntrySchema` (@talchain/schemas 0.30.0, the schema
+ * written for exactly this row). Hand-rolled `typeof` checks over the same three
+ * fields were a SECOND definition of the row contract in a repo whose #1 hazard
+ * is schema skew: the pin can move and a hand-rolled check cannot notice.
+ * `.pick()` binds these three to the schema, so a rename or retype of any of
+ * them is a compile error here rather than rows silently dropping in production.
+ *
+ * ⚠ WHY `.pick(…)` AND NOT THE WHOLE SCHEMA. Parsing the FULL entry would also
+ * validate the audit legs this reader never reads (`units`, `noise_floor`,
+ * `method`, `evppi_raw`, `n_samples`, the clamp booleans, `correlation_active`).
+ * A producer that sent one of those with the wrong type would then have its row
+ * DROPPED — and if it were rank 1, the whole ranking would collapse to the
+ * honest gate. That is a real behaviour change (measured: 3 of 33 probe payloads
+ * flip), it is a product judgement about unread fields, and it is not this
+ * reader's to make silently. Keeping the pick makes the swap provably
+ * behaviour-identical to the checks it replaces.
+ *
+ * Passthrough survives `.pick()`, so unknown/extra producer keys still parse.
+ */
+const FactorEvppiRowSchema = EnrichmentFactorEvppiEntrySchema.pick({
+  factor_id: true,
+  evppi: true,
+  status: true,
+})
+
+type FactorEvppiRow = ReturnType<typeof FactorEvppiRowSchema.parse>
+
+/**
+ * The three deliberate CONSUMER tightenings on top of the wire shape, each
+ * stricter than the schema on purpose:
+ *
+ *   · `factor_id` NON-EMPTY — the wire types it `z.string()`, which admits `''`;
+ *     an empty id resolves to no canvas node and can name nothing.
+ *   · `evppi` PRESENT and FINITE — the wire types it `z.number().optional()`,
+ *     and `z.number()` admits `Infinity`. A row whose magnitude is unreadable is
+ *     a row whose status we decline to trust, and the fail-safe direction is to
+ *     drop it and disclose rather than to rank it. The value itself goes no
+ *     further than this check — it is never stored, compared, or used to order.
+ *   · `status` a CLOSED enum — the wire types it OPEN (`z.string()`) so an
+ *     unknown status cannot fail transport. Here it must be one of the two bands
+ *     we know how to render, because the only other thing we could do with an
+ *     unrecognised band is guess which one it means.
+ */
+function isUsableRow(row: FactorEvppiRow | null): row is FactorEvppiRow {
+  return (
+    row !== null &&
+    row.factor_id.length > 0 &&
+    typeof row.evppi === 'number' &&
+    Number.isFinite(row.evppi) &&
+    (row.status === 'resolved' || row.status === 'below_resolution')
+  )
 }
 
 /** True when the producer disclosed a partial per-factor assessment. */
 function hasPartialWarning(inferenceWarnings: unknown): boolean {
   if (!Array.isArray(inferenceWarnings)) return false
   return inferenceWarnings.some(
-    (w) => isPlainObject(w) && w.code === PARTIAL_WARNING_CODE,
+    (w) => isRecord(w) && w.code === PARTIAL_WARNING_CODE,
   )
 }
 
@@ -127,20 +187,12 @@ export function buildVoiRanking({
 
   for (const raw of rows) {
     // Defensive validation, fail-safe: drop THAT row, never coerce a value.
-    // `evppi` is required to be a finite number here even though the wire
-    // schema types it optional — a row whose magnitude is unreadable is a row
-    // whose status we decline to trust, and the fail-safe direction is to drop
-    // it and disclose rather than to rank it. The value itself goes no further
-    // than this check.
-    const isRowUsable =
-      isPlainObject(raw) &&
-      typeof raw.factor_id === 'string' &&
-      raw.factor_id.length > 0 &&
-      typeof raw.evppi === 'number' &&
-      Number.isFinite(raw.evppi) &&
-      (raw.status === 'resolved' || raw.status === 'below_resolution')
+    // Shape from the PINNED SCHEMA (`FactorEvppiRowSchema`), then the three
+    // consumer tightenings (`isUsableRow`) — both documented above.
+    const parsed = FactorEvppiRowSchema.safeParse(raw)
+    const wireRow = parsed.success ? parsed.data : null
 
-    if (!isRowUsable) {
+    if (!isUsableRow(wireRow)) {
       droppedAnyRow = true
       // A row we declined to VALIDATE is a row whose `status` we cannot trust
       // either — the status may be the very field that failed. So we cannot
@@ -168,8 +220,8 @@ export function buildVoiRanking({
       continue
     }
 
-    const factorId = raw.factor_id as string
-    const isResolvedRow = raw.status === 'resolved'
+    const factorId = wireRow.factor_id
+    const isResolvedRow = wireRow.status === 'resolved'
     const isFirstResolvedRow = isResolvedRow && !sawFirstResolvedRow
     if (isResolvedRow) sawFirstResolvedRow = true
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -441,10 +441,15 @@ const FLAGS_CONFIG = {
     storageKey: 'feature.strengthenPanel',
   },
   // Developer route estate — the scaffolding surfaces in src/poc/AppPoC.tsx
-  // that are NOT the product: /plot, /plot-legacy, /plc, /sandbox-v1,
-  // /dev/hero-gallery, and the router catch-all's POC-sandbox fallback.
-  // When OFF, every one of those URLs renders <Navigate to="/canvas" replace/>,
-  // so a tester who mistypes a URL lands on the canvas instead of on a sandbox.
+  // that are NOT the product. The authoritative list is the children of the
+  // one `<Route element={<DevRoutesGuard/>}>` layout route there; do not mirror
+  // it here (a second copy of the list is the trap-12 defect, and this comment
+  // has already drifted once).
+  //
+  // When OFF, every one of those URLs renders <Navigate to="/" replace/> — the
+  // SCENARIO LIST, deliberately not /canvas, because an open canvas is a live
+  // writer. A tester who mistypes a URL lands somewhere real and read-only.
+  // (This line said `/canvas` while the code said `/` — corrected 30 Jul.)
   //
   // ⚠ DELIBERATELY OFF IN EVERY DEPLOYED BUILD. `VITE_ENABLE_DEV_ROUTES` is not
   // set in netlify.toml for any context and must not be — staging IS the tester
@@ -607,7 +612,6 @@ export const isRequireLoginEnabled = flags.requireLogin
 export const isDecisionOverviewEnabled = flags.decisionOverview
 export const isStrengthenPanelEnabled = flags.strengthenPanel
 export const isDevRoutesEnabled = flags.devRoutes
-export const diagnoseDevRoutes = () => diagnoseFlagState(FLAGS_CONFIG.devRoutes)
 
 
 // ============================================================================

--- a/src/poc/AppPoC.tsx
+++ b/src/poc/AppPoC.tsx
@@ -3,11 +3,11 @@
 
 import { StrictMode, useState, useEffect, Suspense, useMemo, useCallback, useRef, lazy } from 'react'
 import type React from 'react'
-import { HashRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { HashRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { simulateTokens, getJSON } from './adapters/StreamAdapter'
 import { feature } from '../lib/pocFlags'
-import { isDevRoutesEnabled } from '../flags'
+import DevRoutesGuard from '../components/auth/DevRoutesGuard'
 import { fetchFlow as fetchFlowEngine, openSSE } from '../lib/pocEngine'
 import { initMonitoring } from '../lib/monitoring'
 import GraphCanvas from '../components/GraphCanvas'
@@ -103,41 +103,6 @@ const queryClient: any = (QueryClient && typeof QueryClient === 'function')
       },
     })
   : {}
-
-/**
- * TESTER-SAFE ROUTING — the developer scaffolding is behind one condition.
- *
- * `/plot`, `/plot-legacy`, `/plc`, `/sandbox-v1` and `/dev/hero-gallery` are
- * developer surfaces, not product. They shipped reachable-by-URL and outside
- * both `AuthGuard` and any flag (UI-SURFACE-CENSUS-2026-07-30, finding R1);
- * `/dev/hero-gallery` alone self-gated inside its component. This wrapper puts
- * all of them — plus `/test` and the catch-all, which render the same POC
- * sandbox — behind the single declared `devRoutes` flag, which is OFF in every
- * deployed build.
- *
- * ⚠ THE REDIRECT TARGET IS `/`, NOT `/canvas`, AND THAT IS DELIBERATE.
- * `/` is the scenario list; `/canvas` opens a blank "Untitled decision". Two
- * reasons, in order of weight:
- *   1. `/canvas` is a SIDE-EFFECT-PRODUCING landing. An open canvas tab is a
- *      live writer — it is the known staging hazard where an open canvas
- *      recreates deleted scenario rows. A mistyped URL must not start writing.
- *   2. It matches the one in-repo precedent for this shape, which this gate is
- *      modelled on: `HeroGallery.tsx:30` → `<Navigate to="/" replace />`.
- * `AppPoC.routing.spec.tsx` pins the destination as `/` and asserts the canvas
- * is NOT rendered, so a drift back to `/canvas` reds.
- *
- * The scaffolds are NOT deleted and NOT unmounted from the bundle: each is a
- * `React.lazy` chunk, and building the element here does not fetch it — only
- * rendering does. Flag on, the route mounts exactly what it always mounted.
- *
- * Reach them in your own browser, on any environment:
- *   localStorage.setItem('feature.devRoutes', '1')   // then reload
- */
-function DevRoute({ children }: { children: React.ReactNode }) {
-  // Read at RENDER time, not module load, so the localStorage override and the
-  // test suite both take effect without a module reset.
-  return isDevRoutesEnabled() ? <>{children}</> : <Navigate to="/" replace />
-}
 
 export default function AppPoC() {
   // P1: the single, gated DebugPanel mount lives here (the app shell).
@@ -951,30 +916,40 @@ export default function AppPoC() {
                   <Route path="/templates" element={<DecisionTemplates />} />
                 </Route>
 
-                {/* Dev/POC routes — ALL behind the `devRoutes` flag (see the
-                    DevRoute comment above). Off in every deployed build, so a
-                    tester cannot reach developer scaffolding by URL. */}
-                {/* Internal fixture gallery for the analysis hero — typed
-                    example states only (visible fixture banner on every
-                    panel); ALSO self-gated on `heroFixtureGallery`
-                    (staging-on/prod-off) inside the component, and unlinked. */}
-                <Route path="/dev/hero-gallery" element={<DevRoute><HeroGallery /></DevRoute>} />
-                <Route path="/plot" element={<DevRoute><PlotWorkspace /></DevRoute>} />
-                <Route path="/plot-legacy" element={<DevRoute><PlotShowcase /></DevRoute>} />
-                <Route path="/plc" element={<DevRoute><PlcLab /></DevRoute>} />
-                <Route path="/sandbox-v1" element={<DevRoute><SandboxV1 /></DevRoute>} />
-                <Route path="/test" element={<DevRoute><MainSandboxContent /></DevRoute>} />
-                {/* Catch-all. This used to render the POC sandbox, so a tester
-                    who mistyped a URL landed on developer scaffolding. It now
-                    lands on the scenario list — somewhere real, and read-only.
-                    The sandbox remains the catch-all only when `devRoutes` is
-                    on, which is what the Playwright suite runs with
-                    (playwright.config.ts webServer): 74 of 165 e2e specs reach
-                    a gated route, and `gotoSandbox()` plus
-                    `#/sandbox&scenario=<b64>` can ONLY be served by the
-                    catch-all — that hash is a single path segment, so no
-                    explicit route can ever match it. */}
-                <Route path="*" element={<DevRoute><MainSandboxContent /></DevRoute>} />
+                {/* Dev/POC routes — ALL behind the `devRoutes` flag, declared
+                    ONCE by the pathless layout route below (the same shape as
+                    AuthGuard above; see components/auth/DevRoutesGuard.tsx for
+                    why `/` and not `/canvas`). Off in every deployed build, so
+                    a tester cannot reach developer scaffolding by URL. Adding a
+                    dev route means adding a CHILD here — there is no per-route
+                    wrapper left to forget. */}
+                <Route element={<DevRoutesGuard />}>
+                  {/* Internal fixture gallery for the analysis hero — typed
+                      example states only (visible fixture banner on every
+                      panel); ALSO self-gated on `heroFixtureGallery`
+                      (staging-on/prod-off) inside the component, and unlinked. */}
+                  <Route path="/dev/hero-gallery" element={<HeroGallery />} />
+                  <Route path="/plot" element={<PlotWorkspace />} />
+                  <Route path="/plot-legacy" element={<PlotShowcase />} />
+                  <Route path="/plc" element={<PlcLab />} />
+                  <Route path="/sandbox-v1" element={<SandboxV1 />} />
+                  <Route path="/test" element={<MainSandboxContent />} />
+                  {/* Catch-all. This used to render the POC sandbox, so a tester
+                      who mistyped a URL landed on developer scaffolding. It now
+                      lands on the scenario list — somewhere real, and read-only.
+                      The sandbox remains the catch-all only when `devRoutes` is
+                      on, which is what the Playwright suite runs with
+                      (playwright.config.ts webServer): a large share of the e2e
+                      specs reach a gated route, and `gotoSandbox()` plus
+                      `#/sandbox&scenario=<b64>` can ONLY be served by the
+                      catch-all — that hash is a single path segment, so no
+                      explicit route can ever match it.
+
+                      NESTING IT HERE DOES NOT CHANGE ITS PRECEDENCE: a pathless
+                      parent contributes no path segment, so the branch's joined
+                      path is `/*` either way and its rank score is unchanged. */}
+                  <Route path="*" element={<MainSandboxContent />} />
+                </Route>
                 </Routes>
               </CanvasErrorBoundary>
             </Suspense>

--- a/src/poc/__tests__/AppPoC.routing.spec.tsx
+++ b/src/poc/__tests__/AppPoC.routing.spec.tsx
@@ -71,7 +71,8 @@ import AppPoC from '../AppPoC'
 // Every gated path, paired with the testid that proves its scaffold mounted.
 // `/test` renders MainSandboxContent, whose stub marker is `poc-sandbox` — the
 // same marker the catch-all uses, because they render the same POC sandbox.
-// MUST stay in step with the <DevRoute>-wrapped routes in AppPoC.tsx.
+// MUST stay in step with the children of the `<Route element={<DevRoutesGuard/>}>`
+// layout route in AppPoC.tsx.
 const DEV_ROUTE_PATHS = [
   ['/plot', 'route-plot'],
   ['/plot-legacy', 'route-plot-legacy'],

--- a/src/test/__tests__/audit-runtime-fixes.spec.ts
+++ b/src/test/__tests__/audit-runtime-fixes.spec.ts
@@ -90,8 +90,6 @@ function makeData(overrides: {
     isLoading: false,
     isError: false,
     goalLabel: 'Revenue',
-    // V7-C slice 1 (ROADMAP 2.141): `null` is the honest-gate verdict — this
-    // fixture predates the Resolve next view and asserts nothing about it.
     voiRanking: null,
   }
 }

--- a/src/test/helpers/resolveNextView.tsx
+++ b/src/test/helpers/resolveNextView.tsx
@@ -1,0 +1,71 @@
+/**
+ * resolveNextView — the shared scaffolding for the two "Resolve next" suites
+ * (V7-C slice 1, ROADMAP 2.141).
+ *
+ * `v7/__tests__/V7EvidenceDisclosure.resolveNext.spec.tsx` (the rendering-rules
+ * pins) and `results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx`
+ * (the refuted-claim pins) both need the same three things: a ranking row, a
+ * non-degenerate ranking fixture, and "render the disclosure, open it, switch to
+ * the Resolve next view". They arrived in the SAME PR with three private copies
+ * that had already diverged (two `row()` signatures, two fixtures with different
+ * labels) — so the two suites were asserting against subtly different surfaces
+ * while reading as if they shared one.
+ *
+ * The fixture is NON-DEGENERATE by construction (ROADMAP 2.141 probe limit i:
+ * the live rank-order probe was VACUOUS because the run returned two zero-EVPPI
+ * factors, so any order passed). It carries FOUR resolved rows with three
+ * DISTINCT producer positions, a TIE PAIR at ranks 2-3, TWO below-resolution
+ * rows, and enough rows to exercise the row clamp.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../../components/results/v7/V7EvidenceDisclosure'
+import type { V7EvidenceModel } from '../../components/results/v7/buildV7Lenses'
+import type { VoiRanking, VoiRankingRow } from '../../components/results/voi/voiRanking'
+
+/** One ranking row. `canFocus` defaults to true — the focusable case. */
+export function voiRow(factorId: string, label: string, canFocus = true): VoiRankingRow {
+  return { factorId, label, canFocus }
+}
+
+/**
+ * Producer wire order. Ranks 2 and 3 are a TIE on the wire (identical evppi
+ * upstream) — the reader keeps producer order and so must the view.
+ */
+export function voiRankingFixture(partial: Partial<VoiRanking> = {}): VoiRanking {
+  return {
+    resolved: partial.resolved ?? [
+      voiRow('n_market', 'Market receptivity'),
+      voiRow('n_comp', 'Competitor response'),
+      voiRow('n_comp_eu', 'Competitor response (Europe)'),
+      voiRow('n_reg', 'Regulatory timeline'),
+    ],
+    belowResolution: partial.belowResolution ?? [
+      voiRow('n_hiring', 'Hiring pace'),
+      voiRow('n_brand', 'Brand halo'),
+    ],
+    someFactorsUnassessed: partial.someFactorsUnassessed ?? false,
+  }
+}
+
+/** Render the disclosure, open it, and switch to the Resolve next view. */
+export function openResolveNext(
+  evidence: V7EvidenceModel,
+  onFocusNode?: (id: string) => void,
+) {
+  const utils = render(<V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />)
+  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+  fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
+  return utils
+}
+
+/**
+ * As `openResolveNext`, then EXPAND the row clamp and return the whole
+ * document's text. A claim hiding behind "Show N more" is still a claim, so the
+ * refuted-claim sweep must scan the clamped rows too.
+ */
+export function openResolveNextExpanded(evidence: V7EvidenceModel): string {
+  openResolveNext(evidence)
+  fireEvent.click(screen.getByTestId('v7-resolve-next-toggle'))
+  return document.body.textContent ?? ''
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -77,55 +77,22 @@ drift).
 
 ### `talchain-schemas-0.29.0.tgz` (historical — no longer vendored)
 
-**Recorded provenance: fetched with
-`npm pack @talchain/schemas@0.29.0 --registry=https://npm.pkg.github.com` from
-olumi-schemas #28 (merged `80c52743`), i.e. the registry artefact rather than a
-locally-packed branch.** That distinction matters — a merge can publish something
-other than the reviewed branch — but it is a record of what the vendoring lane
-did, **not something any artefact in this repo can prove.**
+The absorption measurements, silent-drop census and reader-first sequencing notes
+for this pin are gone with the pin: it is no longer vendored, nothing resolves
+against it, and prose about a tarball that is not here is the drift this file
+already warns about. Its git history has them if a future lane needs them.
+
+What is kept is the CORRECTION, because the defect it records recurs:
 
 ⚠ **CORRECTED (adversarial review of PR #531).** This section previously cited
 `sha512-BAHbxcy/mIlCc+GNiOxvS4zadrl+0Kwecx4va886b6gicbTPwAzciuhQiPe3YU7kUj+FSclK10ApMf9NNk89qg==`
 from `pnpm-lock.yaml` and asserted it **"is the registry's own"**. That was
 **false**: the pin is `file:./vendor/...`, so pnpm hashed the LOCAL tarball and
 the string is reproducible offline from the checked-in bytes. It was zero evidence
-about the registry. What the lockfile hash and the `.sha256` sidecar actually
-attest is **local integrity of the checked-in file** — nothing more. Same defect,
-same correction, as the 0.30.0 section above.
-
-**What it adds (ROADMAP 1.346):** the `factor_value_edit` system-event kind —
-the VALUE-CARRYING inspector edit `{target_id, value (model scale), raw_value?,
-unit?, field? (literal 'value')}`. A sibling of `direct_graph_edit`, not a value
-on it.
-
-**Absorption cost 0.22.0 → 0.29.0, MEASURED at this tip rather than estimated:
-ZERO.** Both gate projects were compiled at each pin and the sorted diagnostic
-text diffed — **byte-identical** (`tsconfig.app.json` 2178, `tsconfig.tooling.json`
-596; gate ratchet 626 files / 2517 errors either way). Counts alone would not
-have been enough: the per-file ratchet is blind to a within-file swap, so the
-comparison is on the diagnostic TEXT.
-
-The zero is not vacuous — a positive control was run in both directions: a file
-typing `{kind: 'factor_value_edit', …}` as `SystemEventTurnPayload['event']`
-raises TS2322 at 0.22.0 and compiles clean at 0.29.0, so the instrument
-demonstrably discriminates between the two pins.
-
-Silent-drop census (hazard 1 — a consumer on an older pin drops fields it does
-not know): **0 exports removed** from the `dist/boundary` surface and **0 field
-names removed** from `olumi-response.d.ts`, `turn-payload.d.ts` or `enums.d.ts`.
-`turn-payload` gains only additive members (the `graph_state` node/edge shape and
-the `factor_value_edit` fields).
-
-⚠ **Reader-first is mandatory for this member, not a preference.** `SystemEventSchema`
-is a `discriminatedUnion` on `kind` whose members are all `.strict()`, so a
-consumer pinned below 0.29.0 that receives `factor_value_edit` rejects the WHOLE
-turn — not just the unknown field. The order is publish → CEE re-vendors → CEE
-deploys → only then the UI emitter ships. CEE build `74d997a6` (pin ≥0.29.0) was
-deploy-verified before this pin landed.
-
-`src/lib/talchainSchemasVersion.ts` is bumped to `0.29.0` in lockstep (its spec
-derives the expected value from the `file:` pin in `package.json` and fails on
-drift).
+about the registry. What a lockfile hash and a `.sha256` sidecar actually attest
+is **local integrity of the checked-in file** — nothing more. Same defect, same
+correction, as the 0.30.0 section above: **no hash in this file can say anything
+about a registry while the pin is `file:`.**
 
 ### `talchain-schemas-0.21.0.tgz` (historical — no longer vendored)
 


### PR DESCRIPTION
**DO NOT MERGE — for review.**

Applies the 14 accepted UI items from the four-angle `/simplify` sweep over the sprint diff
(#530, #531). Ledger: `PHASE0-EVIDENCE-2026-07-28/simplify-findings-2026-07-30.md` →
"FINAL APPLY PLAN → UI apply lane". Full evidence:
`PHASE0-EVIDENCE-2026-07-28/simplify-apply-ui.md`.

**Quality only.** No feature change, no behaviour change, no baseline or exception-list change.

## Two things to read before the diff

### 1. Item 11 is deliberately narrowed — this is the one reviewer decision

The brief said "replace the hand-rolled `factor_id` row check with
`EnrichmentFactorEvppiEntrySchema.safeParse`". **A full-entry `safeParse` is not
behaviour-preserving.** Measured over 33 row payloads (every payload the 55 `voiRanking` specs
feed, plus adversarial extras):

| form | divergences vs the hand-rolled check |
|---|---|
| full `EnrichmentFactorEvppiEntrySchema.safeParse` | **3 / 33** |
| `.pick({factor_id, evppi, status}).safeParse` | **0 / 33** |

The three that flip are rows whose **unread** audit legs are mistyped — `units: 9`,
`noise_floor: 'x'`, `clamped_low: 'yes'`. Full parsing drops such a row; and if it were rank 1,
the reader's own rank-1 doctrine collapses **the entire ranking to the honest gate**. A producer
sending one malformed field this reader never looks at would silently lose the whole surface.

Shipped: `.pick(...)`. That keeps the finding's substance — **the row contract is derived from the
pinned schema, so a rename or retype of those three fields is a compile error here rather than
rows silently dropping in production**, which is the point in a repo whose #1 hazard is schema
skew — at zero behaviour change. No spec pins the divergence either way, so the brief's literal
STOP condition did not fire; the lane's "provably behaviour-preserving" requirement did.

**Whether a malformed unread audit leg *should* drop the row is a product judgement, not an apply
lane's.** Its direction is fail-safe (gate rather than fabricate) and it is a one-line change.

### 2. Matching suite counts hid a real regression — read the filenames, not the totals

The first after-run reported **counts identical to the baseline** and still contained a
regression this lane caused:

| run | files | tests | failing file |
|---|---|---|---|
| BEFORE (`1e320e5c`) | 1 failed / 1369 passed / 3 skipped | 1 failed / 20455 passed / 66 skipped | `aiPanelV2.parity.spec.tsx` — pre-existing 5s timeout flake |
| AFTER #1 | 1 failed / 1369 passed / 3 skipped | 1 failed / 20455 passed / 66 skipped | `no-evpi-display.contract.test.ts` — **caused here** |
| **AFTER #2 (final)** | **1370 passed / 3 skipped, exit 0** | **20456 passed / 66 skipped, exit 0** | **none** |

The flake stopped recurring and a genuine failure took its slot. Item 13's briefed home,
`src/test/helpers/`, trips `tests/contracts/no-evpi-display.contract.test.ts`: that guard derives
its non-display exemption as `__tests__/` or `/tests/`, and `src/test/helpers/` (singular "test")
matches **neither** — so a helper whose entire content is the banned EVPI vocabulary read as a
non-exempt `src/` module reintroducing the removed copy. **The guard was right to fire.** Fixed by
relocating to `src/components/results/__tests__/helpers/`, which is beside both importing specs,
exempt by the guard's *existing* category, and follows the repo's `__tests__/helpers/` precedent.

The final run is **fully green — strictly better than the baseline.**

### 3. `Typecheck Gate Self-Test` caught a second thing — commit 2 of 2

`pnpm run typecheck` passed on the first commit, and I proved its 4 identity notices were
harmless message re-renders (each differing by exactly one character). **That proof was correct
and still insufficient** — a *different* required check enforces that the notice not appear at all:

```
1/7  green control (clean tree)
  PASS  clean tree passes (exit 0)
  FAIL  no added-diagnostics notice on a clean tree — did NOT expect text
        "NOT in the identity baseline appeared", but the gate printed it
═══ self-test: 17 passed, 1 failed ═══
```

Every "the gate bites" control passed; only the **green control** failed, and `Staging Gate` failed
in 3s as a consequence. I had verified the gate I was told to run and reasoned past its warning;
the repo has a second 5-minute gate whose entire job is to police that warning.

**Fixed by removing the cause, not by regenerating a baseline.** The cause was adding a member to
`ResultsReport['robustness']` — an *inline* object type — which shifts the elided-member counter tsc
prints inside four unrelated baselined diagnostics (`… 8 more …` → `… 9 more …`). Regenerating was
the gate's other suggestion; it edits a tracked baseline for a cosmetic message change and papers
over a required check.

Removing it also puts the change **back in line with the ledger**, which asked only for the fields
in "the existing optional-fields block" (the top level) — the nested member was my own addition. So
`inference_warnings` stays declared at the top level, and the LEGACY nested slot keeps one narrow
cast inside `readInferenceWarnings()`, reason recorded at both sites. That slot measures **0/773**
on live staging facts (root 773/773), so the cast sits on the path production never uses.

Commit 2 is **type-only plus comments — both erased at build** — so the runtime is byte-identical to
the tree that produced the fully-green suite. `typecheck:selftest` is now **18/0**.

### 4. Adversarial-review amendment A1 — commit 3 of 3

Review returned **HOLD for one amendment**; everything else verified against baselines the reviewer
recorded themselves (real-browser routing sweep reproducing their #530 16-row table exactly, the
moved routing pin replaying to a byte-identical 8 failed / 9 passed, coverage 270→270 with identical
test-NAME sets, all 8 of their #531 `.pick` probes green, no baseline/CI script touched).

**A1, and it was this PR's own header claim that was false.**
`evpiSurfacesRemoved.honesty.spec.tsx` imported the three shared regexes but hand-listed inline
controls for only two. `PP_TOKEN` had none — in a file that uses it in three absence assertions:

| mutant | that spec, before the amendment |
|---|---|
| neuter `PP_TOKEN` | **6 / 6 GREEN — blind** |
| neuter `WORTH_CLAIM` | 1 failed / 5 passed |
| neuter `RESOLVING_CLAIM` | 1 failed / 5 passed |

I had flagged this gap myself and chose to report rather than fix it. **Wrong call**, for a reason my
report did not weigh: item 13 moved the definitions into a *shared* module, reversing the direction
of the failure. Before, narrowing `PP_TOKEN` appeared in that file's own diff; after, it can be
hollowed **from another file** while three absence assertions about a *refuted* quantity silently
stop testing anything under a green suite. And the matchers header asserted the opposite twice.

**Fix:** the spec now **iterates `REFUTED_CLAIM_CONTROLS`** rather than hand-listing patterns, plus
the table-length assertion. Chosen over "add one inline line" deliberately — hand-listing is what
left the hole, so the controls are now *derived*: a fourth banned pattern cannot be added without
acquiring a control in both specs. Both header sentences are now true and are **kept, not softened**,
with the history of their falsehood recorded.

**Proof:** neuter `PP_TOKEN` → **1 failed / 5 passed** (was 6/6 green). Shrink the control table →
**both** specs red. Test count and name set unchanged at 6.

**Reviewer's optional-but-preferred §6 item, taken.** The `.pick`-vs-full-schema choice was invisible
to the suite — they swapped the full schema in and got 55/55, 10/10, 25/25 all green, so the decision
was held by a comment. `voiRanking.spec.ts` gains 2 pins (55 → 57): a rank-1 row with every unread
audit leg mistyped still ranks, plus a positive control that a mistyped **read** field does drop it.
**Swapping `.pick` for the full schema now gives 1 failed / 56 passed.**

⚠ Re-derived rather than left standing: `voiRanking.spec.ts` is **no longer byte-unchanged**. That
proof holds as a measurement at `0b004e8c`/`187108ab`; from here it is 57/57 with the original 55
untouched.

Full suite at head: **1370 passed / 3 skipped (1373 files), 20458 passed / 66 skipped (20524),
exit 0** — `+2`, exactly the new pins.

## What changed

| # | Item |
|---|---|
| 1 | `DevRoute` per-route wrapper → one pathless `<Route element={<DevRoutesGuard/>}>` layout route beside `AuthGuard`; `flags.ts` stale mirror (`/canvas` → `/`) corrected |
| 2 | `VISIBLE_DRIVERS` + `VISIBLE_RESOLVE_NEXT` → one `VISIBLE_EVIDENCE_ROWS` (their equality lived in a comment) |
| 3 | `factor_evppi` / `inference_warnings` declared; wire-field double-casts → plain reads; one `readInferenceWarnings()` |
| 4 | static `VIEWS` array hoisted to module level |
| 5 | `ClampToggle` leaf for the duplicated Show-N-more toggle |
| 6 | zero-caller `diagnoseDevRoutes` deleted |
| 7 | hard-coded "74 of 165" dropped from the catch-all comment (prose kept) |
| 8 | 2-line fixture comment trimmed in **10** files (`withheldProse`'s copy KEPT — real scope content) |
| 9 | `vendor/README` 0.29.0 section trimmed to its correction paragraph |
| 10 | honest note on the `resolveLabel` producer: it cannot yet emit `canFocus: false` |
| 11 | `voiRanking` row check → the pinned schema (**narrowed**, above) |
| 12 | one shared `v7EvidenceModel()` + one shared resolveNext scaffolding module |
| 13 | refuted-claim matchers → one shared home; both honesty specs import them (**relocated**, above) |
| 14 | `voiRanking` uses the repo's one exported plain-object guard, not a 7th copy |

## Verification

- **`pnpm run typecheck` PASSED.** Its 4 non-blocking identity notices are **proven** to be
  message re-renders of the same 4 baselined errors: each differs by **exactly one character**
  (`… 8 more …` → `… 9 more …`) because item 3 adds one member to the inline `robustness` type
  those messages print. Same file, position, code and property. Total held at 2510.
  **No baseline regenerated.**
- **Item 1 proven two independent ways.** `AppPoC.routing.spec.tsx` passes **17/17
  byte-unchanged** against the new router (verified with an empty `git diff --stat` at run time,
  before its stale comment was touched); and a `matchRoutes` differential over 23 pathnames using
  the repo's own react-router-dom 6.30.3 gives **DIFFS=0** — identical matched leaf, resolved
  pathname and splat params, including `#/sandbox&scenario=<b64>`, `/plot/extra` and `/test/deep`.
- **Moved pins re-proven RED-first from the home they actually ship in** — 11 mutants, each
  restored and the restoration verified. Includes: planting a real pp-claim in production copy on
  **both** surfaces (`v7LensCopy`, `TriageCard`) → both honesty specs RED; narrowing the one
  shared matcher definition → RED; breaking its control table → RED; merged clamp 3→4 → RED in
  Drivers **and** Resolve next; re-sorting the ranking → RED.
- **`voiRanking.spec` 55/55 byte-unchanged.** Every touched spec's test count unchanged
  (55, 25, 10, 6, 8, 5, 15, 17 — before and after).
- **Lint:** 0 errors; all 7 warnings proven pre-existing by linting
  `git show origin/staging:src/poc/AppPoC.tsx` in isolation (same set, line numbers shifted by the
  35 lines item 1 removes).

## Findings the ledger did not have

1. **`factor_id.length > 0` is defensive but UNPINNED.** Removing it leaves all 55 specs green —
   an empty id never resolves to a canvas label, so the resolver drops the row one step later with
   `someFactorsUnassessed` set either way. **Pre-existing**, kept (load-bearing for any future
   resolver that could map `''`), flagged because an unpinned check is the guarantee-theatre class.
2. **`evpiSurfacesRemoved.honesty.spec.tsx` has no positive control for `PP_TOKEN`.** Narrowing
   that matcher leaves it green — its controls cover `WORTH_CLAIM` and `RESOLVING_CLAIM` only.
   **Pre-existing trap 13, exposed by the move, not caused by it**; now covered at suite level by
   the shared `REFUTED_CLAIM_CONTROLS` table. Not fixed here: that file renders the archived
   `ConfidenceSection` and the sprint ruled it out of scope.
3. **`src/test/helpers/` cannot host anything mentioning the removed EVPI vocabulary** (above).
   The guard's own failure message names the alternative fix — add `src/test/` to its
   `NON_DISPLAY_PREFIXES` — which would close a real gap in its category derivation. Left to a
   reviewer: it edits a trust-surface guard's exemption list. **Rowable.**

Also observed, not applied: two further `PP_TOKEN` copies outside the briefed scope
(`V7EvidenceDisclosure.resolveNext.spec.tsx:281`, `evpiSurfacesRemoved.canvas.honesty.spec.tsx:53`),
and a third divergent `inference_warnings` dual-read at `src/canvas/nodes/GoalNode.tsx:115` for
which `readInferenceWarnings` is now the obvious home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
