### PR TITLE
fix(ui): the readiness debounce can no longer be starved by the canvas churn it watches (ROADMAP 2.345)

### DIFF
--- a/src/canvas/stores/__tests__/readinessStore.churnStarvation.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.churnStarvation.spec.ts
@@ -35,9 +35,20 @@
  * that each CHANGE the payload, and every other spec in this directory seeds
  * nodes BEFORE `startListening` (so the zero-node arm is never taken) and lets
  * the canvas fall silent before asserting. Both halves of the deployed
- * condition were missing. The churn here is payload-IDENTICAL — asserted, not
- * assumed, in every test — and it keeps RUNNING ACROSS THE ASSERTION WINDOW. A
- * churn loop that stops before the assertion goes green on the broken code.
+ * condition were missing. The churn here keeps RUNNING ACROSS THE ASSERTION
+ * WINDOW in every test that uses it — a churn loop that stops before the
+ * assertion goes green on the broken code.
+ *
+ * Precisely which tests assert payload IDENTITY, because "asserted in every
+ * test" would be false and this file is about not asserting more than was
+ * measured: the five where the model is meant to STAND STILL — the churn
+ * positive control, RED-1, RED-3, and both no-op guards — each assert
+ * `currentPayload()` is byte-identical to the payload captured before the
+ * churn started. The two where the model deliberately MOVES under the churn
+ * (RED-2's added node, and the rate-limit test's added node) assert the
+ * REQUEST BODY instead, which is the stronger claim available there: they
+ * prove the mutated model is what got asked about. No test assumes identity
+ * it has not either asserted or deliberately broken.
  *
  * Scope note (CLAUDE.md trap 3): every assertion below is on store state, on
  * module state, or on the request count/body. Nothing here is a visibility
@@ -431,6 +442,86 @@ describe('readinessStore — the first fetch is not starved by canvas churn (ROA
 
       expect(mockFetch).toHaveBeenCalledTimes(2)
       expect(requestBody(1).graph.nodes).toHaveLength(17)
+    })
+  })
+
+  // ── Teardown releases the claim too ──────────────────────────────
+  //
+  // ⚠ THIS SECTION EXISTS BECAUSE AN ADVERSARIAL REVIEW FOUND A LINE OF MY FIX
+  // THAT NOTHING EXECUTED. The claim is released in two places — when the timer
+  // fires, and in `stopListening`. Only the first was pinned: deleting
+  // `pendingScheduledPayload = null` from `stopListening` passed the entire
+  // 294-test scope. That is my own M3 story one layer up, and it is worth
+  // saying plainly: the mutant I did not write is the one that would have
+  // shipped an unexecuted guarantee.
+  //
+  // The claim is module-level and `stopListening` is what `reset()` calls, so a
+  // leaked claim survives even a full store reset — there is no path back to a
+  // clean state short of the timer that was just cancelled. And the failure is
+  // SILENT: the early return sits above the `stale` mark, so the payload is
+  // neither asked about nor flagged as unasked. Ported from the reviewer's
+  // probe 3.
+  describe('the last consumer unmounting releases the scheduled claim', () => {
+    it('leaks no claim when teardown races an armed timer, and a remount asks', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      const release = useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      await vi.advanceTimersByTimeAsync(100) // mid-debounce: armed and claiming
+      expect(__test__.getModuleState().hasDebounceTimer).toBe(true)
+      expect(__test__.getModuleState().hasPendingScheduledPayload).toBe(true)
+
+      release() // the last consumer unmounts while the timer is still armed
+      expect(__test__.getModuleState().hasDebounceTimer).toBe(false)
+      expect(__test__.getModuleState().hasPendingScheduledPayload).toBe(false)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      // Remount: the first-listen immediate fetch asks about the same model.
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).graph.nodes).toHaveLength(16)
+    })
+
+    it('asks about a model the canvas returns to after an unmount, and never goes silent', async () => {
+      // The harm the module-state assertion above only stands proxy for. A
+      // module-state pin proves the mechanism; this proves the damage, and the
+      // two are not the same test.
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      const release = useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      await vi.advanceTimersByTimeAsync(100)
+      release() // claim on the 16-node model, released here or leaked forever
+
+      // The canvas keeps moving while nothing is listening — the panel is shut.
+      useCanvasStore.setState({
+        nodes: [...useCanvasStore.getState().nodes, factorNode(99)] as any,
+      })
+
+      // Reopen. First listen asks about the 17-node model it finds.
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).graph.nodes).toHaveLength(17)
+
+      // Now undo, back to exactly the payload the released claim named. A
+      // leaked claim swallows this: no request, and — because the early return
+      // sits above the mark — no `stale` either. The gate would sit on a
+      // verdict for a model the canvas no longer holds, saying nothing.
+      clearInflightCache()
+      useCanvasStore.setState({
+        nodes: useCanvasStore.getState().nodes.slice(0, 16) as any,
+      })
+      expect(useReadinessStore.getState().stale).toBe(true)
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes).toHaveLength(16)
     })
   })
 

--- a/src/canvas/stores/__tests__/readinessStore.churnStarvation.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.churnStarvation.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * readinessStore — a trailing debounce must not be starved by the churn it is
+ * watching (ROADMAP 2.345).
+ *
+ * THE DEFECT THIS FILE PINS WAS INTRODUCED BY #566, the fix for 2.332. That
+ * PR replaced a hand-written fingerprint with a payload-derived change
+ * detector — the right move, and its honesty machinery (outage arm, retained
+ * verdict, staleness copy, Retry) was witnessed working live. But the payload
+ * marker it compares against, `lastObservedPayload`, is recorded only when a
+ * request ATTEMPT runs, and the cold-load zero-node arm returns before that
+ * line. So on every real session the marker was `null`, and `null` equals no
+ * payload at all.
+ *
+ * What that collided with is not hypothetical and not ours: React Flow's
+ * ResizeObserver drives a permanent ~100–120 Hz storm of `nodes`-identity
+ * commits into the canvas store for the life of a drafted graph (measured on
+ * deployed staging: 1,564 watched-root commits in 16 s, max inter-commit gap
+ * 44 ms over 60 s, stack `ResizeObserver → updateNodeInternals →
+ * triggerNodeChanges → onNodesChange → set`). Every one of those commits
+ * rebuilds a payload IDENTICAL to the last. Against a null marker each read as
+ * a change, cleared the 500 ms trailing timer and re-armed it — about a
+ * hundred times a second, forever. The deadline moved faster than time passed.
+ *
+ * The consequence measured by four witness walks: `graph-readiness` requested
+ * ZERO times in three of four guest sessions (complete request manifests), and
+ * once in the fourth, ~19 s AFTER the run was triggered. The gate a tester saw
+ * on the first screen — `Analyse first pass` disabled, "Not ready for analysis
+ * yet" — was the cold-load LOCAL zero-node verdict retained all session, while
+ * the same turn's `analysis_ready.status` was "ready". And #566's outage
+ * surface was unreachable, because nothing had ever failed: no request had
+ * ever been made.
+ *
+ * ⚠ WHY THE EXISTING STORM COVERAGE DID NOT SEE THIS, stated because it is the
+ * whole methodological point. `invalidation.spec.ts:663` drives ten mutations
+ * that each CHANGE the payload, and every other spec in this directory seeds
+ * nodes BEFORE `startListening` (so the zero-node arm is never taken) and lets
+ * the canvas fall silent before asserting. Both halves of the deployed
+ * condition were missing. The churn here is payload-IDENTICAL — asserted, not
+ * assumed, in every test — and it keeps RUNNING ACROSS THE ASSERTION WINDOW. A
+ * churn loop that stops before the assertion goes green on the broken code.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion below is on store state, on
+ * module state, or on the request count/body. Nothing here is a visibility
+ * claim; that is the browser witness's job and it cannot be made from jsdom.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore, buildReadinessPayload, __test__ } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function mock429Response() {
+  return {
+    ok: false,
+    status: 429,
+    statusText: 'Too Many Requests',
+    json: () => Promise.reject(new Error('not json')),
+    text: () => Promise.resolve('rate limited'),
+    headers: new Headers(),
+  }
+}
+
+/** What `fetch()` does when the host is unreachable (undici, jsdom). */
+function networkRejection() {
+  return Promise.reject(new TypeError('Failed to fetch'))
+}
+
+function factorNode(i: number) {
+  return {
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }
+}
+
+/** The cold canvas a guest lands on: no nodes, no brief, nothing. */
+function emptyCanvas() {
+  useCanvasStore.setState({
+    nodes: [] as any,
+    edges: [] as any,
+    ceeAnalysisReady: null,
+    currentBriefText: null,
+  })
+}
+
+/** A draft landing as ONE nodes+edges commit, which is how CEE's draft lands. */
+function draftLands(nodeCount: number) {
+  useCanvasStore.setState({
+    nodes: Array.from({ length: nodeCount }, (_, i) => factorNode(i)) as any,
+    edges: [
+      { id: 'edge-0-1', source: 'node-0', target: 'node-1', data: { weight: 0.5, direction: 'positive' } },
+    ] as any,
+  })
+}
+
+function currentPayload(): string {
+  return buildReadinessPayload(useCanvasStore.getState() as any)
+}
+
+function requestBody(callIndex: number): Record<string, any> {
+  const init = mockFetch.mock.calls[callIndex]?.[1]
+  return JSON.parse(String(init?.body ?? '{}'))
+}
+
+// ── The storm, reproduced ──────────────────────────────────────────
+//
+// Faithful to what was measured on the deployed canvas rather than to a
+// convenient abstraction: a new `nodes` ARRAY of new node OBJECTS on every
+// tick, with the React Flow `measured` dimension field oscillating — the field
+// probe C found churning. `measured` is not read by `buildReadinessPayload`,
+// so the payload is byte-identical across every tick. That identity is
+// asserted in each test rather than trusted; a churn helper that accidentally
+// moved the payload would turn these into the payload-CHANGING storm tests
+// that already exist and already pass on the broken code.
+
+let churnHandle: ReturnType<typeof setInterval> | null = null
+let churnTicks = 0
+/** Watched-root commits the readiness subscription actually saw. */
+let observedCommits = 0
+let unsubCommitCounter: (() => void) | null = null
+
+function startChurn(intervalMs = 100) {
+  churnTicks = 0
+  churnHandle = setInterval(() => {
+    churnTicks++
+    const { nodes } = useCanvasStore.getState()
+    useCanvasStore.setState({
+      nodes: nodes.map((n: any) => ({
+        ...n,
+        measured: { width: 180 + (churnTicks % 2), height: 44 },
+      })) as any,
+    })
+  }, intervalMs)
+}
+
+function stopChurn() {
+  if (churnHandle) clearInterval(churnHandle)
+  churnHandle = null
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+  observedCommits = 0
+  unsubCommitCounter = useCanvasStore.subscribe((state, prev) => {
+    if (state.nodes !== prev.nodes) observedCommits++
+  })
+})
+
+afterEach(() => {
+  stopChurn()
+  unsubCommitCounter?.()
+  unsubCommitCounter = null
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — the first fetch is not starved by canvas churn (ROADMAP 2.345)', () => {
+  // ── Positive controls (CLAUDE.md trap 13) ────────────────────────
+  //
+  // Three of the tests below assert that a request DOES go out. Two assert one
+  // does NOT. Neither claim is worth anything until the harness is shown to be
+  // capable of both — and, specifically for this file, until the churn helper
+  // is shown to actually emit commits. A silent churn helper would make every
+  // starvation test pass for the wrong reason.
+  describe('positive controls — the harness sees requests, and the churn is real', () => {
+    it('issues the first request once the draft lands on a quiet canvas', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).not.toHaveBeenCalled() // the zero-node arm answers locally
+
+      draftLands(16)
+      await vi.advanceTimersByTimeAsync(600)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).graph.nodes).toHaveLength(16)
+    })
+
+    it('emits payload-identical watched-root commits at the measured cadence', async () => {
+      emptyCanvas()
+      draftLands(16)
+      const before = currentPayload()
+
+      const commitsBefore = observedCommits
+      startChurn(100)
+      await vi.advanceTimersByTimeAsync(5000)
+      stopChurn()
+
+      // The storm is present …
+      expect(churnTicks).toBeGreaterThanOrEqual(45)
+      expect(observedCommits - commitsBefore).toBeGreaterThanOrEqual(45)
+      // … the node identities really do change on every tick …
+      expect(useCanvasStore.getState().nodes[0]).not.toBe(null)
+      expect((useCanvasStore.getState().nodes[0] as any).measured).toBeDefined()
+      // … and it changes NOTHING the server would see.
+      expect(currentPayload()).toBe(before)
+    })
+  })
+
+  // ── RED-1 — the walk's zero, at store level ──────────────────────
+  describe('a draft on a cold canvas is asked about, even while the canvas churns', () => {
+    it('issues exactly one request for the drafted model with the storm still running', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      draftLands(16)
+      const payloadAtDraft = currentPayload()
+      startChurn(100)
+
+      // Assertions are taken WITH THE CHURN STILL RUNNING. This is the whole
+      // test: 5 s of virtual time in which the debounce must reach its
+      // deadline despite ~50 intervening watched-root commits.
+      await vi.advanceTimersByTimeAsync(5000)
+
+      expect(churnTicks).toBeGreaterThanOrEqual(45)
+      expect(currentPayload()).toBe(payloadAtDraft)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(requestBody(0).graph.nodes).toHaveLength(16)
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+    })
+  })
+
+  // ── RED-2 — invalidation still works under the storm ─────────────
+  describe('a mutation after the first answer is asked about, even while the canvas churns', () => {
+    it('refetches with the mutated model', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      startChurn(100)
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // A turn adds an option, mid-storm.
+      clearInflightCache()
+      useCanvasStore.setState({
+        nodes: [...useCanvasStore.getState().nodes, factorNode(99)] as any,
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes).toHaveLength(17)
+    })
+  })
+
+  // ── RED-3 — #566's honesty surface becomes reachable ─────────────
+  describe('an unreachable service is reported, even while the canvas churns', () => {
+    it('publishes the transport error for the drafted model', async () => {
+      mockFetch.mockImplementation(() => networkRejection())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      const payloadAtDraft = currentPayload()
+      startChurn(100)
+      await vi.advanceTimersByTimeAsync(3000)
+
+      expect(currentPayload()).toBe(payloadAtDraft)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      // #566's outage arm — unreachable in the field only because no request
+      // was ever made for it to fail.
+      expect(useReadinessStore.getState().error).toBe('Could not reach the readiness service')
+      expect(useReadinessStore.getState().loading).toBe(false)
+    })
+  })
+
+  // ── The bound #566 promised, extended to sustained churn ─────────
+  //
+  // The fix must not be bought by asking more often. A payload the store has
+  // already asked about is asked about once, and the storm neither re-requests
+  // it nor disturbs the state the surfaces render.
+  describe('sustained churn after the question is answered asks nothing further', () => {
+    it('issues no further request and never marks the answered verdict stale', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      draftLands(16)
+      await vi.advanceTimersByTimeAsync(600)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(useReadinessStore.getState().stale).toBe(false)
+
+      const answered = useReadinessStore.getState().readiness
+      const flips: Array<{ loading: boolean; error: string | null; stale: boolean }> = []
+      const unsub = useReadinessStore.subscribe((s) =>
+        flips.push({ loading: s.loading, error: s.error, stale: s.stale }),
+      )
+
+      const payloadAtAnswer = currentPayload()
+      startChurn(100)
+      await vi.advanceTimersByTimeAsync(10_000)
+      unsub()
+
+      expect(churnTicks).toBeGreaterThanOrEqual(95)
+      expect(currentPayload()).toBe(payloadAtAnswer)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      // Not merely "no request": no store churn either. A hundred `stale: true`
+      // writes a second would re-render every readiness consumer.
+      expect(flips).toEqual([])
+      const after = useReadinessStore.getState()
+      expect(after.readiness).toBe(answered)
+      expect(after.stale).toBe(false)
+      expect(after.error).toBeNull()
+      expect(after.loading).toBe(false)
+    })
+
+    it('never marks the empty-canvas verdict outgrown while the payload stands still', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(useReadinessStore.getState().stale).toBe(false)
+
+      // The zero-node arm answers locally, and its answer is a function of
+      // exactly this payload — so the arm must record the payload as observed,
+      // the same as a request attempt does. Unrecorded, the marker is null,
+      // null equals no payload, and every emission below reads as a change.
+      //
+      // Typing a brief below the 20-character floor is that shape without any
+      // React Flow involved: real watched-root commits that leave the payload
+      // byte-identical. The end state alone cannot see the defect (the
+      // debounce lands back in the same arm and clears the mark again), so
+      // this watches EVERY emission — one flap per typing pause, about a
+      // verdict that never changed.
+      const payloadWhileEmpty = currentPayload()
+      const emissions: boolean[] = []
+      const unsub = useReadinessStore.subscribe((s) => emissions.push(s.stale))
+
+      for (const text of ['A', 'A d', 'A dec', 'A decis']) {
+        useCanvasStore.setState({ currentBriefText: text })
+        await vi.advanceTimersByTimeAsync(700)
+      }
+      unsub()
+
+      expect(currentPayload()).toBe(payloadWhileEmpty)
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(emissions.filter(Boolean)).toEqual([])
+      expect(useReadinessStore.getState().stale).toBe(false)
+    })
+  })
+
+  // ── The scheduled-payload record is a claim, and claims expire ───
+  //
+  // Tracking "what the armed timer will ask" is what makes starvation
+  // impossible, and it is also the thing most likely to be got wrong in the
+  // other direction: a claim that outlives its timer suppresses a question
+  // that was never asked. These two pin the release.
+  describe('a scheduled question is released the moment it is asked', () => {
+    it('holds no scheduled claim once the timer has fired', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      // Armed, and claiming.
+      expect(__test__.getModuleState().hasDebounceTimer).toBe(true)
+      expect(__test__.getModuleState().hasPendingScheduledPayload).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(600)
+
+      // Fired: the claim must go with the timer. The invariant is that these
+      // two agree — a claim without a timer is an unaskable payload.
+      expect(__test__.getModuleState().hasDebounceTimer).toBe(false)
+      expect(__test__.getModuleState().hasPendingScheduledPayload).toBe(false)
+    })
+
+    it('re-schedules a model that was scheduled, abandoned by an undo, and then made again', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+      draftLands(16)
+      await vi.advanceTimersByTimeAsync(600)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const answeredNodes = useCanvasStore.getState().nodes
+
+      // Edit → schedules the 17-node model …
+      useCanvasStore.setState({
+        nodes: [...answeredNodes, factorNode(99)] as any,
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      // … undo inside the debounce window. The payload is back to the model
+      // already answered, so the change detector early-returns and the armed
+      // timer is left holding a claim on a question nobody will now ask.
+      useCanvasStore.setState({ nodes: answeredNodes as any })
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Redo. The claim must have been released, or this model can never be
+      // asked about again.
+      clearInflightCache()
+      useCanvasStore.setState({
+        nodes: [...answeredNodes, factorNode(99)] as any,
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes).toHaveLength(17)
+    })
+  })
+
+  // ── The pre-#566 defect stays dead ───────────────────────────────
+  //
+  // The obvious way to kill the starvation is to record the payload as
+  // OBSERVED at schedule time, which is exactly what the code before #566 did.
+  // It works, and it re-opens the hole #566 closed: a payload that was
+  // scheduled but never actually asked about looks answered forever. The
+  // reachable shape is a scheduled attempt that returns without a request —
+  // the rate-limit backoff arm. Under the deployed storm the recovery is the
+  // churn itself, which is why this test keeps churning.
+  describe('a scheduled attempt that never issued a request does not look answered', () => {
+    it('asks again once a rate-limit backoff has expired', async () => {
+      mockFetch.mockResolvedValue(mock429Response())
+      emptyCanvas()
+      useReadinessStore.getState().startListening()
+      await vi.advanceTimersByTimeAsync(0)
+
+      draftLands(16)
+      startChurn(100)
+      await vi.advanceTimersByTimeAsync(600)
+      // The draft was asked about and rate-limited: backoff is armed for 1 s.
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // A turn adds an option while the backoff is still running. Its debounce
+      // fires INSIDE the backoff window, so `fetchReadiness` returns with no
+      // request and no record of an attempt.
+      clearInflightCache()
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useCanvasStore.setState({
+        nodes: [...useCanvasStore.getState().nodes, factorNode(99)] as any,
+      })
+      await vi.advanceTimersByTimeAsync(300)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Past the backoff, still churning. The mutated model must be asked
+      // about; a payload recorded as observed at schedule time never would be.
+      await vi.advanceTimersByTimeAsync(3000)
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(requestBody(1).graph.nodes).toHaveLength(17)
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+    })
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -151,6 +151,38 @@ let listenerRefCount = 0
  * `buildReadinessPayload`, so neither can drift from the payload.
  */
 let lastObservedPayload: string | null = null
+/**
+ * ROADMAP 2.345 — the payload the CURRENTLY ARMED debounce timer will ask
+ * about. Non-null exactly while `debounceTimer` is armed; cleared the instant
+ * the timer fires or is torn down.
+ *
+ * It answers a THIRD question, distinct from the two above: not "has anything
+ * changed since we last asked?" (`lastObservedPayload`) and not "do we already
+ * hold a verdict for this?" (`lastPayloadHash`), but "is this exact question
+ * ALREADY ON ITS WAY?".
+ *
+ * Without it the debounce could starve itself, and on the deployed canvas it
+ * always did. React Flow's ResizeObserver drives a permanent ~100–120 Hz storm
+ * of `nodes`-identity commits (measured live: max inter-commit gap 44 ms over
+ * 60 s). Every one of those commits rebuilds a payload that is IDENTICAL to
+ * the last — and after the cold-load zero-node arm returned without recording
+ * anything, `lastObservedPayload` was `null`, which equals no payload at all.
+ * So each commit read as a change and cleared + re-armed the 500 ms trailing
+ * timer ~100 times a second, forever. The fetch that would have ended the loop
+ * by recording `lastObservedPayload` sat behind the timer that never fired: a
+ * starvation deadlock, and the reason `graph-readiness` was requested ZERO
+ * times in three of four witnessed guest sessions.
+ *
+ * Tracking the SCHEDULED payload separately is what makes starvation
+ * structurally impossible: a given payload can re-arm the timer at most once,
+ * so the timer always reaches its deadline. It deliberately does NOT reuse
+ * `lastObservedPayload` — recording a payload as observed at SCHEDULE time is
+ * the pre-#566 shape, and it makes a question that was scheduled but never
+ * actually asked (rate-limit backoff, teardown) look answered forever. Both
+ * truths have to hold at once: an unattempted payload is not "asked", and a
+ * scheduled payload must not reset its own timer.
+ */
+let pendingScheduledPayload: string | null = null
 /** The payload of the last SUCCESSFUL request. Never written on failure. */
 let lastPayloadHash: string | null = null
 let fetchInFlight = false
@@ -371,6 +403,22 @@ async function fetchReadiness(): Promise<void> {
     } = canvasState
 
     if (currentNodes.length === 0) {
+      // ── ROADMAP 2.345: this arm ANSWERS the question, so record it ──
+      //
+      // The verdict below is composed locally, but it is still an answer to
+      // exactly this payload (the empty graph), which is why the arm can
+      // honestly clear `stale`. Leaving `lastObservedPayload` unrecorded here
+      // was half of the starvation deadlock: on a cold load this is the FIRST
+      // consumer's immediate fetch, so the marker stayed `null` — and `null`
+      // is equal to no payload, so every subsequent canvas emission read as a
+      // change no matter what it contained.
+      //
+      // Recording it also stops a `stale` flap on an empty canvas: payload-
+      // identical emissions (brief typing below the 20-character floor, a
+      // resize) would otherwise mark the verdict outgrown, fire the debounce,
+      // land back in this arm, and clear the mark again — once per pause,
+      // about a verdict that never changed.
+      lastObservedPayload = buildReadinessPayload(canvasState)
       useReadinessStore.setState({
         readiness: {
           readiness_score: 0,
@@ -856,14 +904,48 @@ export const useReadinessStore = create<ReadinessStoreState & ReadinessStoreActi
         const nextPayload = buildReadinessPayload(state as unknown as ReadinessPayloadInputs)
         if (nextPayload === lastObservedPayload) return
 
+        // ── ROADMAP 2.345: a question already in the timer cannot re-arm it ──
+        //
+        // Step 3. The two steps above ask whether anything CHANGED. Neither
+        // asks whether this exact change is already scheduled — and on the
+        // deployed canvas it always is, because React Flow re-emits a
+        // payload-identical `nodes` array ~100 times a second for the life of
+        // the graph. Each of those emissions used to clear and re-arm the
+        // trailing timer, so the deadline moved faster than time passed and
+        // the fetch was never made: zero `graph-readiness` requests per
+        // session, the gate composed from a cold-load local verdict, and every
+        // surface #566 built to be honest about an outage sitting behind a
+        // request that never went out.
+        //
+        // With the scheduled payload tracked, a payload can arm the timer at
+        // most once, so the deadline is always reached. Storm-independent by
+        // construction: it does not care how fast the churn is, only that the
+        // churn is asking the same question. A max-wait deadline was rejected
+        // as the primary fix — under permanent churn it re-fires forever and
+        // has to be tuned against the dedup window, where this cannot fire
+        // twice for one payload at all.
+        //
+        // The `stale` mark is not skipped by this return: it was set when this
+        // payload was first scheduled, and nothing between then and the timer
+        // firing can clear it (only a fresh verdict does, and a fresh verdict
+        // sets `lastObservedPayload`, which the step above catches first).
+        if (nextPayload === pendingScheduledPayload) return
+
         // The verdict currently on screen was not asked about this model.
         // Marked synchronously — before the debounce, before the request — so
         // there is no window in which an outgrown verdict looks current.
         useReadinessStore.setState({ stale: true })
 
+        pendingScheduledPayload = nextPayload
         if (debounceTimer) clearTimeout(debounceTimer)
         debounceTimer = setTimeout(() => {
           debounceTimer = null
+          // Cleared BEFORE the fetch: from here the question is being asked,
+          // not scheduled, and `lastObservedPayload` takes over as the record
+          // the moment the attempt runs. Left set, a payload that had been
+          // scheduled once could never be scheduled again — which is how a
+          // rate-limited or torn-down attempt would become permanently sticky.
+          pendingScheduledPayload = null
           fetchReadiness().catch(() => {
             // Swallow — fetchReadiness handles errors internally
           })
@@ -905,6 +987,10 @@ function stopListening(): void {
     clearTimeout(debounceTimer)
     debounceTimer = null
   }
+  // ROADMAP 2.345 — the timer is gone, so nothing is scheduled. Held past a
+  // teardown it would suppress the re-scheduling of that same payload after a
+  // remount, which is the shape the last consumer unmounting actually produces.
+  pendingScheduledPayload = null
   if (currentInflightEntry) {
     currentInflightEntry.refCount--
     if (currentInflightEntry.refCount <= 0) {
@@ -944,6 +1030,12 @@ export const __test__ = {
     listenerRefCount,
     hasSubscription: unsubCanvasStore !== null,
     hasDebounceTimer: debounceTimer !== null,
+    /**
+     * ROADMAP 2.345 — whether an armed timer is currently claiming a question.
+     * The invariant is `hasDebounceTimer === hasPendingScheduledPayload`; a
+     * claim outliving its timer is exactly what makes a payload unaskable.
+     */
+    hasPendingScheduledPayload: pendingScheduledPayload !== null,
   }),
   resetModuleState: () => {
     stopListening()


### PR DESCRIPTION
## ROADMAP 2.345 — the readiness debounce could be starved by the canvas churn it watches

**#566 introduced this regression.** That is the first thing to say, because #566 is
mine-adjacent work that is otherwise correct and this PR deliberately does not undo any
of it. #566 replaced a hand-maintained fingerprint with a payload-derived change
detector — the right move — and its honesty machinery was **witnessed working on
deployed staging**: a probe that injected node shapes drew HTTP 400s and the footer
painted the outage row, the cause subline carrying the status, the retained-verdict
timestamp, the staleness copy and Retry, all correctly. Nothing in 2.332's invalidation
design needs reshaping. What #566 got wrong is two lines of scheduling.

### The mechanism, measured live twice

`lastObservedPayload` — the marker the change detector compares each rebuilt payload
against — is recorded **only when a request ATTEMPT runs** (`readinessStore.ts:418`), and
the cold-load zero-node arm (`:373-397`) returns **before** that line. So on every real
session the marker was `null`, and `null` equals no payload at all.

What that collided with is React Flow's ResizeObserver, which drives a **permanent
~100–120 Hz storm of `nodes`-identity commits** for the life of a drafted graph
(measured on staging: 1,564 watched-root commits in 16 s; **max inter-commit gap 44 ms
over 60 s — it never pauses**; stack `ResizeObserver → updateNodeInternals →
triggerNodeChanges → onNodesChange → set`). Every one of those commits rebuilds a payload
**identical** to the last. Against a null marker each read as a change, cleared the 500 ms
trailing timer and re-armed it, ~100×/s. The deadline moved faster than time passed, and
the fetch that would have ended the loop by recording the marker sat **behind** the timer
that never fired: a starvation deadlock.

**Measured consequence (four witness walks, complete request manifests):**
`graph-readiness` requested **ZERO** times in three of four guest sessions; once in the
fourth, ~19 s **after** the run was triggered. The gate a tester saw on the first screen —
`Analyse first pass` disabled, "Not ready for analysis yet" — was the **cold-load local
zero-node verdict retained all session**, while the same turn's `analysis_ready.status`
was `"ready"`. A false reason on the first screen is a PC1 dead end by definition. And
#566's outage surface was unreachable in the field not because it was wrong but because
**nothing had ever failed — no request had ever been made.**

Full diagnosis: `PHASE0-EVIDENCE-2026-07-28/diagnosis-2345-no-first-fetch.md`.

### The fix — forward, not a revert

A revert restores record-at-schedule, which has its own defect (a payload scheduled but
never actually asked about looks answered forever). **Both truths have to hold at once**,
so they get separate state:

- **`pendingScheduledPayload`** — what the *armed timer* will ask. Set at schedule,
  cleared the instant the timer fires or is torn down. A payload can arm the timer **at
  most once**, so the deadline is always reached. Starvation is structurally impossible,
  independent of churn rate — the predicate does not care how fast the storm is, only
  that the storm is asking the same question.
- **`lastObservedPayload`** — semantics unchanged. Still an **attempt** record, so
  #566's truth that an unattempted payload is not "asked" is preserved intact.
- **the zero-node arm now records its payload as observed.** It *is* an answer to exactly
  that payload (locally, honestly — which is why that arm already clears `stale`), and
  leaving it unrecorded was the other half of the deadlock. It also removes a `stale`
  flap on the empty canvas: brief typing below the 20-character floor marked the verdict
  outgrown, fired the debounce, landed back in the same arm and cleared the mark again.

A max-wait / leading-edge deadline was **rejected as the primary fix**: under permanent
churn it re-fires forever and has to be tuned against the 750 ms dedup window, where this
cannot fire twice for one payload at all.

### RED-first — at pristine `5760c752`, the deployed SHA

`readinessStore.churnStarvation.spec.ts`: **6 failed / 4 passed (10)**. The starvation
signature is exact — *expected "spy" to be called 1 times, but got **0** times* — the
store-level reproduction of the walk's zero.

The four pristine-greens are named, not incidental: two **positive controls** (trap 13 —
the harness sees a request go out on a quiet canvas; the churn helper really emits ~50
watched-root commits and the payload is byte-identical across all of them), one
**retained #566 guarantee** (an answered payload is not re-asked under sustained churn,
and no `loading`/`error`/`stale` emission is produced), and one guard for machinery that
did not yet exist.

⚠ **Why the existing storm coverage could not see this**, stated because it is the
methodological point. `invalidation.spec.ts:663` drives ten mutations that each **change**
the payload; every other spec in the directory seeds nodes **before** `startListening`, so
the zero-node arm is never taken, and lets the canvas fall silent before asserting. Both
halves of the deployed condition were missing. The churn here is **payload-IDENTICAL**
(asserted in every test, never assumed) and keeps **running across the assertion window**.
A churn loop that stops before the assertion goes green on the broken code.

### Mutants — 6/6 bite. Throwaway worktree outside the repo root, control exactly 0

| # | mutation | bites |
|---|---|---|
| CONTROL | none | applied-check **0**, 284/284 pass |
| **M1** | revert the re-arm predicate (the shipped defect) | **4** — RED-1 cold draft, RED-2 refetch, RED-3 outage reachability, backoff re-ask |
| **M2** | never release the scheduled payload on timer fire | **3** — claim-release invariant, undo→redo re-schedule, backoff re-ask |
| **M3** | restore record-at-schedule (the pre-#566 shape) | **2** — claim-release invariant, **backoff re-ask (retry-not-sticky)** |
| **M4** | zero-delay debounce | **3** — `invalidation.spec.ts` "coalesces a burst … and never loops", `readinessStore.spec.ts` debounce coalescing, undo→redo |
| **M5** | drop the `stale` mark | **6** — incl. `invalidation.spec.ts` "marks the verdict stale …" and the `readinessOutageVisibility` surface spec |
| **M6** | drop the zero-node payload record | **1** — the empty-canvas stale-flap guard |
| **M7** | drop the **teardown** release of the claim (`stopListening`) | **3** — both new teardown pins + backoff re-ask |

Applied-check `git diff HEAD --numstat -- src/` scoped to `src/` (trap 12e); every mutant
read exactly 1 changed file, control exactly 0. A zero-collected run is a hard error in
the driver — **and it fired**: vitest exits **0** with "No test files found", and zsh does
not word-split unquoted variables, so the first sweep silently collected nothing and would
have reported 6/6 survivors as 6/6 bites had the guard not been there.

### Refuted, and said rather than buried

The diagnosis predicted **M3 would trip the existing retry-not-sticky tests at
`invalidation.spec.ts:515` and `:696`.** **Measured: it does not.** Both survive M3,
because the immediate first-listen fetch records the attempt before either test reaches
its debounce. **So the pre-#566 defect was not pinned by anything in the tree** — a plain
revert would have passed the whole suite. This PR adds the test that does pin it: a
scheduled attempt that returns **without issuing a request** (the rate-limit backoff arm)
must not leave its payload looking answered. That test is where M3 dies.

### Review amendments (adversarial review: MERGE-WITH-AMENDMENTS, test-only)

The shipped code is unchanged — the review confirmed the at-most-once-arm invariant held
against every executed residual shape. Two amendments landed, both in the spec.

**Amendment 1 — an unexecuted line of my own fix, which is this PR's M3 finding one layer
up.** The claim is released in TWO places: when the timer fires, and in `stopListening`
(`readinessStore.ts:993`). Only the first was pinned — **deleting the teardown release
passed the entire 294-test scope.** It matters rather than being tidy: the claim is
module-level and `stopListening` is what `reset()` calls, so a leaked claim survives even a
full store reset; and the early return sits **above** the `stale` mark, so the starvation is
**silent**. Reachable shape: teardown mid-debounce (the panel closes) → the canvas moves
while unmounted → remount asks about what it finds → the user undoes back to the claimed
payload → nothing is ever asked and nothing says so. Pinned with two tests, because they
are not the same test: the module-state pin (ported from the reviewer's probe 3) and the
behavioural pin asserting the request bodies and the raised `stale`. **M7 added to the
table; it bites both.**

**Amendment 2 — a false sentence in my own spec header, corrected.** It claimed the churn
is payload-identical "asserted, not assumed, **in every test**". False for RED-2 and the
rate-limit test, where the payload deliberately **moves** under the churn. The header now
names the five tests that assert byte-identity (churn positive control, RED-1, RED-3, both
no-op guards) and states that the other two assert the **request body** instead — the
stronger claim available there, since it proves the mutated model is what got asked about.
A file about not asserting more than was measured had a summary sentence doing exactly that.

**Second instrument failure, caught by its own guard.** The re-run sweep collected **276**
tests instead of 284 — I had not exported `VITE_SUPABASE_*` in that shell, and 12
inspector-v2 spec files fail at COLLECT without them (CLAUDE.md trap 2b). The exact-count
guard turned a silently smaller suite into a hard error. Final sweep: **284 collected,
control 0 changes, 7/7 mutants bite.**

### Disclosed residuals — now ROADMAP 2.348

Both pre-existing, both visible, both failing in the safe direction; neither introduced or
worsened here:
- **429 on a quiet canvas** — the backoff arm returns without re-arming its own timer, so
  with zero further emissions nothing re-asks; and `refresh()` is a no-op inside the
  backoff window.
- **stale-stuck on undo→redo** — an undo back to an already-answered payload early-returns
  above the mark, so `stale` can stand on a model that *is* current.

### Gates at this tip

- `pnpm run typecheck` — **PASSED**, ratchet **exact** (623 files / 2507 errors vs baseline 2507); coverage 3180/3220, new spec loaded.
- `pnpm run lint:hooks-ratchet` — 234 known violations / 16 files, **exactly matching baseline**.
- `npx eslint` on both changed files — **0 errors** (2 pre-existing warnings in untouched lines).
- Readiness-adjacent suites — **53 files / 859 tests pass**.
- Local **full suite** — 1461 files / **21,520 tests pass**, 3 files / 66 tests skipped.
- `validate-prepush.sh` check 8 (DS v5 drift) fails — **proven pre-existing with a control worktree at pristine `5760c752`: byte-identical counts** (1790/289/62/45, Δ+11). This diff touches two files, neither in the net-new list. Do not accept an `--update-baseline` prompt for it.

### Blast radius, stated

~4–6 `graph-readiness` requests per walk-shaped session instead of 0, bounded at one per
settled payload change (500 ms debounce + 750 ms dedup); PLoT's own counters showed 33
calls/day route-wide, so rate-limit exposure is negligible and the 429 arm already exists.
The gate now **opens on the first screen when CEE says ready**. #566's outage row becomes
genuinely reachable during Render cold starts — that is the honesty working, not a
regression.

### Not fixed here, rowed separately

- The ~120 Hz ResizeObserver loop itself still burns CPU in every canvas subscriber (the readiness listener still `JSON.stringify`s the graph per tick on payload-differing windows). The fix deliberately does **not** depend on killing it.
- The backoff arm still returns without re-arming its own timer, so on a *quiet* canvas a rate-limited model waits for the next mutation. Pre-existing; the new test documents the churn-driven recovery explicitly rather than pretending otherwise.

### Verification not claimed here (trap 3)

Every assertion in this PR is on store state, module state, or the request count/body.
**jsdom cannot prove the first screen.** The browser witness — fresh guest canvas, draft a
graph, ≥1 `graph-readiness` within ~2 s of settle, gate reflecting the **server** verdict
on the first screen — runs against staging after merge and is what actually closes 2.345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
