### PR TITLE
fix(ui): one payload, one target sentence — stop "≥ 0.8 £" and "≥ 800000 £" (ROADMAP 2.315) [PAIRED with CEE #798]

### DIFF
--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -22,13 +22,12 @@ import { NODE_REGISTRY } from '../domain/nodes'
 import { useNodeDisplayMetadata } from '../hooks/useNodeDisplayMetadata'
 import { useCanvasStore } from '../store'
 import { typography } from '../../styles/typography'
-import { formatTargetValue } from '../../components/results/utils/formatTargetValue'
+import { formatGoalTarget } from '../../components/results/utils/formatGoalTarget'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { GOAL_ANCHOR_COPY } from '../../components/results/utils/goalAnchorCopy'
 import { readInferenceWarnings } from '../../components/results/utils/readInferenceWarnings'
 import { DataBar, type DataBarColour } from '../ui/shared/DataBar'
 import { getStabilityClassification } from '../../lib/stability'
-import { isCurrencyUnit, classifyUnit } from '../utils/labelUtils'
 import { NodeChip, NodePopover, ScienceIcon } from './shared'
 import { useScienceIcons } from '../hooks/useScienceIcons'
 import { useGuidanceStore } from '../stores/guidanceStore'
@@ -165,23 +164,24 @@ export const GoalNode = memo((props: NodeProps) => {
     }
   }, [hasThreshold, robustnessData])
 
-  // Format threshold display
+  // Format threshold display.
+  //
+  // ROADMAP 2.315(c): the unit-string → unit-kind mapping that used to live
+  // inline here now lives in `formatGoalTarget`, unchanged in behaviour. It was
+  // moved because Inspector v2's GoalPanel needed the SAME mapping and had none
+  // (it interpolated the number bare with the unit as a suffix — "800000 £"),
+  // and the staging walk saw the two surfaces print different strings for one
+  // goal. Sharing the mapping makes agreement structural rather than a
+  // convention someone has to remember (CLAUDE.md #12). Percent rounding,
+  // 'count' suppression and currency prefixing are all as they were; the only
+  // behavioural difference is that a unit is now TRIMMED before classification,
+  // the same direction the U2 fix took when it retired this site's local
+  // `'%' | 'percent' | 'percentage'` copy.
   const thresholdDisplay = useMemo(() => {
     if (!hasThreshold) return null
     const raw = typeof thresholdRaw === 'number' ? thresholdRaw : Number(thresholdRaw)
     if (Number.isNaN(raw)) return String(thresholdRaw)
-    const u = typeof thresholdUnit === 'string' ? thresholdUnit.toLowerCase() : ''
-    // U2: percent recognition routed through classifyUnit (the single source of
-    // truth) instead of a local `'%' | 'percent' | 'percentage'` copy. Identical
-    // for those three literals; additionally correct for the whitespace and
-    // mixed-case forms this site used to miss (`.toLowerCase()` without `.trim()`
-    // meant `' percent'` rendered as "20  percent").
-    if (classifyUnit(thresholdUnit as string | null | undefined).kind === 'percent') {
-      return formatTargetValue(Math.round(raw), 'percent')
-    }
-    if (u === 'count' || u === '') return formatTargetValue(raw)
-    if (thresholdUnit && isCurrencyUnit(thresholdUnit)) return formatTargetValue(raw, 'currency', thresholdUnit)
-    return `${raw.toLocaleString()} ${thresholdUnit}`
+    return formatGoalTarget(raw, thresholdUnit) ?? String(thresholdRaw)
   }, [hasThreshold, thresholdRaw, thresholdUnit])
 
   // Science icons (spec Section 4.1)

--- a/src/canvas/nodes/__tests__/GoalNode.goalTargetAgreement.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.goalTargetAgreement.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * GoalNode ⇄ GoalPanel — one goal, one target string (ROADMAP 2.315(c)).
+ *
+ * The staging walk saw the canvas card and Inspector v2 print DIFFERENT
+ * strings for the same goal, because each surface hand-rolled its own
+ * unit-string mapping over `formatTargetValue`. Both now route through the
+ * shared `formatGoalTarget` — CLAUDE.md #12, derive don't mirror.
+ *
+ * ⚠ WHAT IS STRUCTURAL IS THE FORMATTER, NOT THE AGREEMENT. An earlier draft
+ * of this header claimed the two surfaces are byte-identical "by
+ * construction". That is overstated and the correction matters. Only the
+ * RENDERING is shared; the INPUTS are two different sources — the panel reads
+ * the store scalar `goalThreshold`, the card reads `node.data`. Same string
+ * out only while those two agree.
+ *
+ * One reachable divergence, named so nobody mistakes this file for a proof it
+ * cannot give: a later graph_patch RAISING the target updates the node through
+ * the ungated backfill while the store gate (raw is not superseded by raw)
+ * leaves the scalar stale. The card then shows the new figure, the panel the
+ * old — and the run sends the old. This is PRE-EXISTING, not a regression:
+ * the pristine gate (`goalThreshold == null`, store.ts:4013 at cb957c8c) blocks
+ * the same refresh identically, and 2.315 deliberately did not widen it
+ * further. Rowed separately by the paired review.
+ *
+ * So: given equal inputs, the two surfaces cannot disagree — that is what this
+ * file pins, and it is the half that was actually broken.
+ *
+ * This file pins the CARD half. The PANEL half is
+ * `src/canvas/ui/inspector-v2/__tests__/GoalPanel.goalTarget.spec.tsx`, which
+ * asserts the same literals against the real store and the real panel. Each
+ * case here asserts BOTH a hard literal (so a broken helper cannot make the
+ * two surfaces agree on garbage) and equality with the helper (so a surface
+ * that stops deferring to it REDs).
+ *
+ * Scope limit (CLAUDE.md trap 3): jsdom pins the rendered string only, never
+ * that the card's target line is visible or laid out.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { GoalNode } from '../GoalNode'
+import { formatGoalTarget } from '../../../components/results/utils/formatGoalTarget'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const makeStoreState = (overrides: Record<string, unknown> = {}) => ({
+  results: { status: 'idle', report: null },
+  highlightedNodes: new Set(),
+  dimmedNodeIds: new Set(),
+  lens: { _dimmedNodeIds: new Set() },
+  goalThreshold: null,
+  goalConstraints: [],
+  nodes: [],
+  edges: [],
+  ceeAnalysisReady: null,
+  viewMode: 'expert',
+  ...overrides,
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector) => selector(makeStoreState())),
+}))
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+    winRate: null,
+    isResultsMode: false,
+    predictedOutcome: null,
+    valueOfInformation: null,
+    voiRank: null,
+  })),
+}))
+
+import { useCanvasStore } from '../../store'
+
+const baseProps = {
+  id: 'goal-1',
+  type: 'goal',
+  selected: false,
+  isConnectable: true,
+  position: { x: 0, y: 0 },
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  deletable: true,
+  selectable: true,
+  draggable: true,
+}
+
+function cardText(data: Record<string, unknown>) {
+  const { container } = render(
+    <ReactFlowProvider>
+      <GoalNode {...baseProps} data={{ label: 'Grow annual revenue', type: 'goal', ...data }} />
+    </ReactFlowProvider>,
+  )
+  return container.textContent ?? ''
+}
+
+describe('GoalNode target string — the canvas half of the one-goal-one-string pair', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useCanvasStore).mockImplementation((selector) => selector(makeStoreState() as never))
+  })
+
+  it('renders a currency target as a prefixed, separated magnitude', () => {
+    const text = cardText({ goal_threshold_raw: 800000, goal_threshold_unit: '£' })
+    expect(text).toContain('£800,000')
+    expect(text).toContain(formatGoalTarget(800000, '£'))
+    expect(text).not.toContain('800000 £')
+  })
+
+  it('suppresses the "count" placeholder — the string Inspector v2 was printing', () => {
+    const text = cardText({ goal_threshold_raw: 800000, goal_threshold_unit: 'count' })
+    expect(text).toContain('800,000')
+    expect(text).toContain(formatGoalTarget(800000, 'count'))
+    expect(text).not.toContain('count')
+  })
+
+  it('renders a real unit as a suffix', () => {
+    const text = cardText({ goal_threshold_raw: 9, goal_threshold_unit: 'months' })
+    expect(text).toContain('9 months')
+    expect(text).toContain(formatGoalTarget(9, 'months'))
+  })
+
+  it('renders percent as a rounded percentage', () => {
+    const text = cardText({ goal_threshold_raw: 84.6, goal_threshold_unit: 'percent' })
+    expect(text).toContain('85%')
+    expect(text).toContain(formatGoalTarget(84.6, 'percent'))
+  })
+})

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -3986,31 +3986,84 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // goal_threshold_raw FIRST: the store field's contract is user units (see
       // the goalThreshold field comment). goal_threshold is normalised 0-1 — syncing
       // it here painted the Results target line at 0.8 when the real target was
-      // 20% (staging trust review, 2026-07). When raw is absent but a cap exists,
-      // derive raw from the producer's own pair (norm × cap) — a genuine RAW
-      // value. When neither raw nor an analysis_ready cap exists, the value is
+      // 20% (staging trust review, 2026-07). When no raw arrives, the value is
       // bare NORMALISED 0-1 — Lane 5 (Codex P0-1) TAGS it 'normalised' rather
       // than storing it as raw: the old code assumed "capless ⇒ raw ≡
       // normalised", but the GOAL NODE can carry a cap the request boundary
       // then divides by (0.6 / 100 → 0.006 on the live wire). The explicit tag
       // makes the request boundary pass a normalised value through untouched.
+      //
+      // ROADMAP 2.315 PART 2 — THE CONSUMER DOES NOT RE-DERIVE AN ATTESTED VALUE.
+      // A `norm × cap` branch used to sit here: when a payload carried a cap but
+      // no raw, it multiplied them and TAGGED THE PRODUCT 'raw'. A value this
+      // consumer computed was then indistinguishable, downstream, from one the
+      // producer attested.
+      //
+      // ⚠ BE PRECISE ABOUT WHY IT IS GONE — an earlier draft of this comment said
+      // CEE #798 "makes it reachable", and that is FALSE in a dangerous
+      // direction. #798 is RAW-ANCHORED: a cap cannot reach the wire without a
+      // raw beside it, so `ceeRaw != null` always wins and the norm × cap branch
+      // stays UNREACHABLE. What #798 changed is that caps are emitted AT ALL —
+      // and its anchor is precisely what keeps the branch dead. Crediting #798
+      // with creating the hazard would invite a future reader to remove that
+      // anchor believing the UI defends itself. (The anchor was verified in the
+      // CEE repo by the paired review of #798/#563, not by this file's author.)
+      //
+      // The branch is removed as DEFENCE IN DEPTH against exactly that: the
+      // anchor lives in another repo on another schema pin, and a consumer must
+      // not be able to manufacture an attested magnitude if it ever loosens.
+      //
+      // Removing it does NOT reopen the double-normalisation that branch was
+      // added to prevent. The value is stored UNTOUCHED and tagged 'normalised',
+      // and `resolveChipGoalThreshold` (useV2Run.ts) short-circuits on that tag
+      // and never divides by a cap. Same value on the wire, nothing invented,
+      // and the display no longer claims a raw scale it cannot support.
       const ceeRaw = (analysisReady as any).goal_threshold_raw
       const ceeNorm = (analysisReady as any).goal_threshold
-      const ceeCap = (analysisReady as any).goal_threshold_cap
-      const hasCap = typeof ceeCap === 'number' && Number.isFinite(ceeCap) && ceeCap > 0
       let ceeThreshold: number | null | undefined
       let ceeRepresentation: 'raw' | 'normalised'
       if (ceeRaw != null) {
         ceeThreshold = ceeRaw
         ceeRepresentation = 'raw'
-      } else if (typeof ceeNorm === 'number' && hasCap) {
-        ceeThreshold = ceeNorm * ceeCap // derived raw from the producer's own pair
-        ceeRepresentation = 'raw'
       } else {
-        ceeThreshold = ceeNorm // bare, already 0-1
+        ceeThreshold = ceeNorm // bare, already 0-1 — stored as received, tagged
         ceeRepresentation = 'normalised'
       }
-      if (ceeThreshold != null && get().goalThreshold == null) {
+      // ROADMAP 2.315 PART 1 — ONE SENTENCE HAD TWO WRITERS AND TWO GATES.
+      // This write (the NUMBER) was gated on `goalThreshold == null`. The goal
+      // node's UNIT is written by `backfillGoalThresholdOntoGoalNode`, which is
+      // UNGATED and fires from the same payload on every accepted graph_patch
+      // (mirrorAnalysisReady) and every V5 turn carrying analysis_ready that
+      // does not flow through applyDraftResult (applyV5State's catch-all).
+      // READINESS_CLEAR_FIELDS clears neither. So a session that had already
+      // stored a bare NORMALISED 0.8 kept the 0.8 while taking the later
+      // payload's '£', and Inspector v2 rendered "≥ 0.8 £" — a magnitude on one
+      // scale wearing the other scale's unit.
+      //
+      // The gate now also lets an ATTESTED RAW value supersede the store's own
+      // un-attested normalised guess. It is safe against clobbering a user's
+      // target because 'normalised' has exactly ONE writer in the repo — the
+      // bare-sync branch immediately above.
+      //
+      // COMPLETE MANIFEST, 8 assignment sites (derive it again before relying on
+      // it — `grep -rn "goalThresholdRepresentation:" src --include='*.ts'
+      // --include='*.tsx'`, minus the three type declarations at :351/:1227/:1267):
+      //   store.ts :1173, :1520, :3950  → null (initial state / resets)
+      //   store.ts :1238, :1240         → deriveGoalThresholdFromNode: 'raw' | null
+      //   store.ts :2920                → setGoalThreshold: opts.representation ?? 'raw'
+      //                                   ← the ONLY site that can yield 'normalised',
+      //                                     and the bare-sync above is its only
+      //                                     non-test caller passing `representation:`
+      //   store.ts :2927                → setGoalThresholdAndUpdateNode: hard-coded 'raw'
+      //   applyDraftResult.ts :228      → null, written beside `goalThreshold: null`,
+      //                                   so it cannot arm this gate
+      // So the only state this can overwrite is a value this same reducer guessed.
+      //
+      // Untagged (null) is treated as raw here, as everywhere else in the
+      // estate, so legacy/restored state is left alone.
+      const supersedesOwnNormalisedGuess =
+        ceeRepresentation === 'raw' && get().goalThresholdRepresentation === 'normalised'
+      if (ceeThreshold != null && (get().goalThreshold == null || supersedesOwnNormalisedGuess)) {
         // Producer write (syncing the threshold FROM the analysis) — must not
         // self-dirty the freshness overlay.
         get().setGoalThreshold(

--- a/src/canvas/store/__tests__/goalThresholdSync.spec.ts
+++ b/src/canvas/store/__tests__/goalThresholdSync.spec.ts
@@ -46,29 +46,98 @@ describe('Canvas Store – setCeeAnalysisReady goal-threshold sync (unit contrac
     expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
   })
 
-  it('derives raw from norm × cap when raw is absent but a cap exists — tagged raw', () => {
-    // Storing 0.8 beside cap 25 would double-normalise at the request
-    // boundary (0.8 / 25 = 0.032) and paint the target at 0.8 user units.
+  it('RED-first (2.315 Part 2): a cap WITHOUT a raw is NOT re-derived into an attested raw', () => {
+    // ⚠ CONTRACT CHANGE, deliberate. This case previously computed norm × cap
+    // (0.8 × 25 = 20) and tagged the product 'raw' — a value the UI derived
+    // itself, presented downstream as one the producer attested.
+    //
+    // ⚠ #798 DOES NOT MAKE THIS REACHABLE — an earlier draft of this comment
+    // said it did, which is false in the dangerous direction. #798 is
+    // RAW-ANCHORED: a cap cannot reach the wire without a raw, so `ceeRaw !=
+    // null` always wins and this branch stays unreachable. #798 begins emitting
+    // caps AT ALL, and its anchor is what keeps the branch dead. The synthesis
+    // is removed as DEFENCE IN DEPTH against that anchor loosening — it lives in
+    // another repo on another schema pin — not because #798 armed a hazard.
+    //
+    // Refusing to synthesise does NOT reopen the double-normalisation this
+    // branch was added to prevent: the value is stored untouched and TAGGED
+    // 'normalised', and resolveChipGoalThreshold short-circuits on that tag
+    // and never divides by a cap (useV2Run.ts). Same wire outcome, no
+    // fabricated magnitude, and the display no longer claims a raw scale.
     useCanvasStore.getState().setCeeAnalysisReady(
       analysisReady({ goal_threshold: 0.8, goal_threshold_cap: 25 }),
     )
-    expect(useCanvasStore.getState().goalThreshold).toBe(20)
-    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
+    expect(useCanvasStore.getState().goalThreshold).toBe(0.8)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
   })
 
-  it('ignores an invalid cap when deriving (zero/negative caps cannot scale)', () => {
+  it('an invalid cap is likewise never used to manufacture a value', () => {
     useCanvasStore.getState().setCeeAnalysisReady(
       analysisReady({ goal_threshold: 0.8, goal_threshold_cap: 0 }),
     )
     expect(useCanvasStore.getState().goalThreshold).toBe(0.8)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
   })
 
-  it('never overwrites a non-null (user-set) threshold', () => {
-    useCanvasStore.setState({ goalThreshold: 15 })
+  it('never overwrites a non-null threshold that is not tagged normalised', () => {
+    // Legacy/untagged (null representation) is treated as raw everywhere else
+    // in the estate, so the widened gate must leave it alone too.
+    // Set the tag EXPLICITLY rather than relying on what reset() leaves behind —
+    // the claim under test is about a null tag, so it must be established, not
+    // inherited from a sibling test.
+    useCanvasStore.setState({ goalThreshold: 15, goalThresholdRepresentation: null })
     useCanvasStore.getState().setCeeAnalysisReady(
       analysisReady({ goal_threshold: 0.8, goal_threshold_raw: 20 }),
     )
     expect(useCanvasStore.getState().goalThreshold).toBe(15)
+  })
+
+  it('RED-first (2.315 Part 1): a RAW payload supersedes a stored bare-NORMALISED value', () => {
+    // The split-brain. The number was gated on `goalThreshold == null` while
+    // the goal node's UNIT (backfillGoalThresholdOntoGoalNode) was ungated, so
+    // a session holding a bare normalised 0.8 kept the 0.8 and took the new
+    // payload's '£' — "≥ 0.8 £" on Inspector v2.
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.8 }))
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
+
+    useCanvasStore.getState().setCeeAnalysisReady(
+      analysisReady({
+        goal_threshold: 0.8,
+        goal_threshold_raw: 800000,
+        goal_threshold_unit: '£',
+        goal_threshold_cap: 1000000,
+      }),
+    )
+    expect(useCanvasStore.getState().goalThreshold).toBe(800000)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
+  })
+
+  it("a user's committed target is never superseded — user commits are tagged raw", () => {
+    // The safety argument for widening the gate, pinned. 'normalised' has
+    // exactly ONE writer in the repo — the bare-sync branch inside
+    // setCeeAnalysisReady itself — so the widened condition can only ever
+    // overwrite the store's own un-attested guess, never a user's number.
+    // setGoalThresholdAndUpdateNode hard-codes 'raw'; setGoalThreshold
+    // defaults to 'raw'.
+    useCanvasStore.setState({ nodes: [{ id: 'goal_node', type: 'goal', position: { x: 0, y: 0 }, data: {} }] } as never)
+    useCanvasStore.getState().setGoalThresholdAndUpdateNode('goal_node', 15, { unit: '£' })
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
+
+    useCanvasStore.getState().setCeeAnalysisReady(
+      analysisReady({ goal_threshold: 0.8, goal_threshold_raw: 800000, goal_threshold_cap: 1000000 }),
+    )
+    expect(useCanvasStore.getState().goalThreshold).toBe(15)
+  })
+
+  it('a normalised payload never supersedes a stored RAW value (the widening is one-way)', () => {
+    useCanvasStore.getState().setCeeAnalysisReady(
+      analysisReady({ goal_threshold: 0.8, goal_threshold_raw: 800000 }),
+    )
+    expect(useCanvasStore.getState().goalThreshold).toBe(800000)
+
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.5 }))
+    expect(useCanvasStore.getState().goalThreshold).toBe(800000)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
   })
 
   it('syncs nothing when CEE provides no threshold fields', () => {

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.goalTarget.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.goalTarget.spec.tsx
@@ -1,0 +1,229 @@
+/**
+ * GoalPanel — the success-target sentence (ROADMAP 2.315(c), CEE #798 pair).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE DEFECT: ONE SENTENCE, TWO WRITERS, TWO GATING DISCIPLINES
+ * ─────────────────────────────────────────────────────────────────────────
+ * The NUMBER in "Success means reaching ≥ …" comes from the store scalar
+ * `goalThreshold`, written by `setCeeAnalysisReady` under a gate that refused
+ * to overwrite ANY non-null value. The UNIT comes from
+ * `node.data.goal_threshold_unit`, written by
+ * `backfillGoalThresholdOntoGoalNode`, which is UNGATED.
+ *
+ * So a session that had already stored a BARE NORMALISED 0.8 kept that 0.8
+ * while the unit was refreshed to '£' from a later, raw-bearing payload — and
+ * the panel rendered "≥ 0.8 £". The canvas GoalNode was never affected
+ * because it reads the number AND the unit from the same node.data, which is
+ * precisely why the walk saw two different strings for one goal.
+ *
+ * Reachability is not hypothetical: `applyAnalysisReadyPatch`
+ * (mirrorAnalysisReady) fires on every accepted graph_patch and calls exactly
+ * these two writers, and `READINESS_CLEAR_FIELDS` clears none of the
+ * threshold fields. This suite drives that REAL pair — not a hand-built store
+ * state — so the sequence under test is the one the product performs.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * RED-first at pristine cb957c8c (signatures in the PR body)
+ * ─────────────────────────────────────────────────────────────────────────
+ *   1. the raw-supersedes-normalised case rendered "≥ 0.8 £"
+ *   2. the good path rendered "≥ 800000 £" (bare number, unit as a suffix)
+ *   3. the placeholder unit rendered "≥ 0.8 count"
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * SCOPE LIMIT (CLAUDE.md trap 3)
+ * ─────────────────────────────────────────────────────────────────────────
+ * jsdom pins the STRING the panel renders. It cannot prove the sentence is
+ * visible, laid out, or above the fold. No claim here is a layout claim.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { GoalPanel } from '../panels/GoalPanel'
+import { useCanvasStore } from '../../../store'
+import { useAuth } from '../../../../contexts/AuthContext'
+import { applyAnalysisReadyPatch } from '../../../conversation/utils/mirrorAnalysisReady'
+import { formatGoalTarget } from '../../../../components/results/utils/formatGoalTarget'
+import type { CEEAnalysisReady } from '../../../../adapters/cee/types'
+
+vi.mock('../../../../contexts/AuthContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../contexts/AuthContext')>()
+  return { ...actual, useAuth: vi.fn() }
+})
+
+const REAL_AUTH = { authenticated: true, user: { id: 'u-123', email: 'real@user.io' } }
+
+const GOAL_NODE = {
+  id: 'goal1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'Grow annual revenue' },
+}
+
+/** A well-formed analysis_ready for the goal node above. */
+function analysisReady(extra: Record<string, unknown>): CEEAnalysisReady {
+  return {
+    goal_node_id: 'goal1',
+    options: [{ id: 'opt_a', label: 'Option A', status: 'ready', interventions: {} }],
+    ...extra,
+  } as CEEAnalysisReady
+}
+
+function seedCanvas() {
+  useCanvasStore.getState().reset()
+  useCanvasStore.setState({ nodes: [GOAL_NODE], edges: [], goalThreshold: null } as never)
+}
+
+function renderPanel() {
+  return render(
+    <GoalPanel nodeId="goal1" techMode={false} onClose={() => {}} onNavigate={() => {}} />,
+  )
+}
+
+function panelText() {
+  return renderPanel().container.textContent ?? ''
+}
+
+describe('GoalPanel — success target: the number and its unit must come from one payload', () => {
+  beforeEach(() => {
+    seedCanvas()
+    vi.mocked(useAuth).mockReset()
+    vi.mocked(useAuth).mockReturnValue(REAL_AUTH as unknown as ReturnType<typeof useAuth>)
+  })
+
+  it('control: the two writers really are what this suite drives (anti-vacuity)', () => {
+    // Trap 13 — prove the sequence PRODUCES the split state before asserting
+    // anything about how it renders. If either writer stops firing, this
+    // control fails and every assertion below is known to be testing nothing.
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.8 }))
+    expect(useCanvasStore.getState().goalThreshold).toBe(0.8)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
+
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: analysisReady({
+          goal_threshold: 0.8,
+          goal_threshold_raw: 800000,
+          goal_threshold_unit: '£',
+          goal_threshold_cap: 1000000,
+        }),
+      },
+      { patchId: 'p1', scenarioId: null },
+    )
+    // The UNIT writer is ungated — it lands regardless.
+    const goal = useCanvasStore.getState().nodes.find(n => n.id === 'goal1')
+    expect((goal?.data as Record<string, unknown>)?.goal_threshold_unit).toBe('£')
+  })
+
+  it('RED-first: a raw-bearing payload SUPERSEDES a stored bare-normalised target', () => {
+    // The exact reachable sequence: a first turn stored a bare normalised 0.8;
+    // a later accepted graph_patch carries the attested raw trio. Pristine
+    // rendered "≥ 0.8 £" — a number on one scale wearing the other scale's unit.
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.8 }))
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: analysisReady({
+          goal_threshold: 0.8,
+          goal_threshold_raw: 800000,
+          goal_threshold_unit: '£',
+          goal_threshold_cap: 1000000,
+        }),
+      },
+      { patchId: 'p1', scenarioId: null },
+    )
+
+    expect(useCanvasStore.getState().goalThreshold).toBe(800000)
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
+
+    const text = panelText()
+    expect(text).toContain('Success means reaching ≥ £800,000')
+    // The self-refuting pair must be gone, not merely joined by a better one.
+    expect(text).not.toContain('0.8 £')
+    expect(text).not.toContain('≥ 0.8')
+  })
+
+  it('RED-first: a raw target renders through the goal-target authority, not bare + suffix', () => {
+    // Even on the good path the panel interpolated the number bare with the
+    // unit as a trailing suffix: "≥ 800000 £".
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: analysisReady({
+          goal_threshold: 0.8,
+          goal_threshold_raw: 800000,
+          goal_threshold_unit: '£',
+          goal_threshold_cap: 1000000,
+        }),
+      },
+      { patchId: 'p1', scenarioId: null },
+    )
+
+    const text = panelText()
+    expect(text).toContain('£800,000')
+    expect(text).not.toContain('800000 £')
+    // Structural: the panel defers to the ONE goal-target formatter rather
+    // than hand-rolling a second rendering. The literal above pins what that
+    // formatter must produce, so this cannot pass by both being wrong.
+    expect(text).toContain(formatGoalTarget(800000, '£'))
+  })
+
+  it('RED-first: the "count" placeholder unit is SUPPRESSED, as the canvas card already does', () => {
+    // `count` is the digit-string brief form's placeholder. It is a real unit
+    // on no scale, and GoalNode (`u === 'count'`) and NodeInspector
+    // (`unitStr !== 'count'`) both already drop it. Inspector v2 was the only
+    // surface printing it.
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: analysisReady({
+          goal_threshold: 0.8,
+          goal_threshold_raw: 800000,
+          goal_threshold_unit: 'count',
+          goal_threshold_cap: 1000000,
+        }),
+      },
+      { patchId: 'p1', scenarioId: null },
+    )
+
+    const text = panelText()
+    expect(text).toContain('Success means reaching ≥ 800,000')
+    expect(text).not.toContain('count')
+  })
+
+  it('a target that is only ever NORMALISED renders WITHOUT a raw unit', () => {
+    // Defence in depth for the split-brain: when CEE sends no raw at all, the
+    // stored number is a 0-1 fraction and the node's unit describes the raw
+    // scale. Pairing them is the very sentence this PR exists to kill, so the
+    // panel refuses to decorate a normalised magnitude with a raw unit.
+    useCanvasStore.getState().setCeeAnalysisReady(analysisReady({ goal_threshold: 0.8 }))
+    applyAnalysisReadyPatch(
+      { ceeAnalysisReady: analysisReady({ goal_threshold: 0.8, goal_threshold_unit: '£' }) },
+      { patchId: 'p1', scenarioId: null },
+    )
+
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('normalised')
+    const text = panelText()
+    expect(text).toContain('Success means reaching ≥ 0.8')
+    expect(text).not.toContain('0.8 £')
+    expect(text).not.toContain('£0.8')
+  })
+
+  it('a user-committed target is never clobbered by a CEE raw payload', () => {
+    // The widened gate keys on representation 'normalised', and the ONLY
+    // writer of that tag is the CEE bare-sync itself. Every user/editor commit
+    // goes through setGoalThresholdAndUpdateNode, which hard-codes 'raw'.
+    useCanvasStore.getState().setGoalThresholdAndUpdateNode('goal1', 15, { unit: '£' })
+    expect(useCanvasStore.getState().goalThresholdRepresentation).toBe('raw')
+
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: analysisReady({
+          goal_threshold: 0.8,
+          goal_threshold_raw: 800000,
+          goal_threshold_unit: '£',
+          goal_threshold_cap: 1000000,
+        }),
+      },
+      { patchId: 'p1', scenarioId: null },
+    )
+
+    expect(useCanvasStore.getState().goalThreshold).toBe(15)
+    expect(panelText()).toContain('£15')
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -42,6 +42,7 @@ import { useAuth } from '../../../../contexts/AuthContext'
 import { isPersistenceActive } from '../../../../lib/persistenceActive'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
+import { formatGoalTarget } from '../../../../components/results/utils/formatGoalTarget'
 
 export const GoalPanel = memo(function GoalPanel({
   nodeId,
@@ -54,6 +55,7 @@ export const GoalPanel = memo(function GoalPanel({
   const resultsStatus = useCanvasStore(s => s.results?.status)
   const isResultsMode = resultsStatus === 'complete'
   const goalThreshold = useCanvasStore(s => s.goalThreshold)
+  const goalThresholdRepresentation = useCanvasStore(s => s.goalThresholdRepresentation)
   // GOAL-PROBABILITY IDENTITY (ROADMAP 2.296 item 5 / 2.282-C2): this panel
   // used to read both producer fields straight off the store, which made it a
   // chooser in its own right; #496 replaced that with a `selectGoalProbability`
@@ -134,6 +136,51 @@ export const GoalPanel = memo(function GoalPanel({
 
   const thresholdUnit = (node?.data as Record<string, unknown>)?.goal_threshold_unit as string | undefined
   const thresholdRaw = (node?.data as Record<string, unknown>)?.goal_threshold_raw as string | number | null | undefined
+
+  /**
+   * The success-target string (ROADMAP 2.315(c)).
+   *
+   * TWO THINGS THIS FIXES, AND WHY THE SECOND IS NOT REDUNDANT.
+   *
+   * 1. FORMATTING. The number used to be interpolated bare with the unit as a
+   *    trailing suffix, so an £800,000 target rendered "≥ 800000 £" even on the
+   *    good path. It now goes through `formatGoalTarget` — the shared mapping
+   *    the canvas GoalNode also uses — so one goal cannot produce two strings.
+   *
+   * 2. PROVENANCE. The number comes from the STORE scalar and the unit from
+   *    NODE data, written by two different reducers. The store gate was widened
+   *    so an attested raw payload supersedes a stored normalised guess, but that
+   *    alone does not make the pair coherent: a payload carrying a unit and NO
+   *    raw still refreshes the unit while the number stays normalised. So the
+   *    unit is applied ONLY when the number is on the scale that unit describes.
+   *    A 'normalised' 0-1 magnitude renders bare — "≥ 0.8" is thin, "≥ 0.8 £" is
+   *    false, and this surface must not assert the second.
+   *
+   *    Untagged (null) representation is treated as raw, matching the request
+   *    boundary and every other reader of this scalar.
+   *
+   * ⚠ THIS GUARD IS PANEL-ONLY. IT IS NOT AN ESTATE-WIDE INVARIANT.
+   *    Every other reader of `store.goalThreshold` renders it with NO tag check
+   *    and would happily pair a normalised magnitude with a raw unit:
+   *      · NodeInspector.tsx:334-348      (legacy inspector target line)
+   *      · SuccessTargetRow.tsx           (0 references to the tag)
+   *      · BaselineTargetRow.tsx          (0 references to the tag)
+   *      · RangeVisualization, via `effectiveGoalThreshold`
+   *        (useResultsSectionData.ts:1338 — 0 references to the tag)
+   *    Harmless TODAY only because CEE #798 is raw-anchored, so a unit-bearing
+   *    payload with no raw is not representable on the wire. That is a producer
+   *    property, not a UI one. Do not read this guard as protection those
+   *    surfaces have — if the anchor ever loosens, they are the exposure.
+   *
+   * Null when the target is absent or not a finite number; the editor renders
+   * instead, rather than a sentence ending in "NaN".
+   */
+  const targetDisplay = goalThreshold == null
+    ? null
+    : formatGoalTarget(
+        goalThreshold,
+        goalThresholdRepresentation === 'normalised' ? null : thresholdUnit,
+      )
 
   // Description — conditional edit state for EmptyDescriptionPrompt pattern
   const [description, setDescription] = useState(String(node?.data?.description ?? ''))
@@ -291,10 +338,10 @@ export const GoalPanel = memo(function GoalPanel({
       <PanelGroup kind="input" label={GROUP_LABELS.input}>
         <PrimaryControlCard>
           {/* §4.2 Success target */}
-          {goalThreshold != null ? (
+          {targetDisplay != null ? (
             <div>
               <p className={`${typography.panelBody} text-text-body`}>
-                Success means reaching {'\u2265'} {goalThreshold}{thresholdUnit ? ` ${thresholdUnit}` : ''}
+                Success means reaching {'\u2265'} {targetDisplay}
               </p>
               {/* Contextual probability when analysis exists */}
               {typeof probGoal === 'number' ? (

--- a/src/components/results/utils/__tests__/formatGoalTarget.spec.ts
+++ b/src/components/results/utils/__tests__/formatGoalTarget.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * formatGoalTarget — the ONE goal-target unit-string mapping (ROADMAP 2.315(c)).
+ *
+ * WHY THIS EXISTS RATHER THAN A FOURTH FORMATTER
+ * ----------------------------------------------
+ * `formatTargetValue` is already the estate's goal-target primitive — named
+ * for the job and used by the canvas GoalNode, NodeInspector,
+ * BaselineTargetRow and SuccessTargetRow. But it takes a STRUCTURED unit kind
+ * ('currency' | 'percent' | 'count'), never the unit STRING that CEE actually
+ * sends, so every caller hand-rolled the string→kind mapping and the three
+ * copies drifted:
+ *
+ *   GoalNode.tsx      percent → round; 'count'/'' → bare; currency → symbol;
+ *                     else "N unit"
+ *   NodeInspector.tsx percent → as-is; ANY non-count unit → 'currency'
+ *                     (so "months" renders as a currency symbol)
+ *   GoalPanel.tsx     no mapping at all — `{value}{' ' + unit}`
+ *
+ * This module is that mapping, extracted from GoalNode (the surface that was
+ * already correct) so the canvas card and Inspector v2 cannot state different
+ * strings for one goal. It renders NOTHING itself: every branch delegates to
+ * `formatTargetValue`, and unit classification comes from the single-source
+ * `classifyUnit`. It is a consolidation, not a new authority.
+ *
+ * DELIBERATELY PRESERVED FROM GoalNode, NOT "FIXED" HERE
+ * -----------------------------------------------------
+ * An ISO code renders WITHOUT a space ("GBP800,000") because
+ * `formatTargetValue` treats the third argument as a symbol. That is the
+ * canvas card's existing output and changing it is a separate, visible copy
+ * change; it is pinned below so the choice is deliberate and any future fix
+ * is a decision rather than a drift.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatGoalTarget } from '../formatGoalTarget'
+
+describe('formatGoalTarget', () => {
+  it('renders a currency symbol as a prefix with thousand separators', () => {
+    // The whole point of the 2.315(c) pair: £800,000, never "800000 £".
+    expect(formatGoalTarget(800000, '£')).toBe('£800,000')
+    expect(formatGoalTarget(1200, '$')).toBe('$1,200')
+  })
+
+  it('suppresses the "count" placeholder unit', () => {
+    // `count` is the digit-string brief form's placeholder — a unit on no
+    // scale. GoalNode and NodeInspector already drop it; this is the shared
+    // rule that makes every surface agree.
+    expect(formatGoalTarget(800000, 'count')).toBe('800,000')
+    expect(formatGoalTarget(42, 'Count')).toBe('42')
+    expect(formatGoalTarget(42, '  count ')).toBe('42')
+  })
+
+  it('suppresses an absent, empty or whitespace-only unit', () => {
+    expect(formatGoalTarget(800000, null)).toBe('800,000')
+    expect(formatGoalTarget(800000, undefined)).toBe('800,000')
+    expect(formatGoalTarget(800000, '')).toBe('800,000')
+    // Pristine GoalNode left a trailing space here (it lower-cased without
+    // trimming); trimming is the same direction the U2 fix already took.
+    expect(formatGoalTarget(800000, '   ')).toBe('800,000')
+  })
+
+  it('renders percent through classifyUnit, including the words CEE emits', () => {
+    expect(formatGoalTarget(85, '%')).toBe('85%')
+    expect(formatGoalTarget(85, 'percent')).toBe('85%')
+    expect(formatGoalTarget(85, 'percentage')).toBe('85%')
+    // Rounded, exactly as the canvas card does.
+    expect(formatGoalTarget(84.6, '%')).toBe('85%')
+  })
+
+  it('renders a real unit as a trailing suffix', () => {
+    expect(formatGoalTarget(9, 'months')).toBe('9 months')
+    expect(formatGoalTarget(1500, 'users')).toBe('1,500 users')
+  })
+
+  it('pins the ISO-code spacing inherited from the canvas card (declared, not endorsed)', () => {
+    // Documented departure from formatValueWithUnit's §2.4 spec ("ISO prefix
+    // WITH a space"). Preserved so this extraction is behaviour-preserving for
+    // the canvas card; changing it is a separate copy decision.
+    expect(formatGoalTarget(800000, 'GBP')).toBe('GBP800,000')
+  })
+
+  it('returns null for a non-finite value rather than rendering "NaN" at the user', () => {
+    // The caller decides what to show instead; a target sentence reading
+    // "Success means reaching ≥ NaN" is worse than no sentence. Callers that
+    // already have their own non-finite handling (GoalNode, which echoes the
+    // original string) keep it and never reach this branch.
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      expect(formatGoalTarget(bad, '£')).toBeNull()
+    }
+    expect(formatGoalTarget(0, '£')).toBe('£0')
+  })
+})

--- a/src/components/results/utils/formatGoalTarget.ts
+++ b/src/components/results/utils/formatGoalTarget.ts
@@ -1,0 +1,91 @@
+/**
+ * formatGoalTarget — the single unit-STRING mapping for goal-target display.
+ *
+ * ROADMAP 2.315(c). This is a CONSOLIDATION, not a new formatting authority:
+ * every branch delegates rendering to `formatTargetValue` (the estate's
+ * goal-target primitive, already used by GoalNode, NodeInspector,
+ * BaselineTargetRow and SuccessTargetRow) and every unit decision comes from
+ * `classifyUnit` (the single-source classifier in src/utils/unitClassifier).
+ *
+ * WHY IT WAS NEEDED
+ * -----------------
+ * `formatTargetValue` takes a STRUCTURED unit kind ('currency' | 'percent' |
+ * 'count'), but CEE sends a unit STRING ('£', 'percent', 'count', 'months').
+ * Every caller therefore grew its own string→kind mapping, and by 2026-08 the
+ * three had drifted:
+ *
+ *   GoalNode.tsx      percent → rounded; 'count'/'' → bare; currency → symbol;
+ *                     otherwise "N unit"                        ← correct
+ *   NodeInspector.tsx ANY non-count, non-percent unit → 'currency', so a
+ *                     "months" target renders as "months9"      ← latent bug
+ *   GoalPanel.tsx     no mapping at all: `{value}{' ' + unit}`, so an
+ *                     £800,000 target rendered "800000 £"       ← ROADMAP 2.315(c)
+ *
+ * The mapping below is GoalNode's — the surface that was already right —
+ * extracted verbatim in behaviour so the canvas card and Inspector v2 cannot
+ * state different strings about one goal.
+ *
+ * WHY `formatValueWithUnit` IS NOT USED HERE
+ * -----------------------------------------
+ * `src/canvas/utils/formatValueWithUnit.ts` turns any 0–1 magnitude carrying
+ * no real unit into a QUALITATIVE WORD ("0.8" → "very high"). That is right
+ * for a factor's observed state and catastrophic for a target sentence: a
+ * goal still held on the normalised scale would read "Success means reaching
+ * ≥ very high". (It is the same hazard #561 review item A3 pinned — the
+ * qualitative branch keys on `classifyUnit(unit).kind` and the 0–1 bound, not
+ * on whether the magnitude is raw.) The model-tab sibling
+ * (`components/model-tab/utils.ts`) is scoped to observed states and has no
+ * percent branch at all, so it would render "20 %".
+ *
+ * DECLARED, DELIBERATE INHERITANCE — ISO SPACING
+ * ----------------------------------------------
+ * An ISO code renders with NO space ("GBP800,000") because `formatTargetValue`
+ * treats its third argument as a symbol. That is the canvas card's existing
+ * output; preserving it keeps this extraction behaviour-preserving for the
+ * card. It differs from `formatValueWithUnit`'s §2.4 spec ("ISO prefix WITH a
+ * space") and is pinned in the spec so a future correction is a decision
+ * rather than a drift.
+ *
+ * `'count'` IS SUPPRESSED, AND THAT IS THE ESTATE'S EXISTING RULE
+ * --------------------------------------------------------------
+ * The digit-string brief form mints `goal_threshold_unit: "count"` (the wire
+ * type documents it: `adapters/cee/types.ts`, "e.g. \"count\", \"USD\""). It
+ * is a placeholder on no real-world scale, and it is in neither COUNT_UNITS
+ * (which is about whole-number ROUNDING of headcounts) nor
+ * GENERIC_PLACEHOLDER_UNITS. Three existing authorities already drop it —
+ * GoalNode (`u === 'count'`), NodeInspector (`unitStr !== 'count'`) and
+ * `formatTargetValue`'s own 'count' kind, which decorates nothing. Inspector
+ * v2 was the one surface printing it. This function makes the rule shared
+ * rather than triplicated; it deliberately does NOT add 'count' to
+ * GENERIC_PLACEHOLDER_UNITS, which would silently change factor and
+ * intervention rendering estate-wide.
+ */
+import { classifyUnit } from '../../../utils/unitClassifier'
+import { formatTargetValue } from './formatTargetValue'
+
+/**
+ * Render a goal target magnitude with its unit.
+ *
+ * @param value - the target magnitude, in the units `unit` describes
+ * @param unit  - the unit string as the producer sent it (may be absent)
+ * @returns the display string, or `null` when `value` is not a finite number —
+ *          callers show no target rather than "≥ NaN".
+ */
+export function formatGoalTarget(value: number, unit: string | null | undefined): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+
+  const { kind, canonical } = classifyUnit(unit ?? null)
+
+  // Percent: rounded to whole percentage points, as the canvas card does.
+  if (kind === 'percent') return formatTargetValue(Math.round(value), 'percent')
+
+  // No unit, or the 'count' placeholder — render the bare magnitude.
+  const trimmed = typeof unit === 'string' ? unit.trim() : ''
+  if (kind === 'none' || trimmed.toLowerCase() === 'count') return formatTargetValue(value)
+
+  // Currency, symbol or ISO code, prefixed.
+  if (kind === 'symbol' || kind === 'iso') return formatTargetValue(value, 'currency', canonical)
+
+  // A real unit ('months', 'users', …) or a generic placeholder — suffixed.
+  return `${value.toLocaleString()} ${canonical}`
+}


### PR DESCRIPTION
**⚠ MERGE PAIRED WITH CEE #798.** Review verdict: **MERGE THE PAIR**, deploy order **CEE first** — #798 is merged and deployed (`24f49fd`), so this is next.

**Four review amendments applied in `c75ede4d` (A1–A4, all record/comment, none blocking).** They are marked ⚠ inline below.

#798 adds `goal_threshold_raw`/`_unit`/`_cap` to `analysis_ready`. On its own it cannot make the Inspector v2 goal sentence true, and a reachable sequence makes the surface *worse* (`≥ 0.8 £`). This is the consumer half.

---

## Part 1 — one sentence, two writers, two gates

`"Success means reaching ≥ …"` takes its **number** from `store.goalThreshold` (written by `setCeeAnalysisReady`, gated on `goalThreshold == null`) and its **unit** from `node.data.goal_threshold_unit` (written by `backfillGoalThresholdOntoGoalNode`, **ungated**). Both read the same payload; only one was allowed to act on it.

A session holding a bare **normalised** `0.8` therefore kept the `0.8` and took a later payload's `'£'` → **`≥ 0.8 £`**: a magnitude on one scale wearing the other scale's unit. Reachable, verified: `applyAnalysisReadyPatch` fires on every accepted `graph_patch`, `applyV5State`'s catch-all on every V5 turn carrying `analysis_ready` outside `applyDraftResult`, and `READINESS_CLEAR_FIELDS` clears none of the threshold fields.

**Two changes, because the gate alone does not close it.**

1. The gate now lets an attested **raw** value supersede the store's own un-attested **normalised** guess.
2. The panel applies the unit **only when the number is on the scale that unit describes** — because a payload carrying a unit and *no* raw still refreshes the unit while the number stays normalised. That residual is not closed by the gate, and it is the same false sentence.

**Why the gate cannot clobber a user's target — complete writer manifest for the `'normalised'` tag.** ⚠ **Amended (review A3): the manifest is 8 sites, not 7.** `goalThresholdRepresentation` is assigned at `store.ts` 1173, 1238, 1240, 1520, 2920, 2927, 3950 **and `applyDraftResult.ts:228`** — the eighth, which writes `null` beside `goalThreshold: null` and so cannot arm the gate. (Three further grep hits, :351/:1227/:1267, are type declarations.) Exactly **one** site can produce `'normalised'`: `store.ts:2920`, `setGoalThreshold`'s `opts.representation`, whose only non-test caller passing that option is the bare-sync branch inside `setCeeAnalysisReady` itself. `setGoalThresholdAndUpdateNode` hard-codes `'raw'` (:2927), `setGoalThreshold` defaults to `'raw'` (:2920), `deriveGoalThresholdFromNode` returns `'raw'` or `null`, and the rest are null resets. So the widened condition can only ever overwrite a value **this same reducer guessed**. Untagged (`null`) is treated as raw, as everywhere else in the estate, so legacy/restored state is untouched.

**⚠ The representation guard is PANEL-ONLY (review A4).** Every other reader of `store.goalThreshold` renders it with **no tag check** and would pair a normalised magnitude with a raw unit: `NodeInspector.tsx:334-348`, `SuccessTargetRow.tsx`, `BaselineTargetRow.tsx`, and `RangeVisualization` via `effectiveGoalThreshold` (`useResultsSectionData.ts:1338`) — all verified at **0 references to the tag**. Harmless today only because #798's raw anchor makes that shape unrepresentable, which is a **producer** property, not a UI one. Noted in `GoalPanel.tsx` so nobody infers protection those surfaces do not have.

**Why not collapse the two writers into one.** Considered and rejected: the node fields serve other readers (`GoalNode`, the debug bundle's `full_graph` export) and the store scalar serves the PLoT request boundary. Merging them changes the persisted node shape — a much larger change than the defect warrants. Coherence is instead enforced at the point of use, where the pair is actually asserted.

## Part 2 — the consumer stops re-deriving an attested value

`store.ts` multiplied `goal_threshold × goal_threshold_cap` when no raw arrived and tagged the **product** `'raw'` — a value this consumer computed, indistinguishable downstream from one the producer attested. ⚠ **Amended (review A2) — an earlier version of this PR said "#798 is precisely what makes it reachable". That was false, in the dangerous direction.** #798 is **raw-anchored**: a cap cannot reach the wire without a raw beside it, so `ceeRaw != null` always wins and the `norm × cap` branch stays **unreachable**. What #798 changed is that caps are emitted *at all* — and **its anchor is what keeps the branch dead**. Crediting #798 with creating the hazard would invite a future reader to remove that anchor believing the UI defends itself. (The anchor was verified in the CEE repo by the paired review, not by me.)

The synthesis is removed as **defence in depth** against that anchor loosening — it lives in another repo on another schema pin — not because a hazard is live.

This does **not** reopen the double-normalisation the branch was added to prevent. The value is stored untouched and tagged `'normalised'`, and `resolveChipGoalThreshold` (`useV2Run.ts:266`) short-circuits on that tag and never divides by a cap. Same value on the wire, nothing invented.

⚠ **This flips an existing pinned test** (`goalThresholdSync.spec.ts`, "derives raw from norm × cap"). Deliberate contract change, called out for reviewer sign-off.

## Part 3 — the formatter

Even on the good path the panel interpolated the number bare with the unit as a suffix: **`≥ 800000 £`**, never `£800,000`.

**Primitive adopted: `formatTargetValue`** (`src/components/results/utils/formatTargetValue.ts`) — it is already the estate's goal-target formatter (GoalNode, NodeInspector, BaselineTargetRow, SuccessTargetRow). But it takes a *structured* unit **kind**, while CEE sends a unit **string**, so every caller hand-rolled the mapping and the three copies drifted (`GoalNode` correct; `NodeInspector` sends any non-count unit as a currency **symbol**, so "months" renders `months9`; `GoalPanel` had no mapping at all). This PR adds the **missing string→kind mapping** in one place, `formatGoalTarget`, extracted **unchanged in behaviour** from GoalNode — the surface that was already right — and used by both. Not a fourth formatter: every branch delegates to `formatTargetValue`, every unit decision to the single-source `classifyUnit`.

**`formatValueWithUnit` was rejected**, deliberately: its qualitative branch turns any unitless 0–1 magnitude into a word, so a still-normalised target would read **`≥ very high`**. That is the exact hazard #561 review item A3 pinned (the branch keys on `classifyUnit(unit).kind` and the 0–1 bound, *not* on whether the magnitude is raw). The model-tab sibling was rejected too — scoped to observed states, no percent branch, would render `20 %`.

**`'count'` is SUPPRESSED.** It is the digit-string brief form's placeholder (the wire type documents it: `adapters/cee/types.ts` — *"e.g. \"count\", \"USD\""*), on no real-world scale, and in neither `COUNT_UNITS` (which is about rounding headcounts) nor `GENERIC_PLACEHOLDER_UNITS`. **Three existing authorities already drop it** — `GoalNode` (`u === 'count'`), `NodeInspector` (`unitStr !== 'count'`), and `formatTargetValue`'s own `'count'` kind, which decorates nothing. Inspector v2 was the one surface printing it. It is deliberately **not** added to `GENERIC_PLACEHOLDER_UNITS`, which would silently change factor and intervention rendering estate-wide.

---

## RED-first at pristine `cb957c8c`

| # | Assertion | Pristine signature |
|---|---|---|
| 1 | store: raw supersedes normalised | `expected 0.8 to be 800000` |
| 2 | store: no norm×cap synthesis | `expected 20 to be 0.8` |
| 3 | panel: raw supersedes normalised | `expected 0.8 to be 800000` |
| 4 | panel: routed through the authority | rendered `Success means reaching ≥ 800000 £` |
| 5 | panel: `count` suppressed | rendered `Success means reaching ≥ 800000 count` |
| 6 | panel: normalised keeps no raw unit | rendered `Success means reaching ≥ 0.8 £` |
| 7 | panel: user target not clobbered | rendered `≥ 15 £`, expected `£15` |

`GoalNode.goalTargetAgreement.spec.tsx` **passes at pristine** — the control showing the canvas card was already correct and the extraction is faithful. It also explains the walk: the card reads number *and* unit from the same `node.data`; only the panel mixed two sources.

## Mutation table — every fix reverted, in a throwaway worktree outside the repo root, on committed state

| Mutant | Reverted | REDs |
|---|---|---|
| M1 | gate widening → `goalThreshold == null` only | 2 (store + panel) |
| M2 | restore `norm × cap` synthesis | 1 (store) |
| M3 | panel back to bare number + unit suffix | 5 (panel) |
| M4 | drop the representation gate in the panel | 1 (panel) |
| M5 | break `count` suppression in the shared helper | 3 — **card, panel and helper** |
| M6 | break the currency prefix in the shared helper | 7 — **card, panel and helper** |

M5/M6 REDding *both* surfaces is the proof that agreement is structural, not a convention.

## Gates (derived at this tip, not quoted from a doc)

- **typecheck** `pnpm typecheck` — coverage 3162/3202 (40 declared out of scope); ratchet **622 files / 2505 errors, exactly at baseline**. Two new errors my first spec introduced were fixed **at source**, never absorbed into a baseline.
- **lint** `npx eslint .` — **0 errors** (1261 warnings; the warnings in touched files are pre-existing and untouched).
- **hooks ratchet** — 234 violations across 16 files, **exactly matching baseline**.
- **full suite** — `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported: **1448 files passed, 3 skipped; 21380 tests passed, 66 skipped, 0 failures.** Inspector v2 alone collects **34 files / 355 tests** (the healthy 33/349 plus this PR's one new file).

⚠ **A voided run, disclosed.** My first baseline run re-read a spec file I had edited mid-flight, so it was contaminated and I discarded it (CLAUDE.md 9b). It also showed 2 failures in `EdgeEditPopover.perf.spec.tsx`; those are **millisecond wall-clock budgets that are load-flaky under a full parallel run** — 15/15 pass unloaded, and 0 failures in two subsequent clean full runs (CLAUDE.md trap 6). The review independently hit a *different* file on the same mechanism (`realtime-signals`, 8.9 ms against a 5 ms budget), which sharpens the attribution: **the flaky set is millisecond wall-clock budgets generally, not the two files I first named.** Not related to this change.

## Scope

Untouched: the #560 receipt-gating, the #561 silent-rebase disclosure, the flip/goal-probability selectors, `GENERIC_PLACEHOLDER_UNITS`, `COUNT_UNITS`.

**Not fixed here, reported instead:** `NodeInspector.tsx:347` (legacy inspector) passes any non-count, non-percent unit to `formatTargetValue` as a **currency symbol**, so a "months" target renders `months9`. It is a real latent bug on a legacy surface, needs its own tests, and is out of this PR's scope.

**Declared inheritance:** an ISO code renders without a space (`GBP800,000`) because `formatTargetValue` treats its third argument as a symbol. That is the canvas card's existing output; preserving it keeps the extraction behaviour-preserving. Pinned in the spec so a future correction is a decision, not a drift.

## After #563 + #798 deploy together

Panel: **"Success means reaching ≥ £800,000"**. Card: **"Target: £800,000"**. Same value+unit token, different surrounding copy by design. Test-proven in jsdom; the review additionally drove both real components from a witnessed-mint payload and got `≥ £6,000,000` / `Target: £6,000,000`.

⚠ **Amended (review A1) — I had called this "byte-identical BY CONSTRUCTION". Overstated.** What is structural is the **formatter**; the **inputs** are two sources — the panel reads the store scalar, the card reads `node.data` — which agree only while the scalar is current. **Given equal inputs the two surfaces cannot disagree**, and that is the half that was actually broken.

**One reachable divergence, named:** a later `graph_patch` **raising** the target updates the node through the ungated backfill while the gate (raw is not superseded by raw) leaves the scalar stale — the panel shows the old figure, the card the new, and the run sends the old. **Pre-existing, not a regression:** the pristine gate (`goalThreshold == null`, `store.ts:4013` at `cb957c8c`) blocks the same refresh identically. Deliberately **not** widened here; rowed separately by the review.

## Scope limit

jsdom pins the **rendered string**. It cannot prove the sentence is visible, laid out, or above the fold (CLAUDE.md trap 3). No claim here is a layout claim. Nothing in this PR has been verified on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
