### PR TITLE
DO-NOT-MERGE: fix(gate) the css-var guard's own payload was one growth spurt from vanishing (2.147)

### DIFF
--- a/scripts/css-var-census.mjs
+++ b/scripts/css-var-census.mjs
@@ -877,14 +877,45 @@ function main() {
     }
   }
 
-  if (summary.errors.length) process.exit(2)
+  // ---------------------------------------------------------------- exit
+  //
+  // `process.exitCode = n`, NEVER `process.exit(n)`.
+  //
+  // When stdout is a PIPE, Node's writes are asynchronous: `console.log`
+  // hands the buffer to libuv, which write(2)s what the pipe will accept and
+  // QUEUES the rest. `process.exit()` tears the process down without
+  // draining that queue, so everything past the pipe's capacity is lost —
+  // silently, with the exit status still correct.
+  //
+  // That made this script's OWN GUARD self-defeating. Its only consumer,
+  // tests/ci-guards/css-var-resolution.spec.ts, reads `--json` through
+  // execFileSync (a pipe), and the exit path taken WHENEVER THERE ARE
+  // FINDINGS was the one that truncated. A guard that works until it has
+  // something to say is not a guard.
+  //
+  // Measured on this platform (darwin, node 22): a `console.log` followed by
+  // `process.exit()` delivers at most 65,536 bytes — 10/10 runs truncated at
+  // exactly that offset for any larger payload, while `exitCode` + natural
+  // drain delivered 2 MB intact, 10/10. Exit STATUS is identical either way.
+  // tests/ci-guards/css-var-resolution.spec.ts pins both halves of that
+  // measurement as an executable control, so the cliff is derived at your
+  // platform rather than trusted from this comment.
+  //
+  // Setting exitCode is sufficient because nothing here holds the event loop
+  // open (no timers, sockets or watchers) — the process ends as soon as the
+  // write drains. Do not "fix" a future hang by reinstating process.exit();
+  // find the handle.
+  if (summary.errors.length) {
+    process.exitCode = 2
+    return
+  }
   if (
     summary.undefinedRefs.length ||
     summary.unresolvable.length ||
     summary.cssUndefined.length ||
     summary.fallbackDrift.length
   ) {
-    process.exit(1)
+    process.exitCode = 1
   }
 }
 

--- a/tests/ci-guards/css-var-resolution.spec.ts
+++ b/tests/ci-guards/css-var-resolution.spec.ts
@@ -31,7 +31,10 @@
  */
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
+import ts from 'typescript'
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/css-var-census.mjs')
 
@@ -58,17 +61,171 @@ interface Census {
   selfTest: { ok: boolean; failures: string[] }
 }
 
-function runCensus(): Census {
+interface CensusRun {
+  census: Census
+  /** Exit status of the census process. 0 clean · 1 findings · 2 census error. */
+  status: number
+  /** Byte length of the JSON that actually arrived down the pipe. */
+  bytes: number
+}
+
+/**
+ * Run the census and parse its `--json` payload.
+ *
+ * THE HAZARD THIS FUNCTION IS WRITTEN AROUND: stdout here is a PIPE, so the
+ * census's writes are asynchronous. A `process.exit()` in the census would
+ * discard everything past the pipe's capacity and still exit with the right
+ * status — a truncated payload that looks like a crashing JSON parser. That
+ * bug lived on the FINDINGS path, i.e. the only path this guard cares about,
+ * so the guard would have broken precisely when it had something to report.
+ * See the exit block at the foot of scripts/css-var-census.mjs, and the two
+ * drain controls below that pin the mechanism at your platform.
+ *
+ * A parse failure therefore reports the byte count and the tail of what
+ * arrived, so truncation is diagnosed on sight instead of being read as
+ * "the census emits invalid JSON".
+ */
+function runCensus(): CensusRun {
   // The census exits 1 when it finds defects; that is a finding, not a
   // crash, so a non-zero status must not abort the spec run.
+  let out: string
+  let status = 0
   try {
-    const out = execFileSync('node', [SCRIPT, '--json'], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
-    return JSON.parse(out) as Census
+    out = execFileSync('node', [SCRIPT, '--json'], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
   } catch (err) {
-    const e = err as { stdout?: string }
-    if (e.stdout) return JSON.parse(e.stdout) as Census
-    throw err
+    const e = err as { stdout?: string; status?: number; message?: string }
+    if (typeof e.stdout !== 'string') throw err
+    out = e.stdout
+    status = typeof e.status === 'number' ? e.status : -1
   }
+
+  const bytes = Buffer.byteLength(out, 'utf8')
+  let census: Census
+  try {
+    census = JSON.parse(out) as Census
+  } catch (parseErr) {
+    throw new Error(
+      `the census's --json payload did not parse: ${(parseErr as Error).message}\n` +
+        `  bytes received: ${bytes} · exit status: ${status}\n` +
+        `  If the payload ends mid-token, it was TRUNCATED in transit, not malformed: the census\n` +
+        `  wrote it to a pipe and exited before the write drained. Fix by setting process.exitCode\n` +
+        `  in scripts/css-var-census.mjs instead of calling process.exit() — never by shrinking\n` +
+        `  what the census reports.\n` +
+        `  tail: …${out.slice(-120)}`,
+    )
+  }
+  return { census, status, bytes }
+}
+
+/**
+ * Every top-level key this spec reads, with a shape predicate. Parsing
+ * without this proved nothing: `JSON.parse('{}')` succeeds, and every
+ * `toEqual([])` absence assertion below would then pass on `undefined`
+ * — trap 13, in the one place the whole guard funnels through.
+ *
+ * DERIVED from the Census interface's own contract, and EXACT in both
+ * directions: an unknown key means the census grew a field this spec is
+ * blind to, which is exactly when somebody should look.
+ */
+const EXPECTED_CENSUS_KEYS: Record<string, (v: unknown) => boolean> = {
+  errors: (v) => Array.isArray(v),
+  counts: (v) => typeof v === 'object' && v !== null && !Array.isArray(v),
+  undefinedRefs: (v) => Array.isArray(v),
+  unresolvable: (v) => Array.isArray(v),
+  cssUndefined: (v) => Array.isArray(v),
+  fallbackDrift: (v) => Array.isArray(v),
+  fallbackUncomparable: (v) => Array.isArray(v),
+  resolvedDynamicNameList: (v) => Array.isArray(v),
+  dynamicSiteFiles: (v) => Array.isArray(v),
+  selfTest: (v) => typeof v === 'object' && v !== null && !Array.isArray(v),
+}
+
+const EXPECTED_COUNT_KEYS = [
+  'cssFiles',
+  'definitions',
+  'dynamicSites',
+  'fallbackUses',
+  'markupFiles',
+  'proseMentions',
+  'references',
+  'resolvedDynamicNames',
+  'scriptFiles',
+].sort()
+
+/**
+ * Spawn a fixture that writes `bytes` of JSON to stdout and then ends the
+ * process the given way, through the SAME pipe mechanism runCensus uses.
+ * Returns how much of it survived.
+ */
+function drainProbe(mode: 'exit' | 'exitCode', bytes: number): { received: number; status: number } {
+  const dir = mkdtempSync(path.join(tmpdir(), 'css-var-drain-'))
+  try {
+    const fixture = path.join(dir, 'emit.mjs')
+    writeFileSync(
+      fixture,
+      `console.log(JSON.stringify({ pad: 'x'.repeat(${bytes}) }))\n` +
+        (mode === 'exit' ? 'process.exit(1)\n' : 'process.exitCode = 1\n'),
+    )
+    let out = ''
+    let status = 0
+    try {
+      out = execFileSync('node', [fixture], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+    } catch (err) {
+      const e = err as { stdout?: string; status?: number }
+      out = e.stdout ?? ''
+      status = typeof e.status === 'number' ? e.status : -1
+    }
+    return { received: Buffer.byteLength(out, 'utf8'), status }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/** Well past any plausible pipe buffer, so the probe is not a coin-flip. */
+const DRAIN_PROBE_BYTES = 1024 * 1024
+
+/** `process.exit(...)` call sites in a source file, comments excluded by AST. */
+function processExitCalls(file: string): string[] {
+  const src = readFileSync(file, 'utf8')
+  const sf = ts.createSourceFile(file, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS)
+  const hits: string[] = []
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === 'process' &&
+      node.expression.name.text === 'exit'
+    ) {
+      hits.push(`${path.basename(file)}:${sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1}`)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+  return hits
+}
+
+/** Literal values assigned to `process.exitCode` in a source file. */
+function processExitCodeAssignments(file: string): number[] {
+  const src = readFileSync(file, 'utf8')
+  const sf = ts.createSourceFile(file, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS)
+  const values: number[] = []
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      ts.isIdentifier(node.left.expression) &&
+      node.left.expression.text === 'process' &&
+      node.left.name.text === 'exitCode' &&
+      ts.isNumericLiteral(node.right)
+    ) {
+      values.push(Number(node.right.text))
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sf)
+  return values
 }
 
 /**
@@ -257,7 +414,108 @@ const EXPECTED_DYNAMIC_SITE_FILES = ['src/styles/evaluative.ts'].sort()
 const EXPECTED_DYNAMIC_NAMES = ['--danger', '--success', '--warning'].sort()
 
 describe('css custom-property resolution guard', () => {
-  const census = runCensus()
+  const run = runCensus()
+  const census = run.census
+
+  /**
+   * THE TRANSPORT CONTROLS. This guard was self-defeating for its whole life
+   * and nothing noticed, because it had no control over the one channel every
+   * assertion in this file arrives through.
+   *
+   * `vitest --changed` can never select this spec — it has no static `src/`
+   * import, it shells out — so it runs only from the pre-push smoke list.
+   * And the census's findings path (the ONLY path that matters here) ended in
+   * `process.exit(1)`, which discards whatever of an async pipe write has not
+   * drained. So the guard's payload was intact only while the census had
+   * little to say: it would have broken exactly when it started catching
+   * something, and reported it as invalid JSON rather than as a defect.
+   *
+   * Both halves are pinned, and both are DERIVED at your platform rather than
+   * asserted from a remembered byte count:
+   *   · the hazard is REAL here — `process.exit()` loses part of a large
+   *     payload (trap 13: an absence assertion must first prove it can see a
+   *     presence);
+   *   · the drain path this script now uses delivers that same payload whole.
+   */
+  it('a process.exit() after a large stdout write LOSES data on this platform (positive control)', () => {
+    const probe = drainProbe('exit', DRAIN_PROBE_BYTES)
+    expect(
+      probe.received,
+      `process.exit() delivered all ${probe.received} bytes on this platform, so this control ` +
+        'proved nothing and the drain assertion below is vacuous here. The hazard is still real on ' +
+        'platforms that buffer less (measured: darwin/node 22 truncates at 65,536 bytes) — keep the ' +
+        'exitCode pattern, and work out why this platform differs before relaxing anything.',
+    ).toBeLessThan(DRAIN_PROBE_BYTES)
+    // The status survives the truncation — which is precisely why this was
+    // invisible: the caller sees a correct exit code and a short payload.
+    expect(probe.status).toBe(1)
+  })
+
+  it('setting process.exitCode instead delivers the whole payload', () => {
+    const probe = drainProbe('exitCode', DRAIN_PROBE_BYTES)
+    expect(
+      probe.received,
+      `the drain path lost data (${probe.received} of >= ${DRAIN_PROBE_BYTES} bytes). Everything ` +
+        'this spec asserts travels this way, so a loss here makes every absence assertion below ' +
+        'unsafe.',
+    ).toBeGreaterThan(DRAIN_PROBE_BYTES)
+    expect(probe.status).toBe(1)
+  })
+
+  it('the census reaches its findings exit path WITHOUT process.exit (guards the guard)', () => {
+    // Comments are trivia in the AST, so the prose in the census that
+    // discusses process.exit cannot satisfy or defeat this — the same reason
+    // the census itself walks the AST rather than grepping text.
+    expect(
+      processExitCalls(SCRIPT),
+      'scripts/css-var-census.mjs calls process.exit(). On the findings path that truncates the ' +
+        '--json payload this spec reads (see the exit block at the foot of the script). Set ' +
+        'process.exitCode and return instead.',
+    ).toEqual([])
+    // Both documented non-zero codes must still be reachable: 1 for findings,
+    // 2 for a census that could not run. An exact set, so deleting the exit
+    // logic altogether fails here rather than turning the gate green.
+    expect(
+      [...new Set(processExitCodeAssignments(SCRIPT))].sort(),
+      'the census no longer sets both documented non-zero exit codes (1 = findings, 2 = census ' +
+        'error). A findings run that exits 0 makes this whole guard advisory.',
+    ).toEqual([1, 2])
+  })
+
+  it('the payload is a complete census object, not merely parseable JSON', () => {
+    // `JSON.parse('{}')` succeeds and every toEqual([]) below would then pass
+    // on undefined. Exact in both directions: a new top-level key means the
+    // census reports something this spec is blind to.
+    expect(Object.keys(census as unknown as Record<string, unknown>).sort()).toEqual(
+      Object.keys(EXPECTED_CENSUS_KEYS).sort(),
+    )
+    for (const [key, ok] of Object.entries(EXPECTED_CENSUS_KEYS)) {
+      const value = (census as unknown as Record<string, unknown>)[key]
+      expect(ok(value), `census.${key} has the wrong shape: ${JSON.stringify(value)?.slice(0, 80)}`).toBe(true)
+    }
+    expect(Object.keys(census.counts).sort()).toEqual(EXPECTED_COUNT_KEYS)
+    for (const [key, value] of Object.entries(census.counts)) {
+      expect(typeof value, `census.counts.${key} is not a number`).toBe('number')
+    }
+    expect(typeof census.selfTest.ok).toBe('boolean')
+    expect(Array.isArray(census.selfTest.failures)).toBe(true)
+  })
+
+  it('this run exercised the findings exit path (not the clean one)', () => {
+    // The path that used to truncate is the non-zero one. If a run never
+    // takes it, the transport is never proven end-to-end on real data —
+    // so DERIVE the expectation from the pins rather than hardcoding 1.
+    const pinnedFindings = KNOWN_UNDEFINED_CSS_PALETTE.length + KNOWN_FALLBACK_DRIFT.length
+    expect(
+      pinnedFindings,
+      'every pinned finding has been repaired, so the census now exits 0 and this spec no longer ' +
+        'exercises the exit path that once truncated its own payload. Keep the transport covered ' +
+        'another way before deleting this.',
+    ).toBeGreaterThan(0)
+    expect(census.cssUndefined.length + census.fallbackDrift.length).toBeGreaterThan(0)
+    expect(run.status, `census exit status ${run.status} with ${pinnedFindings} pinned findings`).toBe(1)
+    expect(run.bytes).toBeGreaterThan(0)
+  })
 
   it('the census can SEE the code it is asserting about (positive control)', () => {
     // Self-test first: proves the scanner detects an undefined reference in

--- a/tests/ci-guards/css-var-resolution.spec.ts
+++ b/tests/ci-guards/css-var-resolution.spec.ts
@@ -123,9 +123,14 @@ function runCensus(): CensusRun {
  * `toEqual([])` absence assertion below would then pass on `undefined`
  * — trap 13, in the one place the whole guard funnels through.
  *
- * DERIVED from the Census interface's own contract, and EXACT in both
- * directions: an unknown key means the census grew a field this spec is
- * blind to, which is exactly when somebody should look.
+ * This IS a hand-maintained mirror of the Census interface above — a TS
+ * interface is erased at runtime, so there is nothing to derive it from. It
+ * is therefore written in the only safe form (trap 12): EXACT in both
+ * directions, so it FAILS LOUD on drift rather than assuming good. An
+ * unknown key means the census grew a field this spec is blind to; a missing
+ * one means it lost a field this spec still reads. Either way somebody
+ * looks. It earned its keep on the first run, catching the Census interface
+ * declaring `definitions` at the top level when it is a `counts` key.
  */
 const EXPECTED_CENSUS_KEYS: Record<string, (v: unknown) => boolean> = {
   errors: (v) => Array.isArray(v),
@@ -476,7 +481,9 @@ describe('css custom-property resolution guard', () => {
     // 2 for a census that could not run. An exact set, so deleting the exit
     // logic altogether fails here rather than turning the gate green.
     expect(
-      [...new Set(processExitCodeAssignments(SCRIPT))].sort(),
+      // Numeric comparator: the default sort is lexicographic, so a future
+      // two-digit code would compare wrong and this control would misreport.
+      [...new Set(processExitCodeAssignments(SCRIPT))].sort((a, b) => a - b),
       'the census no longer sets both documented non-zero exit codes (1 = findings, 2 = census ' +
         'error). A findings run that exits 0 makes this whole guard advisory.',
     ).toEqual([1, 2])


### PR DESCRIPTION
**DO NOT MERGE — for review.**

Third member of the always-failing-guard family found while fixing #536 (ROADMAP 2.147).

## The defect

`tests/ci-guards/css-var-resolution.spec.ts` sits in the pre-push smoke list *precisely because* `vitest --changed` can never select it — it has no static `src/` import, it shells out to `scripts/css-var-census.mjs`. So every assertion in the spec arrives through exactly one channel: the census's `--json` payload, read via `execFileSync`, i.e. **down a pipe**.

The census ended its **findings** path — the only path this guard cares about — in `process.exit(1)`. Node's writes to a pipe are asynchronous; `process.exit()` tears the process down without draining the queue. The guard's payload was therefore intact only while the census had little to say, and the failure mode was inverted: **it breaks when it starts catching something**, and reports the catch as invalid JSON rather than as a defect.

## Diagnosis corrected — and the correction matters

The rowed claim was that this spec **already fails** on pristine staging, truncating at position 8192. **It does not**, at `e42bcaa5` on darwin / node 22: the spec passes 5/5 solo and inside the full 9-file smoke list (9 of 9, 598 tests).

Measured the mechanism instead, via a fixture spawned exactly as the census is:

| pattern | 65,536 B | 70,000 B | 131,072 B | 2,097,152 B |
|---|---|---|---|---|
| `console.log` + `process.exit(1)` | whole | **cut to 65,536** | **cut to 65,536** | **cut to 65,536** |
| `console.log` + `process.exitCode = 1` | whole | whole | whole | whole |

10/10 runs each, deterministic, exit status 1 in every cell. Unchanged under 10-core CPU saturation and under concurrent-pipe pressure. The census currently emits **13,043 bytes** — so this was a **latent** hazard sitting at 20 % of its cliff, not a live red. The reason it stayed latent is the reason it stayed unnoticed: **nothing here ever checked the transport.**

## Fix

`scripts/css-var-census.mjs`: `process.exitCode = n` + `return` on both non-zero paths. Exit statuses unchanged (1 findings, 2 census error, verified); nothing holds the event loop open, so the process still ends as soon as the write drains (timed — no hang). `writeSync` proved unnecessary: drain is sufficient, empirically, to 2 MB.

## Controls

The fix is one line. The *absence of controls* is what let this sit, so the spec gains five:

1. **Transport positive control** — `process.exit()` after a large write **loses data on the platform running the suite**. The cliff is derived at your platform, not asserted from the number in this PR. If a platform ever delivers it whole, the control says so and fails loud rather than passing vacuously (trap 13).
2. **Its twin** — the drain path delivers the same 1 MB payload whole.
3. **Structural** — the census must contain no `process.exit(` call and must still assign both documented non-zero codes, as the exact set `{1,2}`, so *deleting* the exit logic fails here instead of turning the gate green. Walked over the TypeScript AST, so the prose in the census that discusses `process.exit` can neither satisfy nor defeat it — the same comments-are-trivia argument the census itself is built on.
4. **Shape** — the parsed payload's top-level keys and `counts` keys are pinned exactly and shape-checked. `JSON.parse('{}')` succeeds, and every `toEqual([])` absence assertion in this file would then have passed on `undefined` — trap 13 sitting in the one place the whole guard funnels through. Writing the list out immediately caught the spec's own `Census` interface listing `definitions` as top-level when it is a `counts` key.
5. **Findings-path coverage** — the run must have taken the non-zero exit path, *derived from the two pins* rather than hardcoded: if every pinned finding is ever repaired the census exits 0, this spec stops exercising the path that used to truncate, and the control says that in those words instead of going quietly green.

A parse failure now reports byte count, exit status and the payload tail, so truncation is diagnosed on sight.

## Evidence

- **Control 1 (fixed by draining, not by finding nothing)** — 12/12 green with the census reporting **57 real findings** (22 dangling CSS properties + 35 drifted fallbacks), exit status 1.
- **Control 2 (positive)** — a throwaway `var(--zz-probe)` in `src/index.css` REDs exactly one test, for the right reason: `NEW dangling CSS custom property: --zz-probe`. Reverted.
- **Mutant (worktree outside the clone root)** — restoring `process.exit(1)`:
  - REDs control 3 at once: `calls process.exit() … expected [ 'css-var-census.mjs:908', …(1) ] to deeply equal []`.
  - With the payload inflated past the cliff (900 dangling vars → **113,627 bytes**), the pipe delivers **65,536**, and the spec collapses: `did not parse: Expected property name or '}' in JSON at position 65536 · bytes received: 65536 · exit status: 1` → **`Tests  no tests`**. That is the reported symptom reproduced on the real script, one pipe-capacity larger.
  - Restore the fix, keep the 113,627-byte payload: parses whole, and the spec fails on **one** test — the palette pin, naming the 900 new properties — 11 passed. The fix is load-bearing.

## Gates

- `pnpm run typecheck` — **PASSED** (coverage 3072/3112, ratchet 622 files / 2510 errors = baseline 2510). The changed spec **is** loaded by the gate (`tsconfig.tooling.json`, absent from the uncovered exception list), so the gate genuinely covers this change.
- 9-file smoke list — **9 passed (9)**, 603 tests (598 at base + the 5 new controls).
- Check 8 (DS v5 drift) — pre-existing red; output **byte-identical** to `e42bcaa5` (`diff` empty), proven in a base worktree.
- No ratchet or baseline file touched. Scope is `scripts/css-var-census.mjs` + `tests/ci-guards/` only — disjoint from the concurrent `src/`-only UI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit `ddf5bbd7` — self-review corrections

Two findings from re-reading my own controls; both are the defect classes this PR is about, found inside the fix for them.

1. `EXPECTED_CENSUS_KEYS` was documented as **"DERIVED** from the Census interface's own contract". **It is not** — a TS interface is erased at runtime, so there is nothing to derive it from; it is a hand-maintained mirror. In a repo whose dominant defect is the mirror, calling one "derived" is trap 14's false label written into the control added to prevent trap 13. Relabelled honestly: a mirror, kept in the only safe form (exact both ways, fails loud on drift in either direction).
2. The exit-code set was compared after a bare `.sort()`, which is **lexicographic** — harmless for `{1,2}`, wrong the moment a two-digit code is added, i.e. a control that would then misreport. Numeric comparator. *Your own script is not exempt.*

No behavioural change: spec 12/12 and the typecheck gate PASSED (ratchet 2510 = baseline) re-run after both edits.

---

## CI on `ddf5bbd7` — 13 of 13 green, and the guard is verified to have RUN

All checks pass. More to the point for a PR about guards that never execute: shard 2's log carries **all 12** of the spec's tests as `✓`, including

```
✓ … > a process.exit() after a large stdout write LOSES data on this platform (positive control)
✓ … > setting process.exitCode instead delivers the whole payload
```

That resolves the one portability risk in this design. Control 1 *asserts* that `process.exit()` truncates, so on a platform that buffered the whole 1 MB it would have failed loud by design rather than passed vacuously. **Linux CI truncates too** — hazard and fix are both real on the platform that actually gates this repo, measured rather than assumed.
