### PR TITLE
Adopt inference_warnings dual read at both stopped readers (ROADMAP 2.173)

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -34,8 +34,9 @@ import { RelationshipsSection } from './model-tab/RelationshipsSection'
 import type { UserAction, ValidationMetadata } from '../domain/validation'
 import type { EdgeData } from '../domain/edges'
 import { RisksSection } from './model-tab/RisksSection'
-import { ModelHealthSection } from './model-tab/ModelHealthSection'
+import { ModelHealthSection, type AuditTrailData } from './model-tab/ModelHealthSection'
 import { normalizeAutoNoiseProvenance } from '../../components/results/types'
+import { readInferenceWarnings } from '../../components/results/utils/readInferenceWarnings'
 import { ModelTabHeader } from './model-tab/ModelTabHeader'
 import { ReanalyseBar } from './model-tab/ReanalyseBar'
 import { ModelFooter } from './model-tab/ModelFooter'
@@ -315,8 +316,16 @@ export const ModelTabBody = memo(function ModelTabBody({
     nSamples: rawV2Response?.meta?.n_samples ?? null,
     repairsApplied: repairsApplied ?? null,
     inferenceWarnings: (() => {
-      const raw = (results?.report as any)?.robustness?.inference_warnings
-      return Array.isArray(raw) ? raw : null
+      // ROADMAP 2.173 (Paul-ratified 2026-07-30): shared dual read — ROOT
+      // slot first, then the legacy `robustness` nesting. This read was
+      // robustness-only, which is empty on every live run (0/827 measured
+      // 2026-07-30; root 419/827 non-empty), so the ModelHealthSection
+      // banner and audit row were permanently blank. See
+      // readInferenceWarnings' header for the adoption history.
+      const raw = readInferenceWarnings(results?.report as never)
+      return Array.isArray(raw)
+        ? (raw as NonNullable<AuditTrailData['inferenceWarnings']>)
+        : null
     })(),
     recommendationStability: robustness?.recommendationStability ?? null,
     // Legacy fallback: older PLoT builds emitted the flag under `_meta`

--- a/src/canvas/components/__tests__/ModelTabBody.inferenceWarnings.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.inferenceWarnings.spec.tsx
@@ -1,0 +1,167 @@
+/**
+ * ModelTabBody — inference-warnings adoption pin (ROADMAP 2.173, Paul-ratified
+ * 2026-07-30; evidence: PHASE0-EVIDENCE-2026-07-28/inference-warnings-derivation.md).
+ *
+ * The Model card's audit-trail `inferenceWarnings` was one of the two STOPPED
+ * readers recorded in `readInferenceWarnings.ts`: it read ONLY the legacy
+ * `report.robustness.inference_warnings` slot, which is empty on every live
+ * run (0/827 measured 2026-07-30), while the real data lives at the report
+ * ROOT (419/827 non-empty). So the ModelHealthSection banner ("N factors have
+ * no value set") and the codes-only audit row were permanently blank.
+ *
+ * Pin: a fixture carrying ROOT-slot `inference_warnings` renders both
+ * surfaces. RED before the ModelTabBody swap to the shared dual reader,
+ * GREEN after.
+ *
+ * Controls:
+ *  - legacy-slot payload still renders both surfaces (the dual read's second
+ *    arm is not dead — positive control against a root-only regression);
+ *  - absent warnings in BOTH slots → neither surface renders, while the rest
+ *    of the audit block still does (no new blank-state regression).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+let mockCanvasState: any
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    (selector: (s: any) => unknown) => selector(mockCanvasState),
+    { getState: () => mockCanvasState },
+  ),
+}))
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign(
+    (selector: (s: any) => unknown) => selector({ pendingModelTabSection: null }),
+    { getState: () => ({ requestModelTabSection: vi.fn() }) },
+  ),
+}))
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+// Stub the heavy section tree. ModelTabHeader stays REAL (it provides
+// DetailToggleContext, which gates the audit row under test) and
+// ModelHealthSection stays REAL (it renders both surfaces under test).
+vi.mock('../model-tab/StatusBar', () => ({ StatusBar: () => null }))
+vi.mock('../model-tab/EntityBar', () => ({ EntityBar: () => null }))
+vi.mock('../model-tab/GoalSection', () => ({ GoalSection: () => null }))
+vi.mock('../model-tab/OptionsSection', () => ({ OptionsSection: () => null }))
+vi.mock('../model-tab/FactorsSection', () => ({ FactorsSection: () => null }))
+vi.mock('../model-tab/RelationshipsSection', () => ({ RelationshipsSection: () => null }))
+vi.mock('../model-tab/RisksSection', () => ({ RisksSection: () => null }))
+vi.mock('../model-tab/ModelAdjustments', () => ({ ModelAdjustments: () => null }))
+vi.mock('../model-tab/StreamingDiagnostics', () => ({ StreamingDiagnostics: () => null }))
+vi.mock('../model-tab/ReanalyseBar', () => ({ ReanalyseBar: () => null }))
+vi.mock('../model-tab/ModelFooter', () => ({ ModelFooter: () => null }))
+
+import { ModelTabBody } from '../ModelTabBody'
+
+const NODES: Node[] = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+  { id: 'fac-1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor' } },
+]
+
+// Shapes mirror live staging items (code/message/severity, per the 2026-07-30
+// probe): one ROOT_NODE_DEFAULT_VALUE (drives the banner) plus one other code
+// (proves the audit row lists ALL codes, not just the banner's).
+const WARNING_ITEMS = [
+  {
+    code: 'ROOT_NODE_DEFAULT_VALUE',
+    severity: 'info',
+    message: "No observed value provided for root node 'fac-1'; defaulted to 0.0.",
+  },
+  {
+    code: 'CONSTRAINT_TARGET_UNRELIABLE',
+    severity: 'warning',
+    message: 'The success target cannot be evaluated reliably.',
+  },
+]
+
+function renderModelTab() {
+  return render(
+    <ModelTabBody
+      showDebug={false}
+      hasDiagnostics={false}
+      diagnostics={null}
+      hasTrim={false}
+      effectiveCorrelationId={null}
+      correlationMismatch={false}
+      correlationIdHeader={null}
+      nodes={NODES}
+      edges={[]}
+      robustness={null}
+      expertMode
+    />,
+  )
+}
+
+function setReport(report: Record<string, unknown>) {
+  mockCanvasState = {
+    ...mockCanvasState,
+    results: { status: 'complete', report },
+  }
+}
+
+beforeEach(() => {
+  mockCanvasState = {
+    updateEdge: vi.fn(),
+    ceeAnalysisReady: null,
+    ceePipelineTrace: null,
+    repairsApplied: null,
+    results: { status: 'complete', report: {} },
+    hasCompletedFirstRun: true,
+    // Non-warning audit signal, so the audit block renders in EVERY case and
+    // the absence control below measures the warnings row, not the block.
+    rawV2Response: {
+      meta: { seed_used: '4242', n_samples: 1000 },
+      response_hash: 'resp-hash-1',
+    },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    currentScenarioId: null,
+    currentStage: null,
+    v5AnalysisFact: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set() },
+  }
+})
+
+describe('ModelTabBody — inference_warnings dual read (ROADMAP 2.173)', () => {
+  it('ROOT-slot warnings render the ModelHealthSection banner and the codes-only audit row', () => {
+    setReport({ inference_warnings: WARNING_ITEMS })
+    renderModelTab()
+
+    // Banner: 1 ROOT_NODE_DEFAULT_VALUE item → "1 factor has no value set"
+    expect(screen.getByTestId('root-node-warning')).toBeInTheDocument()
+    expect(screen.getByText(/1 factor has no value set/)).toBeInTheDocument()
+
+    // Audit row: codes only, comma-joined — never messages
+    expect(screen.getByText(/Inference warnings:/)).toBeInTheDocument()
+    expect(
+      screen.getByText('ROOT_NODE_DEFAULT_VALUE, CONSTRAINT_TARGET_UNRELIABLE'),
+    ).toBeInTheDocument()
+  })
+
+  it('LEGACY control: robustness-slot-only warnings still render both surfaces (second arm not dead)', () => {
+    setReport({ robustness: { inference_warnings: WARNING_ITEMS } })
+    renderModelTab()
+
+    expect(screen.getByTestId('root-node-warning')).toBeInTheDocument()
+    expect(
+      screen.getByText('ROOT_NODE_DEFAULT_VALUE, CONSTRAINT_TARGET_UNRELIABLE'),
+    ).toBeInTheDocument()
+  })
+
+  it('ABSENCE control: no warnings in either slot → neither surface, audit block still renders', () => {
+    setReport({})
+    renderModelTab()
+
+    expect(screen.queryByTestId('root-node-warning')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Inference warnings:/)).not.toBeInTheDocument()
+    // The audit block itself still renders off the non-warning signal —
+    // adoption must not regress the current empty state.
+    expect(screen.getByTestId('model-health-audit')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * analysisSnapshotFactory — inference-warnings root-wins adoption pin
+ * (ROADMAP 2.173, Paul-ratified 2026-07-30; evidence:
+ * PHASE0-EVIDENCE-2026-07-28/inference-warnings-derivation.md).
+ *
+ * `extractInferenceWarnings` was one of the two STOPPED readers recorded in
+ * `readInferenceWarnings.ts`: it read ONLY `robustness.inference_warnings`,
+ * which is empty on every live run (0/827 measured 2026-07-30), while the
+ * real data lives at the response ROOT (419/827 non-empty). The persisted-run
+ * rebuild path already compensated (`persistedRunSnapshotFactory`'s
+ * `composeRobustness` folds root→robustness before calling the factory), so
+ * the SAME Compare surface was populated for rehydrated snapshots and
+ * permanently `[]` for live-captured ones — the warnings-resolved/introduced
+ * diff compared `[]` to `[]` on every live pair.
+ *
+ * Pin: a rawV2Response carrying ROOT-slot `inference_warnings` produces a
+ * snapshot that carries them, and the Compare diff sees them. RED before the
+ * factory adopts the root-wins dual read, GREEN after.
+ *
+ * Coherence pin: both `buildAnalysisSnapshot` callers (live capture and
+ * persisted rebuild) produce the SAME snapshot warnings for the SAME
+ * enrichment — including that the rehydrate path's existing fold is not
+ * double-applied.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import { buildSnapshotFromPersistedRun } from '../persistedRunSnapshotFactory'
+import { deriveRunPairComparison } from '../../compare-tab/deriveRunPairComparison'
+import { makePersistedRunFactRow } from '../../compare-tab/__tests__/__fixtures__/persistedRunFact'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+function build(rawOverrides: Record<string, unknown>) {
+  return buildAnalysisSnapshot({
+    rawV2Response: {
+      analysis_status: 'computed',
+      option_comparison_status: 'computed',
+      robustness_status: 'unavailable',
+      drivers_status: 'unavailable',
+      option_comparison: [
+        {
+          option_id: 'opt-1',
+          option_label: 'Option A',
+          win_probability: 0.6,
+          confidence_interval: [0.3, 0.7],
+          expected_outcome: 0.5,
+        },
+      ],
+      critiques: [],
+      response_hash: 'resp-1',
+      ...rawOverrides,
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+// Live shape (2026-07-30 probe): objects with code/message/severity at the
+// response ROOT. The factory normalises to message-first strings.
+const ROOT_ITEMS = [
+  { code: 'ROOT_NODE_DEFAULT_VALUE', severity: 'info', message: 'Root node defaulted to 0.0' },
+  { code: 'CONSTRAINT_TARGET_UNRELIABLE', severity: 'warning', message: 'Target withheld for this run' },
+]
+
+describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROADMAP 2.173)', () => {
+  it('ROOT-slot warnings reach the snapshot (the live-capture path)', () => {
+    const snap = build({ inference_warnings: ROOT_ITEMS })
+    expect(snap.inferenceWarnings).toEqual([
+      'Root node defaulted to 0.0',
+      'Target withheld for this run',
+    ])
+  })
+
+  it('LEGACY control: robustness-nested warnings are still read (second arm not dead)', () => {
+    const snap = build({ robustness: { inference_warnings: ['nested warning'] } })
+    expect(snap.inferenceWarnings).toEqual(['nested warning'])
+  })
+
+  it('ROOT wins when both slots are present (same precedence as composeRobustness)', () => {
+    const snap = build({
+      inference_warnings: [{ message: 'root wins' }],
+      robustness: { inference_warnings: ['nested loses'] },
+    })
+    expect(snap.inferenceWarnings).toEqual(['root wins'])
+  })
+
+  it('ABSENCE control: neither slot → [] (no fabrication, current empty state kept)', () => {
+    const snap = build({})
+    expect(snap.inferenceWarnings).toEqual([])
+  })
+
+  it('Compare diff sees live-captured root warnings (was [] vs [] before adoption)', () => {
+    const from = build({ inference_warnings: [{ message: 'resolved later' }] })
+    const to = build({ inference_warnings: [{ message: 'introduced now' }] })
+    const cmp = deriveRunPairComparison(from, to)
+    expect(cmp.warningsResolved).toEqual(['resolved later'])
+    expect(cmp.warningsIntroduced).toEqual(['introduced now'])
+  })
+
+  it('COHERENCE: live capture and persisted rebuild produce the same warnings for the same enrichment', () => {
+    // One enrichment, byte-shaped from the live fact fixture, fed to BOTH
+    // buildAnalysisSnapshot callers' input shapes.
+    const row = makePersistedRunFactRow({ inferenceWarnings: ROOT_ITEMS })
+    const enrichment = (row.payload as any).result.enrichment
+
+    // Live-capture path: store.ts passes the raw response UNFOLDED.
+    const live = buildAnalysisSnapshot({
+      rawV2Response: enrichment as V2RunResponse,
+      report: {} as ReportV1,
+      nodes,
+      edges,
+      runNumber: 1,
+      events: [],
+      previousSnapshotTimestamp: null,
+    })
+
+    // Persisted rebuild path: composeRobustness folds root→robustness first.
+    const persisted = buildSnapshotFromPersistedRun({
+      row,
+      runNumber: 1,
+      events: [],
+      previousSnapshotTimestamp: null,
+    })
+
+    // Trap-13 guard: the equality below must not hold vacuously ([] === []).
+    expect(live.inferenceWarnings).toEqual([
+      'Root node defaulted to 0.0',
+      'Target withheld for this run',
+    ])
+    expect(persisted).not.toBeNull()
+    expect(persisted!.inferenceWarnings).toEqual(live.inferenceWarnings)
+  })
+})

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -164,9 +164,22 @@ function extractEdgeEValues(
 }
 
 function extractInferenceWarnings(
-  robustness: V2RunResponse['robustness'],
+  response: V2RunResponse,
 ): string[] {
-  const raw = (robustness as Record<string, unknown> | undefined)?.inference_warnings
+  // ROADMAP 2.173 (Paul-ratified 2026-07-30): root-wins dual read, the same
+  // precedence `persistedRunSnapshotFactory`'s `composeRobustness` applies.
+  // This extractor read ONLY `robustness.inference_warnings` — empty on every
+  // live run (0/827 measured 2026-07-30; response ROOT 419/827 non-empty) —
+  // while the persisted-rebuild caller folded root→robustness before calling,
+  // so live-captured snapshots carried `[]` and rehydrated ones carried data:
+  // the same Compare diff was blank or populated depending on capture path.
+  // Reading the root here makes both callers agree without double-folding the
+  // already-compensated rehydrate path (root wins in both). See the coherence
+  // pin in __tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts and
+  // readInferenceWarnings' header for the adoption history.
+  const root = (response as unknown as Record<string, unknown> | undefined)?.inference_warnings
+  const nested = (response?.robustness as Record<string, unknown> | undefined)?.inference_warnings
+  const raw = Array.isArray(root) ? root : nested
   if (!Array.isArray(raw)) return []
   return raw
     .map((w: unknown) => {
@@ -462,7 +475,7 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     goalProbability,
     jointGoalProbability,
 
-    inferenceWarnings: extractInferenceWarnings(robustness),
+    inferenceWarnings: extractInferenceWarnings(rawV2Response),
     conditionalWinners: extractConditionalWinners(robustness),
     edgeEValues: extractEdgeEValues(robustness, nodes, edges),
 

--- a/src/components/results/utils/readInferenceWarnings.ts
+++ b/src/components/results/utils/readInferenceWarnings.ts
@@ -20,21 +20,24 @@
  * `humaniseInferenceWarning` and the other leaves `GoalNode` already imports
  * from. Hook and canvas both import it; there is one definition.
  *
- * ⚠ TWO COPIES DELIBERATELY NOT MIGRATED, because doing so is a BEHAVIOUR CHANGE
- * and not a refactor. Both read the `robustness` slot ONLY, so on live data
- * (0/773) they are permanently blank; giving them this dual read makes them start
- * populating:
+ * HISTORY — TWO COPIES WERE DELIBERATELY NOT MIGRATED, THEN ADOPTED. When this
+ * module was extracted (R-6), two `robustness`-slot-only readers were left in
+ * place and recorded here rather than silently migrated, because populating a
+ * previously-blank surface is a BEHAVIOUR CHANGE and a product judgement, not a
+ * refactor:
  *   · `canvas/components/ModelTabBody.tsx` — the Model card's audit-trail
- *     `inferenceWarnings` row. Reads `results.report.robustness.inference_warnings`
- *     off the SAME `ResultsReport` this function takes, so adoption is a one-line
- *     swap — and would surface an audit row that is empty today.
+ *     `inferenceWarnings` (ModelHealthSection banner + codes-only audit row);
  *   · `canvas/stores/analysisSnapshotFactory.ts` `extractInferenceWarnings` —
- *     takes only `V2RunResponse['robustness']` as its parameter (it has no root
- *     object in scope) and normalises members to `string[]`, so adoption needs a
- *     call-site change as well.
- * Both are real findings and neither is a drive-by: what appears in an audit row
- * is a product judgement and wants its own RED-first pin. Recorded, not silently
- * left behind.
+ *     the Compare-tab snapshot (its persisted-rebuild caller compensated via
+ *     `composeRobustness`'s root-wins fold; the live-capture caller did not, so
+ *     the same Compare surface was blank or populated by capture path).
+ * That judgement was settled: BOTH SITES ADOPTED 2026-07-30, Paul-ratified
+ * (ROADMAP 2.173, decision 2), each behind its own RED-first pin. Evidence:
+ * `PHASE0-EVIDENCE-2026-07-28/inference-warnings-derivation.md` — root slot
+ * 419/827 live facts non-empty, robustness slot 0/827, and the identical items
+ * already displayed on the Analysis tab via this reader. ModelTabBody imports
+ * this function; the snapshot factory mirrors the root-wins precedence inline
+ * (its input is a `V2RunResponse`, not a `ResultsReport`).
  *
  * Returns `unknown`: payload redaction may deliver a `{__truncated, items}`
  * wrapper rather than a bare array, so callers unwrap with `safeArray` or


### PR DESCRIPTION
Paul-ratified decision 2 on ROADMAP 2.173: the two permanently-blank inference-warnings surfaces ADOPT the real data location. Derivation: `PHASE0-EVIDENCE-2026-07-28/inference-warnings-derivation.md` (root slot 419/827 live facts non-empty; robustness slot 0/827). Build log: `PHASE0-EVIDENCE-2026-07-28/infwarn-adopt-build.md`.

Base: `staging` @ `863ea27b` — exactly the derivation tip; every file:line in the derivation re-verified at this tip before editing.

## The three fixes (each RED-first)

1. **ModelTabBody.tsx** — `auditTrail.inferenceWarnings` swaps the robustness-only read for the shared `readInferenceWarnings` (root first, then legacy). Lights the ModelHealthSection "N factors have no value set" banner and the codes-only audit row — blank on every live run until now.
2. **analysisSnapshotFactory.ts** — `extractInferenceWarnings` now takes the full `V2RunResponse` and applies the SAME root-wins precedence `composeRobustness` uses on the persisted-rebuild path (`Array.isArray(root) ? root : nested`), call site passes `rawV2Response`. Live-captured and rehydrated snapshots now agree; Compare's warnings-resolved/introduced diff no longer compares `[]` to `[]` on live pairs. A coherence pin asserts both `buildAnalysisSnapshot` callers produce identical warnings for identical enrichment (no double-fold of the compensated rehydrate path).
3. **readInferenceWarnings.ts docstring** — the "TWO COPIES DELIBERATELY NOT MIGRATED" record is replaced with an adoption-history note: stop reasons preserved, adopted 2026-07-30, Paul-ratified 2.173, evidence file named.

## Evidence

- RED first: pin spec 1 failed 1/3 (banner absent), pin spec 2 failed 4/6 (live path `[]`; coherence pin showed live `[]` vs persisted populated) at the base tip with specs only.
- GREEN after: 3/3 and 6/6.
- Controls: legacy-slot arm proven live on both surfaces; absence → `[]` / current empty state (no blank-state regression).
- Mutation checks (throwaway worktree outside the clone root, removed before gates): reverting fix 1 → pin 1 RED (1 failed); reverting fix 2 → pin 2 RED (4 failed, identical pre-fix profile).
- Gates: `pnpm run typecheck` PASSED at exactly baseline (2510/2510, no ratchet/exception changes); eslint clean on touched files (3 pre-existing warnings proven present at HEAD~); 12 adjacent suites per-file all green (snapshot factories, compare-tab derive*, ModelTabBody*, ModelHealthSection, sourceScan) with Supabase env vars set.

## Out of scope, flagged

`extractConditionalWinners` / `extractEdgeEValues` in the same factory have the same robustness-only read (live-captured snapshots carry `[]` for conditionalWinners/edgeEValues while rehydrated ones get the composeRobustness fold). Same defect class, not covered by the 2.173 ratification — left untouched, recorded in the build log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)