### PR TITLE
Adopt root-wins dual read in the two sibling extractors; delete the redundant fold (ROADMAP 2.177)

### DIFF
--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
@@ -21,6 +21,15 @@
  * persisted rebuild) produce the SAME snapshot warnings for the SAME
  * enrichment — including that the rehydrate path's existing fold is not
  * double-applied.
+ *
+ * ROADMAP 2.177 extension: the coherence pin now covers ALL THREE enrichment
+ * root siblings (`inference_warnings`, `conditional_winners`,
+ * `edge_e_values`) — the other two extractors adopted the same root-wins dual
+ * read, and `composeRobustness`'s root→robustness fold arms were deleted as
+ * redundant. Edge ids here resolve to NO node on purpose: the persisted path
+ * has `nodes: null`, so byte-equality on `edgeLabel` is only honest on ids
+ * both paths degrade identically (the designed divergence is pinned in
+ * analysisSnapshotFactory.rootSiblings.spec.ts).
  */
 import { describe, it, expect } from 'vitest'
 import type { Node, Edge } from '@xyflow/react'
@@ -107,10 +116,23 @@ describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROAD
     expect(cmp.warningsIntroduced).toEqual(['introduced now'])
   })
 
-  it('COHERENCE: live capture and persisted rebuild produce the same warnings for the same enrichment', () => {
+  it('COHERENCE: live capture and persisted rebuild produce the same warnings, conditional winners and edge E-values for the same enrichment', () => {
     // One enrichment, byte-shaped from the live fact fixture, fed to BOTH
     // buildAnalysisSnapshot callers' input shapes.
-    const row = makePersistedRunFactRow({ inferenceWarnings: ROOT_ITEMS })
+    const row = makePersistedRunFactRow({
+      inferenceWarnings: ROOT_ITEMS,
+      conditionalWinners: [
+        {
+          factor_id: 'factor-1',
+          factor_label: 'Factor One',
+          split_value: 12,
+          high_bucket: { winner_label: 'Option B' },
+        },
+      ],
+      // Ids no node resolves — both paths degrade the label identically, so
+      // the equality below is byte-honest (see the header note).
+      edgeEValues: [{ edge_id: 'x1->x2', e_value: 1.8 }],
+    })
     const enrichment = (row.payload as any).result.enrichment
 
     // Live-capture path: store.ts passes the raw response UNFOLDED.
@@ -124,7 +146,7 @@ describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROAD
       previousSnapshotTimestamp: null,
     })
 
-    // Persisted rebuild path: composeRobustness folds root→robustness first.
+    // Persisted rebuild path (toV2ResponseShape → the same factory).
     const persisted = buildSnapshotFromPersistedRun({
       row,
       runNumber: 1,
@@ -132,12 +154,26 @@ describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROAD
       previousSnapshotTimestamp: null,
     })
 
-    // Trap-13 guard: the equality below must not hold vacuously ([] === []).
+    // Trap-13 guards: none of the equalities below may hold vacuously
+    // ([] === []) — each field must be SEEN populated on the live path first.
     expect(live.inferenceWarnings).toEqual([
       'Root node defaulted to 0.0',
       'Target withheld for this run',
     ])
+    expect(live.conditionalWinners).toEqual([
+      {
+        factorId: 'factor-1',
+        factorLabel: 'Factor One',
+        winner: 'Option B',
+        condition: 'When Factor One exceeds 12',
+      },
+    ])
+    expect(live.edgeEValues).toEqual([
+      { edgeId: 'x1->x2', edgeLabel: 'x1 → x2', eValue: 1.8 },
+    ])
     expect(persisted).not.toBeNull()
     expect(persisted!.inferenceWarnings).toEqual(live.inferenceWarnings)
+    expect(persisted!.conditionalWinners).toEqual(live.conditionalWinners)
+    expect(persisted!.edgeEValues).toEqual(live.edgeEValues)
   })
 })

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.rootSiblings.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.rootSiblings.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * analysisSnapshotFactory — conditional_winners / edge_e_values root-wins
+ * adoption pins (ROADMAP 2.177; completes the live-capture asymmetry class
+ * PR #540 fixed for inference_warnings).
+ *
+ * `extractConditionalWinners` and `extractEdgeEValues` were the two siblings
+ * of the #540 defect: each read ONLY `robustness.*`, while the live wire puts
+ * both fields at the response ROOT (773/773 live facts root, 0/773 nested —
+ * the same corpus quoted in persistedRunSnapshotFactory's header and the
+ * persistedRunFact fixture header). The persisted-rebuild caller compensated
+ * via `composeRobustness`'s root→robustness fold, so the SAME Compare surface
+ * (deriveTransitions' E-value / conditional-winner lines) was populated for
+ * rehydrated snapshots and permanently `[]` for live-captured ones.
+ *
+ * Pins: a rawV2Response carrying ROOT-slot data produces a populated snapshot
+ * (RED before the extractors adopt the root-wins dual read, GREEN after), with
+ * the EXACT precedence #540 used (`Array.isArray(root) ? root : nested`).
+ *
+ * Controls per extractor: legacy nested-only payloads still extract (second
+ * arm not dead), and both-absent yields `[]` — the current empty rendering
+ * (deriveTransitions returns null eValue / null conditionalWinner on empty).
+ *
+ * Known, DESIGNED live/persisted divergence pinned at the bottom: the
+ * persisted rebuild has no graph (`nodes: null`), so `edgeEValues[].edgeLabel`
+ * degrades to raw edge-id parts there while the live path resolves node
+ * labels. That is T2b honest absence, not drift — the coherence pin in
+ * analysisSnapshotFactory.inferenceWarnings.spec.ts therefore compares label
+ * bytes only on ids no node resolves.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import { buildSnapshotFromPersistedRun } from '../persistedRunSnapshotFactory'
+import { deriveTransitions } from '../../compare-tab/deriveTransitions'
+import { makePersistedRunFactRow } from '../../compare-tab/__tests__/__fixtures__/persistedRunFact'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+function build(rawOverrides: Record<string, unknown>, runNumber = 1) {
+  return buildAnalysisSnapshot({
+    rawV2Response: {
+      analysis_status: 'computed',
+      option_comparison_status: 'computed',
+      robustness_status: 'unavailable',
+      drivers_status: 'unavailable',
+      option_comparison: [
+        {
+          option_id: 'opt-1',
+          option_label: 'Option A',
+          win_probability: 0.6,
+          confidence_interval: [0.3, 0.7],
+          expected_outcome: 0.5,
+        },
+      ],
+      critiques: [],
+      response_hash: 'resp-1',
+      ...rawOverrides,
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+// Live shapes (byte-derived staging fixture, persistedRunFact.ts): items at
+// the response ROOT, sibling of `robustness`.
+const CW_ROOT = [
+  {
+    factor_id: 'n1',
+    factor_label: 'Factor One',
+    split_value: 12,
+    high_bucket: { winner_label: 'Option B' },
+  },
+]
+const CW_MAPPED = [
+  {
+    factorId: 'n1',
+    factorLabel: 'Factor One',
+    winner: 'Option B',
+    condition: 'When Factor One exceeds 12',
+  },
+]
+const EEV_ROOT = [{ edge_id: 'n1->goal', e_value: 1.8 }]
+
+describe('buildAnalysisSnapshot — conditional_winners root-wins dual read (ROADMAP 2.177)', () => {
+  it('ROOT-slot conditional_winners reach the snapshot (the live-capture path)', () => {
+    const snap = build({ conditional_winners: CW_ROOT })
+    expect(snap.conditionalWinners).toEqual(CW_MAPPED)
+  })
+
+  it('ROOT wins when both slots are present (same precedence as #540 / composeRobustness)', () => {
+    const snap = build({
+      conditional_winners: CW_ROOT,
+      robustness: {
+        conditional_winners: [
+          { factor_id: 'nested', factor_label: 'Nested', high_bucket: { winner_label: 'Loses' } },
+        ],
+      },
+    })
+    expect(snap.conditionalWinners).toEqual(CW_MAPPED)
+  })
+
+  it('LEGACY control: robustness-nested conditional_winners are still read (second arm not dead)', () => {
+    const snap = build({ robustness: { conditional_winners: CW_ROOT } })
+    expect(snap.conditionalWinners).toEqual(CW_MAPPED)
+  })
+
+  it('ABSENCE control: neither slot → [] (no fabrication, current empty state kept)', () => {
+    expect(build({}).conditionalWinners).toEqual([])
+  })
+})
+
+describe('buildAnalysisSnapshot — edge_e_values root-wins dual read (ROADMAP 2.177)', () => {
+  it('ROOT-slot edge_e_values reach the snapshot with node labels resolved (the live-capture path)', () => {
+    const snap = build({ edge_e_values: EEV_ROOT })
+    // Label resolution is the signature aspect the adoption must preserve:
+    // `n1` resolves through the caller's nodes to 'A'; `goal` has no node and
+    // degrades to its raw id — both behaviours are the pre-existing ones.
+    expect(snap.edgeEValues).toEqual([
+      { edgeId: 'n1->goal', edgeLabel: 'A → goal', eValue: 1.8 },
+    ])
+  })
+
+  it('ROOT wins when both slots are present (same precedence as #540 / composeRobustness)', () => {
+    const snap = build({
+      edge_e_values: EEV_ROOT,
+      robustness: { edge_e_values: [{ edge_id: 'nested->loses', e_value: 9.9 }] },
+    })
+    expect(snap.edgeEValues).toEqual([
+      { edgeId: 'n1->goal', edgeLabel: 'A → goal', eValue: 1.8 },
+    ])
+  })
+
+  it('LEGACY control: robustness-nested edge_e_values are still read (second arm not dead)', () => {
+    const snap = build({ robustness: { edge_e_values: EEV_ROOT } })
+    expect(snap.edgeEValues).toEqual([
+      { edgeId: 'n1->goal', edgeLabel: 'A → goal', eValue: 1.8 },
+    ])
+  })
+
+  it('ABSENCE control: neither slot → [] (no fabrication, current empty state kept)', () => {
+    expect(build({}).edgeEValues).toEqual([])
+  })
+})
+
+describe('Compare consumer (deriveTransitions) — the surface the asymmetry blanked', () => {
+  // Both snapshots share factor n1 with an elasticity change >20%, so n1 is an
+  // AFFECTED factor and findConditionalWinner can match CW_ROOT's factor_id.
+  const factors = (elasticity: number) => [
+    { node_id: 'n1', factor_label: 'Factor One', elasticity, rank_flip_rate: 0.1 },
+  ]
+
+  it('POSITIVE control: live-captured root-slot data reaches the transition (was null/null before adoption)', () => {
+    const from = build({ factor_sensitivity: factors(0.4) }, 1)
+    const to = build(
+      {
+        factor_sensitivity: factors(0.6),
+        conditional_winners: CW_ROOT,
+        edge_e_values: EEV_ROOT,
+      },
+      2,
+    )
+    const [t] = deriveTransitions([from, to])
+    expect(t.eValue).toBe(1.8)
+    expect(t.eValueEdge).toBe('A → goal')
+    expect(t.conditionalWinner).toBe('When Factor One exceeds 12, Option B takes over')
+  })
+
+  it('ABSENCE: both-absent snapshots keep the current empty rendering (null eValue, null winner)', () => {
+    const from = build({ factor_sensitivity: factors(0.4) }, 1)
+    const to = build({ factor_sensitivity: factors(0.6) }, 2)
+    const [t] = deriveTransitions([from, to])
+    expect(t.eValue).toBeNull()
+    expect(t.eValueEdge).toBeNull()
+    expect(t.conditionalWinner).toBeNull()
+  })
+})
+
+describe('edgeLabel live/persisted divergence — designed absence, not drift', () => {
+  it('live resolves node labels; the persisted rebuild (nodes: null) degrades to raw edge-id parts', () => {
+    // Same edge bytes down both paths.
+    const live = build({ edge_e_values: EEV_ROOT })
+    const persisted = buildSnapshotFromPersistedRun({
+      row: makePersistedRunFactRow({ edgeEValues: EEV_ROOT }),
+      runNumber: 1,
+      events: [],
+      previousSnapshotTimestamp: null,
+    })!
+
+    // Identity where both paths HAVE the inputs…
+    expect(persisted.edgeEValues.map(e => ({ edgeId: e.edgeId, eValue: e.eValue })))
+      .toEqual(live.edgeEValues.map(e => ({ edgeId: e.edgeId, eValue: e.eValue })))
+    // …and honest divergence where only the live path has the graph. A fact
+    // stores the analysis, not the model (T2b): no nodes, no labels invented.
+    expect(live.edgeEValues[0].edgeLabel).toBe('A → goal')
+    expect(persisted.edgeEValues[0].edgeLabel).toBe('n1 → goal')
+  })
+})

--- a/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
+++ b/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
@@ -100,12 +100,56 @@ describe('persistedRunSnapshotFactory — field mapping', () => {
   })
 
   it('MUTATION GUARD for that deviation: values nested under robustness are still read (forward-compat)', () => {
+    // ROADMAP 2.177: extended from inference_warnings to ALL THREE root
+    // siblings when the extractors adopted the root-wins dual read and
+    // composeRobustness's fold arms were deleted — the nested arm now lives
+    // in the extractors, and this guard is what keeps it alive.
     const row = makePersistedRunFactRow()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const enrichment = (row.payload as any).result.enrichment
     delete enrichment.inference_warnings
+    delete enrichment.conditional_winners
+    delete enrichment.edge_e_values
     enrichment.robustness.inference_warnings = ['nested warning']
-    expect(build(row)!.inferenceWarnings).toEqual(['nested warning'])
+    enrichment.robustness.conditional_winners = [
+      {
+        factor_id: 'factor-1',
+        factor_label: 'Factor One',
+        split_value: 12,
+        high_bucket: { winner_label: 'Option B' },
+      },
+    ]
+    enrichment.robustness.edge_e_values = [{ edge_id: 'factor-1->goal', e_value: 1.8 }]
+    const s = build(row)!
+    expect(s.inferenceWarnings).toEqual(['nested warning'])
+    expect(s.conditionalWinners).toEqual([
+      {
+        factorId: 'factor-1',
+        factorLabel: 'Factor One',
+        winner: 'Option B',
+        condition: 'When Factor One exceeds 12',
+      },
+    ])
+    expect(s.edgeEValues).toEqual([
+      { edgeId: 'factor-1->goal', edgeLabel: 'factor-1 → goal', eValue: 1.8 },
+    ])
+  })
+
+  it('BOTH-ABSENT: none of the three fields in either slot → [] for all three, run still builds', () => {
+    // The fixture default is `[]` AT THE ROOT (present-but-empty, the live
+    // sentinel shape). This pin removes the keys entirely from both slots —
+    // absence must stay [] with the run intact, never a drop and never a
+    // fabricated value.
+    const row = makePersistedRunFactRow()
+    const enrichment = (row.payload as any).result.enrichment
+    delete enrichment.inference_warnings
+    delete enrichment.conditional_winners
+    delete enrichment.edge_e_values
+    const s = build(row)
+    expect(s).not.toBeNull()
+    expect(s!.inferenceWarnings).toEqual([])
+    expect(s!.conditionalWinners).toEqual([])
+    expect(s!.edgeEValues).toEqual([])
   })
 
   // -------------------------------------------------------------------------

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -107,13 +107,23 @@ function computeInfluenceConcentration(factors: V2FactorSensitivity[]): number {
 }
 
 // ---------------------------------------------------------------------------
-// ISL field extraction (pass-through from robustness, all optional)
+// ISL field extraction (root-wins dual read off the full response, all
+// optional — live wire puts these at the response ROOT, legacy nested under
+// `robustness`)
 // ---------------------------------------------------------------------------
 
 function extractConditionalWinners(
-  robustness: V2RunResponse['robustness'],
+  response: V2RunResponse,
 ): AnalysisSnapshot['conditionalWinners'] {
-  const raw = (robustness as Record<string, unknown> | undefined)?.conditional_winners
+  // ROADMAP 2.177: root-wins dual read — the same precedence #540 gave
+  // `extractInferenceWarnings` (see its comment below for the full story).
+  // This extractor read ONLY `robustness.conditional_winners`, while the live
+  // wire puts the field at the response ROOT (773/773 live facts root, 0/773
+  // nested), so live-captured snapshots carried `[]` where rehydrated ones
+  // carried data.
+  const root = (response as unknown as Record<string, unknown> | undefined)?.conditional_winners
+  const nested = (response?.robustness as Record<string, unknown> | undefined)?.conditional_winners
+  const raw = Array.isArray(root) ? root : nested
   if (!Array.isArray(raw)) return []
   return raw
     .filter((w: Record<string, unknown>) => w && typeof w === 'object')
@@ -130,11 +140,17 @@ function extractConditionalWinners(
 }
 
 function extractEdgeEValues(
-  robustness: V2RunResponse['robustness'],
+  response: V2RunResponse,
   nodes: Node[] | null,
   _edges: Edge[] | null,
 ): AnalysisSnapshot['edgeEValues'] {
-  const raw = (robustness as Record<string, unknown> | undefined)?.edge_e_values
+  // ROADMAP 2.177: root-wins dual read — same defect and same fix as
+  // `extractConditionalWinners` above. The nodes/edges parameters stay: label
+  // resolution is this extractor's own concern, independent of which slot the
+  // values arrive in.
+  const root = (response as unknown as Record<string, unknown> | undefined)?.edge_e_values
+  const nested = (response?.robustness as Record<string, unknown> | undefined)?.edge_e_values
+  const raw = Array.isArray(root) ? root : nested
   if (!Array.isArray(raw)) return []
 
   // Build node label lookup. Absent nodes (persisted-run rebuild) degrade to
@@ -167,15 +183,16 @@ function extractInferenceWarnings(
   response: V2RunResponse,
 ): string[] {
   // ROADMAP 2.173 (Paul-ratified 2026-07-30): root-wins dual read, the same
-  // precedence `persistedRunSnapshotFactory`'s `composeRobustness` applies.
-  // This extractor read ONLY `robustness.inference_warnings` — empty on every
-  // live run (0/827 measured 2026-07-30; response ROOT 419/827 non-empty) —
-  // while the persisted-rebuild caller folded root→robustness before calling,
-  // so live-captured snapshots carried `[]` and rehydrated ones carried data:
-  // the same Compare diff was blank or populated depending on capture path.
-  // Reading the root here makes both callers agree without double-folding the
-  // already-compensated rehydrate path (root wins in both). See the coherence
-  // pin in __tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts and
+  // precedence `persistedRunSnapshotFactory`'s `composeRobustness` fold
+  // applied (that fold compensated the persisted-rebuild path only, and was
+  // deleted as redundant under ROADMAP 2.177 once all three extractors here
+  // adopted this read — see that module's HISTORY block). This extractor read
+  // ONLY `robustness.inference_warnings` — empty on every live run (0/827
+  // measured 2026-07-30; response ROOT 419/827 non-empty) — so live-captured
+  // snapshots carried `[]` and rehydrated ones carried data: the same Compare
+  // diff was blank or populated depending on capture path. Reading the root
+  // here makes both callers agree. See the coherence pin in
+  // __tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts and
   // readInferenceWarnings' header for the adoption history.
   const root = (response as unknown as Record<string, unknown> | undefined)?.inference_warnings
   const nested = (response?.robustness as Record<string, unknown> | undefined)?.inference_warnings
@@ -476,8 +493,8 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     jointGoalProbability,
 
     inferenceWarnings: extractInferenceWarnings(rawV2Response),
-    conditionalWinners: extractConditionalWinners(robustness),
-    edgeEValues: extractEdgeEValues(robustness, nodes, edges),
+    conditionalWinners: extractConditionalWinners(rawV2Response),
+    edgeEValues: extractEdgeEValues(rawV2Response, nodes, edges),
 
     seedUsed,
     responseHash: rawV2Response.response_hash ?? '',

--- a/src/canvas/stores/persistedRunSnapshotFactory.ts
+++ b/src/canvas/stores/persistedRunSnapshotFactory.ts
@@ -26,12 +26,26 @@
  *     inference_warnings    root 773/773   robustness 0/773
  *
  * They are enrichment-ROOT siblings of `robustness`, never members of it.
- * `buildAnalysisSnapshot` reads all three off the object handed to it in the
- * `robustness` slot, so this module FOLDS the root-level values into that
- * object — root wins, an existing nested value is preserved as a fallback so
- * a future producer that moves them cannot silently blank the fields. Had the
- * doc been implemented verbatim, all three would render permanently empty
- * with no error to notice.
+ * Had the doc been implemented verbatim, all three would render permanently
+ * empty with no error to notice.
+ *
+ * HISTORY OF THE COMPENSATION (kept, not deleted — trap 14). The factory's
+ * three extractors used to read ONLY the `robustness` slot, so this module
+ * FOLDED the root-level values into that object (root wins, nested kept as a
+ * forward-compat fallback). That compensated THIS path while the live-capture
+ * caller (store.ts, raw response unfolded) stayed blank — the same Compare
+ * surface was populated or `[]` depending on which caller built the snapshot.
+ * ROADMAP 2.173 (PR #540, inference_warnings) and 2.177 (conditional_winners
+ * / edge_e_values) moved the root-wins dual read INTO the extractors, so both
+ * callers agree and the fold became redundant: `toV2ResponseShape` spreads
+ * `...fact.enrichment`, so the root slot survives onto the object the factory
+ * reads, and the extractors' nested arm keeps the forward-compat fallback the
+ * fold used to provide. The fold was therefore DELETED, proven
+ * byte-identity-preserving over every constructible shape class (root-bearing,
+ * nested-only, both-absent, root-[] shadowing nested, malformed non-array
+ * root, mixed slots) — see
+ * PHASE0-EVIDENCE-2026-07-28/sibling-extractors-fix.md. The nested-only and
+ * both-absent classes stay pinned in this module's spec.
  */
 import type { V2RunResponse } from '../../adapters/plot/v2/types'
 import type { ScenarioEvent } from '../../types/scenario'
@@ -134,23 +148,22 @@ function parseRunFact(payload: unknown): ParsedRunFact | null {
 }
 
 /**
- * Fold the enrichment-ROOT robustness siblings into the `robustness` object,
- * because that is the slot `buildAnalysisSnapshot`'s three extractors read.
- * Root wins; a nested value is kept as a fallback (forward-compatible if a
- * future PLoT build ever nests them).
+ * The `robustness` slot, read off the untrusted envelope.
+ *
+ * This was `composeRobustness`, the root→robustness fold — deleted as
+ * redundant once all three extractors adopted the root-wins dual read
+ * (ROADMAP 2.173 / 2.177; see the module header's HISTORY block for the full
+ * story and the byte-identity proof). What remains is only the slot read,
+ * with `{}` — not undefined — preserved for an absent or malformed
+ * `robustness`, exactly as the fold-era code behaved.
  */
-function composeRobustness(enrichment: Record<string, unknown>): V2RunResponse['robustness'] {
-  const nested = asRecord(enrichment.robustness) ?? {}
-  const folded: Record<string, unknown> = { ...nested }
-  for (const key of ['inference_warnings', 'conditional_winners', 'edge_e_values'] as const) {
-    if (Array.isArray(enrichment[key])) folded[key] = enrichment[key]
-  }
-  // Double cast, deliberately: the folded object is untrusted JSONB, not a
-  // validated V2RobustnessActual. The factory's extractors already re-read
-  // every field off it defensively (`as Record<string, unknown>` + type
-  // guards), so widening through `unknown` is honest about what is known —
-  // asserting the nominal type directly would claim a validation nobody did.
-  return folded as unknown as V2RunResponse['robustness']
+function readRobustnessSlot(enrichment: Record<string, unknown>): V2RunResponse['robustness'] {
+  // Double cast, deliberately: the object is untrusted JSONB, not a validated
+  // V2RobustnessActual. The factory's extractors already re-read every field
+  // off it defensively (`as Record<string, unknown>` + type guards), so
+  // widening through `unknown` is honest about what is known — asserting the
+  // nominal type directly would claim a validation nobody did.
+  return (asRecord(enrichment.robustness) ?? {}) as unknown as V2RunResponse['robustness']
 }
 
 /**
@@ -178,7 +191,7 @@ function toV2ResponseShape(fact: ParsedRunFact): V2RunResponse {
     ...fact.enrichment,
     option_comparison: fact.optionComparison,
     factor_sensitivity: fact.factorSensitivity,
-    robustness: composeRobustness(fact.enrichment),
+    robustness: readRobustnessSlot(fact.enrichment),
   } as unknown as V2RunResponse
 }
 


### PR DESCRIPTION
Completes the live-capture asymmetry class PR #540 fixed for `inference_warnings`: `extractConditionalWinners` and `extractEdgeEValues` (`src/canvas/stores/analysisSnapshotFactory.ts`) read only `robustness.*`, while the live wire puts both fields at the response ROOT (773/773 live facts root, 0/773 nested — same corpus as #540). Live-captured snapshots carried `[]` where persisted rebuilds carried folded data, so the same Compare surface (`deriveTransitions`' E-value / conditional-winner lines) was blank or populated depending on which caller built the snapshot.

## Fix 1 — extractors
Both extractors now take the full `V2RunResponse` with the exact #540 precedence (`Array.isArray(root) ? root : nested`); `extractEdgeEValues` keeps `nodes`/`edges` (label resolution preserved and pinned). RED-first: 6 pins RED at `cbbadfc6` (both ROOT-slot, both ROOT-wins, Compare-consumer positive, edgeLabel divergence), 5 controls GREEN; all GREEN post-fix.

## Fix 2 — fold adjudication: DELETED, with byte-identity proof
Once all three extractors read root-first, every `composeRobustness` fold arm is redundant by construction (`toV2ResponseShape` spreads `...fact.enrichment`, so the root slot survives; the folded keys have no other reader). Deterministic persisted-path snapshot dumps across SEVEN shape classes (root-bearing, nested-only, both-absent, root-`[]`-shadowing, malformed non-array root, mixed slots, fixture default), fold-present vs fold-deleted: **byte-identical (same SHA-256)**, non-vacuous in every populated class. What remains is `readRobustnessSlot` (`{}` preserved for absent slot); fold history kept in the module docs (trap 14). Standing belts: nested forward-compat guard extended to all three fields, new BOTH-ABSENT pin, #540 COHERENCE pin extended to all three root siblings with trap-13 guards.

## Mutation evidence (throwaway worktree outside clone root, removed before gates)
| Mutant | Result |
|---|---|
| CW extractor reverted to robustness-only | 5 failed (its pins + coherence + persisted root-slot pin) |
| EEV extractor reverted to robustness-only | 6 failed (its pins + divergence + coherence + persisted root-slot pin) |
| Precedence flipped to nested-wins | 2 failed — exactly the two ROOT-wins pins |
| Extractors always `[]` | 11 failed incl. COHERENCE via its trap-13 guard |
| Nested arm deleted (root-only) | 3 failed — LEGACY controls + persisted forward-compat guard (the fold-deletion belt) |

## Gates (head `1334e96b`)
- `pnpm run typecheck`: PASSED — coverage 3083/3123, ratchet exactly at baseline 2510/2510, no exception-list changes.
- eslint on the 5 touched files: 0 errors; 6 warnings all proven pre-existing at the base commit (line-shifted).
- Per-file vitest (Supabase env vars set, collected counts checked): the twelve #540 adjacent suites + 3 pin files — 228/228 GREEN.

Evidence: `PHASE0-EVIDENCE-2026-07-28/sibling-extractors-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)