### PR TITLE
DO NOT MERGE — fix(ui): six claims the producer never authorised (2.233/2.234/2.235/2.236/2.213/2.214)

### DIFF
--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -699,7 +699,18 @@ function RelationshipsSectionInner({
       {/* Coaching: fragile relationships warning */}
       {fragileEdgeIds.size > 0 && (
         <CoachingCard sectionId="relationships-fragile">
-          Fragile relationships could change the recommendation. Review the strongest ones first.
+          {/*
+            ⭐ RE-ANCHORED 2026-08-01 (ROADMAP 2.213 / walk finding F2). Read
+            "Fragile relationships could change the recommendation." — "the
+            recommendation" is the exact noun the no-recommendations doctrine
+            retires, and this line survived PR 548's sweep because it is UI static
+            copy on the Model tab (0 occurrences in the wire) rather than
+            anything the producer sends. Witnessed rendering in BOTH walk
+            scenarios. The replacement states the same fact about the data
+            without the retired noun: what fragility can change is which option
+            comes out ahead, not an endorsement the product does not make.
+          */}
+          Fragile relationships could change which option leads. Review the strongest ones first.
         </CoachingCard>
       )}
 

--- a/src/canvas/utils/labelUtils.ts
+++ b/src/canvas/utils/labelUtils.ts
@@ -164,10 +164,23 @@ export function compactFactorLabel(label: string, maxLength = 15): string {
  */
 export function formatWinProbability(rawProb: number): string {
   if (!Number.isFinite(rawProb)) return '—'
-  if (rawProb <= 0) return '0%'
-  if (rawProb < 0.01) return '< 1%'
-  if (rawProb >= 0.995) return '100%'
-  return `${Math.round(rawProb * 100)}%`
+  // ⭐ ROADMAP 2.236 — DELEGATES; it no longer owns a private copy of the rule.
+  //
+  // This function was CORRECT and the dock was wrong, but it was correct by
+  // holding its own literal `0.01` and its own `'< 1%'` — a second
+  // implementation of the shared floor, invisible to anyone reading
+  // `displayFloors.ts`. That invisibility is exactly how the dock came to ship
+  // without it: one option, one instant, "< 1%" here and "0%" on the option
+  // card (walk-548-pixels.md F5). The threshold and the readout now come from
+  // the one owner.
+  //
+  // ⚠ CORRECTED (2.236 review): this claimed "same behaviour as before for every
+  // input". Not quite — OUT OF DOMAIN it differs: the old local rule clamped
+  // anything >= 0.995 to "100%", so 1.5 rendered "100%" and now renders "150%".
+  // No caller can supply a probability above 1, so there is no live regression —
+  // but "every input" was an overclaim, and an overclaim in a comment is the
+  // same defect class as one in copy.
+  return formatProbabilityWithResolution(rawProb, undefined)
 }
 
 /**
@@ -306,6 +319,7 @@ export {
 } from '@/utils/unitClassifier'
 export type { UnitClass } from '@/utils/unitClassifier'
 
+import { formatProbabilityWithResolution } from '@/utils/formatPercent'
 import { GENERIC_PLACEHOLDER_UNITS, classifyUnit } from '@/utils/unitClassifier'
 import { interventionNumericValue } from '@/utils/interventionValue'
 

--- a/src/components/results/ConfidenceSection.tsx
+++ b/src/components/results/ConfidenceSection.tsx
@@ -374,6 +374,18 @@ function UncertaintyRow({
                 <div className={`${typography.panelBody} text-text-light mt-1`}>
                   {item.threshold.variable && (
                     <p>
+                      {/*
+                        ⚠ LATENT TRAP ARMED BY THE 2.234 WIDENING (R8). This is a
+                        BINARY read of `threshold.direction`, whose type is now
+                        `DriverDirection` = the producer's full domain — so
+                        `mixed`/`unknown` would render "rises above", a
+                        directional claim the producer declined to make. BLAST
+                        RADIUS IS ZERO TODAY: this component has no non-test
+                        mounts and its sole producer
+                        (`useResultsSectionData:2770`) still coerces with
+                        `?? 'positive'`. Both rowed. Recorded so whoever mounts
+                        this does not inherit the defect silently.
+                      */}
                       If {stripEncodingNotation(item.threshold.variable)}{' '}
                       {item.threshold.direction === 'positive' ? 'drops below' : 'rises above'}{' '}
                       {item.threshold.value}

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -278,6 +278,52 @@ function ContestedDriverQuickSelect({ driver }: { driver: DriverItem }) {
 }
 
 // Individual driver row - Compact 2-line structure
+/**
+ * The elasticity tooltip sentence — the ONE place deciding whether a driver's
+ * magnitude is presented WITH a direction (ROADMAP 2.234, R3).
+ *
+ * Exported and pure so the rule can be pinned directly. It previously lived
+ * inline inside a hover-only `Tooltip`, which is exactly why it went on
+ * rendering `mixed`/`unknown`/absent identically to `positive` long after the
+ * mapper stopped fabricating directions: nothing could see it without a hover.
+ *
+ * ⚠ THIS IS THE ONLY LIVE DRIVER SURFACE. `factorDirection.ts` used to justify
+ * "the renderers already handle neutral" by citing `KeyDriversPanel`,
+ * `DriverChips` and `InsightsPanel` — all three have ZERO non-test JSX mounts.
+ * `DriversSection` (`ResultsBody.tsx:559`) is the one a tester sees.
+ *
+ * UI-SEM-046: the ×10 / floor-1 scaling is presentational amplification of the
+ * 0-1 elasticity, unchanged.
+ */
+export function elasticityShiftCopy(driver: DriverItem): string | null {
+  if (!(driver.rawElasticity > 0.001)) return null
+  const shiftPercent = Math.max(1, Math.round(driver.rawElasticity * 10))
+  const binary = isBinaryFactor(driver.factorLabel)
+
+  // Only the two directional states license a signed claim. `mixed`, `unknown`
+  // and absence are PRESENT answers that withhold a direction, so `!= null`
+  // would be the wrong question here.
+  const directional = driver.direction === 'positive' || driver.direction === 'negative'
+  if (!directional) {
+    // ⚠ NEW COPY — TWO STRINGS, both for founder sign-off (an earlier note said
+    // "one string"; they share the ` — direction not reported` suffix but are
+    // two distinct user-visible sentences, and the em-dash is U+2014):
+    //   1. `Higher values tend to shift outcome by {N}% — direction not reported`
+    //   2. `When true, outcome tends to shift by {N}% — direction not reported`
+    // No existing register covers a magnitude whose direction the producer
+    // declined to assert. The magnitude is producer data and stays; only the
+    // implied sign goes.
+    return binary
+      ? `When true, outcome tends to shift by ${shiftPercent}% — direction not reported`
+      : `Higher values tend to shift outcome by ${shiftPercent}% — direction not reported`
+  }
+
+  const sign = driver.direction === 'negative' ? '-' : ''
+  return binary
+    ? `When true, outcome tends to shift by ${sign}${shiftPercent}%`
+    : `Higher values tend to shift outcome by ${sign}${shiftPercent}%`
+}
+
 function DriverRow({
   driver,
   onFocus,
@@ -390,19 +436,10 @@ function DriverRow({
     if (!hasTooltipContent && isTooltipOpen) setIsTooltipOpen(false)
   }, [hasTooltipContent, isTooltipOpen])
 
-  // v7.5 T7: Softened tooltip copy
-  const tooltipElasticityCopy = driver.rawElasticity > 0.001
-    ? (() => {
-        // UI-SEM-046: elasticity display scaling (×10, floor 1) — presentational
-        // amplification of the 0-1 elasticity into a "shift by N%" tooltip.
-        const shiftPercent = Math.max(1, Math.round(driver.rawElasticity * 10))
-        const sign = driver.direction === 'negative' ? '-' : ''
-        if (isBinaryFactor(driver.factorLabel)) {
-          return `When true, outcome tends to shift by ${sign}${shiftPercent}%`
-        }
-        return `Higher values tend to shift outcome by ${sign}${shiftPercent}%`
-      })()
-    : null
+  // v7.5 T7: Softened tooltip copy. The RULE lives in `elasticityShiftCopy`
+  // (exported, unit-pinned) — it was previously reachable only through a
+  // hover-only Tooltip, which is how it kept a fabricated direction so long.
+  const tooltipElasticityCopy = elasticityShiftCopy(driver)
 
   // Task 7c: ranking shift and technique suggestion for tooltip
   const rankingShiftWarn = (() => {

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -39,6 +39,7 @@ import { typography } from '../../styles/typography'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY, isFiniteProbability } from './utils/goalAnchorCopy'
 import { formatGoalProbability } from './utils/displayFloors'
+import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 import Tooltip from '../Tooltip'
 import type { DecisionState } from './types'
 
@@ -361,7 +362,10 @@ export function WinGauge({
                   backgroundColor: colorById[share.id],
                 }}
                 role="img"
-                aria-label={`${stripEncodingNotation(share.label)}: ${displayPct}%`}
+                // ROADMAP 2.236: a segment that IS drawn is labelled with the
+                // shared floored readout, so the screen reader hears what the
+                // legend below prints.
+                aria-label={`${stripEncodingNotation(share.label)}: ${formatProbabilityWithResolution(clamped, null)}`}
               />
             )
           })}
@@ -369,8 +373,18 @@ export function WinGauge({
         {/* Legend — coloured dot + truncated name + percentage */}
         <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1.5">
           {sorted.map((share) => {
-            const displayPct = Math.round(Math.max(0, Math.min(1, share.winProbability)) * 100)
-            if (displayPct <= 0) return null
+            const clamped = Math.max(0, Math.min(1, share.winProbability))
+            // ⭐ ROADMAP 2.236 — TWO defects on this line, both from rounding
+            // before deciding.
+            //
+            // It read `Math.round(clamped * 100)` and then `if (displayPct <= 0)
+            // return null`. So an option with a real, measured 0.19% chance was
+            // not merely printed as "0%" — it was DELETED from the legend
+            // entirely, while the canvas node beside it said "< 1%". The skip is
+            // now on the RAW value, so only a genuine zero is omitted, and the
+            // readout goes through the shared floored formatter.
+            if (clamped <= 0) return null
+            const displayReadout = formatProbabilityWithResolution(clamped, null)
             return (
               <span key={share.id} className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}>
                 <span
@@ -379,7 +393,7 @@ export function WinGauge({
                   aria-hidden="true"
                 />
                 <span className="truncate max-w-[120px]">{stripEncodingNotation(share.label)}</span>
-                <span className="tabular-nums">{displayPct}%</span>
+                <span className="tabular-nums">{displayReadout}</span>
               </span>
             )
           })}

--- a/src/components/results/__tests__/driversSectionDirectionHonesty.spec.tsx
+++ b/src/components/results/__tests__/driversSectionDirectionHonesty.spec.tsx
@@ -1,0 +1,170 @@
+/**
+ * R3 (ROADMAP 2.234 review) — the fix must reach the ONLY LIVE driver surface.
+ *
+ * 2.234 stopped the V5 mapper and `useResultsSectionData` FABRICATING a
+ * direction. But the justification for "neutral renders honestly" named
+ * `KeyDriversPanel`, `DriverChips` and `InsightsPanel` — and **all three have
+ * zero non-test JSX mounts**. The one surface a tester actually sees is
+ * `DriversSection` (`ResultsBody.tsx:559`), and its tooltip read
+ *
+ *     const sign = driver.direction === 'negative' ? '-' : ''
+ *
+ * so `mixed`, `unknown` and absent all produced "Higher values tend to shift
+ * outcome by 12%" — an unsigned figure that reads as a rise, identical to
+ * `positive`. The producer's refusal to assert a direction was still being
+ * rendered as an assertion. **A fix that stops at the mapper is a fix the user
+ * never receives.**
+ *
+ * CLAIM TYPE: text-level assertions on the rendered tooltip string. jsdom
+ * cannot prove visibility (trap 3); nothing here is a layout claim.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DriversSection, elasticityShiftCopy } from '../DriversSection'
+import type { DriverItem } from '../types'
+
+function driver(direction: DriverItem['direction']): DriverItem {
+  return {
+    factorKey: 'n_market',
+    factorLabel: 'Market size',
+    rawElasticity: 1.2,
+    normalisedInfluence: 1,
+    displayInfluence: 1,
+    displayProvenance: 'normalised_elasticity',
+    direction,
+    semanticLabel: 'biggest',
+    rank: 1,
+  } as unknown as DriverItem
+}
+
+describe('elasticityShiftCopy — only a real direction gets a signed claim (ROADMAP 2.234, R3)', () => {
+  it.each(['mixed', 'unknown', null, undefined] as const)(
+    'producer direction %s → the shift is NOT presented as a rise',
+    (d) => {
+      const copy = elasticityShiftCopy(driver(d as DriverItem['direction'])) ?? ''
+      expect(copy).toContain('direction not reported')
+      // The bare positive form is exactly what `mixed` used to render.
+      expect(copy).not.toBe('Higher values tend to shift outcome by 12%')
+      expect(copy).not.toContain('-12%')
+    },
+  )
+
+  it('CONTROL — `positive` keeps its wording, byte-identical to before', () => {
+    expect(elasticityShiftCopy(driver('positive'))).toBe(
+      'Higher values tend to shift outcome by 12%',
+    )
+  })
+
+  it('CONTROL — `negative` keeps its explicit minus sign, byte-identical to before', () => {
+    expect(elasticityShiftCopy(driver('negative'))).toBe(
+      'Higher values tend to shift outcome by -12%',
+    )
+  })
+
+  it('POSITIVE CONTROL — the magnitude survives for a non-directional driver (data is not suppressed)', () => {
+    expect(elasticityShiftCopy(driver('mixed'))).toContain('12%')
+  })
+
+  it('the BINARY variant is gated the same way (a second call site cannot drift)', () => {
+    const binary = { ...driver('mixed'), factorLabel: 'Hire a CTO (0/1)' } as DriverItem
+    expect(elasticityShiftCopy(binary)).toBe(
+      'When true, outcome tends to shift by 12% — direction not reported',
+    )
+    const binaryPos = { ...driver('positive'), factorLabel: 'Hire a CTO (0/1)' } as DriverItem
+    expect(elasticityShiftCopy(binaryPos)).toBe('When true, outcome tends to shift by 12%')
+  })
+
+  it('below the elasticity floor there is no sentence at all (unchanged)', () => {
+    const tiny = { ...driver('positive'), rawElasticity: 0 } as DriverItem
+    expect(elasticityShiftCopy(tiny)).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⚠ THE WIRING PIN — added because the RULE pin above did not cover it.
+//
+// Reverting `const tooltipElasticityCopy = elasticityShiftCopy(driver)` back to
+// the old inline sign-fabricating expression — THE EXACT USER-VISIBLE DEFECT —
+// left 284 files / 5,294 tests GREEN. Every test above calls the pure function
+// directly; not one rendered `DriversSection`. A repo-wide NUL-safe search for
+// "tends to shift" hits exactly two files (the component and that spec), and
+// none of the 14 specs that DO render `<DriversSection` assert the tooltip.
+//
+// That is trap 11 on the one item where it matters most: R3's defect WAS "the
+// fix never reaches the user", so pinning only the rule leaves precisely that
+// defect free to recur. A correct function nobody calls is the same nothing as
+// a correct comment nobody reads.
+//
+// CLAIM TYPE: text/presence on rendered output after a real click. jsdom cannot
+// prove visibility (trap 3) — nothing here is a layout claim. The tooltip is
+// opened through its actual affordance (the "More information" button, which
+// carries `aria-expanded`), so this exercises the path a user takes.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DriversSection — the honest string reaches the RENDERED tooltip (ROADMAP 2.234, R3 wiring)', () => {
+  function renderDrivers(direction: DriverItem['direction']) {
+    return render(
+      <DriversSection
+        data={{
+          // ⚠ `enrichment` is REQUIRED for the tooltip to exist at all.
+          // `hasTooltipContent` has three arms and two are dead constants
+          // (`DISPLAY_SAFE_DRIVER_CONFIDENCE = false`,
+          // `SHOW_FRAGILITY_IN_DRIVER_SECTION = false`), so `hasEnrichment` is
+          // the only live path — i.e. this copy reaches a user only on an
+          // ENRICHED driver. Discovered while writing this pin; recorded because
+          // it bounds who the R3 defect could ever have reached.
+          drivers: [{ ...driver(direction), enrichment: { observations: ['obs'] } }],
+          driversStatus: 'computed',
+          hasMagnitudeData: true,
+          islError: null,
+          hiddenZeroImpactCount: 0,
+        } as never}
+      />,
+    )
+  }
+
+  function openTooltip() {
+    // The real affordance: `hasTooltipContent && isTopDriver` renders this
+    // button, and `index === 0` makes our single driver the top one.
+    const trigger = screen.getByRole('button', { name: 'More information' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  }
+
+  it.each(['mixed', 'unknown', null] as const)(
+    'producer direction %s → the OPEN tooltip says the direction is not reported',
+    (d) => {
+      const { container } = renderDrivers(d as DriverItem['direction'])
+      openTooltip()
+      const text = container.textContent ?? ''
+      expect(text).toContain('direction not reported')
+      // The fabricated form must be absent from the rendered DOM, not merely
+      // from the function's return value.
+      expect(text).not.toContain('Higher values tend to shift outcome by 12%,')
+      expect(text).not.toMatch(/shift outcome by -12%/)
+    },
+  )
+
+  it('CONTROL — `positive` still renders its signed-free rise wording in the open tooltip', () => {
+    const { container } = renderDrivers('positive')
+    openTooltip()
+    const text = container.textContent ?? ''
+    expect(text).toContain('Higher values tend to shift outcome by 12%')
+    expect(text).not.toContain('direction not reported')
+  })
+
+  it('CONTROL — `negative` still renders its minus sign in the open tooltip', () => {
+    const { container } = renderDrivers('negative')
+    openTooltip()
+    expect(container.textContent ?? '').toContain('-12%')
+  })
+
+  it('POSITIVE CONTROL — the tooltip is genuinely CLOSED before the click', () => {
+    // Without this, the assertions above could pass against a tooltip that was
+    // always open, and the click would be proving nothing.
+    const { container } = renderDrivers('mixed')
+    expect(container.textContent ?? '').not.toContain('direction not reported')
+    openTooltip()
+    expect(container.textContent ?? '').toContain('direction not reported')
+  })
+})

--- a/src/components/results/__tests__/getFactorDirection.spec.ts
+++ b/src/components/results/__tests__/getFactorDirection.spec.ts
@@ -32,10 +32,24 @@ describe('normaliseDirection', () => {
     expect(normaliseDirection('NEGATIVE')).toBe('negative') // Case insensitive
   })
 
-  it('returns undefined for unrecognised values', () => {
+  /**
+   * ⭐ ONE ASSERTION SUPERSEDED 2026-08-01 (ROADMAP 2.234). `'unknown'` is not
+   * an unrecognised value — it is a MEMBER of the producer's documented domain
+   * (`positive | negative | mixed | unknown`), and flattening it to `undefined`
+   * here is the same narrowing that let `mapV5AnalysisToReport` turn it into a
+   * positive causal claim. ABSENCE (undefined / empty) still returns undefined;
+   * that half is unchanged and still pinned.
+   */
+  it('returns undefined for ABSENCE, and carries `unknown` as the domain member it is', () => {
     expect(normaliseDirection(undefined)).toBeUndefined()
-    expect(normaliseDirection('unknown')).toBeUndefined()
     expect(normaliseDirection('')).toBeUndefined()
+    // SUPERSEDED (was `toBeUndefined`): the producer said "unknown"; the UI
+    // records that it was told, and renders no direction either way.
+    expect(normaliseDirection('unknown')).toBe('unknown')
+  })
+
+  it('an UNRECOGNISED value fails closed to `unknown`, never to a directional claim', () => {
+    expect(normaliseDirection('sideways')).toBe('unknown')
   })
 })
 

--- a/src/components/results/__tests__/normalizeFactorSensitivity.direction.spec.ts
+++ b/src/components/results/__tests__/normalizeFactorSensitivity.direction.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * ROADMAP 2.234 — the DUPLICATE direction collapse, pinned.
+ *
+ * ⚠ THIS FILE EXISTS BECAUSE A MUTATION CHECK CAUGHT ITS ABSENCE. Reverting
+ * the fix in `normalizeFactorSensitivity` left the entire
+ * `useResultsSectionData` suite GREEN (123/123) — so the second half of the
+ * 2.234 fix was shipping with no test that could see it. A fix whose reversion
+ * turns nothing red is theatre (CLAUDE.md trap 11), and the only reason this
+ * was found is that the mutation was run rather than assumed.
+ *
+ * THE DEFECT. `mapV5AnalysisToReport` narrowed the producer's direction domain
+ * to two values and inferred the rest from a magnitude's sign; the IDENTICAL
+ * collapse was written a second time here:
+ *
+ *     const direction = typed.direction
+ *       ? (String(typed.direction).toLowerCase() === 'negative' ? 'negative' : 'positive')
+ *       : elasticity >= 0 ? 'positive' : 'negative'
+ *
+ * Note the shape of it: ANY non-empty string that is not exactly "negative"
+ * became `'positive'`. So `mixed` and `unknown` were not merely dropped here —
+ * they were converted into the opposite of what the producer said, on the V4
+ * path as well as the V5 one. Two copies of one rule meant a fix to either
+ * would have left the other lying.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { normalizeFactorSensitivity } from '../useResultsSectionData'
+
+const NO_LABELS = new Map<string, string>()
+
+function directionOf(raw: Record<string, unknown>) {
+  return normalizeFactorSensitivity(raw, NO_LABELS).direction
+}
+
+describe('normalizeFactorSensitivity — the producer domain survives (ROADMAP 2.234)', () => {
+  it('positive / negative are carried', () => {
+    expect(directionOf({ node_id: 'n1', direction: 'positive', elasticity: 0.4 })).toBe('positive')
+    expect(directionOf({ node_id: 'n1', direction: 'negative', elasticity: 0.4 })).toBe('negative')
+  })
+
+  it('`mixed` stays `mixed` — it must NOT become "positive"', () => {
+    expect(directionOf({ node_id: 'n1', direction: 'mixed', elasticity: 0.4 })).toBe('mixed')
+  })
+
+  it('`unknown` stays `unknown` — it must NOT become "positive"', () => {
+    expect(directionOf({ node_id: 'n1', direction: 'unknown', elasticity: 0.4 })).toBe('unknown')
+  })
+
+  it('an UNRECOGNISED value fails closed to `unknown`, never to a directional claim', () => {
+    expect(directionOf({ node_id: 'n1', direction: 'sideways', elasticity: 0.4 })).toBe('unknown')
+  })
+
+  it('NO direction and a NON-NEGATIVE magnitude → null (the sign is not evidence)', () => {
+    // This is the exact combination that made the old fallback silently mean
+    // "positive" on every row the producer left undirected.
+    expect(directionOf({ node_id: 'n1', elasticity: 0.4 })).toBeNull()
+    expect(directionOf({ node_id: 'n1', sensitivity_score: 0.4 })).toBeNull()
+  })
+
+  it('NO direction and a NEGATIVE magnitude → null too (not "negative")', () => {
+    expect(directionOf({ node_id: 'n1', elasticity: -0.4 })).toBeNull()
+  })
+
+  it('a null direction is absence, not a default', () => {
+    expect(directionOf({ node_id: 'n1', direction: null, elasticity: 0.4 })).toBeNull()
+  })
+
+  it('the empty-row fallback carries no direction either', () => {
+    expect(normalizeFactorSensitivity(null, NO_LABELS).direction).toBeNull()
+  })
+
+  it('POSITIVE CONTROL — the rest of the row is still normalised (not an "everything went null" pass)', () => {
+    const row = normalizeFactorSensitivity(
+      { node_id: 'n_market', label: 'Market size', direction: 'mixed', elasticity: 0.42, confidence: 0.8 },
+      NO_LABELS,
+    )
+    expect(row.factorId).toBe('n_market')
+    expect(row.label).toBe('Market size')
+    expect(row.elasticity).toBe(0.42)
+    expect(row.confidence).toBe(0.8)
+  })
+})

--- a/src/components/results/__tests__/retiredStaticCopy.walk548.spec.ts
+++ b/src/components/results/__tests__/retiredStaticCopy.walk548.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * RETIRED UI STATIC COPY — the two strings the #548 sweep missed
+ * (ROADMAP 2.213 / 2.214, walk findings F2 and F4).
+ *
+ * WHY A SOURCE-LEVEL PIN. Both strings are UI STATIC COPY — a real-browser
+ * walk on deployed staging `900dbd6c` confirmed each renders to the user and
+ * each has ZERO occurrences in the turn payload, so neither can be caught by a
+ * wire fixture and neither is the producer's to fix
+ * (`PHASE0-EVIDENCE-2026-07-28/walk-548-pixels.md`). They survived the #548
+ * re-anchoring sweep for the dullest possible reason: the retired-string list
+ * covered "winning" / "winner" / "Win probability" and neither "wins" nor "the
+ * recommendation" was on it. A sweep that runs once and is never pinned is a
+ * sweep that has to be re-run by hand forever, which is the hand-maintained
+ * mirror this programme keeps paying for (CLAUDE.md trap 12).
+ *
+ * ── HONEST LIMIT OF THIS GUARD ────────────────────────────────────────────
+ * This reads SOURCE TEXT for two specific retired strings in two specific
+ * files. It is a REGRESSION PIN, not a proof that the estate is free of
+ * retired nouns — a novel phrasing, or the same phrase in a third file, would
+ * pass. It is deliberately not described as more than it is. What it does
+ * guarantee is that these two, having been witnessed on a real screen, cannot
+ * come back to these two files unnoticed.
+ *
+ * ── POSITIVE CONTROL (trap 13) ────────────────────────────────────────────
+ * An absence assertion that has never seen a presence is vacuous. Every rule
+ * below is proved to FIRE against the exact historical string, read from a
+ * literal pinned here permanently rather than from whatever the file currently
+ * says (trap 12b) — a control pinned to "current" decays into a tautology the
+ * first time "current" changes.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = resolve(__dirname, '../../../..')
+
+function source(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8')
+}
+
+/**
+ * The rendered copy only — comments are stripped, because this file's own
+ * explanatory comments quote the retired strings verbatim (as do the fixed
+ * files'), and a guard that trips on its own explanation is a guard people
+ * delete.
+ */
+function renderedCopy(relativePath: string): string {
+  return source(relativePath)
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+}
+
+// The historical strings, pinned BY VALUE and permanently.
+const F2_RETIRED = 'Fragile relationships could change the recommendation.'
+const F4_RETIRED = '>wins<'
+
+const RELATIONSHIPS = 'src/canvas/components/model-tab/RelationshipsSection.tsx'
+const V7_HERO = 'src/components/results/v7/V7Hero.tsx'
+
+describe('F2 — the Model tab does not name "the recommendation" (ROADMAP 2.213)', () => {
+  it('the retired sentence is gone from the rendered copy', () => {
+    expect(renderedCopy(RELATIONSHIPS)).not.toContain(F2_RETIRED)
+    expect(renderedCopy(RELATIONSHIPS)).not.toContain('could change the recommendation')
+  })
+
+  it('the coaching line still EXISTS — this was a re-anchoring, not a deletion', () => {
+    // Over-suppression control: silencing the sentence would cost the user a
+    // true and useful statement about fragility. The fact must survive; only
+    // the retired noun goes.
+    const copy = renderedCopy(RELATIONSHIPS)
+    expect(copy).toContain('Fragile relationships could change')
+    expect(copy).toContain('Review the strongest ones first.')
+  })
+
+  it('POSITIVE CONTROL — the rule fires on the exact historical sentence', () => {
+    const historical = `<CoachingCard>${F2_RETIRED} Review the strongest ones first.</CoachingCard>`
+    expect(historical).toContain('could change the recommendation')
+  })
+
+  it('POSITIVE CONTROL — comment stripping does not blind the rule to real copy', () => {
+    const planted = `{/* a comment mentioning could change the recommendation */}\n<p>could change the recommendation</p>`
+    expect(
+      planted.replace(/\{\/\*[\s\S]*?\*\/\}/g, ''),
+    ).toContain('could change the recommendation')
+  })
+})
+
+describe('F4 — the hero gauge does not caption its number "wins" (ROADMAP 2.214)', () => {
+  it('the bare caption is gone', () => {
+    expect(renderedCopy(V7_HERO)).not.toContain(F4_RETIRED)
+  })
+
+  it('the gauge still carries an ANCHORED accessible name — the number is not left unlabelled', () => {
+    // Over-suppression control: removing the caption must not leave a large
+    // bare percentage with no stated basis, which is the very defect the
+    // comparative register exists to prevent.
+    const copy = renderedCopy(V7_HERO)
+    expect(copy).toContain('COMPARATIVE_COPY.label')
+    expect(copy).toContain('aria-label')
+  })
+
+  it('POSITIVE CONTROL — the rule fires on the exact historical markup', () => {
+    const historical = '<span className="text-[8.5px] text-text-light">wins</span>'
+    expect(historical).toContain(F4_RETIRED)
+  })
+})

--- a/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
+++ b/src/components/results/__tests__/singleVerdict.crossSurface.spec.tsx
@@ -37,6 +37,8 @@ import { OptionNode } from '../../../canvas/nodes/OptionNode'
 import { useCanvasStore } from '../../../canvas/store'
 import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
 import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import { buildV7Lenses } from '../v7/buildV7Lenses'
+import { buildV7Headline } from '../v7/buildV7Headline'
 
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react')
@@ -294,5 +296,74 @@ describe('SINGLE VERDICT — canvas and results panel must not contradict each o
       panel.footerTicksWinner,
       `The checks footer and the headline disagree inside ONE panel.\nPanel text: ${panel.text.slice(0, 400)}`,
     ).toBe(!panel.denies)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// R1 (ROADMAP 2.233 review) — THE HERO HEADLINE AND THE GOAL LENS BENEATH IT
+// MUST DESIGNATE THE SAME OPTION. This file exists for exactly this class:
+// two surfaces rendered together (`V7TopMatter.tsx:68,76`) disagreeing.
+//
+// THE REGRESSION THIS PINS WAS CREATED BY 2.233's OWN FIX. At base both said the
+// COMPARATIVE leader — consistently wrong. Fixing only the headline made the
+// pair CONTRADICTORY.
+//
+// ⚠ IT WENT UNPINNED FOR THE SAME REASON THE HEADLINE DEFECT DID:
+// `buildV7Lenses.spec.ts:123-124` hands the highest goal probability to the very
+// option it marks `isWinner`, so the two can never disagree there — the
+// identical incomplete-fixture weakness found and fixed in the headline spec,
+// repeated one file over. The fixture below DELIBERATELY disagrees.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('R1 — the V7 goal lens designates the GOAL leader, not the comparative one', () => {
+  const A = {
+    id: 'opt_a', label: 'Option A', winProbability: 0.7, goalProbability: 0.4,
+    isRecommended: true, goalFitIsSubstitutedJoint: false,
+  }
+  const B = {
+    id: 'opt_b', label: 'Option B', winProbability: 0.3, goalProbability: 0.8,
+    goalFitIsSubstitutedJoint: false,
+  }
+
+  function goalLensFor(options: unknown[], recommendedId: string) {
+    return buildV7Lenses({
+      recommendation: {
+        allOptions: options,
+        recommendedOption: options.find((o) => (o as { id: string }).id === recommendedId),
+        goalThreshold: 100,
+      },
+      drivers: { drivers: [] },
+      confidence: {},
+      voiRanking: null,
+    } as never).goal
+  }
+
+  it('THE DISAGREEING CASE: the row marked isWinner is the goal argmax (B), not the recommended option (A)', () => {
+    const goal = goalLensFor([A, B], 'opt_a')
+    const marked = goal.options.filter((o) => o.isWinner)
+    expect(marked).toHaveLength(1)
+    expect(marked[0].id).toBe('opt_b')
+    expect(goal.options.find((o) => o.id === 'opt_a')?.isWinner).toBe(false)
+  })
+
+  it('the lens agrees with the HEADLINE on the same data — one subject, one designation', () => {
+    const goal = goalLensFor([A, B], 'opt_a')
+    const headline = buildV7Headline(
+      { recommendedOption: A, allOptions: [A, B], goalThreshold: 100 } as never,
+      'robust',
+    )
+    expect(goal.options.find((o) => o.isWinner)?.label).toBe('Option B')
+    expect(headline.headline).toContain('Option B')
+    // The pair that must never recur: headline names one option, lens bolds another.
+    expect(headline.headline).not.toContain('Option A has the highest')
+  })
+
+  it('OVER-SUPPRESSION CONTROL: when the two leaders AGREE, the row is still marked', () => {
+    const goal = goalLensFor([{ ...A, goalProbability: 0.9 }, B], 'opt_a')
+    expect(goal.options.find((o) => o.isWinner)?.id).toBe('opt_a')
+  })
+
+  it('no honest goal leader (a TIE at the top) ⇒ NO row is marked — never a fallback', () => {
+    const goal = goalLensFor([A, { ...B, goalProbability: 0.4 }], 'opt_a')
+    expect(goal.options.some((o) => o.isWinner)).toBe(false)
   })
 })

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -31,6 +31,7 @@ import {
 import { useCanvasStore } from '../../../canvas/store'
 import { formatFlipRiskMessage } from '../utils/formatScenarioRatio'
 import type { RawFactorSensitivity, EdgeForDirection } from '../types'
+import { isDirectionalFactor } from '../../../lib/factorDirection'
 
 // =============================================================================
 // 1. Dynamic Normalisation Tests
@@ -423,9 +424,28 @@ describe('normaliseDirection', () => {
     expect(normaliseDirection('Negative')).toBe('negative')
   })
 
-  it('returns undefined for unknown variants', () => {
-    expect(normaliseDirection('unknown')).toBeUndefined()
-    expect(normaliseDirection('mixed')).toBeUndefined()
+  /**
+   * ⭐ SUPERSEDED 2026-08-01 (ROADMAP 2.234). Was "returns undefined for
+   * unknown variants", flattening `mixed` and `unknown` to `undefined`.
+   *
+   * That was harmless HERE — undefined reads as "no direction", and no
+   * directional glyph is drawn for it — but it meant this file and
+   * `mapV5AnalysisToReport` each owned a private answer to the same question,
+   * and the mapper's answer was to call them BOTH `'positive'`. The producer's
+   * documented domain now survives end to end; what a surface may DRAW is
+   * decided by `isDirectionalFactor`, not by whether the value is null.
+   */
+  it('carries the producer domain: `mixed` and `unknown` survive as themselves', () => {
+    expect(normaliseDirection('unknown')).toBe('unknown')
+    expect(normaliseDirection('mixed')).toBe('mixed')
+    // Neither is directional, which is what actually governs rendering.
+    expect(isDirectionalFactor(normaliseDirection('mixed'))).toBe(false)
+    expect(isDirectionalFactor(normaliseDirection('unknown'))).toBe(false)
+  })
+
+  it('an UNRECOGNISED value fails closed to `unknown`, never to a directional claim', () => {
+    expect(normaliseDirection('sideways')).toBe('unknown')
+    expect(isDirectionalFactor(normaliseDirection('sideways'))).toBe(false)
   })
 
   it('returns undefined for undefined/empty', () => {

--- a/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/buildHeroModel.spec.ts
@@ -186,6 +186,28 @@ describe('buildHeroModel — leaders and headline', () => {
     expect(m.headline).toBe(HERO_COPY.headline.goalOnly('Upskill the team', goalReadoutOf(m, 'Upskill the team')))
   })
 
+  /**
+   * ⭐ UNCHANGED, AND DELIBERATELY SO (ROADMAP 2.233).
+   *
+   * This test is the PARTIAL-COVERAGE case, and it pins BOTH directions at
+   * once: the goal lens is AVAILABLE (option A's measured value is shown, B's
+   * absence renders as `'—'`) while the goal crown is ABSENT (`leaders.goal`
+   * null, the headline reframed to the analysis basis).
+   *
+   * A revision of 2.233 briefly flipped the first assertion to `not.toContain`
+   * by tightening availability to `.every` — and this test is what caught it.
+   * The reasoning behind that tightening was about protecting the CLAIM, but
+   * the claim was already protected by `selectGoalLeader`'s complete-field
+   * gate, as the `leaders.goal` assertion below has always shown. So the
+   * tightening bought no honesty and cost real data: it blanked the whole goal
+   * view, including the option the producer HAD measured, on a surface that
+   * discloses the gap with `'—'`.
+   *
+   * The two questions are now named apart (`hasAnyGoalValue` for display,
+   * `hasCompleteGoalField` inside `selectGoalLeader` for the claim). This pair
+   * of assertions is what stops them being re-merged: any future change that
+   * conflates them must break one of these two lines.
+   */
   it('does not goal-headline a recommended option that lacks its own goal value', () => {
     // Recommended option B has no goalProbability while A has one: the hero
     // must not claim B "is most likely to meet every target this run scored" beside a "—" readout for B.
@@ -204,7 +226,11 @@ describe('buildHeroModel — leaders and headline', () => {
         }),
       ),
     )
+    // ① AVAILABILITY — the lens IS shown. B's missing value is disclosed as
+    //    '—' (goalReadout), not hidden by blanking the whole view.
     expect(m.lenses).toContain('goal')
+    // ② ENTITLEMENT — and yet NO crown. This is the pair; neither line means
+    //    much without the other.
     expect(m.leaders.goal).toBeNull()
     expect(m.headline).toBe(HERO_COPY.headline.slightlyAhead('Upskill the team'))
     expect(m.subline).toBe(

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -49,6 +49,8 @@ import { stripEncodingNotation } from '../utils/cleanFactorLabel'
 import { THRESHOLDS } from '../../../lib/mappers/constants'
 import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
 import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
+import { hasAnyGoalValue, selectGoalLeader } from '../utils/selectGoalLeader'
+import { isDirectionalFactor } from '../../../lib/factorDirection'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../utils/goalFitBasisCaveatCopy'
 import {
   getExpectedValue,
@@ -379,7 +381,19 @@ export function buildHeroModel(
   // target exists, but the explicit `hasUserTarget` term keeps the gate
   // visible and future-proof (value presence alone must never re-enable
   // the lens for synthesized values).
-  const goalAvailable = hasUserTarget && rows.some((r) => r.goal.value != null)
+  //
+  // ⭐ ROADMAP 2.233 — AVAILABILITY, kept as `.some`, now NAMED.
+  //
+  // This is `hasUserTarget && rows.some(...)` exactly as before; only the
+  // predicate's home and name changed. A revision of 2.233 briefly tightened it
+  // to `.every` to "match" the V7 lens, and that was a mistake worth recording:
+  // it conflated what we may DISPLAY with what we may CLAIM. The crown was
+  // ALREADY withheld on partial coverage by `selectGoalLeader`'s complete-field
+  // gate, so tightening this bought no claim-safety — it only hid goal values
+  // the producer HAD measured, on a surface that renders the missing ones as
+  // `'—'` (`goalReadout`). Data is not a claim; an honest gap marker is not a
+  // reason to blank the row beside it.
+  const goalAvailable = hasAnyGoalValue(rows, (r) => r.goal.value, { hasUserTarget })
   const outcomeAvailable = rows.some(
     (r) => r.outcome.p10 != null && r.outcome.p90 != null,
   )
@@ -612,24 +626,20 @@ export function buildHeroModel(
   // rather than one of its three readers is the single change point — and it
   // removes the hand-maintained mirror in which each new reader has to
   // remember to re-apply the rule.
-  let goalLeaderRow: HeroRowVM | null = null
-  if (!designationsWithheld && hasUserTarget && rows.every((r) => r.goal.value != null)) {
-    let best: HeroRowVM | null = null
-    let bestValue = -Infinity
-    let tiedAtMax = false
-    for (const r of rows) {
-      const v = r.goal.value as number
-      if (v > bestValue) {
-        bestValue = v
-        best = r
-        tiedAtMax = false
-      } else if (v === bestValue) {
-        tiedAtMax = true
-      }
-    }
-    goalLeaderRow =
-      best != null && !tiedAtMax && bestValue >= SUB_ONE_PERCENT_FLOOR ? best : null
-  }
+  //
+  // ⭐ EXTRACTED 2026-08-01 (ROADMAP 2.233). The loop that used to sit here is
+  // now `utils/selectGoalLeader.ts`, unchanged in behaviour except that the
+  // completeness check is `Number.isFinite` rather than `!= null` (a NaN row
+  // passed the old check while losing every comparison, so one NaN could let a
+  // rival be crowned on an "complete" set). It moved because `buildV7Headline`
+  // made the identical claim with NO rule at all and crowned the COMPARATIVE
+  // leader on the goal metric — the second copy of a rule is where the defect
+  // lives, so there is now one copy and both surfaces select through it.
+  const goalLeaderRow: HeroRowVM | null = selectGoalLeader(
+    rows,
+    (r) => r.goal.value,
+    { designationsWithheld, hasUserTarget },
+  )
 
   const safeLabel = (row: HeroRowVM) =>
     safeInterpolatedLabel(row.label, HERO_COPY.labelFallback)
@@ -927,7 +937,14 @@ export function buildHeroModel(
             targetId: d.canFocus ? d.matchedNodeId ?? d.factorKey : null,
             // Producer-normalised direction, passed through; absent stays
             // absent (the sign glyph is omitted, never guessed).
-            direction: d.direction ?? null,
+            //
+            // ROADMAP 2.234: `DriverItem.direction` now carries the producer's
+            // FULL domain, so the narrowing happens HERE — at the boundary of a
+            // render model that can only draw two states. `isDirectionalFactor`
+            // is the shared gate: `'mixed'` and `'unknown'` are PRESENT values
+            // that still forbid a directional glyph, so `!= null` is the wrong
+            // question and this is the right one.
+            direction: isDirectionalFactor(d.direction) ? d.direction : null,
             influence: typeof influenceValue === 'number' && Number.isFinite(influenceValue)
               ? influenceValue
               : null,

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -7,6 +7,7 @@
  * "Coaching over gates" philosophy - users see clear decision guidance.
  */
 
+import type { FactorDirection } from '../../lib/factorDirection'
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import type { ConstraintAnalysis } from '../../types/constraints'
 import type { M1CoachingReadiness } from '../../types/cee'
@@ -347,10 +348,20 @@ export interface DecisionResultData {
 export type DriverSemanticLabel = 'biggest' | 'strong' | 'moderate' | 'minor'
 
 /**
- * Canonical direction after normalisation.
- * 'positive' = increases goal, 'negative' = decreases goal
+ * Canonical direction after normalisation — the PRODUCER's full documented
+ * domain (`src/lib/factorDirection.ts`).
+ *
+ * 'positive' = increases goal · 'negative' = decreases goal ·
+ * 'mixed' / 'unknown' = the producer measured the factor but declined to
+ * assert a single direction.
+ *
+ * ⚠ WIDENED 2026-08-01 (ROADMAP 2.234). This was `'positive' | 'negative'`,
+ * and that narrowing is what turned `mixed`/`unknown`/absent into "up" arrows
+ * and the sentence "increases the outcome". Only the two directional members
+ * license directional rendering — ask `isDirectionalFactor`, never
+ * `direction != null`.
  */
-export type DriverDirection = 'positive' | 'negative'
+export type DriverDirection = FactorDirection
 
 // =============================================================================
 // Confidence Provenance (audit A1-PRIMARY)
@@ -920,7 +931,12 @@ export interface UiFactorSensitivity {
   factorId: string
   label: string
   elasticity: number
-  direction: 'positive' | 'negative'
+  /**
+   * The producer's direction across its full domain, or `null` when the
+   * producer sent none (ROADMAP 2.234). Was `'positive' | 'negative'`, which
+   * could only be satisfied by inventing one.
+   */
+  direction: FactorDirection | null
   confidence: number | null
   importanceRank: number
   /** ISL influence_score (0-1) - structural causal influence */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -52,6 +52,11 @@ import type {
   ConfidenceProvenance,
 } from './types'
 import { normalizeAutoNoiseProvenance, normalizeHeadlineBanded } from './types'
+import {
+  normaliseFactorDirection,
+  polarityToFactorDirection,
+  type FactorDirection,
+} from '../../lib/factorDirection'
 import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
@@ -314,7 +319,9 @@ export function isValidConfidenceProvenance(value: unknown): value is {
 export { isDefaultedConfidenceFromRaw }
 
 export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<string, string>): UiFactorSensitivity {
-  if (raw == null || typeof raw !== 'object') return { factorId: '', label: 'Unknown factor', elasticity: 0, direction: 'positive' as const, confidence: null, importanceRank: 0 }
+  // ROADMAP 2.234: the empty row's direction is `null`, not `'positive'` — a
+  // row with no producer data at all cannot carry a causal claim.
+  if (raw == null || typeof raw !== 'object') return { factorId: '', label: 'Unknown factor', elasticity: 0, direction: null, confidence: null, importanceRank: 0 }
   const typed = raw as Record<string, unknown>
   const nf = normaliseFactorFields(typed)
   const rawId = nf.node_id
@@ -330,9 +337,14 @@ export function normalizeFactorSensitivity(raw: unknown, nodeLabelMap: Map<strin
   const confidence = typeof typed.confidence === 'number'
     ? typed.confidence
     : null
-  const direction = typed.direction
-    ? (String(typed.direction).toLowerCase() === 'negative' ? 'negative' : 'positive')
-    : elasticity >= 0 ? 'positive' : 'negative'
+  // ROADMAP 2.234 — THE DUPLICATE COLLAPSE, REMOVED. This read
+  //   `typed.direction ? (lower === 'negative' ? 'negative' : 'positive')
+  //                    : elasticity >= 0 ? 'positive' : 'negative'`
+  // — the same two-value narrowing `mapV5AnalysisToReport` had, written a
+  // second time, so `mixed` and `unknown` became `positive` HERE TOO and a fix
+  // in one file would have left the other lying. Both now call the one shared
+  // normalizer, and neither infers a direction from a magnitude.
+  const direction = normaliseFactorDirection(typed.direction)
 
   // ISL influence_score (0-1) - structural causal influence
   const influenceScore = typeof typed.influence_score === 'number' ? typed.influence_score : undefined
@@ -588,7 +600,11 @@ export function selectDriverPolicyFeed(
       id: (d as { id?: string }).id,
       label: d.label,
       sensitivity: d.contribution,
-      direction: d.polarity === 'down' ? 'negative' : 'positive',
+      // ROADMAP 2.234: `neutral` must come back as a NON-directional value.
+      // `d.polarity === 'down' ? 'negative' : 'positive'` turned every neutral
+      // driver into a positive causal claim on the way back through this
+      // legacy reconstruction.
+      direction: polarityToFactorDirection(d.polarity) ?? undefined,
     }
     const key = getFactorKey(candidate, rawFactors.length + idx)
     if (!seenKeys.has(key)) {
@@ -760,24 +776,18 @@ function normalizeOutcomeValues(
 // =============================================================================
 
 /**
- * Normalise direction variants to canonical enum.
+ * Normalise direction variants to the canonical domain.
+ *
+ * ⚠ ROADMAP 2.234: delegates to the one shared normalizer. It used to hold its
+ * own alias table and return `undefined` for `mixed`/`unknown` — which read as
+ * "no direction" and was harmless HERE, but meant this file and
+ * `mapV5AnalysisToReport` each owned a private answer to the same question.
+ * The alias sets are unchanged (they were merged into the shared module), so
+ * no payload that used to normalise stops normalising; what changes is that
+ * `mixed` and `unknown` now survive as themselves instead of being flattened.
  */
 function normaliseDirection(direction: string | undefined): DriverDirection | undefined {
-  if (!direction) return undefined
-
-  const normalised = String(direction).toLowerCase().trim()
-
-  // Positive variants
-  if (['positive', 'increases', '+', 'increase', 'up'].includes(normalised)) {
-    return 'positive'
-  }
-
-  // Negative variants
-  if (['negative', 'decreases', '-', 'decrease', 'down'].includes(normalised)) {
-    return 'negative'
-  }
-
-  return undefined
+  return normaliseFactorDirection(direction) ?? undefined
 }
 
 /**
@@ -810,13 +820,19 @@ function getFactorDirection(
   edges: EdgeForDirection[],
   goalNodeId: string | undefined,
   outcomeNodeIds: string[],
-  factorDirection?: string
+  // ROADMAP 2.234: the caller now passes an already-normalised
+  // `FactorDirection | null`, and `string` is still accepted for the canvas-edge
+  // and legacy callers. Note the priority rule is UNCHANGED and is now
+  // load-bearing in a second way: a producer that said `mixed` or `unknown` is
+  // an ANSWER, so it short-circuits here and the canvas-edge fallbacks below do
+  // NOT run. Only genuine absence falls through to the graph's own metadata.
+  factorDirection?: FactorDirection | string | null
 ): DriverDirection | undefined {
   // 1. API factor_sensitivity.direction (PRIMARY SOURCE)
   // The analysis engine computes direction based on sensitivity analysis,
   // which is more accurate than static canvas edge metadata.
   if (factorDirection) {
-    return normaliseDirection(factorDirection)
+    return normaliseFactorDirection(factorDirection) ?? undefined
   }
 
   // 2. Canvas edge to goal (FALLBACK when API direction unavailable)

--- a/src/components/results/utils/displayFloors.ts
+++ b/src/components/results/utils/displayFloors.ts
@@ -1,4 +1,8 @@
-import { formatPercent } from '../../../utils/formatPercent'
+import {
+  SUB_ONE_PERCENT_FLOOR,
+  SUB_ONE_PERCENT_READOUT,
+  formatPercent,
+} from '../../../utils/formatPercent'
 
 /**
  * UI-SEM-057: the sub-1% display-honesty floor, shared by OptionCards
@@ -7,19 +11,21 @@ import { formatPercent } from '../../../utils/formatPercent'
  * no-option-on-track headline switch). ONE constant so the surfaces can
  * never disagree about what "meaningfully on track" means.
  */
-export const SUB_ONE_PERCENT_FLOOR = 0.01
-
-/**
- * The rendered form of a probability below the floor.
- *
- * The same two characters already ship as `HERO_COPY.readout.subOnePercent`
- * and `V7_LENS_COPY.goal.subOnePercent`. Those are not moved here: they live
- * in their surfaces' own copy registers, and the analysis-hero module is
- * under a mount guard that permits exactly two importers repo-wide, so it
- * cannot be the shared home. This constant is the home for the goal surfaces
- * that have no copy register of their own.
- */
-export const SUB_ONE_PERCENT_READOUT = '< 1%'
+// ⭐ RELOCATED 2026-08-01 (ROADMAP 2.236) — the two constants now live in
+// `src/utils/formatPercent.ts` and are RE-EXPORTED here, so every importer of
+// this module is unchanged. They moved because `formatProbabilityWithResolution`
+// (the shared COMPARATIVE formatter) needed the threshold and could not import
+// it from here without a cycle — and the workaround for that cycle was a third
+// hand-written `0.01` in `canvas/utils/labelUtils.ts`. That duplicate is what
+// let the floor ship on the canvas and not in the dock: one option, one instant,
+// "< 1%" on the canvas node and "0%" on the option card beside it.
+//
+// This file remains the home of the GOAL register's formatter below.
+// The readout string ("< 1%") also ships as `HERO_COPY.readout.subOnePercent`
+// and `V7_LENS_COPY.goal.subOnePercent`. Those stay in their surfaces' own copy
+// registers — the analysis-hero module is under a mount guard permitting
+// exactly two importers repo-wide, so it could never be the shared home.
+export { SUB_ONE_PERCENT_FLOOR, SUB_ONE_PERCENT_READOUT }
 
 /**
  * Format a goal-attainment probability for display, applying the floor.
@@ -34,8 +40,13 @@ export const SUB_ONE_PERCENT_READOUT = '< 1%'
  * The predicate is `value < SUB_ONE_PERCENT_FLOOR`, byte-for-byte the
  * siblings' own test — deliberately WITHOUT a `value > 0` carve-out. A floor
  * rule that only one caller has is the hand-maintained divergence this
- * function exists to remove; an exact zero therefore reads "< 1%" here as it
- * already does on every sibling goal surface.
+ * function exists to remove; an exact zero therefore reads "< 1%" here.
+ *
+ * ⚠ CORRECTED (2.236 review): this used to end "as it already does on every
+ * sibling goal surface". FALSE. `GoalNode.tsx:336-338` carries its own
+ * `> 0 && < 0.01` carve-out and renders an exact zero as "0% chance of reaching
+ * target" — live, and the opposite convention. The divergence is real, rowed,
+ * and NOT fixed here; do not read this as a claim that the canvas agrees.
  *
  * Display only: the value itself is untouched and every bar still draws from
  * the raw number. Above the floor this is exactly

--- a/src/components/results/utils/selectGoalLeader.ts
+++ b/src/components/results/utils/selectGoalLeader.ts
@@ -1,0 +1,224 @@
+/**
+ * selectGoalLeader — THE one rule for "which option leads on the GOAL view".
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS MODULE EXISTS
+ * ─────────────────────────────────────────────────────────────────────────
+ * Two surfaces on the same screen make the same superlative claim about the
+ * same quantity, and until ROADMAP 2.233 they answered DIFFERENT questions.
+ *
+ * `buildHeroModel` (UI-SEM-072) held the correct rule: crown the
+ * goal-probability ARGMAX, honestly gated. `buildV7Headline` held no rule at
+ * all — it took `recommendation.recommendedOption` (the COMPARATIVE leader),
+ * checked only that THAT option had a finite goal probability, and printed
+ * "{label} has the highest chance of hitting your goal: {v}". No rival was
+ * ever consulted, so the superlative was unearned by construction. The audit
+ * probe: A(win .70, goal .40, recommended) vs B(win .30, goal .80) produced
+ * "Option A has the highest chance of hitting your goal: 40%" while the goal
+ * block beside it ranked B first at 80%.
+ *
+ * The lesson the codebase keeps re-learning is that the second copy of a rule
+ * is where the defect lives. So the rule moves HERE, both callers select
+ * through it, and neither can drift. The gates below are `buildHeroModel`'s
+ * own, transcribed with their reasons — this module is the owner now, and the
+ * hero delegates to it.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE GATES — a crown is WITHHELD (null, never a wrong crown) unless ALL hold
+ * ─────────────────────────────────────────────────────────────────────────
+ *  1. DESIGNATIONS ARE PERMITTED. On a run whose verdict withholds the leader
+ *     claim, the crown is a DESIGNATION and goes (ROADMAP 1.267). Gated at
+ *     SELECTION, not at each reader, so a new reader cannot be born
+ *     un-gated — the hand-maintained-mirror failure this programme keeps
+ *     paying for.
+ *  2. A USER TARGET EXISTS (UI-SEM-071). Without `goalThreshold` PLoT/ISL
+ *     synthesize an auto threshold and the selector still adopts
+ *     `probability_of_joint_goal` — values describing a target the user never
+ *     set. No user target, no goal claim.
+ *  3. EVERY candidate carries its own FINITE goal value. A maximum taken over
+ *     unmeasured rivals cannot honestly claim "highest".
+ *  4. The maximum is UNIQUELY held. A tie at the top identifies no single
+ *     best option; crowning either would be arbitrary.
+ *  5. The maximum clears the shared sub-1% floor (UI-SEM-057). When nothing
+ *     is meaningfully on track, no option is the one that is.
+ *
+ * ⚠ GATE 3 USES `Number.isFinite`, NOT `!= null` — a deliberate hardening
+ * over the hero's original loop. `NaN != null` is true, and a NaN candidate
+ * fell straight through the old completeness check while losing every `>`
+ * comparison, so a run with one NaN row could still crown a rival and call it
+ * complete. `isFiniteProbability` is the presence test the goal surfaces
+ * already share (`goalAnchorCopy`), and it is the one used here.
+ *
+ * SELECTION ONLY. This module reads producer values and returns one of the
+ * caller's own objects, or null. It never transforms a value, never formats
+ * one, and never authors copy.
+ */
+import { isFiniteProbability } from './goalAnchorCopy'
+import { SUB_ONE_PERCENT_FLOOR } from './displayFloors'
+
+export interface GoalLeaderGates {
+  /**
+   * True when the run's verdict withholds leader designations
+   * (`verdict != null && !verdict.hasLeadingOption`). Callers pass the
+   * decision the hook already derived — they never re-derive one.
+   */
+  designationsWithheld: boolean
+  /** True when the USER set a success target (`goalThreshold != null`). */
+  hasUserTarget: boolean
+}
+
+/**
+ * ═════════════════════════════════════════════════════════════════════════
+ * TWO QUESTIONS, TWO PREDICATES — do not merge them again
+ * ═════════════════════════════════════════════════════════════════════════
+ * There are two different things a surface can ask about a run's goal field,
+ * and for one revision of ROADMAP 2.233 this module conflated them under a
+ * single `hasCompleteGoalField`. That was wrong, and the way it was wrong is
+ * worth keeping on the record because the mistake is so easy to re-make:
+ *
+ *   1. **AVAILABILITY — "may I DISPLAY this?"**  → `hasAnyGoalValue` (`.some`)
+ *      Showing a measured value is not a claim about the values that are
+ *      missing. The hero renders an absent goal as `'—'`
+ *      (`HERO_COPY.readout.missing`), which DISCLOSES the gap rather than
+ *      hiding it. Requiring a complete field here buys no honesty and costs
+ *      the user real data: on partial coverage the whole goal view vanished,
+ *      including the options the producer HAD measured.
+ *
+ *   2. **ENTITLEMENT — "may I CLAIM a leader?"** → `hasCompleteGoalField`
+ *      (`.every`, applied inside `selectGoalLeader`). A superlative ranges
+ *      over the WHOLE field, so a maximum taken over unmeasured rivals cannot
+ *      honestly claim "highest".
+ *
+ * The crown was ALREADY correctly withheld under both rules — which is the
+ * proof that tightening availability bought no claim-safety at all. Keep the
+ * partial-coverage case pinned in BOTH directions (lens VISIBLE, crown
+ * ABSENT); that pair is what stops the two questions being re-conflated.
+ */
+
+/**
+ * AVAILABILITY (display). True when a USER target exists and AT LEAST ONE
+ * option carries a finite goal probability.
+ *
+ * Data is not a claim. Missing rows render as the honest missing-value glyph;
+ * they are not silently dropped and they are not invented.
+ */
+export function hasAnyGoalValue<T>(
+  candidates: readonly T[],
+  getGoalValue: (candidate: T) => number | null | undefined,
+  gates: Pick<GoalLeaderGates, 'hasUserTarget'>,
+): boolean {
+  // UI-SEM-071 — no USER target, no goal view, whatever values are present.
+  // PLoT/ISL synthesize an auto threshold and the selector still adopts
+  // `probability_of_joint_goal`, so value presence alone must never open this.
+  if (!gates.hasUserTarget) return false
+  return candidates.some((candidate) => isFiniteProbability(getGoalValue(candidate)))
+}
+
+/**
+ * ENTITLEMENT (claim). True when a USER target exists and EVERY option carries
+ * its own finite goal probability.
+ *
+ * This is gate 2+3 of `selectGoalLeader` — a superlative needs the whole
+ * field. It is exported for ONE other caller, and that caller is not asking
+ * the availability question either: `buildV7Lenses`' goal row builder types
+ * `V7GoalLens.options[].goalProbability` as a NON-NULLABLE `number` and casts
+ * with `as number`, and `V7LensGroup`'s `GoalRow` does arithmetic on it
+ * (`probability < FLOOR`, `Math.round(probability * 100)`). Handing it a
+ * missing value would render `NaN%` and a NaN-width bar — a placeholder
+ * presented as a measurement, which is the very defect class this lane exists
+ * to remove. So V7 asks the complete-field question because its own model
+ * cannot yet express absence, NOT because availability requires completeness.
+ * Teaching that model `number | null` and rendering `'—'` would let V7 move to
+ * `hasAnyGoalValue` too; until then this is the honest gate for it.
+ */
+export function hasCompleteGoalField<T>(
+  candidates: readonly T[],
+  getGoalValue: (candidate: T) => number | null | undefined,
+  gates: Pick<GoalLeaderGates, 'hasUserTarget'>,
+): boolean {
+  if (!gates.hasUserTarget) return false
+  if (candidates.length === 0) return false
+  return candidates.every((candidate) => isFiniteProbability(getGoalValue(candidate)))
+}
+
+/**
+ * The unique, complete, floor-clearing goal-probability argmax — or null.
+ *
+ * @param candidates    the options/rows in any order; order does not affect
+ *                      the result (a tie yields null either way).
+ * @param getGoalValue  reads the goal probability off one candidate. Kept as
+ *                      an accessor so the hero can pass its row VM and the
+ *                      headline can pass an `OptionResult` without either
+ *                      side building a parallel array — a second array is a
+ *                      second thing to keep in sync.
+ */
+export function selectGoalLeader<T>(
+  candidates: readonly T[],
+  getGoalValue: (candidate: T) => number | null | undefined,
+  gates: GoalLeaderGates,
+): T | null {
+  // Gate 1 — entitlement, before any value is read.
+  if (gates.designationsWithheld) return null
+
+  // Gates 2 and 3 — a user target and a COMPLETE goal field. This is the SAME
+  // function the goal-lens availability check calls, so a surface cannot decide
+  // the field is usable and then be handed a crown selected under a different
+  // standard. They were two hand-written expressions in two files, and they had
+  // already drifted (`.some` vs `.every`).
+  if (!hasCompleteGoalField(candidates, getGoalValue, gates)) return null
+  const values = candidates.map(getGoalValue)
+
+  // Gates 4 and 5 — a unique maximum that clears the floor.
+  let best: T | null = null
+  let bestValue = -Infinity
+  let tiedAtMax = false
+  for (let i = 0; i < candidates.length; i += 1) {
+    const value = values[i] as number
+    if (value > bestValue) {
+      bestValue = value
+      best = candidates[i]
+      tiedAtMax = false
+    } else if (value === bestValue) {
+      tiedAtMax = true
+    }
+  }
+
+  if (best == null || tiedAtMax) return null
+  if (bestValue < SUB_ONE_PERCENT_FLOOR) return null
+  return best
+}
+
+/**
+ * The goal-metric lead in percentage points, leader minus runner-up.
+ *
+ * ⚠ A GOAL HEADLINE MUST NOT CARRY A COMPARATIVE SUBLINE. `buildV7Headline`
+ * printed "Leads by N points" — a `winProbability` gap — directly beneath the
+ * goal-attainment headline, so the reader read a comparative gap as a goal
+ * gap. Worse, once the headline crowns the GOAL leader, the comparative gap
+ * is about a DIFFERENT OPTION entirely. Headline and subline now describe one
+ * subject and one metric, and this is the function that keeps the metrics
+ * paired with their claims.
+ *
+ * Returns null when there is no rival to difference against. Only ever called
+ * with a `candidates` set that already passed `selectGoalLeader`, so every
+ * value is finite — but the finiteness filter stays, because a guard that
+ * depends on its caller's discipline is not a guard.
+ */
+export function goalLeadPoints<T>(
+  candidates: readonly T[],
+  getGoalValue: (candidate: T) => number | null | undefined,
+  leader: T,
+): number | null {
+  const leaderValue = getGoalValue(leader)
+  if (!isFiniteProbability(leaderValue)) return null
+
+  let runnerUp = -Infinity
+  for (const candidate of candidates) {
+    if (candidate === leader) continue
+    const value = getGoalValue(candidate)
+    if (isFiniteProbability(value) && value > runnerUp) runnerUp = value
+  }
+  if (runnerUp === -Infinity) return null
+
+  return Math.round((leaderValue - runnerUp) * 100)
+}

--- a/src/components/results/v7/V7Hero.tsx
+++ b/src/components/results/v7/V7Hero.tsx
@@ -15,7 +15,8 @@
  */
 
 import { typography } from '@/styles/typography'
-import { formatPercent } from '@/utils/formatPercent'
+import { formatProbabilityWithResolution } from '@/utils/formatPercent'
+import { COMPARATIVE_COPY } from '../utils/goalAnchorCopy'
 import type { DecisionResultData, DecisionState, DriverItem } from '../types'
 import { buildV7Headline } from './buildV7Headline'
 import { V7SignalRow } from './V7SignalRow'
@@ -66,8 +67,13 @@ export function V7Hero({
     >
       <div className="flex items-start gap-3">
         {winPct != null && dash && (
-          <div className="relative h-[52px] w-[52px] flex-none" data-testid="v7-hero-gauge">
-            <svg viewBox="0 0 52 52" className="h-[52px] w-[52px]">
+          <div
+            className="relative h-[52px] w-[52px] flex-none"
+            data-testid="v7-hero-gauge"
+            role="img"
+            aria-label={`${COMPARATIVE_COPY.label}: ${formatProbabilityWithResolution(winPct, null)}`}
+          >
+            <svg viewBox="0 0 52 52" className="h-[52px] w-[52px]" aria-hidden="true">
               <circle cx="26" cy="26" r={GAUGE_R} fill="none" stroke="currentColor" strokeWidth="5" className="text-panel-border" />
               <circle
                 cx="26"
@@ -84,9 +90,34 @@ export function V7Hero({
             </svg>
             <div className="absolute inset-0 flex flex-col items-center justify-center leading-none">
               <span className={`${typography.panelHeader} text-text-header`}>
-                {formatPercent(winPct, { fromDecimal: true })}
+                {/*
+                  ROADMAP 2.236: the shared floored comparative formatter. This
+                  was a bare `formatPercent(...)`, so the ring printed "0%" for
+                  a measured sub-1% probability while the canvas node said
+                  "< 1%".
+                */}
+                {formatProbabilityWithResolution(winPct, null)}
               </span>
-              <span className="text-[8.5px] text-text-light">wins</span>
+              {/*
+                ⭐ RETIRED 2026-08-01 (ROADMAP 2.214 / walk finding F4). The
+                caption here was the bare word "wins" under a large percentage
+                — an un-anchored name for the COMPARATIVE quantity, exactly what
+                `COMPARATIVE_COPY` exists to retire. It survived PR 548's sweep
+                because the retired-string list covered "winning" / "winner" /
+                "Win probability" and not "wins".
+
+                It is REMOVED rather than replaced, for two reasons. The
+                register's own label ("Came out ahead across scenarios") is 30
+                characters and this ring is 52px wide — it would wrap to four
+                lines and burst the circle. And the label is redundant: the
+                headline sitting immediately to the right of this ring already
+                reads "{option} came out ahead in {n}% of simulated scenarios",
+                which names the quantity in full. The quantity keeps its name on
+                screen; the gauge stops asserting a second, un-anchored one.
+
+                The register's label is attached to the ring as its accessible
+                name, so a screen-reader user is not left with a bare number.
+              */}
             </div>
           </div>
         )}

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.directionDomain.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.directionDomain.spec.tsx
@@ -1,0 +1,93 @@
+/**
+ * ROADMAP 2.234 — the direction domain, closed at the RENDERED SURFACE.
+ *
+ * The audit named three places: the V5 mapper (`:145-150`), the duplicate
+ * collapse in `useResultsSectionData` (`:316-335`), and THIS RENDERER
+ * (`V7EvidenceDisclosure.tsx:246-254`), which is where a fabricated
+ * `'positive'` finally became a green "+" glyph and the screen-reader sentence
+ * "increases the outcome".
+ *
+ * ⚠ THE RENDERER WAS NEVER THE BUG, and this file says so on purpose.
+ * `buildV7Lenses.driverDirection` already narrowed to `positive | negative |
+ * null`, and this component already gates its glyph on that. Both were correct
+ * and both were being handed a value the producer never sent. These pins exist
+ * so the chain is closed END TO END — a fix proven only at the mapper leaves
+ * the two hops after it unpinned, and it was exactly such an unpinned hop
+ * (`normalizeFactorSensitivity`) that a mutation check caught shipping with no
+ * coverage at all.
+ *
+ * At `900dbd6c` NOTHING asserted the `v7-driver-sign` glyph in either
+ * direction — the fixture below already carried a `direction: null` row and no
+ * test looked at what it rendered.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
+import { buildV7Lenses } from '../buildV7Lenses'
+import type { V7EvidenceModel } from '../buildV7Lenses'
+import type { DriverItem } from '../../types'
+import { v7EvidenceModel as model } from '@/__fixtures__/v7EvidenceModel'
+import { openDisclosureHeader } from '../../../../test/helpers/resolveNextView'
+
+function driversWith(direction: V7EvidenceModel['drivers'][number]['direction']) {
+  return [{ factorKey: 'f1', label: 'Market size', direction, isEstimate: false }]
+}
+
+describe('V7EvidenceDisclosure — only directional states draw a direction (ROADMAP 2.234)', () => {
+  it('positive → a "+" glyph and the "increases the outcome" sentence', () => {
+    render(<V7EvidenceDisclosure evidence={model({ drivers: driversWith('positive') })} />)
+    openDisclosureHeader()
+    expect(screen.getByTestId('v7-driver-sign')).toHaveTextContent('+')
+    expect(screen.getByText('(increases the outcome)')).toBeInTheDocument()
+  })
+
+  it('negative → a "-" glyph and the "decreases the outcome" sentence', () => {
+    render(<V7EvidenceDisclosure evidence={model({ drivers: driversWith('negative') })} />)
+    openDisclosureHeader()
+    expect(screen.getByTestId('v7-driver-sign')).toHaveTextContent('-')
+    expect(screen.getByText('(decreases the outcome)')).toBeInTheDocument()
+  })
+
+  it('NO direction → no glyph, no colour, and NO directional sentence for a screen reader', () => {
+    render(<V7EvidenceDisclosure evidence={model({ drivers: driversWith(null) })} />)
+    openDisclosureHeader()
+    // The row still renders — this is honest silence about direction, not a
+    // dropped driver.
+    expect(screen.getByText('Market size')).toBeInTheDocument()
+    expect(screen.queryByTestId('v7-driver-sign')).not.toBeInTheDocument()
+    expect(screen.queryByText('(increases the outcome)')).not.toBeInTheDocument()
+    expect(screen.queryByText('(decreases the outcome)')).not.toBeInTheDocument()
+  })
+})
+
+describe('buildV7Lenses — `mixed` and `unknown` reach the renderer as "no direction" (ROADMAP 2.234)', () => {
+  function lensesFor(direction: DriverItem['direction']) {
+    const drivers = {
+      drivers: [
+        { factorKey: 'f1', factorLabel: 'Market size', direction } as unknown as DriverItem,
+      ],
+    }
+    return buildV7Lenses({
+      recommendation: { allOptions: [], goalThreshold: null },
+      drivers,
+      confidence: {},
+      voiRanking: null,
+    } as never)
+  }
+
+  it.each(['mixed', 'unknown'] as const)(
+    'producer `%s` → `direction: null` on the evidence model (never a directional claim)',
+    (domainMember) => {
+      expect(lensesFor(domainMember).evidence.drivers[0].direction).toBeNull()
+    },
+  )
+
+  it('CONTROL — the two directional members still survive the same hop', () => {
+    expect(lensesFor('positive').evidence.drivers[0].direction).toBe('positive')
+    expect(lensesFor('negative').evidence.drivers[0].direction).toBe('negative')
+  })
+
+  it('CONTROL — the row itself is still carried, so this is not a "drivers went dark" pass', () => {
+    expect(lensesFor('mixed').evidence.drivers[0].label).toBe('Market size')
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Headline.goalLeader.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.goalLeader.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * ROADMAP 2.233 — the goal headline must crown the GOAL leader, not the
+ * comparative one.
+ *
+ * THE DEFECT (Codex audit A, finding 1, reproduced against the real function
+ * at `900dbd6c`): `buildV7Headline` fixed `winner = recommendation.recommendedOption`
+ * — the COMPARATIVE leader — then checked only whether THAT option carried a
+ * finite `goalProbability`, and printed
+ * `"{label} has the highest chance of hitting your goal: {v}"`. No rival was
+ * ever consulted, so the superlative was unearned by construction:
+ *
+ *   A(win .70, goal .40, recommended)   B(win .30, goal .80)
+ *   → "Option A has the highest chance of hitting your goal: 40%"
+ *
+ * while the goal block on the same screen ranked B first at 80%.
+ *
+ * THE RULE, and where it comes from. `buildHeroModel` (UI-SEM-072) already
+ * holds the correct algorithm and states it: crowning is SELECTION over
+ * producer values, withheld unless a USER target exists, EVERY option carries
+ * its own finite goal value, the maximum is UNIQUELY held, and it clears the
+ * shared sub-1% floor. That rule is now extracted to
+ * `utils/selectGoalLeader.ts` and BOTH surfaces call it, so the hero and this
+ * headline can no longer disagree about who leads on the goal view. These pins
+ * are written against the shared selector's OBSERVABLE effect on the headline,
+ * not against the selector's internals.
+ *
+ * SUBJECT COHERENCE IS PART OF THE FIX. `V7Hero` renders `winProbability`
+ * inside a gauge captioned "wins" IMMEDIATELY BESIDE the headline. If the
+ * headline names the goal leader while the gauge still carries the comparative
+ * leader's number, the reader attaches one option's win probability to a
+ * different option's name — the same two-questions-one-claim defect in a new
+ * place. The model's winner fields therefore follow the crowned option.
+ */
+import { describe, it, expect } from 'vitest'
+import { COMPARATIVE_COPY, GOAL_ANCHOR_COPY } from '../../utils/goalAnchorCopy'
+import { hasAnyGoalValue, hasCompleteGoalField, selectGoalLeader } from '../../utils/selectGoalLeader'
+import { buildV7Headline } from '../buildV7Headline'
+import type { DecisionResultData, OptionResult } from '../../types'
+
+function goalOpt(
+  id: string,
+  label: string,
+  winProbability: number,
+  goalProbability: number | null,
+  isRecommended = false,
+  goalFitIsSubstitutedJoint = false,
+): OptionResult {
+  return {
+    id,
+    label,
+    winProbability,
+    isRecommended,
+    ...(goalProbability !== null ? { goalProbability } : {}),
+    goalFitIsSubstitutedJoint,
+  } as unknown as OptionResult
+}
+
+function rec(partial: Partial<DecisionResultData>): DecisionResultData {
+  // Every fixture carries a USER target unless it is deliberately testing the
+  // no-target gate — UI-SEM-071 nulls every goal claim without one.
+  return { goalThreshold: 100, ...partial } as DecisionResultData
+}
+
+describe('buildV7Headline — the goal crown (ROADMAP 2.233)', () => {
+  it("AUDIT PROBE: does NOT crown the comparative leader on the goal metric when a rival's goal probability is higher", () => {
+    // The audit's exact inputs.
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.8)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    // The defect, stated as the thing that must never be produced again.
+    expect(model.headline).not.toBe(
+      GOAL_ANCHOR_COPY.headline('Option A', '40%', false),
+    )
+    expect(model.headline).not.toContain('Option A has the highest')
+    // The crown goes to the goal argmax, with ITS OWN number.
+    expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option B', '80%', false))
+  })
+
+  it('the gauge value follows the crowned option — a "wins" figure never sits beside a different option\'s name', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.8)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.winnerLabel).toBe('Option B')
+    expect(model.winProbability).toBe(0.3)
+  })
+
+  it('the subline under a GOAL headline measures the GOAL gap, not the comparative one', () => {
+    // Deliberately distinct gaps: comparative 0.70−0.30 = 40 points,
+    // goal 0.90−0.40 = 50 points. The audit's own fixture had BOTH equal to
+    // 40, which cannot tell the two metrics apart.
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.9)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option B', '90%', false))
+    expect(model.subline).toBe('Leads by 50 points')
+    expect(model.subline).not.toBe('Leads by 40 points')
+  })
+
+  it('crowns on the goal metric even when the two leaders AGREE (no behaviour change for the agreeing case)', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.8, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.4)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option A', '80%', false))
+    expect(model.subline).toBe('Leads by 40 points')
+    expect(model.winProbability).toBe(0.7)
+  })
+
+  it("the crowned row's own basis flag drives the wording (substituted joint withholds the possessive)", () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true, false)
+    const b = goalOpt('b', 'Option B', 0.3, 0.8, false, true)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    // B is crowned, so B's flag — not the recommended option's — picks the voice.
+    expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option B', '80%', true))
+    expect(model.headline).toContain('meeting every target this run scored')
+  })
+})
+
+describe('buildV7Headline — when no honest goal crown exists, it does not crown (ROADMAP 2.233)', () => {
+  const COMPARATIVE_A = (pct: string) => `Option A ${COMPARATIVE_COPY.clause(pct)}`
+
+  it('PARTIAL DATA: a rival with no goal value withholds the crown — a max over an unmeasured rival is not a maximum', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const b = goalOpt('b', 'Option B', 0.3, null)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).not.toContain('highest chance')
+    expect(model.headline).toBe(COMPARATIVE_A('70%'))
+    // Subject and metric agree again: the comparative headline gets the
+    // comparative gap.
+    expect(model.subline).toBe('Leads by 40 points')
+  })
+
+  it('TIE AT THE MAX: two options share the highest goal probability → no crown', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.8, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.8)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).not.toContain('highest chance')
+    expect(model.headline).toBe(COMPARATIVE_A('70%'))
+  })
+
+  it('NO USER TARGET (UI-SEM-071): a synthesized goal probability cannot buy a goal claim', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.8)
+    const model = buildV7Headline(
+      { recommendedOption: a, allOptions: [a, b], goalThreshold: null } as unknown as DecisionResultData,
+      'robust',
+    )
+
+    expect(model.headline).not.toContain('chance of hitting your goal')
+    expect(model.headline).toBe(COMPARATIVE_A('70%'))
+  })
+
+  it('BELOW THE SHARED SUB-1% FLOOR: nothing is meaningfully on track, so nothing is crowned', () => {
+    // SUPERSEDES the three #548 sub-1% pins in `buildV7Headline.spec.ts`,
+    // which asserted the headline CROWNS an option on a "< 1%" goal number.
+    // The sibling hero (`buildHeroModel`, UI-SEM-057) withholds the crown
+    // entirely in this state and switches to its no-option-on-track headline;
+    // the two surfaces render on the same screen, so a crown here was a fresh
+    // contradiction. The floor's FORMATTING role is unchanged and is still
+    // pinned by the control below.
+    const a = goalOpt('a', 'Option A', 0.7, 0.004, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.001)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).not.toContain('highest chance')
+    expect(model.headline).not.toContain('< 1%')
+    expect(model.headline).toBe(COMPARATIVE_A('70%'))
+  })
+
+  it('CONTROL — the floor still FORMATS: a crowned value just above it is not mangled', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.012, true)
+    const b = goalOpt('b', 'Option B', 0.3, 0.001)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a, b] }), 'robust')
+
+    expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option A', '1%', false))
+  })
+
+  it('SINGLE OPTION: the only-option form still wins, and carries no superlative', () => {
+    const a = goalOpt('a', 'Option A', 0.7, 0.4, true)
+    const model = buildV7Headline(rec({ recommendedOption: a, allOptions: [a] }), 'robust')
+
+    expect(model.headline).toBe('Option A is your only option')
+  })
+})
+
+/**
+ * TWO QUESTIONS, TWO PREDICATES (ROADMAP 2.233).
+ *
+ * A revision of this lane merged them into a single `.every` "availability"
+ * rule. That was wrong, and the error is instructive: it was reasoning about
+ * protecting the CLAIM, but the claim was already protected by
+ * `selectGoalLeader`'s own complete-field gate. Tightening what we DISPLAY
+ * therefore bought no honesty and cost real data — on partial coverage the
+ * whole goal view vanished, including the options the producer HAD measured,
+ * on a surface that discloses the missing ones as `'—'`.
+ *
+ *   AVAILABILITY (display) → `hasAnyGoalValue`      `.some`
+ *   ENTITLEMENT  (claim)   → `hasCompleteGoalField` `.every`, inside the selector
+ *
+ * ⭐ THE PARTIAL-COVERAGE CASE IS PINNED IN BOTH DIRECTIONS — available AND
+ * uncrowned. That pair is the whole point: it is precisely the case the merged
+ * rule removed silently, and any future re-conflation must break one of them.
+ */
+describe('availability vs entitlement — the two goal predicates (ROADMAP 2.233)', () => {
+  const value = (v: number | null) => ({ goal: v })
+  const read = (r: { goal: number | null }) => r.goal
+  const TARGETED = { hasUserTarget: true }
+  const PARTIAL = [value(0.4), value(null), value(0.8)]
+
+  it('⭐ PARTIAL COVERAGE, BOTH DIRECTIONS: the lens is AVAILABLE and the crown is ABSENT', () => {
+    // ① display — a measured value is shown; the gap is disclosed, not hidden.
+    expect(hasAnyGoalValue(PARTIAL, read, TARGETED)).toBe(true)
+    // ② claim — no superlative over an incomplete field.
+    expect(hasCompleteGoalField(PARTIAL, read, TARGETED)).toBe(false)
+    expect(
+      selectGoalLeader(PARTIAL, read, { designationsWithheld: false, hasUserTarget: true }),
+    ).toBeNull()
+  })
+
+  it('complete coverage: available AND crownable (over-suppression control)', () => {
+    const complete = [value(0.4), value(0.8)]
+    expect(hasAnyGoalValue(complete, read, TARGETED)).toBe(true)
+    expect(hasCompleteGoalField(complete, read, TARGETED)).toBe(true)
+    expect(
+      selectGoalLeader(complete, read, { designationsWithheld: false, hasUserTarget: true }),
+    ).toBe(complete[1])
+  })
+
+  it('no user target → BOTH answer false, however complete the values are (UI-SEM-071)', () => {
+    const complete = [value(0.4), value(0.8)]
+    const NO_TARGET = { hasUserTarget: false }
+    expect(hasAnyGoalValue(complete, read, NO_TARGET)).toBe(false)
+    expect(hasCompleteGoalField(complete, read, NO_TARGET)).toBe(false)
+  })
+
+  it('no measured value at all → not even available', () => {
+    expect(hasAnyGoalValue([value(null), value(null)], read, TARGETED)).toBe(false)
+    expect(hasAnyGoalValue([], read, TARGETED)).toBe(false)
+  })
+
+  it('an empty option set is not "vacuously complete"', () => {
+    expect(hasCompleteGoalField([], read, TARGETED)).toBe(false)
+  })
+
+  it('R7: the WITHHELD gate inside the selector bites on its own', () => {
+    // ⚠ ADDED BECAUSE DELETING THIS GATE LEFT ALL 153 TESTS GREEN. It is
+    // currently REDUNDANT — both live readers compute `designationsWithheld`
+    // themselves and the headline returns early on a withheld verdict. But the
+    // docstring's stated purpose is that the entitlement lives in the SELECTOR
+    // "so a new reader cannot be born un-gated", and an untested guarantee is
+    // not a guarantee. This pins the selector's OWN behaviour, independent of
+    // every caller — which is exactly the claim being made.
+    const complete = [value(0.4), value(0.8)]
+    expect(
+      selectGoalLeader(complete, read, { designationsWithheld: true, hasUserTarget: true }),
+    ).toBeNull()
+    // CONTROL — identical input, designations permitted ⇒ a crown. Without this
+    // the assertion above would pass on a selector that never crowns anything.
+    expect(
+      selectGoalLeader(complete, read, { designationsWithheld: false, hasUserTarget: true }),
+    ).toBe(complete[1])
+  })
+
+  it('a NaN is not a measurement, to EITHER question — `!= null` would have accepted it', () => {
+    const withNaN = [value(0.4), value(Number.NaN)]
+    expect(hasCompleteGoalField(withNaN, read, TARGETED)).toBe(false)
+    // The check the extracted hero loop used, shown failing to discriminate.
+    expect(withNaN.every((r) => r.goal != null)).toBe(true)
+    // A NaN alone is not an available value either.
+    expect(hasAnyGoalValue([value(Number.NaN)], read, TARGETED)).toBe(false)
+  })
+})

--- a/src/components/results/v7/__tests__/buildV7Headline.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.spec.ts
@@ -168,49 +168,86 @@ describe('buildV7Headline — SINGLE VERDICT gate', () => {
 // through `SUB_ONE_PERCENT_FLOOR`.
 //
 // RED-first: the "< 1%" assertion fails on `48adda75` (it reads "0%").
+//
+// ⭐ FIXTURES COMPLETED + ONE EXPECTATION SUPERSEDED, 2026-08-01 (ROADMAP 2.233).
+//
+// TWO changes, and the distinction matters when reading this block.
+//
+// (1) THE FIXTURES WERE INCOMPLETE, and that incompleteness is exactly what
+//     hid the crowning defect. Every case gave the goal probability to the
+//     RECOMMENDED option ALONE and set no `goalThreshold`, so no rival could
+//     ever contradict the superlative and the audit's disagreement case was
+//     unreachable from this file. The rows now carry a user target and a goal
+//     value for BOTH options — which is what `selectGoalLeader` requires
+//     before it will crown anything at all.
+//
+// (2) THE SUB-1% EXPECTATION IS SUPERSEDED. This block used to assert that a
+//     0.4% goal probability produces "…highest chance of hitting your goal:
+//     < 1%". Rendering "< 1%" instead of "0%" was the right fix to the
+//     FORMATTING half, and that half is unchanged and still pinned below. But
+//     crowning at all in that state was the wrong answer to a question this
+//     block was not asking: the sibling hero (`buildHeroModel`, same
+//     UI-SEM-057 floor) WITHHOLDS the crown when nothing clears the floor and
+//     switches to its no-option-on-track headline. The two render on the same
+//     screen, so a crown here was a fresh contradiction of the kind 2.233
+//     exists to remove. The withheld behaviour is pinned in
+//     `buildV7Headline.goalLeader.spec.ts`; what remains here is the FORMATTER
+//     claim, tested across the range where a crown is legitimately earned.
 describe('buildV7Headline — the goal magnitude honours the shared sub-1% floor', () => {
-  function goalWinner(goalProbability: number): OptionResult {
-    return {
+  /** A complete goal fixture: both options measured, A ahead, user target set. */
+  function goalRun(winnerGoal: number, rivalGoal = 0.001): DecisionResultData {
+    const winner = {
       id: 'a',
       label: 'Option A',
       winProbability: 0.71,
       isRecommended: true,
-      goalProbability,
+      goalProbability: winnerGoal,
       goalFitIsSubstitutedJoint: false,
     } as unknown as OptionResult
+    const rival = {
+      id: 'b',
+      label: 'Option B',
+      winProbability: 0.29,
+      goalProbability: rivalGoal,
+      goalFitIsSubstitutedJoint: false,
+    } as unknown as OptionResult
+    return rec({
+      recommendedOption: winner,
+      allOptions: [winner, rival],
+      goalThreshold: 100,
+    })
   }
 
-  it('renders a non-zero sub-1% goal probability as "< 1%", never a bare "0%"', () => {
-    const winner = goalWinner(0.004)
-    const model = buildV7Headline(
-      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.29)] }),
-      'robust',
-    )
-    expect(model.headline).toBe(
-      GOAL_ANCHOR_COPY.headline('Option A', SUB_ONE_PERCENT_READOUT, false),
-    )
+  it('SUPERSEDED — a sub-1% maximum is no longer crowned at all (it is not re-labelled "0%" either)', () => {
+    const model = buildV7Headline(goalRun(0.004, 0.001), 'robust')
+    // The old expectation was GOAL_ANCHOR_COPY.headline('Option A', '< 1%', false).
+    expect(model.headline).not.toContain('highest chance')
+    // The defect the original test was written against stays dead: no bare
+    // "0%" is printed for a non-zero probability anywhere in this headline.
     expect(model.headline).not.toContain(': 0%')
+    expect(model.headline).not.toContain('0%')
   })
 
-  it('uses the SAME floored formatter the sibling goal surfaces use', () => {
-    for (const v of [0.004, 0.0099, 0.01, 0.5]) {
-      const winner = goalWinner(v)
-      const model = buildV7Headline(
-        rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.29)] }),
-        'robust',
-      )
+  it('uses the SAME floored formatter the sibling goal surfaces use, across the crownable range', () => {
+    // 0.01 is the floor itself (inclusive — `value < FLOOR` is the predicate).
+    for (const v of [0.01, 0.012, 0.5, 0.9]) {
+      const model = buildV7Headline(goalRun(v), 'robust')
       expect(model.headline).toBe(
         GOAL_ANCHOR_COPY.headline('Option A', formatGoalProbability(v), false),
       )
     }
   })
 
+  it('CONTROL — the readout constant is still reachable from the shared formatter', () => {
+    // The "< 1%" string has not been deleted or re-defined; it is simply no
+    // longer something a HEADLINE can crown on. Proving the constant and the
+    // formatter still agree keeps the supersession above honest — the claim is
+    // "not crowned", not "the floor was removed".
+    expect(formatGoalProbability(0.004)).toBe(SUB_ONE_PERCENT_READOUT)
+  })
+
   it('CONTROL — the top of the range is unchanged: no ceiling rule the siblings do not have', () => {
-    const winner = goalWinner(0.995)
-    const model = buildV7Headline(
-      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.29)] }),
-      'robust',
-    )
+    const model = buildV7Headline(goalRun(0.995), 'robust')
     expect(model.headline).toBe(GOAL_ANCHOR_COPY.headline('Option A', '100%', false))
   })
 })

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -26,9 +26,10 @@
  */
 
 import type { DecisionResultData, DecisionState } from '../types'
-import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY, isFiniteProbability } from '../utils/goalAnchorCopy'
+import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY } from '../utils/goalAnchorCopy'
 import { formatGoalProbability } from '../utils/displayFloors'
-import { formatPercent as formatPct } from '../../../utils/formatPercent'
+import { goalLeadPoints, selectGoalLeader } from '../utils/selectGoalLeader'
+import { formatProbabilityWithResolution } from '../../../utils/formatPercent'
 
 export interface V7HeadlineModel {
   /** Main headline. Empty string when there is no winner to headline. */
@@ -121,9 +122,71 @@ export function buildV7Headline(
     }
   }
 
-  // Clear winner — "performs best". Subline names the lead in points when the
-  // runner-up carries a win probability we can difference against (store-derived,
-  // never fabricated).
+  /**
+   * ⭐ THE GOAL CROWN (ROADMAP 2.233). This used to read the goal probability
+   * off `winner` — the COMPARATIVE leader — and print "has the highest chance
+   * of hitting your goal" without ever consulting a rival. The superlative was
+   * unearned by construction: A(win .70, goal .40) beside B(win .30, goal .80)
+   * crowned A at 40% while the goal block on the same screen ranked B first at
+   * 80%. Headline identity, headline number and subline gap came from two
+   * different questions.
+   *
+   * The entitlement now comes from `selectGoalLeader` — the rule
+   * `buildHeroModel` (UI-SEM-072) already held and which the hero now shares,
+   * so the two surfaces cannot disagree about who leads on the goal view. It
+   * returns null rather than a wrong crown whenever the claim is not earned
+   * (designations withheld, no user target, an unmeasured rival, a tie at the
+   * top, or nothing clearing the sub-1% floor), and the headline then falls
+   * through to the honest COMPARATIVE arm below — the hero's own fallback.
+   *
+   * ONE SUBJECT, ONE METRIC. When the crown lands, every field of this model
+   * describes the CROWNED option: `V7Hero` paints `winProbability` into a
+   * gauge immediately beside the headline, so carrying the comparative
+   * leader's number under the goal leader's name would recreate the defect one
+   * element to the left. The subline likewise measures the GOAL gap, not the
+   * comparative one.
+   */
+  const goalLeader = selectGoalLeader(allOptions, (o) => o.goalProbability, {
+    // Always false by this point — the `noLeadingOption` gate above returns
+    // early on a withheld verdict. Passed explicitly anyway: the entitlement
+    // belongs to the selector, so a future change to that gate cannot silently
+    // re-open the crown.
+    designationsWithheld: verdict != null && !verdict.hasLeadingOption,
+    hasUserTarget: recommendation.goalThreshold != null,
+  })
+
+  if (goalLeader && goalLeader.label) {
+    const leadPoints = goalLeadPoints(allOptions, (o) => o.goalProbability, goalLeader)
+    return {
+      headline: GOAL_ANCHOR_COPY.headline(
+        goalLeader.label,
+        // UI-SEM-057: the shared floor, so a 1.2% goal probability reads the
+        // same here as on the option card beside it.
+        formatGoalProbability(goalLeader.goalProbability as number),
+        goalLeader.goalFitIsSubstitutedJoint === true,
+      ),
+      subline: leadSubline(leadPoints),
+      winProbability:
+        typeof goalLeader.winProbability === 'number' && Number.isFinite(goalLeader.winProbability)
+          ? goalLeader.winProbability
+          : null,
+      winnerLabel: goalLeader.label,
+    }
+  }
+
+  /**
+   * The COMPARATIVE arm — the analysis leader, named by the quantity that
+   * actually ranks it.
+   *
+   * ⭐ RE-ANCHORED 2026-07-31 (§6.2c, RETIRE). Was `"{winner} performs best"`
+   * — the closest sentence in the product to "choose this": an unqualified
+   * superlative with no stated basis, no number and no timeframe, which a
+   * reader cannot argue with because it drops the figure that would let them.
+   *
+   * Subline names the lead in points when the runner-up carries a win
+   * probability we can difference against (store-derived, never fabricated).
+   * Same metric as the headline above it, same subject.
+   */
   const runnerUp = allOptions
     .filter(o => o.id !== winner?.id)
     .filter((o): o is typeof o & { winProbability: number } => typeof o.winProbability === 'number')
@@ -132,44 +195,31 @@ export function buildV7Headline(
     winProbability != null && runnerUp
       ? Math.round((winProbability - runnerUp.winProbability) * 100)
       : null
-  const subline =
-    gapPoints != null && gapPoints > 0
-      ? `Leads by ${gapPoints} point${gapPoints === 1 ? '' : 's'}`
-      : null
 
-  /**
-   * ⭐ RE-ANCHORED 2026-07-31 (§6.2c, RETIRE). Was `"{winner} performs best"`
-   * — the closest sentence in the product to "choose this": an unqualified
-   * superlative with no stated basis, no number and no timeframe, which a
-   * reader cannot argue with because it drops the figure that would let them.
-   *
-   * The A form is used whenever the run carries a goal number, with the
-   * possessive gated on the winner's own basis flag. Without a target there
-   * is no goal number at all (ISL computes one only against a threshold), so
-   * the claim falls back to the COMPARATIVE quantity, named as such.
-   */
-  const goalProbability = isFiniteProbability(winner?.goalProbability)
-    ? winner.goalProbability
-    : null
   const headline =
-    goalProbability != null
-      ? GOAL_ANCHOR_COPY.headline(
-          winnerLabel,
-          // UI-SEM-057: the shared floor, so a 0.4% goal probability reads
-          // "< 1%" here rather than crowning an option on a number the same
-          // headline prints as "0%" — the option card beside it already says
-          // "< 1%" about the identical value.
-          formatGoalProbability(goalProbability),
-          winner?.goalFitIsSubstitutedJoint === true,
-        )
-      : winProbability != null
-        ? `${winnerLabel} ${COMPARATIVE_COPY.clause(formatPct(winProbability, { fromDecimal: true }))}`
-        : `${winnerLabel} — ${COMPARATIVE_COPY.unavailableClause}`
+    winProbability != null
+      // ROADMAP 2.236: the shared FLOORED comparative formatter, not a bare
+      // `formatPercent`. Same rule as the option card and the canvas node, so
+      // this sentence cannot say "came out ahead in 0% of simulated scenarios"
+      // about a measured non-zero probability while they say "< 1%".
+      ? `${winnerLabel} ${COMPARATIVE_COPY.clause(formatProbabilityWithResolution(winProbability, null))}`
+      : `${winnerLabel} — ${COMPARATIVE_COPY.unavailableClause}`
 
   return {
     headline,
-    subline,
+    subline: leadSubline(gapPoints),
     winProbability,
     winnerLabel,
   }
+}
+
+/**
+ * The shipped lead-in-points subline (certaintyCopy.ts rule 4), built in ONE
+ * place so the goal arm and the comparative arm cannot render the same claim
+ * with different pluralisation. A non-positive or absent gap yields no
+ * subline — silence rather than "Leads by 0 points".
+ */
+function leadSubline(points: number | null): string | null {
+  if (points == null || points <= 0) return null
+  return `Leads by ${points} point${points === 1 ? '' : 's'}`
 }

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -31,6 +31,7 @@ import type { OptionResult, DriverItem, ConditionalWinner } from '../types'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { VoiRanking } from '../voi/voiRanking'
 import { computeOptionScale } from '../shared/OptionRangeBar'
+import { hasCompleteGoalField, selectGoalLeader } from '../utils/selectGoalLeader'
 
 /** One flip-risk row — the challengeFragileEdges slice, unchanged. */
 export interface V7FlipRisk {
@@ -182,10 +183,30 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
     typeof recommendation.goalThreshold === 'number' && Number.isFinite(recommendation.goalThreshold)
       ? recommendation.goalThreshold
       : null
-  const everyGoalProb =
-    options.length > 0 &&
-    options.every((o) => typeof o.goalProbability === 'number' && Number.isFinite(o.goalProbability))
-  const goalAvailable = goalThreshold != null && everyGoalProb
+  // ⭐ ROADMAP 2.233 — UNCHANGED IN BEHAVIOUR (`.every`), and deliberately NOT
+  // moved to `hasAnyGoalValue` like the analysis hero was.
+  //
+  // The hero asks the AVAILABILITY question and answers it with `.some`,
+  // because its row VM types the goal slot `number | null` and renders an
+  // absent value as `'—'`. This lens cannot do that yet: `V7GoalLens.options[]
+  // .goalProbability` is a NON-NULLABLE `number` reached by an `as number`
+  // cast, and `V7LensGroup`'s `GoalRow` does arithmetic on it
+  // (`probability < FLOOR`, `Math.round(probability * 100)`). A missing value
+  // would render `NaN%` behind a NaN-width bar — a placeholder presented as a
+  // measurement.
+  //
+  // So this is the COMPLETE-FIELD question for a concrete reason about THIS
+  // model, not a second opinion about availability. Teaching the model
+  // `number | null` and the row `'—'` would let it join the hero on `.some`;
+  // that is a typed change to a rendered contract and is rowed separately.
+  const goalAvailable = hasCompleteGoalField(options, (o) => o.goalProbability, {
+    hasUserTarget: goalThreshold != null,
+  })
+  // R1: the goal view's own leader — the same selection the headline crowns.
+  const goalRowLeader = selectGoalLeader(options, (o) => o.goalProbability, {
+    designationsWithheld,
+    hasUserTarget: goalThreshold != null,
+  })
   const goal: V7GoalLens = {
     available: goalAvailable,
     gate: goalAvailable ? 'none' : goalThreshold == null ? 'no_target' : 'producer_gap',
@@ -196,7 +217,21 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
           label: o.label,
           goalProbability: o.goalProbability as number,
           goalFitIsSubstitutedJoint: o.goalFitIsSubstitutedJoint === true,
-          isWinner: o.id === winnerId,
+          // ⭐ R1 (ROADMAP 2.233 review) — THE GOAL LENS DESIGNATES THE GOAL
+          // LEADER, not the comparative one.
+          //
+          // This read `o.id === winnerId`, and `winnerId` (`:154`) is
+          // `recommendation.recommendedOption?.id` — the COMPARATIVE leader. At
+          // base that was consistently wrong: headline and lens both said A.
+          // Fixing the headline alone made the pair CONTRADICTORY — "Option B
+          // has the highest chance of hitting your goal: 80%" printed directly
+          // above a goal row bolding Option A. That is the exact defect 2.233
+          // exists to remove, moved one element to the left.
+          //
+          // Same selector as the headline, so the two cannot disagree; it
+          // carries the withheld/target/complete/unique/floor gates and returns
+          // null rather than a wrong designation, in which case no row is marked.
+          isWinner: goalRowLeader != null && o.id === goalRowLeader.id,
         }))
       : [],
   }

--- a/src/lib/factorDirection.ts
+++ b/src/lib/factorDirection.ts
@@ -1,0 +1,134 @@
+/**
+ * factorDirection — THE one normalizer for a producer's factor `direction`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS MODULE EXISTS
+ * ─────────────────────────────────────────────────────────────────────────
+ * The 0.30 boundary contract deliberately leaves `direction` open and
+ * documents the observed domain `positive | negative | mixed | unknown`
+ * (`olumi-schemas/src/boundary/enrichment.ts:262-295`); PLoT emits that domain
+ * or null. The UI narrowed it to TWO values in two different places, and in
+ * both places the leftovers fell back to THE SIGN OF THE MAGNITUDE:
+ *
+ *     direction = explicit ?? (magnitude >= 0 ? 'positive' : 'negative')
+ *
+ * The magnitude fields in question — `sensitivity_score`, `sensitivity`,
+ * `importance_score` — are ordinarily NON-NEGATIVE. So `mixed` became
+ * `positive`, `unknown` became `positive`, and an absent direction became
+ * `positive`, each of them ending up as an "up" arrow and the screen-reader
+ * sentence "increases the outcome". The UI asserted a causal direction the
+ * producer had explicitly declined to assert. That is a false scientific
+ * claim, not a missing disclosure (ROADMAP 2.234 / Codex audit B, B-03).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE RULES
+ * ─────────────────────────────────────────────────────────────────────────
+ * 1. NEVER INFER DIRECTION FROM A MAGNITUDE. Not from an unsigned one, and
+ *    not from a signed one either — the caller cannot tell which field it got
+ *    without re-deriving the producer's own priority order, and a rule that
+ *    depends on remembering which of four aliases happens to be signed is the
+ *    hand-maintained mirror this codebase keeps paying for. Direction comes
+ *    from the direction field or it does not come at all.
+ * 2. ABSENCE STAYS ABSENCE. No producer value → `null`. Never a default.
+ * 3. AN UNRECOGNISED VALUE FAILS CLOSED to `'unknown'` — a value we cannot
+ *    interpret is precisely a direction we do not know, and it must not
+ *    become a directional claim by falling through.
+ * 4. ONLY `positive` AND `negative` LICENSE DIRECTIONAL RENDERING.
+ *
+ *    ⚠ CORRECTED (2.234 review). This used to justify itself by citing
+ *    `KeyDriversPanel` ("renders `~`"), `DriverChips` ("no glyph") and
+ *    `InsightsPanel` ("excludes the row"). ALL THREE HAVE ZERO NON-TEST JSX
+ *    MOUNTS — `InsightsPanel`'s apparent hits are JSDoc. The claim was true of
+ *    components nobody sees, and it hid the fact that the ONE LIVE driver
+ *    surface, `DriversSection` (`ResultsBody.tsx:559`), still rendered
+ *    `mixed`/`unknown`/absent identically to positive in its tooltip. Fixed at
+ *    `elasticityShiftCopy` and pinned; it needed ONE new string, flagged for
+ *    sign-off. A "the renderers already handle it" argument must name a
+ *    MOUNTED renderer.
+ *
+ * 5. ⚠ THIS IS NOT THE ONLY PRODUCER OF `ReportV1`. `adapters/plot/v2/
+ *    responseMapper.ts:993-999` carries this defect VERBATIM
+ *    (`sensitivityVal >= 0 ? 'up' : 'down'` off the same unsigned chain) and is
+ *    reachable ungated via `hydrateAnalysis.ts:118` ← `useScenario.ts:667` on
+ *    every scenario load with `analysis_status === 'ready'`. It is NOT fixed
+ *    here and is rowed. Say "the V5 mapper and the results hook" — never "all
+ *    consumers".
+ *
+ * The alias sets below are the union of the two collapsed implementations, so
+ * no payload that used to normalise now stops normalising.
+ */
+
+/** The producer's documented domain. `null` (absent) is modelled separately. */
+export type FactorDirection = 'positive' | 'negative' | 'mixed' | 'unknown'
+
+/** What a driver row renders. Already the domain of `ReportV1.drivers[].polarity`. */
+export type FactorPolarity = 'up' | 'down' | 'neutral'
+
+const POSITIVE_ALIASES = new Set(['positive', 'increases', 'increase', 'up', '+'])
+const NEGATIVE_ALIASES = new Set(['negative', 'decreases', 'decrease', 'down', '-'])
+
+/**
+ * Normalise one producer `direction` value to the contract domain.
+ *
+ * @returns `null` when the producer sent nothing (absent / null / empty), a
+ *   domain member otherwise. Never throws, never infers, never defaults to a
+ *   directional value.
+ */
+export function normaliseFactorDirection(raw: unknown): FactorDirection | null {
+  if (raw == null) return null
+  if (typeof raw !== 'string' && typeof raw !== 'number') return 'unknown'
+
+  const value = String(raw).toLowerCase().trim()
+  if (value === '') return null
+
+  if (POSITIVE_ALIASES.has(value)) return 'positive'
+  if (NEGATIVE_ALIASES.has(value)) return 'negative'
+  if (value === 'mixed') return 'mixed'
+  if (value === 'unknown') return 'unknown'
+
+  // Rule 3 — fail closed. A direction we cannot read is a direction we do not
+  // know, and saying so is the honest outcome.
+  return 'unknown'
+}
+
+/**
+ * True only for the two states that license an arrow, a +/− glyph, a colour,
+ * or the "increases/decreases the outcome" sentence.
+ *
+ * Every render site asking "should I draw a direction?" must ask THIS, not
+ * `direction != null` — `'mixed'` and `'unknown'` are present values that
+ * still forbid a directional claim.
+ */
+export function isDirectionalFactor(
+  direction: FactorDirection | null | undefined,
+): direction is 'positive' | 'negative' {
+  return direction === 'positive' || direction === 'negative'
+}
+
+/**
+ * The driver-row polarity for a normalised direction. `mixed`, `unknown` and
+ * absence all take the pre-existing neutral affordance.
+ */
+export function factorDirectionToPolarity(
+  direction: FactorDirection | null | undefined,
+): FactorPolarity {
+  if (direction === 'positive') return 'up'
+  if (direction === 'negative') return 'down'
+  return 'neutral'
+}
+
+/**
+ * The inverse, for the one legacy seam that reconstructs a factor row from an
+ * already-rendered `drivers[]` entry (`useResultsSectionData`'s "Source 2").
+ * Lossy by nature — that is a property of the legacy shape, not of this
+ * function — but `neutral` must map back to a NON-directional value rather
+ * than silently becoming `positive`, which is what it did before.
+ */
+export function polarityToFactorDirection(
+  polarity: FactorPolarity | null | undefined,
+): FactorDirection | null {
+  if (polarity === 'up') return 'positive'
+  if (polarity === 'down') return 'negative'
+  if (polarity === 'neutral') return 'unknown'
+  return null
+}

--- a/src/utils/__tests__/comparativeProbabilityFloor.spec.ts
+++ b/src/utils/__tests__/comparativeProbabilityFloor.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * ROADMAP 2.236 (P1-d) — ONE value, ONE instant, ONE floor.
+ *
+ * THE DEFECT, witnessed in a real browser on deployed staging `900dbd6c`
+ * (`PHASE0-EVIDENCE-2026-07-28/walk-548-pixels.md`, finding F5). The sub-1%
+ * display floor was applied on the CANVAS and not in the DOCK, so the same
+ * option's same win probability rendered three different ways on one screen:
+ *
+ *   win_probability = 0.002675
+ *     canvas option node       → "Came out ahead in < 1% of simulated scenarios"  ✅
+ *     Analysis-tab option card → "Came out ahead in 0% of simulated scenarios"    ❌
+ *     Olumi decision chip      → "Phased Hub-and-Spoke Pilot · 0%"                ❌
+ *
+ * The sharpest capture has CEE prose reading "each has less than a 1% chance"
+ * directly ABOVE chips reading "1%" and "0%". Reachability was not forced —
+ * staging produced these values unprompted in both walk scenarios.
+ *
+ * THE ROOT CAUSE was NOT the call sites. `formatProbabilityWithResolution` is
+ * the shared comparative formatter, and its resolution arm is honest: with a
+ * sample count it renders "<0.1%" style readouts. But its NO-SAMPLE-COUNT
+ * FALLBACK arm was a bare `formatPercent(value, { fromDecimal: true })` with no
+ * floor at all — and staging is not sending per-option `n_valid_samples`. So
+ * every dock surface downstream of it (option cards, V7 lens rows, the analysis
+ * hero) printed a bare "0%" while looking locally correct. One arm, three
+ * surfaces: the fix belongs there and not at any of them.
+ *
+ * The values below are the LIVE ONES from the walk, not invented boundaries.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  SUB_ONE_PERCENT_FLOOR,
+  SUB_ONE_PERCENT_READOUT,
+  formatPercent,
+  formatProbabilityWithResolution,
+} from '../formatPercent'
+import { formatWinProbability } from '../../canvas/utils/labelUtils'
+import { formatGoalProbability } from '../../components/results/utils/displayFloors'
+
+/** The three sub-1% win probabilities staging actually produced during the walk. */
+const LIVE_SUB_ONE_PERCENT = [0.0001875, 0.002675, 0.005825]
+
+describe('formatProbabilityWithResolution — the no-sample-count arm applies the shared floor (ROADMAP 2.236)', () => {
+  it.each(LIVE_SUB_ONE_PERCENT)(
+    'live staging value %s renders "< 1%%", never a bare "0%%" or "1%%"',
+    (value) => {
+      const rendered = formatProbabilityWithResolution(value, undefined)
+      expect(rendered).toBe(SUB_ONE_PERCENT_READOUT)
+      expect(rendered).not.toBe('0%')
+      expect(rendered).not.toBe('1%')
+    },
+  )
+
+  it('a null / zero / non-finite sample count takes the same floored arm', () => {
+    for (const nSamples of [null, undefined, 0, -1, Number.NaN]) {
+      expect(formatProbabilityWithResolution(0.002675, nSamples)).toBe(SUB_ONE_PERCENT_READOUT)
+    }
+  })
+
+  it('an exact ZERO is a measurement, not a floor case — it still reads "0%"', () => {
+    // "Came out ahead in 0% of simulated scenarios" is TRUE when the option
+    // never came out ahead. The floor exists to stop a non-zero value being
+    // printed as zero, not to stop zero being printed.
+    expect(formatProbabilityWithResolution(0, undefined)).toBe('0%')
+  })
+
+  it('CONTROL — values at or above the floor are untouched', () => {
+    expect(formatProbabilityWithResolution(SUB_ONE_PERCENT_FLOOR, undefined)).toBe('1%')
+    expect(formatProbabilityWithResolution(0.73, undefined)).toBe('73%')
+    expect(formatProbabilityWithResolution(0.995, undefined)).toBe('100%')
+  })
+
+  it('CONTROL — the RESOLUTION arm is unchanged: a real sample count still wins', () => {
+    // With n=1000 the producer's own resolution is finer than the 1% floor and
+    // must not be coarsened by it: 0.002675 is distinguishable at that sample
+    // count, so it renders as a real number rather than "< 1%".
+    const rendered = formatProbabilityWithResolution(0.002675, 1000)
+    expect(rendered).not.toBe(SUB_ONE_PERCENT_READOUT)
+    expect(rendered).not.toBe('0%')
+  })
+
+  it('POSITIVE CONTROL — the unfloored primitive still exists and still returns the bare string', () => {
+    // Proves these assertions can SEE the defect: `formatPercent` is the
+    // function the fallback arm used to return directly, and it is unchanged.
+    expect(formatPercent(0.002675, { fromDecimal: true })).toBe('0%')
+  })
+})
+
+describe('the sub-1% floor is ONE rule, shared by every register (ROADMAP 2.236)', () => {
+  it.each(LIVE_SUB_ONE_PERCENT)(
+    'canvas and dock agree on %s — the contradiction the walk photographed cannot recur',
+    (value) => {
+      // `formatWinProbability` is the canvas implementation that was already
+      // correct; it now delegates rather than holding a second literal 0.01.
+      expect(formatWinProbability(value)).toBe(SUB_ONE_PERCENT_READOUT)
+      expect(formatProbabilityWithResolution(value, undefined)).toBe(formatWinProbability(value))
+    },
+  )
+
+  it('the goal register uses the same floor CONSTANT (registers differ, the threshold does not)', () => {
+    expect(formatGoalProbability(0.002675)).toBe(SUB_ONE_PERCENT_READOUT)
+    expect(SUB_ONE_PERCENT_FLOOR).toBe(0.01)
+  })
+
+  it('the two registers legitimately differ at EXACT ZERO, and that difference is deliberate', () => {
+    // Goal register: an option with a 0 goal probability is "< 1%" — the same
+    // reading its option card has always shown (displayFloors documents the
+    // deliberate absence of a `> 0` carve-out).
+    expect(formatGoalProbability(0)).toBe(SUB_ONE_PERCENT_READOUT)
+    // Comparative register: 0 means "never came out ahead", a real measurement.
+    expect(formatWinProbability(0)).toBe('0%')
+    expect(formatProbabilityWithResolution(0, undefined)).toBe('0%')
+  })
+
+  it('CONTROL — non-finite input is still the honest missing glyph on the canvas register', () => {
+    expect(formatWinProbability(Number.NaN)).toBe('—')
+  })
+})

--- a/src/utils/formatPercent.ts
+++ b/src/utils/formatPercent.ts
@@ -1,4 +1,31 @@
 /**
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE SUB-1% DISPLAY FLOOR (UI-SEM-057) — ONE constant, every register
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⭐ RELOCATED HERE 2026-08-01 (ROADMAP 2.236). These two lived in
+ * `components/results/utils/displayFloors.ts`, which still re-exports them, so
+ * every existing importer is unchanged. They moved because the formatter that
+ * most needed them lives HERE and could not import them without a cycle
+ * (`displayFloors` imports `formatPercent`) — and the workaround for that
+ * cycle was a THIRD hand-written copy of the threshold as a literal `0.01`
+ * inside `canvas/utils/labelUtils.ts`. That copy is exactly why the floor
+ * shipped on the canvas and not in the dock.
+ *
+ * A real-browser walk on deployed staging photographed the consequence: one
+ * option, one instant, `win_probability = 0.002675`, rendered as "< 1%" on the
+ * canvas node, "0%" on the Analysis option card and "0%" on the Olumi review
+ * chip — with CEE prose saying "less than a 1% chance" immediately above the
+ * chips (`PHASE0-EVIDENCE-2026-07-28/walk-548-pixels.md` F5).
+ *
+ * The constant is a leaf value with no dependencies; its home is the module
+ * every formatter can reach.
+ */
+export const SUB_ONE_PERCENT_FLOOR = 0.01
+
+/** The rendered form of a non-zero probability below the floor. */
+export const SUB_ONE_PERCENT_READOUT = '< 1%'
+
+/**
  * Centralised formatter for percentage values in the Results panel.
  * Prevents inconsistent ~, +, ± symbols across components.
  *
@@ -49,6 +76,29 @@ export function formatProbabilityWithResolution(
   nSamples: number | null | undefined,
 ): string {
   if (nSamples === null || nSamples === undefined || !Number.isFinite(nSamples) || nSamples <= 0) {
+    // ⭐ ROADMAP 2.236 — THE FALLBACK ARM APPLIES THE SHARED FLOOR.
+    //
+    // This arm used to be a bare `formatPercent(value, { fromDecimal: true })`,
+    // and it is the arm staging actually takes: per-option `n_valid_samples`
+    // is not on the wire, so EVERY dock surface downstream of this function
+    // (option cards, V7 lens rows, the analysis hero) printed a bare "0%" for
+    // a measured non-zero probability while each call site looked locally
+    // correct. Three surfaces, one missing line — which is why the fix is here
+    // and not at any of them.
+    //
+    // An exact ZERO keeps reading "0%": "came out ahead in 0% of simulated
+    // scenarios" is TRUE when the option never came out ahead, and the floor
+    // exists to stop a non-zero value being printed as zero — not to stop zero
+    // being printed. (This is the one deliberate difference from the GOAL
+    // register's `formatGoalProbability`, which floors an exact zero too so it
+    // matches the option card beside it. Different registers, same threshold.)
+    // A probability below zero is not a quantity; the canvas formatter has
+    // always clamped it and that behaviour moves here with it, rather than
+    // being lost in the delegation (caught by `labelUtils.spec.ts`'s existing
+    // "treats negative values as 0%" pin — a fix is not finished until the
+    // tests that guarded the old code still hold).
+    if (value <= 0) return '0%'
+    if (value < SUB_ONE_PERCENT_FLOOR) return SUB_ONE_PERCENT_READOUT
     return formatPercent(value, { fromDecimal: true })
   }
 

--- a/src/v5/__tests__/mapV5AnalysisToReport.direction-domain.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.direction-domain.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * ROADMAP 2.234 — `mixed`, `unknown` and null driver directions must not be
+ * rendered as "up".
+ *
+ * THE DEFECT (Codex audit B, B-03, at `900dbd6c`). The 0.30 boundary contract
+ * deliberately leaves `direction` open and documents the observed domain
+ * `positive | negative | mixed | unknown` (+ null); PLoT emits exactly that
+ * (`plot-lite-service/src/routes/v2/run.ts:879-892`). This mapper accepted only
+ * `positive` and `negative` and fell back to THE SIGN OF THE MAGNITUDE:
+ *
+ *     direction = explicitDirection ?? (rawMagnitude >= 0 ? 'positive' : 'negative')
+ *
+ * The magnitude is picked from `sensitivity_score ?? sensitivity ?? elasticity
+ * ?? importance_score` and those are ordinarily NON-NEGATIVE, so every
+ * `mixed`, every `unknown` and every absent direction became `positive`, then
+ * `polarity: 'up'`. The UI ended up asserting that raising a factor raises the
+ * outcome on runs where the producer had explicitly said the direction is
+ * mixed or unknown. That is a false scientific claim, not a missing
+ * disclosure — which is why the fix is "never infer", not "infer better".
+ *
+ * ONE NORMALIZER. The same two-value collapse was written a second time in
+ * `useResultsSectionData.normalizeFactorSensitivity`. Both now call
+ * `src/lib/factorDirection.ts`, so a future domain member cannot be honoured
+ * in one place and dropped in the other.
+ *
+ * CLAIM TYPE: pure-mapper behaviour over a synthesised block conforming to the
+ * producer contract. It proves what the mapper does with a conforming wire; it
+ * is NOT a live-wire incidence claim (the audit did not measure incidence on
+ * staging traffic either).
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+type WidenedReport = ReturnType<typeof mapV5AnalysisToReport> & Record<string, unknown>
+type ReportFactor = { factor_id: string; direction?: unknown }
+
+function block(enrichment: Record<string, unknown>): AnalysisResultBlock {
+  return {
+    type: 'analysis_result',
+    summary: 'A summary',
+    leading_option_id: 'opt_a',
+    win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+    enrichment,
+  } as unknown as AnalysisResultBlock
+}
+
+/** One factor row carrying `direction` exactly as the producer sent it. */
+function mappedWithDirection(direction: unknown): WidenedReport {
+  const row: Record<string, unknown> = {
+    factor_id: 'n_market',
+    factor_label: 'Market size',
+    // Deliberately a NON-NEGATIVE magnitude — the field shape that made the
+    // sign fallback silently mean "positive" for every non-directional value.
+    sensitivity_score: 0.42,
+  }
+  if (direction !== undefined) row.direction = direction
+  return mapV5AnalysisToReport(block({ factor_sensitivity: [row] })) as WidenedReport
+}
+
+function factorsOf(report: WidenedReport): ReportFactor[] {
+  return (report.factor_sensitivity ?? []) as ReportFactor[]
+}
+
+describe('mapV5AnalysisToReport — the direction domain is carried, never inferred (ROADMAP 2.234)', () => {
+  // ONE FIXTURE PER DOMAIN MEMBER, plus null and absent.
+  it('positive → positive / up', () => {
+    const report = mappedWithDirection('positive')
+    expect(factorsOf(report)[0].direction).toBe('positive')
+    expect(report.drivers[0].polarity).toBe('up')
+  })
+
+  it('negative → negative / down', () => {
+    const report = mappedWithDirection('negative')
+    expect(factorsOf(report)[0].direction).toBe('negative')
+    expect(report.drivers[0].polarity).toBe('down')
+  })
+
+  it('mixed → mixed, and NEVER "up"', () => {
+    const report = mappedWithDirection('mixed')
+    expect(factorsOf(report)[0].direction).toBe('mixed')
+    expect(report.drivers[0].polarity).not.toBe('up')
+    expect(report.drivers[0].polarity).toBe('neutral')
+  })
+
+  it('unknown → unknown, and NEVER "up"', () => {
+    const report = mappedWithDirection('unknown')
+    expect(factorsOf(report)[0].direction).toBe('unknown')
+    expect(report.drivers[0].polarity).not.toBe('up')
+    expect(report.drivers[0].polarity).toBe('neutral')
+  })
+
+  it('null → no direction at all (absence stays absence — never defaulted to positive)', () => {
+    const report = mappedWithDirection(null)
+    expect(factorsOf(report)[0].direction ?? null).toBeNull()
+    expect(report.drivers[0].polarity).toBe('neutral')
+  })
+
+  it('field ABSENT → no direction at all', () => {
+    const report = mappedWithDirection(undefined)
+    expect(factorsOf(report)[0].direction ?? null).toBeNull()
+    expect(report.drivers[0].polarity).toBe('neutral')
+  })
+
+  it('an UNRECOGNISED value fails closed to `unknown`, never to a directional claim', () => {
+    const report = mappedWithDirection('sideways')
+    expect(factorsOf(report)[0].direction).toBe('unknown')
+    expect(report.drivers[0].polarity).toBe('neutral')
+  })
+
+  it('POSITIVE CONTROL — the magnitude is still carried untouched, so this is not an "everything went dark" pass', () => {
+    const report = mappedWithDirection('mixed')
+    const factor = factorsOf(report)[0] as ReportFactor & { sensitivity: number }
+    expect(factor.factor_id).toBe('n_market')
+    expect(factor.sensitivity).toBe(0.42)
+    expect(report.drivers[0].contribution).toBe(0.42)
+  })
+
+  it('a NEGATIVE magnitude with no producer direction is still not a direction claim', () => {
+    // The old fallback would have called this 'negative' from the sign alone.
+    // The producer said nothing, so neither does the UI.
+    const report = mapV5AnalysisToReport(
+      block({
+        factor_sensitivity: [
+          { factor_id: 'n_cost', factor_label: 'Cost', elasticity: -0.3 },
+        ],
+      }),
+    ) as WidenedReport
+    expect(factorsOf(report)[0].direction ?? null).toBeNull()
+    expect(report.drivers[0].polarity).toBe('neutral')
+    // Magnitude is still the absolute value — unchanged behaviour.
+    expect(report.drivers[0].contribution).toBe(0.3)
+  })
+})

--- a/src/v5/__tests__/mapV5AnalysisToReport.driver-order.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.driver-order.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * ROADMAP 2.235 (cheap half) — the producer owns the driver order; the UI
+ * renders it WITHOUT reordering.
+ *
+ * THE DEFECT (Codex audit B, B-01, at `900dbd6c`). PLoT holds the one
+ * canonical order and states the authority rule in its own source: "ISL
+ * measures · PLoT orders + attests · CEE permits + projects · UI renders
+ * WITHOUT reordering" (`plot-lite-service/src/lib/driver-order.ts:1-14`). The
+ * emitted `factor_sensitivity[]` order IS that ranking. On a mixed
+ * graph/ISL result the graph-only and ISL-only rows carry INCOMMENSURABLE
+ * quantities — `influence_score` / `sensitivity_score` / `elasticity` — and
+ * PLoT appends the ISL-only rows without a global re-sort precisely because
+ * they cannot be ranked against each other.
+ *
+ * `collectFactors` nevertheless finished with a global
+ * `sort((a,b) => b.sensitivity - a.sensitivity)` plus an `a.factor_id
+ * .localeCompare(b.factor_id)` tie-break, and `mapV5AnalysisToReport` crowns
+ * the first five as Drivers. So the UI both DESTROYED the producer's
+ * attested order and RANKED unlike quantities against one another.
+ *
+ * SCOPE, HONESTLY STATED. This pin covers the cheap half only: stop sorting,
+ * preserve the incoming order. The full contract train — typing and
+ * transporting `driver_order`, asserting `ranked_factor_ids` equals the
+ * transported row IDs, and failing closed on an attestation mismatch — needs
+ * schemas → CEE → UI and is rowed separately. Nothing here claims the
+ * attestation is checked, because it is not.
+ *
+ * CLAIM TYPE: pure-mapper behaviour over a synthesised block. It proves the
+ * mapper preserves what a conforming wire sends.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+type WidenedReport = ReturnType<typeof mapV5AnalysisToReport> & Record<string, unknown>
+type ReportFactor = { factor_id: string; sensitivity: number }
+
+function block(enrichment: Record<string, unknown>): AnalysisResultBlock {
+  return {
+    type: 'analysis_result',
+    summary: 'A summary',
+    leading_option_id: 'opt_a',
+    win_probabilities: { opt_a: 0.6, opt_b: 0.4 },
+    enrichment,
+  } as unknown as AnalysisResultBlock
+}
+
+function idsOf(report: WidenedReport): string[] {
+  return ((report.factor_sensitivity ?? []) as ReportFactor[]).map((f) => f.factor_id)
+}
+
+describe('mapV5AnalysisToReport — producer driver order survives (ROADMAP 2.235)', () => {
+  it('AUDIT PROBE: a mixed_graph_isl payload keeps its emitted order — [A, B, C], never [C, A, B]', () => {
+    // The audit's exact payload: two graph rows in producer order, then an
+    // ISL-only row whose magnitude is on a DIFFERENT scale and therefore
+    // cannot be ranked against them.
+    const report = mapV5AnalysisToReport(
+      block({
+        species: 'mixed_graph_isl',
+        factor_sensitivity: [
+          { factor_id: 'A', factor_label: 'Graph A', sensitivity_score: 0.2 },
+          { factor_id: 'B', factor_label: 'Graph B', sensitivity_score: 0.1 },
+          { factor_id: 'C', factor_label: 'ISL only C', sensitivity_score: 0.9 },
+        ],
+      }),
+    ) as WidenedReport
+
+    expect(idsOf(report)).toEqual(['A', 'B', 'C'])
+    expect(idsOf(report)).not.toEqual(['C', 'A', 'B'])
+  })
+
+  it('the crowned Drivers follow the same producer order', () => {
+    const report = mapV5AnalysisToReport(
+      block({
+        species: 'mixed_graph_isl',
+        factor_sensitivity: [
+          { factor_id: 'A', factor_label: 'Graph A', sensitivity_score: 0.2 },
+          { factor_id: 'B', factor_label: 'Graph B', sensitivity_score: 0.1 },
+          { factor_id: 'C', factor_label: 'ISL only C', sensitivity_score: 0.9 },
+        ],
+      }),
+    ) as WidenedReport
+
+    expect(report.drivers.map((d) => d.nodeId)).toEqual(['A', 'B', 'C'])
+    // The top driver is the producer's first row, not the biggest number.
+    expect(report.drivers[0].label).toBe('Graph A')
+  })
+
+  it('SAME-SPECIES TIE: equal magnitudes are NOT re-ordered by ID', () => {
+    // `z` before `a` on the wire. The old lexical tie-break inverted this.
+    const report = mapV5AnalysisToReport(
+      block({
+        factor_sensitivity: [
+          { factor_id: 'z_first', factor_label: 'Z', sensitivity_score: 0.5 },
+          { factor_id: 'a_second', factor_label: 'A', sensitivity_score: 0.5 },
+        ],
+      }),
+    ) as WidenedReport
+
+    expect(idsOf(report)).toEqual(['z_first', 'a_second'])
+  })
+
+  it('a DESCENDING producer order is passed through unchanged (the fix is not an inversion)', () => {
+    const report = mapV5AnalysisToReport(
+      block({
+        factor_sensitivity: [
+          { factor_id: 'big', factor_label: 'Big', sensitivity_score: 0.9 },
+          { factor_id: 'mid', factor_label: 'Mid', sensitivity_score: 0.5 },
+          { factor_id: 'small', factor_label: 'Small', sensitivity_score: 0.1 },
+        ],
+      }),
+    ) as WidenedReport
+
+    expect(idsOf(report)).toEqual(['big', 'mid', 'small'])
+  })
+
+  it('DE-DUPE keeps the TOP-LEVEL position while still preferring the larger magnitude', () => {
+    // A row present both top-level and per-result must not migrate to the end
+    // of the list just because the per-result copy won on magnitude.
+    const report = mapV5AnalysisToReport(
+      block({
+        factor_sensitivity: [
+          { factor_id: 'A', factor_label: 'A', sensitivity_score: 0.2 },
+          { factor_id: 'B', factor_label: 'B', sensitivity_score: 0.1 },
+        ],
+        results: [
+          { factor_sensitivity: [{ factor_id: 'A', factor_label: 'A', sensitivity_score: 0.8 }] },
+        ],
+      }),
+    ) as WidenedReport
+
+    expect(idsOf(report)).toEqual(['A', 'B'])
+    expect(((report.factor_sensitivity ?? []) as ReportFactor[])[0].sensitivity).toBe(0.8)
+  })
+
+  it('POSITIVE CONTROL — rows are still collected and magnitudes still carried (not an empty pass)', () => {
+    const report = mapV5AnalysisToReport(
+      block({
+        factor_sensitivity: [
+          { factor_id: 'A', factor_label: 'Graph A', sensitivity_score: 0.2 },
+          { factor_id: 'B', factor_label: 'Graph B', sensitivity_score: 0.1 },
+        ],
+      }),
+    ) as WidenedReport
+
+    const factors = (report.factor_sensitivity ?? []) as ReportFactor[]
+    expect(factors).toHaveLength(2)
+    expect(factors[0].sensitivity).toBe(0.2)
+    expect(factors[1].sensitivity).toBe(0.1)
+  })
+})

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -195,7 +195,20 @@ describe('mapV5AnalysisToReport — factor sensitivity (dual shape, alias set)',
     expect(byLabel.get('ISL')?.factor_id).toBe('fac_isl')
   })
 
-  it('direction defaults to sign of magnitude when missing', () => {
+  /**
+   * ⭐ SUPERSEDED 2026-08-01 (ROADMAP 2.234). This test was titled "direction
+   * defaults to sign of magnitude when missing" and it PINNED THE DEFECT: the
+   * mapper inferred a causal direction from `rawMagnitude >= 0`, and because
+   * the magnitude fields it picks from are ordinarily non-negative, every
+   * `mixed`, `unknown` and absent direction became a positive claim — an "up"
+   * arrow and the sentence "increases the outcome" over a direction the
+   * producer never asserted.
+   *
+   * There is no default any more. The MAGNITUDE half of the old assertions is
+   * unchanged and kept, because that half was always right and this must not
+   * read as "the mapper stopped carrying the values".
+   */
+  it('direction is NOT inferred from the sign of a magnitude (absence stays absence)', () => {
     const block = baseBlock({
       enrichment: {
         factor_sensitivity: [
@@ -206,13 +219,17 @@ describe('mapV5AnalysisToReport — factor sensitivity (dual shape, alias set)',
     })
 
     const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
-      factor_sensitivity?: Array<{ factor_id: string; sensitivity: number; direction: string }>
+      factor_sensitivity?: Array<{ factor_id: string; sensitivity: number; direction?: string }>
     }
     const byId = new Map(report.factor_sensitivity!.map((f) => [f.factor_id, f]))
-    expect(byId.get('fac_pos')?.direction).toBe('positive')
-    expect(byId.get('fac_pos')?.sensitivity).toBe(0.3) // absolute value
-    expect(byId.get('fac_neg')?.direction).toBe('negative')
-    expect(byId.get('fac_neg')?.sensitivity).toBe(0.2) // absolute value
+    // Neither row carried a producer direction, so neither gets one.
+    expect(byId.get('fac_pos')?.direction ?? null).toBeNull()
+    expect(byId.get('fac_neg')?.direction ?? null).toBeNull()
+    // UNCHANGED — magnitudes are still carried, still absolute.
+    expect(byId.get('fac_pos')?.sensitivity).toBe(0.3)
+    expect(byId.get('fac_neg')?.sensitivity).toBe(0.2)
+    // And neither becomes a directional driver glyph.
+    expect(report.drivers.map((d) => d.polarity)).toEqual(['neutral', 'neutral'])
   })
 
   it('entries missing both id and magnitude are dropped, never defaulted', () => {
@@ -245,13 +262,24 @@ describe('mapV5AnalysisToReport — factor sensitivity (dual shape, alias set)',
 })
 
 describe('mapV5AnalysisToReport — drivers + confidence derivation', () => {
-  it('drivers derived from top 5 factors by absolute sensitivity', () => {
+  /**
+   * ⭐ SUPERSEDED 2026-08-01 (ROADMAP 2.235). Was "drivers derived from top 5
+   * factors by absolute sensitivity", asserting `drivers[0]` is `fac_7` — the
+   * BIGGEST number. That is a ranking the UI is not entitled to compute: PLoT
+   * owns the canonical order, attests it, and appends ISL-only rows without a
+   * global re-sort precisely because the magnitudes are incommensurable.
+   *
+   * The drivers are still the FIRST FIVE and their strengths/polarities are
+   * unchanged; only the question "first five of what order?" is answered
+   * differently — the producer's, not ours.
+   */
+  it('drivers are the producer\'s first five rows, in the producer\'s order', () => {
     const block = baseBlock({
       enrichment: {
         factor_sensitivity: Array.from({ length: 8 }, (_, i) => ({
           factor_id: `fac_${i}`,
           factor_label: `Factor ${i}`,
-          sensitivity: 0.1 + i * 0.1, // 0.1, 0.2, ..., 0.8
+          sensitivity: 0.1 + i * 0.1, // 0.1, 0.2, ..., 0.8 — ASCENDING on the wire
           direction: 'positive',
         })),
       },
@@ -259,11 +287,16 @@ describe('mapV5AnalysisToReport — drivers + confidence derivation', () => {
 
     const report = mapV5AnalysisToReport(block)
     expect(report.drivers).toHaveLength(5)
-    // Sorted descending by sensitivity, so top driver is fac_7
-    expect(report.drivers[0].label).toBe('Factor 7')
+    // The producer sent fac_0 first, so fac_0 is the top driver — even though
+    // it carries the SMALLEST magnitude. That is the whole point.
+    expect(report.drivers[0].label).toBe('Factor 0')
+    expect(report.drivers[0].nodeId).toBe('fac_0')
+    expect(report.drivers.map((d) => d.nodeId)).toEqual([
+      'fac_0', 'fac_1', 'fac_2', 'fac_3', 'fac_4',
+    ])
+    // UNCHANGED — direction and strength still derive from the row itself.
     expect(report.drivers[0].polarity).toBe('up')
-    expect(report.drivers[0].strength).toBe('high') // 0.8 >= 0.7
-    expect(report.drivers[0].nodeId).toBe('fac_7')
+    expect(report.drivers[0].strength).toBe('low') // 0.1 < 0.3
   })
 
   it('confidence level "high" when robust:fragile edge ratio >= 0.7', () => {

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -46,15 +46,26 @@ import {
 import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
 import { deriveDecisionVerdict } from '../../lib/decisionVerdict'
 import { isRecord } from '../../lib/guards'
+import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 import { calibrateUncertaintyCopy } from '../../components/results/utils/uncertaintyCalibration'
 
 export interface V5AnalysisResultBlockProps {
   block: V5AnalysisResultBlockType
 }
 
+/**
+ * ⭐ ROADMAP 2.236 — the Olumi decision-review chips now apply the shared floor.
+ *
+ * This was `${Math.round(p * 100)}%`, a fourth private percentage rule, and it
+ * is what a real-browser walk photographed printing
+ * `Phased Hub-and-Spoke Pilot · 0%` for `win_probability = 0.002675` — in the
+ * SAME capture where the CEE prose immediately above the chips read "each has
+ * less than a 1% chance" (walk-548-pixels.md F5). The chip and the sentence
+ * above it now agree.
+ */
 function formatProbability(p: number): string {
   if (!Number.isFinite(p)) return '—'
-  return `${Math.round(p * 100)}%`
+  return formatProbabilityWithResolution(p, undefined)
 }
 
 /**

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -33,6 +33,11 @@ import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 
 import type { ReportV1, ConfidenceLevel } from '../adapters/plot/types'
 import type { DecisionVerdictReportLike } from '../lib/decisionVerdict'
+import {
+  factorDirectionToPolarity,
+  normaliseFactorDirection,
+  type FactorDirection,
+} from '../lib/factorDirection'
 
 // ─── Helpers ───────────────────────────────────────────────────────────
 
@@ -77,7 +82,17 @@ interface NormalisedFactor {
   factor_id: string
   factor_label: string
   sensitivity: number // absolute magnitude
-  direction: 'positive' | 'negative'
+  /**
+   * The producer's direction, carried VERBATIM across the contract's full
+   * domain, or `null` when the producer sent none (ROADMAP 2.234).
+   *
+   * ⚠ This used to be `'positive' | 'negative'` with a sign fallback, and the
+   * narrowing was a false-claim generator: `sensitivity` above is an absolute
+   * magnitude, so `mixed`, `unknown` and absent all collapsed to `'positive'`
+   * → `polarity: 'up'` → "increases the outcome". Never infer direction from
+   * a magnitude; see `src/lib/factorDirection.ts`.
+   */
+  direction: FactorDirection | null
   /**
    * Producer influence_score (0-1) — structural causal influence, a DISTINCT
    * measure from sensitivity (roadmap 1.7; provisional_doctrine_v0:
@@ -142,12 +157,14 @@ function normaliseFactorEntry(entry: unknown): NormalisedFactor | null {
   const factorLabel =
     safeString(entry.factor_label) ?? safeString(entry.label) ?? factorId
 
-  const explicitDirection =
-    entry.direction === 'positive' || entry.direction === 'negative'
-      ? entry.direction
-      : undefined
-  const direction: 'positive' | 'negative' =
-    explicitDirection ?? (rawMagnitude >= 0 ? 'positive' : 'negative')
+  // ROADMAP 2.234 — the producer's direction, or nothing. The line that used
+  // to sit here read
+  //   `explicitDirection ?? (rawMagnitude >= 0 ? 'positive' : 'negative')`
+  // and `rawMagnitude` is picked from `sensitivity_score ?? sensitivity ??
+  // elasticity ?? importance_score`, which are ordinarily NON-NEGATIVE — so
+  // every `mixed`, every `unknown` and every absent direction silently became
+  // a positive causal claim. There is no inference here any more.
+  const direction = normaliseFactorDirection(entry.direction)
 
   // Roadmap 1.7 (provisional_doctrine_v0): influence_score / influence_rank /
   // zero_reason are producer-owned fields carried through verbatim. No
@@ -214,11 +231,32 @@ function collectFactors(enrichment: Record<string, unknown>): NormalisedFactor[]
     }
   }
 
-  return Array.from(byId.values()).sort((a, b) => {
-    const diff = b.sensitivity - a.sensitivity
-    if (diff !== 0) return diff
-    return a.factor_id.localeCompare(b.factor_id)
-  })
+  // ⭐ PRODUCER ORDER IS PRESERVED (ROADMAP 2.235, cheap half).
+  //
+  // This used to end with
+  //   `.sort((a, b) => b.sensitivity - a.sensitivity || a.factor_id.localeCompare(b.factor_id))`
+  // and that sort was a claim the UI is not entitled to make. PLoT owns the
+  // one canonical order and says so in its own source: "ISL measures · PLoT
+  // orders + attests · CEE permits + projects · UI renders WITHOUT reordering"
+  // (`plot-lite-service/src/lib/driver-order.ts:1-14`). The emitted
+  // `factor_sensitivity[]` order IS the ranking, and on a mixed graph/ISL run
+  // PLoT appends the ISL-only rows WITHOUT a global re-sort precisely because
+  // `influence_score`, `sensitivity_score` and `elasticity` are
+  // incommensurable — so re-sorting by magnitude ranked unlike quantities
+  // against each other and then crowned the top five as Drivers. The audit's
+  // payload `[graph A=.2, graph B=.1, ISL-only C=.9]` rendered `C, A, B`.
+  //
+  // A `Map` preserves INSERTION order, and `set` on an existing key does not
+  // move it — so the de-dupe above keeps a row at its top-level position even
+  // when a per-result copy wins on magnitude. Insertion order here is
+  // top-level rows first, then per-result rows, which is the producer's own
+  // precedence.
+  //
+  // ⚠ SCOPE. This preserves the order; it does not VERIFY it. Typing and
+  // transporting `driver_order` and failing closed when `ranked_factor_ids`
+  // disagrees with the transported rows is a schemas → CEE → UI train, rowed
+  // separately. Nothing here checks the producer's attestation.
+  return Array.from(byId.values())
 }
 
 // ─── Confidence derivation ─────────────────────────────────────────────
@@ -687,12 +725,15 @@ export function mapV5AnalysisToReport(
   const seed = options.seed ?? null
   const enrichment = isPlainObject(block.enrichment) ? block.enrichment : undefined
 
-  // Factor sensitivity — collected and ranked once; reused for drivers + factor_sensitivity passthrough.
+  // Factor sensitivity — collected once IN PRODUCER ORDER (ROADMAP 2.235);
+  // reused for drivers + factor_sensitivity passthrough.
   const factors = enrichment ? collectFactors(enrichment) : []
   const drivers = factors.slice(0, 5).map((f) => ({
     label: f.factor_label,
-    polarity:
-      f.direction === 'positive' ? ('up' as const) : ('down' as const),
+    // ROADMAP 2.234: `mixed` / `unknown` / absent take the neutral affordance
+    // the driver surfaces already ship, never the "up" arrow they used to get
+    // from a magnitude's sign.
+    polarity: factorDirectionToPolarity(f.direction),
     strength:
       f.sensitivity >= 0.7
         ? ('high' as const)
@@ -1105,7 +1146,11 @@ export function mapV5AnalysisToReport(
       factor_id: f.factor_id,
       factor_label: f.factor_label,
       sensitivity: f.sensitivity,
-      direction: f.direction,
+      // ROADMAP 2.234: absence stays absence — the key is omitted rather than
+      // written as a default, exactly like the additive passthroughs below, so
+      // a consumer can still tell "the producer said nothing" from "the
+      // producer said unknown".
+      ...(f.direction !== null ? { direction: f.direction } : {}),
       // Roadmap 1.7 additive passthrough (provisional_doctrine_v0):
       // influence_score / influence_rank / zero_reason reach the store so
       // the DriversSection "Influence" column renders the PRODUCER's


### PR DESCRIPTION
**DO NOT MERGE — review first.** Six defects, one class: **the UI makes a claim the producer never authorised.**

Rows **2.233 / 2.234 / 2.235** (Codex audits A + B) and, folded in mid-lane, **2.236 / 2.213 / 2.214** (a real-browser pixel walk on deployed staging). Base: `staging` @ **`55d0167b`** (rebased during review; the body previously said `900dbd6c`, which had gone stale). No conflict; zero file overlap with #551.

Full evidence with pins: `PHASE0-EVIDENCE-2026-07-28/fix-2233-2235-ui-truthfulness.md`.


---

## Review round 1 — R1 and R3 fixed, four claims narrowed

### R1 [was BLOCKING] — my fix turned a consistent-but-wrong pair into a CONTRADICTORY one

`buildV7Lenses.ts:215` marked goal rows `isWinner: o.id === winnerId`, and `winnerId` (`:154`) is the **comparative** leader. At base the headline and the lens agreed — both wrong. Fixing only the headline produced:

```
HEADLINE   : "Option B has the highest chance of hitting your goal: 80%"
GOAL LENS  : [{Option A, goal .40, isWinner:TRUE}, {Option B, goal .80, isWinner:false}]
```

**The exact defect 2.233 exists to remove, moved one element to the left** — and `V7TopMatter.tsx:68,76` renders the two together. The goal lens now designates through the same `selectGoalLeader`, so the two cannot disagree; when no honest leader exists, no row is marked.

**Why it went unpinned is the sharper point:** `buildV7Lenses.spec.ts:123-124` gives the highest goal probability to the very option it marks `isWinner` — **the identical incomplete-fixture weakness I found and fixed in the headline spec, one file over and not noticed.** Pinned in `singleVerdict.crossSurface.spec.tsx` (which exists for this class) with a deliberately disagreeing fixture. Mutation R1 → **RED 3**.

### R3 [was BLOCKING] — 2.234 did not reach the user, so the fix was not delivered

My normalizer was right and irrelevant at the surface. `factorDirection.ts` justified "neutral renders honestly" by citing `KeyDriversPanel`, `DriverChips` and `InsightsPanel` — **all three have zero non-test JSX mounts**. The one live driver surface is `DriversSection` (`ResultsBody.tsx:559`), whose tooltip read `driver.direction === 'negative' ? '-' : ''`, so `mixed`/`unknown`/absent rendered **identically to positive**: "Higher values tend to shift outcome by 12%".

Fixed, and the rule **extracted to an exported `elasticityShiftCopy`** — it was previously reachable only through a hover-only `Tooltip`, which is precisely why it kept a fabricated direction long after the mapper stopped producing one. **Untestable in practice is how this survived.** **TWO** new strings, flagged for sign-off (they share the ` — direction not reported` suffix, U+2014, but are two distinct user-visible sentences): `Higher values tend to shift outcome by {N}% — direction not reported` and `When true, outcome tends to shift by {N}% — direction not reported`. Mutation R3 → **RED 5**.

### Claims narrowed — each was false as written, in my own docs

- **R2:** "all consumers route through one normalizer" — **FALSE**. `responseMapper.ts:993-999` is a **second live producer** of the same `ReportV1` carrying 2.234 verbatim, reachable ungated via `hydrateAnalysis.ts:118` ← `useScenario.ts:667` on every scenario load with `analysis_status === 'ready'`. Corrected to "the V5 mapper and the results hook"; rowed.
- **R4:** "exactly four implementations" of the floor undercounts — `DecisionNode.tsx:359` renders **"leads in 0% of scenarios" on the canvas**, the surface my evidence called already-correct. 2.236 narrowed to the dock; canvas gap rowed.
- **R5:** `displayFloors.ts` claimed an exact zero reads "< 1%" "on every sibling goal surface" — `GoalNode.tsx:336-338` has a `> 0` carve-out and renders **"0% chance of reaching target"**. Corrected.
- **R6:** `labelUtils.ts` claimed "same behaviour for every input" — differs out-of-domain (1.5 → `100%` before, `150%` now). No live regression; corrected anyway.

### R7 — a guarantee that was untested

Deleting `selectGoalLeader`'s `designationsWithheld` gate left **all 153 tests green**. It is currently redundant (both readers re-gate), but the docstring claims the gate exists "so a new reader cannot be born un-gated" — an untested guarantee is not one. Pinned on the selector's own behaviour with a permitted-run control. Mutation R7 → **RED 1**.

### R8 — latent trap disclosed in place

The `DriverDirection` widening armed a binary read at `ConfidenceSection.tsx:378`. **Blast radius zero today** (no mounts; its producer still coerces `?? 'positive'`). Recorded at the site and rowed.

### ⚠ A tooling incident worth recording

My mutation harness runs `git checkout -- .` to reset between mutants. Run against a tree with **uncommitted** review fixes, it silently destroyed a full round of them — I had to redo R1, R3 and four doc corrections. The harness now **refuses to run on a dirty tree** (exit 8). Sitting alongside its earlier false-green: *a mutation harness operates on a committed baseline by definition; anything else is not a controlled experiment.*

---

## The four shapes, and where each fix was placed

Every fix is at the **owner**, never the call site:

| Shape | Row | Owner created / repaired |
|---|---|---|
| A superlative asserted without consulting the rivals that would falsify it | 2.233 | `utils/selectGoalLeader.ts` (new shared selector) |
| A multi-state scientific domain narrowed to two, remainder inferred from an unsigned magnitude | 2.234 | `lib/factorDirection.ts` (new shared normalizer) |
| A producer-owned ordering replaced by a UI ranking over incommensurable quantities | 2.235 | `collectFactors` — the sort removed |
| One display rule implemented four times, so it held on some surfaces and not others | 2.236 | `formatProbabilityWithResolution`'s fallback arm + the floor constants relocated |

---

## 2.233 — the goal headline crowned the comparative winner

**RED** (audit A finding 1, reproduced against the real function):

```
A(win .70, goal .40, recommendedOption)   B(win .30, goal .80)
before → "Option A has the highest chance of hitting your goal: 40%"
         subline "Leads by 40 points"   ← a COMPARATIVE gap under a GOAL headline
after  → "Option B has the highest chance of hitting your goal: 80%"
         subline "Leads by 40 points"   ← the GOAL gap (.80 − .40)
         winProbability 0.30            ← B's own
```

The rule was **extracted** from `buildHeroModel.ts:582-650` (UI-SEM-072), which already held it correctly, and **both surfaces now select through it**. Gates: designations permitted · user target exists · every option carries a **finite** goal value · unique maximum · clears `SUB_ONE_PERCENT_FLOOR`. Not earned ⇒ `null`, and the headline falls through to the honest comparative arm — the hero's own documented fallback, using only shipped copy.

Two things a reviewer should look at:

- **Subject coherence was part of the fix.** `V7Hero` paints `winProbability` into a gauge captioned beside the headline. Crowning B while the gauge carried A's 70% would have rebuilt the defect one element to the left.
- **One hardening over the extracted original:** completeness uses `Number.isFinite`, not `!= null`. `NaN != null` is true, so a NaN row passed the old completeness check while losing every `>` comparison — one NaN could let a rival be crowned on a set the code called complete.

**No new copy was written for 2.233.**

### Coordinator item 3 — CORRECTED: one predicate was answering two questions

**My first answer was `.every` for both, and it was wrong.** The reasoning was about
protecting the CLAIM — but the crown was **already** withheld on partial coverage by
`selectGoalLeader`'s own complete-field gate (the hero's existing test asserted exactly
that). So tightening availability bought **no claim-safety** and cost information: it
blanked the whole goal view, including options the producer HAD measured, on a surface that
already discloses gaps as `'—'`. The pre-existing `.some` was a deliberate, better call —
*data is not a claim*.

**Decomposed:**

| Question | Predicate | Rule | Caller |
|---|---|---|---|
| **Availability** — may I DISPLAY this? | `hasAnyGoalValue` | `.some` | analysis hero |
| **Entitlement** — may I CLAIM a leader? | `hasCompleteGoalField` | `.every` | inside `selectGoalLeader` |

Named apart, with the reason at both definitions, so they cannot be re-merged. The hero is
back to its original behaviour and **the test that documented it as deliberate is restored,
not deleted.**

**⭐ Partial coverage is now pinned in BOTH directions — lens VISIBLE, crown ABSENT** — in
`buildHeroModel.spec.ts` and `buildV7Headline.goalLeader.spec.ts`. Mutating **either**
predicate toward the other REDs (M10/M11 below), so neither direction can drift.

**V7's goal lens deliberately keeps `.every`, and that is not a second opinion about
availability.** `V7GoalLens.options[].goalProbability` is a non-nullable `number` reached by
an `as number` cast, and `GoalRow` does arithmetic on it (`probability < FLOOR`,
`Math.round(probability * 100)`) — a missing value renders `NaN%` behind a NaN-width bar,
i.e. a placeholder presented as a measurement. **V7 asks the complete-field question because
its model cannot yet express absence.** Teaching it `number | null` + `'—'` would let it join
the hero on `.some`; that is a typed change to a rendered contract and is flagged as a
separate row rather than smuggled in here.

### Positive controls are FIXTURE-BASED, and that is stated deliberately

Per the coordinator's diagnosis, **staging cannot exercise the populated arm** — CEE's PLoT payload allowlist has no `goal_threshold`, so no live run carries a goal probability and the selector would correctly never crown. A live check would show nothing either way. Every positive control here is a fixture and is labelled as such (trap 13). Both the audit's disagreement fixture and a unique-argmax-exists fixture are present.

---

## 2.234 — `mixed` / `unknown` / null rendered as "up"

`mapV5AnalysisToReport.ts:145-150` was `explicit ?? (rawMagnitude >= 0 ? 'positive' : 'negative')`, and `rawMagnitude` comes from `sensitivity_score ?? sensitivity ?? elasticity ?? importance_score` — ordinarily **non-negative**. So `mixed`, `unknown`, null and absent all became `positive` → `'up'` → "increases the outcome". The identical collapse was written a second time in `useResultsSectionData`.

| producer sends | before | after |
|---|---|---|
| `positive` / `negative` | up / down | up / down (unchanged) |
| `mixed` | **up** ❌ | `mixed` → neutral |
| `unknown` | **up** ❌ | `unknown` → neutral |
| `null` / absent | **up** ❌ | absent → neutral |
| unrecognised | **up** ❌ | fails closed to `unknown` → neutral |

**No new copy was needed.** `'neutral'` is already the third member of `ReportV1.drivers[].polarity` and every driver surface already handles it (`KeyDriversPanel` `~`, `DriverChips` no glyph, `DriversSection` `•`, `InsightsPanel` excludes it, `buildV7Lenses.driverDirection` already narrowed correctly). **The renderers were right; they were being fed a fabricated value.**

Two type errors from the domain widening were **fixed at source, not absorbed into the baseline**.

---

## 2.235 (cheap half) — producer driver order destroyed

`collectFactors` ended with a global magnitude sort + ID lexical tie-break, and the first five are crowned as Drivers. PLoT owns the canonical order and attests it; on a mixed run it appends ISL-only rows *without* a global re-sort precisely because the magnitudes are incommensurable.

```
[graph A=.2, graph B=.1, ISL-only C=.9]  (species mixed_graph_isl)
before → C, A, B          after → A, B, C
```

**Scope, stated honestly:** this preserves the order, it does **not verify** it. Typing/transporting `driver_order` and failing closed on an attestation mismatch is the schemas → CEE → UI train, rowed separately. Nothing here checks the attestation and no test claims it does.

---

## 2.236 (P1-d) — the sub-1% floor held on the canvas, not in the dock — LIVE-WITNESSED

`walk-548-pixels.md` F5. Real browser, deployed staging, **reachability not forced**:

| surface | `win_probability = 0.002675` |
|---|---|
| canvas option node | `< 1%` ✅ |
| Analysis option card | **`0%`** ❌ |
| Olumi decision-review chip | **`0%`** ❌ |

Sharpest capture: CEE prose reading *"each has less than a 1% chance"* directly above chips reading `1%` and `0%`.

**The root cause was not the call sites.** `formatProbabilityWithResolution`'s **no-sample-count fallback arm** was a bare `formatPercent(...)` with no floor — and staging does not send per-option `n_valid_samples`, so that is the arm production takes. Three dock surfaces inherited it while each call site looked locally correct.

There were **four** implementations of one rule. Fix: `SUB_ONE_PERCENT_FLOOR` / `SUB_ONE_PERCENT_READOUT` **relocated** to `src/utils/formatPercent.ts` (the module every formatter can reach without a cycle — the cycle is exactly why the canvas held a private literal `0.01`), `displayFloors.ts` **re-exports them so every existing importer is unchanged**, and `formatWinProbability` / the Olumi chip / `WinGauge` / `V7Hero` all delegate.

**Registers differ at exact zero, deliberately, and it is pinned:** comparative keeps `0%` (an option that never came out ahead is a real measurement); goal keeps `< 1%` (matching the card beside it, as `displayFloors` already documented).

**A second defect found on the same line:** `WinGauge`'s legend read `Math.round(...)` then `if (displayPct <= 0) return null` — so an option with a measured 0.19% chance was not printed as "0%", it was **deleted from the legend entirely** while the canvas beside it said "< 1%". The skip is now on the raw value.

**A regression I introduced and caught:** delegating `formatWinProbability` dropped its negative clamp (`-0.1` → `-10%`), caught by its own existing pin. The clamp moved into the shared arm.

---

## 2.213 (F2) and 2.214 (F4) — two retired nouns that outlived the sweep

Both UI static copy, **zero occurrences in the wire** (walk-verified) — no producer fixture could catch them. They survived PR 548 because the retired-string list covered `winning` / `winner` / `Win probability`.

- **F2** Model tab → Relationships: `…could change the recommendation.` → `…could change which option leads.`
- **F4** hero gauge caption: the bare word `wins` → **removed**, not replaced. The register's label is 30 characters and the ring is 52px (it would burst the circle), and the headline immediately right already reads "{option} came out ahead in {n}% of simulated scenarios". The register label is attached as the ring's **accessible name** so the number is not left unlabelled.

Pinned by `retiredStaticCopy.walk548.spec.ts` (strips comments before matching — the fixed files' own comments quote the retired strings; positive controls pinned **by value**, trap 12b).

**Not touched, per instruction:** F3 (`chance of winning`) is CEE-generated prose in the wire. `Chance of leading` is rowed (2.226). `V5ComparisonBlock` did not render during the walk — unexercised, not clean.

---

## Mutation checks — all 8 bite

Throwaway worktree **outside the clone root**, **removed before every gate run** (trap 9c). The harness asserts the anchor exists, is unique, and that the write landed; it VOIDs rather than passes if a mutation fails to apply (trap 15).

| # | Reverted | Result |
|---|---|---|
| M1 | goal crown → comparative winner | **RED** 10/17 |
| M2 | `hasCompleteGoalField` → `.some` | **RED** 4/17 |
| M3 | V5 mapper → magnitude-sign inference | **RED** 3/9 |
| M4 | hook → duplicate two-value collapse | **RED** 6/9 |
| M5 | `collectFactors` → global sort | **RED** 3/6 |
| M6 | floor removed from the fallback arm | **RED** 7/14 |
| M7 | F2 noun restored | **RED** 1/7 |
| M8 | F4 caption restored | **RED** 1/7 |
| M9 | `driverDirection` passthrough (`mixed` reaches the renderer) | **RED** 2/7 |
| M10 | **availability** tightened back to `.every` | **RED** 3/124 |
| M11 | **entitlement** loosened to `.some` | **RED** 5/124 |

**⚠ My mutation harness reported a false "STILL GREEN" for M10 and M11.** Its result-parsing
silently produced an empty count and defaulted to green; the manual re-run showed both were
RED all along. Trap 15 in my own tooling, and the dangerous direction — it would have led me
to weaken two pins that were working. Both were re-run by hand with the failing test NAMES
captured, not just counts. M10 is caught by the restored hero test *and* the both-directions
pin, i.e. by the very test the wrong instruction would have removed.

**⚠ M4 failed the first time, and it is the most useful result in this PR.** Reverting the duplicate-collapse fix left the entire `useResultsSectionData` suite green (123/123) — the second half of the 2.234 fix was shipping with **no test that could see it** (trap 11). `normalizeFactorSensitivity.direction.spec.ts` was written in response and M4 now bites 6/9. Without running the mutation this would have merged as theatre.

## Gates

- **`pnpm typecheck`** (= `scripts/ci/typecheck-gate.sh`, read at this tip): **PASSED**. Coverage **3119 / 3159** tracked files loaded (40 declared out of scope). Ratchet **622 files / 2505 errors vs baseline 2510** — within. The −5 shrink is **pre-existing** (present on the untouched base tip). **Baseline NOT regenerated.**
- **Check 8 (DS v5 drift):** pre-existing RED, proven against a **pristine control worktree at `900dbd6c`** — `diff` of the NET-NEW sections is **byte-identical**. *Not accepted blindly:* my own comments initially added two net-new `production-hex` entries because the checker reads `#548` in a comment as a hex colour; rewritten as "PR 548" rather than baselined.
- Vitest env `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set on **every** run (trap 2b).

## Five test groups superseded (each with its reason written in-file)

They **pinned the old defects**. 1) "direction defaults to sign of magnitude when missing". 2) "drivers derived from top 5 factors by absolute sensitivity". 3) "returns undefined for unknown variants" (×2 files — `unknown` is a domain *member*; the absence half is kept). 4) Three PR-548 sub-1% pins whose fixtures gave the goal value to the recommended option **alone** with no `goalThreshold` — precisely what made the crowning defect unreachable from that file. 5) One hero assertion, the `.some`/`.every` case above.

## Left deliberately, with reasons

- `useResultsSectionData.ts:2770` — `normaliseDirection(fe.direction) ?? 'positive'` on the **fragile-edge** seam. Same class, different producer field; needs its own consumer trace.
- `canvas/stores/analysisSnapshotFactory.ts:326,463,466` — win probabilities are `Math.round(x*100)`-ed **at the store boundary**, destroying the decimal, so every compare-tab consumer is unfixable without changing the store. Separate row.
- `adapters/plot/v2/responseMapper.ts:1516` bakes a percentage into a copy string.
- Debug surfaces, `SharedBriefPage`, and dormant components untouched.

## Needs founder sign-off

Only the two copy re-anchorings (F2 wording, F4 removal). Everything else reuses shipped registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
