### PR TITLE
feat(ui): raise PHASE3_DEFAULT_EXPANDED 3 → 6 (ROADMAP 2.211-②)

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -3,8 +3,11 @@
  *
  * Supports all ConversationBlock types. Unknown block_type values render
  * a neutral fallback card — never crash.
- * Max 4 visible per turn with "Show more" toggle (graph_patch proposed blocks
- * always stay visible — budget is enforced upstream in useConversation).
+ * Max 4 NON-phase-3 blocks visible per turn with "Show more" toggle
+ * (graph_patch proposed blocks always stay visible — budget is enforced
+ * upstream in useConversation). Phase-3 cards are governed instead by the
+ * pacing group in phase3Pacing.ts (PHASE3_DEFAULT_EXPANDED, 6 since
+ * ROADMAP 2.211-②), never by the legacy budget.
  */
 
 import { useState, useCallback, useMemo, memo, useRef } from 'react'
@@ -140,25 +143,40 @@ export const InlineBlocks = memo(function InlineBlocks({
   assistantTextWordCount = 0,
 }: InlineBlocksProps) {
   const [showAll, setShowAll] = useState(false)
-  // F16: phase-3 card pacing — flood turns default to the top 3 phase-3
-  // cards expanded, the remainder behind ONE count affordance.
+  // F16: phase-3 card pacing — flood turns default to the top
+  // PHASE3_DEFAULT_EXPANDED phase-3 cards expanded (6 since ROADMAP
+  // 2.211-②), the remainder behind ONE count affordance.
   const [showAllPhase3, setShowAllPhase3] = useState(false)
 
   const pacing = useMemo(() => computePhase3Pacing(blocks), [blocks])
 
-  // Legacy per-turn budget. When phase-3 pacing is active, the phase-3
-  // cards carry their own budget (the pacing group), so the legacy cap
-  // counts only the non-phase-3 blocks; otherwise behaviour is unchanged
-  // (cap across all blocks, as before F16). Bias-signal cards are exempt
-  // (review-folds C1) — but only the FIRST DRAFT_BIAS_SIGNAL_CARD_CAP of
-  // them (/simplify item 5), from the ONE exempt set computePhase3Pacing
-  // already derived, so this budget and the pacing budget cannot disagree.
-  // Bias cards beyond the cap fall through to the normal budget path.
+  // Legacy per-turn budget over the NON-phase-3 blocks only: the phase-3
+  // cards always carry their own budget (the pacing group), exactly as this
+  // module's header declares ("the pacing group is the phase-3 budget").
+  //
+  // ⚠ The exclusion used to be conditional on `pacing.pacingActive`, and
+  // ROADMAP 2.211-② turned that into a DEAD BAND. The legacy cap is 4
+  // (MAX_VISIBLE_BLOCKS_PER_TURN). While the default-expanded cap was 3 the
+  // two could not collide — pacing switched on at 4 phase-3 cards, and any
+  // smaller group fitted inside the legacy 4. At a cap of 6, turns carrying
+  // 5 or 6 phase-3 cards no longer activate pacing, fell back into the
+  // legacy budget, and rendered FOUR cards behind "Show N more blocks" —
+  // i.e. the ruled constant would read 6 while the user saw 4, on precisely
+  // the turn sizes the ruling was meant to open up. Making the exclusion
+  // unconditional is what makes the ruled number true; it is monotone
+  // (a block can only become visible, never hidden), and it raises no flood
+  // ceiling, because the pacing group caps phase-3 cards at 6 regardless.
+  //
+  // Bias-signal cards are exempt (review-folds C1) — but only the FIRST
+  // DRAFT_BIAS_SIGNAL_CARD_CAP of them (/simplify item 5), from the ONE
+  // exempt set computePhase3Pacing already derived, so this budget and the
+  // pacing budget cannot disagree. Bias cards beyond the cap fall through to
+  // the normal budget path.
   const { hiddenByBudget, hasOverflow, hiddenCount } = useMemo(() => {
     const budgetIndices: number[] = []
     for (let i = 0; i < blocks.length; i++) {
       if (pacing.biasSignalExemptIndices.has(i)) continue
-      if (pacing.pacingActive && isPhase3CardBlock(blocks[i])) continue
+      if (isPhase3CardBlock(blocks[i])) continue
       budgetIndices.push(i)
     }
     return {

--- a/src/canvas/conversation/__tests__/InlineBlocks.biasSignalBudget.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.biasSignalBudget.spec.tsx
@@ -4,15 +4,23 @@
  * default — they carry their own cap in buildDraftBiasSignalBlocks).
  *
  * Two previously-failing regimes, pinned RED-first:
- *   1. FLOOD turn: >3 producer phase-3 cards + 2 bias cards. Bias cards
- *      used to join phase3Indices, land past the default-expanded 3 and
- *      collapse behind "Show N more".
+ *   1. FLOOD turn: more producer phase-3 cards than the default-expanded
+ *      cap, + 2 bias cards. Bias cards used to join phase3Indices, land
+ *      past the cap and collapse behind "Show N more".
  *   2. BLOCK-RICH turn: ≥4 non-phase-3 blocks + 2 bias cards with pacing
  *      inactive. Bias cards used to join budgetIndices, land past the
  *      legacy per-turn cap (4) and hide behind the overflow toggle.
  *
- * Also pinned: bias cards do not COUNT toward the >3 pacing trigger, so a
- * turn with 3 producer phase-3 cards + 2 bias cards paces nothing.
+ * Also pinned: bias cards do not COUNT toward the pacing trigger, so a turn
+ * with exactly cap-many producer phase-3 cards + 2 bias cards paces nothing.
+ *
+ * ⚠ FIXTURES RESIZED — ROADMAP 2.211-② (founder ruling, 1 Aug) moved
+ * PHASE3_DEFAULT_EXPANDED 3 → 6. Each fixture below was grown so it still
+ * straddles the cap; the ASSERTIONS are unchanged in kind. Two of them had
+ * to grow or they would have kept passing for the wrong reason — a turn of
+ * 3 producer + 2 bias cards is under a cap of 6 whether or not bias cards
+ * are exempt, so that pin would have gone vacuous (platform trap 12b) while
+ * still reading green. Sizes are literal, never derived from the constant.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -96,11 +104,9 @@ const framing: FramingBlock = { type: 'framing', goal: 'A goal', options: [] }
 const visibleBiasCards = () => screen.queryAllByTestId('bias-signal-card')
 
 describe('C1 regime 1 — FLOOD turn: producer phase-3 flood + 2 bias cards', () => {
+  // 7 producer cards against the cap of 6 → exactly 1 collapsed.
   const blocks: ConversationBlock[] = [
-    reviewCard(1),
-    reviewCard(2),
-    reviewCard(3),
-    reviewCard(4),
+    ...[1, 2, 3, 4, 5, 6, 7].map(reviewCard),
     biasCard(1),
     biasCard(2),
   ]
@@ -112,14 +118,19 @@ describe('C1 regime 1 — FLOOD turn: producer phase-3 flood + 2 bias cards', ()
 
   it('the pacing affordance counts ONLY the collapsed producer cards (1 here), not the bias cards', () => {
     render(<InlineBlocks blocks={blocks} />)
+    // Discriminating: were the 2 bias cards counted, 9 cards over a cap of 6
+    // would read "Show 3 more".
     expect(screen.getByRole('button', { name: /show 1 more/i })).toBeInTheDocument()
   })
 
-  it('bias cards do not count toward the >3 pacing trigger: 3 producer + 2 bias paces nothing', () => {
+  it('bias cards do not count toward the pacing trigger: 6 producer + 2 bias paces nothing', () => {
     render(
-      <InlineBlocks blocks={[reviewCard(1), reviewCard(2), reviewCard(3), biasCard(1), biasCard(2)]} />,
+      <InlineBlocks blocks={[...[1, 2, 3, 4, 5, 6].map(reviewCard), biasCard(1), biasCard(2)]} />,
     )
     expect(visibleBiasCards()).toHaveLength(2)
+    // Discriminating at the cap: 6 exempt-excluded cards do not pace, but 8
+    // counted ones would. This fixture was 3 producer cards while the cap was
+    // 3; left at 3 it would sit under a cap of 6 either way and prove nothing.
     expect(screen.queryByRole('button', { name: /show \d+ more/i })).not.toBeInTheDocument()
   })
 })
@@ -163,20 +174,20 @@ describe('/simplify item 5 — the cap is STRUCTURAL: producer bias floods are b
 
   it('13 producer bias blocks → only the first 2 are budget-exempt', () => {
     render(<InlineBlocks blocks={thirteen} />)
-    // 2 exempt + the 3 the phase-3 pacing budget defaults to expanded.
-    expect(visibleBiasCards()).toHaveLength(5)
+    // 2 exempt + the 6 the phase-3 pacing budget defaults to expanded (2.211-②).
+    expect(visibleBiasCards()).toHaveLength(8)
   })
 
-  it('the remaining 8 fall through to the normal pacing path, behind ONE affordance', () => {
+  it('the remaining 5 fall through to the normal pacing path, behind ONE affordance', () => {
     render(<InlineBlocks blocks={thirteen} />)
-    expect(screen.getByRole('button', { name: /show 8 more coaching and review card/i }))
+    expect(screen.getByRole('button', { name: /show 5 more coaching and review card/i }))
       .toBeInTheDocument()
   })
 
   it('revealing the affordance shows all 13 — nothing is dropped, only paced', async () => {
     const { default: userEvent } = await import('@testing-library/user-event')
     render(<InlineBlocks blocks={thirteen} />)
-    await userEvent.click(screen.getByRole('button', { name: /show 8 more coaching and review card/i }))
+    await userEvent.click(screen.getByRole('button', { name: /show 5 more coaching and review card/i }))
     expect(visibleBiasCards()).toHaveLength(13)
   })
 

--- a/src/canvas/conversation/__tests__/InlineBlocks.citationReveal.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.citationReveal.spec.tsx
@@ -12,6 +12,9 @@
  *        rendered for a turn whose ONLY phase-3 card was hidden behind the
  *        legacy "Show 1 more" budget (a legend for invisible cards). It
  *        now gates on at least one phase-3 card CURRENTLY RENDERED.
+ *        ⚠ See the note on the C13 describe below: ROADMAP 2.211-② made
+ *        that construction unreachable, and the pin was rewritten to say so
+ *        rather than left passing for a reason that no longer exists.
  *   C4:  the pacing count span was role="status" nested inside the block
  *        container — a live region that replayed on unhide and
  *        double-announced with the toggle's accessible name. The sr-only
@@ -95,48 +98,53 @@ afterEach(() => {
 
 describe('C11 — citation to collapsed content reveals and scrolls', () => {
   it('a citation targeting a pacing-collapsed phase-3 card expands the collapse and scrolls to it', () => {
-    // blocks[0] commentary with a citation at index 6 → blocks[5] (rc_5),
-    // which sits behind the phase-3 pacing collapse (5 phase-3 cards,
-    // default-expanded 3).
+    // blocks[0] commentary with a citation at index 8 → blocks[7] (rc_7),
+    // which sits behind the phase-3 pacing collapse (7 phase-3 cards,
+    // default-expanded 6). Fixture resized for ROADMAP 2.211-② (was 5 cards
+    // against a cap of 3); same one-card-past-the-cap shape, same assertion.
     const commentary: CommentaryBlock = {
       type: 'commentary',
-      text: 'The verdict rests on the last review card. [6]',
-      citations: [{ index: 6, source: 'Model review' }],
+      text: 'The verdict rests on the last review card. [8]',
+      citations: [{ index: 8, source: 'Model review' }],
     }
     const blocks: ConversationBlock[] = [
       commentary,
-      reviewCard(1),
-      reviewCard(2),
-      reviewCard(3),
-      reviewCard(4),
-      reviewCard(5),
+      ...[1, 2, 3, 4, 5, 6, 7].map(reviewCard),
     ]
     render(<InlineBlocks blocks={blocks} />)
     // The target card is collapsed (not rendered).
-    expect(screen.queryByText('Review card 5')).not.toBeInTheDocument()
+    expect(screen.queryByText('Review card 7')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /citation 6/i }))
+    fireEvent.click(screen.getByRole('button', { name: /citation 8/i }))
 
     // Revealed and scrolled — not a silent no-op.
-    expect(screen.getByText('Review card 5')).toBeInTheDocument()
+    expect(screen.getByText('Review card 7')).toBeInTheDocument()
     expect(scrollSpy).toHaveBeenCalled()
   })
 
   it('a citation targeting a budget-hidden block expands "Show more" and scrolls to it', () => {
-    // Pacing inactive (1 phase-3 card); the 5th block (index 4, citation
-    // target 5) hides behind the legacy per-turn budget of 4.
+    // The 5th block (index 4, citation target 5) hides behind the legacy
+    // per-turn budget of 4.
+    //
+    // ⚠ The hidden block used to be a v5_coaching card. ROADMAP 2.211-②
+    // removed phase-3 cards from the legacy budget entirely (they are
+    // governed by the pacing group alone), so a phase-3 card can no longer
+    // BE budget-hidden — the old fixture would have proved nothing. The
+    // target is now a non-phase-3 block, which is what the legacy budget
+    // still governs, so this pin keeps testing the reveal path it names.
+    const secondBrief: BriefBlock = { type: 'brief', title: 'Second brief', summary: 'More.' }
     const commentary: CommentaryBlock = {
       type: 'commentary',
-      text: 'See the coaching card. [5]',
-      citations: [{ index: 5, source: 'Model coaching' }],
+      text: 'See the second brief. [5]',
+      citations: [{ index: 5, source: 'Model brief' }],
     }
-    const blocks: ConversationBlock[] = [commentary, fact, framing, brief, coaching(1)]
+    const blocks: ConversationBlock[] = [commentary, fact, framing, brief, secondBrief]
     render(<InlineBlocks blocks={blocks} />)
-    expect(screen.queryByText('Coaching card 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Second brief')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /citation 5/i }))
 
-    expect(screen.getByText('Coaching card 1')).toBeInTheDocument()
+    expect(screen.getByText('Second brief')).toBeInTheDocument()
     expect(scrollSpy).toHaveBeenCalled()
   })
 
@@ -159,40 +167,54 @@ describe('C11 — citation to collapsed content reveals and scrolls', () => {
       text: 'See the fact. [2]',
       citations: [{ index: 2, source: 'Lift' }],
     }
+    // 7 phase-3 cards against the 2.211-② cap of 6 → rc_7 stays collapsed
+    // (was 4 cards against a cap of 3).
     const blocks: ConversationBlock[] = [
       commentary,
       fact,
-      reviewCard(1),
-      reviewCard(2),
-      reviewCard(3),
-      reviewCard(4),
+      ...[1, 2, 3, 4, 5, 6, 7].map(reviewCard),
     ]
     render(<InlineBlocks blocks={blocks} />)
     fireEvent.click(screen.getByRole('button', { name: /citation 2/i }))
     expect(scrollSpy).toHaveBeenCalled()
-    // The pacing collapse stays collapsed (rc_4 remains hidden).
-    expect(screen.queryByText('Review card 4')).not.toBeInTheDocument()
+    // The pacing collapse stays collapsed (rc_7 remains hidden).
+    expect(screen.queryByText('Review card 7')).not.toBeInTheDocument()
   })
 })
 
 describe('C13 — legend gates on a phase-3 card being CURRENTLY RENDERED', () => {
-  it('verifier construction: [commentary, fact, framing, brief, v5_coaching] → no legend until "Show 1 more"', () => {
+  /**
+   * ⚠ ROADMAP 2.211-② CHANGED WHAT THIS CAN PROVE — recorded, not papered over.
+   *
+   * The original verifier was [commentary, fact, framing, brief, v5_coaching]:
+   * the turn's ONLY phase-3 card sat behind the legacy "Show 1 more" budget,
+   * so the legend had to stay away until it was revealed. 2.211-② removed
+   * phase-3 cards from the legacy budget, and the pacing group always renders
+   * its first PHASE3_DEFAULT_EXPANDED cards — so **a turn that carries a
+   * phase-3 card now always renders at least one**, and the "every phase-3
+   * card hidden" state is unreachable through either budget.
+   *
+   * The C13 guard in InlineBlocks is deliberately KEPT (it is still the
+   * correct predicate, and it is what makes the reachability argument true
+   * rather than accidental), but no fixture can drive it to false while a
+   * phase-3 card is present. So this pin now asserts the reachability claim
+   * itself — the same construction, opposite expectation — and the live
+   * negative case is "no phase-3 cards at all", pinned below and in
+   * InlineBlocks.phase3Pacing.spec.tsx. Anything else here would be a test
+   * that passes by testing nothing (platform trap 13).
+   */
+  it('2.211-②: the sole phase-3 card is no longer budget-hidden, so the legend renders at once', () => {
     const commentary: CommentaryBlock = { type: 'commentary', text: 'Some commentary.' }
     const blocks: ConversationBlock[] = [commentary, fact, framing, brief, coaching(1)]
     render(<InlineBlocks blocks={blocks} />)
-    // The only phase-3 card is hidden behind the legacy budget — a legend
-    // for invisible cards must not render.
-    expect(screen.queryByText('Coaching card 1')).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: /what do these terms mean/i }),
-    ).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /show 1 more/i }))
-
+    // The card is rendered — the legacy budget no longer governs phase-3 cards.
     expect(screen.getByText('Coaching card 1')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /what do these terms mean/i }),
     ).toBeInTheDocument()
+    // …and the legacy budget still governs the four non-phase-3 blocks, which
+    // fit exactly, so it contributes no overflow toggle of its own.
+    expect(screen.queryByRole('button', { name: /more block/i })).not.toBeInTheDocument()
   })
 
   it('legend renders alongside default-expanded phase-3 cards (unchanged happy path)', () => {
@@ -205,7 +227,11 @@ describe('C13 — legend gates on a phase-3 card being CURRENTLY RENDERED', () =
 
 describe('C4 — the pacing count is static sr-only text, not a nested live region', () => {
   it('renders the collapsed-count text without role="status" (the toggle name already carries the count)', () => {
-    const blocks: ConversationBlock[] = [1, 2, 3, 4, 5].map(reviewCard)
+    // 8 cards against the 2.211-② default-expanded cap of 6 → 2 collapsed.
+    // This fixture was 5 cards while the cap was 3 (same 2-collapsed shape);
+    // it was resized, NOT re-expected, so the assertion below is byte-identical
+    // to the one this pin has always made.
+    const blocks: ConversationBlock[] = [1, 2, 3, 4, 5, 6, 7, 8].map(reviewCard)
     const { container } = render(<InlineBlocks blocks={blocks} />)
     // The sr-only summary text is still present…
     expect(screen.getByText(/2 more coaching and review cards collapsed/i)).toBeInTheDocument()

--- a/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.phase3Pacing.spec.tsx
@@ -6,13 +6,21 @@
  * 5 review_card + 4 coaching + 1 evidence) with no pacing — a card flood.
  * These pins hold the ratified pacing contract at the RENDER layer
  * (InlineBlocks): the store/message keeps ALL blocks; the panel defaults to
- * the top 3 phase-3 cards expanded, the remainder behind exactly ONE count
- * affordance, order preserved exactly, collapsed count announced to screen
- * readers. A small "What do these terms mean?" affordance offers the graph
- * vocabulary legend near the cards.
+ * the top PHASE3_DEFAULT_EXPANDED phase-3 cards expanded, the remainder
+ * behind exactly ONE count affordance, order preserved exactly, collapsed
+ * count announced to screen readers. A small "What do these terms mean?"
+ * affordance offers the graph vocabulary legend near the cards.
+ *
+ * ⚠ COUNTS UPDATED — ROADMAP 2.211-② (founder ruling, 1 Aug): the
+ * default-expanded cap moved 3 → 6. Every count below that used to read 3
+ * expanded / 7 collapsed now reads 6 / 4; nothing else about the contract
+ * changed and the Show-more affordance is deliberately KEPT. The counts are
+ * spelled out literally rather than imported from PHASE3_DEFAULT_EXPANDED
+ * on purpose: a pin computed from the constant it is pinning cannot fail
+ * when the constant moves (platform trap 12b).
  *
  * Flood pin (mutation check): reverting the grouping renders 4 cards by the
- * legacy per-turn cap instead of 3 → the default-expanded pin goes RED.
+ * legacy per-turn cap instead of 6 → the default-expanded pin goes RED.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -127,18 +135,21 @@ function renderedCardTitles(container: HTMLElement): string[] {
 // ─── Pins ────────────────────────────────────────────────────────────────
 
 describe('InlineBlocks — phase-3 card pacing (F16)', () => {
-  it('FLOOD PIN: a 10-block phase-3 flood defaults to exactly 3 expanded cards', () => {
+  it('FLOOD PIN: a 10-block phase-3 flood defaults to exactly 6 expanded cards (2.211-②)', () => {
     const { container } = render(<InlineBlocks blocks={floodBlocks()} />)
     expect(renderedCardTitles(container)).toEqual([
       'Review card 1',
       'Review card 2',
       'Review card 3',
+      'Review card 4',
+      'Review card 5',
+      'Coaching card 1',
     ])
   })
 
   it('the remainder sits behind exactly ONE count affordance announcing the collapsed count', () => {
     render(<InlineBlocks blocks={floodBlocks()} />)
-    const toggles = screen.getAllByRole('button', { name: /show 7 more/i })
+    const toggles = screen.getAllByRole('button', { name: /show 4 more/i })
     expect(toggles).toHaveLength(1)
     expect(toggles[0]).toHaveAttribute('aria-expanded', 'false')
     // No competing second overflow affordance for the same turn.
@@ -147,7 +158,7 @@ describe('InlineBlocks — phase-3 card pacing (F16)', () => {
 
   it('a static sr-only summary carries the collapsed count (no nested live region — review-folds C4)', () => {
     const { container } = render(<InlineBlocks blocks={floodBlocks()} />)
-    expect(screen.getByText(/7 more coaching and review cards collapsed/i)).toBeInTheDocument()
+    expect(screen.getByText(/4 more coaching and review cards collapsed/i)).toBeInTheDocument()
     // The toggle's accessible name already carries the count; InlineBlocks
     // must contribute no live region of its own (the old role="status"
     // replayed on unhide and double-announced every toggle).
@@ -156,7 +167,7 @@ describe('InlineBlocks — phase-3 card pacing (F16)', () => {
 
   it('ONE interaction reveals all 10 cards with order preserved exactly', () => {
     const { container } = render(<InlineBlocks blocks={floodBlocks()} />)
-    fireEvent.click(screen.getByRole('button', { name: /show 7 more/i }))
+    fireEvent.click(screen.getByRole('button', { name: /show 4 more/i }))
     expect(renderedCardTitles(container)).toEqual([
       'Review card 1',
       'Review card 2',
@@ -175,14 +186,17 @@ describe('InlineBlocks — phase-3 card pacing (F16)', () => {
     const { container } = render(
       <InlineBlocks blocks={[factBlock, ...floodBlocks()]} />,
     )
-    // The fact block renders alongside the 3 default-expanded cards.
+    // The fact block renders alongside the 6 default-expanded cards.
     expect(screen.getByTestId('block-fact')).toBeInTheDocument()
     expect(renderedCardTitles(container)).toEqual([
       'Review card 1',
       'Review card 2',
       'Review card 3',
+      'Review card 4',
+      'Review card 5',
+      'Coaching card 1',
     ])
-    expect(screen.getByRole('button', { name: /show 7 more/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show 4 more/i })).toBeInTheDocument()
   })
 
   it('no pacing affordance when the turn carries 3 or fewer phase-3 cards', () => {
@@ -191,6 +205,44 @@ describe('InlineBlocks — phase-3 card pacing (F16)', () => {
     )
     expect(renderedCardTitles(container)).toHaveLength(3)
     expect(screen.queryByRole('button', { name: /show \d+ more/i })).not.toBeInTheDocument()
+  })
+
+  // ── ROADMAP 2.211-② boundary pins ───────────────────────────────────────
+  // The ruled number is 6, so pin it from BOTH sides at the boundary itself.
+  // Both go RED at the old cap of 3: at 3 the 6-card turn paces ("Show 3
+  // more") and the 7-card turn reads "Show 4 more", not "Show 1 more".
+  // The 3-card case above cannot see the difference between 3 and 6 — it
+  // passes under either cap — so these carry the ruling, not that one.
+
+  it('2.211-② BOUNDARY: exactly 6 phase-3 cards render with NO affordance', () => {
+    const six: ConversationBlock[] = [
+      reviewCard(1), reviewCard(2), reviewCard(3), reviewCard(4), reviewCard(5), coaching(1),
+    ]
+    const { container } = render(<InlineBlocks blocks={six} />)
+    expect(renderedCardTitles(container)).toHaveLength(6)
+    expect(screen.queryByRole('button', { name: /show \d+ more/i })).not.toBeInTheDocument()
+  })
+
+  it('2.211-② BOUNDARY: the 7th phase-3 card is the first to collapse ("Show 1 more")', () => {
+    const seven: ConversationBlock[] = [
+      reviewCard(1), reviewCard(2), reviewCard(3), reviewCard(4), reviewCard(5),
+      coaching(1), coaching(2),
+    ]
+    const { container } = render(<InlineBlocks blocks={seven} />)
+    expect(renderedCardTitles(container)).toEqual([
+      'Review card 1',
+      'Review card 2',
+      'Review card 3',
+      'Review card 4',
+      'Review card 5',
+      'Coaching card 1',
+    ])
+    const toggle = screen.getByRole('button', { name: /show 1 more coaching and review card/i })
+    expect(toggle).toBeInTheDocument()
+    // Singular copy at a collapsed count of exactly 1.
+    expect(toggle).toHaveAccessibleName('Show 1 more coaching and review card')
+    fireEvent.click(toggle)
+    expect(renderedCardTitles(container)).toHaveLength(7)
   })
 })
 

--- a/src/canvas/conversation/phase3Pacing.ts
+++ b/src/canvas/conversation/phase3Pacing.ts
@@ -16,9 +16,10 @@
  *   - Every later phase-3 card collapses behind ONE affordance, placed at
  *     the position of the first collapsed card so reading order is
  *     preserved exactly on reveal.
- *   - Non-phase-3 blocks are untouched: when pacing is active they keep
- *     their own legacy per-turn budget, counted WITHOUT the phase-3 cards
- *     (the pacing group is the phase-3 budget).
+ *   - Non-phase-3 blocks are untouched: they keep their own legacy per-turn
+ *     budget, counted WITHOUT the phase-3 cards (the pacing group is the
+ *     phase-3 budget — always, not only while pacing is active; see the
+ *     dead-band note in InlineBlocks, ROADMAP 2.211-②).
  */
 import { DRAFT_BIAS_SIGNAL_CARD_CAP } from './types'
 import type { ConversationBlock } from './types'
@@ -31,8 +32,22 @@ export const PHASE3_CARD_TYPES: ReadonlySet<ConversationBlock['type']> = new Set
   'v5_exercise',
 ] as const)
 
-/** Ratified default-expanded cap: at most 3 phase-3 cards open by default. */
-export const PHASE3_DEFAULT_EXPANDED = 3
+/**
+ * Ratified default-expanded cap: at most 6 phase-3 cards open by default.
+ *
+ * ROADMAP 2.211-② (founder ruling, 1 Aug) raised this from 3 to 6. The
+ * live walk proved rank ≠ visibility: the selected-lens exercise card ranks
+ * correctly (2.211 §2 put it directly after the review cards — see
+ * EXERCISE_RANK_AFTER_REVIEW_CARDS in useConversation.ts) yet still sat
+ * behind `Show N more`, because a collapsed card renders `null` and is not
+ * in the DOM at all. Measured phase-3 counts on the walk's analysis turns
+ * were 8, 8, 8, 11, 13, 14 — so a cap of 3 collapsed everything below the
+ * third card on every single turn.
+ *
+ * The Show-more affordance is deliberately KEPT: the ruling raises the
+ * default, it does not remove pacing.
+ */
+export const PHASE3_DEFAULT_EXPANDED = 6
 
 export interface Phase3Pacing {
   /** True when the turn carries more phase-3 cards than the default cap. */


### PR DESCRIPTION
## ROADMAP 2.211-② — raise `PHASE3_DEFAULT_EXPANDED` 3 → 6

**Ruling cited:** ROADMAP 2.211-② (founder, 1 Aug) — raise the phase-3 default-expanded cap
from 3 to 6, **keeping** the Show-more affordance. Motivation: the live walk proved
*rank ≠ visibility*. The selected-lens exercise card ranks correctly after #547
(`EXERCISE_RANK_AFTER_REVIEW_CARDS`, directly after the review cards) yet still sat behind
`Show N more`, because **a collapsed card renders `null` and is not in the DOM at all**.
Measured phase-3 counts on the walk's analysis turns: **8, 8, 8, 11, 13, 14**.

The number 6 is the founder's. This PR does not change it. Item 4 below reports, honestly,
what 6 does and does not buy — as a report-back, not a licence.

---

### Consumer trace (grep + empirical, and they agree)

`PHASE3_DEFAULT_EXPANDED` is declared in `src/canvas/conversation/phase3Pacing.ts` (name and
location unchanged at this tip) and read in exactly **two** places, both in that file
(`computePhase3Pacing`: the `<=` pacing-inactive early return, and the `slice()` that derives
the collapsed set). **No spec imports the constant** — every pin is behavioural, via
`InlineBlocks`.

Render-layer consumers traced before editing:

| consumer | file | effect of 3 → 6 |
|---|---|---|
| collapsed-card `null` render | `InlineBlocks.tsx` `isBlockHidden` → `return affordance ? … : null` | 4 more cards enter the DOM on a flood turn |
| "Show N more" count | `pacing.collapsedCount`, toggle label + `aria-label` (singular/plural) | 10-card flood: `Show 7 more` → `Show 4 more` |
| sr-only collapsed summary | `InlineBlocks.tsx` static `<span className="sr-only">` | count text follows `collapsedCount` |
| legend gate `phase3Rendered` | `InlineBlocks.tsx` | see the C13 note below |
| legacy per-turn budget | `InlineBlocks.tsx` `MAX_VISIBLE_BLOCKS_PER_TURN = 4` | **collided — see below** |

Running the suite with only the constant changed produced failures in exactly the 3 spec files
the grep predicted (10 tests), and no others.

---

### ⚠ The constant change ALONE ships a regression — measured, not reasoned

Raising the cap to 6 opens a **dead band**. The legacy per-turn budget is 4
(`MAX_VISIBLE_BLOCKS_PER_TURN`), and phase-3 cards were excluded from it *only while pacing was
active*. While the cap was 3 the two could never collide (pacing switched on at 4 cards, and any
smaller group fitted inside the legacy 4). At a cap of 6, turns of **5–6 phase-3 cards no longer
activate pacing**, fall back into the legacy budget, and get clipped at 4 — behind the
*legacy* "Show N more blocks" toggle, with the wrong wording.

Measured (probe over `InlineBlocks`, `extras` = non-phase-3 blocks on the same turn; visible
phase-3 cards):

| shape | cap 3 (today) | cap 6, constant only | cap 6 + this PR |
|---|---|---|---|
| 4 cards, 0 extras | 3 | 4 | 4 |
| 5 cards, 0 extras | 3 | 4 | **5** |
| 6 cards, 0 extras | 3 | 4 | **6** |
| 4 cards, 2 extras | 3 | **2 ⬅ regression** | 4 |
| 5 cards, 2 extras | 3 | **2 ⬅ regression** | 5 |
| 6 cards, 2 extras | 3 | **2 ⬅ regression** | 6 |
| 7+ cards, any | 3 | 6 | 6 |

With any non-phase-3 block present — the normal case, every turn carries at least an
`analysis_result`/fact — the constant change on its own shows **one fewer card than today**.
So `PHASE3_DEFAULT_EXPANDED = 6` would have been a value the renderer did not honour.

**Fix (one line):** the legacy budget now excludes phase-3 cards unconditionally, which is what
this module's own header already declared ("the pacing group is the phase-3 budget"). It is
**monotone** — a block can only become visible, never hidden — and raises no flood ceiling,
because the pacing group still caps phase-3 cards at 6. With it, the change is
**non-regressive at every shape measured**, and the ruled number is true.

This is disclosed as a deliberate second hunk rather than folded in silently (trap 5). It is
mutation-checked independently of the constant.

---

### RED-first evidence / mutation checks

Both performed in a **throwaway worktree outside the clone root** (traps 9/9c), removed before
the gates ran.

1. **Revert 6 → 3, keep every new pin** → **13 tests RED** across the 3 spec files, including
   *both* new boundary pins.
2. **Revert the decoupling only, keep cap 6** → **3 tests RED**
   (`BOUNDARY: exactly 6 … NO affordance`, the bias-trigger pin, and the C13 pin).

New pins added (`InlineBlocks.phase3Pacing.spec.tsx`), pinning the ruled number from both sides:

- `2.211-② BOUNDARY: exactly 6 phase-3 cards render with NO affordance`
- `2.211-② BOUNDARY: the 7th phase-3 card is the first to collapse ("Show 1 more")` — also pins
  the singular copy at a collapsed count of 1, and the reveal.

Counts are spelled out **literally**, never imported from `PHASE3_DEFAULT_EXPANDED`: a pin
computed from the constant it pins cannot fail when the constant moves (trap 12b).

### Pins updated — all with the ruling cited in-file, none silently

- **`InlineBlocks.phase3Pacing.spec.tsx`** — flood pin 3 → 6 expanded; `Show 7 more` →
  `Show 4 more` (10-card fixture); sr-only count; reveal click.
- **`InlineBlocks.citationReveal.spec.tsx`** — C4 fixture resized 5 → 8 cards so it still
  straddles the cap (**assertion byte-identical**: still `2 more … collapsed`). C11
  pacing-collapse fixtures resized 5 → 7 and 4 → 7 cards.
- **`InlineBlocks.biasSignalBudget.spec.tsx`** — regime-1 fixture 4 → 7 producer cards.

**Two pins would have gone vacuous and were fixed, not left green (trap 13):**

- *"bias cards do not count toward the pacing trigger"* used 3 producer + 2 bias. Under a cap of
  6 that turn does not pace **whether or not** bias cards are exempt — it would have passed by
  testing nothing. Regrown to 6 producer + 2 bias, where the exemption is the only thing
  standing between it and an affordance.
- **C13** gated the legend on a phase-3 card being *currently rendered*, and its verifier drove
  that false by hiding the turn's only phase-3 card behind the **legacy** budget. Since phase-3
  cards no longer participate in that budget, and the pacing group always renders its first 6,
  **a turn carrying a phase-3 card now always renders one** — the old construction is
  unreachable. The guard in `InlineBlocks` is **kept** (it is still the correct predicate and is
  what makes that reachability argument true rather than accidental), and the pin was rewritten
  to assert the new reachability fact, with the change recorded in-file. The live negative case
  ("no phase-3 cards at all") is still pinned.

---

### Item 4 — does the exercise card actually surface at 6? **On 1 of 6 walk turns. No, 6 is not enough.**

Derived by running the **real pipeline** (`composePhase3BridgedBlocks` → `computePhase3Pacing`)
over the walk's **retained wire captures** (`/private/tmp/probe-premortem-a1/run/<a>/wire-raw.json`),
with the probe's own synthetic exercise block spliced in — the producer emitted **no** exercise
on those turns, which is the defect the CEE half of 2.211 addresses. Ranks are the producers'.

| turn | phase-3 group (incl. exercise) | exercise position | visible @3 | visible @6 |
|---|---|---|---|---|
| a1 | 14 | **10** | no | no |
| a2 | 12 | **8** | no | no |
| a3 | 9 | **6** | no | **YES** |
| a4 | 9 | **7** | no | no |
| a5 | 15 | **10** | no | no |
| a6 | 9 | **7** | no | no |

**0 of 6 at cap 3 → 1 of 6 at cap 6**, and that one lands *exactly* on the boundary.

**Why 6 falls short, mechanically:** two card kinds sort **ahead of the review cards** and eat
slots before the anchor is even reached. Measured producer bands on these turns:
`evidence` **1–2**, a `coaching_kind:'strengthen'` lens card **15**, `review_card` **10–73**,
other `coaching` **101–202**. The exercise anchors to `max(review_rank) + 0.5`, so its position
is `#evidence + #strengthen + #review_card + 1` — never `#review_card + 1`. Every walk turn
spent 2–3 of the 6 slots on evidence and the strengthen card first. Actual head of each turn,
e.g. a1: `evidence, evidence, review, coaching(strengthen), review, review, review, review,
review, EXERCISE, …`.

**Cap that would surface it** on these six shapes: **7 → 3/6 · 8 → 4/6 · 10 → 6/6.**

Reported for the founder's decision. **No number was changed on this evidence** — the ruling is
6 and 6 is what shipped. If the goal is the exercise reliably on screen, the levers are a higher
cap (10 on this sample) or a producer-side/ordering change; both are separate items.

*Caveat on scope:* six analysis turns from one walk, captured **before** the CEE lens-emission
fix. The review/coaching/evidence distribution is producer-side and unaffected by that fix, but
this is a sample of six, not a population.

---

### Gates

- **`pnpm typecheck` (`scripts/ci/typecheck-gate.sh`, the required *Staging Gate*'s script at
  this tip): PASSED.**
  Coverage **3111 / 3151** tracked TS files loaded (40 declared out of scope).
  Ratchet **622 files / 2505 errors** (baseline 2510). **Baseline NOT regenerated.**
  The gate's `Drift shrank (2510 → 2505)` notice is **pre-existing**: a pristine
  `origin/staging` control worktree emits the identical numbers and the identical notice. This
  PR adds and removes zero diagnostics.
- **Vitest `src/canvas/conversation`: 141 files, 1980 passed | 22 skipped (2002).**
  Baseline at `900dbd6c` was 1978 passed | 22 skipped (2000) — **+2 = the two new boundary pins**.
- **Full unit suite:** see the comment below (attribution against a pristine control).
- **Check 8 (DS v5 drift):** **RED, and byte-identical to pristine.** `diff` of
  `check-ds-compliance.mjs --enforce` output between this branch and an `origin/staging` control
  worktree is **empty**. None of the flagged files (`analyticalNodeFields.ts`, `ErrorBanner.tsx`,
  `claimDriftWalker.ts`, `HowComputedModal.tsx`, `V7*.tsx`) is in this diff. Pre-existing red,
  not this PR's (trap 2b — proven with a control, not asserted).
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were set for **every** vitest run (trap 2b);
  no collect-time failures.

Branch cut from a fresh blobless clone of `origin/staging` at **`900dbd6c`** (#548 present).
