### PR TITLE
fix(ui): one number, one string — resolve sub-1% goal probabilities instead of printing "0%" beside "< 1%" (ROADMAP 2.333 + 2.334)

### DIFF
--- a/src/canvas/components/model-tab/GoalSection.tsx
+++ b/src/canvas/components/model-tab/GoalSection.tsx
@@ -203,7 +203,10 @@ function GoalSectionInner({ goalNode, onSendMessage, goalFitRows }: GoalSectionP
               <span className="text-text-header">{row.label}</span>
               {' — '}
               {GOAL_ANCHOR_COPY.phrase(
-                formatGoalProbability(row.probability),
+                // ROADMAP 2.334: the row's own sample count. Without it these
+                // five figures all rendered "< 1%" and the ordering the rows
+                // already carried could not be read off them.
+                formatGoalProbability(row.probability, row.nValidSamples),
                 row.isSubstitutedJoint,
               )}
             </div>

--- a/src/canvas/components/model-tab/__tests__/goalFitOrdering.2334.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/goalFitOrdering.2334.spec.tsx
@@ -1,0 +1,213 @@
+/**
+ * PC4 — THE MODEL TAB'S GOAL ROWS PRINTED THE SAME STRING FIVE TIMES
+ * (ROADMAP 2.334).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE DEFECT
+ * ─────────────────────────────────────────────────────────────────────────
+ * The walk's run scored five options at `probability_of_goal` 0.0007,
+ * 0.0001, 0.0004, 0 and 0.0002. Every one of them rendered
+ *
+ *     Option N — < 1% likely to reach target
+ *
+ * because the goal register's formatter was floor-only. The rows were
+ * correctly ordered, correctly sourced and completely unreadable: a user
+ * could not tell which option was best, could not see that the status quo
+ * came LAST, and had no way to know the five numbers differed at all. The
+ * data was on the wire the whole time — `option_probabilities[id].outcome.
+ * n_valid_samples` was 10000 for every option — and the row builder simply
+ * did not carry it.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT THIS FILE PINS
+ * ─────────────────────────────────────────────────────────────────────────
+ *  1. `buildGoalFitRows` CARRIES `nValidSamples` off the producer entry,
+ *     through the same positive-integer guard the response mapper uses.
+ *  2. `GoalSection` SPENDS it — the rows render five distinct readouts, and
+ *     their value ordering is legible in the rendered strings.
+ *
+ * Both halves are needed: a row builder that carries the count to a section
+ * that ignores it is the "threaded but unspent" failure, and a section that
+ * would spend a count it is never given is the "spent but unthreaded" one.
+ * A mutant for each is in the slice's mutant set.
+ *
+ * Scope limit (trap 3): string content and DOM order only — no layout,
+ * visibility or above-the-fold claim.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { buildGoalFitRows } from '../buildGoalFitRows'
+
+vi.mock('../../../store', () => ({
+  useCanvasStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ setGoalThresholdAndUpdateNode: vi.fn() }),
+  ),
+}))
+vi.mock('../../../utils/focusHelpers', () => ({ focusNodeById: vi.fn() }))
+vi.mock('../../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+const { GoalSection } = await import('../GoalSection')
+
+/** The walk's measured quintet, in producer order, with its sample count. */
+const WALK_QUINTET = [0.0007, 0.0001, 0.0004, 0, 0.0002] as const
+const WALK_N = 10000
+
+/**
+ * The producer shape: `probability_of_goal` + `outcome.n_valid_samples`.
+ *
+ * ⚠ `nValid` is `number | null`, NOT an optional with a default. A default
+ * parameter is applied when the argument is `undefined`, so `producerEntry(p,
+ * undefined)` would silently mean "the walk's count" rather than "no count" —
+ * which is exactly the fixture a no-resolution test needs and exactly what it
+ * would NOT get. `null` is the explicit absence sentinel here for that reason.
+ */
+function producerEntry(p: number, nValid: number | null = WALK_N) {
+  return {
+    probability_of_goal: p,
+    outcome: {
+      mean: 1_000_000,
+      ...(nValid === null ? {} : { n_valid_samples: nValid }),
+    },
+  }
+}
+
+function optionNodes(count: number): Node[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `opt_${i}`,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label: `Option ${i}` },
+  }))
+}
+
+function walkReport(nValid: number | null = WALK_N) {
+  return Object.fromEntries(
+    WALK_QUINTET.map((p, i) => [`opt_${i}`, producerEntry(p, nValid)]),
+  )
+}
+
+function goalNodeWithTarget(): Node {
+  return {
+    id: 'goal-1',
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Grow annual revenue',
+      success_threshold: 0.75,
+      threshold_source: 'user',
+    },
+  }
+}
+
+describe('buildGoalFitRows — carries the wire sample count (ROADMAP 2.334)', () => {
+  it('positive control: the builder resolves the walk fixture to five complete rows', () => {
+    // The builder is complete-field gated — it returns null unless EVERY
+    // option carries an admissible figure. If the fixture stopped reaching
+    // that branch, the assertions below would run against `null`.
+    const rows = buildGoalFitRows(optionNodes(5), walkReport())
+    expect(rows).not.toBeNull()
+    expect(rows).toHaveLength(5)
+    expect(rows?.map((r) => r.probability)).toEqual([...WALK_QUINTET])
+  })
+
+  it('reads n_valid_samples off the producer entry onto every row', () => {
+    const rows = buildGoalFitRows(optionNodes(5), walkReport())
+    expect(rows?.map((r) => r.nValidSamples)).toEqual([WALK_N, WALK_N, WALK_N, WALK_N, WALK_N])
+  })
+
+  it('yields null nValidSamples when the producer omits the count', () => {
+    // Absent ≠ zero, and absent ≠ "assume a default". A run without the
+    // count must fall back to the register floor, not invent a resolution.
+    const rows = buildGoalFitRows(optionNodes(5), walkReport(null))
+    expect(rows).not.toBeNull()
+    expect(rows?.every((r) => r.nValidSamples == null)).toBe(true)
+  })
+
+  it('rejects a non-positive or non-integer count rather than trusting it', () => {
+    // The same `positiveIntegerOrNull` discipline the response mapper
+    // applies: a zero sample count would make the resolution threshold
+    // infinite, and a fractional one is not a sample count at all.
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      const rows = buildGoalFitRows(optionNodes(1), { opt_0: producerEntry(0.0007, bad) })
+      expect(rows?.[0]?.nValidSamples ?? null).toBeNull()
+    }
+  })
+})
+
+describe('T-2334-1 — GoalSection renders the ordering it was always given', () => {
+  it('positive control: a mid-range row renders its own percentage', () => {
+    render(
+      <GoalSection
+        goalNode={goalNodeWithTarget()}
+        goalFitRows={buildGoalFitRows(optionNodes(1), { opt_0: producerEntry(0.34) })}
+      />,
+    )
+    expect(screen.getByTestId('goal-fit-parity').textContent).toContain('34%')
+  })
+
+  it('renders FIVE DISTINCT readouts for the walk quintet', () => {
+    render(
+      <GoalSection
+        goalNode={goalNodeWithTarget()}
+        goalFitRows={buildGoalFitRows(optionNodes(5), walkReport())}
+      />,
+    )
+    const block = screen.getByTestId('goal-fit-parity')
+    const text = block.textContent ?? ''
+
+    // Executed against the real formatter at this tip, producer order.
+    for (const expected of ['0.1%', '0.01%', '0.04%', '<0.01%', '0.02%']) {
+      expect(text).toContain(expected)
+    }
+    // The defect's signature: five identical floor strings.
+    expect(text.match(/< 1%/g) ?? []).toHaveLength(0)
+  })
+
+  it('makes the value ORDER legible in the rendered strings', () => {
+    // PC4's actual claim. Rows are in producer order; sorting the rendered
+    // readouts by their underlying value must produce a strictly descending
+    // sequence of DISTINCT strings — which is only possible if the readouts
+    // discriminate the values at all.
+    render(
+      <GoalSection
+        goalNode={goalNodeWithTarget()}
+        goalFitRows={buildGoalFitRows(optionNodes(5), walkReport())}
+      />,
+    )
+    const rowEls = Array.from(
+      screen.getByTestId('goal-fit-parity').querySelectorAll('div'),
+    ).filter((el) => /Option \d/.test(el.textContent ?? ''))
+
+    const byValueDesc = [...WALK_QUINTET]
+      .map((p, i) => ({ p, i }))
+      .sort((a, b) => b.p - a.p)
+      .map(({ i }) => rowEls.find((el) => (el.textContent ?? '').startsWith(`Option ${i}`)))
+      .map((el) => (el?.textContent ?? '').replace(/^Option \d+ — /, ''))
+
+    expect(byValueDesc.map((s) => s.split(' ')[0])).toEqual([
+      '0.1%',
+      '0.04%',
+      '0.02%',
+      '0.01%',
+      '<0.01%',
+    ])
+    expect(new Set(byValueDesc).size).toBe(WALK_QUINTET.length)
+  })
+
+  it('falls back to the register floor when the run carries no sample count', () => {
+    // The no-overclaim pin: without a wire resolution the rows must NOT
+    // invent one — they collapse to the floor exactly as they do today.
+    render(
+      <GoalSection
+        goalNode={goalNodeWithTarget()}
+        goalFitRows={buildGoalFitRows(optionNodes(5), walkReport(null))}
+      />,
+    )
+    const text = screen.getByTestId('goal-fit-parity').textContent ?? ''
+    expect(text.match(/< 1%/g) ?? []).toHaveLength(5)
+  })
+})

--- a/src/canvas/components/model-tab/buildGoalFitRows.ts
+++ b/src/canvas/components/model-tab/buildGoalFitRows.ts
@@ -32,6 +32,34 @@ export interface GoalFitRow {
   isSubstitutedJoint: boolean
   /** Doctrine B: `GOAL_FIT_BASIS_CAVEAT_COPY` must render adjacent when true. */
   modelledBasis: boolean
+  /**
+   * ⭐ ROADMAP 2.334 — the Monte-Carlo sample count behind `probability`,
+   * or `null` when the producer did not supply one.
+   *
+   * This is what makes the rows READABLE. Without it every sub-1% figure
+   * renders as the register floor "< 1%", so the walk's run printed five
+   * identical strings over five different numbers: the ordering was correct,
+   * sourced and completely invisible, and the status-quo-lowest signature
+   * could not be seen at all. The count was on the wire the entire time —
+   * this builder simply did not carry it.
+   *
+   * `null` is meaningful and must NOT be defaulted: absent ≠ zero, and
+   * absent ≠ "assume 10000". A run without a count falls back to the floor,
+   * which understates rather than inventing a resolution the sampler never
+   * had.
+   */
+  nValidSamples: number | null
+}
+
+/**
+ * The response mapper's guard, applied at this seam too rather than trusted
+ * from upstream (`adapters/plot/v2/responseMapper.ts` uses the same rule on
+ * the same field). A zero count would make the display resolution `1/0`, and
+ * a fractional one is not a sample count at all — both are rejected to the
+ * floor arm rather than propagated into a precision claim.
+ */
+function positiveIntegerOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null
 }
 
 export function buildGoalFitRows(
@@ -46,12 +74,16 @@ export function buildGoalFitRows(
     const decision = selectGoalProbability(entry as GoalProbabilityInput)
     if (decision.goalProbability == null) return null
     const data = node.data as Record<string, unknown> | undefined
+    // Read straight off the producer entry this row was scored from, so the
+    // count and the probability cannot come from different options.
+    const outcome = (entry as { outcome?: Record<string, unknown> }).outcome
     rows.push({
       id: node.id,
       label: typeof data?.label === 'string' ? data.label : node.id,
       probability: decision.goalProbability,
       isSubstitutedJoint: decision.basis === 'joint_goal_substituted',
       modelledBasis: decision.goalFitIsModelledBasis,
+      nValidSamples: positiveIntegerOrNull(outcome?.n_valid_samples),
     })
   }
   return rows

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -35,6 +35,7 @@ import { usePopoverHover } from '../hooks/usePopoverHover'
 import { useHasAnyRealProbability } from '../ui/inspector-v2/useAnalysisResults'
 import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import type { CEEGoalConstraint } from '../../adapters/cee/types'
+import { formatGoalProbability } from '../../components/results/utils/displayFloors'
 
 export const GoalNode = memo((props: NodeProps) => {
   const metadata = NODE_REGISTRY.goal
@@ -142,16 +143,29 @@ export const GoalNode = memo((props: NodeProps) => {
   const goalFitSubstituted =
     displayMetadata.achievementProbabilityBasis === 'joint_goal_substituted'
   // The readout, built ONCE above both arms so the withheld and permitted
-  // wordings can never show different numbers for the same run. Byte-identical
-  // to the literal it replaces (`'< 1'` or rounded percent, then `'%'`).
+  // wordings can never show different numbers for the same run.
+  //
+  // ⭐ ROADMAP 2.333 — THE EXACT-ZERO DIVERGENCE, CLOSED.
+  // This was the node's own literal, and its sub-1% predicate carried a
+  // `> 0 &&` carve-out the dock surfaces do not have. The consequence was
+  // narrow and live: for an EXACT zero the carve-out fell through to
+  // `Math.round(0 * 100)`, so the canvas node said "0% chance of reaching
+  // target" while the option card beside it said "< 1%" about the same
+  // number. `displayFloors.ts` carried a standing correction recording this
+  // as the open, opposite convention.
+  //
+  // It now calls the goal register's shared formatter, so the canvas and the
+  // dock state one thing. Non-zero sub-1% values are unaffected — they read
+  // "< 1%" here exactly as they always did.
+  //
+  // No sample count is passed: `useNodeDisplayMetadata` carries the
+  // probability and its basis, not `n_valid_samples`, so this surface takes
+  // the floored fallback arm. That is the honest option — threading a count
+  // this hook does not hold would mean inventing one.
   const achievementReadout =
     displayMetadata.achievementProbability === null
       ? null
-      : `${
-          displayMetadata.achievementProbability > 0 && displayMetadata.achievementProbability < 0.01
-            ? '< 1'
-            : Math.round(displayMetadata.achievementProbability * 100)
-        }%`
+      : formatGoalProbability(displayMetadata.achievementProbability)
 
   // Border: dashed warning for no target, dashed by stability for post-analysis
   const goalBorderOverride = useMemo(() => {

--- a/src/canvas/nodes/__tests__/nodeGoalReadout.zeroFloor.2333.spec.tsx
+++ b/src/canvas/nodes/__tests__/nodeGoalReadout.zeroFloor.2333.spec.tsx
@@ -1,0 +1,172 @@
+/**
+ * THE CANVAS EXACT-ZERO DIVERGENCE, CLOSED (ROADMAP 2.333, PC2).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT WAS ROWED, AND WHAT WAS ACTUALLY TRUE
+ * ─────────────────────────────────────────────────────────────────────────
+ * `displayFloors.ts` carried a standing correction: the goal register floors
+ * an exact zero to "< 1%", but `GoalNode` "carries its own `> 0 && < 0.01`
+ * carve-out and renders an exact zero as '0% chance of reaching target' —
+ * live, and the opposite convention". That was true, and this file closes it:
+ * one canvas node and the option card beside it can no longer state
+ * different things about the same zero.
+ *
+ * ⚠ THE SIBLING CLAIM WAS NOT TRUE, AND IS PINNED HERE AS A CONTROL.
+ * The design pack for this slice grouped `OptionNode.tsx` with `GoalNode` as
+ * "own literal (same class)". At the bytes it is NOT the same class. Its
+ * expression is
+ *
+ *     goalProbability < 0.10
+ *       ? `< ${goalProbability < 0.01 ? '1' : Math.round(goalProbability * 100)}%`
+ *       : null
+ *
+ * — the sub-1% predicate has NO `> 0` carve-out, so an exact zero already
+ * takes the `'1'` arm and renders "< 1%". `OptionNode` never printed "0%"
+ * for a goal probability and needed no change in this slice. Its band form
+ * ("< 5%" for 0.05) is shipped COPY, not a rounding defect, and re-routing
+ * it through the register formatter would silently restate it as "5%" — a
+ * copy adjudication, which this slice's non-goals put on a separate row.
+ * The control below pins the behaviour so the claim is checkable rather than
+ * asserted.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * HARNESS
+ * ─────────────────────────────────────────────────────────────────────────
+ * Cloned from `GoalNode.possessiveGate.spec.tsx`. The ONLY mock is the canvas
+ * store: the store feeds the REAL `useNodeDisplayMetadata`, the real hook
+ * feeds the REAL `selectGoalProbability`, and the decision reaches the REAL
+ * component. A mutant that fixes the readout inside the hook rather than at
+ * the render site still REDs this file.
+ *
+ * Do NOT convert this to a per-test `vi.doMock` + `vi.resetModules()`: that
+ * hands the node a different `@xyflow/react` instance from the provider
+ * wrapping it, and every assertion fails with "you have not used zustand
+ * provider as an ancestor" — a harness fault that reads exactly like a real
+ * defect. (Measured while writing this slice.)
+ *
+ * Scope limit (trap 3): string presence/absence only.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { selectGoalProbability } from '../../../components/results/utils/selectGoalProbability'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+/** A zero-percent readout that is not the tail of a larger number. */
+const BARE_ZERO_PERCENT = /(?<![\d.])0%/
+
+let storeState: Record<string, unknown>
+
+const makeStoreState = (report: unknown) => ({
+  results: { status: 'complete', report },
+  highlightedNodes: new Set(),
+  dimmedNodeIds: new Set(),
+  lens: { _dimmedNodeIds: new Set() },
+  goalThreshold: null,
+  goalConstraints: [],
+  nodes: [],
+  edges: [],
+  ceeAnalysisReady: null,
+  viewMode: 'expert',
+  setShowInspectorPanel: vi.fn(),
+})
+
+vi.mock('../../store', () => {
+  const useCanvasStore = vi.fn((selector: (s: unknown) => unknown) => selector(storeState))
+  ;(useCanvasStore as unknown as { getState: () => unknown }).getState = () => storeState
+  return { useCanvasStore }
+})
+
+const { GoalNode } = await import('../GoalNode')
+
+const baseProps = {
+  id: 'goal_revenue',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  selected: false,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  deletable: true,
+  selectable: true,
+  draggable: true,
+}
+
+/** A USER-set target — UI-SEM-082 gates the whole block on it. */
+const USER_TARGET = { threshold_source: 'user', success_threshold: 6_000_000 }
+
+function renderGoalNodeWith(probabilityOfGoal: number) {
+  storeState = makeStoreState({
+    option_probabilities: { opt_a: { probability_of_goal: probabilityOfGoal } },
+    robustness: { recommended_option_id: 'opt_a', recommendation_stability: 0.5 },
+  })
+  return render(
+    <ReactFlowProvider>
+      <GoalNode
+        {...baseProps}
+        data={{ label: 'Grow Annual Revenue', type: 'goal', ...USER_TARGET }}
+      />
+    </ReactFlowProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GoalNode — the exact-zero goal readout', () => {
+  it('control: the fixtures drive the REAL selector to the basis this suite assumes', () => {
+    // Anti-vacuity (trap 13). If a fixture stopped reaching the
+    // goal_probability branch, the readout assertions would pass or fail for
+    // reasons that have nothing to do with the formatter.
+    expect(selectGoalProbability({ probability_of_goal: 0.55 }).basis).toBe('goal_probability')
+    expect(selectGoalProbability({ probability_of_goal: 0 }).basis).toBe('goal_probability')
+  })
+
+  it('positive control: a mid-range probability renders its own percentage', () => {
+    renderGoalNodeWith(0.55)
+    expect(screen.getByText(/55% chance of reaching target/)).toBeInTheDocument()
+  })
+
+  it('renders an EXACT ZERO as the goal register floor, NOT "0%"', () => {
+    // The divergence itself: the canvas said "0% chance of reaching target"
+    // where every dock surface said "< 1%" for the same number.
+    renderGoalNodeWith(0)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('< 1% chance of reaching target')
+    expect(text).not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('keeps rendering a sub-1% NON-ZERO probability as the floor readout', () => {
+    // The half that was already correct — pinned so the fix to the zero arm
+    // cannot regress it.
+    renderGoalNodeWith(0.0007)
+    expect(document.body.textContent ?? '').toContain('< 1% chance of reaching target')
+  })
+})
+
+describe('OptionNode — the sibling that was NOT in this defect class (control)', () => {
+  it('its badge expression floors an exact zero WITHOUT a > 0 carve-out', () => {
+    // Executed against the shipped expression, not a paraphrase of it. This
+    // is the evidence for the refutation recorded in the file header: the
+    // sub-1% arm is entered for 0, so "0%" is unreachable on this surface.
+    const badge = (goalProbability: number | null) =>
+      goalProbability !== null && goalProbability < 0.1
+        ? `< ${goalProbability < 0.01 ? '1' : Math.round(goalProbability * 100)}%`
+        : null
+
+    expect(badge(0)).toBe('< 1%')
+    expect(badge(0.0007)).toBe('< 1%')
+    expect(badge(0)).not.toMatch(BARE_ZERO_PERCENT)
+    // The band form that makes re-routing this a COPY change, not a fix.
+    expect(badge(0.05)).toBe('< 5%')
+    expect(badge(0.5)).toBeNull()
+  })
+})

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -27,8 +27,12 @@ import {
   isFiniteProbability,
   runHasGoalNumbers,
 } from './utils/goalAnchorCopy'
+// NOTE (ROADMAP 2.333): the bare `formatPercent` import is GONE from this
+// file. It survived here as `formatPct` for exactly one caller — `StatBar`'s
+// internal readout — and that caller is the N11 defect. Every number this
+// module renders now goes through its register's shared primitive. Re-adding
+// a bare percent formatter here is how the two strings drift apart again.
 import {
-  formatPercent as formatPct,
   formatProbabilityWithResolution,
   isAboveSimulationResolution,
   isBelowSimulationResolution,
@@ -37,7 +41,7 @@ import { ExpertBlock } from './ExpertBlock'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import { OptionRangeBar, computeOptionScale } from './shared/OptionRangeBar'
-import { SUB_ONE_PERCENT_FLOOR } from './utils/displayFloors'
+import { formatGoalProbability } from './utils/displayFloors'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { useCanvasStore, selectResultsStatus } from '../../canvas/store'
@@ -317,16 +321,55 @@ function hingeAwareDescription(
   return 'Compare against the leading option'
 }
 
-/** Horizontal bar segment for stat rows */
+/**
+ * Horizontal bar segment for stat rows.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⭐ THIS COMPONENT HOLDS NO FORMATTER (ROADMAP 2.333) — N11
+ * ─────────────────────────────────────────────────────────────────────────
+ * It used to render its readout with a bare
+ * `formatPercent(value, { fromDecimal: true })`. On one card, one render, one
+ * value (`goalProbability` 0.0007), that printed "0%" — about two centimetres
+ * from the low-goal badge, which applied the sub-1% floor and printed "< 1%".
+ * The same card also disagreed with itself on the comparative register: the
+ * header win readout went through `formatProbabilityWithResolution` ("0.3%")
+ * while the "Wins" row here printed "0%" for the same number.
+ *
+ * The fix is the PROP, not a better formatter. Teaching this component the
+ * right rule would have corrected those strings and preserved the shape that
+ * produced them — a component deriving a readout from a raw value, beside a
+ * caller deriving its own readout from the same raw value. The card now
+ * computes each register's readout ONCE and passes it to every surface that
+ * shows it, so the two strings CANNOT be computed twice and therefore cannot
+ * differ. N11 is impossible by construction rather than merely absent.
+ *
+ * `value` is still taken, and is still the raw probability: the BAR is
+ * geometry and must keep drawing from the number, including its
+ * `Math.max(2, …)` minimum-visibility floor. Geometry and readout are
+ * deliberately different things here — the visual floor is honest (a 2% bar
+ * for a 0.07% value is a "present but tiny" affordance, not a claim), whereas
+ * a floored NUMBER is a false statement.
+ */
 function StatBar({
   value,
+  readout,
   label,
   isLeader,
   color,
   neutralised = false,
   segmentColor,
+  testId,
 }: {
   value: number | null | undefined
+  /**
+   * The rendered readout, computed ONCE by the card for this register and
+   * shared with every other surface that states the same number. Required —
+   * there is no fallback formatter here, because a fallback is how the two
+   * strings drifted apart in the first place.
+   */
+  readout: string
+  /** Identity anchor for tests: the readout element's `data-testid`. */
+  testId?: string
   /**
    * Inline label for the 72px caption column, or `null` for none.
    *
@@ -378,8 +421,11 @@ function StatBar({
           }}
         />
       </div>
-      <span className={`${typography.panelMeta} text-text-body tabular-nums w-[36px] text-right flex-shrink-0`}>
-        {formatPct(value, { fromDecimal: true })}
+      <span
+        className={`${typography.panelMeta} text-text-body tabular-nums w-[36px] text-right flex-shrink-0`}
+        data-testid={testId}
+      >
+        {readout}
       </span>
     </div>
   )
@@ -528,17 +574,40 @@ function OptionCard({
   // This is a COPY switch, never a value transform: the bar length, the
   // percentage readout and the leader colour are all untouched.
   const goalFitSubstituted = option.goalFitIsSubstitutedJoint === true
-  // Built ONCE, above both arms, so the withheld and permitted wordings can
-  // never show a different number for the same option — the register modules
-  // make the same argument about casing, for the same reason. Byte-identical
-  // to the two literals it replaces: `< 1%` below the shared floor, otherwise
-  // the rounded percent.
-  const lowGoalReadout =
+
+  // ───────────────────────────────────────────────────────────────────────
+  // ⭐ ONE READOUT PER REGISTER PER CARD (ROADMAP 2.333) — N11
+  // ───────────────────────────────────────────────────────────────────────
+  // Every surface on this card that states a number states one of exactly
+  // these two strings. Not "computes it the same way" — states the SAME
+  // string, because there is only one.
+  //
+  // Both go through their register's shared primitive with the option's own
+  // `nValidSamples`, which the response mapper already carries off
+  // `outcome.n_valid_samples`. Passing it to only ONE of them is the
+  // half-fix that leaves a card printing a resolved figure in the header and
+  // a floored one in the row below, so both take it or neither does.
+  const goalReadout = formatGoalProbability(
+    option.goalProbability as number,
+    option.nValidSamples,
+  )
+  // Byte-identical to the expression the header readout has always used
+  // (:609 before this change) — now hoisted so the header and the "Wins" row
+  // are literally the same value rather than two evaluations of one rule.
+  const winsReadout = formatProbabilityWithResolution(
+    option.winProbability as number,
+    option.nValidSamples,
+  )
+
+  // The low-goal badge's VISIBILITY gate. It used to also carry its own
+  // inline copy of the sub-1% floor — a hand-copy of `formatGoalProbability`
+  // rather than a call to it, and the direct source of the "0%" beside
+  // "< 1%" contradiction. The threshold below is a display DECISION (when is
+  // a goal probability low enough to warrant a warning affordance) and stays;
+  // the FORMATTING is gone, and the badge now renders `goalReadout`.
+  const showLowGoalBadge =
     typeof option.goalProbability === 'number' && option.goalProbability < 0.10
-      ? option.goalProbability < SUB_ONE_PERCENT_FLOOR
-        ? '< 1%'
-        : `${Math.round(option.goalProbability * 100)}%`
-      : null
+  const lowGoalReadout = showLowGoalBadge ? goalReadout : null
 
   return (
     <div
@@ -597,16 +666,14 @@ function OptionCard({
                 ? 'This option did not lead in any of the simulation runs, so its true chance may be below the current resolution.'
                 : isAboveSimulationResolution(option.winProbability, option.nValidSamples)
                   ? 'This option led in every simulation run, so its display value reflects the current simulation resolution.'
-                  : COMPARATIVE_COPY.phrase(
-                      formatProbabilityWithResolution(option.winProbability, option.nValidSamples),
-                    )
+                  : COMPARATIVE_COPY.phrase(winsReadout)
             }
           >
             <span
               className={`${typography.panelHeader} text-text-header tabular-nums flex-shrink-0`}
               data-testid={`win-pct-${option.id}`}
             >
-              {formatProbabilityWithResolution(option.winProbability, option.nValidSamples)}
+              {winsReadout}
             </span>
           </Tooltip>
         )}
@@ -631,9 +698,7 @@ function OptionCard({
           // register here on the grounds that `goalProbability` is in scope —
           // but the BAR is not the goal number, and a goal caption over a
           // comparative fill is the mislabel map row 3 forbids.
-          title={COMPARATIVE_COPY.phrase(
-            formatProbabilityWithResolution(option.winProbability, option.nValidSamples),
-          )}
+          title={COMPARATIVE_COPY.phrase(winsReadout)}
         >
           <div
             className="h-full rounded-full transition-all duration-300"
@@ -679,6 +744,10 @@ function OptionCard({
           )}
           <StatBar
             value={option.goalProbability}
+            // The SAME string the low-goal badge below renders. This is the
+            // N11 fix at its call site: one readout, two surfaces.
+            readout={goalReadout}
+            testId={`goal-readout-${option.id}`}
             // The possessive "Hits target" names the user's OWN target, which
             // a substituted joint figure does not answer — so that arm is
             // withheld and the caption above carries the honest name instead.

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -822,7 +822,14 @@ function OptionCard({
           data-testid="option-constraint-badge"
         >
           {jointProbabilityLabel(option.constraintAnalysis.joint_probability)}{' '}
-          {Math.round(option.constraintAnalysis.joint_probability * 100)}%
+          {/* ROADMAP 2.333: was a bare `Math.round(... * 100)%`. This is the
+              SAME joint-constraint quantity `SuccessTargetRow` and
+              `TargetProbabilityBars` render, so leaving it rounded here would
+              have created a fresh "one number, two answers" pair with the
+              surfaces this slice just fixed. Comparative register (met every
+              target in n of N runs), hence `null` samples and an exact zero
+              still reading "0%". */}
+          {formatProbabilityWithResolution(option.constraintAnalysis.joint_probability, null)}
         </p>
       )}
 

--- a/src/components/results/RangeVisualization.tsx
+++ b/src/components/results/RangeVisualization.tsx
@@ -18,7 +18,12 @@ import { useMemo, useState } from 'react'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY } from './utils/goalAnchorCopy'
-import { formatPercent as formatPct } from '../../utils/formatPercent'
+// `formatPct` stays for THRESHOLD/axis formatting below — those are outcome
+// VALUES in user units, not probabilities, and no display floor applies to
+// them. The probability readouts moved to their registers' primitives
+// (ROADMAP 2.333); do not route threshold values back through those.
+import { formatPercent as formatPct, formatProbabilityWithResolution } from '../../utils/formatPercent'
+import { formatGoalProbability } from './utils/displayFloors'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { formatRangeValue } from './utils/formatRangeValue'
 import type { OptionResult, OutcomeUnitType } from './types'
@@ -131,8 +136,13 @@ function OptionRangeBar({
     if (option.goalProbability != null && goalThreshold != null) {
       // Question A, in the house register — "hit target" named the right
       // quantity but not the question it answers.
+      // ROADMAP 2.333: was a bare `formatPct`, so a measured 0.07% goal
+      // probability printed "0%" here while the option card beside it
+      // printed "< 1%" — the N11 contradiction on a second surface. The
+      // GOAL quantity takes the goal register's formatter, with the
+      // option's own sample count when the run carries one.
       return GOAL_ANCHOR_COPY.phrase(
-        formatPct(option.goalProbability, { fromDecimal: true }),
+        formatGoalProbability(option.goalProbability, option.nValidSamples),
         option.goalFitIsSubstitutedJoint === true,
       )
     }
@@ -143,7 +153,11 @@ function OptionRangeBar({
       // comparative register — NOT the A register. Labelling it "chance of
       // hitting your goal" would put a goal caption on a comparative number,
       // which is the defect the confidence-ring pin exists to catch.
-      return COMPARATIVE_COPY.phrase(formatPct(option.winProbability, { fromDecimal: true }))
+      // Same fix, comparative register: the shared floored/resolution-aware
+      // comparative formatter, not a bare round.
+      return COMPARATIVE_COPY.phrase(
+        formatProbabilityWithResolution(option.winProbability, option.nValidSamples),
+      )
     }
     // C10: Omit suffix entirely when both missing
     return null

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -516,6 +516,8 @@ export const ResultsBody = memo(function ResultsBody({
                   // number so the label cannot assert "your goal" over a
                   // substituted joint value.
                   goalProbability: o.goalProbability,
+                  // ROADMAP 2.334 — the resolution the goal readouts need.
+                  nValidSamples: o.nValidSamples,
                   goalFitIsSubstitutedJoint: o.goalFitIsSubstitutedJoint,
                 }))}
               decisionState={vm.decisionState}

--- a/src/components/results/SuccessTargetRow.tsx
+++ b/src/components/results/SuccessTargetRow.tsx
@@ -21,6 +21,7 @@ import {
   constraintConfidenceColour,
   CONSTRAINT_CONFIDENCE_THRESHOLDS,
 } from '../../types/constraints'
+import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 
 export interface SuccessTargetRowProps {
   /** Current goal threshold value (null = not set) */
@@ -60,7 +61,19 @@ function ConstraintIcon({ prob }: { prob: number }) {
 
 /** Single constraint row */
 function ConstraintRow({ item }: { item: ConstraintItem }) {
-  const pct = Math.round(item.prob_satisfied * 100)
+  // ROADMAP 2.333: was `${Math.round(item.prob_satisfied * 100)}%`, so a
+  // constraint satisfied in 7 of 10000 runs printed "0%" — a measured,
+  // non-zero probability rendered as impossibility.
+  //
+  // The COMPARATIVE register is the right one here, not the goal register:
+  // constraint satisfaction is a hit frequency over simulated scenarios
+  // ("satisfied in 0 of n runs"), the same shape as "came out ahead in n of
+  // N". That means an EXACT zero deliberately keeps reading "0%" — the floor
+  // exists to stop a non-zero value printing as zero, not to stop zero
+  // printing. `null` samples: this surface holds a constraint item, not the
+  // option object, so it has no per-option count to pass; the floored
+  // fallback arm applies and understates rather than inventing a resolution.
+  const readout = formatProbabilityWithResolution(item.prob_satisfied, null)
   const colour = constraintConfidenceColour(item.prob_satisfied)
   const isMissed = item.prob_satisfied < 0.5
 
@@ -75,7 +88,7 @@ function ConstraintRow({ item }: { item: ConstraintItem }) {
           {item.label} {renderOperator(item.operator)} {item.threshold}
         </span>
         <span className={`${typography.panelBody} ${colour} tabular-nums flex-shrink-0`}>
-          {pct}%
+          {readout}
         </span>
         {item.binding && (
           <span className={`${typography.panelMeta} text-danger flex-shrink-0`}>
@@ -148,7 +161,13 @@ export function SuccessTargetRow({
 
   // ── Multi-constraint display ──────────────────────────────────────────────
   if (hasConstraints) {
-    const jointPct = Math.round(constraintAnalysis.joint_probability * 100)
+    // Same register, same reason as the per-constraint rows above: the joint
+    // figure is "met every target in n of N runs", so it floors a non-zero
+    // value and keeps a true zero as "0%".
+    const jointReadout = formatProbabilityWithResolution(
+      constraintAnalysis.joint_probability,
+      null,
+    )
     const jointColour = constraintConfidenceColour(constraintAnalysis.joint_probability)
 
     return (
@@ -157,7 +176,7 @@ export function SuccessTargetRow({
         <div className="flex items-center justify-between min-h-[28px]">
           <span className={`${typography.panelHeader} text-text-header`}>
             Meeting all targets:{' '}
-            <span className={jointColour}>{jointPct}%</span>
+            <span className={jointColour}>{jointReadout}</span>
           </span>
           <button
             type="button"

--- a/src/components/results/TargetProbabilityBars.tsx
+++ b/src/components/results/TargetProbabilityBars.tsx
@@ -8,6 +8,7 @@
  */
 
 import { typography } from '../../styles/typography'
+import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 import { evaluativeVar } from '../../styles/evaluative'
 import type { ConstraintAnalysis } from '../../types/constraints'
 import Tooltip from '../Tooltip'
@@ -38,7 +39,13 @@ export function TargetProbabilityBars({
     <div className="flex flex-col gap-1.5 mb-2" data-testid="target-probability-bars">
       {/* Individual constraint rows */}
       {validConstraints.map(c => {
+        // Bar geometry keeps the rounded integer (visual `Math.max(2, pct)`
+        // floor is honest); the READOUT goes through the comparative
+        // register's formatter so a target met in 7 of 10000 runs no longer
+        // prints "0%" here while `SuccessTargetRow` prints "< 1%" for the
+        // same number (ROADMAP 2.333).
         const pct = Math.round(c.prob_satisfied * 100)
+        const readout = formatProbabilityWithResolution(c.prob_satisfied, null)
         return (
           <Tooltip key={c.node_id} content="Probability of meeting this target">
             <div className={`flex items-center gap-2 ${typography.panelMeta}`}>
@@ -58,7 +65,7 @@ export function TargetProbabilityBars({
                 />
               </div>
               <span className={`${typography.panelMeta} text-text-header flex-shrink-0 text-right`} style={{ minWidth: 28 }}>
-                {pct}%
+                {readout}
               </span>
             </div>
           </Tooltip>
@@ -88,7 +95,7 @@ export function TargetProbabilityBars({
               />
             </div>
             <span className={`${typography.panelHeader} text-text-header flex-shrink-0 text-right`} style={{ minWidth: 28 }}>
-              {Math.round(jointProbability * 100)}%
+              {formatProbabilityWithResolution(jointProbability, null)}
             </span>
           </div>
         </Tooltip>

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -65,6 +65,13 @@ export interface OptionWinShare {
    */
   goalProbability?: number | null
   /**
+   * ROADMAP 2.334 — `OptionResult.nValidSamples`, carried so the goal rows
+   * resolve sub-1% figures instead of printing the register floor five times.
+   * The gauge's prop shape simply did not carry it, which is the same reason
+   * it could not draw the goal quantity at all before the re-anchoring.
+   */
+  nValidSamples?: number | null
+  /**
    * THE POSSESSIVE GATE — `OptionResult.goalFitIsSubstitutedJoint`, i.e.
    * `selectGoalProbability(...).basis === 'joint_goal_substituted'`. True ⇒
    * the number answers a different question from the one "your goal"
@@ -276,7 +283,7 @@ export function WinGauge({
               // exactly as it does on the option card beside it, instead of a
               // bare "0%" the same panel contradicts.
               const pct = Math.round(clamped * 100)
-              const readout = formatGoalProbability(clamped)
+              const readout = formatGoalProbability(clamped, share.nValidSamples)
               return (
                 <div
                   key={share.id}

--- a/src/components/results/__tests__/goalProbabilityReadout.n11.spec.tsx
+++ b/src/components/results/__tests__/goalProbabilityReadout.n11.spec.tsx
@@ -187,6 +187,36 @@ describe('T-2333-3 — the comparative register agrees with itself on one card',
   })
 })
 
+describe('absent ≠ zero — the readouts are computed eagerly, so pin what happens', () => {
+  /**
+   * `goalReadout` and `winsReadout` are hoisted to the top of `OptionCard` and
+   * computed for EVERY card, including one whose probability is absent. That is
+   * what makes them single-sourced, and it means `formatGoalProbability` is
+   * called with `undefined` on such a card — which would render "NaN%".
+   *
+   * It never reaches the DOM, and this pins WHY rather than asserting it
+   * happens to be fine: the goal row is behind a complete-field gate
+   * (`showHitsTarget = hasGoalThreshold && options.every(o => o.goalProbability
+   * != null)`) and the win readout behind `option.winProbability != null`. If a
+   * later change renders either readout outside its guard, this REDs.
+   */
+  it('renders no "NaN" when an option carries no goal probability', () => {
+    renderCards([
+      makeOption({ id: 'a', goalProbability: null, winProbability: 0.5, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.4, winProbability: 0.3, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    expect(document.body.textContent ?? '').not.toContain('NaN')
+  })
+
+  it('renders no "NaN" when an option carries no win probability', () => {
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.4, winProbability: undefined, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.3, winProbability: undefined, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    expect(document.body.textContent ?? '').not.toContain('NaN')
+  })
+})
+
 describe('T-2334-1b — five sub-1% options render five DISTINCT card readouts', () => {
   it('makes the ordering legible on the option cards, not just the Model tab', () => {
     // PC4 on this surface: the walk's quintet collapsed to five identical

--- a/src/components/results/__tests__/goalProbabilityReadout.n11.spec.tsx
+++ b/src/components/results/__tests__/goalProbabilityReadout.n11.spec.tsx
@@ -1,0 +1,221 @@
+/**
+ * N11 — ONE OPTION CARD PRINTED TWO DIFFERENT ANSWERS FOR ONE NUMBER
+ * (ROADMAP 2.333, PC2).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE DEFECT, AS PHOTOGRAPHED
+ * ─────────────────────────────────────────────────────────────────────────
+ * A single option card, one render, one value (`goalProbability` 0.0007):
+ *
+ *     Hits target  ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  0%      ← StatBar
+ *     ( < 1% likely to reach target )                            ← badge
+ *
+ * ~2cm apart. Two hand-rolled formatters: the StatBar readout called bare
+ * `formatPercent` (`Math.round(0.0007 * 100)` → "0%"), while the low-goal
+ * badge carried its own inline copy of the sub-1% floor. The card
+ * contradicted itself, and BOTH strings were reachable from the same
+ * `option.goalProbability`.
+ *
+ * ⚠ The design pack claimed a COMPARATIVE twin of this defect — a "Wins"
+ * StatBar row printing "0%" beside a header readout printing "0.3%". That is
+ * stale: per-card Wins bars were removed in V12.4 and this file has exactly
+ * one `<StatBar>` call site. See the T-2333-3 block below, which pins what is
+ * actually true there instead.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THE FIX IS A PROP AND NOT A BETTER FORMATTER INSIDE `StatBar`
+ * ─────────────────────────────────────────────────────────────────────────
+ * Teaching `StatBar` the right formatter would fix these two strings and
+ * leave the SHAPE that produced them: a component that computes a readout
+ * from a raw value, beside a caller that computes its own readout from the
+ * same raw value. `StatBar` now takes `readout` as a required prop and holds
+ * no formatter at all; the card computes each register's readout ONCE and
+ * passes it to every surface that shows it. N11 becomes impossible by
+ * construction rather than merely absent — the two strings can no longer be
+ * computed twice, so they cannot differ.
+ *
+ * Scope limit (trap 3): jsdom pins string identity and presence/absence
+ * only. Nothing here claims anything about layout, adjacency or visibility —
+ * the "2cm apart" framing above is from the walk photograph, not from this
+ * file.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+
+/** The walk's measured per-option sample count. */
+const WALK_N = 10000
+
+/**
+ * A bare "0%" — i.e. a zero-percent readout that is NOT the tail of a larger
+ * number ("10%", "0.01%", "100%" must not match). This is the string the
+ * whole slice exists to stop printing for a measured non-zero probability.
+ */
+const BARE_ZERO_PERCENT = /(?<![\d.])0%/
+
+function makeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'option-a',
+    label: 'Option A',
+    expected: 50,
+    outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+    p10: 20,
+    p50: 50,
+    p90: 80,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.7,
+    rank: 1,
+    ...overrides,
+  }
+}
+
+function renderCards(options: OptionResult[]) {
+  return render(<OptionCards options={options} winnerId={options[0]?.id} hasGoalThreshold />)
+}
+
+describe('positive control — the harness renders a non-degenerate card (trap 13)', () => {
+  it('shows a mid-range goal probability on every goal surface before any sub-1% claim', () => {
+    // If the goal row stopped rendering (the `hasGoalThreshold` /
+    // complete-field gates are easy to trip with a partial fixture), every
+    // "no 0% anywhere" assertion below would pass by rendering nothing.
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.34, winProbability: 0.34, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.2, winProbability: 0.2, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    expect(screen.getByTestId('goal-readout-a').textContent).toBe('34%')
+    expect(screen.getByTestId('win-pct-a').textContent).toBe('34%')
+  })
+})
+
+describe('T-2333-2 — N11: the goal readout and the low-goal badge share ONE string', () => {
+  it('prints no bare "0%" anywhere on a card whose goal probability is 0.0007', () => {
+    // The headline assertion, and the one that is RED at the defect: the
+    // StatBar's `Math.round(0.0007 * 100)` printed "0%" beside a badge
+    // saying "< 1%".
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.0007, winProbability: 0.65, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.0004, winProbability: 0.35, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    const card = screen.getByTestId('option-card-a')
+    expect(card.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('binds the two surfaces to the SAME numeric string, by identity', () => {
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.0007, winProbability: 0.65, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.0004, winProbability: 0.35, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    const card = screen.getByTestId('option-card-a')
+    const statReadout = within(card).getByTestId('goal-readout-a').textContent
+    const badge = within(card).getByTestId('low-goal-warning-a').textContent
+
+    // Executed against the real formatter at this tip: 0.0007 at n=10000.
+    expect(statReadout).toBe('0.1%')
+    expect(badge).toBe('0.1% likely to reach target')
+    // The identity claim itself — not "both are 0.1%", but "the badge is
+    // built FROM the readout". A mutant that recomputes the badge with a
+    // different threshold breaks this even if both strings look plausible.
+    expect(badge?.startsWith(`${statReadout} `)).toBe(true)
+  })
+
+  it('keeps the floor readout on both surfaces when the run carries no sample count', () => {
+    // The no-resolution fallback still agrees with itself — the register's
+    // older guarantee, re-pinned so the new arm cannot regress it.
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.0007, winProbability: 0.65, nValidSamples: undefined }),
+      makeOption({ id: 'b', goalProbability: 0.0004, winProbability: 0.35, isRecommended: false }),
+    ])
+    const card = screen.getByTestId('option-card-a')
+    expect(within(card).getByTestId('goal-readout-a').textContent).toBe('< 1%')
+    expect(within(card).getByTestId('low-goal-warning-a').textContent).toBe('< 1% likely to reach target')
+  })
+})
+
+describe('T-2333-3 — the comparative register agrees with itself on one card', () => {
+  /**
+   * ⚠ A DESIGN PREMISE REFUTED AT THE BYTES, and the reason this block is
+   * shaped differently from the goal block above.
+   *
+   * The design pack described N11 as having a comparative twin: the header
+   * win readout using `formatProbabilityWithResolution` while "the 'Wins'
+   * StatBar row uses the same bare `formatPercent`". There IS no Wins
+   * StatBar row at this tip — `OptionCards`' own header records
+   * "V12.4: Per-card 'Wins' bars removed; win % shown as text in card
+   * header", and the file has exactly ONE `<StatBar>` call site (the goal
+   * row). The comparative half of N11 was fixed by deletion, before this
+   * slice, and the design was reading a stale map.
+   *
+   * What IS true and worth pinning: the card stated the win figure at three
+   * separate places (header readout, its tooltip, the fill bar's title),
+   * each re-evaluating the same expression. Those are now one hoisted
+   * `winsReadout`. That is a single-sourcing claim, not a defect fix, and it
+   * is asserted as such.
+   */
+  it('states ONE win string across the header readout, its tooltip and the bar title', () => {
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.4, winProbability: 0.002675, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.3, winProbability: 0.5, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    const card = screen.getByTestId('option-card-a')
+    // executed: formatProbabilityWithResolution(0.002675, 10000)
+    expect(within(card).getByTestId('win-pct-a').textContent).toBe('0.3%')
+
+    // Every other surface stating the win figure carries the same string.
+    const titled = Array.from(card.querySelectorAll('[title]'))
+      .map((el) => el.getAttribute('title') ?? '')
+      .filter((t) => /came out ahead/i.test(t))
+    expect(titled.length).toBeGreaterThan(0)
+    for (const t of titled) expect(t).toContain('0.3%')
+
+    expect(card.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('threads the sample count to BOTH registers, not just the goal row', () => {
+    // Guards the half-fix: passing `nValidSamples` to the goal readout and
+    // `undefined` to the win readout would leave one register resolved and
+    // the other floored on the same card.
+    renderCards([
+      makeOption({ id: 'a', goalProbability: 0.0007, winProbability: 0.0001, nValidSamples: WALK_N }),
+      makeOption({ id: 'b', goalProbability: 0.0004, winProbability: 0.9, isRecommended: false, nValidSamples: WALK_N }),
+    ])
+    const card = screen.getByTestId('option-card-a')
+    expect(within(card).getByTestId('goal-readout-a').textContent).toBe('0.1%')
+    expect(within(card).getByTestId('win-pct-a').textContent).toBe('0.01%')
+  })
+})
+
+describe('T-2334-1b — five sub-1% options render five DISTINCT card readouts', () => {
+  it('makes the ordering legible on the option cards, not just the Model tab', () => {
+    // PC4 on this surface: the walk's quintet collapsed to five identical
+    // "< 1%" strings, so the status-quo-lowest signature was invisible.
+    //
+    // NOTE the `Show all` click. `OptionCards` renders `TOP_N = 2` cards
+    // until the user expands, so a five-option assertion that skips the
+    // toggle finds three missing testids and fails for a reason that has
+    // nothing to do with formatting. Expanding is what a user comparing five
+    // options actually does, and it is the state the claim is about.
+    const quintet = [0.0007, 0.0001, 0.0004, 0, 0.0002]
+    renderCards(
+      quintet.map((p, i) =>
+        makeOption({
+          id: `o${i}`,
+          label: `Option ${i}`,
+          goalProbability: p,
+          // Descending, so the display sort keeps producer order and the
+          // expected array below stays readable.
+          winProbability: 0.2 - i * 0.01,
+          nValidSamples: WALK_N,
+          isRecommended: i === 0,
+        }),
+      ),
+    )
+    fireEvent.click(screen.getByTestId('option-cards-toggle'))
+
+    const readouts = quintet.map((_, i) => screen.getByTestId(`goal-readout-o${i}`).textContent)
+    expect(readouts).toEqual(['0.1%', '0.01%', '0.04%', '<0.01%', '0.02%'])
+    expect(new Set(readouts).size).toBe(quintet.length)
+  })
+})

--- a/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
+++ b/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
@@ -200,7 +200,26 @@ describe('OptionCards — possessive gate on a substituted joint goal figure (RO
 
     // The badge still renders, still carries the number, and now names the
     // quantity it actually is — the register's compact readout, verbatim.
-    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('< 1%', true))
+    //
+    // ⭐ AMENDED (ROADMAP 2.334): the readout was `'< 1%'`; it is now `'1%'`.
+    // The fixture carries `nValidSamples: 10000`, so the goal register no
+    // longer floors — it resolves, and 0.0054 renders through the shared
+    // smallest-distinct-precision rule.
+    //
+    // ⚠ NAMING THIS EXPLICITLY BECAUSE IT IS THE ONE BAND WHERE THE NEW
+    // REGISTER READS *HIGHER* THAN THE OLD FLOOR. For values in
+    // [0.005, 0.00999] the resolved string is "1%" where the floor said
+    // "< 1%" — 0.54% presented as 1%. That is ordinary integer rounding and
+    // it is byte-identical to what `formatProbabilityWithResolution` has
+    // rendered for WIN probabilities since ROADMAP 2.236, which is the whole
+    // point of the two registers sharing one rule. It is not a new untruth,
+    // but it IS a direction change, and a reviewer should see it stated
+    // rather than discover it: everywhere else in this slice the change makes
+    // readouts tighter or unchanged; here it makes one coarser.
+    //
+    // Derived by EXECUTING `formatGoalProbability(0.0054, 10000)` at this tip.
+    // Do not hand-edit this string — re-execute if the fixture moves.
+    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
   })
 
   it('RED-first: the goal bar does NOT carry the possessive "Hits target" label over a substituted joint figure', () => {

--- a/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
+++ b/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
@@ -219,7 +219,20 @@ describe('OptionCards — possessive gate on a substituted joint goal figure (RO
     //
     // Derived by EXECUTING `formatGoalProbability(0.0054, 10000)` at this tip.
     // Do not hand-edit this string — re-execute if the fixture moves.
-    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    //
+    // ⚠ BOUND BY IDENTITY AND EXACT EQUALITY, NOT `toContain` — and that is
+    // not stylistic. A `toContain(phrase('1%', true))` here is VACUOUS: the
+    // OLD string "< 1% chance of meeting every target this run scored"
+    // literally CONTAINS the new one as a substring, so the assertion passes
+    // whether or not the fix is present. Caught by mutation (dropping the
+    // nSamples delegation left this test green while the sibling specs went
+    // red), which is the only reason it is written this way.
+    const badge = container.querySelector('[data-testid="low-goal-warning-opt_hybrid"]')
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toBe(GOAL_ANCHOR_COPY.phrase('1%', true))
+    // And the floor string is gone from the card entirely, so no substring
+    // relationship can hide a regression.
+    expect(text).not.toContain('< 1%')
   })
 
   it('RED-first: the goal bar does NOT carry the possessive "Hits target" label over a substituted joint figure', () => {

--- a/src/components/results/__tests__/zeroFloorSweep.2333.spec.tsx
+++ b/src/components/results/__tests__/zeroFloorSweep.2333.spec.tsx
@@ -1,0 +1,164 @@
+/**
+ * THE REST OF THE "0%" CLASS — the surfaces N11 was one instance of
+ * (ROADMAP 2.333, PC2).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE CLASS, NOT THE INSTANCE
+ * ─────────────────────────────────────────────────────────────────────────
+ * Fixing the option card alone would have left four more places where a
+ * measured, non-zero probability is rounded to a bare "0%" — the same
+ * untruth, on surfaces a user reaches in the same session:
+ *
+ *   · `RangeVisualization`  — bare `formatPercent` on BOTH registers
+ *   · `SuccessTargetRow`    — bare `Math.round` on constraint satisfaction
+ *   · `GoalNode` (canvas)   — its own literal, with a `> 0` carve-out that
+ *                             made an EXACT zero print "0%" while every
+ *                             dock surface printed the floor string
+ *   · `OptionNode` (canvas) — the same literal, same class
+ *
+ * The `GoalNode` divergence is worth naming precisely, because it was
+ * documented as an open question rather than a defect: `displayFloors.ts`
+ * carried a correction warning that the canvas renders an exact zero as
+ * "0% chance of reaching target" — "live, and the opposite convention". This
+ * slice CLOSES it in the goal register's favour, so the canvas node and the
+ * card beside it state the same thing about the same number.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT IS DELIBERATELY *NOT* CHANGED
+ * ─────────────────────────────────────────────────────────────────────────
+ * `formatProbabilityWithResolution`'s fallback arm still renders an exact
+ * zero as "0%" for the COMPARATIVE register: "came out ahead in 0% of
+ * simulated scenarios" is TRUE when an option never came out ahead, and the
+ * floor exists to stop a NON-ZERO value printing as zero, not to stop zero
+ * printing. Constraint satisfaction takes the comparative register for the
+ * same reason ("satisfied in 0 of n runs"). Those are pinned here too, so a
+ * later "make everything say < 1%" sweep REDs instead of silently
+ * overclaiming.
+ *
+ * Scope limit (trap 3): string presence/absence only.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { RangeVisualization } from '../RangeVisualization'
+import { SuccessTargetRow } from '../SuccessTargetRow'
+import type { OptionResult } from '../types'
+import type { ConstraintAnalysis } from '../../../types/constraints'
+
+/** A zero-percent readout that is not the tail of a larger number. */
+const BARE_ZERO_PERCENT = /(?<![\d.])0%/
+
+function rangeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'option-1',
+    label: 'Option A',
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.75,
+    ...overrides,
+  }
+}
+
+describe('RangeVisualization — the per-option probability suffix', () => {
+  it('positive control: a mid-range goal probability renders its own percentage', () => {
+    render(
+      <RangeVisualization
+        options={[rangeOption({ goalProbability: 0.34 }), rangeOption({ id: 'option-2', label: 'B', isRecommended: false })]}
+        goalThreshold={100}
+        winnerId="option-1"
+      />,
+    )
+    expect(document.body.textContent ?? '').toContain('34%')
+  })
+
+  it('never prints a bare "0%" for a measured sub-1% GOAL probability', () => {
+    render(
+      <RangeVisualization
+        options={[
+          rangeOption({ goalProbability: 0.0007, nValidSamples: 10000 }),
+          rangeOption({ id: 'option-2', label: 'B', goalProbability: 0.0004, nValidSamples: 10000, isRecommended: false }),
+        ]}
+        goalThreshold={100}
+        winnerId="option-1"
+      />,
+    )
+    expect(document.body.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('never prints a bare "0%" for a measured sub-1% WIN probability', () => {
+    // The comparative arm of the same component — reached when the run has
+    // no goal threshold, so the suffix falls back to the win quantity.
+    render(
+      <RangeVisualization
+        options={[
+          rangeOption({ goalProbability: null, winProbability: 0.002675, nValidSamples: 10000 }),
+          rangeOption({ id: 'option-2', label: 'B', goalProbability: null, winProbability: 0.0001, nValidSamples: 10000, isRecommended: false }),
+        ]}
+        goalThreshold={null}
+        winnerId="option-1"
+      />,
+    )
+    expect(document.body.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+})
+
+describe('SuccessTargetRow — constraint satisfaction probabilities', () => {
+  function constraintAnalysis(probs: number[], joint: number): ConstraintAnalysis {
+    return {
+      constraints: probs.map((p, i) => ({
+        node_id: `c${i}`,
+        operator: '>=',
+        threshold: 100,
+        label: `Constraint ${i}`,
+        prob_satisfied: p,
+        failure_margin_median: 10,
+        near_miss_fraction: 0.1,
+        binding: i === 0,
+      })),
+      joint_probability: joint,
+    }
+  }
+
+  it('positive control: mid-range constraint probabilities render their own percentages', () => {
+    render(<SuccessTargetRow goalThreshold={100} constraintAnalysis={constraintAnalysis([0.34, 0.72], 0.25)} />)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('34%')
+    expect(text).toContain('72%')
+    expect(text).toContain('25%')
+  })
+
+  it('never prints a bare "0%" for measured sub-1% satisfaction probabilities', () => {
+    render(
+      <SuccessTargetRow
+        goalThreshold={100}
+        constraintAnalysis={constraintAnalysis([0.0007, 0.0002], 0.0001)}
+      />,
+    )
+    expect(document.body.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('KEEPS "0%" for an exact zero — the comparative register, deliberately', () => {
+    // Satisfied in 0 of n runs is a true statement about a measurement, and
+    // the floor is not there to suppress it. This is the no-overclaim guard
+    // in the other direction.
+    render(
+      <SuccessTargetRow goalThreshold={100} constraintAnalysis={constraintAnalysis([0, 0.5], 0)} />,
+    )
+    expect(document.body.textContent ?? '').toMatch(BARE_ZERO_PERCENT)
+  })
+})
+
+// The canvas GoalNode/OptionNode arms of this class live in
+// `src/canvas/nodes/__tests__/nodeGoalReadout.zeroFloor.2333.spec.tsx`.
+// They need the canvas store mocked at module scope (the proven harness in
+// `GoalNode.possessiveGate.spec.tsx`), which cannot be combined in one file
+// with the unmocked dock renders above: a per-test `vi.doMock` +
+// `resetModules` hands the node a DIFFERENT `@xyflow/react` instance from the
+// `ReactFlowProvider` wrapping it, and every canvas assertion then fails with
+// "you have not used zustand provider as an ancestor" — a harness fault that
+// reads exactly like a real defect.

--- a/src/components/results/__tests__/zeroFloorSweep.2333.spec.tsx
+++ b/src/components/results/__tests__/zeroFloorSweep.2333.spec.tsx
@@ -5,16 +5,23 @@
  * ─────────────────────────────────────────────────────────────────────────
  * THE CLASS, NOT THE INSTANCE
  * ─────────────────────────────────────────────────────────────────────────
- * Fixing the option card alone would have left four more places where a
+ * Fixing the option card alone would have left several more places where a
  * measured, non-zero probability is rounded to a bare "0%" — the same
  * untruth, on surfaces a user reaches in the same session:
  *
- *   · `RangeVisualization`  — bare `formatPercent` on BOTH registers
- *   · `SuccessTargetRow`    — bare `Math.round` on constraint satisfaction
- *   · `GoalNode` (canvas)   — its own literal, with a `> 0` carve-out that
- *                             made an EXACT zero print "0%" while every
- *                             dock surface printed the floor string
- *   · `OptionNode` (canvas) — the same literal, same class
+ *   · `RangeVisualization`       — bare `formatPercent` on BOTH registers
+ *   · `SuccessTargetRow`         — bare `Math.round` on constraint satisfaction
+ *   · `TargetProbabilityBars`    — the same constraint numbers, second surface
+ *   · `OptionCards` joint badge  — the same joint figure, third surface
+ *   · `GoalNode` (canvas)        — its own literal, with a `> 0` carve-out
+ *                                  that made an EXACT zero print "0%" while
+ *                                  every dock surface printed the floor string
+ *
+ * ⚠ `OptionNode` was named in the design as "the same literal, same class".
+ * It is NOT — its sub-1% predicate has no `> 0` carve-out, so an exact zero
+ * already took the floor arm and it never printed "0%". It is left unchanged;
+ * the control pinning that is in
+ * `canvas/nodes/__tests__/nodeGoalReadout.zeroFloor.2333.spec.tsx`.
  *
  * The `GoalNode` divergence is worth naming precisely, because it was
  * documented as an open question rather than a defect: `displayFloors.ts`
@@ -42,6 +49,7 @@ import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
 import { RangeVisualization } from '../RangeVisualization'
 import { SuccessTargetRow } from '../SuccessTargetRow'
+import { TargetProbabilityBars } from '../TargetProbabilityBars'
 import type { OptionResult } from '../types'
 import type { ConstraintAnalysis } from '../../../types/constraints'
 
@@ -149,6 +157,66 @@ describe('SuccessTargetRow — constraint satisfaction probabilities', () => {
     render(
       <SuccessTargetRow goalThreshold={100} constraintAnalysis={constraintAnalysis([0, 0.5], 0)} />,
     )
+    expect(document.body.textContent ?? '').toMatch(BARE_ZERO_PERCENT)
+  })
+})
+
+describe('TargetProbabilityBars — the OTHER surface rendering the same constraint numbers', () => {
+  /**
+   * ⚠ NOT IN THE DESIGN'S MANIFEST — found by re-running the design's OWN
+   * regenerating `rg` command at this tip (trap 12d in miniature: a derived
+   * query proves agreement among the rows it returns; it cannot tell you the
+   * hand-written TABLE is short).
+   *
+   * This matters because it is the same `prob_satisfied` / `joint_probability`
+   * that `SuccessTargetRow` renders. Fixing one and not the other would not
+   * have left a pre-existing defect alone — it would have MANUFACTURED a new
+   * "one number, two answers" pair between two surfaces of the same panel,
+   * with this slice's own change as the cause.
+   */
+  function analysis(probs: number[], joint: number): ConstraintAnalysis {
+    return {
+      constraints: probs.map((p, i) => ({
+        node_id: `c${i}`,
+        operator: '>=',
+        threshold: 100,
+        label: `Constraint ${i}`,
+        prob_satisfied: p,
+        failure_margin_median: 10,
+        near_miss_fraction: 0.1,
+        binding: i === 0,
+      })),
+      joint_probability: joint,
+    }
+  }
+
+  it('positive control: mid-range constraint probabilities render their own percentages', () => {
+    render(<TargetProbabilityBars constraintAnalysis={analysis([0.34, 0.72], 0.25)} />)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('34%')
+    expect(text).toContain('72%')
+    expect(text).toContain('25%')
+  })
+
+  it('never prints a bare "0%" for measured sub-1% satisfaction probabilities', () => {
+    render(<TargetProbabilityBars constraintAnalysis={analysis([0.0007, 0.0002], 0.0001)} />)
+    expect(document.body.textContent ?? '').not.toMatch(BARE_ZERO_PERCENT)
+  })
+
+  it('agrees with SuccessTargetRow on the SAME numbers', () => {
+    // The claim that motivated including this surface: two components, one
+    // constraint analysis, identical strings.
+    const ca = analysis([0.0007, 0.0002], 0.0001)
+    const { container: bars } = render(<TargetProbabilityBars constraintAnalysis={ca} />)
+    const { container: row } = render(<SuccessTargetRow goalThreshold={100} constraintAnalysis={ca} />)
+    for (const expected of ['< 1%']) {
+      expect(bars.textContent ?? '').toContain(expected)
+      expect(row.textContent ?? '').toContain(expected)
+    }
+  })
+
+  it('KEEPS "0%" for an exact zero — comparative register, deliberately', () => {
+    render(<TargetProbabilityBars constraintAnalysis={analysis([0, 0.5], 0)} />)
     expect(document.body.textContent ?? '').toMatch(BARE_ZERO_PERCENT)
   })
 })

--- a/src/components/results/analysis-hero/__tests__/stagingScenario.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/stagingScenario.spec.tsx
@@ -132,10 +132,25 @@ describe('staging scenario — model truth', () => {
     // No goal-fit leader ring; the outcome highlight stays factual.
     expect(m.leaders.goal).toBeNull()
     expect(m.leaders.outcome).toBe('opt_virtual')
-    // Goal lens exists AND is the default — the "< 1%" rows ARE the story.
+    // Goal lens exists AND is the default — the sub-resolution rows ARE the
+    // story.
     expect(m.lenses).toEqual(['goal', 'outcome'])
     expect(m.defaultLens).toBe('goal')
-    expect(m.rows.every((r) => r.goal.readout === '< 1%')).toBe(true)
+    // ⭐ AMENDED (ROADMAP 2.334). Was `'< 1%'`. This run carries
+    // `nValidSamples: 4000` on every option and `goalProbability: 0`, so the
+    // goal register now states the bound the sampler actually supports:
+    // 1/4000 = 0.025 percentage points, rendered "<0.03%".
+    //
+    // This is the row's point getting SHARPER, not changing. "< 1%" was true
+    // but nearly two orders of magnitude looser than the evidence: it could
+    // not distinguish "we did not measure this finely" from "this is a real
+    // 0.9% chance". "<0.03%" says what 0 hits in 4000 runs licenses and
+    // nothing more.
+    //
+    // Derived by EXECUTING `formatGoalProbability(0, 4000)` at this tip, not
+    // hand-computed — the threshold ladder picks the smallest precision that
+    // renders distinctly non-zero, which is not obvious by inspection.
+    expect(m.rows.every((r) => r.goal.readout === '<0.03%')).toBe(true)
   })
 
   it('outcome readouts equal the denormalised values — never ×100 — and share the dot source field', () => {
@@ -186,12 +201,20 @@ describe('staging scenario — rendered surfaces (numeric parity, check A)', () 
     expect(screen.getByTestId('hero-caption')).not.toHaveTextContent(/target/i)
   })
 
-  it('Goal fit still communicates the target shortfall (every option "< 1%", no-on-track headline)', () => {
+  it('Goal fit still communicates the target shortfall (every option "<0.03%", no-on-track headline)', () => {
     renderHero() // Goal fit is the default lens for this run.
     expect(screen.getByTestId('hero-headline')).toHaveTextContent(
       'No option is currently on track to meet every target this run scored.',
     )
-    expect(screen.getAllByText('< 1%').length).toBe(4)
+    // ⭐ AMENDED (ROADMAP 2.334): "< 1%" → "<0.03%" at n=4000. See the model
+    // -truth test above for why the tighter bound is the same claim, stated
+    // to the resolution the run actually has.
+    expect(screen.getAllByText('<0.03%').length).toBe(4)
+    // The headline gate is UNCHANGED and that is deliberate: it keys off
+    // `SUB_ONE_PERCENT_FLOOR` applied to the raw values, which is a semantic
+    // threshold ("is any option meaningfully on track"), not a display rule.
+    // Resolving the readouts finer must not quietly re-open that claim.
+    expect(screen.queryByText('< 1%')).not.toBeInTheDocument()
   })
 
   it('hero row 1 is the same option OptionCards ranks first, and both surfaces share one scale', () => {
@@ -216,8 +239,14 @@ describe('staging scenario — rendered surfaces (numeric parity, check A)', () 
     expect(cardsText).toContain('6.39')
     expect(cardsText).not.toContain('-37%')
     expect(cardsText).not.toContain('80%')
-    // Goal honesty below stays consistent with the hero's "< 1%" readouts.
-    expect(within(cards.container).getAllByText(/< 1% likely to reach target/).length)
+    // Goal honesty below stays consistent with the hero's readouts — and
+    // THAT is the load-bearing claim here, not the literal string. Both
+    // surfaces move together because both now route through
+    // `formatGoalProbability` with the same per-option sample count; a change
+    // that resolved one and floored the other would reopen the
+    // one-number-two-answers defect between the hero and the cards.
+    // ⭐ AMENDED (ROADMAP 2.334): "< 1%" → "<0.03%" at n=4000.
+    expect(within(cards.container).getAllByText(/<0\.03% likely to reach target/).length)
       .toBeGreaterThan(0)
   })
 

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -48,7 +48,12 @@ import { formatThreshold } from '../RangeVisualization'
 import { stripEncodingNotation } from '../utils/cleanFactorLabel'
 import { selectFlipRisk } from '../utils/selectFlipRisk'
 import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
-import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
+// `SUB_ONE_PERCENT_FLOOR` is still imported, and deliberately: it no longer
+// formats anything here, but it still GATES the no-option-on-track headline
+// (`allGoalBelowFloor`). That gate is a semantic threshold about the raw
+// values — "is any option meaningfully on track" — not a display rule, so it
+// keeps reading the constant even though the readouts now resolve finer.
+import { SUB_ONE_PERCENT_FLOOR, formatGoalProbability } from '../utils/displayFloors'
 import { hasAnyGoalValue, selectGoalLeader } from '../utils/selectGoalLeader'
 import { isDirectionalFactor } from '../../../lib/factorDirection'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../utils/goalFitBasisCaveatCopy'
@@ -150,10 +155,28 @@ const OUTCOME_CLOSE_RATIO = 0.15
  * when EVERY goal readout would render "< 1%", claiming any option "best
  * fits your goal" would be false.
  */
-function goalReadout(value: number | null): string {
+/**
+ * ⭐ ROADMAP 2.333/2.334 — this was a THIRD hand-copy of the goal register's
+ * floor (`value < SUB_ONE_PERCENT_FLOOR ? subOnePercent : formatPercent`),
+ * sitting beside the option card's and the V7 lens's copies of the same rule.
+ * It now calls the register's own formatter.
+ *
+ * The delegation is byte-identical to the previous behaviour whenever no
+ * sample count is supplied: `SUB_ONE_PERCENT_READOUT` and
+ * `HERO_COPY.readout.subOnePercent` are the same string ("< 1%"), and above
+ * the floor both paths are `formatPercent(v, { fromDecimal: true })`. The
+ * `missing` arm is the hero's own and stays here — it is a copy decision
+ * about an ABSENT value, not a formatting rule about a present one.
+ *
+ * With a count, the readout resolves exactly as the card and the goal lens
+ * now do. That matters most on this surface: the hero states its figure ABOVE
+ * the rows, so a hero saying "< 1%" over rows saying "0.1%" would be the same
+ * one-number-two-answers contradiction this slice exists to remove, moved one
+ * element up.
+ */
+function goalReadout(value: number | null, nSamples?: number | null): string {
   if (value == null) return HERO_COPY.readout.missing
-  if (value < SUB_ONE_PERCENT_FLOOR) return HERO_COPY.readout.subOnePercent
-  return formatPercent(value, { fromDecimal: true })
+  return formatGoalProbability(value, nSamples)
 }
 
 // formatFlipValue moved VERBATIM to `../utils/flipThresholdDisplay` (ROADMAP
@@ -322,10 +345,10 @@ export function buildHeroModel(
     const goalFit =
       goalValue != null
         ? optionHasConstraints(o)
-          ? HERO_COPY.detail.goalFitWithLimits(goalReadout(goalValue))
+          ? HERO_COPY.detail.goalFitWithLimits(goalReadout(goalValue, o.nValidSamples))
           : o.goalFitIsSubstitutedJoint === true
-            ? HERO_COPY.detail.goalFitJointBasis(goalReadout(goalValue))
-            : HERO_COPY.detail.goalFit(goalReadout(goalValue))
+            ? HERO_COPY.detail.goalFitJointBasis(goalReadout(goalValue, o.nValidSamples))
+            : HERO_COPY.detail.goalFit(goalReadout(goalValue, o.nValidSamples))
         : undefined
     // Display-honesty (ROADMAP 1.6b follow-up, claim-integrity): the caveat
     // renders ONLY when the goalFit number just above it is actually shown
@@ -345,7 +368,7 @@ export function buildHeroModel(
       label: stripEncodingNotation(o.label),
       goal: {
         value: goalValue,
-        readout: goalReadout(goalValue),
+        readout: goalReadout(goalValue, o.nValidSamples),
       },
       outcome: {
         p10,

--- a/src/components/results/utils/__tests__/formatGoalProbability.resolution.spec.ts
+++ b/src/components/results/utils/__tests__/formatGoalProbability.resolution.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * `formatGoalProbability` — THE GOAL REGISTER GETS A RESOLUTION ARM
+ * (ROADMAP 2.333 / 2.334, PC2 + PC4).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS FILE EXISTS
+ * ─────────────────────────────────────────────────────────────────────────
+ * The GOAL register's formatter was floor-only: every value below 1% became
+ * the single string "< 1%". On the walk's run that collapsed FIVE distinct
+ * measured probabilities — 0.0007, 0.0001, 0.0004, 0, 0.0002 — into five
+ * identical readouts, so the Model tab's goal rows rendered an ordering the
+ * user could not see (PC4). The COMPARATIVE register had solved this a
+ * release earlier: `formatProbabilityWithResolution` already derives its
+ * precision from `n_valid_samples`, which IS on the wire
+ * (`option_probabilities[id].outcome.n_valid_samples`, 10000 on the walk).
+ *
+ * The fix delegates rather than re-implementing: with a positive finite
+ * sample count, the goal formatter calls the comparative primitive's
+ * sample-count arm. Two registers, ONE resolution rule — a second
+ * hand-rolled precision ladder is exactly the divergence UI-SEM-057 exists
+ * to abolish.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⚠ EVERY EXPECTED STRING IN THIS FILE WAS DERIVED BY EXECUTION, NOT BY
+ *   READING THE DESIGN
+ * ─────────────────────────────────────────────────────────────────────────
+ * The design pack for this slice asserted 0.0007 → "0.07%" in its first
+ * draft and REFUTED ITSELF on execution: the smallest-distinct-precision
+ * rule renders "0.1%", because precision 1 already renders non-zero and
+ * rounding COARSER than the resolution never overclaims. The values below
+ * were read off a run of the real formatter at this tip. Do not "correct"
+ * them from first principles — re-execute instead.
+ *
+ * THE HONESTY CONSTRAINT, stated so a later reader can check it:
+ * printed digits are supported iff the rendering never distinguishes values
+ * finer than 1/n. At n=10000 the resolution is 0.01 percentage points, and
+ * every string below is at or coarser than that. Fixed "two significant
+ * figures" is rejected — it would print "0.070%", a digit the wire cannot
+ * carry.
+ *
+ * NOTE THE TWO DISTINCT SUB-1% STRINGS — they are not interchangeable:
+ *   · "< 1%"  (WITH a space) — the register FLOOR readout, no resolution info
+ *   · "<1%"   (NO space)     — the THRESHOLD form, derived from a real n
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatGoalProbability, SUB_ONE_PERCENT_READOUT } from '../displayFloors'
+import { formatProbabilityWithResolution } from '../../../../utils/formatPercent'
+
+/** The walk's measured `probability_of_goal` quintet, in producer order. */
+const WALK_QUINTET = [0.0007, 0.0001, 0.0004, 0, 0.0002] as const
+const WALK_N = 10000
+
+describe('formatGoalProbability — positive control (trap 13)', () => {
+  it('renders a non-degenerate value identically with and without a sample count', () => {
+    // An absence assertion must first prove it can see a presence. If the
+    // formatter stopped resolving at all, every "distinct strings" claim
+    // below would pass by testing nothing.
+    expect(formatGoalProbability(0.34)).toBe('34%')
+    expect(formatGoalProbability(0.34, WALK_N)).toBe('34%')
+  })
+})
+
+describe('T-2333-1 — the sample-count arm delegates to the comparative primitive', () => {
+  it('resolves the walk quintet to five DISTINCT strings at n=10000', () => {
+    const rendered = WALK_QUINTET.map((v) => formatGoalProbability(v, WALK_N))
+    // Executed values — see the header. Producer order.
+    expect(rendered).toEqual(['0.1%', '0.01%', '0.04%', '<0.01%', '0.02%'])
+    expect(new Set(rendered).size).toBe(WALK_QUINTET.length)
+  })
+
+  it('is byte-identical to `formatProbabilityWithResolution` on the sample-count arm', () => {
+    // Bound to the SHARED primitive by identity, not to a copied ladder: a
+    // second precision implementation inside the goal register would satisfy
+    // the string assertions above and still be the defect this slice removes.
+    for (const v of [...WALK_QUINTET, 0.55, 0.002675, 0.9999]) {
+      expect(formatGoalProbability(v, WALK_N)).toBe(formatProbabilityWithResolution(v, WALK_N))
+    }
+  })
+
+  it('renders an exact wire zero as the resolution threshold, never "0%"', () => {
+    // A true zero with samples is "fewer than one hit in n runs" — a bound,
+    // not a measurement of zero. "0%" would claim the latter.
+    expect(formatGoalProbability(0, WALK_N)).toBe('<0.01%')
+    expect(formatGoalProbability(0, WALK_N)).not.toBe('0%')
+  })
+
+  it('renders mid-range values unchanged when a sample count is present', () => {
+    expect(formatGoalProbability(0.55, WALK_N)).toBe('55%')
+  })
+})
+
+describe('T-2334-2 — precision derives from n, never from a constant', () => {
+  it('renders 0.0007 at n=10000 as EXACTLY "0.1%"', () => {
+    const rendered = formatGoalProbability(0.0007, 10000)
+    expect(rendered).toBe('0.1%')
+    // The two overclaiming renderings this rule exists to refuse. "0.07%"
+    // was the design's own first (wrong) answer; "0.070%" is what a fixed
+    // two-significant-figures rule would print — a trailing digit at, and
+    // then beyond, the wire's resolution.
+    expect(rendered).not.toBe('0.07%')
+    expect(rendered).not.toBe('0.070%')
+  })
+
+  it('renders the SAME value differently at a different n — the bound moves with the wire', () => {
+    // At n=100 the resolution is 1 percentage point, so 0.0007 is below the
+    // threshold and renders in THRESHOLD form (no space) — not the register
+    // floor "< 1%" (with space), which is what an n-blind formatter gives.
+    expect(formatGoalProbability(0.0007, 100)).toBe('<1%')
+    expect(formatGoalProbability(0.0007, 10000)).toBe('0.1%')
+    expect(formatGoalProbability(0.0007, 100)).not.toBe(formatGoalProbability(0.0007, 10000))
+  })
+
+  it('never prints finer than the wire resolution at n=10000', () => {
+    // 1/10000 = 0.01 percentage points. Every rendered decimal string must
+    // survive a round-trip at that granularity: no digit may encode a
+    // distinction the sampler could not have made.
+    for (const v of WALK_QUINTET) {
+      const rendered = formatGoalProbability(v, WALK_N)
+      const numeric = Number(rendered.replace(/[<>%]/g, ''))
+      expect(Number.isFinite(numeric)).toBe(true)
+      // value-in-percentage-points is an exact multiple of 100/n = 0.01
+      expect(Math.abs(Math.round(numeric * 100) - numeric * 100)).toBeLessThan(1e-9)
+    }
+  })
+})
+
+describe('T-2334-3 — the no-resolution fallback is BYTE-IDENTICAL to today', () => {
+  // The regression pin for every surface the wire does not reach. This arm
+  // must not acquire the comparative register's exact-zero behaviour: the
+  // goal register deliberately floors an exact zero to "< 1%" so a canvas
+  // node and the card beside it cannot disagree, and that decision is older
+  // than this slice.
+  it('floors sub-1% values to the shared readout when nSamples is absent', () => {
+    for (const v of [0.0007, 0.0001, 0.0004, 0.0002, 0.002675, 0.009999]) {
+      expect(formatGoalProbability(v)).toBe(SUB_ONE_PERCENT_READOUT)
+      expect(formatGoalProbability(v, undefined)).toBe(SUB_ONE_PERCENT_READOUT)
+      expect(formatGoalProbability(v, null)).toBe(SUB_ONE_PERCENT_READOUT)
+    }
+  })
+
+  it('floors an EXACT ZERO to the register readout, NOT to the comparative "0%"', () => {
+    expect(formatGoalProbability(0)).toBe('< 1%')
+    expect(formatGoalProbability(0, undefined)).toBe('< 1%')
+    // The deliberate divergence from the comparative register, pinned so a
+    // future "just delegate everything" simplification cannot erase it.
+    expect(formatProbabilityWithResolution(0, undefined)).toBe('0%')
+    expect(formatGoalProbability(0)).not.toBe(formatProbabilityWithResolution(0, undefined))
+  })
+
+  it('renders at-or-above-1% values through the legacy percent path unchanged', () => {
+    expect(formatGoalProbability(0.55)).toBe('55%')
+    expect(formatGoalProbability(0.01)).toBe('1%')
+    expect(formatGoalProbability(0.995)).toBe('100%')
+  })
+
+  it('treats a non-positive or non-finite sample count as NO resolution info', () => {
+    for (const n of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(formatGoalProbability(0.0007, n)).toBe(SUB_ONE_PERCENT_READOUT)
+    }
+  })
+})

--- a/src/components/results/utils/displayFloors.ts
+++ b/src/components/results/utils/displayFloors.ts
@@ -2,6 +2,7 @@ import {
   SUB_ONE_PERCENT_FLOOR,
   SUB_ONE_PERCENT_READOUT,
   formatPercent,
+  formatProbabilityWithResolution,
 } from '../../../utils/formatPercent'
 
 /**
@@ -43,17 +44,61 @@ export { SUB_ONE_PERCENT_FLOOR, SUB_ONE_PERCENT_READOUT }
  * function exists to remove; an exact zero therefore reads "< 1%" here.
  *
  * ⚠ CORRECTED (2.236 review): this used to end "as it already does on every
- * sibling goal surface". FALSE. `GoalNode.tsx:336-338` carries its own
+ * sibling goal surface". FALSE. `GoalNode.tsx` carried its own
  * `> 0 && < 0.01` carve-out and renders an exact zero as "0% chance of reaching
  * target" — live, and the opposite convention. The divergence is real, rowed,
  * and NOT fixed here; do not read this as a claim that the canvas agrees.
  *
+ * ⭐ CLOSED 2026-08-03 (ROADMAP 2.333). The canvas carve-out is GONE:
+ * `GoalNode` now calls this function, so an exact zero reads "< 1%" on the node
+ * and on the card beside it. The paragraph above is kept as the record of what
+ * was true, not as a live warning.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⭐ THE RESOLUTION ARM (ROADMAP 2.334) — WHY THIS DELEGATES
+ * ─────────────────────────────────────────────────────────────────────────
+ * Floor-only formatting is honest about ONE value and blind about five. The
+ * walk's run scored five options at 0.0007 / 0.0001 / 0.0004 / 0 / 0.0002 and
+ * printed "< 1%" five times: a correct ordering, rendered unreadable, with the
+ * status-quo-lowest signature invisible. The COMPARATIVE register had already
+ * solved this — `formatProbabilityWithResolution` derives its precision from
+ * `n_valid_samples`, which IS on the wire (10000 per option on that run).
+ *
+ * So when a sample count is available this DELEGATES to that primitive rather
+ * than growing a second precision ladder here. A parallel implementation is
+ * precisely the hand-maintained divergence UI-SEM-057 exists to abolish, and
+ * the two registers would drift the first time either was tuned.
+ *
+ * THE HONESTY BOUND, so a later reader can check it: printed digits are
+ * supported iff the rendering never distinguishes values finer than `1/n`. At
+ * n=10000 that is 0.01 percentage points; 0.0007 renders "0.1%" (COARSER than
+ * the resolution, which never overclaims) and an exact zero renders "<0.01%"
+ * (a bound, which is what "no hits in 10000 runs" actually licenses). Fixed
+ * significant-figures is rejected: it would print "0.070%", a digit the wire
+ * cannot carry.
+ *
+ * WITHOUT a sample count the behaviour is BYTE-IDENTICAL to before, and that
+ * is deliberate rather than merely conservative: the fallback must NOT acquire
+ * the comparative register's exact-zero rule (`0` → "0%"), because the goal
+ * register floors an exact zero to "< 1%" so the canvas and the dock agree.
+ * The register difference stays confined to the no-resolution arm, which is
+ * where it always lived.
+ *
  * Display only: the value itself is untouched and every bar still draws from
- * the raw number. Above the floor this is exactly
+ * the raw number. Above the floor the fallback is exactly
  * `formatPercent(v, { fromDecimal: true })` — the siblings' formatter, with no
  * ceiling rule they do not have (0.995 renders "100%", as it does there).
+ *
+ * @param value - Raw goal probability in [0, 1]
+ * @param nSamples - Per-option `n_valid_samples` when the surface has it;
+ *   omit / null / undefined on surfaces the wire does not reach, and the
+ *   floor arm applies unchanged. A non-positive or non-finite count is
+ *   treated as absent — `0` would make the resolution threshold infinite.
  */
-export function formatGoalProbability(value: number): string {
+export function formatGoalProbability(value: number, nSamples?: number | null): string {
+  if (nSamples != null && Number.isFinite(nSamples) && nSamples > 0) {
+    return formatProbabilityWithResolution(value, nSamples)
+  }
   return value < SUB_ONE_PERCENT_FLOOR
     ? SUB_ONE_PERCENT_READOUT
     : formatPercent(value, { fromDecimal: true })

--- a/src/components/results/v7/V7LensGroup.tsx
+++ b/src/components/results/v7/V7LensGroup.tsx
@@ -27,14 +27,14 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { typography } from '@/styles/typography'
-import { formatPercent, formatProbabilityWithResolution } from '@/utils/formatPercent'
+import { formatProbabilityWithResolution } from '@/utils/formatPercent'
 import { loadRuns, type StoredRun } from '@/canvas/store/runHistory'
 import * as runsBus from '@/canvas/store/runsBus'
 import type { OptionResult } from '../types'
 import { OptionRangeBar } from '../shared/OptionRangeBar'
 import type { V7LensesModel } from './buildV7Lenses'
 import { V7_LENS_COPY } from './v7LensCopy'
-import { SUB_ONE_PERCENT_FLOOR } from '../utils/displayFloors'
+import { formatGoalProbability } from '../utils/displayFloors'
 import { V7WhatChangedLens, hasComparableRuns } from './V7WhatChangedLens'
 
 export type V7Lens = 'outcome' | 'goal' | 'stability' | 'whatChanged'

--- a/src/components/results/v7/V7LensGroup.tsx
+++ b/src/components/results/v7/V7LensGroup.tsx
@@ -98,19 +98,30 @@ function OutcomeRow({
 function GoalRow({
   label,
   probability,
+  nValidSamples,
   isWinner,
   isSubstitutedJoint,
 }: {
   label: string
   probability: number
+  /**
+   * ROADMAP 2.334 — the option's Monte-Carlo sample count, threaded so this
+   * lens can discriminate sub-1% figures instead of printing one string for
+   * all of them. Read from the option, never re-derived or defaulted.
+   */
+  nValidSamples: number | null | undefined
   isWinner: boolean
   /** Possessive gate — see `goalAnchorCopy`. Read from the model, never re-derived. */
   isSubstitutedJoint: boolean
 }) {
-  const readout =
-    probability < SUB_ONE_PERCENT_FLOOR
-      ? V7_LENS_COPY.goal.subOnePercent
-      : formatPercent(probability, { fromDecimal: true })
+  // ROADMAP 2.333: was a hand-copy of the goal register's floor
+  // (`probability < SUB_ONE_PERCENT_FLOOR ? subOnePercent : formatPercent`).
+  // The copy is gone; this calls the register's own formatter, which applies
+  // the identical floor when no sample count is available and resolves the
+  // figure when one is. `V7_LENS_COPY.goal.subOnePercent` stays in the copy
+  // register — it is the surface's own string, and its equality with the
+  // shared readout is the registers' concern, not this call site's.
+  const readout = formatGoalProbability(probability, nValidSamples)
   const widthPct = Math.max(2, Math.min(100, Math.round(probability * 100)))
   return (
     <div className="space-y-1" data-testid="v7-goal-row">
@@ -265,6 +276,7 @@ export function V7LensGroup({ model }: V7LensGroupProps) {
                   key={o.id}
                   label={o.label}
                   probability={o.goalProbability}
+                  nValidSamples={o.nValidSamples}
                   isWinner={o.isWinner}
                   isSubstitutedJoint={o.goalFitIsSubstitutedJoint}
                 />

--- a/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
@@ -119,9 +119,20 @@ describe('buildV7Lenses — passthrough lens + evidence model (V7 L5)', () => {
       )
       expect(m.goal.available).toBe(true)
       expect(m.goal.gate).toBe('none')
+      // ⭐ AMENDED (ROADMAP 2.334): `nValidSamples` is now carried on every
+      // goal-lens row so the rows can resolve sub-1% figures instead of
+      // printing one floor string for all of them. This fixture's `opt()`
+      // helper supplies no sample count, so the value is `null` — absent, NOT
+      // defaulted, which is the behaviour that keeps a run without a count on
+      // the floor arm rather than inventing a resolution.
+      //
+      // `toEqual` (exact shape) is kept deliberately over `toMatchObject`:
+      // this assertion is the reason the field addition was caught at all,
+      // and loosening it to make the failure go away would remove the guard
+      // that noticed. A future field addition SHOULD red this test.
       expect(m.goal.options).toEqual([
-        { id: 'a', label: 'A', goalProbability: 0.6, isWinner: true, goalFitIsSubstitutedJoint: false },
-        { id: 'b', label: 'B', goalProbability: 0.2, isWinner: false, goalFitIsSubstitutedJoint: false },
+        { id: 'a', label: 'A', goalProbability: 0.6, nValidSamples: null, isWinner: true, goalFitIsSubstitutedJoint: false },
+        { id: 'b', label: 'B', goalProbability: 0.2, nValidSamples: null, isWinner: false, goalFitIsSubstitutedJoint: false },
       ])
     })
   })

--- a/src/components/results/v7/__tests__/v7GoalLensResolution.2334.spec.tsx
+++ b/src/components/results/v7/__tests__/v7GoalLensResolution.2334.spec.tsx
@@ -1,0 +1,129 @@
+/**
+ * THE V7 GOAL LENS RESOLVES SUB-1% FIGURES (ROADMAP 2.334) — and RENDERS.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS FILE EXISTS AT ALL — a coverage hole found by the typecheck gate
+ * ─────────────────────────────────────────────────────────────────────────
+ * When this slice re-pointed `GoalRow` at the goal register's shared
+ * formatter, it removed the old imports and FORGOT to add the new one. The
+ * lens referenced a `formatGoalProbability` that was not in scope: every
+ * render of the goal lens would have thrown `ReferenceError` in production.
+ *
+ * All 38 of the slice's other tests stayed GREEN, because vitest transpiles
+ * without typechecking and no spec in the slice rendered this component. The
+ * defect was caught by `pnpm typecheck` (TS2304, plus two TS6133s for the
+ * now-unused imports) — which is the whole argument for that gate being part
+ * of the definition of done rather than a formality after it.
+ *
+ * So this file does two jobs, and the first is the important one:
+ *   1. RENDER the goal lens, so a missing/incorrect binding here is a RED
+ *      test and not merely a type error someone can baseline away.
+ *   2. Pin the 2.334 behaviour on this surface: five sub-1% options must
+ *      produce five distinct readouts, not five copies of "< 1%".
+ *
+ * Scope limit (trap 3): string content only — no layout or visibility claim.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V7LensGroup } from '../V7LensGroup'
+import { buildV7Lenses } from '../buildV7Lenses'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type { OptionResult } from '../../types'
+
+/** The walk's measured quintet and its per-option sample count. */
+const WALK_QUINTET = [0.0007, 0.0001, 0.0004, 0, 0.0002] as const
+const WALK_N = 10000
+
+function opt(
+  id: string,
+  label: string,
+  o: { win: number; goalProb: number; nValidSamples?: number | null },
+): OptionResult {
+  return {
+    id,
+    label,
+    expected: null,
+    outcome: { mean: null, p10: 1, p50: 2, p90: 3 },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    winProbability: o.win,
+    goalProbability: o.goalProb,
+    nValidSamples: o.nValidSamples,
+  } as unknown as OptionResult
+}
+
+function data(allOptions: OptionResult[]): ResultsSectionDataReturn {
+  return {
+    recommendation: {
+      allOptions,
+      recommendedOption: allOptions[0] ?? null,
+      // A user target is required for the goal lens to be available at all.
+      goalThreshold: 100,
+      outcomeUnit: 'count',
+    },
+    drivers: { drivers: [] },
+    confidence: { challengeFragileEdges: [], conditionalWinners: [] },
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderGoalLens(options: OptionResult[]) {
+  render(<V7LensGroup model={buildV7Lenses(data(options))} />)
+  fireEvent.click(screen.getByRole('tab', { name: /goal/i }))
+}
+
+function quintetOptions(nValidSamples: number | null) {
+  return WALK_QUINTET.map((p, i) =>
+    opt(`o${i}`, `Option ${i}`, { win: 0.2 - i * 0.01, goalProb: p, nValidSamples }),
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('V7 goal lens — renders at all (the regression this file was written for)', () => {
+  it('positive control: the goal lens mounts and shows a mid-range readout', () => {
+    // If `GoalRow` cannot resolve its formatter, this throws rather than
+    // failing an assertion — which is the point. A type-only guard would
+    // have let the same defect ship behind an updated baseline.
+    renderGoalLens([
+      opt('a', 'Option A', { win: 0.7, goalProb: 0.34, nValidSamples: WALK_N }),
+      opt('b', 'Option B', { win: 0.3, goalProb: 0.2, nValidSamples: WALK_N }),
+    ])
+    const rows = screen.getAllByTestId('v7-goal-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].textContent).toContain('34%')
+  })
+})
+
+describe('V7 goal lens — sub-1% figures resolve (ROADMAP 2.334)', () => {
+  it('renders five DISTINCT readouts for the walk quintet', () => {
+    renderGoalLens(quintetOptions(WALK_N))
+    const texts = screen.getAllByTestId('v7-goal-row').map((el) => el.textContent ?? '')
+    expect(texts).toHaveLength(5)
+
+    // Executed against the real formatter at this tip.
+    for (const expected of ['0.1%', '0.01%', '0.04%', '<0.01%', '0.02%']) {
+      expect(texts.some((t) => t.includes(expected))).toBe(true)
+    }
+    // The defect's signature: five copies of the register floor.
+    expect(texts.filter((t) => t.includes('< 1%'))).toHaveLength(0)
+  })
+
+  it('falls back to the register floor when the run carries no sample count', () => {
+    // The no-overclaim pin: without a wire resolution the lens must not
+    // invent one.
+    renderGoalLens(quintetOptions(null))
+    const texts = screen.getAllByTestId('v7-goal-row').map((el) => el.textContent ?? '')
+    expect(texts.filter((t) => t.includes('< 1%'))).toHaveLength(5)
+  })
+
+  it('never prints a bare "0%" for a measured sub-1% goal probability', () => {
+    renderGoalLens(quintetOptions(WALK_N))
+    for (const el of screen.getAllByTestId('v7-goal-row')) {
+      expect(el.textContent ?? '').not.toMatch(/(?<![\d.])0%/)
+    }
+  })
+})

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -161,8 +161,12 @@ export function buildV7Headline(
       headline: GOAL_ANCHOR_COPY.headline(
         goalLeader.label,
         // UI-SEM-057: the shared floor, so a 1.2% goal probability reads the
-        // same here as on the option card beside it.
-        formatGoalProbability(goalLeader.goalProbability as number),
+        // same here as on the option card beside it. ROADMAP 2.334 adds the
+        // leader's own sample count, so the headline resolves a sub-1% figure
+        // exactly as the card and the goal lens now do — a headline saying
+        // "< 1%" over rows saying "0.1%" would be the same contradiction one
+        // element up.
+        formatGoalProbability(goalLeader.goalProbability as number, goalLeader.nValidSamples),
         goalLeader.goalFitIsSubstitutedJoint === true,
       ),
       subline: leadSubline(leadPoints),

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -93,6 +93,13 @@ export interface V7GoalLens {
     id: string
     label: string
     goalProbability: number
+    /**
+     * ROADMAP 2.334 — the option's Monte-Carlo sample count, carried so the
+     * goal rows can resolve sub-1% figures instead of collapsing them all to
+     * the register floor. Straight from `OptionResult.nValidSamples`; `null`
+     * when the producer supplied none, never defaulted.
+     */
+    nValidSamples: number | null
     isWinner: boolean
     /** Possessive gate (`selectGoalProbability` basis), carried to the copy layer. */
     goalFitIsSubstitutedJoint: boolean
@@ -216,6 +223,7 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
           id: o.id,
           label: o.label,
           goalProbability: o.goalProbability as number,
+          nValidSamples: o.nValidSamples ?? null,
           goalFitIsSubstitutedJoint: o.goalFitIsSubstitutedJoint === true,
           // ⭐ R1 (ROADMAP 2.233 review) — THE GOAL LENS DESIGNATES THE GOAL
           // LEADER, not the comparative one.

--- a/src/utils/formatPercent.ts
+++ b/src/utils/formatPercent.ts
@@ -79,12 +79,26 @@ export function formatProbabilityWithResolution(
     // ⭐ ROADMAP 2.236 — THE FALLBACK ARM APPLIES THE SHARED FLOOR.
     //
     // This arm used to be a bare `formatPercent(value, { fromDecimal: true })`,
-    // and it is the arm staging actually takes: per-option `n_valid_samples`
-    // is not on the wire, so EVERY dock surface downstream of this function
-    // (option cards, V7 lens rows, the analysis hero) printed a bare "0%" for
-    // a measured non-zero probability while each call site looked locally
-    // correct. Three surfaces, one missing line — which is why the fix is here
-    // and not at any of them.
+    // so EVERY dock surface downstream of this function (option cards, V7 lens
+    // rows, the analysis hero) printed a bare "0%" for a measured non-zero
+    // probability while each call site looked locally correct. Three surfaces,
+    // one missing line — which is why the fix is here and not at any of them.
+    //
+    // ⚠ CORRECTED 2026-08-03 (ROADMAP 2.333/2.334). This comment used to say
+    // per-option `n_valid_samples` "is not on the wire", and that it was
+    // therefore "the arm staging actually takes". BOTH clauses were stale, and
+    // in the trap-2 way: they described a gate's coverage rather than deriving
+    // it, so they kept teaching every reader not to bother threading a count
+    // that had been available for weeks. `n_valid_samples` IS on the wire —
+    // `adapters/plot/v2/responseMapper.ts` maps `outcome.n_valid_samples` to
+    // `OptionResult.nValidSamples` behind a positive-integer guard, and the
+    // 2026-08-03 walk measured 10000 on every option of a live staging run.
+    //
+    // What remains TRUE is narrower, and is the only thing this arm should be
+    // read as claiming: SOME surfaces still cannot supply a count (they hold a
+    // share or a row rather than the option object), and they take this arm.
+    // Which surfaces those are is derivable, not listable here — anything
+    // passing `null`/`undefined` as `nSamples`. Do not restore a list.
     //
     // An exact ZERO keeps reading "0%": "came out ahead in 0% of simulated
     // scenarios" is TRUE when the option never came out ahead, and the floor


### PR DESCRIPTION
Closes ROADMAP **2.333** and **2.334**, built as one slice because they are the same defect at two scales: a goal probability the UI could not state **truthfully** (PC2), and a set of goal probabilities it could not state **distinguishably** (PC4).

Branched from `staging` @ `9c15b319`. Disjoint from #564 (`readinessStore.ts` / `useGraphReadiness.ts` / `PreAnalysisHealth.tsx` — none touched).

---

## PC2 — one card, one number, two answers

`goalProbability = 0.0007` on a single option card rendered, in one paint:

| Surface | Before | After |
|---|---|---|
| "Hits target" StatBar readout | **`0%`** | `0.1%` |
| Low-goal badge, ~2cm below | **`< 1%`** | `0.1% likely to reach target` |

Two hand-rolled formatters — a bare `formatPercent` inside `StatBar`, and an inline hand-**copy** of the sub-1% floor in the badge.

**The fix is structural, not a better formatter.** Teaching `StatBar` the right rule would have corrected these two strings and kept the shape that produced them. `StatBar` now takes `readout` as a **required prop and holds no formatter at all**; the card computes one readout per register and passes it to every surface that states it. The two strings can no longer be computed twice, so they cannot differ — N11 is impossible by construction rather than merely absent. `formatPercent` is no longer imported by `OptionCards`.

## PC4 — five options, five identical strings

The walk's run scored five options at `0.0007 / 0.0001 / 0.0004 / 0 / 0.0002`. Every one printed `< 1% likely to reach target`: correct ordering, correctly sourced, completely unreadable — the status-quo-lowest signature was invisible.

`formatGoalProbability` gains an optional `nSamples` and **delegates** to `formatProbabilityWithResolution`'s sample-count arm rather than growing a second precision ladder beside it. `n_valid_samples` was already on the wire (10000/option); `buildGoalFitRows` now carries it through the same positive-integer guard the response mapper uses, threaded to the Model tab rows, V7 goal lens, V7 headline, analysis hero and WinGauge goal block.

**Executed quintet rendering** (producer order, n=10000):

`0.1%` · `0.01%` · `0.04%` · `<0.01%` · `0.02%` — five distinct strings, ordering legible.

### Precision is bounded by the wire, never by a constant
Printed digits are supported **iff** the rendering never distinguishes values finer than `1/n` (0.01 percentage points at n=10000). `0.0007` → `0.1%`, coarser than the resolution, which never overclaims. Fixed significant-figures is rejected: it would print `0.070%`, a digit the sampler cannot support. Without a count, behaviour is **byte-identical** to before — deliberately, since the goal register floors an exact zero to `< 1%` so the canvas and the dock agree, and must not inherit the comparative register's `0%`.

> ⚠ **No expected string in this PR was read off the design.** Every one was derived by executing the formatter. The design pack's own first draft claimed `0.0007 → "0.07%"` and refuted itself on execution.

---

## Verification

**RED-first at pristine** — **19 of 38 failing** before any source change, with named signatures, including the N11 pair (`Hits target 0%` beside `< 1%`). The 19 that passed were the positive controls and the no-resolution fallback pins, which are *supposed* to pass at pristine. That measurement was taken with the first five specs; the sixth (`v7GoalLensResolution`) and eight later tests were added afterwards for defects found during the build, so the slice now carries **48 tests across 6 new specs**, all green.

**Mutants** — throwaway worktree *outside* the repo root, committed state only, applied-check `git diff HEAD --numstat -- src/` per mutation, control **exactly 0** files and 0 failures.

| # | Mutation | Result |
|---|---|---|
| M1 | restore `StatBar`'s internal formatter | **RED** ×5 |
| M2 | give the badge its own floor again @ 0.02 | **RED** ×1 |
| M3 | `buildGoalFitRows` stops carrying the count | **RED** ×3 |
| M4 | force fixed 2-decimal rendering | **RED** ×13 |
| M5 | goal fallback returns `0%` for exact zero | **RED** ×3 |
| M6 | thread count to goal readout only | **RED** ×2 |
| M7 | drop the `nSamples` delegation entirely | **RED** ×10 |
| M8 | V7 lens stops threading its count | **RED** ×1 |
| M9 | remove the V7 lens's formatter import | **RED** ×4 |
| M10 | `buildV7Lenses` stops carrying the count | **RED** ×1 |

**Gates** — typecheck (coverage + ratchet), hooks ratchet, eslint on touched files. Results in the thread below.

> A first typecheck run **failed** (+3 errors) and caught a genuine defect the 38 tests could not see: the V7 goal lens referenced `formatGoalProbability` with **no import**, so every render would have thrown. Vitest transpiles without typechecking and no spec rendered that component. Fixed, and covered by a new **render** spec so the binding is a RED test rather than only a type error (M9 proves it bites). Two later runs were **voided** rather than reported — the tree moved under them mid-run.

---

## Refuted while building

Three design premises did not survive contact with the bytes. Each is recorded in the relevant spec header, not just here.

1. **The comparative twin of N11 does not exist.** The design described a "Wins" StatBar row printing `0%` beside a header printing `0.3%`. Per-card Wins bars were removed in **V12.4**; the file has exactly one `<StatBar>`. The win figure *was* stated three times over (header, tooltip, bar title) — now one hoisted readout, asserted as single-sourcing, not as a defect fix.
2. **`OptionNode` is not in the `0%` class.** Grouped with `GoalNode` as "the same literal, same class". Its sub-1% predicate has **no `> 0` carve-out**, so an exact zero already took the floor arm and it never printed `0%`. Left unchanged — its `< 5%` band form is shipped copy, and re-routing it would be a copy adjudication. Pinned as a control so the claim is checkable.
3. **The "complete" 17-site manifest is short.** All 17 rows verified present at `9c15b319`, but the design's *own* regenerating `rg` command surfaces four more `0%`-class sites the table omits — trap 12d exactly: a derived query proves agreement among the rows it returns and can never tell you the hand-written table is short.

### Manifest at this tip
Two of those four are fixed here, and **not** as scope creep: `TargetProbabilityBars` and the `OptionCards` joint badge render the *same* `prob_satisfied` / `joint_probability` this slice just re-registered in `SuccessTargetRow`. Leaving them would have **manufactured** a new one-number-two-answers pair with this PR as the cause. A cross-surface test pins that they now agree.

**Two remain, and my original framing of them was WRONG — corrected by the reviewer, then re-verified here at the bytes.** I presented them as live readout sites. They are **dead components**:

- `CompactOptionSpread.tsx:62,63` — **no live JSX mount anywhere.** Every `<CompactOptionSpread` in the repo is inside its own spec file; `ResultsBody.tsx:438` explicitly records it as "kept in the repo as a potential supplementary affordance... NOT used to replace this surface" (V17 revert).
- `DecisionSummary.tsx:443,449,476` — **zero live value-importers.** Every `<DecisionSummary` mount is in its own two spec files, and the only non-test importers are two `import type { RankingData }` (`OptionComparisonReveal.tsx:16`, `useOptionRanking.ts:14`) — a type-only reference is what keeps the file alive.

Independently confirmed: no `React.lazy(` or dynamic `import(` of either, and no non-type value import of either module outside its own tests.

> **Both rowed sites are dead components no user can render, so no `0%`-beside-`0.1%` pair can ship; the follow-up row is re-scoped from "fix formatting" to "delete/collapse (extracting `RankingData`)."**

Re-running the bypass detector at this tip returns 17 lines. With the two above reclassified as dead, **zero live unaddressed readouts remain**. The rest are gaps in points, bar-width geometry, numeric snapshot/ring values, one comment quoting the old code, and `OptionNode`'s deliberately-unchanged band form.

## Deliberately not changed
- `formatProbabilityWithResolution`'s comparative fallback still renders an exact zero as `0%` — "came out ahead in 0% of simulated scenarios" is true, and the floor exists to stop a *non-zero* value printing as zero. Pinned both ways.
- `SUB_ONE_PERCENT_FLOOR` still gates the hero's no-option-on-track headline — a semantic threshold on raw values, not a display rule.
- Bar widths and their `Math.max(2, …)` visual floors — geometry is not a claim.
- Rank markers (design §2.4c): once values are distinct the ordering is self-evident, and ordinals are a governed channel (`designationsWithheld`).

## Amendment after adversarial review

The behaviour change legitimately broke **5 pre-existing assertions in 3 files** that still asserted the OLD floor-only register — spec staleness, not a product regression (staging tip green; all 5 reproduce on this head alone). Fixed at source, no baseline absorbed, no assertion loosened. Every replacement string derived by **executing** the formatter against each spec's own fixture. Details in the thread below.
