### PR TITLE
DO-NOT-MERGE: fix(gate) pre-push check 6a could never pass; smoke list ran 8 of 9 silently (2.153)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ pnpm run test:full    # Full suite with increased memory (NODE_OPTIONS=--max-old
 
 ### Pre-push validation — two scripts, different scopes
 
-- **`.git/hooks/pre-push`** (git hook, auto-runs on `git push`) delegates to `scripts/validate-prepush.sh`. This is the **fast gate** (~3 min): branch guard, typecheck, lint (changed files only), 8-file smoke suite, stale-.js detection, dependency audit with `@talchain/schemas` allowlist + vendored-tarball SHA manifest check. Blocks the push on failure.
+- **`.git/hooks/pre-push`** (git hook, auto-runs on `git push`) delegates to `scripts/validate-prepush.sh`. This is the **fast gate** (~3 min): branch guard, typecheck, lint (changed files only), 9-file smoke suite, stale-.js detection, dependency audit with `@talchain/schemas` allowlist + vendored-tarball SHA manifest check. Blocks the push on failure. The smoke list is derived, not mirrored: a `SMOKE_FILES` entry naming a spec that no longer exists is a gate FAILURE, never a silent skip (this doc said "8-file" while the list named 9 — the gate had been running 8 of 9 since 2026-04-21).
 - **`bash scripts/pre-push-validate.sh`** (manual, optional) is the **full gate** (~15 min): runs the same checks but replaces the smoke suite with the full ~6,284-test vitest run. Used only when you want the full suite locally. Not invoked automatically — CI covers the full suite via `.github/workflows/staging-full-tests.yml` (7 GB heap, dedicated runner).
 - **`@talchain/schemas` file: dependency is allowlisted** deliberately (v5 A1 policy, commit `b6b1222a`). Both pre-push scripts pair the allowlist with a tarball SHA manifest check that fails on drift. Any OTHER `file:` reference fails either gate.
 

--- a/scripts/pre-push-validate.sh
+++ b/scripts/pre-push-validate.sh
@@ -148,24 +148,27 @@ fi
 header "Check 5a — V5 vendored schemas tarball SHA manifest"
 
 # A1: guard against drift between vendored tarball bytes and the committed
-# SHA manifest. If someone rebuilds the tarball without updating the
-# manifest, push is blocked. Mirrors scripts/validate-prepush.sh Check 6a.
-# Derive tarball filename from package.json (single source of truth).
-TARBALL_NAME=$(grep -o 'vendor/[^"]*\.tgz' "$REPO_ROOT/package.json" | head -1)
-TARBALL="$REPO_ROOT/$TARBALL_NAME"
-MANIFEST="$TARBALL.sha256"
-if [ ! -f "$TARBALL" ] || [ ! -f "$MANIFEST" ]; then
-  fail "vendored tarball or SHA manifest missing"
+# SHA manifest. If someone rebuilds the tarball without updating the manifest,
+# push is blocked.
+#
+# DELEGATED, deliberately — do not re-implement the comparison here.
+# This check previously duplicated validate-prepush.sh Check 6a line for line,
+# including its defect: `tr -d '[:space:]' < "$MANIFEST"` collapses the
+# standard two-column shasum format (`<hash>  <filename>`) into the hash
+# CONCATENATED with the filename, which can never equal a bare 64-char hash.
+# Both copies therefore always failed once the manifest gained the filename
+# column — every push from schemas 0.29.0 (2026-07-28, #513) onward. The
+# duplication is what let one defect break two gates, so the two now share
+# ONE implementation instead of mirroring each other.
+#
+# scripts/check-vendor-sha.mjs is the single source of truth. It derives the
+# tarball name from package.json's dependency field, accepts BOTH manifest
+# formats (`<hash>` and `<hash>  <filename>`), asserts the hash is 64 hex
+# chars, and prints a remediation block on mismatch.
+if node "$REPO_ROOT/scripts/check-vendor-sha.mjs"; then
+  pass "V5 vendored schemas tarball SHA matches manifest"
 else
-  ACTUAL="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
-  EXPECTED="$(tr -d '[:space:]' < "$MANIFEST")"
-  if [ "$ACTUAL" != "$EXPECTED" ]; then
-    echo "    manifest: $EXPECTED"
-    echo "    actual:   $ACTUAL"
-    fail "Vendored schemas tarball changed without manifest update. Rebuild and commit both."
-  else
-    pass "V5 vendored schemas tarball SHA matches manifest"
-  fi
+  fail "Vendored schemas tarball changed without manifest update, or manifest is unreadable (see above). Rebuild and commit both."
 fi
 
 # Also verify the fork directory doesn't exist

--- a/scripts/validate-prepush.sh
+++ b/scripts/validate-prepush.sh
@@ -121,24 +121,52 @@ SMOKE_FILES=(
   "src/utils/__tests__/nodeIdNormalisation.spec.ts"
   "src/components/results/__tests__/buildResultsVM.spec.ts"
   "src/components/results/__tests__/useResultsSectionData.spec.ts"
-  "src/components/results/__tests__/HeroSection.spec.tsx"
+  # Hero render path. This line read
+  # `src/components/results/__tests__/HeroSection.spec.tsx` until f2596f1d
+  # (2026-04-21) deleted that spec as dead code — the component itself had
+  # already gone in Brief 5.4 Phase 2, and vitest.config.ts records the same
+  # deletion. Nobody updated THIS list, so from that day the existence filter
+  # below silently ran 8 of 9 files and still printed "Smoke tests passed".
+  # Re-pointed at the hero surface that is actually live on staging:
+  # netlify.toml [context.staging.environment] sets
+  # VITE_FEATURE_ANALYSIS_HERO_PANEL=1 (the analysis-hero/ family), while
+  # analysisHeroV17 is enabled in no netlify context. buildHeroModel is that
+  # surface's view-model builder — the data-flow node, matching this list's
+  # stated purpose and its buildResultsVM sibling above.
+  "src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts"
   "tests/ci-guards/css-var-resolution.spec.ts"
 )
 
-# Filter to files that exist
-EXISTING_SMOKE=""
+# A missing entry FAILS — it must never silently shrink the suite.
+# The old filter dropped non-existent paths without a word, which is the
+# hand-maintained-mirror defect this repo keeps paying for: a named critical
+# path stops being checked and the gate still reports success. If an entry
+# above no longer exists, repoint it at the successor spec or delete the line
+# deliberately — both are one-line edits, and both are visible in review.
+EXISTING_SMOKE=()
+MISSING_SMOKE=()
 for f in "${SMOKE_FILES[@]}"; do
-  [ -f "$REPO_ROOT/$f" ] && EXISTING_SMOKE="$EXISTING_SMOKE $f"
+  if [ -f "$REPO_ROOT/$f" ]; then
+    EXISTING_SMOKE+=("$f")
+  else
+    MISSING_SMOKE+=("$f")
+  fi
 done
 
-if [ -z "$EXISTING_SMOKE" ]; then
-  skip "No smoke test files found — skipped"
+if [ "${#MISSING_SMOKE[@]}" -ne 0 ]; then
+  echo "    SMOKE_FILES names ${#MISSING_SMOKE[@]} spec file(s) that do not exist:"
+  for f in "${MISSING_SMOKE[@]}"; do echo "      $f"; done
+  fail "SMOKE_FILES is stale — a named critical path would go unchecked. Repoint each entry at its successor spec, or delete the line deliberately."
+fi
+
+if [ "${#EXISTING_SMOKE[@]}" -eq 0 ]; then
+  fail "No smoke test files found — the smoke list must never be empty"
+elif npx vitest run --bail=1 "${EXISTING_SMOKE[@]}" 2>&1; then
+  # Report ran-of-named, both derived. A shrink is then visible in the summary
+  # line itself, not only in the failure above it.
+  pass "Smoke tests passed (${#EXISTING_SMOKE[@]} of ${#SMOKE_FILES[@]} named critical data-flow path(s))"
 else
-  if npx vitest run --bail=1 $EXISTING_SMOKE 2>&1; then
-    pass "Smoke tests passed (critical data-flow paths)"
-  else
-    fail "Smoke tests failed"
-  fi
+  fail "Smoke tests failed"
 fi
 
 # ─── Check 5: Stale .js detection ─────────────────────────────────────
@@ -187,24 +215,28 @@ fi
 header "Check 6a — V5 vendored schemas tarball SHA manifest"
 
 # A1: guard against drift between vendored tarball bytes and the committed
-# SHA manifest. If someone rebuilds the tarball without updating the
-# manifest, push is blocked.
-# Derive tarball filename from package.json (single source of truth).
-TARBALL_NAME=$(grep -o 'vendor/[^"]*\.tgz' "$REPO_ROOT/package.json" | head -1)
-TARBALL="$REPO_ROOT/$TARBALL_NAME"
-MANIFEST="$TARBALL.sha256"
-if [ ! -f "$TARBALL" ] || [ ! -f "$MANIFEST" ]; then
-  fail "vendored tarball or SHA manifest missing"
+# SHA manifest. If someone rebuilds the tarball without updating the manifest,
+# push is blocked.
+#
+# DELEGATED, deliberately — do not re-implement the comparison here.
+# This check used to hash the tarball and parse the manifest in bash, and the
+# parse was wrong: `tr -d '[:space:]' < "$MANIFEST"` collapses the standard
+# two-column shasum format (`<hash>  <filename>`) into the hash CONCATENATED
+# with the filename, which can never equal a bare 64-char hash. Check 6a
+# therefore could not pass on ANY tree whose manifest carried the filename
+# column — i.e. every push from schemas 0.29.0 (2026-07-28, #513) onward.
+# A supply-chain guard that always fails is worse than no guard: it teaches
+# every lane to `--no-verify` past the checks that do work.
+#
+# scripts/check-vendor-sha.mjs is the single source of truth. It derives the
+# tarball name from package.json's dependency field, accepts BOTH manifest
+# formats (`<hash>` and `<hash>  <filename>`), asserts the hash is 64 hex
+# chars, and prints a remediation block on mismatch. It is the same script
+# `pnpm run check:vendor` and `pnpm run dev` already run.
+if node "$REPO_ROOT/scripts/check-vendor-sha.mjs"; then
+  pass "V5 vendored schemas tarball SHA matches manifest"
 else
-  ACTUAL="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
-  EXPECTED="$(tr -d '[:space:]' < "$MANIFEST")"
-  if [ "$ACTUAL" != "$EXPECTED" ]; then
-    echo "    manifest: $EXPECTED"
-    echo "    actual:   $ACTUAL"
-    fail "Vendored schemas tarball changed without manifest update. Rebuild and commit both."
-  else
-    pass "V5 vendored schemas tarball SHA matches manifest"
-  fi
+  fail "Vendored schemas tarball changed without manifest update, or manifest is unreadable (see above). Rebuild and commit both."
 fi
 
 # Also verify the fork directory doesn't exist


### PR DESCRIPTION
**DO NOT MERGE** — review gate first.

Two gate-honesty defects in the fast pre-push gate (ROADMAP 2.153 family). Both
are the hand-maintained-mirror class: machinery that reads as a guarantee while
its result was already decided.

Base `3be7124a` · head `520a119c` · 3 files, none under `src/`.
Evidence: `PHASE0-EVIDENCE-2026-07-28/fix-prepush-gate.md`.
Disjoint from open PR #534 (that PR touches 8 files, all under `src/`; zero overlap).

---

## Defect 1 — check 6a could never pass

```bash
EXPECTED="$(tr -d '[:space:]' < "$MANIFEST")"
```

`tr -d '[:space:]'` deletes the *separator* in the standard two-column shasum
format (`<hash>  <filename>`), so EXPECTED came out as the hash **concatenated
with the filename** and was compared to a bare 64-char hash. Never equal, by
construction. Measured on pristine `3be7124a`:

```
ACTUAL   = cd37…a0cc                              (64 chars)
EXPECTED = cd37…a0cctalchain-schemas-0.30.0.tgz   (91 chars)   -> FAIL
```

Positive control that this is a *parse* bug and not real drift:
`node scripts/check-vendor-sha.mjs` passes silently — the bytes match.

This is the supply-chain guard on the one allowlisted `file:` dependency. **A
guard that always fails trains every lane to `--no-verify` past the checks that
do work.**

**Dated at the bytes** (`git log` over every historical manifest): the parse was
*correct by coincidence*, not by design. `b6b1222a` added both the `tr -d` line
and the first manifest — in bare-hash (1-column) format, which it happens to
handle. Every manifest through 0.22.0 stayed 1-column. It broke transiently at
0.7.0 (`fffe7863`), was accidentally un-broken when 0.7.0 was regenerated
(`871068c5`), and broke for good when the **0.29.0 re-vendor (#513, 2026-07-28)**
wrote 2 columns. 0.30.0 (#531) kept that format. So yes — it was bare-hash once,
and that is precisely why the defect survived three months unseen.

**Fix: delegate, don't reimplement.** `scripts/check-vendor-sha.mjs` already
compares correctly (`split(/\s+/)[0]`, accepts both formats, asserts 64 hex
chars, prints remediation) and is the same script `pnpm run dev` runs. Check 6a
now calls it instead of carrying a second implementation.

**The broken line existed twice.** Complete manifest of scripts that hash the
manifest: exactly two. `scripts/pre-push-validate.sh:161` carried the identical
line under a comment reading *"Mirrors scripts/validate-prepush.sh Check 6a"* —
and that script is **live and documented** (`CLAUDE.md:75`, `docs/DEPLOY.md:17`
both tell people to run it as the ~15 min full gate). Fixing only the fast gate
would have left the documented full gate's supply-chain check permanently
failing, so both now share one implementation.

## Defect 2 — SMOKE_FILES named 9 specs, ran 8, printed "passed"

`src/components/results/__tests__/HeroSection.spec.tsx` was deleted at
`f2596f1d` (2026-04-21) as dead code — its message says the component had
already gone in Brief 5.4 Phase 2. The entry was **not** born dangling (checked,
not assumed: the gate was added at `fe0389da`, 2026-03-02, and the blob exists
at that tree). It drifted at the deletion and was silently absorbed for **~3.3
months**.

Two signs this is trap 12 rather than a one-off:
- `vitest.config.ts:44` **was** updated for the same deletion. One mirror was
  maintained; the gate's was not.
- The repo's `CLAUDE.md:74` had gone further and documented the shrink as
  intended — *"8-file smoke suite"* — while the list named 9.

**Decision: re-point, not remove**, and derived which surface is live because
staging is the product. `ResultsBody.tsx` imports both hero families, each
flag-gated, both off-by-default in `src/flags.ts`; `netlify.toml`
`[context.staging.environment]` sets `VITE_FEATURE_ANALYSIS_HERO_PANEL=1` (the
`analysis-hero/` family) and `ANALYSIS_HERO_V17` appears in **no** netlify
context. So the entry now points at that surface's view-model builder,
`analysis-hero/__tests__/buildHeroModel.spec.ts` — the data-flow node, matching
the list's stated purpose and its `buildResultsVM` sibling.

**Fail loud.** A `SMOKE_FILES` entry naming a spec that does not exist is now a
gate **failure**, never a silent skip (chose fail, per the brief: a named
critical path silently unchecked is exactly what the gate exists to prevent).
The summary line reports **ran-of-named** — `9 of 9`, both derived — so a shrink
shows up in the output itself. Empty list is a fail, not the old `skip`. Array
expansion stays guarded for `bash 3.2.57`, which is what runs the hook.

## Controls

| # | Control | Result |
|---|---|---|
| 1 | 6a, pristine tarball + real 2-column manifest | **PASS** |
| 2 | 6a, byte appended to a throwaway **copy** | **FAIL** (real vendor file hash verified untouched) |
| 3 | 6a, altered manifest hash, tarball pristine | **FAIL** |
| 4 | 6a, bare-hash manifest (pre-0.29.0 format) | **PASS** — not re-broken the other way |
| 5 | check 4, real list at head | `9 of 9`, 0 failures |
| 6 | check 4, deliberately-missing entry injected | guard **FIRES**, `9 of 10` |
| 7 | **mutation-check**: OLD filter, same injected entry | 0 failures + "Smoke tests passed" → **silent**; the fix bites |

Controls ran from a throwaway tree **outside** the repo root (trap 9c), against
blocks **extracted from the fixed script with `sed`** — the real code, not a
retyped copy. Mutant edits reverted; `git status` confirmed only the 3 intended
files.

## Gates at `520a119c`

| Check | Result |
|---|---|
| 1 branch guard | ✅ |
| 2 typecheck | ✅ gate PASSED — 3072/3112 tracked files loaded; ratchet 622 files / 2510 errors = baseline (nothing absorbed) |
| 3 lint changed | ⊘ skipped — diff is `.sh` + `.md`, no `.ts/.tsx` (eslint N/A) |
| 4 smoke | ❌ **pre-existing red** — 8 of 9 pass (595 tests, incl. the new entry's 105); `tests/ci-guards/css-var-resolution.spec.ts` fails |
| 5 stale .js | ✅ |
| 6 dep audit | ✅ |
| **6a vendored SHA** | ✅ **fixed** (was failing on pristine base) |
| 7 close-out doc | ⊘ conditional, skipped |
| 8 DS v5 drift | ❌ known pre-existing red — delta proven **empty** |

`shellcheck -S warning`: finding sets **identical** base↔head for both scripts
(the 2 pre-existing SC2069 at `pre-push-validate.sh:196` are outside my hunks).
`bash -n` clean under 3.2.57.

**Check 8 empty-delta proof:** DS guard output is **byte-identical** at base and
head (`diff` clean, 24 lines each, exit 1 both). It scans `src/` only; this diff
touches no `src/` file. Not fixed here, deliberately.

## ⚠ Third defect found, NOT fixed here — needs a row

**The brief's expectation that the gate fully passes at head is not achievable:
check 4 cannot pass on pristine staging either.**
`tests/ci-guards/css-var-resolution.spec.ts` fails **identically at base
`3be7124a`** — `SyntaxError: Expected double-quoted property name in JSON at
position 8192`. Proven pre-existing and isolated from this change:

- the spec and `scripts/css-var-census.mjs` are **byte-identical** base↔head;
- it fails at base standalone, at head standalone, and inside the 9-file run —
  three independent observations;
- the new `buildHeroModel.spec.ts` entry passes standalone (105 tests), so it is
  not the cause.

Position **8192** is exactly the pipe buffer: the census emits ~13 KB of JSON
then `process.exit(1)` (it exits non-zero *by design* when it finds drift), and
the tail is lost. Outside vitest the same `execFileSync` call captures all 13043
bytes and parses — so this is vitest's child-stdout handling, and it only bites
on the exit-non-zero path.

This matters beyond a red: the `SMOKE_FILES` comment says the css-var guard is
in the list *precisely* because `vitest --changed` can never select it — *"the
whole point of the guard is to catch it before the colour ships"*. It has been
catching nothing. **Same defect class as 6a, third instance in one script.**

Also noticed, not fixed (out of scope, worth rowing): the gate shells out to
`npm run typecheck` and greps `package-lock.json` in check 6, but this repo is
**pnpm-only** (`packageManager: pnpm@10.18.0`, only `pnpm-lock.yaml` tracked) —
so the check-6 lockfile arm greps a file that does not exist and passes
vacuously. `check-vendor-sha.mjs`'s remediation text also still says
`npm is the documented default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
