### PR TITLE
refactor(ui): stop-machinery fence riders R-9/R-15/R-16/R-17 (#534 post-merge)

### DIFF
--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -115,7 +115,7 @@ import {
   EARLY_STOP_ALREADY_SAVED_NOTICE,
   EARLY_STOP_UNCONFIRMED_NOTICE,
 } from '../components/DraftLoadingAnimation'
-import { stopV5Turn } from '../../v5/stopTurn'
+import { stopV5Turn, type TurnStopOutcomeKind } from '../../v5/stopTurn'
 import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
@@ -361,6 +361,22 @@ export function inferLoadingHint(message: string, _nodeCount: number, turnType?:
  * button for. Re-exported here so existing importers are unaffected.
  */
 export { START_NEW_DRAFT_CHIP_ID, RETRY_CHIP_ID } from './chipDispatch'
+
+/**
+ * Terminal stop-notice copy, keyed by the server-derived outcome (R-16, fence
+ * rider on #534). A RECORD, not a ternary chain: when a fourth
+ * `TurnStopOutcomeKind` arrives, this table is a COMPILE ERROR until the new
+ * outcome names its copy — the nested ternary it replaces would have silently
+ * routed a fourth kind to its final else branch. The three constants stay
+ * individually exported from `DraftLoadingAnimation`:
+ * `narrationHonesty.invariant.spec.ts` derives its manifest from that module's
+ * `*_NOTICE` exports, and this table only CONSUMES them.
+ */
+const EARLY_STOP_NOTICE_BY_OUTCOME: Record<TurnStopOutcomeKind, string> = {
+  not_saved: EARLY_STOP_NOT_SAVED_NOTICE,
+  already_saved: EARLY_STOP_ALREADY_SAVED_NOTICE,
+  unconfirmed: EARLY_STOP_UNCONFIRMED_NOTICE,
+}
 
 export interface StreamedDraftEligibility {
   turnType: TurnType
@@ -3879,14 +3895,21 @@ export function useConversation(): UseConversationReturn {
       // indistinguishable from a real outage. Caught by the hook spec, which
       // drives the streaming path.
       {
-        // ── `inFlightTurnIdentityRef` — COMPLETE MANIFEST (#534 round-3, F5b) ──
-        //   :2325-ish  new  useRef<{scenarioId,turnId} | null>(null)
-        //   :3883      WRITE  here — every turn kind, before setIsThinking(true)
-        //   :4027      WRITE  the V5 refinement (may mint a scenario id). ⚠ THAT
-        //              SITE HAS ZERO COVERAGE IN THIS PR: every stop-fence test in
-        //              this branch drives the LEGACY streaming seam, so only the
-        //              write here is exercised. Stated rather than implied.
-        //   :~5990     READ   cancelTurn, the only reader.
+        // ── `inFlightTurnIdentityRef` — COMPLETE MANIFEST (#534 round-3, F5b;
+        //    R-17: sites named by SYMBOL, not line number — line refs drift with
+        //    every edit above them, symbols don't) ──
+        //   new    the `useRef<{ scenarioId, turnId } | null>(null)` declaration,
+        //          directly above `explicitlyStoppedTurnIdsRef`
+        //   WRITE  here — the dispatch-time capture, every turn kind, before
+        //          setIsThinking(true)
+        //   WRITE  the V5 refinement (the `Stop-fence: refine the dispatch-time
+        //          capture` block just before `buildV5Payload` — may mint a
+        //          scenario id). ⚠ THAT SITE HAS ZERO COVERAGE IN THIS PR: every
+        //          stop-fence test in this branch drives the LEGACY streaming
+        //          seam, so only the write here is exercised. Stated rather than
+        //          implied.
+        //   READ   cancelTurn (`const identity = inFlightTurnIdentityRef.current`),
+        //          the only reader.
         //   No other reference. There is no delete: this write is the reset.
         const scenarioAtDispatch = useCanvasStore.getState().currentScenarioId
         inFlightTurnIdentityRef.current = scenarioAtDispatch
@@ -4888,8 +4911,10 @@ export function useConversation(): UseConversationReturn {
             //   Complete manifest of `explicitlyStoppedTurnIdsRef` at this commit:
             //   one `new`, this read, one `add` in cancelTurn. No `delete`. So once
             //   a turn id has been explicitly stopped, a LATER attempt with the
-            //   SAME id (retryLast reuses client_turn_id — :2096 / :3867 / :5791)
-            //   stays marked, and an abort of that attempt that was NOT a user
+            //   SAME id (retryLast reuses client_turn_id via the
+            //   `retryClientTurnId` send option, consumed at sendTurn's
+            //   `turnClientId` mint) stays marked, and an abort of that attempt
+            //   that was NOT a user
             //   stop — the 130 s timeout, a preempt — has its STOPPED_DRAFT_NOTICE
             //   suppressed here: preview standing, run gate shut, nothing said.
             //
@@ -5944,7 +5969,8 @@ export function useConversation(): UseConversationReturn {
     // ═══ STOP-FENCE (Codex P0) — TELL THE SERVER, THEN TELL THE USER ════════
     //
     // The abort above is local and always was. CEE deliberately does not cancel
-    // a turn when the client hangs up (`streamed-turn-sse.ts:71-78`), so until
+    // a turn when the client hangs up (the deliberate no-cancel-on-disconnect
+    // block in CEE's `streamed-turn-sse.ts`), so until
     // this call existed the stopped turn ran to completion and COMMITTED.
     // Reproduced on staging: a draft stopped at +4.0s ran its full 52.7s,
     // committed, and overwrote the graph of a different turn the user sent at
@@ -5962,18 +5988,28 @@ export function useConversation(): UseConversationReturn {
     //   not deliver says so; a turn that had already committed says so. The one
     //   thing none of the three does is predict what the fence will do.
     const identity = inFlightTurnIdentityRef.current
-    if (!identity) {
-      // No wire identity means the turn never reached dispatch (or the scenario
-      // id was absent), so there is nothing the server could tombstone. Still
-      // say something — a Stop the user pressed is never silent.
+    // One helper for both stop notices (R-15, fence rider on #534): the two
+    // emit sites were byte-identical apart from the copy, with the chip
+    // rationale on only one of them. The rationale, ONCE, for both (review F3,
+    // unchanged): the chip is `Start a new draft`, NOT `retry` — `retryLast`
+    // re-sends onto the SAME scenario, which CEE's continuation guard declines
+    // once that scenario has a committed turn, and after a stop we may not
+    // know whether it has one.
+    const emitStopNotice = (content: string) => {
       addMessage({
         id: crypto.randomUUID(),
         role: 'assistant',
         synthetic: true,
-        content: EARLY_STOP_UNCONFIRMED_NOTICE,
+        content,
         actionChips: [{ id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' }],
         timestamp: new Date(),
       })
+    }
+    if (!identity) {
+      // No wire identity means the turn never reached dispatch (or the scenario
+      // id was absent), so there is nothing the server could tombstone. Still
+      // say something — a Stop the user pressed is never silent.
+      emitStopNotice(EARLY_STOP_UNCONFIRMED_NOTICE)
       return
     }
     // ⚠ NO `has(...)` EARLY RETURN HERE, AND THE HISTORY MATTERS — AMENDMENT A2
@@ -5988,16 +6024,24 @@ export function useConversation(): UseConversationReturn {
     //   caught that. The argument was right; the code now matches it.
     //
     //   WHY IT IS OUT, not merely unnecessary. `retryLast` re-sends with the SAME
-    //   `client_turn_id` for idempotent replay (:2096 / :3867 / :5791), and this
+    //   `client_turn_id` for idempotent replay (the `retryClientTurnId` send
+    //   option, consumed at sendTurn's `turnClientId` mint), and this
     //   set is add-only — nothing ever deleted from it.
     //
     //   `explicitlyStoppedTurnIdsRef` — COMPLETE MANIFEST, derived at THIS head
     //   (#534 round-3, F5a; the round-2 record said "two reads", which was true of
-    //   the pre-fix tree and stale the moment the guard came out):
-    //     :2325  new Set()
-    //     :4885  READ — sendTurn's abort branch, suppressing STOPPED_DRAFT_NOTICE
-    //            for a turn cancelTurn has already spoken for. The ONE read.
-    //     :6011  ADD  — cancelTurn.
+    //   the pre-fix tree and stale the moment the guard came out. R-17: sites
+    //   named by SYMBOL — the old ":6011 ADD" line ref had ALREADY drifted to a
+    //   different line by the time it was replaced, which is the rider's whole
+    //   argument):
+    //     new   the `useRef<Set<string>>(new Set())` declaration
+    //     READ  sendTurn's abort branch — the
+    //           `!explicitlyStoppedTurnIdsRef.current.has(turnClientId)`
+    //           conjunct of the `abortedWithPreview` guard, suppressing
+    //           STOPPED_DRAFT_NOTICE for a turn cancelTurn has already spoken
+    //           for. The ONE read.
+    //     ADD   the `.add(identity.turnId)` directly below this comment, in
+    //           cancelTurn.
     //   No delete, no reset, and now only one reader.
     //
     //   So with the guard,
@@ -6023,7 +6067,8 @@ export function useConversation(): UseConversationReturn {
     //   ⚠ AND THE `inFlightTurnIdentityRef.current = null` CLEAR IS ALSO GONE,
     //   BY THE SAME RULE. The round-2 verify asked me to pin it. I could not:
     //   removing it REDs nothing, measured, because the identity is REFRESHED at
-    //   the top of every dispatch (:3883) to either this turn's pair or `null`
+    //   the top of every dispatch (the dispatch-time capture in sendTurn — the
+    //   F5b manifest's "WRITE here" site) to either this turn's pair or `null`
     //   before anything can read it — so a stale PREVIOUS-turn pair is
     //   structurally impossible and the clear had no independent effect.
     //
@@ -6040,27 +6085,15 @@ export function useConversation(): UseConversationReturn {
     //   assertion passed by ABSENCE. The deletion was still correct; the
     //   justification was not.
     //   It is now real: the invariant — a Stop never tombstones a PREVIOUS turn's
-    //   id — is pinned on the mechanism that provides it, the dispatch-time refresh
-    //   at :3883, by "stop A → send B → stop B: the second tombstone names B, never
+    //   id — is pinned on the mechanism that provides it, the dispatch-time
+    //   refresh in sendTurn (the F5b manifest's "WRITE here" site), by "stop A →
+    //   send B → stop B: the second tombstone names B, never
     //   A", in which BOTH stops are asserted to have executed.
     void stopV5Turn(identity).then((result) => {
-      addMessage({
-        id: crypto.randomUUID(),
-        role: 'assistant',
-        synthetic: true,
-        content:
-          result.kind === 'not_saved'
-            ? EARLY_STOP_NOT_SAVED_NOTICE
-            : result.kind === 'already_saved'
-              ? EARLY_STOP_ALREADY_SAVED_NOTICE
-              : EARLY_STOP_UNCONFIRMED_NOTICE,
-        // F3's reasoning, unchanged and now doubly true: NOT `retry`.
-        // `retryLast` re-sends onto the SAME scenario, which CEE's continuation
-        // guard declines once that scenario has a committed turn — and after a
-        // stop we may not know whether it has one.
-        actionChips: [{ id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' }],
-        timestamp: new Date(),
-      })
+      // R-16: copy chosen by TABLE lookup — `EARLY_STOP_NOTICE_BY_OUTCOME`
+      // (module scope) is `Record<TurnStopOutcomeKind, string>`, so a fourth
+      // outcome kind is a compile error here, never a silent fallthrough.
+      emitStopNotice(EARLY_STOP_NOTICE_BY_OUTCOME[result.kind])
     })
   }, [updateMessage, cleanupStreamRefs, addMessage])
 

--- a/src/v5/__tests__/stopTurn.spec.ts
+++ b/src/v5/__tests__/stopTurn.spec.ts
@@ -21,6 +21,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { stopV5Turn, getV5StopEndpoint } from '../stopTurn'
 
+// ---------------------------------------------------------------------------
+// Payload trace store mock — spy on recording calls without real Zustand.
+// Same pattern as v5Adapter.test.ts, whose production twin stopTurn mirrors
+// (R-9: until that rider the stop POST was the only outbound call invisible
+// to the debug bundle).
+// ---------------------------------------------------------------------------
+const mockRecordRequest = vi.fn()
+const mockRecordResponse = vi.fn()
+
+vi.mock('../../lib/payload-trace-store', () => ({
+  recordRequestPayload: (...args: unknown[]) => mockRecordRequest(...args),
+  recordResponsePayload: (...args: unknown[]) => mockRecordResponse(...args),
+}))
+
 const IDENTITY = {
   scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
   turnId: 'dcfc3b50-03b0-4b74-bc56-6dd0ce1531d7',
@@ -174,5 +188,103 @@ describe('stopV5Turn — classifying the server’s answer', () => {
       timeoutMs: 10,
     })
     expect(r).toEqual({ kind: 'unconfirmed', reason: 'timeout' })
+  })
+})
+
+// ══ R-9 (fence rider on #534) — THE DEBUG BUNDLE SEES THE STOP CALL ══════════
+//
+// Every other outbound call records request + response through the payload
+// trace store; the stop POST recorded nothing, so a stop that misbehaved on
+// the wire was invisible to the diagnostic bundle. These pins assert the
+// capture on each path the classifier can take, plus the `opts.headers` seam
+// (mirrors `V5CallOptions.headers`) that CEE's JWT half will wire.
+describe('stopV5Turn — R-9: trace capture + the headers seam', () => {
+  let fetchImpl: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchImpl = vi.fn()
+    mockRecordRequest.mockReset()
+    mockRecordResponse.mockReset()
+  })
+
+  it('captures the request payload — endpoint, method, and the tombstone key', async () => {
+    fetchImpl.mockResolvedValue(jsonResponse({ stopped: true, already_committed: false }))
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    expect(mockRecordRequest).toHaveBeenCalledTimes(1)
+    const captured = mockRecordRequest.mock.calls[0][0] as Record<string, unknown>
+    expect(captured.endpoint).toBe(getV5StopEndpoint())
+    expect(captured.method).toBe('POST')
+    expect(captured.body).toEqual({
+      scenario_id: IDENTITY.scenarioId,
+      turn_id: IDENTITY.turnId,
+    })
+  })
+
+  it('captures the 2xx response — status and the raw body the classifier read', async () => {
+    fetchImpl.mockResolvedValue(jsonResponse({ stopped: true, already_committed: true }))
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    expect(mockRecordResponse).toHaveBeenCalledTimes(1)
+    const captured = mockRecordResponse.mock.calls[0][0] as Record<string, unknown>
+    expect(captured.status).toBe(200)
+    expect(captured.body).toEqual({ stopped: true, already_committed: true })
+    // Same id as the request capture — the bundle correlates the pair.
+    expect(captured.id).toBe((mockRecordRequest.mock.calls[0][0] as { id: string }).id)
+  })
+
+  it('captures a non-2xx with the status the classifier turned into unconfirmed', async () => {
+    fetchImpl.mockResolvedValue(jsonResponse({ error: { code: 'TURN_STOP_NOT_RECORDED' } }, 502))
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    expect(mockRecordResponse).toHaveBeenCalledTimes(1)
+    const captured = mockRecordResponse.mock.calls[0][0] as Record<string, unknown>
+    expect(captured.status).toBe(502)
+    expect(captured.error).toBe('http_502')
+  })
+
+  it('captures a transport failure with status 0 + errorName', async () => {
+    fetchImpl.mockRejectedValue(new TypeError('Failed to fetch'))
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    expect(mockRecordResponse).toHaveBeenCalledTimes(1)
+    const captured = mockRecordResponse.mock.calls[0][0] as Record<string, unknown>
+    expect(captured.status).toBe(0)
+    expect(captured.errorName).toBe('TypeError')
+  })
+
+  it('captures the ack-budget timeout as browser_timeout, exactly once', async () => {
+    fetchImpl.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+          })
+        }),
+    )
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch, timeoutMs: 10 })
+    expect(mockRecordResponse).toHaveBeenCalledTimes(1)
+    const captured = mockRecordResponse.mock.calls[0][0] as Record<string, unknown>
+    expect(captured.source).toBe('browser_timeout')
+  })
+
+  it('the headers seam: opts.headers merge after Content-Type, on the wire AND in the capture', async () => {
+    fetchImpl.mockResolvedValue(jsonResponse({ stopped: true, already_committed: false }))
+    await stopV5Turn(IDENTITY, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      headers: { 'X-User-Id': 'user-1', Authorization: 'Bearer tok' },
+    })
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    const expected = {
+      'Content-Type': 'application/json',
+      'X-User-Id': 'user-1',
+      Authorization: 'Bearer tok',
+    }
+    expect(init.headers).toEqual(expected)
+    const captured = mockRecordRequest.mock.calls[0][0] as { headers: Record<string, string> }
+    expect(captured.headers).toEqual(expected)
+  })
+
+  it('no headers passed → the wire carries exactly Content-Type (byte-identical to pre-seam)', async () => {
+    fetchImpl.mockResolvedValue(jsonResponse({ stopped: true, already_committed: false }))
+    await stopV5Turn(IDENTITY, { fetchImpl: fetchImpl as unknown as typeof fetch })
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit]
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
   })
 })

--- a/src/v5/stopTurn.ts
+++ b/src/v5/stopTurn.ts
@@ -2,8 +2,9 @@
  * stopTurn — telling the SERVER that the user pressed Stop.
  *
  * Until this existed, Stop aborted our own `AbortController` and nothing else.
- * CEE deliberately does not cancel a turn when the client hangs up
- * (`streamed-turn-sse.ts:71-78`), so the turn ran to completion and COMMITTED.
+ * CEE deliberately does not cancel a turn when the client hangs up (the
+ * deliberate no-cancel-on-disconnect block in CEE's `streamed-turn-sse.ts`),
+ * so the turn ran to completion and COMMITTED.
  * Reproduced end-to-end on staging (`PHASE0-EVIDENCE-2026-07-28/fix-stop-fence.md`):
  * a draft stopped at +4.0s ran its full 52.7s, committed, and overwrote the graph
  * of a different turn the user had sent at +5.0s. The user saw an empty composer,
@@ -42,6 +43,7 @@
  * A single boolean would have collapsed 'already_saved' and 'unconfirmed' into
  * the same silence, which is exactly the state this whole lane is about.
  */
+import { recordRequestPayload, recordResponsePayload } from '../lib/payload-trace-store'
 import { __internals as adapterInternals } from './v5Adapter'
 
 export type TurnStopOutcomeKind = 'not_saved' | 'already_saved' | 'unconfirmed'
@@ -69,6 +71,14 @@ export function getV5StopEndpoint(): string {
 export interface StopTurnOptions {
   fetchImpl?: typeof fetch
   timeoutMs?: number
+  /**
+   * Extra headers, merged after Content-Type — the auth seam (R-9, fence rider
+   * on #534). Mirrors `V5CallOptions.headers` on `callV5Turn`. No production
+   * caller passes any today; when CEE's JWT half lands (LOGIN-CEE-HALF-SPEC),
+   * the stop call carries the same `buildTurnAuthHeaders(...)` output as the
+   * turn it stops.
+   */
+  headers?: Record<string, string>
 }
 
 /**
@@ -85,17 +95,53 @@ export async function stopV5Turn(
   const budget = opts.timeoutMs ?? STOP_ACK_BUDGET_MS
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), budget)
+  const url = getV5StopEndpoint()
+  const headers = { 'Content-Type': 'application/json', ...(opts.headers ?? {}) }
+  const wireBody = { scenario_id: identity.scenarioId, turn_id: identity.turnId }
+  // ── R-9: trace capture, mirroring `callV5Turn` ─────────────────────────────
+  // Until this existed the stop POST was the ONLY outbound call invisible to
+  // the debug bundle. Auth headers are redacted downstream: the trace store
+  // runs headers through redactPayload (default sensitiveKeys include
+  // 'authorization') plus free-form Bearer/JWT scrubbing — the same guarantee
+  // the PR #268 review verified for the buffered turn. Capture sits before the
+  // try, exactly where the sibling puts it.
+  const requestId = crypto.randomUUID()
+  const requestedAt = Date.now()
+  recordRequestPayload({
+    id: requestId,
+    endpoint: url,
+    method: 'POST',
+    headers,
+    body: wireBody,
+  })
   try {
-    const res = await fetchFn(getV5StopEndpoint(), {
+    const res = await fetchFn(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scenario_id: identity.scenarioId, turn_id: identity.turnId }),
+      headers,
+      body: JSON.stringify(wireBody),
       signal: controller.signal,
     })
     if (!res.ok) {
+      recordResponsePayload({
+        id: requestId,
+        status: res.status,
+        headers: Object.fromEntries(res.headers.entries()),
+        body: null,
+        duration: Date.now() - requestedAt,
+        error: `http_${res.status}`,
+      })
       return { kind: 'unconfirmed', reason: `http_${res.status}` }
     }
     const body: unknown = await res.json().catch(() => null)
+    // One capture for every 2xx path — the trace records the WIRE (status,
+    // headers, raw body), never the classification verdict below.
+    recordResponsePayload({
+      id: requestId,
+      status: res.status,
+      headers: Object.fromEntries(res.headers.entries()),
+      body,
+      duration: Date.now() - requestedAt,
+    })
     if (body === null || typeof body !== 'object') {
       return { kind: 'unconfirmed', reason: 'unparseable_body' }
     }
@@ -127,6 +173,21 @@ export async function stopV5Turn(
     return { kind: 'unconfirmed', reason: 'already_committed_unrecognised' }
   } catch (err) {
     const name = (err as { name?: string } | null)?.name
+    recordResponsePayload({
+      id: requestId,
+      status: 0,
+      headers: {},
+      body: null,
+      duration: Date.now() - requestedAt,
+      error: err instanceof Error ? err.message : String(err),
+      errorName: name ?? 'Error',
+      // AbortError here is OUR ack-budget timer, not the user's Stop — the
+      // sibling's classification for its own aborts. Other throws keep their
+      // errorName + message, which is enough to tell preflight/DNS apart in
+      // the bundle without copying v5Adapter's message-sniffing classifier
+      // (a second copy of that would be the trap-12 mirror).
+      source: name === 'AbortError' ? 'browser_timeout' : 'unknown',
+    })
     return { kind: 'unconfirmed', reason: name === 'AbortError' ? 'timeout' : 'transport' }
   } finally {
     clearTimeout(timer)


### PR DESCRIPTION
Fence riders on the #534-merged stop machinery — the four the CEE quality lane correctly refused as wrong-repo. Canonical definitions: `PHASE0-EVIDENCE-2026-07-28/simplify-findings-sweep2.md:28-35,93-96`. Full lane evidence: `PHASE0-EVIDENCE-2026-07-28/ui-fence-riders.md`.

**3 files, +254/−48 — disjoint from PR #540's five files (verified against its live file list before starting).**

## The riders

- **R-9** — `stopV5Turn` gains the `opts.headers` seam (mirrors `V5CallOptions.headers`; no production caller passes headers yet — wiring the caller's `buildTurnAuthHeaders` output belongs to CEE's JWT half, LOGIN-CEE-HALF-SPEC) **+ payload-trace capture** mirroring `callV5Turn`: the stop POST was the only outbound call invisible to the debug bundle. Exactly one response capture per call on every path (non-2xx, 2xx, throw/timeout). 7 new pins in `stopTurn.spec.ts` (23 → 30).
- **R-15** — `emitStopNotice(content)` local helper in `cancelTurn`; the two byte-identical `addMessage` blocks collapse to one, the F3 chip rationale stated once.
- **R-16** — `EARLY_STOP_NOTICE_BY_OUTCOME: Record<TurnStopOutcomeKind, string>` replaces the nested ternary. A fourth outcome kind is now a **compile error**, never a silent fallthrough. `*_NOTICE` constants stay individually exported (`narrationHonesty.invariant.spec.ts` derives its manifest from them — still 48/48).
- **R-17** — the F5a/F5b complete-manifest comments (and the retryLast / dispatch-refresh / `streamed-turn-sse` citations) name symbols and markers, not line numbers. At this tip the F5a ":6011 ADD" ref had **already drifted** — the rider's own argument, recorded before any edit.

## Evidence (both directions)

| Check | Result |
|---|---|
| Typecheck gate, baseline tip `863ea27b` | PASS — 2510 errors (= frozen baseline) |
| **R-16 pre-fix control**: `\| 'fourth_kind'` union mutant on the UNEDITED tip | **PASS (exit 0)** — the ternary silently tolerates a fourth kind; defect proven at the authoritative gate |
| Typecheck gate at this PR's head | PASS — 2510/2510, coverage 3080/3120 unchanged |
| **R-16 post-fix mutant**: same mutant on this head | **RED (exit 1)** — `TS2741: Property 'fourth_kind' is missing … in 'Record<TurnStopOutcomeKind, string>'`, ratchet 2511 vs 2510 |
| Vitest, 5 stop-machinery specs (collect counts checked) | baseline 193 passed / 215 collected → 200 passed / 222 collected; delta +7 = exactly the new R-9 pins |
| Mutant: delete `recordRequestPayload` call | 3 pins RED |
| Mutant: drop `...(opts.headers ?? {})` merge | headers-seam pin RED |
| Mutant: drop `actionChips` in `emitStopNotice` | 2 EXISTING hook-spec pins RED — the pre-existing suite sees the helper's output |

All mutants run in a throwaway worktree outside the clone root, restored clean after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)