### PR TITLE
DO-NOT-MERGE fix(gate): pnpm-first pre-push scripts; lockfile file:-audit no longer vacuous

### DIFF
--- a/scripts/check-vendor-sha.mjs
+++ b/scripts/check-vendor-sha.mjs
@@ -8,8 +8,8 @@
  * exits non-zero.
  *
  * The tarball filename is derived from package.json so there is exactly one
- * source of truth for the version. The bash pre-push scripts do the same
- * derivation via grep + sed.
+ * source of truth for the version. The bash pre-push gates delegate to this
+ * script — do not re-implement the comparison there.
  */
 import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
@@ -41,11 +41,11 @@ function recoveryBlock(expected, actual) {
     `  actual:   ${actual}`,
     `  manifest: vendor/${TARBALL_NAME}.sha256`,
     '',
-    'Recovery (use the package manager already in use for this working copy; npm is the documented default):',
+    'Recovery (this repo is pnpm-only — package.json "packageManager" pins pnpm):',
     `  git checkout -- vendor/${TARBALL_NAME}`,
     '  rm -rf node_modules/.vite node_modules/@talchain',
-    '  npm install      # or: pnpm install',
-    '  npm run dev -- --force   # or: pnpm dev --force',
+    '  pnpm install',
+    '  pnpm dev --force   # restart dev with a fresh Vite cache',
   ].join('\n')
 }
 

--- a/scripts/pre-push-validate.sh
+++ b/scripts/pre-push-validate.sh
@@ -6,6 +6,29 @@
 # peak RAM. CI handles parallelism with dedicated runners and more memory.
 set -euo pipefail
 
+# Resolve the package runner. This repo is pnpm-only (`packageManager` in
+# package.json; pnpm-lock.yaml is the only tracked lockfile). npm remains ONLY
+# as a last-resort fallback and must announce itself loudly, never substitute
+# silently: npm ignores pnpm-lock.yaml and can resolve a different dependency
+# tree than the one CI installs. Kept in lockstep with validate-prepush.sh.
+if command -v pnpm &>/dev/null; then
+  PKG_RUN=(pnpm run)
+  PKG_EXEC=(pnpm exec)
+else
+  printf '\033[1;33m⚠ WARNING: pnpm not found on PATH — falling back to npm/npx.\n'
+  printf '  This repo is pnpm-only (package.json "packageManager" pins pnpm;\n'
+  printf '  pnpm-lock.yaml is the only tracked lockfile). npm is OFF-CONTRACT here:\n'
+  printf '  it does not read pnpm-lock.yaml, so it may typecheck/test against a\n'
+  printf '  different dependency tree. Install pnpm (e.g. `corepack enable`) and\n'
+  printf '  re-run before trusting this result.\033[0m\n'
+  if ! command -v npm &>/dev/null; then
+    printf '\033[1;31mNeither pnpm nor npm found on PATH — cannot run the gate.\033[0m\n' >&2
+    exit 1
+  fi
+  PKG_RUN=(npm run)
+  PKG_EXEC=(npx --no-install)
+fi
+
 FAILURES=0
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="$(git branch --show-current)"
@@ -51,7 +74,7 @@ fi
 # ─── Check 2: TypeScript compilation ──────────────────────────────────
 header "Check 2 — TypeScript compilation"
 
-if npm run typecheck 2>&1; then
+if "${PKG_RUN[@]}" typecheck 2>&1; then
   pass "TypeScript compilation succeeded"
 else
   fail "TypeScript compilation failed"
@@ -69,7 +92,7 @@ TEST_OUTPUT_FILE="$(mktemp /tmp/pre-push-test-XXXXXX)"
 # docs/ops/vitest-full-suite-oom-diagnosis.md for the full trace + fix
 # options if 6 GB ever becomes insufficient. The ERR_WORKER_OUT_OF_MEMORY
 # tolerance below remains as a safety net.
-NODE_OPTIONS=--max-old-space-size=6144 npx vitest run --bail=1 2>&1 | tee "$TEST_OUTPUT_FILE" || true
+NODE_OPTIONS=--max-old-space-size=6144 "${PKG_EXEC[@]}" vitest run --bail=1 2>&1 | tee "$TEST_OUTPUT_FILE" || true
 VITEST_EXIT=${PIPESTATUS[0]}
 
 if [ "$VITEST_EXIT" -eq 0 ]; then
@@ -128,19 +151,44 @@ header "Check 5 — Dependency audit (file: references)"
 # scripts/validate-prepush.sh — the two scripts must agree or they
 # emit contradictory signals (historical divergence caught in Brief 5.2
 # close-out, commit 8679ea79 run).
+# The lockfile arm audits pnpm-lock.yaml — the repo's ONLY lockfile. Until
+# 2026-07-30 it grepped package-lock.json, which does not exist here, so the
+# arm passed vacuously: an absence assertion that could never see a presence.
+# See scripts/validate-prepush.sh Check 6 for the serialisation notes; the two
+# blocks are kept in lockstep.
 FILE_REFS=$(grep -n '"file:' "$REPO_ROOT/package.json" 2>/dev/null \
   | grep -v '"@talchain/schemas"' || true)
-LOCK_FILE_REFS=$(grep -n '"file:' "$REPO_ROOT/package-lock.json" 2>/dev/null \
-  | grep -v 'talchain-schemas' || true)
+
+PNPM_LOCKFILE="$REPO_ROOT/pnpm-lock.yaml"
+LOCK_REF_PATTERN="[[:space:]'\"@]file:"
+# Allowlist: exempt only refs whose file: TARGET is the vendored schemas
+# tarball (any version — Check 5a pins the bytes via the SHA manifest).
+ALLOWED_LOCK_REF="file:(\./)?vendor/talchain-schemas-[^/[:space:]]*\.tgz"
+LOCK_AUDIT_BROKEN=0
+LOCK_FILE_REFS=""
+if [ ! -f "$PNPM_LOCKFILE" ]; then
+  LOCK_AUDIT_BROKEN=1
+  fail "pnpm-lock.yaml not found — the lockfile file:-ref audit cannot run (this repo is pnpm-only)"
+elif ! grep -aqE "${LOCK_REF_PATTERN}(\./)?vendor/talchain-schemas-" "$PNPM_LOCKFILE"; then
+  # Positive control: the pattern must SEE the one known file: ref (the
+  # vendored schemas tarball) before its verdict on all others means anything.
+  LOCK_AUDIT_BROKEN=1
+  fail "Lockfile audit positive control failed: pattern cannot see the vendored @talchain/schemas file: ref in pnpm-lock.yaml — serialisation or pattern drift; the audit would be vacuous"
+else
+  LOCK_FILE_REFS=$(grep -anE "$LOCK_REF_PATTERN" "$PNPM_LOCKFILE" \
+    | grep -vE "$ALLOWED_LOCK_REF" || true)
+fi
 
 if [ -n "$FILE_REFS" ]; then
   echo "    non-allowlisted file: dependency references found in package.json:"
   echo "$FILE_REFS" | while IFS= read -r line; do echo "      $line"; done
   fail "Only @talchain/schemas may use a file: link (vendored)"
 elif [ -n "$LOCK_FILE_REFS" ]; then
-  echo "    non-allowlisted file: dependency references found in package-lock.json:"
+  echo "    non-allowlisted file: dependency references found in pnpm-lock.yaml:"
   echo "$LOCK_FILE_REFS" | head -5 | while IFS= read -r line; do echo "      $line"; done
-  fail "package-lock.json contains unexpected file: references"
+  fail "pnpm-lock.yaml contains unexpected file: references"
+elif [ "$LOCK_AUDIT_BROKEN" -eq 1 ]; then
+  : # already failed above — do not print a pass for an audit that could not run
 else
   pass "No non-allowlisted file: references"
 fi
@@ -193,7 +241,7 @@ fi
 if [ -n "$OPENAPI_SCRIPT" ]; then
   echo "  Found generation script: $OPENAPI_SCRIPT"
   # Run generation and check for uncommitted diff
-  if npm run "$OPENAPI_SCRIPT" 2>&1 >/dev/null; then
+  if "${PKG_RUN[@]}" "$OPENAPI_SCRIPT" 2>&1 >/dev/null; then
     if git diff --quiet; then
       pass "OpenAPI spec is up to date"
     else

--- a/scripts/validate-prepush.sh
+++ b/scripts/validate-prepush.sh
@@ -9,17 +9,41 @@
 # lightweight to avoid the 18-min full suite and Worker OOM issues.
 set -euo pipefail
 
-# Ensure Node.js is on PATH (nvm, brew, or system)
-if ! command -v npm &>/dev/null; then
+# Ensure pnpm is on PATH (nvm, PNPM_HOME, brew, or system). This repo is
+# pnpm-only (`packageManager` in package.json; pnpm-lock.yaml is the only
+# tracked lockfile) — the gate must hunt for pnpm, not npm.
+if ! command -v pnpm &>/dev/null; then
   export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
   # shellcheck disable=SC1091
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 fi
-if ! command -v npm &>/dev/null; then
-  # Try common Homebrew paths
-  for p in /usr/local/bin /opt/homebrew/bin; do
-    [ -x "$p/npm" ] && export PATH="$p:$PATH" && break
+if ! command -v pnpm &>/dev/null; then
+  # Try common pnpm install locations (standalone installer, Homebrew, system)
+  for p in "${PNPM_HOME:-$HOME/Library/pnpm}" "$HOME/.local/share/pnpm" /usr/local/bin /opt/homebrew/bin; do
+    [ -x "$p/pnpm" ] && export PATH="$p:$PATH" && break
   done
+fi
+
+# Resolve the package runner. pnpm is the contract. npm remains ONLY as a
+# last-resort fallback so a minimal shell can still run the gate — and it must
+# announce itself loudly, never substitute silently: npm ignores pnpm-lock.yaml
+# and can resolve a different dependency tree than the one CI installs.
+if command -v pnpm &>/dev/null; then
+  PKG_RUN=(pnpm run)
+  PKG_EXEC=(pnpm exec)
+else
+  printf '\033[1;33m⚠ WARNING: pnpm not found on PATH — falling back to npm/npx.\n'
+  printf '  This repo is pnpm-only (package.json "packageManager" pins pnpm;\n'
+  printf '  pnpm-lock.yaml is the only tracked lockfile). npm is OFF-CONTRACT here:\n'
+  printf '  it does not read pnpm-lock.yaml, so it may typecheck/test against a\n'
+  printf '  different dependency tree. Install pnpm (e.g. `corepack enable`) and\n'
+  printf '  re-run before trusting this result.\033[0m\n'
+  if ! command -v npm &>/dev/null; then
+    printf '\033[1;31mNeither pnpm nor npm found on PATH — cannot run the gate.\033[0m\n' >&2
+    exit 1
+  fi
+  PKG_RUN=(npm run)
+  PKG_EXEC=(npx --no-install)
 fi
 
 FAILURES=0
@@ -67,7 +91,7 @@ fi
 # ─── Check 2: TypeScript compilation ──────────────────────────────────
 header "Check 2 — TypeScript compilation"
 
-if npm run typecheck 2>&1; then
+if "${PKG_RUN[@]}" typecheck 2>&1; then
   pass "TypeScript compilation succeeded"
 else
   fail "TypeScript compilation failed"
@@ -94,7 +118,7 @@ else
 
   if [ "${#EXISTING_LINT_FILES[@]}" -eq 0 ]; then
     skip "All changed .ts/.tsx files were deleted — lint skipped"
-  elif npx eslint --no-error-on-unmatched-pattern "${EXISTING_LINT_FILES[@]}" 2>&1; then
+  elif "${PKG_EXEC[@]}" eslint --no-error-on-unmatched-pattern "${EXISTING_LINT_FILES[@]}" 2>&1; then
     pass "Lint passed (${#EXISTING_LINT_FILES[@]} changed file(s))"
   else
     fail "Lint failed on changed files"
@@ -161,7 +185,7 @@ fi
 
 if [ "${#EXISTING_SMOKE[@]}" -eq 0 ]; then
   fail "No smoke test files found — the smoke list must never be empty"
-elif npx vitest run --bail=1 "${EXISTING_SMOKE[@]}" 2>&1; then
+elif "${PKG_EXEC[@]}" vitest run --bail=1 "${EXISTING_SMOKE[@]}" 2>&1; then
   # Report ran-of-named, both derived. A shrink is then visible in the summary
   # line itself, not only in the failure above it.
   pass "Smoke tests passed (${#EXISTING_SMOKE[@]} of ${#SMOKE_FILES[@]} named critical data-flow path(s))"
@@ -195,19 +219,55 @@ header "Check 6 — Dependency audit (file: references)"
 # A1 allowlist: @talchain/schemas is deliberately vendored via
 # `file:./vendor/talchain-schemas-*.tgz`. The SHA manifest check below
 # guards against drift on that specific dep. Any OTHER file: reference fails.
+#
+# The lockfile arm audits pnpm-lock.yaml — the repo's ONLY lockfile. Until
+# 2026-07-30 it grepped package-lock.json, which does not exist here, so the
+# arm passed vacuously: an absence assertion that could never see a presence.
+# pnpm-lock.yaml (lockfileVersion 9.0) serialises file: deps on four line
+# shapes, all with `file:` preceded by whitespace, a quote, or `@`:
+#     specifier: file:./vendor/<name>.tgz             (importers)
+#     version: file:vendor/<name>.tgz                 (importers)
+#     'pkg@file:vendor/<name>.tgz':                   (packages/snapshots keys)
+#     resolution: {..., tarball: file:vendor/<name>.tgz}
+# The preceding-char anchor is what keeps identifiers that merely END in
+# `file:` (excludeLinksFromLockfile:, jsonfile:, get-caller-file:) from
+# false-positiving. grep -a per repo trap 17: absence claims must not go
+# silently blind on a NUL-bearing file.
 FILE_REFS=$(grep -n '"file:' "$REPO_ROOT/package.json" 2>/dev/null \
   | grep -v '"@talchain/schemas"' || true)
-LOCK_FILE_REFS=$(grep -n '"file:' "$REPO_ROOT/package-lock.json" 2>/dev/null \
-  | grep -v 'talchain-schemas' || true)
+
+PNPM_LOCKFILE="$REPO_ROOT/pnpm-lock.yaml"
+LOCK_REF_PATTERN="[[:space:]'\"@]file:"
+# Allowlist: exempt only refs whose file: TARGET is the vendored schemas
+# tarball (any version — check 6a pins the bytes via the SHA manifest).
+ALLOWED_LOCK_REF="file:(\./)?vendor/talchain-schemas-[^/[:space:]]*\.tgz"
+LOCK_AUDIT_BROKEN=0
+LOCK_FILE_REFS=""
+if [ ! -f "$PNPM_LOCKFILE" ]; then
+  LOCK_AUDIT_BROKEN=1
+  fail "pnpm-lock.yaml not found — the lockfile file:-ref audit cannot run (this repo is pnpm-only)"
+elif ! grep -aqE "${LOCK_REF_PATTERN}(\./)?vendor/talchain-schemas-" "$PNPM_LOCKFILE"; then
+  # Positive control: the pattern must SEE the one known file: ref (the
+  # vendored schemas tarball) before its verdict on all others means anything.
+  # If this fires, the lockfile serialisation or the pattern has drifted and
+  # the absence assertion below would be vacuous — fail loud instead.
+  LOCK_AUDIT_BROKEN=1
+  fail "Lockfile audit positive control failed: pattern cannot see the vendored @talchain/schemas file: ref in pnpm-lock.yaml — serialisation or pattern drift; the audit would be vacuous"
+else
+  LOCK_FILE_REFS=$(grep -anE "$LOCK_REF_PATTERN" "$PNPM_LOCKFILE" \
+    | grep -vE "$ALLOWED_LOCK_REF" || true)
+fi
 
 if [ -n "$FILE_REFS" ]; then
   echo "    non-allowlisted file: dependency references found in package.json:"
   echo "$FILE_REFS" | while IFS= read -r line; do echo "      $line"; done
   fail "Only @talchain/schemas may use a file: link (vendored)"
 elif [ -n "$LOCK_FILE_REFS" ]; then
-  echo "    non-allowlisted file: dependency references found in package-lock.json:"
+  echo "    non-allowlisted file: dependency references found in pnpm-lock.yaml:"
   echo "$LOCK_FILE_REFS" | head -5 | while IFS= read -r line; do echo "      $line"; done
-  fail "package-lock.json contains unexpected file: references"
+  fail "pnpm-lock.yaml contains unexpected file: references"
+elif [ "$LOCK_AUDIT_BROKEN" -eq 1 ]; then
+  : # already failed above — do not print a pass for an audit that could not run
 else
   pass "No non-allowlisted file: references"
 fi


### PR DESCRIPTION
Fourth member of tonight's gate-honesty family (#536 fixed check 6a + SMOKE_FILES). Three defects in the pre-push gate scripts, all fixed at base `e42bcaa5`.

## Fix 1 — the gate ran npm in a pnpm-only repo
`packageManager` pins `pnpm@10.18.0` and `pnpm-lock.yaml` is the only tracked lockfile, but `validate-prepush.sh` bootstrapped PATH by hunting **npm** and ran check 2 as `npm run typecheck` (plus `npx` for lint/smoke). Now: the bootstrap hunts pnpm (nvm, `PNPM_HOME`, Homebrew, system); check 2 / lint / smoke run via `pnpm run` / `pnpm exec`. npm survives only as a last-resort fallback that **WARNS loudly it is off-contract** (npm ignores pnpm-lock.yaml and can resolve a different tree) — never a silent substitute; neither-found is a hard error. `pre-push-validate.sh` gets the same runner block (its own comment mandates lockstep, and it had the same `npm run typecheck` / `npx vitest` / `npm run <openapi>` calls).

## Fix 2 — the vacuous lockfile audit (the real defect)
Both scripts' check-6/check-5 lockfile arm grepped `package-lock.json` with `2>/dev/null`. That file does not exist here (CLAUDE.md explicitly bans it), so `LOCK_FILE_REFS` was **always empty and the arm passed vacuously** — an absence assertion that could never see a presence. Rewritten to derive from `pnpm-lock.yaml`'s real serialisation (verified at the bytes: `specifier: file:…`, `version: file:…`, `'pkg@file:…':` keys, `tarball: file:…`), with:
- a preceding-char anchor (`[[:space:]'"@]file:`) so identifiers merely *ending* in `file:` (`excludeLinksFromLockfile:`, `jsonfile:`, `get-caller-file:` — all present in the real lockfile) cannot false-positive;
- a **positive control**: the pattern must SEE the vendored `@talchain/schemas` ref before its absence verdict counts — serialisation/pattern drift fails loud instead of going vacuous again (trap 13);
- a fail-loud arm for a missing `pnpm-lock.yaml`;
- allowlist tightened from a bare `talchain-schemas` substring to the vendored tarball TARGET (`file:(./)?vendor/talchain-schemas-*.tgz`); check 6a still pins the bytes via the SHA manifest.

## Fix 3 — check-vendor-sha.mjs remediation text
Claimed "npm is the documented default" (false) and led with `npm install` / `npm run dev -- --force`. Now leads with pnpm. Also corrected the stale header claim that the bash gates re-derive the tarball name via grep+sed — since #536 they delegate to this script.

CLAUDE.md needed no change: its gate documentation is already pnpm-only and already bans `package-lock.json`.

## Controls
**Presence (RED).** Injected into a throwaway copy's `pnpm-lock.yaml` (outside the clone root), in real importer serialisation:
```
      evil-local-pkg:
        specifier: file:../evil-local-pkg
        version: file:../evil-local-pkg
```
Full gate run in the throwaway — check 6 output, verbatim:
```
── Check 6 — Dependency audit (file: references) ──
    non-allowlisted file: dependency references found in pnpm-lock.yaml:
      42:        specifier: file:../evil-local-pkg
      43:        version: file:../evil-local-pkg
  ✗ pnpm-lock.yaml contains unexpected file: references
```
The same injected lockfile also turns `pre-push-validate.sh`'s check 5 RED (verified by executing that script's extracted check-5 bytes against the poisoned tree; its full run is the 15-min suite).

**Absence (GREEN).** On the real, unmodified lockfile the pattern hits exactly 5 lines — all the vendored schemas ref (lines 39, 40, 1395, 1396, 5453) — and the allowlist filter leaves zero. Check 6 passes in the full branch-gate run.

**Mutation-check (fix is load-bearing).** In the same throwaway with the poisoned lockfile still in place, `git checkout -- scripts/validate-prepush.sh` restored the old staging-tip script (the `package-lock.json` grep). Full gate re-run: check 6 printed `✓ No non-allowlisted file: references` — the injection sails through the old code. Only the new derivation catches it.

**Fail-loud arms + fallback paths** (harness runs of the exact script bytes): missing lockfile → FAIL "pnpm-lock.yaml not found…"; schemas ref invisible to the pattern → FAIL "positive control failed… the audit would be vacuous"; pnpm absent + npm present → loud off-contract WARN then npm/npx; neither → hard error exit 1.

## Full-gate delta vs base (pre-existing reds untouched)
`bash scripts/validate-prepush.sh` on pristine `e42bcaa5` and on this branch, identical env (dummy `VITE_SUPABASE_*` set per trap 2b): **both runs fail exactly one check — check 8 (DS v5 ratchet: `panel-typography-scoped` Δ+11, 4 net-new `production-hex`), and the entire check 8 section is byte-identical between runs.** The only differing check-result line across the two logs is the branch name in check 1. No ratchet/baseline file touched. Note: the check-4 css-var spec was listed as a pre-existing red in my brief but is GREEN on pristine `e42bcaa5` (7/7) — recorded here so nobody hunts a red that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
