### PR TITLE
fix(ui): auto-return to the Olumi tab when the analysis result arrives (ROADMAP 2.204)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1536,11 +1536,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     // did not happen. A run start also CLEARS the interaction record — the Run
     // control is itself a click inside the dock, and the click that started the
     // run must not be read as "the user is busy on this tab".
+    // ⚠ An ASSIGNMENT, never a conditional set. As an `if` this record was
+    // only ever raised and never lowered, so it survived a run that produced
+    // no block (error / cancel / the useV2Run path): the user sat on Analysis,
+    // ran again FROM Analysis — a run that switched nothing and earns no
+    // return — and was yanked on the new arrival by the FIRST run's stale
+    // record, contradicting this record's own stated invariant. Reachable
+    // because `resultsSettle` lands a reportless run on 'idle'
+    // (store.ts:3359-3365), which makes the next run's `wasInactive` true.
+    // Assigning both ways means the record always describes THIS run.
     if (statusTransitioned) {
       userInteractedSinceRunRef.current = false
-      if (activeTabRef.current !== 'results') {
-        runAutoSwitchedToAnalysisRef.current = true
-      }
+      runAutoSwitchedToAnalysisRef.current = activeTabRef.current !== 'results'
     }
 
     // Task F: Auto-open results — close overlay panels so OutputsDock becomes visible
@@ -1927,15 +1934,27 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       aria-label="Outputs dock"
       data-testid="outputs-dock"
       // ROADMAP 2.204: the honest "the user is engaged here" signal for the
-      // post-run return. Capture phase on the dock ROOT, so any pointerdown or
-      // keydown anywhere inside it counts — the tab strip, every Analysis-tab
-      // control, the composer. DERIVED from real events rather than an
-      // enumerated list of controls, which would rot the moment one is added
-      // and read green while it did (trap 12). Passive waiting fires neither,
-      // so the tester who clicks Run and watches is still returned. Read-only
-      // ref writes: no state, no re-render, no interference with any handler.
+      // post-run return. Capture phase on the dock ROOT, so any pointerdown,
+      // keydown or wheel anywhere inside it counts — the tab strip, every
+      // Analysis-tab control, the composer, and the scroll region. DERIVED
+      // from real events rather than an enumerated list of controls, which
+      // would rot the moment one is added and read green while it did
+      // (trap 12). Read-only ref writes: no state, no re-render, no
+      // interference with any handler.
+      //
+      // ⚠ WHEEL, NOT SCROLL — and the distinction is load-bearing. The dock
+      // body is `overflow-y-auto`, so scroll-reading the Analysis tab while a
+      // run finishes is the most likely waiting behaviour there is, and a
+      // pointer/key pair cannot see it: that user was yanked mid-read.
+      // `onScrollCapture` would be the wrong repair — ChatThread's
+      // useSmartScroll fires `scrollIntoView` programmatically
+      // (useSmartScroll.ts:33), emitting a `scroll` event with no user behind
+      // it, which would stand the return down for exactly the passive tester
+      // this row exists to serve. `wheel` only fires for a real gesture, so
+      // passive waiting still fires nothing.
       onPointerDownCapture={markDockInteraction}
       onKeyDownCapture={markDockInteraction}
+      onWheelCapture={markDockInteraction}
     >
       {/* Parity P7a: the Work-through-it-with-Olumi drawer mounts ONCE at the
           dock root (fixed-position overlay) so asks routed from ANY tab —

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -61,6 +61,10 @@ import {
   latestRealMessageIsAssistantReply,
   latestRealMessageIsFailedTurn,
 } from './collapsedResponseSignal'
+import {
+  countAnalysisReviewBlocks,
+  shouldReturnToOlumiAfterRun,
+} from './runReturnSignal'
 import { useTransitionReceipt } from '../hooks/useTransitionReceipt'
 import { focusFloating } from '../hooks/useFloatingFocus'
 import { isV5CanonicalRunPath } from '../../v5/eligibility'
@@ -1487,6 +1491,21 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const lastDockOpenRef = useRef<number>(0)
   const prevAutoSwitchStatusRef = useRef(resultsStatus)
 
+  // ROADMAP 2.204 — the bookkeeping the post-run RETURN effect below reads.
+  // Kept next to the effect that creates the situation, so the two halves of
+  // "we moved them / we move them back" are read together.
+  //   - activeTabRef mirrors the selected tab for the effects that carry an
+  //     exhaustive-deps disable (their closures over `state` are stale by
+  //     construction; the ref is not).
+  //   - runAutoSwitchedToAnalysisRef records that THIS run is what moved the
+  //     user off their tab. Only a run that actually switched earns a return.
+  //   - userInteractedSinceRunRef records deliberate engagement with the dock
+  //     since the run started (see the capture handlers on the <aside>).
+  const activeTabRef = useRef(state.activeTab)
+  activeTabRef.current = state.activeTab
+  const runAutoSwitchedToAnalysisRef = useRef(false)
+  const userInteractedSinceRunRef = useRef(false)
+
   useEffect(() => {
     const prevStatus = prevAutoSwitchStatusRef.current
     prevAutoSwitchStatusRef.current = resultsStatus
@@ -1512,6 +1531,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
     lastDockOpenRef.current = now
 
+    // ROADMAP 2.204: record the navigation this effect is ABOUT to perform.
+    // Placed after the debounce so the record can never claim a switch that
+    // did not happen. A run start also CLEARS the interaction record — the Run
+    // control is itself a click inside the dock, and the click that started the
+    // run must not be read as "the user is busy on this tab".
+    if (statusTransitioned) {
+      userInteractedSinceRunRef.current = false
+      if (activeTabRef.current !== 'results') {
+        runAutoSwitchedToAnalysisRef.current = true
+      }
+    }
+
     // Task F: Auto-open results — close overlay panels so OutputsDock becomes visible
     useUIStore.getState().openRightPanel('results')
 
@@ -1529,6 +1560,57 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     // We intentionally depend on both triggers. setState from useDockState is stable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultsStatus, showResultsPanel])
+
+  // ROADMAP 2.204 — RETURN the user to the surface the run produced.
+  //
+  // The effect above navigates AWAY on run start; this one is its counterpart.
+  // The turn that completes the analysis puts its output — the decision-review
+  // card and the turn's review/coaching cards — in the OLUMI tab, whose wrapper
+  // is `hidden` while Analysis is fronted (see the wrapper at the bottom of this
+  // file). Live-proven 31 Jul: it stayed at 0 px² for a 180 s poll with the
+  // analysis complete and never self-revealed, so a tester who clicks Run and
+  // stays put never sees it.
+  //
+  // The trigger is the ARRIVAL of a new analysis-result block, not
+  // `resultsStatus === 'complete'`: the non-conversational run path completes
+  // the results store while putting nothing in the Olumi tab, and returning a
+  // user to an empty surface is worse than leaving them. Decision rules and the
+  // full rationale live in runReturnSignal.ts; this effect only gathers inputs.
+  const reviewBlockCount = useMemo(
+    () => countAnalysisReviewBlocks(conversationCtxForFirstUse?.messages),
+    [conversationCtxForFirstUse?.messages],
+  )
+  const prevReviewBlockCountRef = useRef(reviewBlockCount)
+  useEffect(() => {
+    const previousCount = prevReviewBlockCountRef.current
+    prevReviewBlockCountRef.current = reviewBlockCount
+    const shouldReturn = shouldReturnToOlumiAfterRun({
+      aiPanelV2On,
+      runAutoSwitchedToAnalysis: runAutoSwitchedToAnalysisRef.current,
+      dockTab: state.activeTab,
+      dockEffectiveOpen: effectiveIsOpen,
+      userInteractedSinceRun: userInteractedSinceRunRef.current,
+      reviewContentArrived: reviewBlockCount > previousCount,
+    })
+    if (!shouldReturn) return
+    // Spend the record: one return per run, never a repeat.
+    runAutoSwitchedToAnalysisRef.current = false
+    setState(prev => ({ ...prev, isOpen: true, activeTab: 'olumi' }))
+    useUIStore.getState().setActiveOutputTab('olumi' as OutputTab)
+    // The same bookkeeping handleTabClick performs for any non-Results tab.
+    // `showResultsPanel` is the merged effect's SECOND trigger, so leaving it
+    // true here would let that effect pull the user straight back on the next
+    // results-status change.
+    if (showResultsPanel) setShowResultsPanel(false)
+  }, [
+    reviewBlockCount,
+    aiPanelV2On,
+    state.activeTab,
+    effectiveIsOpen,
+    showResultsPanel,
+    setShowResultsPanel,
+    setState,
+  ])
 
   // Effect: Switch to compare tab when showComparePanel flag is set
   useEffect(() => {
@@ -1692,7 +1774,20 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     })
   }
 
+  // ROADMAP 2.204: any deliberate interaction inside the dock stands the
+  // post-run return down. Ref-only — deliberately not state, so it cannot
+  // re-render the dock on every keystroke.
+  const markDockInteraction = useCallback(() => {
+    userInteractedSinceRunRef.current = true
+  }, [])
+
   const handleTabClick = (tab: OutputsDockTab) => {
+    // ROADMAP 2.204: an explicit tab choice is the strongest "leave me where I
+    // put myself" signal there is, so it spends the auto-switch record outright
+    // rather than relying on the pointer/key capture above (which a keyboard
+    // activation via click() would not produce).
+    runAutoSwitchedToAnalysisRef.current = false
+    userInteractedSinceRunRef.current = true
     // UX correction (round 3): clicking the Olumi tab ALWAYS docks the
     // conversation into the right panel. If the floating panel is open,
     // close it first so the conversation surface is unambiguous. The
@@ -1831,6 +1926,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       style={asideStyle}
       aria-label="Outputs dock"
       data-testid="outputs-dock"
+      // ROADMAP 2.204: the honest "the user is engaged here" signal for the
+      // post-run return. Capture phase on the dock ROOT, so any pointerdown or
+      // keydown anywhere inside it counts — the tab strip, every Analysis-tab
+      // control, the composer. DERIVED from real events rather than an
+      // enumerated list of controls, which would rot the moment one is added
+      // and read green while it did (trap 12). Passive waiting fires neither,
+      // so the tester who clicks Run and watches is still returned. Read-only
+      // ref writes: no state, no re-render, no interference with any handler.
+      onPointerDownCapture={markDockInteraction}
+      onKeyDownCapture={markDockInteraction}
     >
       {/* Parity P7a: the Work-through-it-with-Olumi drawer mounts ONCE at the
           dock root (fixed-position overlay) so asks routed from ANY tab —

--- a/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
@@ -331,6 +331,84 @@ describe('ROADMAP 2.204 — the run returns the user to the surface it produced'
     expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
   })
 
+  it('NEVER YANK: a user SCROLL-READING the Analysis tab during the run is left there', () => {
+    // AMENDMENT A1. A pointerdown/keydown pair cannot see a trackpad or wheel
+    // scroll, and the dock body is `overflow-y-auto` — so the most likely
+    // waiting behaviour of all (scroll-reading the Analysis tab while the run
+    // finishes) read as "passive" and got yanked mid-read when the block landed.
+    //
+    // ⚠ The fix is `onWheelCapture`, NOT `onScrollCapture`: ChatThread's
+    // useSmartScroll calls `scrollIntoView` programmatically
+    // (useSmartScroll.ts:33), which emits a `scroll` event with no user behind
+    // it — listening for `scroll` would suppress the return for exactly the
+    // passive tester this whole row exists to serve.
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+    startRun()
+    expect(olumiTabIsFronted()).toBe(false)
+
+    // Fired on the dock BODY, not the root: the scrollable region the user
+    // actually reads in, which also proves the capture reaches a descendant.
+    act(() => {
+      fireEvent.wheel(screen.getByTestId('outputs-dock-body'))
+    })
+
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+
+  it('NEVER YANK: a run that landed nothing must not arm the NEXT run\'s return', async () => {
+    // AMENDMENT A2. The auto-switch record was only ever SET true, never
+    // cleared, so it survived a run that produced no block (error / cancel /
+    // the useV2Run path). The user then sat on Analysis, ran again FROM
+    // Analysis — a run that switched nothing and therefore earns no return —
+    // and was yanked on the new arrival by run ONE's stale record. That
+    // contradicts runReturnSignal.ts's own stated invariant.
+    //
+    // Reachability is exact, not hypothetical: `resultsSettle` acts only from
+    // 'preparing' and, with no report to restore, lands on **'idle'**
+    // (store.ts:3343-3365). 'idle' is what makes the SECOND run's
+    // `wasInactive` true, so the record site is genuinely re-entered.
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Run 1 — moves them to Analysis (record armed), then settles with no
+    // report: the failure/cancel shape.
+    startRun()
+    expect(olumiTabIsFronted()).toBe(false)
+    act(() => {
+      useCanvasStore.getState().resultsSettle()
+    })
+    expect(useCanvasStore.getState().results.status).toBe('idle')
+
+    // The merged effect debounces re-entry within 50ms (its React #185 fix),
+    // so a second run dispatched in the same millisecond would never reach the
+    // record at all and this test would pass by testing nothing. The wait is
+    // what makes it exercise the line it names.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60))
+    })
+
+    // Run 2 — dispatched while they are ALREADY on Analysis (e.g. the canvas
+    // toolbar / palette, outside the dock, so no interaction event fires).
+    // This run switches nothing, so it must NOT earn a return.
+    startRun()
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+
   it('RERUN: the return waits for the NEW analysis, and does not fire on the old one', () => {
     // ⚠ This test exists because a mutant SURVIVED without it. Changing the
     // trigger from "a new analysis-result block ARRIVED"

--- a/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
@@ -331,9 +331,53 @@ describe('ROADMAP 2.204 — the run returns the user to the surface it produced'
     expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
   })
 
+  it('RERUN: the return waits for the NEW analysis, and does not fire on the old one', () => {
+    // ⚠ This test exists because a mutant SURVIVED without it. Changing the
+    // trigger from "a new analysis-result block ARRIVED"
+    // (`reviewBlockCount > previousCount`) to "one EXISTS"
+    // (`reviewBlockCount > 0`) left every other test green — the reload test
+    // below is gated by the auto-switch record, not by the arrival check, so
+    // it could not see the difference. On a RERUN the two come apart: the
+    // transcript already holds the previous run's block, so a presence check
+    // would return the user the instant they pressed Rerun, mid-analysis,
+    // before anything new had landed.
+    convState.messages = [analysisTurnMessage('m-previous-run')]
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+    expect(olumiTabIsFronted()).toBe(true)
+
+    // Rerun pressed: the dock moves to Analysis, and the previous run's block
+    // is still sitting in the transcript.
+    startRun()
+    expect(olumiTabIsFronted()).toBe(false)
+
+    // Mid-run re-render with NOTHING new: the user must stay on the numbers
+    // they are waiting for.
+    act(() => {
+      rerender(
+        <Wrapper>
+          <OutputsDock />
+        </Wrapper>,
+      )
+    })
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+
+    // The NEW analysis lands — now the return fires.
+    landAnalysisTurn(rerender, 'm-rerun')
+    expect(olumiTabIsFronted()).toBe(true)
+  })
+
   it('NEVER YANK: a returning session whose transcript already holds an analysis is not moved', () => {
     // A page reload with a completed analysis in the conversation must not
-    // re-fire the return: the count does not INCREASE, so nothing arrived.
+    // fire the return. Honest note on what guards this: no run happened, so
+    // the auto-switch record is false and the conjunction fails there — the
+    // arrival check is NOT what this case exercises (see the rerun test
+    // above, which is the one that isolates it).
     convState.messages = [analysisTurnMessage('m-historical')]
     seedDockOnAnalysis()
     const { rerender } = render(

--- a/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
@@ -1,0 +1,356 @@
+/**
+ * ROADMAP 2.204 — *Run analysis* must not strand its own output in a hidden tab.
+ *
+ * ## The defect, live-proven 31 Jul in a real browser
+ * Clicking **Run analysis** switches the dock to the **Analysis** tab
+ * (useConversation.ts:4041 `resultsAnalysing()` → OutputsDock's merged
+ * auto-switch effect). The turn's own output — the decision-review card the
+ * 2.154 work rescued — lands in the **Olumi** tab, whose wrapper then carries
+ * `hidden` + `aria-hidden`. With the analysis complete the probe polled for
+ * **180 s** and the container stayed at 0 px²; a single click on the Olumi tab
+ * took it to 268,862 px².
+ * (`PHASE0-EVIDENCE-2026-07-28/probe-2154-visibility.md` §4 Q1 CAVEAT;
+ * `probe-premortem-live.md` §4 Q2.) A tester who clicks Run and stays where the
+ * UI put them never sees it.
+ *
+ * ## What this file pins, and what it CANNOT
+ * jsdom cannot prove visibility (platform trap 3), so nothing here claims a
+ * pixel. What it pins is the STATE that decides visibility — the dock's active
+ * tab, and the `hidden` class + `aria-hidden` the wrapper derives from it. That
+ * is exactly the attribute the live probe measured resolving to `display: none`.
+ * The pixel proof rides the post-deploy walk on staging.
+ *
+ * ## Why every "never yank" case is here
+ * The fix's whole risk is over-firing: moving a user who chose where to be is a
+ * worse defect than the one being fixed. Cases 2-5 are the load-bearing half —
+ * a fix that passed only case 1 would be a fix that yanks everybody.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { ConversationMessage } from '../../conversation/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+// ---------------------------------------------------------------------------
+// Heavy-import stubs — must precede any OutputsDock evaluation. Layout mirrors
+// OutputsDock.conversationSingleton.spec.tsx (the established dock harness).
+// ---------------------------------------------------------------------------
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+vi.mock('../../hooks/useV2Run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useV2Run')>()
+  return { ...actual, useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }) }
+})
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => null }))
+vi.mock('../../hooks/useGraphReadiness', () => ({
+  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+}))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+// Flags: spread the REAL module so a flag added later arrives with its real
+// implementation (trap 12 — a hand-listed factory REPLACES the module and
+// silently drops everything it forgot). `aiPanelV2` is left at its production
+// default (ON, flags.ts:390) because the Olumi tab only exists under it — that
+// default is part of what is under test. Only the noisy adjacent surfaces are
+// forced off.
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isCompareTabEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isOrchestratorV2Enabled: () => false,
+    isLegacyDirectRunEnabled: () => true,
+    isV5CanonicalAnalysisEnabled: () => false,
+  }
+})
+
+// THE controllable conversation. ConversationProvider calls useConversation(),
+// so swapping `convState.messages` and re-rendering delivers a new message list
+// to the dock exactly as a live turn does.
+const convState: { messages: ConversationMessage[] } = { messages: [] }
+const conversationBase = {
+  isThinking: false,
+  longRunningHint: null as unknown,
+  sendMessage: vi.fn(),
+  sendSystemEvent: vi.fn(),
+  sendChip: vi.fn(),
+  retryLast: vi.fn(),
+  patchBlockStates: new Map(),
+  setPatchBlockState: vi.fn(),
+  patchRejections: new Map(),
+  setPatchRejection: vi.fn(),
+}
+// importOriginal, not a hand-listed factory: the module also exports pure
+// helpers the render path calls (`isNonConversationalContent` in
+// MessageBubble.tsx:193, among others). A factory that lists only the hook
+// REPLACES the module and throws at first render — trap 12, and this spec hit
+// it on its first run.
+vi.mock('../../conversation/useConversation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../conversation/useConversation')>()
+  return {
+    ...actual,
+    useConversation: () => ({ ...conversationBase, messages: convState.messages }),
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { OutputsDock, OUTPUTS_DOCK_STORAGE_KEY } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+const RESPONSE_HASH = 'sha256:2204-run-return'
+
+function minimalReport(): ReportV1 {
+  return { summary: 'Option A currently leads.', options: [] } as unknown as ReportV1
+}
+
+/**
+ * The turn's assistant message carrying the block that renders the
+ * decision-review card. `type: 'v5_analysis_result'` is what mapV5Blocks.ts:62
+ * emits for an `analysis_result` wire block and what InlineBlocks.tsx:412
+ * dispatches to <V5AnalysisResultBlock>.
+ */
+function analysisTurnMessage(id: string): ConversationMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: 'Here is what the analysis found.',
+    timestamp: new Date(),
+    blocks: [
+      {
+        type: 'v5_analysis_result',
+        summary: 'Option A currently leads.',
+        leading_option_id: 'opt-a',
+        enrichment: { decision_review: { narrative_summary: 'Because…' } },
+      },
+    ],
+  } as ConversationMessage
+}
+
+/** jsdom implements no layout, so ChatThread's smart-scroll effect
+ *  (useSmartScroll.ts:33) has no `scrollIntoView` to call. */
+function ensureScrollIntoView() {
+  if (typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = vi.fn()
+  }
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/** The dock's own derivation of "the Olumi tab is showing": the wrapper drops
+ *  its `hidden` class and flips `aria-hidden` (OutputsDock.tsx:2646-2648). */
+function olumiTabIsFronted(): boolean {
+  const wrapper = screen.getByTestId('olumi-tab-wrapper')
+  return !wrapper.classList.contains('hidden') && wrapper.getAttribute('aria-hidden') === 'false'
+}
+
+/** Start on the Olumi tab with a populated canvas — the state the probes
+ *  measured a tester in when they pressed Run (conversing, graph drafted). */
+function seedDockOnOlumi() {
+  sessionStorage.setItem(
+    OUTPUTS_DOCK_STORAGE_KEY,
+    JSON.stringify({ isOpen: true, activeTab: 'olumi' }),
+  )
+  useUIStore.setState({ activeOutputTab: 'olumi', activeOutputTabVersion: 0 })
+}
+
+function seedDockOnAnalysis() {
+  sessionStorage.setItem(
+    OUTPUTS_DOCK_STORAGE_KEY,
+    JSON.stringify({ isOpen: true, activeTab: 'results' }),
+  )
+  useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+}
+
+/** The run STARTS: exactly the live shape — `resultsAnalysing`, never
+ *  `resultsStart` (useConversation.ts:4041, and the store spec's own note). */
+function startRun() {
+  act(() => {
+    useCanvasStore.getState().resultsAnalysing()
+  })
+}
+
+/** The turn RETURNS: the analysis block lands in the conversation and the
+ *  results store completes off the same turn (applyV5State.ts:1058-1064). */
+function landAnalysisTurn(rerender: (ui: React.ReactElement) => void, id = 'm-analysis') {
+  convState.messages = [...convState.messages, analysisTurnMessage(id)]
+  act(() => {
+    useCanvasStore.getState().resultsComplete({
+      report: minimalReport(),
+      hash: `${RESPONSE_HASH}-${id}`,
+      resultsSource: 'conversation',
+    })
+  })
+  act(() => {
+    rerender(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+  })
+}
+
+describe('ROADMAP 2.204 — the run returns the user to the surface it produced', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    ensureScrollIntoView()
+    convState.messages = []
+    try { sessionStorage.clear() } catch { /* private mode */ }
+    try { localStorage.clear() } catch { /* private mode */ }
+    useFloatingPanelState.getState().reset()
+    useCanvasStore.getState().resetCanvas()
+    // A populated canvas: without it the dock is forced to its 40px first-use
+    // rail and hosts no tabs at all.
+    useCanvasStore.getState().addNode(undefined, 'decision')
+    useCanvasStore.setState({ results: { status: 'idle', progress: 0 } })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  it('THE DEFECT: Run navigates away from Olumi, and the completed analysis brings the user back', () => {
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    // Precondition — the tester is reading the conversation.
+    expect(olumiTabIsFronted()).toBe(true)
+
+    // Half one of the defect, pinned so the fix cannot be mistaken for a
+    // removal of the auto-switch: pressing Run DOES move them to Analysis.
+    startRun()
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+
+    // Half two — the defect itself. The analysis completes and its output
+    // lands in the tab that is now hidden. BEFORE the fix the wrapper stays
+    // `hidden` here forever (the probe polled 180 s); AFTER, the dock returns.
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(true)
+    expect(screen.getByTestId('olumi-tab-wrapper')).not.toHaveClass('hidden')
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+  })
+
+  it('NEVER YANK: a user who navigated to Analysis themselves is left there', () => {
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+    startRun()
+
+    // The user makes their own choice mid-run: they click the Analysis tab.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Analysis' }))
+    })
+
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+
+  it('NEVER YANK: a user already on Analysis when they pressed Run is left there', () => {
+    // Nothing auto-switched, so there is no one to return.
+    seedDockOnAnalysis()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+    expect(olumiTabIsFronted()).toBe(false)
+
+    startRun()
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+
+  it('NEVER YANK: a user interacting with the Analysis tab during the run is left there', () => {
+    seedDockOnOlumi()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+    startRun()
+    expect(olumiTabIsFronted()).toBe(false)
+
+    // Deliberate engagement anywhere inside the dock while the run is in
+    // flight — the honest "I am busy here" signal, derived from a real event
+    // rather than an enumerated list of controls.
+    act(() => {
+      fireEvent.pointerDown(screen.getByTestId('outputs-dock'))
+    })
+
+    landAnalysisTurn(rerender)
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+
+  it('NEVER YANK: a returning session whose transcript already holds an analysis is not moved', () => {
+    // A page reload with a completed analysis in the conversation must not
+    // re-fire the return: the count does not INCREASE, so nothing arrived.
+    convState.messages = [analysisTurnMessage('m-historical')]
+    seedDockOnAnalysis()
+    const { rerender } = render(
+      <Wrapper>
+        <OutputsDock />
+      </Wrapper>,
+    )
+
+    act(() => {
+      rerender(
+        <Wrapper>
+          <OutputsDock />
+        </Wrapper>,
+      )
+    })
+
+    expect(olumiTabIsFronted()).toBe(false)
+    expect(screen.getByTestId('olumi-tab-wrapper')).toHaveClass('hidden')
+  })
+})

--- a/src/canvas/components/__tests__/runReturnSignal.spec.ts
+++ b/src/canvas/components/__tests__/runReturnSignal.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * runReturnSignal — decision table for the ROADMAP 2.204 post-run return.
+ *
+ * The component-level pins live in OutputsDock.runReturnsToOlumi.spec.tsx (they
+ * prove the dock is WIRED to this decision). This file proves the decision
+ * itself, exhaustively and cheaply: one positive case, then EVERY input flipped
+ * individually against it.
+ *
+ * Why the per-input negatives are the point. `shouldReturnToOlumiAfterRun` is a
+ * six-way conjunction, and a conjunction is the easiest shape in which to ship a
+ * gate that never binds: drop any `&&` and the function still returns `true` for
+ * the happy path, so a test that only checks the happy path passes against a
+ * gate that has been deleted. Each `it` below is the named mutant for one
+ * clause — remove that clause from the implementation and exactly that test
+ * goes red.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ConversationMessage } from '../../conversation/types'
+import {
+  countAnalysisReviewBlocks,
+  shouldReturnToOlumiAfterRun,
+  type RunReturnSignalInput,
+} from '../runReturnSignal'
+
+function message(id: string, blocks?: unknown[]): ConversationMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: 'text',
+    timestamp: new Date(),
+    ...(blocks ? { blocks } : {}),
+  } as ConversationMessage
+}
+
+const analysisBlock = {
+  type: 'v5_analysis_result',
+  summary: 'Option A leads.',
+  leading_option_id: 'opt-a',
+}
+const coachingBlock = { type: 'v5_coaching', coaching_kind: 'strengthen', body: 'x' }
+const reviewCardBlock = { type: 'v5_review_card', card_kind: 'pre_mortem', body: 'y' }
+
+describe('countAnalysisReviewBlocks', () => {
+  it('is 0 for no conversation at all (undefined / null / empty)', () => {
+    expect(countAnalysisReviewBlocks(undefined)).toBe(0)
+    expect(countAnalysisReviewBlocks(null)).toBe(0)
+    expect(countAnalysisReviewBlocks([])).toBe(0)
+  })
+
+  it('is 0 for messages that carry no blocks', () => {
+    expect(countAnalysisReviewBlocks([message('a'), message('b')])).toBe(0)
+  })
+
+  it('counts the analysis-result block that renders the decision-review card', () => {
+    expect(countAnalysisReviewBlocks([message('a', [analysisBlock])])).toBe(1)
+  })
+
+  it('POSITIVE CONTROL for the type filter: the OTHER phase-3 block kinds do not count', () => {
+    // The same turn lands 8-14 phase-3 cards in the Olumi tab (measured in
+    // probe-premortem-live.md §4 Q2). If the count were "any block", every
+    // coaching card would read as a fresh analysis and the return would fire
+    // on conversational turns that ran no analysis at all.
+    const noise = [message('a', [coachingBlock, reviewCardBlock, coachingBlock])]
+    expect(countAnalysisReviewBlocks(noise)).toBe(0)
+    // …and it still finds the real one when it is buried among them.
+    const mixed = [message('a', [coachingBlock, analysisBlock, reviewCardBlock])]
+    expect(countAnalysisReviewBlocks(mixed)).toBe(1)
+  })
+
+  it('RERUN: a second analysis raises the count, so 1 → 2 is as detectable as 0 → 1', () => {
+    const first = [message('a', [analysisBlock])]
+    const second = [...first, message('b', [coachingBlock]), message('c', [analysisBlock])]
+    expect(countAnalysisReviewBlocks(first)).toBe(1)
+    expect(countAnalysisReviewBlocks(second)).toBe(2)
+    expect(countAnalysisReviewBlocks(second)).toBeGreaterThan(countAnalysisReviewBlocks(first))
+  })
+
+  it('RELOAD: an unchanged transcript yields an unchanged count (no phantom arrival)', () => {
+    const hydrated = [message('a', [analysisBlock])]
+    expect(countAnalysisReviewBlocks(hydrated)).toBe(countAnalysisReviewBlocks(hydrated))
+  })
+})
+
+/** The exact state of the tester the probes measured: they were reading the
+ *  conversation, Run moved them to Analysis, they waited, the analysis landed. */
+const RETURNS: RunReturnSignalInput = {
+  aiPanelV2On: true,
+  runAutoSwitchedToAnalysis: true,
+  dockTab: 'results',
+  dockEffectiveOpen: true,
+  userInteractedSinceRun: false,
+  reviewContentArrived: true,
+}
+
+describe('shouldReturnToOlumiAfterRun', () => {
+  it('returns the passive tester the probes measured', () => {
+    expect(shouldReturnToOlumiAfterRun(RETURNS)).toBe(true)
+  })
+
+  it('MUTANT — drop the flag gate: stands down with aiPanelV2 OFF (there is no Olumi tab)', () => {
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, aiPanelV2On: false })).toBe(false)
+  })
+
+  it('MUTANT — drop the we-moved-them gate: stands down when the run did not switch the tab', () => {
+    // A user already on Analysis when they pressed Run chose that tab.
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, runAutoSwitchedToAnalysis: false })).toBe(false)
+  })
+
+  it('MUTANT — drop the tab gate: stands down when the user is no longer on Analysis', () => {
+    // They navigated to Model/Compare mid-run; returning them to Olumi would
+    // be a second unwanted move, not a correction of the first.
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, dockTab: 'diagnostics' })).toBe(false)
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, dockTab: 'compare' })).toBe(false)
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, dockTab: 'olumi' })).toBe(false)
+  })
+
+  it('MUTANT — drop the dock-open gate: stands down while the dock is the collapsed rail', () => {
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, dockEffectiveOpen: false })).toBe(false)
+  })
+
+  it('MUTANT — drop the interaction gate: stands down for a user who is doing something', () => {
+    // THE ruling's load-bearing clause: never yank a user who navigated or
+    // engaged themselves.
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, userInteractedSinceRun: true })).toBe(false)
+  })
+
+  it('MUTANT — drop the content gate: stands down when nothing arrived to return TO', () => {
+    // The non-conversational run path completes the results store while putting
+    // nothing in the Olumi tab; returning a user to an empty surface is worse
+    // than leaving them on the numbers.
+    expect(shouldReturnToOlumiAfterRun({ ...RETURNS, reviewContentArrived: false })).toBe(false)
+  })
+})

--- a/src/canvas/components/runReturnSignal.ts
+++ b/src/canvas/components/runReturnSignal.ts
@@ -93,6 +93,12 @@ export interface RunReturnSignalInput {
    * honest: a user who was ALREADY on Analysis when they pressed Run chose that
    * tab, so they are never moved off it. Cleared by any manual tab click and by
    * the return itself, so it can only ever spend once per run.
+   *
+   * The caller ASSIGNS this on every run start rather than only raising it. As
+   * a raise-only flag it survived a run that produced no block (error / cancel
+   * / the non-conversational path) and armed the NEXT run — so a user who
+   * errored, stayed on Analysis and re-ran from there was yanked by the first
+   * run's record, in direct contradiction of the invariant this field states.
    */
   runAutoSwitchedToAnalysis: boolean
   /** The dock's currently selected tab. */
@@ -105,14 +111,21 @@ export interface RunReturnSignalInput {
   dockEffectiveOpen: boolean
   /**
    * The user has deliberately interacted with the dock since this run started —
-   * any pointerdown or keydown anywhere inside it (which includes the tab strip
-   * and every Analysis-tab control).
+   * any pointerdown, keydown or WHEEL anywhere inside it (which includes the
+   * tab strip, every Analysis-tab control, and the scroll region).
    *
    * DERIVED FROM REAL EVENTS, not from an enumerated list of "controls that
    * count" (trap 12: such a list rots the moment a control is added and reads
-   * green while it does). Passive waiting produces neither event, so the tester
+   * green while it does). Passive waiting produces none of them, so the tester
    * the probes measured — who clicks Run and watches — is returned; a tester
    * who is reading and clicking around the Analysis tab is left alone.
+   *
+   * `wheel` is in that set and `scroll` deliberately is NOT: the dock body is
+   * `overflow-y-auto`, so scroll-reading while waiting is the likeliest waiting
+   * behaviour of all and a pointer/key pair could not see it — but `scroll` is
+   * also emitted by ChatThread's own programmatic `scrollIntoView`, with no
+   * user behind it, which would stand the return down for the very tester it
+   * exists to serve.
    */
   userInteractedSinceRun: boolean
   /**

--- a/src/canvas/components/runReturnSignal.ts
+++ b/src/canvas/components/runReturnSignal.ts
@@ -1,0 +1,151 @@
+/**
+ * runReturnSignal — decides whether a completed analysis must return the dock
+ * to the Olumi tab the run action navigated it away from.
+ *
+ * ## The defect this fixes (ROADMAP 2.204)
+ * Clicking **Run analysis** dispatches a `run_analysis` turn, which calls
+ * `resultsAnalysing()` synchronously at dispatch (useConversation.ts:4041 →
+ * store.ts:3322, `status: 'preparing'`). OutputsDock's merged auto-switch
+ * effect sees `resultsStatus` transition idle/cancelled → active and moves the
+ * dock to the **Analysis** tab.
+ *
+ * The turn's own output lands somewhere else. `applyV5State.ts:1058` flips the
+ * results store to 'complete' off the SAME turn whose blocks become
+ * `v5_analysis_result` (mapV5Blocks.ts:63) and render through
+ * `InlineBlocks.tsx:412` → `<V5AnalysisResultBlock>` — inside the **Olumi**
+ * conversation tab, whose wrapper carries `hidden` + `aria-hidden` whenever the
+ * active tab is not 'olumi' (OutputsDock.tsx:2541-2543).
+ *
+ * So the run action navigates away from the surface it produces, and nothing
+ * brings the user back. Live-proven 31 Jul in a real browser: with the analysis
+ * complete, the review container measured 0 px² for a **180 s** poll and did not
+ * self-reveal; a single click on the Olumi tab took it to 268,862 px²
+ * (`PHASE0-EVIDENCE-2026-07-28/probe-2154-visibility.md` §4 Q1 CAVEAT, and
+ * `probe-premortem-live.md` §4 Q2 — "two ordinary clicks stand between a tester
+ * and this card"). A tester who clicks Run and stays where the UI put them never
+ * sees it.
+ *
+ * ## Why a return, and not a copy in the Analysis tab
+ * The review content is a CONVERSATION BLOCK (`messages[].blocks[]`, the
+ * `V5AnalysisResultBlock` member of the ConversationBlock union), not a canvas
+ * store slice — there is no shared slice for an Analysis-tab copy to read. It is
+ * also one of 8-14 phase-3 cards the same turn lands in that tab (measured, see
+ * probe-premortem-live.md §4 Q2). Rendering one of them in a second surface
+ * leaves the rest stranded and puts two live copies of the same card on screen;
+ * returning the user restores all of it, and reuses the tab-dock action the file
+ * already performs verbatim at OutputsDock.tsx:571-572.
+ *
+ * ## Why a pure helper
+ * Same convention as the other dock decision helpers — `dockHostsOlumi`
+ * (olumiSurface.ts), `shouldAutoExpandDockForResponse` (collapsedResponseSignal.ts),
+ * `deriveNextDockIsOpen` — so the decision is directly and mutation-checkably
+ * testable independent of the component. OutputsDock's effect is a thin caller
+ * that only gathers the inputs.
+ */
+
+import type { OlumiDockTab } from './olumiSurface'
+import type { ConversationMessage } from '../conversation/types'
+
+/**
+ * How many V5 analysis-result blocks the conversation currently carries.
+ *
+ * DERIVED, not mirrored (trap 12): counted from the live message list on every
+ * call rather than tracked by a parallel flag that a future producer change
+ * could leave stale. The caller compares consecutive counts, so a rerun
+ * (1 → 2) is as detectable as a first run (0 → 1), and a page reload with a
+ * completed analysis already in the transcript produces NO increase — a
+ * returning user is never yanked by their own history.
+ *
+ * `'v5_analysis_result'` is the single conversation-block type the V5 mapper
+ * emits for an analysis result (mapV5Blocks.ts:61-68), and it is the block that
+ * renders the decision-review card (InlineBlocks.tsx:412). Synthetic messages
+ * are NOT skipped: a synthetic bubble never carries this block type, and
+ * filtering would add a second condition with no live effect.
+ */
+export function countAnalysisReviewBlocks(
+  messages: readonly ConversationMessage[] | undefined | null,
+): number {
+  if (!messages || messages.length === 0) return 0
+  let count = 0
+  for (const message of messages) {
+    const blocks = message.blocks
+    if (!blocks) continue
+    for (const block of blocks) {
+      if (block.type === 'v5_analysis_result') count++
+    }
+  }
+  return count
+}
+
+export interface RunReturnSignalInput {
+  /**
+   * aiPanelV2 floating-first UX is active. The whole signal is FF-gated: with
+   * the flag OFF there is no Olumi tab at all — OutputsDock redirects
+   * 'olumi' → 'results' (OutputsDock.tsx:325-327) — so a return would be a
+   * no-op that fights its own guard.
+   */
+  aiPanelV2On: boolean
+  /**
+   * THIS run moved the dock to the Analysis tab (the merged auto-switch effect
+   * fired on a run-start transition while the dock was showing some other tab).
+   *
+   * This is the "we took them here" record, and it is what makes the return
+   * honest: a user who was ALREADY on Analysis when they pressed Run chose that
+   * tab, so they are never moved off it. Cleared by any manual tab click and by
+   * the return itself, so it can only ever spend once per run.
+   */
+  runAutoSwitchedToAnalysis: boolean
+  /** The dock's currently selected tab. */
+  dockTab: OlumiDockTab
+  /**
+   * The dock is VISUALLY showing its body, not the collapsed 40px rail
+   * (`effectiveIsOpen`). Switching the tab of a collapsed rail reveals nothing;
+   * that state is the collapsed-response signal's job, not this one.
+   */
+  dockEffectiveOpen: boolean
+  /**
+   * The user has deliberately interacted with the dock since this run started —
+   * any pointerdown or keydown anywhere inside it (which includes the tab strip
+   * and every Analysis-tab control).
+   *
+   * DERIVED FROM REAL EVENTS, not from an enumerated list of "controls that
+   * count" (trap 12: such a list rots the moment a control is added and reads
+   * green while it does). Passive waiting produces neither event, so the tester
+   * the probes measured — who clicks Run and watches — is returned; a tester
+   * who is reading and clicking around the Analysis tab is left alone.
+   */
+  userInteractedSinceRun: boolean
+  /**
+   * A NEW analysis-result block just landed in the conversation — i.e. the
+   * content that is stranded in the hidden tab now exists.
+   *
+   * This, rather than `resultsStatus === 'complete'`, is the trigger: the
+   * non-conversational run path (useV2Run) also completes the results store but
+   * puts nothing in the Olumi tab, and returning a user to an empty surface
+   * would be worse than leaving them. Deliberately NOT narrowed further to
+   * "…and the block carries prose": the tab also receives the turn's review
+   * cards and coaching, and a hidden conjunction that silently stands the fix
+   * down on some turns is the failure mode the pre-mortem lens probe measured.
+   */
+  reviewContentArrived: boolean
+}
+
+/**
+ * Whether a completed analysis must return the dock to the Olumi tab.
+ *
+ * Every gate must hold. The two that carry the ruling are
+ * `runAutoSwitchedToAnalysis` (only return a user we moved) and
+ * `!userInteractedSinceRun` (never yank a user who is doing something) — together
+ * they mean the dock moves only for the passive tester the probes measured, and
+ * never against a deliberate choice.
+ */
+export function shouldReturnToOlumiAfterRun(input: RunReturnSignalInput): boolean {
+  return (
+    input.aiPanelV2On &&
+    input.runAutoSwitchedToAnalysis &&
+    input.dockTab === 'results' &&
+    input.dockEffectiveOpen &&
+    !input.userInteractedSinceRun &&
+    input.reviewContentArrived
+  )
+}


### PR DESCRIPTION
Fixes **ROADMAP 2.204** — a live-proven, tester-visible defect: *Run analysis* navigates away
from the surface it produces, and never brings the user back.

Evidence: `PHASE0-EVIDENCE-2026-07-28/fix-2204-run-navigation.md`.

## The defect, traced at the bytes (not inferred)

| # | file:line | what happens |
|---|---|---|
| 1 | `useConversation.ts:4041` | a `run_analysis` turn calls `resultsAnalysing()` synchronously at dispatch |
| 2 | `store.ts:3322` | `results.status = 'preparing'` |
| 3 | `OutputsDock.tsx` merged auto-switch effect | sees idle → active and moves the dock to **Analysis** |
| 4 | `applyV5State.ts:1058` | the turn returns with an `analysisBlock` → `resultsComplete` |
| 5 | `mapV5Blocks.ts:63` → `InlineBlocks.tsx:412` | the same turn's block renders `<V5AnalysisResultBlock>` — in the **Olumi** tab |
| 6 | `OutputsDock.tsx:2646-2648` | `olumi-tab-wrapper` carries `hidden` + `aria-hidden` whenever Analysis is fronted |

Live-proven 31 Jul in a real browser: with the analysis complete the review container measured
**0 px² across a 180 s poll** and did not self-reveal; one click on the Olumi tab took it to
**268,862 px²** (`probe-2154-visibility.md` §4 Q1 CAVEAT, re-confirmed in
`probe-premortem-live.md` §4 Q2). A tester who clicks Run and stays put never sees the five
explanation fields 2.154 rescued.

## Form (a) — auto-return — and why, at the bytes

The ruling allowed (a) auto-return or (b) surface it in the Analysis tab. **(a)**, because:

- **(b) has no store slice to read from.** The content is a CONVERSATION BLOCK
  (`ConversationMessage.blocks[]`, `types.ts:20/151`), rendered through `ConversationPanel` →
  `InlineBlocks`. The ruling's own condition for (b) — "render from the SAME store slice the
  Olumi tab reads" — has no referent; there is no such slice.
- **(b) rescues one card of 8-14.** Measured, not assumed: the same turn lands 13 phase-3
  cards in that tab (`probe-premortem-live.md` §4 Q2 — `Show 10 more` → *"Showing all 13
  coaching and review cards"*). The review cards, coaching and the conversation itself would
  stay stranded. (a) restores all of it.
- **(b) puts two live copies of the same card on screen.** The Olumi tab is deliberately kept
  mounted across tab switches (`OutputsDock.tsx:2637-2643`), and this file spends four
  documented rounds enforcing the opposite doctrine (`olumiSurface.ts`: *"exactly one may be
  visible at a time"*).
- **(a) is the smaller, more consistent diff.** The switch-away is one effect in this same
  file, already carrying the "only on transition, never yank" discipline. The return is its
  symmetric counterpart, reusing the tab-dock action the file already performs verbatim at
  `OutputsDock.tsx:571-572`, and the pure-decision-helper convention it already uses three
  times (`dockHostsOlumi`, `shouldAutoExpandDockForResponse`, `deriveNextDockIsOpen`).

**+105 lines of product code**, one new pure helper, nothing moved or re-parented.

## Two design choices worth reviewing

**The trigger is the ARRIVAL of a new `v5_analysis_result` block, not `status === 'complete'`.**
`useV2Run.ts:863,991` also completes the results store on a path that puts nothing in the Olumi
tab; a status-keyed trigger would return the user to an empty surface. Counting rather than
flagging also makes a rerun (1 → 2) as detectable as a first run (0 → 1), and makes a page
reload produce **no** increase — a returning user is never yanked by their own history.

**"Has interacted" is derived from real DOM events**, not an enumerated list of controls that
count (that list is trap 12's hand-maintained mirror). `onPointerDownCapture` +
`onKeyDownCapture` on the dock root: any deliberate press or keystroke anywhere inside stands
the return down. Passive waiting fires neither, so the tester the probes measured is returned.

## RED-first

Throwaway worktree **outside** the clone root (trap 9c), detached at pristine `15c48143`, helper
+ specs copied onto unfixed product code:

```
 FAIL  OutputsDock.runReturnsToOlumi.spec.tsx > THE DEFECT: Run navigates away from Olumi,
       and the completed analysis brings the user back
AssertionError: expected false to be true
 ❯ …spec.tsx:269:33   expect(olumiTabIsFronted()).toBe(true)
      Tests  1 failed | 17 passed (18)
```

**Recorded because it matters: the four "NEVER YANK" tests pass on the unfixed code** — an
unfixed dock never moves anyone, so "it didn't move them" is free there. Test 1 is the only one
detecting the defect; the other four exist to constrain the fix.

## Mutants — four, each biting exactly one named test

| # | mutation (all in `OutputsDock.tsx` — WIRING, not the helper) | test that REDs |
|---|---|---|
| M1 | delete the interaction capture handlers | user interacting with the Analysis tab |
| M2 | trigger on `> 0` instead of `> previousCount` | RERUN waits for the NEW analysis |
| M3 | set the auto-switch record unconditionally | user already on Analysis when they pressed Run |
| M4 | drop the record reset in `handleTabClick` | user who navigated to Analysis themselves |

Each `1 failed | 18 passed (19)`. M5 (delete the effect) is the RED-first above. The mutation
script asserts its own anchor matched and exits non-zero otherwise (trap 15).

**⚠ M2 SURVIVED the first pass.** My "returning session" test could not see it: with no run in
that scenario the auto-switch record is `false`, so the conjunction fails on a *different*
clause and the arrival check is never reached — vacuous, trap 13's shape. The isolating case is
a **rerun**, where the transcript already holds the previous run's block: under `> 0` the dock
snaps back to Olumi the instant Rerun is pressed, mid-analysis. That test was added (`a9ba6cdd`),
M2 now bites, and the reload test's docstring was corrected to name the clause that actually
guards it.

## Gates — `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set on every run (trap 2b)

| gate | result |
|---|---|
| `pnpm run typecheck` | **PASS** — coverage 3101/3141, ratchet 622 files / 2505 errors (baseline 2510) |
| new specs | **19 passed (19)** |
| scoped regression (`canvas/components/__tests__` + `useDockState`) | **129 files, 1514 passed / 24 skipped, 0 failed** |
| fast pre-push gate | checks **1-7 PASS**; check 8 fails — pre-existing, proven below |
| `npx eslint` over all 4 changed files | **0 errors** (1 warning at `:1188`, ahead of my first edit) |

No full suite locally (it OOMs — repo `CLAUDE.md`).

**Both known-red claims are proven empty against base, not asserted:**
- **Typecheck**: a pristine `15c48143` worktree through the same gate gives the *identical*
  622 files / 2505 errors / baseline 2510 and the same `5 fixed, none added` notice. The shrink
  is pre-existing; my error delta is **zero**. `--update-baseline` **NOT** accepted.
- **Check 8 (DS v5 drift)**: `check-ds-compliance.mjs --enforce` run at pristine base and on
  the branch, outputs `diff`ed → **byte-identical, both exit 1**. Every net-new violation it
  lists is in a file this PR does not touch. `--update-baseline` **NOT** accepted.

## Honest limits

- **No pixel is claimed.** jsdom cannot prove visibility (trap 3). What is pinned is the STATE
  that decides it — active tab, and the `hidden` class + `aria-hidden` the wrapper derives from
  it, which is the exact attribute the live probe measured as `display: none`. **Pixel proof
  rides the post-deploy walk on staging and is owed.**
- The specs drive a controlled `useConversation` stub, so they prove the dock reacts to a block
  arriving — not that CEE emits one (already measured by the 2154 probe).
- Only the aiPanelV2-ON path is exercised; with the flag OFF there is no Olumi tab.
- **The pre-push gate's check 3 lints `HEAD~1..HEAD` only** (`validate-prepush.sh:57`), so it
  reported "1 changed file". All four were linted explicitly instead.

## Not touched (out of scope by instruction)

**ROADMAP 2.211 is untouched**: `PHASE3_DEFAULT_EXPANDED`, the lens selector and block ranking
are unmodified. The premortem probe names TWO clicks between a tester and a card — the tab
(this PR) and the `Show N more` pacing affordance (2.211). This PR removes the first only.
No telemetry/measurement file touched (another lane owns those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
