### PR TITLE
fix(ui): disclose a silently rebased value edit — and why boot hydration cannot be built here (ROADMAP 2.312)

### DIFF
--- a/src/canvas/conversation/__tests__/silentRebase.spec.ts
+++ b/src/canvas/conversation/__tests__/silentRebase.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * ROADMAP 2.312 — the pure half: can we PROVE the engine rebased this edit?
+ *
+ * THE MEASURED DEFECT (`PHASE0-EVIDENCE-2026-07-28/probe-560-confirm-as-is-receipt.md`
+ * §6, deployed guest build, live-observed). The canvas restores
+ * `localStorage['olumi-canvas-autosave']` on boot and fetches no graph — the
+ * complete boot request manifest is 7 requests, none of which is the scenario
+ * graph. So the tab showed `Monthly Observability Spend · From brief · £4,000`
+ * while the engine held a different number. The operator typed £4,200 and CEE
+ * recorded:
+ *
+ *   "Updated Monthly Observability Spend from £3,500 to £4,200"
+ *
+ * — a before-value the operator was never shown, on a base they never chose.
+ * The canonical graph was edited against a base that existed nowhere on screen,
+ * and nothing said so.
+ *
+ * WHY THE ASSERTIONS ARE MOSTLY CONTROLS. The RED direction is one line — a
+ * mismatch must be reported. The whole difficulty is the other direction: a
+ * detector that cried "rebase" whenever it was unsure would fire on ordinary
+ * edits, and a warning about the user's own data that is usually wrong is worse
+ * than no warning at all (CLAUDE.md trap 7b — the standing-red that taught every
+ * lane to stop looking). So every case where the answer is NOT PROVABLE is
+ * pinned to null here, and each of those controls also blocks a cheaper wrong
+ * fix: `always warn`, `warn whenever a receipt exists`, `warn on any numeric
+ * difference regardless of scale or unit`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  captureOptimisticFactorEdit,
+  describeRebaseDivergence,
+  detectSilentRebase,
+  readReceiptBaseline,
+  type RebaseDivergence,
+} from '../optimisticFactorEdit'
+
+const TARGET = 'fac_monthly_cost'
+
+/**
+ * What the STALE canvas was showing — lifted from the probe's own capture of
+ * `localStorage['olumi-canvas-autosave']` at the moment of the edit.
+ */
+const SHOWN_ON_SCREEN = {
+  value: 0.8,
+  raw_value: 4000,
+  unit: '£',
+  cap: 5000,
+  source: 'brief_extraction',
+}
+
+/** The base the ENGINE actually held — visible only in its own receipt. */
+const SERVER_HELD = { value: 0.7, raw_value: 3500, unit: '£', cap: 5000 }
+
+/** An applied `graph_patch` receipt, block-level `target_id` shape. */
+const receipt = (before: unknown, targetId = TARGET) => ({
+  assistant_text: 'Updated Monthly Observability Spend from £3,500 to £4,200.',
+  blocks: [
+    {
+      type: 'graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: targetId,
+      before,
+      after: { value: 0.84, raw_value: 4200, unit: '£', cap: 5000 },
+    },
+  ],
+  graph_hash: 'c41b7a02e9d3f815',
+})
+
+/** The snapshot the panel captures BEFORE its optimistic write. */
+const editFrom = (observed: unknown) =>
+  captureOptimisticFactorEdit(TARGET, 0.84, { observedState: observed })!
+
+// ---------------------------------------------------------------------------
+// RED — the measured defect, in both receipt shapes
+// ---------------------------------------------------------------------------
+
+describe('detectSilentRebase — the rebase the probe measured', () => {
+  it('reports the £4,000-on-screen / £3,500-on-server divergence', () => {
+    const d = detectSilentRebase(editFrom(SHOWN_ON_SCREEN), receipt(SERVER_HELD))
+    expect(d).toEqual<RebaseDivergence>({
+      nodeId: TARGET,
+      shownBase: 4000,
+      serverBase: 3500,
+      basis: 'raw_value',
+      unit: '£',
+    })
+  })
+
+  it('reads the operations[] receipt shape too — both exist in the contract', () => {
+    const response = {
+      blocks: [
+        {
+          type: 'graph_patch',
+          status: 'applied',
+          operations: [{ target_id: TARGET, before: SERVER_HELD }],
+        },
+      ],
+    }
+    expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), response)?.serverBase).toBe(3500)
+  })
+
+  it('falls back to model scale when NEITHER side states a raw magnitude', () => {
+    const d = detectSilentRebase(editFrom({ value: 0.8 }), receipt({ value: 0.7 }))
+    expect(d).toMatchObject({ basis: 'value', shownBase: 0.8, serverBase: 0.7 })
+  })
+
+  it('unwraps the {value:n} wrapper CEE and legacy paths both emit', () => {
+    const d = detectSilentRebase(
+      editFrom({ raw_value: { value: 4000 }, unit: '£' }),
+      receipt({ raw_value: { value: 3500 }, unit: '£' }),
+    )
+    expect(d).toMatchObject({ shownBase: 4000, serverBase: 3500 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CONTROLS — every case where a rebase is NOT PROVABLE reports nothing
+// ---------------------------------------------------------------------------
+
+describe('detectSilentRebase — reports nothing unless it can prove it', () => {
+  it('the ordinary edit — canvas in step with the engine — is silent', () => {
+    // Blocks the cheapest wrong fix: a detector that always warns passes every
+    // RED assertion above and fires on every edit anyone ever makes.
+    expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), receipt(SHOWN_ON_SCREEN))).toBeNull()
+  })
+
+  it('a float artefact is not a rebase', () => {
+    const d = detectSilentRebase(
+      editFrom({ value: 0.1 + 0.2 }),
+      receipt({ value: 0.30000000000000004 }),
+    )
+    expect(d).toBeNull()
+  })
+
+  it('CEE’s REFUSAL (blocks: []) proves nothing about the base', () => {
+    expect(
+      detectSilentRebase(editFrom(SHOWN_ON_SCREEN), {
+        assistant_text: "That exceeds the cap. I haven't changed anything.",
+        blocks: [],
+      }),
+    ).toBeNull()
+  })
+
+  it('a receipt for a DIFFERENT factor does not speak for mine', () => {
+    expect(
+      detectSilentRebase(editFrom(SHOWN_ON_SCREEN), receipt(SERVER_HELD, 'fac_other')),
+    ).toBeNull()
+  })
+
+  it('an UNATTRIBUTABLE patch does not speak for mine either', () => {
+    // Deliberately stricter than `responseAppliedFactorEdit`, which counts an
+    // untargeted patch as ours. That direction is safe for "don't revert an
+    // accepted value"; it is NOT safe for accusing a base of being wrong.
+    const response = { blocks: [{ type: 'graph_patch', status: 'applied', before: SERVER_HELD }] }
+    expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), response)).toBeNull()
+  })
+
+  it('a receipt carrying no `before` proves nothing', () => {
+    const response = {
+      blocks: [{ type: 'graph_patch', status: 'applied', target_id: TARGET }],
+    }
+    expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), response)).toBeNull()
+  })
+
+  it('a NON-applied patch is not evidence of the applied base', () => {
+    for (const status of ['rejected', 'proposed', 'dismissed', 'failed', 'error', 'pending']) {
+      const response = {
+        blocks: [{ type: 'graph_patch', status, target_id: TARGET, before: SERVER_HELD }],
+      }
+      expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), response), status).toBeNull()
+    }
+  })
+
+  it('DIFFERENT UNITS are a units bug, not a rebase', () => {
+    const d = detectSilentRebase(
+      editFrom({ raw_value: 3500, unit: 'months' }),
+      receipt({ raw_value: 4000, unit: '£' }),
+    )
+    expect(d).toBeNull()
+  })
+
+  it('a raw magnitude on ONE side only is not comparable', () => {
+    // £4,000 against a model-scale 0.7 is not a divergence of 3999.3 — the two
+    // numbers are not on the same scale, and reporting it would be a fabricated
+    // magnitude in a message about the user's money.
+    expect(detectSilentRebase(editFrom({ raw_value: 4000 }), receipt({ value: 0.7 }))).toBeNull()
+    expect(detectSilentRebase(editFrom({ value: 0.8 }), receipt({ raw_value: 3500 }))).toBeNull()
+  })
+
+  it('a snapshot with no observed state at all reports nothing', () => {
+    expect(detectSilentRebase(editFrom(undefined), receipt(SERVER_HELD))).toBeNull()
+  })
+
+  it('a malformed response reports nothing rather than throwing', () => {
+    for (const bad of [null, undefined, {}, { blocks: null }, { blocks: 'nope' }, 42]) {
+      expect(() => detectSilentRebase(editFrom(SHOWN_ON_SCREEN), bad)).not.toThrow()
+      expect(detectSilentRebase(editFrom(SHOWN_ON_SCREEN), bad)).toBeNull()
+    }
+  })
+})
+
+describe('readReceiptBaseline', () => {
+  it('returns the before snapshot verbatim', () => {
+    expect(readReceiptBaseline(receipt(SERVER_HELD), TARGET)).toEqual(SERVER_HELD)
+  })
+
+  it('returns null for an empty target id rather than guessing', () => {
+    expect(readReceiptBaseline(receipt(SERVER_HELD), '')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// THE SENTENCE — what the operator is actually told
+// ---------------------------------------------------------------------------
+
+describe('describeRebaseDivergence', () => {
+  const divergence: RebaseDivergence = {
+    nodeId: TARGET,
+    shownBase: 4000,
+    serverBase: 3500,
+    basis: 'raw_value',
+    unit: '£',
+  }
+
+  it('names the factor, what was shown, and what the engine held', () => {
+    const msg = describeRebaseDivergence(divergence, 'Monthly Observability Spend')
+    expect(msg).toContain('Monthly Observability Spend')
+    expect(msg).toContain('£4,000')
+    expect(msg).toContain('£3,500')
+  })
+
+  it('says the change was applied on top of the ENGINE’s base, not the shown one', () => {
+    expect(describeRebaseDivergence(divergence, 'Spend')).toContain(
+      'applied on top of £3,500',
+    )
+  })
+
+  it('warns that the rest of the canvas may be stale too', () => {
+    // The divergence proves the local copy is behind the engine — and nothing
+    // scopes that staleness to the one factor that happened to be edited.
+    expect(describeRebaseDivergence(divergence, 'Spend').toLowerCase()).toContain('stale')
+  })
+
+  it('offers no remedy that does not work', () => {
+    // Reloading is the obvious closing line and it is FALSE: the boot path
+    // restores localStorage and fetches no graph (the defect this guard exists
+    // under). Asking in chat genuinely works — CEE answers from its own graph.
+    const msg = describeRebaseDivergence(divergence, 'Spend').toLowerCase()
+    expect(msg).not.toContain('reload')
+    expect(msg).not.toContain('refresh')
+    expect(msg).toContain('ask me')
+  })
+
+  it('renders model-scale numbers as numbers, never as a qualitative word', () => {
+    // `formatValueWithUnit` maps an unitless 0–1 value to "moderate"/"high".
+    // That is right on a chip and wrong in a sentence whose entire job is to
+    // state two specific numbers.
+    const msg = describeRebaseDivergence(
+      { nodeId: TARGET, shownBase: 0.8, serverBase: 0.7, basis: 'value' },
+      'Spend',
+    )
+    expect(msg).toContain('0.8')
+    expect(msg).toContain('0.7')
+    expect(msg).not.toMatch(/moderate|very high|\bhigh\b/)
+  })
+})

--- a/src/canvas/conversation/__tests__/silentRebase.spec.ts
+++ b/src/canvas/conversation/__tests__/silentRebase.spec.ts
@@ -232,15 +232,41 @@ describe('describeRebaseDivergence', () => {
   })
 
   it('says the change was applied on top of the ENGINE’s base, not the shown one', () => {
+    const msg = describeRebaseDivergence(divergence, 'Spend')
+    expect(msg).toContain('on top of £3,500')
+    expect(msg).toContain('not the £4,000 shown on your canvas')
+  })
+
+  it('warns that other values may also differ from the model', () => {
+    // Nothing scopes a divergence to the one factor that happened to be edited.
     expect(describeRebaseDivergence(divergence, 'Spend')).toContain(
-      'applied on top of £3,500',
+      'may also differ from the model',
     )
   })
 
-  it('warns that the rest of the canvas may be stale too', () => {
-    // The divergence proves the local copy is behind the engine — and nothing
-    // scopes that staleness to the one factor that happened to be edited.
-    expect(describeRebaseDivergence(divergence, 'Spend').toLowerCase()).toContain('stale')
+  it('makes NO claim about which side is out of date', () => {
+    // The receipt proves the two bases DIFFER. It does not prove a direction,
+    // and the canvas-ahead case below produces identical evidence. An earlier
+    // draft opened with "Your canvas was out of date" and would have reported
+    // a canvas that was AHEAD of the engine as one that was behind.
+    const msg = describeRebaseDivergence(divergence, 'Spend').toLowerCase()
+    for (const causal of ['out of date', 'stale', 'behind', 'outdated', 'older']) {
+      expect(msg, `must not diagnose "${causal}"`).not.toContain(causal)
+    }
+  })
+
+  it('reads the same when the CANVAS is the side that moved', () => {
+    // Same sentence, no accusation either way — the operator is told which
+    // number the change landed on, which is all the receipt witnesses.
+    const canvasAhead: RebaseDivergence = {
+      nodeId: TARGET,
+      shownBase: 0.6,
+      serverBase: 0.4,
+      basis: 'value',
+    }
+    const msg = describeRebaseDivergence(canvasAhead, 'Team morale')
+    expect(msg).toContain('on top of 0.4')
+    expect(msg).toContain('not the 0.6 shown on your canvas')
   })
 
   it('offers no remedy that does not work', () => {
@@ -264,5 +290,59 @@ describe('describeRebaseDivergence', () => {
     expect(msg).toContain('0.8')
     expect(msg).toContain('0.7')
     expect(msg).not.toMatch(/moderate|very high|\bhigh\b/)
+  })
+
+  // -------------------------------------------------------------------------
+  // The RAW basis is NOT self-protecting — this is where the sentence refuted
+  // itself. `formatValueWithUnit` keys its qualitative branch on the UNIT and
+  // the 0–1 bound, never on the basis, so a raw magnitude in 0–1 with no real
+  // unit rendered as a word: "it showed Team morale as low, but the model held
+  // low". Reachable because an UNCAPPED factor stores the same number in
+  // `value` and `raw_value` (CEE `normalise-factor-value.ts:12-16`, `:138-141`)
+  // and `snapshotObservedState` copies it into `before` verbatim.
+  // -------------------------------------------------------------------------
+  it.each([
+    ['no unit at all', undefined],
+    ['an empty unit', ''],
+    ['the placeholder unit "scale"', 'scale'],
+    ['the placeholder unit "score"', 'score'],
+    ['the placeholder unit "index"', 'index'],
+  ])('states RAW-basis 0–1 magnitudes as numbers with %s', (_label, unit) => {
+    const msg = describeRebaseDivergence(
+      {
+        nodeId: TARGET,
+        shownBase: 0.6,
+        serverBase: 0.4,
+        basis: 'raw_value',
+        ...(unit === undefined ? {} : { unit }),
+      },
+      'Team morale',
+    )
+    expect(msg).toContain('0.6')
+    expect(msg).toContain('0.4')
+    expect(msg).not.toMatch(/\b(very low|low|moderate|high|very high)\b/)
+    // The self-refuting shape, pinned directly: the two magnitudes must never
+    // render to the SAME string in a sentence that exists to contrast them.
+    expect(msg).not.toMatch(/on top of (\S+), not the \1 shown/)
+  })
+
+  it('still wears a REAL unit on the raw basis', () => {
+    // The guard must not have been bought by dropping units everywhere.
+    const msg = describeRebaseDivergence(
+      { nodeId: TARGET, shownBase: 4000, serverBase: 3500, basis: 'raw_value', unit: '£' },
+      'Spend',
+    )
+    expect(msg).toContain('£4,000')
+    expect(msg).toContain('£3,500')
+  })
+
+  it('does not attach a unit to a model-scale magnitude', () => {
+    // `unit` is carried on the divergence even when the comparison fell back to
+    // model scale; printing "£0.8" would be a fabricated magnitude.
+    const msg = describeRebaseDivergence(
+      { nodeId: TARGET, shownBase: 0.8, serverBase: 0.7, basis: 'value', unit: '£' },
+      'Spend',
+    )
+    expect(msg).not.toContain('£')
   })
 })

--- a/src/canvas/conversation/__tests__/silentRebaseDisclosure.spec.ts
+++ b/src/canvas/conversation/__tests__/silentRebaseDisclosure.spec.ts
@@ -221,6 +221,13 @@ afterEach(() => {
   clearAutosave()
 })
 
+/**
+ * The phrase only the divergence disclosure emits. Deliberately a fragment of
+ * the SENTENCE and not a word like "stale" — the copy makes no claim about
+ * which side moved, so there is no directional word to key off.
+ */
+const DISCLOSURE_MARK = 'on top of'
+
 /** Every synthetic assistant line the turn produced. */
 function syntheticLines(messages: ReadonlyArray<Record<string, unknown>>): string[] {
   return messages
@@ -296,7 +303,7 @@ describe('an edit made against a STALE canvas is no longer silently rebased', ()
     await flush()
 
     const lines = syntheticLines(result.current.messages as never)
-    expect(lines.filter((l) => l.includes('out of date'))).toEqual([])
+    expect(lines.filter((l) => l.includes(DISCLOSURE_MARK))).toEqual([])
   })
 
   it('CONTROL — a REFUSED edit discloses no base and still reverts', async () => {
@@ -319,6 +326,84 @@ describe('an edit made against a STALE canvas is no longer silently rebased', ()
     ).observedState as Record<string, unknown>
     expect(observed.raw_value, 'the refused value is rolled back').toBe(4000)
     const lines = syntheticLines(result.current.messages as never)
-    expect(lines.filter((l) => l.includes('out of date'))).toEqual([])
+    expect(lines.filter((l) => l.includes(DISCLOSURE_MARK))).toEqual([])
+  })
+
+  /**
+   * CANVAS AHEAD — the same evidence, the opposite cause, and no techMode gate.
+   *
+   * A factor with no `raw_value` on EITHER side, written locally over a
+   * server-held value, produces a receipt indistinguishable from the stale-boot
+   * walk: two bases that differ. Here the canvas is AHEAD of the engine, not
+   * behind it. An earlier draft opened the disclosure with "Your canvas was out
+   * of date" and reported this case as the canvas being stale — a diagnosis the
+   * receipt cannot support, in a message whose entire purpose is to stop the
+   * product asserting things it has not established.
+   */
+  it('CONTROL — a CANVAS-AHEAD divergence is disclosed without blaming either side', async () => {
+    const MORALE = 'fac_team_morale'
+    useCanvasStore.setState({
+      nodes: [
+        {
+          id: MORALE,
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Team morale',
+            category: 'controllable',
+            // No raw_value, no unit, no cap — the uncapped/unitless shape.
+            // The canvas already sits AHEAD at 0.6 from an earlier local write
+            // the engine never took; the engine still holds 0.4.
+            observedState: { value: 0.6, source: 'user' },
+          },
+        },
+      ],
+    } as never)
+
+    const { result } = renderHook(() => useConversation())
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === MORALE)!
+    const undo = captureOptimisticFactorEdit(MORALE, 0.7, node.data)!
+    useCanvasStore.getState().updateNode(MORALE, {
+      data: {
+        ...(node.data as Record<string, unknown>),
+        observedState: { value: 0.7, source: 'user' },
+      },
+    } as never)
+
+    replies.push({
+      assistant_text: 'Updated Team morale.',
+      blocks: [
+        {
+          type: 'graph_patch',
+          status: 'applied',
+          operation: 'set_factor_value',
+          target_id: MORALE,
+          before: { value: 0.4 },
+          after: { value: 0.7 },
+        },
+      ],
+    })
+    await act(async () => {
+      await result.current.sendSystemEvent(
+        { type: 'factor_value_edit', payload: { target_id: MORALE, value: 0.7, field: 'value' } },
+        { optimisticFactorEdit: undo },
+      )
+    })
+    await flush()
+
+    const disclosure = syntheticLines(result.current.messages as never).find((l) =>
+      l.includes(DISCLOSURE_MARK),
+    )
+    expect(disclosure, 'the divergence is still disclosed').toBeDefined()
+    expect(disclosure).toContain('Team morale')
+    expect(disclosure).toContain('0.4')
+    expect(disclosure).toContain('0.6')
+    // RED before the amendment: the sentence opened "Your canvas was out of
+    // date" over a canvas that was ahead.
+    for (const causal of ['out of date', 'stale', 'behind']) {
+      expect(disclosure!.toLowerCase(), `must not diagnose "${causal}"`).not.toContain(causal)
+    }
+    // And the magnitudes must be numbers, not "low"/"moderate".
+    expect(disclosure).not.toMatch(/\b(very low|low|moderate|high|very high)\b/)
   })
 })

--- a/src/canvas/conversation/__tests__/silentRebaseDisclosure.spec.ts
+++ b/src/canvas/conversation/__tests__/silentRebaseDisclosure.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * ROADMAP 2.312 — the measured sequence, end to end, through the real dispatcher.
+ *
+ * THE WALK THIS REPRODUCES (`PHASE0-EVIDENCE-2026-07-28/probe-560-confirm-as-is-receipt.md`
+ * §6, deployed guest build):
+ *
+ *   1. An edit is committed and CEE persists it.
+ *   2. The tab is RELOADED. The boot path restores
+ *      `localStorage['olumi-canvas-autosave']` and fetches no graph — the whole
+ *      boot request manifest is 7 requests and none of them is the scenario
+ *      graph. The Model tab therefore renders the ORIGINAL drafted figure,
+ *      `Monthly Observability Spend · From brief · £4,000`, while a message turn
+ *      in the same session had CEE saying, in its own prose, that the model held
+ *      a different number.
+ *   3. The operator edits against that stale figure. CEE applies the change on
+ *      top of ITS base and reports "Updated … from £3,500 to £4,200" — a
+ *      before-value that appeared nowhere on the operator's screen.
+ *
+ * Step 3 is the data-integrity defect: the canonical graph is edited against a
+ * base the user never saw, silently. This file pins that it can no longer be
+ * silent.
+ *
+ * WHY IT DRIVES THE DISPATCHER AND NOT A PANEL. The engine's own base for the
+ * edit is visible in exactly one place — the applied `graph_patch` receipt on
+ * the reply — and a panel spec that mocks `ConversationContext` sits above the
+ * only layer that sees a reply. Same reasoning, and the same harness, as
+ * `optimisticFactorEditRevert.spec.ts`, which pins the refusal direction.
+ *
+ * HOW THE STALE BOOT IS STAGED, stated plainly so the scope is not overread.
+ * Step 2 is reproduced through the production restore CALL — `saveAutosave` →
+ * `loadAutosave` → `hydrateGraphSlice`, which is exactly what
+ * `ReactFlowGraph.tsx:1377-1416` does on boot — rather than by mounting the
+ * canvas component. So this file proves the STORE state the boot produces and
+ * everything downstream of it. It does NOT re-prove the network manifest; that
+ * is the probe's measurement, cited above, and jsdom could not prove it anyway.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import { saveAutosave, loadAutosave, clearAutosave } from '../../store/scenarios'
+import type { WireSystemEvent } from '../types'
+import { captureOptimisticFactorEdit } from '../optimisticFactorEdit'
+
+const replies: Array<Record<string, unknown>> = []
+const dispatched: Array<Record<string, unknown>> = []
+
+// Mock the TRANSPORT, not the context (CLAUDE.md trap 12: `importOriginal`
+// spread, never a hand-listed factory).
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    callV5Turn: vi.fn(async (payload: Record<string, unknown>) => {
+      dispatched.push(payload)
+      const response = replies.shift() ?? { assistant_text: 'ok', blocks: [] }
+      return { ok: true, response }
+    }),
+  }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    isOrchestratorV2Enabled: () => true,
+    isOrchestratorStreamingEnabled: () => false,
+  }
+})
+
+import { useConversation } from '../useConversation'
+
+const SCENARIO = 'cbce69ac-1111-4222-8333-444444444444'
+const FACTOR_ID = 'fac_monthly_cost'
+const CAP = 5000
+
+/**
+ * The node as the STALE autosave record holds it — copied in shape from the
+ * probe's own capture of `localStorage['olumi-canvas-autosave']`:
+ *   "id":"fac_monthly_cost" … "display_value":"£4k","provenance":"from_brief"
+ *   "observedState":{"value":0.8,"unit":"£","source":"brief_extraction",
+ *                    "raw_value":4000,"cap":5000}
+ */
+function staleFactorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Monthly Observability Spend',
+      category: 'controllable',
+      display_value: '£4k',
+      provenance: 'from_brief',
+      observedState: {
+        value: 0.8,
+        raw_value: 4000,
+        unit: '£',
+        cap: CAP,
+        source: 'brief_extraction',
+      },
+    },
+  } as Node
+}
+
+/** The operator's entry: £4,200 → model scale 4200/5000. */
+const TYPED_RAW = 4200
+const TYPED_MODEL = TYPED_RAW / CAP
+
+const edit = (): WireSystemEvent => ({
+  type: 'factor_value_edit',
+  payload: {
+    target_id: FACTOR_ID,
+    value: TYPED_MODEL,
+    raw_value: TYPED_RAW,
+    unit: '£',
+    field: 'value',
+  },
+})
+
+/**
+ * CEE's reply, verbatim in shape from the probe: an APPLIED receipt whose
+ * `before` is £3,500 — the base the operator never saw.
+ */
+const REBASED_ACCEPTANCE = {
+  assistant_text: 'Updated Monthly Observability Spend from £3,500 to £4,200.',
+  blocks: [
+    {
+      type: 'graph_patch',
+      status: 'applied',
+      operation: 'set_factor_value',
+      target_id: FACTOR_ID,
+      before: { value: 0.7, raw_value: 3500, unit: '£', cap: CAP },
+      after: { value: TYPED_MODEL, raw_value: TYPED_RAW, unit: '£', cap: CAP },
+    },
+  ],
+  graph_hash: 'c41b7a02e9d3f815',
+}
+
+/** The same reply with the base the operator DID see — the control. */
+const IN_STEP_ACCEPTANCE = {
+  ...REBASED_ACCEPTANCE,
+  assistant_text: 'Updated Monthly Observability Spend from £4,000 to £4,200.',
+  blocks: [
+    {
+      ...REBASED_ACCEPTANCE.blocks[0],
+      before: { value: 0.8, raw_value: 4000, unit: '£', cap: CAP },
+    },
+  ],
+}
+
+/** The panel's optimistic write, through the same sanctioned setter it uses. */
+function writeOptimistically() {
+  const store = useCanvasStore.getState()
+  const node = store.nodes.find((n) => n.id === FACTOR_ID)!
+  const existing = (node.data as Record<string, unknown>).observedState as Record<string, unknown>
+  store.updateNode(FACTOR_ID, {
+    data: {
+      ...(node.data as Record<string, unknown>),
+      display_value: undefined,
+      observedState: {
+        ...existing,
+        value: TYPED_MODEL,
+        raw_value: TYPED_RAW,
+        source: 'user',
+        display_value: undefined,
+      },
+    },
+  } as never)
+}
+
+const flush = async () => {
+  for (let round = 0; round < 25; round++) {
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 1))
+  }
+}
+
+/**
+ * Step 2 of the walk: the production boot restore, by its own calls.
+ * `ReactFlowGraph.tsx:1377` reads `loadAutosave()` and passes `nodes`/`edges`
+ * straight to `hydrateGraphSlice` — reproduced here exactly, so what the
+ * operator is looking at in step 3 is genuinely what the restore produced.
+ */
+function bootRestoreFromAutosave() {
+  const autosave = loadAutosave()
+  expect(autosave, 'the autosave slot is what boot restores from').not.toBeNull()
+  useCanvasStore.getState().hydrateGraphSlice({
+    nodes: autosave!.nodes,
+    edges: autosave!.edges,
+  } as never)
+  useCanvasStore.setState({ currentScenarioId: SCENARIO } as never)
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  dispatched.length = 0
+  replies.length = 0
+  clearAutosave()
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' } as never,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    pendingEmittedEdits: 0,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+  // Step 1→2: the stale record is in the autosave slot, as the probe found it.
+  saveAutosave({
+    nodes: [staleFactorNode()],
+    edges: [],
+    timestamp: Date.now(),
+    scenarioId: SCENARIO,
+  } as never)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  clearAutosave()
+})
+
+/** Every synthetic assistant line the turn produced. */
+function syntheticLines(messages: ReadonlyArray<Record<string, unknown>>): string[] {
+  return messages
+    .filter((m) => m.synthetic === true && typeof m.content === 'string')
+    .map((m) => String(m.content))
+}
+
+describe('an edit made against a STALE canvas is no longer silently rebased', () => {
+  it('tells the operator the engine held £3,500, not the £4,000 they were shown', async () => {
+    bootRestoreFromAutosave()
+
+    // What the operator is looking at: the ORIGINAL drafted figure, restored
+    // from localStorage, exactly as the Model tab rendered it in the probe.
+    const shownNode = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!
+    const shownObserved = (shownNode.data as Record<string, unknown>)
+      .observedState as Record<string, unknown>
+    expect(shownObserved.raw_value, 'the tab shows the stale £4,000').toBe(4000)
+
+    const { result } = renderHook(() => useConversation())
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, TYPED_MODEL, shownNode.data)!
+    writeOptimistically()
+
+    replies.push(REBASED_ACCEPTANCE)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    // RED before the fix: nothing anywhere named £3,500. The operator's model
+    // had been rebased onto a number that appeared on no screen they saw.
+    const lines = syntheticLines(result.current.messages as never)
+    const disclosure = lines.find((l) => l.includes('£3,500'))
+    expect(disclosure, 'the engine’s real base must be disclosed').toBeDefined()
+    expect(disclosure).toContain('Monthly Observability Spend')
+    expect(disclosure).toContain('£4,000')
+  })
+
+  it('keeps the value the engine accepted — disclosure is not a revert', async () => {
+    // The number the operator chose IS what the engine now holds, so reverting
+    // it would swap a silent wrong base for silently discarded work.
+    bootRestoreFromAutosave()
+    const { result } = renderHook(() => useConversation())
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, TYPED_MODEL, node.data)!
+    writeOptimistically()
+
+    replies.push(REBASED_ACCEPTANCE)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    const observed = (
+      useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!.data as Record<string, unknown>
+    ).observedState as Record<string, unknown>
+    expect(observed.raw_value).toBe(TYPED_RAW)
+    expect(observed.value).toBe(TYPED_MODEL)
+  })
+
+  it('CONTROL — an edit made against an IN-STEP canvas says nothing', async () => {
+    // Blocks the cheap wrong fix: a disclosure emitted on every applied receipt
+    // would satisfy the RED above and shout at every ordinary edit.
+    bootRestoreFromAutosave()
+    const { result } = renderHook(() => useConversation())
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, TYPED_MODEL, node.data)!
+    writeOptimistically()
+
+    replies.push(IN_STEP_ACCEPTANCE)
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    const lines = syntheticLines(result.current.messages as never)
+    expect(lines.filter((l) => l.includes('out of date'))).toEqual([])
+  })
+
+  it('CONTROL — a REFUSED edit discloses no base and still reverts', async () => {
+    // The refusal reply carries no receipt, so there is no engine base to
+    // disclose; the 2.129 revert must be untouched by this change.
+    bootRestoreFromAutosave()
+    const { result } = renderHook(() => useConversation())
+    const node = useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!
+    const undo = captureOptimisticFactorEdit(FACTOR_ID, TYPED_MODEL, node.data)!
+    writeOptimistically()
+
+    replies.push({ assistant_text: "That exceeds the cap. I haven't changed anything.", blocks: [] })
+    await act(async () => {
+      await result.current.sendSystemEvent(edit(), { optimisticFactorEdit: undo })
+    })
+    await flush()
+
+    const observed = (
+      useCanvasStore.getState().nodes.find((n) => n.id === FACTOR_ID)!.data as Record<string, unknown>
+    ).observedState as Record<string, unknown>
+    expect(observed.raw_value, 'the refused value is rolled back').toBe(4000)
+    const lines = syntheticLines(result.current.messages as never)
+    expect(lines.filter((l) => l.includes('out of date'))).toEqual([])
+  })
+})

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -41,8 +41,8 @@
 
 import { useCanvasStore } from '../store'
 import { withObservedStateUpdate, type ObservedStateData } from '../utils/observedStateHelpers'
-import { unwrapInterventionValue } from '../utils/labelUtils'
-import { formatValueWithUnit } from '../utils/formatValueWithUnit'
+import { unwrapInterventionValue, classifyUnit } from '../utils/labelUtils'
+import { formatValueWithUnit, formatNumber } from '../utils/formatValueWithUnit'
 
 /**
  * Everything needed to undo one optimistic value write, captured BEFORE it.
@@ -210,6 +210,19 @@ export function responseAppliedFactorEdit(response: unknown, targetId: string): 
  * base the operator did not see, and nothing anywhere says so. That is a
  * data-integrity defect on the canonical graph, not a rendering one.
  *
+ * ⚠ WHAT THE RECEIPT PROVES IS A DIFFERENCE, NOT A DIRECTION — and the copy
+ * must not exceed it. The stale-boot walk above is the case that MOTIVATED this
+ * guard, but it is not the only way the two bases part company, and the receipt
+ * cannot tell them apart. The CANVAS-AHEAD case is live and ungated: a factor
+ * with no `raw_value` on either side, written locally via a one-argument
+ * `setObservedValue(0.6)` over a server-held `0.4`, produces exactly the same
+ * evidence as a stale canvas. An earlier draft of this module asserted "Your
+ * canvas was out of date" and would have reported that case — canvas AHEAD of
+ * the engine — as the canvas being behind. Diagnosing a cause the evidence does
+ * not carry is the same defect class as the silence it replaces, so the
+ * disclosure now states only what the receipt witnesses: the engine applied the
+ * change on top of one number, and a different number was on screen.
+ *
  * WHY DETECTION AND DISCLOSURE, RATHER THAN PREVENTION.
  * Prevention needs the operator's base ON THE WIRE and a server that refuses a
  * mismatch — a CEE-side change, and a bigger piece of work. What the UI can do
@@ -225,9 +238,9 @@ export function responseAppliedFactorEdit(response: unknown, targetId: string): 
  * reverting it would replace one lie with another. The defect is the SILENCE.
  * Correspondingly the reviewed stamp is NOT withheld: "checked by you" is a
  * claim about the number now on the engine, and that claim survives — what does
- * not survive is the implicit claim that the canvas the operator was reading
- * matched the engine. So the value stands, the stamp stands, and the divergence
- * is SAID.
+ * not survive is the implicit claim that the number on screen was the one the
+ * change was applied to. So the value stands, the stamp stands, and the
+ * divergence is SAID.
  *
  * FAIL-SAFE DIRECTION, and it is the opposite of `responseAppliedFactorEdit`'s.
  * That predicate assumes APPLIED when it cannot tell, because a false revert
@@ -238,13 +251,17 @@ export function responseAppliedFactorEdit(response: unknown, targetId: string): 
  * scale-ambiguous case returns null.
  */
 
-/** A proven mismatch between the base the user saw and the base the server had. */
+/**
+ * A proven DIFFERENCE between the base the user saw and the base the server
+ * applied to. Deliberately not a claim about which of the two is older — see
+ * the direction note above.
+ */
 export interface RebaseDivergence {
   /** The factor the receipt and the snapshot agree they are both talking about. */
   nodeId: string
-  /** The magnitude the operator was looking at when they typed. */
+  /** The magnitude that was on the operator's screen when they typed. */
   shownBase: number
-  /** The magnitude the engine actually held, per its own receipt. */
+  /** The magnitude the engine applied the change to, per its own receipt. */
   serverBase: number
   /**
    * Which field the two sides were compared on. `raw_value` is a user-unit
@@ -252,7 +269,14 @@ export interface RebaseDivergence {
    * `value` is model scale and is used only when neither side states a raw one.
    */
   basis: 'raw_value' | 'value'
-  /** The unit both sides agreed on, when either stated one. */
+  /**
+   * The unit to render these magnitudes in: the SERVER's when it states one,
+   * otherwise the snapshot's. Not an agreed value — a disagreement between the
+   * two units means the magnitudes are not comparable at all and
+   * `detectSilentRebase` has already returned null, so the only case where the
+   * two differ here is one side saying nothing. CEE is the unit authority, so
+   * its answer wins when both are present.
+   */
   unit?: string
 }
 
@@ -389,10 +413,31 @@ export function detectSilentRebase(
  * THE MAGNITUDES ARE RENDERED, NOT PRINTED RAW. `formatValueWithUnit` is the
  * repo's single source of truth for "a raw value with its unit" (£3,500, not
  * 3500), so the numbers in this sentence read the same as the ones on the row
- * the user was just looking at. It is applied ONLY on the `raw_value` basis: on
- * the model-scale `value` basis that helper maps 0–1 to a qualitative word
- * ("moderate"), which would turn a precise statement about two specific numbers
- * into an unfalsifiable one.
+ * the user was just looking at.
+ *
+ * ⚠ BUT IT IS NOT SAFE TO CALL UNCONDITIONALLY, AND THE BASIS ALONE DOES NOT
+ * MAKE IT SAFE. An earlier draft of this comment claimed the `raw_value` basis
+ * was enough. It is not: `formatValueWithUnit` keys its qualitative branch on
+ * `classifyUnit(unit).kind ∈ {none, placeholder}` AND `0 ≤ v ≤ 1`
+ * (`formatValueWithUnit.ts:51-53`) — the BASIS is not part of that test. A
+ * raw-basis 0–1 magnitude with no unit therefore rendered as a word, and the
+ * sentence refuted itself:
+ *
+ *   "it showed Team morale as low, but the model held low.
+ *    Your change has been applied on top of low."
+ *
+ * That is reachable, not hypothetical: an UNCAPPED factor stores the same
+ * number in `value` and `raw_value` (CEE `normalise-factor-value.ts:12-16`,
+ * `:138-141`) and `snapshotObservedState` (`set-factor-value.ts:194-203`)
+ * copies it into `before` verbatim, so both sides carry a raw magnitude that
+ * can sit in 0–1 with no unit attached.
+ *
+ * So the guard is the CONDITION ITSELF, derived from the same `classifyUnit`
+ * the formatter uses rather than mirrored from its behaviour (CLAUDE.md trap
+ * 12): whenever the unit is one the formatter would treat as absent or
+ * placeholder, render a bare number instead. The model-scale `value` basis
+ * takes the same bare-number path for a different reason — a normalised
+ * fraction has no unit to wear, so attaching the factor's would print "£0.8".
  *
  * NO REMEDY IS OFFERED THAT DOES NOT WORK. "Reload to get the current figures"
  * is the obvious closing line and it is FALSE — the boot path restores
@@ -406,14 +451,22 @@ export function describeRebaseDivergence(
   divergence: RebaseDivergence,
   factorLabel: string,
 ): string {
-  const render = (n: number): string =>
-    divergence.basis === 'raw_value' ? formatValueWithUnit(n, divergence.unit) : String(n)
+  const render = (n: number): string => {
+    // Model scale wears no unit, so it never goes near the unit-aware helper.
+    if (divergence.basis !== 'raw_value') return formatNumber(n)
+    // Otherwise: only hand it to the formatter when the formatter's qualitative
+    // branch CANNOT fire — i.e. when the unit is a real one. Same predicate the
+    // formatter consults, not a copy of its output.
+    const { kind } = classifyUnit(divergence.unit ?? null)
+    if (kind === 'none' || kind === 'placeholder') return formatNumber(n)
+    return formatValueWithUnit(n, divergence.unit)
+  }
   const shown = render(divergence.shownBase)
   const server = render(divergence.serverBase)
   return (
-    `Your canvas was out of date: it showed ${factorLabel} as ${shown}, but the model held ${server}. ` +
-    `Your change has been applied on top of ${server}. ` +
-    `Other values on this canvas may also be stale — ask me and I'll tell you what the model currently holds.`
+    `The engine applied your change to ${factorLabel} on top of ${server}, ` +
+    `not the ${shown} shown on your canvas. ` +
+    `Other values on this canvas may also differ from the model — ask me and I'll tell you what the model currently holds.`
   )
 }
 

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -41,6 +41,8 @@
 
 import { useCanvasStore } from '../store'
 import { withObservedStateUpdate, type ObservedStateData } from '../utils/observedStateHelpers'
+import { unwrapInterventionValue } from '../utils/labelUtils'
+import { formatValueWithUnit } from '../utils/formatValueWithUnit'
 
 /**
  * Everything needed to undo one optimistic value write, captured BEFORE it.
@@ -185,6 +187,234 @@ export function responseAppliedFactorEdit(response: unknown, targetId: string): 
     if (targets.includes(targetId)) return true
   }
   return false
+}
+
+/**
+ * THE SILENT REBASE — what this next section detects, and why it is here.
+ *
+ * ROADMAP 2.312. Live-measured on the deployed guest build
+ * (`PHASE0-EVIDENCE-2026-07-28/probe-560-confirm-as-is-receipt.md` §6): the
+ * canvas does NOT hydrate from the server on boot — it restores
+ * `localStorage['olumi-canvas-autosave']`, and the complete boot request
+ * manifest contains no graph fetch. So after a reload the tab can be showing a
+ * number the engine stopped holding some time ago.
+ *
+ * The consequence is not a display bug. With the tab showing £4,000 the
+ * operator typed £4,200, and CEE recorded
+ *
+ *   "Updated Monthly Observability Spend from £3,500 to £4,200"
+ *
+ * — a BEFORE-value the user was never shown, on a base they never chose. The
+ * wire event carries only the new value (`buildFactorValueEditEvent`); the
+ * server derives `before` from its OWN graph. So the edit is applied against a
+ * base the operator did not see, and nothing anywhere says so. That is a
+ * data-integrity defect on the canonical graph, not a rendering one.
+ *
+ * WHY DETECTION AND DISCLOSURE, RATHER THAN PREVENTION.
+ * Prevention needs the operator's base ON THE WIRE and a server that refuses a
+ * mismatch — a CEE-side change, and a bigger piece of work. What the UI can do
+ * ALONE it can do completely: the applied receipt already carries the server's
+ * own `before` (see `responseAppliedFactorEdit`'s contract note), and
+ * `OptimisticFactorEdit.prevObservedState` is, by construction, the state the
+ * operator was looking at when they typed. Comparing those two is an exact
+ * test for "was this edit rebased?", answerable on every applied edit, with no
+ * new wire field and no new round trip.
+ *
+ * WHY THE VALUE IS KEPT AND NOT REVERTED.
+ * The server DID apply the number the operator chose, so that number is true and
+ * reverting it would replace one lie with another. The defect is the SILENCE.
+ * Correspondingly the reviewed stamp is NOT withheld: "checked by you" is a
+ * claim about the number now on the engine, and that claim survives — what does
+ * not survive is the implicit claim that the canvas the operator was reading
+ * matched the engine. So the value stands, the stamp stands, and the divergence
+ * is SAID.
+ *
+ * FAIL-SAFE DIRECTION, and it is the opposite of `responseAppliedFactorEdit`'s.
+ * That predicate assumes APPLIED when it cannot tell, because a false revert
+ * destroys accepted work. This one reports NOTHING when it cannot tell, because
+ * a false rebase warning is an accusation about the user's own data that would
+ * teach them to ignore a true one (CLAUDE.md trap 7b — a broken alarm is worse
+ * than no alarm). Every unreadable, unattributable, unit-mismatched or
+ * scale-ambiguous case returns null.
+ */
+
+/** A proven mismatch between the base the user saw and the base the server had. */
+export interface RebaseDivergence {
+  /** The factor the receipt and the snapshot agree they are both talking about. */
+  nodeId: string
+  /** The magnitude the operator was looking at when they typed. */
+  shownBase: number
+  /** The magnitude the engine actually held, per its own receipt. */
+  serverBase: number
+  /**
+   * Which field the two sides were compared on. `raw_value` is a user-unit
+   * magnitude and is preferred because it is the number a person recognises;
+   * `value` is model scale and is used only when neither side states a raw one.
+   */
+  basis: 'raw_value' | 'value'
+  /** The unit both sides agreed on, when either stated one. */
+  unit?: string
+}
+
+/** Read one numeric field off a receipt/observed-state object, defensively. */
+function readNumeric(field: unknown): number | undefined {
+  const n = unwrapInterventionValue(field).value
+  return typeof n === 'number' && Number.isFinite(n) ? n : undefined
+}
+
+function readUnit(source: Record<string, unknown> | undefined): string | undefined {
+  const u = source?.unit
+  return typeof u === 'string' && u.length > 0 ? u : undefined
+}
+
+/**
+ * Are these two magnitudes the same number?
+ *
+ * A relative epsilon, not equality: both sides have been through JSON and, on
+ * the `value` basis, through a divide-by-cap, so an exact `===` would report a
+ * float artefact as a rebase. The tolerance is nowhere near any real
+ * divergence — the measured defect was £4,000 against £3,500.
+ */
+function sameMagnitude(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-9 * Math.max(1, Math.abs(a), Math.abs(b))
+}
+
+/**
+ * The `before` snapshot this reply's receipt carries for `targetId`, if any.
+ *
+ * ATTRIBUTABLE RECEIPTS ONLY — deliberately stricter than
+ * `responseAppliedFactorEdit`, which treats an untargeted patch as ours. A
+ * patch that does not name this factor cannot prove anything about this
+ * factor's base, and guessing here would manufacture the false alarm this
+ * module exists to avoid. Both contract shapes are read: block-level
+ * `before` beside a block-level `target_id`, and a per-operation `before`
+ * inside `operations[]`.
+ */
+export function readReceiptBaseline(
+  response: unknown,
+  targetId: string,
+): Record<string, unknown> | null {
+  if (!targetId) return null
+  const blocks = (response as { blocks?: unknown })?.blocks
+  if (!Array.isArray(blocks)) return null
+  const NOT_APPLIED = new Set(['rejected', 'proposed', 'dismissed', 'failed', 'error', 'pending'])
+
+  for (const raw of blocks) {
+    const block = (raw ?? {}) as Record<string, unknown>
+    if (block.type !== 'graph_patch') continue
+    const status = typeof block.status === 'string' ? block.status.toLowerCase() : undefined
+    if (status && NOT_APPLIED.has(status)) continue
+
+    if (block.target_id === targetId && block.before && typeof block.before === 'object') {
+      return block.before as Record<string, unknown>
+    }
+    const ops = block.operations
+    if (Array.isArray(ops)) {
+      for (const rawOp of ops) {
+        const op = (rawOp ?? {}) as Record<string, unknown>
+        if (op.target_id === targetId && op.before && typeof op.before === 'object') {
+          return op.before as Record<string, unknown>
+        }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Did the engine apply this edit against a base the operator never saw?
+ *
+ * PURE — no store, no React, so the whole rule is testable without a canvas.
+ * Returns null unless a rebase can be PROVEN; see the fail-safe note above.
+ */
+export function detectSilentRebase(
+  edit: OptimisticFactorEdit,
+  response: unknown,
+): RebaseDivergence | null {
+  const serverBefore = readReceiptBaseline(response, edit.nodeId)
+  if (!serverBefore) return null
+
+  const shown = (edit.prevObservedState ?? undefined) as Record<string, unknown> | undefined
+  if (!shown || typeof shown !== 'object') return null
+
+  // Units first: two magnitudes in different units are not comparable, and
+  // "£3,500 vs 3,500 hours" is a units bug to be reported elsewhere, not a
+  // rebase. Compared only when BOTH sides state one — an absent unit is "not
+  // stated", never a claim of dimensionlessness.
+  const serverUnit = readUnit(serverBefore)
+  const shownUnit = readUnit(shown)
+  if (serverUnit && shownUnit && serverUnit !== shownUnit) return null
+
+  // Prefer the user-unit magnitude. Fall back to model scale only when NEITHER
+  // side states a raw one — mixing the two bases would compare £4,000 with 0.8.
+  const serverRaw = readNumeric(serverBefore.raw_value)
+  const shownRaw = readNumeric(shown.raw_value)
+  let basis: 'raw_value' | 'value'
+  let serverBase: number | undefined
+  let shownBase: number | undefined
+
+  if (serverRaw != null && shownRaw != null) {
+    basis = 'raw_value'
+    serverBase = serverRaw
+    shownBase = shownRaw
+  } else if (serverRaw == null && shownRaw == null) {
+    basis = 'value'
+    serverBase = readNumeric(serverBefore.value)
+    shownBase = readNumeric(shown.value)
+  } else {
+    // One side states a raw magnitude and the other does not. The scales are
+    // not known to match, so no comparison is honest here.
+    return null
+  }
+
+  if (serverBase == null || shownBase == null) return null
+  if (sameMagnitude(serverBase, shownBase)) return null
+
+  return {
+    nodeId: edit.nodeId,
+    shownBase,
+    serverBase,
+    basis,
+    ...(serverUnit || shownUnit ? { unit: serverUnit ?? shownUnit } : {}),
+  }
+}
+
+/**
+ * The sentence a proven rebase earns, in the transcript.
+ *
+ * PURE and exported so the COPY is testable — the precedent is
+ * `noticeForUnsentEdit` in `useConversation`, whose whole point is that a value
+ * edit the user can see on the canvas must never fail quietly.
+ *
+ * THE MAGNITUDES ARE RENDERED, NOT PRINTED RAW. `formatValueWithUnit` is the
+ * repo's single source of truth for "a raw value with its unit" (£3,500, not
+ * 3500), so the numbers in this sentence read the same as the ones on the row
+ * the user was just looking at. It is applied ONLY on the `raw_value` basis: on
+ * the model-scale `value` basis that helper maps 0–1 to a qualitative word
+ * ("moderate"), which would turn a precise statement about two specific numbers
+ * into an unfalsifiable one.
+ *
+ * NO REMEDY IS OFFERED THAT DOES NOT WORK. "Reload to get the current figures"
+ * is the obvious closing line and it is FALSE — the boot path restores
+ * localStorage and fetches no graph (ROADMAP 2.312, the defect this guard
+ * exists under). Asking in chat genuinely does work: CEE answers from its own
+ * graph, which is how the probe caught the divergence in the first place
+ * ("Your model currently has monthly observability spend set to £3,300" while
+ * the Model tab said £4,000). So that is the remedy named.
+ */
+export function describeRebaseDivergence(
+  divergence: RebaseDivergence,
+  factorLabel: string,
+): string {
+  const render = (n: number): string =>
+    divergence.basis === 'raw_value' ? formatValueWithUnit(n, divergence.unit) : String(n)
+  const shown = render(divergence.shownBase)
+  const server = render(divergence.serverBase)
+  return (
+    `Your canvas was out of date: it showed ${factorLabel} as ${shown}, but the model held ${server}. ` +
+    `Your change has been applied on top of ${server}. ` +
+    `Other values on this canvas may also be stale — ask me and I'll tell you what the model currently holds.`
+  )
 }
 
 /** What `revertOptimisticFactorEdit` did, for tests and DEV logging. */

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -123,6 +123,8 @@ import { trackEvent } from '../../lib/posthog'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 import {
   confirmOptimisticFactorEdit,
+  describeRebaseDivergence,
+  detectSilentRebase,
   mergeOptimisticFactorEdit,
   responseAppliedFactorEdit,
   revertOptimisticFactorEdit,
@@ -4460,6 +4462,40 @@ export function useConversation(): UseConversationReturn {
                 console.warn(
                   `[sendTurn] receipt for ${optimisticEdit.nodeId} arrived after the value moved on; reviewed stamp withheld`,
                 )
+              }
+
+              // ROADMAP 2.312 — THE SILENT REBASE, said out loud.
+              //
+              // The canvas does not hydrate from the server on boot (measured:
+              // the whole boot manifest fetches no graph), so the number the
+              // user typed over can be one the engine stopped holding. The
+              // receipt is the first and only moment the engine's OWN base for
+              // this edit becomes visible to the client — so it is the moment
+              // the divergence is checkable, and it is checked here.
+              //
+              // AFTER the confirm, deliberately. The value and its "checked by
+              // you" stamp are both TRUE — the engine applied the number the
+              // user chose — so neither is withheld. What was untrue is the
+              // implicit claim that the canvas matched the engine, and that is
+              // what this corrects. Reverting instead would swap a silent wrong
+              // base for a silently discarded edit.
+              //
+              // `detectSilentRebase` reports only what it can prove and returns
+              // null otherwise, so the common case (canvas in step with the
+              // engine) adds no message and no behaviour change at all.
+              const divergence = detectSilentRebase(optimisticEdit, target.response)
+              if (divergence) {
+                const factorLabel = String(
+                  useCanvasStore.getState().nodes.find((n) => n.id === divergence.nodeId)?.data
+                    ?.label ?? divergence.nodeId,
+                )
+                addMessage({
+                  id: crypto.randomUUID(),
+                  role: 'assistant',
+                  synthetic: true,
+                  timestamp: new Date(),
+                  content: describeRebaseDivergence(divergence, factorLabel),
+                })
               }
             }
           }


### PR DESCRIPTION
## What this is

ROADMAP **2.312**. The lane was dispatched to build *server-authoritative hydration on boot*. **Step 1 changed the plan, and the derivation is the headline of this PR.** Hydration cannot be built in this repo today; what CAN be closed completely, UI-side, is the severe half of the defect — the **silent rebase** — and that is what this ships.

---

## STEP 1 — the derivation (report first, because it overturns two premises)

### 1.1 Boot behaviour, per tier

| | route | hydrates from server? | evidence |
|---|---|---|---|
| **Guest** (every deployed session) | `/canvas`, no `:id` | **NO, ever** | `ReactFlowGraph.tsx:1350-1590` — the whole boot effect is synchronous `localStorage`; no `await`, no `fetch`, no `supabase` anywhere in it |
| **Signed-in** | `/scenario/:id` | **YES** | `CanvasMVP.tsx:59-70` → `useScenario.loadScenario` → `scenarioService.loadScenario` |
| **Signed-in** | `/canvas`, no `:id` | **NO** | same effect, gated on `scenarioIdFromRoute` from `useParams` — a `currentScenarioId` in `localStorage` is never read by it |

The probe's "guest, n=1" caveat is now closed: **guest is not a sample, it is the deployed configuration.** `netlify.toml:11` pins `VITE_AUTH_MODE = "guest"` in `[build.environment]`, so `isPersistenceActive` (`src/lib/persistenceActive.ts:19-23`, `authenticated && !!user && user.id !== 'guest'`) is **false** for every default session on staging and production alike. The only forward path off the landing page for a guest is `ScenarioListPage.tsx:387` → `navigate('/canvas')`, and **nothing** ever navigates `/canvas` → `/scenario/:id` (no `useNavigate` exists anywhere under `src/canvas/`). The URL stays `#/canvas` for the whole session even after CEE mints a scenario UUID (`useConversation.ts:2799-2808`, `:4139-4147`).

Staging does set `VITE_STUB_SUPABASE = "0"` (`netlify.toml:103`), so the real SDK is in the staging bundle and an opt-in sign-in is genuinely possible there. Production keeps the stub.

### 1.2 The two autosaves — **genuinely separate**, but the retirement premise needs correcting

**Separate.** Different code paths, different stores, no shared function:

* **(a) Supabase writer** — `useScenario.ts:312-394` (debounced 1500 ms) → `persistGraphNow` `:162-198` → `scenarioService.saveGraphViaGatedPath` `:174-210` → RPC **`apply_patch_and_log`** (`scenarioService.ts:189`) → `UPDATE scenarios SET graph = …` (`supabase/migrations/20260226000000_scenario_schema_v2.sql:167-169`).
* **(b) localStorage restore** — `scenarios.saveAutosave/loadAutosave` (`store/scenarios.ts:616,670`, key `olumi-canvas-autosave` `:53`) → read once on boot at `ReactFlowGraph.tsx:1377`.

So on the letter of the standing ruling, **the retirement is not cancelled by a shared path.** But it should not proceed on the old rationale either, and this is the correction: **`scenarios.graph` is not a UI-private column — it is CEE's own store.** CEE reads *and writes* it (`persistedGraph.ts:19-22`: the column "is a cross-boundary artefact — CEE reads and writes it too"; `mergeAppliedGraph.ts:102-108` names CEE's writer, `mergeAppliedGraphForPersistence`). The prior derivation's "zero `graph_saved` events, ownership check rejects" is consistent — guests cannot write, by RLS — but it does not follow that the column is unused. **Nothing is retired in this PR.**

### 1.3 What the server offers — and why hydration still cannot be built here

The canonical read exists: **`scenarioService.loadScenario(id)` at `src/services/scenarioService.ts:137-157`** — `supabase.from('scenarios').select('*').eq('id', id).single()`, one PostgREST round trip, returning `graph`, `framing`, `analysis`, `thread`, `events` and **`updated_at`** (the identity available to compare against the local autosave's `timestamp`; a `graph_hash` comparison is *not* safe here — the repo has two same-named `generateGraphHash` twins, CLAUDE.md trap 10).

**Two blockers, both verified at the bytes:**

1. **No read for the tier that has the defect.** The guest browser has no session, `scenarios` is `REVOKE ALL … FROM anon` with RLS `TO authenticated USING (auth.uid() = user_id)` (`20260307000000_rls_audit_hardening.sql:11,23-26`), and **CEE exposes no graph-fetch endpoint at all** — every CEE graph ingestion in the repo is *turn-response* ingestion (`useConversation.ts:4617-4620` `draft_graph`, the `GRAPH_READY` SSE frame, `/draft-graph`). There is no "get graph" call to make on boot.
2. **Server-wins would destroy the user's layout.** CEE's write "overwrites the whole `nodes` array of `scenarios.graph` with the GraphV3-parsed applied graph, **which has no position fields**. So at the moment a receipt arrives the DB has already LOST the user's layout, and the UI's save is the only thing that restores it" (`mergeAppliedGraph.ts:102-108`). Hydrating server-wins on boot would silently scramble the canvas — a *new* work-loss defect in exchange for the one being fixed.

**Conclusion:** server-authoritative hydration needs (a) a CEE-side graph read for unauthenticated sessions and (b) a position-preserving merge on the hydrate path. That is a cross-repo, separately-reviewable piece of work, not a UI slice. **Recommend it be rowed as such.**

---

## STEP 2 — what this PR builds: the silent rebase, killed as a *silent* failure

The severe consequence does not depend on hydration landing, and it is fixable here completely.

**The defect, live-measured** (`probe-560-confirm-as-is-receipt.md` §6): tab showing £4,000, operator typed £4,200, CEE recorded *"Updated Monthly Observability Spend from **£3,500** to £4,200"* — a before-value that appeared on no screen the operator saw. The canonical graph was edited against a base they never chose, and nothing said so.

**The mechanism.** `buildFactorValueEditEvent` sends only the new value; the server derives `before` from its own graph. But **the applied `graph_patch` receipt already carries that `before`**, and `OptimisticFactorEdit.prevObservedState` is by construction the state the operator was looking at when they typed. Comparing the two is an exact test for "was this edit rebased?" — **no new wire field, no new round trip.**

**What it does:**

* `readReceiptBaseline(response, targetId)` — the engine's own `before` for this factor, both contract shapes (block-level `target_id`, `operations[]`).
* `detectSilentRebase(edit, response)` — pure; returns a divergence **only when it can prove one**.
* `describeRebaseDivergence(divergence, label)` — the sentence, rendered through the repo's canonical `formatValueWithUnit` so the numbers read as they do on the row.
* Wired at the single resolution site in `useConversation.ts`, immediately after the 2.304 confirm.

### The three judgement calls, and why

**The value is kept, not reverted.** The engine applied the number the operator chose, so that number is true; reverting would swap a silent wrong base for silently discarded work. **The defect is the silence, so the silence is what is removed.**

**The "checked by you" stamp is kept too.** It is a claim about what the engine now holds, and that claim survives. What did *not* survive is the implicit claim that the canvas matched the engine — and that is what the disclosure corrects. #560's receipt-gating is untouched.

**The detector fails silent, not loud** — the opposite direction to `responseAppliedFactorEdit`, deliberately. Every unreadable, unattributable, unit-mismatched or scale-ambiguous receipt returns `null`. A warning about the user's own data that is usually wrong would teach them to ignore the true one (CLAUDE.md trap 7b). Six of the pure spec's assertions exist only to pin this direction.

**No remedy is offered that does not work.** "Reload to see current figures" is the obvious closing line and it is **false** — that is this very defect. The message names the one thing that does work: asking in chat, which reads CEE's own graph (exactly how the probe caught the divergence).

> The engine applied your change to Monthly Observability Spend on top of £3,500, not the £4,000 shown on your canvas. Other values on this canvas may also differ from the model — ask me and I'll tell you what the model currently holds.

### Not touched
#560's receipt-gating · the #559 entry guard · flip / goal-probability surfaces · both autosave writers (nothing retired).

---

---

## Review amendments at `081af658` (A1, A3, A4)

**A1 — the copy diagnosed a cause the receipt cannot carry.** It opened *"Your canvas was out of date"*. An applied receipt proves the two bases **differ**; it never proves which of them moved. The **canvas-AHEAD** case is live and ungated — a factor with no `raw_value` on either side, written locally over a server-held value, produces identical evidence and was being reported as a stale canvas. Restated to what is witnessed, with **no diagnosis of cause**, plus a canvas-ahead control at *both* the copy level and the dispatcher level.

**A3 — the formatter guard was vacuous, and the module docstring claimed a safety that did not exist.** `formatValueWithUnit` keys its qualitative branch on `classifyUnit(unit).kind ∈ {none, placeholder}` **and** `0 ≤ v ≤ 1` (`formatValueWithUnit.ts:51-53`) — **the basis is not part of that test**. So a raw-basis 0–1 magnitude with no real unit rendered as a word and the sentence refuted itself:

> it showed Team morale as **low**, but the model held **low**. Your change has been applied on top of **low**.

Reachable at CEE's bytes, not by reasoning: an uncapped factor stores the same number in `value` and `raw_value` (`normalise-factor-value.ts:12-16`, `:138-141`) and `snapshotObservedState` (`set-factor-value.ts:194-203`) copies it into `before` verbatim. The guard is now **the formatter's own `classifyUnit` predicate** rather than the basis (derived, not mirrored — CLAUDE.md trap 12), and the self-refuting *shape* is pinned directly: the two magnitudes must never render to the same string in a sentence that exists to contrast them. My only previous covering spec constructed `basis:'value'`, so the raw basis was genuinely unpinned; it now has 5 parameterised cases plus two anti-cheap-fix controls.

**A4 — the `unit` field doc claimed an agreement the code does not compute.** Comment only; behaviour unchanged and defensible (CEE is the unit authority, and a genuine unit *disagreement* has already returned `null` upstream).

---

## Evidence

**RED at pristine `1735e2c7`** (throwaway worktree **outside** the repo root, removed before every gate run):

```
FAIL silentRebaseDisclosure.spec.ts > tells the operator the engine held £3,500,
     not the £4,000 they were shown
AssertionError: the engine's real base must be disclosed: expected undefined not to be undefined
```

That spec imports **only pre-existing symbols**, so it runs at pristine and fails *behaviourally* — and its other 3 assertions **pass** at pristine, because they are controls, not REDs. (`silentRebase.spec.ts` is a new-symbol RED: 22 collection failures.)

**Mutation battery — 11 mutants, every one bites.** M1-M7 pin the original guard; M8-M11 pin the review amendments.

| # | guarantee reverted | REDs |
|---|---|---|
| M1 | disclosure removed at the call site (the pristine defect restored) | 1 |
| M2 | same-magnitude short-circuit removed (warn on every edit) | 3 |
| M3 | unit-mismatch guard removed | 1 |
| M4 | attribution guard removed | 2 |
| M5 | mixed raw/model-scale guard removed | 1 |
| M6 | model-scale rendered through the qualitative formatter | 1 |
| M7 | applied-status filter removed | 1 |
| **M8** | **A1 reverted — copy diagnoses the canvas as out of date** | **5** |
| **M9** | **A3 reverted — basis-only guard, qualitative branch reachable** | **5** |
| **M10** | **A3 "satisfied" the lazy way — units dropped everywhere** | **4** |
| **M11** | **model-scale magnitudes wear the factor's unit ("£0.8")** | **1** |

M10 is the one that matters most for A3: it blocks buying the fix by never printing a unit at all.

## Gates — re-derived at `081af658`, and **two corrections to my own earlier numbers (A2)**

| gate | base `1735e2c7` | tip `081af658` |
|---|---|---|
| typecheck coverage | 3160 / 3200 loaded (40 out of scope) | **3162 / 3202** (40 out of scope) |
| typecheck ratchet | 622 files / 2505 errors | **622 / 2505 — exactly at baseline** |
| `pnpm lint` | 0 errors, 1261 warnings | **0 errors, 1261 warnings** |
| hooks ratchet | 234 violations / 16 files | **234 / 16, exactly matching** |
| full suite | 1443 passed, 3 skipped (**1446** files); 21323 passed, 66 skipped (**21389**) | **1445 passed, 3 skipped (1448); 21359 passed, 66 skipped (21425) — 0 failures** |

**Correction 1 — the coverage figures were base figures reported as tip figures.** The reviewer is right: the tip is **3162 / 3202**. My own final-gate log printed exactly that; I copied the base row into the tip column and wrote "identical" without reading phase 1 of the run I had just done. The `+2` is precisely my two new spec files.

**Correction 2 — the suite figures reconcile exactly; there was no discrepancy, only two conventions.** My log reads `Test Files 1445 passed | 3 skipped (1448)` / `Tests 21359 passed | 66 skipped (21425)`. I quoted the **passed** counts; the verifier quoted the **totals** in parentheses. Both are correct readings of the same run. The table above now gives both, so the convention cannot be mistaken again. Suite delta base→tip is **+2 files / +36 tests** — exactly this PR's additions (26 original + 10 from the amendments), no collateral movement.

## Unverified — stated as such

* **jsdom proves DOM presence, never layout.** The disclosure is asserted as a message in the transcript model. That it is *visible* on screen is a **browser-walk residual**.
* The integration spec reproduces the stale boot through the production restore **calls** (`saveAutosave` → `loadAutosave` → `hydrateGraphSlice`, exactly `ReactFlowGraph.tsx:1377-1416`), not by mounting the canvas. It proves the store state boot produces and everything downstream; it does **not** re-prove the 7-request network manifest — that is the probe's measurement.
* Whether CEE ever emits an applied receipt **without** a `before` in production is unmeasured. That case reports nothing (fail-silent) and is pinned by a control.
* The **canvas-ahead** producing chain is taken from the review, not independently re-measured by me. My controls pin the *behaviour* on that shape of evidence regardless of which door produces it.
