### PR TITLE
fix(ui): a verdict the model has outgrown is not a current verdict, a 502 is not a verdict at all, and both are now visible (ROADMAP 2.332 + 2.339 + the #564 invisible-outage interim)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -157,6 +157,10 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
         isAnalysing={isAnalysing}
         canRun={canRun}
         blockedReason={blockedReason}
+        // ROADMAP 2.332 / 2.339 — when the readiness CHECK failed, this footer
+        // is the surface that used to claim "Analysis available" about a model
+        // nothing had assessed. It says so instead. Run authority is unchanged.
+        readinessCheck={model.readinessCheck}
       />
     </div>
   )

--- a/src/canvas/components/pre-analysis-v3/__tests__/readinessOutageVisibility.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/readinessOutageVisibility.spec.tsx
@@ -1,0 +1,332 @@
+/**
+ * The pre-analysis panel tells the user when readiness could not be checked.
+ *
+ * ROADMAP 2.332 / 2.339 — closing the interim #564 merged on record:
+ *
+ *   "an unreachable or missing readiness service is invisible: no readiness
+ *    assessment, no error, Run stays enabled."
+ *
+ * #564 and 2.329 made the STORE honest — a transport failure, a 404 and (with
+ * 2.339) a 5xx all publish no verdict and set a truthful `error`. Nobody could
+ * see any of it. The only component that renders that state,
+ * `PreAnalysisHealth`, has ZERO non-test importers in `src/` (derived with
+ * `grep -arn PreAnalysisHealth src/`, per CLAUDE.md trap 17: the whole tree,
+ * binary-flagged files included). Meanwhile the surface users DO see —
+ * `PreAnalysisPanelV3`, mounted by `OutputsDock` in the Analysis tab pre-run
+ * slot — read the outage as good news: with `readiness === null` the run gate
+ * (`canRunAnalysis`, which blocks only on `readiness && !can_run_analysis`)
+ * stays OPEN, and the panel footer prints "Analysis available".
+ *
+ * So the honest store state was being rendered as a POSITIVE claim about a
+ * model nothing had assessed. That is what these tests close.
+ *
+ * Why this panel and not a mount of `PreAnalysisHealth`: that component brings
+ * its own readiness tier badge, its own improvements list and its own "Run
+ * analysis" button. Mounting it beside the V3 footer would put two run
+ * controls and two readiness assessments in one panel — the same one-state,
+ * two-strings defect class this programme keeps closing. The honest states
+ * belong in the surface that today makes the false claim, which is the footer.
+ *
+ * Scope (CLAUDE.md trap 3): these are PRESENCE and TEXT assertions on the
+ * rendered output of the real, mounted panel driven by the real store through
+ * a real (mocked) transport. They are not layout, visibility or
+ * above-the-fold claims; those belong to a walk.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { PreAnalysisPanelV3 } from '../PreAnalysisPanelV3'
+import { FOOTER_COPY } from '../constants'
+import { ToastProvider } from '../../../ToastContext'
+import { useCanvasStore } from '../../../store'
+import { useReadinessStore } from '../../../stores/readinessStore'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { useSignalSessionStore } from '../signals/signalSessionStore'
+import { clearInflightCache } from '../../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+
+function node(
+  id: string,
+  kind: string,
+  label: string,
+  data: Record<string, unknown> = {},
+): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+function seedGraph() {
+  useCanvasStore.setState({
+    nodes: [
+      node('d1', 'decision', 'Hire a tech lead or two developers?'),
+      node('g1', 'goal', 'Increase delivery output', {
+        goal_threshold: 0.8,
+        goal_threshold_raw: 20,
+        goal_threshold_unit: '%',
+      }),
+      node('o1', 'option', 'Hire a tech lead'),
+      node('o2', 'option', 'Hire two developers'),
+    ] as any,
+    edges: [] as any,
+    preAnalysisSensitivity: null,
+    ceeAnalysisReady: null,
+    draftCoaching: null,
+    currentBriefText: null,
+    goalThreshold: null,
+    goalConstraints: null,
+  })
+}
+
+function openServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function networkRejection() {
+  return Promise.reject(new TypeError('Failed to fetch'))
+}
+
+function renderPanel() {
+  return render(
+    <ToastProvider>
+      <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun={true} />
+    </ToastProvider>,
+  )
+}
+
+/** Drain the debounce, the fetch microtasks and React's effects together. */
+async function settle() {
+  await act(async () => {
+    await vi.runAllTimersAsync()
+  })
+}
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.stubGlobal('fetch', mockFetch)
+  vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+  useSignalSessionStore.getState().reset()
+  useGuidanceStore.setState({ _sendChip: null, _prefillChat: null })
+  seedGraph()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('pre-analysis panel — an unchecked model is never presented as a checked one', () => {
+  // ── Negative control, stated first ───────────────────────────────
+  //
+  // Everything below asserts that something NEW appears. This proves it does
+  // not appear when the service is healthy — without it, a component that
+  // always rendered the outage row would pass every test in this file.
+  describe('a healthy readiness check renders nothing new', () => {
+    it('shows the ordinary footer and no outage row when the server answers', async () => {
+      mockFetch.mockResolvedValue(openServerResponse())
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+      expect(useReadinessStore.getState().error).toBeNull()
+
+      expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(FOOTER_COPY.ready)
+      expect(screen.queryByTestId('pre-analysis-v3-readiness-outage')).toBeNull()
+      expect(screen.queryByRole('button', { name: /retry readiness check/i })).toBeNull()
+    })
+  })
+
+  // ── (a) The user can SEE "could not check", and can act on it ────
+  describe('an unreachable readiness service is visible where readiness renders', () => {
+    it('shows a could-not-check row instead of an availability claim', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      renderPanel()
+      await settle()
+
+      // The store reached the honest state #564 installed…
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+
+      // …and the panel now says so, instead of "Analysis available".
+      const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')
+      expect(outage).toHaveTextContent(/could not check/i)
+      expect(screen.getByTestId('pre-analysis-v3-footer')).not.toHaveTextContent(
+        FOOTER_COPY.ready,
+      )
+    })
+
+    it('offers a retry control that issues a real second request', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      renderPanel()
+      await settle()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const retry = screen.getByRole('button', { name: /retry readiness check/i })
+
+      clearInflightCache()
+      mockFetch.mockResolvedValue(openServerResponse())
+      await act(async () => {
+        fireEvent.click(retry)
+        await vi.runAllTimersAsync()
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+      expect(screen.queryByTestId('pre-analysis-v3-readiness-outage')).toBeNull()
+    })
+
+    it('does not gate the run locally — the verdict stays the server’s', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      renderPanel()
+      await settle()
+
+      // Visibility is the deliverable; the run gate is OutputsDock's and is
+      // deliberately untouched by this slice. `canRun` is passed true here, so
+      // an Analyse button that had become locally disabled would fail this.
+      expect(screen.getByTestId('pre-analysis-v3-analyse')).not.toBeDisabled()
+    })
+  })
+
+  // ── (b) The stale marking on a RETAINED verdict ──────────────────
+  describe('a verdict the model has outgrown is marked, with the service unreachable', () => {
+    it('keeps the served verdict and says it predates the current model', async () => {
+      mockFetch.mockResolvedValue(openServerResponse())
+      renderPanel()
+      await settle()
+      expect(screen.queryByTestId('pre-analysis-v3-readiness-outage')).toBeNull()
+
+      // The service drops, then the model changes underneath the verdict — the
+      // walk's exact sequence, with `ceeAnalysisReady` written by a turn.
+      mockFetch.mockImplementation(() => networkRejection())
+      clearInflightCache()
+      await act(async () => {
+        useCanvasStore.setState({
+          ceeAnalysisReady: {
+            options: [{ id: 'opt_retention', label: 'Retention push', status: 'ready' }],
+            goal_node_id: 'g1',
+            status: 'ready',
+          } as any,
+        })
+        await vi.runAllTimersAsync()
+      })
+
+      const store = useReadinessStore.getState()
+      expect(store.readiness?.can_run_analysis).toBe(true)
+      expect(store.error).not.toBeNull()
+      expect(store.stale).toBe(true)
+
+      const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')
+      expect(outage).toHaveTextContent(/changed since/i)
+      // …and the retained answer is cited with the time it was taken, not
+      // presented as if it described the model now on the canvas.
+      expect(outage).toHaveTextContent(/showing the check from/i)
+      expect(outage).toHaveTextContent(/could not reach/i)
+      // The retained verdict is still the server's, and the panel does not
+      // reprint it as a current availability claim.
+      expect(screen.getByTestId('pre-analysis-v3-footer')).not.toHaveTextContent(
+        FOOTER_COPY.ready,
+      )
+      expect(
+        screen.getByRole('button', { name: /retry readiness check/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  // ── A locally-composed verdict is never cited with a time ────────
+  //
+  // The adversarial review's amendment 2, at the surface where it does harm:
+  // the empty-canvas arm composes its verdict locally and used to stamp
+  // `verdictAtMs`. Add the first node while the service is down and the footer
+  // cited "Showing the check from HH:MM" for a verdict no server produced.
+  describe('a verdict composed locally is never cited as a timed server check', () => {
+    it('names the failure without a timestamp after the first node on an empty canvas', async () => {
+      useCanvasStore.setState({ nodes: [] as any, edges: [] as any })
+      mockFetch.mockImplementation(() => networkRejection())
+      renderPanel()
+      await settle()
+
+      // The first node arrives while the service is unreachable.
+      await act(async () => {
+        seedGraph()
+        await vi.runAllTimersAsync()
+      })
+
+      const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')
+      expect(outage).toHaveTextContent(/could not reach/i)
+      expect(outage).not.toHaveTextContent(/showing the check from/i)
+    })
+  })
+
+  // ── The 429 limb: a local fallback is never cited as a check ─────
+  //
+  // This slice added a footer arm that fires on ANY non-null store error, and
+  // 429 sets one. Its verdict is the LOCAL heuristic, not a server answer — so
+  // the arm must name the rate limit and must NOT print "Showing the check
+  // from HH:MM" over a number no server produced. That would re-create the
+  // fabrication class one field over, inside the fix for it.
+  describe('a rate-limited check is named as one, and cites no server time', () => {
+    it('shows the rate-limit reason without claiming a timestamped check', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () => Promise.reject(new Error('not json')),
+        text: () => Promise.resolve('rate limited'),
+        headers: new Headers(),
+      })
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness).not.toBeNull()
+      expect(useReadinessStore.getState().verdictAtMs).toBeNull()
+
+      const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')
+      expect(outage).toHaveTextContent(/rate limited/i)
+      expect(outage).not.toHaveTextContent(/showing the check from/i)
+    })
+  })
+
+  // ── The 2.339 limb reaches the same surface ──────────────────────
+  describe('a 5xx from the readiness service reaches the same honest surface', () => {
+    it('shows the could-not-check row on a 502 rather than a fabricated verdict', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: () => Promise.reject(new Error('not json')),
+        text: () => Promise.resolve('<html>502 Bad Gateway</html>'),
+        headers: new Headers(),
+      })
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness).toBeNull()
+      const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')
+      expect(outage).toHaveTextContent(/could not check/i)
+      // The response body never reaches the surface.
+      expect(outage).not.toHaveTextContent(/html/i)
+    })
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -242,6 +242,43 @@ export const FOOTER_COPY = {
   running: 'Analysis running',
   runningSub: 'Hold on while the first pass completes',
   analyse: 'Analyse first pass',
+
+  // ── ROADMAP 2.332 / 2.339 — the readiness check itself failed ─────
+  //
+  // Closing the interim #564 merged on record: "an unreachable or missing
+  // readiness service is invisible: no readiness assessment, no error, Run
+  // stays enabled." The store had been made honest — a transport failure, a
+  // 404 and a 5xx all publish no verdict and set a truthful `error` — but the
+  // only component rendering that state, `PreAnalysisHealth`, has zero
+  // non-test importers. Meanwhile THIS footer read the outage as good news and
+  // printed `ready` ("Analysis available") about a model nothing had assessed.
+  //
+  // These three lines are what the footer says instead. Each states only what
+  // we hold: that the check did not complete, and — where a prior server
+  // verdict is being retained — that it is being shown and when it was taken.
+  // None of them asserts anything about the model, and none of them changes
+  // the run gate: the verdict stays the server's, and visibility is the whole
+  // deliverable.
+  /** No timestamped server answer stands behind what is on screen. */
+  readinessUnchecked: 'Could not check readiness',
+  /** Something is on screen, but the latest check did not complete. */
+  readinessRecheckFailed: 'Could not re-check readiness',
+  /** A timestamped server answer is retained, and the model HAS moved since. */
+  readinessStale: 'Your model changed since this readiness check',
+  /**
+   * Every subline names the CAUSE — the store's own account of the failure,
+   * which is composed in this repo and never carries a response body. A footer
+   * that says only "could not check" tells the user nothing they can act on.
+   */
+  readinessSub: (reason: string) => `${reason}.`,
+  /**
+   * …and, where a timestamped SERVER answer is being retained, says so with
+   * the time it was taken. "Showing an older answer" is then a statement with
+   * a timestamp rather than a vague hedge.
+   */
+  readinessRetainedSub: (reason: string, takenAt: string) =>
+    `${reason}. Showing the check from ${takenAt}.`,
+  readinessRetry: 'Retry readiness check',
 } as const
 
 /**

--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -9,12 +9,69 @@
  */
 
 import { memo } from 'react'
+import { RefreshCw } from 'lucide-react'
 import { Button } from '../../../../components/ui'
 import { typography, typo } from '../../../../styles/typography'
 import { FOOTER_COPY } from '../constants'
 import { guardCeeText } from '../signals/ceeTextGuard'
 import { classifyBlockedReason } from '../../../utils/composeBlockedReason'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
+
+/**
+ * ROADMAP 2.332 — the moment a retained verdict was taken, as a clock time.
+ *
+ * Deliberately time-of-day and not a "5 minutes ago" elapsed string: elapsed
+ * copy goes stale the instant it is rendered unless something re-renders it on
+ * a timer, and a wrong elapsed figure is a worse claim than no figure. The
+ * locale format is the browser's; the SENTENCE is what the tests bind to.
+ */
+function formatTakenAt(ms: number): string {
+  return new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+/**
+ * ROADMAP 2.332 / 2.339 — what the footer says when the readiness CHECK
+ * failed, as opposed to when the model was graded and found wanting.
+ *
+ * Three distinct states, because they are three distinct facts:
+ *   · nothing timestamped stands behind the panel — either no answer has ever
+ *     arrived, or what is on screen is a LOCAL fallback rather than a server
+ *     answer (the 429 arm, whose behaviour is unchanged and rowed separately);
+ *   · a timestamped server answer, retained, still describing this model;
+ *   · a timestamped server answer the model has outgrown.
+ *
+ * ⚠ The discriminator is `verdictAtMs`, NOT "is there a verdict object". The
+ * store stamps `verdictAtMs` only where a real answer landed and explicitly
+ * NULLS it on the 429 local-fallback arm, so a surface can never cite a time
+ * for a number no server produced. Discriminating on the presence of
+ * `readiness` would do exactly that — it is a hand-read of a field that means
+ * something else.
+ *
+ * Every arm names the cause. Returns null when the check completed, which is
+ * what keeps this slice invisible on the healthy path.
+ */
+function describeReadinessCheck(
+  check: PreAnalysisModel['readinessCheck'],
+): { headline: string; subline: string } | null {
+  if (!check) return null
+
+  // The store's own message names WHICH failure it was (unreachable / missing
+  // / could not answer / rate limited). It is composed in this repo and never
+  // carries the response body, so it is safe to render verbatim.
+  if (check.verdictAtMs == null) {
+    return {
+      headline: check.verdictRetained
+        ? FOOTER_COPY.readinessRecheckFailed
+        : FOOTER_COPY.readinessUnchecked,
+      subline: FOOTER_COPY.readinessSub(check.message),
+    }
+  }
+
+  return {
+    headline: check.stale ? FOOTER_COPY.readinessStale : FOOTER_COPY.readinessRecheckFailed,
+    subline: FOOTER_COPY.readinessRetainedSub(check.message, formatTakenAt(check.verdictAtMs)),
+  }
+}
 
 /** See the call site for why composed copy never meets the substituting guard. */
 function vetBlockedReason(blockedReason: string): string {
@@ -42,6 +99,11 @@ interface PanelFooterProps {
   canRun: boolean
   /** Advisory tooltip when canRun; the blocked explanation when not. */
   blockedReason?: string
+  /**
+   * ROADMAP 2.332 / 2.339 — non-null only when the readiness CHECK failed.
+   * Never gates the run; it replaces the footer's claim about the check.
+   */
+  readinessCheck?: PreAnalysisModel['readinessCheck']
 }
 
 export const PanelFooter = memo(function PanelFooter({
@@ -50,6 +112,7 @@ export const PanelFooter = memo(function PanelFooter({
   isAnalysing,
   canRun,
   blockedReason,
+  readinessCheck = null,
 }: PanelFooterProps) {
   const disabled = isAnalysing || !canRun
 
@@ -79,15 +142,30 @@ export const PanelFooter = memo(function PanelFooter({
   // treating it as a gate made an enabled-looking state read as disabled).
   // While a run is in flight the gate reports blocked ("analysis is
   // currently running") — say that, not "not ready".
-  const display = isAnalysing
-    ? { dot: 'success' as const, headline: FOOTER_COPY.running, subline: FOOTER_COPY.runningSub }
-    : !canRun
-      ? {
-          dot: 'muted' as const,
-          headline: FOOTER_COPY.notReady,
-          subline: safeBlockedReason || FOOTER_COPY.notReadySubFallback,
-        }
-      : footer
+  //
+  // ROADMAP 2.332 / 2.339 — the outage arm outranks BOTH the gate copy and the
+  // model's own footer, and it has to.
+  //
+  // Below it, `!canRun ? notReady : footer` is a total function over a boolean:
+  // whichever way the gate lands, the footer makes a claim about a readiness
+  // assessment. With `readiness === null` the gate stays OPEN (canRunAnalysis
+  // blocks only on `readiness && !can_run_analysis`), so an unreachable service
+  // rendered as "Analysis available" — the exact invisible outage #564 merged
+  // on record. Deriving this state from `canRun` cannot fix that: `canRun` is a
+  // fact about the run, not about whether anything was checked.
+  const outage = describeReadinessCheck(readinessCheck)
+
+  const display = outage
+    ? { dot: 'warning' as const, headline: outage.headline, subline: outage.subline }
+    : isAnalysing
+      ? { dot: 'success' as const, headline: FOOTER_COPY.running, subline: FOOTER_COPY.runningSub }
+      : !canRun
+        ? {
+            dot: 'muted' as const,
+            headline: FOOTER_COPY.notReady,
+            subline: safeBlockedReason || FOOTER_COPY.notReadySubFallback,
+          }
+        : footer
 
   return (
     <div
@@ -98,10 +176,29 @@ export const PanelFooter = memo(function PanelFooter({
         aria-hidden
         className={`h-2 w-2 flex-none rounded-full transition-colors ${DOT_CLASSES[display.dot]}`}
       />
-      <div className="min-w-0 flex-1">
+      <div
+        className="min-w-0 flex-1"
+        {...(outage ? { 'data-testid': 'pre-analysis-v3-readiness-outage' } : {})}
+      >
         <p className={typo('panelBody', 'text-text-header')}>{display.headline}</p>
         <p className={`${typography.panelMeta} text-text-light`}>{display.subline}</p>
       </div>
+      {/* The check can be retried without touching the run. Deliberately NOT a
+          gate: the verdict is the server's, and this asks it again — it never
+          decides in its place. */}
+      {outage && readinessCheck && (
+        <Button
+          size="sm"
+          variant="secondary"
+          className="flex-none"
+          onClick={readinessCheck.retry}
+          aria-label={FOOTER_COPY.readinessRetry}
+          data-testid="pre-analysis-v3-readiness-retry"
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          Retry
+        </Button>
+      )}
       <Button
         size="sm"
         className="flex-none"

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -64,6 +64,28 @@ export interface PreAnalysisModel {
     headline: string
     subline: string
   }
+  /**
+   * ROADMAP 2.332 / 2.339 — the state of the readiness CHECK, as distinct from
+   * the readiness VERDICT.
+   *
+   * `null` whenever the last check completed: the footer then renders exactly
+   * what it always did, and this slice adds nothing to the panel. It is
+   * non-null only when the store holds a truthful failure — an unreachable
+   * service, a missing route, or a server error — which is precisely the state
+   * that was invisible before this slice existed.
+   *
+   * `verdictRetained` distinguishes "we have never had an answer" from "we are
+   * showing you an older one", and `stale` distinguishes an older answer that
+   * still describes this model from one the model has outgrown. Nothing here
+   * gates the run: the verdict remains the server's.
+   */
+  readinessCheck: {
+    message: string
+    verdictRetained: boolean
+    stale: boolean
+    verdictAtMs: number | null
+    retry: () => void
+  } | null
 }
 
 export function usePreAnalysisModel(): PreAnalysisModel {
@@ -78,7 +100,13 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   const sensitivity = useCanvasStore(s => s.preAnalysisSensitivity)
   const currentBriefText = useCanvasStore(s => s.currentBriefText)
   const scenarioId = useCanvasStore(s => s.currentScenarioId)
-  const { readiness } = useGraphReadiness()
+  const {
+    readiness,
+    error: readinessError,
+    stale: readinessStale,
+    verdictAtMs: readinessVerdictAtMs,
+    refresh: refreshReadiness,
+  } = useGraphReadiness()
   const seen = useSignalSessionStore(s => s.seen)
   const markSeen = useSignalSessionStore(s => s.markSeen)
   const ensureScenario = useSignalSessionStore(s => s.ensureScenario)
@@ -360,6 +388,25 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     [facts.factorNodes.length, edges.length, readiness?.readiness_score, canRun, provenance],
   )
 
+  // ROADMAP 2.332 / 2.339. `error` is set ONLY by the store's honest failure
+  // arms — transport rejection (2.319a), 404 (2.329) and every other non-ok
+  // status (2.339). The 429 arm sets an error too, but it also publishes a
+  // labelled local fallback, so it is a verdict-bearing state and reaches the
+  // retained arm rather than the never-checked one, which is the truth.
+  const readinessCheck = useMemo(
+    () =>
+      readinessError
+        ? {
+            message: readinessError,
+            verdictRetained: readiness != null,
+            stale: readinessStale,
+            verdictAtMs: readinessVerdictAtMs,
+            retry: refreshReadiness,
+          }
+        : null,
+    [readinessError, readiness, readinessStale, readinessVerdictAtMs, refreshReadiness],
+  )
+
   return useMemo(
     () => ({
       hero,
@@ -371,7 +418,19 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       risks,
       advanced,
       footer,
+      readinessCheck,
     }),
-    [hero, bars, ladder, derived.sharpen, estimates, options, risks, advanced, footer],
+    [
+      hero,
+      bars,
+      ladder,
+      derived.sharpen,
+      estimates,
+      options,
+      risks,
+      advanced,
+      footer,
+      readinessCheck,
+    ],
   )
 }

--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -323,6 +323,10 @@ export function useGraphReadiness() {
   const readiness = useReadinessStore((s) => s.readiness)
   const loading = useReadinessStore((s) => s.loading)
   const error = useReadinessStore((s) => s.error)
+  // ROADMAP 2.332: a retained verdict can outlive the model it graded, so the
+  // surface needs to know both that it has, and when it was taken.
+  const stale = useReadinessStore((s) => s.stale)
+  const verdictAtMs = useReadinessStore((s) => s.verdictAtMs)
   const refresh = useReadinessStore((s) => s.refresh)
 
   // Ref-counted: startListening increments, returned cleanup decrements.
@@ -332,5 +336,5 @@ export function useGraphReadiness() {
     return unsub
   }, [])
 
-  return { readiness, loading, error, refresh }
+  return { readiness, loading, error, stale, verdictAtMs, refresh }
 }

--- a/src/canvas/stores/__tests__/readinessStore.invalidation.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.invalidation.spec.ts
@@ -1,0 +1,721 @@
+/**
+ * readinessStore — a verdict the model has outgrown is not a current verdict.
+ *
+ * ROADMAP 2.332. The 3 Aug walk's binding dead end: after add-option, the
+ * `Analyse first pass` control stayed disabled through seven remedy paths,
+ * INCLUDING the one that SUCCEEDED at the server (`opt_retention` → status
+ * "ready"). The UI issued `graph-readiness` exactly twice all session — once on
+ * the draft, once on the structural change — and never again. The rendered
+ * verdict was eight turns / ~5 minutes stale, and a reload alone opened the
+ * gate.
+ *
+ * The mechanism, derived at the bytes rather than argued:
+ *
+ *   · The refresh trigger was a canvas subscription that fired only on
+ *     `nodes`/`edges` IDENTITY change, and then only when a hand-written
+ *     `createGraphFingerprint` — node `id:type:data.value` plus edge
+ *     `key:data.confidence` — differed. That fingerprint was a hand-maintained
+ *     mirror of "what the payload depends on" (CLAUDE.md trap 12) and it had
+ *     drifted BOTH ways: it hashed `edge.data.confidence`, a field the request
+ *     payload never carries, and it did NOT hash `observedState`, node labels,
+ *     edge weights, the brief, or `ceeAnalysisReady` — every one of which the
+ *     payload DOES carry.
+ *   · The walk's successful remedy landed in the UI as
+ *     `mirrorAnalysisReady → setCeeAnalysisReady`, i.e. a write to
+ *     `ceeAnalysisReady`. The subscription did not watch that root at all, so
+ *     the one event that changed the answer could not trigger the question.
+ *
+ * The fix is derivation, not a wider hand-list: `buildReadinessPayload` is the
+ * single truth about what the verdict is a function of, and both the change
+ * detector and the request use it. `createGraphFingerprint` is deleted — the
+ * payload hash cannot drift from the payload because it IS the payload.
+ *
+ * These tests pin:
+ *   1. every payload input triggers a refetch when it changes (1, 2, 3);
+ *   2. a payload-IDENTICAL canvas change issues no request and does not wipe
+ *      the honest error state #564 installed (4) — the second, smaller defect
+ *      on the same path: `{loading:true, error:null}` was set BEFORE the
+ *      payload was built and compared, so any node drag erased "Could not
+ *      reach the readiness service" with no request in flight;
+ *   3. a verdict the model has outgrown is MARKED, never presented as current
+ *      (5), including while the service is unreachable (6);
+ *   4. an invalidation storm against an unreachable service stays bounded and
+ *      honest — no retry loop, no flap-open (8);
+ *   5. the watched-root list cannot silently fall short of what the payload
+ *      builder reads (7) — trap 12d: the derived guard proves agreement, so it
+ *      is paired with real mutations driving each root end to end.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion in this file is on store
+ * state or on the request body. No claim here is a layout or visibility claim;
+ * the user-visible surface is pinned in
+ * `pre-analysis-v3/__tests__/readinessOutageVisibility.spec.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  useReadinessStore,
+  buildReadinessPayload,
+  WATCHED_ROOTS,
+  __test__,
+} from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/** A server answer that OPENS the gate. */
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** A server answer that CLOSES the gate — the ROADMAP 2.308 blocked state. */
+function mockBlockedServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: 'One option still needs its effect values',
+        improvements: [],
+        options_ready: 1,
+        options_total: 2,
+        goal_node_valid: true,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** What `fetch()` does when the host is unreachable (undici, jsdom). */
+function networkRejection() {
+  return Promise.reject(new TypeError('Failed to fetch'))
+}
+
+function factorNode(i: number, extra: Record<string, unknown> = {}) {
+  return {
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor', ...extra },
+  }
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => factorNode(i))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  useCanvasStore.setState({
+    nodes: nodes as any,
+    edges: edges as any,
+    ceeAnalysisReady: null,
+    currentBriefText: null,
+  })
+}
+
+/** The body of the Nth `fetch` call, parsed. */
+function requestBody(callIndex: number): Record<string, any> {
+  const init = mockFetch.mock.calls[callIndex]?.[1]
+  return JSON.parse(String(init?.body ?? '{}'))
+}
+
+/** `ceeAnalysisReady` as a turn's `mirrorAnalysisReady` writes it. */
+function analysisReady(optionStatus: string) {
+  return {
+    options: [{ id: 'opt_retention', label: 'Retention push', status: optionStatus }],
+    goal_node_id: 'node-0',
+    status: optionStatus,
+  } as any
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — invalidation on mutation (ROADMAP 2.332)', () => {
+  // ── Positive control (CLAUDE.md trap 13) ─────────────────────────
+  // Every assertion below counts requests or reads bodies. Prove first that
+  // this harness SEES a request go out and a verdict come back; otherwise a
+  // "refetched" assertion could pass against a harness that fetches by
+  // accident, and a "did not refetch" assertion could pass against one that
+  // never fetches at all.
+  describe('positive control — the harness observes requests and verdicts', () => {
+    it('issues exactly one request on first listen and stores the verdict', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+      expect(requestBody(0).graph.nodes).toHaveLength(3)
+    })
+
+    it('issues a second request when the graph structure changes', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      seedCanvasWithNodes(4)
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes).toHaveLength(4)
+    })
+  })
+
+  // ── T-2332-1 — the walk's dead end, exactly ──────────────────────
+  describe('a change to ceeAnalysisReady re-asks the question', () => {
+    it('refetches with the updated analysis_ready when a turn changes an option status', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('needs_values') })
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // The walk's successful remedy: the turn's `mirrorAnalysisReady` writes
+      // `ceeAnalysisReady` and nothing else. `nodes`/`edges` identity does not
+      // change, so the pristine subscription never sees this at all.
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      // Bound to the BODY, not merely to the call count: this proves the
+      // trigger is payload-derived, not a coincidence of some other watcher.
+      expect(requestBody(1).analysis_ready.options[0].status).toBe('ready')
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+    })
+  })
+
+  // ── T-2332-2 — a payload field the old fingerprint never hashed ──
+  describe('a change to a factor observed_state re-asks the question', () => {
+    it('refetches when observedState.value changes on a node', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useCanvasStore.setState({
+        nodes: [
+          factorNode(0, { observedState: { value: 0.2, raw_value: 20 } }),
+          factorNode(1),
+          factorNode(2),
+        ] as any,
+        edges: [] as any,
+        ceeAnalysisReady: null,
+        currentBriefText: null,
+      })
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).graph.nodes[0].observed_state.value).toBe(0.2)
+
+      // New array + new node objects, same ids and same `data.value` — the
+      // pristine fingerprint (id:type:data.value) is byte-identical, so it
+      // returns early and no request is issued.
+      useCanvasStore.setState({
+        nodes: [
+          factorNode(0, { observedState: { value: 0.9, raw_value: 90 } }),
+          factorNode(1),
+          factorNode(2),
+        ] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes[0].observed_state.value).toBe(0.9)
+    })
+
+    it('refetches when a node label changes', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(requestBody(0).graph.nodes[0].label).toBe('Factor 0')
+
+      // `label` rides the payload and was never in the fingerprint — a rename
+      // (by hand or by `graph_patch`) changed what CEE would be asked about,
+      // and asked nothing.
+      useCanvasStore.setState({
+        nodes: [
+          factorNode(0, { label: 'Customer retention rate' }),
+          factorNode(1),
+          factorNode(2),
+        ] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes[0].label).toBe('Customer retention rate')
+    })
+
+    it('refetches when an edge weight changes', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(requestBody(0).graph.edges[0].weight).toBe(0.5)
+
+      useCanvasStore.setState({
+        edges: [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.95, direction: 'negative' },
+          },
+        ] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.edges[0].weight).toBe(0.95)
+      expect(requestBody(1).graph.edges[0].effect_direction).toBe('negative')
+    })
+  })
+
+  // ── T-2332-3 — a payload input on no watched root at all ─────────
+  describe('a change to the brief re-asks the question', () => {
+    it('refetches when the brief text crosses the 20-character floor', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).brief).toBeUndefined()
+
+      useCanvasStore.setState({
+        currentBriefText: 'Should we move billing to edge computing this quarter?',
+      })
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).brief).toMatch(/edge computing/)
+    })
+  })
+
+  // ── T-2332-4 — the second defect: a no-op change wiped the error ─
+  //
+  // ⚠ THE DESIGN'S EXAMPLE FOR THIS TEST WAS WRONG, AND MEASUREMENT SAID SO.
+  // Design 1 §1.2 named "any node drag" as the trigger: new node identities,
+  // same payload, `{loading:true, error:null}` set before the payload is built,
+  // so the honest error is erased with no request. A drag does NOT do this at
+  // pristine — the fingerprint is `id:type:data.value`, which a position change
+  // leaves byte-identical, so the subscription returns before `fetchReadiness`
+  // is ever entered. That version of this test PASSED at pristine, i.e. it was
+  // pinning nothing.
+  //
+  // The real trigger is the fingerprint's OTHER drift direction, the one the
+  // design's own table records and its prose then forgot: the fingerprint
+  // hashes `edge.data.confidence`, a field the request payload has NEVER
+  // carried. Changing it passes the fingerprint gate, enters `fetchReadiness`,
+  // sets `{loading:true, error:null}` — and then finds the payload identical
+  // and returns. Error erased, no request issued, nothing re-checked. Same
+  // defect, reachable only through the field the mirror invented.
+  describe('a payload-identical canvas change asks nothing and erases nothing', () => {
+    it('does not clear a transport error when a non-payload field changes', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const failed = useReadinessStore.getState()
+      expect(failed.error).not.toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const errorBefore = failed.error
+
+      // `data.confidence` on an edge: in the pristine fingerprint, absent from
+      // the payload at every commit this endpoint has existed.
+      useCanvasStore.setState({
+        edges: [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive', confidence: 0.9 },
+          },
+        ] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      const after = useReadinessStore.getState()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(after.error).toBe(errorBefore)
+      expect(after.loading).toBe(false)
+    })
+
+    it('does not issue a request when only node positions move', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      useCanvasStore.setState({
+        nodes: [
+          { ...factorNode(0), position: { x: 40, y: 90 } },
+          { ...factorNode(1), position: { x: 41, y: 91 } },
+          { ...factorNode(2), position: { x: 42, y: 92 } },
+        ] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      // GREEN at pristine (the fingerprint ignores position) and it must stay
+      // green: replacing a hand-written fingerprint with a payload hash must
+      // not turn every drag into a request.
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(useReadinessStore.getState().stale).toBe(false)
+    })
+
+    // ⚠ THIS TEST EXISTS BECAUSE A MUTANT SURVIVED WITHOUT IT.
+    //
+    // Design 1 §1.4 step 3 moves `{loading: true, error: null}` BELOW the
+    // payload-hash check, and §1.5 calls that reorder "what PREVENTS a
+    // regression against #564". The first mutant sweep put the setState back
+    // above the check and ALL 36 tests still passed — because the subscription's
+    // own payload compare now filters payload-identical emissions before
+    // `fetchReadiness` is ever entered, so nothing in the suite reached the
+    // reordered lines. A fix whose reversal turns nothing red is theatre
+    // (CLAUDE.md trap 11), and the honest options were to reach it or drop it.
+    //
+    // It IS reachable, by an ordinary sequence: edit something while the
+    // service is down, then undo the edit. The edit schedules a fetch that
+    // fails; the undo schedules another, and THAT one finds the payload
+    // identical to the last SUCCESSFUL one. With the setState above the check,
+    // the undo erases the honest error and leaves `loading` stuck true — a
+    // permanent spinner over a wiped outage — with no request in flight.
+    it('an undo back to the last answered model neither erases the error nor sticks loading', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useCanvasStore.setState({
+        nodes: [factorNode(0, { value: 0.2 }), factorNode(1), factorNode(2)] as any,
+        edges: [] as any,
+        ceeAnalysisReady: null,
+        currentBriefText: null,
+      })
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+
+      // The service drops, and the user edits a value.
+      mockFetch.mockImplementation(() => networkRejection())
+      clearInflightCache()
+      useCanvasStore.setState({
+        nodes: [factorNode(0, { value: 0.9 }), factorNode(1), factorNode(2)] as any,
+      })
+      await vi.runAllTimersAsync()
+      const errored = useReadinessStore.getState()
+      expect(errored.error).not.toBeNull()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      // …then undoes it. The model is now exactly the one the server last
+      // answered about, so there is nothing to ask.
+      useCanvasStore.setState({
+        nodes: [factorNode(0, { value: 0.2 }), factorNode(1), factorNode(2)] as any,
+      })
+      await vi.runAllTimersAsync()
+
+      const after = useReadinessStore.getState()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(after.error).toBe(errored.error)
+      expect(after.loading).toBe(false)
+    })
+  })
+
+  // ── T-2332-5 — the verdict carries its own age ───────────────────
+  describe('a verdict the model has outgrown is marked, not presented as current', () => {
+    it('marks the verdict stale on mutation and clears the mark only on a fresh verdict', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const settled = useReadinessStore.getState()
+      expect(settled.stale).toBe(false)
+      expect(settled.verdictAtMs).toEqual(expect.any(Number))
+      const firstVerdictAt = settled.verdictAtMs!
+
+      // The mark lands SYNCHRONOUSLY with the mutation — before the debounce,
+      // before the request. The window in which a surface could show an
+      // outgrown verdict without saying so is what this closes.
+      vi.setSystemTime(new Date(Date.now() + 60_000))
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      expect(useReadinessStore.getState().stale).toBe(true)
+
+      await vi.runAllTimersAsync()
+
+      const refreshed = useReadinessStore.getState()
+      expect(refreshed.stale).toBe(false)
+      expect(refreshed.verdictAtMs).toBeGreaterThan(firstVerdictAt)
+    })
+  })
+
+  // ── A mutation that arrives DURING a fetch ───────────────────────
+  //
+  // ⚠ THIS SECTION EXISTS BECAUSE AN ADVERSARIAL REVIEW FALSIFIED A CLAIM I
+  // MADE IN THIS FILE. The comment on `stale` said the mark is set "before the
+  // debounce, before the request — so there is no window in which an outgrown
+  // verdict looks current". That was FALSE, and the counterexample is the most
+  // ordinary shape there is: a slow fetch.
+  //
+  // `fetchReadiness` opened with `if (fetchInFlight) return`. So when a
+  // mutation landed while a request was in the air, its debounced refetch
+  // fired at +500ms, hit that guard, and was DROPPED — silently, with no
+  // retry, no timer and no record that anything had been discarded. The
+  // in-flight request then completed and its success arm cleared `stale`
+  // unconditionally. Net result: the mark was laundered off by an answer that
+  // PREDATED the mutation, and no request was ever issued for the mutated
+  // model — the 3 Aug walk's exact defect, resurrected inside its own fix,
+  // reachable whenever readiness latency exceeds 500ms. That is the Render
+  // cold-start shape, i.e. the same outage this PR's other half is about.
+  //
+  // Two independent repairs, because they close two different holes:
+  //   1. queue-on-drop — a dropped call sets a pending flag and is re-invoked
+  //      from `finally`, so the request is deferred rather than discarded;
+  //   2. the success arm clears `stale` only when the completing answer still
+  //      describes the model on the canvas — derived by rebuilding the payload
+  //      at completion, so no answer can clear a mark raised after it was sent.
+  // (1) alone still leaves `stale` false for the duration of the re-fetch; (2)
+  // alone leaves the mark true but never asks the question. Both, or the state
+  // is wrong in one direction or the other.
+  describe('an answer that predates a mutation cannot clear that mutation’s mark', () => {
+    it('issues the deferred request and keeps the mark until the mutated model is answered', async () => {
+      // Fetch 1 is held open — the slow-service case.
+      let releaseFirst: ((value: unknown) => void) | undefined
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirst = resolve
+          }),
+      )
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // The model changes while that request is still in the air.
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      expect(useReadinessStore.getState().stale).toBe(true)
+
+      // The debounce fires and finds a fetch in flight. At the reviewed head
+      // this call was dropped on the floor and never rescheduled.
+      await vi.advanceTimersByTimeAsync(600)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Now the ORIGINAL request answers — about the pre-mutation model.
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      releaseFirst!(mockBlockedServerResponse())
+      await vi.runAllTimersAsync()
+
+      // The deferred request went out, and it asked about the mutated model.
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).analysis_ready.options[0].status).toBe('ready')
+
+      // Only now is the mark cleared — by an answer that describes this model.
+      const after = useReadinessStore.getState()
+      expect(after.stale).toBe(false)
+      expect(after.readiness?.can_run_analysis).toBe(true)
+    })
+
+    it('does not clear the mark at the moment the pre-mutation answer lands', async () => {
+      let releaseFirst: ((value: unknown) => void) | undefined
+      let releaseSecond: ((value: unknown) => void) | undefined
+      mockFetch
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseFirst = resolve
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseSecond = resolve
+            }),
+        )
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      await vi.advanceTimersByTimeAsync(600)
+
+      // Release ONLY the first request and let the store settle it. The second
+      // request is now in flight, so this is the exact instant the stale mark
+      // would be laundered: a verdict is on screen, it predates the mutation,
+      // and the honest answer has not arrived.
+      releaseFirst!(mockBlockedServerResponse())
+      await vi.advanceTimersByTimeAsync(10)
+
+      const midFlight = useReadinessStore.getState()
+      expect(midFlight.readiness?.can_run_analysis).toBe(false)
+      expect(midFlight.stale).toBe(true)
+
+      releaseSecond!(mockOpenServerResponse())
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().stale).toBe(false)
+    })
+  })
+
+  // ── T-2332-6 — composition with #564 (2.319a) ────────────────────
+  describe('an unreachable service keeps the served verdict AND says it is outgrown', () => {
+    it('retains the server verdict by identity, sets the error, and keeps the stale mark', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const served = useReadinessStore.getState().readiness
+      expect(served?.can_run_analysis).toBe(false)
+
+      mockFetch.mockImplementation(() => networkRejection())
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      await vi.runAllTimersAsync()
+
+      const after = useReadinessStore.getState()
+      // Identity, not field equality: no re-derived look-alike can satisfy it.
+      expect(after.readiness).toBe(served)
+      expect(after.error).not.toBeNull()
+      expect(after.stale).toBe(true)
+      // The gate never opens on local authority — #564's invariant, re-asserted
+      // here as the composition witness.
+      expect(after.readiness?.can_run_analysis).toBe(false)
+    })
+  })
+
+  // ── T-2332-7 — the watched-root list cannot fall short ───────────
+  //
+  // CLAUDE.md trap 12d, stated honestly: this guard proves the watched roots
+  // AGREE with what `buildReadinessPayload` reads. It cannot prove the payload
+  // itself is complete — only a corpus can, and that corpus is tests 1/2/3
+  // above, each driving a real store mutation through a real root.
+  describe('the watched-root list is derived from the payload builder, not from memory', () => {
+    it('reads nothing from canvas state that is not a watched root', () => {
+      seedCanvasWithNodes(3)
+      const reads = new Set<string>()
+      const state = useCanvasStore.getState() as unknown as Record<string, unknown>
+      const recorder = new Proxy(state, {
+        get(target, prop, receiver) {
+          if (typeof prop === 'string') reads.add(prop)
+          return Reflect.get(target, prop, receiver)
+        },
+      })
+
+      buildReadinessPayload(recorder as any)
+
+      // Positive control first: a builder that read nothing would satisfy the
+      // subset assertion vacuously.
+      expect(reads.size).toBeGreaterThan(0)
+      expect(reads.has('nodes')).toBe(true)
+
+      const unwatched = [...reads].filter(
+        (r) => !(WATCHED_ROOTS as readonly string[]).includes(r),
+      )
+      expect(unwatched).toEqual([])
+    })
+
+    it('names every root the subscription watches', () => {
+      expect([...WATCHED_ROOTS].sort()).toEqual(
+        ['ceeAnalysisReady', 'currentBriefText', 'edges', 'nodes'].sort(),
+      )
+    })
+  })
+
+  // ── Interaction guard — a storm against a dead service ───────────
+  //
+  // The composition #564 + 2.332 has an obvious failure mode: honest errors on
+  // every edit could become a retry loop, or the retained verdict could flap.
+  // Neither is acceptable, and neither is argued here — both are measured.
+  describe('an invalidation storm against an unreachable service stays bounded', () => {
+    it('coalesces a burst of mutations into one request and never loops', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      const served = useReadinessStore.getState().readiness
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      mockFetch.mockImplementation(() => networkRejection())
+      clearInflightCache()
+
+      // Ten distinct payload-affecting mutations inside one debounce window.
+      for (let i = 0; i < 10; i++) {
+        useCanvasStore.setState({ ceeAnalysisReady: analysisReady(`pass-${i}`) })
+        await vi.advanceTimersByTimeAsync(20)
+      }
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      // …and then nothing. A failure schedules no retry of its own: the next
+      // request comes from the next mutation or from the Retry control.
+      await vi.advanceTimersByTimeAsync(120_000)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      const after = useReadinessStore.getState()
+      expect(after.readiness).toBe(served)
+      expect(after.readiness?.can_run_analysis).toBe(false)
+      expect(after.error).not.toBeNull()
+      expect(after.stale).toBe(true)
+      expect(after.loading).toBe(false)
+    })
+
+    it('recovers on the next mutation once the service answers again', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().error).not.toBeNull()
+
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useCanvasStore.setState({ ceeAnalysisReady: analysisReady('ready') })
+      await vi.runAllTimersAsync()
+
+      const after = useReadinessStore.getState()
+      expect(after.error).toBeNull()
+      expect(after.stale).toBe(false)
+      expect(after.readiness?.can_run_analysis).toBe(true)
+    })
+  })
+
+  // ── The fingerprint is gone, not merely bypassed ─────────────────
+  describe('the hand-maintained fingerprint no longer exists', () => {
+    it('exposes no createGraphFingerprint test helper', () => {
+      expect((__test__ as Record<string, unknown>).createGraphFingerprint).toBeUndefined()
+    })
+  })
+})

--- a/src/canvas/stores/__tests__/readinessStore.serverError.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.serverError.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * readinessStore — a 5xx is the service failing, not the model being graded.
+ *
+ * ROADMAP 2.339, found by the #564 review: that PR's body said "only 429
+ * remains untouched", and the bytes refuted it. Any non-ok response that is
+ * neither 429 nor 404 — 500, 502, 503, 401, 403 — was thrown into the OUTER
+ * catch, which still published `calculateFallbackReadiness` as the readiness
+ * verdict. That is the last fabrication path in the file, and it is the most
+ * likely one to fire in production: a Render cold start answers 502.
+ *
+ * Why it matters exactly as much as the transport path #564 closed:
+ *
+ *   · `calculateFallbackReadiness` sets `can_run_analysis: blockers.length === 0`
+ *     where the blockers come from `graphHealth`, which is `null` until an
+ *     analysis has already run. On the PRE-analysis canvas it therefore always
+ *     finds zero blockers and always grants the run.
+ *   · It OVERWRITES `readiness`, so a `can_run_analysis: false` the server had
+ *     already given — the ROADMAP 2.308 blocked state, pinned shut on the
+ *     transport and 404 paths by #564 — was replaced by a locally invented
+ *     `true` that no consumer could tell from the server's own answer.
+ *   · Its error string was the raw `HTTP <status> - <body>`, i.e. the response
+ *     body rendered into user-facing copy. For the outage shape that matters
+ *     most — a proxy's HTML error page — that is a page of markup where a
+ *     sentence belongs.
+ *
+ * The treatment is the one #564 established, applied to the limb it left:
+ * publish no verdict, name the failure truthfully without echoing the body,
+ * retain any prior server verdict BY IDENTITY, stay retryable.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion here is on store state. No
+ * claim in this file is a layout or visibility claim.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore, __test__ } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/**
+ * A gateway error, shaped as `deduplicatedFetch` sees it: `ok: false`, so it
+ * RESOLVES rather than rejecting, and the body is read with `.text()`. The
+ * body is deliberately an HTML error page — the real shape a proxy returns,
+ * and the one the pristine error string pasted into the UI.
+ */
+function mockStatusResponse(status: number, statusText: string) {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.reject(new Error('not json')),
+    text: () =>
+      Promise.resolve(
+        '<html><head><title>502 Bad Gateway</title></head><body>upstream connect error</body></html>',
+      ),
+    headers: new Headers(),
+  }
+}
+
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function mock429Response() {
+  return {
+    ok: false,
+    status: 429,
+    statusText: 'Too Many Requests',
+    json: () => Promise.reject(new Error('not json')),
+    text: () => Promise.resolve('rate limited'),
+    headers: new Headers(),
+  }
+}
+
+/** The ROADMAP 2.308 blocked state — the verdict a 5xx must never overwrite. */
+function mockBlockedServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: 'One option still needs its effect values',
+        improvements: [],
+        options_ready: 1,
+        options_total: 2,
+        goal_node_valid: true,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  // `graphHealth` stays at its initial `null` — the state of a canvas that has
+  // not been analysed, and the state in which the heuristic finds no blockers
+  // and grants the run.
+  useCanvasStore.setState({
+    nodes: nodes as any,
+    edges: edges as any,
+    ceeAnalysisReady: null,
+    currentBriefText: null,
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — a server error is not a verdict (ROADMAP 2.339)', () => {
+  // ── Positive control (CLAUDE.md trap 13) ─────────────────────────
+  describe('positive control — the harness can observe a real server verdict', () => {
+    it('observes can_run_analysis true and a null error when the server opens the gate', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+
+    it('observes can_run_analysis false when the server closes the gate', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+    })
+  })
+
+  // ── RED 1 — the fabricated verdict ───────────────────────────────
+  describe('a 502 publishes no locally-invented verdict', () => {
+    it('leaves readiness null when the service answers 502 and it has no prior verdict', async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(502, 'Bad Gateway'))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
+    })
+
+    it('does not grant the run on local authority when the service answers 502', async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(502, 'Bad Gateway'))
+      // Three nodes and an edge with graphHealth null: the heuristic's most
+      // permissive input, scoring 80 and finding zero blockers.
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).not.toBe(true)
+    })
+  })
+
+  // ── RED 2 — the ROADMAP 2.308 clause, on this limb ───────────────
+  describe('a 502 never replaces a verdict the server already gave', () => {
+    it('retains the prior server verdict BY IDENTITY when the next answer is 502', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const served = useReadinessStore.getState().readiness
+      expect(served?.can_run_analysis).toBe(false)
+
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockStatusResponse(502, 'Bad Gateway'))
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      const after = useReadinessStore.getState()
+      // Identity, not field equality — a re-derived look-alike cannot satisfy
+      // this, and the heuristic would have scored this graph 80 / 'strong'.
+      expect(after.readiness).toBe(served)
+      expect(after.readiness?.readiness_score).toBe(62)
+      expect(after.error).not.toBeNull()
+    })
+  })
+
+  // ── RED 3 — every status on the limb, not just the one we named ──
+  describe('the whole non-429, non-404 status class takes the honest path', () => {
+    it.each([
+      [500, 'Internal Server Error'],
+      [502, 'Bad Gateway'],
+      [503, 'Service Unavailable'],
+      [401, 'Unauthorized'],
+      [403, 'Forbidden'],
+    ])('publishes no verdict on HTTP %i', async (status, statusText) => {
+      mockFetch.mockResolvedValue(mockStatusResponse(status as number, statusText as string))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+    })
+  })
+
+  // ── RED 4 — the error is a sentence, not a response body ─────────
+  describe('the failure is named without echoing the response body', () => {
+    it('reports a readable sentence carrying the status, and no markup', async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(502, 'Bad Gateway'))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const error = useReadinessStore.getState().error ?? ''
+      expect(error).toMatch(/could not answer/i)
+      expect(error).toMatch(/502/)
+      expect(error).not.toMatch(/</)
+      expect(error).not.toMatch(/upstream connect error/)
+    })
+
+    it('tells a server error apart from an unreachable service', async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(503, 'Service Unavailable'))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const error = useReadinessStore.getState().error ?? ''
+      expect(error).not.toMatch(/could not reach/i)
+      expect(error).not.toMatch(/could not find/i)
+    })
+  })
+
+  // ── The retained guarantee — a 5xx is not sticky ─────────────────
+  //
+  // GREEN at pristine (`lastPayloadHash` is only written on success). Kept as a
+  // regression pin: the honest-path rewrite must not start caching the failed
+  // payload, or a redeploy would never be picked up.
+  describe('a 502 leaves the payload re-requestable', () => {
+    it('issues a real second request for the identical graph once the service recovers', async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(502, 'Bad Gateway'))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Deliberately NOT via refresh(): refresh() clears the payload hash
+      // itself and would mask a hash the failure had poisoned.
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      await __test__.fetchReadiness()
+      await vi.runAllTimersAsync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  // ── The one limb deliberately left alone ─────────────────────────
+  //
+  // 429 still publishes the local fallback, with an error string that says so.
+  // It is out of scope for 2.339 (named in the PR body and rowed separately);
+  // this pin exists so its behaviour cannot drift silently while the sibling
+  // limbs are being rewritten.
+  describe('the 429 limb is unchanged and still labelled', () => {
+    it('publishes the local fallback with the rate-limit label', async () => {
+      mockFetch.mockResolvedValue(mock429Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness).not.toBeNull()
+      expect(state.error).toBe('Rate limited - using local validation')
+    })
+
+    // ROADMAP 2.332 — `verdictAtMs` means "when `readiness` was last set from
+    // an ANSWER". The 429 arm sets `readiness` from the LOCAL heuristic, so
+    // stamping it would let a surface cite a time for a number no server
+    // produced — the fabrication class this slice closes, re-created one field
+    // over. It is explicitly nulled, and this is the pin.
+    it('does not stamp verdictAtMs on the local rate-limit fallback', async () => {
+      mockFetch.mockResolvedValue(mock429Response())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness).not.toBeNull()
+      expect(state.verdictAtMs).toBeNull()
+    })
+
+    // Same invariant, the limb the adversarial review found me breaking in my
+    // own file: the empty-canvas arm composes its verdict LOCALLY ("Add some
+    // nodes to get started") and was stamping `verdictAtMs: Date.now()` on it.
+    // Reachable on the deployed configuration: open an empty canvas, add the
+    // first node while the service is down, and the footer cites "Showing the
+    // check from HH:MM" for a verdict no server ever produced — the exact
+    // claim I nulled the 429 arm to prevent, one branch over.
+    it('does not stamp verdictAtMs on the locally-composed empty-canvas verdict', async () => {
+      useCanvasStore.setState({
+        nodes: [] as any,
+        edges: [] as any,
+        ceeAnalysisReady: null,
+        currentBriefText: null,
+      })
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      // The verdict is published (it is a real, honest state) …
+      expect(state.readiness?.readiness_score).toBe(0)
+      expect(state.readiness?.can_run_analysis).toBe(false)
+      // … and no request was made, so there is no answer to timestamp.
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(state.verdictAtMs).toBeNull()
+    })
+
+    it('clears a real verdict timestamp when a later 429 replaces the verdict', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().verdictAtMs).toEqual(expect.any(Number))
+
+      // The 429 arm OVERWRITES the server verdict with the heuristic (its own
+      // pre-existing defect, rowed separately). What must not survive that is
+      // the timestamp of the answer it replaced.
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mock429Response())
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().verdictAtMs).toBeNull()
+    })
+  })
+})

--- a/src/canvas/stores/index.ts
+++ b/src/canvas/stores/index.ts
@@ -70,6 +70,9 @@ export {
   selectReadiness,
   selectReadinessLoading,
   selectReadinessError,
+  // ROADMAP 2.332 — the verdict's own freshness, alongside the verdict.
+  selectReadinessStale,
+  selectReadinessVerdictAtMs,
 } from './readinessStore'
 
 /**

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -12,7 +12,6 @@
 import { create } from 'zustand'
 import { useCanvasStore } from '../store'
 import type { Node, Edge } from '@xyflow/react'
-import { getEdgeKey } from '../domain/edgeUtils'
 import type {
   GraphReadiness,
   GraphReadinessLevel,
@@ -64,6 +63,24 @@ function normaliseReadinessLevel(raw: unknown): GraphReadinessLevel {
   return 'fair'
 }
 
+/**
+ * ROADMAP 2.339 — a non-ok status that is neither 429 nor 404.
+ *
+ * Carries the STATUS and nothing else. The response body is logged at the
+ * throw site and never travels with the error, so no arm downstream can paste
+ * a proxy's HTML error page into user-facing copy — which is exactly what the
+ * pristine `HTTP ${status} - ${errorBody}` string did.
+ */
+export class ReadinessServiceStatusError extends Error {
+  readonly status: number
+
+  constructor(status: number) {
+    super(`Readiness service responded HTTP ${status}`)
+    this.name = 'ReadinessServiceStatusError'
+    this.status = status
+  }
+}
+
 const CEE_BASE_URL = (import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'
 
 // ── Constants ──────────────────────────────────────────────────────
@@ -78,6 +95,20 @@ export interface ReadinessStoreState {
   readiness: GraphReadiness | null
   loading: boolean
   error: string | null
+  /**
+   * ROADMAP 2.332 — true when the model has changed in a way the CURRENT
+   * `readiness` verdict was not asked about.
+   *
+   * Set the moment a payload-affecting mutation is detected, cleared only when
+   * a fresh verdict lands. It exists because #564 made failure retain the last
+   * server verdict rather than replace it with a guess — the right call, but it
+   * means a retained verdict can outlive the model it graded. `stale` is what
+   * stops a surface presenting that verdict as current; it never changes the
+   * verdict itself, and never opens or closes the gate.
+   */
+  stale: boolean
+  /** `Date.now()` when `readiness` was last set from an answer. Null until then. */
+  verdictAtMs: number | null
 }
 
 export interface ReadinessStoreActions {
@@ -97,6 +128,8 @@ const initialState: ReadinessStoreState = {
   readiness: null,
   loading: false,
   error: null,
+  stale: false,
+  verdictAtMs: null,
 }
 
 // ── Module-level singletons ────────────────────────────────────────
@@ -106,9 +139,34 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null
 let unsubCanvasStore: (() => void) | null = null
 /** Number of active consumers (hook instances). Subscription tears down at 0. */
 let listenerRefCount = 0
-let lastFingerprint: string | null = null
+/**
+ * The payload of the last request ATTEMPT, successful or not. The change
+ * detector compares against this, so a canvas emission that leaves the payload
+ * identical asks nothing — including after a failure, where `lastPayloadHash`
+ * is deliberately left unset.
+ *
+ * These two are NOT a mirror of each other: they answer different questions
+ * ("has anything the server would see changed since we last asked?" vs "do we
+ * already hold a verdict for exactly this?") and both derive from the SAME
+ * `buildReadinessPayload`, so neither can drift from the payload.
+ */
+let lastObservedPayload: string | null = null
+/** The payload of the last SUCCESSFUL request. Never written on failure. */
 let lastPayloadHash: string | null = null
 let fetchInFlight = false
+/**
+ * ROADMAP 2.332 (adversarial review, amendment 1) — a call that arrived while
+ * a fetch was in flight and had to be deferred.
+ *
+ * `fetchReadiness` opens with `if (fetchInFlight) return`. Without this flag
+ * that early return DISCARDED the call: a mutation landing during a slow fetch
+ * scheduled its refetch, the debounce fired at +500ms into the in-flight
+ * guard, and the request vanished with no timer and no record. Whenever
+ * readiness latency exceeds `DEBOUNCE_DELAY` — the Render cold-start shape —
+ * the mutated model was never asked about at all. That is the 3 Aug walk's own
+ * defect, re-created inside the fix for it.
+ */
+let fetchQueued = false
 let backoff = { delay: 0, until: 0 }
 let lastLogTime = 0
 /** Ref-counted dedup entry from the shared inflight cache */
@@ -121,27 +179,122 @@ function generateCorrelationId(): string {
 }
 
 /**
- * Create a stable fingerprint for graph state.
- * Only changes when graph content actually changes.
+ * ROADMAP 2.332 — the canvas state roots `buildReadinessPayload` reads.
+ *
+ * This is the change-detection predicate for the canvas subscription. It is
+ * kept honest by `readinessStore.invalidation.spec.ts`, which Proxy-wraps the
+ * state handed to `buildReadinessPayload`, records every top-level property it
+ * reads and asserts the set is a subset of this list — so a payload input
+ * added without a watcher fails the suite rather than going quietly dark.
+ *
+ * ⚠ CLAUDE.md trap 12d, stated rather than assumed: that guard proves this
+ * list AGREES with the builder. It cannot prove the PAYLOAD is complete — a
+ * field CEE needs that the builder never reads is invisible to both. The only
+ * thing that catches that is the corpus of tests driving real mutations
+ * (a turn writing `ceeAnalysisReady`, an observed-state edit, a rename, an
+ * edge weight, the brief), which is why those exist alongside the guard and
+ * neither replaces the other.
  */
-function createGraphFingerprint(nodes: Node[], edges: Edge[]): string {
-  const nodeFingerprint = nodes
-    .map((n) => {
-      const value = (n.data as any)?.value
-      return `${n.id}:${n.type}:${typeof value === 'number' ? value.toFixed(3) : 'x'}`
-    })
-    .sort()
-    .join(',')
+export const WATCHED_ROOTS = [
+  'nodes',
+  'edges',
+  'ceeAnalysisReady',
+  'currentBriefText',
+] as const
 
-  const edgeFingerprint = edges
-    .map((e) => {
-      const conf = (e.data as any)?.confidence
-      return `${getEdgeKey(e)}:${conf !== undefined ? conf.toFixed(3) : 'x'}`
-    })
-    .sort()
-    .join(',')
+/** The slice of canvas state the readiness request is a function of. */
+export interface ReadinessPayloadInputs {
+  nodes: Node[]
+  edges: Edge[]
+  ceeAnalysisReady: { options?: unknown[] } | null | undefined
+  currentBriefText: string | null | undefined
+}
 
-  return `n${nodes.length}|e${edges.length}|${nodeFingerprint}|${edgeFingerprint}`
+/**
+ * Build the `/graph-readiness` request body. Pure: everything it reads arrives
+ * in `s`, nothing is pulled from `useCanvasStore` inside.
+ *
+ * ROADMAP 2.332 — THIS FUNCTION IS THE SINGLE TRUTH ABOUT WHAT THE VERDICT IS
+ * A FUNCTION OF, and both callers use it: the request, and the change detector
+ * that decides whether to make one.
+ *
+ * It replaces `createGraphFingerprint`, a hand-written hash of node
+ * `id:type:data.value` plus edge `key:data.confidence`. That hash was a mirror
+ * of this payload maintained by memory, and it had drifted BOTH ways:
+ *   · it hashed `edge.data.confidence`, which this payload has never carried —
+ *     so a change to it entered the fetch, cleared the honest error state and
+ *     asked the server a question it had already answered; and
+ *   · it did NOT hash `observedState`, node `label`/`kind`, edge
+ *     `weight`/`belief`/`direction`, the brief, or `ceeAnalysisReady` — every
+ *     one of which this payload DOES carry. That is why the 3 Aug walk's
+ *     successful remedy (a turn writing `ceeAnalysisReady` via
+ *     `mirrorAnalysisReady`) changed the answer without ever asking for it,
+ *     and the gate stayed shut on a verdict eight turns old.
+ * A hash derived from the payload cannot drift from the payload, because it IS
+ * the payload.
+ */
+export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
+  const { nodes, edges, ceeAnalysisReady, currentBriefText } = s
+
+  const payload: Record<string, unknown> = {
+    graph: {
+      nodes: nodes.map((n) => {
+        const data = n.data as any
+        const nodeKind = data?.kind || n.type || 'factor'
+        const node: Record<string, unknown> = {
+          id: n.id,
+          type: nodeKind,
+          kind: nodeKind,
+          label: data?.label || n.id,
+        }
+        if (typeof data?.value === 'number') {
+          node.data = { value: data.value }
+        }
+        // F4 (A1 GO 21 Jul — CEE widen merged + deploy-verified live): send factor
+        // observed_state so /assist/v1/graph-readiness can report
+        // scaffold_plan.will_scaffold_options (fixes "blocked despite scaffold fired").
+        // Built EXPLICITLY (never spread observedState) so unit/source and any
+        // metadata-shaped key are excluded — a metadata key routes CEE to the strict
+        // constraint branch (needs metadata.operator) → HTTP 400. value REQUIRED (0-1
+        // model scale); raw_value OPTIONAL (display magnitude), only when numeric.
+        const observedState = data?.observedState
+        if (nodeKind === 'factor' && typeof observedState?.value === 'number') {
+          node.observed_state = {
+            value: observedState.value,
+            ...(typeof observedState.raw_value === 'number'
+              ? { raw_value: observedState.raw_value }
+              : {}),
+          }
+        }
+        return node
+      }),
+      /**
+       * UI-SEM-011: Default belief injection (belief: 0.8).
+       * UI-SEM-030: Edge defaults for CEE coaching (weight 0.5, belief 0.8, direction 'positive').
+       */
+      edges: edges.map((e) => ({
+        id: e.id,
+        from: e.source,
+        to: e.target,
+        weight: (e.data as any)?.weight ?? 0.5,
+        belief: (e.data as any)?.beliefExists ?? (e.data as any)?.belief ?? 0.8,
+        effect_direction: (e.data as any)?.direction ?? 'positive',
+      })),
+    },
+  }
+
+  if (currentBriefText && currentBriefText.length >= 20) {
+    payload.brief = currentBriefText
+  }
+
+  if (ceeAnalysisReady?.options?.length) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { model_adjustments: _strip, ...analysisReadyForPayload } =
+      ceeAnalysisReady as Record<string, unknown>
+    payload.analysis_ready = analysisReadyForPayload
+  }
+
+  return JSON.stringify(payload)
 }
 
 /**
@@ -189,7 +342,11 @@ function calculateFallbackReadiness(
 // ── Core fetch logic ───────────────────────────────────────────────
 
 async function fetchReadiness(): Promise<void> {
-  if (fetchInFlight) return
+  // ROADMAP 2.332 amendment 1 — defer, never discard. See `fetchQueued`.
+  if (fetchInFlight) {
+    fetchQueued = true
+    return
+  }
   fetchInFlight = true
 
   const store = useReadinessStore.getState()
@@ -205,12 +362,13 @@ async function fetchReadiness(): Promise<void> {
       return
     }
 
+    const canvasState = useCanvasStore.getState()
     const {
       nodes: currentNodes,
       edges: currentEdges,
       graphHealth,
       ceeAnalysisReady: currentCeeAnalysisReady,
-    } = useCanvasStore.getState()
+    } = canvasState
 
     if (currentNodes.length === 0) {
       useReadinessStore.setState({
@@ -223,9 +381,41 @@ async function fetchReadiness(): Promise<void> {
         },
         loading: false,
         error: null,
+        // This verdict IS a function of the current payload (zero nodes), so
+        // nothing about it is outgrown — the mark clears honestly.
+        stale: false,
+        // ROADMAP 2.332 amendment 2 — but it is composed HERE, not answered.
+        // `verdictAtMs` means "when `readiness` was last set from an ANSWER",
+        // and no request was made. Stamping it let the footer cite "Showing
+        // the check from HH:MM" for a verdict no server produced — reachable
+        // by adding the first node to an empty canvas while the service is
+        // down. Same invariant the 429 arm is nulled for; this is the branch
+        // that was still breaking it.
+        verdictAtMs: null,
       })
       return
     }
+
+    // ── ROADMAP 2.332: build and compare BEFORE touching store state ──
+    //
+    // The payload-hash check used to sit AFTER `{loading: true, error: null}`,
+    // so a canvas emission that changed nothing the server sees still flashed
+    // `loading` and — once #564 made failure set a truthful `error` — ERASED
+    // that error, with no request in flight to replace it. Composed with
+    // #564 the ordering was the difference between "Could not check readiness"
+    // and a panel that silently went quiet again.
+    //
+    // A no-op now touches NO store state at all: it does not clear the error,
+    // does not flash loading, and does not disturb the stale mark.
+    const payloadJson = buildReadinessPayload(canvasState)
+
+    if (payloadJson === lastPayloadHash) {
+      return
+    }
+
+    // Record the ATTEMPT (not the success): the change detector needs to know
+    // what was last asked, including when the answer never arrived.
+    lastObservedPayload = payloadJson
 
     // Release previous shared dedup entry
     if (currentInflightEntry) {
@@ -241,70 +431,6 @@ async function fetchReadiness(): Promise<void> {
     const correlationId = generateCorrelationId()
 
     try {
-      const payload: Record<string, unknown> = {
-        graph: {
-          nodes: currentNodes.map((n) => {
-            const data = n.data as any
-            const nodeKind = data?.kind || n.type || 'factor'
-            const node: Record<string, unknown> = {
-              id: n.id,
-              type: nodeKind,
-              kind: nodeKind,
-              label: data?.label || n.id,
-            }
-            if (typeof data?.value === 'number') {
-              node.data = { value: data.value }
-            }
-            // F4 (A1 GO 21 Jul — CEE widen merged + deploy-verified live): send factor
-            // observed_state so /assist/v1/graph-readiness can report
-            // scaffold_plan.will_scaffold_options (fixes "blocked despite scaffold fired").
-            // Built EXPLICITLY (never spread observedState) so unit/source and any
-            // metadata-shaped key are excluded — a metadata key routes CEE to the strict
-            // constraint branch (needs metadata.operator) → HTTP 400. value REQUIRED (0-1
-            // model scale); raw_value OPTIONAL (display magnitude), only when numeric.
-            const observedState = data?.observedState
-            if (nodeKind === 'factor' && typeof observedState?.value === 'number') {
-              node.observed_state = {
-                value: observedState.value,
-                ...(typeof observedState.raw_value === 'number'
-                  ? { raw_value: observedState.raw_value }
-                  : {}),
-              }
-            }
-            return node
-          }),
-          /**
-           * UI-SEM-011: Default belief injection (belief: 0.8).
-           * UI-SEM-030: Edge defaults for CEE coaching (weight 0.5, belief 0.8, direction 'positive').
-           */
-          edges: currentEdges.map((e) => ({
-            id: e.id,
-            from: e.source,
-            to: e.target,
-            weight: (e.data as any)?.weight ?? 0.5,
-            belief: (e.data as any)?.beliefExists ?? (e.data as any)?.belief ?? 0.8,
-            effect_direction: (e.data as any)?.direction ?? 'positive',
-          })),
-        },
-      }
-
-      const briefText = useCanvasStore.getState().currentBriefText
-      if (briefText && briefText.length >= 20) {
-        payload.brief = briefText
-      }
-
-      if (currentCeeAnalysisReady?.options?.length) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { model_adjustments: _strip, ...analysisReadyForPayload } = currentCeeAnalysisReady
-        payload.analysis_ready = analysisReadyForPayload
-      }
-
-      const payloadJson = JSON.stringify(payload)
-
-      if (payloadJson === lastPayloadHash) {
-        useReadinessStore.setState({ loading: false })
-        return
-      }
       // Set after successful fetch (not here) so failed fetches don't poison the cache.
       // See the setState call after response normalization below.
       const currentPayloadJson = payloadJson
@@ -437,6 +563,15 @@ async function fetchReadiness(): Promise<void> {
             readiness: fallback,
             error: 'Rate limited - using local validation',
             loading: false,
+            // ROADMAP 2.332 — this arm's BEHAVIOUR is deliberately unchanged
+            // (it still publishes the labelled local fallback; retiring that is
+            // a separate row). But `verdictAtMs` means "when `readiness` was
+            // last set from an ANSWER", and this verdict is not one — it is the
+            // local heuristic. Stamping it would let a surface cite a time for
+            // a number no server produced, which is the fabrication class this
+            // whole slice exists to close. Explicitly null, so the absence is a
+            // decision rather than an oversight.
+            verdictAtMs: null,
           })
           return
         }
@@ -494,12 +629,19 @@ async function fetchReadiness(): Promise<void> {
           return
         }
 
+        // ── ROADMAP 2.339: every remaining non-ok status ─────────────
+        //
+        // 500, 502, 503, 401, 403 — everything that is not 429 or 404. The
+        // body is logged, never carried: the pristine error string was
+        // `HTTP ${status} - ${errorBody}`, which for the outage shape that
+        // matters most (a proxy's HTML error page) put a page of markup where
+        // the UI expected a sentence.
         console.error('[readinessStore] CEE error response:', {
           status: response.status,
           statusText: response.statusText,
           body: response.errorBody,
         })
-        throw new Error(`HTTP ${response.status} - ${response.errorBody}`)
+        throw new ReadinessServiceStatusError(response.status)
       }
 
       backoff = { delay: 0, until: 0 }
@@ -584,20 +726,91 @@ async function fetchReadiness(): Promise<void> {
       // Only cache the payload hash after a successful fetch — failed fetches
       // should allow retry on the same payload.
       lastPayloadHash = currentPayloadJson
-      useReadinessStore.setState({ readiness: normalized, loading: false, error: null })
+      // ── ROADMAP 2.332 amendment 1: an answer clears only its OWN mark ──
+      //
+      // `stale: false` was unconditional here, and that let an answer launder
+      // a mark raised AFTER it was sent: mutate during a slow fetch, the
+      // in-flight answer lands, and the mark for a model it never saw is wiped.
+      // The queue-on-drop repair above guarantees the mutated model IS asked
+      // about, but the deferred request has not returned yet at this instant —
+      // so without this the store would report "current" about a model whose
+      // honest answer is still in the air.
+      //
+      // Derived, not tracked: rebuild the payload from the canvas as it stands
+      // NOW and compare with what this response answered. Same function as the
+      // request and the change detector, so it cannot disagree with either.
+      const answersCurrentModel =
+        buildReadinessPayload(useCanvasStore.getState()) === currentPayloadJson
+      useReadinessStore.setState({
+        readiness: normalized,
+        loading: false,
+        error: null,
+        // Cleared only when this verdict describes the model on the canvas.
+        // When it does not, the mark stands until the deferred answer arrives.
+        ...(answersCurrentModel ? { stale: false } : {}),
+        verdictAtMs: Date.now(),
+      })
     } catch (err) {
       if ((err as Error).name === 'AbortError') return
 
-      console.warn('[readinessStore] Fetch failed, using fallback:', err)
-      const fallback = calculateFallbackReadiness(currentNodes, currentEdges, graphHealth)
-      useReadinessStore.setState({
-        readiness: fallback,
-        error: err instanceof Error ? err.message : 'Unknown error',
-        loading: false,
-      })
+      // ── ROADMAP 2.339: the last fabrication path in this file ────
+      //
+      // This catch used to publish `calculateFallbackReadiness` as the
+      // readiness verdict. #564 closed that on the transport limb and 2.329
+      // closed it on the 404 limb; the #564 PR body then said "only 429
+      // remains untouched", and the review refuted it at the bytes — EVERY
+      // other non-ok status (500/502/503/401/403) was thrown into here and
+      // answered with the heuristic.
+      //
+      // It is the same defect with the same two teeth. The heuristic's verdict
+      // is `can_run_analysis: blockers.length === 0`, the blockers come from
+      // `graphHealth`, and `graphHealth` is null until an analysis has already
+      // run — so before the first analysis a 502 did not merely RISK opening
+      // the gate, it ALWAYS granted the run. And because it overwrote
+      // `readiness`, it could replace a `can_run_analysis: false` the server
+      // had already given with a locally invented `true` no consumer could
+      // tell from the server's own answer.
+      //
+      // A Render cold start answers 502. This is the most likely real outage
+      // shape there is, and it was the one limb with no test at all.
+      //
+      // So: publish no verdict, and say why — the mechanism #564 established.
+      //   · `readiness` is left EXACTLY as it was: null on first load (the
+      //     store's own "unknown" state, alongside a non-null `error`), and
+      //     otherwise the last answer the server actually gave, which a local
+      //     guess is not entitled to replace.
+      //   · `stale` is deliberately NOT touched. If the model changed since
+      //     that retained verdict, it is still stale, and saying so is the
+      //     truth; clearing it here would launder an outgrown verdict into a
+      //     current-looking one.
+      //   · `lastPayloadHash` stays unset, so the identical graph can be
+      //     re-requested the moment the service recovers.
+      //   · The message names the failure and carries the status. It never
+      //     carries the response body (see the throw site above).
+      //
+      // The alternatives were considered and rejected at the transport catch
+      // for reasons that apply here unchanged: a tri-state threaded through
+      // six consumers is the hand-maintained-mirror shape (CLAUDE.md trap 12),
+      // and `can_run_analysis: false` is equally a locally invented verdict,
+      // just in the blocking direction.
+      const message =
+        err instanceof ReadinessServiceStatusError
+          ? `The readiness service could not answer (HTTP ${err.status})`
+          : 'Could not complete the readiness check'
+      console.warn(`[readinessStore] ${message} — publishing no verdict:`, err)
+      useReadinessStore.setState({ error: message, loading: false })
     }
   } finally {
     fetchInFlight = false
+    // Drain exactly one deferred call. Re-entry is bounded, not a loop: the
+    // flag is cleared BEFORE the re-invoke, and the re-invoked fetch returns
+    // without a request whenever the payload already has a verdict.
+    if (fetchQueued) {
+      fetchQueued = false
+      fetchReadiness().catch(() => {
+        // Swallow — fetchReadiness handles its own errors internally.
+      })
+    }
   }
 }
 
@@ -608,6 +821,7 @@ export const useReadinessStore = create<ReadinessStoreState & ReadinessStoreActi
 
   refresh: () => {
     lastPayloadHash = null
+    lastObservedPayload = null
     fetchReadiness().catch(() => {
       // Swallow — fetchReadiness handles errors internally
     })
@@ -619,13 +833,33 @@ export const useReadinessStore = create<ReadinessStoreState & ReadinessStoreActi
     if (!unsubCanvasStore) {
       // First consumer — create the subscription
       unsubCanvasStore = useCanvasStore.subscribe((state, prevState) => {
-        // Only react to node/edge changes — skip unrelated store updates.
-        // Identity check is cheap; fingerprint is computed only on mismatch.
-        if (state.nodes === prevState.nodes && state.edges === prevState.edges) return
+        // ── ROADMAP 2.332: derive the change signal from the payload ──
+        //
+        // Step 1, cheap: did any root the payload is built from change
+        // IDENTITY? Same early-out the pristine code had, widened from
+        // `nodes`/`edges` to the full watched set — `ceeAnalysisReady` (where
+        // the 3 Aug walk's successful remedy landed, via
+        // `mirrorAnalysisReady → setCeeAnalysisReady`, and was never seen) and
+        // `currentBriefText` (never watched at all).
+        const rootChanged = WATCHED_ROOTS.some(
+          (root) =>
+            (state as unknown as Record<string, unknown>)[root] !==
+            (prevState as unknown as Record<string, unknown>)[root],
+        )
+        if (!rootChanged) return
 
-        const fp = createGraphFingerprint(state.nodes, state.edges)
-        if (fp === lastFingerprint) return
-        lastFingerprint = fp
+        // Step 2: did anything the SERVER would see actually change? Built by
+        // the same function the request uses, so it cannot answer differently
+        // from the request. A node drag produces new identities and an
+        // identical payload — no mark, no request, and (critically, composing
+        // with #564) no disturbance to a standing error.
+        const nextPayload = buildReadinessPayload(state as unknown as ReadinessPayloadInputs)
+        if (nextPayload === lastObservedPayload) return
+
+        // The verdict currently on screen was not asked about this model.
+        // Marked synchronously — before the debounce, before the request — so
+        // there is no window in which an outgrown verdict looks current.
+        useReadinessStore.setState({ stale: true })
 
         if (debounceTimer) clearTimeout(debounceTimer)
         debounceTimer = setTimeout(() => {
@@ -637,8 +871,6 @@ export const useReadinessStore = create<ReadinessStoreState & ReadinessStoreActi
       })
 
       // Fire immediately on first listen
-      const { nodes, edges } = useCanvasStore.getState()
-      lastFingerprint = createGraphFingerprint(nodes, edges)
       fetchReadiness().catch(() => {
         // Swallow — fetchReadiness handles its own errors internally.
         // This catch prevents unhandled rejection in test environments
@@ -680,9 +912,10 @@ function stopListening(): void {
     }
     currentInflightEntry = null
   }
-  lastFingerprint = null
+  lastObservedPayload = null
   lastPayloadHash = null
   fetchInFlight = false
+  fetchQueued = false
   backoff = { delay: 0, until: 0 }
   lastLogTime = 0
 }
@@ -691,18 +924,22 @@ function stopListening(): void {
 export const selectReadiness = (state: ReadinessStoreState) => state.readiness
 export const selectReadinessLoading = (state: ReadinessStoreState) => state.loading
 export const selectReadinessError = (state: ReadinessStoreState) => state.error
+/** ROADMAP 2.332 — true when the model has moved on from the verdict on screen. */
+export const selectReadinessStale = (state: ReadinessStoreState) => state.stale
+/** ROADMAP 2.332 — when the verdict on screen was taken. */
+export const selectReadinessVerdictAtMs = (state: ReadinessStoreState) => state.verdictAtMs
 
 // ── Test helpers ───────────────────────────────────────────────────
 
 /** @internal — exposed for unit testing. Not part of public API. */
 export const __test__ = {
   fetchReadiness,
-  createGraphFingerprint,
   calculateFallbackReadiness,
   getModuleState: () => ({
-    lastFingerprint,
+    lastObservedPayload,
     lastPayloadHash,
     fetchInFlight,
+    fetchQueued,
     backoff,
     listenerRefCount,
     hasSubscription: unsubCanvasStore !== null,


### PR DESCRIPTION
**ROADMAP 2.332** (readiness invalidation — PC1's binding dead end) + **ROADMAP 2.339** (the 5xx outer-catch fabrication, mandatory in this build) + **closing the invisible-outage interim #564 merged on record**.

Base: `0cb94016` (staging tip: #565 on top of #564 `313f2a42`).

---

## The three parts

### 1. ROADMAP 2.332 — the gate failed SHUT on a stale verdict

The 3 Aug walk: after add-option, `Analyse first pass` stayed disabled through seven remedy paths **including the one that SUCCEEDED at the server** (`opt_retention` → `"ready"`). The UI issued `graph-readiness` exactly twice all session; a reload alone opened the gate.

The mechanism, at the bytes: the refresh trigger was a canvas subscription on `nodes`/`edges` **identity**, then a hand-written `createGraphFingerprint` (node `id:type:data.value` + edge `key:data.confidence`). That fingerprint was a hand-maintained mirror of the request payload (CLAUDE.md trap 12) and had drifted **both ways** — it hashed `edge.data.confidence`, which the payload has never carried, and it did **not** hash `observedState`, node `label`, edge `weight`/`direction`, the brief, or `ceeAnalysisReady`. The walk's successful remedy landed as `mirrorAnalysisReady → setCeeAnalysisReady`: a write to a root the subscription never watched.

**Fix — derivation, not a wider hand-list.** `buildReadinessPayload()` is extracted as the single truth about what the verdict is a function of, and **both** callers use it: the request, and the change detector that decides whether to make one. `createGraphFingerprint`, `lastFingerprint` and the `__test__.createGraphFingerprint` export are **deleted** — a hash derived from the payload cannot drift from the payload because it *is* the payload.

- Subscription: `WATCHED_ROOTS = nodes | edges | ceeAnalysisReady | currentBriefText` (cheap identity early-out), then a payload compare against the last **attempt**.
- `stale: boolean` + `verdictAtMs: number | null` added to the store. `stale` is set **synchronously with the mutation**, before the debounce and before the request, and is cleared only by an answer that describes the model on the canvas. ⚠ An earlier draft of this bullet claimed there is "no window in which an outgrown verdict looks current" — the adversarial review falsified that at head; see the amendments section below for the drop-and-launder path and its two repairs.
- The payload-hash check moves **above** the `{loading:true, error:null}` setState.
- **TTL rejected**, and the premise re-checked at this tip: the verdict is `f(payload)` against a stateless per-request endpoint, so payload-derived invalidation is complete by construction. The premise holds.

**Cost, stated rather than assumed.** The change detector now serialises the payload on every watched-root identity change (a drag emits one per frame). The identity early-out runs first and is free; the work it gates is one `JSON.stringify` over a mapped node/edge projection. What it replaced was two `map`+`sort`+`join` passes (nodes and edges) on the same emissions, so this is the same order of work, not a new cost — and it is the price of a signal that cannot drift from the request. If a large graph ever makes this measurable, the fix is to memoise on the four root identities, not to reintroduce a hand-written hash.

### 2. ROADMAP 2.339 — the last fabrication path in the file (MANDATORY)

Every non-ok status that is not 429 or 404 — 500, 502, 503, 401, 403 — was thrown into the outer catch, which **still published `calculateFallbackReadiness` as the readiness verdict**. Same two teeth as the transport limb #564 closed: `graphHealth` is `null` before the first analysis, so the heuristic always found zero blockers and **always granted the run**; and it OVERWROTE `readiness`, so a server `can_run_analysis:false` (the 2.308 blocked state) could be replaced by a locally invented `true`. A Render cold start answers 502 — the most likely real outage shape, and the one limb with no test at all.

Converted to the mechanism #564 established: **no verdict, truthful error, prior verdict retained by identity, still retryable, `stale` deliberately untouched**. A new `ReadinessServiceStatusError` carries only the status, so the response body (a proxy's HTML error page) can no longer reach user-facing copy — the pristine string was `HTTP ${status} - ${errorBody}`.

**429's behaviour is deliberately untouched** and still publishes the labelled local fallback; it has its own pin here so it cannot drift silently, and remains rowed separately. **One field was added to it, and the reason matters:** `verdictAtMs` means *"when `readiness` was last set from an ANSWER"*, and 429 sets `readiness` from the local heuristic — so it is explicitly nulled there. Without that, the new footer would print *"Showing the check from 14:32"* over a number no server produced: the fabrication class this slice closes, re-created one field over, inside the fix for it. Two store pins and one render pin hold it (M16, M17).

### 3. Closing the invisible outage — the honest states are now VISIBLE

#564's disclosed interim: *"an unreachable or missing readiness service is invisible: no readiness assessment, no error, Run stays enabled."*

**Surface decision, derived at the bytes:**
- `PreAnalysisHealth.tsx` — the only renderer of the error/retry state — has **ZERO non-test importers** in `src/` (`grep -arn`, trap 17). So does `PreAnalysisGuidance.tsx`.
- The surface users actually see is `PreAnalysisPanelV3`, mounted by `OutputsDock.tsx:2421` in the Analysis-tab pre-run slot (the panel's own header records that it is the LIVE staging surface).
- With `readiness === null` the run gate stays OPEN (`canRunAnalysis` blocks only on `readiness && !can_run_analysis`), and `PanelFooter`'s `!canRun ? notReady : footer` is total over a boolean — so an unreachable service rendered as **"Analysis available"**. The honest store state was being displayed as a *positive claim about a model nothing had assessed*.
- **Mounting `PreAnalysisHealth` was rejected**: it brings its own tier badge, improvements list and "Run analysis" button, which would put two run controls and two readiness assessments in one panel — the one-state-two-strings class this programme keeps closing. The honest states belong in the surface that today makes the false claim.

So `PanelFooter` gains an outage arm that **outranks both the gate copy and the model footer**, plus a Retry control. Three distinct states because they are three distinct facts: nothing timestamped stands behind the panel · a timestamped server answer still describing this model · a timestamped server answer the model has outgrown. Every arm names the cause (the store's own message). The discriminator is **`verdictAtMs`, not "is there a verdict object"** — see the 429 note above for why that distinction is load-bearing rather than stylistic. **The run is NOT gated locally** — verdicts remain the server's; visibility is the deliverable.

---

## RED-first evidence (all three parts, at pristine `0cb94016`)

All three final specs, run together against a worktree at `0cb94016` **outside** the repo root: **31 failed / 9 passed (40)**. Every one of the 9 that passes at pristine is a deliberate control or a retained guarantee, listed below — no assertion in this PR passes at pristine by accident.

| Spec | At pristine | Now |
|---|---|---|
| `readinessStore.invalidation.spec.ts` | **15 failed / 2 passed** (17) | 17 passed |
| `readinessStore.serverError.spec.ts` | **11 failed / 5 passed** (16) | 16 passed |
| `readinessOutageVisibility.spec.tsx` | **5 failed / 2 passed** (7) | 7 passed |

The 9 pristine-green, by name: `issues exactly one request on first listen and stores the verdict` · `issues a second request when the graph structure changes` · `observes can_run_analysis true and a null error when the server opens the gate` · `observes can_run_analysis false when the server closes the gate` · `tells a server error apart from an unreachable service` · `issues a real second request for the identical graph once the service recovers` · `publishes the local fallback with the rate-limit label` · `shows the ordinary footer and no outage row when the server answers` · `does not gate the run locally — the verdict stays the server's`.

Named pristine signatures include: `refetches with the updated analysis_ready when a turn changes an option status` → called 2, got **1** · `retains the server verdict by identity, sets the error, and keeps the stale mark` → error **null** (no refetch at all) · `leaves readiness null when the service answers 502` → `{readiness_score: 80, can_run_analysis: true}` published · `reports a readable sentence carrying the status, and no markup` → `'HTTP 502 - <html><head><title>502 Bad…'` · `shows a could-not-check row instead of an availability claim` → **Unable to find `[data-testid="pre-analysis-v3-readiness-outage"]`**.

Positive controls first in every file (trap 13); prior-verdict assertions bind by **object identity** (`toBe`), so no re-derived look-alike can satisfy them.

## Mutants — 21/21 bite

Throwaway worktree **outside** the repo root, committed state only, `git diff HEAD --numstat -- src/` per mutation, control **EXACTLY 0 changes / 44 collected / 44 passed**, zero-collected treated as a hard error, `set -o pipefail`. Every anchor is asserted to occur exactly once before it is applied — and that guard earned its keep on this round: rewriting the success arm for amendment 1 moved M6's anchor, and the sweep **failed loudly** (`ANCHOR FAIL M6: 0 occurrences`) instead of silently testing nothing. M6 was re-derived against the new arm.

| # | Mutation | Named RED |
|---|---|---|
| M1 | drop `ceeAnalysisReady` from `WATCHED_ROOTS` | 8 tests incl. the walk's own dead end + both watch-list guards + the stale render |
| M2 | replace the payload compare with an id-only fingerprint | both payload-identical tests |
| M3 | drop `currentBriefText` from `WATCHED_ROOTS` | brief refetch + both watch-list guards |
| M4 | move `{loading:true,error:null}` back above the hash check | `an undo back to the last answered model neither erases the error nor sticks loading` |
| M5 | clear `stale` in the transport-failure arm | retained-verdict + storm + the stale render |
| M6 | never clear `stale` on success | stale round-trip + storm recovery |
| M7 | make `buildReadinessPayload` read an unwatched root | the Proxy watch-list guard |
| M8 | remove the debounce | the storm bound |
| M9 | restore `calculateFallbackReadiness` in the outer catch | 9 tests: every 5xx/4xx status + identity retention + the 502 render |
| M10 | put `errorBody` back in the message | the no-markup pin |
| M11 | cache the payload hash on failure | the not-sticky pin |
| M12 | never return an outage description | all 5 visibility assertions |
| M13 | drop the `stale` distinction in the footer copy | the stale render |
| M14 | remove the Retry control | retry wiring + the stale render |
| M15 | always report `verdictRetained: true` | the never-checked arm (2 surfaces) |
| M16 | stamp `verdictAtMs` on the 429 local fallback | both 429 timestamp pins + the 429 render |
| M17 | discriminate the footer arms on `verdictRetained` instead of `verdictAtMs` | the 429 render |
| M18 | revert queue-on-drop (discard the deferred call) | both deferred-resolution pins |
| M19 | never drain the queue in `finally` | both deferred-resolution pins |
| M20 | clear `stale` unconditionally on success | `does not clear the mark at the moment the pre-mutation answer lands` |
| M21 | stamp `verdictAtMs` on the empty-canvas verdict again | the store pin + the render pin |

**Self-report: M4 SURVIVED the first sweep and the test was rewritten.** Design 1 §1.5 calls the setState reorder "what PREVENTS a regression against #564", but with the subscription's own payload compare in place nothing in the suite reached the reordered lines — 36/36 green with the mutation applied. A fix whose reversal turns nothing red is theatre (trap 11), so rather than keep an unfalsifiable claim I found the reachable path (edit while the service is down, then **undo** — the undo finds the payload identical to the last *successful* one) and pinned it. RED at pristine (`expected null to be 'Could not reach the readiness service'` — the error is erased), and M4 now bites that exact test.

## Premises refuted at the bytes (corrected premises are deliverables)

1. **The dispatch said a 502 "publishes a fabricated verdict with no error". The "no error" half is FALSE** — the pristine outer catch *does* set `error = err.message`. The real defects are the fabricated verdict, the overwrite of a prior server `false`, and the raw response **body** landing in user-facing copy. Row 2.339's own text is accurate; the dispatch summary was not.
2. **Design 1 §1.2's example was wrong: "any node drag wipes #564's error state with no request issued" is FALSE.** A drag leaves the pristine fingerprint (`id:type:data.value`) byte-identical, so the subscription returns before `fetchReadiness` is entered — the first draft of that test PASSED at pristine, i.e. pinned nothing. The reachable trigger is the fingerprint's *other* drift: `edge.data.confidence`, which is in the fingerprint and has never been in the payload. It enters the fetch, wipes the error **and** (because `lastPayloadHash` is unset after a failure) issues a real request. Test rewritten against that; both directions now pinned.
3. **Design F-0.1 is resolved at this tip** — the 404 arm HAS landed (publishes no verdict, `'Could not find the readiness service'`), so §1.5's "if the 404-amend does not land" contingency is moot.

## Gates

- `pnpm typecheck` — **PASSED**, exact: coverage 3179/3219 tracked TS files loaded (40 declared out of scope, unchanged); ratchet 623 files / 2507 errors, **equal to baseline**, no baseline regenerated. The one new error this branch introduced (TS2352 in a spec) was fixed at source, never absorbed.
- `pnpm lint:hooks-ratchet` — **PASSED**, 234 violations / 16 files, exactly matching baseline.
- `eslint` on every changed path — 0 errors. 3 warnings, all pre-existing and untouched by this branch (`HealthBars.tsx` DS token; two unused bindings in `readinessStore.ts` that exist at `0cb94016`).
- `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported before every run; inspector-v2 collection verified against disk (**34 spec files on disk = 34 collected, 355 tests**) — trap 2b clear.

## Deferred / disclosed

- **The 429 limb still publishes `calculateFallbackReadiness`** (labelled `'Rate limited - using local validation'`). Out of scope, rowed separately, and now pinned by a test so it cannot drift silently while its siblings are rewritten.
- **The legacy flag-off panel (`PreAnalysisPanel`, `isPreAnalysisV3Enabled()` false) does not surface the outage.** It consumes readiness via `usePreAnalysisData`, which never read `error`. V3 is the live staging surface; the legacy branch is unchanged and no worse than before.
- **`PreAnalysisHealth.tsx` still has zero non-test importers.** Its own `error && !readiness` arm remains reachable only from its spec. This PR does not mount it and does not claim to; retiring or mounting it is separate work.
- **No live witness.** Every claim here is repo-level (store state, request bodies, rendered output under jsdom). jsdom cannot prove visibility (trap 3) — a staging walk owes the screen-level confirmation that the outage row is actually seen.
- The two pre-existing eslint warnings in `readinessStore.ts` were left in place rather than bundled into this diff.

---

## Adversarial review — MERGE-WITH-AMENDMENTS, both amendments landed

The review **falsified a claim I made in this file**, and it was the load-bearing one. My comment on `stale` said the mark is set *"before the debounce, before the request — so there is no window in which an outgrown verdict looks current."* **False**, and the counterexample is the most ordinary shape there is: a slow fetch.

### Amendment 1 — a mutation during an in-flight fetch was DROPPED, and its mark laundered

`fetchReadiness` opened with `if (fetchInFlight) return`. A mutation landing mid-flight scheduled its refetch; the debounce fired at +500 ms into that guard; the call was **discarded** — no timer, no retry, no record. The in-flight request then completed and its success arm cleared `stale` **unconditionally**. Net: the mark was wiped by an answer that *predated* the mutation, and **no request was ever issued for the mutated model** — the 3 Aug walk's exact defect, re-created inside its own fix, reachable whenever readiness latency exceeds 500 ms. That is the Render cold-start shape, i.e. the same outage this PR's other half is about.

Two repairs, because they close two different holes and **neither is sufficient alone**:
1. **queue-on-drop** — the early return sets `fetchQueued`; `finally` clears it and re-invokes. Bounded, not a loop: the flag is cleared *before* the re-invoke, and the re-invoked fetch returns without a request when the payload already has a verdict.
2. **an answer clears only its own mark** — the success arm rebuilds the payload from the canvas *as it stands at completion* and clears `stale` only if it still equals what this response answered. Derived from the same `buildReadinessPayload` as the request and the change detector, so it cannot disagree with either.

(1) alone leaves `stale` false for the duration of the re-fetch — and if that re-fetch fails, the footer under-warns with "Could not re-check" instead of "Your model changed". (2) alone keeps the mark honest but never asks the question. Both.

### Amendment 2 — the empty-canvas verdict was stamped with a time no server produced

`currentNodes.length === 0` composes its verdict **locally** and was setting `verdictAtMs: Date.now()` — breaking the invariant I had just written and nulled the 429 arm to protect. Reachable on the deployed configuration: empty canvas → add the first node while the service is down → the footer cites *"Showing the check from HH:MM"* for a verdict nothing answered. Now `verdictAtMs: null`; `stale: false` stays, because that verdict genuinely is a function of the current (empty) payload.

### Amendment RED-first, at the reviewed head `3db12046`

**4 failed / 40 passed (44)** — the four new pins, each with the signature the review predicted:

| Pin | RED at `3db12046` |
|---|---|
| `issues the deferred request and keeps the mark until the mutated model is answered` | `expected "spy" to be called 2 times, but got 1 times` — the request never went out |
| `does not clear the mark at the moment the pre-mutation answer lands` | `expected false to be true` — `stale` laundered |
| `does not stamp verdictAtMs on the locally-composed empty-canvas verdict` | `expected 1785731061886 to be null` |
| `names the failure without a timestamp after the first node on an empty canvas` | the footer rendered "Showing the check from …" |

**Noted-no-action items stand as disclosed** (undo over-warns — fail-safe; first-load 429 copy; outage-row precedence).

### Evidence I am voiding, and why

My local full-suite run at `3db12046` reported 1460 files passed / 3 skipped / exit 0 — **I am voiding that number.** I checked the amended commit into the worktree hosting it while it was still running (`TREE` at start `e23f2391`, `TREE_AFTER` `a5879ba1`), so the tree moved under the run and the result describes no single commit (CLAUDE.md trap 9b/9c). It is not evidence and I am not citing it. What stands independently: **CI at `3db12046` was green on all 13 checks including Staging Gate and all four Full Test Suite shards**, and CI re-runs on this amended head.
