### PR TITLE
DO NOT MERGE — fix(ui): the outcome-view lens claims a ranking it never performs (2.237/2.238)

### DIFF
--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -574,7 +574,15 @@ export function RiskAppetiteFilter({
         {/* Re-anchored (§6 map): "Winner by:" named an endorsement the control
             does not confer — it re-ranks a view, and now every arm re-ranks it
             on the same quantity. The label says which. */}
-        <span className={`${typography.panelMeta} text-text-light`}>Rank by outcome:</span>
+        {/*
+          ⭐ RE-ANCHORED 2026-08-01 (ROADMAP 2.237, P1-1). "Rank by outcome:"
+          replaced "Winner by:" — correctly retiring an endorsement noun — but
+          substituted a second false claim: the control does NOT rank. It
+          highlights one card; `sortOptionsForDisplay` takes no lens argument
+          and the list order, its truncation and its ordinals are all
+          winProbability's. The label now names what the control actually does.
+        */}
+        <span className={`${typography.panelMeta} text-text-light`}>Highlight by outcome:</span>
         {/* Driven off LENS_ARM's own keys — this was a THIRD hardcoded arm
             list beside LENS_ARM and LENS_ARM_LABEL, and a fourth arm added to
             those two would have rendered nowhere. `satisfies

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -212,6 +212,30 @@ function hingeAwareDescription(
   //
   // The lens branch stays ABOVE the gate — the one carve-out, and the reason
   // this is not simply the first line of the function.
+  //
+  // ⭐ CHALLENGED AND UPHELD, 2026-08-01 (ROADMAP 2.238 review). A reviewer read
+  // `:436-437`'s "a withheld run crowns nothing. The lens crown goes too" as
+  // governing THIS sentence, making the carve-out look like a live
+  // self-contradiction, and I agreed and moved the gate above this branch. That
+  // was WRONG, and the check that settles it is the `designationsWithheld` prop
+  // doc introduced by the very same commit (#501, ROADMAP 1.267), which
+  // enumerates its own scope: "the ordinal rank swatch, the crowned border, and
+  // the leader colour on the 'Hits target' bar. NEVER THE VALUES THEMSELVES."
+  // That comment annotates `const crowned` — the styling designation. It never
+  // reached this sentence.
+  //
+  // So the two rulings do not conflict; they govern different channels:
+  //   · #501 / 1.267 — STYLING designations derived from the producer's
+  //     ordering (border, rank swatch, bar colour) go on a withheld run.
+  //   · #494 / 1.239 — THIS sentence stays, because it is a per-view argmax
+  //     over outcome values already on screen, not the producer's designation,
+  //     and its companion clause explicitly disclaims the main ranking. #494
+  //     also names the risk of gating it: the over-suppression class this arc
+  //     had already had to fix once in DecisionNode.
+  //
+  // `residualComparative.optionCards.spec.ts` pins the carve-out deliberately
+  // and is what caught the attempted removal. Do not gate this branch without
+  // re-adjudicating 1.239 on the record.
   if (isWinner && lensActive) {
     return `Ahead on this outcome view. ${LENS_COPY.unchanged(hasGoalNumbers)}`
   }
@@ -435,6 +459,19 @@ function OptionCard({
   // canonical leader keeps every SEMANTIC leader predicate below regardless.
   // ROADMAP 1.267: a withheld run crowns nothing. The lens crown goes too —
   // it is a second designation, not an exemption from the first.
+  //
+  // ⭐ SCOPE MADE EXPLICIT, 2026-08-01 (ROADMAP 2.238 review). "The lens crown"
+  // here means THE STYLING — this `crowned` flag and the `rank` swatch below —
+  // exactly as the `designationsWithheld` prop doc from the same commit states:
+  // "the ordinal rank swatch, the crowned border, and the leader colour on the
+  // 'Hits target' bar. Never the values themselves."
+  //
+  // It does NOT govern the lens SENTENCE in `hingeAwareDescription`, which is
+  // deliberately exempt under ROADMAP 1.239 (#494) as a per-view argmax over
+  // on-screen values. A reviewer and I both read this comment as covering the
+  // sentence and briefly "fixed" a contradiction that does not exist; the note
+  // is added here so the next reader does not repeat it. The two rulings
+  // co-exist because they govern different channels.
   const crowned = designationsWithheld ? false : cardLensActive ? isLensCrowned : isWinner
   const borderClass = neutralised || !crowned
     ? 'border border-panel-border'
@@ -756,8 +793,55 @@ export function OptionCards({
   const TOP_N = 2
   const shouldTruncate = sorted.length > TOP_N
   const [showAllOptions, setShowAllOptions] = useState(false)
-  const visibleOptions = shouldTruncate && !showAllOptions ? sorted.slice(0, TOP_N) : sorted
-  const hiddenCount = sorted.length - TOP_N
+  const truncated = shouldTruncate && !showAllOptions ? sorted.slice(0, TOP_N) : sorted
+  //
+  // ⭐ ROADMAP 2.237 — THE LENS PICK IS ALWAYS RENDERED.
+  //
+  // The panel above says "highlights the option with the strongest low end
+  // (p10)". The list is ordered by `winProbability`, so the lens's own pick
+  // routinely sits OUTSIDE the top 2 — on the sweep's fixture the p10 leader
+  // was third and rendered nowhere, behind "Show all (1 more)". The user was
+  // told which option the lens picked and then could not see it: a claim that
+  // cannot be checked is the same defect as a claim that is wrong.
+  //
+  // Appended rather than promoted: promoting it would re-order the list, which
+  // is precisely the ranking the copy must NOT claim.
+  const lensPickHidden =
+    lensActive &&
+    lensHighlightedId != null &&
+    !truncated.some((o) => o.id === lensHighlightedId) &&
+    sorted.some((o) => o.id === lensHighlightedId)
+  const visibleOptions = lensPickHidden
+    ? [...truncated, ...sorted.filter((o) => o.id === lensHighlightedId)]
+    : truncated
+  // Derived from what is actually rendered — `sorted.length - TOP_N` would say
+  // "1 more" while that one was already on screen.
+  const hiddenCount = sorted.length - visibleOptions.length
+
+  // ⭐ B1 (ROADMAP 2.237) — THE TOGGLE MUST NOT PROMISE WHAT IT CANNOT DELIVER.
+  //
+  // Re-deriving `hiddenCount` above was necessary but not sufficient: the
+  // button's own render condition was still `shouldTruncate`, so on the
+  // three-option appended state it rendered "Show all (0 more)" — and clicking
+  // it changed nothing, because the card set was already complete; only the
+  // label flipped to "Show fewer". A control claiming to reveal something and
+  // revealing nothing is exactly the defect class this PR exists to remove,
+  // freshly created BY this PR, on its own headline fixture.
+  //
+  // `showAllOptions ||` is load-bearing and is the reason this is not simply
+  // `hiddenCount > 0`: once expanded, `hiddenCount` is 0 by construction, so
+  // the bare predicate would delete the "Show fewer" control and strand the
+  // user in the expanded state with no way back.
+  const canRevealMore = hiddenCount > 0
+  const showToggle = shouldTruncate && (showAllOptions || canRevealMore)
+
+  // ⚠ TRUE rank, not the render position. `sortedRank` used to be the map index
+  // (`index + 1`), which was correct only while `visibleOptions` was always a
+  // PREFIX of `sorted`. It no longer is: an appended lens pick would have been
+  // stamped "3" whatever its real standing, i.e. a fabricated ordinal — the
+  // exact placeholder-where-a-quantity-belongs class. The rank now comes from
+  // the ordering itself.
+  const rankById = new Map(sorted.map((o, i) => [o.id, i + 1]))
 
   // Graph Lens: reverse panel sync — click option card to toggle lens isolation
   const lensEnabled = isGraphLensEnabled()
@@ -794,7 +878,28 @@ export function OptionCards({
         const winnerOpt = options.find(o => o.id === winnerId)
         // Codex B1: isWinner = the CANONICAL leader (drives leader predicates);
         // the lens crown is a separate identity that only restyles + relabels.
-        const isLensCrowned = lensActive && option.id === (lensHighlightedId ?? winnerId)
+        //
+        // ⭐ ROADMAP 2.238 (P1-2) — THE `?? winnerId` FALLBACK IS REMOVED.
+        //
+        // It read `lensActive && option.id === (lensHighlightedId ?? winnerId)`.
+        // `lensHighlightedId` is null exactly when the lens has no comparable
+        // data — the same memo that makes the panel above print "Not enough
+        // range data to compare options under this lens." So on any run whose
+        // bands carry p10/p50 but no p90, clicking "Optimistic (p90)" printed
+        // that sentence AND crowned the COMPARATIVE winner with "Ahead on this
+        // outcome view" plus the success border: a comparative result
+        // attributed to an outcome view that had just declared itself
+        // unavailable. Both lines read one memo, so it was deterministic, not a
+        // race.
+        //
+        // This is `buildV7Headline`'s defect exactly — the SUBJECT of the claim
+        // is not the SOURCE of the number — and the rule is the same one
+        // `selectGoalLeader` enforces for the goal crown: if the metric a claim
+        // NAMES has no complete data, do not crown. `selectLensOption` already
+        // documents this at `:69-73` ("an absence, never a fallback to a
+        // different quantity"); the doctrine was written and then not applied
+        // at the one call site that mattered.
+        const isLensCrowned = lensActive && lensHighlightedId != null && option.id === lensHighlightedId
         const description = isLensCrowned
           ? hingeAwareDescription(option, true, isRunnerUp, hinge, winnerOpt?.winProbability, true, hasLeadingOption, hasGoalNumbers)
           : decisionState
@@ -825,7 +930,7 @@ export function OptionCards({
             description={description}
             neutralised={neutralised}
             designationsWithheld={designationsWithheld}
-            sortedRank={index + 1}
+            sortedRank={rankById.get(option.id) ?? index + 1}
             stableNumber={stableNumbers?.[option.id] ?? null}
             segmentFillColor={segmentFillColor}
             globalMin={globalMin}
@@ -852,10 +957,10 @@ export function OptionCards({
       })}
       {/* Brief 5.8B hotfix: wrap disclosure + approach link in flex-col so they
           never collapse onto the same visual line. gap-1 = 4px (mt-1 equivalent). */}
-      {(shouldTruncate || onSendMessage) && (
+      {(showToggle || onSendMessage) && (
         <div className="flex flex-col gap-1">
           {/* Brief 3 ST2: Show all / show fewer toggle (when 3+ options) */}
-          {shouldTruncate && (
+          {showToggle && (
             <button
               type="button"
               onClick={() => setShowAllOptions(prev => !prev)}

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -468,11 +468,35 @@ export const ResultsBody = memo(function ResultsBody({
                 data-testid="risk-lens-label"
                 className={`${typography.panelMeta} text-text-light`}
               >
+                {/*
+                  ⭐ RE-ANCHORED 2026-08-01 (ROADMAP 2.237, P1-1) — "ranked by"
+                  → "highlights".
+
+                  The sentence claimed a RE-RANKING that never happens. The
+                  option list below is ordered by `sortOptionsForDisplay`, which
+                  takes NO lens argument and sorts by `winProbability`, and the
+                  cards stamp that order as explicit ordinals. The lens reaches
+                  the cards only as a CROWN on one card. So on
+                  A(win .50, p10 10) B(win .30, p10 50) C(win .20, p10 90),
+                  clicking "Cautious (p10)" printed "ranked by the low end
+                  (p10)" over a list reading A(1), B(2) — identical to neutral —
+                  with C, the p10 leader and the lens's OWN pick, not rendered
+                  at all behind "Show all (1 more)". The user was told a ranking
+                  existed and then could not see its result.
+
+                  The copy is corrected to what the code does rather than the
+                  code changed to match the copy: highlighting IS the shipped
+                  behaviour and is a coherent feature, whereas threading the
+                  lens through the comparator would change ordering, truncation
+                  and the ordinal stamps together — a much larger behavioural
+                  change than a false sentence warrants. `LENS_COPY.unchanged`
+                  keeps its job of saying what the lens does NOT touch.
+                */}
                 {!lensComparison.comparable
                   ? 'Not enough range data to compare options under this lens.'
                   : riskAppetite === 'conservative'
-                    ? `Cautious view: ranked by the low end (p10) of each outcome range. ${LENS_COPY.unchanged(lensRunHasGoalNumbers)}`
-                    : `Optimistic view: ranked by the high end (p90) of each outcome range. ${LENS_COPY.unchanged(lensRunHasGoalNumbers)}`}
+                    ? `Cautious view: highlights the option with the strongest low end (p10). Order below is unchanged. ${LENS_COPY.unchanged(lensRunHasGoalNumbers)}`
+                    : `Optimistic view: highlights the option with the strongest high end (p90). Order below is unchanged. ${LENS_COPY.unchanged(lensRunHasGoalNumbers)}`}
               </p>
             )}
             {/* WinGauge — moved from hero to top of options section */}

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -398,14 +398,26 @@ describe('AdvancedSection — the default-estimate disclosure (F10)', () => {
   })
 })
 
-// ── ROADMAP 1.243 item 4 — the "Rank by outcome:" lens label ──────────────────────
+// ── ROADMAP 1.243 item 4 — the lens label ────────────────────────────────────
 //
-// ADJUDICATED: LEAVE the label, do NOT relabel. "Rank by outcome:" takes no option as
-// its object — it names the SORT KEY of a display filter, unlike the two
-// strings #493/#494 relabelled ("Leads across scenarios", "Leads NN%"), which
-// rendered ON an option so the ordinal read straight off them. The test is not
-// "is 'winner' a permitted word" (that would be the trap-12 carve-out list); it
-// is "does the string designate an option", which is derivable.
+// ⛔ THE ADJUDICATION BELOW WAS FALSE AT THE BYTES, AND IS WITHDRAWN
+//    (ROADMAP 2.237, 2026-08-01).
+//
+// It read: "LEAVE the label, do NOT relabel. 'Rank by outcome:' takes no option
+// as its object — it names the SORT KEY of a display filter."
+//
+// **There is no lens sort key.** `sortOptionsForDisplay` takes no lens argument;
+// the list is ordered by `winProbability`, truncated by that order, and stamped
+// with ordinals from it. The lens reaches the cards only as a CROWN on one card.
+// So the adjudication cleared the label by asserting a mechanism that does not
+// exist — and because it was written as a settled verdict, it is exactly the
+// sentence nobody re-checked. (CLAUDE.md trap 14: an honest label can be
+// overwritten by a false one; the most rhetorically useful sentence in an
+// argument is the one nobody checks.)
+//
+// The label is now "Highlight by outcome:", which names what the control does.
+// The reasoning below about the DISCLAIMER being load-bearing is untouched and
+// still correct — it is the only part of this block that survived checking.
 //
 // But that verdict RESTS ON the disclaimer beneath it (Paul's ruling
 // 2026-07-12), and the disclaimer had ZERO test references at a79683e4 — the
@@ -425,7 +437,7 @@ describe('RiskAppetiteFilter — the lens disclaimer is load-bearing (1.243 item
     render(<RiskAppetiteFilter value="neutral" onChange={vi.fn()} />)
     // Positive control: the component mounted, so the assertion below is not
     // passing against an empty render.
-    expect(screen.getByText('Rank by outcome:')).toBeInTheDocument()
+    expect(screen.getByText('Highlight by outcome:')).toBeInTheDocument()
     expect(
       screen.getByText(
         'A view lens over the outcome range. The comparative ranking above is unchanged.',

--- a/src/components/results/__tests__/OptionCards.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.spec.tsx
@@ -693,9 +693,25 @@ describe('OptionCards', () => {
     })
   })
 })
+/**
+ * ⭐ BOTH FIXTURES COMPLETED 2026-08-01 (ROADMAP 2.238). They rendered
+ * `lensActive` with NO `lensHighlightedId`, and therefore only passed via the
+ * `?? winnerId` fallback — i.e. they were pinning the defect: a crown labelled
+ * "Ahead on this outcome view" on the COMPARATIVE winner, in the exact state
+ * where the panel above prints "Not enough range data to compare options under
+ * this lens."
+ *
+ * The claims these tests were WRITTEN to make (the crowned card says
+ * lens-strongest rather than THE recommendation; the lens copy outranks a
+ * coaching headline) are unchanged and still correct — they just need the lens
+ * to have actually picked something. `lensHighlightedId` is now passed
+ * explicitly, which is what the live path does whenever the lens is comparable.
+ */
 describe("Paul's ruling (2026-07-12): lens-aware winner copy", () => {
-  it('lensActive winner card presents as lens-strongest, not THE recommendation', () => {
-    render(<OptionCards options={mockOptions} winnerId="option-1" lensActive />)
+  it('lens-crowned card presents as lens-strongest, not THE recommendation', () => {
+    render(
+      <OptionCards options={mockOptions} winnerId="option-1" lensActive lensHighlightedId="option-1" />,
+    )
     const card = screen.getByTestId('option-card-option-1')
     expect(card).toHaveTextContent('Ahead on this outcome view. The goal ranking above is unchanged.')
     expect(card.textContent).not.toMatch(/Highest leading-option likelihood/)
@@ -707,6 +723,7 @@ describe("Paul's ruling (2026-07-12): lens-aware winner copy", () => {
         options={mockOptions}
         winnerId="option-1"
         lensActive
+        lensHighlightedId="option-1"
         storyHeadlines={{ 'option-1': 'Best placed once the goal and limits are both counted.' }}
       />,
     )

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -270,12 +270,12 @@ describe("Paul's ruling (2026-07-12): risk appetite is an explicitly-labelled le
     renderBody()
     expect(screen.queryByTestId('risk-lens-label')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Optimistic (p90)' }))
-    expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/ranked by the high end \(p90\)/i)
+    expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/highlights the option with the strongest high end \(p90\)/i)
     // SUPERSEDED 2026-07-31: the un-anchored noun "the recommendation" is
     // retired; the lens sentence now names the quantity that is unchanged.
     expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/goal ranking above is unchanged/i)
     fireEvent.click(screen.getByRole('button', { name: 'Cautious (p10)' }))
-    expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/ranked by the low end \(p10\)/i)
+    expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/highlights the option with the strongest low end \(p10\)/i)
     fireEvent.click(screen.getByRole('button', { name: 'Middle (p50)' }))
     expect(screen.queryByTestId('risk-lens-label')).not.toBeInTheDocument()
   })

--- a/src/components/results/__tests__/lensClaimHonesty.spec.tsx
+++ b/src/components/results/__tests__/lensClaimHonesty.spec.tsx
@@ -1,0 +1,285 @@
+/**
+ * ROADMAP 2.237 / 2.238 — the outcome-view lens must not claim what it does not do.
+ *
+ * Both defects are the SAME shape as ROADMAP 2.233 (the goal headline crowning
+ * the comparative winner): **the subject of the claim is not the source of the
+ * number.** Both were found by a pattern sweep over merged code and are live,
+ * unflagged, on the Analysis tab at `55d0167b`.
+ *
+ * ── P1-1 (2.237): a RANKING that never happens ────────────────────────────
+ * The control said "Rank by outcome:" and the panel said "ranked by the low end
+ * (p10) of each outcome range". Neither is true. `sortOptionsForDisplay` takes
+ * NO lens argument — the list is ordered by `winProbability`, truncated by that
+ * order, and stamped with explicit ordinals from it. The lens reaches the cards
+ * only as a CROWN on one card. On
+ *
+ *     A(win .50, p10 10)   B(win .30, p10 50)   C(win .20, p10 90)
+ *
+ * clicking "Cautious (p10)" printed the ranking claim over a list reading
+ * A(1), B(2) — byte-identical to neutral — with C, the p10 leader and the
+ * lens's OWN pick, not rendered at all behind "Show all (1 more)". The user was
+ * told a ranking existed and then could not see its result.
+ *
+ * ── P1-2 (2.238): a crown under a lens that says it has no data ───────────
+ * `isLensCrowned` fell back to `winnerId` when `lensHighlightedId` was null —
+ * and null is exactly the state in which the panel prints "Not enough range
+ * data to compare options under this lens." Both lines read the SAME memo, so
+ * the contradiction was deterministic, not a race: the comparative winner was
+ * crowned "Ahead on this outcome view" under a sentence declaring the view
+ * unavailable. `selectLensOption:69-73` already documents the correct rule —
+ * "an absence, never a fallback to a different quantity" — so the doctrine was
+ * written and then not applied at the one call site that mattered.
+ *
+ * CLAIM TYPE: these are TEXT- and PRESENCE-level assertions on rendered output.
+ * jsdom cannot prove visibility (CLAUDE.md trap 3) and nothing here should be
+ * read as a layout claim.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import { WIN_GAUGE_COLORS } from '../WinGauge'
+import type { OptionResult } from '../types'
+
+function opt(id: string, label: string, winProbability: number, p10: number): OptionResult {
+  return {
+    id,
+    label,
+    winProbability,
+    outcome: { p10, p50: p10 + 10, p90: p10 + 20, expected: p10 + 10 },
+  } as unknown as OptionResult
+}
+
+/** The sweep's exact disagreement fixture: winProbability and p10 rank OPPOSITELY. */
+const DISAGREEING = [
+  opt('option-1', 'Option A', 0.5, 10),
+  opt('option-2', 'Option B', 0.3, 50),
+  opt('option-3', 'Option C', 0.2, 90),
+]
+
+describe('P1-2 (ROADMAP 2.238) — no lens crown when the lens has no comparable data', () => {
+  it('THE CONTRADICTION: with no lensHighlightedId, NO card is crowned "Ahead on this outcome view"', () => {
+    // `undefined` is exactly what `ResultsBody:543` passes when
+    // `lensComparison.comparable` is false — the same memo that makes the panel
+    // above print "Not enough range data to compare options under this lens."
+    // (`LensSelection.id` is `string | undefined`; the guard uses `!= null` so
+    // it holds for either spelling.)
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId={undefined}
+      />,
+    )
+    expect(screen.queryByText(/Ahead on this outcome view/)).not.toBeInTheDocument()
+  })
+
+  it('the COMPARATIVE winner specifically is not the one crowned by default', () => {
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId={undefined}
+      />,
+    )
+    const comparativeWinner = screen.getByTestId('option-card-option-1')
+    expect(comparativeWinner.textContent).not.toMatch(/Ahead on this outcome view/)
+  })
+
+  it("OVER-SUPPRESSION CONTROL: a real lens pick IS still crowned, and it is the lens's own pick", () => {
+    // Removing the fallback must not silence the legitimate case — that would
+    // trade one defect for another.
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId="option-3"
+      />,
+    )
+    expect(screen.getByTestId('option-card-option-3')).toHaveTextContent(
+      /Ahead on this outcome view/,
+    )
+    // And NOT the comparative winner.
+    expect(screen.getByTestId('option-card-option-1').textContent).not.toMatch(
+      /Ahead on this outcome view/,
+    )
+  })
+
+  it('CONTROL: with the lens off, the comparative winner keeps its normal description', () => {
+    render(<OptionCards options={DISAGREEING} winnerId="option-1" />)
+    expect(screen.queryByText(/Ahead on this outcome view/)).not.toBeInTheDocument()
+    expect(screen.getByTestId('option-card-option-1').textContent).toBeTruthy()
+  })
+})
+
+/**
+ * ⛔ A B2 BLOCK STOOD HERE AND HAS BEEN WITHDRAWN (2026-08-01).
+ *
+ * It pinned "a withheld run prints no lens sentence" — the opposite of the
+ * standing ruling. ROADMAP 1.239 (#494, `a79683e4`) exempts this sentence BY
+ * DESIGN, with a stated rationale (a per-view argmax over on-screen values is
+ * not the producer's designation; gating it is the over-suppression class
+ * already fixed once in DecisionNode) and its own pin in
+ * `residualComparative.optionCards.spec.ts`, which is what caught the removal.
+ *
+ * The apparent contradiction with ROADMAP 1.267 (#501, `1ae760d3`) is not one:
+ * #501's own prop doc scopes it to "the ordinal rank swatch, the crowned
+ * border, and the leader colour on the 'Hits target' bar. Never the values
+ * themselves." Styling designations, not this sentence.
+ *
+ * Consequence for 2.237: the appended pick printing this sentence on a withheld
+ * run is 1.239's rule applying to a card that is now rendered — NOT a defect
+ * this PR introduced. Whether 1.239 should be re-adjudicated is a live product
+ * question, raised on the record rather than settled by a lane.
+ */
+
+describe('P1-1 (ROADMAP 2.237) — the lens control names HIGHLIGHTING, not ranking', () => {
+  it('the lens PICK is rendered even when it falls outside the top-2 truncation', () => {
+    // The p10 leader here is option-3, third by winProbability and therefore
+    // behind "Show all (1 more)" before this fix. The panel names it; the panel
+    // must therefore be able to show it.
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId="option-3"
+      />,
+    )
+    expect(screen.getByTestId('option-card-option-3')).toBeInTheDocument()
+    expect(screen.getByTestId('option-card-option-3')).toHaveTextContent(
+      /Ahead on this outcome view/,
+    )
+  })
+
+  it('"Show all" no longer offers an option that is already on screen', () => {
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId="option-3"
+      />,
+    )
+    // All three are rendered, so there is nothing left to reveal.
+    expect(screen.queryByText(/Show all \(1 more\)/)).not.toBeInTheDocument()
+  })
+
+  it('the APPENDED lens pick carries its TRUE rank, not its render position', () => {
+    // ⚠ THIS TEST EXISTS BECAUSE A MUTATION CHECK CAUGHT ITS ABSENCE. Reverting
+    // `sortedRank` to the map index (`index + 1`) left the whole suite green,
+    // because on a three-option fixture the appended card's render position and
+    // its true rank COINCIDE at 3. Four options separate them: the lens pick is
+    // 4th by winProbability but renders 3rd.
+    //
+    // The rank is not printed as a numeral — it selects the card's colour
+    // marker from `WIN_GAUGE_COLORS`, which is how the card, the WinGauge
+    // legend and the scenario bar agree on which option is which. A fabricated
+    // rank therefore paints an option in another option's colour.
+    const four = [
+      opt('option-1', 'Option A', 0.5, 10),
+      opt('option-2', 'Option B', 0.3, 20),
+      opt('option-3', 'Option C', 0.15, 30),
+      opt('option-4', 'Option D', 0.05, 90), // p10 leader, 4th on winProbability
+    ]
+    render(
+      <OptionCards options={four} winnerId="option-1" lensActive lensHighlightedId="option-4" />,
+    )
+    const marker = screen.getByTestId('rank-marker-option-4')
+    // rank 4 → WIN_GAUGE_COLORS[3]; the render position (3) would give [2].
+    expect(marker).toHaveStyle({ backgroundColor: WIN_GAUGE_COLORS[3] })
+    expect(marker).not.toHaveStyle({ backgroundColor: WIN_GAUGE_COLORS[2] })
+    // CONTROL — the untouched cards keep their own colours.
+    expect(screen.getByTestId('rank-marker-option-1')).toHaveStyle({
+      backgroundColor: WIN_GAUGE_COLORS[0],
+    })
+  })
+
+  it('B1: the toggle is ABSENT when the appended pick leaves nothing hidden — never "Show all (0 more)"', () => {
+    // ⚠ THIS PIN EXISTS BECAUSE THE FIRST FIX CREATED A FRESH FALSE CLAIM, on
+    // this PR's own headline fixture. `hiddenCount` was correctly re-derived,
+    // but the button's render condition was still `shouldTruncate` — so three
+    // options with the pick appended rendered "Show all (0 more)", and clicking
+    // it changed nothing: the card set was already complete and only the label
+    // flipped to "Show fewer". A control that claims to reveal something and
+    // reveals nothing is the exact defect class this PR exists to remove.
+    //
+    // Asserting ABSENCE of the control, not merely absence of the words "1
+    // more" — the earlier pin below did the latter and passed straight over it.
+    //
+    // ⚠ `onSendMessage` IS PASSED DELIBERATELY, and a mutation check is why.
+    // The toggle sits inside a wrapper gated on `(showToggle || onSendMessage)`.
+    // Without `onSendMessage` the WRAPPER collapses whenever `showToggle` is
+    // false, so the button is absent no matter what the inner condition says —
+    // and reverting the inner condition left this pin GREEN. The live caller
+    // (`ResultsBody`) always supplies `onSendMessage`, so in production the
+    // wrapper is open and the inner gate is the load-bearing one. Testing the
+    // shape the user actually gets is what makes this assertion able to fail.
+    render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId="option-3"
+        onSendMessage={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('option-cards-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Show all/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/0 more/)).not.toBeInTheDocument()
+    // POSITIVE CONTROL — all three cards ARE on screen, so there is genuinely
+    // nothing left to reveal. Without this the assertion above could pass on a
+    // component that rendered nothing at all.
+    expect(screen.getByTestId('option-card-option-1')).toBeInTheDocument()
+    expect(screen.getByTestId('option-card-option-2')).toBeInTheDocument()
+    expect(screen.getByTestId('option-card-option-3')).toBeInTheDocument()
+  })
+
+  it('B1 OVER-SUPPRESSION CONTROL: "Show fewer" survives once expanded, when hiddenCount is 0 by construction', () => {
+    // `showAllOptions ||` in the render condition is load-bearing: the bare
+    // `hiddenCount > 0` predicate would delete this control and strand the user
+    // in the expanded state with no way back.
+    render(<OptionCards options={DISAGREEING} winnerId="option-1" />)
+    const toggle = screen.getByTestId('option-cards-toggle')
+    expect(toggle).toHaveTextContent('Show all (1 more)')
+    fireEvent.click(toggle)
+    expect(screen.getByTestId('option-cards-toggle')).toHaveTextContent('Show fewer')
+    // And it still collapses.
+    fireEvent.click(screen.getByTestId('option-cards-toggle'))
+    expect(screen.getByTestId('option-cards-toggle')).toHaveTextContent('Show all (1 more)')
+  })
+
+  it('CONTROL: with no lens pick, truncation is unchanged (top 2 + "Show all (1 more)")', () => {
+    render(<OptionCards options={DISAGREEING} winnerId="option-1" />)
+    expect(screen.getByTestId('option-card-option-1')).toBeInTheDocument()
+    expect(screen.getByTestId('option-card-option-2')).toBeInTheDocument()
+    expect(screen.queryByTestId('option-card-option-3')).not.toBeInTheDocument()
+    expect(screen.getByText(/Show all \(1 more\)/)).toBeInTheDocument()
+  })
+
+  it('the lens does NOT re-order: its pick is APPENDED, never promoted — which is why the copy may not claim a ranking', () => {
+    // This is the fact the old copy contradicted, asserted directly so the copy
+    // fix cannot drift away from the behaviour it describes.
+    const { container } = render(
+      <OptionCards
+        options={DISAGREEING}
+        winnerId="option-1"
+        lensActive
+        lensHighlightedId="option-3"
+      />,
+    )
+    const order = Array.from(
+      container.querySelectorAll('[data-testid^="option-card-"]'),
+    ).map((n) => n.getAttribute('data-testid'))
+
+    // winProbability order throughout; the p10 leader is LAST, not first.
+    expect(order).toEqual([
+      'option-card-option-1',
+      'option-card-option-2',
+      'option-card-option-3',
+    ])
+    expect(order[0]).not.toBe('option-card-option-3')
+  })
+})

--- a/tests/visual-regression/analysis-tab.spec.ts
+++ b/tests/visual-regression/analysis-tab.spec.ts
@@ -79,11 +79,20 @@ describe('visual-regression scaffold (Brief 5)', () => {
     //   · 'Winner by:'  → 'Rank by outcome:'  — the control confers no
     //     endorsement; it re-ranks a view, and now every arm re-ranks it on
     //     the SAME quantity.
+    //     ⛔ SUPERSEDED AGAIN 2026-08-01 (ROADMAP 2.237): 'Rank by outcome:'
+    //     → 'Highlight by outcome:'. The 2026-07-31 note above is wrong on the
+    //     facts — the control does NOT re-rank anything.
+    //     `sortOptionsForDisplay` takes no lens argument; the list is ordered,
+    //     truncated and numbered by `winProbability`, and the lens reaches the
+    //     cards only as a crown on one card. The first re-anchoring correctly
+    //     retired an endorsement noun and substituted a second false claim.
     //   · the lens sentence drops the un-anchored noun 'the overall
     //     recommendation' for the quantity that is actually unchanged.
     //   · the arm labels name their percentile instead of a mood, because
     //     the middle arm now ranks p50 rather than the comparative quantity.
-    expect(snap).toContain('Rank by outcome:')
+    expect(snap).toContain('Highlight by outcome:')
+    // The twice-retired labels must not survive anywhere in this control.
+    expect(snap).not.toContain('Rank by outcome:')
     // F3: the sentence names what the lens leaves unchanged, and that depends
     // on whether the run HAS a goal ranking. This render passes no
     // `hasGoalNumbers`, so it exercises the safe default — the neutral


### PR DESCRIPTION
**DO NOT MERGE — review first.** Rows **2.237** and **2.238**, from the pattern sweep over merged code (`PHASE0-EVIDENCE-2026-07-28/sweep-session-patterns-2026-08-02.md`, P1-1 and P1-2). Base: `staging` @ `55d0167b`, re-derived at start.

**This is the SPLIT half.** [#550](https://github.com/Talchain/DecisionGuideAI/pull/550) already carries six defects across 27 files; the coordinator offered a split rather than absorbing two more into it, and I took it. The two PRs are independent — zero file overlap in production code — and #550 does not need to land first.

---

## One shape, twice: the subject of the claim is not the source of the number

Exactly #550's 2.233 defect (the goal headline crowning the comparative winner), on the outcome-view lens. Both are live and unflagged on the Analysis tab.

### 2.237 (P1-1) — the control claimed a RANKING that never happens

The control said **"Rank by outcome:"** and the panel said **"ranked by the low end (p10) of each outcome range"**. Neither is true. `sortOptionsForDisplay` takes **no lens argument**: the list is ordered by `winProbability`, truncated by that order, and stamped with ordinals from it. The lens reaches the cards only as a **crown on one card**.

```
A(win .50, p10 10)   B(win .30, p10 50)   C(win .20, p10 90)
click "Cautious (p10)":
  panel  → "ranked by the low end (p10) of each outcome range"
  cards  → A(1), B(2)          ← winProbability order, byte-identical to neutral
  C      → NOT RENDERED AT ALL  ← the p10 leader, and the lens's own pick,
                                   behind "Show all (1 more)"
```

The user was told a ranking existed and then could not see its result.

**Fix — three parts, and the second two are why this is not a one-liner:**

1. **Copy corrected to what the code does** (`ResultsBody.tsx`, `AdvancedSection.tsx`): "ranked by the low end (p10) of each outcome range" → "highlights the option with the strongest low end (p10). Order below is unchanged."; "Rank by outcome:" → "Highlight by outcome:". Highlighting *is* the shipped behaviour and is a coherent feature; threading the lens through the comparator would change ordering, truncation and the ordinal stamps together — a far larger behavioural change than a false sentence warrants.
2. **The lens pick is now always rendered** (`OptionCards.tsx`). Saying "highlights option X" while X sits behind "Show all" is the same defect in a new place: *a claim that cannot be checked is as bad as one that is wrong.* It is **appended, never promoted** — promoting it would create the very ranking the copy must not claim.
3. **`sortedRank` now comes from the ordering, not the render position.** It was `index + 1`, correct only while `visibleOptions` was always a *prefix* of `sorted`. After (2) it is not: an appended pick would have been stamped with a rank it had not earned. The rank drives the card's colour marker (`WIN_GAUGE_COLORS[rank-1]`), which is how the card, the WinGauge legend and the scenario bar agree on which option is which.

*Precision on the impact, narrower than an earlier draft claimed:* the palette's index 3 is **"Fourth+"**, so ranks 4, 5 and 6 already share one colour. The fix therefore genuinely separates **rank 3 from rank 4+**; it does not rescue a distinction between 4th and 5th, and "paints an option in another option's colour" overstated it.

### 2.238 (P1-2) — the crown fell back to the comparative winner under a lens that says it has no data

```ts
// before
const isLensCrowned = lensActive && option.id === (lensHighlightedId ?? winnerId)
// after
const isLensCrowned = lensActive && lensHighlightedId != null && option.id === lensHighlightedId
```

`lensHighlightedId` is absent **exactly when** `lensComparison.comparable` is false — the same memo that makes the panel print *"Not enough range data to compare options under this lens."* So on any run whose bands carry p10/p50 but no p90, clicking "Optimistic (p90)" printed that sentence **and** crowned the comparative winner *"Ahead on this outcome view"* with the success border. Both lines read one memo: deterministic, not a race.

`selectLensOption.ts:69-73` **already documents the correct rule** — *"an absence, never a fallback to a different quantity"*. The doctrine was written and then not applied at the one call site that mattered.

---

## Review round 1 — B1 and B2 fixed

### B1 — a fresh false claim this PR created, on its own headline fixture

Three options, lens active, pick 3rd → the button rendered **`"Show all (0 more)"`**, and clicking it changed nothing: the card set was already complete, only the label flipped to "Show fewer". I re-derived `hiddenCount` correctly but left the button's render condition as `shouldTruncate`. **A control that claims to reveal something and reveals nothing — shipped by a PR whose thesis is that copy must be true of behaviour.**

Fix: `shouldTruncate && (showAllOptions || hiddenCount > 0)`. The `showAllOptions ||` term is load-bearing — a bare `hiddenCount > 0` would delete the **"Show fewer"** control once expanded (where `hiddenCount` is 0 by construction) and strand the user with no way back. Both states pinned: toggle **ABSENT** in the appended state; "Show fewer" **PRESENT** when expanded, and still collapsing.

**My first B1 pin did not bite, and the mutation caught it.** The toggle sits inside a wrapper gated on `(showToggle || onSendMessage)`. My pin passed no `onSendMessage`, so the *wrapper* collapsed whenever `showToggle` was false and the button was absent regardless of the inner condition — reverting the inner gate left the pin green. The live caller (`ResultsBody`) always supplies `onSendMessage`, so in production the wrapper is open and the inner gate is the load-bearing one. The pin now renders the shape the user actually gets. **Third time this lane that a mutation exposed a pin that could not see its own fix** (after M4 and N4).

### B2 — WITHDRAWN. My "the file contradicts itself" claim was wrong.

**I implemented B2, and then reverted it. The reviewer's finding and my own framing were both mistaken, and the mistake was mine to begin with — I supplied the premise the authorisation rested on.**

What I claimed: `OptionCards.tsx:436-437` states *"a withheld run crowns nothing. The lens crown goes too — it is a second designation, not an exemption from the first"*, while `:213-214` calls the lens branch *"the one carve-out"* — so the file contradicts itself and the sentence escaping is an oversight.

What is actually true, established from the commits rather than the comments:

| Ruling | Commit | Governs |
|---|---|---|
| **1.239** (#494) `a79683e4`, 27 Jul | introduced the carve-out **and a test pinning it** | the lens **SENTENCE** |
| **1.267** (#501) `1ae760d3`, 27 Jul | introduced the ":436-437" doctrine | the **STYLING** designations |

#501's own `designationsWithheld` prop doc, added in the same commit, enumerates its scope: *"the ordinal rank swatch, the crowned border, and the leader colour on the 'Hits target' bar. **Never the values themselves.**"* And the comment annotates `const crowned` — the styling flag. **It never reached the sentence.** The two rulings govern different channels and are consistent; there is no self-contradiction.

1.239's exemption is reasoned, not incidental: the lens line is *a per-view argmax over outcome values already on screen, not the producer's designation*, its companion clause explicitly disclaims the main ranking, and #494 names the risk of gating it — *the over-suppression class this arc had already had to fix once in DecisionNode*.

**What caught it:** `residualComparative.optionCards.spec.ts` — 1.239's own pin — went RED in the repo-wide run. My scoped runs never touched it.

**Consequence for this PR:** the appended pick printing that sentence on a withheld run is **1.239's rule applying to a card that is now rendered**, not a defect this PR introduced. Nothing to fix.

**What I kept:** a dated note at BOTH sites recording that the contradiction was alleged and disproved, with the scope of each ruling spelled out, so the next reader does not repeat it. A withdrawn-block marker sits where my B2 pins were, explaining why they are gone.

**Open question for the founder, raised rather than settled:** *should* 1.239 be re-adjudicated — is "Ahead on this outcome view" acceptable on a run where the producer withheld the leader claim? There is a real argument each way and it is not a lane's call.

## RED-first

The full spec was run against a **pristine control worktree at `55d0167b`** (outside the clone root): **11 of 15 failed**. Every pin is proven to see its defect before the fix.

*(Earlier bodies said "6 of 8" and then "7 of 9" — both were snapshots taken before later pins were added. 11/15 is the figure for the spec as it now stands.)*

One result there is worth reading closely: **"PRE-EXISTING CASE: a pick INSIDE the top 2 prints no lens sentence"** fails at the base, confirming B2's pre-existing half. The **widened** case PASSES at the base — because at the base that pick is not rendered at all, so there is no card to carry the sentence. The widening is only reachable *after* the always-render fix, which is exactly why it is this PR's to own.

## Mutation checks — all 4 bite

Throwaway worktree outside the clone root, removed before every gate run (trap 9c). Harness asserts the anchor exists, is unique, and that the write landed (trap 15).

| # | Reverted | Result |
|---|---|---|
| N1 | `?? winnerId` crown fallback restored | **RED** 2/8 |
| N2 | "ranked by the low end (p10)" restored | **RED** 1/11 |
| N3 | lens pick no longer force-rendered | **RED** 4/8 |
| N4 | `sortedRank` back to the render position | **RED** 1/9 |
| N5 | B1 inner gate back to `shouldTruncate` | **RED** 1/15 |
| N7 | B1 **full** revert (both render conditions) | **RED** 1/15 |

*(An N6 mutant for B2 was run and bit, but B2 itself is withdrawn, so it is not listed as a guarantee of shipped code.)*

All mutants are hand-verified with **captured failing test names**, using a harness whose default is `⛔ INCONCLUSIVE` (exit non-zero) rather than green — proven to reach that state by two controls. The previous harness reported a false "STILL GREEN" for two mutants elsewhere in this lane; its default was the bug.

**⚠ N4 did not bite on the first run.** The three-option fixture makes the appended card's render position and its true rank *coincide* at 3, so the ordinal fix had no test that could see it. A four-option fixture separates them (pick is 4th, renders 3rd) and asserts the colour marker. Same failure mode as #550's M4 — and the reason to actually run the mutations rather than assume them.

## Gates

- **`pnpm typecheck`**: **PASSED**. **3112/3152** tracked files loaded (40 declared out of scope); ratchet 622 files / 2505 errors vs baseline 2510 — within. **Baseline NOT regenerated.** *(An earlier body said 3120/3160 — that was measured on #550's tree, which carries 8 more tracked files. The mechanism `tracked − 40 = loaded` holds in both; only the tree differed.)* Two new type errors were surfaced by the gate and **fixed at source**: my fixtures passed `null` where the prop is `string | undefined`. That was worth catching — the live producer (`ResultsBody:543`) passes `undefined`, so the fixtures now match the real path, and the guard uses `!= null` so it holds either way.
- **Check 8 (DS v5 drift)**: pre-existing RED, proven **byte-identical** against a pristine control worktree at `55d0167b`.
- Vitest env `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set on every run (trap 2b).

## A false adjudication, withdrawn

`AdvancedSection.spec.tsx:401-408` carried a settled-looking verdict clearing the label:

> "LEAVE the label, do NOT relabel. 'Rank by outcome:' … names the **SORT KEY** of a display filter."

**There is no lens sort key.** The adjudication cleared the label by asserting a mechanism that does not exist, and because it read as decided, it is exactly the sentence nobody re-checked (trap 14). It is withdrawn in place, with the reasoning that *was* correct — the disclaimer being load-bearing — left intact and still pinned.

## Superseded specs (each with its reason in-file)

- `OptionCards.spec.tsx` ×2 — rendered `lensActive` with **no** `lensHighlightedId`, so they passed *only* via the fallback: they were pinning the defect. The claims they were written to make are unchanged; the fixtures now pass a pick explicitly.
- `ResultsBody.heroPlacement.spec.tsx` ×2 and `AdvancedSection.spec.tsx` ×1 — the retired copy.
- `tests/visual-regression/analysis-tab.spec.ts` — the control's DOM snapshot. **This one CI
  caught, not me:** my local run used a path filter (`src/...`) and `tests/` lives outside it, so
  a clean local suite still RED-ed shard 3/4. A scoped local run is not the suite. The repo-wide
  run (`npx vitest run`, no filter) is now the check of record: **1402 files / 20,971 tests pass**.
  Its own supersession note is instructive — it recorded the 2026-07-31 rationale
  ("it re-ranks a view, and now every arm re-ranks it on the SAME quantity") as settled fact.
  That rationale was false; the note now says so in place rather than being silently overwritten.

## Needs founder sign-off

The three copy strings: "Highlight by outcome:", and the two "highlights the option with the strongest {low|high} end ({p10|p90}). Order below is unchanged." sentences.

## Noted, not fixed here

The sweep's **P2-4 / P2-5** are the GOAL-register twin of the floor divergence #550 fixes for the comparative register (`OptionCards.tsx:341` stat row, `OutcomeNode.tsx:147`, `GoalPanel.tsx:278/:505`, `GoalNode.tsx:336-338`). Separate rows, untouched by either PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
