### PR TITLE
fix(ui): drill-in value commits are real turns, and "checked by you" is receipt-gated (2.304 slice 1)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
@@ -327,8 +327,20 @@ describe('signal resolution', () => {
   })
 })
 
+/**
+ * ROADMAP 2.304 slice 1 — these two now pin the RECEIPT-GATED rule.
+ *
+ * The drill-in's commit is a `factor_value_edit` turn, and the reviewed stamp
+ * (`user_override` / `user_confirmed`) is written only when CEE's applied
+ * `graph_patch` receipt comes back. This panel is rendered here with NO
+ * ConversationProvider, so no turn is dispatched and no receipt can arrive:
+ * the NUMBER moves (optimistic write) and the CLAIM does not. That is the
+ * defect being closed — the old assertions passed against a stamp the engine
+ * had never seen. The receipt path itself is driven end-to-end, against the
+ * real dispatcher, in `model/__tests__/calibrateDrillInReceipt.spec.tsx`.
+ */
 describe('calibrate flow (canonical observed-state writes)', () => {
-  it('saving a value writes raw_value + user_override and moves the estimates bar', () => {
+  it('saving a value writes raw_value but withholds the reviewed stamp until a receipt', () => {
     renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /Your decision/ }))
     fireEvent.click(screen.getByRole('button', { name: /What this depends on/ }))
@@ -341,14 +353,16 @@ describe('calibrate flow (canonical observed-state writes)', () => {
     const f1 = useCanvasStore.getState().nodes.find(n => n.id === 'f1')!
     const observed = (f1.data as { observedState?: Record<string, unknown> }).observedState!
     expect(observed.raw_value).toBe(40)
-    expect(observed.source).toBe('user_override')
+    expect(observed.source).toBe('cee_inference')
 
+    // The bar counts CHECKED rows, so it cannot move on an unreceipted commit
+    // either — the two now agree, which is the point.
     expect(screen.getByTestId('pre-analysis-v3-bar-estimates')).toHaveAccessibleName(
-      'Estimates: medium. 1 of 3 checked',
+      'Estimates: low. 0 of 3 checked',
     )
   })
 
-  it('confirm as is writes user_confirmed without touching the value', () => {
+  it('confirm as is leaves the value alone and withholds user_confirmed until a receipt', () => {
     renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /Your decision/ }))
     fireEvent.click(screen.getByRole('button', { name: /What this depends on/ }))
@@ -357,7 +371,7 @@ describe('calibrate flow (canonical observed-state writes)', () => {
 
     const f1 = useCanvasStore.getState().nodes.find(n => n.id === 'f1')!
     const observed = (f1.data as { observedState?: Record<string, unknown> }).observedState!
-    expect(observed.source).toBe('user_confirmed')
+    expect(observed.source).toBe('cee_inference')
     expect(observed.raw_value).toBe(30)
   })
 })

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -1,23 +1,58 @@
 /**
  * CalibrateDrillIn — inline numeric calibration for one estimate.
  *
- * Mirrors the canonical pre-analysis save paths exactly:
- * - Save value:    observedState { raw_value, value: raw/cap (when cap>0),
- *                  source: 'user_override' }  — the legacy inline-edit handler.
- * - Confirm as is: observedState { source: 'user_confirmed',
- *                  extractionType: 'explicit' } — the legacy confirm handler.
+ * ⭐ ROADMAP 2.304 slice 1 — THIS COMMIT IS A REAL TURN, AND "CHECKED BY YOU"
+ * IS GATED ON THE RECEIPT.
+ *
+ * What it used to be: `commitValue` / `commitConfirm` were pure
+ * `useCanvasStore` writes. The number never left the browser, CEE's
+ * `graph_hash` never moved, the re-run the panel invites returned the same
+ * answer — and the row stamped **"checked by you"** on the strength of
+ * nothing. That is the same store-only-edit class #513 closed for the
+ * inspector and 2.121/2.129 closed for the Model tab, still live on the third
+ * surface (design-s3-edit-persistence-2026-08-03.md §2 manifest).
+ *
+ * What it is now — the EXISTING `factor_value_edit` machinery, reused verbatim,
+ * not a private path:
+ *   `buildFactorValueEditEvent` (the one scale authority) → `sendSystemEvent`
+ *   (so the edit rides the dispatcher's deferral buffer when an analysis holds
+ *   the lock) → CEE's deterministic `set_factor_value` → fence + CAS at commit
+ *   → an applied `graph_patch` receipt → `confirmOptimisticFactorEdit` writes
+ *   the provenance stamp. A refusal (200, no receipt) reverts through
+ *   `revertOptimisticFactorEdit`, exactly as it does for the other two
+ *   surfaces.
+ *
+ * THE SPLIT THAT MATTERS: the NUMBER is written optimistically (the canvas
+ * moves at once, even if the turn is slow) but the CLAIM is not. `source`
+ * paints "checked by you" and drops the factor out of the "N to verify" count
+ * — it is an assertion about what the ENGINE holds, so it waits for the
+ * engine's receipt. Writing it at commit, or at dispatch, is the 2.304 defect.
+ *
+ * NO GUEST ARM, deliberately. The `factor_value_edit` machinery has none:
+ * `sendSystemEvent` → `sendTurn` → `callV5Turn` carries no auth gate, and CEE
+ * commits the mutation server-side regardless of auth tier. Guests therefore
+ * take this identical path and get identical receipts. No new copy is
+ * introduced here for any tier.
  *
  * Value-scale guard: rows with canEditValue=false render confirm-only (no
  * numeric input) because only a normalised model-scale value exists.
  */
 
-import { memo, useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 import { Check } from 'lucide-react'
 import Tooltip from '../../../../components/Tooltip'
 import { typography, typo } from '../../../../styles/typography'
 import { FIELD_FEEDBACK_COPY } from '../constants'
 import { useCanvasStore } from '../../../store'
-import { getObservedState, normaliseRawFactorValue, withObservedStateUpdate } from '../../../utils/observedStateHelpers'
+import { getObservedState, type ObservedStateData } from '../../../utils/observedStateHelpers'
+import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
+import {
+  buildFactorValueEditEvent,
+  resolveValueInputSeed,
+  type ValueInputSeedBasis,
+} from '../../../conversation/factorValueEdit'
+import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
+import { useNodeMutations } from '../../../ui/inspector-v2/useInspectorMutations'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import { parseSuccessTarget } from '../hero/parseSuccessTarget'
 import type { EstimateRowModel } from '../types'
@@ -27,19 +62,16 @@ interface CalibrateDrillInProps {
   onDone: () => void
 }
 
-function commitValue(nodeId: string, rawValue: number, cap: number | null): void {
-  const { nodes, updateNode } = useCanvasStore.getState()
-  const node = nodes.find(n => n.id === nodeId)
-  if (!node) return
-  const normalised = normaliseRawFactorValue(rawValue, cap)
-  updateNode(nodeId, {
-    data: withObservedStateUpdate(node.data, {
-      raw_value: rawValue,
-      value: normalised,
-      source: 'user_override',
-    }),
-  })
-}
+/**
+ * The provenance stamps this surface earns on a receipt.
+ *
+ * Same two values the legacy handlers wrote, unchanged — only their TIMING
+ * moves. `user_override` for a typed value, `user_confirmed` +
+ * `extractionType: 'explicit'` for "Confirm as is", both members of
+ * `isReviewedByUser`'s REVIEWED_SOURCES set, so the pill copy is untouched.
+ */
+const VALUE_STAMP = { source: 'user_override' } as const
+const CONFIRM_STAMP = { source: 'user_confirmed', extractionType: 'explicit' } as const
 
 /**
  * Range guard for normalised-scale-only factors — journey-walk 2026-08-03
@@ -78,21 +110,105 @@ function refusesNormalisedScaleEntry(
   return parsedValue < 0 || parsedValue > 1
 }
 
-function commitConfirm(nodeId: string): void {
-  const { nodes, updateNode } = useCanvasStore.getState()
-  const node = nodes.find(n => n.id === nodeId)
-  if (!node) return
-  updateNode(nodeId, {
-    data: withObservedStateUpdate(node.data, {
-      source: 'user_confirmed',
-      extractionType: 'explicit',
-    }),
-  })
-}
-
 export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: CalibrateDrillInProps) {
   const [draft, setDraft] = useState(row.rawPrefill != null ? String(row.rawPrefill) : '')
   const [hint, setHint] = useState<string | null>(null)
+
+  // The sanctioned setter (the `NODE_SETTER_FIELDS` manifest the writtenFields
+  // guard spec enforces), not a hand-rolled `updateNode` — the same one both
+  // other value-committing surfaces use. It writes `observedState.value`,
+  // `raw_value` and clears BOTH stale `display_value` copies in ONE update, so
+  // the row cannot render CEE's prose for the previous number.
+  const mutations = useNodeMutations(row.nodeId)
+
+  // Optional by design, exactly as `FactorControllablePanel` and
+  // `FactorsSection` do it: this panel renders in surfaces that are not inside
+  // the ConversationProvider (and in unit tests), and a missing provider must
+  // degrade to "local edit only", never throw. Routing through the context is
+  // also what puts these edits behind `useConversation`'s deferral buffer — an
+  // edit committed during a running analysis is queued and flushed when the
+  // in-flight lock clears, rather than dropped.
+  const sendSystemEvent = useOptionalConversationContext()?.sendSystemEvent
+
+  /**
+   * ONE commit path for both affordances.
+   *
+   * Building the event FIRST and feeding both the local write and the wire from
+   * it is what makes the two structurally unable to disagree about the same
+   * edit — the property the Model tab's nine hand-rolled handlers lacked.
+   *
+   * `seedBasis` is NOT a second scale rule: it tells the single scale authority
+   * WHICH number the committing control was displaying, which is the one thing
+   * that authority cannot derive for itself.
+   * - the typed field passes `'raw_only'` — it is prefilled from
+   *   `row.rawPrefill` (the node's `raw_value`, or EMPTY) and by design never
+   *   shows the normalised model-scale `value`, so a stored `value` says
+   *   nothing about the scale of what was typed. Reading it as the seed would
+   *   classify a `£60,000` entry on a capped factor as a model-scale number —
+   *   the 6000000% class the #559 entry guard exists to stop, re-entered
+   *   through the scale module.
+   * - "Confirm as is" passes the DEFAULT basis: the user typed nothing, they
+   *   endorsed the numbers already stored, and `raw_value ?? value` is exactly
+   *   what "the numbers already stored" means.
+   *
+   * `writeValue: false` is likewise not an optimisation. A confirmation changes
+   * no number, and `setObservedValue` clears BOTH `display_value` copies — so
+   * running it here would silently drop CEE's display prose off a row the user
+   * asked to leave alone.
+   */
+  const commit = useCallback(
+    (
+      typedValue: number,
+      reviewedStamp: Partial<ObservedStateData>,
+      opts: { seedBasis?: ValueInputSeedBasis; writeValue: boolean },
+    ): void => {
+      const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
+      if (!node) return
+      // The node's data as it is BEFORE the local write — its own cap/unit is
+      // what decides the scale of what the user typed, and it is what the undo
+      // snapshot must restore.
+      const nodeData = node.data
+
+      const event = buildFactorValueEditEvent({
+        nodeId: row.nodeId,
+        typedValue,
+        nodeData,
+        ...(opts.seedBasis ? { seedBasis: opts.seedBasis } : {}),
+      })
+      // Fail CLOSED: an unencodable edit (no id, non-finite number) writes
+      // nothing rather than committing a number the wire cannot carry — and,
+      // with no wire event, there can be no receipt and so no honest claim.
+      if (!event) return
+      const { value: modelValue, raw_value: rawMagnitude } = event.payload as {
+        value: number
+        raw_value?: number
+      }
+
+      // Captured BEFORE the write, from the same pre-write data the event was
+      // built from. Carries the receipt-gated stamp: a refusal restores the
+      // whole pre-edit observed state, an acceptance writes the stamp.
+      const undo = captureOptimisticFactorEdit(row.nodeId, modelValue, nodeData, reviewedStamp)
+
+      // The number moves now; the CLAIM does not. No `{ source }` option is
+      // passed — that is the 2.304 fix in one line.
+      if (opts.writeValue) mutations.setObservedValue(modelValue, rawMagnitude)
+
+      if (!sendSystemEvent) return
+      void Promise.resolve(
+        // The undo (and its stamp) travel WITH the send: the dispatcher owns
+        // the reply, including a DEFERRED edit's reply, which a `.then` here
+        // could never see (that promise resolves with SEND_DEFERRED before the
+        // turn exists).
+        sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
+      ).catch(() => {
+        // Swallowed deliberately: a genuine send failure is recorded by the
+        // conversation's own failure channel (and, past the deferral attempt
+        // cap, by `noticeForUnsentEdit`'s transcript line). A server REFUSAL is
+        // not a failure and never reaches here — the dispatcher reverts.
+      })
+    },
+    [row.nodeId, mutations, sendSystemEvent],
+  )
 
   const save = () => {
     // Shares the hero field's parser (#396). The digit-strip this replaced
@@ -100,16 +216,16 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
     // `parseDisplayNumber` deleted from HeroSection: it dropped magnitude
     // suffixes and FUSED unrelated numbers, so "£500k" committed 500 and
     // "£500k within 12 months" committed 50012. This field writes through
-    // commitValue into node observedState, so those fabrications reached the
-    // ANALYSIS, not just a label.
+    // `commit` into node observedState AND onto the wire, so those fabrications
+    // reached the ANALYSIS, not just a label.
     //
     // parseSuccessTarget fails CLOSED on ambiguity (returns null), which is the
     // behaviour this call site wants: an unresolvable estimate must hint rather
     // than guess, exactly as the old unparseable branch did.
     //
-    // `unit` is deliberately ignored — the drill-in's scale comes from
-    // `row.cap` (see commitValue), so consuming the parser's unit here would
-    // add a second, conflicting scale authority.
+    // `unit` is deliberately ignored — the scale comes from the factor's own
+    // cap/unit inside `buildFactorValueEditEvent`, so consuming the parser's
+    // unit here would add a second, conflicting scale authority.
     const parsed = parseSuccessTarget(draft)
     if (parsed === null) {
       setHint(FIELD_FEEDBACK_COPY.numberHint)
@@ -123,8 +239,33 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
       setHint(FIELD_FEEDBACK_COPY.normalisedRangeHint)
       return
     }
-    commitValue(row.nodeId, parsed.value, row.cap)
+    commit(parsed.value, VALUE_STAMP, { seedBasis: 'raw_only', writeValue: true })
     onDone()
+  }
+
+  /**
+   * "Confirm as is" — the user endorses the number already on the row.
+   *
+   * It is the SAME turn, carrying the stored value, for one reason: a
+   * confirmation is a claim about what the ENGINE holds, so the engine has to
+   * answer it. CEE's `set_factor_value` emits a receipt either way —
+   * `status: 'applied'` when the number moved, `status: 'noop'` when it did not
+   * (`orchestrator-v5/tools/handlers/set-factor-value.ts`, the `noop`
+   * predicate; the composer passes that status straight through to the boundary
+   * `graph_patch` block). `responseAppliedFactorEdit` counts `noop` as applied
+   * — its NOT_APPLIED set is closed over the genuinely-not-applied statuses and
+   * fails SAFE on anything else — so a confirmed-unchanged value earns its
+   * stamp, and only a genuine refusal (no receipt at all) withholds it.
+   *
+   * Fails CLOSED when the node carries no number: nothing to confirm means
+   * nothing to receipt, and an unreceipted stamp is the defect. "Confirm as is"
+   * is not offered on those rows anyway (`!row.needsValue`).
+   */
+  const confirmAsIs = () => {
+    const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
+    const { seed } = resolveValueInputSeed(node?.data)
+    if (seed == null) return
+    commit(seed, CONFIRM_STAMP, { writeValue: false })
   }
 
   return (
@@ -158,7 +299,7 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
         <button
           type="button"
           onClick={() => {
-            commitConfirm(row.nodeId)
+            confirmAsIs()
             onDone()
           }}
           className={typo(

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -28,6 +28,18 @@
  * — it is an assertion about what the ENGINE holds, so it waits for the
  * engine's receipt. Writing it at commit, or at dispatch, is the 2.304 defect.
  *
+ * IN-FLIGHT PILL — the trade, and the alternative that was RULED OUT (#560).
+ * While the turn is unanswered the row shows the user's number beside its
+ * PRE-EXISTING pill (e.g. "Olumi estimate"), because `setObservedValue`
+ * preserves `source`. The obvious alternative — writing a neutral placeholder
+ * source ('not checked yet' / 'user_pending') for the in-flight window — was
+ * considered and REJECTED: `observedState` is spread wholesale into the PLoT
+ * payload by `extractObservedState` (`src/adapters/plot/v2/adapter.ts:913-937`),
+ * so a placeholder would cross the wire untraced, and it would become PERMANENT
+ * on every path where no receipt can arrive. If this window's presentation
+ * needs changing, change the RENDER — never the stored `source`. Do not
+ * re-propose the placeholder.
+ *
  * NO GUEST ARM, deliberately. The `factor_value_edit` machinery has none:
  * `sendSystemEvent` → `sendTurn` → `callV5Turn` carries no auth gate, and CEE
  * commits the mutation server-side regardless of auth tier. Guests therefore

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInParse.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInParse.spec.tsx
@@ -123,6 +123,29 @@ describe('CalibrateDrillIn — no fabricated numbers reach observedState', () =>
   })
 
   it('a cap normalises the PARSED value, not the digit-stripped one', () => {
+    // ROADMAP 2.304 slice 1 — the FIXTURE moved, the CLAIM did not. The cap now
+    // sits on the NODE, which is where production always put it:
+    // `buildEstimateRows` derives `row.cap` from `observedState.cap`, and the
+    // commit reads the factor's own cap through `buildFactorValueEditEvent`
+    // (one scale authority, not two). This fixture used to set `row.cap` while
+    // leaving the node capless — a decoupling the product cannot produce. The
+    // assertion below is unchanged: parsed 500000, normalised to 0.5 by a cap
+    // of 1,000,000.
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: 'f1',
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: {
+            kind: 'factor',
+            label: 'Incremental ARR',
+            observedState: { cap: 1000000 },
+          },
+        } as Node,
+      ],
+      edges: [],
+    })
     render(<CalibrateDrillIn row={{ ...row, cap: 1000000 }} onDone={vi.fn()} />)
     fireEvent.change(screen.getByLabelText(`Your estimate for ${row.label}`), {
       target: { value: '£500k' },

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInRange.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInRange.spec.tsx
@@ -128,7 +128,14 @@ describe('CalibrateDrillIn — normalised-scale-only factors refuse magnitude en
     )
     expect(os.raw_value).toBe(0.6)
     expect(os.value).toBe(0.6)
-    expect(os.source).toBe('user_override')
+    // ROADMAP 2.304 slice 1 — the `user_override` stamp is now RECEIPT-gated.
+    // This spec renders the drill-in with NO ConversationProvider, so no turn
+    // is dispatched and no receipt can arrive; the pre-edit provenance
+    // therefore stands. That is the fix, not a regression: the stamp is a claim
+    // about what the engine holds, and nothing here has told the engine
+    // anything. The receipt-gated stamp is pinned in
+    // `calibrateDrillInReceipt.spec.tsx`, which drives the real dispatcher.
+    expect(os.source).toBe('cee_inference')
     expect(onDone).toHaveBeenCalled()
   })
 

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
@@ -35,14 +35,40 @@
  * carries no value event for those (`factor_value_edit.field` is the literal
  * `'value'`).
  *
- * FENCE-409 POSTURE (verified, not assumed — see the last describe). A typed
- * 409 on a system-mode turn renders NO transcript bubble by design
- * (`useConversation`'s typed_error branch gates the bubble on `mode === 'user'`)
- * and does NOT revert (the resolution branch excludes `typed_error` so the
- * deferral buffer owns retries). That is the machinery's EXISTING posture,
- * shared byte-for-byte with the Model tab and the inspector; this surface
- * inherits it rather than growing a private one. The test pins that inheritance
- * so a future divergence on one surface goes RED.
+ * RED-FIRST, re-derived at pristine `704df8f7` out-of-repo (#560 review):
+ * **8 failed | 3 passed (11)**. `expected [] to have a length of 1` appears SIX
+ * times (no dispatch existed at all) alongside
+ * `expected 'user_confirmed' to be 'cee_inference'` and
+ * `expected document not to contain element, found <span` (the unreceipted
+ * "checked by you"). ⚠ An earlier record said "6 RED / 4 controls green" (=10);
+ * the file has 11 `it()` blocks at BOTH commits, so that figure described
+ * neither — it was taken against an earlier draft of this file and never
+ * re-derived. Corrected here rather than left to be inherited.
+ *
+ * FENCE-REFUSAL POSTURE — restated on MEASURED evidence (#560 review, live wire
+ * probe at `2aee5f13`). An earlier version of this docstring asserted that "a
+ * system-mode turn renders NO transcript bubble by design". ⚠ THAT PREMISE IS
+ * WITHDRAWN: the probe observed a `mode:'system'` turn rendering a full
+ * transcript receipt card ("… is already set to £3,300 / No change / Factor
+ * already at this value"). System turns DO reach the transcript; only the
+ * `typed_error` BRANCH is user-gated, which is a much narrower claim than the
+ * one recorded here.
+ *
+ * The conclusion survives, for a stronger reason the probe established: a
+ * CONTENDED commit on this path returns an UNTYPED HTTP 500 (`INTERNAL_ERROR`,
+ * `system_event_commit_failed`) — NOT a typed 409. `resolveFenceRefusalCopy`
+ * keys on `GRAPH_DIVERGED` + `details.conflict_category`, so it is unreachable
+ * here because **no typed 409 exists on this path at all**, on this surface or
+ * on the Model tab / inspector that share the machinery.
+ *
+ * ⚠ AND THIS FILE DOES NOT VERIFY THE `mode === 'user'` GATE. Mutating
+ * `if (mode === 'user')` → `if (true)` at `useConversation.ts:4953` leaves all
+ * 11 tests here GREEN. The spec that REDs on that mutant is the pre-existing
+ * `conversation/__tests__/useConversation.systemEventFailure.spec.ts:212` —
+ * cite that one, never this file, for the gating claim. The last describe below
+ * pins only what it drives: with a typed 409 injected at the transport, no
+ * fence copy renders, the optimistic value stands, and no reviewed stamp is
+ * written.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -202,7 +228,15 @@ const REFUSAL = {
   blocks: [],
 }
 
-/** A fence-class GRAPH_DIVERGED 409 — the typed refusal shape (#559). */
+/**
+ * A fence-class GRAPH_DIVERGED 409 — the typed refusal shape (#559).
+ *
+ * ⚠ SYNTHETIC. The #560 live probe measured a contended commit on this path
+ * returning an UNTYPED HTTP 500 (`INTERNAL_ERROR`, `system_event_commit_failed`)
+ * instead, so this shape is not what CEE emits here. It is injected anyway to
+ * pin the CLIENT's handling of a typed error on a system turn; do not cite this
+ * fixture as evidence that CEE sends a typed 409 on this path.
+ */
 const FENCE_409 = {
   error: 'GRAPH_DIVERGED',
   message: 'graph fence conflict',
@@ -458,8 +492,8 @@ describe('controls — the fix must not be satisfiable by something cheaper and 
   })
 })
 
-describe('fence-409 posture — INHERITED from the shared machinery, verified not assumed', () => {
-  it('a typed fence 409 renders no transcript bubble and does not revert (the deferral buffer owns retries)', async () => {
+describe('typed-error posture on this path — pins CURRENT behaviour, inherited from the shared machinery', () => {
+  it('a typed 409 injected at the transport surfaces no fence copy, leaves the optimistic value standing, and writes no reviewed stamp', async () => {
     boundaryErrors.push(FENCE_409)
     renderHarness()
     await act(async () => {
@@ -468,17 +502,31 @@ describe('fence-409 posture — INHERITED from the shared machinery, verified no
     })
 
     expect(factorValueEdits()).toHaveLength(1)
-    // System-mode turns render no synthetic bubble — `resolveFenceRefusalCopy`
-    // is reached only from the `mode === 'user'` branch and TypedErrorRenderer.
-    // The fence copy therefore does NOT appear on this path, exactly as it does
-    // not on the Model tab or the inspector.
+    // No fence copy. NOTE the reason, restated on measured evidence (#560 live
+    // probe): a contended commit on this path returns an UNTYPED HTTP 500
+    // (`INTERNAL_ERROR`, `system_event_commit_failed`), so the typed 409 this
+    // test injects does not occur in production at all — `resolveFenceRefusalCopy`
+    // keys on GRAPH_DIVERGED + `details.conflict_category` and is unreachable
+    // here for that reason, not because system turns are silent (they are not:
+    // the probe saw a system turn render a full receipt card). This assertion
+    // therefore pins the CLIENT's handling of the shape, not a claim about what
+    // CEE emits.
     expect(
       screen.queryByText(/wasn't saved because a newer change/i),
     ).not.toBeInTheDocument()
-    // And the optimistic write stands: a typed error is a FAILURE, excluded
-    // from the receipt-resolution branch by design.
+    // The optimistic write SURVIVES a typed error. ⚠ This pins CURRENT
+    // BEHAVIOUR — it is NOT a design guarantee, and an earlier version of this
+    // comment wrongly called it one. The stated justification ("failures are
+    // the deferral buffer's business") holds only for a DEFERRED send:
+    // `enqueueDeferredSystemSend` has exactly one call site
+    // (`useConversation.ts:3978`, the in-flight defer branch), so an IMMEDIATE
+    // send that fails is never enqueued and nothing retries or reverts it. That
+    // gap is disclosed in #560 and is pre-existing across all three
+    // value-committing surfaces; when it is fixed, THIS assertion is the one to
+    // change — it must not be read as a guarantee defending the current state.
     expect(observedNow().value).toBe(NEW_MODEL)
-    // The completion claim still requires a receipt, which never arrived.
+    // The completion claim still requires a receipt, which never arrived — this
+    // half IS the 2.304 guarantee, and it holds in the failure direction too.
     expect(observedNow().source).toBe('cee_inference')
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
   })

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
@@ -1,0 +1,473 @@
+/**
+ * ROADMAP 2.304 slice 1 — the pre-analysis drill-in commit is a REAL TURN, and
+ * "checked by you" is gated on the RECEIPT.
+ *
+ * THE DEFECT THIS PINS (design-s3-edit-persistence-2026-08-03.md §2, §3, §7).
+ * `CalibrateDrillIn.commitValue` / `commitConfirm` were pure `useCanvasStore`
+ * writes: the number never left the browser, CEE's `graph_hash` never moved,
+ * and the row stamped **"checked by you"** on the strength of nothing. The
+ * user is shown a completion claim about a value the engine has never seen —
+ * the same split-brain 2.129 (b) closed for the Model tab and #513 closed for
+ * the inspector, still live on the third surface. The #559 lane looked for a
+ * receipt on this path and found none, because none was ever requested.
+ *
+ * WHAT THIS FILE DRIVES, and why it is not a panel-context mock.
+ * A receipt is only visible at the DISPATCHER. A refusal is not a failure —
+ * CEE answers 200 with prose and `blocks: []`, so no `catch` at the call site
+ * can see it, and a spec that mocks `ConversationContext` sits ABOVE the only
+ * layer where the reply exists. So this file renders the REAL `CalibrateDrillIn`
+ * inside a REAL `ConversationProvider`, derives the row through the REAL
+ * `buildEstimateRows` selector, renders the REAL `EstimateRow` pill, and mocks
+ * only the TRANSPORT (`callV5Turn`) — `importOriginal`-spread, never a hand
+ * listed factory (CLAUDE.md trap 12).
+ *
+ * THE CLAIM TYPES, precisely (evidence-completeness rule):
+ *   1. a drill-in value commit reaches the transport as exactly ONE
+ *      `factor_value_edit` event carrying the model-scale value (and the
+ *      user-unit magnitude when the factor declares a scale);
+ *   2. the reviewed state ("checked by you") appears ONLY after an applied
+ *      `graph_patch` receipt for that target — not at commit, not at dispatch;
+ *   3. a refusal (200, no receipt) REVERTS the optimistic number and leaves the
+ *      pre-edit provenance intact;
+ *   4. the #559 normalised-scale entry guard still runs BEFORE any dispatch;
+ *   5. "Confirm as is" is the same turn, receipt-gated the same way.
+ * It does NOT claim anything about baseline / prior / edge edits — the contract
+ * carries no value event for those (`factor_value_edit.field` is the literal
+ * `'value'`).
+ *
+ * FENCE-409 POSTURE (verified, not assumed — see the last describe). A typed
+ * 409 on a system-mode turn renders NO transcript bubble by design
+ * (`useConversation`'s typed_error branch gates the bubble on `mode === 'user'`)
+ * and does NOT revert (the resolution branch excludes `typed_error` so the
+ * deferral buffer owns retries). That is the machinery's EXISTING posture,
+ * shared byte-for-byte with the Model tab and the inspector; this surface
+ * inherits it rather than growing a private one. The test pins that inheritance
+ * so a future divergence on one surface goes RED.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+/** Every payload that reached the transport, in order. */
+const dispatched: Array<Record<string, unknown>> = []
+/** Reply bodies the transport answers with, in order. */
+const replies: Array<Record<string, unknown>> = []
+/** Boundary errors the transport answers with, in order (409 fence class). */
+const boundaryErrors: Array<Record<string, unknown>> = []
+/** When true, the first turn is held open until `releaseInFlight` is called. */
+let holdFirstTurn = false
+let resolveInFlight: ((v: unknown) => void) | null = null
+
+vi.mock('../../../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    callV5Turn: vi.fn(async (payload: Record<string, unknown>) => {
+      dispatched.push(payload)
+      if (holdFirstTurn && dispatched.length === 1) {
+        await new Promise((res) => {
+          resolveInFlight = res
+        })
+      }
+      const boundary = boundaryErrors.shift()
+      if (boundary) return { kind: 'boundary_error', error: boundary }
+      const response = replies.shift() ?? { assistant_text: 'ok', blocks: [] }
+      return { kind: 'response', response }
+    }),
+  }
+})
+
+vi.mock('../../../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    isOrchestratorV2Enabled: () => true,
+    isOrchestratorStreamingEnabled: () => false,
+  }
+})
+
+import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import { EstimateRow } from '../EstimateRow'
+import { buildEstimateRows } from '../../selectors/buildEstimateRows'
+import { ConversationProvider } from '../../../../conversation/ConversationContext'
+import { useCanvasStore } from '../../../../store'
+import { getObservedState } from '../../../../utils/observedStateHelpers'
+import type { RankingResult } from '../../types'
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const FACTOR_ID = 'fac_delivery_time'
+const CAP = 6
+const LABEL = 'Estimated Delivery Time'
+
+/** CEE's own estimate of 3 months on a factor capped at 6 (model scale 0.5). */
+const PRIOR_OBSERVED = {
+  value: 0.5,
+  raw_value: 3,
+  unit: 'months',
+  cap: CAP,
+  source: 'cee_inference',
+}
+
+const NEW_RAW = 5
+const NEW_MODEL = NEW_RAW / CAP
+
+function factorNode(observed: Record<string, unknown> = { ...PRIOR_OBSERVED }): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'factor',
+      label: LABEL,
+      display_value: '3 months',
+      observedState: observed,
+    },
+  } as unknown as Node
+}
+
+function seed(node: Node = factorNode()): void {
+  useCanvasStore.setState(
+    {
+      currentScenarioId: SCENARIO,
+      nodes: [node],
+      edges: [],
+      results: { status: 'idle' } as never,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      pendingEmittedEdits: 0,
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    } as never,
+    false,
+  )
+}
+
+const ranking: RankingResult = {
+  source: 'degree',
+  weights: { [FACTOR_ID]: 1 },
+  ordered: [FACTOR_ID],
+}
+
+/**
+ * The REAL derivation chain: store → `buildEstimateRows` → `EstimateRow` pill,
+ * with the REAL drill-in beneath it. A mutant that stamps the reviewed source
+ * at commit or at dispatch flips this pill early, which is the whole point.
+ */
+function Harness(): JSX.Element {
+  const nodes = useCanvasStore((s) => s.nodes)
+  const rows = buildEstimateRows(nodes, ranking, null)
+  const row = rows[0]
+  if (!row) return <div />
+  return (
+    <>
+      <EstimateRow row={row} expanded onToggle={() => {}} />
+      <CalibrateDrillIn row={row} onDone={() => {}} />
+    </>
+  )
+}
+
+function renderHarness() {
+  return render(
+    <ConversationProvider>
+      <Harness />
+    </ConversationProvider>,
+  )
+}
+
+/** CEE's ACCEPTANCE — the applied `graph_patch` receipt for this target. */
+const acceptance = (model: number, raw: number) => ({
+  assistant_text: `Updated ${LABEL} from 3 months to ${raw} months.`,
+  blocks: [
+    {
+      type: 'graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: FACTOR_ID,
+      before: { value: 0.5, raw_value: 3, unit: 'months', cap: CAP },
+      after: { value: model, raw_value: raw, unit: 'months', cap: CAP },
+    },
+  ],
+  graph_hash: 'f0719cb3b8905ef4',
+})
+
+/**
+ * CEE's REFUSAL, verbatim in shape: prose, EMPTY blocks, no graph_hash. There
+ * is no `status: 'rejected'` on the wire — the ABSENCE of an applied receipt is
+ * the only machine-readable signal.
+ */
+const REFUSAL = {
+  assistant_text:
+    "Value 25 months exceeds the factor's cap of 6 months. I haven't changed anything.",
+  blocks: [],
+}
+
+/** A fence-class GRAPH_DIVERGED 409 — the typed refusal shape (#559). */
+const FENCE_409 = {
+  error: 'GRAPH_DIVERGED',
+  message: 'graph fence conflict',
+  retryable: true,
+  request_id: 'req_fence_1',
+  details: { phase: 'commit', conflict_category: 'turn_fence_superseded' },
+}
+
+function factorValueEdits(): Array<Record<string, unknown>> {
+  return dispatched
+    .filter((p) => (p as { event?: { kind?: string } }).event?.kind === 'factor_value_edit')
+    .map((p) => (p as { event: Record<string, unknown> }).event)
+}
+
+function observedNow(): Record<string, unknown> {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)
+  return getObservedState(node?.data) as Record<string, unknown>
+}
+
+const flush = async () => {
+  // Drain microtasks AND macrotasks: the dispatch, the response-processing path
+  // and the buffer flush each contain real awaits, so a fixed microtask count
+  // is not enough.
+  for (let round = 0; round < 25; round++) {
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 1))
+  }
+}
+
+function typeAndSave(text: string): void {
+  fireEvent.change(screen.getByLabelText(`Your estimate for ${LABEL}`), {
+    target: { value: text },
+  })
+  fireEvent.click(screen.getByLabelText(`Save estimate for ${LABEL}`))
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  dispatched.length = 0
+  replies.length = 0
+  boundaryErrors.length = 0
+  holdFirstTurn = false
+  resolveInFlight = null
+  seed()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+})
+
+describe('the drill-in commit is a real factor_value_edit turn (2.304 slice 1)', () => {
+  it('a value commit dispatches EXACTLY ONE factor_value_edit carrying the model-scale value and the user-unit magnitude', async () => {
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    expect(edits[0]).toEqual({
+      kind: 'factor_value_edit',
+      target_id: FACTOR_ID,
+      value: NEW_MODEL,
+      raw_value: NEW_RAW,
+      unit: 'months',
+      field: 'value',
+    })
+  })
+
+  it('"Confirm as is" dispatches the same turn, carrying the value the user is confirming', async () => {
+    replies.push({ assistant_text: 'ok', blocks: [] })
+    renderHarness()
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('pre-analysis-v3-confirm-as-is'))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    expect(edits[0]).toMatchObject({
+      kind: 'factor_value_edit',
+      target_id: FACTOR_ID,
+      value: PRIOR_OBSERVED.value,
+      raw_value: PRIOR_OBSERVED.raw_value,
+    })
+  })
+})
+
+describe('"checked by you" is gated on the RECEIPT, not on the commit or the dispatch', () => {
+  it('does NOT claim the row is checked while the turn is still in flight', async () => {
+    holdFirstTurn = true
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    // The turn is dispatched and unanswered: the number may show optimistically,
+    // but the completion claim must not.
+    expect(factorValueEdits()).toHaveLength(1)
+    expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(observedNow().source).toBe('cee_inference')
+
+    await act(async () => {
+      resolveInFlight?.(undefined)
+      await flush()
+    })
+
+    expect(screen.getByText('checked by you')).toBeInTheDocument()
+    expect(observedNow().source).toBe('user_override')
+  })
+
+  it('stamps the row checked once the applied graph_patch receipt lands', async () => {
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    // The dispatch assertion is load-bearing HERE too: without it this test
+    // passes vacuously against the pristine store-only write, which stamped
+    // `user_override` with no turn at all (trap 13).
+    expect(factorValueEdits()).toHaveLength(1)
+    expect(observedNow().source).toBe('user_override')
+    expect(observedNow().value).toBe(NEW_MODEL)
+    expect(screen.getByText('checked by you')).toBeInTheDocument()
+  })
+
+  it('"Confirm as is" only stamps user_confirmed after its own receipt', async () => {
+    holdFirstTurn = true
+    replies.push(acceptance(PRIOR_OBSERVED.value, PRIOR_OBSERVED.raw_value))
+    renderHarness()
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('pre-analysis-v3-confirm-as-is'))
+      await flush()
+    })
+    expect(observedNow().source).toBe('cee_inference')
+    expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveInFlight?.(undefined)
+      await flush()
+    })
+    expect(observedNow().source).toBe('user_confirmed')
+    expect(observedNow().extractionType).toBe('explicit')
+    expect(screen.getByText('checked by you')).toBeInTheDocument()
+  })
+
+  it('a REFUSED commit (200, no receipt) reverts the optimistic number and never claims the row is checked', async () => {
+    replies.push(REFUSAL)
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    expect(factorValueEdits()).toHaveLength(1)
+    // The pre-edit state is back, whole: value, magnitude AND provenance.
+    expect(observedNow().value).toBe(PRIOR_OBSERVED.value)
+    expect(observedNow().raw_value).toBe(PRIOR_OBSERVED.raw_value)
+    expect(observedNow().source).toBe('cee_inference')
+    expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.getByText('Olumi estimate')).toBeInTheDocument()
+  })
+})
+
+describe('controls — the fix must not be satisfiable by something cheaper and wrong', () => {
+  it('the #559 normalised-scale entry guard still runs BEFORE any dispatch', async () => {
+    // The walk shape: no cap, no unit, no raw anchor, a declared model-scale
+    // value in [0,1]. A magnitude entry must be refused at entry — nothing
+    // written, nothing sent.
+    seed(
+      factorNode({ value: 0, display_value: 'Low (0)', source: 'cee_inference' }) as never,
+    )
+    renderHarness()
+    await act(async () => {
+      typeAndSave('£60,000')
+      await flush()
+    })
+
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedNow().raw_value).toBeUndefined()
+    expect(observedNow().value).toBe(0)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('an unparseable entry commits nothing and sends nothing', async () => {
+    renderHarness()
+    await act(async () => {
+      typeAndSave('quite a lot')
+      await flush()
+    })
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedNow().value).toBe(PRIOR_OBSERVED.value)
+  })
+
+  it('a LATE receipt does not stamp a value that has moved on since the send', async () => {
+    holdFirstTurn = true
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    // Something newer happens while the turn is in flight — an undo, a scenario
+    // load, a server patch. The receipt below is about a number the node no
+    // longer holds, so the review claim it would earn is about a value the user
+    // never reviewed.
+    await act(async () => {
+      const store = useCanvasStore.getState()
+      const node = store.nodes.find((n) => n.id === FACTOR_ID)!
+      store.updateNode(FACTOR_ID, {
+        data: {
+          ...(node.data as Record<string, unknown>),
+          observedState: { ...PRIOR_OBSERVED },
+        },
+      } as never)
+      resolveInFlight?.(undefined)
+      await flush()
+    })
+
+    expect(observedNow().source).toBe('cee_inference')
+    expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+  })
+
+  it('an ACCEPTED commit is never reverted (a fix that reverted unconditionally would pass every RED assertion)', async () => {
+    replies.push(acceptance(NEW_MODEL, NEW_RAW))
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+    expect(observedNow().value).toBe(NEW_MODEL)
+    expect(observedNow().raw_value).toBe(NEW_RAW)
+  })
+})
+
+describe('fence-409 posture — INHERITED from the shared machinery, verified not assumed', () => {
+  it('a typed fence 409 renders no transcript bubble and does not revert (the deferral buffer owns retries)', async () => {
+    boundaryErrors.push(FENCE_409)
+    renderHarness()
+    await act(async () => {
+      typeAndSave(String(NEW_RAW))
+      await flush()
+    })
+
+    expect(factorValueEdits()).toHaveLength(1)
+    // System-mode turns render no synthetic bubble — `resolveFenceRefusalCopy`
+    // is reached only from the `mode === 'user'` branch and TypedErrorRenderer.
+    // The fence copy therefore does NOT appear on this path, exactly as it does
+    // not on the Model tab or the inspector.
+    expect(
+      screen.queryByText(/wasn't saved because a newer change/i),
+    ).not.toBeInTheDocument()
+    // And the optimistic write stands: a typed error is a FAILURE, excluded
+    // from the receipt-resolution branch by design.
+    expect(observedNow().value).toBe(NEW_MODEL)
+    // The completion claim still requires a receipt, which never arrived.
+    expect(observedNow().source).toBe('cee_inference')
+    expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
@@ -275,8 +275,12 @@ describe('the drill-in commit is a real factor_value_edit turn (2.304 slice 1)',
     })
   })
 
-  it('"Confirm as is" dispatches the same turn, carrying the value the user is confirming', async () => {
-    replies.push({ assistant_text: 'ok', blocks: [] })
+  it('"Confirm as is" dispatches the same turn, carrying the value the user is confirming, and changes nothing locally', async () => {
+    // The turn is HELD OPEN so the assertions below see the local state the
+    // commit itself produced. With a reply in hand the revert/confirm arm has
+    // already run, which would mask a commit that had written the value.
+    holdFirstTurn = true
+    replies.push(acceptance(PRIOR_OBSERVED.value, PRIOR_OBSERVED.raw_value))
     renderHarness()
     await act(async () => {
       fireEvent.click(screen.getByTestId('pre-analysis-v3-confirm-as-is'))
@@ -291,6 +295,14 @@ describe('the drill-in commit is a real factor_value_edit turn (2.304 slice 1)',
       value: PRIOR_OBSERVED.value,
       raw_value: PRIOR_OBSERVED.raw_value,
     })
+    // ...and CHANGES NOTHING locally. A confirmation is an endorsement, not an
+    // edit: routing it through the optimistic value write would run
+    // `setObservedValue`, which clears BOTH `display_value` copies — silently
+    // dropping CEE's own prose off a row the user asked to leave alone.
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!
+    expect((node.data as Record<string, unknown>).display_value).toBe('3 months')
+    expect(observedNow().value).toBe(PRIOR_OBSERVED.value)
+    expect(observedNow().raw_value).toBe(PRIOR_OBSERVED.raw_value)
   })
 })
 

--- a/src/canvas/conversation/factorValueEdit.ts
+++ b/src/canvas/conversation/factorValueEdit.ts
@@ -51,6 +51,28 @@ function readNumber(field: unknown): number | undefined {
   return typeof n === 'number' && Number.isFinite(n) ? n : undefined
 }
 
+/**
+ * WHICH number the input the user typed into was DISPLAYING.
+ *
+ * The scale of a typed number is decided by what the field showed, not by what
+ * the node happens to store — so a surface whose input is seeded differently
+ * needs to say so HERE rather than grow its own rule. Two bases exist today:
+ *
+ * - `'raw_or_value'` (default) — the inspector panel and the Model-tab chips,
+ *   whose inputs display `raw_value ?? value`.
+ * - `'raw_only'` — the pre-analysis drill-in, whose prefill is
+ *   `EstimateRowModel.rawPrefill` (the node's `raw_value`, or an EMPTY field)
+ *   and which by design NEVER displays the normalised model-scale `value`
+ *   (`buildEstimateRows`: "The normalised model-scale `value` is never
+ *   displayed"). On that surface a stored `value` therefore says nothing about
+ *   the scale of what was typed, and reading it as the seed would classify a
+ *   `£60,000` entry on a capped factor as a model-scale number — the
+ *   6000000% class the #559 entry guard exists to stop, re-entered through the
+ *   scale module. `'raw_only'` falls through to the module's own EMPTY-input
+ *   rule instead (see `ValueInputSeed.inUserUnits`).
+ */
+export type ValueInputSeedBasis = 'raw_or_value' | 'raw_only'
+
 export interface ValueInputSeed {
   /** The number the input should display, or undefined for an empty input. */
   seed: number | undefined
@@ -72,12 +94,18 @@ export interface ValueInputSeed {
  * scale that number is in. Derived from the node's own observed state — never
  * from a hard-coded bound, because scales vary per draft.
  */
-export function resolveValueInputSeed(nodeData: unknown): ValueInputSeed {
+export function resolveValueInputSeed(
+  nodeData: unknown,
+  basis: ValueInputSeedBasis = 'raw_or_value',
+): ValueInputSeed {
   const obs = getObservedState(nodeData)
   const rawValue = readNumber(obs.raw_value)
   const value = readNumber(obs.value)
 
   if (rawValue != null) return { seed: rawValue, inUserUnits: true }
+  // A `raw_only` input never showed `value`, so the field the user typed into
+  // was EMPTY — which is the module's existing user-units case, not a new rule.
+  if (basis === 'raw_only') return { seed: undefined, inUserUnits: true }
   if (value != null) return { seed: value, inUserUnits: false }
   return { seed: undefined, inUserUnits: true }
 }
@@ -89,6 +117,11 @@ export interface FactorValueEditInput {
   typedValue: number
   /** The node's `data`, read for its OWN cap / unit. */
   nodeData: unknown
+  /**
+   * Which number the committing input was DISPLAYING. Omit for the
+   * `raw_value ?? value` inputs; see `ValueInputSeedBasis`.
+   */
+  seedBasis?: ValueInputSeedBasis
 }
 
 /**
@@ -101,14 +134,14 @@ export interface FactorValueEditInput {
 export function buildFactorValueEditEvent(
   input: FactorValueEditInput,
 ): WireSystemEvent | null {
-  const { nodeId, typedValue, nodeData } = input
+  const { nodeId, typedValue, nodeData, seedBasis } = input
   if (!nodeId) return null
   if (typeof typedValue !== 'number' || !Number.isFinite(typedValue)) return null
 
   const obs = getObservedState(nodeData)
   const cap = readNumber(obs.cap)
   const unit = typeof obs.unit === 'string' && obs.unit.length > 0 ? obs.unit : undefined
-  const { inUserUnits } = resolveValueInputSeed(nodeData)
+  const { inUserUnits } = resolveValueInputSeed(nodeData, seedBasis)
 
   // `value` is ALWAYS model scale. `normaliseRawFactorValue` is the canonical
   // rule (raw/cap, with the typed number passed through when no honest scale

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -40,6 +40,7 @@
  */
 
 import { useCanvasStore } from '../store'
+import { withObservedStateUpdate, type ObservedStateData } from '../utils/observedStateHelpers'
 
 /**
  * Everything needed to undo one optimistic value write, captured BEFORE it.
@@ -66,6 +67,22 @@ export interface OptimisticFactorEdit {
    * its live fallback instead of the server's own string.
    */
   prevDisplayValue: unknown
+  /**
+   * ROADMAP 2.304 — the provenance patch to apply ONLY when the reply carries
+   * an APPLIED receipt for this target. Optional: a caller that supplies none
+   * keeps the pre-2.304 behaviour (revert-on-refusal, nothing on acceptance).
+   *
+   * WHY THE STAMP TRAVELS WITH THE UNDO rather than being written at commit.
+   * `observedState.source` is a TRUST CLAIM — it is what paints "checked by
+   * you" and drops the factor out of the "N to verify" count. Written at commit
+   * or at dispatch it asserts a review the engine has not acknowledged, which
+   * is the 2.304 defect verbatim (the pre-analysis drill-in stamped
+   * `user_override` on a write that never left the browser). Riding on the same
+   * `SendTurnOpts` as the undo means ONE code path resolves BOTH directions —
+   * refusal reverts, acceptance stamps — for the immediate dispatch and for a
+   * deferred flush alike, rather than two that have to stay in sync.
+   */
+  reviewedStamp?: Partial<ObservedStateData>
 }
 
 /**
@@ -90,6 +107,7 @@ export function captureOptimisticFactorEdit(
   nodeId: string,
   sentValue: number,
   nodeData: unknown,
+  reviewedStamp?: Partial<ObservedStateData>,
 ): OptimisticFactorEdit | null {
   if (!nodeId) return null
   if (typeof sentValue !== 'number' || !Number.isFinite(sentValue)) return null
@@ -99,6 +117,7 @@ export function captureOptimisticFactorEdit(
     sentValue,
     prevObservedState: readObservedState(nodeData),
     prevDisplayValue: d.display_value,
+    ...(reviewedStamp ? { reviewedStamp } : {}),
   }
 }
 
@@ -118,8 +137,11 @@ export function mergeOptimisticFactorEdit(
   if (!incoming) return queued
   if (queued.nodeId !== incoming.nodeId) return incoming
   // Keep the ORIGINAL pre-edit state; adopt the NEW value being sent, because
-  // that is the number whose fate the reply will decide.
-  return { ...queued, sentValue: incoming.sentValue }
+  // that is the number whose fate the reply will decide — and with it the
+  // INCOMING stamp, which describes the commit that is actually going to be
+  // sent (a value edit and a "confirm as is" stamp different provenance, and
+  // the reply decides the later one's fate, not the superseded one's).
+  return { ...queued, sentValue: incoming.sentValue, reviewedStamp: incoming.reviewedStamp }
 }
 
 /** Collect every target id a graph_patch block can be read to address. */
@@ -167,6 +189,44 @@ export function responseAppliedFactorEdit(response: unknown, targetId: string): 
 
 /** What `revertOptimisticFactorEdit` did, for tests and DEV logging. */
 export type RevertOutcome = 'reverted' | 'node_gone' | 'value_moved_on'
+
+/** What `confirmOptimisticFactorEdit` did, for tests and DEV logging. */
+export type ConfirmOutcome = 'stamped' | 'no_stamp' | 'node_gone' | 'value_moved_on'
+
+/**
+ * Write the provenance stamp the RECEIPT has now earned (ROADMAP 2.304).
+ *
+ * The mirror image of `revertOptimisticFactorEdit`, and deliberately built from
+ * the same parts: same snapshot, same `updateNode` chokepoint, same
+ * still-holds-`sentValue` precondition. The precondition is the whole safety
+ * story in this direction too — a late receipt for a value that has since been
+ * re-edited, undone, or overwritten by a server patch must NOT stamp the
+ * CURRENT number as reviewed, because the user reviewed a different one.
+ *
+ * Writes through `withObservedStateUpdate`, which writes BOTH the camelCase and
+ * snake_case keys. That is not decoration: `isReviewedByUser` — the predicate
+ * that paints "checked by you" — resolves `observed_state.source` BEFORE
+ * `observedState.source`, the opposite precedence to `getObservedState`. On a
+ * node carrying both keys (every node any `withObservedStateUpdate` call site
+ * has ever touched), a camelCase-only stamp would be read straight past.
+ *
+ * Returns `'no_stamp'` when the edit carries none — the pre-2.304 callers
+ * (Model tab, inspector) pass no stamp and are byte-identical through here.
+ */
+export function confirmOptimisticFactorEdit(edit: OptimisticFactorEdit): ConfirmOutcome {
+  if (!edit.reviewedStamp) return 'no_stamp'
+  const store = useCanvasStore.getState()
+  const node = store.nodes.find((n) => n.id === edit.nodeId)
+  if (!node) return 'node_gone'
+
+  const obs = (readObservedState(node.data) ?? {}) as Record<string, unknown>
+  if (obs.value !== edit.sentValue) return 'value_moved_on'
+
+  store.updateNode(edit.nodeId, {
+    data: withObservedStateUpdate(node.data, edit.reviewedStamp),
+  } as never)
+  return 'stamped'
+}
 
 /**
  * Put the pre-edit value (and its provenance stamp) back.

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -122,6 +122,7 @@ import { getSessionIdentity } from '../../lib/supabase'
 import { trackEvent } from '../../lib/posthog'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 import {
+  confirmOptimisticFactorEdit,
   mergeOptimisticFactorEdit,
   responseAppliedFactorEdit,
   revertOptimisticFactorEdit,
@@ -4445,6 +4446,19 @@ export function useConversation(): UseConversationReturn {
               if (import.meta.env.DEV) {
                 console.warn(
                   `[sendTurn] CEE did not apply the edit to ${optimisticEdit.nodeId}; optimistic write ${outcome}`,
+                )
+              }
+            } else {
+              // ROADMAP 2.304 — the OTHER half of the same decision. The
+              // reviewed stamp ("checked by you") is a claim about what the
+              // ENGINE holds, so it is written here, against the receipt, and
+              // nowhere else. Callers that pass no stamp (Model tab, inspector)
+              // are unaffected: `confirmOptimisticFactorEdit` returns
+              // 'no_stamp' and writes nothing.
+              const outcome = confirmOptimisticFactorEdit(optimisticEdit)
+              if (import.meta.env.DEV && outcome === 'value_moved_on') {
+                console.warn(
+                  `[sendTurn] receipt for ${optimisticEdit.nodeId} arrived after the value moved on; reviewed stamp withheld`,
                 )
               }
             }


### PR DESCRIPTION
## What

**ROADMAP 2.304 slice 1** (design brief `PHASE0-EVIDENCE-2026-07-28/design-s3-edit-persistence-2026-08-03.md` §7). UI-only. No contract change, no CEE change.

`CalibrateDrillIn.commitValue` / `commitConfirm` were pure Zustand writes. The number never left the browser, CEE's `graph_hash` never moved, the re-run the panel invites returned the same answer — and the row stamped **"checked by you"** on the strength of nothing. Same store-only-edit class #513 closed for the inspector and 2.121/2.129 closed for the Model tab, still live on the third value-committing surface (design brief §2 manifest).

This wires the drill-in into the **existing** `factor_value_edit` machinery, verbatim — no new transport, no private path:

```
buildFactorValueEditEvent  (the one scale authority)
  -> sendSystemEvent       (so the edit rides useConversation's deferral buffer)
  -> CEE set_factor_value  (deterministic, no LLM)
  -> fence + CAS at commit
  -> applied graph_patch receipt
  -> confirmOptimisticFactorEdit writes the provenance stamp
```

**The split that matters:** the NUMBER is written optimistically (the canvas moves at once), the CLAIM is not. `observedState.source` paints "checked by you" and drops the factor out of the "N to verify" count — it is an assertion about what the ENGINE holds, so it now waits for the engine's receipt. A refusal (200, `blocks: []`, no receipt) reverts through the existing `revertOptimisticFactorEdit`.

## How

| File | Change |
|---|---|
| `CalibrateDrillIn.tsx` | one `commit` path for both affordances; sanctioned `setObservedValue` setter; `sendSystemEvent` via the optional conversation context |
| `factorValueEdit.ts` | `ValueInputSeedBasis` — extends the single scale authority rather than forking it |
| `optimisticFactorEdit.ts` | `reviewedStamp` on the snapshot + `confirmOptimisticFactorEdit` (mirror of the revert: same snapshot, same chokepoint, same still-holds-`sentValue` precondition) |
| `useConversation.ts` | the `applied` arm of the existing resolution branch |

### Why `ValueInputSeedBasis` and not a second rule

The drill-in's field is prefilled from `row.rawPrefill` (the node's `raw_value`, or EMPTY) and **by design never displays the model-scale `value`** (`buildEstimateRows`: *"The normalised model-scale `value` is never displayed"*). So `resolveValueInputSeed`'s default `raw_value ?? value` rule — correct for the inspector and Model-tab inputs, which do display `value` — would classify a `£60,000` entry on a capped, raw-less factor as a **model-scale** number. That is the 6000000% class the #559 entry guard exists to stop, re-entered through the scale module. `'raw_only'` falls through to the module's own EMPTY-input rule instead. Mutant M4 below is this defect.

### Preserved, verified not assumed

- **#559 entry guard** (`refusesNormalisedScaleEntry`) is byte-identical and still runs BEFORE any dispatch — pinned, and mutant M7 (guard moved after the dispatch) goes RED.
- **Fence-refusal copy — premise WITHDRAWN and restated on measured evidence (review amendment A1).** The original version of this section claimed a `mode:'system'` turn *"renders no synthetic bubble by design"*. **That premise is false and is withdrawn.** The review's live wire probe observed a `mode:'system'` turn rendering a full transcript receipt card (*"… is already set to £3,300 / No change / Factor already at this value"*). System turns do reach the transcript; only the `typed_error` **branch** is user-gated, which is a far narrower claim than the one recorded.
  The **conclusion survives, for a stronger reason the probe established**: a contended commit on this path returns an **untyped HTTP 500** (`INTERNAL_ERROR`, `system_event_commit_failed`) — **not a typed 409**. `resolveFenceRefusalCopy` keys on `GRAPH_DIVERGED` + `details.conflict_category`, so it is unreachable here because **no typed 409 exists on this path at all** — on this surface or on the Model tab / inspector that share the machinery. The spec's `FENCE_409` fixture is therefore explicitly labelled synthetic in-file, and must not be cited as evidence that CEE emits a typed 409 here.
  **This PR does not verify the `mode === 'user'` gate.** Mutating `if (mode === 'user')` → `if (true)` at `useConversation.ts:4953` leaves all 11 tests in the new spec GREEN; the pre-existing `conversation/__tests__/useConversation.systemEventFailure.spec.ts:212` is what REDs. The docstring now points there. Closing the underlying gap is a shared-machinery change across three surfaces plus a user-facing copy decision — flagged, not smuggled in here.
- **Guest arm.** There is none to reuse: `sendSystemEvent -> sendTurn -> callV5Turn` carries no auth gate, and CEE commits the mutation server-side regardless of tier (design brief §5A). Guests take this identical path. **No new copy for any tier** — the open Paul ruling on guest pre-commit wording is untouched.
- **"Confirm as is"** sends the stored value and earns its stamp from CEE's receipt. CEE's `set_factor_value` emits `status: 'noop'` when the number did not move (handler's `noop` predicate; the composer passes the status straight to the boundary `graph_patch` block), and `responseAppliedFactorEdit` counts `noop` as applied — its NOT_APPLIED set is closed over the genuinely-not-applied statuses and fails SAFE on anything else. It writes nothing locally: `setObservedValue` clears both `display_value` copies, which would silently drop CEE's prose off a row the user asked to leave alone (mutant M6).

## Tests — RED-first at pristine `704df8f7`

New: `model/__tests__/calibrateDrillInReceipt.spec.tsx` (11 tests). Drives the REAL `CalibrateDrillIn` inside a REAL `ConversationProvider`, derives the row through the REAL `buildEstimateRows`, renders the REAL `EstimateRow` pill, and mocks **only the transport** (`callV5Turn`), `importOriginal`-spread (trap 12).

**RED-first at pristine `704df8f7`, re-derived out-of-repo (review amendment A2): 8 failed | 3 passed (11).** Signatures: `expected [] to have a length of 1` **six** times (tests 1, 2, 3, 4, 6, 11 — no dispatch existed at all), `expected 'user_confirmed' to be 'cee_inference'`, and `expected document not to contain element, found <span` (the unreceipted "checked by you"). ⚠ The figure originally recorded here — "6 RED / 4 controls green" (=10) — described **neither** commit: the file has 11 `it()` blocks at both. It was taken against an earlier draft of the spec and never re-derived. Direction is safe (more coverage than was claimed), and "11 green post-fix" was correct.

### Mutation table

| # | Mutant | Result |
|---|---|---|
| M1 | dispatch unwired | **RED** 7/11 |
| M2 | stamp written on dispatch-sent instead of on the receipt | **RED** 5/11 |
| M3 | receipt-confirm arm removed from `useConversation` | **RED** 3/11 |
| M4 | `seedBasis: 'raw_only'` dropped | **RED** 3 (incl. the capped `£60,000 -> 0.4` control) |
| M5 | still-holds-`sentValue` precondition dropped | **RED** 1 (late receipt stamps a moved-on value) |
| M6 | Confirm-as-is routed through the value write | **RED** 1 (CEE's `display_value` cleared) |
| M7 | #559 entry guard moved after the dispatch | **RED** 4 |

Mutants were applied in a throwaway worktree **outside** the repo root (traps 9/9c), removed before the gates.

### Pre-existing specs touched: **two invert, one is fixture-only** (review amendment A4)

**Inverted — 3 assertions across 2 files**, each pinning the defect being fixed: `PreAnalysisPanelV3.spec.tsx` (x2) and `calibrateDrillInRange.spec.tsx` (x1) asserted `user_override` / `user_confirmed` after a commit made with **no ConversationProvider** — i.e. a stamp the engine had never seen. They now assert the pre-edit provenance stands, plus the estimates bar `0 of 3 checked` (it counts checked rows, so it cannot move on an unreceipted commit either — the two now agree).

**Not inverted:** `calibrateDrillInParse.spec.tsx` is **+23 / -0 with zero deleted assertion lines**. The FIXTURE was extended, the CLAIM untouched: it set `row.cap` while leaving the node capless — a decoupling production cannot produce (`buildEstimateRows` derives `row.cap` from `observedState.cap`). The cap now also sits on the node; the assertion (parsed 500000, normalised to 0.5) is byte-identical. The earlier "three specs / four assertions" framing over-counted this one.

## Gates (derived at this tip)

- `pnpm typecheck` — **622 files / 2505 errors, baseline 2505**; coverage 3160/3200 (+1 = the new spec, loaded). Exactly at baseline.
- `pnpm lint` — **0 errors**, 1261 warnings (baseline 1261).
- `lint:hooks-ratchet` — **234 violations / 16 files, exactly matching the baseline**.
- Suite run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set (trap 2b).

## Recorded rulings and disclosed gaps

- **The in-flight pill alternative is RULED OUT — do not re-propose it.** During the unanswered-turn window the row shows the user's number beside its pre-existing pill (e.g. "Olumi estimate"), because `setObservedValue` preserves `source`. Writing a neutral placeholder source (`'not checked yet'` / `user_pending`) for that window was considered and rejected in review: `observedState` is spread wholesale into the PLoT payload by `extractObservedState` (`src/adapters/plot/v2/adapter.ts:913-937`), so a placeholder would cross the wire **untraced**, and would become **permanent** on every path where no receipt can arrive. The trade stands as shipped. If this window's presentation changes later, it changes the **render**, never the stored `source`. Recorded in the `CalibrateDrillIn` header.
- **Immediate-send failure gap (pre-existing, all three value-committing surfaces, NOT fixed here).** `enqueueDeferredSystemSend` has exactly one call site (`useConversation.ts:3978`, the in-flight defer branch), so an **immediate** send that fails is never enqueued: nothing retries it and nothing reverts it — the canvas keeps the number with no notice. Only *deferred* edits reach `noticeForUnsentEdit` at the attempt cap. The new spec's surviving-optimistic-write assertion is therefore labelled **"pins CURRENT behaviour"**, explicitly not a design guarantee (review amendment A3b) — an earlier comment called it "by design", which would have made the eventual fix meet a RED that read as a guarantee.
- **Every regression in this PR fails CLOSED**: the reviewed stamp is *withheld*, never falsely written.

## Out of scope (untouched)

Dead-autosave retirement (Paul ruling pending), structural edits, Compare/Olumi surfaces, slice 2 (edge strength / constraints).
