### PR TITLE
DO-NOT-MERGE: refactor(ui) /simplify sweep 2 — UI apply lane (S2-1..8, E-1/2, R-1/3/4/6/10/11/12, A-1, A-3a/b, guards.ts)

### DIFF
--- a/src/canvas/conversation/utils/applyPatch.ts
+++ b/src/canvas/conversation/utils/applyPatch.ts
@@ -7,8 +7,9 @@
  */
 
 import { useCanvasStore } from '../../store'
-import { DEFAULT_EDGE_DATA } from '../../domain/edges'
+import { DEFAULT_EDGE_DATA, readValidationMetadata } from '../../domain/edges'
 import { edgeValueSourcePatch } from '../../domain/edgeValueProvenance'
+import { edgeProvenanceDisplayPatch } from '../../utils/draftIngestion'
 import { saveAutosave } from '../../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../../store/autosaveProjection'
 import { pulseAppliedTargets } from '../../utils/appliedEditPulse'
@@ -17,7 +18,6 @@ import { validateNodesBatch } from '../../domain/nodes'
 import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from '../../domain/analyticalChange'
 import type { PatchOperation, GraphPatchBlock } from '../types'
 import type { EffectDirection, CEEAnalysisReady, CEEInterventionV3 } from '../../../adapters/cee/types'
-import type { ValidationMetadata } from '../../domain/validation'
 
 // ---------------------------------------------------------------------------
 // Operation sort order — ensures nodes exist before edges reference them,
@@ -152,24 +152,15 @@ function buildEdge(op: PatchOperation) {
   // mapDraftEdgeToCanvas. Adding `validation` only there would have produced the
   // worst kind of bug: contested markers present after a fresh draft and silently
   // GONE after the next `edit_graph` receipt touching the edge, with no error
-  // anywhere. Kept byte-for-byte equivalent to hop 1's extraction, and pinned in
-  // lockstep by src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts.
+  // anywhere.
   //
-  // The cast is a DECLARED BOUNDARY ASSUMPTION, not a validated narrowing, and it
-  // matches how every existing reader and the one existing writer of this field
-  // already treat it: the wire schema is `z.unknown().optional()` on purpose
-  // (`domain/edges.ts:270-273` — the UI deliberately does not re-declare CEE's
-  // shape), while the canvas `data` bag types it `ValidationMetadata`
-  // (`domain/edges.ts:293-296`) so consumers can read it. Every consumer
-  // null-guards before use — `StyledEdge` requires `status`, `user_action` AND a
-  // non-null `max_divergence` before it styles anything, and `RelationshipsSection`
-  // requires `status` + `user_action` — so a malformed payload degrades to "not
-  // contested" rather than throwing. Runtime-validating the shape here would be a
-  // fourth mirror of a contract that already lives in two repos.
-  const validation =
-    d.validation !== undefined && d.validation !== null
-      ? (d.validation as ValidationMetadata)
-      : undefined
+  // For THIS field the twins can no longer disagree: both call the one
+  // `readValidationMetadata` (S2-7), which lives with the schema slot and
+  // DEFAULT_EDGE_DATA it depends on and carries the opaque-passthrough rationale
+  // and the boundary-cast disclosure that used to be duplicated here. The mirror
+  // spec (edgeValidationMapperMirror.spec.ts) stays as belt for the fields that
+  // are still extracted twice.
+  const validation = readValidationMetadata(d.validation)
 
   return {
     id: op.target_id,
@@ -192,10 +183,36 @@ function buildEdge(op: PatchOperation) {
       // when the patch carried no value, so an operation that supplies neither
       // leaves the edge honestly marked as unset rather than claiming a
       // producer estimate.
+      //
+      // ⚠ `strengthStd` WAS MISSING FROM THIS CALL and hop 1 passed it. Found by
+      // the whole-`data` parity assertion in
+      // src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts, which was
+      // written because pinning ONE field's lockstep says nothing about the next
+      // field — and this was the next field. `strengthStd` is one of the three
+      // `EDGE_PROVENANCED_FIELDS` (domain/edgeValueProvenance.ts:75), so a receipt
+      // carrying `strength.std` wrote the VALUE with no stamp and every display
+      // surface that reads the stamp treated a real CEE estimate as never set:
+      // the inverse of the laundering `edgeProvenanceLaundering.sourceScan.spec.ts`
+      // guards, arriving through the mirror instead of through a spread.
       ...edgeValueSourcePatch({
         beliefExists: beliefExists !== undefined ? 'cee' : undefined,
         weight: wireSuppliedStrength ? 'cee' : undefined,
+        strengthStd: strengthStd !== undefined ? 'cee' : undefined,
       }),
+      // CEE display provenance (snake_case → camelCase). Distinct from
+      // `provenance_source` above.
+      //
+      // ⚠ ALSO MISSING FROM THIS HOP, found by the same parity assertion: hop 1
+      // applied this patch and hop 2 did not, so a receipt's `provenance_display`
+      // was dropped outright. Adjudicated at the bytes rather than waved through
+      // as "the receipt cannot carry it": `provenance_display` appears NOWHERE in
+      // the pinned @talchain/schemas 0.30.0, `DraftGraphBlockSchema.edges` is
+      // `z.array(z.unknown())`, and this hop's carrier `PatchOperation.data` is
+      // `Record<string, unknown>` (canvas/conversation/types.ts:464). Both hops
+      // read an open bag; only one of them looked. Sharing hop 1's helper also
+      // shares its CLOSED vocabulary gate (from_brief / ai_inferred / user_set),
+      // so an unrecognised value still maps to nothing.
+      ...edgeProvenanceDisplayPatch(d),
     },
   }
 }

--- a/src/canvas/domain/edges.ts
+++ b/src/canvas/domain/edges.ts
@@ -296,6 +296,51 @@ export type EdgeData = z.infer<typeof EdgeDataSchema> & {
 }
 
 /**
+ * S2-7 — read `validation` off a wire edge, for BOTH hand-mirrored ingestion
+ * mappers. ONE implementation, so the lockstep is structural for this field.
+ *
+ * WHY IT LIVES HERE. This module owns the two halves the read depends on: the
+ * schema slot (`validation: z.unknown().optional()` above — the UI deliberately
+ * does not re-declare CEE's shape), and `DEFAULT_EDGE_DATA`, whose deliberate
+ * ABSENCE of a `validation` entry is load-bearing (`overlayEdge` in
+ * mergeAppliedGraph.ts treats a mapped value equal to the mapper baseline as "the
+ * wire did not supply this", so a non-undefined default here would silently stop
+ * validation metadata from ever overlaying onto an existing edge). A reader of
+ * that slot belongs beside the slot.
+ *
+ * WHAT IT REPLACES. `mapDraftEdgeToCanvas` (applyDraftResult.ts, hop 1) and
+ * `buildEdge` (conversation/utils/applyPatch.ts, hop 2) are hand-mirrored twins,
+ * and each carried its own copy of this four-line extraction under its own
+ * ~15-line comment explaining that the copies must stay byte-equivalent. Both
+ * comments were right about the hazard and both were the hazard: two copies of a
+ * rule whose whole content is "these two must agree" (CLAUDE.md trap 12). The
+ * mirror spec (`edgeValidationMapperMirror.spec.ts`) STAYS as belt — it pins the
+ * two hops through their public entry points, and it now also pins whole-`data`
+ * parity, so it catches the NEXT field to drift rather than only this one.
+ *
+ * ⚠ THE CAST IS A DECLARED BOUNDARY ASSUMPTION, NOT A VALIDATED NARROWING, and
+ * centralising it does not upgrade it. The wire schema is `z.unknown().optional()`
+ * on purpose while the canvas `data` bag types the field `ValidationMetadata` so
+ * consumers can read it; every consumer null-guards before use (`StyledEdge`
+ * requires `status`, `user_action` AND a non-null `max_divergence` before it
+ * styles anything; `RelationshipsSection` requires `status` + `user_action`), so a
+ * malformed payload degrades to "not contested" rather than throwing.
+ * Runtime-validating the shape here would be a mirror of a contract that already
+ * lives in two repos.
+ *
+ * ⚠ `null` IS ABSENT, NOT A VALUE. A cleared field must OMIT the key rather than
+ * write `null`, for the `DEFAULT_EDGE_DATA` reason above — `undefined` is what
+ * both mappers then spread away.
+ */
+export function readValidationMetadata(
+  wireValidation: unknown,
+): ValidationMetadata | undefined {
+  return wireValidation !== undefined && wireValidation !== null
+    ? (wireValidation as ValidationMetadata)
+    : undefined
+}
+
+/**
  * Default edge data for new edges (used by adapters, CEE, PLoT as fallback).
  * Keep weight at 0.5 for backward compatibility with downstream services.
  *

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -24,6 +24,7 @@ import { useCanvasStore } from '../store'
 import { typography } from '../../styles/typography'
 import { formatTargetValue } from '../../components/results/utils/formatTargetValue'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
+import { readInferenceWarnings } from '../../components/results/utils/readInferenceWarnings'
 import { DataBar, type DataBarColour } from '../ui/shared/DataBar'
 import { getStabilityClassification } from '../../lib/stability'
 import { isCurrencyUnit, classifyUnit } from '../utils/labelUtils'
@@ -112,7 +113,12 @@ export const GoalNode = memo((props: NodeProps) => {
 
   const hasConstraintDefaultWarning = useMemo(() => {
     if (!isPostAnalysis || !report) return false
-    const warnings = (report as any)?.inference_warnings ?? (report as any)?.robustness?.inference_warnings
+    // R-6: the ONE dual-slot reader (root first, then the legacy `robustness`
+    // nesting). This was a fourth private copy of that fallback, in its own cast
+    // style; the shared reader carries the 773-fact measurement showing the
+    // legacy slot is 0/773, which is why reading only one slot renders
+    // permanently empty with nothing red.
+    const warnings = readInferenceWarnings(report as never)
     if (!Array.isArray(warnings)) return false
     return warnings.some((w: any) => w.code === 'CONSTRAINT_NODE_DEFAULT_BASE')
   }, [report, isPostAnalysis])

--- a/src/canvas/utils/__tests__/__helpers__/mergeAppliedGraphHarness.ts
+++ b/src/canvas/utils/__tests__/__helpers__/mergeAppliedGraphHarness.ts
@@ -1,0 +1,76 @@
+/**
+ * The shared harness for the `reconcileAppliedGraph` suites — R-10.
+ *
+ * ⚠ WHY THIS EXISTS. `mergeAppliedGraph.validation.spec.ts` re-declared
+ * `EXISTING_NODES`, `EXISTING_EDGES` and `seedCanvas` from its SAME-DIRECTORY
+ * sibling `mergeAppliedGraph.spec.ts`, including the identical `setState` field
+ * set — and the `lastAuthoritativeGraph: null` line in it is a LEAK GUARD whose
+ * rationale existed only in the older file. A reader of the newer spec had no way
+ * to know why that field was there, and a future edit to the guard would have
+ * been applied to one of two seeds.
+ *
+ * It also SKIPPED the sibling's `counts()` helper, whose docstring states the
+ * rule ("every assertion checks ALL SIX exactly — an unasserted counter is how an
+ * unintended removal would slip through") and then asserted only 2 of the 6
+ * counters on the overlay path. So the duplication was not merely wasteful: the
+ * copy was WEAKER than the original in the specific way the original's own
+ * comment warned about.
+ *
+ * ⚠ IT IS A HELPER MODULE, NOT A SPEC IMPORT. Importing the sibling spec directly
+ * would execute its `describe`/`beforeEach` inside the importing file — the
+ * sibling's whole suite would run twice, under the wrong file name, with its
+ * `beforeEach` reseeding the store between the importer's own cases. A shared
+ * `__helpers__` module is the only form of "both specs use one definition" that
+ * does not have that side effect. (`src/canvas/__tests__/__helpers__/` is the
+ * existing precedent for this directory shape.)
+ *
+ * ⚠ THE SEED IS PARAMETERISED, THE FIELD SET IS NOT. What the two suites genuinely
+ * share is the `setState` FIELD SET (including the leak guard) and `counts()`.
+ * What they legitimately differ on is DATA — the newer suite needs a
+ * canonical-form edge id (`factor-1::goal-1::0`) rather than the older suite's
+ * locally-rewritten fallback (`e-0`), and only the older one needs
+ * `observedState` on the factor. Forcing one fixture on both would have been the
+ * opposite error: the already-diverged copy in `edgeValidationRebuildHops.spec.ts`
+ * hard-wired its `graph` and then could not vary nodes or framing.
+ */
+import { useCanvasStore } from '../../../store'
+import type { ReconcileAppliedGraphResult } from '../../mergeAppliedGraph'
+
+/**
+ * Fill the counters a case does not mention with 0, so every assertion checks
+ * ALL SIX exactly. Deliberately not `objectContaining`: an unasserted counter is
+ * how an unintended removal would slip through.
+ */
+export function counts(
+  p: Partial<ReconcileAppliedGraphResult> = {},
+): ReconcileAppliedGraphResult {
+  return {
+    addedNodeCount: 0,
+    addedEdgeCount: 0,
+    updatedNodeCount: 0,
+    updatedEdgeCount: 0,
+    removedNodeCount: 0,
+    removedEdgeCount: 0,
+    ...p,
+  }
+}
+
+/**
+ * Seed the canvas store as though the given graph were already on screen.
+ *
+ * ⚠ `lastAuthoritativeGraph: null` IS A LEAK GUARD, NOT BOILERPLATE. It means
+ * "CEE has acknowledged nothing", which leaves the DELETION path OFF unless a
+ * case opts in. Without the reset the field leaks between cases and a later test
+ * can delete the seed graph. This is the line whose reason lived in only one of
+ * the two copies of this function.
+ */
+export function seedCanvas(nodes: unknown[], edges: unknown[]): void {
+  useCanvasStore.setState({
+    currentScenarioId: 'scenario-1',
+    nodes: structuredClone(nodes) as never,
+    edges: structuredClone(edges) as never,
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    history: { past: [], future: [] },
+  } as never)
+}

--- a/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
+++ b/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * A-3a — every EDGE-DATA REBUILD keeps the wholesale spread of the existing
+ * edge's `data`. A derived source guard, not a list of files.
+ *
+ * ── WHY A SOURCE SCAN AND NOT MORE UNIT TESTS ────────────────────────────────
+ * `edgeValidationRebuildHops.spec.ts` already drives five rebuild hops end to
+ * end and asserts `validation` survives each. It is a good suite and it is not
+ * enough, for the reason its own header states: those five sites survive only
+ * because each happens to be written as a WHOLESALE SPREAD over the defaults —
+ *
+ *     { ...DEFAULT_EDGE_DATA, ...(edge.data ?? {}) }
+ *
+ * — so the hop-level tests pin ONE FIELD's survival at FIVE KNOWN SITES. They say
+ * nothing about the SIXTH site that arrives next month, and nothing about the
+ * NEXT field. That is the same shape as the defect the sibling scan
+ * (`canvas/__tests__/edgeProvenanceLaundering.sourceScan.spec.ts`) exists for: a
+ * hand-maintained list of places to be careful, which drifts silently and reads
+ * as green (CLAUDE.md trap 12).
+ *
+ * ── WHY IT MATTERS NOW, RATHER THAN AS A ROWED IDEA ──────────────────────────
+ * The resolve-contested writer puts USER DECISIONS in `edge.data.validation`
+ * (`user_action`, `resolved_value`, `resolved_by`). Once that flag flips, a
+ * rebuild hop written as a named-field copy is not a cosmetic regression — it is
+ * DATA LOSS of a choice the user made, on scenario resume, the journey every
+ * tester takes daily, with a fully green suite. The repo already owns this idiom
+ * and it costs one file.
+ *
+ * ── WHAT COUNTS AS A REBUILD, AND WHY THE SIGNAL SURVIVES THE MUTATION ───────
+ * A rebuild is an object literal that spreads an EXISTING edge (`...edge,`) and
+ * then supplies a fresh `data` bag built over `DEFAULT_EDGE_DATA`. Both halves
+ * are load-bearing:
+ *
+ *   · the OUTER `...<ident>,` spread is what identifies the input as an existing
+ *     canvas edge rather than a wire object. It is ALSO what a named-field-copy
+ *     mutation does not touch — the mutation rewrites the inner `data` bag — so
+ *     the site stays visible to this scan exactly when it starts violating it.
+ *     A detector keyed on the inner spread alone would go BLIND at the moment of
+ *     the defect and report zero findings, i.e. pass.
+ *   · the `...DEFAULT_EDGE_DATA` inside `data:` is what makes it a REBUILD rather
+ *     than a patch — the bag is being reconstructed from scratch, which is when
+ *     an unenumerated field can be lost.
+ *
+ * A FRESH CONSTRUCTION is therefore correctly excluded with no allowlist: the
+ * blueprint insert (`ReactFlowGraph.tsx`), the user-drawn `onConnect`, the two
+ * clarifier paths in `store.ts` and the two ingestion mappers all build a NEW
+ * object (`id`/`source`/`target`/…) with no outer edge spread, because there is
+ * no existing edge to spread. Nothing there can be dropped, so a pin would
+ * assert a vacuous truth — the same reasoning `edgeValidationRebuildHops.spec.ts`
+ * applies to the same sites, reached here structurally instead of by hand.
+ *
+ * ── SCOPE OF THE CLAIM ──────────────────────────────────────────────────────
+ * This scans `src/` for the SYNTACTIC shape above. It does not prove that every
+ * conceivable edge-data rebuild takes that shape — a rebuild written with
+ * `Object.assign`, or one that spreads a variable holding `DEFAULT_EDGE_DATA`
+ * under another name, is outside the detector. The claim is: every rebuild
+ * written in the repo's own idiom is covered, and a new one written in that idiom
+ * is covered automatically. The detector's reach is pinned by the positive
+ * control below rather than asserted.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { blankNonCode } from '../../../../tests/helpers/stripSourceComments'
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const EXCLUDED_DIR_NAMES = new Set([
+  '__tests__',
+  '__fixtures__',
+  '__helpers__',
+  '__mocks__',
+  'node_modules',
+])
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stats = statSync(full)
+    if (stats.isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(entry)) out.push(...sourceFiles(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+/**
+ * The rebuild opener: a spread of an identifier, then (allowing intervening
+ * members) a `data:` object. Capturing the identifier is what lets the check
+ * below demand a spread of THAT edge's `data` rather than of any `.data`.
+ *
+ * `blankNonCode` runs first, so this file's own prose above — which quotes the
+ * very shape being hunted — cannot read as a call site. That is not theoretical
+ * here: `domain/edgeValueProvenance.ts` carries a `{ ...DEFAULT_EDGE_DATA, … }`
+ * example inside a JSDoc block, and without the blanking it would be scanned as
+ * code.
+ */
+const REBUILD_OPENER = /\.\.\.\s*([A-Za-z_$][\w$]*)\s*,/g
+
+/** How far after the outer spread the `data:` opener may sit. */
+const DATA_WINDOW = 400
+
+interface Finding {
+  file: string
+  /** The identifier spread by the outer literal — the existing edge. */
+  identifier: string
+  /** Does the rebuilt `data` bag wholesale-spread `<identifier>.data`? */
+  wholesale: boolean
+}
+
+/**
+ * Find the `data: {` that belongs to this outer spread and return its literal
+ * body, or `null` when the spread is not an edge rebuild.
+ */
+function rebuiltDataBody(code: string, afterSpread: number): string | null {
+  const window = code.slice(afterSpread, afterSpread + DATA_WINDOW)
+  const dataAt = window.search(/\bdata\s*:\s*\{/)
+  if (dataAt === -1) return null
+  const open = afterSpread + window.indexOf('{', dataAt)
+  let depth = 0
+  for (let i = open; i < code.length; i++) {
+    if (code[i] === '{') depth++
+    else if (code[i] === '}') {
+      depth--
+      if (depth === 0) {
+        const body = code.slice(open, i + 1)
+        // Only a bag rebuilt over the mapper defaults is a REBUILD. A `data:`
+        // that merely patches named keys onto an existing bag is a different
+        // operation and cannot lose an unenumerated field.
+        return body.includes('DEFAULT_EDGE_DATA') ? body : null
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * The SPREAD ELEMENTS of an object literal body — each `...expr`, where `expr`
+ * runs to the member-separating comma at depth 0.
+ *
+ * ⚠ THIS REPLACES A REGEX THAT MADE THIS WHOLE GUARD VACUOUS, and the failure is
+ * worth recording because it is the guard-theatre shape this file exists to
+ * prevent, committed inside the file itself. The first version asked whether the
+ * body matched `/\.\.\.\s*\(?[^)]*\b<ident>\s*\.\s*data\b/`. `[^)]*` happily
+ * skips across arbitrary text, so ANY `...` anywhere in the bag followed later by
+ * ANY mention of `edge.data` satisfied it — and a named-field copy still contains
+ * both (`...DEFAULT_EDGE_DATA,` and `weight: edge.data?.weight`). The seeded
+ * mutation therefore left the scan GREEN: the guard reported "all rebuilds are
+ * wholesale" while reading a rebuild that was not. Caught by the mutation check,
+ * which is the only thing that could have caught it (CLAUDE.md trap 15: your own
+ * script is not exempt; trap 13: prove the detector can see a PRESENCE).
+ *
+ * Splitting into actual spread elements makes the question the right one: is
+ * `<identifier>.data` inside a SPREAD, rather than merely somewhere in the bag.
+ */
+function spreadElements(body: string): string[] {
+  const out: string[] = []
+  for (let i = 0; i < body.length - 2; i++) {
+    if (body.slice(i, i + 3) !== '...') continue
+    let depth = 0
+    let j = i + 3
+    for (; j < body.length; j++) {
+      const c = body[j]
+      if (c === '(' || c === '[' || c === '{') depth++
+      else if (c === ')' || c === ']') depth--
+      else if (c === '}') {
+        if (depth === 0) break
+        depth--
+      } else if (c === ',' && depth === 0) break
+    }
+    out.push(body.slice(i + 3, j))
+  }
+  return out
+}
+
+function scan(): Finding[] {
+  const findings: Finding[] = []
+  for (const file of sourceFiles(SRC_ROOT)) {
+    const code = blankNonCode(readFileSync(file, 'utf8'))
+    for (const match of code.matchAll(REBUILD_OPENER)) {
+      const identifier = match[1]
+      const after = (match.index ?? 0) + match[0].length
+      const body = rebuiltDataBody(code, after)
+      if (body === null) continue
+      // The required shape: a SPREAD whose expression reads `<identifier>.data`.
+      // Every real site wraps it (`...(edge.data as Partial<EdgeData> | undefined
+      // ?? {})`), so the test is on the spread's CONTENT, not on an exact form.
+      const dataRead = new RegExp(`\\b${identifier}\\s*\\.\\s*data\\b`)
+      const wholesale = spreadElements(body).some((e) => dataRead.test(e))
+      findings.push({ file: relative(SRC_ROOT, file), identifier, wholesale })
+    }
+  }
+  return findings
+}
+
+describe('edge-data rebuilds — derived source guard (A-3a)', () => {
+  const findings = scan()
+
+  /**
+   * POSITIVE CONTROL (trap 13). If the detector finds nothing, the assertion
+   * below passes by testing nothing — which is precisely how the unpinned class
+   * survived until now. `useScenario.ts` (the Supabase resume hop) and
+   * `store.ts` (the rehydrate + three repair hops) are the known homes; the scan
+   * must SEE them, by file, not merely return a non-zero count.
+   */
+  it('the detector can see the real edge-data rebuilds (non-vacuous)', () => {
+    expect(findings.length).toBeGreaterThan(0)
+    const files = new Set(findings.map((f) => f.file))
+    expect(files.has('hooks/useScenario.ts')).toBe(true)
+    expect(files.has('canvas/store.ts')).toBe(true)
+    // The five hops `edgeValidationRebuildHops.spec.ts` drives end to end. Not a
+    // hand-maintained list of WHERE to look — the scan found these — but a floor
+    // on the detector's reach, so a regex change that quietly narrowed it reds.
+    expect(findings.length).toBeGreaterThanOrEqual(5)
+  })
+
+  /**
+   * SECOND POSITIVE CONTROL — the detector's blindness to comments and strings
+   * is a property, so it is pinned rather than trusted. `edgeValueProvenance.ts`
+   * quotes `{ ...DEFAULT_EDGE_DATA, weight, beliefExists, … }` inside a JSDoc
+   * block; a scan that read comments would report it and would then need an
+   * allowlist entry, which is how a real violation later hides behind a
+   * plausible exception.
+   */
+  it('ignores the shape when it appears in a comment (blankNonCode holds)', () => {
+    expect(findings.some((f) => f.file === 'canvas/domain/edgeValueProvenance.ts')).toBe(false)
+  })
+
+  it('every edge-data rebuild spreads the existing edge data wholesale', () => {
+    // THE PIN. Converting any one of these to a named-field copy — the exact
+    // discipline the two INGESTION mappers deliberately use, and therefore the
+    // change a well-intentioned reader is most likely to make here — turns this
+    // red. Without it the same change is invisible: 139 pre-existing tests
+    // across 8 files stay green through it, including both `useScenario` specs.
+    const named = findings.filter((f) => !f.wholesale)
+    expect(named.map((f) => `${f.file}: rebuild of ...${f.identifier}`)).toEqual([])
+  })
+})

--- a/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
+++ b/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
@@ -48,14 +48,36 @@
  * assert a vacuous truth — the same reasoning `edgeValidationRebuildHops.spec.ts`
  * applies to the same sites, reached here structurally instead of by hand.
  *
+ * ── WHAT IS ASSERTED: TWO PROPERTIES, NOT ONE ───────────────────────────────
+ *   1. every rebuild spreads the existing edge's `data` WHOLESALE; and
+ *   2. NOTHING is written after that spread.
+ *
+ * Property 2 was added by the adversarial review of PR #539, which seeded
+ * `{...DEFAULT_EDGE_DATA, ...(edge.data ?? {}), validation: undefined}` and found
+ * the guard GREEN. Property 1 alone reads as "persisted edge data survives the
+ * rebuild" while permitting the single line that guarantees it does not.
+ *
  * ── SCOPE OF THE CLAIM ──────────────────────────────────────────────────────
- * This scans `src/` for the SYNTACTIC shape above. It does not prove that every
- * conceivable edge-data rebuild takes that shape — a rebuild written with
- * `Object.assign`, or one that spreads a variable holding `DEFAULT_EDGE_DATA`
- * under another name, is outside the detector. The claim is: every rebuild
- * written in the repo's own idiom is covered, and a new one written in that idiom
- * is covered automatically. The detector's reach is pinned by the positive
- * control below rather than asserted.
+ * This scans `src/` for the SYNTACTIC shapes above. It does not prove that every
+ * conceivable edge-data rebuild takes one of them. Known outside the detector,
+ * disclosed rather than discovered later:
+ *
+ *   · `Object.assign(...)` in place of an object literal;
+ *   · a rebuild that spreads a variable holding `DEFAULT_EDGE_DATA` under another
+ *     name (the `rebuiltDataBody` gate looks for that identifier by name);
+ *   · a `data:` opener sitting more than `DATA_WINDOW` characters after the outer
+ *     spread;
+ *   · a rebuild assembled across statements (`const d = {...}; return {...edge,
+ *     data: d}`) rather than in one literal.
+ *
+ * Two shapes that WERE outside it and are now inside, both from the #539 review:
+ * a member-expression outer spread (`...edges[i],`) and an override after the
+ * wholesale spread. Two that were already covered and are pinned so they stay
+ * covered: multiline and comment-interleaved named copies.
+ *
+ * The claim is: every rebuild written in the repo's own idiom is covered, a new
+ * one written in that idiom is covered automatically, and the detector's reach is
+ * PINNED by the three positive controls below rather than asserted.
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
@@ -89,9 +111,17 @@ function sourceFiles(dir: string): string[] {
 }
 
 /**
- * The rebuild opener: a spread of an identifier, then (allowing intervening
- * members) a `data:` object. Capturing the identifier is what lets the check
- * below demand a spread of THAT edge's `data` rather than of any `.data`.
+ * The rebuild opener: a spread of a REFERENCE EXPRESSION, then (allowing
+ * intervening members) a `data:` object. Capturing the expression is what lets
+ * the check below demand a spread of THAT edge's `data` rather than of any
+ * `.data`.
+ *
+ * ⚠ THE EXPRESSION IS NOT JUST A BARE IDENTIFIER — that was blind spot (ii) from
+ * the adversarial review of PR #539. The first version matched
+ * `[A-Za-z_$][\w$]*` only, so an index or member rebuild — `...edges[i],`,
+ * `...pair.edge,` — was **invisible**, and a named-field copy at such a site
+ * passed the scan silently. A `for (let i…)` rebuild loop is an entirely ordinary
+ * way to write one of these, so this was not an exotic gap.
  *
  * `blankNonCode` runs first, so this file's own prose above — which quotes the
  * very shape being hunted — cannot read as a call site. That is not theoretical
@@ -99,34 +129,76 @@ function sourceFiles(dir: string): string[] {
  * example inside a JSDoc block, and without the blanking it would be scanned as
  * code.
  */
-const REBUILD_OPENER = /\.\.\.\s*([A-Za-z_$][\w$]*)\s*,/g
+const REBUILD_OPENER =
+  /\.\.\.\s*([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*|\s*\[\s*[\w$]+\s*\])*)\s*,/g
 
 /** How far after the outer spread the `data:` opener may sit. */
 const DATA_WINDOW = 400
 
+/** Whitespace-insensitive comparison, so `edges [ i ] .data` reads as `edges[i].data`. */
+function squash(s: string): string {
+  return s.replace(/\s+/g, '')
+}
+
 interface Finding {
   file: string
-  /** The identifier spread by the outer literal — the existing edge. */
+  /** The reference expression spread by the outer literal — the existing edge. */
   identifier: string
   /** Does the rebuilt `data` bag wholesale-spread `<identifier>.data`? */
   wholesale: boolean
+  /**
+   * Members written AFTER the wholesale spread. Each one can override a field the
+   * spread just carried through — blind spot (i) from the same review.
+   */
+  overridesAfterSpread: string[]
 }
 
 /**
- * Find the `data: {` that belongs to this outer spread and return its literal
- * body, or `null` when the spread is not an edge rebuild.
+ * Find the `data: {` that is a SIBLING MEMBER of the same object literal as this
+ * outer spread, and return its body — or `null` when the spread is not an edge
+ * rebuild.
+ *
+ * ⚠ THE SIBLING TEST IS NOT COSMETIC; A PLAIN LOOKAHEAD WINDOW PRODUCED A FALSE
+ * POSITIVE THE MOMENT THE OPENER WAS WIDENED. `OutputsDock.tsx` spreads
+ * `...newNode.data` inside a NODE data literal, and a few lines later — inside a
+ * *different* literal, in a `addEdge({...})` call — writes
+ * `data: { ...DEFAULT_EDGE_DATA, confidence: 0 }`. A window that only looks
+ * FORWARD walked out of the node literal, found the edge literal, and reported a
+ * rebuild of `...newNode.data` that does not exist. Requiring the `data:` opener
+ * to sit at depth 0 RELATIVE TO THE SPREAD — i.e. to be a member of the same
+ * literal, not merely nearby — is the structural version of the question, and it
+ * costs nothing.
  */
 function rebuiltDataBody(code: string, afterSpread: number): string | null {
-  const window = code.slice(afterSpread, afterSpread + DATA_WINDOW)
-  const dataAt = window.search(/\bdata\s*:\s*\{/)
-  if (dataAt === -1) return null
-  const open = afterSpread + window.indexOf('{', dataAt)
+  // Walk forward from the spread, tracking nesting. Depth < 0 means we have left
+  // the literal the spread belongs to: any `data:` beyond that is a sibling of
+  // something else.
   let depth = 0
-  for (let i = open; i < code.length; i++) {
-    if (code[i] === '{') depth++
-    else if (code[i] === '}') {
+  let open = -1
+  for (let i = afterSpread; i < code.length && i < afterSpread + DATA_WINDOW; i++) {
+    const c = code[i]
+    if (c === '{' || c === '(' || c === '[') {
+      depth++
+      continue
+    }
+    if (c === '}' || c === ')' || c === ']') {
       depth--
-      if (depth === 0) {
+      if (depth < 0) return null // left the enclosing literal
+      continue
+    }
+    if (depth === 0 && /^data\s*:\s*\{/.test(code.slice(i))) {
+      open = code.indexOf('{', i)
+      break
+    }
+  }
+  if (open === -1) return null
+
+  let d = 0
+  for (let i = open; i < code.length; i++) {
+    if (code[i] === '{') d++
+    else if (code[i] === '}') {
+      d--
+      if (d === 0) {
         const body = code.slice(open, i + 1)
         // Only a bag rebuilt over the mapper defaults is a REBUILD. A `data:`
         // that merely patches named keys onto an existing bag is a different
@@ -139,8 +211,8 @@ function rebuiltDataBody(code: string, afterSpread: number): string | null {
 }
 
 /**
- * The SPREAD ELEMENTS of an object literal body — each `...expr`, where `expr`
- * runs to the member-separating comma at depth 0.
+ * The TOP-LEVEL MEMBERS of an object literal body, in source order — each spread
+ * and each named key, split at depth-0 commas.
  *
  * ⚠ THIS REPLACES A REGEX THAT MADE THIS WHOLE GUARD VACUOUS, and the failure is
  * worth recording because it is the guard-theatre shape this file exists to
@@ -154,27 +226,25 @@ function rebuiltDataBody(code: string, afterSpread: number): string | null {
  * which is the only thing that could have caught it (CLAUDE.md trap 15: your own
  * script is not exempt; trap 13: prove the detector can see a PRESENCE).
  *
- * Splitting into actual spread elements makes the question the right one: is
- * `<identifier>.data` inside a SPREAD, rather than merely somewhere in the bag.
+ * Parsing MEMBERS (rather than only spreads) makes both questions answerable: is
+ * `<identifier>.data` inside a SPREAD, and is anything written AFTER it.
  */
-function spreadElements(body: string): string[] {
+function topLevelMembers(body: string): string[] {
+  const inner = body.slice(1, -1) // strip the braces
   const out: string[] = []
-  for (let i = 0; i < body.length - 2; i++) {
-    if (body.slice(i, i + 3) !== '...') continue
-    let depth = 0
-    let j = i + 3
-    for (; j < body.length; j++) {
-      const c = body[j]
-      if (c === '(' || c === '[' || c === '{') depth++
-      else if (c === ')' || c === ']') depth--
-      else if (c === '}') {
-        if (depth === 0) break
-        depth--
-      } else if (c === ',' && depth === 0) break
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i]
+    if (c === '(' || c === '[' || c === '{') depth++
+    else if (c === ')' || c === ']' || c === '}') depth--
+    else if (c === ',' && depth === 0) {
+      out.push(inner.slice(start, i))
+      start = i + 1
     }
-    out.push(body.slice(i + 3, j))
   }
-  return out
+  out.push(inner.slice(start))
+  return out.map((s) => s.trim()).filter((s) => s !== '')
 }
 
 function scan(): Finding[] {
@@ -186,16 +256,69 @@ function scan(): Finding[] {
       const after = (match.index ?? 0) + match[0].length
       const body = rebuiltDataBody(code, after)
       if (body === null) continue
+
+      const members = topLevelMembers(body)
       // The required shape: a SPREAD whose expression reads `<identifier>.data`.
       // Every real site wraps it (`...(edge.data as Partial<EdgeData> | undefined
       // ?? {})`), so the test is on the spread's CONTENT, not on an exact form.
-      const dataRead = new RegExp(`\\b${identifier}\\s*\\.\\s*data\\b`)
-      const wholesale = spreadElements(body).some((e) => dataRead.test(e))
-      findings.push({ file: relative(SRC_ROOT, file), identifier, wholesale })
+      // Compared whitespace-squashed so a member expression spanning line breaks
+      // still matches.
+      const wanted = squash(identifier) + '.data'
+      const spreadIdx = members.findIndex(
+        (m) => m.startsWith('...') && squash(m).includes(wanted),
+      )
+      // ⚠ ANYTHING AFTER THE WHOLESALE SPREAD CAN UNDO IT — blind spot (i). The
+      // guard used to assert only that the spread was PRESENT, so
+      // `{...DEFAULT_EDGE_DATA, ...(edge.data ?? {}), validation: undefined}`
+      // passed while destroying exactly the user-decision field this file's
+      // WHY-IT-MATTERS section is about. Both named keys and further spreads
+      // count: either can overwrite a field the spread just carried through, and
+      // a rebuild whose whole purpose is "carry everything through" has no
+      // business writing after it. A site that genuinely must force a field
+      // should have to argue for it against a RED, not do it silently.
+      const overridesAfterSpread =
+        spreadIdx === -1
+          ? []
+          : members.slice(spreadIdx + 1).map((m) => m.split(/[:(]/)[0].trim())
+
+      findings.push({
+        file: relative(SRC_ROOT, file),
+        identifier,
+        wholesale: spreadIdx !== -1,
+        overridesAfterSpread,
+      })
     }
   }
   return findings
 }
+
+/**
+ * Overrides after the wholesale spread that are ADJUDICATED DELIBERATE, each with
+ * the reason it is here. Keyed `<file>:<key>`.
+ *
+ * ⚠ NOT A SUPPRESSION LIST. It fails loud in BOTH directions — an undisclosed
+ * override reds because it is absent here, and a disclosed one that stops
+ * existing reds because this list would then over-state. Adding an entry is a
+ * decision someone has to make in a diff, with a reason, against a RED. That is
+ * the only honest way to hold "nothing is written after the spread" as a property
+ * when one legitimate exception genuinely exists: the alternative — a clever
+ * predicate that tries to tell a good override from a bad one — is how a guard
+ * trades one vacuity for another.
+ *
+ * The single entry is a v1→v2 MIGRATION, not a rebuild-in-flight:
+ * `migrateEdgeV1ToV2` hoists the legacy TOP-LEVEL `edge.label` into `data.label`,
+ * and "top-level edge.label takes precedence over edge.data.label" IS the
+ * migration's documented purpose (its own docstring says so). The override reads
+ * FROM the same edge — it moves data within the edge rather than discarding it —
+ * which is the opposite of the seeded `validation: undefined` this pin exists to
+ * catch.
+ */
+const KNOWN_POST_SPREAD_OVERRIDES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'canvas/domain/migrations.ts:label',
+    'migrateEdgeV1ToV2 hoists the legacy top-level edge.label into data.label — the documented purpose of the v1→v2 migration, and it reads from the same edge',
+  ],
+]
 
 describe('edge-data rebuilds — derived source guard (A-3a)', () => {
   const findings = scan()
@@ -230,6 +353,31 @@ describe('edge-data rebuilds — derived source guard (A-3a)', () => {
     expect(findings.some((f) => f.file === 'canvas/domain/edgeValueProvenance.ts')).toBe(false)
   })
 
+  /**
+   * THIRD POSITIVE CONTROL — the widened opener must actually see a
+   * member-expression spread, or blind spot (ii) is only nominally closed.
+   *
+   * There is no member-expression rebuild in `src/` today, so this control is on
+   * the DETECTOR rather than on the tree: it runs the opener over a fixture of
+   * each shape the review named and requires each to be recognised. A control
+   * pinned to "whatever is in the tree" would silently become vacuous the moment
+   * the tree changed (CLAUDE.md trap 12b), which is exactly the wrong property for
+   * a control guarding a widened regex.
+   */
+  it('the widened opener recognises index, member and bare-identifier spreads', () => {
+    const cases: Array<[string, string]> = [
+      ['...edge,', 'edge'],
+      ['...edges[i],', 'edges[i]'],
+      ['...pair.edge,', 'pair.edge'],
+      ['...state.edges[0],', 'state.edges[0]'],
+    ]
+    for (const [src, expected] of cases) {
+      const m = [...src.matchAll(REBUILD_OPENER)]
+      expect(m.length, `opener must see ${src}`).toBe(1)
+      expect(squash(m[0][1])).toBe(expected)
+    }
+  })
+
   it('every edge-data rebuild spreads the existing edge data wholesale', () => {
     // THE PIN. Converting any one of these to a named-field copy — the exact
     // discipline the two INGESTION mappers deliberately use, and therefore the
@@ -238,5 +386,47 @@ describe('edge-data rebuilds — derived source guard (A-3a)', () => {
     // across 8 files stay green through it, including both `useScenario` specs.
     const named = findings.filter((f) => !f.wholesale)
     expect(named.map((f) => `${f.file}: rebuild of ...${f.identifier}`)).toEqual([])
+  })
+
+  /**
+   * ⭐ THE SECOND PIN — added by the adversarial review of PR #539 (blind spot i).
+   *
+   * The pin above asks whether the wholesale spread is PRESENT. It does not ask
+   * whether anything UNDOES it. So
+   *
+   *     { ...DEFAULT_EDGE_DATA, ...(edge.data ?? {}), validation: undefined }
+   *
+   * passed the guard while destroying exactly the `validation` user-decision field
+   * this file's WHY-IT-MATTERS section is written about — the resolve-contested
+   * writer's `user_action` / `resolved_value` / `resolved_by`. A guard that reads
+   * as "persisted edge data survives the rebuild" while permitting the one line
+   * that guarantees it does not is worse than no guard, because it is cited.
+   */
+  it('nothing is written AFTER the wholesale spread (an override undoes it)', () => {
+    const found = findings
+      .flatMap((f) => f.overridesAfterSpread.map((k) => `${f.file}:${k}`))
+      .sort()
+    const known = KNOWN_POST_SPREAD_OVERRIDES.map(([k]) => k).sort()
+
+    // No UNDISCLOSED override.
+    expect(found.filter((k) => !known.includes(k))).toEqual([])
+
+    // …and no STALE disclosure: an entry whose override has since been removed
+    // must be deleted in the same change, so the record cannot outlive the thing
+    // it describes. Same both-directions rule as `KNOWN_HOP_DIVERGENCES` in
+    // `edgeValidationMapperMirror.spec.ts` — which has already caught a wrong
+    // entry once.
+    expect(
+      KNOWN_POST_SPREAD_OVERRIDES.filter(([k]) => !found.includes(k)).map(
+        ([k, why]) => `${k} (recorded as: ${why}) no longer overrides — delete this entry`,
+      ),
+    ).toEqual([])
+  })
+
+  it('the disclosed override set is exactly the one documented migration hoist', () => {
+    // Pinned separately so the SIZE of the exception set is visible in a diff.
+    expect(KNOWN_POST_SPREAD_OVERRIDES.map(([k]) => k)).toEqual([
+      'canvas/domain/migrations.ts:label',
+    ])
   })
 })

--- a/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
@@ -200,3 +200,215 @@ describe('edge.validation — the two hand-mirrored mappers stay in lockstep', (
     expect('validation' in drafted.data).toBe('validation' in storeEdges[0].data)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A-3b — WHOLE-`data` PARITY, NOT ONE FIELD'S PARITY
+//
+// Everything above pins `validation`, because `validation` was the field that
+// went missing. That is one field of a bag the two mappers claim to build
+// identically, so the suite would have been just as green if the NEXT field had
+// been added to one hop only — which is the same defect, one field along, and the
+// reason this section exists.
+//
+// ⚠ THIS ASSERTION FOUND TWO REAL DIVERGENCES ON ITS FIRST RUN, AND BOTH WERE
+// DEFECTS. `strengthStdSource` (hop 2 omitted `strengthStd` from
+// `edgeValueSourcePatch`, so a receipt wrote a provenanced VALUE with no stamp)
+// and `provenanceDisplay` (hop 2 never applied `edgeProvenanceDisplayPatch`, so
+// the field was dropped outright). Both were adjudicated at the bytes and FIXED in
+// the same change — see the two describes at the bottom of this file for the
+// evidence, the RED-first pins, and why the receipt is not structurally incapable
+// of carrying `provenance_display`.
+//
+// The two hops now build a BYTE-IDENTICAL `data` bag for the full wire edge, so
+// the difference set below is EMPTY, and that is the assertion — not a
+// disclosure of tolerated gaps.
+//
+// ⚠ IT FAILS LOUD IN BOTH DIRECTIONS (CLAUDE.md trap 12): a NEW divergence reds
+// because it is not in the set, and a STALE entry reds because the set would then
+// over-state. Do NOT add an entry to make a red go away — a new entry means a
+// mapper drifted, and the honest move is to fix the hop or to record, in the
+// entry's reason string, the derived evidence that the difference is structural.
+// (That second arm has already earned its keep: it caught this very file's first
+// draft recording `provenanceDisplay` as differing while its fixture used a
+// provenance value outside the closed vocabulary, so neither hop emitted the key
+// and the "divergence" was an artefact of the fixture.)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Keys the two hops are KNOWN to disagree on, with the reason each is here.
+ *
+ * EMPTY, and meant to stay empty. An entry is a defect awaiting its own change or
+ * a structural difference with derived evidence in its reason string — never a
+ * sanctioned exception, and never a way to quiet this test.
+ */
+const KNOWN_HOP_DIVERGENCES: ReadonlyArray<readonly [string, string]> = []
+
+/** The full wire edge, with every field either mapper reads. */
+const WIRE_EDGE_FULL = {
+  from: 'factor-1',
+  to: 'goal-1',
+  strength: { mean: 0.42, std: 0.11 },
+  exists_probability: 0.77,
+  belief: 0.66,
+  belief_exists: 0.55,
+  effect_direction: 'negative',
+  edge_type: 'directed',
+  provenance_source: 'cee_draft',
+  // Must be one of `PROVENANCE_VALUES` (`from_brief` / `ai_inferred` /
+  // `user_set`) or `edgeProvenanceDisplayPatch` emits nothing and hop 1 agrees
+  // with hop 2 by both producing no key — a fixture that would make divergence
+  // #2 look already-fixed. The stale-disclosure arm below caught exactly that on
+  // this test's first run, which is the arm earning its place.
+  provenance_display: 'ai_inferred',
+  validation: WIRE_VALIDATION,
+}
+
+describe('edge data — the two hand-mirrored mappers build the SAME bag', () => {
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('every key of the rebuilt data bag agrees, except the recorded divergences', () => {
+    const drafted = mapDraftEdgeToCanvas({ ...WIRE_EDGE_FULL }, 0)
+    applyAutoApplyPatch(addEdgePatch({ ...WIRE_EDGE_FULL }) as any)
+    const patched = storeEdges[0]
+
+    // POSITIVE CONTROL for the comparison itself (trap 13): a bag with nothing in
+    // it, or a comparison over an empty key set, would make every assertion below
+    // vacuous. The live payload above must actually populate the bag.
+    const keys = new Set([...Object.keys(drafted.data), ...Object.keys(patched.data)])
+    expect(keys.size).toBeGreaterThan(10)
+    expect(keys.has('validation')).toBe(true)
+
+    const known = new Set(KNOWN_HOP_DIVERGENCES.map(([k]) => k))
+    const differing = [...keys]
+      .filter((k) => JSON.stringify(drafted.data[k]) !== JSON.stringify(patched.data[k]))
+      .sort()
+
+    // No UNDISCLOSED divergence.
+    expect(differing.filter((k) => !known.has(k))).toEqual([])
+
+    // …and no STALE disclosure: every recorded divergence must still be real. A
+    // fix that closes one has to shrink this list in the same change, so the
+    // record can never outlive the defect it describes.
+    const stale = KNOWN_HOP_DIVERGENCES.filter(([k]) => !differing.includes(k)).map(
+      ([k, why]) => `${k} (recorded as: ${why}) no longer differs — delete this entry`,
+    )
+    expect(stale).toEqual([])
+  })
+
+  it('the recorded divergences are exactly the ones listed', () => {
+    // Pinned separately so the SIZE of the exception set is itself visible in a
+    // diff. Growing it is a decision someone has to make on purpose. It is EMPTY:
+    // both divergences this assertion originally recorded were adjudicated as
+    // defects and fixed in the same change — see the two describes below.
+    expect(KNOWN_HOP_DIVERGENCES.map(([k]) => k)).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE TWO DIVERGENCES THE PARITY ASSERTION FOUND, ADJUDICATED AND FIXED
+//
+// Both were real field loss on the `edit_graph` receipt path, and both are the
+// 2.154 class: a producer value the UI paid for and then dropped at an ingestion
+// boundary, silently, with the whole suite green.
+//
+// ⚠ ADJUDICATION EVIDENCE FOR `provenanceDisplay` — the question was whether the
+// receipt can even CARRY the field, because if it structurally could not, hop 2
+// omitting the patch would be correct rather than a defect. Derived at the bytes,
+// not assumed:
+//   · `provenance_display` appears NOWHERE in `@talchain/schemas` 0.30.0 (the
+//     pinned vendored tarball) — zero matches across the whole package. So the
+//     contract neither declares nor forbids it.
+//   · `DraftGraphBlockSchema.edges` is `z.array(z.unknown())` (boundary/blocks
+//     :209) — the DRAFT edge hop 1 reads it from is itself untyped by the
+//     contract, so the field's only declaration is the UI's own
+//     `adapters/cee/types.ts:74` / `:135`.
+//   · the receipt's carrier, `PatchOperation.data`, is
+//     `Record<string, unknown>` (`canvas/conversation/types.ts:464`) — fully OPEN.
+// So the receipt is NOT structurally incapable of carrying it. Both hops read an
+// open bag; only one of them looked. → DEFECT, fixed.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('divergence 1 — strengthStdSource is stamped on a receipt, not just a draft', () => {
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('an add_edge receipt carrying strength.std stamps strengthStdSource', () => {
+    // `strengthStd` is one of the three `EDGE_PROVENANCED_FIELDS`
+    // (domain/edgeValueProvenance.ts:75). Hop 2 wrote the VALUE while omitting the
+    // stamp, so every display surface that reads the stamp treated a real CEE
+    // estimate as never set — the exact inverse of the laundering
+    // `edgeProvenanceLaundering.sourceScan.spec.ts` guards.
+    applyAutoApplyPatch(
+      addEdgePatch({ from: 'factor-1', to: 'goal-1', strength: { mean: 0.42, std: 0.11 } }) as any,
+    )
+    const data = storeEdges[0].data
+    expect(data.strengthStd).toBeCloseTo(0.11)
+    expect(data.strengthStdSource).toBe('cee')
+  })
+
+  it('a receipt WITHOUT strength.std stamps nothing (the absence arm)', () => {
+    // POSITIVE CONTROL for this absence is the test above: the same path DOES
+    // stamp when the receipt supplies the value, so this measures a real absence
+    // rather than measuring nothing. An unconditional stamp would be the opposite
+    // defect — claiming a producer estimate that was never sent.
+    applyAutoApplyPatch(addEdgePatch({ from: 'factor-1', to: 'goal-1', weight: 0.5 }) as any)
+    const data = storeEdges[0].data
+    expect(data).not.toHaveProperty('strengthStd')
+    expect(data).not.toHaveProperty('strengthStdSource')
+  })
+
+  it('the draft hop already did this — the two now agree', () => {
+    const drafted = mapDraftEdgeToCanvas(
+      { from: 'factor-1', to: 'goal-1', strength: { mean: 0.42, std: 0.11 } },
+      0,
+    )
+    applyAutoApplyPatch(
+      addEdgePatch({ from: 'factor-1', to: 'goal-1', strength: { mean: 0.42, std: 0.11 } }) as any,
+    )
+    expect(drafted.data.strengthStdSource).toBe('cee')
+    expect(storeEdges[0].data.strengthStdSource).toBe(drafted.data.strengthStdSource)
+  })
+})
+
+describe('divergence 2 — provenanceDisplay survives a receipt, not just a draft', () => {
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('an add_edge receipt carrying provenance_display maps it to provenanceDisplay', () => {
+    applyAutoApplyPatch(
+      addEdgePatch({ from: 'factor-1', to: 'goal-1', provenance_display: 'ai_inferred' }) as any,
+    )
+    expect(storeEdges[0].data.provenanceDisplay).toBe('ai_inferred')
+  })
+
+  it('an UNRECOGNISED provenance value is not mapped (the closed vocabulary holds)', () => {
+    // `edgeProvenanceDisplayPatch` admits only `from_brief` / `ai_inferred` /
+    // `user_set`. Sharing hop 1's helper means sharing that gate, which is the
+    // point of reusing it rather than writing a second read.
+    applyAutoApplyPatch(
+      addEdgePatch({ from: 'factor-1', to: 'goal-1', provenance_display: 'made_up' }) as any,
+    )
+    expect(storeEdges[0].data).not.toHaveProperty('provenanceDisplay')
+  })
+
+  it('a receipt carrying no provenance_display gains no key (the absence arm)', () => {
+    applyAutoApplyPatch(addEdgePatch({ from: 'factor-1', to: 'goal-1', weight: 0.5 }) as any)
+    expect(storeEdges[0].data).not.toHaveProperty('provenanceDisplay')
+  })
+
+  it('the draft hop already did this — the two now agree', () => {
+    const drafted = mapDraftEdgeToCanvas(
+      { from: 'factor-1', to: 'goal-1', provenance_display: 'ai_inferred' },
+      0,
+    )
+    applyAutoApplyPatch(
+      addEdgePatch({ from: 'factor-1', to: 'goal-1', provenance_display: 'ai_inferred' }) as any,
+    )
+    expect(drafted.data.provenanceDisplay).toBe('ai_inferred')
+    expect(storeEdges[0].data.provenanceDisplay).toBe(drafted.data.provenanceDisplay)
+  })
+})

--- a/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts
@@ -60,32 +60,30 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
 // ── Mocks for hop 4 (the Supabase scenario-load path) ───────────────────────
-// Same harness shape as src/hooks/__tests__/useScenario.goalConstraints.lifecycle
-// .spec.ts, which pins the sibling property (goal_constraints) on this same hop.
-const mockRpc = vi.fn()
-const mockSingle = vi.fn()
-let mockRowsById: Record<string, Record<string, unknown>> = {}
+// R-3: the harness is IMPORTED, not copied. It was copied line-for-line from
+// src/hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts — which pins
+// the sibling property (goal_constraints) on this same hop — and this file's own
+// header said so while copying anyway, because no shared home existed. It does
+// now: src/test/helpers/useScenarioSupabaseHarness.ts.
+//
+// ⚠ THIS IMPORT MUST STAY ABOVE the imports of the code under test below: the
+// `vi.mock` factories close over the harness, and ESM evaluates static imports in
+// source order. See the harness header.
+import {
+  HARNESS_NODES,
+  supabaseMockModule,
+  authMockModule,
+  routerMockModule,
+  resetScenarioHarness,
+  setScenarioRow,
+  scenarioRowWithEdges,
+} from '../../../test/helpers/useScenarioSupabaseHarness'
 
-vi.mock('../../../lib/supabase', () => ({
-  supabase: {
-    from: () => ({
-      select: () => ({
-        eq: (_col: string, id: string) => ({
-          single: () => mockSingle(id),
-        }),
-      }),
-      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
-    }),
-    rpc: (...args: unknown[]) => mockRpc(...args),
-  },
-}))
-
-vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
-
-const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
-vi.mock('../../../contexts/AuthContext', () => ({
-  useAuth: () => ({ user: { id: REAL_USER_ID }, authenticated: true }),
-}))
+// Only the SPECIFIERS stay here — they resolve relative to this file, so they
+// cannot move into the harness. The factory bodies did.
+vi.mock('../../../lib/supabase', () => supabaseMockModule())
+vi.mock('react-router-dom', () => routerMockModule())
+vi.mock('../../../contexts/AuthContext', () => authMockModule())
 
 // ── Mock for hop 5 (the store's own localStorage-backed scenario load) ──────
 // importOriginal-spread, overriding ONLY `getScenario`. A hand-written stand-in
@@ -131,10 +129,8 @@ const WIRE_VALIDATION = {
   resolved_by: 'default',
 } as unknown as ValidationMetadata
 
-const NODES = [
-  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
-  { id: 'factor-1', type: 'factor', position: { x: 0, y: 100 }, data: { kind: 'factor', label: 'Spend' } },
-]
+/** R-3: the two canvas nodes both suites seed, from the shared harness. */
+const NODES = HARNESS_NODES
 
 const EDGE_ID = 'factor-1::goal-1::0'
 
@@ -153,21 +149,13 @@ function persistedEdge(withValidation: boolean) {
   }
 }
 
-function scenarioRow(id: string, edges: unknown[]): Record<string, unknown> {
-  return {
-    id,
-    graph: { nodes: NODES, edges },
-    framing: null,
-    stage: 'analyse',
-    updated_at: new Date().toISOString(),
-    analysis_status: 'none',
-    analysis: null,
-    analysis_provenance: null,
-    analysis_error: null,
-    thread: null,
-    events: null,
-  }
-}
+/*
+ * R-3: `scenarioRow` came from the shared harness as `scenarioRowWithEdges`. The
+ * local copy had ALREADY DIVERGED from the original in the direction that loses
+ * reach — it took `(id, edges)` with `graph` hard-wired, so this suite could not
+ * vary nodes or framing. The harness keeps the original's `(id, graph)` signature
+ * and offers this nodes-plus-edges convenience on top.
+ */
 
 /** The rebuilt edge as it ended up in the canvas store. */
 function storeEdgeData(): Record<string, unknown> {
@@ -189,14 +177,11 @@ function seedCanvas(withValidation: boolean) {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockRowsById = {}
   mockScenariosById.clear()
-  mockSingle.mockImplementation(async (id: string) =>
-    mockRowsById[id]
-      ? { data: mockRowsById[id], error: null }
-      : { data: null, error: { code: 'PGRST116' } },
-  )
-  mockRpc.mockResolvedValue({ data: {}, error: null })
+  // R-3: clears the served rows and RE-ARMS both spies — `vi.clearAllMocks()`
+  // above strips the implementations, including the `PGRST116` "no rows" arm that
+  // `useScenario` branches on. Must run after it.
+  resetScenarioHarness()
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -207,7 +192,7 @@ beforeEach(() => {
 
 describe('hop 4 — validation survives a Supabase scenario resume', () => {
   it('an edge persisted WITH validation still carries it after loadScenario', async () => {
-    mockRowsById['scenario-A'] = scenarioRow('scenario-A', [persistedEdge(true)])
+    setScenarioRow('scenario-A', scenarioRowWithEdges('scenario-A', [persistedEdge(true)]))
     const { result } = renderHook(() => useScenario())
 
     await act(async () => {
@@ -223,7 +208,7 @@ describe('hop 4 — validation survives a Supabase scenario resume', () => {
     // POSITIVE CONTROL for the assertion below is the test above: the same code
     // path DOES produce the key when the record carries it, so this measures a
     // real absence rather than measuring nothing.
-    mockRowsById['scenario-B'] = scenarioRow('scenario-B', [persistedEdge(false)])
+    setScenarioRow('scenario-B', scenarioRowWithEdges('scenario-B', [persistedEdge(false)]))
     const { result } = renderHook(() => useScenario())
 
     await act(async () => {

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.spec.ts
@@ -17,31 +17,18 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { reconcileAppliedGraph, type ReconcileAppliedGraphResult } from '../mergeAppliedGraph'
+import { reconcileAppliedGraph } from '../mergeAppliedGraph'
 import { useCanvasStore } from '../../store'
 import { logger } from '../../../lib/logger'
 // Derived, never hardcoded: the pair separator is a NUL, which is invisible
 // in source and unwritable as a literal without corrupting the file.
 import { edgePairKey } from '../graphIdentity'
 
-/**
- * Fill the counters a case does not mention with 0, so every assertion checks
- * ALL SIX exactly. Deliberately not `objectContaining`: an unasserted counter
- * is how an unintended removal would slip through.
- */
-function counts(
-  p: Partial<ReconcileAppliedGraphResult> = {},
-): ReconcileAppliedGraphResult {
-  return {
-    addedNodeCount: 0,
-    addedEdgeCount: 0,
-    updatedNodeCount: 0,
-    updatedEdgeCount: 0,
-    removedNodeCount: 0,
-    removedEdgeCount: 0,
-    ...p,
-  }
-}
+// R-10: `counts()` and the store-seeding field set now live in
+// `./__helpers__/mergeAppliedGraphHarness.ts`, shared with
+// `mergeAppliedGraph.validation.spec.ts` — which had re-declared both, and had
+// then asserted only 2 of the 6 counters because it skipped this `counts()`.
+import { counts, seedCanvas as seedStore } from './__helpers__/mergeAppliedGraphHarness'
 
 const EXISTING_NODES = [
   {
@@ -69,17 +56,7 @@ const EXISTING_EDGES = [
 ]
 
 function seedCanvas() {
-  useCanvasStore.setState({
-    currentScenarioId: 'scenario-1',
-    nodes: structuredClone(EXISTING_NODES) as any,
-    edges: structuredClone(EXISTING_EDGES) as any,
-    ceeAnalysisReady: null,
-    // B2: default to "CEE has acknowledged nothing" so the deletion path is
-    // OFF unless a case opts in. Without this reset the field would leak
-    // between cases and a later test could delete the seed graph.
-    lastAuthoritativeGraph: null,
-    history: { past: [], future: [] },
-  } as any)
+  seedStore(EXISTING_NODES, EXISTING_EDGES)
 }
 
 beforeEach(() => {

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.validation.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.validation.spec.ts
@@ -17,6 +17,13 @@ import { describe, it, expect, beforeEach } from 'vitest'
 
 import { reconcileAppliedGraph } from '../mergeAppliedGraph'
 import { useCanvasStore } from '../../store'
+// R-10: the store-seeding field set (incl. the `lastAuthoritativeGraph` leak
+// guard) and `counts()` come from the harness shared with
+// `mergeAppliedGraph.spec.ts`. Both were re-declared here — and `counts()` was
+// SKIPPED, so the overlay path asserted 2 of 6 counters while the sibling's own
+// docstring states that an unasserted counter is how an unintended removal slips
+// through. Importing it restores the stronger rule as well as removing the copy.
+import { counts, seedCanvas as seedStore } from './__helpers__/mergeAppliedGraphHarness'
 
 const WIRE_VALIDATION = {
   status: 'contested',
@@ -56,15 +63,8 @@ const EXISTING_EDGES = [
   },
 ]
 
-function seedCanvas(edges = EXISTING_EDGES) {
-  useCanvasStore.setState({
-    currentScenarioId: 'scenario-1',
-    nodes: structuredClone(EXISTING_NODES) as any,
-    edges: structuredClone(edges) as any,
-    ceeAnalysisReady: null,
-    lastAuthoritativeGraph: null,
-    history: { past: [], future: [] },
-  } as any)
+function seedCanvas(edges: unknown[] = EXISTING_EDGES) {
+  seedStore(EXISTING_NODES, edges)
 }
 
 function receipt(edgeExtras: Record<string, unknown>) {
@@ -91,9 +91,14 @@ describe('reconcileAppliedGraph — edge.validation overlay (hop 3)', () => {
   it('overlays validation onto an existing edge that had none', () => {
     const result = reconcileAppliedGraph(receipt({ validation: WIRE_VALIDATION }))
 
-    // The overlay is an UPDATE, not an add — the edge already existed.
-    expect(result.addedEdgeCount).toBe(0)
-    expect(result.updatedEdgeCount).toBe(1)
+    // R-10 — ALL SIX counters, via the shared `counts()`. This case used to assert
+    // `addedEdgeCount` and `updatedEdgeCount` only, which is the exact weakening
+    // that helper's docstring warns about: an unasserted counter is how an
+    // unintended REMOVAL slips through, and this receipt names both existing nodes
+    // and the existing edge, so a spurious removal here is a live possibility
+    // rather than a hypothetical. The overlay is an UPDATE, not an add — the edge
+    // already existed.
+    expect(result).toEqual(counts({ updatedEdgeCount: 1 }))
     expect(overlaidEdge().data.validation).toEqual(WIRE_VALIDATION)
   })
 

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -12,13 +12,12 @@
  */
 
 import { useCanvasStore } from '../store'
-import { DEFAULT_EDGE_DATA } from '../domain/edges'
+import { DEFAULT_EDGE_DATA, readValidationMetadata } from '../domain/edges'
 import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
 import { hasAnalysisReady } from '../../adapters/cee/types'
 import type { CEEDraftResponse, CEEGoalConstraint, CEEv2Response, CEEv3Response, EffectDirection } from '../../adapters/cee/types'
-import type { ValidationMetadata } from '../domain/validation'
 import { commitDraftCoachingToStore, edgeProvenanceDisplayPatch } from './draftIngestion'
 import { logger } from '../../lib/logger'
 import { validateNodesBatch } from '../domain/nodes'
@@ -131,28 +130,13 @@ export function mapDraftEdgeToCanvas(e: any, i: number): any {
   // automatically. The lockstep is pinned by
   // src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts.
   //
-  // Carried as an OPAQUE OBJECT on purpose. It is `z.unknown()` at the UI's edge
-  // schema boundary (domain/edges.ts:273) with a typed overlay in
-  // types/validation.ts, so field-level extraction here would be a THIRD mirror
-  // of a shape this layer has no business knowing. Consumers narrow it.
-  //
-  // Omitted (not defaulted) when absent, and deliberately given NO entry in
-  // DEFAULT_EDGE_DATA: `overlayEdge` treats a mapped value equal to the mapper
-  // baseline as "the wire did not supply this", so a non-undefined default here
-  // would silently stop validation metadata overlaying onto an existing edge.
-  //
-  // The cast is a DECLARED BOUNDARY ASSUMPTION, not a validated narrowing (see
-  // the identical note in the hop-2 twin): the wire schema is
-  // `z.unknown().optional()` on purpose while the canvas `data` bag types it
-  // `ValidationMetadata`, and every consumer null-guards. Written the same way in
-  // both mappers on purpose — the two are supposed to be byte-equivalent, and a
-  // difference here would be the first crack in the mirror this comment warns
-  // about. (This function's declared return type is `any`, so TypeScript would
-  // NOT have flagged an inconsistency; the hop-2 twin is typed and does.)
-  const validation =
-    e.validation !== undefined && e.validation !== null
-      ? (e.validation as ValidationMetadata)
-      : undefined
+  // For THIS field the lockstep is now STRUCTURAL rather than pinned: hop 2 calls
+  // the same `readValidationMetadata` (S2-7). Both hops previously carried a copy
+  // of the extraction under a copy of the reasoning — the opaque-passthrough
+  // rationale, the "omitted not defaulted" rule and the boundary-cast disclosure
+  // all lived twice. That reasoning now lives once, with the schema slot and
+  // DEFAULT_EDGE_DATA it depends on, in domain/edges.ts. Read it there.
+  const validation = readValidationMetadata(e.validation)
 
   return {
     id,

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -194,9 +194,40 @@ function edgeMapperDefaults(): Record<string, unknown> {
   return edgeMapperDefaultsCache
 }
 
-/** Stable deep-equality for plain JSON-ish canvas data. */
+/**
+ * Stable deep-equality for plain JSON-ish canvas data.
+ *
+ * E-2 — THE `undefined` SHORT-CIRCUIT IS A REAL COST, NOT A MICRO-OPTIMISATION.
+ * The dominant call pattern is `sameValue(mappedValue, baseline[key])` where the
+ * baseline (`edgeMapperDefaults`) has NO entry for the key — the deliberate case
+ * for `validation`, which carries no `DEFAULT_EDGE_DATA` default by design. So
+ * `b` is `undefined` while `a` is the whole validation bag: two `pass` objects,
+ * `contested_reasons`, the evoi legs. `JSON.stringify(a)` then serialises that
+ * entire bag, per edge, only to compare it against the literal `undefined` —
+ * which `JSON.stringify` renders as `undefined` (not a string), so the comparison
+ * was already decided before the work began.
+ *
+ * On an applied-edit receipt over a contested graph that is ~150-250KB of string
+ * allocation and immediate garbage per receipt.
+ *
+ * BEHAVIOUR-IDENTICAL ON EVERY REACHABLE INPUT, and the one unreachable exception
+ * is named rather than glossed. When exactly one side is `undefined` the two
+ * `JSON.stringify` results cannot match — `undefined` against any string — and
+ * `a === b` above already answered the both-`undefined` case. The exception is a
+ * value `JSON.stringify` ALSO renders as `undefined`: a function or a symbol,
+ * which the old code therefore reported as EQUAL to `undefined`. Both sides of
+ * every call site are mapper output over parsed wire JSON
+ * (`mapDraftNodeToCanvas` / `mapDraftEdgeToCanvas`, and `edgeMapperDefaults`
+ * which is itself one of those calls), so neither can be a function or a symbol.
+ * Were one to arrive, the new answer ("different") sends the key down the
+ * wire-supplied path — the OVER-applying direction this module already declares
+ * fail-safe two comments up, rather than silently dropping an update.
+ */
 function sameValue(a: unknown, b: unknown): boolean {
   if (a === b) return true
+  // Exactly one side is `undefined` (both-undefined was caught above), so they
+  // cannot be equal and there is nothing to serialise.
+  if (a === undefined || b === undefined) return false
   try {
     return JSON.stringify(a) === JSON.stringify(b)
   } catch {

--- a/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
+++ b/src/components/results/__tests__/evpiSurfacesRemoved.honesty.spec.tsx
@@ -180,7 +180,7 @@ describe('the removed prose templates appear nowhere in a rendered results surfa
     // Iterating the shared table closes that by construction: a pattern cannot be
     // added to the vocabulary without acquiring a control here, and the length
     // assertion means a SHRUNK table reds rather than quietly checking less.
-    expect(REFUTED_CLAIM_CONTROLS).toHaveLength(3)
+    expect(REFUTED_CLAIM_CONTROLS.length).toBeGreaterThanOrEqual(6)
     for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
       expect(re.test(original), `matcher must see: ${original}`).toBe(true)
     }

--- a/src/components/results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx
+++ b/src/components/results/__tests__/evpiSurfacesRemoved.resolveNext.honesty.spec.tsx
@@ -30,22 +30,21 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 import { V7EvidenceDisclosure } from '../v7/V7EvidenceDisclosure'
 import type { V7EvidenceModel } from '../v7/buildV7Lenses'
 import { buildVoiRanking } from '../voi/voiRanking'
 import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
 import {
-  PP_TOKEN,
-  RESOLVING_CLAIM,
-  WORTH_CLAIM,
   REFUTED_CLAIM_CONTROLS,
 } from './helpers/refutedEvpiClaimMatchers'
 import { v7EvidenceModel } from '../../../__fixtures__/v7EvidenceModel'
 import {
   voiRankingFixture,
   openResolveNextExpanded as renderResolveNext,
+  openDisclosureHeader,
+  switchEvidenceView,
 } from '../../../test/helpers/resolveNextView'
 
 /**
@@ -77,24 +76,32 @@ describe('Resolve next — the refuted EVPI claim does not come back here', () =
     // this file, so this control also proves the import resolved to real
     // patterns rather than to `undefined` (a bad import would otherwise make
     // every `.not.toMatch` below throw, but an over-broad one would not).
-    expect(REFUTED_CLAIM_CONTROLS).toHaveLength(3)
+    expect(REFUTED_CLAIM_CONTROLS.length).toBeGreaterThanOrEqual(6)
     for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
       expect(re.test(original), `matcher must see: ${original}`).toBe(true)
     }
   })
 
-  it('renders no percentage-point token', () => {
-    expect(renderResolveNext(populated())).not.toMatch(PP_TOKEN)
-  })
-
-  it('renders neither removed sentence', () => {
+  /**
+   * ⭐ R-1 — ITERATE THE VOCABULARY, DO NOT NAME PATTERNS.
+   *
+   * These four assertions used to be three named-pattern checks (`PP_TOKEN`,
+   * `RESOLVING_CLAIM`, `WORTH_CLAIM`) plus an INLINE `/ranked by EVPI/i` — a
+   * SEVENTH copy of the banned vocabulary, written here because the pattern was
+   * not in the table this file imported. Unifying the two tables made the fix
+   * available: the DOM projection now carries all six patterns, so sweeping it in
+   * a loop applies every one of them and a pattern added anywhere in the
+   * vocabulary extends this sweep automatically.
+   *
+   * The positive control immediately above is what keeps this non-vacuous: each
+   * pattern is proven to fire on the string it was written to catch, so a
+   * `not.toMatch` here measures a real absence rather than an inert regex.
+   */
+  it('renders NONE of the banned value-of-information vocabulary', () => {
     const text = renderResolveNext(populated())
-    expect(text).not.toMatch(RESOLVING_CLAIM)
-    expect(text).not.toMatch(WORTH_CLAIM)
-  })
-
-  it('renders no "ranked by EVPI" label (the removed factor-list sort note)', () => {
-    expect(renderResolveNext(populated())).not.toMatch(/ranked by EVPI/i)
+    for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
+      expect(text, `banned pattern resurfaced (control: ${original})`).not.toMatch(re)
+    }
   })
 
   it('the honest-gate state is equally clean', () => {
@@ -113,12 +120,13 @@ describe('Resolve next — the refuted EVPI claim does not come back here', () =
         })}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
+    openDisclosureHeader()
+    switchEvidenceView('resolveNext')
     const text = screen.getByTestId('v7-evidence-resolve-next').textContent ?? ''
-    expect(text).not.toMatch(PP_TOKEN)
-    expect(text).not.toMatch(RESOLVING_CLAIM)
-    expect(text).not.toMatch(WORTH_CLAIM)
+    // R-1: the whole vocabulary, iterated. See the note on the populated sweep.
+    for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
+      expect(text, `banned pattern in the GATE state (control: ${original})`).not.toMatch(re)
+    }
     // POSITIVE CONTROL: the gate really did render (not an empty subtree).
     expect(screen.getByTestId('v7-evidence-resolve-next-gate')).toBeInTheDocument()
   })
@@ -186,8 +194,8 @@ describe('Resolve next — a pp-bearing wire fixture reaches the DOM with no fig
         evidence={{ drivers: [], flipRisks: [], tradeOffs: [], resolveNext, designationsWithheld: false }}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
+    openDisclosureHeader()
+    switchEvidenceView('resolveNext')
     return { report, rendered: document.body.textContent ?? '' }
   }
 
@@ -205,11 +213,13 @@ describe('Resolve next — a pp-bearing wire fixture reaches the DOM with no fig
     expect(screen.getByTestId('v7-resolve-next-below')).toHaveTextContent('Hiring pace')
   })
 
-  it('no pp token, and neither removed sentence, reaches the DOM', () => {
+  it('none of the banned vocabulary reaches the DOM from real wire bytes', () => {
+    // R-1: iterated, not named — same reason as the two sweeps above. This is the
+    // strongest of the three: the input is captured producer bytes, not a fixture.
     const { rendered } = renderFromWire()
-    expect(rendered).not.toMatch(PP_TOKEN)
-    expect(rendered).not.toMatch(RESOLVING_CLAIM)
-    expect(rendered).not.toMatch(WORTH_CLAIM)
+    for (const [re, original] of REFUTED_CLAIM_CONTROLS) {
+      expect(rendered, `banned pattern from live bytes (control: ${original})`).not.toMatch(re)
+    }
   })
 
   it('none of the seeded magnitudes reaches the DOM in any form', () => {

--- a/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
+++ b/src/components/results/__tests__/helpers/refutedEvpiClaimMatchers.ts
@@ -60,6 +60,57 @@
  * trust-surface guard, so it is left to a reviewer rather than taken here.
  */
 
+/**
+ * ⭐ R-1 — THERE WERE TWO TABLES OF THIS VOCABULARY AND THEY HAD ALREADY
+ * DIVERGED. THIS IS NOW THE ONE.
+ *
+ * `tests/contracts/no-evpi-display.contract.test.ts` held a second table,
+ * `FORBIDDEN_COPY`, with its own hand-written positive-control loop of the same
+ * construct. It was not a copy of this one — it had drifted in BOTH directions
+ * before anyone noticed:
+ *
+ *   · the contract table carried `/would improve confidence by/i`,
+ *     `/pp via EVPI/i` and `/ranked by EVPI/i`, which THIS file lacked;
+ *   · this file carried `PP_TOKEN` and `WORTH_CLAIM`, which IT lacked;
+ *   · `RESOLVING_CLAIM` was byte-identical in both.
+ *
+ * So the sentence the StatusBar chip actually wore (`Npp via EVPI`) was outside
+ * the render-time vocabulary, and the token the refuted quantity wore everywhere
+ * (`Npp`) was outside the source-scan vocabulary. Two guards, each blind to the
+ * other's patterns, both green, each file's header claiming to hold "the ONE
+ * definition". The header above was written against exactly this hazard and was
+ * itself an instance of it.
+ *
+ * One table, two consumer projections, each derived by SCOPE (below) rather than
+ * by hand.
+ */
+
+/**
+ * Where a pattern is safe to apply. Not decoration — the two consumers ask
+ * genuinely different questions and one pattern is legitimately not for both:
+ *
+ *   · `'dom'` — matched against RENDERED TEXT by the two honesty specs. Anything
+ *     the user could read is in scope, including bare tokens.
+ *   · `'source'` — matched against SOURCE LINES by the no-EVPI-display contract,
+ *     after comment stripping. A pattern here must be specific enough that a hit
+ *     IS a re-introduction: `PP_TOKEN` is deliberately absent, because "5pp" is
+ *     legitimate in a comparison threshold's code (`within 5pp of the leader`)
+ *     and reddening on it would teach the next lane to widen the exemption list,
+ *     which is how a real violation gets an exception written for it.
+ */
+export type RefutedClaimScope = 'dom' | 'source'
+
+export interface RefutedClaimPattern {
+  /** The matcher. */
+  readonly pattern: RegExp
+  /** A string it MUST match — its positive control. */
+  readonly control: string
+  /** The surface or claim it names, quoted in failure messages. */
+  readonly what: string
+  /** Which consumers may apply it. See `RefutedClaimScope`. */
+  readonly scopes: ReadonlyArray<RefutedClaimScope>
+}
+
 /** Any "<n>pp" token — the shape the refuted quantity wore on every surface. */
 export const PP_TOKEN = /\d+(\.\d+)?\s*pp\b/i
 
@@ -69,19 +120,75 @@ export const RESOLVING_CLAIM = /resolving could improve confidence/i
 /** The per-factor "worth Npp if resolved" claim. */
 export const WORTH_CLAIM = /worth\s+\d+(\.\d+)?pp if resolved/i
 
+/** The factor chip's improvement clause — was contract-table-only. */
+export const IMPROVE_CONFIDENCE_CLAIM = /would improve confidence by/i
+
+/** The StatusBar chip that SUMMED three refuted figures — was contract-only. */
+export const PP_VIA_EVPI = /pp via EVPI/i
+
+/** The visible factor-list sort label — was contract-only. */
+export const RANKED_BY_EVPI = /ranked by EVPI/i
+
 /**
- * Each matcher paired with a string it MUST match — the positive-control table
- * both honesty specs drive, so the controls cannot drift apart from the patterns
- * they guard.
+ * ⭐ THE VOCABULARY. Every pattern, its positive control, and its scopes.
  *
- * ⚠ EVERY PATTERN EXPORTED ABOVE MUST HAVE A ROW HERE. That is what makes the
- * controls derived rather than remembered: a fourth banned pattern added above
- * without a row here is a pattern with no control in either spec, which is how
- * `PP_TOKEN` went uncontrolled in one of them (see the header). Both specs assert
- * this table's LENGTH, so shrinking it reds instead of quietly checking less.
+ * ⚠ EVERY PATTERN EXPORTED ABOVE MUST HAVE A ROW HERE, and every row must carry a
+ * control. That is what makes the controls derived rather than remembered: a
+ * pattern added above without a row here is a pattern with no control in any
+ * consumer, which is how `PP_TOKEN` went uncontrolled in one spec (see the
+ * header). Every consumer asserts the LENGTH of the projection it drives, so a
+ * SHRUNK table reds instead of quietly checking less.
  */
-export const REFUTED_CLAIM_CONTROLS: ReadonlyArray<readonly [RegExp, string]> = [
-  [PP_TOKEN, 'Worth 12.3pp if resolved'],
-  [RESOLVING_CLAIM, 'Resolving could improve confidence by up to 10pp'],
-  [WORTH_CLAIM, 'Worth 6.6pp if resolved'],
+export const REFUTED_CLAIM_VOCABULARY: ReadonlyArray<RefutedClaimPattern> = [
+  {
+    pattern: PP_TOKEN,
+    control: 'Worth 12.3pp if resolved',
+    what: 'any percentage-point token for the refuted quantity',
+    scopes: ['dom'],
+  },
+  {
+    pattern: RESOLVING_CLAIM,
+    control: 'Resolving could improve confidence by up to 10pp',
+    what: 'the "Resolving could improve confidence by up to Xpp" line',
+    scopes: ['dom', 'source'],
+  },
+  {
+    pattern: WORTH_CLAIM,
+    control: 'Worth 6.6pp if resolved',
+    what: 'the per-factor "Worth Npp if resolved" claim',
+    scopes: ['dom', 'source'],
+  },
+  {
+    pattern: IMPROVE_CONFIDENCE_CLAIM,
+    control:
+      'Worth {evpiPp}pp if resolved: your knowledge of {label} would improve confidence by {evpiPp} percentage points',
+    what: 'the "Worth Xpp if resolved" factor chip',
+    scopes: ['dom', 'source'],
+  },
+  {
+    pattern: PP_VIA_EVPI,
+    control: 'label: `${Math.round(top3Sum)}pp via EVPI`,',
+    what: 'the StatusBar chip that SUMMED three refuted figures',
+    scopes: ['dom', 'source'],
+  },
+  {
+    pattern: RANKED_BY_EVPI,
+    control: "sortNote={hasRobustnessData && evpiMap.size > 0 ? 'ranked by EVPI' : undefined}",
+    what: 'the visible factor-list sort label',
+    scopes: ['dom', 'source'],
+  },
 ] as const
+
+/** The rows a given consumer may apply. Derived — never hand-listed. */
+export function refutedClaimsForScope(
+  scope: RefutedClaimScope,
+): ReadonlyArray<RefutedClaimPattern> {
+  return REFUTED_CLAIM_VOCABULARY.filter((r) => r.scopes.includes(scope))
+}
+
+/**
+ * The DOM projection, in the `[pattern, control]` shape the two honesty specs
+ * already drive. Kept as a named export so those specs' loops are unchanged.
+ */
+export const REFUTED_CLAIM_CONTROLS: ReadonlyArray<readonly [RegExp, string]> =
+  refutedClaimsForScope('dom').map((r) => [r.pattern, r.control] as const)

--- a/src/components/results/__tests__/withheldProse.spec.tsx
+++ b/src/components/results/__tests__/withheldProse.spec.tsx
@@ -59,6 +59,8 @@ import {
   PERMITTED_VERDICT,
   WITHHELD_VERDICT,
 } from '../__fixtures__/withheldDesignations.fixtures'
+// R-12: the disclosure open/switch sequence — one definition, see the helper.
+import { openDisclosureHeader, switchEvidenceView } from '../../../test/helpers/resolveNextView'
 
 /**
  * Anything that asserts, or presupposes, that one option is out in front.
@@ -96,14 +98,21 @@ function evidenceModel(designationsWithheld: boolean): V7EvidenceModel {
   }
 }
 
-/** Open the disclosure and switch to one of its three views. */
+/**
+ * Build THIS spec's evidence model, then open the disclosure on one of its views.
+ *
+ * R-12: the two-click sequence is no longer written here — `openDisclosureHeader`
+ * / `switchEvidenceView` come from `src/test/helpers/resolveNextView.tsx`, along
+ * with the `fireEvent`-not-`node.click()` rationale this copy used to be the sole
+ * carrier of (the raw DOM call escapes React's `act()`, the disclosure never
+ * re-renders, and every assertion afterwards reads a COLLAPSED section — a false
+ * green that looks exactly like a real one). What stays local is the part that is
+ * genuinely local: the `designationsWithheld` model this file is about.
+ */
 function openEvidence(designationsWithheld: boolean, view: 'flipRisks' | 'tradeOffs') {
   const utils = render(<V7EvidenceDisclosure evidence={evidenceModel(designationsWithheld)} />)
-  // fireEvent, not node.click(): the raw DOM call escapes React's act() and
-  // the disclosure never re-renders, which makes every assertion below read a
-  // collapsed section — a false green that looks exactly like a real one.
-  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-  fireEvent.click(screen.getByTestId(`v7-evidence-tab-${view}`))
+  openDisclosureHeader()
+  switchEvidenceView(view)
   return utils
 }
 

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -59,6 +59,7 @@ import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactor
 import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
+import { readInferenceWarnings } from './utils/readInferenceWarnings'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
 import { computeNormalisedInfluences, selectDriverDisplayModel } from './driverDisplayModel'
@@ -514,37 +515,14 @@ function readEnrichmentFactors(report: ResultsReport): unknown[] | null {
   return Array.isArray(factors) ? factors : null
 }
 
-/**
- * ISL `inference_warnings[]`, from BOTH slots a mapper may use — ROOT first,
- * then the legacy `robustness` nesting.
- *
- * ONE reader because this file needed the identical dual read twice (the VOI
- * ranking's PARTIAL disclosure and the Analysis-tab warning strip) and had it
- * in two DIVERGENT cast styles. Two copies of a two-slot fallback is two
- * chances for the next copy to read only one slot and render permanently empty
- * with nothing red — which is exactly what the design doc's §2 mapping table
- * would have caused had it been implemented verbatim (measured over all 773
- * live non-noop `run_analysis` facts on staging, 2026-07-29: root 773/773,
- * robustness 0/773 — see `canvas/stores/persistedRunSnapshotFactory.ts`).
- *
- * Returns `unknown`: payload redaction may deliver a `{__truncated, items}`
- * wrapper rather than a bare array, so callers unwrap with `safeArray` or
- * validate for themselves. Never throws, never defaults to `[]` — an absent
- * key must stay distinguishable from an empty one.
- *
- * The top-level read is plain (the key is declared on `ResultsReport`). The
- * legacy nested slot keeps ONE narrow cast, deliberately: declaring a member on
- * `ResultsReport['robustness']` — an inline object type — changes the
- * elided-member counter tsc prints inside four unrelated baselined diagnostics
- * in this file, which trips `typecheck:selftest`'s clean-tree control. See the
- * note at that slot in `types.ts`.
+/*
+ * `readInferenceWarnings` — the dual-slot reader this file introduced — now lives
+ * at `./utils/readInferenceWarnings.ts` and is IMPORTED above (R-6). It was
+ * file-private here, which meant the three copies in `src/canvas` could not adopt
+ * it even though the reason it exists is the hazard those copies embody. Its full
+ * rationale, the 773-fact measurement, the load-bearing-cast warning and the note
+ * on which copies were deliberately NOT migrated all moved with it.
  */
-function readInferenceWarnings(report: ResultsReport | null | undefined): unknown {
-  return (
-    report?.inference_warnings ??
-    (report?.robustness as { inference_warnings?: unknown } | undefined)?.inference_warnings
-  )
-}
 
 /** Labels play no part in policy keys/metrics (getFactorKey resolves ids
  * before labels, and the label-map fallback needs an id anyway), so the feed

--- a/src/components/results/utils/readInferenceWarnings.ts
+++ b/src/components/results/utils/readInferenceWarnings.ts
@@ -1,0 +1,61 @@
+/**
+ * ISL `inference_warnings[]`, from BOTH slots a mapper may use — ROOT first,
+ * then the legacy `robustness` nesting.
+ *
+ * ONE reader because `useResultsSectionData.ts` needed the identical dual read
+ * twice (the VOI ranking's PARTIAL disclosure and the Analysis-tab warning strip)
+ * and had it in two DIVERGENT cast styles. Two copies of a two-slot fallback is
+ * two chances for the next copy to read only one slot and render permanently
+ * empty with nothing red — which is exactly what the design doc's §2 mapping
+ * table would have caused had it been implemented verbatim (measured over all 773
+ * live non-noop `run_analysis` facts on staging, 2026-07-29: root 773/773,
+ * robustness 0/773 — see `canvas/stores/persistedRunSnapshotFactory.ts`).
+ *
+ * ⚠ R-6 — WHY THIS IS A LEAF MODULE RATHER THAN AN EXPORT FROM THE HOOK. It was
+ * file-private in `useResultsSectionData.ts`, which meant the three remaining
+ * copies in `src/canvas` could not adopt it even though the reason it exists is
+ * the hazard those copies embody. Exporting it FROM the hook would have made
+ * every adopter — including `GoalNode`, which renders once per canvas node —
+ * import a 3,000-line results hook, so it lives here instead, beside
+ * `humaniseInferenceWarning` and the other leaves `GoalNode` already imports
+ * from. Hook and canvas both import it; there is one definition.
+ *
+ * ⚠ TWO COPIES DELIBERATELY NOT MIGRATED, because doing so is a BEHAVIOUR CHANGE
+ * and not a refactor. Both read the `robustness` slot ONLY, so on live data
+ * (0/773) they are permanently blank; giving them this dual read makes them start
+ * populating:
+ *   · `canvas/components/ModelTabBody.tsx` — the Model card's audit-trail
+ *     `inferenceWarnings` row. Reads `results.report.robustness.inference_warnings`
+ *     off the SAME `ResultsReport` this function takes, so adoption is a one-line
+ *     swap — and would surface an audit row that is empty today.
+ *   · `canvas/stores/analysisSnapshotFactory.ts` `extractInferenceWarnings` —
+ *     takes only `V2RunResponse['robustness']` as its parameter (it has no root
+ *     object in scope) and normalises members to `string[]`, so adoption needs a
+ *     call-site change as well.
+ * Both are real findings and neither is a drive-by: what appears in an audit row
+ * is a product judgement and wants its own RED-first pin. Recorded, not silently
+ * left behind.
+ *
+ * Returns `unknown`: payload redaction may deliver a `{__truncated, items}`
+ * wrapper rather than a bare array, so callers unwrap with `safeArray` or
+ * validate for themselves. Never throws, never defaults to `[]` — an absent key
+ * must stay distinguishable from an empty one.
+ *
+ * ⚠ THE NARROW CAST ON THE LEGACY SLOT IS LOAD-BEARING AND MUST NOT BE "TIDIED"
+ * INTO A TYPE DECLARATION. The top-level read is plain (the key is declared on
+ * `ResultsReport`). Declaring a member on `ResultsReport['robustness']` — an
+ * inline object type — changes the elided-member counter tsc prints inside four
+ * unrelated baselined diagnostics in `useResultsSectionData.ts`, which trips
+ * `typecheck:selftest`'s clean-tree control. See the note at that slot in
+ * `../types.ts`.
+ */
+import type { ResultsReport } from '../types'
+
+export function readInferenceWarnings(
+  report: ResultsReport | null | undefined,
+): unknown {
+  return (
+    report?.inference_warnings ??
+    (report?.robustness as { inference_warnings?: unknown } | undefined)?.inference_warnings
+  )
+}

--- a/src/components/results/v7/ClampToggle.tsx
+++ b/src/components/results/v7/ClampToggle.tsx
@@ -1,0 +1,72 @@
+/**
+ * ClampToggle — the row-clamp reveal affordance, ONE leaf for the THREE verbatim
+ * copies in this directory.
+ *
+ * ⚠ R-11 — IT WAS EXTRACTED FOR "THE TWO VERBATIM COPIES" AND THERE WERE THREE.
+ * The extraction landed inside `V7EvidenceDisclosure.tsx` as a module-private
+ * component covering its own two copies (Drivers and Resolve next). The third —
+ * `V7GuidanceSection.tsx`'s `v7-guidance-toggle` — is in the SAME directory, with
+ * a byte-identical `className` down to the focus-ring, the same `showAll`
+ * ternary, and the same "label counts the hidden rows" contract. Being
+ * module-private is what stopped it from being consumed: the copy was not missed
+ * out of carelessness, it was unreachable. A private extraction that leaves a
+ * reachable copy behind converts one duplication into a duplication PLUS a claim
+ * to have removed it, which is the worse of the two states.
+ *
+ * `hiddenCount` is the number of rows the clamp HIDES and does not change when
+ * the list expands, so the affordance stays mounted as "Show fewer" — the
+ * behaviour all three suites pin. Renders nothing when the clamp hides nothing.
+ *
+ * ⚠ THE COUNTER IS THE ONLY DIGIT-BEARING STRING IN THE RESOLVE-NEXT VIEW, and it
+ * is a count of HIDDEN ROWS — never a value of information. It is the string that
+ * view's no-digit assertion carves out and then pins exactly, so the carve-out
+ * cannot widen into a hole a magnitude arrives through. That property now belongs
+ * to one component instead of three, which is the point.
+ */
+import { typography } from '../../../styles/typography'
+
+/**
+ * ⚠ ONE DEFINITION OF THE REVEAL LABEL. `v7LensCopy.seeMore` and
+ * `v7GuidanceCopy.showMore` were two differently-NAMED functions returning the
+ * byte-identical string, in the same directory, for the same affordance — so a
+ * copy change would have been applied to whichever one the author happened to
+ * open. Both now reference this, keeping their own property names so their
+ * consumers and copy-hygiene manifests are unchanged; what is gone is the second
+ * definition of the string.
+ *
+ * ⚠ SCOPE. Four FURTHER copies of `Show ${n} more` exist outside this directory
+ * (`strengthen/strengthenCopy.ts`, `coaching-panel/constants.ts`,
+ * `pre-analysis-v3/constants.ts`, and `analysis-hero/heroCopy.ts`'s `showFewer`
+ * half). They are pre-existing, belong to four other panels with their own copy
+ * modules and copy-hygiene suites, and unifying user-facing copy across panels is
+ * a copy decision rather than a refactor. Named here so the next reader knows the
+ * count is six and not two, and does not mistake this file for the finish line.
+ */
+export const clampRevealLabel = (n: number): string => `Show ${n} more`
+
+/** The collapse label, paired with `clampRevealLabel` for the same reason. */
+export const clampCollapseLabel = 'Show fewer'
+
+export function ClampToggle({
+  testId,
+  hiddenCount,
+  expanded,
+  onToggle,
+}: {
+  testId: string
+  hiddenCount: number
+  expanded: boolean
+  onToggle: () => void
+}) {
+  if (hiddenCount <= 0) return null
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      data-testid={testId}
+      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+    >
+      {expanded ? clampCollapseLabel : clampRevealLabel(hiddenCount)}
+    </button>
+  )
+}

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -42,6 +42,7 @@ import { formatPercent } from '@/utils/formatPercent'
 import { formatRangeValue } from '../utils/formatRangeValue'
 import type { V7EvidenceModel } from './buildV7Lenses'
 import { V7_LENS_COPY } from './v7LensCopy'
+import { ClampToggle } from './ClampToggle'
 import { useAnalysisProjection } from '@/canvas/highlighting/useAnalysisProjection'
 
 const E = V7_LENS_COPY.evidence
@@ -85,42 +86,13 @@ function EvidenceNote({ children }: { children: React.ReactNode }) {
   return <p className={`${typography.panelMeta} text-text-light`}>{children}</p>
 }
 
-/**
- * The row-clamp toggle — one leaf for the two verbatim copies (Drivers and
- * Resolve next), down to the focus-ring class string.
- *
- * `hiddenCount` is the number of rows the clamp HIDES and does not change when
- * the list expands, so the affordance stays mounted as "Show fewer" — the
- * behaviour both suites pin. Renders nothing when the clamp hides nothing.
- *
- * ⚠ That counter is the ONLY digit-bearing string in the Resolve next view, and
- * it is a count of HIDDEN ROWS — never a value of information. It is the string
- * that view's no-digit assertion carves out and then pins exactly, so the
- * carve-out cannot widen into a hole a magnitude arrives through.
+/*
+ * `ClampToggle` moved to `./ClampToggle.tsx` (R-11). It was extracted here for
+ * "the two verbatim copies" while a THIRD lived one file away in
+ * `V7GuidanceSection.tsx`, unable to consume it because it was module-private.
+ * Its full rationale — including the hidden-row-counter property that the
+ * Resolve-next no-digit assertion carves out — moved with it.
  */
-function ClampToggle({
-  testId,
-  hiddenCount,
-  expanded,
-  onToggle,
-}: {
-  testId: string
-  hiddenCount: number
-  expanded: boolean
-  onToggle: () => void
-}) {
-  if (hiddenCount <= 0) return null
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      data-testid={testId}
-      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-    >
-      {expanded ? E.showFewer : E.seeMore(hiddenCount)}
-    </button>
-  )
-}
 
 export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclosureProps) {
   const [open, setOpen] = useState(false)

--- a/src/components/results/v7/V7GuidanceSection.tsx
+++ b/src/components/results/v7/V7GuidanceSection.tsx
@@ -39,6 +39,7 @@ import { openAskOlumi } from '../coaching/askOlumiStore'
 import { buildV7Guidance, deriveGuidanceAffordance } from './buildV7Guidance'
 import { V7_GUIDANCE_COPY } from './v7GuidanceCopy'
 import { V7HeldProposalCard } from './V7HeldProposalCard'
+import { ClampToggle } from './ClampToggle'
 
 const C = V7_GUIDANCE_COPY.guidance
 
@@ -217,14 +218,21 @@ export function V7GuidanceSection({ onFocusNode, onSendMessage }: V7GuidanceSect
                   ))}
                 </div>
               )}
-              <button
-                type="button"
-                data-testid="v7-guidance-toggle"
-                onClick={() => setShowAll((s) => !s)}
-                className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-              >
-                {showAll ? C.showFewer : C.showMore(moreCount)}
-              </button>
+              {/*
+                R-11 — the THIRD copy of this affordance, now the third consumer
+                of the one `ClampToggle`. It was byte-identical to the two in
+                `V7EvidenceDisclosure.tsx` (className included, down to the
+                focus-ring) and could not consume the extraction there because it
+                was module-private. `hiddenCount` is `moreCount`, which the
+                enclosing `moreCount > 0` gate already guarantees is positive —
+                the component's own `<= 0` guard is then simply consistent.
+              */}
+              <ClampToggle
+                testId="v7-guidance-toggle"
+                hiddenCount={moreCount}
+                expanded={showAll}
+                onToggle={() => setShowAll((s) => !s)}
+              />
             </>
           )}
         </div>

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.projection.spec.tsx
@@ -8,10 +8,12 @@
  * graph with no evidence produces zero marks.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render, cleanup } from '@testing-library/react'
 import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
 import { useCanvasStore } from '@/canvas/store'
 import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
+// R-12: the disclosure open/switch sequence — one definition, see the helper.
+import { openDisclosureHeader, switchEvidenceView } from '../../../../test/helpers/resolveNextView'
 
 // A minimal canvas: two factors → one outcome, plus a second outgoing edge from
 // fac_price so a bare from_id would be ambiguous.
@@ -32,7 +34,7 @@ function seedCanvas() {
 }
 
 const openDisclosure = () =>
-  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+  openDisclosureHeader()
 
 const highlight = () => useCanvasStore.getState().analysisHighlight
 
@@ -55,7 +57,7 @@ describe('V7EvidenceDisclosure — analysis-graph projection', () => {
       />,
     )
     openDisclosure()
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    switchEvidenceView('flipRisks')
 
     const h = highlight()
     expect(h.source).toBe('flip_risks')
@@ -96,7 +98,7 @@ describe('V7EvidenceDisclosure — analysis-graph projection', () => {
     expect(highlight().source).toBe('drivers')
     expect([...highlight().nodeIds]).toEqual(['fac_price'])
 
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    switchEvidenceView('flipRisks')
     const h = highlight()
     expect(h.source).toBe('flip_risks')
     expect([...h.edgeIds]).toEqual(['e3'])
@@ -135,7 +137,7 @@ describe('V7EvidenceDisclosure — analysis-graph projection', () => {
     openDisclosure()
     expect(highlight().source).toBe('drivers')
 
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-tradeOffs'))
+    switchEvidenceView('tradeOffs')
     expect(highlight().source).toBeNull()
   })
 
@@ -153,7 +155,7 @@ describe('V7EvidenceDisclosure — analysis-graph projection', () => {
       />,
     )
     openDisclosure()
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    switchEvidenceView('flipRisks')
 
     const h = highlight()
     expect(h.source).toBe('flip_risks')

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNext.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNext.spec.tsx
@@ -30,13 +30,15 @@ import {
   voiRankingFixture as ranking,
   openResolveNext,
 } from '@/test/helpers/resolveNextView'
+// R-12: the disclosure open/switch sequence — one definition, see the helper.
+import { openDisclosureHeader } from '../../../../test/helpers/resolveNextView'
 
 const E = V7_LENS_COPY.evidence
 
 describe('V7EvidenceDisclosure — Resolve next: the ranking', () => {
   it('exposes a fourth view chip beside the existing three', () => {
     render(<V7EvidenceDisclosure evidence={model({ resolveNext: ranking() })} />)
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    openDisclosureHeader()
     for (const key of ['drivers', 'flipRisks', 'tradeOffs', 'resolveNext']) {
       expect(screen.getByTestId(`v7-evidence-tab-${key}`)).toBeInTheDocument()
     }

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.spec.tsx
@@ -12,6 +12,8 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
 import type { V7EvidenceModel } from '../buildV7Lenses'
 import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
+// R-12: the disclosure open/switch sequence — one definition, see the helper.
+import { openDisclosureHeader, switchEvidenceView } from '../../../../test/helpers/resolveNextView'
 
 const FIVE_DRIVERS: V7EvidenceModel['drivers'] = [
   { factorKey: 'f1', label: 'Price', direction: 'negative', isEstimate: true },
@@ -29,7 +31,7 @@ describe('V7EvidenceDisclosure (V7 L5)', () => {
 
   it('expands to the Drivers view, clamps to three, and shows "Show N more"', () => {
     render(<V7EvidenceDisclosure evidence={model({ drivers: FIVE_DRIVERS })} />)
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    openDisclosureHeader()
     expect(screen.getByTestId('v7-evidence-drivers')).toBeInTheDocument()
     expect(screen.getByText('Price')).toBeInTheDocument()
     expect(screen.getByText('Cost')).toBeInTheDocument()
@@ -42,7 +44,7 @@ describe('V7EvidenceDisclosure (V7 L5)', () => {
 
   it('shows the "est." tag on a defaulted (low-confidence) driver', () => {
     render(<V7EvidenceDisclosure evidence={model({ drivers: FIVE_DRIVERS })} />)
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+    openDisclosureHeader()
     const est = screen.getAllByTestId('v7-driver-est')
     expect(est).toHaveLength(1)
     expect(est[0]).toHaveTextContent('est.')
@@ -56,8 +58,8 @@ describe('V7EvidenceDisclosure (V7 L5)', () => {
         })}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-flipRisks'))
+    openDisclosureHeader()
+    switchEvidenceView('flipRisks')
     expect(screen.getByTestId('v7-evidence-flip-risks')).toBeInTheDocument()
     expect(screen.getByText(/Price → Profit/)).toBeInTheDocument()
     expect(screen.getByText(/48% switch/)).toBeInTheDocument()
@@ -80,8 +82,8 @@ describe('V7EvidenceDisclosure (V7 L5)', () => {
         })}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-    fireEvent.click(screen.getByTestId('v7-evidence-tab-tradeOffs'))
+    openDisclosureHeader()
+    switchEvidenceView('tradeOffs')
     expect(screen.getByTestId('v7-evidence-trade-offs')).toBeInTheDocument()
     expect(screen.getByText(/If Interest rate is above 5 %, Rent leads; below it, Buy leads\./)).toBeInTheDocument()
   })

--- a/src/components/results/v7/v7GuidanceCopy.ts
+++ b/src/components/results/v7/v7GuidanceCopy.ts
@@ -13,6 +13,8 @@
  * Copy only — no thresholds, no data, no inference lives here.
  */
 
+import { clampRevealLabel, clampCollapseLabel } from './ClampToggle'
+
 /** The single model-limit caveat, shared verbatim with V7SharpenLine. */
 export const V7_MODEL_LIMIT_CAVEAT =
   'Olumi can point to what the model implies, but not guarantee the real world behaves the same.'
@@ -28,9 +30,18 @@ export const V7_GUIDANCE_COPY = {
       could_fix: 'Could fix',
       technique: 'Technique',
     } as const,
-    /** One item is shown open; the rest are counted behind this toggle. */
-    showMore: (n: number) => `Show ${n} more`,
-    showFewer: 'Show fewer',
+    /**
+     * One item is shown open; the rest are counted behind this toggle.
+     *
+     * ⚠ R-11 — REFERENCES the shared definition rather than re-declaring the
+     * string. This and `v7LensCopy.evidence.seeMore` were two differently-NAMED
+     * functions returning the byte-identical `Show ${n} more`, in this directory,
+     * for the same affordance — so a copy change would have landed in whichever
+     * one the author opened. The property name stays (its consumers and copy
+     * manifests are unchanged); the second definition of the string is gone.
+     */
+    showMore: clampRevealLabel,
+    showFewer: clampCollapseLabel,
     /** Honest action affordances (spec row 9). Each maps to ONE action type;
      * an unknown action type renders none of these (fail closed). */
     action: {

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -11,6 +11,8 @@
  * surfaces can never disagree about what "not produced yet" means.
  */
 
+import { clampRevealLabel, clampCollapseLabel } from './ClampToggle'
+
 export const V7_LENS_COPY = {
   /** Accessible name for the lens tablist. */
   tablistAria: 'Results lens',
@@ -95,8 +97,15 @@ export const V7_LENS_COPY = {
      * (an estimate), a direct producer read (never a threshold). */
     estimateTag: 'est.',
     estimateTagAria: 'estimated value',
-    seeMore: (n: number) => `Show ${n} more`,
-    showFewer: 'Show fewer',
+    /**
+     * ⚠ R-11 — REFERENCES the shared definition rather than re-declaring the
+     * string. See the twin note at `v7GuidanceCopy.showMore`: two differently
+     * named functions returned this byte-identical label for the same affordance
+     * in the same directory. `seeMore` keeps its name (the resolve-next spec
+     * asserts through it); only the duplicate definition is gone.
+     */
+    seeMore: clampRevealLabel,
+    showFewer: clampCollapseLabel,
     driversGate: 'No drivers to show for this run.',
     /**
      * ROADMAP 1.267 — the note is a CLAIM, the rows beneath it are DATA.

--- a/src/components/results/voi/voiRanking.ts
+++ b/src/components/results/voi/voiRanking.ts
@@ -117,6 +117,20 @@ const FactorEvppiRowSchema = EnrichmentFactorEvppiEntrySchema.pick({
 type FactorEvppiRow = ReturnType<typeof FactorEvppiRowSchema.parse>
 
 /**
+ * The two bands this reader knows how to render, CLOSED here on purpose while the
+ * wire types `status` OPEN (`z.string()`) so an unknown status cannot fail
+ * transport.
+ *
+ * Named rather than written as two inline literals because the docstring below
+ * calls this "a CLOSED enum" and a pair of `||`-ed strings is not one: a third
+ * band would be added to the predicate by whoever needed it and nothing would
+ * connect it to the `isResolvedRow` branch downstream that also reads this
+ * vocabulary. One declaration, so "which statuses does this reader accept" has a
+ * single answer.
+ */
+const RENDERABLE_STATUSES = ['resolved', 'below_resolution'] as const
+
+/**
  * The three deliberate CONSUMER tightenings on top of the wire shape, each
  * stricter than the schema on purpose:
  *
@@ -127,18 +141,22 @@ type FactorEvppiRow = ReturnType<typeof FactorEvppiRowSchema.parse>
  *     a row whose status we decline to trust, and the fail-safe direction is to
  *     drop it and disclose rather than to rank it. The value itself goes no
  *     further than this check — it is never stored, compared, or used to order.
- *   · `status` a CLOSED enum — the wire types it OPEN (`z.string()`) so an
- *     unknown status cannot fail transport. Here it must be one of the two bands
- *     we know how to render, because the only other thing we could do with an
- *     unrecognised band is guess which one it means.
+ *     (`Number.isFinite` is the ES2015 static, NOT the coercing global: it
+ *     returns false for a non-number without converting, so it carries the
+ *     PRESENT half of this check as well. A preceding `typeof === 'number'` guard
+ *     used to sit here and could not fail independently of it.)
+ *   · `status` one of `RENDERABLE_STATUSES` — the only other thing we could do
+ *     with an unrecognised band is guess which one it means.
  */
 function isUsableRow(row: FactorEvppiRow | null): row is FactorEvppiRow {
   return (
     row !== null &&
     row.factor_id.length > 0 &&
-    typeof row.evppi === 'number' &&
     Number.isFinite(row.evppi) &&
-    (row.status === 'resolved' || row.status === 'below_resolution')
+    // `status` is `z.string().optional()` on the wire, so the presence check is
+    // explicit rather than implied by a literal comparison.
+    row.status !== undefined &&
+    (RENDERABLE_STATUSES as readonly string[]).includes(row.status)
   )
 }
 
@@ -221,6 +239,8 @@ export function buildVoiRanking({
     }
 
     const factorId = wireRow.factor_id
+    // `isUsableRow` has already restricted `status` to RENDERABLE_STATUSES, so the
+    // two bands are exhaustive here: not-resolved IS below_resolution.
     const isResolvedRow = wireRow.status === 'resolved'
     const isFirstResolvedRow = isResolvedRow && !sawFirstResolvedRow
     if (isResolvedRow) sawFirstResolvedRow = true

--- a/src/hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts
+++ b/src/hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts
@@ -32,30 +32,30 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
 // --- supabase (the real boundary) ------------------------------------------
-const mockRpc = vi.fn()
-let mockRowsById: Record<string, Record<string, unknown>> = {}
+// R-3: the harness now lives at src/test/helpers/useScenarioSupabaseHarness.ts,
+// shared with canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts, which had
+// copied it from here line-for-line (~135 lines) and had already narrowed
+// `scenarioRow` to `(id, edges)` with `graph` hard-wired. The harness keeps THIS
+// file's `(id, graph)` signature, so nothing here loses reach.
+//
+// ⚠ THIS IMPORT MUST STAY ABOVE the imports of the code under test below — the
+// `vi.mock` factories close over the harness. See the harness header.
+import {
+  HARNESS_NODES,
+  supabaseMockModule,
+  authMockModule,
+  routerMockModule,
+  resetScenarioHarness,
+  setScenarioRow,
+  scenarioRow,
+  mockRpc,
+  lastWrittenGraph,
+} from '../../test/helpers/useScenarioSupabaseHarness'
 
-const mockSingle = vi.fn()
-vi.mock('../../lib/supabase', () => ({
-  supabase: {
-    from: () => ({
-      select: () => ({
-        eq: (_col: string, id: string) => ({
-          single: () => mockSingle(id),
-        }),
-      }),
-      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
-    }),
-    rpc: (...args: unknown[]) => mockRpc(...args),
-  },
-}))
-
-vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
-
-const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
-vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: () => ({ user: { id: REAL_USER_ID }, authenticated: true }),
-}))
+// Only the SPECIFIERS stay here — they resolve relative to this file.
+vi.mock('../../lib/supabase', () => supabaseMockModule())
+vi.mock('react-router-dom', () => routerMockModule())
+vi.mock('../../contexts/AuthContext', () => authMockModule())
 
 import { useScenario } from '../useScenario'
 import { useCanvasStore } from '../../canvas/store'
@@ -74,44 +74,20 @@ const CAP_50K = [
   },
 ]
 
-const NODES = [
-  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
-  { id: 'factor-1', type: 'factor', position: { x: 0, y: 100 }, data: { kind: 'factor', label: 'Spend' } },
-]
+/** R-3: from the shared harness — `scenarioRow` and `lastWrittenGraph` too. */
+const NODES = HARNESS_NODES
 
-function scenarioRow(id: string, graph: unknown): Record<string, unknown> {
-  return {
-    id,
-    graph,
-    framing: null,
-    stage: 'analyse',
-    updated_at: new Date().toISOString(),
-    analysis_status: 'none',
-    analysis: null,
-    analysis_provenance: null,
-    analysis_error: null,
-    thread: null,
-    events: null,
-  }
-}
-
-/** The `p_graph` of the most recent gated write. */
-function lastWrittenGraph(): Record<string, unknown> | null {
-  const calls = mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log')
-  if (calls.length === 0) return null
-  return (calls[calls.length - 1][1] as Record<string, unknown>)
-    .p_graph as Record<string, unknown>
+/** Make the faked Supabase serve a scenario row holding this graph. */
+function seedRow(id: string, graph: unknown): void {
+  setScenarioRow(id, scenarioRow(id, graph))
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockRowsById = {}
-  mockSingle.mockImplementation(async (id: string) =>
-    mockRowsById[id]
-      ? { data: mockRowsById[id], error: null }
-      : { data: null, error: { code: 'PGRST116' } },
-  )
-  mockRpc.mockResolvedValue({ data: {}, error: null })
+  // Re-arms both spies, including the `PGRST116` "no rows" arm `useScenario`
+  // branches on — `vi.clearAllMocks()` above strips the implementations, so this
+  // must run after it.
+  resetScenarioHarness()
   useCanvasStore.getState().setGoalConstraints(null)
 })
 
@@ -125,14 +101,14 @@ afterEach(() => {
 
 describe('B3 — goal_constraints do not leak across a scenario switch', () => {
   it('switching from a scenario WITH a constraint to one WITHOUT clears it', async () => {
-    mockRowsById['scenario-A'] = scenarioRow('scenario-A', {
+    seedRow('scenario-A', {
       nodes: NODES,
       edges: [],
       goal_constraints: CAP_50K,
     })
     // B genuinely has no constraint — the key is absent, as it is for every
     // scenario created before this lane.
-    mockRowsById['scenario-B'] = scenarioRow('scenario-B', {
+    seedRow('scenario-B', {
       nodes: NODES,
       edges: [],
     })
@@ -160,12 +136,12 @@ describe('B3 — goal_constraints do not leak across a scenario switch', () => {
   it('switching between two scenarios that BOTH have constraints installs the new one', () => {
     // Guards against "fixed the leak by always clearing" — a clear-only fix
     // would pass the case above and still lose every real constraint.
-    mockRowsById['scenario-A'] = scenarioRow('scenario-A', {
+    seedRow('scenario-A', {
       nodes: NODES,
       edges: [],
       goal_constraints: CAP_50K,
     })
-    mockRowsById['scenario-C'] = scenarioRow('scenario-C', {
+    seedRow('scenario-C', {
       nodes: NODES,
       edges: [],
       goal_constraints: [{ ...CAP_50K[0], constraint_id: 'c_other', value: 120000 }],
@@ -193,7 +169,7 @@ describe('B3 — goal_constraints survive save → cold load', () => {
 
     // Cold-load a constraint-free scenario, then have CEE deliver a
     // constraint into the store (what applyDraftResult does on a real turn).
-    mockRowsById['scenario-A'] = scenarioRow('scenario-A', { nodes: NODES, edges: [] })
+    seedRow('scenario-A', { nodes: NODES, edges: [] })
 
     const { result, unmount } = renderHook(() => useScenario())
 
@@ -231,7 +207,7 @@ describe('B3 — goal_constraints survive save → cold load', () => {
     // memory, so anything present afterwards came out of the column.
     vi.useRealTimers()
     useCanvasStore.getState().setGoalConstraints(null)
-    mockRowsById['scenario-A'] = scenarioRow('scenario-A', written)
+    seedRow('scenario-A', written)
 
     const reloaded = renderHook(() => useScenario())
     await act(async () => {
@@ -245,7 +221,7 @@ describe('B3 — goal_constraints survive save → cold load', () => {
 
   it('a malformed persisted constraint degrades to null rather than reaching a run', async () => {
     // The column is untyped JSONB and this value feeds the run request.
-    mockRowsById['scenario-junk'] = scenarioRow('scenario-junk', {
+    seedRow('scenario-junk', {
       nodes: NODES,
       edges: [],
       goal_constraints: [{ label: 'no operator, no value' }, 'not an object'],

--- a/src/lib/guards.ts
+++ b/src/lib/guards.ts
@@ -1,0 +1,49 @@
+/**
+ * guards — the repo's canonical runtime type guards for untyped wire values.
+ *
+ * WHY THIS FILE EXISTS. The plain-object guard had **eight** definitions across
+ * `src/`: one exported (`canvas/conversation/ceeRecovery.ts`, reached by
+ * `transportFailure.ts` and `voi/voiRanking.ts`) and seven private copies under
+ * `src/v5` and `src/lib` — a hand-maintained mirror by any other name (CLAUDE.md
+ * trap 12). The exported one lived in a CEE-error-recovery module, so every new
+ * boundary reader that wanted it had to either import from a module about
+ * something else or write copy N+1. Copy N+1 is what kept happening.
+ *
+ * ⚠ THIS FILE IS THE HOME, NOT THE MIGRATION. The migration of the remaining
+ * private copies is a separate rowed change: each is a one-line delete plus an
+ * import, but they sit in five further modules with their own suites, and folding
+ * them in here would bury a cross-module rename inside a quality PR. What landed
+ * with this file is the home plus the two consumers whose files were already open
+ * — `v5/decisionReviewAdapter.ts` (the newest copy, written in PR #535, the one
+ * that made the count eight) and `v5/blocks/V5AnalysisResultBlock.tsx`. Eight
+ * definitions became six plus this home, so the file is not itself copy nine.
+ *
+ * ⚠ WHAT IS DELIBERATELY *NOT* FOLDED IN: `canvas/conversation/ceeRecovery.ts`
+ * keeps its own exported copy. Its docstring declares it "a zero-dependency pure
+ * leaf on purpose … imports nothing", and that property is load-bearing for the
+ * narrow typecheck gate it is covered by. Collapsing it means re-deciding that
+ * invariant, which is a judgement for the migration row and not a drive-by. Its
+ * two importers (`transportFailure.ts`, `voi/voiRanking.ts`) are untouched.
+ *
+ * ⚠ NAMING. Six of the private copies are called `isPlainObject` and two
+ * `isRecord`, for the identical predicate. `isRecord` is the name kept: it is the
+ * one that was already exported, it names the TYPE the guard narrows to
+ * (`Record<string, unknown>`), and `isPlainObject` invites the reader to expect a
+ * prototype check this predicate does not perform.
+ */
+
+/**
+ * A non-null, non-array object — the shape an untyped wire value must have
+ * before its keys can be read.
+ *
+ * Deliberately NOT a prototype or `Object.getPrototypeOf` check: every caller is
+ * reading JSON that crossed an HTTP boundary, where a class instance cannot
+ * arrive, and a stricter predicate would reject `Object.create(null)` bags that
+ * are perfectly readable. `null` is excluded because `typeof null === 'object'`;
+ * arrays are excluded because every caller goes on to read named keys, and an
+ * array satisfying the guard is how a wrong-typed field becomes a silent empty
+ * read instead of a rejection.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/test/helpers/resolveNextView.tsx
+++ b/src/test/helpers/resolveNextView.tsx
@@ -48,15 +48,63 @@ export function voiRankingFixture(partial: Partial<VoiRanking> = {}): VoiRanking
   }
 }
 
-/** Render the disclosure, open it, and switch to the Resolve next view. */
+/** The four views the evidence disclosure can be switched to. */
+export type EvidenceViewKey = 'drivers' | 'flipRisks' | 'tradeOffs' | 'resolveNext'
+
+/**
+ * Click the disclosure header open. The FIRST of the two clicks, on its own, for
+ * the sites that only need the section expanded — the default Drivers view, or a
+ * test whose subject is the tab strip itself.
+ *
+ * ⚠ `fireEvent`, NOT `node.click()` — see `openEvidence` below. Extracted so that
+ * rationale attaches to the click itself and cannot be left behind by a site that
+ * only needs this half. Four sites hand-rolled exactly this line.
+ */
+export function openDisclosureHeader(): void {
+  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
+}
+
+/** Switch to one view. Assumes the disclosure is already open. */
+export function switchEvidenceView(view: EvidenceViewKey): void {
+  fireEvent.click(screen.getByTestId(`v7-evidence-tab-${view}`))
+}
+
+/**
+ * ⭐ R-12 — RENDER THE DISCLOSURE, OPEN IT, AND SWITCH TO ONE VIEW. The one
+ * definition of the two-click sequence.
+ *
+ * ⚠ `fireEvent`, NOT `node.click()`. The raw DOM call escapes React's `act()`, so
+ * the disclosure never re-renders and every assertion afterwards reads a
+ * COLLAPSED section — a false green that looks exactly like a real one. That
+ * rationale existed on the older private copy in
+ * `results/__tests__/withheldProse.spec.tsx` and NOT on the newer
+ * `openResolveNext`, which is the drift shape: two copies where the one carrying
+ * the reason is not the one a reader is most likely to copy next.
+ *
+ * ⚠ PARAMETERISED OVER THE VIEW on purpose. `openResolveNext` hard-coded its tab,
+ * which is why it could not replace the inline copies of this same sequence in
+ * `V7EvidenceDisclosure.spec.tsx`, `V7EvidenceDisclosure.projection.spec.tsx` and
+ * `withheldProse.spec.tsx` — a helper narrower than the duplication it sits next
+ * to cannot absorb it. `openResolveNext` is kept below as the named `resolveNext`
+ * projection, so the two suites that read well with the specific name keep it.
+ */
+export function openEvidence(
+  evidence: V7EvidenceModel,
+  view: EvidenceViewKey,
+  onFocusNode?: (id: string) => void,
+) {
+  const utils = render(<V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />)
+  openDisclosureHeader()
+  switchEvidenceView(view)
+  return utils
+}
+
+/** `openEvidence` for the Resolve next view — the two suites' preferred name. */
 export function openResolveNext(
   evidence: V7EvidenceModel,
   onFocusNode?: (id: string) => void,
 ) {
-  const utils = render(<V7EvidenceDisclosure evidence={evidence} onFocusNode={onFocusNode} />)
-  fireEvent.click(screen.getByRole('button', { name: /Why, and what could change it/i }))
-  fireEvent.click(screen.getByTestId('v7-evidence-tab-resolveNext'))
-  return utils
+  return openEvidence(evidence, 'resolveNext', onFocusNode)
 }
 
 /**

--- a/src/test/helpers/useScenarioSupabaseHarness.ts
+++ b/src/test/helpers/useScenarioSupabaseHarness.ts
@@ -1,0 +1,171 @@
+/**
+ * The shared Supabase / `useScenario` test harness — R-3.
+ *
+ * ⚠ WHY THIS EXISTS. `canvas/utils/__tests__/edgeValidationRebuildHops.spec.ts`
+ * copied this harness line-for-line from
+ * `hooks/__tests__/useScenario.goalConstraints.lifecycle.spec.ts` — the `NODES`
+ * array byte-identical, the `scenarioRow` body identical, the same
+ * `REAL_USER_ID` literal, the same `PGRST116` `mockSingle` implementation, ~135
+ * lines. The copying spec's own header NAMED the file it was copying from and
+ * copied anyway, because no shared home existed. This is that home.
+ *
+ * ⚠ AND THE COPY HAD ALREADY DIVERGED, IN THE DIRECTION THAT LOSES CAPABILITY:
+ * the original takes `scenarioRow(id, graph)`; the copy took
+ * `scenarioRow(id, edges)` with `graph: { nodes: NODES, edges }` hard-wired — so
+ * the newer spec could not vary nodes or framing at all. The signature here is
+ * the original's (`graph` in full), with a `scenarioRowWithEdges` convenience for
+ * the common "these nodes plus these edges" case, so neither caller loses reach.
+ *
+ * ── ⚠ HOW THE `vi.mock` HALF WORKS, AND WHY IT IS SHAPED THIS WAY ────────────
+ * `vi.mock` CALLS are hoisted above imports and their module specifiers are
+ * resolved relative to the FILE THAT CALLS THEM. The two consumers sit at
+ * different depths (`src/hooks/__tests__/` and `src/canvas/utils/__tests__/`), so
+ * the specifiers genuinely cannot move here — each spec must keep its own
+ * `vi.mock('<its own path>/lib/supabase', …)` line. What CAN move, and what is
+ * the actual bulk and the actual drift risk, is the FACTORY BODY and the mock
+ * state it closes over. Each spec therefore keeps a one-line registration and
+ * hands the factory over:
+ *
+ *     import { supabaseMockModule, authMockModule } from '<...>/useScenarioSupabaseHarness'
+ *     vi.mock('../../lib/supabase', () => supabaseMockModule())
+ *     vi.mock('../../contexts/AuthContext', () => authMockModule())
+ *
+ * The factories are LAZY — vitest invokes them when the module under test first
+ * requests the mocked module, which is after every static import in the spec has
+ * been evaluated. So this module is initialised by then. ⚠ Keep the harness
+ * import ABOVE the spec's import of the code under test: ESM evaluates static
+ * imports in source order, and a factory that runs before this module initialises
+ * would see `undefined` mocks.
+ *
+ * ⚠ THESE FACTORIES REPLACE THE MODULE, they do not spread it — which is correct
+ * for `lib/supabase` and `contexts/AuthContext` (both consumers want the whole
+ * boundary faked) but is exactly the trap-12 shape that once killed 51 tests
+ * elsewhere. If a consumer ever needs a REAL export from either module, use
+ * `importOriginal`-spread in that spec rather than widening this factory.
+ */
+import { vi } from 'vitest'
+
+/** The gated-RPC spy. `apply_patch_and_log` calls land here. */
+export const mockRpc = vi.fn()
+
+/** The single-row read spy, keyed by scenario id. */
+export const mockSingle = vi.fn()
+
+/**
+ * Rows the faked Supabase will serve, by id. Mutated by `setScenarioRow`;
+ * cleared by `resetScenarioHarness`.
+ *
+ * Exposed through functions rather than as a mutable binding so a consumer
+ * cannot hold a stale reference to a replaced object — the failure mode where a
+ * spec's `beforeEach` reassigns the map and the harness keeps reading the old one.
+ */
+const rowsById: Record<string, Record<string, unknown>> = {}
+
+/** A real UUID: the auth boundary rejects non-UUID ids, so a stub id hides bugs. */
+export const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+/** The two canvas nodes both suites seed. */
+export const HARNESS_NODES: ReadonlyArray<Record<string, unknown>> = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Revenue' } },
+  { id: 'factor-1', type: 'factor', position: { x: 0, y: 100 }, data: { kind: 'factor', label: 'Spend' } },
+]
+
+/** The module body for `vi.mock('<...>/lib/supabase', () => supabaseMockModule())`. */
+export function supabaseMockModule() {
+  return {
+    supabase: {
+      from: () => ({
+        select: () => ({
+          eq: (_col: string, id: string) => ({
+            single: () => mockSingle(id),
+          }),
+        }),
+        update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      }),
+      rpc: (...args: unknown[]) => mockRpc(...args),
+    },
+  }
+}
+
+/** The module body for `vi.mock('<...>/contexts/AuthContext', () => authMockModule())`. */
+export function authMockModule() {
+  return {
+    useAuth: () => ({ user: { id: REAL_USER_ID }, authenticated: true }),
+  }
+}
+
+/** The module body for `vi.mock('react-router-dom', () => routerMockModule())`. */
+export function routerMockModule() {
+  return { useNavigate: () => vi.fn() }
+}
+
+/** Make the faked read serve this row for this id. */
+export function setScenarioRow(id: string, row: Record<string, unknown>): void {
+  rowsById[id] = row
+}
+
+/**
+ * Reset the harness: clear the served rows and re-arm both spies.
+ *
+ * ⚠ THE `PGRST116` ARM IS THE POINT, not boilerplate. An unseeded id must read
+ * back as Supabase's own "no rows" error rather than as a success with `null`
+ * data, because `useScenario` branches on that code. Both copies of this harness
+ * carried it; only one explained it.
+ *
+ * Call AFTER `vi.clearAllMocks()` — that call strips the implementations this
+ * re-installs.
+ */
+export function resetScenarioHarness(): void {
+  for (const key of Object.keys(rowsById)) delete rowsById[key]
+  mockSingle.mockImplementation(async (id: string) =>
+    rowsById[id]
+      ? { data: rowsById[id], error: null }
+      : { data: null, error: { code: 'PGRST116' } },
+  )
+  mockRpc.mockResolvedValue({ data: {}, error: null })
+}
+
+/**
+ * A persisted scenario row as it sits in the `scenarios` table.
+ *
+ * Takes the WHOLE `graph`, as the original did — see the divergence note in the
+ * header. `overrides` covers `framing`, `stage` and the analysis columns without
+ * a caller having to restate the other nine.
+ */
+export function scenarioRow(
+  id: string,
+  graph: unknown,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id,
+    graph,
+    framing: null,
+    stage: 'analyse',
+    updated_at: new Date().toISOString(),
+    analysis_status: 'none',
+    analysis: null,
+    analysis_provenance: null,
+    analysis_error: null,
+    thread: null,
+    events: null,
+    ...overrides,
+  }
+}
+
+/** `scenarioRow` for the common "the harness nodes plus these edges" case. */
+export function scenarioRowWithEdges(
+  id: string,
+  edges: unknown[],
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return scenarioRow(id, { nodes: HARNESS_NODES, edges }, overrides)
+}
+
+/** The `p_graph` of the most recent gated write, or `null` if there was none. */
+export function lastWrittenGraph(): Record<string, unknown> | null {
+  const calls = mockRpc.mock.calls.filter((c) => c[0] === 'apply_patch_and_log')
+  if (calls.length === 0) return null
+  return (calls[calls.length - 1][1] as Record<string, unknown>)
+    .p_graph as Record<string, unknown>
+}

--- a/src/v5/__tests__/decisionReviewAdapter.test.ts
+++ b/src/v5/__tests__/decisionReviewAdapter.test.ts
@@ -1,5 +1,13 @@
 /**
- * `extractDecisionReview` — the M1 REST branch ONLY.
+ * The M1 REST branch of `readDecisionReviewWireState` — ONLY that branch.
+ *
+ * ⚠ THE SUBJECT OF THIS FILE USED TO BE AN EXPORT CALLED `extractDecisionReview`
+ * AND IT NO LONGER EXISTS. It was a one-line projection of
+ * `readDecisionReviewWireState` with zero production callers, and these specs
+ * were the only thing keeping it alive — the shape of dead code that reads as
+ * live. It is now the local `extractM1Review` below: same projection, same
+ * coverage of the M1 validator, but reached through the public API every real
+ * caller uses, so this file can no longer be the reason an export survives.
  *
  * ⚠ READ THIS BEFORE TRUSTING A GREEN RUN OF THIS FILE (ROADMAP 2.154).
  *
@@ -26,8 +34,21 @@
  * one fact that matters about it: it does not fire on the live payload.
  */
 import { describe, it, expect } from 'vitest'
-import { extractDecisionReview } from '../decisionReviewAdapter'
+import type { CeeDecisionReviewPayloadV1 } from '../../types/cee'
+import { readDecisionReviewWireState } from '../decisionReviewAdapter'
 import r1Block from './fixtures/live-decision-review-0_30.r1-cee-76d2e1c.json'
+
+/**
+ * The projection the deleted `extractDecisionReview` export performed, kept
+ * local to the one file that wanted it: "the M1 payload, or null if this wire
+ * state is anything else". Local on purpose — see the header.
+ */
+function extractM1Review(
+  enrichment: Record<string, unknown> | undefined,
+): CeeDecisionReviewPayloadV1 | null {
+  const state = readDecisionReviewWireState(enrichment)
+  return state.kind === 'm1' ? state.review : null
+}
 
 const validDR = {
   intent: 'selection',
@@ -48,23 +69,23 @@ const validDR = {
   ],
 }
 
-describe('extractDecisionReview — the M1 REST branch (inert on live payloads)', () => {
+describe('the M1 REST branch (inert on live payloads)', () => {
   it('returns null for undefined enrichment', () => {
-    expect(extractDecisionReview(undefined)).toBeNull()
+    expect(extractM1Review(undefined)).toBeNull()
   })
 
   it('returns null when enrichment has no decision_review key', () => {
-    expect(extractDecisionReview({ something_else: 'x' })).toBeNull()
+    expect(extractM1Review({ something_else: 'x' })).toBeNull()
   })
 
   it('returns null when decision_review is not an object', () => {
-    expect(extractDecisionReview({ decision_review: 'string' })).toBeNull()
-    expect(extractDecisionReview({ decision_review: [] })).toBeNull()
-    expect(extractDecisionReview({ decision_review: null })).toBeNull()
+    expect(extractM1Review({ decision_review: 'string' })).toBeNull()
+    expect(extractM1Review({ decision_review: [] })).toBeNull()
+    expect(extractM1Review({ decision_review: null })).toBeNull()
   })
 
   it('returns a valid payload when shape is well-formed', () => {
-    const r = extractDecisionReview({ decision_review: validDR })
+    const r = extractM1Review({ decision_review: validDR })
     expect(r).not.toBeNull()
     expect(r?.intent).toBe('selection')
     expect(r?.readiness?.level).toBe('ready')
@@ -73,19 +94,19 @@ describe('extractDecisionReview — the M1 REST branch (inert on live payloads)'
 
   it('returns null for invalid intent', () => {
     expect(
-      extractDecisionReview({ decision_review: { ...validDR, intent: 'bogus' } }),
+      extractM1Review({ decision_review: { ...validDR, intent: 'bogus' } }),
     ).toBeNull()
   })
 
   it('returns null for invalid analysis_state', () => {
     expect(
-      extractDecisionReview({ decision_review: { ...validDR, analysis_state: 'bogus' } }),
+      extractM1Review({ decision_review: { ...validDR, analysis_state: 'bogus' } }),
     ).toBeNull()
   })
 
   it('returns null for invalid readiness.level', () => {
     expect(
-      extractDecisionReview({
+      extractM1Review({
         decision_review: { ...validDR, readiness: { ...validDR.readiness, level: 'nope' } },
       }),
     ).toBeNull()
@@ -93,13 +114,13 @@ describe('extractDecisionReview — the M1 REST branch (inert on live payloads)'
 
   it('returns null when blocks is not an array', () => {
     expect(
-      extractDecisionReview({ decision_review: { ...validDR, blocks: 'not-array' } }),
+      extractM1Review({ decision_review: { ...validDR, blocks: 'not-array' } }),
     ).toBeNull()
   })
 
   it('returns null when any block is missing required fields', () => {
     expect(
-      extractDecisionReview({
+      extractM1Review({
         decision_review: {
           ...validDR,
           blocks: [{ id: 'x', status: 'ok' /* missing source, summary, priority */ }],
@@ -109,7 +130,7 @@ describe('extractDecisionReview — the M1 REST branch (inert on live payloads)'
   })
 
   it('preserves extra keys via index signature', () => {
-    const r = extractDecisionReview({
+    const r = extractM1Review({
       decision_review: { ...validDR, meta: { produced_at: '2026-04-21' } },
     })
     expect(r).not.toBeNull()
@@ -125,6 +146,6 @@ describe('extractDecisionReview — the M1 REST branch (inert on live payloads)'
   it('returns null on the LIVE 0.30 payload — this branch is not the live path', () => {
     const enrichment = (r1Block as unknown as { enrichment: Record<string, unknown> }).enrichment
     expect(enrichment.decision_review).toBeTruthy()
-    expect(extractDecisionReview(enrichment)).toBeNull()
+    expect(extractM1Review(enrichment)).toBeNull()
   })
 })

--- a/src/v5/__tests__/decisionReviewAdapter.wire030.spec.ts
+++ b/src/v5/__tests__/decisionReviewAdapter.wire030.spec.ts
@@ -29,7 +29,6 @@
 import { describe, it, expect } from 'vitest'
 import {
   readDecisionReviewWireState,
-  extractDecisionReview,
   type DecisionReview030,
 } from '../decisionReviewAdapter'
 import r1Block from './fixtures/live-decision-review-0_30.r1-cee-76d2e1c.json'
@@ -414,8 +413,9 @@ describe('A2 — shape precedence is strict-M1-first, and it is pinned', () => {
   })
 
   it('⭐ THE A2 CASE — M1 + a content key + produced_at → m1, and the review survives', () => {
-    // The recorded winner. Under 0.30-first this was `v0_30`, and
-    // extractDecisionReview returned null — dropping a real M1 review.
+    // The recorded winner. Under 0.30-first this was `v0_30`, so the M1
+    // projection saw a non-`m1` kind and yielded null — dropping a real M1
+    // review.
     const state = readDecisionReviewWireState({
       decision_review: { ...M1, bias_findings: [{ id: 'b1' }], produced_at: AT },
     })
@@ -424,11 +424,13 @@ describe('A2 — shape precedence is strict-M1-first, and it is pinned', () => {
     expect(state.review.intent).toBe('selection')
     expect(state.review.readiness?.level).toBe('ready')
     // The consumer-facing regression guard: the payload must reach ceeReviewV1.
-    expect(
-      extractDecisionReview({
-        decision_review: { ...M1, bias_findings: [{ id: 'b1' }], produced_at: AT },
-      }),
-    ).not.toBeNull()
+    // That projection is `state.kind === 'm1' ? state.review : null`, performed
+    // in `applyV5State.applyDecisionReviewToRunMeta` — so the two assertions
+    // above ARE the guard, applied to the real consumer's own predicate. This
+    // used to be re-checked through an `extractDecisionReview` export that
+    // performed exactly that ternary and had no production callers; the export
+    // is gone and the assertion is unchanged in substance.
+    expect(state.review).not.toBeNull()
   })
 
   it.each([

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -494,13 +494,19 @@ function normaliseStage(
  * `decisionReviewAdapter.ts`'s header for the honest (weaker) rationale.
  *
  * The eviction itself is still worth having and is unaffected by any of that:
- * `runMeta.ceeReviewV1` has THREE live producers outside this path —
- * `useResultsRun.ts:159` (REAL M1 off the PLoT v1 SSE stream),
- * `useV2Run.ts:1055` and `hydrateAnalysis.ts:154` (both synthesised) — so a
- * stale review from one of them must not outlive the turn that replaced it.
- * (`useConversation.ts:3112` and `useV2Run.ts:994` also pass a `ceeReviewV1`,
- * but through `resultsComplete`, which discards it — see the manifest table in
- * `decisionReviewAdapter.ts`. Naming those as live was the earlier error.)
+ * `runMeta.ceeReviewV1` has live producers OUTSIDE this path, so a stale review
+ * from one of them must not outlive the turn that replaced it.
+ *
+ * ⚠ THE PRODUCER MANIFEST IS NOT REPEATED HERE. It lives in exactly one place —
+ * the `| site | route | reaches runMeta? | payload |` table in
+ * `decisionReviewAdapter.ts`'s header — and this comment holds a POINTER, not a
+ * copy. That is not tidiness: that manifest was **wrong twice**, once naming a
+ * dead site as live and once omitting the real writer, and it was only corrected
+ * by tracing each candidate to the store boundary. A second copy with its own
+ * line numbers is a hand-maintained mirror of a list whose entire history is
+ * silent drift (CLAUDE.md trap 12), and it would drift in the direction that
+ * reads as green — a reader consulting the nearer copy and finding it plausible.
+ * If you need to know which sites reach `runMeta`, read the table.
  */
 function applyDecisionReviewToRunMeta(
   enrichment: Record<string, unknown> | undefined,

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -205,13 +205,33 @@ function useOptionLabelResolver(
   const canvasLabels = useCanvasNodeLabels()
   const merged = useMemo(() => {
     const map = new Map<string, string>(canvasLabels)
-    // Payload wins: written after the store copy, so it overwrites.
+    // ⚠ THE POLICY IS APPLIED PER TIER, NOT ONCE AT THE END. This is the A1 fix
+    // from the adversarial review of PR #539, and the ordering is the whole point.
+    //
+    // The first cut merged both tiers with "payload wins" and resolved ONCE
+    // afterwards. When the producer seeds `option_label` from the option's own id
+    // — the exact upstream behaviour `useCanvasLabels` warns about — that
+    // raw-id-shaped payload label OVERWROTE a good store label, and only then was
+    // it rejected. Nothing rendered, though an honest label sat in the fallback
+    // tier: the fallback was dead precisely when it was needed.
+    //
+    // So a tier may only WIN with a label that has already survived the policy.
+    // `resolveCanvasLabel` is applied to the payload map itself, which reuses the
+    // one null-refusing + RAW_ID_PATTERN policy rather than re-implementing half
+    // of it here.
+    //
     // `resolveOptionLabelById` builds a fresh Map per call, so it is invoked
     // INSIDE the memo and keyed on `enrichment` — calling it outside would make
     // the dependency change on every render and the memo a no-op.
-    for (const [id, label] of resolveOptionLabelById(enrichment)) map.set(id, label)
+    const payloadLabels = resolveOptionLabelById(enrichment)
+    for (const id of payloadLabels.keys()) {
+      const honest = resolveCanvasLabel(id, payloadLabels)
+      if (honest !== null) map.set(id, honest)
+    }
     return map as ReadonlyMap<string, string>
   }, [canvasLabels, enrichment])
+  // Applied a final time so there is ONE exit point for the policy. Idempotent by
+  // construction: every entry in `merged` already survived it.
   return (optionId: string) => resolveCanvasLabel(optionId, merged)
 }
 

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -34,7 +34,7 @@
  *   - Body: typography.panelBody (12px)
  *   - Pills: bg-transparent border-{semantic}/30 text-text-body
  */
-import { type ReactElement } from 'react'
+import { memo, useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5AnalysisResultBlock as V5AnalysisResultBlockType } from '../../canvas/conversation/types'
 import { readDecisionReviewWireState } from '../decisionReviewAdapter'
@@ -43,7 +43,9 @@ import {
   resolveLeaderKeys,
   resolveOptionLabelById,
 } from '../mapV5AnalysisToReport'
+import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
 import { deriveDecisionVerdict } from '../../lib/decisionVerdict'
+import { isRecord } from '../../lib/guards'
 import { calibrateUncertaintyCopy } from '../../components/results/utils/uncertaintyCalibration'
 
 export interface V5AnalysisResultBlockProps {
@@ -74,12 +76,55 @@ function formatProbability(p: number): string {
  */
 const PROSE_WRAP = 'whitespace-pre-wrap break-words min-w-0'
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return v != null && typeof v === 'object' && !Array.isArray(v)
-}
-
 function finiteNumber(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+/**
+ * One labelled bullet list of factor strings — `stability_factors` and
+ * `fragility_factors` render identically and used to do so as two byte-identical
+ * JSX blocks differing only in a title, two test ids and the array.
+ *
+ * This is the exact duplication class `ClampToggle` was extracted for one PR
+ * earlier in the same sprint: two copies where the SECOND copy is what makes a
+ * change to the first silently partial. The index-key rationale in particular
+ * existed twice, verbatim, so a reader had no way to know whether the two were
+ * meant to agree.
+ *
+ * Renders nothing for an empty list — every field on this card carries its own
+ * absence arm and never a placeholder.
+ */
+function FactorList({
+  title,
+  factors,
+  sectionTestId,
+  itemTestId,
+}: {
+  title: string
+  factors: ReadonlyArray<string>
+  sectionTestId: string
+  itemTestId: string
+}): ReactElement | null {
+  if (factors.length === 0) return null
+  return (
+    <div data-testid={sectionTestId}>
+      <p className={`${typography.panelMeta} text-text-light font-medium`}>{title}</p>
+      <ul className="list-disc pl-4">
+        {factors.map((f, i) => (
+          <li
+            // Index key: the LLM can legitimately repeat a factor string, and
+            // this list is display-only — never reordered, filtered or keyed on
+            // by anything else.
+            key={`${i}-${f}`}
+            className={`${typography.panelBody} ${PROSE_WRAP}`}
+            data-testid={itemTestId}
+          >
+            {f}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 /**
@@ -94,17 +139,17 @@ function resolveUncertaintyInputs(
   enrichment: Record<string, unknown> | undefined,
   leadingOptionId: string | null,
 ): { robustnessLevel?: string; robustnessLabel?: string; p10: number | null; p90: number | null } {
-  const robustness = isPlainObject(enrichment?.robustness) ? enrichment!.robustness : undefined
+  const robustness = isRecord(enrichment?.robustness) ? enrichment!.robustness : undefined
   const robustnessLevel = typeof robustness?.level === 'string' ? robustness.level : undefined
   const robustnessLabel = typeof robustness?.label === 'string' ? robustness.label : undefined
 
   const comparisons = Array.isArray(enrichment?.option_comparison)
     ? (enrichment!.option_comparison as unknown[])
     : []
-  const entries = comparisons.filter(isPlainObject) as Array<Record<string, unknown>>
+  const entries = comparisons.filter(isRecord) as Array<Record<string, unknown>>
   const headline =
     entries.find((e) => (e.id ?? e.option_id) === leadingOptionId) ?? entries[0]
-  const outcome = isPlainObject(headline?.outcome) ? headline!.outcome : undefined
+  const outcome = isRecord(headline?.outcome) ? headline!.outcome : undefined
 
   return {
     robustnessLevel,
@@ -114,7 +159,63 @@ function resolveUncertaintyInputs(
   }
 }
 
-export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): ReactElement {
+/**
+ * ⭐ R-4 — ONE OPTION-LABEL POLICY FOR src/v5/blocks, AND IT REFUSES RAW IDS.
+ *
+ * WHAT THIS REPLACED, AND WHY IT WAS A DEFECT AND NOT A STYLE CHOICE. The story
+ * headlines used to resolve their label as `optionLabels.get(id) ?? id`, under a
+ * comment arguing *"showing the raw id is honest; showing nothing would silently
+ * drop a headline the producer paid for"*. The first clause is false and the
+ * second is a false dilemma:
+ *
+ *   · The live payloads' `story_headlines` keys are `opt_status_quo` /
+ *     `opt_hubspot` — a direct `RAW_ID_PATTERN` match. So the fallthrough is not
+ *     a hypothetical: it prints a wire identifier to the user as copy, in a card
+ *     whose own docstring promises no UI-authored copy, exactly when
+ *     `option_comparison` misses. And it CAN miss — the wire ships a sibling
+ *     `option_comparison_status` field precisely because that array is not
+ *     guaranteed.
+ *   · Both sibling blocks in this directory already refuse to do it, through
+ *     ONE shared policy: `resolveCanvasLabel` returns `null` rather than the id
+ *     ("that is the whole point … there is no way to accidentally fall through
+ *     to the identifier") and additionally rejects a stored label that is ITSELF
+ *     a raw id, because upstream sometimes seeds a node's label from its id.
+ *     This card was a THIRD policy in the same folder, and the weakest of the
+ *     three.
+ *   · Nothing is dropped. The headline still renders; only the unresolvable
+ *     LABEL is omitted. That is the `V5ExplanationBlock` rule (omit what cannot
+ *     be named) applied where `V5FlipAnalysisBlock`'s reason to keep the row
+ *     also holds (the row carries producer content that would be lost with it).
+ *     The id survives as the `data-option-id` machine reference, which is the
+ *     use CEE's field-coverage allowlist permits and the siblings also keep.
+ *
+ * THE CANVAS-STORE TIER IS A SECOND, SEPARATE FIX. The old path consulted only
+ * the payload, so an option whose label WAS in the canvas store went unlabelled
+ * anyway. Both tiers now feed one map and both pass through the null-refusing
+ * resolver, so a raw-id-shaped label is rejected whichever tier supplied it.
+ *
+ * Payload FIRST, canvas store second: the payload's `option_comparison` label is
+ * the producer's own naming for the very payload being rendered, and preferring
+ * it keeps every currently-labelled headline byte-identical. The store is a
+ * fallback, not an override.
+ */
+function useOptionLabelResolver(
+  enrichment: Record<string, unknown> | undefined,
+): (optionId: string) => string | null {
+  const canvasLabels = useCanvasNodeLabels()
+  const merged = useMemo(() => {
+    const map = new Map<string, string>(canvasLabels)
+    // Payload wins: written after the store copy, so it overwrites.
+    // `resolveOptionLabelById` builds a fresh Map per call, so it is invoked
+    // INSIDE the memo and keyed on `enrichment` — calling it outside would make
+    // the dependency change on every render and the memo a no-op.
+    for (const [id, label] of resolveOptionLabelById(enrichment)) map.set(id, label)
+    return map as ReadonlyMap<string, string>
+  }, [canvasLabels, enrichment])
+  return (optionId: string) => resolveCanvasLabel(optionId, merged)
+}
+
+function V5AnalysisResultBlockImpl({ block }: V5AnalysisResultBlockProps): ReactElement {
   // ROADMAP 2.154 — the wire has FOUR states and only ONE of them is an alarm.
   // `absent` (the enricher's soft-fail skips) and `degraded`
   // (`decision_review: null`, CEE's "attempted, degraded at the call site")
@@ -126,7 +227,7 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
   // section is worse than no section.
   const showProse = review030?.hasProse === true
   const hasReview = reviewState.kind === 'v0_30' || reviewState.kind === 'm1'
-  const optionLabels = resolveOptionLabelById(block.enrichment)
+  const resolveOptionLabel = useOptionLabelResolver(block.enrichment)
   const hasProbs =
     block.win_probabilities && Object.keys(block.win_probabilities).length > 0
 
@@ -269,25 +370,30 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
 
           {review030.story_headlines.length > 0 && (
             <ul className="space-y-1" data-testid="v5-analysis-result-story-headlines">
-              {review030.story_headlines.map((h) => (
-                <li
-                  key={h.optionId}
-                  className={`${typography.panelBody} ${PROSE_WRAP}`}
-                  data-testid="v5-analysis-result-story-headline"
-                  data-option-id={h.optionId}
-                >
-                  {/*
-                    The label when the payload resolves one for this id, else
-                    the raw id. Showing the raw id is honest; showing nothing
-                    would silently drop a headline the producer paid for.
-                  */}
-                  <span className="font-medium text-text-body">
-                    {optionLabels.get(h.optionId) ?? h.optionId}
-                  </span>
-                  <span className="text-text-light"> — </span>
-                  <span>{h.headline}</span>
-                </li>
-              ))}
+              {review030.story_headlines.map((h) => {
+                // R-4: the shared null-refusing policy. `null` means no honest
+                // label exists for this id — the label and its separator are
+                // then omitted and the producer's headline renders alone. The id
+                // never becomes user copy; it stays a machine reference on
+                // `data-option-id`. See `useOptionLabelResolver` above.
+                const label = resolveOptionLabel(h.optionId)
+                return (
+                  <li
+                    key={h.optionId}
+                    className={`${typography.panelBody} ${PROSE_WRAP}`}
+                    data-testid="v5-analysis-result-story-headline"
+                    data-option-id={h.optionId}
+                  >
+                    {label !== null && (
+                      <>
+                        <span className="font-medium text-text-body">{label}</span>
+                        <span className="text-text-light"> — </span>
+                      </>
+                    )}
+                    <span>{h.headline}</span>
+                  </li>
+                )
+              })}
             </ul>
           )}
 
@@ -313,48 +419,18 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
                   {review030.robustness_explanation.primary_risk}
                 </p>
               )}
-              {review030.robustness_explanation.stability_factors.length > 0 && (
-                <div data-testid="v5-analysis-result-stability-factors">
-                  <p className={`${typography.panelMeta} text-text-light font-medium`}>
-                    Stability factors
-                  </p>
-                  <ul className="list-disc pl-4">
-                    {review030.robustness_explanation.stability_factors.map((f, i) => (
-                      <li
-                        // Index key: the LLM can legitimately repeat a factor
-                        // string, and this list is display-only — never
-                        // reordered, filtered or keyed on by anything else.
-                        key={`${i}-${f}`}
-                        className={`${typography.panelBody} ${PROSE_WRAP}`}
-                        data-testid="v5-analysis-result-stability-factor"
-                      >
-                        {f}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {review030.robustness_explanation.fragility_factors.length > 0 && (
-                <div data-testid="v5-analysis-result-fragility-factors">
-                  <p className={`${typography.panelMeta} text-text-light font-medium`}>
-                    Fragility factors
-                  </p>
-                  <ul className="list-disc pl-4">
-                    {review030.robustness_explanation.fragility_factors.map((f, i) => (
-                      <li
-                        // Index key: the LLM can legitimately repeat a factor
-                        // string, and this list is display-only — never
-                        // reordered, filtered or keyed on by anything else.
-                        key={`${i}-${f}`}
-                        className={`${typography.panelBody} ${PROSE_WRAP}`}
-                        data-testid="v5-analysis-result-fragility-factor"
-                      >
-                        {f}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
+              <FactorList
+                title="Stability factors"
+                factors={review030.robustness_explanation.stability_factors}
+                sectionTestId="v5-analysis-result-stability-factors"
+                itemTestId="v5-analysis-result-stability-factor"
+              />
+              <FactorList
+                title="Fragility factors"
+                factors={review030.robustness_explanation.fragility_factors}
+                sectionTestId="v5-analysis-result-fragility-factors"
+                itemTestId="v5-analysis-result-fragility-factor"
+              />
             </div>
           )}
 
@@ -408,5 +484,27 @@ export function V5AnalysisResultBlock({ block }: V5AnalysisResultBlockProps): Re
     </div>
   )
 }
+
+/**
+ * E-1 — memoised on `block`, following the house convention.
+ *
+ * This card lives in the streamed conversation panel, so it re-renders whenever
+ * ANY sibling block or message arrives — roughly ten times on a single analysis
+ * turn. Each render re-does the whole render-body projection from the untyped
+ * `enrichment` passthrough: the four-state wire classification with its two shape
+ * validators, the uncertainty-input walk over `option_comparison`, the verdict
+ * derivation, the leader-key resolution and the probability sort. Post-#535 that
+ * is roughly an order more work per render than it was before, for a `block` prop
+ * that does not change between those renders.
+ *
+ * `memo` with the default shallow compare is exactly right here: `block` is the
+ * one prop, and it is a wire object the panel holds by reference for the life of
+ * the turn. The three sibling cards doing comparable derivation
+ * (`DecisionConfidencePanel`, `AnalysisHeroV17`, `StressTestSection`) already use
+ * this convention, including its `memo(function Name(...))` form so the component
+ * keeps its name in React DevTools and in test output.
+ */
+export const V5AnalysisResultBlock = memo(V5AnalysisResultBlockImpl)
+V5AnalysisResultBlock.displayName = 'V5AnalysisResultBlock'
 
 export default V5AnalysisResultBlock

--- a/src/v5/blocks/__tests__/V5AnalysisResultBlock.decisionReview030.spec.tsx
+++ b/src/v5/blocks/__tests__/V5AnalysisResultBlock.decisionReview030.spec.tsx
@@ -72,14 +72,22 @@ const LIVE: Array<[string, V5AnalysisResultBlockType, Record<string, unknown>]> 
   ['r3', R3, reviewOf(r3Block)],
 ]
 
-/** A block whose enrichment carries the given decision_review, nothing else. */
-function blockWithReview(decision_review: unknown): V5AnalysisResultBlockType {
+/**
+ * A block whose enrichment carries the given decision_review, nothing else.
+ *
+ * `extraEnrichment` overlays the default `{option_comparison: []}` — used by the
+ * R-4 cases, which need to control what the label chain can resolve.
+ */
+function blockWithReview(
+  decision_review: unknown,
+  extraEnrichment: Record<string, unknown> = {},
+): V5AnalysisResultBlockType {
   return {
     type: 'analysis_result',
     summary: 'Analysis summary from the parent block.',
     leading_option_id: 'opt_a',
     win_probabilities: { 'Option A': 0.6, 'Option B': 0.4 },
-    enrichment: { decision_review, option_comparison: [] },
+    enrichment: { decision_review, option_comparison: [], ...extraEnrichment },
   } as unknown as V5AnalysisResultBlockType
 }
 
@@ -162,10 +170,34 @@ describe('the five orphaned prose fields reach the DOM on a live payload', () =>
     },
   )
 
-  it('a story headline is keyed by option LABEL when the payload resolves one, else the raw id', () => {
-    // Identity resolution over the SAME payload (`enrichment.option_comparison`,
-    // falling back to `enrichment.decision_brief.options`) — the chain the pills
-    // already use. Not a second hand-maintained mapping, and not invented copy.
+  // ─────────────────────────────────────────────────────────────────────────
+  // ⭐ R-4 — THE OPTION-LABEL POLICY. A BEHAVIOUR FIX, WITH THE OLD BEHAVIOUR'S
+  // PIN REPLACED RATHER THAN DELETED.
+  //
+  // These two cases used to read "…else the raw id" and "falls back to the raw
+  // id RATHER THAN RENDERING NOTHING". That was a real pin on real behaviour:
+  // when `option_comparison` missed, this card printed `opt_status_quo` to the
+  // user as copy. It can miss — the wire ships a sibling
+  // `option_comparison_status` field precisely because the array is not
+  // guaranteed — and the live payloads' `story_headlines` keys are exactly the
+  // `opt_*` shape `RAW_ID_PATTERN` exists to catch.
+  //
+  // Both sibling blocks in `src/v5/blocks` already refuse to print an
+  // identifier, through the shared `resolveCanvasLabel` policy that returns
+  // `null` instead of the id. This card is now the third consumer of that one
+  // policy rather than a third policy.
+  //
+  // The absence assertion below is paired with the presence it denies (trap 13):
+  // the labelled case immediately above proves the same harness DOES render a
+  // label when one resolves, so "no raw id in the DOM" measures a real absence.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('a story headline is keyed by option LABEL when the payload resolves one', () => {
+    // THE LABELLED CONTROL for the two absence cases below. Identity resolution
+    // over the SAME payload (`enrichment.option_comparison`, falling back to
+    // `enrichment.decision_brief.options`, then to the canvas store) — the chain
+    // the pills already use. Not a second hand-maintained mapping, and not
+    // invented copy.
     render(<V5AnalysisResultBlock block={R1} />)
     const rows = screen.getAllByTestId('v5-analysis-result-story-headline')
     const first = rows.find((n) => n.getAttribute('data-option-id') === 'opt_status_quo')
@@ -173,7 +205,7 @@ describe('the five orphaned prose fields reach the DOM on a live payload', () =>
     expect(first!).toHaveTextContent('Keep Current Setup (Status Quo)')
   })
 
-  it('an unresolvable option id falls back to the raw id rather than rendering nothing', () => {
+  it('⭐ an unresolvable option id renders NO raw id — the headline stands alone', () => {
     render(
       <V5AnalysisResultBlock
         block={blockWithReview({
@@ -183,9 +215,43 @@ describe('the five orphaned prose fields reach the DOM on a live payload', () =>
       />,
     )
     const row = screen.getByTestId('v5-analysis-result-story-headline')
+    // The id survives as the MACHINE reference — the use the field-coverage
+    // allowlist permits, and what the two sibling blocks also keep.
     expect(row).toHaveAttribute('data-option-id', 'opt_unknown')
-    expect(row).toHaveTextContent('opt_unknown')
+    // …and nowhere in the user-visible text.
+    expect(row.textContent).not.toContain('opt_unknown')
+    // Nothing the producer paid for is dropped: the headline still renders. This
+    // is why the row is kept rather than omitted (the `V5FlipAnalysisBlock`
+    // reason), while the unnameable LABEL is omitted (the `V5ExplanationBlock`
+    // reason). No substitute copy is invented either.
     expect(row).toHaveTextContent('A headline with no matching option entry.')
+    expect(row.textContent).not.toContain('—')
+  })
+
+  it('⭐ rejects a resolved label that is ITSELF a raw id (RAW_ID_PATTERN)', () => {
+    // The leak one hop upstream. Upstream sometimes seeds an option's label from
+    // its own id; without the pattern guard inside `resolveCanvasLabel` the raw
+    // id would arrive as a "resolved label" and print anyway. This is the half of
+    // the shared policy a bespoke `map.get(id) ?? id` cannot express at all.
+    render(
+      <V5AnalysisResultBlock
+        block={blockWithReview(
+          {
+            produced_at: '2026-07-30T00:00:00.000Z',
+            story_headlines: { opt_status_quo: 'A headline whose option is labelled by its id.' },
+          },
+          {
+            option_comparison: [
+              { id: 'opt_status_quo', option_label: 'opt_status_quo', win_probability: 0.5 },
+            ],
+          },
+        )}
+      />,
+    )
+    const row = screen.getByTestId('v5-analysis-result-story-headline')
+    expect(row).toHaveAttribute('data-option-id', 'opt_status_quo')
+    expect(row.textContent).not.toContain('opt_status_quo')
+    expect(row).toHaveTextContent('A headline whose option is labelled by its id.')
   })
 
   it.each(LIVE)('%s marks the card as carrying a 0.30 review', (_tag, block) => {

--- a/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
+++ b/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
@@ -1,5 +1,7 @@
 /**
- * V5ExplanationBlock / V5FlipAnalysisBlock — id → label resolution.
+ * V5ExplanationBlock / V5FlipAnalysisBlock / V5AnalysisResultBlock — id → label
+ * resolution. All three consumers of the ONE `useCanvasLabels` policy, in one
+ * file, so a change to the policy is answered by every component that shares it.
  *
  * The contract harness (tests/contracts/cee-rendering-claims.contract.test.tsx)
  * proves the raw id is ABSENT from the user-facing surface. Absence alone is
@@ -7,6 +9,16 @@
  * that the human label is PRESENT, that the machine reference survives in
  * attributes, and that each component makes the no-label decision its own
  * docstring claims it makes.
+ *
+ * ⚠ THE THREE COMPONENTS MAKE DIFFERENT NO-LABEL DECISIONS, ON PURPOSE, and the
+ * difference is about what would be LOST with the row:
+ *   · `V5ExplanationBlock` OMITS the chip — it carries nothing but the label.
+ *   · `V5FlipAnalysisBlock` KEEPS the row under "Unnamed factor" — it carries
+ *     threshold numbers.
+ *   · `V5AnalysisResultBlock` KEEPS the row and omits only the label — it
+ *     carries the producer's headline prose.
+ * What they do NOT differ on, and what this file exists to hold, is that none of
+ * them ever renders the identifier as user copy.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, within } from '@testing-library/react'
@@ -20,6 +32,7 @@ vi.mock('../../../canvas/store', () => ({
 
 import { V5ExplanationBlock } from '../V5ExplanationBlock'
 import { V5FlipAnalysisBlock } from '../V5FlipAnalysisBlock'
+import { V5AnalysisResultBlock } from '../V5AnalysisResultBlock'
 
 afterEach(() => {
   cleanup()
@@ -150,5 +163,85 @@ describe('V5FlipAnalysisBlock — factor ids', () => {
     const row = screen.getByTestId('v5-flip-scenario-fac_morale')
     expect(row).toHaveTextContent('Unnamed factor:')
     expect(row.textContent).not.toContain('fac_morale')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// R-4 — V5AnalysisResultBlock joins the same policy.
+//
+// It used to hold a THIRD one: `optionLabels.get(id) ?? id`, which printed the
+// wire identifier as user copy exactly when `option_comparison` missed. The two
+// halves this section pins are the two the bespoke version could not express —
+// the canvas-store TIER (a label that IS in the store was previously unused) and
+// the RAW_ID_PATTERN refusal.
+//
+// The payload tier and the paired "headline still renders" arm live with the rest
+// of this card's render pins, in
+// V5AnalysisResultBlock.decisionReview030.spec.tsx.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function analysisResult(storyHeadlines: Record<string, string>) {
+  return {
+    type: 'analysis_result' as const,
+    summary: 'Analysis summary.',
+    leading_option_id: null,
+    win_probabilities: {},
+    // Deliberately EMPTY: the payload label chain resolves nothing, so what these
+    // cases measure is the canvas-store tier alone.
+    enrichment: {
+      option_comparison: [],
+      decision_review: {
+        produced_at: '2026-07-30T00:00:00.000Z',
+        story_headlines: storyHeadlines,
+      },
+    },
+  }
+}
+
+describe('V5AnalysisResultBlock — story-headline option ids', () => {
+  it('resolves the label from the CANVAS STORE when the payload carries none', () => {
+    // The tier the bespoke resolver skipped entirely: `option_comparison` is
+    // empty here, so a green assertion can only come from the store.
+    mockNodes = [{ id: 'opt_london', data: { label: 'Hire in London' } }]
+    render(
+      <V5AnalysisResultBlock
+        block={analysisResult({ opt_london: 'London absorbs the demand spike.' }) as never}
+      />,
+    )
+
+    const row = screen.getByTestId('v5-analysis-result-story-headline')
+    expect(row).toHaveTextContent('Hire in London')
+    expect(row).toHaveTextContent('London absorbs the demand spike.')
+    expect(row.textContent).not.toContain('opt_london')
+  })
+
+  it('renders no identifier when NEITHER tier resolves, and keeps the headline', () => {
+    // POSITIVE CONTROL for this absence is the test above: the same harness DOES
+    // render a label when one resolves, so this measures a real absence.
+    mockNodes = []
+    render(
+      <V5AnalysisResultBlock
+        block={analysisResult({ opt_ghost: 'A headline for an option nothing can name.' }) as never}
+      />,
+    )
+
+    const row = screen.getByTestId('v5-analysis-result-story-headline')
+    expect(row.textContent).not.toContain('opt_ghost')
+    expect(row).toHaveTextContent('A headline for an option nothing can name.')
+    // The machine reference survives, exactly as in the two siblings.
+    expect(row).toHaveAttribute('data-option-id', 'opt_ghost')
+  })
+
+  it('rejects a canvas label that is itself a raw id', () => {
+    mockNodes = [{ id: 'opt_london', data: { label: 'opt_london' } }]
+    render(
+      <V5AnalysisResultBlock
+        block={analysisResult({ opt_london: 'London absorbs the demand spike.' }) as never}
+      />,
+    )
+
+    const row = screen.getByTestId('v5-analysis-result-story-headline')
+    expect(row.textContent).not.toContain('opt_london')
+    expect(row).toHaveTextContent('London absorbs the demand spike.')
   })
 })

--- a/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
+++ b/src/v5/blocks/__tests__/V5BlockIdLabelResolution.spec.tsx
@@ -180,16 +180,20 @@ describe('V5FlipAnalysisBlock — factor ids', () => {
 // V5AnalysisResultBlock.decisionReview030.spec.tsx.
 // ═══════════════════════════════════════════════════════════════════════════
 
-function analysisResult(storyHeadlines: Record<string, string>) {
+function analysisResult(
+  storyHeadlines: Record<string, string>,
+  optionComparison: unknown[] = [],
+) {
   return {
     type: 'analysis_result' as const,
     summary: 'Analysis summary.',
     leading_option_id: null,
     win_probabilities: {},
-    // Deliberately EMPTY: the payload label chain resolves nothing, so what these
-    // cases measure is the canvas-store tier alone.
+    // `option_comparison` defaults to EMPTY so the payload label chain resolves
+    // nothing and the case measures the canvas-store tier alone. The
+    // tier-masking cases below supply it.
     enrichment: {
-      option_comparison: [],
+      option_comparison: optionComparison,
       decision_review: {
         produced_at: '2026-07-30T00:00:00.000Z',
         story_headlines: storyHeadlines,
@@ -243,5 +247,89 @@ describe('V5AnalysisResultBlock — story-headline option ids', () => {
     const row = screen.getByTestId('v5-analysis-result-story-headline')
     expect(row.textContent).not.toContain('opt_london')
     expect(row).toHaveTextContent('London absorbs the demand spike.')
+  })
+
+  /**
+   * ⭐ A1 (adversarial review of #539) — A RAW-ID PAYLOAD LABEL MUST NOT MASK A
+   * HUMAN STORE LABEL.
+   *
+   * The first cut of this two-tier resolver merged both tiers into one map with
+   * "payload wins", then applied the null-refusing policy ONCE at the end. That
+   * ordering had a hole the reviewer witnessed as live behaviour: when the
+   * producer seeds an option's `option_label` from its own id — the exact upstream
+   * behaviour `useCanvasLabels`' docstring warns about — the raw-id-shaped payload
+   * label OVERWROTE a perfectly good store label, and only THEN did
+   * `resolveCanvasLabel` reject it. Result: nothing rendered, although an honest
+   * human label was sitting in the fallback tier. **The fallback tier was dead
+   * exactly when it was needed.**
+   *
+   * Not a regression — the pre-#539 code printed `opt_hubspot` here, so any of
+   * these outcomes beats the base. But it was an incomplete fix measured against
+   * this resolver's own stated two-tier intent, which is what makes it an
+   * amendment rather than a nice-to-have.
+   *
+   * The fix applies the policy PER TIER, so a tier can only win with a label that
+   * already survived it.
+   */
+  describe('A1 — tier masking', () => {
+    const HUBSPOT_HEADLINE = 'HubSpot closes the integration gap.'
+
+    it('⭐ a raw-id-shaped PAYLOAD label does not mask a human STORE label', () => {
+      mockNodes = [{ id: 'opt_hubspot', data: { label: 'HubSpot CRM' } }]
+      render(
+        <V5AnalysisResultBlock
+          block={
+            analysisResult({ opt_hubspot: HUBSPOT_HEADLINE }, [
+              // The producer seeded the label from the id.
+              { id: 'opt_hubspot', label: 'opt_hubspot' },
+            ]) as never
+          }
+        />,
+      )
+
+      const row = screen.getByTestId('v5-analysis-result-story-headline')
+      // The store's human label serves, because the payload's did not survive
+      // the policy and therefore never got to win.
+      expect(row).toHaveTextContent('HubSpot CRM')
+      expect(row).toHaveTextContent(HUBSPOT_HEADLINE)
+      expect(row.textContent).not.toContain('opt_hubspot')
+    })
+
+    it('an HONEST payload label still wins over the store label (precedence intact)', () => {
+      // The other direction, so the fix cannot be satisfied by simply demoting
+      // the payload tier. Payload-first is deliberate: it is the producer's own
+      // naming for the very payload being rendered.
+      mockNodes = [{ id: 'opt_hubspot', data: { label: 'Stale store label' } }]
+      render(
+        <V5AnalysisResultBlock
+          block={
+            analysisResult({ opt_hubspot: HUBSPOT_HEADLINE }, [
+              { id: 'opt_hubspot', label: 'HubSpot CRM (payload)' },
+            ]) as never
+          }
+        />,
+      )
+
+      const row = screen.getByTestId('v5-analysis-result-story-headline')
+      expect(row).toHaveTextContent('HubSpot CRM (payload)')
+      expect(row.textContent).not.toContain('Stale store label')
+    })
+
+    it('both tiers raw-id-shaped → nothing renders but the headline (no leak either way)', () => {
+      mockNodes = [{ id: 'opt_hubspot', data: { label: 'opt_hubspot' } }]
+      render(
+        <V5AnalysisResultBlock
+          block={
+            analysisResult({ opt_hubspot: HUBSPOT_HEADLINE }, [
+              { id: 'opt_hubspot', label: 'opt_hubspot' },
+            ]) as never
+          }
+        />,
+      )
+
+      const row = screen.getByTestId('v5-analysis-result-story-headline')
+      expect(row.textContent).not.toContain('opt_hubspot')
+      expect(row).toHaveTextContent(HUBSPOT_HEADLINE)
+    })
   })
 })

--- a/src/v5/decisionReviewAdapter.ts
+++ b/src/v5/decisionReviewAdapter.ts
@@ -41,7 +41,7 @@
  *    enrichment**, at either upstream tip (PLoT `3d13e0ac`: complete manifest,
  *    PLoT never writes a `decision_review` key at all; CEE `2180702`/#758:
  *    exactly two writers of the wire key, the 0.30 enricher and a `null`
- *    patch). `extractDecisionReview` handles it and is therefore INERT on live
+ *    patch). `validateM1Payload` below handles it and is therefore INERT on live
  *    payloads.
  *
  * ## THE FALSE LABEL THIS DOCSTRING REPLACES (ROADMAP 2.154)
@@ -124,7 +124,9 @@
  * and a wrong-typed array member is dropped. The prose is CEE-authored and has
  * already passed CEE's egress gate — the UI renders it, never edits it.
  */
+import { EnrichmentDecisionReviewSchema } from '@talchain/schemas/boundary'
 import type { CeeDecisionReviewPayloadV1, ReviewBlock } from '../types/cee'
+import { isRecord } from '../lib/guards'
 
 const VALID_INTENTS = new Set(['selection', 'prediction', 'validation'])
 const VALID_ANALYSIS_STATES = new Set(['not_run', 'ran', 'partial', 'stale'])
@@ -178,9 +180,39 @@ const V0_30_CONTENT_KEYS = [
   ...V0_30_ENRICHER_OWNED_KEYS,
 ] as const
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v)
-}
+/**
+ * ⭐ A-1 — THE SHAPE DISCRIMINATOR IS BOUND TO THE CONTRACT, NOT HAND-ROLLED.
+ *
+ * `produced_at` is this module's discriminator: it is the field that decides
+ * whether a payload is judged as a 0.30 review at all (`readV0_30`). A
+ * hand-rolled `typeof raw.produced_at === 'string'` would keep compiling if the
+ * contract renamed or retyped the pin, and the failure would be SILENT and
+ * TOTAL — every live payload reclassified `not_v0_30`, then `malformed`, which
+ * is precisely the whole-payload drop ROADMAP 2.154 exists to have fixed. The
+ * repo's #1 hazard is schema skew (CLAUDE.md hazard 1), and a discriminator is
+ * the worst possible place to carry a second, private declaration of it.
+ *
+ * `.pick({produced_at: true})` binds it: a rename or retype upstream becomes a
+ * COMPILE error here rather than a behavioural one. Follows the live precedent
+ * in `voi/voiRanking.ts` (`EnrichmentFactorEvppiEntrySchema.pick`), whose own
+ * docstring names hand-rolled `typeof` checks "a SECOND definition of the row
+ * contract in a repo whose #1 hazard is schema skew".
+ *
+ * ⚠ SCOPE, AND WHY IT IS THIS NARROW. `EnrichmentDecisionReviewSchema` declares
+ * `produced_at` and NOTHING ELSE — it is `.passthrough()`, so the five prose
+ * fields this view-model renders have nothing to bind to and their hand-rolled
+ * readers below are FORCED, not a choice. The trichotomy (absent / `null` /
+ * record) is likewise already declared by the contract, at the parent:
+ * `decision_review: EnrichmentDecisionReviewSchema.nullable().optional()`. So
+ * this binding buys exactly one thing — the discriminator — and claims no more.
+ *
+ * The parse is deliberately `safeParse` at the call site rather than a throw:
+ * a missing/blank `produced_at` is a legitimate "not a 0.30 payload" answer that
+ * must still let the M1 branch have its look, not an exception.
+ */
+const DecisionReviewDiscriminatorSchema = EnrichmentDecisionReviewSchema.pick({
+  produced_at: true,
+})
 
 /** A non-blank string, verbatim; `null` for anything else. Never coerces. */
 function prose(v: unknown): string | null {
@@ -253,15 +285,35 @@ type FieldRead<T> =
   /** Key sent with the WRONG TYPE — a contract break; caller → malformed. */
   | { ok: false }
 
+/**
+ * A COLLECTION read. Deliberately NOT `FieldRead<T[]>`: there is no null arm,
+ * because no consumer of these three readers distinguishes "the key was absent"
+ * from "the key held an empty list" — every one of them asks only `.length > 0`,
+ * and the render surface treats both as "no rows".
+ *
+ * The null arm used to exist and was paid for FOUR times, once per call site, as
+ * a `?? []` coalesce. Every coalesce is a place where a future reader could
+ * forget it and get `null.length`; collapsing the arm makes that unrepresentable
+ * rather than merely currently-correct. The strictness that MATTERS is untouched:
+ * a wrong-typed CONTAINER is still `{ok: false}` → `malformed`, which is the
+ * whole point of the `FieldRead` header above. What went is a distinction nobody
+ * consumed, not a distinction that guarded anything.
+ */
+type ListRead<T> = { ok: true; value: T[] } | { ok: false }
+
 function absent(v: unknown): v is undefined | null {
   return v === undefined || v === null
 }
 
-/** Strict singleton string. */
+/**
+ * Strict singleton string. The blankness rule is `prose()`'s, not restated:
+ * "present, correctly-typed but blank reads as absent content" is one policy and
+ * it belongs to one function.
+ */
 function readProseField(v: unknown): FieldRead<string> {
   if (absent(v)) return { ok: true, value: null }
   if (typeof v !== 'string') return { ok: false }
-  return { ok: true, value: v.trim() === '' ? null : v }
+  return { ok: true, value: prose(v) }
 }
 
 /** Strict singleton record (container kind only — members stay lenient). */
@@ -272,8 +324,8 @@ function readRecordField(v: unknown): FieldRead<Record<string, unknown>> {
 }
 
 /** Strict array container; its MEMBERS are filtered leniently. */
-function readStringListField(v: unknown): FieldRead<string[]> {
-  if (absent(v)) return { ok: true, value: null }
+function readStringListField(v: unknown): ListRead<string> {
+  if (absent(v)) return { ok: true, value: [] }
   if (!Array.isArray(v)) return { ok: false }
   return { ok: true, value: stringList(v) }
 }
@@ -366,13 +418,11 @@ function readRobustnessExplanation(
     return { ok: false }
   }
 
-  const stabilityList = stability.value ?? []
-  const fragilityList = fragility.value ?? []
   if (
     summary.value === null &&
     primaryRisk.value === null &&
-    stabilityList.length === 0 &&
-    fragilityList.length === 0
+    stability.value.length === 0 &&
+    fragility.value.length === 0
   ) {
     // Well-typed but carrying nothing — absent content, not a contract break.
     return { ok: true, value: null }
@@ -382,17 +432,17 @@ function readRobustnessExplanation(
     value: {
       summary: summary.value,
       primary_risk: primaryRisk.value,
-      stability_factors: stabilityList,
-      fragility_factors: fragilityList,
+      stability_factors: stability.value,
+      fragility_factors: fragility.value,
     },
   }
 }
 
 /** Strict on the container kind; lenient per item (a dropped row is countable). */
-function readStoryHeadlines(v: unknown): FieldRead<DecisionReviewStoryHeadline[]> {
+function readStoryHeadlines(v: unknown): ListRead<DecisionReviewStoryHeadline> {
   const container = readRecordField(v)
   if (!container.ok) return { ok: false }
-  if (container.value === null) return { ok: true, value: null }
+  if (container.value === null) return { ok: true, value: [] }
 
   const out: DecisionReviewStoryHeadline[] = []
   // Object key order is the wire order. Not sorted: any reordering would be a
@@ -405,10 +455,10 @@ function readStoryHeadlines(v: unknown): FieldRead<DecisionReviewStoryHeadline[]
 }
 
 /** Strict on the container kind; lenient per entry. */
-function readScenarioContexts(v: unknown): FieldRead<DecisionReviewScenarioContext[]> {
+function readScenarioContexts(v: unknown): ListRead<DecisionReviewScenarioContext> {
   const container = readRecordField(v)
   if (!container.ok) return { ok: false }
-  if (container.value === null) return { ok: true, value: null }
+  if (container.value === null) return { ok: true, value: [] }
 
   const out: DecisionReviewScenarioContext[] = []
   for (const [id, entry] of Object.entries(container.value)) {
@@ -424,29 +474,32 @@ function readScenarioContexts(v: unknown): FieldRead<DecisionReviewScenarioConte
 }
 
 /**
- * Three outcomes, not two — see the `FieldRead` header for why conflating the
- * last two inverts the alarm.
+ * The 0.30 view-model, or `null` when this payload is not a usable 0.30 review.
  *
- *   `not_v0_30`   — does not look like a 0.30 payload; caller may try M1.
- *   `type_error`  — IS 0.30-shaped, but a field this view-model renders was
- *                   sent with the wrong type. Caller → `malformed`.
- *   the review    — usable, though possibly carrying no prose.
+ * ⚠ THIS USED TO RETURN A THREE-OUTCOME UNION (`ok` / `not_v0_30` /
+ * `type_error`) AND THE THIRD ARM WAS PURE OVERHEAD BY THE TIME IT LANDED.
+ * The union was written when 0.30 was tried FIRST, so a caller genuinely had to
+ * tell "not this shape, go try M1" from "this shape, broken". The A2 fix moved
+ * M1 ahead of 0.30 (`readDecisionReviewWireState`, see its precedence section)
+ * and the sole caller has mapped BOTH non-ok arms to `malformed` ever since —
+ * two names, three lines of dispatch, one behaviour.
+ *
+ * ⚠ WHAT IS NOT LOST, because it would matter if it were: the STRICTNESS is
+ * untouched. A field this view-model renders arriving wrong-typed still refuses
+ * the whole payload and still lights the operator marker, which is the A1 fix and
+ * the reason `FieldRead` distinguishes absent from wrong-typed at all (see its
+ * header). Only the caller-facing LABEL on the refusal is gone, and the caller
+ * never branched on it.
  */
-type V0_30Read =
-  | { outcome: 'ok'; review: DecisionReview030 }
-  | { outcome: 'not_v0_30' }
-  | { outcome: 'type_error' }
-
-function readV0_30(raw: Record<string, unknown>): V0_30Read {
-  // The produced_at + content-key pair is the SHAPE discriminator, and it is
-  // deliberately unchanged by the A1 fix: a payload that fails it is not being
-  // judged as a broken 0.30 review, it is being judged as not a 0.30 review at
-  // all, which is what lets the M1 branch still get a look.
-  const producedAt = prose(raw.produced_at)
-  if (producedAt === null) return { outcome: 'not_v0_30' }
-  if (!V0_30_CONTENT_KEYS.some((k) => raw[k] !== undefined)) {
-    return { outcome: 'not_v0_30' }
-  }
+function readV0_30(raw: Record<string, unknown>): DecisionReview030 | null {
+  // The produced_at + content-key pair is the SHAPE discriminator: it decides
+  // whether this payload is judged as a 0.30 review at all, rather than judged
+  // as a broken one. `produced_at` is read through the CONTRACT (see
+  // `DecisionReviewDiscriminatorSchema`), not a hand-rolled typeof.
+  const parsed = DecisionReviewDiscriminatorSchema.safeParse(raw)
+  const producedAt = parsed.success ? prose(parsed.data.produced_at) : null
+  if (producedAt === null) return null
+  if (!V0_30_CONTENT_KEYS.some((k) => raw[k] !== undefined)) return null
 
   const narrative = readProseField(raw.narrative_summary)
   const readiness = readProseField(raw.readiness_rationale)
@@ -454,32 +507,27 @@ function readV0_30(raw: Record<string, unknown>): V0_30Read {
   const headlines = readStoryHeadlines(raw.story_headlines)
   const scenarios = readScenarioContexts(raw.scenario_contexts)
 
-  // ANY of the five sent with the wrong type is a contract break. Failing here
-  // rather than nulling the field is the whole point: a null would render as
-  // "the producer sent nothing", with no alarm, and the field's content would
+  // ANY of the five sent with the wrong type is a contract break. Refusing the
+  // payload rather than nulling the field is the whole point: a null would render
+  // as "the producer sent nothing", with no alarm, and the field's content would
   // be lost in silence.
   if (!narrative.ok || !readiness.ok || !robustness.ok || !headlines.ok || !scenarios.ok) {
-    return { outcome: 'type_error' }
+    return null
   }
 
-  const headlineList = headlines.value ?? []
-  const scenarioList = scenarios.value ?? []
   return {
-    outcome: 'ok',
-    review: {
-      narrative_summary: narrative.value,
-      story_headlines: headlineList,
-      robustness_explanation: robustness.value,
-      readiness_rationale: readiness.value,
-      scenario_contexts: scenarioList,
-      produced_at: producedAt,
-      hasProse:
-        narrative.value !== null ||
-        readiness.value !== null ||
-        robustness.value !== null ||
-        headlineList.length > 0 ||
-        scenarioList.length > 0,
-    },
+    narrative_summary: narrative.value,
+    story_headlines: headlines.value,
+    robustness_explanation: robustness.value,
+    readiness_rationale: readiness.value,
+    scenario_contexts: scenarios.value,
+    produced_at: producedAt,
+    hasProse:
+      narrative.value !== null ||
+      readiness.value !== null ||
+      robustness.value !== null ||
+      headlines.value.length > 0 ||
+      scenarios.value.length > 0,
   }
 }
 
@@ -536,11 +584,13 @@ export function readDecisionReviewWireState(
   if (m1) return { kind: 'm1', review: m1 }
 
   const v030 = readV0_30(raw)
-  if (v030.outcome === 'ok') return { kind: 'v0_30', review: v030.review }
-  // 0.30-shaped but type-broken → the alarm. M1 has already been tried and
-  // failed above, so there is nothing left to fall through to.
-  if (v030.outcome === 'type_error') return { kind: 'malformed' }
+  if (v030) return { kind: 'v0_30', review: v030 }
 
+  // A record on the key that neither branch could use. M1 has already been tried
+  // and failed above, so there is nothing left to fall through to — and BOTH
+  // reasons `readV0_30` can refuse (not 0.30-shaped, or 0.30-shaped but
+  // type-broken) land here identically. That is why it returns a nullable rather
+  // than a labelled union: this line is the only consumer, and it never branched.
   return { kind: 'malformed' }
 }
 
@@ -588,23 +638,29 @@ function validateM1Payload(raw: Record<string, unknown>): CeeDecisionReviewPaylo
   }
 }
 
-/**
- * Return a validated `CeeDecisionReviewPayloadV1` when
- * `enrichment.decision_review` carries the **M1 REST** shape; `null`
- * otherwise — including on the 0.30 payload CEE actually sends today, which
- * is a different payload and is read by `readDecisionReviewWireState`.
+/*
+ * ⚠ `extractDecisionReview` USED TO BE EXPORTED FROM HERE AND IS DELETED.
  *
- * Validation is deliberately lenient: each field is checked for presence and
- * primitive type, not exhaustive schema conformance.
+ * It was a one-line projection of `readDecisionReviewWireState` —
+ * `state.kind === 'm1' ? state.review : null` — with **zero production callers**
+ * at the tip that removed it (complete manifest over `src/`: the only remaining
+ * mentions are prose in this file, in `V5AnalysisResultBlock.tsx`, and in
+ * `ContractIntegrityTab.tsx`'s note about the same-named local it renamed away
+ * from). Its two specs kept calling it, which is what made it look live.
  *
- * ⚠ A `null` from this function means "no M1 payload here". It does **not**
- * mean the turn carried no decision review, and it must **not** be used to
- * mount an invalid-enrichment marker — that inference is exactly the bug
- * ROADMAP 2.154 fixed. Use `readDecisionReviewWireState` for that question.
+ * ⚠ THE DANGER IT CARRIED IS THE REASON IT IS GONE, NOT ITS LINE COUNT. Its own
+ * docstring had to warn, in bold, that a `null` from it must NEVER be read as
+ * "the turn carried no decision review" — because that exact inference IS the
+ * ROADMAP 2.154 defect: the card mounted an invalid-enrichment marker on every
+ * live turn by treating this function's `null` as malformed-ness. A zero-caller
+ * export whose contract needs a warning about the bug it already caused once is
+ * a loaded gun in a drawer.
+ *
+ * The M1 BRANCH ITSELF STAYS (`validateM1Payload` above, reached by
+ * `readDecisionReviewWireState`). That branch is a documented conservative call
+ * against a named residual gap in the producer sweep — see the header's
+ * "Why the M1 branch is KEPT" section — and the M1 coverage that used to run
+ * through this wrapper now runs through a one-line local helper in
+ * `__tests__/decisionReviewAdapter.test.ts`, so the branch is tested through the
+ * public API every real caller uses.
  */
-export function extractDecisionReview(
-  enrichment: Record<string, unknown> | undefined,
-): CeeDecisionReviewPayloadV1 | null {
-  const state = readDecisionReviewWireState(enrichment)
-  return state.kind === 'm1' ? state.review : null
-}

--- a/tests/contracts/no-evpi-display.contract.test.ts
+++ b/tests/contracts/no-evpi-display.contract.test.ts
@@ -50,6 +50,7 @@ import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import { refutedClaimsForScope } from '../../src/components/results/__tests__/helpers/refutedEvpiClaimMatchers'
 
 const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
 
@@ -243,24 +244,43 @@ describe('no EVPI figure reaches a display module', () => {
  * EVPI identifier sat on an enclosing line). Two guards keyed on different
  * things is the point: one on the quantity, one on the sentence.
  */
-const FORBIDDEN_COPY: Array<[RegExp, string]> = [
-  [/would improve confidence by/i, 'the "Worth Xpp if resolved" factor chip'],
-  [/resolving could improve confidence/i, 'the "Resolving could improve confidence by up to Xpp" line'],
-  [/pp via EVPI/i, 'the StatusBar chip that SUMMED three refuted figures'],
-  [/ranked by EVPI/i, 'the visible factor-list sort label'],
-]
+/**
+ * ⭐ R-1 — DERIVED FROM THE SHARED VOCABULARY, NOT DECLARED HERE.
+ *
+ * This used to be a hand-written table plus a hand-written parallel array of
+ * control strings, positionally zipped. `src/components/results/__tests__/helpers/
+ * refutedEvpiClaimMatchers.ts` held a SECOND table of the same vocabulary, whose
+ * own header claimed to be "the ONE definition of the banned
+ * value-of-information vocabulary" — and the two had already drifted apart in
+ * BOTH directions: this table had `/would improve confidence by/i`,
+ * `/pp via EVPI/i` and `/ranked by EVPI/i` that the render-time guard lacked,
+ * while that one had `PP_TOKEN` and `WORTH_CLAIM` that this scan lacked. The
+ * StatusBar sentence was therefore outside the render vocabulary and the refuted
+ * quantity's own token was outside this one. Both guards green.
+ *
+ * There is now one table, and each row declares which consumers may apply it.
+ * `PP_TOKEN` is deliberately NOT in the `'source'` scope — see the scope
+ * docstring there; a bare "5pp" is legitimate in comparison-threshold code.
+ *
+ * The control strings come with the patterns, so the positional zip is gone: a
+ * new pattern cannot arrive without the string it must match.
+ */
+const FORBIDDEN_COPY: Array<[RegExp, string]> = refutedClaimsForScope('source').map(
+  (r) => [r.pattern, r.what],
+)
 
 describe('the removed user-facing copy does not come back under another name', () => {
   it('POSITIVE CONTROL: every pattern fires on the string it was written to catch', () => {
-    const originals = [
-      'Worth {evpiPp}pp if resolved: your knowledge of {label} would improve confidence by {evpiPp} percentage points',
-      'Resolving could improve confidence by up to {Math.round(actionItem.evpiPp)}pp',
-      'label: `${Math.round(top3Sum)}pp via EVPI`,',
-      "sortNote={hasRobustnessData && evpiMap.size > 0 ? 'ranked by EVPI' : undefined}",
-    ]
-    originals.forEach((s, i) => {
-      expect(FORBIDDEN_COPY[i][0].test(s), `pattern ${i} must see: ${s}`).toBe(true)
-    })
+    const rows = refutedClaimsForScope('source')
+    // A SHRUNK vocabulary must red rather than quietly check less — the same rule
+    // the two honesty specs apply to their own projection.
+    expect(rows.length).toBeGreaterThanOrEqual(5)
+    // Zipped BY ROW, not by index into a second array. The previous form paired
+    // `FORBIDDEN_COPY[i]` with `originals[i]`, so reordering either list silently
+    // controlled the wrong pattern.
+    for (const { pattern, control, what } of rows) {
+      expect(pattern.test(control), `[${what}] must see: ${control}`).toBe(true)
+    }
   })
 
   it('no display source contains any of the removed sentences', () => {


### PR DESCRIPTION
## DO NOT MERGE

Gated review PR. `/simplify` sweep-2's **UI apply lane** — the accepted UI findings of
`PHASE0-EVIDENCE-2026-07-28/simplify-findings-sweep2.md`, applied.

Behaviour-preserving throughout **except three deliberate fixes**, each with its own
RED-first pin and mutation proof. LATER/rowed/fence-rider items are out of scope;
`useConversation.ts` was never opened (R-16 is a fence rider, not this lane's).

---

## The three behaviour fixes

### R-4 — a raw wire id was being printed to users as copy

`V5AnalysisResultBlock` resolved story-headline labels as `optionLabels.get(id) ?? id`,
under a comment arguing *"showing the raw id is honest; showing nothing would silently
drop a headline the producer paid for."* The first clause is false and the second is a
false dilemma:

- the live payloads' `story_headlines` keys are `opt_status_quo` / `opt_hubspot` — a
  direct `RAW_ID_PATTERN` match — so the fallthrough fires exactly when
  `option_comparison` misses, and it **can** miss: the wire ships a sibling
  `option_comparison_status` field precisely because that array is not guaranteed;
- **both sibling blocks in the same directory already refuse to**, through one shared
  policy — `resolveCanvasLabel` returns `null` rather than the id ("that is the whole
  point … there is no way to accidentally fall through to the identifier") and also
  rejects a stored label that is ITSELF a raw id, because upstream sometimes seeds a
  node's label from its id. This card was a **third** policy in that folder, and the
  weakest of the three;
- **nothing is dropped.** The headline still renders; only the unnameable label is
  omitted. That is `V5ExplanationBlock`'s rule applied where `V5FlipAnalysisBlock`'s
  reason to keep the row also holds. The id survives as the `data-option-id` machine
  reference, which the allowlist permits and both siblings keep.

It also gains the **canvas-store tier** the bespoke resolver skipped entirely, so a
label that IS in the store is no longer unused. Payload tier wins, store as fallback,
both through the null-refusing resolver.

Payload-first is deliberate: it keeps every headline whose payload label is a genuine
human string rendering byte-identically. **The one currently-labelled case that DOES
change is a payload label that is itself raw-id-shaped** — `RAW_ID_PATTERN` now rejects
it and the label is omitted. That is not collateral, it is half the fix: upstream
sometimes seeds a label from its own id, and without that guard the leak simply moves
one hop upstream and still reaches the user. It is pinned by its own test in both specs.

**The old behaviour was PINNED** by a test titled *"an unresolvable option id falls back
to the raw id rather than rendering nothing."* Applying the fix turned that one test RED
while 60 others in the file — including the labelled control and every live-payload
render pin — stayed green. It is **replaced, not deleted**, and the replacement records
why.

| mutant | result |
|---|---|
| restore `?? h.optionId` | **RED** — 4 failures across two specs; `opt_unknown`, `opt_status_quo`, `opt_ghost`, `opt_london` all resurface as copy |
| drop the canvas-store tier | **RED** — 1 failure, the store-tier test |

### A-3b's two findings — field loss on the `edit_graph` receipt path

The new whole-`data` parity assertion compares the FULL bag the two hand-mirrored
ingestion mappers build. Everything before it pinned `validation` **only** — one field
of a bag the two claim to build identically, so the suite would have been just as green
if the next field had been added to one hop only. **It found two on its first run.**

**1. `strengthStdSource` — DEFECT.** Hop 1 passed `strengthStd` to
`edgeValueSourcePatch`; hop 2 passed only `beliefExists` and `weight`. But `strengthStd`
**is** one of the three `EDGE_PROVENANCED_FIELDS` (`domain/edgeValueProvenance.ts:75`).
So an `add_edge` receipt carrying `strength.std` wrote the VALUE with **no source
stamp**, and every display surface that reads the stamp treated a real CEE estimate as
never set — the inverse of the laundering `edgeProvenanceLaundering.sourceScan.spec.ts`
guards, arriving through the mirror instead of through a spread.

**2. `provenanceDisplay` — DEFECT.** Hop 1 applied `edgeProvenanceDisplayPatch(e)`; hop
2 never applied it, so a receipt's `provenance_display` was dropped outright.

<details>
<summary><b>Adjudication — can the receipt even carry it?</b> (derived, not assumed)</summary>

The question mattered: if the receipt were structurally incapable of carrying the
field, hop 2 omitting the patch would be correct rather than a defect.

- `provenance_display` appears **NOWHERE** in the pinned `@talchain/schemas` 0.30.0 —
  zero matches across the whole package. The contract neither declares nor forbids it.
- `DraftGraphBlockSchema.edges` is `z.array(z.unknown())`
  (`dist/boundary/blocks.js:209`) — the DRAFT edge hop 1 reads it from is itself
  untyped by the contract; the field's only declaration is the UI's own
  `src/adapters/cee/types.ts:74` / `:135`.
- the receipt's carrier `PatchOperation.data` is `Record<string, unknown>`
  (`src/canvas/conversation/types.ts:464`) — fully **OPEN**.

**Verdict: not structurally incapable.** Both hops read an open bag; only one looked.
DEFECT, same field-loss class as 2.154. Sharing hop 1's helper also shares its CLOSED
vocabulary gate (`from_brief` / `ai_inferred` / `user_set`), so an unrecognised value
still maps to nothing.
</details>

Both fixed in hop 2, **RED-first**: the 4 presence assertions were written and run
against unfixed hop 2 — all 4 RED, absence arms green.

| mutant | result |
|---|---|
| revert hop 2 `strengthStd` stamp | **RED** — 3 failures, incl. the stale-disclosure arm demanding the entry back |
| revert hop 2 `edgeProvenanceDisplayPatch` | **RED** — 3 failures, same shape |
| break the shared `readValidationMetadata` (S2-7) | **RED** — 4 in the mirror spec, 2 in the merge validation spec |

`KNOWN_HOP_DIVERGENCES` is now **empty**, and the two hops build a byte-identical `data`
bag. The set fails loud in **both** directions — a new divergence reds (not in the set),
a stale entry reds (set over-states) — so no exception can outlive the defect it names.

---

## ⚠ Two guards found their own authors out. Both are recorded, not quietly fixed.

**A-3a's first detector was VACUOUS.** It asked whether the rebuilt `data` body matched
`/\.\.\.\s*\(?[^)]*\b<ident>\s*\.\s*data\b/`. `[^)]*` skips across arbitrary text, so
ANY `...` anywhere in the bag followed later by ANY mention of `edge.data` satisfied it
— and a named-field copy contains both (`...DEFAULT_EDGE_DATA,` and
`weight: edge.data?.weight`). **The seeded mutation left the scan GREEN**: it reported
"all rebuilds are wholesale" while reading one that was not. Guard theatre, committed
inside the file written to prevent guard theatre. **Only the mutation check caught it**
(CLAUDE.md trap 15: your own script is not exempt). Fixed by splitting the bag into
real spread elements, depth-tracked to the member comma.

**A-3b's stale-disclosure arm refused this PR's own first draft**, which recorded
`provenanceDisplay` as differing while its fixture used a provenance value outside the
closed vocabulary — so neither hop emitted the key and the "divergence" was an artefact
of the fixture. An unverified claim, refused by the control written to refuse it.

---

## Everything else (no behaviour change)

<details>
<summary><b>SIMPLIFICATION — S2-1..8</b></summary>

- **S2-1** `FactorList` leaf — the two byte-identical stability/fragility blocks,
  including a verbatim duplicated index-key rationale.
- **S2-2** `extractDecisionReview` **deleted** — zero production callers (complete
  manifest over `src/`; the remaining mentions are prose in three files). Its own
  docstring had to warn in bold that a `null` from it must never be read as "the turn
  carried no decision review", because that inference IS the 2.154 defect. A
  zero-caller export whose contract needs a warning about the bug it already caused is
  a loaded gun in a drawer. M1 coverage moved to a one-line local helper reached
  through the public API. **The M1 BRANCH stays** — documented conservative call,
  untouched.
- **S2-3** `readV0_30`'s three-outcome union → nullable. Both non-ok arms have mapped
  to `malformed` at the single caller ever since A2 put M1 first — two names, three
  lines of dispatch, one behaviour. The two STALE pre-A2 comments ("caller may try M1",
  "what lets the M1 branch still get a look") deleted.
- **S2-4** the three list readers return `[]` for absent, via `ListRead<T>` with **no
  null arm** — the four `?? []` coalesces are gone and now unrepresentable.
  Container-kind strictness (the A1 fix) untouched.
- **S2-5** `readProseField` delegates the blankness rule to `prose()`.
- **S2-6** the five-row producer manifest lives **once**; `applyV5State` holds a
  pointer, not a copy with its own line numbers. That manifest was wrong twice in its
  history — a second copy mirrors a list whose entire history is silent drift.
- **S2-7** one exported `readValidationMetadata` in `canvas/domain/edges.ts`, beside
  the `z.unknown()` slot and the `DEFAULT_EDGE_DATA` absence it depends on, called from
  **both** mapper hops. ~30 lines of duplicated rationale collapse to one; lockstep for
  this field becomes structural. The mirror spec stays as belt.
- **S2-8** `isUsableRow` — the redundant `typeof === 'number'` before `Number.isFinite`
  removed (the ES2015 static does not coerce, so it already carried the PRESENT half);
  the two bands named `RENDERABLE_STATUSES` so the docstring's "CLOSED enum" claim is
  structural rather than two `||`-ed literals.
</details>

<details>
<summary><b>EFFICIENCY — E-1, E-2</b></summary>

- **E-1** `memo()` on `V5AnalysisResultBlock`, house `memo(fn)` + `displayName`
  convention. The label map is memoised on `[canvasLabels, enrichment]` — the payload
  map builder is called INSIDE the memo, because calling it outside would change the
  dependency every render and make the memo inert.
- **E-2** `sameValue` undefined short-circuit in `mergeAppliedGraph.ts`. The dominant
  call is `sameValue(mappedValue, baseline[key])` where the baseline has no entry —
  the deliberate case for `validation`, which carries no `DEFAULT_EDGE_DATA` default by
  design. `JSON.stringify` then serialised the whole validation bag per edge to compare
  it against literal `undefined`, ~150-250KB of immediate garbage per applied-edit
  receipt.
  **Behaviour-identical on every reachable input, and the one unreachable exception is
  named rather than glossed:** a value `JSON.stringify` also renders as `undefined` (a
  function or symbol) was previously reported EQUAL to `undefined`. Both sides of all
  four call sites are mapper output over parsed wire JSON, so neither can be one; if
  one arrived, the new answer sends the key down the over-applying path this module
  already declares fail-safe.
</details>

<details>
<summary><b>REUSE — R-1, R-3, R-6, R-10, R-11, R-12</b></summary>

- **R-1** ONE banned-EVPI table. The two **had already diverged in both directions** —
  the contract's `FORBIDDEN_COPY` held `/would improve confidence by/i`,
  `/pp via EVPI/i`, `/ranked by EVPI/i` the render-time helper lacked; the helper held
  `PP_TOKEN` + `WORTH_CLAIM` the contract scan lacked. **Both files' headers claimed to
  hold "the ONE definition."** Now one `REFUTED_CLAIM_VOCABULARY` with per-row `scopes`
  (`'dom'` / `'source'`), both consumers deriving. `PP_TOKEN` is deliberately
  `'dom'`-only: a bare "5pp" is legitimate in comparison-threshold code, and reddening
  on it would teach the next lane to widen the exemption list — which is how a real
  violation later hides behind a plausible exception.
  **A SEVENTH copy surfaced while doing this** — an inline `/ranked by EVPI/i`, written
  precisely because the pattern was not in the table that file imported. All three DOM
  sweeps now **iterate** the vocabulary instead of naming patterns, so a new pattern
  extends the sweep automatically.
- **R-3** the supabase/`useScenario` harness extracted. `vi.mock` SPECIFIERS stay
  per-file (they resolve relative to the calling file, and the two specs sit at
  different depths); the factory BODIES and mock state moved. The copy had already
  diverged in the direction that **loses reach** — `scenarioRow(id, edges)` with `graph`
  hard-wired, so it could not vary nodes or framing; the harness keeps the ORIGINAL's
  `(id, graph)` signature plus a convenience wrapper.
- **R-6** `readInferenceWarnings` exported — as a **leaf**, not from the 3,000-line
  hook (`GoalNode` renders per canvas node; importing the hook there would drag it into
  the canvas bundle). Adopted at the one behaviour-identical copy. **Stopped at the
  other two** — see below.
- **R-10** `counts()` + the store-seeding field set moved to a shared `__helpers__`
  module (not a spec import — importing the sibling spec would execute its
  `describe`/`beforeEach` inside the importer). The `lastAuthoritativeGraph: null`
  **leak guard**, whose rationale existed in only one of the two copies, now has one
  home. The validation spec asserted **2 of 6** counters because it skipped `counts()`;
  it now asserts all six — the stronger rule the sibling's own docstring states.
- **R-11** `ClampToggle` extracted for "the two verbatim copies" — **there were three.**
  The third is byte-identical down to the focus-ring class and could not consume the
  extraction because it was module-private. A private extraction that leaves a
  reachable copy behind converts one duplication into a duplication *plus a claim to
  have removed it*. The two same-named copy functions now reference one
  `clampRevealLabel`; both property names kept so consumers and copy-hygiene manifests
  are unchanged.
- **R-12** `openEvidence(evidence, view)` parameterised over the tab, plus
  `openDisclosureHeader` / `switchEvidenceView` primitives. **18 inline click sites
  absorbed across 5 specs; zero inline copies of the open sequence remain in any spec**
  (derived: `rg "Why, and what could change it"` over `*.spec.tsx` outside the helper
  returns 0). The `fireEvent`-not-`node.click()` rationale — the raw call escapes
  `act()`, the disclosure never re-renders, and every later assertion reads a COLLAPSED
  section, a false green that looks exactly like a real one — lived on the older copy
  only; it now lives with the click.
</details>

<details>
<summary><b>ALTITUDE — A-1, A-3a, guards.ts</b></summary>

- **A-1** the decision-review discriminator bound to the pinned schema:
  `EnrichmentDecisionReviewSchema.pick({produced_at: true})`, following the live
  `voiRanking.ts` precedent. A hand-rolled `typeof` would keep compiling if the
  contract renamed the pin, and the failure would be SILENT and TOTAL — every live
  payload reclassified, which is the whole-payload drop 2.154 exists to have fixed.
  **Scope claimed narrowly:** that schema declares `produced_at` and nothing else (it
  is `.passthrough()`), so the five prose readers are FORCED, and the trichotomy is
  already declared by the parent. This binding buys exactly the discriminator.
- **A-3a** `edgeDataRebuildScan.spec.ts` — a DERIVED source scan over `src/`, modelled
  on the sibling provenance scan including `blankNonCode` and a positive control. The
  OUTER `...edge,` spread is the load-bearing signal: it identifies the input as an
  existing canvas edge, and it is what a named-field-copy mutation does NOT touch, so
  the site stays visible exactly when it starts violating. A detector keyed on the
  inner spread goes blind at the moment of the defect. Fresh constructions (blueprint
  insert, user `onConnect`, the two clarifier paths, the two ingestion mappers) are
  excluded **structurally, with no allowlist**.
  RED at two distinct seeded sites (`useScenario.ts` hop 4, `store.ts` hop 5), GREEN
  unmutated, and the `blankNonCode` property is its own test — `edgeValueProvenance.ts`
  quotes the hunted shape in a JSDoc block and must not be reported.
- **guards.ts** the canonical `isRecord` home, with the two consumers whose files were
  already open. **8 definitions → 6 plus the home**, so the file is not itself copy
  nine. `ceeRecovery.ts` deliberately not folded in — its docstring declares it "a
  zero-dependency pure leaf … imports nothing" and that property is load-bearing for
  the narrow gate it is covered by; re-deciding it belongs to the rowed migration.
</details>

---

## Stopped, with reasons — recorded in code, not only here

- **R-6 at `ModelTabBody.tsx` and `analysisSnapshotFactory.ts`.** Both read the
  `robustness` slot ONLY, measured **0/773** on live facts, so they are permanently
  blank — giving them the dual read makes them start **populating**. That is a
  behaviour change, and this lane's sanctioned behaviour changes are R-4 plus the two
  adjudicated divergences, each with its own pin. What appears in the Model card's
  audit row is a product judgement wanting its own RED-first pin;
  `extractInferenceWarnings` also takes only `V2RunResponse['robustness']` and
  normalises to `string[]`, so adoption needs a call-site change too. **Recorded in the
  shared reader's own docstring**, naming both sites and both reasons, so it cannot be
  lost.
- **Four out-of-directory `Show ${n} more` copies** (`strengthenCopy`,
  `coaching-panel/constants`, `pre-analysis-v3/constants`, `heroCopy`) — pre-existing,
  four other panels with their own copy modules and copy-hygiene suites. Unifying
  user-facing copy across panels is a copy decision, not a refactor. Named in
  `ClampToggle.tsx` so the next reader knows the count is six, not two.

---

## Base moved twice; disjointness derived both times

| move | commits | overlap with this lane's 38 files |
|---|---|---|
| `3be7124a` → `e42bcaa5` | #536 (gate-script lane) | **none** |
| `e42bcaa5` → `95f54458` | #534 (stop fence, merged), #537, #538 | **none** |

`comm -12` empty both times. The fence PR #534 — whose `useConversation` stop paths this
lane was told to avoid — merged mid-lane; its eight files do not intersect these
thirty-eight, and `useConversation.ts` was never opened.

## ⚠ Two full-suite runs voided — the tree moved under the measurement, twice

1. **The first baseline** ran in the working clone *while editing was underway*. Vitest
   reads files as it collects, so it sampled a mixture of pre- and post-edit sources —
   its "3 failures" were this lane's own new tests read against a half-applied
   component.
2. **The first after-run** was mid-flight when the rebase landed three commits' worth
   of files under it.

Both voided rather than reported. Both are recorded because both failures were
**silent** — a contaminated run exits 0 and reads as authoritative. The reported pair is
baseline `95f54458` (pristine clone, never edited) vs after `95f54458` + this commit
(working clone, tree clean and untouched for the whole run) — one base, both halves,
diffed **per-file by NAME** because totals hide a regression in one file behind
additions in another.

**Result: 1379 → 1380 files, 20734 → 20751 tests, 0 failures on both sides, 0 new
failures, and nothing disappeared from collection.** Every one of the 6 moved files
is attributed and the arithmetic reconciles to `+17` exactly (see the evidence).
⚠ One file's count DECREASED by 2 and it is **not** a coverage loss: R-1 replaced
three `it` blocks plus a hand-inlined seventh copy of the banned vocabulary with one
block iterating the unified table, in each of three sweeps — pattern applications
went 9 + 1 inline → **18**. A count diff reads that as a regression; it is the
opposite.

## Gates

| gate | result |
|---|---|
| `pnpm run typecheck` | **PASS** at exactly baseline — 622 files / 2510 errors |
| `pnpm run typecheck:selftest` | **PASS** — 18/18 |
| `npx eslint` (changed files) | **PASS** — 0 errors; 2 warnings proved pre-existing by running the same file in the pristine clone |
| `check-zustand-selectors.mjs` | **PASS** |
| `check-duplicates.mjs` | **PASS** |
| full suite | **baseline 20734 / after 20751 tests, 0 failures both sides** (matched pair at `95f54458`) |

**NO baseline / exception / ratchet changes.** The gate initially reported 4 new errors;
all four fixed at cause — three unused imports left by the R-12 absorption, and one real
`string | undefined` narrowing where the S2-8 rewrite needed an explicit presence check
(`status` is `z.string().optional()` on the wire).

Evidence: `PHASE0-EVIDENCE-2026-07-28/simplify-apply-ui-2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
