### PR TITLE
Close the marginal-quantity RENDER tier: presence-branch all five surfaces (selection tier rowed)

### DIFF
--- a/src/canvas/components/LensInfoPanel.tsx
+++ b/src/canvas/components/LensInfoPanel.tsx
@@ -158,22 +158,44 @@ function RobustnessPanel() {
     const rawFragile = (rob?.fragile_edges ?? []) as Array<Record<string, unknown>>
     const nodeMap = new Map(nodes.map(n => [n.id, (n.data as Record<string, unknown>)?.label as string ?? n.id]))
 
-    // Build ranked fragile list sorted by switch_probability desc
-    const list: Array<{ from: string; to: string; switchProb: number; altWinner: string | null }> = []
+    // Build ranked fragile list. Presence branch (schemas 0.30.0, the same
+    // class #543 closed on the results surfaces): `switch_probability` ABSENT
+    // means NOT COMPUTED — never zero — and `marginal_switch_probability` is a
+    // DIFFERENT Monte Carlo (P(flip | only this edge varies)), never a
+    // fallback. Only a MEASURED switch probability earns a rendered percentage
+    // or a threshold pass on its own account; an unmeasured edge the marginal
+    // MC evidences as fragile is listed qualitatively (em dash, after every
+    // measured edge — the contract forbids deriving a ranking position from a
+    // substitute).
+    const list: Array<{ from: string; to: string; switchProb: number | undefined; altWinner: string | null }> = []
     for (const fe of rawFragile) {
-      const sp = (fe.switch_probability ?? fe.switchProbability ?? fe.marginal_switch_probability) as number | undefined
-      if (typeof sp !== 'number' || sp <= 0.3) continue
+      const measuredRaw = (fe.switch_probability ?? fe.switchProbability) as number | undefined
+      const measured = typeof measuredRaw === 'number' ? measuredRaw : undefined
+      const marginal = (fe.marginal_switch_probability ?? fe.marginalSwitchProbability) as number | undefined
+      // A present measurement — including 0 — decides eligibility itself; the
+      // marginal MC qualifies an edge only when NO measurement exists.
+      const eligible = measured !== undefined
+        ? measured > 0.3
+        : typeof marginal === 'number' && marginal > 0.3
+      if (!eligible) continue
       const fromId = (fe.from_id ?? fe.fromId ?? fe.source) as string
       const toId = (fe.to_id ?? fe.toId ?? fe.target) as string
       const altWinner = (fe.alternative_winner_label ?? fe.alternativeWinnerLabel) as string | null ?? null
       list.push({
         from: nodeMap.get(fromId) ?? fromId,
         to: nodeMap.get(toId) ?? toId,
-        switchProb: sp,
+        switchProb: measured,
         altWinner,
       })
     }
-    list.sort((a, b) => b.switchProb - a.switchProb)
+    // Measured desc; unmeasured last with producer order preserved
+    // (-Infinity is an ordering sentinel only — the comparator
+    // plot-lite-service#294 shipped — and never renders).
+    list.sort((a, b) => {
+      const av = typeof a.switchProb === 'number' ? a.switchProb : Number.NEGATIVE_INFINITY
+      const bv = typeof b.switchProb === 'number' ? b.switchProb : Number.NEGATIVE_INFINITY
+      return bv - av
+    })
 
     return {
       stability: typeof rob?.recommendation_stability === 'number'
@@ -202,7 +224,14 @@ function RobustnessPanel() {
         <div className="mt-2 space-y-1" style={{ fontSize: 11 }}>
           {fragileList.map((fe, i) => (
             <div key={i} className="flex items-center gap-1">
-              <span className="text-danger font-semibold" style={{ minWidth: 32 }}>{Math.round(fe.switchProb * 100)}%</span>
+              {typeof fe.switchProb === 'number' ? (
+                <span className="text-danger font-semibold" style={{ minWidth: 32 }}>{Math.round(fe.switchProb * 100)}%</span>
+              ) : (
+                // Not computed — the file's own absent-quantity mark (the
+                // causal table's Std / P(exists) cells): an em dash, never a
+                // number derived from the marginal quantity.
+                <span style={{ minWidth: 32, color: 'var(--text-light, #6E6B6B)' }}>{'\u2014'}</span>
+              )}
               <span className="text-text-body truncate" title={`${fe.from} \u2192 ${fe.to}`}>
                 {fe.from} \u2192 {fe.to}
               </span>

--- a/src/canvas/components/__tests__/LensInfoPanel.spec.tsx
+++ b/src/canvas/components/__tests__/LensInfoPanel.spec.tsx
@@ -1,0 +1,155 @@
+/**
+ * LensInfoPanel robustness list — switch_probability presence pins.
+ *
+ * Contract (vendored @talchain/schemas 0.30.0, EnrichmentRobustnessEdgeSchema):
+ * `switch_probability` is OPTIONAL — ABSENT means NOT COMPUTED, and consumers
+ * "must omit any value derived from it (severity, visible, ranking position)
+ * rather than derive one from a substitute". `marginal_switch_probability` is
+ * a DIFFERENT Monte Carlo — P(flip | only this edge varies) — never a
+ * fallback. Same class as #543's chains A/B, different surface: the lens
+ * fragile list rendered `NN%` from the coalesced marginal.
+ *
+ * Honest absence here matches the file's own absent-quantity handling — the
+ * causal table renders an em dash for absent Std / P(exists) cells.
+ *
+ * Controls prove a measured value — including 0 — still travels the measured
+ * path, so the absence assertions are not vacuous (trap 13).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LensInfoPanel } from '../LensInfoPanel'
+import { useCanvasStore } from '../../store'
+
+const EM_DASH = '—'
+
+function seedRobustnessLens(fragileEdges: Array<Record<string, unknown>>): void {
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'price', data: { label: 'Price' }, position: { x: 0, y: 0 } },
+      { id: 'revenue', data: { label: 'Revenue' }, position: { x: 0, y: 0 } },
+      { id: 'demand', data: { label: 'Demand' }, position: { x: 0, y: 0 } },
+      { id: 'margin', data: { label: 'Margin' }, position: { x: 0, y: 0 } },
+    ] as never,
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        robustness: {
+          recommendation_stability: 0.8,
+          fragile_edges: fragileEdges,
+        },
+      },
+    } as never,
+    lens: {
+      ...useCanvasStore.getState().lens,
+      active: 'robustness',
+    },
+  } as never)
+}
+
+describe('LensInfoPanel robustness list — presence-branch on measured switch_probability', () => {
+  beforeEach(() => {
+    localStorage.setItem('feature.graphLens', '1')
+  })
+
+  afterEach(() => {
+    localStorage.removeItem('feature.graphLens')
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 } as never,
+      nodes: [] as never,
+      lens: { ...useCanvasStore.getState().lens, active: 'full' },
+    } as never)
+  })
+
+  it('PIN: a marginal-only fragile edge is listed WITHOUT a percentage (em dash, the file’s absent-quantity mark)', () => {
+    seedRobustnessLens([
+      {
+        from_id: 'price',
+        to_id: 'revenue',
+        marginal_switch_probability: 0.9,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    render(<LensInfoPanel />)
+    const panel = screen.getByTestId('lens-info-robustness')
+    // The row itself surfaces (labels are real data) — only the number is absent.
+    expect(panel.textContent).toContain('Price')
+    expect(panel.textContent).toContain('Revenue')
+    expect(panel.textContent).not.toContain('90%')
+    expect(panel.textContent).toContain(EM_DASH)
+  })
+
+  it('PIN: a measured edge outranks a marginal-only edge (ranking position is never derived from a substitute)', () => {
+    seedRobustnessLens([
+      {
+        from_id: 'price',
+        to_id: 'revenue',
+        marginal_switch_probability: 0.9,
+        alternative_winner_label: 'Plan B',
+      },
+      {
+        from_id: 'demand',
+        to_id: 'margin',
+        switch_probability: 0.4,
+        alternative_winner_label: 'Plan C',
+      },
+    ])
+    render(<LensInfoPanel />)
+    const panel = screen.getByTestId('lens-info-robustness')
+    const text = panel.textContent ?? ''
+    // Measured 40% renders; the marginal 0.9 never becomes a number.
+    expect(text).toContain('40%')
+    expect(text).not.toContain('90%')
+    // Measured sorts first: the measured row's label precedes the marginal row's.
+    expect(text.indexOf('Demand')).toBeGreaterThan(-1)
+    expect(text.indexOf('Demand')).toBeLessThan(text.indexOf('Price'))
+    // The "focus on" coaching names the measured edge, not the marginal one.
+    expect(text).toContain('focus on: Demand → Margin')
+  })
+
+  it('CONTROL: a measured switch_probability renders its percentage', () => {
+    seedRobustnessLens([
+      {
+        from_id: 'price',
+        to_id: 'revenue',
+        switch_probability: 0.85,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    render(<LensInfoPanel />)
+    expect(screen.getByTestId('lens-info-robustness').textContent).toContain('85%')
+  })
+
+  it('CONTROL: a measured 0 is a measurement — below the display floor, and never overridden by marginal', () => {
+    seedRobustnessLens([
+      {
+        from_id: 'price',
+        to_id: 'revenue',
+        switch_probability: 0,
+        marginal_switch_probability: 0.9,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    render(<LensInfoPanel />)
+    const panel = screen.getByTestId('lens-info-robustness')
+    // Measured 0 <= 0.3 floor: not listed. The marginal 0.9 must not resurrect
+    // it (that would prefer a substitute over a present measurement).
+    expect(panel.textContent).not.toContain('90%')
+    expect(panel.textContent).not.toContain('Price')
+  })
+
+  it('CONTROL: a measured edge below the floor stays unlisted; stability line unaffected', () => {
+    seedRobustnessLens([
+      {
+        from_id: 'price',
+        to_id: 'revenue',
+        switch_probability: 0.2,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    render(<LensInfoPanel />)
+    const panel = screen.getByTestId('lens-info-robustness')
+    expect(panel.textContent).toContain('Recommendation stability: 80%')
+    expect(panel.textContent).not.toContain('20%')
+  })
+})

--- a/src/canvas/edges/__tests__/StyledEdge.fragilePresence.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.fragilePresence.spec.tsx
@@ -1,0 +1,193 @@
+/**
+ * StyledEdge fragility badge + hover popover — switch_probability presence
+ * pins (marginal-quantity honesty batch; same class as #543).
+ *
+ * Contract (vendored @talchain/schemas 0.30.0): switch_probability ABSENT
+ * means NOT COMPUTED; marginal_switch_probability is a DIFFERENT Monte Carlo,
+ * never a fallback. The badge "Sensitive · NN%" (+ its title sentence) and
+ * the hover popover "Sensitive: NN% flip risk" must render ONLY a measured
+ * value — a marginal-only fragile edge still badges as Sensitive (matching
+ * tier keeps marginal eligibility, rowed) but shows no number. Both render
+ * sites already presence-branch on `!== null` with honest-absence copy; the
+ * defect was the shared accessor (getFragileEdgeSwitchProbability) coalescing
+ * the marginal. fragileEdgeMatch is deliberately NOT mocked here — the real
+ * accessor is the unit under test.
+ *
+ * ReactFlow/store mock structure follows StyledEdge.hover.spec.tsx.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, act, screen } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import { Position } from '@xyflow/react'
+
+// Mutable per-test report — the store mock factory reads it at selector time.
+let mockReport: Record<string, unknown> | null = null
+
+// ── ReactFlow mocks (as in StyledEdge.hover.spec.tsx) ────────────────────────
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: () => <path data-testid="base-edge" />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: () => null,
+      getEdges: () => [],
+      getNodes: () => [],
+    }),
+    useStore: (selector: any) => selector({ nodes: [] }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: 'complete', report: mockReport },
+      viewMode: 'detailed',
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+
+vi.mock('../../hooks/useTheme', () => ({
+  useIsDark: () => false,
+}))
+
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}))
+
+vi.mock('../../../flags', () => ({
+  isGraphLensEnabled: () => false,
+}))
+
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: () => 'solid',
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 2,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+
+vi.mock('../../theme/edges', () => ({
+  applyEdgeVisualProps: (_: any, props: any) => props,
+}))
+
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+const defaultEdgeProps = {
+  id: 'e1',
+  source: 'n1',
+  target: 'n2',
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 100,
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  selected: false,
+  data: {
+    weight: 0.6,
+    direction: 'positive' as const,
+    beliefExists: 0.8,
+  },
+}
+
+function setFragileEdges(fragileEdges: Array<Record<string, unknown>>): void {
+  mockReport = { robustness: { fragile_edges: fragileEdges } }
+}
+
+function openHoverPopover(container: HTMLElement): void {
+  const hitPath = container.querySelector('path[stroke="transparent"]')
+  expect(hitPath).not.toBeNull()
+  act(() => {
+    fireEvent.mouseEnter(hitPath!)
+  })
+  act(() => {
+    vi.advanceTimersByTime(350)
+  })
+}
+
+describe('StyledEdge — fragility number presence-branches on measured switch_probability', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockReport = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('PIN (badge): a marginal-only fragile edge badges "Sensitive" with NO percentage and the honest-absence title', () => {
+    setFragileEdges([{ edge_id: 'e1', marginal_switch_probability: 0.9 }])
+    render(<StyledEdge {...(defaultEdgeProps as any)} />)
+    const badge = screen.getByText(/Sensitive/)
+    expect(badge.textContent).not.toContain('90%')
+    expect(badge.textContent).not.toMatch(/·\s*\d+%/)
+    const titled = badge.closest('[title]')
+    expect(titled?.getAttribute('title')).toBe(
+      'Sensitive assumption: outcome may flip if this relationship changes',
+    )
+  })
+
+  it('PIN (popover): a marginal-only fragile edge hovers to "Sensitive" with NO flip-risk percentage', () => {
+    setFragileEdges([{ edge_id: 'e1', marginal_switch_probability: 0.9 }])
+    const { container } = render(<StyledEdge {...(defaultEdgeProps as any)} />)
+    openHoverPopover(container)
+    const popover = screen.getByTestId('edge-hover-popover')
+    expect(popover.textContent).toContain('Sensitive')
+    expect(popover.textContent).not.toContain('flip risk')
+    expect(popover.textContent).not.toContain('90%')
+  })
+
+  it('CONTROL (badge): a measured switch_probability still renders "Sensitive · NN%" and the quantified title', () => {
+    setFragileEdges([{ edge_id: 'e1', switch_probability: 0.42, marginal_switch_probability: 0.9 }])
+    render(<StyledEdge {...(defaultEdgeProps as any)} />)
+    const badge = screen.getByText(/Sensitive/)
+    expect(badge.textContent).toContain('42%')
+    expect(badge.textContent).not.toContain('90%')
+    const titled = badge.closest('[title]')
+    expect(titled?.getAttribute('title')).toContain('42% chance the result flips')
+  })
+
+  it('CONTROL (popover): a measured switch_probability still renders "NN% flip risk"', () => {
+    setFragileEdges([{ edge_id: 'e1', switch_probability: 0.42, marginal_switch_probability: 0.9 }])
+    const { container } = render(<StyledEdge {...(defaultEdgeProps as any)} />)
+    openHoverPopover(container)
+    const popover = screen.getByTestId('edge-hover-popover')
+    expect(popover.textContent).toContain('42% flip risk')
+    expect(popover.textContent).not.toContain('90%')
+  })
+
+  it('CONTROL: a measured 0 is a measurement — not fragile, no badge, never resurrected by marginal', () => {
+    setFragileEdges([{ edge_id: 'e1', switch_probability: 0, marginal_switch_probability: 0.9 }])
+    render(<StyledEdge {...(defaultEdgeProps as any)} />)
+    expect(screen.queryByText(/Sensitive/)).toBeNull()
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/EdgePanel.fragilePresence.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/EdgePanel.fragilePresence.spec.tsx
@@ -1,0 +1,108 @@
+/**
+ * EdgePanel fragile-edge percentage — switch_probability presence pins
+ * (marginal-quantity honesty batch; same class as #543).
+ *
+ * Contract (vendored @talchain/schemas 0.30.0): switch_probability ABSENT
+ * means NOT COMPUTED; marginal_switch_probability is a DIFFERENT Monte Carlo,
+ * never a fallback. The "NN% flip risk" line and the tech-mode
+ * "switch_probability: 0.NN" disclosure must render ONLY a measured value —
+ * a marginal-only fragile edge keeps its Sensitive-assumption context (the
+ * matching tier deliberately keeps marginal eligibility) but shows no number.
+ * Both render sites already presence-branch on `!== null`; the defect was the
+ * shared accessor (getFragileEdgeSwitchProbability) coalescing the marginal.
+ *
+ * Controls prove a measured value still renders in the same harness, so the
+ * absence assertions are not vacuous (trap 13). Inspector-v2 is hardcoded ON
+ * (InspectorModal USE_INSPECTOR_V2) — this is the live path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { EdgePanel } from '../panels/EdgePanel'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+
+function setStoreWithFragileEdges(fragileEdges: Array<Record<string, unknown>>) {
+  const state = useCanvasStore.getState()
+  useCanvasStore.setState({
+    ...state,
+    nodes: [
+      { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Marketing budget' } },
+      { id: 'out1', type: 'outcome', position: { x: 100, y: 0 }, data: { label: 'Revenue' } },
+    ],
+    edges: [
+      { id: 'e1', source: 'fac1', target: 'out1', data: { weight: 0.35, direction: 'positive', beliefExists: 0.82, strengthStd: 0.15 } },
+    ],
+    results: {
+      status: 'complete',
+      report: { robustness: { fragile_edges: fragileEdges } },
+    },
+  } as never)
+}
+
+const panelProps = {
+  edgeId: 'e1',
+  techMode: false,
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+}
+
+beforeEach(() => {
+  useCanvasStore.setState(useCanvasStore.getState(), true)
+  useGuidanceStore.setState({ guidanceItems: [], _prefillChat: null, _sendMessage: null })
+})
+
+describe('EdgePanel — flip-risk percentage presence-branches on measured switch_probability', () => {
+  it('PIN: a marginal-only fragile edge keeps its Sensitive context but renders NO "% flip risk"', () => {
+    setStoreWithFragileEdges([
+      { edge_id: 'e1', from: 'fac1', to: 'out1', marginal_switch_probability: 0.9 },
+    ])
+    const { container } = render(<EdgePanel {...panelProps} />)
+    // The context group survives (marginal-matched fragility is visibility,
+    // not a displayed quantity) — only the number is absent.
+    expect(container.querySelector('[data-panel-group="context"]')).not.toBeNull()
+    expect(screen.getByText('Sensitive assumption')).toBeTruthy()
+    expect(screen.queryByText(/% flip risk/)).toBeNull()
+    expect(screen.queryByText(/90%/)).toBeNull()
+  })
+
+  it('PIN (tech mode): a marginal-only value is never printed under the switch_probability label', () => {
+    setStoreWithFragileEdges([
+      { edge_id: 'e1', from: 'fac1', to: 'out1', marginal_switch_probability: 0.9 },
+    ])
+    render(<EdgePanel {...panelProps} techMode={true} />)
+    // The disclosure is collapsed by default — expand it, or the absence
+    // assertion is vacuous (trap 13; the measured CONTROL below proves the
+    // same expanded harness CAN see the line).
+    fireEvent.click(screen.getByText('Model detail'))
+    expect(screen.queryByText(/switch_probability:/)).toBeNull()
+  })
+
+  it('CONTROL: a measured switch_probability still renders its percentage (never displaced by marginal)', () => {
+    setStoreWithFragileEdges([
+      { edge_id: 'e1', from: 'fac1', to: 'out1', switch_probability: 0.65, marginal_switch_probability: 0.9 },
+    ])
+    render(<EdgePanel {...panelProps} />)
+    expect(screen.getByText('65% flip risk')).toBeTruthy()
+    expect(screen.queryByText(/90%/)).toBeNull()
+  })
+
+  it('CONTROL (tech mode): a measured value still prints in the technical disclosure', () => {
+    setStoreWithFragileEdges([
+      { edge_id: 'e1', from: 'fac1', to: 'out1', switch_probability: 0.65, marginal_switch_probability: 0.9 },
+    ])
+    render(<EdgePanel {...panelProps} techMode={true} />)
+    fireEvent.click(screen.getByText('Model detail'))
+    expect(screen.getByText(/switch_probability: 0\.65/)).toBeTruthy()
+  })
+
+  it('CONTROL: a measured 0 is a measurement — below the fragility floor, never resurrected by marginal', () => {
+    setStoreWithFragileEdges([
+      { edge_id: 'e1', from: 'fac1', to: 'out1', switch_probability: 0, marginal_switch_probability: 0.9 },
+    ])
+    const { container } = render(<EdgePanel {...panelProps} />)
+    // The matching tier coalesces and sees 0 (a measurement) — not fragile,
+    // no context group, and certainly no marginal-derived number.
+    expect(container.querySelector('[data-panel-group="context"]')).toBeNull()
+    expect(screen.queryByText(/% flip risk/)).toBeNull()
+  })
+})

--- a/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
+++ b/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
@@ -78,6 +78,47 @@ describe('getFragileEdgeSwitchProbability', () => {
   })
 })
 
+// ─── Presence branch (schemas 0.30.0; marginal-quantity honesty batch) ──────
+//
+// getFragileEdgeSwitchProbability is a DISPLAY accessor: its value renders as
+// "NN% flip risk" (EdgePanel context + tech disclosure) and "Sensitive · NN%"
+// (StyledEdge badge/popover). switch_probability ABSENT means NOT COMPUTED,
+// and marginal_switch_probability is a DIFFERENT Monte Carlo — never a
+// fallback for a rendered number. The MATCHING tier (isEdgeFragile /
+// isTopFragileEdge) deliberately keeps marginal eligibility — that is
+// visibility, not a displayed quantity (rowed follow-up).
+
+describe('getFragileEdgeSwitchProbability — presence branch on the MEASURED quantity', () => {
+  it('PIN: a marginal-only entry yields NO display value (never the marginal substitute)', () => {
+    const fragile: FragileEdgeCandidate[] = [{ edge_id: 'e1', marginal_switch_probability: 0.42 }]
+    expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeNull()
+  })
+
+  it('PIN: a camelCase marginal-only entry yields NO display value either', () => {
+    const fragile: FragileEdgeCandidate[] = [{ edgeId: 'e1', marginalSwitchProbability: 0.42 }]
+    expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeNull()
+  })
+
+  it('CONTROL: a measured value renders, never displaced by a larger marginal', () => {
+    const fragile: FragileEdgeCandidate[] = [
+      { edge_id: 'e1', switch_probability: 0.42, marginal_switch_probability: 0.99 },
+    ]
+    expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeCloseTo(0.42)
+  })
+
+  it('CONTROL: a measured 0 is a measurement below the floor — null, and never falls through to marginal', () => {
+    const fragile: FragileEdgeCandidate[] = [
+      { edge_id: 'e1', switch_probability: 0, marginal_switch_probability: 0.9 },
+    ]
+    expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeNull()
+  })
+
+  it('CONTROL: the camelCase MEASURED shape still renders', () => {
+    const fragile: FragileEdgeCandidate[] = [{ edgeId: 'e1', switchProbability: 0.42 }]
+    expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeCloseTo(0.42)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // QA Brief G-series — fragile edge threshold boundary cases
 // ---------------------------------------------------------------------------

--- a/src/canvas/utils/fragileEdgeMatch.ts
+++ b/src/canvas/utils/fragileEdgeMatch.ts
@@ -81,8 +81,22 @@ export function isTopFragileEdge(
 }
 
 /**
- * Return the switch_probability for a matching fragile edge, or null if not found.
- * Used to display the numeric sensitivity detail (Task 7).
+ * Return the MEASURED switch_probability for a matching fragile edge, or null.
+ * Used to display the numeric sensitivity detail (Task 7): "NN% flip risk" in
+ * EdgePanel (context + tech disclosure) and "Sensitive · NN%" on the
+ * StyledEdge badge/hover popover — every caller renders this value.
+ *
+ * Presence branch (schemas 0.30.0; same class as #543): `switch_probability`
+ * ABSENT means NOT COMPUTED — never zero — and `marginal_switch_probability`
+ * is a DIFFERENT Monte Carlo (P(flip | only this edge varies)), never a
+ * fallback for a rendered number. The coalesce here previously fed a
+ * marginal-only value to every one of those surfaces under flip-risk wording;
+ * each already presence-branches on `!== null` with honest-absence copy, so
+ * returning null degrades every render honestly. A measured value — including
+ * a measured 0, which the display floor then filters as a MEASUREMENT — is
+ * never displaced by, or resurrected from, the marginal quantity. The
+ * MATCHING tier (isEdgeFragile / isTopFragileEdge above) deliberately keeps
+ * marginal eligibility — visibility, not a displayed number.
  */
 export function getFragileEdgeSwitchProbability(
   edgeId: string,
@@ -91,16 +105,15 @@ export function getFragileEdgeSwitchProbability(
   fragileEdges: FragileEdgeCandidate[],
 ): number | null {
   for (const fe of fragileEdges) {
-    const switchProb = fe.switch_probability ?? fe.switchProbability ??
-                       fe.marginal_switch_probability ?? fe.marginalSwitchProbability
-    if (typeof switchProb !== 'number' || switchProb <= THRESHOLDS.FRAGILE_EDGE_FILTER) continue
+    const measured = fe.switch_probability ?? fe.switchProbability
+    if (typeof measured !== 'number' || measured <= THRESHOLDS.FRAGILE_EDGE_FILTER) continue
 
     const feEdgeId = fe.edge_id ?? fe.edgeId
-    if (feEdgeId === edgeId) return switchProb
+    if (feEdgeId === edgeId) return measured
 
     const from = fe.from_id ?? fe.fromId ?? fe.source
     const to = fe.to_id ?? fe.toId ?? fe.target
-    if (from === edgeSource && to === edgeTarget) return switchProb
+    if (from === edgeSource && to === edgeTarget) return measured
   }
   return null
 }

--- a/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
+++ b/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
@@ -29,7 +29,11 @@ import { fireEvent, render, renderHook, screen } from '@testing-library/react'
 import { useResultsSectionData } from '../useResultsSectionData'
 import { TriageActionCardsBody } from '../TriageActionCardsBody'
 import { StrengthenContainer } from '../strengthen/StrengthenContainer'
+import { ConfidenceSection } from '../ConfidenceSection'
+import { buildHeroModel } from '../analysis-hero/buildHeroModel'
+import type { HeroChartModel } from '../analysis-hero/heroTypes'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { ConfidenceSectionData } from '../types'
 import { useCanvasStore } from '../../../canvas/store'
 import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
 import { selectActive, useStrengthenStore } from '../../../canvas/stores/strengthenStore'
@@ -224,5 +228,263 @@ describe('chain B — Strengthen flip trigger presence-branches on switch_probab
     const flip = findFlipRec()
     expect(flip).toBeDefined()
     expect(flip!.snapshot.signal).toContain('0% chance the result flips to Plan B')
+  })
+})
+
+// ─── fragileEdgesMap → driver fragileEdgeInfo → hero switchMeta / bar ───────
+//
+// Adv-review #543 F1: the map's marginal fallback fed buildHeroModel's
+// switchProbByNodeId, so a marginal-only fragile edge rendered a
+// marginal-derived "NN% switch" + MagnitudeBar on the staging-ON analysis
+// hero. buildHeroModel is already presence-guarded — the defect is the map.
+
+function seedReportForHero(fragileEdges: Array<Record<string, unknown>>): void {
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        run: { critique: [] },
+        robustness: {
+          fragile_edges: fragileEdges,
+          flip_thresholds: [
+            { node_id: 'fac_a', label: 'Factor A', current_value: 40, flip_value: 30, unit: '%' },
+          ],
+        },
+        option_comparison: [],
+        option_probabilities: {
+          opt_a: {
+            goal_probability: 0.6,
+            expected: 0.5,
+            outcome: { mean: 0.5, p10: 0.2, p90: 0.8 },
+          },
+        },
+        factor_sensitivity: [{ factor_id: 'fac_a', label: 'Factor A', sensitivity_score: 0.5 }],
+      },
+    } as never,
+    runMeta: {} as never,
+    nodes: [
+      { id: 'opt_a', data: { kind: 'option', label: 'Plan A' }, position: { x: 0, y: 0 } },
+    ] as never,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+const heroChart = (data: ResultsSectionDataReturn): HeroChartModel => {
+  const model = buildHeroModel(data)
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+describe('fragileEdgesMap presence-branches on switch_probability (hero switchMeta feed)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      draftCoaching: null,
+    } as never)
+  })
+
+  it('PIN: a marginal-only fragile edge yields NO fragileEdgeInfo.switchProbability on the driver', () => {
+    seedReportForHero([
+      { edge_id: 'a::b', from_id: 'fac_a', to_id: 'out_b', marginal_switch_probability: 0.6, alternative_winner_label: 'Plan B' },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const driver = result.current.drivers.drivers.find((d) => d.factorKey === 'fac_a')
+    expect(driver).toBeDefined()
+    // The join itself survives (the label is real data) — only the number is absent.
+    expect(driver!.fragileEdgeInfo?.alternativeWinnerLabel).toBe('Plan B')
+    expect(driver!.fragileEdgeInfo?.switchProbability).toBeUndefined()
+  })
+
+  it('PIN (hero): a marginal-only edge renders NO switchMeta and NO magnitude bar — the sentence still reads', () => {
+    seedReportForHero([
+      { edge_id: 'a::b', from_id: 'fac_a', to_id: 'out_b', marginal_switch_probability: 0.6, alternative_winner_label: 'Plan B' },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks).toHaveLength(1)
+    expect(m.evidence.flipRisks[0].text).toContain('Factor A')
+    expect(m.evidence.flipRisks[0].switchMeta).toBeNull()
+    expect(m.evidence.flipRisks[0].magnitude).toBeNull()
+  })
+
+  it('CONTROL (hero): a measured switch_probability still renders its switchMeta and magnitude', () => {
+    seedReportForHero([
+      {
+        edge_id: 'a::b',
+        from_id: 'fac_a',
+        to_id: 'out_b',
+        switch_probability: 0.48,
+        marginal_switch_probability: 0.99,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks[0].switchMeta).toBe('48% switch')
+    expect(m.evidence.flipRisks[0].magnitude).toBe(0.48)
+  })
+
+  it('CONTROL (hero): a measured 0 survives as "0% switch" (0 is a measurement, not absence)', () => {
+    seedReportForHero([
+      {
+        edge_id: 'a::b',
+        from_id: 'fac_a',
+        to_id: 'out_b',
+        switch_probability: 0,
+        marginal_switch_probability: 0.8,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks[0].switchMeta).toBe('0% switch')
+    expect(m.evidence.flipRisks[0].magnitude).toBe(0)
+  })
+})
+
+// ─── SENSITIVE_ASSUMPTION severity — producer verdict only ──────────────────
+//
+// Contract (schemas 0.30.0, EnrichmentRobustnessEdgeSchema.severity): severity
+// is "ABSENT when switch_probability is absent — a severity derived from a
+// substituted probability is a fabricated verdict, so the producer omits both
+// together". The expired pre-B1 deprecation fallback (classifySeverityLegacy
+// over `switch ?? marginal`, window ended 2026-05-12) fabricated that verdict
+// locally and rendered it as ConfidenceSection's "Critical assumption" label.
+
+const findSensitiveAssumption = (data: ResultsSectionDataReturn) =>
+  data.confidence.uncertainties.find((u) => u.code === 'SENSITIVE_ASSUMPTION')
+
+describe('SENSITIVE_ASSUMPTION severity — absence propagates (schemas 0.30.0)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      draftCoaching: null,
+    } as never)
+  })
+
+  it('PIN: a marginal-only edge without producer severity carries NO severity (never classified from the marginal)', () => {
+    seedReportWithFragileEdges([{ ...EDGE_BASE, marginal_switch_probability: 0.8 }])
+    const { result } = renderHook(() => useResultsSectionData())
+    const item = findSensitiveAssumption(result.current)
+    expect(item).toBeDefined()
+    expect(item!.severity).toBeUndefined()
+  })
+
+  it('PIN: a measured edge without producer severity carries NO severity (no local reclassification either)', () => {
+    seedReportWithFragileEdges([{ ...EDGE_BASE, switch_probability: 0.8 }])
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(findSensitiveAssumption(result.current)!.severity).toBeUndefined()
+  })
+
+  it('CONTROL: a producer-classified severity is carried verbatim', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0.8, severity: 'critical' },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(findSensitiveAssumption(result.current)!.severity).toBe('critical')
+  })
+
+  it('PIN (render): no producer severity → no "Critical assumption" verdict label in ConfidenceSection', () => {
+    seedReportWithFragileEdges([{ ...EDGE_BASE, marginal_switch_probability: 0.8 }])
+    const { result } = renderHook(() => useResultsSectionData())
+    render(<ConfidenceSection data={result.current.confidence as ConfidenceSectionData} />)
+    expect(screen.queryByText(/Critical assumption/)).toBeNull()
+  })
+
+  it('CONTROL (render): a producer "critical" severity still renders the verdict label', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0.8, severity: 'critical' },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    render(<ConfidenceSection data={result.current.confidence as ConfidenceSectionData} />)
+    expect(screen.getByText(/Critical assumption/)).toBeTruthy()
+  })
+})
+
+// ─── topFragileEdge SELECTION — presence-first ranking ──────────────────────
+//
+// Adv-review #543 F2, adjudicated: the contract requires consumers to "omit
+// any value derived from it (severity, visible, ranking position) rather than
+// derive one from a substitute" — so the top-edge SELECTION sorts measured
+// switch_probability desc with unmeasured edges LAST (producer order
+// preserved), the same comparator plot-lite-service#294 shipped. Previously
+// an edge could be PICKED as most-fragile by the marginal quantity that #543
+// made every surface refuse to display.
+
+const EDGE_TWO = {
+  edge_id: 'demand::margin',
+  from_id: 'demand',
+  to_id: 'margin',
+  from_label: 'Demand',
+  to_label: 'Margin',
+  alternative_winner_id: 'opt_c',
+  alternative_winner_label: 'Plan C',
+}
+
+describe('topFragileEdge selection — measured presence-first (schemas 0.30.0 ranking doctrine)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      draftCoaching: null,
+    } as never)
+  })
+
+  it('PIN: a measured edge outranks a marginal-only edge with a larger marginal', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, marginal_switch_probability: 0.9 },
+      { ...EDGE_TWO, switch_probability: 0.4 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const tfe = result.current.confidence.topFragileEdge
+    expect(tfe!.fromLabel).toBe('Demand')
+    expect(tfe!.switchProbability).toBe(0.4)
+  })
+
+  it('PIN: with no measured edge, producer order is preserved (no rank derived from the marginal)', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, marginal_switch_probability: 0.2 },
+      { ...EDGE_TWO, marginal_switch_probability: 0.9 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const tfe = result.current.confidence.topFragileEdge
+    expect(tfe!.fromLabel).toBe('Price')
+    expect(tfe!.switchProbability).toBeUndefined()
+  })
+
+  it('PIN: a measured 0 outranks an unmeasured edge (a measurement beats no measurement, never vice versa)', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_TWO, marginal_switch_probability: 0.9 },
+      { ...EDGE_BASE, switch_probability: 0 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const tfe = result.current.confidence.topFragileEdge
+    expect(tfe!.fromLabel).toBe('Price')
+    expect(tfe!.switchProbability).toBe(0)
+  })
+
+  it('CONTROL: among measured edges the highest measured value still wins', () => {
+    seedReportWithFragileEdges([
+      { ...EDGE_BASE, switch_probability: 0.4 },
+      { ...EDGE_TWO, switch_probability: 0.7 },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const tfe = result.current.confidence.topFragileEdge
+    expect(tfe!.fromLabel).toBe('Demand')
+    expect(tfe!.switchProbability).toBe(0.7)
   })
 })

--- a/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
+++ b/src/components/results/__tests__/switchProbabilityPresence.spec.tsx
@@ -30,8 +30,6 @@ import { useResultsSectionData } from '../useResultsSectionData'
 import { TriageActionCardsBody } from '../TriageActionCardsBody'
 import { StrengthenContainer } from '../strengthen/StrengthenContainer'
 import { ConfidenceSection } from '../ConfidenceSection'
-import { buildHeroModel } from '../analysis-hero/buildHeroModel'
-import type { HeroChartModel } from '../analysis-hero/heroTypes'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { ConfidenceSectionData } from '../types'
 import { useCanvasStore } from '../../../canvas/store'
@@ -231,12 +229,15 @@ describe('chain B — Strengthen flip trigger presence-branches on switch_probab
   })
 })
 
-// ─── fragileEdgesMap → driver fragileEdgeInfo → hero switchMeta / bar ───────
+// ─── fragileEdgesMap → driver fragileEdgeInfo (hero switchMeta producer) ────
 //
 // Adv-review #543 F1: the map's marginal fallback fed buildHeroModel's
 // switchProbByNodeId, so a marginal-only fragile edge rendered a
 // marginal-derived "NN% switch" + MagnitudeBar on the staging-ON analysis
 // hero. buildHeroModel is already presence-guarded — the defect is the map.
+// The hook→buildHeroModel integration pins live in
+// analysis-hero/__tests__/switchMetaPresence.spec.tsx (module-internal —
+// the hero inertness guard forbids hero imports from THIS file).
 
 function seedReportForHero(fragileEdges: Array<Record<string, unknown>>): void {
   useCanvasStore.setState({
@@ -272,12 +273,6 @@ function seedReportForHero(fragileEdges: Array<Record<string, unknown>>): void {
   } as never)
 }
 
-const heroChart = (data: ResultsSectionDataReturn): HeroChartModel => {
-  const model = buildHeroModel(data)
-  expect(model.kind).toBe('chart')
-  return model as HeroChartModel
-}
-
 describe('fragileEdgesMap presence-branches on switch_probability (hero switchMeta feed)', () => {
   beforeEach(() => {
     useCanvasStore.setState({
@@ -302,19 +297,7 @@ describe('fragileEdgesMap presence-branches on switch_probability (hero switchMe
     expect(driver!.fragileEdgeInfo?.switchProbability).toBeUndefined()
   })
 
-  it('PIN (hero): a marginal-only edge renders NO switchMeta and NO magnitude bar — the sentence still reads', () => {
-    seedReportForHero([
-      { edge_id: 'a::b', from_id: 'fac_a', to_id: 'out_b', marginal_switch_probability: 0.6, alternative_winner_label: 'Plan B' },
-    ])
-    const { result } = renderHook(() => useResultsSectionData())
-    const m = heroChart(result.current)
-    expect(m.evidence.flipRisks).toHaveLength(1)
-    expect(m.evidence.flipRisks[0].text).toContain('Factor A')
-    expect(m.evidence.flipRisks[0].switchMeta).toBeNull()
-    expect(m.evidence.flipRisks[0].magnitude).toBeNull()
-  })
-
-  it('CONTROL (hero): a measured switch_probability still renders its switchMeta and magnitude', () => {
+  it('CONTROL: a measured switch_probability passes through the map verbatim, never displaced by marginal', () => {
     seedReportForHero([
       {
         edge_id: 'a::b',
@@ -326,12 +309,11 @@ describe('fragileEdgesMap presence-branches on switch_probability (hero switchMe
       },
     ])
     const { result } = renderHook(() => useResultsSectionData())
-    const m = heroChart(result.current)
-    expect(m.evidence.flipRisks[0].switchMeta).toBe('48% switch')
-    expect(m.evidence.flipRisks[0].magnitude).toBe(0.48)
+    const driver = result.current.drivers.drivers.find((d) => d.factorKey === 'fac_a')
+    expect(driver!.fragileEdgeInfo?.switchProbability).toBe(0.48)
   })
 
-  it('CONTROL (hero): a measured 0 survives as "0% switch" (0 is a measurement, not absence)', () => {
+  it('CONTROL: a measured 0 survives the map (0 is a measurement, not absence)', () => {
     seedReportForHero([
       {
         edge_id: 'a::b',
@@ -343,9 +325,8 @@ describe('fragileEdgesMap presence-branches on switch_probability (hero switchMe
       },
     ])
     const { result } = renderHook(() => useResultsSectionData())
-    const m = heroChart(result.current)
-    expect(m.evidence.flipRisks[0].switchMeta).toBe('0% switch')
-    expect(m.evidence.flipRisks[0].magnitude).toBe(0)
+    const driver = result.current.drivers.drivers.find((d) => d.factorKey === 'fac_a')
+    expect(driver!.fragileEdgeInfo?.switchProbability).toBe(0)
   })
 })
 

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -22,7 +22,6 @@ import {
   mapConfidenceLevel,
   getConfidenceTier,
   deriveConfidenceTierLegacy,
-  classifySeverityLegacy,
   detectDominantFactorLegacy,
   normaliseImprovements,
   normalizeOutcomeValues,
@@ -597,34 +596,11 @@ describe('getConfidenceTier', () => {
 })
 
 // =============================================================================
-// B2: classifySeverityLegacy
+// B2: classifySeverityLegacy — DELETED with the expired severity fallback
+// (marginal-quantity honesty batch): the 0.30.0 contract omits severity when
+// switch_probability is absent; the hook no longer classifies locally. The
+// live severity behaviour is pinned in switchProbabilityPresence.spec.tsx.
 // =============================================================================
-
-describe('classifySeverityLegacy', () => {
-  it('returns critical for switch_probability > 0.7', () => {
-    expect(classifySeverityLegacy(0.71)).toBe('critical')
-    expect(classifySeverityLegacy(0.9)).toBe('critical')
-  })
-
-  it('returns error for switch_probability > 0.5 and <= 0.7', () => {
-    expect(classifySeverityLegacy(0.51)).toBe('error')
-    expect(classifySeverityLegacy(0.7)).toBe('error')
-  })
-
-  it('returns warning for switch_probability <= 0.5', () => {
-    expect(classifySeverityLegacy(0.5)).toBe('warning')
-    expect(classifySeverityLegacy(0.3)).toBe('warning')
-    expect(classifySeverityLegacy(0)).toBe('warning')
-  })
-
-  it('returns warning when flipProbability is undefined', () => {
-    expect(classifySeverityLegacy(undefined)).toBe('warning')
-  })
-
-  it('returns warning when flipProbability is null', () => {
-    expect(classifySeverityLegacy(null)).toBe('warning')
-  })
-})
 
 // =============================================================================
 // B2: deriveConfidenceTierLegacy
@@ -954,14 +930,9 @@ describe('switch_probability filtering (primary over marginal)', () => {
     expect(filtered).toHaveLength(0)
   })
 
-  it('severity derivation uses switch_probability via classifySeverityLegacy', () => {
-    // B2: Tests the actual exported legacy function (replaces stale blocker-taxonomy mirror)
-    // switch_probability is the primary field; classifySeverityLegacy receives the resolved value
-    expect(classifySeverityLegacy(0.8)).toBe('critical')  // >0.7
-    expect(classifySeverityLegacy(0.6)).toBe('error')     // >0.5
-    expect(classifySeverityLegacy(0.75)).toBe('critical')  // marginal fallback resolved by caller
-    expect(classifySeverityLegacy(0.3)).toBe('warning')   // <=0.5
-  })
+  // 'severity derivation via classifySeverityLegacy' test DELETED with the
+  // function (marginal-quantity honesty batch): severity is producer-verbatim
+  // or absent — pinned in switchProbabilityPresence.spec.tsx.
 })
 
 // =============================================================================
@@ -1600,7 +1571,10 @@ describe('B2: hook-level fragile edge severity', () => {
     expect(saEdge?.severity).toBe('critical')
   })
 
-  it('falls back to legacy severity when PLoT severity absent', () => {
+  it('omits severity when PLoT severity absent (no local reclassification — schemas 0.30.0)', () => {
+    // Formerly 'falls back to legacy severity when PLoT severity absent':
+    // the expired B2 fallback classified locally (0.71 → 'critical'). The
+    // contract omits severity with the quantity — absence propagates.
     useCanvasStore.setState({
       results: {
         status: 'complete',
@@ -1615,7 +1589,7 @@ describe('B2: hook-level fragile edge severity', () => {
                 from_id: 'fac_b', to_id: 'goal_1',
                 from_label: 'Factor B', to_label: 'Goal',
                 switch_probability: 0.71,
-                // No severity field — pre-B1 cached result
+                // No severity field — producer omitted it
               },
             ],
           },
@@ -1633,8 +1607,8 @@ describe('B2: hook-level fragile edge severity', () => {
     const { result } = renderHook(() => useResultsSectionData())
     const uncertainties = result.current.confidence.uncertainties
     const saEdge = uncertainties.find((u: any) => u.code === 'SENSITIVE_ASSUMPTION')
-    // 0.71 > 0.7 → legacy classifies as 'critical'
-    expect(saEdge?.severity).toBe('critical')
+    expect(saEdge).toBeDefined()
+    expect(saEdge?.severity).toBeUndefined()
   })
 
   it('challengeFragileEdges carries from_id AND to_id through (analysis-graph projection endpoint resolution)', () => {

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -1368,6 +1368,39 @@ describe('Wave 2 (§6.6): evidence disclosure model', () => {
     expect(m.evidence.flipRisks[0].magnitude).toBe(0.48)
   })
 
+  it('flip rows with NO measured switch probability render no meta and no bar — the sentence still reads (schemas 0.30.0)', () => {
+    // Presence branch: fragileEdgesMap now leaves switchProbability absent for
+    // marginal-only edges (never the marginal substitute), and this mapper's
+    // own guard must degrade honestly — no "NN% switch", no empty "( )", no
+    // zero-width bar, sentence intact. Pinned end-to-end (hook → model) in
+    // switchProbabilityPresence.spec.tsx; this is the mapper-level guarantee.
+    const unmeasured = {
+      ...makeDriver('Team capacity'),
+      factorKey: 'fac_capacity',
+      canFocus: true,
+      matchedNodeId: 'fac_capacity',
+      fragileEdgeInfo: { alternativeWinnerLabel: 'Two developers' },
+    }
+    const m = chart(buildHeroModel(makeHeroData({ drivers: { drivers: [unmeasured] } })))
+    expect(m.evidence.flipRisks).toHaveLength(1)
+    expect(m.evidence.flipRisks[0].text).toContain('Team capacity')
+    expect(m.evidence.flipRisks[0].switchMeta).toBeNull()
+    expect(m.evidence.flipRisks[0].magnitude).toBeNull()
+  })
+
+  it('a measured 0 still renders "0% switch" (0 is a measurement, not absence)', () => {
+    const zeroMeasured = {
+      ...makeDriver('Team capacity'),
+      factorKey: 'fac_capacity',
+      canFocus: true,
+      matchedNodeId: 'fac_capacity',
+      fragileEdgeInfo: { switchProbability: 0 },
+    }
+    const m = chart(buildHeroModel(makeHeroData({ drivers: { drivers: [zeroMeasured] } })))
+    expect(m.evidence.flipRisks[0].switchMeta).toBe('0% switch')
+    expect(m.evidence.flipRisks[0].magnitude).toBe(0)
+  })
+
   it('flip-risk focus pre-gate: a node absent from the canvas yields a null target (fail-closed)', () => {
     // With canvas knowledge supplied, fac_capacity not on the canvas → text
     // row (null target); present → target passes through. The sentence and

--- a/src/components/results/analysis-hero/__tests__/switchMetaPresence.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/switchMetaPresence.spec.tsx
@@ -1,0 +1,123 @@
+/**
+ * Hook → buildHeroModel integration pins for the switchMeta presence branch
+ * (marginal-quantity honesty batch; adv-review #543 F1).
+ *
+ * Lives INSIDE analysis-hero/__tests__ because it imports buildHeroModel:
+ * the module's inertness guard (inertness.spec.ts) walks the disk and fails
+ * on any hero import from outside the module directory — module-internal
+ * files are exempt. The map-level pin (no hero import) stays in
+ * results/__tests__/switchProbabilityPresence.spec.tsx.
+ *
+ * Contract (vendored @talchain/schemas 0.30.0): switch_probability ABSENT
+ * means NOT COMPUTED; marginal_switch_probability is a DIFFERENT Monte Carlo,
+ * never a fallback. The defect was upstream (fragileEdgesMap coalesced the
+ * marginal into fragileEdgeInfo.switchProbability, feeding switchProbByNodeId
+ * → "NN% switch" + MagnitudeBar on the staging-ON hero); buildHeroModel's own
+ * guards degrade honestly once the map is presence-branched.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../../useResultsSectionData'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel } from '../heroTypes'
+import { useCanvasStore } from '../../../../canvas/store'
+
+function seedReportForHero(fragileEdges: Array<Record<string, unknown>>): void {
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        run: { critique: [] },
+        robustness: {
+          fragile_edges: fragileEdges,
+          flip_thresholds: [
+            { node_id: 'fac_a', label: 'Factor A', current_value: 40, flip_value: 30, unit: '%' },
+          ],
+        },
+        option_comparison: [],
+        option_probabilities: {
+          opt_a: {
+            goal_probability: 0.6,
+            expected: 0.5,
+            outcome: { mean: 0.5, p10: 0.2, p90: 0.8 },
+          },
+        },
+        factor_sensitivity: [{ factor_id: 'fac_a', label: 'Factor A', sensitivity_score: 0.5 }],
+      },
+    } as never,
+    runMeta: {} as never,
+    nodes: [
+      { id: 'opt_a', data: { kind: 'option', label: 'Plan A' }, position: { x: 0, y: 0 } },
+    ] as never,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+const heroChart = (data: ResultsSectionDataReturn): HeroChartModel => {
+  const model = buildHeroModel(data)
+  expect(model.kind).toBe('chart')
+  return model as HeroChartModel
+}
+
+describe('hero switchMeta feed — presence-branch end-to-end (hook → buildHeroModel)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+      draftCoaching: null,
+    } as never)
+  })
+
+  it('PIN (hero): a marginal-only edge renders NO switchMeta and NO magnitude bar — the sentence still reads', () => {
+    seedReportForHero([
+      { edge_id: 'a::b', from_id: 'fac_a', to_id: 'out_b', marginal_switch_probability: 0.6, alternative_winner_label: 'Plan B' },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks).toHaveLength(1)
+    expect(m.evidence.flipRisks[0].text).toContain('Factor A')
+    expect(m.evidence.flipRisks[0].switchMeta).toBeNull()
+    expect(m.evidence.flipRisks[0].magnitude).toBeNull()
+  })
+
+  it('CONTROL (hero): a measured switch_probability still renders its switchMeta and magnitude', () => {
+    seedReportForHero([
+      {
+        edge_id: 'a::b',
+        from_id: 'fac_a',
+        to_id: 'out_b',
+        switch_probability: 0.48,
+        marginal_switch_probability: 0.99,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks[0].switchMeta).toBe('48% switch')
+    expect(m.evidence.flipRisks[0].magnitude).toBe(0.48)
+  })
+
+  it('CONTROL (hero): a measured 0 survives as "0% switch" (0 is a measurement, not absence)', () => {
+    seedReportForHero([
+      {
+        edge_id: 'a::b',
+        from_id: 'fac_a',
+        to_id: 'out_b',
+        switch_probability: 0,
+        marginal_switch_probability: 0.8,
+        alternative_winner_label: 'Plan B',
+      },
+    ])
+    const { result } = renderHook(() => useResultsSectionData())
+    const m = heroChart(result.current)
+    expect(m.evidence.flipRisks[0].switchMeta).toBe('0% switch')
+    expect(m.evidence.flipRisks[0].magnitude).toBe(0)
+  })
+})

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -954,20 +954,11 @@ function getConfidenceTier(
 // B2 Deprecation Fallbacks — Remove after 2026-05-12
 // =============================================================================
 
-/**
- * Classify fragile edge severity from switch_probability thresholds.
- * UI-SEM-012: >0.7 critical, >0.5 error, else warning.
- * @deprecated Remove after 2026-05-12 — PLoT B1 now provides severity on fragile_edges items.
- */
-function classifySeverityLegacy(
-  flipProbability: number | undefined | null
-): 'critical' | 'error' | 'warning' {
-  if (typeof flipProbability === 'number') {
-    if (flipProbability > 0.7) return 'critical'
-    if (flipProbability > 0.5) return 'error'
-  }
-  return 'warning'
-}
+// classifySeverityLegacy (B2 severity fallback, "Remove after 2026-05-12")
+// DELETED with its expired call site: the 0.30.0 contract requires severity
+// to be OMITTED when the producer omits it, never re-derived locally — least
+// of all from `switch ?? marginal_switch_probability`, which classified a
+// verdict from a substituted quantity.
 
 /**
  * Detect dominant factor via local heuristic: top driver influence > 0.5
@@ -2067,13 +2058,20 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     fragileEdgesRaw.forEach((fe: any) => {
       const fromId = fe.from_id ?? fe.fromId ?? fe.source
       if (fromId) {
-        // Bug fix: use switch_probability as primary (direct flip probability from ISL)
-        // Fall back to marginal_switch_probability only if switch_probability missing
+        // Presence branch (schemas 0.30.0; same class as #543): ONLY a
+        // measured switch_probability populates switchProbability.
+        // marginal_switch_probability is a DIFFERENT Monte Carlo, never a
+        // fallback — the coalesce here fed buildHeroModel's "NN% switch"
+        // meta + MagnitudeBar (staging-ON analysis hero) a marginal value
+        // under switch-probability wording (#543 adv-review F1). Absence
+        // propagates: the hero flip row renders its sentence with no meta
+        // and no bar, and the topFlipRisk quick link / DriversSection
+        // microline gates simply don't fire. The invariant mirror
+        // (src/test/__tests__/invariants/ui/fragile-edge-selection.test.ts)
+        // already documents exactly these semantics.
         const newProb = typeof fe.switch_probability === 'number'
           ? fe.switch_probability
-          : typeof fe.marginal_switch_probability === 'number'
-            ? fe.marginal_switch_probability
-            : undefined
+          : undefined
         const existing = fragileEdgesMap.get(fromId)
         const existingProb = existing?.switchProbability
 
@@ -2509,10 +2507,27 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // Only show stable template when fragile_edges is genuinely empty (length === 0)
     // =========================================================================
     const topFragileEdgeData = (() => {
-      // Sort ALL fragile edges by switch_probability descending, pick top one
+      // Sort ALL fragile edges: measured switch_probability desc; unmeasured
+      // LAST, producer order preserved.
+      //
+      // ADJUDICATED (#543 adv-review F2, marginal-quantity honesty batch):
+      // selection is presence-first. The contract (schemas 0.30.0,
+      // EnrichmentRobustnessEdgeSchema.switch_probability) requires consumers
+      // to "omit any value derived from it (severity, visible, RANKING
+      // POSITION) rather than derive one from a substitute", and
+      // plot-lite-service#294 shipped this exact comparator for the coaching
+      // fragile-edge rank — same doctrine, same shape, cross-service.
+      // Previously the marginal quantity could PICK the top edge (`switch ??
+      // marginal ?? -Infinity`) even though every render surface now refuses
+      // to display it (#543): with {marginal-only 0.9, measured 0.4} the 0.9
+      // edge won and rendered numberless while a displayable measurement sat
+      // on the sibling. A measured value — including a measured 0 — outranks
+      // any unmeasured edge; -Infinity is an ordering sentinel only and never
+      // leaves the comparator (two unmeasured edges compare NaN → treated as
+      // equal, so the stable sort keeps producer order).
       const allSortedByRisk = [...dedupedFragileEdges].sort((a: any, b: any) => {
-        const bProb = b.switch_probability ?? b.marginal_switch_probability ?? -Infinity
-        const aProb = a.switch_probability ?? a.marginal_switch_probability ?? -Infinity
+        const aProb = typeof a.switch_probability === 'number' ? a.switch_probability : Number.NEGATIVE_INFINITY
+        const bProb = typeof b.switch_probability === 'number' ? b.switch_probability : Number.NEGATIVE_INFINITY
         return bProb - aProb
       })
       const fe = allSortedByRisk[0]
@@ -2707,13 +2722,21 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       const friendlyMessage = fe.description ||
         `If "${edgeLabel}" changes significantly, "${alternativeWinnerLabel}" could become the better choice`
 
-      // UI-SEM-012: Read PLoT-classified severity (B1+); fall back to local heuristic for pre-B1 cached results.
-      const severity: 'critical' | 'error' | 'warning' =
+      // UI-SEM-012: PLoT-classified severity (B1+), carried VERBATIM or
+      // omitted. Contract (schemas 0.30.0, EnrichmentRobustnessEdgeSchema):
+      // severity is "ABSENT when switch_probability is absent — a severity
+      // derived from a substituted probability is a fabricated verdict, so
+      // the producer omits both together". Absence propagates: no local
+      // reclassification. (The expired pre-B1 deprecation fallback — window
+      // ended 2026-05-12 — classified locally from
+      // `switch ?? marginal_switch_probability` and rendered the fabricated
+      // verdict as ConfidenceSection's "Critical assumption" label; an
+      // absent severity now gets that section's default styling and no
+      // verdict text.)
+      const severity: 'critical' | 'error' | 'warning' | undefined =
         (fe.severity === 'critical' || fe.severity === 'error' || fe.severity === 'warning')
           ? fe.severity
-          // DEPRECATION FALLBACK: Remove after 2026-05-12
-          // Pre-B1 cached results lack severity field; compute locally via classifySeverityLegacy.
-          : classifySeverityLegacy(fe.switch_probability ?? fe.marginal_switch_probability)
+          : undefined
 
       // Look up factor confidence from driver items for confidence pill display
       const factorConfidence = (() => {
@@ -3307,7 +3330,6 @@ export {
   mapConfidenceLevel,
   getConfidenceTier,
   deriveConfidenceTierLegacy,
-  classifySeverityLegacy,
   detectDominantFactorLegacy,
   normaliseImprovements,
 }


### PR DESCRIPTION
Remaining members of the switch_probability fabrication class #543 closed (its manifest + adversarial-review F1/F2), **amended per adv-review #544** (`adv-review-ui-544.md`): the reviewer's independent manifest surfaced the class's last two rendered-percentage surfaces, folded in at `c35c177a`. Contract: vendored @talchain/schemas 0.30.0 — `switch_probability` ABSENT means NOT COMPUTED; consumers must branch on presence and *"omit any value derived from it (severity, visible, ranking position) rather than derive one from a substitute"*. `marginal_switch_probability` is a DIFFERENT Monte Carlo, never a fallback.

## The six render/verdict/selection fixes

1. **LensInfoPanel robustness list** — coalesced `switch ?? switchProbability ?? marginal` rendered `NN%`, passed the 0.3 floor, and took a rank. Now only a MEASURED value renders a percentage or passes the floor on its own account; an unmeasured edge the marginal MC evidences as fragile stays listed qualitatively (em dash — the file's own absent-quantity mark) and sorts after every measured edge.
2. **fragileEdgesMap → hero switchMeta (F1)** — the map's marginal fallback fed `buildHeroModel.switchProbByNodeId`, so a marginal-only fragile edge rendered a marginal-derived "NN% switch" + MagnitudeBar on the staging-ON analysis hero. Coalesce killed at the map; buildHeroModel's existing presence guards degrade honestly (no meta, no bar, no empty "( )", sentence reads).
3. **Severity fallback deleted** — `classifySeverityLegacy(switch ?? marginal)` fabricated the verdict the contract forbids; window expired 2026-05-12. Producer severity verbatim or omitted; ConfidenceSection (sole `uncertainties[]` reader, audit reproduced by the reviewer) absence-handles: default styling, no "Critical assumption" label, warning-rank sort.
4. **topFragileEdge SELECTION (F2, adjudicated)** — presence-first: measured desc, unmeasured LAST with producer order preserved — the exact comparator plot-lite-service#294 shipped (byte-shape match verified by the reviewer). The contract names **ranking position** among values never derived from a substitute; reasoning recorded at the sort. A measured 0 outranks any unmeasured edge.
5. **`getFragileEdgeSwitchProbability` (amendment)** — the shared display accessor coalesced `switch ?? switchProb ?? marginal ?? marginalCamel`; BOTH callers render it: **EdgePanel** "NN% flip risk" + tech-mode "switch_probability: 0.NN" (inspector-v2 hardcoded ON) and **StyledEdge** "Sensitive · NN%" badge/title + "Sensitive: NN% flip risk" hover popover. Every site already presence-branches on `!== null` with honest-absence copy — the accessor now returns only a measured value. Marginal-matched edges keep their Sensitive visibility (matching tier), numberless.
6. **Hero-pin relocation (blocking amendment)** — the hero-importing integration pins moved module-internal (`analysis-hero/__tests__/switchMetaPresence.spec.tsx`); the analysis-hero **inertness guard is green (23/23)** — it walks the disk, so it was invisible to per-file/--changed runs (noted in the evidence log for future lanes).

## Evidence

- **RED-first**: batch 1 — 10 pins RED at pristine `8638d39d`; amendment — 6 pins RED at `fa55c579` (2 accessor + 2 EdgePanel incl. the tech-disclosure mislabel + 2 StyledEdge badge/popover). Controls green both sides, incl. measured-0 and camelCase-measured controls per surface; the tech-mode absence pin expands the collapsed disclosure so it cannot pass vacuously.
- **Mutants** (throwaway detached worktrees outside the repo root, removed): batch 1 — 5 mutants bite exactly their own pins (2/2/4/3/1). Amendment — accessor full-coalesce revert bites all 6 pins across the three files; subtle camel-only fallback caught by exactly the camelCase pin (1/35).
- **Gates at `c35c177a`**: `pnpm run typecheck` PASS — coverage 3088/3128, ratchet 2510 == baseline 2510. `vitest --changed origin/staging`: 121 files / 1670 tests green. Batch spec set incl. inertness + smoke-listed buildHeroModel: 9 files / 317 green. eslint on touched files: 0 errors.

## Behavioural deltas (full list in the evidence log)

- topFlipRisk hero quick link + DriversSection microline: marginal-only edges no longer qualify (label-only gates).
- Pre-B1 cached results (severity-less fragile edges): severity omitted → default styling, no verdict label, warning-rank sort (can drop out of the initial top-3 into "Show more").
- Lens robustness list: numberless em-dash rows for marginal-evidenced unmeasured edges, ranked after measured rows.
- EdgePanel/StyledEdge: marginal-only fragile edges keep Sensitive context/badge/popover, numberless; tech disclosure no longer prints a marginal value under the `switch_probability` label.
- **Micro-delta (reviewer-found, disclosed):** in `fragileEdgesMap` dedup, among MULTIPLE marginal-only edges for the same factor the kept `alternativeWinnerLabel` changes from the highest-marginal edge's to the first-in-producer-order's (both numberless; label choice only). Conversely a measured entry can no longer be DISPLACED by a same-factor sibling's higher marginal — the old clause compared mixed quantities.

## Out of scope, unchanged (selection/threshold tier, rowed follow-up)

Display filter/sort at `useResultsSectionData` 2452-2478 · challenge-slice sort (fields separate by design) · StressTestSection sort key · `isTopFragileEdge` badge CHOICE (ranking tier) · `isEdgeFragile`/lens threshold matching (`useLensFilter`/`fragileEdgeMatch` — marginal eligibility is visibility, not a displayed number). With item 5 folded in, the RENDER tier of the class is closed.

Evidence log: `PHASE0-EVIDENCE-2026-07-28/ui-marginal-batch.md` (programme workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)