### PR TITLE
fix(results,canvas): possessive gate on substituted joint goal figures — OptionCards + GoalPanel + OptionNode (ROADMAP 2.282) — DO NOT MERGE, review lane

### DIFF
--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -21,7 +21,7 @@ import { detectBaseline } from '../utils/baselineDetection'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { NodeChip, ActionIcons, BriefIcon, NodePopover, ScienceIcon } from './shared'
 import { selectGoalProbability } from '../../components/results/utils/selectGoalProbability'
-import { COMPARATIVE_COPY } from '../../components/results/utils/goalAnchorCopy'
+import { COMPARATIVE_COPY, GOAL_ANCHOR_COPY } from '../../components/results/utils/goalAnchorCopy'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
 
@@ -773,6 +773,27 @@ export const OptionNode = memo((props: NodeProps) => {
   }, [isPostAnalysis, resultsReport, props.id])
   const goalProbability = goalDecision?.goalProbability ?? null
 
+  // THE POSSESSIVE GATE (ROADMAP 2.282). `basis === 'joint_goal_substituted'`
+  // means this number is P(all constraints jointly satisfied) STANDING IN for
+  // an absent `probability_of_goal`, so the possessive "chance of target"
+  // names a question it does not answer. Read off the owner's own published
+  // decision — the same expression `useResultsSectionData` uses to set
+  // `OptionResult.goalFitIsSubstitutedJoint` — never re-derived here.
+  //
+  // ⚠ SCOPED TO `joint_goal_substituted`, NOT to "the figure is joint".
+  // `joint_goal_constrained` is the user's own goal AND the user's own
+  // limits, where the possessive is EARNED and stays. `OptionNode.spec.tsx`'s
+  // ROADMAP 1.49 positive control is exactly that constrained case and must
+  // keep rendering "chance of target."
+  const goalFitSubstituted = goalDecision?.basis === 'joint_goal_substituted'
+  // The badge readout, built ONCE above both arms so the withheld and
+  // permitted wordings cannot show different numbers for the same option.
+  // Byte-identical to the literal it replaces (`'< '` + digits + `%`).
+  const goalBadgeReadout =
+    goalProbability !== null && goalProbability < 0.10
+      ? `< ${goalProbability < 0.01 ? '1' : Math.round(goalProbability * 100)}%`
+      : null
+
   // "Behind:" reason for non-winner options (including status quo).
   // Computed via the pure helper so this option's reason can be compared
   // against its non-leading siblings: an identical reason on multiple losers
@@ -920,10 +941,15 @@ export const OptionNode = memo((props: NodeProps) => {
       {/* Goal probability warning (< 10%) -- post-analysis only.
           UI-SEM-082: gated on a USER target (goalThreshold != null) so it never
           crowns a target the user never set, matching GoalNode + OptionCards. */}
-      {goalThreshold != null && isPostAnalysis && goalProbability !== null && goalProbability < 0.10 && (
+      {goalThreshold != null && isPostAnalysis && goalBadgeReadout != null && (
         <p className={`${typography.edgeLabel} text-text-light mt-0.5 m-0`}>
-          {'< '}
-          {goalProbability < 0.01 ? '1' : Math.round(goalProbability * 100)}% chance of target.{' '}
+          {/* ROADMAP 2.282: the withheld arm is the shared register's SENTENCE
+              form verbatim (phrase + full stop) — the same wording the results
+              panel, the hero and the V7 goal lens render for this basis. The
+              permitted arm is byte-identical to the string it replaced. */}
+          {goalFitSubstituted
+            ? GOAL_ANCHOR_COPY.sentence(goalBadgeReadout, goalFitSubstituted)
+            : `${goalBadgeReadout} chance of target.`}{' '}
           <button
             type="button"
             className={`${typography.edgeLabel} text-danger underline cursor-pointer nodrag nopan`}
@@ -1059,7 +1085,7 @@ export const OptionNode = memo((props: NodeProps) => {
           in this inline layer-2 block. Body never renders chips directly. */}
       {optionChips}
     </>
-  ), [isPostAnalysis, goalThreshold, goalProbability, goalDecision, props.id, handleGoalReviewClick, allInterventionChips, isBaselineOption, baselineOptionInterventions, isOptionFromCee, props.data, totalInterventionCount, optionChips])
+  ), [isPostAnalysis, goalThreshold, goalProbability, goalBadgeReadout, goalFitSubstituted, goalDecision, props.id, handleGoalReviewClick, allInterventionChips, isBaselineOption, baselineOptionInterventions, isOptionFromCee, props.data, totalInterventionCount, optionChips])
 
   // ----- Pre-analysis popover content -----
   const preAnalysisPopoverContent = useMemo(() => {

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -92,6 +92,11 @@ vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
 import { useCanvasStore } from '../../store'
 import { useNodeDisplayMetadata } from '../../hooks/useNodeDisplayMetadata'
 import { useLayoutStore } from '../../layoutStore'
+// ROADMAP 2.282 — the REAL chooser and the REAL copy register, so the
+// possessive-gate tests below pin the shipped predicate and the shipped
+// wording rather than a restatement of either.
+import { selectGoalProbability } from '../../../components/results/utils/selectGoalProbability'
+import { GOAL_ANCHOR_COPY } from '../../../components/results/utils/goalAnchorCopy'
 
 const baseProps = {
   id: 'option-1',
@@ -1204,6 +1209,93 @@ describe('OptionNode', () => {
     // 5% < 10% threshold → the warning line renders with the joint value,
     // matching what OptionCards/hero derive via useResultsSectionData.
     expect(screen.getByText(/5% chance of target\./)).toBeDefined()
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // THE POSSESSIVE GATE (ROADMAP 2.282)
+  //
+  // The two tests above are the CONSTRAINED case (`constraint_analysis`
+  // present ⇒ basis `joint_goal_constrained`), where the joint figure covers
+  // the user's own goal AND their own limits and the possessive "chance of
+  // target" is EARNED. The tests below are the SUBSTITUTED case — the same
+  // joint number with no constraint analysis, standing in for a
+  // `probability_of_goal` ISL refused to compute (witnessed live on staging
+  // 2026-08-01: unstamped `goal_threshold_frame`). There the possessive names
+  // a question the number does not answer, and the selector says so with
+  // `mayUsePossessiveGoalFraming: false`.
+  //
+  // The pair is the point: the SAME 0.05-ish joint value must keep the
+  // possessive in one fixture and lose it in the other, so a fix that simply
+  // deleted the possessive copy fails the constrained test above.
+  //
+  // RED-first: both fail at `fef179ce`.
+  const makeSubstitutedJointStore = () =>
+    makeStoreState({
+      goalThreshold: 0.8, // UI-SEM-082: a user target is set
+      results: {
+        status: 'complete',
+        report: {
+          option_probabilities: {
+            'option-1': {
+              confidence: 0.5,
+              win_probability: 0.5,
+              // The witnessed shape: the joint figure arrives, the goal
+              // figure does not, and there is NO constraint_analysis — so the
+              // selector's third branch fires and substitutes.
+              probability_of_joint_goal: 0.0054,
+              goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+            },
+          },
+        },
+      },
+      nodes: [{ id: 'option-1', type: 'option', data: { type: 'option' } }],
+    })
+
+  it('control: the substituted fixture really does drive the selector to `joint_goal_substituted` (not `joint_goal_constrained`)', () => {
+    // Anti-vacuity (trap 13). If this fixture ever stopped being the
+    // substituted case, the two copy tests below would pass by testing
+    // nothing — and they would be indistinguishable from a real fix.
+    mockTrust.suspect = false
+    const substituted = selectGoalProbability({
+      probability_of_joint_goal: 0.0054,
+      goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+    })
+    expect(substituted.basis).toBe('joint_goal_substituted')
+    expect(substituted.mayUsePossessiveGoalFraming).toBe(false)
+
+    // …and the neighbouring fixture is genuinely the OTHER basis.
+    const constrained = selectGoalProbability({
+      probability_of_joint_goal: 0.05,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+    })
+    expect(constrained.basis).toBe('joint_goal_constrained')
+    expect(constrained.mayUsePossessiveGoalFraming).toBe(true)
+  })
+
+  it('RED-first: WITHHOLDS the possessive "chance of target." when the joint figure is SUBSTITUTED for an absent goal probability', () => {
+    mockTrust.suspect = false
+    mockResultsModeMetadata()
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeSubstitutedJointStore() as any)
+    )
+    renderOption()
+    expect(screen.queryByText(/chance of target\./)).toBeNull()
+    // The number is NOT suppressed — it is renamed. Same value, honest voice,
+    // in the shared register's sentence form.
+    expect(screen.getByText(new RegExp(GOAL_ANCHOR_COPY.sentence('< 1%', true).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))))
+      .toBeDefined()
+  })
+
+  it('positive control: the CONSTRAINED joint figure KEEPS the possessive wording (the gate is basis-scoped, not joint-scoped)', () => {
+    mockTrust.suspect = false
+    mockResultsModeMetadata()
+    vi.mocked(useCanvasStore).mockImplementation((selector) =>
+      selector(makeConstrainedJointOnlyStore() as any)
+    )
+    renderOption()
+    expect(screen.getByText(/5% chance of target\./)).toBeDefined()
+    expect(screen.queryByText(new RegExp(GOAL_ANCHOR_COPY.label(true).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))))
+      .toBeNull()
   })
 
   // Lane 4 fold (UI-SEM-082, extends UI-SEM-071): the "chance of target" badge

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
@@ -1,0 +1,204 @@
+/**
+ * GoalPanel — THE POSSESSIVE GATE (ROADMAP 2.282).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT THIS PANEL WAS DOING
+ * ─────────────────────────────────────────────────────────────────────────
+ * `GoalPanel` correctly refuses to be a CHOOSER — #496 deleted its
+ * reach-around and it now calls `selectGoalProbability` and renders what it
+ * is given. But it was still a NARRATOR: it destructured `.goalProbability`
+ * and `.jointGoalProbability` and walked straight past `.basis`, so on a
+ * substituted run it rendered the joint figure as
+ *
+ *   ":278  {N}% chance of reaching this target based on the current model."
+ *   ":505  {N}% chance of success"
+ *
+ * — possessive goal framing over a number whose owner had published
+ * `mayUsePossessiveGoalFraming: false`.
+ *
+ * ⚠ AND IT CONTRADICTED ITSELF ABOUT THE SAME NUMBER. Under substitution the
+ * selector returns `goalProbability === jointGoalProbability` BY
+ * CONSTRUCTION (`goalProbabilityIsJoint ⇒ goalProbability = jointGoalProb`).
+ * So the Impact block stated one value twice, in two incompatible voices:
+ * "{N}% chance of success" directly above "Chance of hitting every target:
+ * {N}%". A reader had no way to tell those were the same measurement — and
+ * exactly one of the two sentences was true. That is the sharpest form of
+ * this defect anywhere in the estate, and it gets its own test below.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * FIXTURE PROVENANCE
+ * ─────────────────────────────────────────────────────────────────────────
+ * `probability_of_joint_goal: 0.0054` with no `goal_probability` and no
+ * `constraint_analysis` is the witnessed staging shape (2026-08-01,
+ * `witness-2258-raw/run1b/`), where CEE left `goal_threshold_frame`
+ * unstamped and ISL therefore refused `probability_of_goal` outright.
+ *
+ * The gate is scoped to `joint_goal_substituted` ONLY. `joint_goal_
+ * constrained` — the user's own goal AND their own limits — keeps the
+ * possessive, and the last test pins that so a blanket copy deletion fails.
+ *
+ * RED-first: tests 2, 3 and 4 fail at `fef179ce`.
+ *
+ * Scope limit (trap 3): jsdom pins string presence/absence only.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { GoalPanel } from '../panels/GoalPanel'
+import { useCanvasStore } from '../../../store'
+import { useAuth } from '../../../../contexts/AuthContext'
+import { selectGoalProbability } from '../../../../components/results/utils/selectGoalProbability'
+import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
+
+vi.mock('../../../../contexts/AuthContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../contexts/AuthContext')>()
+  return { ...actual, useAuth: vi.fn() }
+})
+
+const REAL_AUTH = { authenticated: true, user: { id: 'u-123', email: 'real@user.io' } }
+const GOAL_NODE = {
+  id: 'goal1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'Grow Annual Revenue to £6,000,000' },
+}
+
+/** The witnessed substituted report: joint present, goal absent, unconstrained. */
+const SUBSTITUTED_REPORT = {
+  probability_of_joint_goal: 0.0054,
+  goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  meta: { n_samples: 10000 },
+}
+
+/** The same panel on a run that carries a REAL goal probability. */
+const REAL_GOAL_REPORT = {
+  probability_of_goal: 0.55,
+  probability_of_joint_goal: 0.0054,
+  meta: { n_samples: 10000 },
+}
+
+/** The CONSTRAINED joint case — possessive earned, must survive. */
+const CONSTRAINED_REPORT = {
+  probability_of_joint_goal: 0.42,
+  constraint_analysis: { constraints: [{ id: 'c1' }] },
+  meta: { n_samples: 10000 },
+}
+
+function setStore(report: Record<string, unknown>) {
+  const state = useCanvasStore.getState()
+  useCanvasStore.setState({
+    ...state,
+    nodes: [GOAL_NODE],
+    edges: [],
+    goalThreshold: 0.8,
+    goalConstraints: null,
+    results: { status: 'complete', report },
+  } as any)
+}
+
+function renderPanel() {
+  return render(
+    <GoalPanel nodeId="goal1" techMode={false} onClose={() => {}} onNavigate={() => {}} />,
+  )
+}
+
+describe('GoalPanel — possessive gate on a substituted joint goal figure (ROADMAP 2.282)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState(useCanvasStore.getState(), true)
+    vi.mocked(useAuth).mockReset()
+    vi.mocked(useAuth).mockReturnValue(REAL_AUTH as unknown as ReturnType<typeof useAuth>)
+  })
+
+  it('control: each fixture drives the selector to the basis this suite claims for it', () => {
+    // Anti-vacuity (trap 13) — without this, every absence assertion below
+    // could pass because the fixture stopped reaching the branch under test.
+    const sub = selectGoalProbability(SUBSTITUTED_REPORT)
+    expect(sub.basis).toBe('joint_goal_substituted')
+    expect(sub.mayUsePossessiveGoalFraming).toBe(false)
+    // The identity that makes the two Impact sentences the SAME number.
+    expect(sub.goalProbability).toBe(sub.jointGoalProbability)
+
+    expect(selectGoalProbability(REAL_GOAL_REPORT).basis).toBe('goal_probability')
+    expect(selectGoalProbability(CONSTRAINED_REPORT).basis).toBe('joint_goal_constrained')
+  })
+
+  it('RED-first: the success-target line does NOT say "chance of reaching this target" over a substituted joint figure', () => {
+    setStore(SUBSTITUTED_REPORT)
+    const { container } = renderPanel()
+    const text = container.textContent ?? ''
+
+    expect(text).not.toContain('chance of reaching this target')
+    // Renamed, not removed — the register's compact readout, with the panel's
+    // existing "current model" qualifier kept.
+    expect(text).toContain(`${GOAL_ANCHOR_COPY.phrase('1%', true)}, based on the current model.`)
+  })
+
+  it('RED-first: the Impact readout does NOT say "chance of success" over a substituted joint figure', () => {
+    setStore(SUBSTITUTED_REPORT)
+    const { container } = renderPanel()
+    const text = container.textContent ?? ''
+
+    expect(text).not.toContain('chance of success')
+    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+  })
+
+  it('RED-first — THE SELF-CONTRADICTION: the Impact block states ONE claim about the substituted number, not two incompatible ones', () => {
+    setStore(SUBSTITUTED_REPORT)
+    const { container } = renderPanel()
+
+    // Scoped to the IMPACT group specifically — `PanelGroup` renders
+    // `<section data-panel-group={kind}>`, so this is a real DOM anchor, not
+    // a guess. The scoping matters: the honest readout legitimately appears
+    // in the "Your input" group TOO (the success-target line), and a
+    // whole-panel count would conflate two different surfaces with the
+    // duplication inside one of them.
+    const impact = container.querySelector('[data-panel-group="impact"]')
+    expect(impact).not.toBeNull()
+    const text = impact?.textContent ?? ''
+
+    // Before the fix this ONE block rendered "1% chance of success" AND
+    // "Chance of hitting every target: 1%" — the same measurement asserted
+    // twice, once truthfully and once not.
+    expect(text).not.toContain('chance of success')
+    expect(text).not.toContain('Chance of hitting every target')
+
+    // Exactly one goal-attainment claim survives here, and it names the
+    // quantity the number actually is.
+    const honest = GOAL_ANCHOR_COPY.phrase('1%', true)
+    expect(text.split(honest).length - 1).toBe(1)
+  })
+
+  it('positive control: a REAL probability_of_goal KEEPS the possessive wording on BOTH sites', () => {
+    setStore(REAL_GOAL_REPORT)
+    const { container } = renderPanel()
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('55% chance of reaching this target based on the current model.')
+    expect(text).toContain('55% chance of success')
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('55%', true))
+    // The joint line is a genuinely DIFFERENT quantity here, so it stays.
+    expect(text).toContain('Chance of hitting every target')
+  })
+
+  it('positive control: the CONSTRAINED joint basis KEEPS the possessive wording (the gate is basis-scoped, not joint-scoped)', () => {
+    setStore(CONSTRAINED_REPORT)
+    const { container } = renderPanel()
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('42% chance of success')
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('42%', true))
+  })
+
+  it('techMode: the diagnostic names the field the number ACTUALLY is under substitution', () => {
+    // The most literally false line in the block, and the one a tech-mode
+    // reader would trust most: it labelled the value `probability_of_goal`
+    // when `probability_of_goal` is precisely the field ISL refused to emit.
+    setStore(SUBSTITUTED_REPORT)
+    const { container } = render(
+      <GoalPanel nodeId="goal1" techMode onClose={() => {}} onNavigate={() => {}} />,
+    )
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('probability_of_joint_goal (substituted for absent probability_of_goal)')
+    expect(text).not.toContain('System: probability_of_goal:')
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -45,6 +45,7 @@ import {
   selectGoalProbability,
   type GoalProbabilityInput,
 } from '../../../../components/results/utils/selectGoalProbability'
+import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
 
 export const GoalPanel = memo(function GoalPanel({
   nodeId,
@@ -72,6 +73,22 @@ export const GoalPanel = memo(function GoalPanel({
   )
   const probGoal = goalDecision.goalProbability
   const probJoint = goalDecision.jointGoalProbability
+  // THE POSSESSIVE GATE (ROADMAP 2.282). The panel already refuses to be a
+  // chooser; it was still being a NARRATOR — rendering the owner's number in
+  // possessive wording the owner had explicitly forbidden
+  // (`mayUsePossessiveGoalFraming: false`). `basis` was published for exactly
+  // this and was the one field this panel destructured past.
+  //
+  // ⚠ SCOPED TO `joint_goal_substituted` ONLY. `joint_goal_constrained` is
+  // the user's own goal AND their own limits — the possessive is earned there
+  // and is untouched.
+  //
+  // ⚠ AND THE TWO CLAIMS BELOW ARE THE SAME NUMBER. Under substitution the
+  // selector returns `goalProbability === jointGoalProbability` by
+  // construction, so the Impact block was stating one value twice in two
+  // different voices: "N% chance of success" over "Chance of hitting every
+  // target: N%". One of those was false. They are collapsed to the honest one.
+  const goalFitSubstituted = goalDecision.basis === 'joint_goal_substituted'
   // Passthrough: the REAL Monte Carlo sample count from this run's meta.n_samples
   // (canonical reader — same source AdvancedSection's "Simulation quality" row
   // uses). Null on the V5 conversational path (meta stripped upstream), in which
@@ -275,7 +292,15 @@ export const GoalPanel = memo(function GoalPanel({
               {/* Contextual probability when analysis exists */}
               {typeof probGoal === 'number' ? (
                 <p className={`${typography.panelBody} text-text-body mt-1`}>
-                  {Math.round(probGoal * 100)}% chance of reaching this target based on the current model.
+                  {/* ROADMAP 2.282. Withheld arm: the shared register's
+                      compact readout verbatim, with the existing
+                      "current model" qualifier kept as a trailing clause —
+                      the only adaptation is the joining comma, which the
+                      register's own no-full-stop `phrase()` form is designed
+                      to accept. Permitted arm byte-identical. */}
+                  {goalFitSubstituted
+                    ? `${GOAL_ANCHOR_COPY.phrase(`${Math.round(probGoal * 100)}%`, goalFitSubstituted)}, based on the current model.`
+                    : `${Math.round(probGoal * 100)}% chance of reaching this target based on the current model.`}
                 </p>
               ) : (
                 <p className={`${typography.panelMeta} text-text-light mt-1`}>
@@ -502,22 +527,46 @@ export const GoalPanel = memo(function GoalPanel({
               <div className="flex items-center gap-4 py-2">
                 <ProbabilityArc value={probGoal} color="var(--success)" />
                 <div>
-                  <div className={`${typography.panelHeader}`}>{Math.round(probGoal * 100)}% chance of success</div>
+                  {/* ROADMAP 2.282 — "chance of success" is a goal-attainment
+                      claim; over a substituted joint figure it takes the
+                      register's compact readout instead. */}
+                  <div className={`${typography.panelHeader}`}>
+                    {goalFitSubstituted
+                      ? GOAL_ANCHOR_COPY.phrase(`${Math.round(probGoal * 100)}%`, goalFitSubstituted)
+                      : `${Math.round(probGoal * 100)}% chance of success`}
+                  </div>
                   {scenarioCount != null && (
                     <div className={`${typography.panelMeta} text-text-light mt-0.5`}>
                       Based on {scenarioCount.toLocaleString('en-GB')} simulations
                     </div>
                   )}
                   <div className="mt-1"><ResultsLink label="View full results" tab="results" /></div>
-                  {typeof probJoint === 'number' && (
+                  {/* ROADMAP 2.282: suppressed under substitution because the
+                      readout above IS this number \u2014 the selector returns
+                      `goalProbability === jointGoalProbability` on that basis
+                      \u2014 and now says so in these exact words. Rendering it
+                      again would restate one value as two findings. On every
+                      other basis the two are genuinely different quantities
+                      and this line stays. */}
+                  {typeof probJoint === 'number' && !goalFitSubstituted && (
                     <div className={`${typography.panelBody} text-text-body mt-1.5`}>
                       Chance of hitting every target: <strong>{Math.round(probJoint * 100)}%</strong>
                     </div>
                   )}
                   {techMode && (
                     <div className={`${typography.panelMeta} text-text-light mt-1`}>
-                      System: probability_of_goal: {probGoal.toFixed(2)}
-                      {typeof probJoint === 'number' && ` \u00B7 probability_of_joint_goal: ${probJoint.toFixed(2)}`}
+                      {/* The diagnostic named the field `probability_of_goal`
+                          for a value that, under substitution, is NOT that
+                          field \u2014 the most literally false line in the block,
+                          and the one a tech-mode reader would trust most. */}
+                      {goalFitSubstituted ? (
+                        <>System: probability_of_joint_goal (substituted for absent probability_of_goal): {probGoal.toFixed(2)}</>
+                      ) : (
+                        <>
+                          System: probability_of_goal: {probGoal.toFixed(2)}
+                          {typeof probJoint === 'number' && ` \u00B7 probability_of_joint_goal: ${probJoint.toFixed(2)}`}
+                        </>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -3,7 +3,10 @@
  *
  * - Ordinal colour marker + option name + win percentage text (D17: "#N of M" prefix removed)
  * - 1-2 line contextual description (story headline or fallback)
- * - "Hits target" stat row: horizontal bar + percentage (conditional on target set)
+ * - "Hits target" stat row: horizontal bar + percentage (conditional on target set).
+ *   ROADMAP 2.282: that possessive wording is WITHHELD when the number is a
+ *   substituted joint figure (`goalFitIsSubstitutedJoint`) — see the possessive
+ *   gate in `OptionCard`.
  * V12.4: Per-card "Wins" bars removed; win % shown as text in card header.
  * Brief 5.8B D3: per-rank palette (V14.2: border-2 border-success/60 / border-info/60 /
  *   border-option/60) collapsed to a 2-state hierarchy — winner cards carry
@@ -19,6 +22,7 @@ import { useRef, useState, useCallback, type RefObject } from 'react'
 import { typography } from '../../styles/typography'
 import {
   COMPARATIVE_COPY,
+  GOAL_ANCHOR_COPY,
   LENS_COPY,
   isFiniteProbability,
   runHasGoalNumbers,
@@ -323,7 +327,18 @@ function StatBar({
   segmentColor,
 }: {
   value: number | null | undefined
-  label: string
+  /**
+   * Inline label for the 72px caption column, or `null` for none.
+   *
+   * ROADMAP 2.282: `null` is how the goal row renders its WITHHELD state. The
+   * withheld label (`GOAL_ANCHOR_COPY.label(true)`, 45 characters) cannot live
+   * in a fixed 72px column at 11px — it would wrap to four or five lines — so
+   * that state hoists the label to a full-width caption ABOVE the bar, which
+   * is exactly the shape `WinGauge`'s goal block already uses for the same
+   * register string. The column is omitted rather than emptied so no blank
+   * 72px gutter is left behind.
+   */
+  label: string | null
   isLeader: boolean
   color: 'success' | 'info'
   /** V11: When true, use stone colours for all bars (indeterminate state) */
@@ -349,9 +364,11 @@ function StatBar({
 
   return (
     <div className="flex items-center gap-2">
-      <span className={`${typography.panelMeta} text-text-light w-[72px] flex-shrink-0`}>
-        {label}
-      </span>
+      {label != null && (
+        <span className={`${typography.panelMeta} text-text-light w-[72px] flex-shrink-0`}>
+          {label}
+        </span>
+      )}
       <div className="flex-1 h-2 bg-panel-border/30 rounded-full overflow-hidden">
         <div
           className={`h-2 rounded-full transition-all ${barColorClass}`}
@@ -486,6 +503,43 @@ function OptionCard({
     ? undefined
     : sortedRank ?? option.rank ?? (isWinner ? 1 : undefined)
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // THE POSSESSIVE GATE (ROADMAP 2.282) — this card was the one unwired
+  // consumer of a mitigation six sibling surfaces already honour.
+  //
+  // `selectGoalProbability` publishes `basis`. When it is
+  // `'joint_goal_substituted'` the number in `option.goalProbability` is
+  // P(all constraints jointly satisfied) STANDING IN for an absent
+  // `probability_of_goal` — it answers a DIFFERENT question from the one
+  // "target" asserts, and the selector's `mayUsePossessiveGoalFraming` is
+  // false. `useResultsSectionData` carries that decision here as
+  // `goalFitIsSubstitutedJoint`; it is READ, never re-derived at this render
+  // site (types.ts states the rule; `WinGauge`, `DecisionConfidencePanel`,
+  // `RangeVisualization`, `buildHeroModel`, `buildV7Headline` and
+  // `V7LensGroup` all read it the same way).
+  //
+  // Witnessed live on staging 2026-08-01: with the frame unstamped, this card
+  // rendered "Hits target" / "< 1% likely to reach target" over the joint
+  // figure while the V7 goal lens BESIDE IT rendered the withheld wording for
+  // the same number — two contradictory claims about one value in one render.
+  // The withheld number is 0.0054 (answers "is the uplift >= £6M?") where the
+  // user asked "is the uplift >= £2M?" (~0.55).
+  //
+  // This is a COPY switch, never a value transform: the bar length, the
+  // percentage readout and the leader colour are all untouched.
+  const goalFitSubstituted = option.goalFitIsSubstitutedJoint === true
+  // Built ONCE, above both arms, so the withheld and permitted wordings can
+  // never show a different number for the same option — the register modules
+  // make the same argument about casing, for the same reason. Byte-identical
+  // to the two literals it replaces: `< 1%` below the shared floor, otherwise
+  // the rounded percent.
+  const lowGoalReadout =
+    typeof option.goalProbability === 'number' && option.goalProbability < 0.10
+      ? option.goalProbability < SUB_ONE_PERCENT_FLOOR
+        ? '< 1%'
+        : `${Math.round(option.goalProbability * 100)}%`
+      : null
+
   return (
     <div
       ref={cardRef}
@@ -607,25 +661,51 @@ function OptionCard({
       {/* Stat rows */}
       {hasGoalThreshold && (
         <div className="space-y-1.5">
+          {/* ROADMAP 2.282 — the withheld arm of the goal-row caption. The
+              register string is 45 characters, so it is hoisted to a
+              full-width line above the bar instead of the StatBar's 72px
+              column; `WinGauge`'s goal block renders the SAME register string
+              in the SAME shape (`win-gauge-goal-heading`), so this is the
+              established layout for this copy, not a new one. Rendered only
+              when the basis is substituted — the permitted arm keeps the
+              card's shipped inline "Hits target" label unchanged. */}
+          {goalFitSubstituted && option.goalProbability != null && (
+            <p
+              className={`${typography.panelMeta} text-text-light`}
+              data-testid={`goal-fit-substituted-label-${option.id}`}
+            >
+              {GOAL_ANCHOR_COPY.label(goalFitSubstituted)}
+            </p>
+          )}
           <StatBar
             value={option.goalProbability}
-            label="Hits target"
+            // The possessive "Hits target" names the user's OWN target, which
+            // a substituted joint figure does not answer — so that arm is
+            // withheld and the caption above carries the honest name instead.
+            // `null` omits the column rather than emptying it (see StatBar).
+            label={goalFitSubstituted ? null : 'Hits target'}
             // ROADMAP 1.267: the bar length stays (it is the goal
             // probability); only the leader COLOUR is withheld.
             isLeader={isWinner && !designationsWithheld}
             color="info"
             neutralised={neutralised}
           />
-          {/* T6 fix: Warning badge when goal probability is very low (<10%) */}
-          {typeof option.goalProbability === 'number' && option.goalProbability < 0.10 && (
+          {/* T6 fix: Warning badge when goal probability is very low (<10%).
+              ROADMAP 2.282: the badge is the register's COMPACT READOUT slot
+              — "number first, no full stop" — so the withheld arm is
+              `GOAL_ANCHOR_COPY.phrase(...)` verbatim, no adapted wording. The
+              permitted arm keeps the shipped sentence byte-for-byte. The two
+              arms are mutually exclusive by construction: one boolean, one
+              ternary, one readout. */}
+          {lowGoalReadout != null && (
             <div className="flex items-center gap-1.5">
               <span
                 className={`${typography.panelMeta} inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border border-danger/30 text-text-body`}
                 data-testid={`low-goal-warning-${option.id}`}
               >
-                {option.goalProbability < SUB_ONE_PERCENT_FLOOR
-                  ? '< 1% likely to reach target'
-                  : `${Math.round(option.goalProbability * 100)}% likely to reach target`}
+                {goalFitSubstituted
+                  ? GOAL_ANCHOR_COPY.phrase(lowGoalReadout, goalFitSubstituted)
+                  : `${lowGoalReadout} likely to reach target`}
               </span>
             </div>
           )}

--- a/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
+++ b/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
@@ -1,0 +1,273 @@
+/**
+ * OptionCards — THE POSSESSIVE GATE (ROADMAP 2.282).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE DEFECT, WITNESSED LIVE ON STAGING, 2026-08-01
+ * ─────────────────────────────────────────────────────────────────────────
+ * CEE never stamped `goal_threshold_frame` and never wrote the goal node's
+ * `observed_state` baseline, so ISL REFUSED to produce `probability_of_goal`
+ * (`GOAL_THRESHOLD_FRAME_UNSPECIFIED` — "a level threshold compared against
+ * the goal's change-from-origin samples yields a structurally impossible
+ * probability, so probability_of_goal is omitted rather than guessed").
+ *
+ * The threshold is nonetheless auto-materialised as a constraint
+ * (`auto_goal_threshold`) and evaluated against the delta samples anyway, so
+ * `probability_of_joint_goal` arrives populated. `selectGoalProbability`
+ * then substitutes it — `basis: 'joint_goal_substituted'`,
+ * `mayUsePossessiveGoalFraming: false`.
+ *
+ * Six surfaces honour that withhold. `OptionCards` did not: it rendered the
+ * substituted number as "Hits target" and "< 1% likely to reach target",
+ * possessive wording naming a target the number does not answer. On the
+ * witnessed run the shipped 0.0054 answers "is the uplift >= £6M?" while the
+ * user asked "is the uplift >= £2M?" (~0.55) — a ~100x understatement, in
+ * the direction of "this decision is hopeless", delivered in the user's own
+ * possessive voice. The V7 goal lens BESIDE IT rendered the withheld wording
+ * for the very same number, in the same render.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS FIXTURE IS SHAPED THE WAY IT IS
+ * ─────────────────────────────────────────────────────────────────────────
+ * The option rows below are the RAW PRODUCER BYTES from the witnessed run
+ * (`PHASE0-EVIDENCE-2026-07-28/witness-2258-raw/run1b/wire-analysis-2-res.txt`,
+ * `enrichment.option_comparison`) — not values invented to suit the
+ * assertion. `probability_of_joint_goal` present, `goal_probability` and
+ * `probability_of_goal` absent, no `constraint_analysis`,
+ * `goal_fit_basis.scored_from === 'modelled_outcome_distribution'`.
+ *
+ * ⚠ AND THE FLAG IS NOT HAND-SET. `goalFitIsSubstitutedJoint` here is
+ * derived by calling the REAL `selectGoalProbability` on those raw bytes and
+ * reading its `basis`, with the SAME expression `useResultsSectionData` uses
+ * (`basis === 'joint_goal_substituted'`). A hand-set `true` would pin a
+ * boolean this spec invented; this pins the live producer shape through the
+ * real chooser into the real component. Test 1 is the anti-vacuity control
+ * (CLAUDE.md trap 13): it proves the fixture is genuinely IN the state under
+ * test before any copy is asserted about it — if a future selector change
+ * stopped substituting, that control REDs rather than the copy tests passing
+ * by testing nothing.
+ *
+ * RED-first: tests 2 and 3 fail at `fef179ce` (the tip this was written
+ * against), where the rendered card carries "< 1% likely to reach target"
+ * and "Hits target".
+ *
+ * Mutual exclusivity is pinned in BOTH directions: tests 4 and 5 supply a
+ * REAL `probability_of_goal` on the identical payload and require the
+ * possessive wording to SURVIVE. A fix that simply deleted the possessive
+ * copy would pass 2 and 3 and fail 4 and 5.
+ *
+ * Scope limit (CLAUDE.md trap 3): jsdom proves PRESENCE and ABSENCE of
+ * strings in the rendered output. It proves nothing about layout, wrapping
+ * or visibility.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+import { GOAL_ANCHOR_COPY } from '../utils/goalAnchorCopy'
+import {
+  selectGoalProbability,
+  type GoalProbabilityInput,
+} from '../utils/selectGoalProbability'
+
+/** The two possessive forms this card shipped, quoted for the assertions. */
+const POSSESSIVE_BAR_LABEL = 'Hits target'
+const POSSESSIVE_BADGE_TAIL = 'likely to reach target'
+
+/**
+ * The five options exactly as the producer sent them on the witnessed run.
+ * Kept as the raw wire shape (snake_case, producer field names) because that
+ * is what `selectGoalProbability` consumes — mapping them by hand first
+ * would put a reimplementation between the evidence and the assertion.
+ */
+const WITNESSED_PRODUCER_OPTIONS: ReadonlyArray<
+  GoalProbabilityInput & { option_id: string; label: string; win_probability: number }
+> = [
+  {
+    option_id: 'opt_hybrid',
+    label: 'Hybrid: Moderate Price Rise + New Channels',
+    win_probability: 0.4242199999999999,
+    probability_of_joint_goal: 0.0054,
+    goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  },
+  {
+    option_id: 'opt_new_channels',
+    label: 'Expand into New Sales Channels',
+    win_probability: 0.06275333333333334,
+    probability_of_joint_goal: 0.0018,
+    goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  },
+  {
+    option_id: 'opt_price_increase',
+    label: 'Raise Prices Across Product Lines',
+    win_probability: 0.14703666666666668,
+    probability_of_joint_goal: 0.0001,
+    goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  },
+  {
+    option_id: 'opt_sales_push',
+    label: 'Aggressive Sales & Marketing Push',
+    win_probability: 0.3516200000000001,
+    probability_of_joint_goal: 0.0009,
+    goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  },
+  {
+    option_id: 'opt_status_quo',
+    label: 'Continue Current Activities (Status Quo)',
+    win_probability: 0.014369999999999996,
+    probability_of_joint_goal: 0,
+    goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+  },
+]
+
+/** The witnessed outcome distributions, in the same wire order. */
+const WITNESSED_OUTCOMES = [
+  { mean: 0.29154567698619926, p10: 0.025710384846958232, p50: 0.29398102336776166, p90: 0.5549520306467898 },
+  { mean: 0.2598664187491496, p10: 0.025978776107274636, p50: 0.2590512530425989, p90: 0.49750823188643584 },
+  { mean: 0.22474601439768335, p10: -0.01286168520096562, p50: 0.23742923214536393, p90: 0.4427062511108739 },
+  { mean: 0.26910334664085706, p10: 0.037108037935912205, p50: 0.2727971439915111, p90: 0.4933236377564564 },
+  { mean: 0.18532435319408924, p10: 0.009734954649756239, p50: 0.19174522198351251, p90: 0.35000594277527003 },
+]
+
+/**
+ * The hook's mapping, and ONLY the hook's mapping.
+ *
+ * `goalProbability`, `goalFitIsModelledBasis` and `goalFitIsSubstitutedJoint`
+ * all come out of the real selector's return value — the last one via the
+ * exact expression at `useResultsSectionData.ts` ("Which quantity
+ * `goalProbability` actually IS, carried to the render layer"). Nothing about
+ * the substitution decision is re-derived here.
+ */
+function toOptionResults(
+  producerOptions: ReadonlyArray<
+    GoalProbabilityInput & { option_id: string; label: string; win_probability: number }
+  >,
+): OptionResult[] {
+  return producerOptions.map((prob, i) => {
+    const goalDecision = selectGoalProbability(prob)
+    return {
+      id: prob.option_id,
+      label: prob.label,
+      expected: WITNESSED_OUTCOMES[i].mean,
+      outcome: WITNESSED_OUTCOMES[i],
+      isRecommended: i === 0,
+      winProbability: prob.win_probability,
+      nValidSamples: 10000,
+      goalProbability: goalDecision.goalProbability,
+      goalFitIsModelledBasis: goalDecision.goalFitIsModelledBasis,
+      goalFitIsSubstitutedJoint: goalDecision.basis === 'joint_goal_substituted',
+    } as OptionResult
+  })
+}
+
+/** The witnessed payload with a REAL goal probability added per option. */
+function withRealGoalProbability(value: number) {
+  return WITNESSED_PRODUCER_OPTIONS.map((o) => ({ ...o, probability_of_goal: value }))
+}
+
+function renderCards(options: OptionResult[]) {
+  return render(
+    <OptionCards options={options} winnerId="opt_hybrid" hasGoalThreshold />,
+  )
+}
+
+describe('OptionCards — possessive gate on a substituted joint goal figure (ROADMAP 2.282)', () => {
+  it('control: the witnessed payload really does drive the selector to `joint_goal_substituted` (so the copy tests below are not vacuous)', () => {
+    const decisions = WITNESSED_PRODUCER_OPTIONS.map((o) => selectGoalProbability(o))
+
+    for (const d of decisions) {
+      expect(d.basis).toBe('joint_goal_substituted')
+      expect(d.mayUsePossessiveGoalFraming).toBe(false)
+    }
+    // The substituted VALUE is the joint figure, unchanged — the fix is a
+    // copy switch, and this control would catch a "fix" that suppressed the
+    // number instead of the framing.
+    expect(decisions[0].goalProbability).toBe(0.0054)
+
+    // And it survives the hook's mapping into the prop the card reads.
+    const mapped = toOptionResults(WITNESSED_PRODUCER_OPTIONS)
+    expect(mapped.every((o) => o.goalFitIsSubstitutedJoint === true)).toBe(true)
+    expect(mapped[0].goalProbability).toBe(0.0054)
+  })
+
+  it('RED-first: the low-goal badge does NOT say "likely to reach target" over a substituted joint figure', () => {
+    const { container } = renderCards(toOptionResults(WITNESSED_PRODUCER_OPTIONS))
+    const text = container.textContent ?? ''
+
+    // The witnessed string, verbatim.
+    expect(text).not.toContain('< 1% likely to reach target')
+    expect(text).not.toContain(POSSESSIVE_BADGE_TAIL)
+
+    // The badge still renders, still carries the number, and now names the
+    // quantity it actually is — the register's compact readout, verbatim.
+    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('< 1%', true))
+  })
+
+  it('RED-first: the goal bar does NOT carry the possessive "Hits target" label over a substituted joint figure', () => {
+    const { container } = renderCards(toOptionResults(WITNESSED_PRODUCER_OPTIONS))
+    const text = container.textContent ?? ''
+
+    expect(text).not.toContain(POSSESSIVE_BAR_LABEL)
+    // Replaced by the register's label form — the same string `WinGauge`'s
+    // goal block renders for the same state.
+    expect(text).toContain(GOAL_ANCHOR_COPY.label(true))
+    // Exactly one caption per RENDERED card. The count is DERIVED from the
+    // DOM rather than hard-coded to the five fixture options, because
+    // `OptionCards` truncates to `TOP_N` behind a "Show all" toggle — a
+    // literal 5 here would be a hand-maintained mirror of a constant this
+    // spec does not own (CLAUDE.md trap 12), and it would silently become
+    // the wrong number the day that constant moves.
+    const renderedCards = container.querySelectorAll('[data-testid^="option-card-"]')
+    expect(renderedCards.length).toBeGreaterThan(0)
+    expect(container.querySelectorAll('[data-testid^="goal-fit-substituted-label-"]'))
+      .toHaveLength(renderedCards.length)
+  })
+
+  it('positive control: a REAL probability_of_goal KEEPS the possessive "Hits target" label and renders no withheld caption', () => {
+    // 0.55 is the honest answer the witness derived for the leading option
+    // once the frame is stamped ("is the uplift >= £2M?").
+    const options = toOptionResults(withRealGoalProbability(0.55))
+    expect(options.every((o) => o.goalFitIsSubstitutedJoint === false)).toBe(true)
+
+    const { container } = renderCards(options)
+    const text = container.textContent ?? ''
+
+    expect(text).toContain(POSSESSIVE_BAR_LABEL)
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.label(true))
+    expect(container.querySelectorAll('[data-testid^="goal-fit-substituted-label-"]'))
+      .toHaveLength(0)
+  })
+
+  it('positive control: a REAL probability_of_goal below the low-goal threshold KEEPS the possessive badge wording', () => {
+    // Below 0.10 so the badge branch is exercised in this arm too — without
+    // this the badge's possessive wording would be pinned in one direction
+    // only, and deleting it outright would still pass.
+    const options = toOptionResults(withRealGoalProbability(0.055))
+    expect(options.every((o) => o.goalFitIsSubstitutedJoint === false)).toBe(true)
+
+    const { container } = renderCards(options)
+    const text = container.textContent ?? ''
+
+    expect(text).toContain(`6% ${POSSESSIVE_BADGE_TAIL}`)
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('6%', true))
+    expect(container.querySelectorAll('[data-testid="low-goal-warning-opt_hybrid"]'))
+      .toHaveLength(1)
+  })
+
+  it('the two arms are mutually exclusive: no render shows both voices at once', () => {
+    for (const options of [
+      toOptionResults(WITNESSED_PRODUCER_OPTIONS),
+      toOptionResults(withRealGoalProbability(0.055)),
+    ]) {
+      const { container, unmount } = renderCards(options)
+      const text = container.textContent ?? ''
+      const possessive = text.includes(POSSESSIVE_BADGE_TAIL) || text.includes(POSSESSIVE_BAR_LABEL)
+      const withheld =
+        text.includes(GOAL_ANCHOR_COPY.label(true)) ||
+        text.includes(GOAL_ANCHOR_COPY.phrase('< 1%', true)) ||
+        text.includes(GOAL_ANCHOR_COPY.phrase('6%', true))
+      expect(possessive).toBe(!withheld)
+      unmount()
+    }
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.goalProbability.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.goalProbability.spec.ts
@@ -96,6 +96,26 @@ function adaptedGoalProbabilities(): Record<string, number | null | undefined> {
   return out
 }
 
+/**
+ * ROADMAP 2.282 — the same hook render, reading the OTHER field the adapter
+ * publishes for each option.
+ *
+ * Every assertion above reads `goalProbability` and none reads
+ * `goalFitIsSubstitutedJoint`, so `useResultsSectionData.ts:1593` — the SOLE
+ * production expression that decides whether OptionCards may use possessive
+ * goal framing — was never executed by any spec on a substituted or a
+ * constrained payload. The surface tests pin the render given the flag; this
+ * pins the flag itself, through the real hook and the real adapter.
+ */
+function adaptedSubstitutedFlags(): Record<string, boolean | undefined> {
+  const { result } = renderHook(() => useResultsSectionData())
+  const out: Record<string, boolean | undefined> = {}
+  for (const o of result.current.recommendation?.allOptions ?? []) {
+    out[o.id] = o.goalFitIsSubstitutedJoint
+  }
+  return out
+}
+
 describe('useResultsSectionData — goalProbability collapse — gate ON (default)', () => {
   beforeEach(() => {
     mockTrust.suspect = true
@@ -204,5 +224,97 @@ describe('useResultsSectionData — goalProbability collapse — POSITIVE CONTRO
     const probs = adaptedGoalProbabilities()
     expect(probs.opt_a).toBe(0.2)
     expect(probs.opt_b).toBe(0.7)
+  })
+})
+
+/**
+ * ROADMAP 2.282 — THE POSSESSIVE GATE'S SOURCE EXPRESSION.
+ *
+ * `useResultsSectionData.ts:1593` is:
+ *
+ *   goalFitIsSubstitutedJoint: goalDecision.basis === 'joint_goal_substituted'
+ *
+ * It is the ONLY production expression that sets the flag OptionCards gates
+ * its goal copy on, and before this block no spec executed it on either of
+ * the two bases that discriminate. The surface specs
+ * (`substitutedJointGate.optionCards.spec.tsx`) necessarily REBUILD this
+ * expression in their fixture factory to construct an `OptionResult`, so they
+ * would keep passing if `:1593` were widened or inverted — the textual-mirror
+ * failure mode #555 hit in this repo the same day (CLAUDE.md trap 11: test
+ * the real thing, not a restatement of its predicate).
+ *
+ * The gate must be ON-substituted and OFF-constrained, and NOTHING else
+ * distinguishes those two payloads but `constraint_analysis`. Both arms run
+ * with `mockTrust.suspect = false`, because while the UI-SEM-088 honesty gate
+ * is ON the selector never substitutes at all and every assertion here would
+ * pass by testing nothing (trap 13) — the first test pins exactly that.
+ */
+describe('useResultsSectionData — goalFitIsSubstitutedJoint (ROADMAP 2.282, the gate OptionCards reads)', () => {
+  beforeEach(() => {
+    mockTrust.suspect = false
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as any)
+  })
+
+  it('control: with the UI-SEM-088 gate ON no option is ever flagged substituted (so the arms below are not vacuous)', () => {
+    mockTrust.suspect = true
+    setStoreWithMappedReport(makeV2Response(
+      { probability_of_joint_goal: 0.0054 },
+      { probability_of_joint_goal: 0.0018 },
+    ))
+    const flags = adaptedSubstitutedFlags()
+    expect(flags.opt_a).toBe(false)
+    expect(flags.opt_b).toBe(false)
+    // …and the reason is that nothing was substituted, not that the flag lies.
+    expect(adaptedGoalProbabilities().opt_a).toBeNull()
+  })
+
+  it('SUBSTITUTED: joint present, goal_probability absent, no constraint_analysis → flag TRUE', () => {
+    // The witnessed staging shape (2026-08-01): ISL refused
+    // `probability_of_goal` because `goal_threshold_frame` was never
+    // stamped, and the auto-materialised constraint's joint figure stands in.
+    setStoreWithMappedReport(makeV2Response(
+      { probability_of_joint_goal: 0.0054 },
+      { probability_of_joint_goal: 0.0018 },
+    ))
+    const flags = adaptedSubstitutedFlags()
+    expect(flags.opt_a).toBe(true)
+    expect(flags.opt_b).toBe(true)
+    // The VALUE is still published — the withhold is on the framing only.
+    expect(adaptedGoalProbabilities().opt_a).toBe(0.0054)
+  })
+
+  it('CONSTRAINED: the same joint figure WITH constraint_analysis → flag FALSE (possessive earned)', () => {
+    setStoreWithMappedReport(makeV2Response(
+      {
+        probability_of_joint_goal: 0.2,
+        constraint_analysis: {
+          constraints: [{ constraint_id: 'c1', node_id: 'n1', direction: 'max', threshold: 1 }],
+          joint_probability: 0.2,
+        },
+      },
+      { probability_of_joint_goal: 0.2 },
+    ))
+    const flags = adaptedSubstitutedFlags()
+    // opt_a carries its own constraints → 'joint_goal_constrained'.
+    expect(flags.opt_a).toBe(false)
+    // opt_b has the identical joint number and NO constraints → substituted.
+    // The pair is the discriminator: one payload shape apart, opposite flags.
+    expect(flags.opt_b).toBe(true)
+  })
+
+  it('REAL goal probability → flag FALSE', () => {
+    setStoreWithMappedReport(makeV2Response(
+      { probability_of_goal: 0.55, probability_of_joint_goal: 0.0054 },
+      { probability_of_goal: 0.7 },
+    ))
+    const flags = adaptedSubstitutedFlags()
+    expect(flags.opt_a).toBe(false)
+    expect(flags.opt_b).toBe(false)
   })
 })


### PR DESCRIPTION
## ROADMAP 2.282 — three surfaces stop rendering a substituted joint figure in possessive goal framing

**Build-only lane. Do not merge — adversarial review follows.**

Base: `staging` @ `fef179ce924cf58288b43b2df4c414ce54fc1a0d` (#555).

> **⚠ SCOPE GREW AFTER THE FIRST PUSH, DELIBERATELY.** The brief named `OptionCards.tsx` as "one unwired consumer", following the witness. The required consumer sweep found that framing **too narrow**: three more production surfaces render possessive goal framing over the same substituted figure. Two of them (`GoalPanel`, `OptionNode`) are the same simple pattern and are **now gated in this PR**. The third (`GoalNode`) is **not** the simple pattern and is **deliberately left un-gated** — see [GoalNode is deferred, on purpose](#goalnode-is-deferred-on-purpose). Do not read it as a missed surface.
>
> **Gated here:** `OptionCards.tsx` · `GoalPanel.tsx` · `OptionNode.tsx`. **Deferred:** `GoalNode.tsx`.

### The defect, witnessed live

Evidence: `PHASE0-EVIDENCE-2026-07-28/witness-2258-goal-probability-live.md` §10, raw payloads in `witness-2258-raw/run1b/`.

CEE never stamped `goal_threshold_frame` and never wrote the goal node's `observed_state` baseline, so ISL **refused** `probability_of_goal` by design (`GOAL_THRESHOLD_FRAME_UNSPECIFIED` — *"probability_of_goal is omitted rather than guessed"*). The threshold is nonetheless auto-materialised as a constraint (`auto_goal_threshold`) and evaluated against the delta samples anyway, so `probability_of_joint_goal` arrives populated and `selectGoalProbability` substitutes it: `basis: 'joint_goal_substituted'`, `mayUsePossessiveGoalFraming: false`.

On the witnessed run the shipped `0.0054` answers *"is the uplift ≥ £6M?"*, while the user asked *"is the uplift ≥ £2M?"* (≈ `0.55`) — a **~100× understatement**, biased toward "this decision is hopeless", delivered in the user's own possessive voice.

### The one rule the whole PR turns on

**The gate is scoped to `joint_goal_substituted`, never to "the figure is joint."**

`joint_goal_constrained` is the user's own goal **and** the user's own limits — the possessive is *earned* there and is untouched everywhere. This distinction is load-bearing, not decorative: mutants C and E below widen the gate to `goalProbabilityIsJoint` and **break the pre-existing ROADMAP 1.49 control** in `OptionNode.spec.tsx`. A reviewer should check this scoping first.

---

## Surface 1 — `OptionCards.tsx` (the brief's original target)

Had **zero occurrences** of the flag at `fef179ce` — verified `git show fef179ce:src/components/results/OptionCards.tsx | grep -a GOAL_ANCHOR_COPY` → no output. It rendered `StatBar label="Hits target"` and the badge `"< 1% likely to reach target"`. The V7 goal lens beside it rendered the withheld wording for the very same number, in the same render.

| slot | withheld arm | permitted arm (unchanged) |
|---|---|---|
| goal-row caption | `GOAL_ANCHOR_COPY.label(true)` → *"Chance of meeting every target this run scored"*, hoisted to a full-width line above the bar | inline `StatBar label="Hits target"` |
| low-goal badge | `GOAL_ANCHOR_COPY.phrase(readout, true)` → *"< 1% chance of meeting every target this run scored"* | `` `${readout} likely to reach target` `` |

**One structural adaptation, stated explicitly.** `StatBar`'s label lives in a fixed `w-[72px]` column at 11px (`typography.panelMeta`). The withheld label is 45 characters and would wrap to four or five lines there. So the withheld state **hoists the label to a full-width line above the bar and omits the inline column** (`label={null}`) — precisely the shape `WinGauge`'s goal block already uses to render *the same register string* (`win-gauge-goal-heading`). Existing sibling pattern, not a new one.

## Surface 2 — `GoalPanel.tsx` (the sharpest instance)

`GoalPanel` already refuses to be a **chooser** (#496 deleted its reach-around; it calls `selectGoalProbability` and renders what it is given). It was still being a **narrator**: it destructured `.goalProbability` and `.jointGoalProbability` and walked straight past `.basis`.

**⚠ And it contradicted itself about the same number.** Under substitution the selector returns `goalProbability === jointGoalProbability` **by construction** (`goalProbabilityIsJoint ⇒ goalProbability = jointGoalProb`). So the Impact block stated one value twice, in two incompatible voices — `"{N}% chance of success"` directly above `"Chance of hitting every target: {N}%"`. A reader had no way to tell those were one measurement, and exactly one of the two sentences was true. The pristine RED-first output captures it verbatim: `'Impact1%1% chance of successBased on …'`.

| site | withheld arm | permitted arm (unchanged) |
|---|---|---|
| `:278` success-target line | `` `${GOAL_ANCHOR_COPY.phrase(pct, true)}, based on the current model.` `` | *"{N}% chance of reaching this target based on the current model."* |
| `:505` Impact readout | `GOAL_ANCHOR_COPY.phrase(pct, true)` | *"{N}% chance of success"* |
| `:514` joint line | **suppressed** — it *is* the number above, now stated in these exact words | rendered (genuinely a different quantity on every other basis) |
| `:517` techMode | `probability_of_joint_goal (substituted for absent probability_of_goal)` | `probability_of_goal` |

The techMode line was the most *literally* false in the block — it named the value `probability_of_goal` when `probability_of_goal` is precisely the field ISL refused to emit, and it is the line a tech-mode reader trusts most.

**⚠ Precision on the "no new copy" claim — corrected in adversarial review.** An earlier draft of this body said the only new characters were a joining comma; that **understated it**. The truthful split:

- **User-voice copy: no invention at all.** Every string a user reads on all three surfaces is existing `GOAL_ANCHOR_COPY` output, verbatim. The single new character in user-voice copy is the **joining comma** at `:278` (the register's `phrase()` form is deliberately full-stop-free so a trailing clause can be appended). This claim was verified in review and stands.
- **Developer-voice diagnostic: genuinely new text.** The techMode withheld arm (`GoalPanel.tsx:556`) adds a new **45-character parenthetical** — `(substituted for absent probability_of_goal)` — which is not register output and was written for this PR. It renders only behind `techMode`, never to an ordinary user, but it is new copy and is named here rather than folded into "just a comma".

## Surface 3 — `OptionNode.tsx`

The canvas badge `"< {N}% chance of target."` gated on `goalDecision?.goalFitIsModelledBasis` — a **different** flag — and never on the basis. `goalDecision` was already in scope, so this is the plain pattern.

| slot | withheld arm | permitted arm (unchanged) |
|---|---|---|
| goal badge | `GOAL_ANCHOR_COPY.sentence(readout, true)` → *"< 1% chance of meeting every target this run scored."* | `` `${readout} chance of target.` `` |

Every permitted arm across all three surfaces is **byte-identical** to the string it replaced; the readout is built once above both arms so the two voices can never show different numbers for one option.

### <a name="goalnode-is-deferred-on-purpose"></a>⚠ GoalNode is deferred, on purpose — not missed

`src/canvas/nodes/GoalNode.tsx:353` renders *"{N}% chance of reaching target"* and **remains un-gated after this PR.**

**Mechanism:** the value reaches it through `useNodeDisplayMetadata`, which **drops the basis**. That hook returns only `achievementProbability` (`:364`) and `achievementProbabilityIsModelledBasis` (`:365`) — the latter set from `decision.goalFitIsModelledBasis` at `:290`, where `decision.basis` is read and discarded. So `basis` / `goalFitIsSubstitutedJoint` is **not available at the render site at all**. Gating it is not a wiring change; it requires widening that hook's return type — a structural change to a hook #555 has just touched. Rowed separately per the coordinator. Attempting it here would have been the "forcing it" the brief warned against.

*(Field name corrected in adversarial review: the hook's field is `achievementProbabilityIsModelledBasis`, not `goalFitIsModelledBasis` — that is the selector-side name it is assigned from. Mechanism identical either way.)*

---

## RED-first

All specs drive the **real `selectGoalProbability`** on the witnessed producer shape and render the **real components**. No flag is hand-set anywhere; each spec derives it from the chooser's own `basis`, the same expression `useResultsSectionData.ts:1593` uses. (The #555 trap-11 lesson in this repo: the predicate under test is the component's wiring, not a reimplementation of it.)

| spec | tests | RED at pristine `fef179ce` |
|---|---|---|
| `src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx` (new) | 6 | **2 fail** |
| `src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx` (new) | 7 | **4 fail** |
| `src/canvas/nodes/__tests__/OptionNode.spec.tsx` (3 tests added to the existing suite, reusing its harness) | +3 | **1 fail** |
| `src/components/results/__tests__/useResultsSectionData.goalProbability.spec.ts` (+4, added in review) | +4 | n/a — pins the unchanged source expression, see below |

### The hook pin added in adversarial review

Review caught a real gap, before it bit: **`useResultsSectionData.ts:1593` is the sole production expression that sets the flag OptionCards gates on, and no spec executed it on a substituted or a constrained payload.** The OptionCards surface spec necessarily *rebuilds* that expression in its fixture factory to construct an `OptionResult`, so it would keep passing if `:1593` were widened or inverted — the textual-mirror failure mode #555 hit in this repo the same day (trap 11).

Four `renderHook` tests now drive the real hook and the real V2 adapter:

| payload | expected flag |
|---|---|
| joint present, `goal_probability` absent, no `constraint_analysis` (the witnessed shape) | **true** |
| same joint figure **with** `constraint_analysis` | **false** (possessive earned) |
| real `probability_of_goal` | **false** |
| UI-SEM-088 honesty gate ON | **false** for all — anti-vacuity control, proves the arms above are not passing by never substituting |

The constrained test is the discriminator: `opt_a` and `opt_b` carry the **identical** joint number and differ only by `constraint_analysis`, and the spec requires **opposite** flags.

**Mutants on `:1593` itself** (pristine `fef179ce` + the new spec, throwaway clone; the source file is otherwise untouched by this PR):

| mutant | change | result |
|---|---|---|
| F | `goalDecision.goalProbabilityIsJoint` (widen) | **RED** — constrained test, `expected true to be false` |
| G | `false` (unwire) | **RED** — substituted test + the constrained pair's `opt_b` arm |

Restore → **11/11 green**.

Verified in throwaway clones at pristine `fef179ce` with `git status --porcelain` proving the three components unmodified, specs copied in. Failure messages quote the exact witnessed strings (`'< 1% likely to reach target'`, `'Hits target'`, `'chance of reaching this target'`, `'chance of success'`).

**Anti-vacuity control in every spec** (trap 13): each suite first asserts its fixture genuinely reaches the basis it claims — and, for the OptionNode pair, that the *neighbouring* fixture is genuinely `joint_goal_constrained`. Without that, every absence assertion could pass by having stopped reaching the branch under test.

**Positive controls pass at pristine too**, which is the point: they pin that possessive wording must **survive** a real `probability_of_goal` and a constrained joint basis, so a "fix" that merely deleted the possessive copy fails them.

## Mutation

Throwaway clones at `/private/tmp/ui-2282-redfirst*` — **outside the repo root** (trap 9c), removed after. Patch applied → green, then each mutant applied to that green tree, every one through the real render path.

**OptionCards** (6/6 green → mutate):

| mutant | change | result |
|---|---|---|
| 1 | `goalFitSubstituted = false` (unwire) | **RED** — badge + bar-label tests |
| 2 | badge arm only reverted | **RED** — badge test + mutual-exclusivity |
| 3 | caption/label arm only reverted | **RED** — bar-label test + mutual-exclusivity |
| 4 | `goalFitSubstituted = true` (inverted) | **RED** — both positive controls |

**GoalPanel + OptionNode** (83/83 green → mutate):

| mutant | change | result |
|---|---|---|
| A | GoalPanel `goalFitSubstituted = false` (unwire) | **RED** — 4 tests |
| B | GoalPanel `= true` (inverted) | **RED** — both positive controls |
| C | GoalPanel `= goalDecision.goalProbabilityIsJoint` (widen to any joint basis) | **RED** — the constrained positive control |
| D | OptionNode `= false` (unwire) | **RED** — the withhold test |
| E | OptionNode `= goalProbabilityIsJoint` (widen to any joint basis) | **RED** — **the pre-existing ROADMAP 1.49 control** + the new constrained control |

Restore → **6/6 and 83/83 green**.

**Mutant E is the one to read.** Widening the gate from `joint_goal_substituted` to "any joint basis" breaks a control that predates this PR — independent evidence that the basis-scoping is correct and that the constrained case was not collateral damage.

## Gates

| gate | result |
|---|---|
| `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) | **PASS** — coverage 3138/3178 tracked files (40 declared out of scope); ratchet **2505 errors, baseline 2505 — exactly at baseline**, no `--update-baseline` |
| `pnpm lint` | **0 errors**; 1261 warnings, **unchanged from base** |
| `lint:hooks-ratchet` | **PASS** — 234 known violations across 16 files, exactly matching baseline |
| `vitest run src/components/results src/canvas src/hooks` | **see the CI run on this PR** (local run recorded in the lane report) |
| CI at the first head (`8188f179`, OptionCards only) | **13/13 green** incl. required `Staging Gate`, all 4 full-suite shards |

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were set for every measurement (trap 2b).

**No existing spec needed changing.** `OptionNode.spec.tsx`'s ROADMAP 1.49 control is the **constrained** case (it carries `constraint_analysis`), so it is outside the gate and stays green untouched. `GoalPanel.simulationCount.spec.tsx` uses a real `probability_of_goal: 0.62`, likewise green. The only edit to an existing spec file is **three added tests**, no assertion altered.

## Consumer manifest at this SHA

Scope searched: `src/**` only. All greps used `-a` (trap 17); zero `.ts/.tsx/.js/.jsx` files under `src/` carry NUL bytes. 51 non-test production files read the owned producer fields (`goal_probability` / `probability_of_goal` / `probability_of_joint_goal`) or the flag.

**Renders goal-probability copy AND consults the substituted basis (9 after this PR):**

| file | consulted at |
|---|---|
| `results/OptionCards.tsx` | **this PR** |
| `canvas/ui/inspector-v2/panels/GoalPanel.tsx` | **this PR** |
| `canvas/nodes/OptionNode.tsx` | **this PR** |
| `results/WinGauge.tsx` | `:253` |
| `results/DecisionConfidencePanel.tsx` | `:171` |
| `results/RangeVisualization.tsx` | `:136` |
| `results/analysis-hero/buildHeroModel.ts` | `:340` |
| `results/v7/buildV7Headline.ts` | `:166` |
| `results/v7/V7LensGroup.tsx` | `:269`, `:279` |

Plumbing carrying the flag correctly: `useResultsSectionData.ts:1593` (sole producer), `ResultsBody.tsx:519`, `buildV7Lenses.ts:219`. Copy tables parameterised on it: `goalAnchorCopy.ts`, `heroCopy.ts`, `v7LensCopy.ts`.

**Live possessive render sites remaining un-gated in production — the complete list:**

1. **`canvas/nodes/GoalNode.tsx:353`** — deliberately deferred, mechanism above. **The only un-gated surface with a confirmed live render path.**

**Previously "liveness unconfirmed" — both RESOLVED DEAD in adversarial review:**

2. `canvas/components/DecisionSummary.tsx:422-436` — *"{N}% chance of reaching {threshold} for {goalLabel}"*, `goalLabel` falling back to the literal `'your goal'` (`:274`).
3. `hooks/useResultsPanelData.ts:330` — `goalLabel: … || 'your goal'`, no basis read.

Review resolved both: **type-only importers, zero call sites.** Their un-gated possessives therefore have **zero blast radius** — a claim with no reader cannot mislead anyone (the reader-manifest discipline of CLAUDE.md trap 10). Dead-file cleanup is rowed separately, not done here.

**So after this PR the complete list of live, reachable, un-gated possessive goal surfaces in `src/**` is exactly one: `GoalNode.tsx:353`, deferred with the mechanism above.**

**Checked and judged clear (no possessive claim over a probability):** `GoalTargetNudge.tsx:61` (pre-analysis unlock nudge, renders no number) · `DefineSuccessModal.tsx:80` · `humaniseCritique.ts:144,170` (direction-confirmation prose, no goal figure) · `groupActionItems.ts:225` · `DotProgression.tsx:41` (bare `Target` noun on a dot row — the closest call) · `NodeInspector.tsx:481` · `OutcomeNode.tsx:147` · `TransitionCard.tsx:113` · `RunPairCompare.tsx:174-178` · `SuccessTargetRow.tsx:159` · `model-tab/**` (no reader) · `canvas/share/**` and `components/debug/**` (no goal-probability render anywhere — export/share surfaces clean).

**Precise claim type.** This is a *static* reading of JSX branches over the stated glob — not an executed-coverage claim. It supports: *"within `src/**` at this SHA, these files read the named fields, and these are the ones whose user-facing copy is un-gated."* It does not prove any listed surface is reachable in a given product flow.

## Bycatch — flagged, not fixed

- **`analysis-hero/__tests__/stagingScenario.spec.tsx` is internally inconsistent about this very state.** Its docstring (`:9`) says the run is *"probability_of_joint_goal = 0 for every option (auto goal threshold)"* — the substituted case — and its hero assertion (`:191`) pins the **substituted** wording. But `STAGING_OPTIONS` sets `goalProbability: 0` with **no `goalFitIsSubstitutedJoint`**, so its OptionCards assertion (`:220`) pins the **possessive** *"< 1% likely to reach target"*. Two bases asserted about one payload in one file. Left green and unmodified here; setting the flag would flip an existing spec's assertions and deserves its own review.
- `GoalPanel.tsx:514` hardcodes *"Chance of hitting every target"* while `:379` renders the identical string from `GOAL_CONSTRAINT_COPY.jointProbability`. Duplicated copy, one of two sites unregistered.
- `results/modals/HowComputedModal.tsx:58,86` — static explainer prose quoting *"Chance of hitting your goal"* as the name of the panel's goal figure. Reads no probability, so outside the literal claim, but it now describes a label a substituted run does not show.
- `analysis-hero/fixtures/galleryModels.ts:103-166` — gallery fixture strings *"{N}% chance of hitting your goal."*; demo data, not a live surface.

## Not verified

- **Layout.** jsdom pins string presence/absence only (trap 3). Unverified on all three surfaces: `OptionCards`' hoisted caption (line count, card height, alignment against the sibling `goalFitIsModelledBasis` caveat); `GoalPanel`'s Impact block now that the joint line is suppressed; `OptionNode`'s longer badge inside a fixed-width canvas node — **the last is the most likely to need a look**, since the withheld sentence is materially longer than *"< 1% chance of target."* and lives on a node with a layout-driven width. **Wants one browser pass before merge.**
- The witness's `< 1%` strings were proven present in `innerText`, not painted; that limitation is inherited.
- No staging deploy or live re-witness was performed — this lane is build-only.
- `DecisionSummary.tsx` liveness (manifest item 2) is genuinely unresolved, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
