### PR TITLE
fix(ui): walk-honesty batch — fence-409 copy, value-entry validation, goal-code humanise, Model-tab goal fit

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -28,6 +28,7 @@ import { SectionErrorBoundary } from './GraphTextView'
 import type { MappedRobustness } from '../../lib/mappers/types'
 import { trackGuidance } from '../../telemetry/guidanceEvents'
 import { GoalSection } from './model-tab/GoalSection'
+import { buildGoalFitRows } from './model-tab/buildGoalFitRows'
 import { OptionsSection } from './model-tab/OptionsSection'
 import { FactorsSection } from './model-tab/FactorsSection'
 import { RelationshipsSection } from './model-tab/RelationshipsSection'
@@ -430,6 +431,16 @@ export const ModelTabBody = memo(function ModelTabBody({
     [nodes, edges]
   )
 
+  // Per-option goal-fit rows for the goal card (journey-walk §10.4 tab
+  // parity). Same source object the conditional-winners and e-value maps
+  // above already read (`results.report`); the chooser and the complete-field
+  // gate live in buildGoalFitRows.
+  const goalFitRows = useMemo(() => {
+    const report = (results as { report?: { option_probabilities?: Record<string, unknown> } } | null)
+      ?.report
+    return buildGoalFitRows(grouped.option, report?.option_probabilities)
+  }, [results, grouped.option])
+
   // ── Robustness data ───────────────────────────────────────────────────────
 
   // hasAnalysisData is true if either:
@@ -736,7 +747,7 @@ export const ModelTabBody = memo(function ModelTabBody({
 
         {/* ── Sections ───────────────────────────────────────────────── */}
         <div className="space-y-4">
-          <GoalSection goalNode={grouped.goal[0]} onSendMessage={onSendMessage} />
+          <GoalSection goalNode={grouped.goal[0]} onSendMessage={onSendMessage} goalFitRows={goalFitRows} />
 
           <OptionsSection
             optionNodes={grouped.option}

--- a/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
@@ -1,0 +1,219 @@
+/**
+ * Goal-probability tab parity — journey-walk 2026-08-03 §10.4 (Paul's 2.262
+ * tab-parity directive), Model-tab arm.
+ *
+ * THE WITNESSED GAP (journey-walk-2026-08-03.md §10.4, quartet UI 43fd19e1):
+ * per-option goal probability renders on the Analysis tab only ("N% chance of
+ * hitting your goal", Goal fit lens) — the Model tab's goal card shows Target
+ * only. WIRING GAP, not a design decision, derived at the bytes: ModelTabBody
+ * already holds `results.report` and maps report data into sibling sections
+ * (conditional winners → OptionsSection, edge e-values → Relationships), and
+ * the per-option figures sit in the SAME report at
+ * `report.option_probabilities` — GoalSection is simply never handed them.
+ *
+ * DISCIPLINE (matches the Analysis-tab surfaces exactly):
+ *  · ONE chooser: every figure resolves through `selectGoalProbability` —
+ *    never a raw read of the owned fields (claim-ownership registration).
+ *  · Register-only copy: `GOAL_ANCHOR_COPY.phrase` carries the possessive
+ *    gate — the substituted-joint basis withholds "your goal" wording.
+ *  · Complete-field gate (the V7 goal lens / OptionCards "Hits target" rule):
+ *    rows render only when a target is set AND every option carries an
+ *    admissible figure — no partial rankings.
+ *  · Modelled-basis caveat: `GOAL_FIT_BASIS_CAVEAT_COPY` adjacent whenever
+ *    the number rides `scored_from === 'modelled_outcome_distribution'`.
+ *  · Producer order preserved (grouped option order) — no re-sorting, no
+ *    winner designation minted here.
+ *
+ * RED-first at pristine 43fd19e1: the goal card renders no per-option rows,
+ * so the first describe fails. Fixture values are the walk's real wire
+ * figures (0.0987 / 0.12 / 0.1633 / 0.02 → 10% / 12% / 16% / 2%).
+ *
+ * CLAIM TYPE: jsdom presence only — never layout or visibility (trap 3).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { ModelTabBody } from '../ModelTabBody'
+import type { Node } from '@xyflow/react'
+
+// ── Mocks (same shape as ModelTabBody.goalDiscuss.spec.tsx) ──────────────────
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+let mockResults: unknown = null
+
+function getMockState() {
+  return {
+    nodes: mockGraph.nodes,
+    edges: mockGraph.edges,
+    updateNode: vi.fn(),
+    updateEdge: vi.fn(),
+    ceePipelineTrace: null,
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+    currentScenarioId: null,
+    currentStage: null,
+    graphEditedSinceLastRun: false,
+    results: mockResults,
+  }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(getMockState())),
+    { getState: getMockState },
+  ),
+}))
+
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// ── Fixtures — the walk's real option set and wire figures ────────────────────
+
+function makeNodes(): Node[] {
+  const mk = (id: string, type: string, label: string, data: Record<string, unknown> = {}): Node =>
+    ({ id, type, position: { x: 0, y: 0 }, data: { label, ...data } }) as Node
+  return [
+    mk('goal_arr', 'goal', 'Reach £1,000,000 ARR', {
+      goal_threshold_raw: 1000000,
+      goal_threshold_unit: '£',
+      goal_threshold: 0.8,
+    }),
+    mk('opt_content', 'option', 'Invest in Content Marketing'),
+    mk('opt_sales', 'option', 'Hire Two Sales Reps'),
+    mk('opt_selfserve', 'option', 'Build Self-Serve Tier'),
+    mk('opt_statusquo', 'option', 'Continue Current Approach (Status Quo)'),
+  ]
+}
+
+/** Walk wire figures (journey-walk §2): goal probabilities per option. */
+function walkOptionProbabilities(): Record<string, Record<string, unknown>> {
+  return {
+    opt_content: { win_probability: 0.23, goal_probability: 0.0987 },
+    opt_sales: { win_probability: 0.3, goal_probability: 0.12 },
+    opt_selfserve: { win_probability: 0.46, goal_probability: 0.1633 },
+    opt_statusquo: { win_probability: 0.0145, goal_probability: 0.02 },
+  }
+}
+
+function setResults(optionProbabilities: Record<string, unknown> | undefined): void {
+  mockResults = optionProbabilities
+    ? { status: 'complete', report: { option_probabilities: optionProbabilities } }
+    : null
+}
+
+const DEFAULT_PROPS = {
+  showDebug: false,
+  hasDiagnostics: false,
+  diagnostics: null,
+  hasTrim: false,
+  effectiveCorrelationId: null,
+  correlationMismatch: false,
+  correlationIdHeader: null,
+  robustness: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockResults = null
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Model-tab goal card — per-option goal fit (real ModelTabBody→GoalSection path)', () => {
+  it('renders every option with its register-copy goal-fit readout (walk figures)', () => {
+    setResults(walkOptionProbabilities())
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    const section = screen.getByTestId('model-goal-section')
+    const rows = within(section).getByTestId('goal-fit-parity')
+    // All four options, producer figures faithfully rounded, register phrase.
+    expect(rows).toHaveTextContent('Invest in Content Marketing')
+    expect(rows).toHaveTextContent('10% chance of hitting your goal')
+    expect(rows).toHaveTextContent('Hire Two Sales Reps')
+    expect(rows).toHaveTextContent('12% chance of hitting your goal')
+    expect(rows).toHaveTextContent('Build Self-Serve Tier')
+    expect(rows).toHaveTextContent('16% chance of hitting your goal')
+    expect(rows).toHaveTextContent('Continue Current Approach (Status Quo)')
+    expect(rows).toHaveTextContent('2% chance of hitting your goal')
+  })
+
+  it('substituted-joint basis withholds the possessive and renders the modelled-basis caveat', () => {
+    // The witnessed 2.282 shape: goal_probability absent, joint present,
+    // scored from the modelled outcome distribution.
+    setResults({
+      opt_content: {
+        probability_of_joint_goal: 0.0054,
+        goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+      },
+      opt_sales: {
+        probability_of_joint_goal: 0.55,
+        goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+      },
+      opt_selfserve: {
+        probability_of_joint_goal: 0.3,
+        goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+      },
+      opt_statusquo: {
+        probability_of_joint_goal: 0.1,
+        goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+      },
+    })
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    const rows = screen.getByTestId('goal-fit-parity')
+    // The possessive claim names a question the substituted number does not
+    // answer — the register's withheld arm renders instead.
+    expect(rows).not.toHaveTextContent('chance of hitting your goal')
+    expect(rows).toHaveTextContent('chance of meeting every target this run scored')
+    // Doctrine B: the caveat must sit adjacent to the number.
+    expect(screen.getByTestId('goal-fit-modelled-caveat')).toHaveTextContent(
+      "Modelled from the target's projected outcome distribution",
+    )
+  })
+})
+
+describe('honest gates — no partial rankings, no rows without a basis', () => {
+  it('one option without an admissible figure → NO rows at all (complete-field rule)', () => {
+    const probs = walkOptionProbabilities()
+    delete probs.opt_statusquo
+    setResults(probs)
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('goal-fit-parity')).toBeNull()
+  })
+
+  it('no target set on the goal → no rows even with full figures', () => {
+    setResults(walkOptionProbabilities())
+    const nodes = makeNodes().map(n =>
+      n.id === 'goal_arr'
+        ? ({ ...n, data: { label: 'Reach £1,000,000 ARR' } } as Node)
+        : n,
+    )
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={[]} />)
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('goal-fit-parity')).toBeNull()
+  })
+
+  it('no analysis results → the goal card is unchanged (target row only)', () => {
+    setResults(undefined)
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+    expect(screen.queryByTestId('goal-fit-parity')).toBeNull()
+  })
+
+  it('sub-1% figures render the floor readout, never a rounded-to-zero claim', () => {
+    const probs = walkOptionProbabilities()
+    probs.opt_statusquo = { win_probability: 0.0145, goal_probability: 0.004 }
+    setResults(probs)
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    expect(screen.getByTestId('goal-fit-parity')).toHaveTextContent('< 1%')
+  })
+})

--- a/src/canvas/components/model-tab/GoalSection.tsx
+++ b/src/canvas/components/model-tab/GoalSection.tsx
@@ -17,10 +17,23 @@ import { SourceProvenancePill } from './SourceProvenancePill'
 import { InlineEdit } from './InlineEdit'
 import { formatSmartNumber, formatValueWithUnit } from './utils'
 import { DetailToggleContext } from './DetailToggleContext'
+import { GOAL_ANCHOR_COPY } from '../../../components/results/utils/goalAnchorCopy'
+import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../../components/results/utils/goalFitBasisCaveatCopy'
+import { formatGoalProbability } from '../../../components/results/utils/displayFloors'
+import type { GoalFitRow } from './buildGoalFitRows'
 
 interface GoalSectionProps {
   goalNode: Node | undefined
   onSendMessage?: (message: string) => void
+  /**
+   * Per-option goal-fit rows (journey-walk §10.4 tab parity). Built by
+   * `buildGoalFitRows` in ModelTabBody — complete-field gated (null unless
+   * EVERY option carries an admissible figure), one chooser
+   * (`selectGoalProbability`), producer order. Rendered only when the card
+   * also shows a target: the figures answer "chance of reaching the target",
+   * so they never render on a card that displays no target.
+   */
+  goalFitRows?: GoalFitRow[] | null
 }
 
 /**
@@ -45,7 +58,7 @@ interface GoalSectionProps {
  * unmount happens instead of a mid-render bail-out. Narrowing the prop is what
  * stops the guard being reintroduced here: there is no `undefined` left to test.
  */
-function GoalSectionInner({ goalNode, onSendMessage }: GoalSectionProps & { goalNode: Node }) {
+function GoalSectionInner({ goalNode, onSendMessage, goalFitRows }: GoalSectionProps & { goalNode: Node }) {
   const { showDetail } = useContext(DetailToggleContext)
   // ROADMAP 2.121 slice 1 — the ONE production writer of a user success target
   // (this file's own comment below has always named it). Every other
@@ -175,6 +188,37 @@ function GoalSectionInner({ goalNode, onSendMessage }: GoalSectionProps & { goal
         </div>
       )}
 
+      {/* Per-option goal fit (journey-walk §10.4 tab parity). Register-only
+          copy: GOAL_ANCHOR_COPY.phrase carries the possessive gate (the
+          substituted-joint basis withholds "your goal"); formatGoalProbability
+          is the shared floor+formatter (sub-1% renders "< 1%", never "0%");
+          the caveat is doctrine B — adjacent whenever a figure rides the
+          modelled-outcome-distribution basis. Rows are complete-field gated
+          upstream (buildGoalFitRows) and render only beside a displayed
+          target. */}
+      {displayThreshold !== null && goalFitRows && goalFitRows.length > 0 && (
+        <div className="mt-2 space-y-0.5" data-testid="goal-fit-parity">
+          {goalFitRows.map(row => (
+            <div key={row.id} className={`${typography.panelMeta} text-text-body`}>
+              <span className="text-text-header">{row.label}</span>
+              {' — '}
+              {GOAL_ANCHOR_COPY.phrase(
+                formatGoalProbability(row.probability),
+                row.isSubstitutedJoint,
+              )}
+            </div>
+          ))}
+          {goalFitRows.some(row => row.modelledBasis) && (
+            <p
+              className={`${typography.panelMeta} text-text-light`}
+              data-testid="goal-fit-modelled-caveat"
+            >
+              {GOAL_FIT_BASIS_CAVEAT_COPY}
+            </p>
+          )}
+        </div>
+      )}
+
       {/* Feasibility warning */}
       {showFeasibilityWarning && (
         <div
@@ -232,7 +276,7 @@ function GoalSectionInner({ goalNode, onSendMessage }: GoalSectionProps & { goal
   )
 }
 
-export function GoalSection({ goalNode, onSendMessage }: GoalSectionProps) {
+export function GoalSection({ goalNode, onSendMessage, goalFitRows }: GoalSectionProps) {
   // The absence guard lives HERE, in a component with no hooks, so an arriving
   // or departing goal node mounts/unmounts the inner component rather than
   // changing its hook count mid-render. See `GoalSectionInner`'s header.
@@ -244,10 +288,11 @@ export function GoalSection({ goalNode, onSendMessage }: GoalSectionProps) {
   // ModelTabBody kept supplying the callback. Pinned by
   // `__tests__/ModelTabBody.goalDiscuss.spec.tsx` through the REAL
   // ModelTabBody→GoalSection path — the hop this defect lived in.
+  // `goalFitRows` is pinned the same way by ModelTabBody.goalFitParity.spec.tsx.
   if (!goalNode) return null
   return (
     <SectionErrorBoundary section="goal">
-      <GoalSectionInner goalNode={goalNode} onSendMessage={onSendMessage} />
+      <GoalSectionInner goalNode={goalNode} onSendMessage={onSendMessage} goalFitRows={goalFitRows} />
     </SectionErrorBoundary>
   )
 }

--- a/src/canvas/components/model-tab/buildGoalFitRows.ts
+++ b/src/canvas/components/model-tab/buildGoalFitRows.ts
@@ -1,0 +1,58 @@
+/**
+ * buildGoalFitRows — per-option goal-fit rows for the Model tab's goal card
+ * (journey-walk 2026-08-03 §10.4 tab-parity: goal probability rendered on the
+ * Analysis tab only; the report data was already in ModelTabBody's hands).
+ *
+ * Discipline, matching the Analysis-tab surfaces exactly:
+ *  · ONE chooser — every figure resolves through `selectGoalProbability`
+ *    (the claim-ownership registered owner of goal_probability /
+ *    probability_of_goal / probability_of_joint_goal). This module never
+ *    reads those fields itself; it hands each `option_probabilities` entry
+ *    to the owner and reads the decision.
+ *  · Complete-field rule (the V7 goal lens / OptionCards "Hits target"
+ *    gate): rows are returned ONLY when every option node has an admissible
+ *    figure. A partial list would be a ranking over a subset presented as a
+ *    ranking over the options — return null instead and render nothing.
+ *  · Producer order preserved — rows follow the caller's option order; no
+ *    re-sorting, no winner designation minted here.
+ */
+
+import type { Node } from '@xyflow/react'
+import {
+  selectGoalProbability,
+  type GoalProbabilityInput,
+} from '../../../components/results/utils/selectGoalProbability'
+
+export interface GoalFitRow {
+  id: string
+  label: string
+  /** The chosen producer probability in [0,1] — see `selectGoalProbability`. */
+  probability: number
+  /** Possessive gate: basis 'joint_goal_substituted' withholds "your goal". */
+  isSubstitutedJoint: boolean
+  /** Doctrine B: `GOAL_FIT_BASIS_CAVEAT_COPY` must render adjacent when true. */
+  modelledBasis: boolean
+}
+
+export function buildGoalFitRows(
+  optionNodes: ReadonlyArray<Node>,
+  optionProbabilities: Record<string, unknown> | null | undefined,
+): GoalFitRow[] | null {
+  if (!optionProbabilities || optionNodes.length === 0) return null
+  const rows: GoalFitRow[] = []
+  for (const node of optionNodes) {
+    const entry = optionProbabilities[node.id]
+    if (!entry || typeof entry !== 'object') return null
+    const decision = selectGoalProbability(entry as GoalProbabilityInput)
+    if (decision.goalProbability == null) return null
+    const data = node.data as Record<string, unknown> | undefined
+    rows.push({
+      id: node.id,
+      label: typeof data?.label === 'string' ? data.label : node.id,
+      probability: decision.goalProbability,
+      isSubstitutedJoint: decision.basis === 'joint_goal_substituted',
+      modelledBasis: decision.goalFitIsModelledBasis,
+    })
+  }
+  return rows
+}

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -272,6 +272,16 @@ export const FIELD_FEEDBACK_COPY = {
   olumiUnavailable: 'Olumi is unavailable right now. Open the Olumi panel and try again.',
   addValue: 'Add value',
   check: 'Check',
+  edit: 'Edit',
+  /**
+   * Range refusal for normalised-scale-only factors (journey-walk gap #3):
+   * no cap, no unit, no raw-value anchor — the committed number IS the
+   * model-scale value, so a magnitude like £60,000 would paint 6000000%.
+   * Mirrors the NL path's honest refusal vocabulary ("recorded without a
+   * unit").
+   */
+  normalisedRangeHint:
+    'This factor is recorded without a unit on a 0–1 scale. Enter a value between 0 and 1.',
 } as const
 
 export const HERO_COPY = {

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -17,7 +17,7 @@ import Tooltip from '../../../../components/Tooltip'
 import { typography, typo } from '../../../../styles/typography'
 import { FIELD_FEEDBACK_COPY } from '../constants'
 import { useCanvasStore } from '../../../store'
-import { normaliseRawFactorValue, withObservedStateUpdate } from '../../../utils/observedStateHelpers'
+import { getObservedState, normaliseRawFactorValue, withObservedStateUpdate } from '../../../utils/observedStateHelpers'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import { parseSuccessTarget } from '../hero/parseSuccessTarget'
 import type { EstimateRowModel } from '../types'
@@ -39,6 +39,43 @@ function commitValue(nodeId: string, rawValue: number, cap: number | null): void
       source: 'user_override',
     }),
   })
+}
+
+/**
+ * Range guard for normalised-scale-only factors — journey-walk 2026-08-03
+ * gap #3 (ROADMAP 2.159/S1/S3 class), the witnessed `£60,000` → "6000000%"
+ * chain.
+ *
+ * When a factor carries NO cap, NO unit and NO raw-value display anchor but
+ * DOES carry a model-scale `value` in [0,1], the number this editor commits
+ * IS the model-scale value (normaliseRawFactorValue returns it verbatim
+ * without a cap) and every downstream surface treats it as 0–1 — the canvas
+ * painted the walk's 60000 as "6000000%". The NL edit path already refuses
+ * exactly this shape ("recorded without a unit … I haven't changed
+ * anything"); this guard gives the direct editor the same discipline.
+ *
+ * Validation reads ONLY what the node data genuinely carries
+ * (observedState value / raw_value / unit / cap) — ROADMAP 2.193: no
+ * structured bound crosses the wire, so no server contract is invented.
+ * Factors with a cap (raw/cap normalisation exists), a unit, a raw anchor,
+ * or no value at all keep today's behaviour: for those, the typed number is
+ * the factor's own display-scale anchor (pinned by
+ * calibrateDrillInParse.spec.tsx).
+ */
+function refusesNormalisedScaleEntry(
+  nodeData: unknown,
+  cap: number | null,
+  parsedValue: number,
+): boolean {
+  if (typeof cap === 'number' && Number.isFinite(cap) && cap > 0) return false
+  const observed = getObservedState(nodeData)
+  if (observed.unit != null && String(observed.unit).trim() !== '') return false
+  if (observed.raw_value != null) return false
+  const existing = observed.value
+  const declaredNormalised =
+    typeof existing === 'number' && Number.isFinite(existing) && existing >= 0 && existing <= 1
+  if (!declaredNormalised) return false
+  return parsedValue < 0 || parsedValue > 1
 }
 
 function commitConfirm(nodeId: string): void {
@@ -76,6 +113,14 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
     const parsed = parseSuccessTarget(draft)
     if (parsed === null) {
       setHint(FIELD_FEEDBACK_COPY.numberHint)
+      return
+    }
+    // Walk gap #3: on a normalised-scale-only factor the committed number IS
+    // the model-scale value — refuse out-of-range magnitudes at entry with
+    // honest copy instead of painting them as absurd percentages.
+    const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
+    if (node && refusesNormalisedScaleEntry(node.data, row.cap, parsed.value)) {
+      setHint(FIELD_FEEDBACK_COPY.normalisedRangeHint)
       return
     }
     commitValue(row.nodeId, parsed.value, row.cap)

--- a/src/canvas/components/pre-analysis-v3/model/EstimateRow.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/EstimateRow.tsx
@@ -38,8 +38,30 @@ export const EstimateRow = memo(function EstimateRow({ row, expanded, onToggle }
   )
 
   const action = row.reviewed ? (
-    <span className="inline-flex h-7 w-7 items-center justify-center" aria-hidden>
-      <Check className="h-3.5 w-3.5 text-success" />
+    // Journey-walk gap #3 (dead-end half): once "checked by you", the Check
+    // button vanished and a wrong checked value could not be repaired from
+    // the surface that accepted it. The tick stays (the state is truthful);
+    // an Edit affordance reopens the same drill-in.
+    <span className="inline-flex items-center gap-1">
+      <span className="inline-flex h-7 w-4 items-center justify-center" aria-hidden>
+        <Check className="h-3.5 w-3.5 text-success" />
+      </span>
+      <Tooltip content="Edit the value you checked" delay={300}>
+        <button
+          type="button"
+          onClick={() => onToggle(row.nodeId)}
+          aria-expanded={expanded}
+          aria-label={`Edit your estimate for ${row.label}`}
+          className={typo(
+            'panelMeta',
+            'inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-panel-border bg-transparent px-2 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+          )}
+          data-testid={`pre-analysis-v3-edit-${row.nodeId}`}
+        >
+          <Pencil className="h-3 w-3" aria-hidden />
+          {FIELD_FEEDBACK_COPY.edit}
+        </button>
+      </Tooltip>
     </span>
   ) : row.needsValue ? (
     <button

--- a/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
@@ -368,7 +368,11 @@ export const YourDecisionSection = memo(function YourDecisionSection({
                   setExpandedEstimate(current => (current === nodeId ? null : nodeId))
                 }
               />
-              {expandedEstimate === row.nodeId && !row.reviewed && (
+              {/* Walk gap #3 (dead-end half): the old `&& !row.reviewed` guard
+                  locked a wrong checked value out of the editor that accepted
+                  it. Reviewed rows now reopen the same drill-in via the row's
+                  Edit affordance. */}
+              {expandedEstimate === row.nodeId && (
                 <CalibrateDrillIn row={row} onDone={() => setExpandedEstimate(null)} />
               )}
             </div>

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInRange.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInRange.spec.tsx
@@ -1,0 +1,212 @@
+/**
+ * CalibrateDrillIn range guard — journey-walk 2026-08-03 gap #3 (ROADMAP
+ * 2.159/S1/S3 class), the witnessed shape at the bytes.
+ *
+ * THE WITNESSED DEFECT (journey-walk-2026-08-03.md §1b, UI 43fd19e1): the
+ * guided "Best next step" configure path offered "Your estimate for Content
+ * Marketing Investment" on a factor recorded WITHOUT a unit, without a cap,
+ * with a normalised model-scale value (0, painted "Low (0)"). Typing
+ * `£60,000` was accepted silently; commitValue wrote raw_value=60000 AND
+ * value=60000 (normaliseRawFactorValue returns the raw number verbatim when
+ * cap is absent), the canvas painted "6000000%" on three option nodes, the
+ * sidebar claimed "checked by you", and the server never received any of it.
+ * The NL path refused the same edit honestly ("recorded without a unit …
+ * I haven't changed anything") — the direct editor enforced nothing.
+ *
+ * THE GUARD: when the factor's own declared shape is normalised-scale-only —
+ * no cap, no unit, no raw-value display anchor, but an existing model-scale
+ * `value` in [0,1] — the committed number IS a model-scale value, so an entry
+ * outside [0,1] is refused at entry with an honest hint. Validation uses ONLY
+ * what the node data genuinely carries (observedState value/raw_value/unit/
+ * cap) — 2.193: no structured bound crosses the wire, so no server contract
+ * is invented.
+ *
+ * RED-first at pristine 43fd19e1: the walk-shape test commits 60000 and shows
+ * no hint, so it fails.
+ *
+ * GUARD-NOT-OVERFIRING controls pin the two neighbouring behaviours the
+ * repo's own tests already rely on (calibrateDrillInParse.spec.tsx): an EMPTY
+ * factor (no observedState at all) still accepts a magnitude verbatim, and a
+ * cap-bearing factor still normalises raw/cap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import type { EstimateRowModel } from '../../types'
+import { useCanvasStore } from '../../../../store'
+import { getObservedState } from '../../../../utils/observedStateHelpers'
+
+/** The walk's row shape: capless, unitless, value-bearing, editable. */
+const walkRow: EstimateRowModel = {
+  nodeId: 'fac_content_marketing',
+  label: 'Content Marketing Investment',
+  rankLabel: 'top',
+  weight: 1,
+  reviewed: false,
+  aiSourced: true,
+  attribution: { kind: 'olumi' },
+  displayText: 'Low (0)',
+  rawPrefill: null,
+  cap: null,
+  canEditValue: true,
+  needsValue: false,
+}
+
+/** Seed the walk's node shape: normalised value 0, no raw_value, no unit, no cap. */
+function seedWalkNode(): void {
+  useCanvasStore.setState({
+    nodes: [
+      {
+        id: 'fac_content_marketing',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: {
+          kind: 'factor',
+          label: 'Content Marketing Investment',
+          observedState: {
+            value: 0,
+            display_value: 'Low (0)',
+            source: 'cee_inference',
+            extractionType: 'inferred',
+          },
+        },
+      } as Node,
+    ],
+    edges: [],
+  })
+}
+
+function typeAndSave(text: string, row: EstimateRowModel = walkRow): void {
+  fireEvent.change(screen.getByLabelText(`Your estimate for ${row.label}`), {
+    target: { value: text },
+  })
+  fireEvent.click(screen.getByLabelText(`Save estimate for ${row.label}`))
+}
+
+describe('CalibrateDrillIn — normalised-scale-only factors refuse magnitude entries (walk gap #3)', () => {
+  beforeEach(() => {
+    cleanup()
+    seedWalkNode()
+  })
+
+  it('the witnessed entry "£60,000" is refused: nothing committed, honest hint shown', () => {
+    render(<CalibrateDrillIn row={walkRow} onDone={vi.fn()} />)
+    typeAndSave('£60,000')
+    const os = getObservedState(
+      useCanvasStore.getState().nodes.find(n => n.id === 'fac_content_marketing')?.data,
+    )
+    // The 6000000% chain starts here: neither field may move.
+    expect(os.raw_value).toBeUndefined()
+    expect(os.value).toBe(0)
+    expect(os.source).toBe('cee_inference')
+    const hint = screen.getByRole('status')
+    // Honest, factual, actionable: names the factor's own recorded shape.
+    expect(hint.textContent).toMatch(/without a unit/i)
+    expect(hint.textContent).toMatch(/between 0 and 1/i)
+  })
+
+  it('"60%" is refused the same way (the NL path already refuses % on this factor)', () => {
+    render(<CalibrateDrillIn row={walkRow} onDone={vi.fn()} />)
+    typeAndSave('60%')
+    const os = getObservedState(
+      useCanvasStore.getState().nodes.find(n => n.id === 'fac_content_marketing')?.data,
+    )
+    expect(os.raw_value).toBeUndefined()
+    expect(os.value).toBe(0)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('an in-range entry "0.6" commits (the guard refuses magnitudes, not the editor)', () => {
+    const onDone = vi.fn()
+    render(<CalibrateDrillIn row={walkRow} onDone={onDone} />)
+    typeAndSave('0.6')
+    const os = getObservedState(
+      useCanvasStore.getState().nodes.find(n => n.id === 'fac_content_marketing')?.data,
+    )
+    expect(os.raw_value).toBe(0.6)
+    expect(os.value).toBe(0.6)
+    expect(os.source).toBe('user_override')
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('boundary values 0 and 1 commit; a negative entry is refused', () => {
+    render(<CalibrateDrillIn row={walkRow} onDone={vi.fn()} />)
+    typeAndSave('1')
+    expect(
+      getObservedState(
+        useCanvasStore.getState().nodes.find(n => n.id === 'fac_content_marketing')?.data,
+      ).raw_value,
+    ).toBe(1)
+
+    cleanup()
+    seedWalkNode()
+    render(<CalibrateDrillIn row={walkRow} onDone={vi.fn()} />)
+    typeAndSave('-0.2')
+    const os = getObservedState(
+      useCanvasStore.getState().nodes.find(n => n.id === 'fac_content_marketing')?.data,
+    )
+    expect(os.raw_value).toBeUndefined()
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('control: an EMPTY factor (no observedState) still accepts a magnitude verbatim — the parse-spec contract is untouched', () => {
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'f-empty',
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: { kind: 'factor', label: 'Incremental ARR' },
+        } as Node,
+      ],
+      edges: [],
+    })
+    const emptyRow: EstimateRowModel = {
+      ...walkRow,
+      nodeId: 'f-empty',
+      label: 'Incremental ARR',
+      displayText: null,
+      needsValue: true,
+    }
+    render(<CalibrateDrillIn row={emptyRow} onDone={vi.fn()} />)
+    typeAndSave('£60,000', emptyRow)
+    expect(
+      getObservedState(useCanvasStore.getState().nodes.find(n => n.id === 'f-empty')?.data)
+        .raw_value,
+    ).toBe(60000)
+  })
+
+  it('control: a cap-bearing factor still normalises raw/cap ("£60,000" on cap 150000 → 0.4)', () => {
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'f-cap',
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: {
+            kind: 'factor',
+            label: 'Growth Budget Spend',
+            observedState: { value: 0.2, cap: 150000, source: 'cee_inference' },
+          },
+        } as Node,
+      ],
+      edges: [],
+    })
+    const capRow: EstimateRowModel = {
+      ...walkRow,
+      nodeId: 'f-cap',
+      label: 'Growth Budget Spend',
+      cap: 150000,
+    }
+    render(<CalibrateDrillIn row={capRow} onDone={vi.fn()} />)
+    typeAndSave('£60,000', capRow)
+    const os = getObservedState(
+      useCanvasStore.getState().nodes.find(n => n.id === 'f-cap')?.data,
+    )
+    expect(os.raw_value).toBe(60000)
+    expect(os.value).toBeCloseTo(0.4)
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/estimateReEdit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/estimateReEdit.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * Reviewed-estimate re-edit affordance — journey-walk 2026-08-03 gap #3,
+ * dead-end half.
+ *
+ * THE WITNESSED DEAD END (journey-walk-2026-08-03.md §1b item 5, UI
+ * 43fd19e1): once a row reads "checked by you" its Check button is GONE —
+ * `EstimateRow`'s reviewed branch renders a static tick with no affordance,
+ * and `YourDecisionSection` additionally guards the drill-in with
+ * `expandedEstimate === row.nodeId && !row.reviewed`. A wrong checked value
+ * (the walk's silently-accepted `£60,000`) therefore cannot be repaired from
+ * the surface that accepted it: the tester is locked out of their own edit.
+ *
+ * FIX SHAPE: reviewed rows keep an "Edit" affordance that reopens the same
+ * drill-in; the parent guard drops `!row.reviewed`. No optimistic-state
+ * change, no new write path — the same commitValue/commitConfirm handlers.
+ *
+ * RED-first at pristine 43fd19e1: the edit affordance testid does not exist
+ * and the drill-in cannot open for a reviewed row.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { EstimateRow } from '../EstimateRow'
+import type { EstimateRowModel } from '../../types'
+import { PreAnalysisPanelV3 } from '../../PreAnalysisPanelV3'
+import { ToastProvider } from '../../../../ToastContext'
+import { useCanvasStore } from '../../../../store'
+import { useReadinessStore } from '../../../../stores/readinessStore'
+
+const base: EstimateRowModel = {
+  nodeId: 'f1',
+  label: 'Content Marketing Investment',
+  rankLabel: 'lower',
+  weight: 1,
+  reviewed: true,
+  aiSourced: false,
+  attribution: { kind: 'person', displayName: 'You' },
+  displayText: '0.6',
+  rawPrefill: 0.6,
+  cap: null,
+  canEditValue: true,
+  needsValue: false,
+}
+
+describe('EstimateRow — a reviewed row still offers a way back into the editor', () => {
+  it('reviewed row renders an Edit affordance alongside the completion tick', () => {
+    const onToggle = vi.fn()
+    render(<EstimateRow row={base} expanded={false} onToggle={onToggle} />)
+    // The completion pill stays — the affordance does not falsify the state.
+    expect(screen.getByText('checked by you')).toBeInTheDocument()
+    const edit = screen.getByTestId('pre-analysis-v3-edit-f1')
+    expect(edit.tagName).toBe('BUTTON')
+    fireEvent.click(edit)
+    expect(onToggle).toHaveBeenCalledWith('f1')
+  })
+
+  it('confirm-only reviewed rows (canEditValue false) offer the affordance too — Confirm-as-is state is also revisitable', () => {
+    render(
+      <EstimateRow
+        row={{ ...base, canEditValue: false, displayText: null }}
+        expanded={false}
+        onToggle={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('pre-analysis-v3-edit-f1')).toBeInTheDocument()
+  })
+})
+
+function node(id: string, kind: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+describe('YourDecisionSection guard — the drill-in opens for a reviewed row (real panel path)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+    useReadinessStore.setState({
+      readiness: {
+        readiness_score: 60,
+        readiness_level: 'fair',
+        can_run_analysis: true,
+        confidence_explanation: '',
+        improvements: [],
+      },
+      loading: false,
+      error: null,
+    })
+    useCanvasStore.setState({
+      nodes: [
+        node('d1', 'decision', 'Grow ARR to £1M?'),
+        node('g1', 'goal', 'Reach £1,000,000 ARR', { goal_threshold: 0.8 }),
+        node('o1', 'option', 'Invest in Content Marketing'),
+        node('o2', 'option', 'Hire Two Sales Reps'),
+        // A user-reviewed factor: source user_override = "checked by you".
+        node('f1', 'factor', 'Content Marketing Investment', {
+          observedState: { raw_value: 0.6, value: 0.6, source: 'user_override' },
+        }),
+      ],
+      edges: [],
+      preAnalysisSensitivity: null,
+      draftCoaching: null,
+      currentBriefText: null,
+      goalThreshold: 0.8,
+    })
+  })
+
+  it('clicking Edit on the reviewed row opens the drill-in input', () => {
+    render(
+      <ToastProvider>
+        <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun blockedReason={undefined} />
+      </ToastProvider>,
+    )
+    // Open the "Your decision" disclosure, then the estimates group (both
+    // closed at rest — the group renders children only when open).
+    fireEvent.click(
+      within(screen.getByTestId('pre-analysis-v3-your-decision')).getAllByRole('button')[0],
+    )
+    fireEvent.click(
+      within(screen.getByTestId('pre-analysis-v3-group-estimates')).getAllByRole('button')[0],
+    )
+    fireEvent.click(screen.getByTestId('pre-analysis-v3-edit-f1'))
+    expect(
+      screen.getByLabelText('Your estimate for Content Marketing Investment'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.fence409Honesty.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.fence409Honesty.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Fence-409 transcript honesty — journey-walk 2026-08-03 gap #2 (LIVE V5 chain).
+ *
+ * THE WITNESSED LIE (journey-walk-2026-08-03.md §4/§8, quartet CEE 78cbb60 ·
+ * UI 43fd19e1): every graph-commit value edit died with HTTP 409
+ * `GRAPH_DIVERGED`, `details.conflict_category: 'turn_fence_unclaimed'`,
+ * `retryable: false` — and the UI rendered *"Your decision has changed since
+ * this result was computed. Re-run the analysis to refresh it."* On scenario 3
+ * (virgin control) NOTHING had ever been computed; obeying the banner (Rerun)
+ * produced byte-identical numbers and the next edit 409'd identically. The
+ * banner was false and its remedy an infinite loop.
+ *
+ * THE MECHANISM AT THE BYTES: the copy is the canonical
+ * `FAILURE_USER_TEXT.GRAPH_DIVERGED` staleness string (vendored
+ * @talchain/schemas 0.31.0, boundary/error-codes.js:38), authored for the
+ * analysed-graph-drifted case. CEE deliberately rides fence refusals on the
+ * SAME wire code (olumi-assistants-service `turn-executor.ts` at fee17e3a:
+ * "Rides the EXISTING 409-class envelope … rather than minting a wire code"),
+ * carrying the distinguisher ONLY in `details.conflict_category`
+ * (`turn_fence_${verdict}`, verdict ∈ stopped|superseded|unclaimed|unavailable)
+ * — and the UI read that field NOWHERE (`rg -a conflict_category src/` → 0
+ * hits at pristine 43fd19e1). So a write-fence refusal borrowed the staleness
+ * banner. This spec drives the walk's wire shape through the REAL
+ * callV5Turn → parseV5Response → routeV5Response → useConversation
+ * typed_error branch (same harness discipline as
+ * useConversation.transcriptHonesty504.spec.ts) and pins honest copy.
+ *
+ * RED-first at pristine 43fd19e1: the transcript renders the staleness banner
+ * for this fixture, so every test in the first describe fails.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+
+// ---------------------------------------------------------------------------
+// Mocks — seams only; the V5 adapter/parser/router chain stays REAL.
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(msg: string, status: number, body: unknown) {
+      super(msg)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Wire fixtures — the walk's witnessed 409 shape (journey-walk §4/§8; producer
+// literal shape from CEE turn-executor.ts at fee17e3a: `conflict_category:
+// `turn_fence_${verdict}``, `recovery_action` per verdict).
+// ---------------------------------------------------------------------------
+
+function fence409Body(verdict: 'stopped' | 'superseded' | 'unclaimed') {
+  return {
+    error: 'GRAPH_DIVERGED',
+    boundary: 'B1',
+    direction: 'egress',
+    validator: 'turn_commit',
+    details: {
+      phase: 'commit',
+      fence_verdict: verdict,
+      conflict_category: `turn_fence_${verdict}`,
+      recovery_action:
+        verdict === 'stopped'
+          ? 'start_new_draft'
+          : verdict === 'superseded'
+            ? 'refresh_and_reconfirm'
+            : 'retry_later',
+      // Walk §8 (scenario 3, virgin control): the compound parsed and executed;
+      // only the write fence killed it. Details is a passthrough object, so the
+      // extra key rides exactly as it did on the live wire.
+      stages_completed: ['build_turn_context', 'orient', 'validate', 'execute', 'confirm', 'coach', 'compose'],
+    },
+    request_id: 'req_walk_409',
+    retryable: false,
+  }
+}
+
+/** A NON-fence GRAPH_DIVERGED (graph-CAS class): the canonical staleness copy
+ * remains the honest rendering for this class and must be untouched. */
+const CAS_409_BODY = {
+  error: 'GRAPH_DIVERGED',
+  boundary: 'B1',
+  direction: 'egress',
+  validator: 'turn_commit',
+  details: {
+    phase: 'commit',
+    recovery_action: 'refresh_and_reconfirm',
+    conflict_category: 'analysis_affecting_conflict',
+    expected_base_graph_hash: null,
+  },
+  request_id: 'req_cas_409',
+  retryable: false,
+}
+
+const STALENESS_BANNER =
+  'Your decision has changed since this result was computed. Re-run the analysis to refresh it.'
+
+function stubFetchWith(status: number, body: unknown) {
+  const fetchStub = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fence 409 — the staleness banner must NOT render for a write-fence refusal', () => {
+  it('turn_fence_unclaimed (the walk shape): no "decision has changed", no "re-run" instruction; says nothing was changed', async () => {
+    stubFetchWith(409, fence409Body('unclaimed'))
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Set Monthly Email Spend to £1,800')
+    })
+
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.role).toBe('assistant')
+    // The witnessed untruth, in either fragment, must be gone.
+    expect(last.content).not.toContain('Your decision has changed')
+    expect(last.content).not.toContain('Re-run the analysis')
+    // The honest core: the change was not saved and the model is unchanged.
+    expect(last.content).toMatch(/couldn.t be saved|wasn.t saved/i)
+    expect(last.content).toMatch(/nothing in your decision (was )?changed/i)
+  })
+
+  it('turn_fence_stopped: names the stop as the cause, states nothing changed', async () => {
+    stubFetchWith(409, fence409Body('stopped'))
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Set Churn Trend to 80%')
+    })
+
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.content).not.toContain(STALENESS_BANNER)
+    expect(last.content).toMatch(/stopped/i)
+    expect(last.content).toMatch(/nothing in your decision (was )?changed/i)
+  })
+
+  it('turn_fence_superseded: names the newer-change conflict, states nothing was overwritten', async () => {
+    stubFetchWith(409, fence409Body('superseded'))
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Set Available Growth Budget to 70%')
+    })
+
+    const last = result.current.messages[result.current.messages.length - 1]
+    expect(last.content).not.toContain(STALENESS_BANNER)
+    expect(last.content).toMatch(/newer change/i)
+    expect(last.content).toMatch(/nothing was overwritten/i)
+  })
+
+  it('user message still marked failed (delivery honesty unchanged by the copy fix)', async () => {
+    stubFetchWith(409, fence409Body('unclaimed'))
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Set Capital Expenditure to £300,000')
+    })
+    const userMsg = result.current.messages.find((m) => m.role === 'user')
+    expect(userMsg?.deliveryState).toBe('failed')
+    expect(result.current.lastSendFailure?.kind).toBe('server')
+  })
+})
+
+describe('non-fence GRAPH_DIVERGED — canonical copy preserved (guard against overreach)', () => {
+  it('graph-CAS conflict_category keeps the canonical staleness copy (that class genuinely diverged)', async () => {
+    stubFetchWith(409, CAS_409_BODY)
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendMessage('Set Churn Trend to 80%')
+    })
+    const last = result.current.messages[result.current.messages.length - 1]
+    // Positive control (trap 13): this spec CAN see the canonical copy when it
+    // is the honest rendering — so the absences asserted above test something.
+    expect(last.content).toContain('Your decision has changed')
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -33,7 +33,7 @@ import {
   extractReason as extractV5ErrorReason,
   resolveGuidance as resolveV5ErrorGuidance,
   resolveRetryable as resolveV5Retryable,
-  resolveFailureBaseCopy,
+  resolveFailureCopyForError,
 } from '../../v5/failureTypeRetryability'
 import { mapV5Blocks } from '../../v5/blocks/mapV5Blocks'
 import { buildSuggestedActionChips } from '../../v5/blocks/suggestedActionChips'
@@ -4904,7 +4904,15 @@ export function useConversation(): UseConversationReturn {
               //   4. generic code-keyed guidance only when no specific
               //      suggestion filled the what-next slot (non-retryable codes
               //      only — the Try again chip serves that role otherwise).
-              const baseCopy = resolveFailureBaseCopy(target.code, retryable)
+              // Fence-aware (journey-walk gap #2): a fence-class GRAPH_DIVERGED
+              // (details.conflict_category 'turn_fence_*') is a write refusal,
+              // never staleness — it gets honest "nothing changed" copy instead
+              // of the canonical re-run banner. See resolveFenceRefusalCopy.
+              const baseCopy = resolveFailureCopyForError(
+                target.code,
+                retryable,
+                target.boundaryError,
+              )
               const reason = extractV5ErrorReason(target.boundaryError)
               const reasonLayer =
                 recovery.suggestion === undefined && isDisplaySafeReason(reason) ? reason : ''

--- a/src/canvas/hooks/__tests__/useScienceIcons.userOwned.spec.tsx
+++ b/src/canvas/hooks/__tests__/useScienceIcons.userOwned.spec.tsx
@@ -1,0 +1,83 @@
+/**
+ * Science-icon provenance honesty — journey-walk 2026-08-03 gap #3, third
+ * contradicting surface.
+ *
+ * THE WITNESSED CONTRADICTION (journey-walk-2026-08-03.md §1b item 5, UI
+ * 43fd19e1): after the user "checked" Content Marketing Investment, the
+ * sidebar pill said "checked by you" while clicking the canvas node surfaced
+ * "Olumi estimated this value. May not match reality." — two surfaces, one
+ * factor, opposite provenance claims.
+ *
+ * THE MECHANISM AT THE BYTES: `useScienceIcons.ts` gates the olumi-estimate
+ * icon on `extractionType === 'inferred'` ALONE. The user-override write path
+ * (`CalibrateDrillIn.commitValue` → `withObservedStateUpdate` spread) sets
+ * `source: 'user_override'` but never touches `extractionType`, so a factor
+ * the user has explicitly overridden keeps claiming "Olumi estimated this
+ * value". The sidebar's claim derives from the canonical reviewed-source
+ * predicate (`isReviewedSource`); the icon must consult the SAME predicate so
+ * the two surfaces cannot disagree — never a second hand-kept source list
+ * (trap 12).
+ *
+ * RED-first at pristine 43fd19e1: the user-override case still shows the
+ * icon, so the first test fails.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { useScienceIcons } from '../useScienceIcons'
+import { useCanvasStore } from '../../store'
+
+function seedFactor(observedState: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    nodes: [
+      {
+        id: 'f1',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { kind: 'factor', label: 'Content Marketing Investment', observedState },
+      } as Node,
+    ],
+    edges: [],
+    ceeAnalysisReady: null,
+  })
+}
+
+describe('useScienceIcons — "Olumi estimated this value" never renders on a user-owned value', () => {
+  beforeEach(() => {
+    seedFactor({})
+  })
+
+  it('the walk shape: extractionType inferred + source user_override → NO olumi-estimate icon', () => {
+    seedFactor({
+      value: 0.6,
+      raw_value: 0.6,
+      source: 'user_override',
+      extractionType: 'inferred',
+    })
+    const { result } = renderHook(() => useScienceIcons('f1', 'factor'))
+    expect(result.current.find(i => i.id === 'olumi-estimate')).toBeUndefined()
+  })
+
+  it('user_confirmed keeps the icon off too (Confirm-as-is is user ownership)', () => {
+    seedFactor({
+      value: 0,
+      source: 'user_confirmed',
+      extractionType: 'inferred',
+    })
+    const { result } = renderHook(() => useScienceIcons('f1', 'factor'))
+    expect(result.current.find(i => i.id === 'olumi-estimate')).toBeUndefined()
+  })
+
+  it('positive control (trap 13): an untouched inferred estimate still shows the icon', () => {
+    seedFactor({
+      value: 0.4,
+      source: 'cee_inference',
+      extractionType: 'inferred',
+    })
+    const { result } = renderHook(() => useScienceIcons('f1', 'factor'))
+    const icon = result.current.find(i => i.id === 'olumi-estimate')
+    expect(icon).toBeDefined()
+    expect(icon?.tooltip).toBe('Olumi estimated this value. May not match reality.')
+  })
+})

--- a/src/canvas/hooks/useScienceIcons.ts
+++ b/src/canvas/hooks/useScienceIcons.ts
@@ -16,6 +16,7 @@ import type { ComponentType } from 'react'
 import type { NodeType } from '../domain/nodes'
 import { computeSignedMean } from '../domain/edges'
 import { unwrapInterventionValue } from '../utils/labelUtils'
+import { isReviewedSource } from '../components/pre-analysis/utils/isReviewedByUser'
 
 export interface ScienceIconDef {
   id: string
@@ -61,8 +62,16 @@ export function useScienceIcons(nodeId: string, nodeType: NodeType): ScienceIcon
         })
       }
 
-      // 2. Olumi estimate
-      if (extractionType === 'inferred') {
+      // 2. Olumi estimate — journey-walk gap #3 (third contradicting
+      // surface): gating on `extractionType === 'inferred'` ALONE kept this
+      // claim alive after a user override (commitValue sets source
+      // 'user_override' but never touches extractionType), so the canvas said
+      // "Olumi estimated this value" about a factor the sidebar called
+      // "checked by you". The user-ownership question is answered by the
+      // canonical reviewed-source predicate — the SAME one the sidebar pill
+      // derives from — never a second hand-kept source list (trap 12).
+      const source = observedState?.source as string | undefined
+      if (extractionType === 'inferred' && !isReviewedSource(source)) {
         icons.push({
           id: 'olumi-estimate',
           icon: Sparkles,

--- a/src/components/results/__tests__/humaniseCritique.goalCodes.spec.ts
+++ b/src/components/results/__tests__/humaniseCritique.goalCodes.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Goal-threshold refusal codes get goal-scoped humanised copy — ROADMAP 2.300
+ * item 1 (extends 2.271's named-reason last mile).
+ *
+ * THE DEFECT: ISL's two goal-threshold refusal codes survive every transport
+ * hop (PLoT keeps the code; `inference_warnings` is on CEE's keep-list;
+ * InferenceWarningStrip mounts unconditionally) but `humaniseCritique.ts`
+ * `CODE_TEMPLATES` has no entry for either, so a GOAL-level refusal renders
+ * the generic FACTOR-framed fallback "Review this factor's inputs"
+ * (humaniseCritique.ts:270-274 at pristine 43fd19e1) — mislabelling the
+ * condition and discarding the actionable remedy.
+ *
+ * PRODUCER SEMANTICS, derived at ISL staging tip (robustness_analyzer_v2.py,
+ * `_resolve_goal_threshold` refuse() sites):
+ *   · GOAL_THRESHOLD_FRAME_UNSPECIFIED — the threshold was supplied without a
+ *     frame ('level' vs 'delta'), so ISL omits probability_of_goal rather
+ *     than guess (witnessed verbatim in witness-2258).
+ *   · GOAL_THRESHOLD_NOT_CONVERTIBLE — a level threshold could not be
+ *     converted into the goal samples' frame (reasons include
+ *     missing_goal_baseline — no recorded current level — plus structural
+ *     ones: goal pinned by an intervention, root goal, parameter uncertainty
+ *     on the goal, auto-noise). Copy states the withhold factually and names
+ *     the user-actionable remedy (state the current level) without claiming
+ *     it is the only cause.
+ *
+ * RED-first at pristine 43fd19e1: both codes fall through to the generic
+ * factor-framed fallback, so every assertion on goal-scoped copy fails.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { humaniseCritique } from '../utils/humaniseCritique'
+import type { UncertaintyItem } from '../types'
+
+function item(code: string): UncertaintyItem {
+  return {
+    code,
+    severity: 'warning',
+    message: 'raw producer prose — must never render',
+  } as UncertaintyItem
+}
+
+describe('humaniseCritique — goal-threshold refusals are goal-scoped, never factor-framed', () => {
+  it('GOAL_THRESHOLD_NOT_CONVERTIBLE: goal-scoped title, honest withhold description, actionable current-level remedy', () => {
+    const result = humaniseCritique(item('GOAL_THRESHOLD_NOT_CONVERTIBLE'))
+    // Not the generic factor-framed fallback.
+    expect(result.title).not.toBe("Review this factor's inputs")
+    expect(result.title.toLowerCase()).toContain('goal')
+    expect(result.title.toLowerCase()).not.toContain('factor')
+    // The honest substance: withheld, not guessed.
+    expect(result.description).toMatch(/withheld|left out/i)
+    // The actionable remedy the walk's tester needed.
+    expect(result.suggestion?.toLowerCase()).toContain('current level')
+    // Banner-eligible: goal-scoped copy carries no internal tokens.
+    expect(result.displayText).toBe(result.title)
+  })
+
+  it('GOAL_THRESHOLD_FRAME_UNSPECIFIED: names the level-vs-change ambiguity and how to resolve it', () => {
+    const result = humaniseCritique(item('GOAL_THRESHOLD_FRAME_UNSPECIFIED'))
+    expect(result.title).not.toBe("Review this factor's inputs")
+    expect(result.title.toLowerCase()).toContain('goal')
+    expect(result.title.toLowerCase()).not.toContain('factor')
+    expect(result.description).toMatch(/level/i)
+    expect(result.description).toMatch(/change/i)
+    expect(result.description).toMatch(/withheld|left out/i)
+    expect(result.suggestion).toMatch(/level|change/i)
+    expect(result.displayText).toBe(result.title)
+  })
+
+  it('neither template leaks the raw producer message', () => {
+    for (const code of ['GOAL_THRESHOLD_NOT_CONVERTIBLE', 'GOAL_THRESHOLD_FRAME_UNSPECIFIED']) {
+      const result = humaniseCritique(item(code))
+      expect(result.title).not.toContain('raw producer prose')
+      expect(result.description).not.toContain('raw producer prose')
+    }
+  })
+})

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -170,6 +170,31 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: "The direction of your target (whether higher or lower is better) wasn't confirmed, so it was assumed for this run. Goal-fit results for this option may be less reliable.",
     suggestion: `Confirm the target direction for ${label}`,
   }),
+  // ROADMAP 2.300 item 1 (extends 2.271) — ISL's two goal-threshold refusal
+  // codes (robustness_analyzer_v2.py `_resolve_goal_threshold`, fail-closed:
+  // probability_of_goal is OMITTED rather than guessed, the warning names
+  // why). Without templates these goal-level refusals fell to the generic
+  // FACTOR-framed fallback ("Review this factor's inputs"), mislabelling the
+  // condition. Both templates deliberately ignore the resolved label: the
+  // condition is about the GOAL's target/baseline, and the fallback label
+  // ("This factor") would be a category error when affectedNodes is absent.
+  //
+  // NOT_CONVERTIBLE's producer reasons include missing_goal_baseline (no
+  // recorded current level — the tester-reachable case) plus structural ones
+  // (goal pinned by an intervention, root goal, parameter uncertainty on the
+  // goal, auto-noise), so the description states the withhold factually and
+  // the suggestion names the user-actionable remedy without claiming it is
+  // the only cause.
+  GOAL_THRESHOLD_NOT_CONVERTIBLE: () => ({
+    title: "Your goal's target couldn't be measured for this run",
+    description: 'The target couldn\'t be compared with where the goal stands today — for example when no current level is recorded for it — so goal-fit results were withheld rather than guessed.',
+    suggestion: 'State the current level for your goal',
+  }),
+  GOAL_THRESHOLD_FRAME_UNSPECIFIED: () => ({
+    title: "Your goal's target could mean a level or a change",
+    description: "The target doesn't say whether it's a level to reach or a change from today, so goal-fit results were withheld for this run rather than guessed.",
+    suggestion: 'Restate the target as a level to reach or a change from your current level',
+  }),
 }
 
 // ─── Internal token detection ────────────────────────────────────────────────

--- a/src/v5/TypedErrorRenderer.tsx
+++ b/src/v5/TypedErrorRenderer.tsx
@@ -18,7 +18,7 @@ import {
   type BoundaryError,
 } from '@talchain/schemas/boundary'
 
-import { extractReason, resolveGuidance } from './failureTypeRetryability'
+import { extractReason, resolveFenceRefusalCopy, resolveGuidance } from './failureTypeRetryability'
 
 export interface TypedErrorRendererProps {
   code: FailureTypeLiteral
@@ -57,7 +57,11 @@ function resolveUserText(code: FailureTypeLiteral): string {
 
 export function TypedErrorRenderer(props: TypedErrorRendererProps): ReactElement {
   const { code, requestId, severity = 'error', boundaryError } = props
-  const text = resolveUserText(code)
+  // Fence-aware (journey-walk gap #2): a fence-class GRAPH_DIVERGED
+  // (details.conflict_category 'turn_fence_*') is a write refusal, never
+  // staleness — same resolution as useConversation's typed_error branch.
+  const fenceCopy = code === 'GRAPH_DIVERGED' ? resolveFenceRefusalCopy(boundaryError) : null
+  const text = fenceCopy ?? resolveUserText(code)
   const guidance = resolveGuidance(code)
   const reason = extractReason(boundaryError)
 

--- a/src/v5/__tests__/TypedErrorRenderer.test.tsx
+++ b/src/v5/__tests__/TypedErrorRenderer.test.tsx
@@ -136,3 +136,55 @@ describe('TypedErrorRenderer — Phase 4 retryability + reason passthrough', () 
     expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
   });
 });
+
+describe('TypedErrorRenderer — fence-class GRAPH_DIVERGED (journey-walk gap #2)', () => {
+  it('a turn_fence conflict_category renders honest write-refusal copy, never the staleness banner', () => {
+    render(
+      <TypedErrorRenderer
+        code="GRAPH_DIVERGED"
+        boundaryError={{
+          error: 'GRAPH_DIVERGED',
+          boundary: 'B1',
+          direction: 'egress',
+          validator: 'turn_commit',
+          details: {
+            phase: 'commit',
+            fence_verdict: 'unclaimed',
+            conflict_category: 'turn_fence_unclaimed',
+            recovery_action: 'retry_later',
+          },
+          request_id: 'req-walk-409',
+          retryable: false,
+        }}
+      />,
+    );
+    const text = screen.getByTestId('typed-error-text').textContent ?? '';
+    expect(text).not.toContain('Your decision has changed');
+    expect(text).not.toContain('Re-run the analysis');
+    expect(text).toMatch(/nothing in your decision changed/i);
+  });
+
+  it('a non-fence GRAPH_DIVERGED keeps the canonical staleness copy (positive control)', () => {
+    render(
+      <TypedErrorRenderer
+        code="GRAPH_DIVERGED"
+        boundaryError={{
+          error: 'GRAPH_DIVERGED',
+          boundary: 'B1',
+          direction: 'egress',
+          validator: 'turn_commit',
+          details: {
+            phase: 'commit',
+            conflict_category: 'analysis_affecting_conflict',
+            recovery_action: 'refresh_and_reconfirm',
+          },
+          request_id: 'req-cas-409',
+          retryable: false,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('typed-error-text').textContent).toBe(
+      FAILURE_USER_TEXT.GRAPH_DIVERGED,
+    );
+  });
+});

--- a/src/v5/__tests__/fenceRefusalCopy.spec.ts
+++ b/src/v5/__tests__/fenceRefusalCopy.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * resolveFenceRefusalCopy — the fail-closed fallback, pinned (#559 review
+ * amendment 1).
+ *
+ * The safety core of the fence-copy fix is the fallback direction: a fence
+ * category this table does not know must resolve to the GENERIC fence copy
+ * (honest "nothing changed"), NEVER to null — null would fall through to
+ * `resolveFailureBaseCopy` and silently restore the false staleness banner
+ * for exactly the future verdict the prefix gate exists to protect. Before
+ * this spec, a `FENCE_REFUSAL_COPY[category] ?? null` mutant survived the
+ * entire suite (the live-chain spec only exercises known verdicts); the
+ * three assertions below make that mutant RED.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { BoundaryError } from '@talchain/schemas/boundary'
+import { resolveFenceRefusalCopy } from '../failureTypeRetryability'
+
+function boundary409(details: Record<string, unknown>): BoundaryError {
+  return {
+    error: 'GRAPH_DIVERGED',
+    boundary: 'B1',
+    direction: 'egress',
+    validator: 'turn_commit',
+    details,
+    request_id: 'req-fence-unit',
+    retryable: false,
+  } as BoundaryError
+}
+
+const GENERIC_FENCE_COPY =
+  "That change couldn't be saved, so nothing in your decision changed. Try it again in a moment."
+
+describe('resolveFenceRefusalCopy — fail-closed fallback (never the staleness banner)', () => {
+  it('turn_fence_unavailable (real verdict, no dedicated copy) → the generic fence copy', () => {
+    const copy = resolveFenceRefusalCopy(
+      boundary409({
+        phase: 'commit',
+        fence_verdict: 'unavailable',
+        conflict_category: 'turn_fence_unavailable',
+        recovery_action: 'retry_later',
+      }),
+    )
+    expect(copy).toBe(GENERIC_FENCE_COPY)
+  })
+
+  it('an UNKNOWN future turn_fence_ verdict → the generic fence copy, never null', () => {
+    const copy = resolveFenceRefusalCopy(
+      boundary409({
+        phase: 'commit',
+        fence_verdict: 'quarantined',
+        conflict_category: 'turn_fence_quarantined',
+        recovery_action: 'retry_later',
+      }),
+    )
+    // The load-bearing half: null here would fall through to the canonical
+    // staleness banner for a write refusal.
+    expect(copy).not.toBeNull()
+    expect(copy).toBe(GENERIC_FENCE_COPY)
+  })
+
+  it('absent or non-string conflict_category → null (non-fence errors keep canonical resolution)', () => {
+    expect(resolveFenceRefusalCopy(boundary409({ phase: 'commit' }))).toBeNull()
+    expect(
+      resolveFenceRefusalCopy(boundary409({ phase: 'commit', conflict_category: 42 })),
+    ).toBeNull()
+    expect(
+      resolveFenceRefusalCopy(
+        boundary409({ phase: 'commit', conflict_category: 'analysis_affecting_conflict' }),
+      ),
+    ).toBeNull()
+    expect(resolveFenceRefusalCopy(undefined)).toBeNull()
+  })
+})

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -97,6 +97,89 @@ export function resolveFailureBaseCopy(
 }
 
 /**
+ * ── Fence-refusal copy (journey-walk 2026-08-03 gap #2) ────────────────────
+ *
+ * CEE rides turn-fence refusals on the SAME wire code as graph staleness —
+ * `GRAPH_DIVERGED` — deliberately (olumi-assistants-service
+ * `turn-executor.ts` at fee17e3a: "Rides the EXISTING 409-class envelope …
+ * rather than minting a wire code"), carrying the distinguisher in
+ * `details.conflict_category: 'turn_fence_${verdict}'` where verdict is the
+ * closed `TurnFenceVerdict` enum (stopped | superseded | unclaimed |
+ * unavailable; 'current' never refuses). Until this module read that field,
+ * every fence refusal rendered the canonical staleness banner ("Your
+ * decision has changed since this result was computed. Re-run the analysis
+ * to refresh it.") — witnessed FALSE on the walk: it fired on a scenario
+ * where nothing had ever been computed, and its remedy (Rerun) provably
+ * does not clear the fence.
+ *
+ * A fence refusal is a WRITE conflict, never staleness: the one truth shared
+ * by every verdict is "the change was not saved and the model is unchanged",
+ * so every entry below states exactly that plus the verdict's own cause.
+ *
+ * NOT a hand-kept mirror (trap 12): the gate is the producer's own naming
+ * scheme — the `turn_fence_` prefix is emitted as a template literal over
+ * the closed verdict enum — so an UNKNOWN future verdict still routes to the
+ * honest generic fence copy (fail closed against the staleness lie), never
+ * back to the banner. Non-fence conflict categories (the graph-CAS class,
+ * e.g. 'analysis_affecting_conflict') keep the canonical copy: for them the
+ * graph genuinely diverged.
+ */
+const FENCE_CONFLICT_PREFIX = 'turn_fence_'
+
+const FENCE_GENERIC_COPY =
+  "That change couldn't be saved, so nothing in your decision changed. Try it again in a moment."
+
+const FENCE_REFUSAL_COPY: Record<string, string> = {
+  turn_fence_stopped:
+    "That change wasn't saved because this turn was stopped. Nothing in your decision changed. Send the change again if you still want it.",
+  turn_fence_superseded:
+    "That change wasn't saved because a newer change to this decision got in first. Nothing was overwritten. Check the latest state, then make the edit again if it's still needed.",
+  turn_fence_unclaimed: FENCE_GENERIC_COPY,
+  turn_fence_unavailable: FENCE_GENERIC_COPY,
+}
+
+/**
+ * Read `details.conflict_category` off a BoundaryError. Fail closed: absent,
+ * non-string, or empty → ''. (details is a Zod passthrough object, so the
+ * field survives strict parsing when CEE sends it.)
+ */
+export function extractConflictCategory(err: BoundaryError | undefined): string {
+  const category = (err?.details as { conflict_category?: unknown } | undefined)
+    ?.conflict_category
+  return typeof category === 'string' ? category : ''
+}
+
+/**
+ * Honest copy for a fence-class GRAPH_DIVERGED, or null when the error is not
+ * fence-class (no conflict_category, or a non-fence category) — callers fall
+ * back to `resolveFailureBaseCopy` for those.
+ */
+export function resolveFenceRefusalCopy(err: BoundaryError | undefined): string | null {
+  const category = extractConflictCategory(err)
+  if (!category.startsWith(FENCE_CONFLICT_PREFIX)) return null
+  return FENCE_REFUSAL_COPY[category] ?? FENCE_GENERIC_COPY
+}
+
+/**
+ * Base failure copy resolved WITH the error envelope in hand: fence-class
+ * GRAPH_DIVERGED gets its honest write-refusal copy; everything else takes
+ * the canonical `resolveFailureBaseCopy` path unchanged. Both live typed-
+ * error surfaces (useConversation's V5 typed_error branch and
+ * TypedErrorRenderer) resolve through here so they cannot drift.
+ */
+export function resolveFailureCopyForError(
+  code: FailureTypeLiteral,
+  showRetry: boolean,
+  err: BoundaryError | undefined,
+): string {
+  if (code === 'GRAPH_DIVERGED') {
+    const fenceCopy = resolveFenceRefusalCopy(err)
+    if (fenceCopy !== null) return fenceCopy
+  }
+  return resolveFailureBaseCopy(code, showRetry)
+}
+
+/**
  * DEV-only check that server `retryable` agrees with the client table.
  * Fires a console.warn on disagreement so staging telemetry surfaces drift
  * between CEE and UI classifications. No-op in production builds.


### PR DESCRIPTION
UI-side honesty batch from the journey walk (`PHASE0-EVIDENCE-2026-07-28/journey-walk-2026-08-03.md`), built at `43fd19e1`, build-only (adversarial review to follow). Four items, each RED-first at pristine and mutation-checked.

## 1. Honest copy for fence-class 409s (walk gap #2 residual)

**Diagnosis verdict (gap #2 trigger): UI-side, fixed here.** The banner *"Your decision has changed since this result was computed. Re-run the analysis to refresh it."* is the canonical `FAILURE_USER_TEXT.GRAPH_DIVERGED` (vendored schemas 0.31.0, `boundary/error-codes.js:38`), rendered for **every** GRAPH_DIVERGED. CEE deliberately rides turn-fence refusals on that same wire code (derived read-only from CEE `turn-executor.ts` at `fee17e3a`, lines 9732-9766: *"Rides the EXISTING 409-class envelope … rather than minting a wire code"*), distinguishing only via `details.conflict_category = 'turn_fence_' + verdict` — **which the UI read nowhere** (complete manifest: `rg -a conflict_category src/` = 0 hits at pristine `43fd19e1`; claim type: no-read anywhere in `src/`). That is why a virgin scenario's first-ever edit rendered a staleness banner. The fence-claim failure itself (why `unclaimed` fires at all) is the separate CEE lane — untouched here.

**Derived fence code set at CEE `fee17e3a`** (closed `TurnFenceVerdict` enum minus `current`): `turn_fence_stopped` · `turn_fence_superseded` · `turn_fence_unclaimed` · `turn_fence_unavailable`; `recovery_action` = `start_new_draft` / `refresh_and_reconfirm` / `retry_later` / `retry_later`. Non-fence categories (graph-CAS class, e.g. `analysis_affecting_conflict`) keep the canonical copy — for them the graph genuinely diverged.

**Fix:** `resolveFenceRefusalCopy` (in `failureTypeRetryability.ts`) maps fence categories to honest write-refusal copy — cause + "nothing in your decision changed" + remedy. Prefix-gated on the producer's own `turn_fence_` naming scheme, so an unknown future verdict fails closed to the generic fence copy, never back to the staleness banner (not a hand-kept mirror). Applied at both live typed-error surfaces (`useConversation` typed_error branch; `TypedErrorRenderer`).

## 2. Value-entry validation (walk gap #3, 2.159/S1/S3 class)

**(b) Entry range guard — fixed.** The witnessed chain at the bytes: `CalibrateDrillIn.save()` → `commitValue` → `normaliseRawFactorValue(60000, null)` returns 60000 **verbatim** when cap is absent → `observedState.value = 60000` on a 0–1 factor → canvas paints "6000000%". New guard `refusesNormalisedScaleEntry`: on a **normalised-scale-only** factor (no cap, no unit, no raw-value anchor, existing `value` ∈ [0,1]) an entry outside [0,1] is refused at entry with an honest hint. **What the node data genuinely carries, and all that is validated on** (2.193 — no structured bound crosses the wire): `observedState.value / raw_value / unit / cap`. Factors with a cap (raw/cap normalisation), a unit, a raw anchor, or no value at all keep today's pinned behaviour (`calibrateDrillInParse.spec.tsx` untouched and green).

**(a) Optimistic-paint derivation — reported, not fixable client-side:** `commitValue`/`commitConfirm` are **pure local canvas-store writes — no commit call/receipt exists on this path**, so there is no commit result to gate "checked by you" on. (Precision fix from review: `src/hooks/useScenario.ts:311-313` carries a debounced 1500ms graph autosave that can persist the canvas graph UI-side to Supabase in an authenticated session — while still never reaching CEE's canonical model. The walk was a guest session, so its triple confirmation — edit absent from the wire, wiped by the next turn's server truth, absent after reload — stands for what it measured.) Gating the badge on a commit receipt requires the S3 receipt machinery (producer-side; commit path is the CEE fence lane). Two adjacent display lies **were** at the bytes and are fixed: the reviewed-row lock-out (Edit affordance restored in `EstimateRow` + the `&& !row.reviewed` drill-in guard dropped in `YourDecisionSection`), and the false "Olumi estimated this value" popover on user-overridden factors (`useScienceIcons` now consults the canonical `isReviewedSource` predicate — the same one the sidebar pill derives from, so the two surfaces cannot disagree).

## 3. Goal-code humanise templates (ROADMAP 2.300 item 1)

`GOAL_THRESHOLD_NOT_CONVERTIBLE` / `GOAL_THRESHOLD_FRAME_UNSPECIFIED` added to `CODE_TEMPLATES` — goal-scoped, no factor framing, no label interpolation (the "This factor" fallback would be a category error). Semantics derived from ISL's `_resolve_goal_threshold` refuse() sites at staging: FRAME_UNSPECIFIED = level-vs-change frame unstated; NOT_CONVERTIBLE = level target inconvertible (reasons include `missing_goal_baseline` — the tester-reachable case — plus structural ones: goal pinned by intervention, root goal, goal PU, auto-noise), so the description says "for example when no current level is recorded" rather than claiming a single cause.

## 4. Goal-probability tab parity (Model tab)

**Derive-and-report verdict: WIRING GAP, not a design decision.** `ModelTabBody` already holds `results.report` and maps report data into sibling sections (conditional winners → OptionsSection, edge e-values → Relationships, robustness → StatusBar); the per-option goal figures sit in the same report at `report.option_probabilities`; `GoalSection` was never handed them, and no exclusion rationale exists in the file family. **Wired** with the Analysis-tab discipline: one chooser (`selectGoalProbability` — claim-ownership compliant, no raw field reads), complete-field gate (rows only when every option has an admissible figure — the V7 lens / OptionCards rule), possessive gate via the `GOAL_ANCHOR_COPY` register (substituted-joint basis withholds "your goal"), shared floor+formatter (`formatGoalProbability`, sub-1% → "< 1%"), doctrine-B modelled-basis caveat adjacent, producer order, no winner designation. Rows render only beside a displayed target. Compare/Olumi tabs untouched (as dispatched).

## New user-voice strings (for Paul's copy deck)

Item 1 (`failureTypeRetryability.ts`):
- `turn_fence_stopped`: "That change wasn't saved because this turn was stopped. Nothing in your decision changed. Send the change again if you still want it."
- `turn_fence_superseded`: "That change wasn't saved because a newer change to this decision got in first. Nothing was overwritten. Check the latest state, then make the edit again if it's still needed."
- `turn_fence_unclaimed` / `turn_fence_unavailable` / unknown fence verdicts: "That change couldn't be saved, so nothing in your decision changed. Try it again in a moment."

Item 2 (`constants.ts` / `EstimateRow.tsx`):
- Range hint: "This factor is recorded without a unit on a 0–1 scale. Enter a value between 0 and 1."
- Button label "Edit" · aria "Edit your estimate for {label}" · tooltip "Edit the value you checked"

Item 3 (`humaniseCritique.ts`):
- "Your goal's target couldn't be measured for this run" / "The target couldn't be compared with where the goal stands today — for example when no current level is recorded for it — so goal-fit results were withheld rather than guessed." / "State the current level for your goal"
- "Your goal's target could mean a level or a change" / "The target doesn't say whether it's a level to reach or a change from today, so goal-fit results were withheld for this run rather than guessed." / "Restate the target as a level to reach or a change from your current level"

Item 4: **zero new user-voice strings** (register-only: `GOAL_ANCHOR_COPY`, `GOAL_FIT_BASIS_CAVEAT_COPY`, shared "< 1%" readout).

## RED-first evidence (pristine `43fd19e1`)

16 failed / 10 passed across the six new spec files — every failure a new-behaviour assertion, every pass a control (incl. trap-13 positive controls: the CAS 409 renders the canonical copy; the untouched inferred estimate shows the icon; empty-factor and cap-bearing entries still commit).

## Mutation table (throwaway worktree outside the repo root, removed before gate runs)

| # | Mutant | Named tests RED |
|---|---|---|
| M1 | useConversation passes `undefined` instead of boundaryError | fence409Honesty: 3 failed |
| M2 | `resolveFenceRefusalCopy` returns null always | fence409Honesty + TypedErrorRenderer: 4 failed |
| M3 | range-guard call skipped (`if (false && …)`) | calibrateDrillInRange: 3 failed |
| M4 | guard refuses everything (`return true`) | calibrateDrillInRange: 2 failed (in-range + boundary) |
| M5a | Edit affordance testid neutralised | estimateReEdit: 3 failed |
| M5b | `&& !row.reviewed` drill-in guard restored | estimateReEdit: 1 failed (panel path) |
| M6 | `!isReviewedSource` gate dropped | useScienceIcons.userOwned: 2 failed |
| M7 | both goal templates renamed away | humaniseCritique.goalCodes: 2 failed |
| M8a | complete-field `return null` → `continue` | goalFitParity: 1 failed |
| M8b | `displayThreshold` gate dropped | goalFitParity: 1 failed |
| M8c | possessive gate hardcoded open | goalFitParity: 1 failed |
| M8d | bare `Math.round` instead of floor formatter | goalFitParity: 1 failed |

12/12 bite.

## Gates (at branch tip, fresh blobless clone, `VITE_SUPABASE_URL`/`ANON_KEY` set)

- `pnpm typecheck`: PASS, ratchet **exactly at baseline — 622 files / 2505 errors** (identical at pristine and at tip)
- `pnpm lint`: 0 errors; rules-of-hooks ratchet **exactly at baseline — 234 violations / 16 files**
- Suites around every touched family: v5 + canvas/hooks + FactorNode (111 files / 1481), pre-analysis-v3 + model-tab (51 / 880), conversation (132 / 1890+22 skipped), results (124 / 2493), canvas components + nodes (2041+24 skipped) — all green
- New specs: 6 files / 26+2 tests green

## Review amendment (post-approval, head `25819f06`)

- **Fail-closed fallback pinned** (`src/v5/__tests__/fenceRefusalCopy.spec.ts`): `turn_fence_unavailable` → generic fence copy; unknown `turn_fence_<future>` → generic fence copy, never null; absent/non-string/non-fence category → null. Mutant `FENCE_REFUSAL_COPY[category] ?? null` verified BOTH directions in a throwaway worktree: survives the pre-amendment suite (64 green — the reviewer's gap, confirmed), REDs on the new unknown-verdict assertion (`turn_fence_unavailable` is a table key, so the `??` fallback rightly doesn't fire for it). Gates re-run at `25819f06`: typecheck 622/2505 exact, lint 0, hooks ratchet 234/16 exact.
- Item 2(a) wording precision-fixed above (autosave path acknowledged).

## Unverified, stated as such (browser-walk residuals)

- All visibility/affordance claims here are **jsdom presence, never layout** (trap 3): the fence copy in a real transcript bubble, the Edit button's clickability at real densities, the Model-tab goal-fit rows' visual placement, and the hint's visibility beside the input all need the next real-browser walk.
- The fence 409 fixture is walk-faithful (shape from `wire` captures + CEE producer literals) but **not replayed against live staging** — the staging write path was down for guest sessions at the walk's quartet, and this lane is build-only.
- `turn_fence_unavailable` and unknown-verdict fallbacks are producer-derived but not live-witnessed (the walk only witnessed `unclaimed`).
- Item 2(a) residual stands: "checked by you" still describes a local-only write until a commit-receipt exists to gate on (producer-side, S3 class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
