### PR TITLE
fix(ui): before the first analysis, an unreachable OR missing readiness service ALWAYS granted the run — publish no verdict instead (ROADMAP 2.319a + 2.329)

### DIFF
--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -36,6 +36,35 @@ export interface DeduplicatedResponse {
   retryAfterHeader: string | null
 }
 
+/**
+ * The server answered, but its body could not be read as JSON.
+ *
+ * This type exists to keep two different facts apart at the ONE catch site
+ * that sees both. `deduplicatedFetch` performs the `fetch()` and the
+ * `response.json()` inside a single async IIFE, so a caller awaiting the
+ * returned promise cannot otherwise distinguish "I never reached the server"
+ * from "I reached it and could not read its reply". Neither is a readiness
+ * verdict — but they are different things to report, and conflating them is
+ * how a transport failure came to be presented as a model assessment
+ * (ROADMAP 2.319a).
+ *
+ * Transport rejections are deliberately NOT wrapped: they propagate exactly
+ * as `fetch()` threw them, so a caller can still read the underlying cause.
+ */
+export class ReadinessBodyUnreadableError extends Error {
+  /** HTTP status of the response whose body would not parse. */
+  readonly status: number
+  /** The original `response.json()` rejection. */
+  readonly parseError: unknown
+
+  constructor(status: number, parseError: unknown) {
+    super(`Readiness response body was not readable JSON (HTTP ${status})`)
+    this.name = 'ReadinessBodyUnreadableError'
+    this.status = status
+    this.parseError = parseError
+  }
+}
+
 interface InflightEntry {
   promise: Promise<DeduplicatedResponse>
   timestamp: number
@@ -85,7 +114,15 @@ function deduplicatedFetch(
       signal: controller.signal,
     })
     if (response.ok) {
-      const data = await response.json()
+      // Tag a parse failure so the caller can tell it from a transport
+      // failure. Both mean "no verdict", but only one of them means the
+      // server was never reached — see ReadinessBodyUnreadableError.
+      let data: unknown
+      try {
+        data = await response.json()
+      } catch (parseErr) {
+        throw new ReadinessBodyUnreadableError(response.status, parseErr)
+      }
       return {
         ok: true,
         status: response.status,

--- a/src/canvas/stores/__tests__/readinessStore.notFound.spec.tsx
+++ b/src/canvas/stores/__tests__/readinessStore.notFound.spec.tsx
@@ -1,0 +1,317 @@
+/**
+ * readinessStore — a 404 from the readiness service is an OUTAGE, not a verdict.
+ *
+ * ROADMAP 2.329. PR #564 made a rejected fetch publish no verdict and say why,
+ * and deliberately left the 404 branch alone pending adjudication. The
+ * adjudication is now derived, at the deployed bytes
+ * (`PHASE0-EVIDENCE-2026-07-28/adjudication-2329-404-branch.md`):
+ *
+ *   · No deployed configuration produces a 404 on this path BY DESIGN. On the
+ *     PLoT deploy branch the route is registered unconditionally — no flag or
+ *     env posture can remove it — and a missing `CEE_BASE_URL`/`CEE_API_KEY`
+ *     yields an error RESPONSE from a registered handler, never a 404. Staging
+ *     answers 401 (registered, auth-gated) against a control path that 404s.
+ *   · The `'/bff/cee'` same-origin fallback does not survive minification in
+ *     either deployed bundle (zero literals across an 81-chunk staging crawl
+ *     and a 40-chunk production crawl), so the "dead SPA redirect" 404 vector
+ *     is unreachable in the shipped artifacts.
+ *   · One deployed configuration DOES 404 in steady state: production, whose
+ *     PLoT predates the route by ~6.5 months while its paired UI bundle bakes
+ *     the call in. That is deploy drift — the outage class — and this very
+ *     branch is what has kept it invisible.
+ *
+ * So the 404 branch was answering an outage with a locally-computed verdict
+ * and `error: null`: the same defect 2.319(a) fixed for transport failures,
+ * on the branch that was left out of it. These tests pin the same treatment —
+ * publish no verdict, set a truthful error, stay retryable.
+ *
+ * Scope notes:
+ *   · CLAUDE.md trap 3 — every store assertion here is on store state. The one
+ *     component test asserts the PRESENCE of the retry control in the rendered
+ *     output; it is not a visibility, layout or above-the-fold claim.
+ *   · CLAUDE.md trap 13 — the absence assertions are preceded by positive
+ *     controls proving this harness can SEE a verdict and a null error arrive.
+ *   · The prior-verdict test binds by OBJECT IDENTITY (`toBe`), not by field
+ *     values, so no re-derived look-alike object can satisfy it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useReadinessStore, __test__ } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { PreAnalysisHealth } from '../../components/PreAnalysisHealth'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/**
+ * What the readiness path returns when the route is not there. Shaped as
+ * `deduplicatedFetch` sees it: `ok: false`, so it RESOLVES rather than
+ * rejecting, and the body is read with `.text()`.
+ */
+function mock404Response() {
+  return {
+    ok: false,
+    status: 404,
+    statusText: 'Not Found',
+    json: () => Promise.reject(new Error('not json')),
+    text: () => Promise.resolve('{"message":"Route POST:/v1/cee/graph-readiness not found"}'),
+    headers: new Headers(),
+  }
+}
+
+/** A server answer that CLOSES the gate — the ROADMAP 2.308 blocked state. */
+function mockBlockedServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: 'One option still needs its effect values',
+        improvements: [],
+        options_ready: 1,
+        options_total: 2,
+        goal_node_valid: true,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** A server answer that OPENS the gate — the trap-13 positive control. */
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  // graphHealth is deliberately left at its initial `null` — the state of a
+  // canvas that has not yet been analysed. That is what made the local
+  // heuristic find zero blockers and therefore ALWAYS grant the run.
+  useCanvasStore.setState({ nodes: nodes as any, edges: edges as any })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — a 404 is an outage, not a verdict (ROADMAP 2.329)', () => {
+  // ── Positive controls (CLAUDE.md trap 13) ────────────────────────
+  // Prove the harness can observe BOTH a verdict arriving and a null error,
+  // before asserting that a 404 produces neither.
+  describe('positive control — the harness can observe a real server verdict', () => {
+    it('observes can_run_analysis true and error null when the server opens the gate', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+
+    it('observes can_run_analysis false when the server closes the gate', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+    })
+  })
+
+  // ── RED 1 — the silent half: a 404 reported as no failure at all ──
+  describe('a 404 is reported as a failure', () => {
+    it('does not report error: null when the readiness route is not found', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mock404Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
+    })
+
+    it('names the failure as the service not being found, distinctly from unreachable and unreadable', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mock404Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const error = useReadinessStore.getState().error
+      expect(error).toMatch(/could not find/i)
+      // The three no-verdict paths stay tellable apart at the store: this is
+      // not the transport failure (2.319a) and not the unreadable body.
+      expect(error).not.toMatch(/could not reach/i)
+      expect(error).not.toMatch(/could not read the/i)
+    })
+  })
+
+  // ── RED 2 — the dangerous half: the gate opened on local authority ──
+  describe('a 404 never grants the run on local authority', () => {
+    it('does not set can_run_analysis true when the readiness route is not found', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mock404Response())
+      // 3 nodes + 1 edge with graphHealth null — the heuristic's most
+      // permissive input: it scores 80 and finds zero blockers.
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).not.toBe(true)
+    })
+
+    it('publishes no locally-invented verdict at all when it has never had one from the server', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mock404Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      // `readiness === null` alongside a non-null `error` is the store's
+      // pre-existing "unknown" state — the same one 2.319(a) restored for
+      // transport failures. No third state is introduced here.
+      expect(useReadinessStore.getState().readiness).toBeNull()
+      expect(useReadinessStore.getState().error).not.toBeNull()
+    })
+  })
+
+  // ── RED 3 — a 404 must not overwrite a verdict the server gave ────
+  describe('a 404 never replaces a verdict the server already gave', () => {
+    it('leaves the exact verdict object the server produced in place', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      // Bind to the verdict by IDENTITY. A value predicate (score === 62)
+      // could be satisfied by any object carrying the same numbers; this can
+      // only be satisfied by the object the server's answer produced.
+      const serverVerdict = useReadinessStore.getState().readiness
+      expect(serverVerdict).not.toBeNull()
+      expect(serverVerdict!.can_run_analysis).toBe(false)
+
+      // The route disappears under it. refresh() clears the payload hash, so
+      // this is a real second request for the same graph, exactly as a retry
+      // or a redeploy mid-session would be.
+      mockFetch.mockResolvedValue(mock404Response())
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness).toBe(serverVerdict)
+      expect(useReadinessStore.getState().error).not.toBeNull()
+    })
+  })
+
+  // ── Preserved behaviour (passes at pristine — pinned, not claimed) ──
+  describe('a 404 stays retryable', () => {
+    it('leaves the failed payload re-requestable — a 404 is not sticky', async () => {
+      vi.useFakeTimers()
+      mockFetch.mockResolvedValue(mock404Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Re-enter with the IDENTICAL payload, deliberately NOT via refresh():
+      // refresh() clears `lastPayloadHash` itself and would therefore mask a
+      // hash the 404 had poisoned. clearInflightCache() isolates the store's
+      // own hash from the 750ms dedup window.
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      await __test__.fetchReadiness()
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  // ── The state a 404 leaves is one a surface can act on ────────────
+  //
+  // PRESENCE, not visibility (CLAUDE.md trap 3): this renders the component
+  // that owns the `error && !readiness` branch and asserts the retry control
+  // is in the output. It binds to the real component rather than restating
+  // its predicate, so a change that made the 404 state unreachable from that
+  // branch would fail here.
+  //
+  // ⚠ HONEST SCOPE — this proves the state is ACTIONABLE, not that any user
+  // sees it: `PreAnalysisHealth` has ZERO importers in `src/` at this commit
+  // (derived: `grep -arn PreAnalysisHealth` over the tree hits only the
+  // component itself, this spec, a store comment and two CI-baseline
+  // artifacts). Mounting it is separate work and is NOT claimed by this PR.
+  describe('the state a 404 leaves is one the health surface can act on', () => {
+    it('reaches the retry control in PreAnalysisHealth after a 404', async () => {
+      mockFetch.mockResolvedValue(mock404Response())
+      seedCanvasWithNodes(3)
+
+      render(<PreAnalysisHealth />)
+
+      expect(
+        await screen.findByRole('button', { name: /retry health check/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('positive control — the same surface does NOT show retry when the server answers', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+
+      render(<PreAnalysisHealth />)
+
+      // Wait for the verdict to land, then assert the retry branch is absent.
+      expect(await screen.findByTestId('pre-analysis-health')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /retry health check/i })).toBeNull()
+    })
+  })
+})

--- a/src/canvas/stores/__tests__/readinessStore.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.spec.ts
@@ -6,7 +6,7 @@
  * - Debounce coalesces rapid changes
  * - refresh() bypasses debounce
  * - reset() unsubscribes and clears state
- * - Fallback on 404 / backoff on 429
+ * - No verdict + error on 404 (ROADMAP 2.329) / backoff on 429
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useReadinessStore, __test__ } from '../readinessStore'
@@ -299,17 +299,25 @@ describe('readinessStore', () => {
   })
 
   describe('error handling', () => {
-    it('falls back to local readiness on 404', async () => {
+    // ROADMAP 2.329 — this test used to read `falls back to local readiness on
+    // 404` and asserted `error === null` with a locally-computed verdict
+    // present. It was pinning the defect: a 404 on the readiness path is an
+    // outage (no deployed configuration produces one by design — derived at the
+    // deployed bytes, PHASE0-EVIDENCE-2026-07-28/adjudication-2329-404-branch.md)
+    // and an outage is not a readiness verdict. The full treatment, with its
+    // positive controls and identity-bound prior-verdict clause, lives in
+    // readinessStore.notFound.spec.tsx; this is the sibling suite's own guard
+    // against the old behaviour returning.
+    it('publishes no verdict and reports an error on 404', async () => {
       mockFetch.mockResolvedValue(mock404Response())
       seedCanvasWithNodes(3)
       useReadinessStore.getState().startListening()
       await vi.runAllTimersAsync()
 
       const state = useReadinessStore.getState()
-      expect(state.readiness).not.toBeNull()
-      // Fallback score for 3 nodes + 1 edge: 50 + 10 + 10 + 10 = 80
-      expect(state.readiness!.readiness_score).toBeGreaterThan(0)
-      expect(state.error).toBeNull()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
     })
 
     it('backs off on 429 and uses fallback', async () => {

--- a/src/canvas/stores/__tests__/readinessStore.unreachable.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.unreachable.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * readinessStore — "I could not reach the server" is not a server verdict.
+ *
+ * ROADMAP 2.319(a). `deduplicatedFetch` performs BOTH the `fetch()` and the
+ * `response.json()` inside one async IIFE, so `await promise` in
+ * `fetchReadiness` rejects for EVERY transport failure — cold start, CORS,
+ * DNS, TLS — and not merely for a non-JSON body. The deployed UI calls its
+ * readiness service cross-origin, so those are live failure modes, not
+ * theoretical ones.
+ *
+ * At pristine that rejection fell through to `calculateFallbackReadiness` — a
+ * node/edge-count heuristic whose verdict is `can_run_analysis:
+ * blockers.length === 0`, where `blockers` come from `graphHealth`, which is
+ * `null` until an analysis has already run (canvas `store.ts` initial state).
+ * So on the pre-analysis canvas the heuristic ALWAYS granted the run, and the
+ * store reported `error: null` — presenting a locally-invented verdict as the
+ * server's, on the exact surface ROADMAP 2.308 had just repaired.
+ *
+ * What these tests pin:
+ *   1. a transport failure never reports `error: null`;
+ *   2. a transport failure never grants `can_run_analysis` on local authority;
+ *   3. a transport failure never REPLACES a verdict the server already gave —
+ *      this is the clause that keeps the 2.308 blocked state closed;
+ *   4. the jsdom accommodation the original catch was written for still holds:
+ *      a rejecting fetch settles the store instead of crashing or hanging.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion here is on store state. No
+ * claim in this file is a layout or visibility claim.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore, __test__ } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/** A server answer that CLOSES the gate — the ROADMAP 2.308 blocked state. */
+function mockBlockedServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: 'One option still needs its effect values',
+        improvements: [],
+        options_ready: 1,
+        options_total: 2,
+        goal_node_valid: true,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** A server answer that OPENS the gate — used as the trap-13 positive control. */
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/**
+ * What `fetch()` does when the host is unreachable. undici (Node's fetch, the
+ * one jsdom uses) rejects with a TypeError for a cold start, a CORS refusal, a
+ * DNS failure, a TLS failure AND for the invalid relative URL that jsdom
+ * produces — one class, one rejection, all arriving at the same catch.
+ */
+function networkRejection() {
+  return Promise.reject(new TypeError('Failed to fetch'))
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  // graphHealth is deliberately left at its initial `null`: that is the state
+  // of a canvas that has not yet been analysed, and it is what makes the local
+  // heuristic's `blockers.length === 0` grant the run.
+  useCanvasStore.setState({ nodes: nodes as any, edges: edges as any })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — unreachable readiness service (ROADMAP 2.319a)', () => {
+  // ── Positive control (CLAUDE.md trap 13) ─────────────────────────
+  // Before asserting what the store does NOT report on a rejection, prove this
+  // harness can SEE both verdicts arriving from a server that does answer.
+  // Without this, every assertion below could pass by testing nothing.
+  describe('positive control — the harness can observe a real server verdict', () => {
+    it('observes can_run_analysis true and a null error when the server opens the gate', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+
+    it('observes can_run_analysis false when the server closes the gate', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+    })
+  })
+
+  // ── RED 1 — the silent part of the defect ────────────────────────
+  describe('a transport failure is reported as a failure', () => {
+    it('does not report error: null when the readiness service cannot be reached', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
+    })
+
+    it('names the failure as a reachability failure, not a model verdict', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().error).toMatch(/could not reach/i)
+    })
+  })
+
+  // ── RED 2 — the dangerous part of the defect ─────────────────────
+  describe('a transport failure never grants the run on local authority', () => {
+    it('does not set can_run_analysis true when the readiness service cannot be reached', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      // 3 nodes + 1 edge with graphHealth null — the heuristic's most
+      // permissive input, scoring 80 and finding zero blockers.
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).not.toBe(true)
+    })
+
+    it('publishes no locally-invented verdict at all when it has never had one from the server', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      // `readiness === null` alongside a non-null `error` is the store's
+      // existing, already-rendered "unknown" state (PreAnalysisHealth's
+      // "Could not check graph health" + Retry). No third state is invented.
+      expect(useReadinessStore.getState().readiness).toBeNull()
+      expect(useReadinessStore.getState().error).not.toBeNull()
+    })
+  })
+
+  // ── RED 3 — the ROADMAP 2.308 clause ─────────────────────────────
+  describe('a transport failure never replaces a verdict the server already gave', () => {
+    it('keeps the server\'s can_run_analysis:false when the next fetch cannot reach the server', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+
+      // The network drops. refresh() clears the payload hash so this is a real
+      // second request for the same graph, exactly as a retry would be.
+      mockFetch.mockImplementation(() => networkRejection())
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(false)
+      expect(state.readiness?.confidence_explanation).toBe(
+        'One option still needs its effect values',
+      )
+      expect(state.error).not.toBeNull()
+    })
+
+    it('does not overwrite the server verdict with the heuristic score', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      mockFetch.mockImplementation(() => networkRejection())
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      // The heuristic would score this graph 80 ('strong'); the server said 62.
+      expect(useReadinessStore.getState().readiness?.readiness_score).toBe(62)
+      expect(useReadinessStore.getState().readiness?.readiness_level).toBe('fair')
+    })
+  })
+
+  // ── The two failure modes are told apart ─────────────────────────
+  describe('a 2xx whose body will not parse is reported as its own failure', () => {
+    it('says the response was unreadable, not that the service was unreachable', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+        text: () => Promise.resolve('<html>maintenance</html>'),
+        headers: new Headers(),
+      })
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.error).toMatch(/could not read/i)
+      expect(state.error).not.toMatch(/could not reach/i)
+      // Still no verdict — an unreadable answer is not an answer.
+      expect(state.readiness).toBeNull()
+    })
+  })
+
+  // ── The accommodation the original catch existed for ─────────────
+  describe('the jsdom accommodation still holds', () => {
+    it('settles rather than crashing or hanging when fetch rejects', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+
+      expect(() => useReadinessStore.getState().startListening()).not.toThrow()
+      await expect(vi.runAllTimersAsync()).resolves.toBeDefined()
+
+      expect(useReadinessStore.getState().loading).toBe(false)
+    })
+
+    it('leaves the failed payload re-requestable — a transport failure is not sticky', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Re-enter the fetch with the IDENTICAL payload. Deliberately NOT via
+      // refresh(): refresh() clears `lastPayloadHash` itself, so it would mask
+      // a hash the failure had poisoned — an earlier draft of this test did
+      // exactly that and a mutant caching the failed hash SURVIVED it.
+      // clearInflightCache() isolates the store's own hash from the 750ms
+      // dedup window, which under fake timers would otherwise replay the same
+      // rejected promise.
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      await __test__.fetchReadiness()
+      await vi.runAllTimersAsync()
+
+      // A second real request went out — the failed payload was not cached.
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -441,14 +441,56 @@ async function fetchReadiness(): Promise<void> {
           return
         }
 
+        // ── ROADMAP 2.329: a 404 here is an OUTAGE, not a deployment choice ──
+        //
+        // This branch used to publish `calculateFallbackReadiness` with NO
+        // error — the same defect 2.319(a) fixed one level up, on the path
+        // that was left out of it pending adjudication. The adjudication is
+        // now derived at the deployed bytes
+        // (PHASE0-EVIDENCE-2026-07-28/adjudication-2329-404-branch.md):
+        //
+        //   · NO deployed configuration produces a 404 on this path BY DESIGN.
+        //     On PLoT's deploy branch the route is registered UNCONDITIONALLY
+        //     — `createServer` → `registerV1Routes` → `registerCeeProxyRoutes`
+        //     → `app.post('/v1/cee/graph-readiness', …)`, no guard at any hop —
+        //     and a missing CEE_BASE_URL/CEE_API_KEY yields an error RESPONSE
+        //     from a registered handler, never a 404. Staging answers 401
+        //     (registered, auth-gated) where a control path answers 404.
+        //   · The `'/bff/cee'` same-origin fallback does not survive
+        //     minification in either deployed bundle (zero literals across an
+        //     81-chunk staging crawl and a 40-chunk production crawl), so the
+        //     "dead SPA redirect returns index.html" 404 vector is unreachable
+        //     in the shipped artifacts.
+        //   · One deployed configuration DOES 404 in steady state: production,
+        //     whose PLoT predates the route by ~6.5 months while its paired UI
+        //     bundle (built two months AFTER the route landed) bakes the call
+        //     in. That is deploy drift — the outage class — and this branch is
+        //     precisely what kept it invisible for those months.
+        //
+        // So there is no configuration this branch could be serving. Treat it
+        // exactly as a transport failure is treated: publish no verdict, set a
+        // truthful error, leave `lastPayloadHash` unset so a redeploy is picked
+        // up on the next request. `readiness` is left EXACTLY as it was — null
+        // on first load (the store's own "unknown" state), otherwise the last
+        // answer the server actually gave, which a local guess is not entitled
+        // to replace.
+        //
+        // Deliberately NOT a third state, and deliberately not `false`: both
+        // were considered and rejected at the transport catch above, for the
+        // same reasons (trap-12 tri-state threading; a false "no" is still a
+        // locally invented verdict).
+        //
+        // Consequence, stated rather than buried: shipped to production as-is
+        // against today's production PLoT, readiness would report a permanent,
+        // TRUTHFUL "could not check" until prod PLoT redeploys. That is a real
+        // outage becoming visible, not a regression introduced here.
         if (response.status === 404) {
-          if (import.meta.env.DEV) {
-            console.info(
-              '[readinessStore] CEE graph-readiness endpoint not available (404), using local validation',
-            )
-          }
-          const fallback = calculateFallbackReadiness(currentNodes, currentEdges, graphHealth)
-          useReadinessStore.setState({ readiness: fallback, loading: false })
+          const message = 'Could not find the readiness service'
+          console.warn(
+            `[readinessStore] ${message} (HTTP 404) — publishing no verdict:`,
+            response.errorBody,
+          )
+          useReadinessStore.setState({ error: message, loading: false })
           return
         }
 

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -21,6 +21,7 @@ import type {
 } from '../hooks/useGraphReadiness'
 import {
   ACCEPTED_READINESS_LEVELS,
+  ReadinessBodyUnreadableError,
   __test__ as dedupUtils,
 } from '../hooks/useGraphReadiness'
 import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
@@ -331,16 +332,88 @@ async function fetchReadiness(): Promise<void> {
         currentInflightEntry = entry
         response = await promise
       } catch (fetchErr) {
-        // In test environments (jsdom), relative URLs cause TypeError.
-        // Fall back to local readiness rather than crashing.
+        // An abort is a cancellation, not a failure — the outer catch owns it.
         if ((fetchErr as Error).name === 'AbortError') throw fetchErr
-        console.warn('[readinessStore] Fetch setup failed, using fallback:', fetchErr)
-        const fallback = calculateFallbackReadiness(currentNodes, currentEdges, graphHealth)
-        useReadinessStore.setState({
-          readiness: fallback,
-          error: null,
-          loading: false,
-        })
+
+        // ── ROADMAP 2.319(a): no verdict is not a verdict ────────────
+        //
+        // `deduplicatedFetch` performs BOTH the `fetch()` and the
+        // `response.json()` inside one async IIFE, so everything below lands
+        // here as a single rejection:
+        //   · every transport failure — connection reset, cold start, offline,
+        //     DNS, TLS, and CORS. This call IS cross-origin in the deployed
+        //     UI, and that is NOT derivable from this repo (CLAUDE.md trap 18):
+        //     `CEE_BASE_URL` defaults to the same-origin path `/bff/cee` and
+        //     nothing in the tree sets `VITE_CEE_BFF_BASE`. It is set in the
+        //     NETLIFY DASHBOARD to the absolute URL
+        //     `https://plot-lite-service-staging.onrender.com/v1/cee` and Vite
+        //     INLINES it at build time — established by a recursive crawl of
+        //     the deployed JS chunks (zero `/bff/cee` literals, four absolute
+        //     `/v1/cee` hits) and corroborated by that service's own route
+        //     counters showing live traffic to those paths. So a cold start on
+        //     Render, a CORS refusal or a TLS failure all land here in
+        //     production. The fix does not rest on that fact — same-origin
+        //     fetches reject too — but it is why the blast radius is wide;
+        //   · jsdom's invalid-relative-URL TypeError, which is the single
+        //     case this catch was originally written for; and
+        //   · a 2xx whose body would not parse as JSON.
+        // A non-2xx response does NOT arrive here — `response.ok` is false and
+        // it is handled immediately below.
+        //
+        // What this used to do is the defect, and it was SYSTEMATIC rather
+        // than transient. It fell through to `calculateFallbackReadiness` — a
+        // node/edge-count heuristic whose verdict is
+        // `can_run_analysis: blockers.length === 0`, where the blockers come
+        // from `graphHealth`. `graphHealth` is `null` in the canvas store's
+        // initial state and is only ever populated from a COMPLETED analysis
+        // report's `graph_quality`. So before the first analysis there are
+        // never any blockers to find, and an unreachable server did not merely
+        // RISK opening the gate — it ALWAYS granted the run, on the most
+        // common path there is.
+        //
+        // And because it OVERWROTE `readiness` while reporting `error: null`,
+        // it also replaced a `can_run_analysis: false` the server had already
+        // given (the ROADMAP 2.308 blocked state) with a locally invented
+        // `true` that no consumer could distinguish from the server's own
+        // answer.
+        //
+        // So: publish no verdict, and say why.
+        //   · `readiness` is left EXACTLY as it was. On first load that is
+        //     `null`, which — alongside a non-null `error` — is the store's
+        //     OWN pre-existing "unknown" state, and it already has a rendered
+        //     surface: PreAnalysisHealth shows "Could not check graph health"
+        //     with a Retry button on `error && !readiness`. That branch was
+        //     UNREACHABLE on this path precisely because the fallback always
+        //     populated `readiness`. Nothing new is introduced here; a dormant
+        //     honest path is restored.
+        //   · Otherwise it is the last answer the server actually gave, which
+        //     a local guess is not entitled to replace.
+        //   · `lastPayloadHash` is deliberately still unset, so the identical
+        //     graph can be re-requested — a failure here must not be sticky.
+        //
+        // Two alternatives were considered and rejected, recorded here because
+        // the next reader will reach for one of them:
+        //   · Threading a tri-state `can_run_analysis` ('yes' | 'no' |
+        //     'unknown') through its SIX non-test consumers — PreAnalysisHealth,
+        //     usePreAnalysisData, usePreAnalysisModel, canRunAnalysis,
+        //     composeBlockedReason and the two gate call sites. That is the
+        //     hand-maintained-mirror shape (CLAUDE.md trap 12): a consumer
+        //     missed keeps reading a boolean and fails SILENTLY, in the
+        //     permissive direction. A state the store cannot lie about beats a
+        //     state six readers must each remember to honour.
+        //   · Setting `can_run_analysis: false` here. It is equally a locally
+        //     invented verdict, just in the blocking direction — and with no
+        //     prior server answer it strands the user behind a disabled Run
+        //     button with copy composed from verdict fields that do not exist,
+        //     which is exactly the permanent-dead-end class ROADMAP 2.308 was
+        //     opened to fix. Trading a false "yes" for a false "no" is not a
+        //     fix; refusing to answer is.
+        const message =
+          fetchErr instanceof ReadinessBodyUnreadableError
+            ? 'Could not read the readiness service response'
+            : 'Could not reach the readiness service'
+        console.warn(`[readinessStore] ${message} — publishing no verdict:`, fetchErr)
+        useReadinessStore.setState({ error: message, loading: false })
         return
       }
 


### PR DESCRIPTION
## ROADMAP 2.319(a), P0 — before the first analysis, an unreachable readiness service **always** granted the run

`deduplicatedFetch` performs **both** the `fetch()` and the `response.json()` inside one async IIFE, so `await promise` in `fetchReadiness` rejects for **every** transport failure, not merely for a non-JSON body.

The catch then fell through to `calculateFallbackReadiness` — a node/edge-count heuristic whose verdict is `can_run_analysis: blockers.length === 0`, where the blockers come from `graphHealth`. **`graphHealth` is `null` in the canvas store's initial state and is only ever populated from a *completed* analysis report's `graph_quality`.** So before the first analysis there are never any blockers to find, and an unreachable server did not merely *risk* opening the gate — **it always granted the run, on the most common path there is.** The row framed this as "a network blip can flip the gate open"; the `graphHealth` initial state makes it systematic rather than transient.

And because it *overwrote* `readiness` while reporting **`error: null`**, it also replaced a `can_run_analysis: false` the server had already given — the ROADMAP 2.308 blocked state, repaired in CEE #796 — with a locally invented `true` that no consumer could distinguish from the server's own answer.

**The call is cross-origin in the deployed UI, and that is not derivable from this repo** (CLAUDE.md trap 18): `CEE_BASE_URL` defaults to the same-origin path `/bff/cee` and nothing in the tree sets `VITE_CEE_BFF_BASE`. It is set in the **Netlify dashboard** to `https://plot-lite-service-staging.onrender.com/v1/cee`, inlined by Vite at build time — established by a recursive crawl of the deployed JS chunks (zero `/bff/cee` literals, four absolute `/v1/cee` hits) and corroborated by that service's own route counters. So a Render cold start, a CORS refusal or a TLS failure all land here in production. The fix does not rest on that fact — same-origin fetches reject too — but it is why the blast radius is wide.

**RED-first at `9c15b319`, measured not argued.** Server answering `can_run_analysis: false, readiness_score: 62`; a rejecting fetch left the store holding `can_run_analysis: true, readiness_score: 80`, `error: null`.

```
× does not report error: null when the service cannot be reached  → expected null not to be null
× names the failure as a reachability failure, not a model verdict → toMatch(/could not reach/i)
× does not set can_run_analysis true when unreachable              → expected true not to be true
× publishes no locally-invented verdict when it never had one      → expected { readiness_score: 80, …(4) } to be null
× keeps the server's can_run_analysis:false on the next failure    → expected true to be false
× does not overwrite the server verdict with the heuristic score   → expected 80 to be 62
```

Two positive controls (trap 13) and both jsdom-accommodation tests **passed at pristine**, so the absence assertions can see a presence, and the preserved behaviour is preserved rather than claimed.

## What changes

1. **The two failure modes are told apart at their source.** `.json()` is wrapped so a parse failure throws `ReadinessBodyUnreadableError`. Transport rejections are deliberately **not** wrapped — they propagate exactly as `fetch()` threw them, so the dedup spec's existing `rejects.toThrow('Failed to parse URL')` still holds.
2. **The catch publishes no verdict, and says why.** `readiness` is left exactly as it was; only `error` and `loading` are written. `error` is never `null` on this path.

## No third state was invented — a dormant one was restored

The store already had one: `readiness === null` alongside a non-null `error`. `PreAnalysisHealth` renders exactly that as **"Could not check graph health" with a Retry button** (`error && !readiness`, `PreAnalysisHealth.tsx:196`) — a branch that was **unreachable on this path** precisely because the fallback always populated `readiness`. This is not new machinery; it is machinery that already existed and could never fire.

Both rejected alternatives are recorded **at the catch site**, because the next reader will reach for one of them:

- **Threading a tri-state through the six non-test consumers** — the hand-maintained-mirror shape (trap 12); a consumer missed keeps reading a boolean and fails *silently*, in the permissive direction.
- **`can_run_analysis: false`** — equally a locally invented verdict, just in the blocking direction, stranding the user behind a disabled Run button with copy composed from verdict fields that do not exist: the same dead-end class 2.308 was opened to fix. Trading a false "yes" for a false "no" is not a fix; refusing to answer is.

**Stated plainly rather than buried:** with no prior server verdict the run gate stays permissive, because every consumer reads `readiness == null` as "not known yet" (`?? true` / `: null`). That is **unchanged from the state before the first response ever arrives**, and it is not a heuristic grant — the store now asserts nothing. What changed is that the state is *labelled* instead of masquerading as the server's answer.

## Can 2.308 be re-opened by this path?

**At pristine: yes — proven, not argued** (`expected true to be false`, the fifth RED above). On this branch: no.

## Consumer manifest

Scope: whole working tree, `rg -a` (NUL-safe), excluding `node_modules`/`.git`, with a positive control confirming the grep fires. **Seven** non-test call sites of `useGraphReadiness()`:

| Reader | Reads | Behaviour when the verdict is absent |
|---|---|---|
| `PreAnalysisHealth.tsx:135` ⚠[^ph] | `readiness`, `loading`, **`error`**, `refresh` | **Only reader of `error`.** Gates the Analyse-now button (`:266`); `onCanRunChange` (`:144`) `loading ? true : ?? true` |
| `usePreAnalysisData.ts:521` | `readiness`, `loading` | `graphCanRun` (`:620`) `readinessLoading ? true : ?? true` |
| `useUnifiedActions.ts:165` | `readiness`, `loading` | `improvements` **only** (`:176`) — does not read `can_run_analysis` |
| `ConversationPanel.tsx:133` | `readiness` | feeds the `canRunAnalysis()` gate input (`:498`) |
| `PreAnalysisGuidance.tsx:113` | `readiness` | `improvements` **only** (`:390`) |
| `usePreAnalysisModel.ts:81` | `readiness` | ladder (`:169`), `canRun` (`:280`), footer (`:284`) |
| `OutputsDock.tsx:805` | `readiness` | feeds the `canRunAnalysis()` gate input (`:868`) |

[^ph]: **⚠ Corrected in the AMEND section below: `PreAnalysisHealth` has ZERO importers in `src/` — nothing mounts it.** It is the only reader of `error`, and it is not rendered anywhere.

Plus the pure utils `canRunAnalysis.ts:324` (the unified gate) and `composeBlockedReason.ts:241` (`promiseIsLicensed`).

`selectReadinessError` (`readinessStore.ts`, re-exported `stores/index.ts:72`) has **zero importers** — two occurrences repo-wide, both definitions.

`docs/blocked-readiness-ux-verification-2026-04-08.md` claims `ResultsPanel.tsx` reads `useGraphReadiness()`. **That doc is stale** — `src/components/ResultsPanel.tsx` has zero readiness references today. Not fixed here (docs out of scope for this lane).

## Gates — all re-run against the final commit `d79985eb`, clean tree

| Gate | Result |
|---|---|
| `pnpm typecheck` | PASS — ratchet **exactly** at baseline, 623 files / 2507 errors (baseline 2507); coverage 3169/3209, **+1 vs pristine 3168/3208**, confirming the new spec is loaded |
| `pnpm lint` | **0 errors**; 1261 warnings, **zero in the three touched files** (the 3 on `readinessStore.ts` sit at pristine lines 194/373/491 and pre-exist) |
| hooks ratchet | 234 violations / 16 files, **exactly** matching baseline |
| full suite | **1450 files / 21404 passed, 0 failed** (66 skipped), exit 0 |
| CI on `d79985eb` | **13/13 success**, incl. the required **Staging Gate** and all 4 shards |

Pristine baseline at `9c15b319`: **1449 files / 21393 passed, 0 failed**. Delta **+1 file / +11 tests** — exactly this PR's new spec, nothing else moved. Both runs had `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported and collected **34 inspector-v2 spec files**, so neither suite was shrunken. The branch run recorded `TREE_SHA_AT_START == TREE_SHA_AT_END == d79985eb` with `DIRTY=0` at both ends, so the tree did not move under it.

## Mutation table — re-run against `d79985eb`

Throwaway worktree **outside the repo root**, removed before the gate runs, **committed state only**, applied-check on every mutant (anchor present exactly once + byte-length delta + write read back).

| # | Mutation | Verdict |
|---|---|---|
| M0 | control, no mutation | **GREEN** 11/11 — the harness runs |
| M1 | revert half 1 — `error: null` again | **RED** ×5 (26617 → 26614 B) |
| M2 | revert half 2 — publish `calculateFallbackReadiness` | **RED** ×5 (26617 → 26731 B) |
| M3 | revert the `.json()` tagging | **RED** ×1 (13317 → 13176 B) |
| M4 | make a transport failure sticky (cache the failed hash) | **RED** ×1 (26617 → 26662 B) |

**M4 survived its first sweep, and that is reported rather than buried.** The retry test went through `refresh()`, which clears `lastPayloadHash` itself — so it could never observe a poisoned one. A trap-13 vacuity in my own test; it now re-enters `__test__.fetchReadiness()` directly and asserts a second request goes out. Separately, the git-based applied-check initially carried a constant `+1` offset from an untracked `node_modules` symlink (`.gitignore` lists `node_modules/` with a trailing slash, which does not match a symlink); it is now scoped to `src/` and the control reads `changed=0`.

## Scope

jsdom pins store state only — **no claim here is a layout or visibility claim** (CLAUDE.md trap 3). ~~The **404 and 429 paths still publish the local heuristic and are deliberately untouched**: in both, the server *did* answer. The 404 branch has the same *shape* (silent local verdict, no `error` set, grants the run pre-analysis) and has been rowed as a separate follow-up rather than widened into this PR.~~ **⚠ SUPERSEDED by commit `32687fe3` — the 404 branch is closed in this PR (ROADMAP 2.329, adjudicated OUTAGE). See the AMEND section below. The 429 path and the generic HTTP-error path (non-429/404 → outer catch, `readinessStore.ts:588`) remain untouched — the latter still publishes the local heuristic and can still overwrite a server `false`. Rowed as ROADMAP 2.339; its fix is a MANDATORY named part of the 2.332 build (same file, next on this seat).** The `isPromptCachePreloaded()` sibling finding is 2.319(b), P3, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# AMEND (commit `32687fe3`) — ROADMAP 2.329: the 404 branch, adjudicated

The section above closed the transport path and **deliberately left the 404 branch alone pending adjudication**. That adjudication has now been made and the branch is closed here. *(The "Scope" paragraph above is superseded on this point: the 404 path is no longer untouched. The 429 path still is — it labels itself, and the server did answer.)*

## The adjudication: a 404 here is an OUTAGE, never a deployment choice

Derived at the deployed bytes — `PHASE0-EVIDENCE-2026-07-28/adjudication-2329-404-branch.md`. The falsifiable question was: **can any deployed configuration produce a 404 on the readiness path *by design*?** No.

- **Registration is unconditional on PLoT's deploy branch.** `createServer.ts` → `registerV1Routes` (no guard) → `registerCeeProxyRoutes` (no guard) → `app.post('/v1/cee/graph-readiness', …)` (no guard). A missing `CEE_BASE_URL`/`CEE_API_KEY` produces an **error response from a registered handler**, never a 404. There is no mechanism by which any env or flag posture expresses "I chose local validation".
- **Staging answers 401** on that exact method+path — registered, auth-gated — against a **control path that answers 404**, so the prober can see absence and the 401 is not an artifact. (401 proves registration, not computation.)
- **The `/bff/cee` same-origin fallback does not survive minification** in either deployed bundle: **zero** literals across an **81-chunk staging crawl** and a **40-chunk production crawl**, all HTTP 200. The "dead SPA redirect returns index.html" 404 vector is unreachable in the shipped artifacts.
- **One deployed configuration does 404 in steady state: production** — whose PLoT predates the route by ~6.5 months (route landed on `main` in `763a4834`, 2026-01-15) while its paired UI bundle, built 2026-03-12, bakes the call in. That is deploy drift, i.e. the outage class — **and this branch is exactly what kept it invisible.**

**Witnessed on screen — with its claim type stated, because it is adjacent evidence rather than a 404 witness.** The 3 Aug walk (`journey-rewalk-2026-08-03b.md` §9) intercepted every `graph-readiness` request at UI build `9c15b319` with `route.abort('failed')` and measured: 1 request attempted, **0 retries**, run control **`disabled: false`**, **0 matches** for any "could not check"/"unavailable"/"try again" copy anywhere in the painted body, the click **granted** (`POST /proxy/v5/turn` 200, 33,134 B) and a confident-looking analysis returned. **That is an ABORT — the transport shape this PR's first commit already fixed — NOT a 404, and not a claim about PLoT's availability.** It witnesses the failure *mode* (silent fail-open with no error copy) on the same code path family; the 404-specific case is established by derivation at the deployed bytes above, not by that probe.

## The change

The `response.status === 404` branch now gets the same treatment as a transport failure: **publish no verdict, set a truthful error, `loading: false`.**

```diff
-          const fallback = calculateFallbackReadiness(currentNodes, currentEdges, graphHealth)
-          useReadinessStore.setState({ readiness: fallback, loading: false })
+          const message = 'Could not find the readiness service'
+          useReadinessStore.setState({ error: message, loading: false })
```

`readiness` is left **exactly** as it was — `null` on first load (the store's own pre-existing "unknown" state), otherwise the answer the server actually gave, which a local guess is not entitled to replace. `lastPayloadHash` stays unset, so a redeploy is picked up on the next request rather than cached out. **No third state**, and **not** `can_run_analysis: false` — both alternatives were considered and rejected at the transport catch, for reasons that apply here unchanged.

Three no-verdict paths now stay tellable apart at the store: `Could not reach…` (transport), `Could not read…` (unreadable body), `Could not find…` (404).

## Consequence for production, stated rather than buried

Deployed to production as-is against today's production PLoT, readiness would report a **permanent, truthful "could not check"** until prod PLoT redeploys or the UI stops calling the route. **That is a real outage becoming visible, not a regression introduced here** — and whoever ships it should expect the red. Staging is unaffected: its route is registered (401, measured). Production is out of POC scope.

## Explicitly out of scope — disclosed, not hidden

- **ROADMAP 2.332 (refresh-triggering / staleness) is a separate lane and is NOT addressed here.** Nothing in this commit changes *when* a re-fetch is attempted, so a 404 error state persists until the next graph change or an explicit `refresh()`. This is therefore a **partial fix**: it makes the state honest, not self-healing.
- The **429** branch is untouched — it labels itself, and the server did answer.

## ⚠ Refutation of a claim in the section above

The original body's consumer manifest lists `PreAnalysisHealth.tsx` as the **only** reader of `error`. True — but incomplete, and the missing half matters:

**`PreAnalysisHealth` has ZERO importers in `src/` at this commit.** Scope of the claim: `grep -arn 'PreAnalysisHealth'` (NUL-safe, trap 17) over the whole tree excluding `node_modules`/`.git` — the complete hit manifest is the component itself, the new spec, one comment in `readinessStore.ts`, `ds-compliance-report.md`, and `tools/ci-guards/ds-compliance-baseline.json`. No import, static or dynamic (no constructed `import()` exists in the tree). Corroborated at the store level: no other consumer of `useGraphReadiness()`/`useReadinessStore` destructures `error`.

So the "dormant surface restored" framing is accurate **at the component**, and the surface is dormant **one level deeper than the original body said**: nothing mounts it. The store-level fix stands on its own — refusing to invent a verdict is correct regardless of what renders — but **no user-visible error copy is claimed by this PR**, and mounting a readiness-error surface is separate work.

## RED-first at `d79985eb` (pre-amend), by name

New spec `src/canvas/stores/__tests__/readinessStore.notFound.spec.tsx` — **6 failed | 4 passed (10)**:

```
× does not report error: null when the readiness route is not found          → expected null not to be null
× names the failure as the service not being found, distinctly from
  unreachable and unreadable                                                 → .toMatch() expects a string, but got object
× does not set can_run_analysis true when the readiness route is not found    → expected true not to be true
× publishes no locally-invented verdict at all when it has never had one
  from the server                                                            → expected { readiness_score: 80, …(4) } to be null
× leaves the exact verdict object the server produced in place               → expected { readiness_score: 80, …(4) } to be
                                                                                { readiness_score: 62, …(8) } // Object.is
× reaches the retry control in PreAnalysisHealth after a 404                 → Unable to find role="button" name /retry health check/i
```

The four that **passed at pristine** are labelled as such in the file: two trap-13 positive controls (the harness can see a real verdict and a `null` error arrive), the not-sticky pin, and the surface negative control. The pristine render of the sixth test is the defect on screen at presence level: on a 404 the component rendered **"Strong (80%)"** with a **"Run analysis"** button.

**Identity binding:** the prior-verdict clause asserts `toBe` on the **object reference** the server's answer produced — not `readiness_score === 62`, which any look-alike object could satisfy.

**A test that pinned the defect was rewritten, not deleted:** `readinessStore.spec.ts`'s `falls back to local readiness on 404` asserted `error === null` with a verdict present. It is now `publishes no verdict and reports an error on 404`, so the sibling suite keeps its own guard against the old behaviour returning.

## Mutation table — amend commit `32687fe3`

Throwaway worktree **outside the repo root**, **committed state only**, removed before the gate runs. `set -o pipefail`; applied-check per mutation scoped to `src/`; an unreadable vitest result is a hard error (exit 94).

| # | Mutation | Applied-check (`git diff HEAD --numstat -- src/`) | Verdict |
|---|---|---|---|
| M0 | control, no mutation | **exactly 0 files** | **GREEN** 30/30 across 2 files |
| M1 | revert the 404 change entirely (restore the file as `d79985eb` left it) | 1 file, `+7 −49` | **RED ×7** — all 6 new tests + the rewritten sibling |
| M2 | keep the truthful error, restore **only** the invented-verdict publish | 1 file, `+2 −1` | **RED ×5** — precisely the no-verdict clause; the two error-copy tests correctly stay green |

M2 is the isolation that matters: it proves the *no-verdict* half is pinned independently of the *error-is-set* half, so neither is carried by the other.

**Instrument defect found and fixed mid-run, reported rather than buried:** the applied-check first used `git diff --numstat`, which reads worktree-vs-index — M1 stages via `git checkout <sha> -- <path>`, so the check read **0 changed files and hard-errored** ("the mutation did not apply"). It was wrong about the instrument, not the mutant. Corrected to `git diff HEAD --numstat` and the control re-run to confirm it still reads exactly 0. (Related to trap 12e: the check is scoped to `src/` so the untracked `node_modules` symlink cannot offset it.)

## Gates at `32687fe3` (clean tree, unique `/private/tmp` clone, never the iCloud tree)

| Gate | Result | Delta vs `d79985eb` |
|---|---|---|
| `scripts/ci/typecheck-gate.sh` | **PASS** — ratchet 623 files / **2507** errors (baseline **2507**), coverage **3170 / 3210** (40 out of scope) | **zero error delta**; coverage **+1 loaded**, derived: `git ls-files '*.ts' '*.tsx'` = **3205** at this tip vs **3204** at `d79985eb` — the new spec, nothing else |
| hooks ratchet | **PASS** — **234** violations / **16** files, exactly baseline | zero |
| `eslint` (3 touched files) | **0 errors**, 3 warnings | **zero delta** — all three pre-exist verbatim at `d79985eb` (`store` unused at `readinessStore.ts:195` is byte-identical at pristine) |
| readiness suites (6 files) | **65 passed / 65** | +10 tests (the new spec) |
| inspector-v2 collect control | **34 / 34 spec files** collected, **355 tests passed**, with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported | **derived, not remembered**: `find src -path '*inspector-v2*' -name '*.spec.*'` = **34** on disk, **34** collected — none died at collect, so no run here was silently shrunken (CLAUDE.md trap 2b). Matches the 34 the pristine run recorded. |

**CI on `32687fe3`: 13/13 success**, including the required **Staging Gate**, all four **Full Test Suite** shards, **TypeScript + Lint**, and the **Typecheck Gate Self-Test** (the gate's own positive control — it still goes RED when it should).

**Not merged — an adversarial review follows.**



---
**Interim UX (review-supplied, honest statement of the merged state):** Until 2.332 mounts a surface, an unreachable or missing readiness service is invisible: the pre-analysis panel shows no readiness assessment and no error, the Run button stays enabled exactly as before any verdict ever arrived, and after a first analysis the last server verdict remains on screen with no staleness marking.
