### PR TITLE
fix(netlify): serve /bff/cee/* via an edge function so the SPA catch-all stops answering it (ROADMAP 2.317)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -197,24 +197,25 @@
   status = 200
   force = true
 
-# CEE (Assistants) Service - graph-readiness endpoint
-# Routes /bff/cee/* → https://olumi-assistants-service.onrender.com/assist/v1/*
-# Required for Results Panel confidence tier display
-[[redirects]]
-  from = "/bff/cee/*"
-  to = "https://olumi-assistants-service.onrender.com/assist/v1/:splat"
-  status = 200
-  force = true
-  headers = {X-Olumi-Assist-Key = "${ASSIST_API_KEY}"}
-
-# CEE fallback route for /v1/cee/* path pattern
-# Handles requests when VITE_CEE_BFF_BASE points to /v1/cee instead of /bff/cee
-[[redirects]]
-  from = "/v1/cee/*"
-  to = "https://olumi-assistants-service.onrender.com/assist/v1/:splat"
-  status = 200
-  force = true
-  headers = {X-Olumi-Assist-Key = "${ASSIST_API_KEY}"}
+# CEE (Assistants) Service — ROADMAP 2.317.
+#
+# There is deliberately NO [[redirects]] rule for /bff/cee/* here. Two used to
+# live at this spot (/bff/cee/* and a /v1/cee/* "fallback"), both pointing at
+# olumi-assistants-service.onrender.com with a header-injection block. BOTH WERE
+# UNREACHABLE ON EVERY DEPLOY: Netlify processes public/_redirects before
+# netlify.toml redirects, and public/_redirects ends in the SPA catch-all
+# `/*  /index.html  200`, so /bff/cee/health returned HTTP 200 text/html — the
+# SPA index — instead of reaching CEE. They also named a host running a
+# different, older build than CEE staging, so they were wrong twice over.
+#
+# The seam is now served by the `cee-proxy` edge function (registered below),
+# which outranks the _redirects catch-all and can inject the auth header that a
+# redirect rule cannot inject without putting the key somewhere the browser can
+# read. Do not re-add a redirect rule here: it would be dead on arrival, and a
+# second declaration of the same path in a second config file is exactly how
+# this defect was born. See tests/ci-guards/netlify-bff-route-precedence.spec.ts,
+# which fails if any /bff/* proxy path is declared only in a place the catch-all
+# outranks.
 
 # =============================================================================
 # Edge Functions (security-critical functions listed first for audit clarity)
@@ -238,3 +239,12 @@
 [[edge_functions]]
   function = "orchestrator-proxy"
   path = "/bff/orchestrate/*"
+
+# CEE (Assistants) proxy - handles auth header injection for /bff/cee/*
+# Requires ASSIST_API_KEY env var in Netlify dashboard (already provisioned;
+# the same var orchestrator-proxy reads). An edge function rather than a
+# redirect because _redirects cannot inject request headers and a netlify.toml
+# redirect is outranked by the _redirects SPA catch-all — see ROADMAP 2.317.
+[[edge_functions]]
+  function = "cee-proxy"
+  path = "/bff/cee/*"

--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -1,0 +1,207 @@
+/**
+ * CEE (Assistants) Service Proxy Edge Function — ROADMAP 2.317
+ *
+ * Serves the `/bff/cee/*` seam by proxying to CEE staging and injecting the
+ * caller-auth header. Sibling of `orchestrator-proxy.ts` (which owns
+ * `/bff/orchestrate/*`) and `isl-proxy.ts` (which owns `/bff/isl/*`).
+ *
+ * WHY AN EDGE FUNCTION AND NOT A REDIRECT — the defect this fixes.
+ * `/bff/cee/*` used to be declared ONLY in `netlify.toml` `[[redirects]]`.
+ * Netlify processes `public/_redirects` BEFORE `netlify.toml` redirects, and
+ * `_redirects` ends in the SPA catch-all `/*  /index.html  200`. The catch-all
+ * therefore won every time: `GET /bff/cee/health` returned HTTP 200
+ * `text/html` — the SPA index — and never reached CEE at all. The netlify.toml
+ * rules were unreachable on every deploy context, and both of them pointed at
+ * `olumi-assistants-service.onrender.com` (a different, older build than CEE
+ * staging), so even had they been reachable they would have hit the wrong host.
+ *
+ * Moving the rule into `_redirects` above the catch-all is NOT an option: the
+ * rule exists to inject `X-Olumi-Assist-Key`, and `_redirects` cannot inject
+ * request headers — the key would have to be a literal in a file the browser
+ * can fetch. An edge function keeps the key server-side in the Netlify edge
+ * runtime, and an edge function bound to a path runs BEFORE the `_redirects`
+ * catch-all. That precedence is not assumed: `/bff/isl/*` and
+ * `/bff/orchestrate/*` are declared ONLY as edge functions, and both answer
+ * with their own JSON on the live staging host while `/bff/cee/*` answered
+ * with SPA HTML — the same-host three-way control that established the
+ * mechanism.
+ *
+ * TARGET HOST. `https://cee-staging.onrender.com`, matching
+ * `orchestrator-proxy.ts`. Verified live: its `/healthz` reports build
+ * `7f57602`, which is the exact tip of olumi-assistants-service `staging`,
+ * and `prompt_environment: "staging"`. Hardcoded rather than env-selected, to
+ * match the established sibling proxies and to add no new environment gate.
+ *
+ * PATH REWRITE. `/bff/cee/<x>` → `/assist/v1/<x>`. CEE mounts its assist
+ * surface under `/assist/v1`. Three independent in-repo sources agree on the
+ * prefix: the netlify.toml rule this function replaces, the `vite.config.ts`
+ * dev proxy ("CEE service expects /assist/v1 prefix"), and the cross-repo note
+ * in `src/canvas/hooks/useGraphReadiness.ts` citing CEE's own source at a
+ * pinned SHA. It could NOT be confirmed by unauthenticated probing: CEE's auth
+ * middleware runs before routing, so a bogus path returns 401 exactly like a
+ * real one — 401 here proves auth-ordering, not registration.
+ *
+ * Environment Variables:
+ * - ASSIST_API_KEY: caller-auth key for CEE (X-Olumi-Assist-Key header).
+ *   Already provisioned in the Netlify dashboard and already read by
+ *   `orchestrator-proxy.ts`. This function introduces NO new secret and makes
+ *   no new decision about where a secret lives.
+ *
+ * SECURITY:
+ * - Uses explicit origin allow-list (no wildcard CORS)
+ * - The API key is never returned to the client and never enters the bundle
+ * See SECURITY.md for compliance requirements.
+ */
+
+import type { Config, Context } from '@netlify/edge-functions'
+
+const CEE_TARGET = 'https://cee-staging.onrender.com'
+
+// SECURITY: CORS allow-list (never use wildcard in production)
+const ALLOWED_ORIGINS = [
+  'https://decisionguide.ai',
+  'https://app.olumi.app',
+  'https://decision-guide-ai.netlify.app',  // Netlify main
+  'https://staging--olumi.netlify.app',     // Staging environment
+  'http://localhost:5173',  // Dev only
+  'http://localhost:4173',  // Preview builds
+]
+
+// Pattern for Netlify preview/branch deploys
+const NETLIFY_PREVIEW_PATTERN = /^https:\/\/[a-z0-9-]+--olumi\.netlify\.app$/
+
+function isOriginAllowed(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    return true
+  }
+  return NETLIFY_PREVIEW_PATTERN.test(origin)
+}
+
+function getCorsHeaders(requestOrigin: string): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': requestOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-correlation-id, x-request-id, x-user-id',
+    'Vary': 'Origin, Access-Control-Request-Headers',
+  }
+}
+
+export default async function handler(request: Request, _context: Context) {
+  const origin = request.headers.get('origin')
+
+  // SECURITY: an origin that is PRESENT and not on the allow-list is a
+  // cross-origin caller we do not serve — reject it.
+  //
+  // A MISSING origin is a different case and must NOT be rejected. Per the
+  // Fetch spec the browser omits `Origin` on same-origin GET/HEAD, and this
+  // seam is same-origin by construction (`/bff/cee/*` on the app's own host).
+  // `src/lib/service-health.ts` issues exactly such a request — GET
+  // `${CEE_BASE_URL}/health` — so rejecting a missing origin would 403 the
+  // app's own health check. Rejecting it buys no security either: CORS governs
+  // cross-origin READS, and any non-browser client can set any Origin it likes.
+  //
+  // NOTE — `isl-proxy.ts` and `orchestrator-proxy.ts` DO reject a missing
+  // origin, which is why `GET /bff/isl/health` answers 403 to the app's own
+  // same-origin health check. That is a pre-existing defect in those two
+  // functions, out of scope here and flagged for separate repair; this
+  // function deliberately does not copy it.
+  if (origin !== null && !isOriginAllowed(origin)) {
+    console.warn('[CEE Proxy] Rejected request from unknown origin:', origin)
+    return new Response(
+      JSON.stringify({ error: 'Origin not allowed' }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )
+  }
+
+  // CORS headers are only meaningful when an origin was supplied.
+  const corsHeaders = origin === null ? null : getCorsHeaders(origin)
+
+  // Handle preflight OPTIONS requests
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders ?? {} })
+  }
+
+  // Extract the path after /bff/cee/
+  // e.g. /bff/cee/graph-readiness → /assist/v1/graph-readiness
+  const url = new URL(request.url)
+  const targetPath = url.pathname.replace(/^\/bff\/cee/, '/assist/v1')
+  const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
+
+  // SECURITY: Build headers from scratch with explicit allowlist.
+  // 'authorization' carries the user's Supabase access token (same rationale
+  // as orchestrator-proxy.ts: CEE's flag-gated JWT half verifies identity from
+  // it). It is the USER token; the caller-auth X-Olumi-Assist-Key is injected
+  // separately below and never collides.
+  const ALLOWED_FORWARD_HEADERS = [
+    'content-type',
+    'accept',
+    'authorization',
+    'x-correlation-id',
+    'x-request-id',
+    'x-user-id',
+  ]
+
+  const headers = new Headers()
+
+  for (const headerName of ALLOWED_FORWARD_HEADERS) {
+    const value = request.headers.get(headerName)
+    if (value) {
+      headers.set(headerName, value)
+    }
+  }
+
+  // Inject caller-auth header — the same key orchestrator-proxy.ts uses.
+  const assistKey = Deno.env.get('ASSIST_API_KEY')
+  if (assistKey) {
+    headers.set('X-Olumi-Assist-Key', assistKey)
+  } else {
+    console.warn('[CEE Proxy] ASSIST_API_KEY not set - requests may fail with 401')
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+      // @ts-ignore - duplex is required for streaming bodies
+      duplex: 'half',
+    })
+
+    // Return response with validated CORS headers
+    const responseHeaders = new Headers(response.headers)
+    if (corsHeaders) {
+      Object.entries(corsHeaders).forEach(([key, value]) => {
+        responseHeaders.set(key, value)
+      })
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
+  } catch (error) {
+    console.error('[CEE Proxy] Error:', error)
+    // SECURITY: Do not leak internal error details to client
+    const isTimeout = (error as Error).name === 'AbortError' ||
+      (error as Error).message?.includes('timed out')
+    return new Response(
+      JSON.stringify({
+        error: isTimeout
+          ? 'CEE request timed out. Please try again.'
+          : 'CEE service unavailable. Please try again.',
+      }),
+      {
+        status: isTimeout ? 504 : 502,
+        headers: { ...(corsHeaders ?? {}), 'Content-Type': 'application/json' },
+      }
+    )
+  }
+}
+
+export const config: Config = {
+  path: '/bff/cee/*',
+}

--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -51,6 +51,27 @@
  * - Uses explicit origin allow-list (no wildcard CORS)
  * - The API key is never returned to the client and never enters the bundle
  * See SECURITY.md for compliance requirements.
+ *
+ * ── COMPLETE DIVERGENCE SET FROM THE SIBLING PROXIES ────────────────────────
+ * This function is a clone of `orchestrator-proxy.ts` and differs from it in
+ * exactly two ways. Both are deliberate; neither is an accident of copying.
+ *
+ * 1. MISSING `Origin` IS ALLOWED (the siblings reject it). See the comment at
+ *    the origin check below. `Origin` was never an auth control here: these
+ *    functions carry no ambient credential (no cookies are forwarded, and
+ *    `Access-Control-Allow-Credentials` is never set), and browsers omit the
+ *    header on same-origin GET/HEAD — which is precisely the shape
+ *    `service-health.ts` sends. The siblings' rejection is the defect, and it
+ *    is why `GET /bff/isl/health` 403s the app's own health check.
+ *
+ * 2. METHOD SET IS `GET/HEAD/POST/OPTIONS` (orchestrator-proxy is POST-only;
+ *    isl-proxy restricts nothing at all). This seam needs GET for
+ *    `/health` and POST for `graph-readiness` / `prompts/warm` / `ask`, so
+ *    neither sibling's rule fits. What must NOT happen is isl-proxy's posture:
+ *    forwarding every verb while carrying an injected credential. The enforced
+ *    set below and the advertised `Access-Control-Allow-Methods` are kept
+ *    identical on purpose — an allow-list that advertises less than it enforces
+ *    is a false guarantee, which is the defect class this whole change is about.
  */
 
 import type { Config, Context } from '@netlify/edge-functions'
@@ -77,10 +98,18 @@ function isOriginAllowed(origin: string): boolean {
   return NETLIFY_PREVIEW_PATTERN.test(origin)
 }
 
+/**
+ * The verbs this seam forwards. GET/HEAD for `/health`, POST for
+ * `graph-readiness` / `prompts/warm` / `ask`, OPTIONS for preflight.
+ * ENFORCED below and ADVERTISED verbatim in Access-Control-Allow-Methods —
+ * the two must not drift apart.
+ */
+const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'OPTIONS'] as const
+
 function getCorsHeaders(requestOrigin: string): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': requestOrigin,
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Methods': ALLOWED_METHODS.join(', '),
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-correlation-id, x-request-id, x-user-id',
     'Vary': 'Origin, Access-Control-Request-Headers',
   }
@@ -122,6 +151,25 @@ export default async function handler(request: Request, _context: Context) {
   // Handle preflight OPTIONS requests
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: corsHeaders ?? {} })
+  }
+
+  // SECURITY: refuse any verb outside the advertised set. This function injects
+  // a caller-auth credential on every request it forwards, so an unrestricted
+  // verb set would hand an authenticated PUT/DELETE/PATCH to CEE from anywhere
+  // the origin check lets through. `orchestrator-proxy.ts` guards this (POST
+  // only); `isl-proxy.ts` does not, and that gap is the one not to copy.
+  if (!(ALLOWED_METHODS as readonly string[]).includes(request.method)) {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      {
+        status: 405,
+        headers: {
+          ...(corsHeaders ?? {}),
+          'Content-Type': 'application/json',
+          Allow: ALLOWED_METHODS.join(', '),
+        },
+      }
+    )
   }
 
   // Extract the path after /bff/cee/

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,27 @@
 # BFF proxies (must come BEFORE SPA catch-all)
-# Note: /bff/isl/* handled by edge function (isl-proxy.ts) for auth header injection
-# Note: /bff/cee/* handled by netlify.toml redirect with header injection
+#
+# ORDERING RULE — the one thing to know before adding a proxy path here.
+# Netlify processes THIS FILE BEFORE netlify.toml's [[redirects]]. This file
+# ends in the SPA catch-all `/*  /index.html  200`, so a proxy path declared
+# ONLY in netlify.toml [[redirects]] is dead — the catch-all answers it with
+# the SPA index (HTTP 200 text/html) and the request never leaves Netlify.
+# A proxy path is reachable only if it is declared ABOVE the catch-all in this
+# file, or bound to an [[edge_functions]] path (edge functions run first).
+# tests/ci-guards/netlify-bff-route-precedence.spec.ts fails on any /bff/*
+# path that satisfies neither.
+#
+# Seams NOT declared in this file, because each needs a request header injected
+# and this file cannot inject headers — they are edge functions instead:
+#   /bff/isl/*         → netlify/edge-functions/isl-proxy.ts        (ISL_API_KEY)
+#   /bff/orchestrate/* → netlify/edge-functions/orchestrator-proxy.ts (ASSIST_API_KEY)
+#   /bff/cee/*         → netlify/edge-functions/cee-proxy.ts        (ASSIST_API_KEY)
+#
+# Until ROADMAP 2.317 the third line above read "/bff/cee/* handled by
+# netlify.toml redirect with header injection". That was false, and the line
+# directly below it was what made it false: the catch-all outranked the
+# netlify.toml rule, so /bff/cee/* served SPA HTML on every deploy. A comment
+# asserting a guarantee that the adjacent config defeats is the defect class
+# here — hence the guard, which derives reachability instead of trusting prose.
 /bff/engine/*  https://plot-lite-service-staging.onrender.com/:splat  200!
 
 # Legacy engine proxy (VITE_EDGE_GATEWAY_URL=/engine uses this)

--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2505
+# count=2507
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -88,6 +88,8 @@
 1	e2e/unified/ui-pack.screenshots.spec.ts	TS6133	'expect' is declared but its value is never read.
 3	e2e/webvitals.spec.ts	TS18048	'window.__webVitals' is possibly 'undefined'.
 1	integration/integration-check.ts	TS2769	No overload matches this call.
+1	netlify/edge-functions/cee-proxy.ts	TS2304	Cannot find name 'Deno'.
+1	netlify/edge-functions/cee-proxy.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
 1	netlify/edge-functions/csp-nonce.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
 1	netlify/edge-functions/isl-proxy.ts	TS2304	Cannot find name 'Deno'.
 1	netlify/edge-functions/isl-proxy.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2505
+# count=2507
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -54,6 +54,7 @@
 1	e2e/unified/ui-pack.screenshots.spec.ts
 3	e2e/webvitals.spec.ts
 1	integration/integration-check.ts
+2	netlify/edge-functions/cee-proxy.ts
 1	netlify/edge-functions/csp-nonce.ts
 3	netlify/edge-functions/isl-proxy.ts
 2	netlify/edge-functions/orchestrator-proxy.ts

--- a/tests/ci-guards/netlify-bff-route-precedence.spec.ts
+++ b/tests/ci-guards/netlify-bff-route-precedence.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Netlify BFF route-precedence guard — ROADMAP 2.317.
+ *
+ * THE DEFECT CLASS. Netlify resolves `public/_redirects` BEFORE `netlify.toml`
+ * `[[redirects]]`. `public/_redirects` ends in the SPA catch-all
+ * `/*  /index.html  200`. So a proxy path declared ONLY in netlify.toml
+ * `[[redirects]]` is dead on arrival: the catch-all answers it with the SPA
+ * index (HTTP 200 `text/html`) and the request never leaves Netlify.
+ *
+ * That is not hypothetical. `/bff/cee/*` lived only in netlify.toml for
+ * months. `GET https://staging--olumi.netlify.app/bff/cee/health` returned
+ * HTTP 200 `text/html` — 4,883 bytes of SPA index — while the control
+ * `/bff/engine/health` (declared in `_redirects`, above the catch-all)
+ * returned live PLoT JSON from the same host. Nothing in the build, in
+ * TypeScript, in ESLint or in CI objected. Worse, `_redirects` carried the
+ * comment "Note: /bff/cee/* handled by netlify.toml redirect with header
+ * injection" — an assertion the line immediately below it defeated. A comment
+ * is not a guarantee; this guard derives the guarantee instead.
+ *
+ * WHAT IT ENFORCES. Every `/bff/*` proxy path declared anywhere in the Netlify
+ * configuration must be served by a mechanism that OUTRANKS the `_redirects`
+ * catch-all — that is, it must either
+ *   · appear in `public/_redirects` at a line ABOVE the catch-all, or
+ *   · be bound to an `[[edge_functions]]` path in netlify.toml.
+ * A `/bff/*` path that satisfies neither is unreachable and fails this test.
+ *
+ * IT ALSO PINS THE CREDENTIAL BOUNDARY. `_redirects` cannot inject request
+ * headers, so a seam needing an auth header must be an edge function, never a
+ * redirect — otherwise the key ends up in a file the browser can fetch. The
+ * final test asserts no API-key token appears anywhere under `public/`.
+ *
+ * CONTROLS (run every CI pass, not once by hand):
+ *   · POSITIVE — the ACTUAL pre-fix configuration, frozen below as a fixture,
+ *     MUST be flagged. It is pinned to the historical artefact at commit
+ *     cb957c8c and MUST NOT be updated to track the current files: a control
+ *     whose reference is "whatever is deployed now" decays into a tautology
+ *     the first time "now" changes. If this fixture ever stops being flagged,
+ *     the detector has been hollowed out.
+ *   · NEGATIVE — a redirect declared above the catch-all, and a path bound to
+ *     an edge function, must NOT be flagged, proving the rule is about
+ *     precedence rather than "no netlify.toml redirects ever".
+ *   · REAL — the repo's actual config at HEAD must be clean.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve as resolvePath } from 'node:path'
+
+const REPO_ROOT = resolvePath(__dirname, '../..')
+const REDIRECTS_PATH = join(REPO_ROOT, 'public/_redirects')
+const TOML_PATH = join(REPO_ROOT, 'netlify.toml')
+
+/** Any path under this prefix is a same-origin proxy seam we must keep reachable. */
+const PROXY_PREFIX = '/bff/'
+
+interface ParsedConfig {
+  /** `from` paths in public/_redirects, in file order. */
+  redirectRules: string[]
+  /** Index of the SPA catch-all in `redirectRules`; -1 if absent. */
+  catchAllIndex: number
+  /** `from` paths of netlify.toml [[redirects]] blocks. */
+  tomlRedirects: string[]
+  /** `path` values of netlify.toml [[edge_functions]] blocks. */
+  edgeFunctionPaths: string[]
+}
+
+/**
+ * Parse both config files. Deliberately literal: comments are skipped, so a
+ * path mentioned only in prose (as several now are, by design) is not treated
+ * as a declaration.
+ */
+export function parseNetlifyConfig(redirectsText: string, tomlText: string): ParsedConfig {
+  const redirectRules: string[] = []
+  for (const rawLine of redirectsText.split('\n')) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) continue
+    const from = line.split(/\s+/)[0]
+    if (from) redirectRules.push(from)
+  }
+  const catchAllIndex = redirectRules.indexOf('/*')
+
+  // TOML: walk block headers so a `from`/`path` key is attributed to the block
+  // it belongs to, rather than grepped globally.
+  const tomlRedirects: string[] = []
+  const edgeFunctionPaths: string[] = []
+  let block: 'redirects' | 'edge_functions' | 'other' = 'other'
+  for (const rawLine of tomlText.split('\n')) {
+    const line = rawLine.trim()
+    if (line.startsWith('#')) continue
+    if (line.startsWith('[[') || line.startsWith('[')) {
+      if (line.startsWith('[[redirects]]')) block = 'redirects'
+      else if (line.startsWith('[[edge_functions]]')) block = 'edge_functions'
+      else block = 'other'
+      continue
+    }
+    const kv = line.match(/^(from|path)\s*=\s*"([^"]+)"/)
+    if (!kv) continue
+    if (block === 'redirects' && kv[1] === 'from') tomlRedirects.push(kv[2])
+    if (block === 'edge_functions' && kv[1] === 'path') edgeFunctionPaths.push(kv[2])
+  }
+
+  return { redirectRules, catchAllIndex, tomlRedirects, edgeFunctionPaths }
+}
+
+/**
+ * Return every `/bff/*` proxy path that the SPA catch-all outranks.
+ * Empty array = every proxy seam is reachable.
+ */
+export function findUnreachableProxyPaths(redirectsText: string, tomlText: string): string[] {
+  const { redirectRules, catchAllIndex, tomlRedirects, edgeFunctionPaths } = parseNetlifyConfig(
+    redirectsText,
+    tomlText,
+  )
+
+  // No catch-all ⇒ nothing is outranked by it.
+  if (catchAllIndex === -1) return []
+
+  const servedAboveCatchAll = new Set(redirectRules.slice(0, catchAllIndex))
+  const servedByEdgeFunction = new Set(edgeFunctionPaths)
+
+  const isReachable = (p: string) => servedAboveCatchAll.has(p) || servedByEdgeFunction.has(p)
+
+  const unreachable: string[] = []
+
+  // A netlify.toml redirect for a proxy path is unreachable unless the same
+  // path is also declared above the catch-all or bound to an edge function.
+  for (const p of tomlRedirects) {
+    if (p.startsWith(PROXY_PREFIX) && !isReachable(p)) unreachable.push(p)
+  }
+
+  // A proxy rule sitting BELOW the catch-all in _redirects is equally dead.
+  for (const p of redirectRules.slice(catchAllIndex + 1)) {
+    if (p.startsWith(PROXY_PREFIX) && !servedByEdgeFunction.has(p)) unreachable.push(p)
+  }
+
+  return [...new Set(unreachable)]
+}
+
+// ── FROZEN HISTORICAL FIXTURE ────────────────────────────────────────────────
+// The real configuration at commit cb957c8c, immediately before the 2.317 fix.
+// PINNED — never regenerate this from the current files. Its whole job is to
+// keep proving the detector can still see the defect that actually shipped.
+const HISTORICAL_REDIRECTS_CB957C8C = `# BFF proxies (must come BEFORE SPA catch-all)
+# Note: /bff/isl/* handled by edge function (isl-proxy.ts) for auth header injection
+# Note: /bff/cee/* handled by netlify.toml redirect with header injection
+/bff/engine/*  https://plot-lite-service-staging.onrender.com/:splat  200!
+
+# Legacy engine proxy (VITE_EDGE_GATEWAY_URL=/engine uses this)
+/engine/*      https://plot-lite-service-staging.onrender.com/:splat  200!
+
+# Static routes
+/poc           /poc.html                                               200
+/fixtures/*    /fixtures/:splat                                        200
+
+# SPA catch-all (MUST BE LAST - catches all unmatched routes)
+/*             /index.html                                             200
+`
+
+const HISTORICAL_TOML_CB957C8C = `[[redirects]]
+  from = "/bff/engine/*"
+  to = "https://plot-lite-service-staging.onrender.com/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/bff/cee/*"
+  to = "https://olumi-assistants-service.onrender.com/assist/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-Olumi-Assist-Key = "\${ASSIST_API_KEY}"}
+
+[[edge_functions]]
+  function = "csp-nonce"
+  path = "/*"
+
+[[edge_functions]]
+  function = "isl-proxy"
+  path = "/bff/isl/*"
+
+[[edge_functions]]
+  function = "orchestrator-proxy"
+  path = "/bff/orchestrate/*"
+`
+
+describe('Netlify BFF route precedence', () => {
+  it('POSITIVE CONTROL: flags the historical /bff/cee/* defect (frozen at cb957c8c)', () => {
+    const unreachable = findUnreachableProxyPaths(
+      HISTORICAL_REDIRECTS_CB957C8C,
+      HISTORICAL_TOML_CB957C8C,
+    )
+    expect(unreachable).toContain('/bff/cee/*')
+  })
+
+  it('NEGATIVE CONTROL: a redirect above the catch-all is reachable', () => {
+    // /bff/engine/* is declared above the catch-all in the historical file and
+    // must NOT be flagged — the rule is about precedence, not about redirects.
+    const unreachable = findUnreachableProxyPaths(
+      HISTORICAL_REDIRECTS_CB957C8C,
+      HISTORICAL_TOML_CB957C8C,
+    )
+    expect(unreachable).not.toContain('/bff/engine/*')
+  })
+
+  it('NEGATIVE CONTROL: a path bound to an edge function is reachable', () => {
+    const redirects = '/*  /index.html  200\n'
+    const toml = [
+      '[[redirects]]',
+      '  from = "/bff/thing/*"',
+      '  to = "https://example.invalid/:splat"',
+      '',
+      '[[edge_functions]]',
+      '  function = "thing-proxy"',
+      '  path = "/bff/thing/*"',
+      '',
+    ].join('\n')
+    expect(findUnreachableProxyPaths(redirects, toml)).toEqual([])
+  })
+
+  it('NEGATIVE CONTROL: a path named only in a comment is not treated as declared', () => {
+    const redirects = '# /bff/ghost/* is discussed here but not declared\n/*  /index.html  200\n'
+    const toml = '# [[redirects]]\n#   from = "/bff/ghost/*"\n'
+    expect(findUnreachableProxyPaths(redirects, toml)).toEqual([])
+  })
+
+  it('flags a proxy rule that sits BELOW the catch-all', () => {
+    const redirects = '/*  /index.html  200\n/bff/late/*  https://example.invalid/:splat  200!\n'
+    expect(findUnreachableProxyPaths(redirects, '')).toContain('/bff/late/*')
+  })
+
+  it('REAL CONFIG: every /bff/* proxy seam at HEAD is reachable', () => {
+    const redirectsText = readFileSync(REDIRECTS_PATH, 'utf8')
+    const tomlText = readFileSync(TOML_PATH, 'utf8')
+    expect(findUnreachableProxyPaths(redirectsText, tomlText)).toEqual([])
+  })
+
+  it('REAL CONFIG: /bff/cee/* is served by the cee-proxy edge function, targeting CEE staging', () => {
+    const tomlText = readFileSync(TOML_PATH, 'utf8')
+    const { edgeFunctionPaths } = parseNetlifyConfig('', tomlText)
+    expect(edgeFunctionPaths).toContain('/bff/cee/*')
+
+    const fn = readFileSync(join(REPO_ROOT, 'netlify/edge-functions/cee-proxy.ts'), 'utf8')
+    // The seam must point at CEE staging, not at the differently-built host the
+    // dead netlify.toml rules named.
+    expect(fn).toContain("const CEE_TARGET = 'https://cee-staging.onrender.com'")
+    expect(fn).not.toContain('olumi-assistants-service.onrender.com/assist')
+  })
+
+  it('CREDENTIAL BOUNDARY: no key VALUE is placed in anything served from public/', () => {
+    // `_redirects` cannot inject request headers, so any seam needing a key
+    // must be an edge function. If a key ever lands under public/ it is, by
+    // construction, browser-fetchable.
+    //
+    // What counts as an offence is a key VALUE arriving — a Netlify
+    // `${…_API_KEY}` interpolation (exactly the mechanism the dead netlify.toml
+    // rules used) or a literal auth-header assignment. A bare MENTION of a var
+    // name in a comment is not an offence: this repo has twice reddened CI over
+    // a token that existed only in a comment (#385, #386), and the `_redirects`
+    // header block deliberately names these vars in prose to say where the keys
+    // do live. Comments are therefore stripped before scanning.
+    const KEY_VALUE_PATTERNS = [
+      /\$\{[A-Z0-9_]*API_KEY\}/,          // ${ASSIST_API_KEY} interpolation
+      /X-Olumi-Assist-Key\s*[=:]/i,       // header assignment
+      /\bx-api-key\s*[=:]/i,
+      /\bAuthorization\s*[=:]\s*["']?Bearer\s+\S/i,
+    ]
+    const stripHashComments = (text: string) =>
+      text
+        .split('\n')
+        .filter((l) => !l.trim().startsWith('#'))
+        .join('\n')
+
+    const offenders: string[] = []
+    const walk = (dir: string) => {
+      for (const name of readdirSync(dir)) {
+        const full = join(dir, name)
+        if (statSync(full).isDirectory()) {
+          walk(full)
+          continue
+        }
+        // Only text-ish config/markup files; skip binaries and bundles.
+        if (!/\.(txt|json|toml|html|js|ts|md)$/.test(name) && name !== '_redirects') continue
+        const text = stripHashComments(readFileSync(full, 'utf8'))
+        if (KEY_VALUE_PATTERNS.some((re) => re.test(text))) {
+          offenders.push(full.replace(REPO_ROOT + '/', ''))
+        }
+      }
+    }
+    walk(join(REPO_ROOT, 'public'))
+    expect(offenders).toEqual([])
+  })
+
+  it('CREDENTIAL BOUNDARY control: the detector sees a key placed in a _redirects rule', () => {
+    // Positive control for the assertion above — without it, "no key under
+    // public/" could pass by testing nothing.
+    const rule = '/bff/cee/*  https://cee-staging.onrender.com/assist/v1/:splat  200!  X-Olumi-Assist-Key=${ASSIST_API_KEY}'
+    expect(/\$\{[A-Z0-9_]*API_KEY\}/.test(rule)).toBe(true)
+    // …and that a comment-only mention does NOT trip it.
+    const commentOnly = '# the key lives in ASSIST_API_KEY, injected by cee-proxy.ts'
+    const stripped = commentOnly
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'))
+      .join('\n')
+    expect(/\$\{[A-Z0-9_]*API_KEY\}/.test(stripped)).toBe(false)
+  })
+})

--- a/tests/ci-guards/netlify-bff-route-precedence.spec.ts
+++ b/tests/ci-guards/netlify-bff-route-precedence.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Netlify BFF route-precedence guard — ROADMAP 2.317.
+ * Netlify CEE/BFF route-configuration guard — ROADMAP 2.317.
  *
  * THE DEFECT CLASS. Netlify resolves `public/_redirects` BEFORE `netlify.toml`
  * `[[redirects]]`. `public/_redirects` ends in the SPA catch-all
@@ -17,25 +17,46 @@
  * injection" — an assertion the line immediately below it defeated. A comment
  * is not a guarantee; this guard derives the guarantee instead.
  *
- * WHAT IT ENFORCES. Every `/bff/*` proxy path declared anywhere in the Netlify
- * configuration must be served by a mechanism that OUTRANKS the `_redirects`
- * catch-all — that is, it must either
- *   · appear in `public/_redirects` at a line ABOVE the catch-all, or
- *   · be bound to an `[[edge_functions]]` path in netlify.toml.
- * A `/bff/*` path that satisfies neither is unreachable and fails this test.
+ * ── SCOPE: THE ORIGINAL DEFECT HAD TWO HALVES, AND THIS GUARD COVERS BOTH ───
+ * The shipped rules were wrong twice over, and an earlier revision of this file
+ * caught only the first half — a review found two mutants that stayed GREEN
+ * against it. Both are now controls below.
+ *
+ *   HALF 1 — PRECEDENCE. A proxy path must be served by a mechanism that
+ *   OUTRANKS the `_redirects` catch-all: declared in `public/_redirects` ABOVE
+ *   the catch-all, or bound to an `[[edge_functions]]` path. Enforced for
+ *   `/bff/*` AND `/v1/cee/*` — the dead `/v1/cee/*` rule was the second of the
+ *   two shipped rules and must not be re-addable unnoticed.
+ *
+ *   HALF 2 — TARGET. Both dead rules also named
+ *   `olumi-assistants-service.onrender.com` (version 1.11.1 / `50fea04`) rather
+ *   than CEE staging (1.12.0 / `7f57602`, the exact tip of the CEE `staging`
+ *   branch). So a rule can be perfectly reachable and still wrong. Every
+ *   CEE-family redirect must target `https://cee-staging.onrender.com`.
+ *   This is an ALLOW-list (must equal the one correct host), not a deny-list of
+ *   known-bad hosts — a deny-list is a hand-maintained mirror and would go
+ *   stale the first time someone invents a new wrong host.
  *
  * IT ALSO PINS THE CREDENTIAL BOUNDARY. `_redirects` cannot inject request
  * headers, so a seam needing an auth header must be an edge function, never a
  * redirect — otherwise the key ends up in a file the browser can fetch. The
- * final test asserts no API-key token appears anywhere under `public/`.
+ * credential tests assert no key VALUE appears anywhere under `public/`, and
+ * that `cee-proxy` enforces the same method set it advertises (it injects a
+ * credential on every forwarded request).
+ *
+ * WHAT IT DOES NOT COVER, STATED SO NOBODY OVER-READS IT: it is a static read
+ * of two config files plus one source file. It cannot prove the deployed host
+ * actually answers, that `/assist/v1` is the prefix CEE expects, or that
+ * `ASSIST_API_KEY` is provisioned. Those need the live post-merge probe in the
+ * PR body.
  *
  * CONTROLS (run every CI pass, not once by hand):
  *   · POSITIVE — the ACTUAL pre-fix configuration, frozen below as a fixture,
- *     MUST be flagged. It is pinned to the historical artefact at commit
- *     cb957c8c and MUST NOT be updated to track the current files: a control
- *     whose reference is "whatever is deployed now" decays into a tautology
- *     the first time "now" changes. If this fixture ever stops being flagged,
- *     the detector has been hollowed out.
+ *     MUST be flagged, on BOTH halves and BOTH rules. It is pinned to the
+ *     historical artefact at commit cb957c8c and MUST NOT be updated to track
+ *     the current files: a control whose reference is "whatever is deployed
+ *     now" decays into a tautology the first time "now" changes. If this
+ *     fixture ever stops being flagged, the detector has been hollowed out.
  *   · NEGATIVE — a redirect declared above the catch-all, and a path bound to
  *     an edge function, must NOT be flagged, proving the rule is about
  *     precedence rather than "no netlify.toml redirects ever".
@@ -48,17 +69,32 @@ import { join, resolve as resolvePath } from 'node:path'
 const REPO_ROOT = resolvePath(__dirname, '../..')
 const REDIRECTS_PATH = join(REPO_ROOT, 'public/_redirects')
 const TOML_PATH = join(REPO_ROOT, 'netlify.toml')
+const CEE_PROXY_PATH = join(REPO_ROOT, 'netlify/edge-functions/cee-proxy.ts')
 
-/** Any path under this prefix is a same-origin proxy seam we must keep reachable. */
-const PROXY_PREFIX = '/bff/'
+/** Path families that are same-origin proxy seams we must keep reachable. */
+const PROXY_PATH_PREFIXES = ['/bff/', '/v1/cee']
+
+/** Path families that must reach CEE, and nothing else. */
+const CEE_PATH_PREFIXES = ['/bff/cee', '/v1/cee']
+
+/** The one correct CEE origin. Allow-list, deliberately not a deny-list. */
+const CEE_STAGING_ORIGIN = 'https://cee-staging.onrender.com'
+
+const isProxyPath = (p: string) => PROXY_PATH_PREFIXES.some((pre) => p.startsWith(pre))
+const isCeePath = (p: string) => CEE_PATH_PREFIXES.some((pre) => p.startsWith(pre))
+
+interface RedirectRule {
+  from: string
+  to: string
+}
 
 interface ParsedConfig {
-  /** `from` paths in public/_redirects, in file order. */
-  redirectRules: string[]
+  /** Rules in public/_redirects, in file order. */
+  redirectRules: RedirectRule[]
   /** Index of the SPA catch-all in `redirectRules`; -1 if absent. */
   catchAllIndex: number
-  /** `from` paths of netlify.toml [[redirects]] blocks. */
-  tomlRedirects: string[]
+  /** netlify.toml [[redirects]] blocks. */
+  tomlRedirects: RedirectRule[]
   /** `path` values of netlify.toml [[edge_functions]] blocks. */
   edgeFunctionPaths: string[]
 }
@@ -69,40 +105,48 @@ interface ParsedConfig {
  * as a declaration.
  */
 export function parseNetlifyConfig(redirectsText: string, tomlText: string): ParsedConfig {
-  const redirectRules: string[] = []
+  const redirectRules: RedirectRule[] = []
   for (const rawLine of redirectsText.split('\n')) {
     const line = rawLine.trim()
     if (line === '' || line.startsWith('#')) continue
-    const from = line.split(/\s+/)[0]
-    if (from) redirectRules.push(from)
+    const parts = line.split(/\s+/)
+    if (parts[0]) redirectRules.push({ from: parts[0], to: parts[1] ?? '' })
   }
-  const catchAllIndex = redirectRules.indexOf('/*')
+  const catchAllIndex = redirectRules.findIndex((r) => r.from === '/*')
 
-  // TOML: walk block headers so a `from`/`path` key is attributed to the block
-  // it belongs to, rather than grepped globally.
-  const tomlRedirects: string[] = []
+  // TOML: walk block headers so a `from`/`to`/`path` key is attributed to the
+  // block it belongs to, rather than grepped globally.
+  const tomlRedirects: RedirectRule[] = []
   const edgeFunctionPaths: string[] = []
   let block: 'redirects' | 'edge_functions' | 'other' = 'other'
+  let pending: Partial<RedirectRule> = {}
+  const flush = () => {
+    if (pending.from !== undefined) tomlRedirects.push({ from: pending.from, to: pending.to ?? '' })
+    pending = {}
+  }
   for (const rawLine of tomlText.split('\n')) {
     const line = rawLine.trim()
     if (line.startsWith('#')) continue
     if (line.startsWith('[[') || line.startsWith('[')) {
+      flush()
       if (line.startsWith('[[redirects]]')) block = 'redirects'
       else if (line.startsWith('[[edge_functions]]')) block = 'edge_functions'
       else block = 'other'
       continue
     }
-    const kv = line.match(/^(from|path)\s*=\s*"([^"]+)"/)
+    const kv = line.match(/^(from|to|path)\s*=\s*"([^"]+)"/)
     if (!kv) continue
-    if (block === 'redirects' && kv[1] === 'from') tomlRedirects.push(kv[2])
+    if (block === 'redirects' && kv[1] === 'from') pending.from = kv[2]
+    if (block === 'redirects' && kv[1] === 'to') pending.to = kv[2]
     if (block === 'edge_functions' && kv[1] === 'path') edgeFunctionPaths.push(kv[2])
   }
+  flush()
 
   return { redirectRules, catchAllIndex, tomlRedirects, edgeFunctionPaths }
 }
 
 /**
- * Return every `/bff/*` proxy path that the SPA catch-all outranks.
+ * HALF 1 — every proxy path the SPA catch-all outranks.
  * Empty array = every proxy seam is reachable.
  */
 export function findUnreachableProxyPaths(redirectsText: string, tomlText: string): string[] {
@@ -114,7 +158,7 @@ export function findUnreachableProxyPaths(redirectsText: string, tomlText: strin
   // No catch-all ⇒ nothing is outranked by it.
   if (catchAllIndex === -1) return []
 
-  const servedAboveCatchAll = new Set(redirectRules.slice(0, catchAllIndex))
+  const servedAboveCatchAll = new Set(redirectRules.slice(0, catchAllIndex).map((r) => r.from))
   const servedByEdgeFunction = new Set(edgeFunctionPaths)
 
   const isReachable = (p: string) => servedAboveCatchAll.has(p) || servedByEdgeFunction.has(p)
@@ -123,22 +167,49 @@ export function findUnreachableProxyPaths(redirectsText: string, tomlText: strin
 
   // A netlify.toml redirect for a proxy path is unreachable unless the same
   // path is also declared above the catch-all or bound to an edge function.
-  for (const p of tomlRedirects) {
-    if (p.startsWith(PROXY_PREFIX) && !isReachable(p)) unreachable.push(p)
+  for (const { from } of tomlRedirects) {
+    if (isProxyPath(from) && !isReachable(from)) unreachable.push(from)
   }
 
   // A proxy rule sitting BELOW the catch-all in _redirects is equally dead.
-  for (const p of redirectRules.slice(catchAllIndex + 1)) {
-    if (p.startsWith(PROXY_PREFIX) && !servedByEdgeFunction.has(p)) unreachable.push(p)
+  for (const { from } of redirectRules.slice(catchAllIndex + 1)) {
+    if (isProxyPath(from) && !servedByEdgeFunction.has(from)) unreachable.push(from)
   }
 
   return [...new Set(unreachable)]
 }
 
+/**
+ * HALF 2 — every CEE-family redirect whose target is not CEE staging.
+ * A reachable rule pointed at the wrong host is still a defect.
+ */
+export function findWrongHostCeeRules(redirectsText: string, tomlText: string): string[] {
+  const { redirectRules, tomlRedirects } = parseNetlifyConfig(redirectsText, tomlText)
+  const offenders: string[] = []
+  for (const { from, to } of [...redirectRules, ...tomlRedirects]) {
+    if (!isCeePath(from)) continue
+    // A relative target (e.g. an internal rewrite) is not a host claim.
+    if (!/^https?:\/\//.test(to)) continue
+    if (!to.startsWith(CEE_STAGING_ORIGIN + '/') && to !== CEE_STAGING_ORIGIN) {
+      offenders.push(`${from} -> ${to}`)
+    }
+  }
+  return offenders
+}
+
+/** Both halves, for the real-config assertion. */
+export function findProxyConfigDefects(redirectsText: string, tomlText: string): string[] {
+  return [
+    ...findUnreachableProxyPaths(redirectsText, tomlText),
+    ...findWrongHostCeeRules(redirectsText, tomlText),
+  ]
+}
+
 // ── FROZEN HISTORICAL FIXTURE ────────────────────────────────────────────────
-// The real configuration at commit cb957c8c, immediately before the 2.317 fix.
-// PINNED — never regenerate this from the current files. Its whole job is to
-// keep proving the detector can still see the defect that actually shipped.
+// The real configuration at commit cb957c8c, immediately before the 2.317 fix,
+// including BOTH shipped CEE rules. PINNED — never regenerate this from the
+// current files. Its whole job is to keep proving the detector can still see
+// the defect that actually shipped.
 const HISTORICAL_REDIRECTS_CB957C8C = `# BFF proxies (must come BEFORE SPA catch-all)
 # Note: /bff/isl/* handled by edge function (isl-proxy.ts) for auth header injection
 # Note: /bff/cee/* handled by netlify.toml redirect with header injection
@@ -161,8 +232,17 @@ const HISTORICAL_TOML_CB957C8C = `[[redirects]]
   status = 200
   force = true
 
+# CEE (Assistants) Service - graph-readiness endpoint
 [[redirects]]
   from = "/bff/cee/*"
+  to = "https://olumi-assistants-service.onrender.com/assist/v1/:splat"
+  status = 200
+  force = true
+  headers = {X-Olumi-Assist-Key = "\${ASSIST_API_KEY}"}
+
+# CEE fallback route for /v1/cee/* path pattern
+[[redirects]]
+  from = "/v1/cee/*"
   to = "https://olumi-assistants-service.onrender.com/assist/v1/:splat"
   status = 200
   force = true
@@ -181,13 +261,39 @@ const HISTORICAL_TOML_CB957C8C = `[[redirects]]
   path = "/bff/orchestrate/*"
 `
 
-describe('Netlify BFF route precedence', () => {
-  it('POSITIVE CONTROL: flags the historical /bff/cee/* defect (frozen at cb957c8c)', () => {
+describe('Netlify CEE/BFF route configuration', () => {
+  it('POSITIVE CONTROL: flags BOTH historical CEE rules as unreachable (frozen at cb957c8c)', () => {
     const unreachable = findUnreachableProxyPaths(
       HISTORICAL_REDIRECTS_CB957C8C,
       HISTORICAL_TOML_CB957C8C,
     )
     expect(unreachable).toContain('/bff/cee/*')
+    // The second shipped rule — a review mutant proved an earlier revision of
+    // this guard let it back in unnoticed.
+    expect(unreachable).toContain('/v1/cee/*')
+  })
+
+  it('POSITIVE CONTROL: flags BOTH historical CEE rules as wrong-host (frozen at cb957c8c)', () => {
+    const wrongHost = findWrongHostCeeRules(
+      HISTORICAL_REDIRECTS_CB957C8C,
+      HISTORICAL_TOML_CB957C8C,
+    )
+    expect(wrongHost).toHaveLength(2)
+    expect(wrongHost.join('\n')).toContain('olumi-assistants-service.onrender.com')
+  })
+
+  it('POSITIVE CONTROL: a REACHABLE CEE redirect pointed at the wrong host is still flagged', () => {
+    // The review mutant that stayed green against the precedence-only guard:
+    // correct precedence, wrong target.
+    const redirects = [
+      '/bff/cee/*  https://olumi-assistants-service.onrender.com/assist/v1/:splat  200!',
+      '/*          /index.html                                                     200',
+      '',
+    ].join('\n')
+    expect(findUnreachableProxyPaths(redirects, '')).toEqual([])
+    expect(findWrongHostCeeRules(redirects, '')).toEqual([
+      '/bff/cee/* -> https://olumi-assistants-service.onrender.com/assist/v1/:splat',
+    ])
   })
 
   it('NEGATIVE CONTROL: a redirect above the catch-all is reachable', () => {
@@ -198,6 +304,16 @@ describe('Netlify BFF route precedence', () => {
       HISTORICAL_TOML_CB957C8C,
     )
     expect(unreachable).not.toContain('/bff/engine/*')
+  })
+
+  it('NEGATIVE CONTROL: a non-CEE seam is not subject to the CEE host rule', () => {
+    // PLoT is a different service; its host must not be forced to CEE staging.
+    const wrongHost = findWrongHostCeeRules(
+      HISTORICAL_REDIRECTS_CB957C8C,
+      HISTORICAL_TOML_CB957C8C,
+    )
+    expect(wrongHost.join('\n')).not.toContain('/bff/engine/*')
+    expect(wrongHost.join('\n')).not.toContain('plot-lite-service-staging')
   })
 
   it('NEGATIVE CONTROL: a path bound to an edge function is reachable', () => {
@@ -218,7 +334,7 @@ describe('Netlify BFF route precedence', () => {
   it('NEGATIVE CONTROL: a path named only in a comment is not treated as declared', () => {
     const redirects = '# /bff/ghost/* is discussed here but not declared\n/*  /index.html  200\n'
     const toml = '# [[redirects]]\n#   from = "/bff/ghost/*"\n'
-    expect(findUnreachableProxyPaths(redirects, toml)).toEqual([])
+    expect(findProxyConfigDefects(redirects, toml)).toEqual([])
   })
 
   it('flags a proxy rule that sits BELOW the catch-all', () => {
@@ -226,10 +342,10 @@ describe('Netlify BFF route precedence', () => {
     expect(findUnreachableProxyPaths(redirects, '')).toContain('/bff/late/*')
   })
 
-  it('REAL CONFIG: every /bff/* proxy seam at HEAD is reachable', () => {
+  it('REAL CONFIG: no proxy seam at HEAD is unreachable or wrongly targeted', () => {
     const redirectsText = readFileSync(REDIRECTS_PATH, 'utf8')
     const tomlText = readFileSync(TOML_PATH, 'utf8')
-    expect(findUnreachableProxyPaths(redirectsText, tomlText)).toEqual([])
+    expect(findProxyConfigDefects(redirectsText, tomlText)).toEqual([])
   })
 
   it('REAL CONFIG: /bff/cee/* is served by the cee-proxy edge function, targeting CEE staging', () => {
@@ -237,11 +353,24 @@ describe('Netlify BFF route precedence', () => {
     const { edgeFunctionPaths } = parseNetlifyConfig('', tomlText)
     expect(edgeFunctionPaths).toContain('/bff/cee/*')
 
-    const fn = readFileSync(join(REPO_ROOT, 'netlify/edge-functions/cee-proxy.ts'), 'utf8')
+    const fn = readFileSync(CEE_PROXY_PATH, 'utf8')
     // The seam must point at CEE staging, not at the differently-built host the
     // dead netlify.toml rules named.
-    expect(fn).toContain("const CEE_TARGET = 'https://cee-staging.onrender.com'")
+    expect(fn).toContain(`const CEE_TARGET = '${CEE_STAGING_ORIGIN}'`)
     expect(fn).not.toContain('olumi-assistants-service.onrender.com/assist')
+  })
+
+  it('REAL CONFIG: cee-proxy enforces the same method set it advertises', () => {
+    // It injects a caller-auth credential on every forwarded request, so an
+    // unrestricted verb set would hand an authenticated PUT/DELETE to CEE.
+    // isl-proxy has exactly that gap; this pins that cee-proxy does not.
+    const fn = readFileSync(CEE_PROXY_PATH, 'utf8')
+    expect(fn).toContain("const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'OPTIONS'] as const")
+    // Enforced…
+    expect(fn).toMatch(/ALLOWED_METHODS as readonly string\[\]\)\.includes\(request\.method\)/)
+    expect(fn).toContain('status: 405')
+    // …and advertised from the SAME constant, so the two cannot drift apart.
+    expect(fn).toContain("'Access-Control-Allow-Methods': ALLOWED_METHODS.join(', ')")
   })
 
   it('CREDENTIAL BOUNDARY: no key VALUE is placed in anything served from public/', () => {


### PR DESCRIPTION
## The defect (ROADMAP 2.317)

`/bff/cee/*` was declared **only** in `netlify.toml` `[[redirects]]`. Netlify resolves `public/_redirects` **first**, and that file ends in the SPA catch-all `/*  /index.html  200` — so the catch-all won on every deploy and the request never left Netlify.

Reproduced on deployed staging before changing anything, with its control on the same host:

```
GET https://staging--olumi.netlify.app/bff/cee/health
  -> HTTP 200   content-type: text/html; charset=UTF-8   4883 bytes  (SPA index)
GET https://staging--olumi.netlify.app/bff/cee/limits
  -> HTTP 200   text/html   4883 bytes
GET https://staging--olumi.netlify.app/v1/cee/prompts/warm
  -> HTTP 200   text/html   4949 bytes

CONTROL (declared in _redirects, above the catch-all):
GET https://staging--olumi.netlify.app/bff/engine/health
  -> HTTP 200   application/json
     {"status":"ok","build":"eb73c6a",...}     <- live PLoT
```

Both dead `netlify.toml` rules also targeted `olumi-assistants-service.onrender.com`, which is **not** CEE staging — verified live:

| host | version | build |
|---|---|---|
| `cee-staging.onrender.com` | 1.12.0 | `7f57602`, `prompt_environment: staging` |
| `olumi-assistants-service.onrender.com` | 1.11.1 | `50fea04` |

`7f57602` is the exact tip of `olumi-assistants-service` `staging`. So the rules were wrong twice over: unreachable, **and** pointed at a differently-built host.

## Consumer sweep — the headline

**No deployed caller is currently receiving HTML, because no deployed caller uses the broken route.** Derived at the bytes: I crawled the deployed staging build to a closed set of **78 JS chunks** (count corrected by an independent review redo, which resolved every JS-shaped token against the URL of the file it was found in, recursed to fixpoint, and cross-checked relative refs, dynamic construction and the Vite manifest; chunk hashes match).

- **Zero `/bff/cee` occurrences across the closed set** — independently reproduced by the review.
- `VITE_CEE_BFF_BASE` is set in the Netlify staging dashboard to the **absolute** URL `https://plot-lite-service-staging.onrender.com/v1/cee`, which Vite inlines at build time.
- Corroborated by PLoT's own `/health` `route_callers.top_routes`: `/v1/cee/prompts/warm` 19, `/v1/cee/graph-readiness` 17.

**So 2.317 is a latent defect, not a live one — but it is armed.** Six source callers default to `/bff/cee` whenever that dashboard var is absent. Behaviour on HTTP 200 `text/html`:

| Caller | Behaviour |
|---|---|
| `readinessStore.ts:323` | **⚠ SILENT DEGRADATION** — `.json()` throws, caught by a `catch` written for a jsdom quirk, falls back to local readiness and sets **`error: null`**. Indistinguishable from a real CEE verdict. |
| `prompt-preloader.ts:53` | **⚠ SILENT FALSE SUCCESS** — only checks `response.ok`, sets `preloadComplete = true`. `isPromptCachePreloaded()` then lies. |
| `service-health.ts:67` | Degrades to `'unknown'`, not `'down'` — understates a hard misroute. |
| `adapters/cee/client.ts:594` | Raw `SyntaxError: Unexpected token '<'`. |
| `useAsk.ts:444` | Handled correctly — throws `PARSE_ERROR`. |
| `useFormRecommendations.ts:143` | Substitutes fallback recommendations, sets an error. |

The two flagged rows are **reported for rowing, not fixed here** — neither is a one-liner, and `readinessStore`'s catch is load-bearing for the jsdom path. (A 7th declaration, `featureFlags.getCeeBffBase`, reads a different source and has zero invocations.)

## The fix

`_redirects` **cannot inject request headers**, and these rules exist to inject `X-Olumi-Assist-Key` — so moving them there would put the key in a browser-fetchable file. Instead: a **`cee-proxy` edge function**, cloned from the existing `orchestrator-proxy.ts`.

**Credential decision: (a).** Same already-provisioned `ASSIST_API_KEY`, same CEE-staging target, same runtime as the sibling proxy. No new secret, no new placement decision. The key never leaves the edge runtime and never enters `_redirects` or the bundle.

Edge-function precedence was **measured, not assumed**: `/bff/isl/*` and `/bff/orchestrate/*` are declared *only* as edge functions and both answer with their own JSON on the live host, while `/bff/cee/*` answered with SPA HTML.

Also: removed both unreachable `netlify.toml` rules, and replaced the false `_redirects` comment — *"Note: /bff/cee/\* handled by netlify.toml redirect with header injection"* — which the line immediately below it defeated. `/v1/cee/*` is **not** re-declared: zero same-origin consumers, and PLoT owns that path family in the live config.

### Complete divergence set from the sibling proxies

`cee-proxy` is a clone of `orchestrator-proxy.ts` and differs in **exactly two** ways. Both deliberate, both now stated in the file itself:

1. **Missing `Origin` is allowed** (siblings reject it). `Origin` was never an auth control here — these functions carry no ambient credential (no cookies forwarded, `Access-Control-Allow-Credentials` never set), and browsers omit the header on same-origin GET/HEAD, which is exactly what `service-health.ts` sends. A present-but-unknown origin is still rejected. *Review ruled this correct: the siblings are the defect — it is why `GET /bff/isl/health` 403s the app's own health check.* Not fixed here; flagged for rowing.
2. **Method set is `GET/HEAD/POST/OPTIONS`** — enforced with a 405 + `Allow` header. *Added in review:* the first revision dropped `orchestrator-proxy`'s 405 guard and forwarded **every verb** while carrying the injected key, advertising only `GET, POST, OPTIONS`. An injected credential on an unrestricted verb set is not something to ship. Enforced set and advertised `Access-Control-Allow-Methods` are now built from the **same constant** so they cannot drift, with a control pinning it.

## The guard

`tests/ci-guards/netlify-bff-route-precedence.spec.ts` **derives** defects from both config files. The original defect had **two halves**, and review found the first revision covered only one — two mutants stayed GREEN against it. **I extended the guard rather than merely narrowing its docstring.** Both are now controls:

- **Half 1 — precedence**, now covering `/bff/*` **and `/v1/cee/*`** (the second shipped rule).
- **Half 2 — target**: every CEE-family redirect must point at `https://cee-staging.onrender.com`, expressed as an **allow-list** (must equal the one right host) rather than a deny-list of known-bad hosts, which would be a hand-maintained mirror.
- The frozen `cb957c8c` fixture now carries **both** shipped rules, so the positive control exercises both halves against the real historical artefact.

The docstring also states plainly what the guard **cannot** cover — liveness, the `/assist/v1` prefix, key provisioning — so it is not over-read.

8 mutants, all RED (throwaway worktree outside the repo root, removed before gate runs):

| Mutant | Result |
|---|---|
| Re-introduce the netlify.toml rule + unregister the edge function | RED ×2 |
| Repoint `cee-proxy` at the non-staging host | RED |
| `${ASSIST_API_KEY}` into `public/_redirects` | RED |
| Hollow the frozen positive-control fixture | RED |
| **Review mutant A** — *reachable* `/bff/cee/*` at the wrong host (was GREEN) | **RED** |
| **Review mutant B** — re-add the dead `/v1/cee/*` rule (was GREEN) | **RED** |
| Remove the 405 method guard | RED |
| Let advertised methods drift from enforced | RED |

## Gates (amended head)

| Gate | Result |
|---|---|
| `pnpm typecheck` | ✅ 623 files / **2507** errors = baseline 2507; coverage 3164/3204 |
| `pnpm lint` | ✅ **0 errors** |
| hooks ratchet | ✅ 234/16, exactly baseline |
| full suite | ✅ see PR comments for the amended-head run |

**Baseline bump disclosed for sign-off.** 2505 → 2507: `cee-proxy.ts` carries `TS2304 Cannot find name 'Deno'` and `TS2307 Cannot find module '@netlify/edge-functions'` — the identical pair already baselined for `csp-nonce`, `isl-proxy` and `orchestrator-proxy`. The regenerated diff adds **only those two rows**, verified line by line. The review amendments added no further baseline movement.

## ⚠ This PR is NOT verified live — and cannot be

Netlify builds `staging` **on merge**, so this branch is not deployed. A config change cannot be proven by unit tests. **The fix is unproven until the probe below is run.**

### Required post-merge probe

```bash
# 1. REACHED CEE AT ALL?
curl -s -i https://staging--olumi.netlify.app/bff/cee/health | head -20
```
Expect: **not** `text/html`, and not the 4883-byte SPA index.
⚠ **This alone does NOT prove the `/assist/v1` prefix** — a JSON **404** would satisfy "reached CEE" while meaning the rewrite is wrong. Probe 2 is what settles it.

```bash
# 2. THE PREFIX — the real consumer endpoint must actually compute
curl -s -i -X POST https://staging--olumi.netlify.app/bff/cee/graph-readiness \
  -H 'Content-Type: application/json' \
  -H 'Origin: https://staging--olumi.netlify.app' \
  -d '{"nodes":[],"edges":[]}' | head -30
```
Expect: `application/json` with a readiness-shaped body (`readiness_score` / `readiness_level` / `can_run_analysis`).
- **404 ⇒ the `/assist/v1` rewrite is wrong** — the failure this probe exists to catch.
- **401 ⇒ `ASSIST_API_KEY` missing or unaccepted at the edge.**

```bash
# 3. THE DELIBERATE DIVERGENCE — an unknown Origin must be refused
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
  -H 'Origin: https://evil.example.com' \
  https://staging--olumi.netlify.app/bff/cee/health
```
Expect: **`403 application/json`**.

```bash
# 3b. …and a MISSING Origin must be SERVED (the point of the divergence)
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' \
  https://staging--olumi.netlify.app/bff/cee/health
```
Expect: **not 403** — this is exactly what `service-health.ts` sends.

```bash
# 3c. METHOD GUARD — an unlisted verb must be refused before the key is used
curl -s -o /dev/null -w '%{http_code}\n' -X DELETE \
  -H 'Origin: https://staging--olumi.netlify.app' \
  https://staging--olumi.netlify.app/bff/cee/health
```
Expect: **405**.

```bash
# 4. CONTROL — PLoT must keep working, unchanged
curl -s https://staging--olumi.netlify.app/bff/engine/health
```
Expect: `application/json`, live PLoT. If this regressed, the `_redirects` edit is at fault.

```bash
# 5. CONTROLS — sibling edge functions undisturbed
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' https://staging--olumi.netlify.app/bff/isl/health
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' https://staging--olumi.netlify.app/bff/orchestrate/v1/turn
```
Expect both: `403 application/json` (unchanged from today).

```bash
# 6. NEGATIVE CONTROL — SPA routes must still serve the SPA
curl -s -o /dev/null -w '%{http_code} %{content_type}\n' https://staging--olumi.netlify.app/canvas
```
Expect: `200 text/html`. Proves the edge function did not swallow app routes.

## Stated as unverified

- **The `/assist/v1` rewrite is not live-proven.** CEE's auth middleware runs *before* routing — a deliberately bogus path returns `401` exactly like a real one, so unauthenticated probing **cannot** confirm the prefix (401 proves auth-ordering, **not** registration). It rests on three independent in-repo sources agreeing: the netlify.toml rule this replaces, the `vite.config.ts` dev proxy, and the cross-repo note in `useGraphReadiness.ts`. **Probe 2 settles it.**
- **`olumi-assistants-service.onrender.com` is described only as "a different, older build"** — that is what I measured. I did not prove it is the production host.
- **`cee-proxy` hardcodes `cee-staging`, so production deploys target staging CEE too.** Matches `orchestrator-proxy.ts` exactly and adds no env gate; `/bff/cee/*` previously served SPA HTML everywhere, so nothing regresses. Flagged rather than left implicit.
- **The siblings' missing-`Origin` rejection is a live defect I did not fix** — `GET /bff/isl/health` 403s the app's own health check. Rowing candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
