### PR TITLE
fix(results): presence-branch on switch_probability — never render marginal as a flip percentage

### DIFF
--- a/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
+++ b/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
@@ -1,0 +1,228 @@
+/**
+ * switch_probability presence-branching pins — the UI half of the
+ * platform-wide fabrication-class close-out (PLoT half: plot-lite-service#294,
+ * merged 867c92d1).
+ *
+ * Contract (vendored @talchain/schemas 0.30.0, EnrichmentRobustnessEdgeSchema):
+ * `switch_probability` is OPTIONAL — ABSENT means NOT COMPUTED, and the
+ * producer "would rather omit the field than derive one from a substitute".
+ * `marginal_switch_probability` is a DIFFERENT Monte Carlo — P(flip | only
+ * this edge varies) — not a fallback. A percentage rendered from the marginal
+ * quantity under switch-probability wording is a fabricated claim, so
+ * consumers must branch on presence, never coalesce.
+ *
+ * Two chains are pinned:
+ *   A. useResultsSectionData `topFragileEdgeData` → confidence.topFragileEdge
+ *      → TriageActionCardsBody's T1FlipRiskCallout "(NN% probability)".
+ *      Defect at tip: `fe.switch_probability ?? fe.marginal_switch_probability`
+ *      renders a percentage for a marginal-only edge.
+ *   B. StrengthenContainer fragileEdges mapping → buildRecommendations flip
+ *      trigger "NN% chance the result flips…" + the action wire param
+ *      literally named `switch_probability`. Defect at tip: the mapping
+ *      PREFERRED marginal over a PRESENT measured switch_probability.
+ *
+ * Controls prove a measured switch_probability — including 0 — still renders,
+ * so the absence assertions are not vacuous (trap 13).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { fireEvent, render, renderHook, screen } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { TriageActionCardsBody } from '../TriageActionCardsBody'
+import { StrengthenContainer } from '../strengthen/StrengthenContainer'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import { selectActive, useStrengthenStore } from '../../../canvas/stores/strengthenStore'
+
+// ─── Chain A: hook → topFragileEdge → T1FlipRiskCallout ─────────────────────
+
+function seedReportWithFragileEdges(edges: Array<Record<string, unknown>>): void {
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: { robustness: { fragile_edges: edges } },
+    } as any,
+    runMeta: {} as any,
+    nodes: [],
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as any)
+}
+
+const EDGE_BASE = {
+  edge_id: 'price::revenue',
+  from_id: 'price',
+  to_id: 'revenue',
+  from_label: 'Price',
+  to_label: 'Revenue',
+  alternative_winner_id: 'opt_b',
+  alternative_winner_label: 'Plan B',
+}
+
+describe('chain A — topFragileEdge presence-branches on switch_probability (schemas 0.30.0)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      draftCoaching: null,
+    } as any)
+  })
+
+  it('PIN: a marginal-only fragile edge yields NO switchProbability (absent = not computed, never the marginal value)', () => {
+    seedReportWithFragileEdges([{ ...EDGE_BASE, marginal_switch_probability: 0.35 }])
+    const { result } = renderHook(() => useResultsSectionData())
+    const tfe = result.current.confidence.topFragileEdge
+    // The edge itself still surfaces (labels are real) — only the number is absent.
+    expect(tfe).toBeDefined()
+    expect(tfe!.fromLabel).toBe('Price')
+    expect(tfe!.switchProbability).toBeUndefined()
+  })
+
+  it('CONTROL: a measured switch_probability passes through verbatim, never displaced by marginal', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0.42, marginal_switch_probability: 0.99 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence.topFragileEdge!.switchProbability).toBe(0.42)
+  })
+
+  it('CONTROL: a measured switch_probability of 0 survives (0 is a measurement, not absence)', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0, marginal_switch_probability: 0.8 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence.topFragileEdge!.switchProbability).toBe(0)
+  })
+
+  it('PIN (render): a marginal-only edge renders the flip-risk callout WITHOUT a percentage', () => {
+    seedReportWithFragileEdges([{ ...EDGE_BASE, marginal_switch_probability: 0.35 }])
+    const { result } = renderHook(() => useResultsSectionData())
+    render(<TriageActionCardsBody data={result.current} />)
+    const callout = screen.getByTestId('t1-flip-risk-callout')
+    // Honest absent state: "If Price shifts, Plan B could overtake." — no number.
+    expect(callout.textContent).toContain('could overtake')
+    expect(callout.textContent).not.toMatch(/%\s*probability/)
+  })
+
+  it('CONTROL (render): a measured switch_probability still renders its percentage', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0.42, marginal_switch_probability: 0.99 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    render(<TriageActionCardsBody data={result.current} />)
+    expect(screen.getByTestId('t1-flip-risk-callout').textContent).toMatch(/42% probability/)
+  })
+})
+
+// ─── Chain B: StrengthenContainer → buildRecommendations flip trigger ───────
+
+const makeStrengthenData = (challengeFragileEdges: unknown[]): ResultsSectionDataReturn =>
+  ({
+    recommendation: { goalThreshold: null, analysisStatus: 'computed' },
+    confidence: { challengeFragileEdges, robustnessStatus: null, robustnessLevel: null },
+    drivers: { drivers: [] },
+  }) as unknown as ResultsSectionDataReturn
+
+const findFlipRec = () =>
+  selectActive(useStrengthenStore.getState()).find((r) => r.id.startsWith('strengthen:flip:'))
+
+describe('chain B — Strengthen flip trigger presence-branches on switch_probability (schemas 0.30.0)', () => {
+  beforeEach(() => {
+    useStrengthenStore.getState()._reset()
+    try { sessionStorage.clear() } catch { /* jsdom */ }
+    useGuidanceStore.setState({ guidanceItems: [], _dispatchAction: null, _sendMessage: null } as never)
+    useCanvasStore.setState({
+      currentStage: null,
+      draftCoaching: null,
+      results: { ...useCanvasStore.getState().results, hash: 'h-switch-prob' },
+    } as never)
+  })
+
+  it('PIN: the rendered flip percentage is the MEASURED switch_probability, never the marginal quantity', () => {
+    render(
+      <StrengthenContainer
+        data={makeStrengthenData([
+          {
+            edge_id: 'e1',
+            from_label: 'Price',
+            to_label: 'Revenue',
+            switch_probability: 0.2,
+            marginal_switch_probability: 0.6,
+            alternative_winner_label: 'Plan B',
+          },
+        ])}
+      />,
+    )
+    const flip = findFlipRec()
+    expect(flip).toBeDefined()
+    expect(flip!.snapshot.signal).toContain('20% chance the result flips to Plan B')
+    expect(flip!.snapshot.signal).not.toContain('60%')
+    // The wire param named switch_probability must carry the measured value.
+    expect((flip!.snapshot.action as any).parameters.switch_probability).toBe(0.2)
+    // And the DOM shows the honest number (the flip rec can sit behind the
+    // panel's "Show N more" fold — expand before asserting).
+    const showMore = screen.queryByText(/Show \d+ more/)
+    if (showMore) fireEvent.click(showMore)
+    expect(screen.getByText(/20% chance the result flips to Plan B/)).toBeTruthy()
+  })
+
+  it('PIN: an edge WITHOUT a measured switch_probability produces NO flip recommendation (absence renders nothing)', () => {
+    render(
+      <StrengthenContainer
+        data={makeStrengthenData([
+          {
+            edge_id: 'e1',
+            from_label: 'Price',
+            to_label: 'Revenue',
+            marginal_switch_probability: 0.6,
+            alternative_winner_label: 'Plan B',
+          },
+        ])}
+      />,
+    )
+    expect(findFlipRec()).toBeUndefined()
+  })
+
+  it('CONTROL: a measured switch_probability alone still produces the flip rec with its percentage', () => {
+    render(
+      <StrengthenContainer
+        data={makeStrengthenData([
+          {
+            edge_id: 'e1',
+            from_label: 'Price',
+            to_label: 'Revenue',
+            switch_probability: 0.45,
+            alternative_winner_label: 'Plan B',
+          },
+        ])}
+      />,
+    )
+    const flip = findFlipRec()
+    expect(flip).toBeDefined()
+    expect(flip!.snapshot.signal).toContain('45% chance the result flips to Plan B')
+  })
+
+  it('CONTROL: a measured switch_probability of 0 still renders (0% is a measurement, not absence)', () => {
+    render(
+      <StrengthenContainer
+        data={makeStrengthenData([
+          {
+            edge_id: 'e1',
+            from_label: 'Price',
+            to_label: 'Revenue',
+            switch_probability: 0,
+            alternative_winner_label: 'Plan B',
+          },
+        ])}
+      />,
+    )
+    const flip = findFlipRec()
+    expect(flip).toBeDefined()
+    expect(flip!.snapshot.signal).toContain('0% chance the result flips to Plan B')
+  })
+})

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -103,12 +103,19 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
       // Undefined when a legacy caller supplies no verdict; the engine's read
       // is strict (`=== false`), so only an explicit withheld claim suppresses.
       hasLeadingOption: data.recommendation.verdict?.hasLeadingOption,
+      // Presence branch (schemas 0.30.0; UI half of plot-lite-service#294):
+      // only a MEASURED switch_probability may feed the engine's rendered
+      // "% chance the result flips" claim and the switch_probability wire
+      // param. marginal_switch_probability is a DIFFERENT Monte Carlo
+      // (P(flip | only this edge varies)) and was previously PREFERRED here —
+      // a mislabel whenever both quantities arrived. An unmeasured edge
+      // produces no flip recommendation (absence renders nothing).
       fragileEdges: fragile
-        .filter((fe) => typeof (fe.marginal_switch_probability ?? fe.switch_probability) === 'number')
+        .filter((fe) => typeof fe.switch_probability === 'number')
         .map((fe) => ({
           edgeId: String(fe.edge_id ?? `${fe.from_id ?? fe.from_label}->${fe.to_label}`),
           factorLabel: String(fe.from_label ?? 'this factor'),
-          switchProbability: Number(fe.marginal_switch_probability ?? fe.switch_probability),
+          switchProbability: Number(fe.switch_probability),
           alternativeWinnerLabel:
             typeof fe.alternative_winner_label === 'string' ? fe.alternative_winner_label : undefined,
         })),

--- a/src/components/results/strengthen/buildRecommendations.ts
+++ b/src/components/results/strengthen/buildRecommendations.ts
@@ -288,8 +288,10 @@ export function buildRecommendations(inputs: StrengthenInputs): Recommendation[]
 
   // ── Evaluate: the single top flip risk (producer fragile_edges) ──────────
   // 1.243 GATE. A "flip" is a change in the ORDERING, so this rec is
-  // comparative in all three of its parts: the SELECTION (argmax over
-  // `marginal_switch_probability` — "most likely to change the leader"), the
+  // comparative in all three of its parts: the SELECTION (argmax over the
+  // MEASURED `switch_probability` — StrengthenContainer's presence branch
+  // admits no other quantity; `marginal_switch_probability` is a different
+  // Monte Carlo and never substitutes), the
   // TITLE, and the SIGNAL, which names `alternative_winner_label` and so
   // designates by elimination (the #494 residual-1 argument: naming what the
   // result would flip TO asserts that something else is currently ahead).

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -2583,7 +2583,14 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         toLabel: targetName,
         alternativeWinnerLabel,
         alternativeWinnerId: altWinnerId,
-        switchProbability: fe.switch_probability ?? fe.marginal_switch_probability,
+        // Presence branch (schemas 0.30.0; UI half of plot-lite-service#294):
+        // switch_probability ABSENT means NOT COMPUTED — the producer omits it
+        // rather than derive one from a substitute. marginal_switch_probability
+        // is a DIFFERENT Monte Carlo (P(flip | only this edge varies)), never a
+        // fallback: coalescing it here rendered a fabricated "(NN% probability)"
+        // in T1FlipRiskCallout, whose own `!= null` branch already degrades
+        // honestly when the number is absent.
+        switchProbability: typeof fe.switch_probability === 'number' ? fe.switch_probability : undefined,
         // Task C: Flag for HeroSection to show generic bullet when labels unresolved
         labelsResolved,
       }


### PR DESCRIPTION
UI half of the platform-wide switch_probability fabrication-class close-out. PLoT half: Talchain/plot-lite-service#294 (merged `867c92d1`). Contract: vendored `@talchain/schemas` 0.30.0 — `switch_probability` ABSENT means NOT COMPUTED; consumers branch on presence, never coalesce. `marginal_switch_probability` is a DIFFERENT Monte Carlo (P(flip | only this edge varies)), not a fallback.

## The defect — two chains, verified at the bytes on tip `cbbadfc6`

- **Chain A (fabrication from absence):** `useResultsSectionData.ts` `topFragileEdgeData` aliased `switch_probability ?? marginal_switch_probability`, so a marginal-only fragile edge rendered `(NN% probability)` in TriageActionCardsBody's T1FlipRiskCallout — which already presence-branches (`!= null`) and degrades honestly once the producer stops fabricating.
- **Chain B (mislabel with preference):** `StrengthenContainer.tsx` mapped `marginal_switch_probability ?? switch_probability` — **preferring marginal over a PRESENT measured value** — into the flip trigger's "NN% chance the result flips…" render (`buildRecommendations.ts:311`) and the action wire param literally named `switch_probability`. The dispatch brief described one chain (2586 → buildRecommendations:311); the live trace shows those are two distinct producer sites, and the named render is fed by chain B, so both are fixed.

## Fix

Presence-branch on the measured field alone at both producers (the #294 `hasMeasuredSwitchProb` semantic): absent → no number, no flip rec — never a substituted quantity. Stale "argmax over marginal" comment in `buildRecommendations.ts` corrected.

## Evidence

- **RED-first:** `switchProbabilityPresence.spec.tsx` — 4 pins RED at pristine tip (`4 failed | 5 passed`), GREEN after fix. Controls prove measured values including **0** still render (vacuity guard).
- **Mutation checks** (throwaway worktree outside the clone root): restoring the chain-A alias → exactly the 2 chain-A pins RED; restoring the chain-B alias → exactly the 2 chain-B pins RED.
- **Gates:** typecheck gate PASS at exactly baseline (ratchet 2510 == 2510; coverage 3083/3123, +1 = the new spec, loaded). eslint on touched files: 0 errors (2 pre-existing warnings in untouched regions). Sibling specs 6 files / 190 tests green; `vitest run --changed`: 108 files / 1459 tests green.
- **Reader manifest:** `marginal_switch_probability` retains other UI readers (sort keys, lens thresholds, `LensInfoPanel` % render, legacy severity fallback) — complete classified manifest in `PHASE0-EVIDENCE-2026-07-28/ui-marginal-alias-fix.md`; remaining same-class sites are a rowable follow-up, out of this bounded lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)