### PR TITLE
fix(ui): 2.296 batch — five Codex-audit defects on POC demo surfaces [DO NOT MERGE, review lane]

### DIFF
--- a/src/canvas/components/__tests__/ModelTabBody.goalDiscuss.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.goalDiscuss.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * ROADMAP 2.296 C1 — the Model tab Goal card's "Discuss with AI" action.
+ *
+ * THE DEFECT (#553): `GoalSection`'s outer wrapper was rewritten to accept and
+ * forward ONLY `goalNode` — `export function GoalSection({ goalNode }:
+ * GoalSectionProps)` — while `ModelTabBody` still supplies `onSendMessage`
+ * (ModelTabBody.tsx `<GoalSection goalNode={...} onSendMessage={onSendMessage} />`).
+ * `GoalSectionInner` renders the Discuss button only under `{onSendMessage &&
+ * ...}`, so the action silently vanished from the goal card while every
+ * sibling section (Options, Factors, Relationships, Risks) kept its own.
+ *
+ * RED-first: these tests render the REAL ModelTabBody→GoalSection path — not
+ * GoalSectionInner directly — because the defect lives in the wrapper hop. At
+ * the pristine tip the `goal-discuss` testid is absent from the document.
+ *
+ * CLAIM TYPE: jsdom presence/click-wiring only — never layout or visibility
+ * (trap 3).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModelTabBody } from '../ModelTabBody'
+import type { Node } from '@xyflow/react'
+
+// ── Mocks (same shape as ModelTabBody.spec.tsx) ───────────────────────────────
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+function getMockState() {
+  return {
+    nodes: mockGraph.nodes,
+    edges: mockGraph.edges,
+    updateNode: vi.fn(),
+    updateEdge: vi.fn(),
+    ceePipelineTrace: null,
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+    currentScenarioId: null,
+    currentStage: null,
+    graphEditedSinceLastRun: false,
+  }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(getMockState())),
+    { getState: getMockState },
+  ),
+}))
+
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeGoalNode(id = 'goal-1', label = 'Maximise Revenue'): Node {
+  return { id, type: 'goal', position: { x: 0, y: 0 }, data: { label } }
+}
+
+const DEFAULT_PROPS = {
+  showDebug: false,
+  hasDiagnostics: false,
+  diagnostics: null,
+  hasTrim: false,
+  effectiveCorrelationId: null,
+  correlationMismatch: false,
+  correlationIdHeader: null,
+  robustness: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Goal section Discuss with AI — real ModelTabBody→GoalSection path (2.296 C1)', () => {
+  it('RED-first: the goal card renders the Discuss action when ModelTabBody supplies onSendMessage', () => {
+    const onSendMessage = vi.fn()
+    render(
+      <ModelTabBody
+        {...DEFAULT_PROPS}
+        nodes={[makeGoalNode()]}
+        edges={[]}
+        onSendMessage={onSendMessage}
+      />,
+    )
+    // Anti-vacuity (trap 13): the goal section itself is on screen, so the
+    // absence of the button below cannot mean "the card never rendered".
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+    // The defect: #553's wrapper dropped the callback, so this was absent.
+    expect(screen.getByTestId('goal-discuss')).toBeInTheDocument()
+  })
+
+  it('clicking the Discuss action sends a message naming the goal', () => {
+    const onSendMessage = vi.fn()
+    render(
+      <ModelTabBody
+        {...DEFAULT_PROPS}
+        nodes={[makeGoalNode('g1', 'Maximise Revenue')]}
+        edges={[]}
+        onSendMessage={onSendMessage}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('goal-discuss'))
+    expect(onSendMessage).toHaveBeenCalledTimes(1)
+    expect(String(onSendMessage.mock.calls[0][0])).toContain('Maximise Revenue')
+  })
+
+  it('control: with no onSendMessage supplied, no Discuss action renders', () => {
+    // Guards the fix's shape: forwarding must remain conditional pass-through,
+    // never a fabricated default handler.
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={[makeGoalNode()]} edges={[]} />)
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('goal-discuss')).toBeNull()
+  })
+})

--- a/src/canvas/components/model-tab/GoalSection.tsx
+++ b/src/canvas/components/model-tab/GoalSection.tsx
@@ -232,14 +232,22 @@ function GoalSectionInner({ goalNode, onSendMessage }: GoalSectionProps & { goal
   )
 }
 
-export function GoalSection({ goalNode }: GoalSectionProps) {
+export function GoalSection({ goalNode, onSendMessage }: GoalSectionProps) {
   // The absence guard lives HERE, in a component with no hooks, so an arriving
   // or departing goal node mounts/unmounts the inner component rather than
   // changing its hook count mid-render. See `GoalSectionInner`'s header.
+  //
+  // ROADMAP 2.296 C1: this wrapper MUST forward every prop the inner
+  // component renders on. The #553 rewrite narrowed it to `goalNode` alone,
+  // and because `GoalSectionInner` gates the "Discuss with AI" action on
+  // `onSendMessage`, the action silently vanished from the goal card while
+  // ModelTabBody kept supplying the callback. Pinned by
+  // `__tests__/ModelTabBody.goalDiscuss.spec.tsx` through the REAL
+  // ModelTabBody→GoalSection path — the hop this defect lived in.
   if (!goalNode) return null
   return (
     <SectionErrorBoundary section="goal">
-      <GoalSectionInner goalNode={goalNode} />
+      <GoalSectionInner goalNode={goalNode} onSendMessage={onSendMessage} />
     </SectionErrorBoundary>
   )
 }

--- a/src/canvas/components/model-tab/OptionsSection.tsx
+++ b/src/canvas/components/model-tab/OptionsSection.tsx
@@ -241,14 +241,27 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
       </div>
 
       {/* Conditional winner card (post-analysis only).
-          Cards are attached to the lowBucket winner (overall winner).
-          The highBucket winner is who takes over when the factor exceeds splitValue. */}
+          ROADMAP 2.296 C3 — NO "overall" CLAIM MAY BE MINTED HERE. This card
+          used to attach every entry to the LOW-bucket winner and print "Leads
+          overall, but when {factor} exceeds {split}, {other} takes over". ISL's
+          conditional winners establish ONLY which option wins below and above a
+          median split of one factor; neither bucket winner is necessarily the
+          global leader, so "Leads overall" was a claim the producer never made,
+          handed to whichever option won the low bucket. Each winner's card now
+          states its own bucket's fact, neutrally, and nothing else. */}
       {hasAnalysisData && conditionalWinners && conditionalWinners.map((cw, i) => {
-        // Determine which option takes over: it's the one NOT on this card
-        const takesOverLabel = cw.lowBucket.winnerId === option.id
-          ? cw.highBucket.winnerLabel
-          : cw.lowBucket.winnerLabel
-        if (!takesOverLabel) return null
+        const splitDisplay = cw.splitUnit
+          ? formatValueWithUnit(cw.splitValue, cw.splitUnit)
+          : formatSmartNumber(cw.splitValue)
+        // Exactly one of these holds per card: same-winner entries are
+        // filtered out at the map (they state nothing about leadership
+        // change), and the map only attaches an entry to its bucket winners.
+        const statement = cw.lowBucket.winnerId === option.id
+          ? `Leads when ${cw.factorLabel} is below ${splitDisplay}`
+          : cw.highBucket.winnerId === option.id
+            ? `Leads when ${cw.factorLabel} is above ${splitDisplay}`
+            : null
+        if (!statement) return null
         return (
           <div
             key={`cw-${i}`}
@@ -256,7 +269,7 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
             data-testid={`conditional-winner-${option.id}`}
           >
             <span className={`${typography.panelMeta} text-warning leading-relaxed`}>
-              Leads overall, but when {cw.factorLabel} exceeds {cw.splitUnit ? formatValueWithUnit(cw.splitValue, cw.splitUnit) : formatSmartNumber(cw.splitValue)}, {takesOverLabel} takes over
+              {statement}
             </span>
           </div>
         )
@@ -398,18 +411,28 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
  * code-integrity guard, not crash prevention.
  */
 function OptionsSectionInner({ optionNodes, allNodes, conditionalWinners, hasAnalysisData, onSendMessage, isExpanded, onExpandChange }: OptionsSectionProps) {
-  // Build per-option conditional winner lookup (match on option ID, not label)
+  // Build per-option conditional winner lookup (match on option ID, not label).
+  //
+  // ROADMAP 2.296 C3 — attach each entry to BOTH bucket winners, not to the
+  // low-bucket winner as a fabricated "default option". Each option's card
+  // then states the one conditional fact the producer established about IT
+  // ("leads below the split" / "leads above the split"). Entries whose two
+  // buckets name the SAME winner are skipped: they state nothing about
+  // leadership change (the same filter the results panel's
+  // ConditionalWinnerCards applies).
   const optionWinnerMap = useMemo(() => {
     if (!conditionalWinners) return new Map<string, ConditionalWinner[]>()
     const map = new Map<string, ConditionalWinner[]>()
+    const attach = (winnerOptionId: string | undefined, cw: ConditionalWinner) => {
+      if (!winnerOptionId) return
+      const existing = map.get(winnerOptionId) ?? []
+      existing.push(cw)
+      map.set(winnerOptionId, existing)
+    }
     for (const cw of conditionalWinners) {
-      // Attach to the option that wins in the low bucket (the "default" winner)
-      const winnerOptionId = cw.lowBucket.winnerId
-      if (winnerOptionId) {
-        const existing = map.get(winnerOptionId) ?? []
-        existing.push(cw)
-        map.set(winnerOptionId, existing)
-      }
+      if (cw.lowBucket.winnerId === cw.highBucket.winnerId) continue
+      attach(cw.lowBucket.winnerId, cw)
+      attach(cw.highBucket.winnerId, cw)
     }
     return map
   }, [conditionalWinners])

--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -180,7 +180,22 @@ function EdgeCard({
    * back to `'positive'` by accident.
    */
   const directionDisplay = resolveEdgeDirectionDisplay(data)
-  const strengthStd = data?.strengthStd ?? data?.strength_std
+  /**
+   * ROADMAP 2.296 C4 — the σ/±/Std surfaces are PROVENANCE-GATED, like every
+   * other number on this card. The raw read this replaces
+   * (`data?.strengthStd ?? data?.strength_std`) displayed
+   * `USER_EDGE_DEFAULTS.strengthStd = 0.15` — a constant nobody measured — as
+   * a measured uncertainty on three surfaces (inline σ, ±, the detail Std
+   * row). The registry (`edgeValueProvenance.ts`) names `strengthStd` as
+   * exactly this gap and deliberately declares NO back-compat fallback for a
+   * raw `strength_std`: a producer std is displayable only once its ingestion
+   * site stamps it (as `applyDraftResult` and the inspector's `setStd`
+   * already do). Consequence, stated openly: the legacy raw-spelling read leg
+   * is gone — an unstamped `strength_std` renders nothing rather than
+   * laundering the default.
+   */
+  const strengthStdDisplay = resolveEdgeValueDisplay(data, 'strengthStd')
+  const strengthStd = strengthStdDisplay.show ? strengthStdDisplay.value : undefined
 
   const hasStrength = strengthDisplay.show
   const rawWeight = strengthDisplay.show ? Math.abs(strengthDisplay.value) : undefined

--- a/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
@@ -396,11 +396,17 @@ import { DetailToggleContext } from '../DetailToggleContext'
 
 describe('RelationshipsSection — expert inline data', () => {
   it('shows σ and p on compact row when expert mode ON', () => {
+    // ROADMAP 2.296 C4: `strengthStd` joined the provenance gate, so this
+    // fixture now stamps it — the same evolution this file's own header
+    // documents for weight/belief ("the stamps are what make this fixture a
+    // model of a real edge"). Unstamped, 0.15 is the USER_EDGE_DEFAULTS
+    // fallthrough and correctly renders nothing; the unstamped case has its
+    // own spec in `relationshipsSectionStdProvenance.spec.tsx`.
     const edgeWithStd: Edge = {
       id: 'e1', source: 'f1', target: 'f2',
       data: {
         weight: 0.5, direction: 'positive', beliefExists: 0.8, strengthStd: 0.15, provenance: 'assumption',
-        ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user' }),
+        ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user', strengthStd: 'user' }),
       },
     }
     render(

--- a/src/canvas/components/model-tab/__tests__/optionsSectionConditionalNeutrality.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/optionsSectionConditionalNeutrality.spec.tsx
@@ -1,0 +1,144 @@
+/**
+ * ROADMAP 2.296 C3 — a CONDITIONAL bucket winner may not be crowned "overall".
+ *
+ * THE DEFECT (#553, OptionsSection.tsx conditional-winner card): the section
+ * attached each conditional-winner entry to `lowBucket.winnerId` as "the
+ * default option" and rendered
+ *
+ *   "Leads overall, but when {factor} exceeds {split}, {other} takes over"
+ *
+ * ISL's conditional winners only establish which option wins BELOW and ABOVE a
+ * median split of one factor. Neither bucket winner is necessarily the global
+ * leader — "Leads overall" is a claim the producer never made, attached to
+ * whichever option happened to win the LOW bucket.
+ *
+ * THE FIX: render the two conditional statements neutrally, one on each
+ * winner's card — "Leads when {factor} is below {split}" on the low-bucket
+ * winner, "Leads when {factor} is above {split}" on the high-bucket winner —
+ * with no "overall" claim and no default-option attachment. Entries whose two
+ * buckets name the SAME winner state nothing about leadership change and are
+ * not rendered (same filter the results panel's ConditionalWinnerCards
+ * applies).
+ *
+ * CLAIM TYPE: rendered text via jsdom — presence/absence only, never layout
+ * (trap 3). The 2.263 rule (no bare conditional probability beside the name)
+ * is re-pinned here so this fix cannot regress it.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { OptionsSection, type ConditionalWinner } from '../OptionsSection'
+
+const mockUpdateNode = vi.fn()
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+vi.mock('../../../store', () => {
+  const useCanvasStore = Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector({ updateNode: mockUpdateNode })),
+    { getState: () => ({ ...mockGraph, updateNode: mockUpdateNode }) },
+  )
+  return { useCanvasStore }
+})
+
+vi.mock('../../../utils/focusHelpers', () => ({ focusNodeById: vi.fn() }))
+
+vi.mock('../../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+/** Mapped interventions put the real OptionCard on screen (trap 13). */
+function option(id: string, label: string): Node {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label, interventions: { 'f-adopt': 0.7 } },
+  }
+}
+
+/** One genuine winner-flip split: Option A leads below, Option B above. */
+const CROSS_WINNERS: ConditionalWinner[] = [
+  {
+    factorLabel: 'Adoption rate',
+    factorId: 'f-adopt',
+    splitValue: 0.4,
+    highBucket: { winnerId: 'opt-b', winnerLabel: 'Option B', winProbability: 0.71 },
+    lowBucket: { winnerId: 'opt-a', winnerLabel: 'Option A', winProbability: 0.63 },
+  },
+]
+
+/** Degenerate: the same option wins BOTH buckets — no leadership change. */
+const SAME_WINNER: ConditionalWinner[] = [
+  {
+    factorLabel: 'Adoption rate',
+    factorId: 'f-adopt',
+    splitValue: 0.4,
+    highBucket: { winnerId: 'opt-a', winnerLabel: 'Option A', winProbability: 0.71 },
+    lowBucket: { winnerId: 'opt-a', winnerLabel: 'Option A', winProbability: 0.63 },
+  },
+]
+
+const options = [option('opt-a', 'Option A'), option('opt-b', 'Option B')]
+
+function renderSection(winners: ConditionalWinner[]) {
+  return render(
+    <OptionsSection
+      optionNodes={options}
+      allNodes={[
+        ...options,
+        { id: 'f-adopt', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Adoption rate' } },
+      ]}
+      conditionalWinners={winners}
+      hasAnalysisData
+      isExpanded
+    />,
+  )
+}
+
+describe('OptionsSection — conditional winners rendered neutrally (2.296 C3)', () => {
+  it('RED-first: "Leads overall" appears nowhere', () => {
+    const { container } = renderSection(CROSS_WINNERS)
+    expect(container.textContent).not.toContain('Leads overall')
+  })
+
+  it('RED-first: no "takes over" handover claim survives', () => {
+    const { container } = renderSection(CROSS_WINNERS)
+    expect(container.textContent).not.toContain('takes over')
+  })
+
+  it('RED-first: the HIGH-bucket winner gets its own conditional statement', () => {
+    // At the pristine tip the card is attached to the LOW-bucket winner only,
+    // so Option B — who the producer says leads above the split — showed
+    // nothing at all.
+    renderSection(CROSS_WINNERS)
+    const cardB = screen.getByTestId('conditional-winner-opt-b')
+    expect(cardB.textContent).toContain('Leads when Adoption rate is above 0.4')
+  })
+
+  it('the LOW-bucket winner gets the below-split statement, with no "overall" claim', () => {
+    renderSection(CROSS_WINNERS)
+    const cardA = screen.getByTestId('conditional-winner-opt-a')
+    expect(cardA.textContent).toContain('Leads when Adoption rate is below 0.4')
+    expect(cardA.textContent).not.toContain('overall')
+  })
+
+  it('a same-winner-both-buckets entry renders no conditional card at all', () => {
+    renderSection(SAME_WINNER)
+    expect(screen.queryByTestId('conditional-winner-opt-a')).toBeNull()
+    expect(screen.queryByTestId('conditional-winner-opt-b')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: both option names still render', () => {
+    renderSection(CROSS_WINNERS)
+    expect(screen.getByText('Option A')).toBeInTheDocument()
+    expect(screen.getByText('Option B')).toBeInTheDocument()
+  })
+
+  it('re-pins 2.263: no bucket probability appears as a bare number, and "win" appears nowhere', () => {
+    const { container } = renderSection(CROSS_WINNERS)
+    expect(container.textContent).not.toContain('63%')
+    expect(container.textContent).not.toContain('71%')
+    expect(container.textContent).not.toMatch(/\bwins?\b/i)
+  })
+})

--- a/src/canvas/components/model-tab/__tests__/relationshipsSectionStdProvenance.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/relationshipsSectionStdProvenance.spec.tsx
@@ -1,0 +1,194 @@
+/**
+ * ROADMAP 2.296 C4 — the unsourced `strengthStd` default may not display as a
+ * measured uncertainty.
+ *
+ * THE DEFECT: `RelationshipsSection` read the raw field
+ * (`data?.strengthStd ?? data?.strength_std`) and rendered it on three
+ * surfaces — the collapsed-card inline `σ0.15`, the expanded-card `±0.15`,
+ * and the full-detail "Std" row `0.150`. `USER_EDGE_DEFAULTS.strengthStd =
+ * 0.15` fabricates that number on every user-drawn edge, and the provenance
+ * registry (`edgeValueProvenance.ts`) names `strengthStd` as exactly the gap
+ * this mechanism exists to close: a default must never display as set.
+ *
+ * THE FIX: every Std display surface in this file resolves through
+ * `resolveEdgeValueDisplay(data, 'strengthStd')`, which cannot hand back a
+ * number without a source. Consequence, stated openly: the legacy raw
+ * `strength_std` read-leg is removed. The registry deliberately declares NO
+ * back-compat fallback for std (its own comment: inventing one would launder
+ * the default) — so a raw producer `strength_std` that arrives without a
+ * stamp renders nothing until its ingestion site stamps it, exactly like an
+ * unstamped weight.
+ *
+ * σ/±-rendering surfaces in the touched file, complete manifest at this tip
+ * (rg -an "strengthStd|strength_std" on RelationshipsSection.tsx):
+ *   · :183 the source read (fixed here)
+ *   · :306-308 inline σ chip           (gated by these tests)
+ *   · :387-389 ± beside semantic label (gated by these tests)
+ *   · :441,453-457 full-detail Std row (gated by these tests)
+ * Deliberately NOT in scope, named: ContestedEdgeCard renders
+ * `validation.pass1.strength_std` — a producer-signed validator value that
+ * exists only when CEE sent it, not the edge-data default.
+ *
+ * CLAIM TYPE: jsdom text presence/absence only (trap 3).
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RelationshipsSection } from '../RelationshipsSection'
+import { DetailToggleContext } from '../DetailToggleContext'
+import type { Edge, Node } from '@xyflow/react'
+import { edgeValueSourcePatch } from '../../../domain/edgeValueProvenance'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const { mockStoreState } = vi.hoisted(() => {
+  return {
+    mockStoreState: {
+      updateEdge: vi.fn(),
+      setHighlightedEdges: vi.fn(),
+      setHighlightedNodes: vi.fn(),
+      highlightedEdges: new Set<string>(),
+      edges: [] as unknown[],
+    },
+  }
+})
+
+vi.mock('../../../store', () => {
+  const useCanvasStore = Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(mockStoreState)),
+    { getState: () => mockStoreState },
+  )
+  return { useCanvasStore }
+})
+
+vi.mock('../../../utils/focusHelpers', () => ({
+  focusEdgeById: vi.fn(),
+  focusNodeById: vi.fn(),
+}))
+
+vi.mock('../../../utils/evidenceCoverage', () => ({
+  NON_EVIDENCE_PROVENANCE: ['assumption', 'template', 'ai-suggested'],
+}))
+
+vi.mock('../../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+function makeNode(id: string, label: string): Node {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }
+}
+
+const nodes = [makeNode('f1', 'Factor A'), makeNode('f2', 'Factor B')]
+
+/**
+ * The fallthrough shape a user-drawn edge actually carries: strength and
+ * belief characterised (stamped), `strengthStd: 0.15` present but UNSTAMPED —
+ * the `USER_EDGE_DEFAULTS` constant, which nobody measured.
+ */
+function defaultStdEdge(id: string): Edge {
+  return {
+    id,
+    source: 'f1',
+    target: 'f2',
+    data: {
+      weight: 0.5,
+      direction: 'positive',
+      beliefExists: 0.7,
+      strengthStd: 0.15,
+      provenance: 'assumption',
+      ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user', direction: 'user' }),
+    },
+  }
+}
+
+/** An edge whose std was actually SET — the stamp is what makes it real. */
+function stampedStdEdge(id: string): Edge {
+  return {
+    id,
+    source: 'f1',
+    target: 'f2',
+    data: {
+      weight: 0.5,
+      direction: 'positive',
+      beliefExists: 0.7,
+      strengthStd: 0.32,
+      provenance: 'assumption',
+      ...edgeValueSourcePatch({
+        weight: 'user',
+        beliefExists: 'user',
+        direction: 'user',
+        strengthStd: 'user',
+      }),
+    },
+  }
+}
+
+/** Legacy raw wire spelling only — no `strengthStd`, no stamp. */
+function legacyRawStdEdge(id: string): Edge {
+  return {
+    id,
+    source: 'f1',
+    target: 'f2',
+    data: {
+      weight: 0.5,
+      direction: 'positive',
+      beliefExists: 0.7,
+      strength_std: 0.27,
+      provenance: 'assumption',
+      ...edgeValueSourcePatch({ weight: 'user', beliefExists: 'user', direction: 'user' }),
+    },
+  }
+}
+
+function renderWithDetail(edges: Edge[], showDetail = true) {
+  return render(
+    <DetailToggleContext.Provider value={{ showDetail }}>
+      <RelationshipsSection edges={edges} nodes={nodes} isExpanded />
+    </DetailToggleContext.Provider>,
+  )
+}
+
+describe('RelationshipsSection — σ/±/Std display is provenance-gated (2.296 C4)', () => {
+  it('RED-first: the UNSTAMPED default renders NO inline σ chip (collapsed card, full detail on)', () => {
+    renderWithDetail([defaultStdEdge('e-def')])
+    // Anti-vacuity: the card itself renders, with its characterised strength.
+    expect(screen.getByTestId('edge-card-e-def')).toBeInTheDocument()
+    expect(screen.queryByTestId('edge-e-def-inline-std')).toBeNull()
+  })
+
+  it('RED-first: the UNSTAMPED default renders no ± figure on the expanded card', () => {
+    const { container } = renderWithDetail([defaultStdEdge('e-def')])
+    fireEvent.click(screen.getByTestId('edge-card-e-def'))
+    expect(container.textContent).not.toContain('±0.15')
+  })
+
+  it('RED-first: the UNSTAMPED default renders no full-detail Std value', () => {
+    const { container } = renderWithDetail([defaultStdEdge('e-def')])
+    fireEvent.click(screen.getByTestId('edge-card-e-def'))
+    expect(container.textContent).not.toContain('0.150')
+  })
+
+  it('POSITIVE CONTROL: a stamped std renders on all three surfaces (trap 13)', () => {
+    const { container } = renderWithDetail([stampedStdEdge('e-set')])
+    // Collapsed inline σ chip.
+    expect(screen.getByTestId('edge-e-set-inline-std')).toHaveTextContent('σ0.32')
+    // Expanded card: ± beside the semantic label, and the detail Std row.
+    fireEvent.click(screen.getByTestId('edge-card-e-set'))
+    expect(container.textContent).toContain('±0.32')
+    expect(container.textContent).toContain('0.320')
+  })
+
+  it('the legacy raw `strength_std` spelling no longer displays unstamped (disclosed behaviour change)', () => {
+    // The registry has NO back-compat fallback for std, by design. An
+    // unstamped raw `strength_std` therefore renders nothing — if a producer
+    // path needs it shown, the fix is a stamp at its ingestion site, never a
+    // display-side fallback that would also launder the 0.15 default.
+    const { container } = renderWithDetail([legacyRawStdEdge('e-raw')])
+    expect(screen.getByTestId('edge-card-e-raw')).toBeInTheDocument()
+    expect(screen.queryByTestId('edge-e-raw-inline-std')).toBeNull()
+    fireEvent.click(screen.getByTestId('edge-card-e-raw'))
+    expect(container.textContent).not.toContain('0.27')
+  })
+})

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.jointGoal.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.jointGoal.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * useNodeDisplayMetadata — the JOINT figure rides the SAME decision
+ * (ROADMAP 2.296 item 5 / 2.282-C2).
+ *
+ * `GoalPanel` renders the joint-goal quantity as its own separately-labelled
+ * claim ("Chance of hitting every target") beside the goal figure. Until this
+ * lane it obtained BOTH by passing the WHOLE report into
+ * `selectGoalProbability` — a selector that expects ONE option-probability
+ * record — so on the real V5 mapper shape (values under
+ * `report.option_probabilities[id]`) every read returned null and #556's
+ * corrected copy never executed.
+ *
+ * The fix routes the panel through THIS hook — the established pointer-owner
+ * for the goal surface family — which therefore has to publish
+ * `jointGoalProbability`, forwarded VERBATIM from the same
+ * `selectGoalProbability` decision that produced `achievementProbability`.
+ * Forwarded, never re-read off the raw record: a second read would be the
+ * two-choosers defect the selector exists to end.
+ *
+ * Same test discipline as `useNodeDisplayMetadata.goalBasis.spec.ts`: the
+ * REAL hook over a mock store — nothing here re-derives the decision.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { create, type StoreApi, type UseBoundStore } from 'zustand'
+
+interface MockCanvasState {
+  results: { status: string; report: unknown }
+}
+
+let store: UseBoundStore<StoreApi<MockCanvasState>>
+
+vi.mock('../../store', () => ({
+  get useCanvasStore() {
+    return store
+  },
+}))
+
+const { useNodeDisplayMetadata } = await import('../useNodeDisplayMetadata')
+const { selectGoalProbability } = await import(
+  '../../../components/results/utils/selectGoalProbability'
+)
+
+/** Witnessed substituted shape: joint present, goal absent, unconstrained. */
+const SUBSTITUTED_OPTION = {
+  probability_of_joint_goal: 0.0054,
+  goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+}
+
+/** Both quantities present — they are genuinely different numbers here. */
+const REAL_GOAL_OPTION = {
+  probability_of_goal: 0.55,
+  probability_of_joint_goal: 0.0054,
+}
+
+function reportFor(option: Record<string, unknown>, withPointer = true) {
+  return {
+    option_probabilities: { opt_a: option },
+    robustness: withPointer
+      ? { recommended_option_id: 'opt_a', display_verdict: 'fragile' }
+      : { display_verdict: 'fragile' },
+  }
+}
+
+function setReport(report: unknown, status = 'complete') {
+  store = create<MockCanvasState>(() => ({ results: { status, report } }))
+}
+
+function renderForGoal() {
+  return renderHook(() => useNodeDisplayMetadata('goal_revenue', 'goal')).result.current
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useNodeDisplayMetadata — jointGoalProbability (REAL hook)', () => {
+  it('control: the fixtures drive the REAL selector where this suite claims (trap 13)', () => {
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).jointGoalProbability).toBe(0.0054)
+    expect(selectGoalProbability(REAL_GOAL_OPTION).jointGoalProbability).toBe(0.0054)
+    expect(selectGoalProbability(REAL_GOAL_OPTION).basis).toBe('goal_probability')
+  })
+
+  it('RED-first: forwards the joint figure beside a REAL goal probability', () => {
+    setReport(reportFor(REAL_GOAL_OPTION))
+    const md = renderForGoal()
+    expect(md.achievementProbability).toBe(0.55)
+    // The two quantities are genuinely different here, and BOTH are published.
+    expect(md.jointGoalProbability).toBe(0.0054)
+  })
+
+  it('under substitution the joint figure IS the achievement figure — the selector identity survives the hop', () => {
+    setReport(reportFor(SUBSTITUTED_OPTION))
+    const md = renderForGoal()
+    expect(md.achievementProbabilityBasis).toBe('joint_goal_substituted')
+    expect(md.jointGoalProbability).toBe(0.0054)
+    expect(md.jointGoalProbability).toBe(md.achievementProbability)
+  })
+
+  it('no pointer (the 2.275 gap) → no joint figure either — nothing is read outside the owner', () => {
+    setReport(reportFor(REAL_GOAL_OPTION, /* withPointer */ false))
+    const md = renderForGoal()
+    expect(md.achievementProbability).toBeNull()
+    expect(md.jointGoalProbability ?? null).toBeNull()
+  })
+
+  it('no report → null', () => {
+    setReport(null, 'idle')
+    const md = renderForGoal()
+    expect(md.jointGoalProbability ?? null).toBeNull()
+  })
+})

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -112,6 +112,23 @@ interface NodeDisplayMetadata {
    */
   achievementProbabilityBasis?: GoalProbabilityBasis | null
   /**
+   * ROADMAP 2.296 item 5 (2.282-C2) — the raw joint-goal quantity, FORWARDED
+   * VERBATIM from the SAME `selectGoalProbability` decision that produced
+   * `achievementProbability`. It exists because `GoalPanel` renders the joint
+   * figure as its own separately-labelled claim ("Chance of hitting every
+   * target") beside the goal figure; until this field the panel obtained both
+   * by feeding the WHOLE report into the selector — which expects one
+   * option-probability record — so on the real V5 mapper shape every read was
+   * null and #556's basis gate was dark. Never re-read off the raw record and
+   * never re-derived at a render site: the selector's `jointGoalProbability`
+   * is the one answer, and this hook only carries it.
+   *
+   * OPTIONAL for the same mock-churn reason as `achievementProbabilityBasis`
+   * below; the real hook populates it whenever the pointer resolves.
+   * `useNodeDisplayMetadata.jointGoal.spec.ts` pins that.
+   */
+  jointGoalProbability?: number | null
+  /**
    * ROADMAP 2.275. True when this run carries an admissible per-option goal
    * figure (per `selectGoalProbability`) even though no single probability is
    * attributable to the goal node itself — the live case where
@@ -180,6 +197,7 @@ export function useNodeDisplayMetadata(
         achievementProbability: null,
         achievementProbabilityIsModelledBasis: false,
         achievementProbabilityBasis: null,
+        jointGoalProbability: null,
         goalFitAvailable: false,
         stabilityPercentage: null,
         winRate: null,
@@ -292,6 +310,7 @@ export function useNodeDisplayMetadata(
     let achievementProbability: number | null = null
     let achievementProbabilityIsModelledBasis = false
     let achievementProbabilityBasis: GoalProbabilityBasis | null = null
+    let jointGoalProbability: number | null = null
     let stabilityPercentage: number | null = null
     let goalFitAvailable = false
 
@@ -325,6 +344,9 @@ export function useNodeDisplayMetadata(
           // ROADMAP 2.283. Forwarded, not interpreted: the one place the basis
           // was previously read and thrown away.
           achievementProbabilityBasis = decision.basis
+          // ROADMAP 2.296 item 5. Same discipline: the joint figure rides the
+          // SAME decision — never a second read of the raw record.
+          jointGoalProbability = decision.jointGoalProbability
         }
       }
 
@@ -401,6 +423,7 @@ export function useNodeDisplayMetadata(
       achievementProbability,
       achievementProbabilityIsModelledBasis,
       achievementProbabilityBasis,
+      jointGoalProbability,
       goalFitAvailable,
       stabilityPercentage,
       winRate,

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
@@ -1,43 +1,56 @@
 /**
- * GoalPanel — THE POSSESSIVE GATE (ROADMAP 2.282).
+ * GoalPanel — THE POSSESSIVE GATE (ROADMAP 2.282), NOW OVER THE REAL SHAPE
+ * (ROADMAP 2.296 item 5 / 2.282-C2).
  *
  * ─────────────────────────────────────────────────────────────────────────
  * WHAT THIS PANEL WAS DOING
  * ─────────────────────────────────────────────────────────────────────────
  * `GoalPanel` correctly refuses to be a CHOOSER — #496 deleted its
- * reach-around and it now calls `selectGoalProbability` and renders what it
- * is given. But it was still a NARRATOR: it destructured `.goalProbability`
- * and `.jointGoalProbability` and walked straight past `.basis`, so on a
- * substituted run it rendered the joint figure as
+ * reach-around — and #556 gated its possessive copy on the selector's basis.
+ * But the panel passed the WHOLE REPORT into `selectGoalProbability`, a
+ * selector that expects ONE option-probability record. The live V5 mapper
+ * stores every such record under `report.option_probabilities[optionId]`
+ * (`mapV5AnalysisToReport`), and the report root carries none of the owned
+ * fields — so on every real V5 payload `probGoal` was null, the Impact block
+ * fell back to its empty state, and the entire #556 gate was DARK: correct
+ * copy, wired to a read that could never produce a number.
  *
- *   ":278  {N}% chance of reaching this target based on the current model."
- *   ":505  {N}% chance of success"
- *
- * — possessive goal framing over a number whose owner had published
- * `mayUsePossessiveGoalFraming: false`.
- *
- * ⚠ AND IT CONTRADICTED ITSELF ABOUT THE SAME NUMBER. Under substitution the
- * selector returns `goalProbability === jointGoalProbability` BY
- * CONSTRUCTION (`goalProbabilityIsJoint ⇒ goalProbability = jointGoalProb`).
- * So the Impact block stated one value twice, in two incompatible voices:
- * "{N}% chance of success" directly above "Chance of hitting every target:
- * {N}%". A reader had no way to tell those were the same measurement — and
- * exactly one of the two sentences was true. That is the sharpest form of
- * this defect anywhere in the estate, and it gets its own test below.
+ * The panel now reads through `useNodeDisplayMetadata` — the established
+ * pointer-owner for the goal surface family (the same hop `GoalNode` uses,
+ * so the panel and the canvas cannot disagree about one report) — which
+ * forwards `selectGoalProbability`'s decision verbatim.
  *
  * ─────────────────────────────────────────────────────────────────────────
- * FIXTURE PROVENANCE
+ * FIXTURE PROVENANCE — BUILT THROUGH THE REAL MAPPER (the named lesson)
  * ─────────────────────────────────────────────────────────────────────────
- * `probability_of_joint_goal: 0.0054` with no `goal_probability` and no
- * `constraint_analysis` is the witnessed staging shape (2026-08-01,
- * `witness-2258-raw/run1b/`), where CEE left `goal_threshold_frame`
- * unstamped and ISL therefore refused `probability_of_goal` outright.
+ * The previous fixtures fabricated ROOT-LEVEL probability fields
+ * (`{ probability_of_joint_goal: 0.0054 }` on the report itself) — a shape NO
+ * producer emits — which is exactly how a green suite certified a dark gate.
+ * This estate has now paid for that lesson three times. Every V5 fixture here
+ * is produced by the REAL `mapV5AnalysisToReport` over an analysis block
+ * whose per-option shape is the witnessed one (2026-08-01,
+ * `witness-2258-raw/run1b/`: joint present, goal absent, unconstrained).
+ *
+ * ⚠ ONE DECLARED DEPARTURE, same as `useNodeDisplayMetadata.goalBasis.spec.ts`:
+ * the witnessed runs omit `robustness.recommended_option_id` (the separately
+ * rowed 2.275 pointer gap, during which the goal surfaces honestly show no
+ * figure). These fixtures supply the pointer so the gate under test is
+ * EXECUTED; the 2026-07-31 witnessed payload
+ * (`cee-analysis-turn-probe2154-2026-07-31.json`) carries the pointer for
+ * real, so this is a live shape, not an invention.
+ *
+ * ⚠ THE CONSTRAINED FIXTURE CANNOT COME FROM THIS MAPPER, AND SAYS SO. The V5
+ * mapper never emits per-option `constraint_analysis` (seam 2 of UI-SEM-088
+ * is constant-gated in the V4 responseMapper). The constrained positive
+ * control therefore uses the INTERNAL post-mapper record shape directly,
+ * declared as such — it pins the panel's basis-narrowing, not a V5 wire shape.
  *
  * The gate is scoped to `joint_goal_substituted` ONLY. `joint_goal_
  * constrained` — the user's own goal AND their own limits — keeps the
  * possessive, and the last test pins that so a blanket copy deletion fails.
  *
- * RED-first: tests 2, 3 and 4 fail at `fef179ce`.
+ * RED-first (2.296 item 5): at pristine tip 925eb818 every PRESENCE assertion
+ * on a mapper-built report fails — the panel renders no probability at all.
  *
  * Scope limit (trap 3): jsdom pins string presence/absence only.
  */
@@ -49,6 +62,8 @@ import { useAuth } from '../../../../contexts/AuthContext'
 import { selectGoalProbability } from '../../../../components/results/utils/selectGoalProbability'
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
 import { GOAL_CONSTRAINT_COPY } from '../inspectorStrings'
+import { mapV5AnalysisToReport } from '../../../../v5/mapV5AnalysisToReport'
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 
 vi.mock('../../../../contexts/AuthContext', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../contexts/AuthContext')>()
@@ -63,25 +78,61 @@ const GOAL_NODE = {
   data: { label: 'Grow Annual Revenue to £6,000,000' },
 }
 
-/** The witnessed substituted report: joint present, goal absent, unconstrained. */
-const SUBSTITUTED_REPORT = {
+/**
+ * A real V5 analysis block → report, through the REAL mapper. `optionEntry`
+ * is spread into the recommended option's `option_comparison` entry — the
+ * wire location the mapper actually reads the goal quantities from.
+ */
+function analysisReport(optionEntry: Record<string, unknown>) {
+  const block = {
+    type: 'analysis_result',
+    summary: 'A summary',
+    leading_option_id: 'opt_a',
+    win_probabilities: { 'Option A': 0.6, 'Option B': 0.4 },
+    enrichment: {
+      option_comparison: [
+        { option_id: 'opt_a', option_label: 'Option A', win_probability: 0.6, ...optionEntry },
+        { option_id: 'opt_b', option_label: 'Option B', win_probability: 0.4 },
+      ],
+      robustness: { recommended_option_id: 'opt_a', display_verdict: 'fragile' },
+    },
+  } as unknown as AnalysisResultBlock
+  return mapV5AnalysisToReport(block) as unknown as Record<string, unknown>
+}
+
+/** The witnessed substituted shape: joint present, goal absent, unconstrained. */
+const SUBSTITUTED_REPORT = analysisReport({
   probability_of_joint_goal: 0.0054,
   goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
-  meta: { n_samples: 10000 },
-}
+})
 
 /** The same panel on a run that carries a REAL goal probability. */
-const REAL_GOAL_REPORT = {
+const REAL_GOAL_REPORT = analysisReport({
   probability_of_goal: 0.55,
   probability_of_joint_goal: 0.0054,
-  meta: { n_samples: 10000 },
+})
+
+/**
+ * The CONSTRAINED joint case — possessive earned, must survive. INTERNAL
+ * post-mapper shape, declared above: the V5 mapper cannot emit per-option
+ * `constraint_analysis`, so this pins the panel's basis-narrowing only.
+ */
+const CONSTRAINED_REPORT = {
+  option_probabilities: {
+    opt_a: {
+      probability_of_joint_goal: 0.42,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+      confidence: 0.5,
+    },
+  },
+  robustness: { recommended_option_id: 'opt_a', display_verdict: 'fragile' },
 }
 
-/** The CONSTRAINED joint case — possessive earned, must survive. */
-const CONSTRAINED_REPORT = {
-  probability_of_joint_goal: 0.42,
-  constraint_analysis: { constraints: [{ id: 'c1' }] },
-  meta: { n_samples: 10000 },
+/** The record the panel's read must land on. */
+function recordOf(report: Record<string, unknown>) {
+  return (report.option_probabilities as Record<string, unknown>).opt_a as Parameters<
+    typeof selectGoalProbability
+  >[0]
 }
 
 function setStore(report: Record<string, unknown>) {
@@ -102,27 +153,28 @@ function renderPanel() {
   )
 }
 
-describe('GoalPanel — possessive gate on a substituted joint goal figure (ROADMAP 2.282)', () => {
+describe('GoalPanel — possessive gate on a substituted joint goal figure (2.282, real shape per 2.296 item 5)', () => {
   beforeEach(() => {
     useCanvasStore.setState(useCanvasStore.getState(), true)
     vi.mocked(useAuth).mockReset()
     vi.mocked(useAuth).mockReturnValue(REAL_AUTH as unknown as ReturnType<typeof useAuth>)
   })
 
-  it('control: each fixture drives the selector to the basis this suite claims for it', () => {
-    // Anti-vacuity (trap 13) — without this, every absence assertion below
-    // could pass because the fixture stopped reaching the branch under test.
-    const sub = selectGoalProbability(SUBSTITUTED_REPORT)
+  it('control: the MAPPER-BUILT fixtures drive the selector to the basis this suite claims', () => {
+    // Anti-vacuity (trap 13) — and this time the control also proves the REAL
+    // mapper writes the owned fields where the panel's read must look.
+    const sub = selectGoalProbability(recordOf(SUBSTITUTED_REPORT))
     expect(sub.basis).toBe('joint_goal_substituted')
     expect(sub.mayUsePossessiveGoalFraming).toBe(false)
-    // The identity that makes the two Impact sentences the SAME number.
     expect(sub.goalProbability).toBe(sub.jointGoalProbability)
 
-    expect(selectGoalProbability(REAL_GOAL_REPORT).basis).toBe('goal_probability')
-    expect(selectGoalProbability(CONSTRAINED_REPORT).basis).toBe('joint_goal_constrained')
+    expect(selectGoalProbability(recordOf(REAL_GOAL_REPORT)).basis).toBe('goal_probability')
+    expect(selectGoalProbability(recordOf(CONSTRAINED_REPORT)).basis).toBe(
+      'joint_goal_constrained',
+    )
   })
 
-  it('RED-first: the success-target line does NOT say "chance of reaching this target" over a substituted joint figure', () => {
+  it('RED-first (2.296): the substituted figure RENDERS at all off the real mapper shape — the gate is no longer dark', () => {
     setStore(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
     const text = container.textContent ?? ''
@@ -146,24 +198,13 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (ROAD
     setStore(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
 
-    // Scoped to the IMPACT group specifically — `PanelGroup` renders
-    // `<section data-panel-group={kind}>`, so this is a real DOM anchor, not
-    // a guess. The scoping matters: the honest readout legitimately appears
-    // in the "Your input" group TOO (the success-target line), and a
-    // whole-panel count would conflate two different surfaces with the
-    // duplication inside one of them.
     const impact = container.querySelector('[data-panel-group="impact"]')
     expect(impact).not.toBeNull()
     const text = impact?.textContent ?? ''
 
-    // Before the fix this ONE block rendered "1% chance of success" AND
-    // "Chance of hitting every target: 1%" — the same measurement asserted
-    // twice, once truthfully and once not.
     expect(text).not.toContain('chance of success')
     expect(text).not.toContain('Chance of hitting every target')
 
-    // Exactly one goal-attainment claim survives here, and it names the
-    // quantity the number actually is.
     const honest = GOAL_ANCHOR_COPY.phrase('1%', true)
     expect(text.split(honest).length - 1).toBe(1)
   })
@@ -190,9 +231,6 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (ROAD
   })
 
   it('techMode: the diagnostic names the field the number ACTUALLY is under substitution', () => {
-    // The most literally false line in the block, and the one a tech-mode
-    // reader would trust most: it labelled the value `probability_of_goal`
-    // when `probability_of_goal` is precisely the field ISL refused to emit.
     setStore(SUBSTITUTED_REPORT)
     const { container } = render(
       <GoalPanel nodeId="goal1" techMode onClose={() => {}} onNavigate={() => {}} />,
@@ -202,21 +240,34 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (ROAD
     expect(text).toContain('probability_of_joint_goal (substituted for absent probability_of_goal)')
     expect(text).not.toContain('System: probability_of_goal:')
   })
+
+  it('honest absence: WITHOUT the producer pointer the panel shows no figure (the 2.275 posture, same as the canvas)', () => {
+    // Strip the pointer the fixtures add: the hook never reaches the selector
+    // and the panel must fabricate nothing — the same honest state GoalNode
+    // shows on the witnessed pointer-less runs.
+    const report = analysisReport({
+      probability_of_joint_goal: 0.0054,
+      goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+    })
+    delete (report.robustness as Record<string, unknown>).recommended_option_id
+    setStore(report)
+    const { container } = renderPanel()
+    const text = container.textContent ?? ''
+    expect(text).not.toContain('chance of success')
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+  })
 })
 
 /**
- * ROADMAP 2.283 — the #556 review rowables, in the same file.
+ * ROADMAP 2.283 — the #556 review rowables, over the real shape.
  *
- * #556 suppressed the Impact block's duplicate under substitution. It did NOT
- * touch the SAME sentence in the Constraints section, which is gated on the
- * STORE-level `goalConstraints` — i.e. on the user having defined constraints
- * at all — a condition entirely INDEPENDENT of the basis. So on the live
- * posture (user constraints defined, run substituted) the panel still stated
- * the suppressed number, one section down: one-number-twice ACROSS sections
- * rather than within one.
+ * #556 suppressed the Impact block's duplicate under substitution. The SAME
+ * sentence in the Constraints section is gated on the STORE-level
+ * `goalConstraints` — independent of the basis — so on the live posture
+ * (user constraints defined, run substituted) it restated the suppressed
+ * number one section down.
  */
-describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283)', () => {
-  /** The same store shape, but with the user's own constraints defined. */
+describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283, real shape)', () => {
   function setStoreWithConstraints(report: Record<string, unknown>) {
     const state = useCanvasStore.getState()
     useCanvasStore.setState({
@@ -238,9 +289,6 @@ describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283)', ()
   })
 
   it('control: the Constraints section actually renders for these fixtures', () => {
-    // Anti-vacuity (trap 13). The absence assertion below is worthless unless
-    // this store shape genuinely opens the `goalConstraints` gate — otherwise
-    // "the line is gone" would just mean "the section never rendered".
     setStoreWithConstraints(REAL_GOAL_REPORT)
     const { container } = renderPanel()
     expect(container.textContent ?? '').toContain('Stay under budget')
@@ -251,11 +299,11 @@ describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283)', ()
     const { container } = renderPanel()
     const text = container.textContent ?? ''
 
-    // The section is open (the constraint label proves it) and the sentence is
-    // nonetheless withheld — because the number it would state is the one the
-    // Impact block just suppressed.
     expect(text).toContain('Stay under budget')
     expect(text).not.toContain(JOINT_LINE)
+    // Paired presence proof (this suite's RED half): the Impact block carries
+    // the ONE honest statement of the number.
+    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
   })
 
   it('positive control: with constraints defined, a REAL probability_of_goal KEEPS the Constraints line', () => {
@@ -264,41 +312,18 @@ describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283)', ()
   })
 
   it('positive control: the CONSTRAINED basis KEEPS the Constraints line (basis-scoped, not joint-scoped)', () => {
-    // ROADMAP 1.49: the user's own goal AND their own limits. The figure is
-    // joint, and the framing is earned. A gate widened from
-    // `!goalFitSubstituted` to `!goalProbabilityIsJoint` REDs here.
-    //
-    // ⚠ COUNTED, NOT `toContain` — AND THAT IS THE WHOLE TEST. The first
-    // version of this asserted `toContain(JOINT_LINE)`, which BOTH sites
-    // satisfy, so it could not tell which one had rendered: the widening mutant
-    // suppressed the Constraints line, the Impact line alone still matched, and
-    // the mutant survived with zero reds. Caught by the mutation matrix, not by
-    // review. On a constrained run with constraints defined BOTH sites must
-    // render, so the count is 2 and dropping either one REDs.
+    // COUNTED, NOT `toContain` — both sites must render on this basis, so the
+    // count is 2 and dropping either one REDs (the mutation lesson recorded in
+    // this file's previous revision).
     setStoreWithConstraints(CONSTRAINED_REPORT)
     const text = renderPanel().container.textContent ?? ''
     expect(text.split(JOINT_LINE).length - 1).toBe(2)
   })
 
   it('DEDUP: both sites render the REGISTER string — neither re-types the literal', () => {
-    // `GoalPanel:553` hand-typed "Chance of hitting every target:" — a second
-    // copy, in the same file, of a sentence the register already owned and
-    // rendered at `:404`. Two copies of one sentence is how the halves end up
-    // different; COMPARATIVE_COPY.clause and .leadNoMagnitude both exist
-    // because that already happened elsewhere in this estate.
-    //
-    // This is a DERIVED guard, not a mirror (trap 12): the expectation is the
-    // REGISTER VALUE, never a literal. Re-type either site with different
-    // wording and the count drops to 1 and this REDs; change the register and
-    // both sites move together and it stays green.
-    //
-    // ⚠ STATED HONESTLY: this test is NOT RED-first, and it does not prove the
-    // deduplication happened. At pristine `e5d2111c` the hand-typed literal was
-    // byte-identical to the register's value, so the count was already 2 and
-    // this passed. It is a DRIFT pin, not a defect pin — it catches the failure
-    // the duplicate makes possible (the two copies diverging), which is the
-    // only thing a test CAN catch here. Its bite is proven by mutation, not by
-    // RED-first: re-typing `:553` with different wording REDs it.
+    // DERIVED guard, not a mirror (trap 12): the expectation is the REGISTER
+    // VALUE. Re-type either site with different wording and the count drops to
+    // 1; change the register and both sites move together.
     setStoreWithConstraints(REAL_GOAL_REPORT)
     const text = renderPanel().container.textContent ?? ''
     expect(text.split(JOINT_LINE).length - 1).toBe(2)

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.simulationCount.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.simulationCount.spec.tsx
@@ -47,8 +47,23 @@ describe('GoalPanel — Impact "Based on N simulations"', () => {
     vi.mocked(useAuth).mockReturnValue(REAL_AUTH as unknown as ReturnType<typeof useAuth>)
   })
 
+  // ROADMAP 2.296 item 5: these fixtures previously fabricated a ROOT-LEVEL
+  // `probability_of_goal` — a shape no producer emits, which is exactly how
+  // the panel's dark whole-report read stayed green (the named lesson from
+  // `GoalPanel.possessiveGate.spec.tsx`). The probability now lives where the
+  // mappers put it — `option_probabilities[recommended_option_id]` — while
+  // `meta.n_samples` genuinely IS a root field (the V4 responseMapper emits
+  // it there; the V5 mapper strips it, which is the omission case below).
+  function reportWithGoal(meta: Record<string, unknown>) {
+    return {
+      option_probabilities: { opt_a: { probability_of_goal: 0.62, confidence: 0.5 } },
+      robustness: { recommended_option_id: 'opt_a', display_verdict: 'fragile' },
+      meta,
+    }
+  }
+
   it('renders the REAL sample count from meta.n_samples (not a fabricated 1,000)', () => {
-    setStore({ probability_of_goal: 0.62, meta: { n_samples: 5000 } })
+    setStore(reportWithGoal({ n_samples: 5000 }))
     const { getByText, queryByText } = renderPanel()
     expect(getByText('62% chance of success')).toBeTruthy()
     expect(getByText('Based on 5,000 simulations')).toBeTruthy()
@@ -58,7 +73,7 @@ describe('GoalPanel — Impact "Based on N simulations"', () => {
 
   it('OMITS the simulations line when the run carries no sample count (V5 path)', () => {
     // meta stripped upstream → scenarioCount null → line hidden, never fabricated.
-    setStore({ probability_of_goal: 0.62, meta: { seed: null } })
+    setStore(reportWithGoal({ seed: null }))
     const { getByText, queryByText } = renderPanel()
     // The probability itself still renders — only the count sentence is gated.
     expect(getByText('62% chance of success')).toBeTruthy()

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -41,10 +41,6 @@ import { GoalAdvancedEditor } from '../editors/GoalAdvancedEditor'
 import { useAuth } from '../../../../contexts/AuthContext'
 import { isPersistenceActive } from '../../../../lib/persistenceActive'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
-import {
-  selectGoalProbability,
-  type GoalProbabilityInput,
-} from '../../../../components/results/utils/selectGoalProbability'
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
 
 export const GoalPanel = memo(function GoalPanel({
@@ -58,37 +54,24 @@ export const GoalPanel = memo(function GoalPanel({
   const resultsStatus = useCanvasStore(s => s.results?.status)
   const isResultsMode = resultsStatus === 'complete'
   const goalThreshold = useCanvasStore(s => s.goalThreshold)
-  // GOAL-PROBABILITY IDENTITY: this panel used to read both producer fields
-  // straight off the store, which made it a chooser in its own right — the same
-  // reach-around #496 had to delete from `useNodeDisplayMetadata`, where the
-  // canvas and the results panel ended up stating different things about the
-  // same option in the same session. The owner decides which quantity may be
-  // shown; this panel renders what it is given. The store selector returns the
-  // report reference itself (no object literal, so no React #185 churn) and the
-  // decision is memoised on it.
-  const goalReport = useCanvasStore(s => s.results?.report)
-  const goalDecision = useMemo(
-    () => selectGoalProbability(goalReport as GoalProbabilityInput | undefined),
-    [goalReport],
-  )
-  const probGoal = goalDecision.goalProbability
-  const probJoint = goalDecision.jointGoalProbability
-  // THE POSSESSIVE GATE (ROADMAP 2.282). The panel already refuses to be a
-  // chooser; it was still being a NARRATOR — rendering the owner's number in
-  // possessive wording the owner had explicitly forbidden
-  // (`mayUsePossessiveGoalFraming: false`). `basis` was published for exactly
-  // this and was the one field this panel destructured past.
+  // GOAL-PROBABILITY IDENTITY (ROADMAP 2.296 item 5 / 2.282-C2): this panel
+  // used to read both producer fields straight off the store, which made it a
+  // chooser in its own right; #496 replaced that with a `selectGoalProbability`
+  // call — over the WHOLE REPORT. The selector expects ONE option-probability
+  // record, and the live V5 mapper stores every such record under
+  // `report.option_probabilities[optionId]`, so on every real V5 payload the
+  // read returned null and the #556 possessive gate below was DARK.
   //
-  // ⚠ SCOPED TO `joint_goal_substituted` ONLY. `joint_goal_constrained` is
-  // the user's own goal AND their own limits — the possessive is earned there
-  // and is untouched.
+  // The panel now renders what `useNodeDisplayMetadata` gives it — the
+  // established pointer-owner for the goal surface family (it resolves
+  // `robustness.recommended_option_id` and forwards the selector's decision
+  // verbatim). Same hop the canvas GoalNode uses, so the panel and the canvas
+  // cannot state different things about one report; and when the producer
+  // designates no option (the 2.275 pointer gap), BOTH honestly show no
+  // figure rather than the panel inventing a leader.
   //
-  // ⚠ AND THE TWO CLAIMS BELOW ARE THE SAME NUMBER. Under substitution the
-  // selector returns `goalProbability === jointGoalProbability` by
-  // construction, so the Impact block was stating one value twice in two
-  // different voices: "N% chance of success" over "Chance of hitting every
-  // target: N%". One of those was false. They are collapsed to the honest one.
-  const goalFitSubstituted = goalDecision.basis === 'joint_goal_substituted'
+  // The reads themselves sit just below `displayMetadata`'s declaration.
+  //
   // Passthrough: the REAL Monte Carlo sample count from this run's meta.n_samples
   // (canonical reader — same source AdvancedSection's "Simulation quality" row
   // uses). Null on the V5 conversational path (meta stripped upstream), in which
@@ -124,6 +107,30 @@ export const GoalPanel = memo(function GoalPanel({
   const node = nodeId ? nodes.find(n => n.id === nodeId) : undefined
   const mutations = useNodeMutations(nodeId ?? '')
   const displayMetadata = useNodeDisplayMetadata(nodeId ?? '', 'goal')
+
+  // The owner's decision, forwarded (see the identity comment above): the
+  // number, the joint figure, and which quantity the number IS.
+  const probGoal = displayMetadata.achievementProbability
+  const probJoint = displayMetadata.jointGoalProbability ?? null
+  // THE POSSESSIVE GATE (ROADMAP 2.282). The panel already refuses to be a
+  // chooser; it was still being a NARRATOR — rendering the owner's number in
+  // possessive wording the owner had explicitly forbidden
+  // (`mayUsePossessiveGoalFraming: false`). `basis` was published for exactly
+  // this and was the one field this panel destructured past.
+  //
+  // ⚠ SCOPED TO `joint_goal_substituted` ONLY. `joint_goal_constrained` is
+  // the user's own goal AND their own limits — the possessive is earned there
+  // and is untouched. The `=== 'joint_goal_substituted'` narrowing is the
+  // canvas's one vocabulary for this test (OptionNode, GoalNode) — never a
+  // re-derivation.
+  //
+  // ⚠ AND THE TWO CLAIMS BELOW ARE THE SAME NUMBER. Under substitution the
+  // selector returns `goalProbability === jointGoalProbability` by
+  // construction, so the Impact block was stating one value twice in two
+  // different voices: "N% chance of success" over "Chance of hitting every
+  // target: N%". One of those was false. They are collapsed to the honest one.
+  const goalFitSubstituted =
+    displayMetadata.achievementProbabilityBasis === 'joint_goal_substituted'
 
   const thresholdUnit = (node?.data as Record<string, unknown>)?.goal_threshold_unit as string | undefined
   const thresholdRaw = (node?.data as Record<string, unknown>)?.goal_threshold_raw as string | number | null | undefined

--- a/src/components/results/__tests__/ResultsBody.v7TopMatter.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7TopMatter.spec.tsx
@@ -230,7 +230,14 @@ describe('ResultsBody — V7 L4 top matter', () => {
     // superlative retired under §6.2c. The BRANCH is unchanged.
     expect(screen.getByTestId('v7-hero-headline')).toHaveTextContent(new RegExp(`${WINNER_LABEL} came out ahead in .+ of simulated scenarios`))
     // Signal chips echo the fixture's fragile edge + top driver, verbatim.
-    expect(screen.getByTestId('v7-signal-flip-risk')).toHaveTextContent('22% flip risk · Tech lead hired')
+    // ROADMAP 2.296 / 2.291: this fixture carries NO flip thresholds, so the
+    // chip is on the legacy arm — the retained percentage is an EDGE statistic
+    // (switch_probability) and is now labelled with the register's own name
+    // for the quantity ("N% switch") and attributed to the edge it belongs
+    // to, named "{from} → {to}". The previous pin ("22% flip risk · Tech lead
+    // hired") asserted the defect: an edge number dressed as the factor's
+    // flip evidence.
+    expect(screen.getByTestId('v7-signal-flip-risk')).toHaveTextContent('22% switch · Tech lead hired → Outsource')
     expect(screen.getByTestId('v7-signal-main-driver')).toHaveTextContent('Main driver · Tech lead hired')
     // Sharpen line quotes Paul's own brief wording.
     expect(screen.getByTestId('v7-sharpen-quote')).toHaveTextContent('Ship the Q4 migration without blowing the budget')

--- a/src/components/results/analysis-hero/__tests__/heroCopyDelegation.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/heroCopyDelegation.spec.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from 'vitest'
 import { HERO_COPY } from '../heroCopy'
 import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY } from '../../utils/goalAnchorCopy'
+import { FLIP_THRESHOLD_COPY } from '../../utils/flipThresholdDisplay'
 
 const N = '72%'
 
@@ -109,5 +110,26 @@ describe('HERO_COPY.headline.mostLikelyStrongest — no magnitude, no placeholde
 
   it('carries the magnitude when there is one', () => {
     expect(HERO_COPY.headline.mostLikelyStrongest('Option A', N)).toContain(N)
+  })
+})
+
+describe('HERO_COPY.evidence — the flip-threshold register exists once (ROADMAP 2.291)', () => {
+  /**
+   * The flip sentences moved to `utils/flipThresholdDisplay` so the V7 signal
+   * chip — outside this mount-guarded module — can render the same producer
+   * rows with the same words. `HERO_COPY.evidence` delegates BY REFERENCE:
+   * these are identity assertions, so re-inlining any of them here (a second
+   * voice for one claim) goes RED even if the restated string starts out
+   * byte-identical.
+   */
+  it.each([
+    ['switchMeta'],
+    ['flipRiskWithAlternative'],
+    ['flipRiskNoAlternative'],
+    ['fallsBelow'],
+    ['risesAbove'],
+    ['crosses'],
+  ] as const)('%s IS the shared register member', (name) => {
+    expect(HERO_COPY.evidence[name]).toBe(FLIP_THRESHOLD_COPY[name])
   })
 })

--- a/src/components/results/analysis-hero/__tests__/heroCopyDelegation.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/heroCopyDelegation.spec.ts
@@ -117,10 +117,21 @@ describe('HERO_COPY.evidence — the flip-threshold register exists once (ROADMA
   /**
    * The flip sentences moved to `utils/flipThresholdDisplay` so the V7 signal
    * chip — outside this mount-guarded module — can render the same producer
-   * rows with the same words. `HERO_COPY.evidence` delegates BY REFERENCE:
-   * these are identity assertions, so re-inlining any of them here (a second
-   * voice for one claim) goes RED even if the restated string starts out
-   * byte-identical.
+   * rows with the same words. `HERO_COPY.evidence` delegates BY REFERENCE.
+   *
+   * ⚠ STATED HONESTLY, the guarantee is two-tier (adversarial-review finding
+   * on #558). For the three FUNCTION members (`switchMeta`,
+   * `flipRiskWithAlternative`, `flipRiskNoAlternative`) `toBe` is reference
+   * identity: re-inlining one here goes RED even if the restated body starts
+   * out byte-identical. For the three PRIMITIVE tokens (`fallsBelow`,
+   * `risesAbove`, `crosses`) `toBe` is value equality: a byte-identical
+   * re-inline passes today and this pin catches it only at the FIRST
+   * DIVERGENCE — a drift pin, not a re-inline pin, exactly like the
+   * possessiveGate DEDUP test. That trade is deliberate: making the tokens
+   * functions to buy reference identity would churn every consumer (they are
+   * interpolated as strings by the sentence builders and returned by
+   * `flipDirectionWording`), and the failure that matters — the two copies
+   * saying different words — is the one the equality pin already REDs on.
    */
   it.each([
     ['switchMeta'],

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -60,7 +60,7 @@ import {
 } from '../utils/getExpectedValue'
 import { safeInterpolatedLabel, containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
 import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
-import { classifyUnit } from '@/utils/unitClassifier'
+import { flipDirectionWording, formatFlipValue } from '../utils/flipThresholdDisplay'
 import { HERO_COPY } from './heroCopy'
 import type { HeroChartModel, HeroLens, HeroModel, HeroRowVM, HeroStatusModel } from './heroTypes'
 
@@ -156,24 +156,10 @@ function goalReadout(value: number | null): string {
   return formatPercent(value, { fromDecimal: true })
 }
 
-/**
- * Format a flip-threshold factor value with its OWN unit string (factor
- * space, not outcome space). Unit placement follows the app-wide
- * classifyUnit convention (symbol prefix, ISO space-prefix, % suffix,
- * generic space-suffix) — but unlike formatValueWithUnit, the value ALWAYS
- * renders as a number: a "crosses <value>" sentence must never substitute
- * a qualitative word for the producer's numeric threshold. Display
- * formatting only; the value itself is unchanged.
- */
-function formatFlipValue(value: number, unit?: string): string {
-  const rendered = value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
-  const { kind, canonical } = classifyUnit(unit ?? null)
-  if (kind === 'symbol') return `${canonical}${rendered}`
-  if (kind === 'iso') return `${canonical} ${rendered}`
-  if (kind === 'percent') return `${rendered}%`
-  if (kind === 'none' || kind === 'placeholder') return rendered
-  return `${rendered} ${canonical}`
-}
+// formatFlipValue moved VERBATIM to `../utils/flipThresholdDisplay` (ROADMAP
+// 2.291) so the V7 signal chip renders the same producer rows through the
+// same formatter — "one threshold must never render two ways in one panel"
+// now holds across surfaces, not just within this module.
 
 // ─── Main mapper ─────────────────────────────────────────────────────────────
 
@@ -984,13 +970,10 @@ export function buildHeroModel(
       if (!label || containsBannedTerm(label)) return null
       // UI-SEM-074 (Codex B3 tightened): a direction claim needs BOTH values —
       // with no producer baseline the direction is unknowable, so the
-      // neutral 'crosses' wording is the only honest option.
-      const direction =
-        typeof ft.current_value === 'number' && ft.flip_value < ft.current_value
-          ? HERO_COPY.evidence.fallsBelow
-          : typeof ft.current_value === 'number' && ft.flip_value > ft.current_value
-            ? HERO_COPY.evidence.risesAbove
-            : HERO_COPY.evidence.crosses
+      // neutral 'crosses' wording is the only honest option. The rule lives
+      // in the shared `flipThresholdDisplay` module (2.291) so the V7 chip
+      // cannot state a different direction for the same row.
+      const direction = flipDirectionWording(ft.current_value, ft.flip_value)
       const value = formatFlipValue(ft.flip_value, ft.unit)
       const alt = ft.alternative_winner_label
         ? stripEncodingNotation(ft.alternative_winner_label)

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -13,6 +13,7 @@
  */
 
 import { COMPARATIVE_COPY, GOAL_ANCHOR_COPY } from '../utils/goalAnchorCopy'
+import { FLIP_THRESHOLD_COPY } from '../utils/flipThresholdDisplay'
 
 export const HERO_COPY = {
   panelAria: 'Analysis',
@@ -434,41 +435,24 @@ export const HERO_COPY = {
       designationsWithheld
         ? 'Chance the comparison between options changes when a relationship is varied within its plausible range.'
         : 'Chance the leading option changes when a relationship is varied within its plausible range.',
-    /** Switch-probability meta beside a flip row, e.g. "48% switch". */
-    switchMeta: (pct: string) => `${pct} switch`,
+    /**
+     * ROADMAP 2.291 — the flip-threshold sentences and tokens DELEGATE to
+     * `utils/flipThresholdDisplay`'s register (one-copy guarantee, same
+     * pattern as the A/comparative registers above; pinned by
+     * `heroCopyDelegation.spec.ts`). The V7 signal chip renders the same
+     * producer rows, and the hero module is mount-guarded, so the shared
+     * spelling has to live OUTSIDE it. The 1.267 discipline is the
+     * register's: the alternative-winner NAME survives a withheld run; only
+     * the designation verb changes.
+     */
+    switchMeta: FLIP_THRESHOLD_COPY.switchMeta,
     seeAllFactors: 'See all factors',
     showFewer: 'Show fewer',
-    /**
-     * ROADMAP 1.267. The producer's `alternative_winner_label` SURVIVES on a
-     * withheld run — it is data, and dropping it would be the
-     * over-suppression the ruling forbids. What goes is the designation
-     * verb: "becomes the likely leader" both asserts a leader exists after
-     * the flip and implies a different one exists now.
-     */
-    flipRiskWithAlternative: (
-      factor: string,
-      direction: string,
-      value: string,
-      alternative: string,
-      designationsWithheld: boolean,
-    ) =>
-      designationsWithheld
-        ? `If ${factor} ${direction} ${value}, the comparison shifts towards ${alternative}.`
-        : `If ${factor} ${direction} ${value}, ${alternative} becomes the likely leader.`,
-    flipRiskNoAlternative: (
-      factor: string,
-      direction: string,
-      value: string,
-      designationsWithheld: boolean,
-    ) =>
-      designationsWithheld
-        ? `If ${factor} ${direction} ${value}, the comparison is likely to change.`
-        : `If ${factor} ${direction} ${value}, the leading option is likely to change.`,
-    fallsBelow: 'falls below',
-    risesAbove: 'rises above',
-    // Direction-neutral fallback (UI-SEM-074): used when flip_value equals
-    // current_value — a direction claim would not be honestly determinable.
-    crosses: 'crosses',
+    flipRiskWithAlternative: FLIP_THRESHOLD_COPY.flipRiskWithAlternative,
+    flipRiskNoAlternative: FLIP_THRESHOLD_COPY.flipRiskNoAlternative,
+    fallsBelow: FLIP_THRESHOLD_COPY.fallsBelow,
+    risesAbove: FLIP_THRESHOLD_COPY.risesAbove,
+    crosses: FLIP_THRESHOLD_COPY.crosses,
     tradeOffGain: 'You gain',
     tradeOffGiveUp: 'You give up',
     tradeOffDependsOn: 'Depends on',

--- a/src/components/results/utils/__tests__/selectFlipRisk.thresholdJoin.spec.ts
+++ b/src/components/results/utils/__tests__/selectFlipRisk.thresholdJoin.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * ROADMAP 2.291 — `selectFlipRisk` publishes the JOINED flip-threshold row for
+ * the factor it names, so the surface can state the factor's own flip evidence
+ * (threshold, direction, alternative winner) instead of dressing an edge's
+ * `switch_probability` up as "flip risk".
+ *
+ * The join lives HERE, in the owner, because the selector already builds the
+ * flipping-ID set — a surface re-deriving "which row is my factor's" would be
+ * a second chooser (the two-choosers defect this module exists to end).
+ *
+ * Additive only: evidence classification, the gate, the floor and the ranking
+ * are #557's machinery and are untouched — its own spec
+ * (`selectFlipRisk.spec.ts`) runs alongside this file.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { selectFlipRisk } from '../selectFlipRisk'
+
+const CANDIDATES = [
+  { label: 'Vendor Fit', switchProbability: 0.4, targetId: 'f1', joinId: 'f1' },
+  { label: 'Adoption', switchProbability: 0.3, targetId: 'f2', joinId: 'f2' },
+]
+
+describe('selectFlipRisk — flip-threshold join (2.291)', () => {
+  it('RED-first: on flips_present the named factor carries its OWN threshold row', () => {
+    const thresholds = [
+      { node_id: 'f2', flip_value: null, flip_reason: 'structurally_invariant' },
+      {
+        node_id: 'f1',
+        flip_value: 4000,
+        current_value: 2000,
+        unit: '£',
+        flip_reason: 'found',
+        alternative_winner_label: 'Option B',
+      },
+    ]
+    const selection = selectFlipRisk(thresholds, CANDIDATES)
+    expect(selection.evidence).toBe('flips_present')
+    expect(selection.topFlipRisk?.label).toBe('Vendor Fit')
+    expect(selection.topFlipRisk?.flipThreshold).toEqual(thresholds[1])
+  })
+
+  it('joins the row that actually FLIPS when a node has several rows', () => {
+    const attested = { node_id: 'f1', flip_value: null, flip_reason: 'no_effect_within_bounds' }
+    const flipping = { node_id: 'f1', flip_value: 0.9, flip_reason: 'found' }
+    const selection = selectFlipRisk([attested, flipping], CANDIDATES)
+    expect(selection.topFlipRisk?.flipThreshold).toEqual(flipping)
+  })
+
+  it('no producer flip data → no fabricated threshold on the selection', () => {
+    const selection = selectFlipRisk(undefined, CANDIDATES)
+    expect(selection.evidence).toBe('no_producer_flip_data')
+    expect(selection.topFlipRisk?.label).toBe('Vendor Fit')
+    expect(selection.topFlipRisk?.flipThreshold).toBeUndefined()
+  })
+
+  it('POSITIVE CONTROL (#557 unchanged): flips_absent still names nothing', () => {
+    const selection = selectFlipRisk(
+      [{ node_id: 'f1', flip_value: null, flip_reason: 'structurally_invariant' }],
+      CANDIDATES,
+    )
+    expect(selection.evidence).toBe('flips_absent')
+    expect(selection.mayNameFlipRisk).toBe(false)
+    expect(selection.topFlipRisk).toBeNull()
+  })
+})

--- a/src/components/results/utils/flipThresholdDisplay.ts
+++ b/src/components/results/utils/flipThresholdDisplay.ts
@@ -1,0 +1,99 @@
+/**
+ * flipThresholdDisplay — ONE formatter, ONE direction rule and ONE copy
+ * register for a producer flip threshold, shared by every surface that
+ * renders one.
+ *
+ * ROADMAP 2.291. The formatter and the direction rule moved VERBATIM out of
+ * `analysis-hero/buildHeroModel.ts`, and the flip sentences moved VERBATIM
+ * out of `analysis-hero/heroCopy.ts` (which now delegates to this register —
+ * pinned by `heroCopyDelegation.spec.ts`), because the V7 signal chip renders
+ * the same producer rows. They live HERE, outside the hero module, because
+ * the hero is mount-guarded (`analysis-hero/__tests__/inertness.spec.ts`
+ * permits exactly two importers of `analysis-hero/**` repo-wide) — the
+ * dependency arrow must point out of the guarded module, never into it.
+ * buildHeroModel's own comment states the invariant: "one threshold must
+ * never render two ways in one panel" — now held across surfaces, not just
+ * within the hero.
+ *
+ * Direction rule (UI-SEM-074, Codex B3 tightened): a direction claim needs
+ * BOTH values, and only a STRICT inequality earns one. Equality — and
+ * therefore also any upstream missing-baseline default when the flip value is
+ * 0 — falls back to the direction-neutral "crosses" wording. With no producer
+ * baseline at all the direction is unknowable, so "crosses" is the only
+ * honest option.
+ */
+
+import { classifyUnit } from '@/utils/unitClassifier'
+
+/**
+ * The flip-threshold sentences and tokens, exactly as `HERO_COPY.evidence`
+ * has always rendered them (ROADMAP 1.267 discipline preserved: the
+ * alternative-winner NAME is data and survives a withheld run; only the
+ * designation VERB changes with the verdict).
+ */
+export const FLIP_THRESHOLD_COPY = {
+  /** Switch-probability meta beside a flip row, e.g. "48% switch". */
+  switchMeta: (pct: string) => `${pct} switch`,
+  fallsBelow: 'falls below',
+  risesAbove: 'rises above',
+  // Direction-neutral fallback (UI-SEM-074): used when a direction claim
+  // would not be honestly determinable.
+  crosses: 'crosses',
+  flipRiskWithAlternative: (
+    factor: string,
+    direction: string,
+    value: string,
+    alternative: string,
+    designationsWithheld: boolean,
+  ) =>
+    designationsWithheld
+      ? `If ${factor} ${direction} ${value}, the comparison shifts towards ${alternative}.`
+      : `If ${factor} ${direction} ${value}, ${alternative} becomes the likely leader.`,
+  flipRiskNoAlternative: (
+    factor: string,
+    direction: string,
+    value: string,
+    designationsWithheld: boolean,
+  ) =>
+    designationsWithheld
+      ? `If ${factor} ${direction} ${value}, the comparison is likely to change.`
+      : `If ${factor} ${direction} ${value}, the leading option is likely to change.`,
+} as const
+
+/**
+ * Format a flip-threshold factor value with its OWN unit string (factor
+ * space, not outcome space). Unit placement follows the app-wide
+ * classifyUnit convention (symbol prefix, ISO space-prefix, % suffix,
+ * generic space-suffix) — but unlike formatValueWithUnit, the value ALWAYS
+ * renders as a number: a "crosses <value>" sentence must never substitute
+ * a qualitative word for the producer's numeric threshold. Display
+ * formatting only; the value itself is unchanged.
+ */
+export function formatFlipValue(value: number, unit?: string): string {
+  const rendered = value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
+  const { kind, canonical } = classifyUnit(unit ?? null)
+  if (kind === 'symbol') return `${canonical}${rendered}`
+  if (kind === 'iso') return `${canonical} ${rendered}`
+  if (kind === 'percent') return `${rendered}%`
+  if (kind === 'none' || kind === 'placeholder') return rendered
+  return `${rendered} ${canonical}`
+}
+
+/**
+ * The register wording for a threshold's direction against the current value:
+ * `falls below` / `rises above` on a strict inequality with a numeric
+ * baseline; `crosses` otherwise. Returns the register tokens so consumers
+ * cannot drift apart on the words.
+ */
+export function flipDirectionWording(
+  currentValue: number | null | undefined,
+  flipValue: number,
+): string {
+  if (typeof currentValue === 'number' && flipValue < currentValue) {
+    return FLIP_THRESHOLD_COPY.fallsBelow
+  }
+  if (typeof currentValue === 'number' && flipValue > currentValue) {
+    return FLIP_THRESHOLD_COPY.risesAbove
+  }
+  return FLIP_THRESHOLD_COPY.crosses
+}

--- a/src/components/results/utils/selectFlipRisk.ts
+++ b/src/components/results/utils/selectFlipRisk.ts
@@ -117,6 +117,14 @@ export interface FlipRiskCandidate {
   targetId?: string | null
   /** Producer factor / node id, joined to `flip_thresholds[].node_id`. */
   joinId?: string | null
+  /**
+   * ROADMAP 2.291: the EDGE's target-node label, carried verbatim so a
+   * surface that retains the edge statistic (`switch_probability`) can NAME
+   * the edge it belongs to ("{label} → {toLabel}") instead of attributing an
+   * edge number to a bare factor. Optional — callers with no edge to name
+   * omit it.
+   */
+  toLabel?: string | null
 }
 
 export interface FlipRiskSelection {
@@ -127,7 +135,25 @@ export interface FlipRiskSelection {
    */
   mayNameFlipRisk: boolean
   /** The one factor that may be named, or null. Never fabricated. */
-  topFlipRisk: { label: string; switchProbability: number; targetId?: string } | null
+  topFlipRisk: {
+    label: string
+    switchProbability: number
+    targetId?: string
+    /** The named candidate's edge target label, passed through verbatim. */
+    toLabel?: string
+    /**
+     * ROADMAP 2.291 — the producer's OWN flip evidence for the named factor:
+     * the `flip_thresholds` row (numeric `flip_value`) whose `node_id` is the
+     * candidate's join id. Present ONLY on `flips_present`, where the
+     * candidate set is already restricted to factors that flip, so a surface
+     * can state the factor's threshold / direction / alternative winner
+     * rather than dressing the edge's `switch_probability` up as "flip risk".
+     * The join lives HERE because this module already owns the id gate — a
+     * surface re-deriving "which row is my factor's" would be a second
+     * chooser, the defect this module exists to end.
+     */
+    flipThreshold?: FlipThresholdLike
+  } | null
 }
 
 /** Minimal shape read off a mapped flip threshold. */
@@ -141,6 +167,16 @@ export interface FlipThresholdLike {
    * vocabulary is open; `flipReasonVocabulary` does the classification.
    */
   flip_reason?: string | null
+  /**
+   * ROADMAP 2.291 — display fields carried VERBATIM off the mapped
+   * `FlipThreshold` row so the joined `topFlipRisk.flipThreshold` can drive
+   * the factor's own threshold statement. Never read by the gate, the floor
+   * or the ranking.
+   */
+  label?: string | null
+  current_value?: number | null
+  unit?: string | null
+  alternative_winner_label?: string | null
 }
 
 /**
@@ -234,6 +270,19 @@ export function selectFlipRisk(
     (c.switchProbability as number) > (best.switchProbability as number) ? c : best,
   )
 
+  // ROADMAP 2.291 — join the named factor's OWN flip evidence. Only on
+  // `flips_present` (eligibility already guarantees the join id flips), and
+  // only a row that actually carries the numeric `flip_value` — the same
+  // predicate `flippingIds` was built from, so the joined row is the evidence
+  // that admitted the candidate, never a sibling no-flip row for the same
+  // node.
+  const joinedThreshold =
+    evidence === 'flips_present' && top.joinId
+      ? (flipThresholds ?? []).find(
+          (ft) => ft?.node_id === top.joinId && typeof ft?.flip_value === 'number',
+        )
+      : undefined
+
   return {
     evidence,
     mayNameFlipRisk: true,
@@ -241,6 +290,8 @@ export function selectFlipRisk(
       label: top.label,
       switchProbability: top.switchProbability as number,
       ...(top.targetId ? { targetId: top.targetId } : {}),
+      ...(top.toLabel ? { toLabel: top.toLabel } : {}),
+      ...(joinedThreshold ? { flipThreshold: joinedThreshold } : {}),
     },
   }
 }

--- a/src/components/results/v7/V7Hero.tsx
+++ b/src/components/results/v7/V7Hero.tsx
@@ -137,6 +137,12 @@ export function V7Hero({
         topDrivers={topDrivers}
         fragileEdges={fragileEdges}
         flipThresholds={recommendation.flipThresholds}
+        // The panel-canonical withheld expression (same spelling as
+        // buildV7Headline / buildV7Lenses); the chip QUOTES it, never
+        // re-derives it (ROADMAP 2.291).
+        designationsWithheld={
+          recommendation.verdict != null && !recommendation.verdict.hasLeadingOption
+        }
         onFocusNode={onFocusNode}
       />
       <V7SuggestedChips onSendMessage={onSendMessage} />

--- a/src/components/results/v7/V7SignalRow.tsx
+++ b/src/components/results/v7/V7SignalRow.tsx
@@ -19,6 +19,11 @@ import { typography } from '@/styles/typography'
 import { formatPercent } from '@/utils/formatPercent'
 import type { DriverItem } from '../types'
 import { selectFlipRisk, type FlipThresholdLike } from '../utils/selectFlipRisk'
+import {
+  FLIP_THRESHOLD_COPY,
+  flipDirectionWording,
+  formatFlipValue,
+} from '../utils/flipThresholdDisplay'
 
 type FragileEdge = {
   edge_id?: string
@@ -39,11 +44,25 @@ export interface V7SignalRowProps {
    * the run produced any flip at all.
    */
   flipThresholds?: FlipThresholdLike[]
+  /**
+   * `!DecisionVerdict.hasLeadingOption`, QUOTED from the caller (V7Hero
+   * derives it with the panel-canonical expression) — never re-derived here,
+   * per the `fragileEdgeCopy` pattern. Chooses the withheld arm of the
+   * register's flip sentences: on a withheld run the threshold statement may
+   * not presuppose a leader exists to flip from.
+   */
+  designationsWithheld?: boolean
   /** Focus the matching canvas element when a chip is clicked. */
   onFocusNode?: (nodeId: string) => void
 }
 
-export function V7SignalRow({ topDrivers, fragileEdges, flipThresholds, onFocusNode }: V7SignalRowProps) {
+export function V7SignalRow({
+  topDrivers,
+  fragileEdges,
+  flipThresholds,
+  designationsWithheld = false,
+  onFocusNode,
+}: V7SignalRowProps) {
   // ROADMAP 2.276 — TWO defects closed here, both witnessed on staging
   // `a27cadf7` (witness-2267 §10):
   //
@@ -72,6 +91,7 @@ export function V7SignalRow({ topDrivers, fragileEdges, flipThresholds, onFocusN
       switchProbability: e.switch_probability,
       targetId: e.from_id,
       joinId: e.from_id,
+      toLabel: e.to_label,
     })),
   )
   const flip = flipSelection.topFlipRisk
@@ -80,9 +100,25 @@ export function V7SignalRow({ topDrivers, fragileEdges, flipThresholds, onFocusN
 
   const chips: React.ReactNode[] = []
 
-  // Flip-risk chip — only when the producer's flip evidence permits naming one.
+  // Flip chip — only when the producer's flip evidence permits naming one.
+  //
+  // ROADMAP 2.291 (Codex A8) — the number this chip used to print,
+  // `switch_probability`, is PLoT's probability that flipping an EDGE
+  // switches the recommendation. Rendering it as "N% flip risk · {factor}"
+  // attributed an edge statistic to a factor and called it flip evidence.
+  // Two honest arms now:
+  //   · `flips_present` — the selector supplies the named factor's OWN
+  //     threshold row, and the chip states THAT: threshold, direction and
+  //     alternative winner, through the same register sentences and the same
+  //     formatter the hero uses (one threshold never renders two ways on one
+  //     panel). The edge percentage is not mixed into the factor statement.
+  //   · `no_producer_flip_data` — the percentage is the only signal, so it is
+  //     retained, but under the register's own name for the quantity
+  //     ("N% switch") and attributed to the EDGE it belongs to, named
+  //     "{from} → {to}". The words "flip risk" leave this arm.
   if (flip && flipPct != null) {
     const focusId = flip.targetId
+    const ft = flip.flipThreshold
     chips.push(
       <button
         key="flip"
@@ -93,12 +129,33 @@ export function V7SignalRow({ topDrivers, fragileEdges, flipThresholds, onFocusN
         className={`inline-flex items-center gap-1.5 rounded-full border border-panel-border bg-transparent px-2 py-0.5 ${typography.panelMeta} text-text-body enabled:hover:bg-panel-hover disabled:cursor-default`}
       >
         <AlertTriangle className="h-3 w-3 flex-none text-warning" aria-hidden />
-        <span>
-          <span className="font-semibold text-text-header">
-            {formatPercent(flipPct, { fromDecimal: true })}
-          </span>{' '}
-          flip risk · {flip.label}
-        </span>
+        {ft && typeof ft.flip_value === 'number' ? (
+          <span>
+            {ft.alternative_winner_label
+              ? FLIP_THRESHOLD_COPY.flipRiskWithAlternative(
+                  flip.label,
+                  flipDirectionWording(ft.current_value, ft.flip_value),
+                  formatFlipValue(ft.flip_value, ft.unit ?? undefined),
+                  ft.alternative_winner_label,
+                  designationsWithheld,
+                )
+              : FLIP_THRESHOLD_COPY.flipRiskNoAlternative(
+                  flip.label,
+                  flipDirectionWording(ft.current_value, ft.flip_value),
+                  formatFlipValue(ft.flip_value, ft.unit ?? undefined),
+                  designationsWithheld,
+                )}
+          </span>
+        ) : (
+          <span>
+            <span className="font-semibold text-text-header">
+              {FLIP_THRESHOLD_COPY.switchMeta(formatPercent(flipPct, { fromDecimal: true }))}
+            </span>
+            {' · '}
+            {flip.label}
+            {flip.toLabel ? ` → ${flip.toLabel}` : ''}
+          </span>
+        )}
       </button>,
     )
   }

--- a/src/components/results/v7/__tests__/V7SignalRow.edgeStatHonesty.spec.tsx
+++ b/src/components/results/v7/__tests__/V7SignalRow.edgeStatHonesty.spec.tsx
@@ -1,0 +1,194 @@
+/**
+ * ROADMAP 2.291 (Codex A8) — an EDGE statistic may not display under a FACTOR
+ * label called "flip risk".
+ *
+ * THE DEFECT: `selectFlipRisk` uses `flip_thresholds` only as an ID gate and
+ * then returns `fragile_edges[].switch_probability`; the chip printed
+ * "N% flip risk · {from_label}". PLoT defines `switch_probability` as the
+ * probability that flipping an EDGE switches the recommendation — the number
+ * belongs to the edge, not the factor, and "flip risk" attributes it to the
+ * factor's own flip evidence.
+ *
+ * THE FIX, arm by arm:
+ *   · `flips_present` — the chip states the FACTOR'S OWN flip evidence: the
+ *     producer's threshold, its direction against the current value, and the
+ *     alternative winner where present, via the SAME register sentences and
+ *     the same formatter the hero uses (`FLIP_THRESHOLD_COPY.*`,
+ *     `formatFlipValue` — one threshold must never render two ways in one
+ *     panel). The edge percentage is NOT mixed into the factor statement.
+ *   · `no_producer_flip_data` — the percentage is the only signal, so it is
+ *     retained, but labelled with the register's own name for the quantity
+ *     ("N% switch", `FLIP_THRESHOLD_COPY.switchMeta`) and attributed to the
+ *     EDGE it belongs to, named "{from} → {to}". The words "flip risk" leave
+ *     this arm.
+ *
+ * ⚠ #557's attestation machinery (`classifyFlipEvidence`, `flips_absent`
+ * gating) is NOT touched — its specs (`V7SignalRow.flipHonesty.spec.tsx`,
+ * `selectFlipRisk.spec.ts`) must stay green alongside this file.
+ *
+ * CLAIM TYPE: jsdom text presence/absence only (trap 3).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7SignalRow } from '../V7SignalRow'
+import { FLIP_THRESHOLD_COPY } from '../../utils/flipThresholdDisplay'
+
+const EDGE = {
+  edge_id: 'fac_vendor_fit->out_success',
+  from_id: 'fac_vendor_fit',
+  from_label: 'Vendor Fit',
+  to_label: 'Deal Success',
+  switch_probability: 0.4,
+}
+
+const FLIPPING_THRESHOLD = {
+  node_id: 'fac_vendor_fit',
+  label: 'Vendor Fit',
+  current_value: 2000,
+  flip_value: 4000,
+  unit: '£',
+  flip_reason: 'found',
+  alternative_winner_label: 'Option B',
+}
+
+describe('V7SignalRow — flips_present states the factor threshold, not the edge stat (2.291)', () => {
+  it('RED-first: the chip no longer reads "N% flip risk · factor"', () => {
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[FLIPPING_THRESHOLD]}
+        topDrivers={[]}
+      />,
+    )
+    const chip = screen.getByTestId('v7-signal-flip-risk')
+    expect(chip.textContent).not.toContain('flip risk')
+    // The edge percentage is not mixed into the factor statement.
+    expect(chip.textContent).not.toContain('40%')
+  })
+
+  it('RED-first: threshold + direction + alternative winner, in the hero register sentence', () => {
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[FLIPPING_THRESHOLD]}
+        topDrivers={[]}
+      />,
+    )
+    const chip = screen.getByTestId('v7-signal-flip-risk')
+    // flip_value 4,000 > current 2,000 → "rises above"; £-symbol prefix.
+    expect(chip.textContent).toContain(
+      FLIP_THRESHOLD_COPY.flipRiskWithAlternative(
+        'Vendor Fit',
+        FLIP_THRESHOLD_COPY.risesAbove,
+        '£4,000',
+        'Option B',
+        false,
+      ),
+    )
+  })
+
+  it('withheld designations use the withheld register arm', () => {
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[FLIPPING_THRESHOLD]}
+        topDrivers={[]}
+        designationsWithheld
+      />,
+    )
+    const chip = screen.getByTestId('v7-signal-flip-risk')
+    expect(chip.textContent).toContain(
+      FLIP_THRESHOLD_COPY.flipRiskWithAlternative(
+        'Vendor Fit',
+        FLIP_THRESHOLD_COPY.risesAbove,
+        '£4,000',
+        'Option B',
+        true,
+      ),
+    )
+    // The permitted arm's designation verb must not appear.
+    expect(chip.textContent).not.toContain('becomes the likely leader')
+  })
+
+  it('direction: below-current flip value reads "falls below"; missing baseline reads "crosses"', () => {
+    const { unmount } = render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[{ ...FLIPPING_THRESHOLD, flip_value: 1000 }]}
+        topDrivers={[]}
+      />,
+    )
+    expect(screen.getByTestId('v7-signal-flip-risk').textContent).toContain(
+      `${FLIP_THRESHOLD_COPY.fallsBelow} £1,000`,
+    )
+    unmount()
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[{ ...FLIPPING_THRESHOLD, current_value: null }]}
+        topDrivers={[]}
+      />,
+    )
+    // No producer baseline → a direction claim is unknowable (UI-SEM-074).
+    expect(screen.getByTestId('v7-signal-flip-risk').textContent).toContain(
+      `${FLIP_THRESHOLD_COPY.crosses} £4,000`,
+    )
+  })
+
+  it('no alternative winner → the no-alternative register sentence', () => {
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[{ ...FLIPPING_THRESHOLD, alternative_winner_label: undefined }]}
+        topDrivers={[]}
+      />,
+    )
+    expect(screen.getByTestId('v7-signal-flip-risk').textContent).toContain(
+      FLIP_THRESHOLD_COPY.flipRiskNoAlternative(
+        'Vendor Fit',
+        FLIP_THRESHOLD_COPY.risesAbove,
+        '£4,000',
+        false,
+      ),
+    )
+  })
+
+  it('the chip still focuses the factor node', () => {
+    const onFocusNode = vi.fn()
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[FLIPPING_THRESHOLD]}
+        topDrivers={[]}
+        onFocusNode={onFocusNode}
+      />,
+    )
+    screen.getByTestId('v7-signal-flip-risk').click()
+    expect(onFocusNode).toHaveBeenCalledWith('fac_vendor_fit')
+  })
+})
+
+describe('V7SignalRow — legacy payloads label the retained percentage as the edge quantity (2.291)', () => {
+  it('RED-first: no flip thresholds → "N% switch" naming the EDGE, never "flip risk"', () => {
+    render(<V7SignalRow fragileEdges={[EDGE]} topDrivers={[]} />)
+    const chip = screen.getByTestId('v7-signal-flip-risk')
+    expect(chip.textContent).not.toContain('flip risk')
+    // The register's own name for the quantity, attributed to its edge.
+    expect(chip.textContent).toContain(FLIP_THRESHOLD_COPY.switchMeta('40%'))
+    expect(chip.textContent).toContain('Vendor Fit → Deal Success')
+  })
+
+  it('POSITIVE CONTROL (#557 unchanged): all-attested-no-flip still renders no chip at all', () => {
+    render(
+      <V7SignalRow
+        fragileEdges={[EDGE]}
+        flipThresholds={[
+          { node_id: 'fac_vendor_fit', flip_value: null, flip_reason: 'structurally_invariant' },
+        ]}
+        topDrivers={[]}
+      />,
+    )
+    expect(screen.queryByTestId('v7-signal-flip-risk')).toBeNull()
+  })
+})


### PR DESCRIPTION
ROADMAP **2.296** batch — the five confirmed defects from the external Codex audit, each independently premise-verified at staging tip `925eb818` before any code was written. One commit per item. Build-only lane: **adversarial review follows; do not merge on green CI alone.**

## The five fixes

### 1. C1 — Model Goal "Discuss with AI" restored (`c46ce891`)
`GoalSection`'s #553 wrapper accepted only `goalNode` and never forwarded the `onSendMessage` callback ModelTabBody still supplies, so the provider-gated Discuss button silently vanished from the goal card. The wrapper now forwards it.
**RED at pristine:** `Unable to find an element by: [data-testid="goal-discuss"]` through the REAL ModelTabBody→GoalSection path (the hop the defect lived in), ×2.

### 2. C3 — conditional bucket winners rendered neutrally (`418d9eea`)
The card attached every ISL conditional-winner entry to the low-bucket winner as "the default option" and printed **"Leads overall, but when {factor} exceeds {split}, {other} takes over"** — an overall claim the producer never made. Each bucket winner's card now states its own conditional fact; same-winner-both-buckets entries render nothing (the results panel's `ConditionalWinnerCards` filter).
**⚠ NEW USER-VOICE COPY — for Paul's copy deck:** `Leads when {factor} is below {split}` / `Leads when {factor} is above {split}` (minimal, factual, the brief's sanctioned shape). Removed string: `Leads overall, but when … exceeds …, … takes over`.
**RED at pristine:** `'…Leads overall…' not to contain 'Leads overall'`; high-bucket winner's card testid absent; same-winner card rendered.

### 3. C4 — unsourced `strengthStd=0.15` no longer displays as measured uncertainty (`7c22db62`)
`RelationshipsSection` read the raw field (`strengthStd ?? strength_std`), so the `USER_EDGE_DEFAULTS` constant displayed as a measured σ on three surfaces. All three now resolve through `resolveEdgeValueDisplay(data, 'strengthStd')` — the registry (`edgeValueProvenance.ts`) which cannot hand back a number without a source.

**Complete Std-surface manifest (`rg -an "strengthStd|strength_std|σ|±"`, post-fix), touched file:**
- `RelationshipsSection.tsx:197-198` — the ONE gated read (fixed)
- `:321-323` inline σ chip · `:402-404` ± beside semantic label · `:456,468-472` full-detail Std row — all fed only by the gated read
- **Deliberately left, named:** `ContestedEdgeCard.tsx:516,528` render `validation.pass1.strength_std` — a producer-signed CEE validator value that exists only when CEE sent it, not the edge-data default. `useModelHealth`'s extreme-weight check reads std as a computation input; the 0.15 default cannot reach its printed branch (requires `std < 0.05`). Non-Model-tab surfaces out of this item's scope (rowable): `EdgeInspector.tsx:488`, `EdgePanel.tsx:196` (slider default), `EdgeAdvancedEditor.tsx:26`, `GraphTextView.tsx:195` (component itself has no production render site), `PayloadLabTab` (debug).

**Disclosed behaviour change:** the legacy raw `strength_std` display leg is REMOVED. The registry deliberately declares no back-compat fallback for std ("inventing one would launder the default"). An unstamped producer `strength_std` (e.g. a `graph_patch` `after` spread via `applyV5State`, if CEE ever sends one there) now renders nothing until its ingestion site stamps it — the sanctioned fix for that, if wanted, is a stamp at the ingestion site, never a display-side fallback. Sanctioned stamp writers already exist: `applyDraftResult` (`'cee'`), inspector `setStd` (`'user'`).
One existing fixture (`RelationshipsSection.spec.tsx` expert-inline test) updated to stamp `strengthStd` — it models a characterised edge; unstamped it modelled the fallthrough default, which now has its own spec.

### 4. 2.291 / Codex A8 — edge statistic no longer displayed as a factor's "flip risk" (`32bb70d4`)
The V7 chip printed `N% flip risk · {from_label}` where N% is `fragile_edges[].switch_probability` — PLoT's probability that flipping an **EDGE** switches the recommendation. Two honest arms now:
- **`flips_present`** — `selectFlipRisk` additionally returns the named factor's OWN `flip_thresholds` row (the join lives in the owner; a surface re-deriving it would be a second chooser), and the chip states **threshold + direction + alternative winner** via the register sentences (e.g. *"If Vendor Fit rises above £4,000, Option B becomes the likely leader."* / withheld arm *"…the comparison shifts towards Option B."*). The edge percentage is not mixed into the factor statement.
- **`no_producer_flip_data`** — the percentage is the only signal, so it is retained, but labelled with the register's own name for the quantity (**"N% switch"**, `switchMeta`) and attributed to the edge it belongs to, named **"{from} → {to}"**. "flip risk" leaves this arm.

Structure: the flip sentences + `formatFlipValue` + the UI-SEM-074 direction rule moved **verbatim** to `utils/flipThresholdDisplay.ts` (the hero module is mount-guarded by `inertness.spec.ts`, so the shared spelling must live outside it); `HERO_COPY.evidence` now delegates **by reference**, pinned by new identity tests in `heroCopyDelegation.spec.ts`. `designationsWithheld` is quoted from V7Hero with the panel-canonical expression (`verdict != null && !verdict.hasLeadingOption`), per the `fragileEdgeCopy` pattern. `selectFlipRisk` changes are additive only.
**⚠ #557 non-regression:** `classifyFlipEvidence`, the `flips_absent` gate, the UI-SEM-013 floor and the rank-by-displayed-metric rule are untouched; `V7SignalRow.flipHonesty.spec.tsx` (5), `selectFlipRisk.spec.ts` (9), `flipReasonVocabulary.spec.ts`, `useResultsSectionData.flipThresholdEvidence.spec.ts` all green on this branch.
No new user-voice copy in this item: both arms reuse existing register strings verbatim.

### 5. 2.282-C2 — GoalPanel's possessive gate lit on the real V5 shape (`0d95c945`)
The panel passed the WHOLE report into `selectGoalProbability`, which expects one option-probability record; the live mapper stores those under `report.option_probabilities[id]`, so `probGoal` was null on every real payload and #556's corrected copy never executed — a dark gate certified green by fixtures that fabricated root-level probability fields (the named lesson).
The panel now renders what `useNodeDisplayMetadata` gives it — the established pointer-owner for the goal surface family (resolves `robustness.recommended_option_id`, forwards the selector's decision verbatim; same hop as the canvas GoalNode, so panel and canvas cannot disagree, and on the 2.275 pointer-less posture both honestly show no figure). The hook gains optional `jointGoalProbability`, forwarded from the SAME decision. The #556 gates confirmed active over the real shape: the Impact-block suppression, the Constraints-section cross-gate and the register dedupe are all pinned by the rewritten spec (counted assertions, not `toContain`).
**Fixtures now built through the REAL `mapV5AnalysisToReport`**; the constrained positive control is declared as the internal post-mapper shape (the V5 mapper cannot emit per-option `constraint_analysis` — seam 2 is constant-gated in the V4 responseMapper). `GoalPanel.simulationCount.spec.tsx`'s root-level fixtures corrected to the real shape too.

## RED-first evidence — full decomposition (amended after adversarial review)
Two captures exist, and both are stated so the arithmetic is derivable (completeness rule):

**(1) FINAL spec files run at base `925eb818`** (reproduced in a throwaway base-tip worktree, this branch's spec bytes): **27 assertion-REDs + 8 collect-REDs / 12 controls green**, per file:

| Spec file | tests | assertion-RED | controls green |
|---|---|---|---|
| `ModelTabBody.goalDiscuss.spec.tsx` | 3 | 2 | 1 |
| `optionsSectionConditionalNeutrality.spec.tsx` | 7 | 5 | 2 |
| `relationshipsSectionStdProvenance.spec.tsx` | 5 | 4 | 1 |
| `useNodeDisplayMetadata.jointGoal.spec.ts` | 5 | 2 | 3 |
| `GoalPanel.possessiveGate.spec.tsx` | 13 | 10 | 3 |
| `GoalPanel.simulationCount.spec.tsx` | 2 | 2 | 0 |
| `selectFlipRisk.thresholdJoin.spec.ts` | 4 | 2 | 2 |
| `V7SignalRow.edgeStatHonesty.spec.tsx` | 8 | **8 collect-RED** (`Failed to resolve import "../../utils/flipThresholdDisplay"` — the module does not exist at base) | 0 |

Notes on the two deltas from the in-flight capture: (a) `simulationCount`'s 2 REDs are **introduced by this branch's fixture-shape correction** — the ORIGINAL spec content is 2/2 green at pristine and was never claimed as RED-first evidence; the reviewer's 25-assertion tally excludes these two (25 + 2 = 27). (b) `edgeStatHonesty` REDs at COLLECT with the final bytes because its register import postdates base; its per-assertion signatures were captured with the intermediate import (below).

**(2) In-flight capture at pristine** (intermediate `edgeStatHonesty` still importing `analysis-hero/heroCopy`, which exists at base, so the file collected; `simulationCount` not yet touched): **31 assertion-REDs / 14 controls green over 45** — decomposes as the 25 above + `edgeStatHonesty` 6 assertion-RED / 2 controls green. Every named signature identical across both captures.

All are green at this branch's tip; every control still green.

## Mutation table (throwaway detached worktree OUTSIDE the repo root, removed before gate runs — traps 9/9c/11)

| Mutant | What it does | Named spec(s) | Result |
|---|---|---|---|
| M1 | revert C1 forwarding | ModelTabBody.goalDiscuss | **2 RED** / 1 control green |
| M2a | restore "Leads overall … takes over" copy | optionsSectionConditionalNeutrality | **3 RED** |
| M2b | re-attach to low-bucket winner only | same | **1 RED** (high-bucket statement) |
| M2c | drop same-winner filter | same | **1 RED** |
| M3 | revert std read to raw `strengthStd ?? strength_std` | relationshipsSectionStdProvenance | **4 RED** / control green |
| M4a | chip ignores joined threshold | V7SignalRow.edgeStatHonesty | **5 RED** |
| M4b | selector never joins (`flips_present && joinId` → false) | thresholdJoin + edgeStatHonesty | **7 RED** |
| M4c | direction rule always "crosses" | edgeStatHonesty + full hero suite | **8 RED** (incl. hero UI-SEM-074 pins — the delegation is load-bearing on BOTH surfaces) |
| M4d | legacy arm relabelled back to "flip risk", edge name dropped | edgeStatHonesty | **1 RED** |
| M5a | hook forwards `jointGoalProbability = null` | jointGoal + possessiveGate | **6 RED** |
| M5b | panel `probGoal = null` (the dark gate reproduced) | possessiveGate + simulationCount | **11 RED** |
| M5c | possessive gate widened to any joint basis | possessiveGate | **2 RED** (constrained positive controls) |

## Gates at this branch tip
- `pnpm typecheck` — PASS, exactly at baseline: 3144/3184 files loaded, **622 files / 2505 errors (baseline 2505)**. No new errors absorbed, no `--update-baseline`.
- `pnpm lint` (eslint + hooks ratchet) — PASS; hooks ratchet **234 violations / 16 files, exact baseline match**.
- Full vitest suite: run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` set (trap 2b) — result in the lane report and this PR's checks.

## Residuals / honest limits
- All claims here are jsdom presence/absence — **no layout or visibility claims** (trap 3). The five surfaces (Model-tab goal card, options cards, relationship cards, V7 hero chip, Goal inspector panel) belong on the next browser walk.
- Item 5 activates on payloads that carry `robustness.recommended_option_id` (present in the witnessed 2026-07-31 payload `cee-analysis-turn-probe2154`). On the 2.275 pointer-less posture the panel now honestly shows no figure — same as the canvas; the pointer gap remains separately rowed.
- C4 rowable follow-up: a `strengthStdSource` stamp at `applyV5State`'s `adjust_edge_strength` ingestion if CEE ever ships `strength_std` in a patch `after`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
