### PR TITLE
Compare shows two runs within a guest session (ROADMAP 2.350)

### DIFF
--- a/src/canvas/compare-tab/__tests__/CompareTabBody.v5GuestSession.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.v5GuestSession.spec.tsx
@@ -1,0 +1,171 @@
+/**
+ * ROADMAP 2.350 — a GUEST who runs the analysis twice in one session sees two
+ * versions side by side (PC1 step 6, its last gap).
+ *
+ * ⚠ HOW THIS DIFFERS FROM `CompareTabBody.pickTwoRuns.spec.tsx`, WHICH IS
+ * ALREADY GREEN AND PROVES NOTHING ABOUT THIS.
+ * That spec mocks `../../store` wholesale and seeds the journey through
+ * `hydrateFromPersisted` from persisted-fact fixtures — i.e. it exercises
+ * FEED B, the signed-in path, and it hands the store its runs. This spec uses
+ * the REAL canvas store, drives the REAL `applyV5State` applicator from real
+ * captured wire bytes, and keeps FEED B EXPLICITLY CLOSED by holding
+ * `getSessionIdentity()` at the guest answer (`userId: null`) — the same
+ * answer staging gives every session (`VITE_AUTH_MODE=guest`). If the pickers
+ * render here, they render for a guest, from the session alone.
+ *
+ * ⚠⚠ jsdom PROVES PRESENCE, NEVER LAYOUT (CLAUDE.md trap 3). "The pickers are
+ * in the DOM" is the whole claim; that they are visible, above the fold, or
+ * reachable on a real screen is NOT proven here and rides the next walk.
+ *
+ * THE RED SIGNATURE IS THE WALK'S OWN. `journey-witness-2026-08-04b-raw/p3b/
+ * P3b-compare-before.json` captured, for a guest with two completed runs:
+ *     runPickerCount: 0, runAgainCopy: 1,
+ *     compareTestids: [… "compare-tab-body", "compare-empty-state"]
+ * Both halves are pinned below — the pickers appearing AND the empty state
+ * (whose copy tells the user to run an analysis they have already run twice —
+ * N6's untruth, PC2) no longer rendering.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
+import { useCanvasStore } from '../../store'
+import { useAnalysisSnapshotStore } from '../../stores/analysisSnapshotStore'
+import { applyV5State } from '../../../v5/applyV5State'
+import { CompareTabBody } from '../CompareTabBody'
+import blocksFixture from './__fixtures__/v5GuestWalkAnalysisBlocks.json'
+
+// ── The ONLY seam mocked: session identity, held at the GUEST answer. ──────
+// This is not a convenience stub — it is the condition under test. Feed B
+// (persisted hydration) returns before any read when `userId` is null, so
+// every snapshot the tab renders below must have come from the session
+// capture. `listPersistedAnalysisRuns` is mocked to THROW so that a
+// regression which loosened the guest skip would fail loudly here rather than
+// quietly supplying the runs this spec credits to Feed A.
+const getSessionIdentity = vi.fn(async () => ({ userId: null }))
+const listPersistedAnalysisRuns = vi.fn(async () => {
+  throw new Error('Feed B must not be reached at guest tier')
+})
+
+vi.mock('../../../lib/supabase', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getSessionIdentity: () => getSessionIdentity(),
+}))
+
+vi.mock('../../../services/analysisRunHistoryService', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listPersistedAnalysisRuns: () => listPersistedAnalysisRuns(),
+}))
+
+type AnalysisBlock = Record<string, unknown> & { type: 'analysis_result' }
+const runA = blocksFixture.runA as unknown as AnalysisBlock
+const runB = blocksFixture.runB as unknown as AnalysisBlock
+
+/** The production wiring, verbatim (useConversation.ts:4532-4537). */
+function applyTurn(block: AnalysisBlock) {
+  const snapshot = useCanvasStore.getState()
+  return applyV5State({ blocks: [block] } as never, {
+    ...snapshot,
+    currentResultsHash: snapshot.results?.hash ?? null,
+  } as never)
+}
+
+const EMPTY_STATE_COPY = 'Refine your model and run the analysis again'
+
+describe('ROADMAP 2.350 — guest, two runs in one session, Compare tab', () => {
+  beforeEach(() => {
+    localStorage.setItem('feature.compareTab', '1')
+    useAnalysisSnapshotStore.getState().clearSnapshots()
+    useCanvasStore.getState().resultsReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+    useAnalysisSnapshotStore.getState().clearSnapshots()
+    vi.clearAllMocks()
+  })
+
+  // ── Negative control FIRST (trap 13) ──────────────────────────────────
+  // With ONE run the tab must still show the empty state. Without this, a
+  // change that rendered the pickers unconditionally would satisfy every
+  // assertion below while breaking the <2-runs branch, and the "empty state is
+  // gone" assertions would be passing for the wrong reason.
+  it('CONTROL: with ONE run the guest still sees the empty state and no pickers', () => {
+    applyTurn(runA)
+    render(<CompareTabBody onRunAnalysis={() => {}} />)
+
+    expect(screen.getByTestId('compare-empty-state')).toBeTruthy()
+    expect(screen.getByText(EMPTY_STATE_COPY)).toBeTruthy()
+    expect(screen.queryByTestId('run-pick-from')).toBeNull()
+    expect(screen.queryByTestId('run-pick-to')).toBeNull()
+  })
+
+  // ── Spec 2 (diagnosis §5 RED-first #2) ────────────────────────────────
+  it('renders BOTH run pickers after two runs, with Feed B never read', () => {
+    applyTurn(runA)
+    applyTurn(runB)
+
+    render(<CompareTabBody onRunAnalysis={() => {}} />)
+
+    // The `Pick two runs` preset is what mounts the pair picker
+    // (RunSelector.tsx:73); the tab opens on `prev`.
+    fireEvent.click(screen.getByText('Pick two runs'))
+
+    expect(screen.getByTestId('run-pair-picker')).toBeTruthy()
+    expect(screen.getByTestId('run-pick-from')).toBeTruthy()
+    expect(screen.getByTestId('run-pick-to')).toBeTruthy()
+
+    // The guest skip held: no persisted read was attempted.
+    expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()
+  })
+
+  // Identity-bound, not count-bound (trap 19). Two <select>s each holding two
+  // <option>s is satisfiable by a picker listing the same run twice, or by
+  // options belonging to runs that were never captured. Assert the OPTION SET
+  // matches the runs actually in the store, by their run numbers.
+  it('the pickers list the two runs that were actually captured', () => {
+    applyTurn(runA)
+    applyTurn(runB)
+
+    render(<CompareTabBody onRunAnalysis={() => {}} />)
+    fireEvent.click(screen.getByText('Pick two runs'))
+
+    const captured = useAnalysisSnapshotStore.getState().snapshots
+    expect(captured).toHaveLength(2)
+    const expectedValues = captured.map(s => String(s.runNumber))
+    expect(expectedValues).toEqual(['1', '2'])
+
+    for (const testid of ['run-pick-from', 'run-pick-to']) {
+      const select = screen.getByTestId(testid) as HTMLSelectElement
+      const options = within(select).getAllByRole('option') as HTMLOptionElement[]
+      expect(options.map(o => o.value)).toEqual(expectedValues)
+      // Distinct runs, not the same run twice.
+      expect(new Set(options.map(o => o.value)).size).toBe(2)
+    }
+
+    // The picker resolves to a forward-ordered pair of DISTINCT runs, which is
+    // what makes the side-by-side comparison meaningful rather than a run
+    // compared with itself.
+    const from = screen.getByTestId('run-pick-from') as HTMLSelectElement
+    const to = screen.getByTestId('run-pick-to') as HTMLSelectElement
+    expect(from.value).not.toBe(to.value)
+    expect(Number(from.value)).toBeLessThan(Number(to.value))
+  })
+
+  // ── N6 kill pin (PC2) ─────────────────────────────────────────────────
+  // The empty state's copy instructs the user to "run the analysis again" —
+  // an instruction they have already followed twice by this point. It must not
+  // be on the screen. This is asserted on the COPY, not only the testid,
+  // because the untruth is the sentence.
+  it('N6: the "run the analysis again" copy no longer renders at two runs', () => {
+    applyTurn(runA)
+    applyTurn(runB)
+
+    render(<CompareTabBody onRunAnalysis={() => {}} />)
+
+    expect(screen.queryByTestId('compare-empty-state')).toBeNull()
+    expect(screen.queryByText(EMPTY_STATE_COPY)).toBeNull()
+    // The tab itself is still mounted — the empty state is gone because the
+    // populated branch rendered, not because the tab failed to render.
+    expect(screen.getByTestId('compare-tab-body')).toBeTruthy()
+  })
+})

--- a/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
@@ -79,7 +79,20 @@ export function makeAnalysisSnapshot(
     conditionalWinners: [],
     edgeEValues: [],
     seedUsed: 12345,
-    responseHash: 'abc123',
+    /**
+     * ⚠ VARIES WITH `runNumber`, LIKE `runId` ABOVE — it used to be a constant
+     * `'abc123'`, which made every snapshot this fixture produced claim to be
+     * the SAME RUN.
+     *
+     * That was invisible until ROADMAP 2.350 made `addSnapshot`
+     * identity-idempotent: `makeSnapshot(1)`, `makeSnapshot(2)`,
+     * `makeSnapshot(3)` are meant to be three distinct runs, and every test
+     * that cares about identity already overrides this field explicitly, so
+     * only the tests that DON'T care were relying on the collision. A default
+     * that contradicts the fixture's own `runId: run-${runNumber}` is a trap
+     * for the next reader; deriving both from the same input removes it.
+     */
+    responseHash: `resp-hash-${overrides.runNumber}`,
     editSummary: 'Test edit',
     ...overrides,
   }

--- a/src/canvas/compare-tab/__tests__/__fixtures__/v5GuestWalkAnalysisBlocks.json
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/v5GuestWalkAnalysisBlocks.json
@@ -1,0 +1,2515 @@
+{
+ "runA": {
+  "computed_against_hash": "561785c952eb00bb",
+  "enrichment": {
+   "confidence_tier": "needs_work",
+   "decision_brief": {
+    "analysis_summary": {
+     "robustness_band": "fragile"
+    },
+    "brief_id": "b48e3d9f-3cb1-4ab5-b085-8b264fa5aef7",
+    "created_at": "2026-08-03T07:55:35.688Z",
+    "defaulted_assumptions": [
+     {
+      "doctrine": "provisional_doctrine_v0",
+      "factor_label": "Available Growth Budget",
+      "note": "No starting value was provided for \"Available Growth Budget\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+      "source": "value_defaulted"
+     },
+     {
+      "doctrine": "provisional_doctrine_v0",
+      "factor_label": "Current ARR",
+      "note": "No starting value was provided for \"Current ARR\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+      "source": "value_defaulted"
+     },
+     {
+      "doctrine": "provisional_doctrine_v0",
+      "factor_label": "B2B Market Demand",
+      "note": "No starting value was provided for \"B2B Market Demand\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+      "source": "value_defaulted"
+     }
+    ],
+    "key_assumptions": [
+     "B2B Market Demand",
+     "Current ARR",
+     "Available Growth Budget"
+    ],
+    "options": [
+     {
+      "label": "Invest in Content Marketing",
+      "option_id": "opt_content",
+      "win_probability": 0.5241916666666667
+     },
+     {
+      "label": "Hire Two Sales Reps",
+      "option_id": "opt_sales",
+      "win_probability": 0.2504416666666667
+     },
+     {
+      "label": "Build Self-Serve Tier",
+      "option_id": "opt_selfserve",
+      "win_probability": 0.2191916666666667
+     },
+     {
+      "label": "Continue Current Approach (Status Quo)",
+      "option_id": "opt_status_quo",
+      "win_probability": 0.006175
+     }
+    ],
+    "robustness": "fragile",
+    "top_drivers": [
+     {
+      "direction": "positive",
+      "factor_label": "B2B Market Demand",
+      "sensitivity": 0.8482420210272987
+     },
+     {
+      "direction": "positive",
+      "factor_label": "Current ARR",
+      "sensitivity": 0.256274292241524
+     },
+     {
+      "direction": "positive",
+      "factor_label": "Available Growth Budget",
+      "sensitivity": 0.16788993003539204
+     }
+    ],
+    "version": "1",
+    "warning_codes": [],
+    "warnings": [
+     {
+      "code": "DOMINANT_FACTOR",
+      "message": "One factor dominates. What would change if B2B Market Demand had less influence?",
+      "severity": "warning"
+     },
+     {
+      "code": "INFLUENTIAL_EXTERNALS",
+      "message": "External factors B2B Market Demand, Current ARR significantly affect your outcome but are inherently uncertain. How might you bound these?",
+      "severity": "warning"
+     },
+     {
+      "code": "M2_UNAVAILABLE",
+      "message": "Decision review was unavailable; brief uses deterministic coaching fallback",
+      "severity": "warning"
+     }
+    ],
+    "what_would_change": [
+     "Sales Pipeline Velocity \u2192 Reach \u00a31,000,000 ARR",
+     "New ARR Generated \u2192 Reach \u00a31,000,000 ARR",
+     "Current ARR \u2192 New ARR Generated",
+     "Customer Churn Rate \u2192 Reach \u00a31,000,000 ARR",
+     "Budget Overrun Risk \u2192 Reach \u00a31,000,000 ARR"
+    ]
+   },
+   "decision_evpi": 0.0789680300194515,
+   "edge_e_values": [
+    {
+     "current_mean": 0.20096153846153847,
+     "e_value": 1,
+     "edge_id": "fac_content_spend::out_new_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.059105,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.462748,
+      "band_median": 0.195803,
+      "band_min": -0.477219,
+      "band_width": 0.939967,
+      "n_seeds": 10,
+      "n_seeds_flipped": 9,
+      "seed_flip_means": [
+       0.325408,
+       0.462748,
+       0.237849,
+       -0.15376,
+       -0.209284,
+       -0.477219,
+       0.195803,
+       -0.102004,
+       null,
+       0.456533
+      ]
+     },
+     "to_id": "out_new_arr",
+     "to_label": "New ARR Generated"
+    },
+    {
+     "current_mean": 0.24181818181818182,
+     "e_value": 1,
+     "edge_id": "fac_content_spend::out_pipeline_velocity",
+     "flip_direction": "decrease",
+     "flip_mean": -0.035964,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.788022,
+      "band_median": -0.025766,
+      "band_min": -0.928281,
+      "band_width": 1.716303,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       null,
+       null,
+       0.788022,
+       null,
+       -0.1799,
+       -0.928281,
+       -0.223916,
+       0.337558,
+       -0.025766,
+       0.227794
+      ]
+     },
+     "to_id": "out_pipeline_velocity",
+     "to_label": "Sales Pipeline Velocity"
+    },
+    {
+     "current_mean": -0.18,
+     "e_value": 1.6591,
+     "edge_id": "fac_content_spend::risk_churn",
+     "flip_direction": "increase",
+     "flip_mean": 0.29864,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.660537,
+      "band_median": -0.201396,
+      "band_min": -0.991569,
+      "band_width": 1.652106,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       -0.991569,
+       -0.476531,
+       -0.686583,
+       1e-06,
+       -0.192852,
+       null,
+       0.080977,
+       null,
+       0.660537,
+       -0.209939
+      ]
+     },
+     "to_id": "risk_churn",
+     "to_label": "Customer Churn Rate"
+    },
+    {
+     "current_mean": 0.5354545454545454,
+     "e_value": 1.4394,
+     "edge_id": "fac_sales_headcount::out_pipeline_velocity",
+     "flip_direction": "increase",
+     "flip_mean": 0.770753,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.913856,
+      "band_median": 0.719221,
+      "band_min": 0.469998,
+      "band_width": 0.443858,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       0.913856,
+       null,
+       0.469998,
+       null,
+       0.719221,
+       0.605374,
+       null,
+       0.860293
+      ]
+     },
+     "to_id": "out_pipeline_velocity",
+     "to_label": "Sales Pipeline Velocity"
+    },
+    {
+     "current_mean": 0.4114173228346457,
+     "e_value": 1,
+     "edge_id": "fac_sales_headcount::risk_budget_overrun",
+     "flip_direction": "decrease",
+     "flip_mean": -0.137612,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.031344,
+      "band_median": -0.41362,
+      "band_min": -0.971601,
+      "band_width": 1.002945,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       -0.971601,
+       null,
+       -0.026175,
+       -0.41362,
+       null,
+       -0.877914,
+       -0.210318,
+       0.031344,
+       -0.432941,
+       null
+      ]
+     },
+     "to_id": "risk_budget_overrun",
+     "to_label": "Budget Overrun Risk"
+    },
+    {
+     "current_mean": 0.38,
+     "e_value": 1,
+     "edge_id": "fac_sales_headcount::risk_time_to_revenue",
+     "flip_direction": "decrease",
+     "flip_mean": -0.369567,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.178327,
+      "band_median": -0.238368,
+      "band_min": -0.536397,
+      "band_width": 0.714724,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       null,
+       -0.536397,
+       0.178327,
+       null,
+       -0.238368,
+       -0.113725,
+       -0.490411,
+       null
+      ]
+     },
+     "to_id": "risk_time_to_revenue",
+     "to_label": "Time to Revenue Contribution"
+    },
+    {
+     "current_mean": 0.31971153846153844,
+     "e_value": 1.8589,
+     "edge_id": "fac_self_serve::out_new_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.594313,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.638037,
+      "band_median": 0.506334,
+      "band_min": 0.231961,
+      "band_width": 0.406076,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       0.362607,
+       0.491428,
+       0.231961,
+       0.526535,
+       0.490332,
+       null,
+       0.615392,
+       0.638037,
+       null,
+       0.521241
+      ]
+     },
+     "to_id": "out_new_arr",
+     "to_label": "New ARR Generated"
+    },
+    {
+     "current_mean": 0.31417322834645667,
+     "e_value": 1.2895,
+     "edge_id": "fac_self_serve::risk_budget_overrun",
+     "flip_direction": "decrease",
+     "flip_mean": -0.405142,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.818886,
+      "band_median": 0.351714,
+      "band_min": -0.947264,
+      "band_width": 1.76615,
+      "n_seeds": 10,
+      "n_seeds_flipped": 4,
+      "seed_flip_means": [
+       null,
+       0.818886,
+       0.719877,
+       null,
+       null,
+       null,
+       -0.947264,
+       -0.016449,
+       null,
+       null
+      ]
+     },
+     "to_id": "risk_budget_overrun",
+     "to_label": "Budget Overrun Risk"
+    },
+    {
+     "current_mean": -0.25,
+     "e_value": 3.0129,
+     "edge_id": "fac_self_serve::risk_churn",
+     "flip_direction": "decrease",
+     "flip_mean": -0.753224,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.600563,
+      "band_median": -0.374515,
+      "band_min": -0.692356,
+      "band_width": 1.292919,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       0.600563,
+       -0.104182,
+       -0.374515,
+       -0.692356,
+       -0.617322,
+       null,
+       -0.644984,
+       null,
+       null,
+       -0.336295
+      ]
+     },
+     "to_id": "risk_churn",
+     "to_label": "Customer Churn Rate"
+    },
+    {
+     "current_mean": 0.45,
+     "e_value": 1.0393,
+     "edge_id": "fac_self_serve::risk_time_to_revenue",
+     "flip_direction": "decrease",
+     "flip_mean": -0.4677,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.46807,
+      "band_median": -0.290988,
+      "band_min": -0.97937,
+      "band_width": 1.44744,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       null,
+       -0.290988,
+       -0.97937,
+       null,
+       -0.336359,
+       0.258458,
+       null,
+       0.46807
+      ]
+     },
+     "to_id": "risk_time_to_revenue",
+     "to_label": "Time to Revenue Contribution"
+    },
+    {
+     "current_mean": 0.75,
+     "e_value": 1,
+     "edge_id": "out_new_arr::goal_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.220581,
+     "from_id": "out_new_arr",
+     "from_label": "New ARR Generated",
+     "stability": {
+      "band_max": 0.884165,
+      "band_median": 0.527852,
+      "band_min": -0.982939,
+      "band_width": 1.867104,
+      "n_seeds": 10,
+      "n_seeds_flipped": 6,
+      "seed_flip_means": [
+       0.405074,
+       0.65063,
+       0.72767,
+       null,
+       null,
+       -0.982939,
+       0.390005,
+       null,
+       null,
+       0.884165
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": 0.7,
+     "e_value": 1,
+     "edge_id": "out_pipeline_velocity::goal_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.236451,
+     "from_id": "out_pipeline_velocity",
+     "from_label": "Sales Pipeline Velocity",
+     "stability": {
+      "band_max": 0.835971,
+      "band_median": 0.615772,
+      "band_min": -0.199766,
+      "band_width": 1.035737,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       0.588583,
+       0.111852,
+       0.714592,
+       0.259204,
+       null,
+       null,
+       0.835971,
+       0.642961,
+       -0.199766,
+       0.699232
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.3,
+     "e_value": 1,
+     "edge_id": "risk_budget_overrun::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.100345,
+     "from_id": "risk_budget_overrun",
+     "from_label": "Budget Overrun Risk",
+     "stability": {
+      "band_max": 0.851387,
+      "band_median": 0.065207,
+      "band_min": -0.942342,
+      "band_width": 1.793729,
+      "n_seeds": 10,
+      "n_seeds_flipped": 9,
+      "seed_flip_means": [
+       null,
+       -0.11365,
+       -0.942342,
+       0.260719,
+       0.31358,
+       0.851387,
+       0.065207,
+       -0.022498,
+       0.461287,
+       0.0011
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.45,
+     "e_value": 1.6591,
+     "edge_id": "risk_churn::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.746601,
+     "from_id": "risk_churn",
+     "from_label": "Customer Churn Rate",
+     "stability": {
+      "band_max": 0.526561,
+      "band_median": -0.186382,
+      "band_min": -0.443732,
+      "band_width": 0.970293,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       null,
+       -0.443732,
+       -0.353185,
+       1e-06,
+       -0.326169,
+       null,
+       0.16744,
+       -0.186382,
+       null,
+       0.526561
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.25,
+     "e_value": 1,
+     "edge_id": "risk_time_to_revenue::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.243135,
+     "from_id": "risk_time_to_revenue",
+     "from_label": "Time to Revenue Contribution",
+     "stability": {
+      "band_max": 0.647001,
+      "band_median": -0.055768,
+      "band_min": -0.942152,
+      "band_width": 1.589153,
+      "n_seeds": 10,
+      "n_seeds_flipped": 10,
+      "seed_flip_means": [
+       -0.942152,
+       -0.056075,
+       -0.383372,
+       0.149706,
+       -0.065396,
+       0.647001,
+       0.509538,
+       -0.098686,
+       0.261448,
+       -0.055461
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    }
+   ],
+   "factor_evppi": [
+    {
+     "baseline_max_expected_utility": 0.252812,
+     "clamped_high": false,
+     "clamped_low": false,
+     "conditional_max_expected_utility": 0.252812,
+     "correlation_active": false,
+     "evppi": 0,
+     "evppi_raw": 0,
+     "factor_id": "fac_budget",
+     "method": "regression_evppi_v1",
+     "n_samples": 10000,
+     "noise_floor": 0,
+     "regression_degree": 4,
+     "status": "below_resolution",
+     "units": "outcome"
+    },
+    {
+     "baseline_max_expected_utility": 0.252812,
+     "clamped_high": false,
+     "clamped_low": false,
+     "conditional_max_expected_utility": 0.252812,
+     "correlation_active": false,
+     "evppi": 0,
+     "evppi_raw": 0,
+     "factor_id": "fac_current_arr",
+     "method": "regression_evppi_v1",
+     "n_samples": 10000,
+     "noise_floor": 1.7e-05,
+     "regression_degree": 4,
+     "status": "below_resolution",
+     "units": "outcome"
+    },
+    {
+     "baseline_max_expected_utility": 0.252812,
+     "clamped_high": false,
+     "clamped_low": false,
+     "conditional_max_expected_utility": 0.252812,
+     "correlation_active": false,
+     "evppi": 0,
+     "evppi_raw": 0,
+     "factor_id": "fac_market_demand",
+     "method": "regression_evppi_v1",
+     "n_samples": 10000,
+     "noise_floor": 6e-06,
+     "regression_degree": 4,
+     "status": "below_resolution",
+     "units": "outcome"
+    }
+   ],
+   "factor_sensitivity": [
+    {
+     "attribution_stability": "low",
+     "confidence": 0.43879999999999997,
+     "confidence_components": {
+      "sampling_stability": 0.25,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "biggest",
+     "elasticity": 0.8482420210272987,
+     "elasticity_std": 0.00745838,
+     "evidence_hint": false,
+     "evpi_method": "heuristic",
+     "evpi_percentage_points": 0,
+     "factor_id": "fac_market_demand",
+     "factor_label": "B2B Market Demand",
+     "flip_risk_category": "negligible",
+     "importance_basis": "graph_structural",
+     "importance_rank": 1,
+     "influence_rank": 2,
+     "influence_score": 0.8482420210272987,
+     "rank_flip_rate": 0.15,
+     "sensitivity_score": 0.34013986013986014,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0
+    },
+    {
+     "attribution_stability": "low",
+     "confidence": 0.4399,
+     "confidence_components": {
+      "sampling_stability": 0.25,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0.256274292241524,
+     "elasticity_std": 0.00260559,
+     "evidence_hint": false,
+     "evpi_method": "heuristic",
+     "evpi_percentage_points": 0,
+     "factor_id": "fac_current_arr",
+     "factor_label": "Current ARR",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 2,
+     "influence_rank": 5,
+     "influence_score": 0.256274292241524,
+     "rank_flip_rate": 0.05,
+     "sensitivity_score": 0.10276442307692307,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0
+    },
+    {
+     "attribution_stability": "low",
+     "confidence": 0.4394,
+     "confidence_components": {
+      "sampling_stability": 0.25,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "minor",
+     "elasticity": 0.16788993003539204,
+     "elasticity_std": 0.00158312,
+     "evidence_hint": false,
+     "evpi_method": "heuristic",
+     "evpi_percentage_points": 0,
+     "factor_id": "fac_budget",
+     "factor_label": "Available Growth Budget",
+     "flip_risk_category": "negligible",
+     "importance_basis": "graph_structural",
+     "importance_rank": 3,
+     "influence_rank": 6,
+     "influence_score": 0.16788993003539204,
+     "rank_flip_rate": 0.2,
+     "sensitivity_score": 0.06732283464566928,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "strong",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_content_spend",
+     "factor_label": "Content Marketing Investment",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 4,
+     "influence_rank": 1,
+     "influence_score": 1,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_sales_headcount",
+     "factor_label": "Sales Headcount Expansion",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 5,
+     "influence_rank": 3,
+     "influence_score": 0.3900133950458531,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_self_serve",
+     "factor_label": "Self-Serve Product Tier",
+     "flip_risk_category": "isolated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 6,
+     "influence_rank": 4,
+     "influence_score": 0.362927446514007,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    }
+   ],
+   "flip_thresholds": [
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_budget",
+     "factor_label": "Available Growth Budget",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_content_spend",
+     "factor_label": "Content Marketing Investment",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_current_arr",
+     "factor_label": "Current ARR",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_market_demand",
+     "factor_label": "B2B Market Demand",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_sales_headcount",
+     "factor_label": "Sales Headcount Expansion",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_self_serve",
+     "factor_label": "Self-Serve Product Tier",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    }
+   ],
+   "inference_warnings": [
+    {
+     "code": "EDGE_E_VALUE_NON_FINITE_DROPPED",
+     "message": "4 edge E-value entries were omitted from edge_e_values: 4 carried no finite E-value from the analysis engine (an unflippable edge, whose current and flip means coincide, has no evidence ratio). edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
+     "severity": "info"
+    }
+   ],
+   "option_comparison": [
+    {
+     "id": "opt_content",
+     "label": "Invest in Content Marketing",
+     "option_id": "opt_content",
+     "option_label": "Invest in Content Marketing",
+     "outcome": {
+      "mean": 0.2528118957615988,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": 0.03037713171723777,
+      "p50": 0.23852676873179696,
+      "p90": 0.4875847151319461,
+      "std": 0.17472785797427934,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.1835,
+     "status": "computed",
+     "win_probability": 0.5241916666666667
+    },
+    {
+     "id": "opt_sales",
+     "label": "Hire Two Sales Reps",
+     "option_id": "opt_sales",
+     "option_label": "Hire Two Sales Reps",
+     "outcome": {
+      "mean": 0.12685715009568935,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.17811571886642125,
+      "p50": 0.15122496181528855,
+      "p90": 0.38682011242776504,
+      "std": 0.2148170176803424,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.121,
+     "status": "computed",
+     "win_probability": 0.2504416666666667
+    },
+    {
+     "id": "opt_selfserve",
+     "label": "Build Self-Serve Tier",
+     "option_id": "opt_selfserve",
+     "option_label": "Build Self-Serve Tier",
+     "outcome": {
+      "mean": 0.11025885801692778,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.14669321694667276,
+      "p50": 0.10639281150191318,
+      "p90": 0.377809092739696,
+      "std": 0.20396522130231437,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.1046,
+     "status": "computed",
+     "win_probability": 0.2191916666666667
+    },
+    {
+     "id": "opt_status_quo",
+     "label": "Continue Current Approach (Status Quo)",
+     "option_id": "opt_status_quo",
+     "option_label": "Continue Current Approach (Status Quo)",
+     "outcome": {
+      "mean": 0.00026174114899919066,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.04975089781846805,
+      "p50": -2.5101205930631518e-05,
+      "p90": 0.05184920405609029,
+      "std": 0.04420444818788763,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.0208,
+     "status": "computed",
+     "win_probability": 0.006175
+    }
+   ],
+   "option_comparison_status": "computed",
+   "p_win_sensitivity": [
+    {
+     "clamped": false,
+     "current_metric": 0.53275,
+     "factor_id": "fac_market_demand",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0.014708,
+     "p_win_delta_percentage_points": 1.47,
+     "perfect_metric": 0.547458,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": false,
+     "current_metric": 0.53275,
+     "factor_id": "fac_content_spend",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0.00775,
+     "p_win_delta_percentage_points": 0.78,
+     "perfect_metric": 0.5405,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": false,
+     "current_metric": 0.53275,
+     "factor_id": "fac_self_serve",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0.002667,
+     "p_win_delta_percentage_points": 0.27,
+     "perfect_metric": 0.535417,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": false,
+     "current_metric": 0.53275,
+     "factor_id": "fac_current_arr",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0.0015,
+     "p_win_delta_percentage_points": 0.15,
+     "perfect_metric": 0.53425,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.53275,
+     "factor_id": "fac_sales_headcount",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.511333,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.53275,
+     "factor_id": "fac_budget",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.528542,
+     "status": "below_resolution"
+    }
+   ],
+   "robustness": {
+    "confidence": 0.5241916666666667,
+    "confidence_basis": "recommendation_stability_uncalibrated",
+    "display_verdict": "fragile",
+    "display_verdict_reason": "none of the factors we could test changed which option leads on its own, but this result scored low on our other robustness checks",
+    "fragile_edges": [
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->out_pipeline_velocity",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0.01,
+      "severity": "warning",
+      "switch_probability": 0.37301038062283737,
+      "to_id": "out_pipeline_velocity",
+      "to_label": "Sales Pipeline Velocity",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_selfserve",
+      "alternative_winner_label": "Build Self-Serve Tier",
+      "edge_id": "out_pipeline_velocity->goal_arr",
+      "from_id": "out_pipeline_velocity",
+      "from_label": "Sales Pipeline Velocity",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.368,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->out_new_arr",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0.04,
+      "severity": "warning",
+      "switch_probability": 0.35989159891598915,
+      "to_id": "out_new_arr",
+      "to_label": "New ARR Generated",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_sales_headcount->risk_budget_overrun",
+      "from_id": "fac_sales_headcount",
+      "from_label": "Sales Headcount Expansion",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.3228,
+      "to_id": "risk_budget_overrun",
+      "to_label": "Budget Overrun Risk",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_self_serve->out_new_arr",
+      "from_id": "fac_self_serve",
+      "from_label": "Self-Serve Product Tier",
+      "marginal_switch_probability": 0.17,
+      "severity": "warning",
+      "switch_probability": 0.3083048919226394,
+      "to_id": "out_new_arr",
+      "to_label": "New ARR Generated",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "out_new_arr->goal_arr",
+      "from_id": "out_new_arr",
+      "from_label": "New ARR Generated",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.3076,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_current_arr->out_new_arr",
+      "from_id": "fac_current_arr",
+      "from_label": "Current ARR",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2584,
+      "to_id": "out_new_arr",
+      "to_label": "New ARR Generated",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_selfserve",
+      "alternative_winner_label": "Build Self-Serve Tier",
+      "edge_id": "risk_churn->goal_arr",
+      "from_id": "risk_churn",
+      "from_label": "Customer Churn Rate",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2508,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_selfserve",
+      "alternative_winner_label": "Build Self-Serve Tier",
+      "edge_id": "risk_budget_overrun->goal_arr",
+      "from_id": "risk_budget_overrun",
+      "from_label": "Budget Overrun Risk",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.1904,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->risk_churn",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.1784,
+      "to_id": "risk_churn",
+      "to_label": "Customer Churn Rate",
+      "visible": true
+     }
+    ],
+    "is_robust": false,
+    "level": "low",
+    "near_tie": {
+     "gap": 0.27375000000000005,
+     "is_tie": false,
+     "threshold": 0.1
+    },
+    "robust_edges": [
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_market_demand->out_pipeline_velocity",
+      "from_id": "fac_market_demand",
+      "from_label": "B2B Market Demand",
+      "to_id": "out_pipeline_velocity",
+      "to_label": "Sales Pipeline Velocity"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_sales_headcount->risk_time_to_revenue",
+      "from_id": "fac_sales_headcount",
+      "from_label": "Sales Headcount Expansion",
+      "to_id": "risk_time_to_revenue",
+      "to_label": "Time to Revenue Contribution"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_self_serve->risk_budget_overrun",
+      "from_id": "fac_self_serve",
+      "from_label": "Self-Serve Product Tier",
+      "to_id": "risk_budget_overrun",
+      "to_label": "Budget Overrun Risk"
+     }
+    ]
+   }
+  },
+  "leading_option_id": null,
+  "summary": "Ran analysis on your current scenario. One of the conditions you set was not checked: \u201cDelivery deadline\u201d. The analysis engine could not evaluate it against this model, so no option can be put forward yet. Re-state that limit against a measure recorded in the same units as the limit, then run the analysis again.",
+  "type": "analysis_result",
+  "win_probabilities": {
+   "Build Self-Serve Tier": 0.2191916666666667,
+   "Continue Current Approach (Status Quo)": 0.006175,
+   "Hire Two Sales Reps": 0.2504416666666667,
+   "Invest in Content Marketing": 0.5241916666666667
+  }
+ },
+ "runB": {
+  "computed_against_hash": "501a71bd3f3d7433",
+  "enrichment": {
+   "confidence_tier": "needs_work",
+   "decision_brief": {
+    "analysis_summary": {
+     "robustness_band": "fragile"
+    },
+    "brief_id": "079df4dd-2f40-4e13-b12c-833cf5f9f036",
+    "created_at": "2026-08-03T07:56:46.878Z",
+    "defaulted_assumptions": [
+     {
+      "doctrine": "provisional_doctrine_v0",
+      "factor_label": "Current ARR",
+      "note": "No starting value was provided for \"Current ARR\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+      "source": "value_defaulted"
+     },
+     {
+      "doctrine": "provisional_doctrine_v0",
+      "factor_label": "B2B Market Demand",
+      "note": "No starting value was provided for \"B2B Market Demand\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+      "source": "value_defaulted"
+     }
+    ],
+    "key_assumptions": [
+     "B2B Market Demand",
+     "Current ARR"
+    ],
+    "options": [
+     {
+      "label": "Invest in Content Marketing",
+      "option_id": "opt_content",
+      "win_probability": 0.564825
+     },
+     {
+      "label": "Hire Two Sales Reps",
+      "option_id": "opt_sales",
+      "win_probability": 0.2312083333333333
+     },
+     {
+      "label": "Build Self-Serve Tier",
+      "option_id": "opt_selfserve",
+      "win_probability": 0.20160833333333333
+     },
+     {
+      "label": "Continue Current Approach (Status Quo)",
+      "option_id": "opt_status_quo",
+      "win_probability": 0.0023583333333333334
+     }
+    ],
+    "robustness": "fragile",
+    "top_drivers": [
+     {
+      "direction": "positive",
+      "factor_label": "B2B Market Demand",
+      "sensitivity": 0.8482420210272987
+     },
+     {
+      "direction": "positive",
+      "factor_label": "Current ARR",
+      "sensitivity": 0.256274292241524
+     }
+    ],
+    "version": "1",
+    "warning_codes": [],
+    "warnings": [
+     {
+      "code": "DOMINANT_FACTOR",
+      "message": "One factor dominates. What would change if B2B Market Demand had less influence?",
+      "severity": "warning"
+     },
+     {
+      "code": "INFLUENTIAL_EXTERNALS",
+      "message": "External factors B2B Market Demand, Current ARR significantly affect your outcome but are inherently uncertain. How might you bound these?",
+      "severity": "warning"
+     },
+     {
+      "code": "M2_UNAVAILABLE",
+      "message": "Decision review was unavailable; brief uses deterministic coaching fallback",
+      "severity": "warning"
+     }
+    ],
+    "what_would_change": [
+     "Sales Pipeline Velocity \u2192 Reach \u00a31,000,000 ARR",
+     "New ARR Generated \u2192 Reach \u00a31,000,000 ARR",
+     "Current ARR \u2192 New ARR Generated",
+     "Customer Churn Rate \u2192 Reach \u00a31,000,000 ARR"
+    ]
+   },
+   "decision_evpi": 0.0699605311407617,
+   "edge_e_values": [
+    {
+     "current_mean": 0.20096153846153847,
+     "e_value": 1,
+     "edge_id": "fac_content_spend::out_new_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.101624,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.457797,
+      "band_median": 0.168432,
+      "band_min": -0.551597,
+      "band_width": 1.009394,
+      "n_seeds": 10,
+      "n_seeds_flipped": 9,
+      "seed_flip_means": [
+       0.280283,
+       0.457797,
+       0.210876,
+       -0.19168,
+       -0.209284,
+       -0.551597,
+       0.168432,
+       -0.102004,
+       null,
+       0.456533
+      ]
+     },
+     "to_id": "out_new_arr",
+     "to_label": "New ARR Generated"
+    },
+    {
+     "current_mean": 0.24181818181818182,
+     "e_value": 1,
+     "edge_id": "fac_content_spend::out_pipeline_velocity",
+     "flip_direction": "decrease",
+     "flip_mean": -0.081381,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.743889,
+      "band_median": 0.101014,
+      "band_min": -0.257379,
+      "band_width": 1.001268,
+      "n_seeds": 10,
+      "n_seeds_flipped": 6,
+      "seed_flip_means": [
+       null,
+       null,
+       0.743889,
+       null,
+       -0.1799,
+       null,
+       -0.257379,
+       0.337558,
+       -0.025766,
+       0.227794
+      ]
+     },
+     "to_id": "out_pipeline_velocity",
+     "to_label": "Sales Pipeline Velocity"
+    },
+    {
+     "current_mean": -0.18,
+     "e_value": 2.0939,
+     "edge_id": "fac_content_spend::risk_churn",
+     "flip_direction": "increase",
+     "flip_mean": 0.376896,
+     "from_id": "fac_content_spend",
+     "from_label": "Content Marketing Investment",
+     "stability": {
+      "band_max": 0.660537,
+      "band_median": -0.201396,
+      "band_min": -0.913195,
+      "band_width": 1.573732,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       -0.913195,
+       -0.460822,
+       -0.629834,
+       0.050079,
+       -0.192852,
+       null,
+       0.128082,
+       null,
+       0.660537,
+       -0.209939
+      ]
+     },
+     "to_id": "risk_churn",
+     "to_label": "Customer Churn Rate"
+    },
+    {
+     "current_mean": 0.5354545454545454,
+     "e_value": 1.5113,
+     "edge_id": "fac_sales_headcount::out_pipeline_velocity",
+     "flip_direction": "increase",
+     "flip_mean": 0.809223,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.913856,
+      "band_median": 0.747566,
+      "band_min": 0.469998,
+      "band_width": 0.443858,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       0.913856,
+       null,
+       0.469998,
+       null,
+       0.747566,
+       0.605374,
+       null,
+       0.860293
+      ]
+     },
+     "to_id": "out_pipeline_velocity",
+     "to_label": "Sales Pipeline Velocity"
+    },
+    {
+     "current_mean": 0.4114173228346457,
+     "e_value": 1,
+     "edge_id": "fac_sales_headcount::risk_budget_overrun",
+     "flip_direction": "decrease",
+     "flip_mean": -0.227375,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.031344,
+      "band_median": -0.432941,
+      "band_min": -0.990846,
+      "band_width": 1.02219,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       -0.971601,
+       null,
+       -0.026175,
+       -0.51563,
+       null,
+       -0.990846,
+       -0.319072,
+       0.031344,
+       -0.432941,
+       null
+      ]
+     },
+     "to_id": "risk_budget_overrun",
+     "to_label": "Budget Overrun Risk"
+    },
+    {
+     "current_mean": 0.38,
+     "e_value": 1.295,
+     "edge_id": "fac_sales_headcount::risk_time_to_revenue",
+     "flip_direction": "decrease",
+     "flip_mean": -0.492117,
+     "from_id": "fac_sales_headcount",
+     "from_label": "Sales Headcount Expansion",
+     "stability": {
+      "band_max": 0.178327,
+      "band_median": -0.287085,
+      "band_min": -0.604662,
+      "band_width": 0.782989,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       null,
+       -0.604662,
+       0.178327,
+       null,
+       -0.287085,
+       -0.113725,
+       -0.490411,
+       null
+      ]
+     },
+     "to_id": "risk_time_to_revenue",
+     "to_label": "Time to Revenue Contribution"
+    },
+    {
+     "current_mean": 0.31971153846153844,
+     "e_value": 1.9795,
+     "edge_id": "fac_self_serve::out_new_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.632864,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.640209,
+      "band_median": 0.508579,
+      "band_min": 0.231961,
+      "band_width": 0.408248,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       0.362607,
+       0.495918,
+       0.231961,
+       0.560916,
+       0.490332,
+       null,
+       0.640209,
+       0.638037,
+       null,
+       0.521241
+      ]
+     },
+     "to_id": "out_new_arr",
+     "to_label": "New ARR Generated"
+    },
+    {
+     "current_mean": 0.31417322834645667,
+     "e_value": 1.611,
+     "edge_id": "fac_self_serve::risk_budget_overrun",
+     "flip_direction": "decrease",
+     "flip_mean": -0.506126,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.748242,
+      "band_median": 0.719877,
+      "band_min": -0.016449,
+      "band_width": 0.764691,
+      "n_seeds": 10,
+      "n_seeds_flipped": 3,
+      "seed_flip_means": [
+       null,
+       0.748242,
+       0.719877,
+       null,
+       null,
+       null,
+       null,
+       -0.016449,
+       null,
+       null
+      ]
+     },
+     "to_id": "risk_budget_overrun",
+     "to_label": "Budget Overrun Risk"
+    },
+    {
+     "current_mean": -0.25,
+     "e_value": 3.2955,
+     "edge_id": "fac_self_serve::risk_churn",
+     "flip_direction": "decrease",
+     "flip_mean": -0.823872,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.600563,
+      "band_median": -0.374515,
+      "band_min": -0.737566,
+      "band_width": 1.338129,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       0.600563,
+       -0.118366,
+       -0.374515,
+       -0.737566,
+       -0.617322,
+       null,
+       -0.687509,
+       null,
+       null,
+       -0.336295
+      ]
+     },
+     "to_id": "risk_churn",
+     "to_label": "Customer Churn Rate"
+    },
+    {
+     "current_mean": 0.45,
+     "e_value": 1.3256,
+     "edge_id": "fac_self_serve::risk_time_to_revenue",
+     "flip_direction": "decrease",
+     "flip_mean": -0.596535,
+     "from_id": "fac_self_serve",
+     "from_label": "Self-Serve Product Tier",
+     "stability": {
+      "band_max": 0.46807,
+      "band_median": -0.362754,
+      "band_min": -0.97937,
+      "band_width": 1.44744,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       null,
+       null,
+       null,
+       -0.362754,
+       -0.97937,
+       null,
+       -0.387575,
+       0.258458,
+       null,
+       0.46807
+      ]
+     },
+     "to_id": "risk_time_to_revenue",
+     "to_label": "Time to Revenue Contribution"
+    },
+    {
+     "current_mean": 0.75,
+     "e_value": 1,
+     "edge_id": "out_new_arr::goal_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.379268,
+     "from_id": "out_new_arr",
+     "from_label": "New ARR Generated",
+     "stability": {
+      "band_max": 0.884165,
+      "band_median": 0.680229,
+      "band_min": 0.335486,
+      "band_width": 0.548679,
+      "n_seeds": 10,
+      "n_seeds_flipped": 5,
+      "seed_flip_means": [
+       0.4106,
+       0.680229,
+       0.72767,
+       null,
+       null,
+       null,
+       0.335486,
+       null,
+       null,
+       0.884165
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": 0.7,
+     "e_value": 1,
+     "edge_id": "out_pipeline_velocity::goal_arr",
+     "flip_direction": "decrease",
+     "flip_mean": -0.36792,
+     "from_id": "out_pipeline_velocity",
+     "from_label": "Sales Pipeline Velocity",
+     "stability": {
+      "band_max": 0.868917,
+      "band_median": 0.615772,
+      "band_min": -0.199766,
+      "band_width": 1.068683,
+      "n_seeds": 10,
+      "n_seeds_flipped": 8,
+      "seed_flip_means": [
+       0.588583,
+       0.093125,
+       0.714592,
+       0.292192,
+       null,
+       null,
+       0.868917,
+       0.642961,
+       -0.199766,
+       0.699232
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.3,
+     "e_value": 1,
+     "edge_id": "risk_budget_overrun::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.082373,
+     "from_id": "risk_budget_overrun",
+     "from_label": "Budget Overrun Risk",
+     "stability": {
+      "band_max": 0.703501,
+      "band_median": 0.027311,
+      "band_min": -0.97103,
+      "band_width": 1.674531,
+      "n_seeds": 10,
+      "n_seeds_flipped": 10,
+      "seed_flip_means": [
+       -0.97103,
+       -0.096481,
+       -0.694341,
+       0.206435,
+       0.234821,
+       0.703501,
+       0.053882,
+       -0.022498,
+       0.461287,
+       0.00074
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.45,
+     "e_value": 2.0939,
+     "edge_id": "risk_churn::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.942239,
+     "from_id": "risk_churn",
+     "from_label": "Customer Churn Rate",
+     "stability": {
+      "band_max": 0.526561,
+      "band_median": -0.186382,
+      "band_min": -0.417652,
+      "band_width": 0.944213,
+      "n_seeds": 10,
+      "n_seeds_flipped": 7,
+      "seed_flip_means": [
+       null,
+       -0.417652,
+       -0.353185,
+       0.160644,
+       -0.326169,
+       null,
+       0.26484,
+       -0.186382,
+       null,
+       0.526561
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    },
+    {
+     "current_mean": -0.25,
+     "e_value": 1.295,
+     "edge_id": "risk_time_to_revenue::goal_arr",
+     "flip_direction": "increase",
+     "flip_mean": 0.323761,
+     "from_id": "risk_time_to_revenue",
+     "from_label": "Time to Revenue Contribution",
+     "stability": {
+      "band_max": 0.717078,
+      "band_median": -0.053285,
+      "band_min": -0.942152,
+      "band_width": 1.65923,
+      "n_seeds": 10,
+      "n_seeds_flipped": 10,
+      "seed_flip_means": [
+       -0.942152,
+       -0.051109,
+       -0.339898,
+       0.186628,
+       -0.065396,
+       0.717078,
+       0.587123,
+       -0.098686,
+       0.261448,
+       -0.055461
+      ]
+     },
+     "to_id": "goal_arr",
+     "to_label": "Reach \u00a31,000,000 ARR"
+    }
+   ],
+   "factor_evppi": [
+    {
+     "baseline_max_expected_utility": 0.274419,
+     "clamped_high": false,
+     "clamped_low": false,
+     "conditional_max_expected_utility": 0.274419,
+     "correlation_active": false,
+     "evppi": 0,
+     "evppi_raw": 0,
+     "factor_id": "fac_current_arr",
+     "method": "regression_evppi_v1",
+     "n_samples": 10000,
+     "noise_floor": 1e-05,
+     "regression_degree": 4,
+     "status": "below_resolution",
+     "units": "outcome"
+    },
+    {
+     "baseline_max_expected_utility": 0.274419,
+     "clamped_high": false,
+     "clamped_low": false,
+     "conditional_max_expected_utility": 0.274419,
+     "correlation_active": false,
+     "evppi": 0,
+     "evppi_raw": 0,
+     "factor_id": "fac_market_demand",
+     "method": "regression_evppi_v1",
+     "n_samples": 10000,
+     "noise_floor": 5e-06,
+     "regression_degree": 4,
+     "status": "below_resolution",
+     "units": "outcome"
+    }
+   ],
+   "factor_sensitivity": [
+    {
+     "attribution_stability": "low",
+     "confidence": 0.43879999999999997,
+     "confidence_components": {
+      "sampling_stability": 0.25,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "biggest",
+     "elasticity": 0.8482420210272987,
+     "elasticity_std": 0.00687112,
+     "evidence_hint": false,
+     "evpi_method": "heuristic",
+     "evpi_percentage_points": 0,
+     "factor_id": "fac_market_demand",
+     "factor_label": "B2B Market Demand",
+     "flip_risk_category": "negligible",
+     "importance_basis": "graph_structural",
+     "importance_rank": 1,
+     "influence_rank": 2,
+     "influence_score": 0.8482420210272987,
+     "rank_flip_rate": 0.1,
+     "sensitivity_score": 0.34013986013986014,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0
+    },
+    {
+     "attribution_stability": "low",
+     "confidence": 0.4399,
+     "confidence_components": {
+      "sampling_stability": 0.25,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0.256274292241524,
+     "elasticity_std": 0.00240043,
+     "evidence_hint": false,
+     "evpi_method": "heuristic",
+     "evpi_percentage_points": 0,
+     "factor_id": "fac_current_arr",
+     "factor_label": "Current ARR",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 2,
+     "influence_rank": 5,
+     "influence_score": 0.256274292241524,
+     "rank_flip_rate": 0.05,
+     "sensitivity_score": 0.10276442307692307,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "strong",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_content_spend",
+     "factor_label": "Content Marketing Investment",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 3,
+     "influence_rank": 1,
+     "influence_score": 1,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_sales_headcount",
+     "factor_label": "Sales Headcount Expansion",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 4,
+     "influence_rank": 3,
+     "influence_score": 0.3900133950458531,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "moderate",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_self_serve",
+     "factor_label": "Self-Serve Product Tier",
+     "flip_risk_category": "negligible",
+     "importance_basis": "graph_structural",
+     "importance_rank": 5,
+     "influence_rank": 4,
+     "influence_score": 0.362927446514007,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    },
+    {
+     "attribution_stability": "negligible",
+     "confidence": 0.3,
+     "confidence_components": {
+      "sampling_stability": 0,
+      "structural_certainty": 0.5
+     },
+     "confidence_provenance": {
+      "calibration_status": "provisional_pending_pilot_calibration",
+      "computation_source": "plot_unified_from_isl_bootstrap",
+      "formula_version": "plot_unified_v3",
+      "input_quality": "standard",
+      "is_provisional": true
+     },
+     "confidence_source": "plot_unified_from_isl_bootstrap",
+     "direction": "positive",
+     "driver_label": "minor",
+     "elasticity": 0,
+     "elasticity_std": 0,
+     "factor_id": "fac_budget",
+     "factor_label": "Available Growth Budget",
+     "flip_risk_category": "correlated",
+     "importance_basis": "graph_structural",
+     "importance_rank": 6,
+     "influence_rank": 6,
+     "influence_score": 0.16788993003539204,
+     "range_derivation_source": "default",
+     "rank_flip_rate": 0,
+     "sensitivity_score": 0,
+     "source": "graph",
+     "stability_method": "bootstrap_20",
+     "value_defaulted": true,
+     "value_of_information": 0,
+     "zero_reason": "intervention_override"
+    }
+   ],
+   "flip_thresholds": [
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_budget",
+     "factor_label": "Available Growth Budget",
+     "flip_reason": "no_effect_within_bounds",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_content_spend",
+     "factor_label": "Content Marketing Investment",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_current_arr",
+     "factor_label": "Current ARR",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_market_demand",
+     "factor_label": "B2B Market Demand",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_sales_headcount",
+     "factor_label": "Sales Headcount Expansion",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    },
+    {
+     "alternative_winner_id": null,
+     "alternative_winner_label": null,
+     "current_value": 0,
+     "factor_id": "fac_self_serve",
+     "factor_label": "Self-Serve Product Tier",
+     "flip_reason": "structurally_invariant",
+     "flip_value": null,
+     "iterations_used": 0,
+     "no_flip_in_range": true,
+     "probes_used": 0
+    }
+   ],
+   "inference_warnings": [
+    {
+     "code": "EDGE_E_VALUE_NON_FINITE_DROPPED",
+     "message": "4 edge E-value entries were omitted from edge_e_values: 4 carried no finite E-value from the analysis engine (an unflippable edge, whose current and flip means coincide, has no evidence ratio). edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
+     "severity": "info"
+    }
+   ],
+   "option_comparison": [
+    {
+     "id": "opt_content",
+     "label": "Invest in Content Marketing",
+     "option_id": "opt_content",
+     "option_label": "Invest in Content Marketing",
+     "outcome": {
+      "mean": 0.2744190580486545,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": 0.05390856573619588,
+      "p50": 0.2615644336339719,
+      "p90": 0.5091059290268755,
+      "std": 0.17377733153715663,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.2042,
+     "status": "computed",
+     "win_probability": 0.564825
+    },
+    {
+     "id": "opt_sales",
+     "label": "Hire Two Sales Reps",
+     "option_id": "opt_sales",
+     "option_label": "Hire Two Sales Reps",
+     "outcome": {
+      "mean": 0.12721216213160386,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.1753388377046899,
+      "p50": 0.14884762645586713,
+      "p90": 0.3888782789406791,
+      "std": 0.21556923428324987,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.1185,
+     "status": "computed",
+     "win_probability": 0.2312083333333333
+    },
+    {
+     "id": "opt_selfserve",
+     "label": "Build Self-Serve Tier",
+     "option_id": "opt_selfserve",
+     "option_label": "Build Self-Serve Tier",
+     "outcome": {
+      "mean": 0.1096933939999379,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.14958099568006641,
+      "p50": 0.10632164816758027,
+      "p90": 0.3768093040748312,
+      "std": 0.20512553213370202,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.1068,
+     "status": "computed",
+     "win_probability": 0.20160833333333333
+    },
+    {
+     "id": "opt_status_quo",
+     "label": "Continue Current Approach (Status Quo)",
+     "option_id": "opt_status_quo",
+     "option_label": "Continue Current Approach (Status Quo)",
+     "outcome": {
+      "mean": 0.0005258091074057324,
+      "n_samples": 10000,
+      "n_valid_samples": 10000,
+      "p10": -0.05000110612009092,
+      "p50": 0,
+      "p90": 0.05111075974553971,
+      "std": 0.043812683869529606,
+      "validity_ratio": 1
+     },
+     "probability_of_goal": 0.0223,
+     "status": "computed",
+     "win_probability": 0.0023583333333333334
+    }
+   ],
+   "option_comparison_status": "computed",
+   "p_win_sensitivity": [
+    {
+     "clamped": false,
+     "current_metric": 0.57775,
+     "factor_id": "fac_market_demand",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0.011792,
+     "p_win_delta_percentage_points": 1.18,
+     "perfect_metric": 0.589542,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.57775,
+     "factor_id": "fac_content_spend",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.576083,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.57775,
+     "factor_id": "fac_sales_headcount",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.54675,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.57775,
+     "factor_id": "fac_self_serve",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.570333,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.57775,
+     "factor_id": "fac_budget",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.563625,
+     "status": "below_resolution"
+    },
+    {
+     "clamped": true,
+     "current_metric": 0.57775,
+     "factor_id": "fac_current_arr",
+     "labelling_doctrine": "provisional_doctrine_v0",
+     "method": "p_win_delta_at_mean_v1",
+     "metric_type": "p_win_recommended",
+     "n_samples": 2000,
+     "noise_floor": 0.03099,
+     "noise_floor_method": "z95_worst_case_bernoulli_diff",
+     "p_win_delta": 0,
+     "p_win_delta_percentage_points": 0,
+     "perfect_metric": 0.571917,
+     "status": "below_resolution"
+    }
+   ],
+   "robustness": {
+    "confidence": 0.564825,
+    "confidence_basis": "recommendation_stability_uncalibrated",
+    "display_verdict": "fragile",
+    "display_verdict_reason": "none of the factors we could test changed which option leads on its own, but this result scored low on our other robustness checks",
+    "fragile_edges": [
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->out_pipeline_velocity",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.36130374479889044,
+      "to_id": "out_pipeline_velocity",
+      "to_label": "Sales Pipeline Velocity",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->out_new_arr",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0.01,
+      "severity": "warning",
+      "switch_probability": 0.3327873327873328,
+      "to_id": "out_new_arr",
+      "to_label": "New ARR Generated",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_selfserve",
+      "alternative_winner_label": "Build Self-Serve Tier",
+      "edge_id": "out_pipeline_velocity->goal_arr",
+      "from_id": "out_pipeline_velocity",
+      "from_label": "Sales Pipeline Velocity",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.3284,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_sales_headcount->risk_budget_overrun",
+      "from_id": "fac_sales_headcount",
+      "from_label": "Sales Headcount Expansion",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2972,
+      "to_id": "risk_budget_overrun",
+      "to_label": "Budget Overrun Risk",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "out_new_arr->goal_arr",
+      "from_id": "out_new_arr",
+      "from_label": "New ARR Generated",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2872,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_budget->risk_budget_overrun",
+      "from_id": "fac_budget",
+      "from_label": "Available Growth Budget",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2364,
+      "to_id": "risk_budget_overrun",
+      "to_label": "Budget Overrun Risk",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_current_arr->out_new_arr",
+      "from_id": "fac_current_arr",
+      "from_label": "Current ARR",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.2328,
+      "to_id": "out_new_arr",
+      "to_label": "New ARR Generated",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_selfserve",
+      "alternative_winner_label": "Build Self-Serve Tier",
+      "edge_id": "risk_churn->goal_arr",
+      "from_id": "risk_churn",
+      "from_label": "Customer Churn Rate",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.232,
+      "to_id": "goal_arr",
+      "to_label": "Reach \u00a31,000,000 ARR",
+      "visible": true
+     },
+     {
+      "alternative_winner_id": "opt_sales",
+      "alternative_winner_label": "Hire Two Sales Reps",
+      "edge_id": "fac_content_spend->risk_churn",
+      "from_id": "fac_content_spend",
+      "from_label": "Content Marketing Investment",
+      "marginal_switch_probability": 0,
+      "severity": "warning",
+      "switch_probability": 0.1576,
+      "to_id": "risk_churn",
+      "to_label": "Customer Churn Rate",
+      "visible": true
+     }
+    ],
+    "is_robust": false,
+    "level": "low",
+    "near_tie": {
+     "gap": 0.33361666666666673,
+     "is_tie": false,
+     "threshold": 0.1
+    },
+    "robust_edges": [
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_market_demand->out_pipeline_velocity",
+      "from_id": "fac_market_demand",
+      "from_label": "B2B Market Demand",
+      "to_id": "out_pipeline_velocity",
+      "to_label": "Sales Pipeline Velocity"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_sales_headcount->out_pipeline_velocity",
+      "from_id": "fac_sales_headcount",
+      "from_label": "Sales Headcount Expansion",
+      "to_id": "out_pipeline_velocity",
+      "to_label": "Sales Pipeline Velocity"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_sales_headcount->risk_time_to_revenue",
+      "from_id": "fac_sales_headcount",
+      "from_label": "Sales Headcount Expansion",
+      "to_id": "risk_time_to_revenue",
+      "to_label": "Time to Revenue Contribution"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_self_serve->risk_budget_overrun",
+      "from_id": "fac_self_serve",
+      "from_label": "Self-Serve Product Tier",
+      "to_id": "risk_budget_overrun",
+      "to_label": "Budget Overrun Risk"
+     },
+     {
+      "alternative_winner_id": null,
+      "alternative_winner_label": null,
+      "edge_id": "fac_self_serve->risk_churn",
+      "from_id": "fac_self_serve",
+      "from_label": "Self-Serve Product Tier",
+      "to_id": "risk_churn",
+      "to_label": "Customer Churn Rate"
+     }
+    ]
+   }
+  },
+  "leading_option_id": null,
+  "summary": "Ran analysis on your current scenario. One of the conditions you set was not checked: \u201cDelivery deadline\u201d. The analysis engine could not evaluate it against this model, so no option can be put forward yet. Re-state that limit against a measure recorded in the same units as the limit, then run the analysis again.",
+  "type": "analysis_result",
+  "win_probabilities": {
+   "Build Self-Serve Tier": 0.20160833333333333,
+   "Continue Current Approach (Status Quo)": 0.0023583333333333334,
+   "Hire Two Sales Reps": 0.2312083333333333,
+   "Invest in Content Marketing": 0.564825
+  }
+ }
+}

--- a/src/canvas/compare-tab/__tests__/v5SessionCapture.applicator.spec.ts
+++ b/src/canvas/compare-tab/__tests__/v5SessionCapture.applicator.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * ROADMAP 2.350 — within-session Compare at guest tier (PC1 step 6).
+ *
+ * ⚠ WHY THIS SPEC EXISTS WHEN `analysisSnapshotStore.spec.ts` AND
+ * `CompareTabBody.pickTwoRuns.spec.tsx` ARE ALREADY GREEN.
+ *
+ * Both of those SEED the snapshot store — one calls `addSnapshot` directly, the
+ * other mocks `../../store` wholesale and feeds `hydrateFromPersisted` from
+ * persisted-fact fixtures. Neither can see the defect 2.350 is about, because
+ * the defect is not in the store or the tab: it is that **nothing on the
+ * deployed wire ever writes to that store**. A spec that hands the store its
+ * runs proves the renderer works and proves exactly nothing about the wire.
+ *
+ * So this spec drives the REAL applicator against the REAL canvas store, wired
+ * the way `useConversation.ts:4532-4537` wires it in production:
+ *
+ *     applyV5State(response, { ...useCanvasStore.getState(),
+ *                              currentResultsHash: state.results?.hash ?? null })
+ *
+ * and asserts on the snapshot store afterwards. Nothing here constructs an
+ * `AnalysisSnapshot`.
+ *
+ * ⭐ THE FIXTURE IS THE REAL GUEST WALK, NOT A HAND-WRITTEN SHAPE.
+ * `__fixtures__/v5GuestWalkAnalysisBlocks.json` holds the two DISTINCT
+ * `analysis_result` blocks captured off the live staging wire during the
+ * 2026-08-04b journey walk, verbatim:
+ *
+ *   runA ← journey-witness-2026-08-04b-raw/p3b/wire-run1-4-res.txt
+ *   runB ← journey-witness-2026-08-04b-raw/p3b/wire-run2-8-res.txt
+ *
+ * Both carry `enrichment.option_comparison` (4) and `enrichment.factor_sensitivity`
+ * (6) at the enrichment ROOT — the premise the fix rests on, verified at the
+ * bytes on the walk that produced the 0-picker capture rather than assumed from
+ * a code comment. That walk is also where the empty-state signature pinned
+ * below comes from (`P3b-compare-before.json`: `runPickerCount: 0`, testids
+ * `[compare-tab-body, compare-empty-state]`).
+ *
+ * ⚠ NEITHER BLOCK CARRIES A `model_card` — so `response_hash` is DERIVED by
+ * `mapV5AnalysisToReport` (fnv1a-64 over summary + leading_option_id +
+ * win_probabilities + enrichment). Run identity on this path is therefore
+ * content-derived, and the dedupe assertions below are about that derived
+ * value, not a producer-supplied one.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { useAnalysisSnapshotStore } from '../../stores/analysisSnapshotStore'
+import { applyV5State } from '../../../v5/applyV5State'
+import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
+import blocksFixture from './__fixtures__/v5GuestWalkAnalysisBlocks.json'
+
+type AnalysisBlock = Record<string, unknown> & { type: 'analysis_result' }
+
+const runA = blocksFixture.runA as unknown as AnalysisBlock
+const runB = blocksFixture.runB as unknown as AnalysisBlock
+
+/**
+ * A turn response carrying exactly one `analysis_result` block, shaped the way
+ * the walk's captures are shaped. `applyV5State` reads `response.blocks`.
+ */
+function turnWith(block: AnalysisBlock) {
+  return { blocks: [block] } as never
+}
+
+/** The production wiring, verbatim (useConversation.ts:4532-4537). */
+function applyTurn(block: AnalysisBlock) {
+  const snapshot = useCanvasStore.getState()
+  return applyV5State(turnWith(block), {
+    ...snapshot,
+    currentResultsHash: snapshot.results?.hash ?? null,
+  } as never)
+}
+
+/** The identity the applicator itself uses for "is this a new run". */
+function derivedHash(block: AnalysisBlock): string {
+  return mapV5AnalysisToReport(block as never).model_card.response_hash
+}
+
+describe('ROADMAP 2.350 — V5 session capture feeds the Compare snapshot store', () => {
+  beforeEach(() => {
+    // The capture gate is flag-gated on `compareTab`, which resolves from
+    // localStorage FIRST (src/lib/flagFactory.ts). Setting the key is the same
+    // switch staging uses, and it avoids mocking `../../../flags` — a
+    // `vi.mock` factory REPLACES the module, and a hand-listed flag allowlist
+    // is precisely the mirror CLAUDE.md trap 12 is about.
+    localStorage.setItem('feature.compareTab', '1')
+    useAnalysisSnapshotStore.getState().clearSnapshots()
+    useCanvasStore.getState().resultsReset()
+  })
+
+  afterEach(() => {
+    localStorage.removeItem('feature.compareTab')
+    useAnalysisSnapshotStore.getState().clearSnapshots()
+  })
+
+  // ── Positive control FIRST (trap 13) ──────────────────────────────────
+  // Before asserting that snapshots appear, prove the harness can actually
+  // drive the applicator: the results slice must hydrate. If this fails, every
+  // assertion below would be testing a turn that never applied.
+  it('CONTROL: the applicator hydrates the results slice from the fixture turn', () => {
+    const result = applyTurn(runA)
+    expect(result.applied).toContain('analysis_result:results_hydrated')
+    expect(useCanvasStore.getState().results?.hash).toBe(derivedHash(runA))
+    expect(useCanvasStore.getState().results?.report).toBeTruthy()
+  })
+
+  // ── Spec 1 (diagnosis §5 RED-first #1) ────────────────────────────────
+  it('captures two runs from two live-shaped V5 turns in ONE session', () => {
+    expect(useAnalysisSnapshotStore.getState().getRunCount()).toBe(0)
+
+    applyTurn(runA)
+    expect(useAnalysisSnapshotStore.getState().getRunCount()).toBe(1)
+
+    applyTurn(runB)
+    expect(useAnalysisSnapshotStore.getState().getRunCount()).toBe(2)
+  })
+
+  // Identity-bound, not count-bound (trap 19): a count of 2 is satisfied by two
+  // copies of the same run, or by two snapshots of the wrong runs entirely.
+  it('the two captured snapshots ARE run A and run B, by response hash', () => {
+    applyTurn(runA)
+    applyTurn(runB)
+
+    const snaps = useAnalysisSnapshotStore.getState().snapshots
+    expect(snaps.map(s => s.responseHash)).toEqual([derivedHash(runA), derivedHash(runB)])
+    expect(derivedHash(runA)).not.toBe(derivedHash(runB))
+    expect(snaps.map(s => s.runNumber)).toEqual([1, 2])
+    expect(snaps.map(s => s.source)).toEqual(['session', 'session'])
+  })
+
+  // The snapshot must carry the producer's OWN measurements, not a renderable
+  // shell of zeros. This is the absent≠zero guard that `parseRunFact`'s
+  // non-empty-array checks exist for, asserted on the V5 path.
+  it('the captured snapshot carries the producer values, not fabricated zeros', () => {
+    applyTurn(runA)
+    const snap = useAnalysisSnapshotStore.getState().snapshots[0]
+
+    // Winner comes from the fixture's own option_comparison, sorted by
+    // win_probability desc. These are LITERALS taken from the captured wire
+    // bytes, deliberately not re-derived from the fixture in the assertion:
+    // re-deriving would reimplement the factory and the two would agree by
+    // construction whatever the factory did. Provenance —
+    //   "Invest in Content Marketing"  win_probability 0.5241916666666667
+    //   "Hire Two Sales Reps"          win_probability 0.2504416666666667
+    // and the snapshot reports 0-100 rounded (types.ts:57), so 52 and 25.
+    expect(snap.winnerLabel).toBe('Invest in Content Marketing')
+    expect(snap.winnerProbability).toBe(52)
+    expect(snap.runnerUpProbability).toBe(25)
+    // Six factors in the fixture, capped at the factory's top 5
+    // (analysisSnapshotFactory.ts:86 `.slice(0, 5)`) — so 5, not 6. Asserting
+    // the exact number rather than `> 0` is what makes this see a regression
+    // that silently truncated the block to one factor.
+    expect(snap.topFactors.length).toBe(5)
+    expect(snap.topCalibrationFactor).not.toBe('')
+  })
+
+  // ── Spec 3 (diagnosis §5 RED-first #3) — dedupe ────────────────────────
+  it('a CONSECUTIVE re-delivery of the same analysis does not double-count', () => {
+    // This is the real walk's own shape: p3b/wire-run2-4-res.txt is a
+    // byte-identical re-delivery of run 1's block inside run 2's turn
+    // sequence, before the genuinely new analysis arrives at wire-run2-8.
+    applyTurn(runA)
+    applyTurn(runA)
+    expect(useAnalysisSnapshotStore.getState().getRunCount()).toBe(1)
+  })
+
+  it('a NON-CONSECUTIVE replay of an earlier analysis does not double-count', () => {
+    // A, B, A. The applicator's own `hash !== prevHash` guard is CONSECUTIVE
+    // only — after B, prevHash is B's, so a re-delivered A passes it and calls
+    // resultsComplete again. Only an identity-bound dedupe in the capture can
+    // stop that becoming a third "run" in the journey.
+    applyTurn(runA)
+    applyTurn(runB)
+    applyTurn(runA)
+
+    const snaps = useAnalysisSnapshotStore.getState().snapshots
+    expect(snaps).toHaveLength(2)
+    expect(snaps.map(s => s.responseHash)).toEqual([derivedHash(runA), derivedHash(runB)])
+  })
+
+  // The store's sequential renumber must survive a rejected duplicate — a
+  // journey numbered 1, 3 would be a visible artefact of the dedupe.
+  it('run numbering stays contiguous when a duplicate is rejected', () => {
+    applyTurn(runA)
+    applyTurn(runA)
+    applyTurn(runB)
+    expect(useAnalysisSnapshotStore.getState().snapshots.map(s => s.runNumber)).toEqual([1, 2])
+  })
+
+  // ── Producer-drift drops, on THIS caller ──────────────────────────────
+  //
+  // ⚠ WHY THESE EXIST WHEN `persistedRunSnapshotFactory.spec.ts` ALREADY PINS
+  // THE SAME GUARDS. The guards live in ONE shared reader
+  // (`stores/analysisEnrichmentShape.ts`) used by both the persisted rebuild
+  // and this live capture. Sharing the reader makes the two callers AGREE; it
+  // does not make either one COVERED. Before these cases, deleting a guard
+  // RED-ed only the persisted spec — so the V5 path's drop behaviour was
+  // asserted nowhere, and a future change that gave this caller its own
+  // lenient parse would have shipped under a green gate. (CLAUDE.md trap 12d:
+  // a derived/shared guard proves agreement, never completeness.)
+  //
+  // The claim is DROP, not degrade: a block that cannot be read as a completed
+  // analysis must produce NO snapshot, rather than a run plotted at 0% with an
+  // empty winner label.
+  const dropCases: Array<[string, unknown]> = [
+    ['an EMPTY option_comparison', { ...(runA.enrichment as object), option_comparison: [] }],
+    ['NO option_comparison key at all', (() => {
+      const e = { ...(runA.enrichment as Record<string, unknown>) }
+      delete e.option_comparison
+      return e
+    })()],
+    ['an EMPTY factor_sensitivity', { ...(runA.enrichment as object), factor_sensitivity: [] }],
+    ['a non-array option_comparison', { ...(runA.enrichment as object), option_comparison: {} }],
+    ['no enrichment envelope at all', null],
+  ]
+
+  for (const [label, enrichment] of dropCases) {
+    it(`DROPS a V5 analysis block with ${label} — no phantom run`, () => {
+      const block = { ...runA, enrichment } as AnalysisBlock
+      const result = applyV5State(turnWith(block), {
+        ...useCanvasStore.getState(),
+        currentResultsHash: null,
+      } as never)
+
+      // Control: the turn DID apply — the results slice hydrated. Without
+      // this, "no snapshot" would be satisfied by a turn that never ran, and
+      // every case here would pass by testing nothing (trap 13).
+      expect(result.applied).toContain('analysis_result:results_hydrated')
+      // …and the run is absent from the journey rather than present-and-zeroed.
+      expect(useAnalysisSnapshotStore.getState().getRunCount()).toBe(0)
+    })
+  }
+
+  // The capture must not resurrect the OTHER two dead writers, and must not
+  // start writing the V2-shaped slots the V5 path deliberately clears.
+  it('does not repopulate the V2 enrichment / rawV2Response slots', () => {
+    applyTurn(runA)
+    const state = useCanvasStore.getState()
+    // `enrichment` is on the results slice; `rawV2Response` is a TOP-LEVEL
+    // store field (store.ts:615). Both are V2-shaped and both are cleared on
+    // purpose by the V5 path — the new `v5Enrichment` param must not have
+    // leaked into either.
+    expect(state.results?.enrichment ?? null).toBeNull()
+    expect(state.rawV2Response ?? null).toBeNull()
+  })
+})

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -51,6 +51,7 @@ import { identityFromCanvasGraph } from './utils/graphIdentity'
 import { isCompareTabEnabled } from '../flags'
 import { useAnalysisSnapshotStore } from './stores/analysisSnapshotStore'
 import { buildAnalysisSnapshot } from './stores/analysisSnapshotFactory'
+import { buildSnapshotFromV5Analysis } from './stores/v5RunSnapshotFactory'
 import { handleLayoutWithRecovery } from './layout/handleLayoutWithRecovery'
 import { useComparisonStore } from './stores/comparisonStore'
 import { useDraftStore } from './stores/draftStore'
@@ -722,6 +723,15 @@ interface CanvasState {
     resultsSource?: 'direct' | 'conversation'
     /** Raw V2RunResponse from PLoT — preserved for typed field access and debug */
     rawV2Response?: V2RunResponse | null
+    /**
+     * ROADMAP 2.350 — the V5 `analysis_result` block's OWN enrichment record.
+     *
+     * Read by ONE thing: the Compare-tab snapshot capture at the bottom of
+     * this action. It is NOT written to any results slice, and it is
+     * deliberately not folded into `enrichment` above (which is V2-shaped and
+     * which the V5 path clears on purpose).
+     */
+    v5Enrichment?: unknown
   }) => void
   resultsError: (params: { code: string; message: string; retryAfter?: number; request_id?: string; canRetry?: boolean; affectedOptions?: Array<{ id: string; label: string }> }) => void
   /** Capture detailed error information for Debug Panel */
@@ -3009,7 +3019,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     }))
   },
 
-  resultsComplete: ({ report, hash, drivers, ceeReview, ceeTrace, ceeError, ceeReviewV1: _ceeReviewV1, ceeTraceV1: _ceeTraceV1, ceeErrorV1: _ceeErrorV1, enrichment, resultsSource, rawV2Response }) => {
+  resultsComplete: ({ report, hash, drivers, ceeReview, ceeTrace, ceeError, ceeReviewV1: _ceeReviewV1, ceeTraceV1: _ceeTraceV1, ceeErrorV1: _ceeErrorV1, enrichment, resultsSource, rawV2Response, v5Enrichment }) => {
     const { nodes, edges, results, currentScenarioId, graphHealth: existingHealth } = get()
 
     const finishedAt = Date.now()
@@ -3235,22 +3245,56 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       console.warn('[resultsComplete] Failed to persist analysis to autosave', err)
     }
 
-    // Refinement Journey: capture analysis snapshot for Compare tab
-    if (isCompareTabEnabled() && rawV2Response && report) {
+    // Refinement Journey: capture analysis snapshot for Compare tab.
+    //
+    // ⭐ ROADMAP 2.350 — THIS GATE USED TO READ `rawV2Response && report`, AND
+    // THAT CONJUNCT IS WHY COMPARE HAD NO DATA ON THE DEPLOYED WIRE AT ALL.
+    // The V5 applicator — the only analyse path in production — calls this
+    // action with `rawV2Response: null` EXPLICITLY ("V5 carries no V2
+    // envelope"). So this capture never executed on a real turn, for ANY tier,
+    // and the tab's only other feed (`useCompareHistoryHydration`) skips
+    // guests by design while staging serves every session as guest. Result:
+    // a guest who ran the analysis twice was shown an empty state instructing
+    // them to "run the analysis again". Witnessed on the 2026-08-04b walk
+    // (`p3b/P3b-compare-before.json`: runPickerCount 0, compare-empty-state).
+    //
+    // The V5 branch reads the analysis block's OWN enrichment — the same
+    // material the persisted rebuild parses, through the same shared reader
+    // (`stores/analysisEnrichmentShape.ts`), because a persisted run_analysis
+    // fact IS this enrichment after CEE wrote it.
+    if (isCompareTabEnabled() && report && (rawV2Response || v5Enrichment)) {
       try {
         const snapshotStore = useAnalysisSnapshotStore.getState()
         const capturedEvents = (get()._hydratedEvents ?? []) as ScenarioEvent[]
         const prevTimestamp = snapshotStore.getLatest()?.timestamp ?? null
-        const snapshot = buildAnalysisSnapshot({
-          rawV2Response,
-          report,
-          nodes,
-          edges,
-          runNumber: snapshotStore.getRunCount() + 1,
-          events: capturedEvents,
-          previousSnapshotTimestamp: prevTimestamp,
-        })
-        snapshotStore.addSnapshot(snapshot)
+        const runNumber = snapshotStore.getRunCount() + 1
+        const snapshot = rawV2Response
+          ? buildAnalysisSnapshot({
+              rawV2Response,
+              report,
+              nodes,
+              edges,
+              runNumber,
+              events: capturedEvents,
+              previousSnapshotTimestamp: prevTimestamp,
+            })
+          : buildSnapshotFromV5Analysis({
+              enrichment: v5Enrichment,
+              // Run identity, shared with the Results panel: `hash` is the
+              // response_hash the applicator already used to decide this was a
+              // NEW analysis. Carrying it is what lets addSnapshot reject a
+              // re-delivered run, and what lets a later sign-in merge dedupe
+              // this session run against its own persisted row.
+              responseHash: hash,
+              nodes,
+              edges,
+              runNumber,
+              events: capturedEvents,
+              previousSnapshotTimestamp: prevTimestamp,
+            })
+        // null ⇒ the block could not be read as a completed analysis. Omit the
+        // run rather than publish a snapshot of zeros nobody measured.
+        if (snapshot) snapshotStore.addSnapshot(snapshot)
       } catch (err) {
         if (import.meta.env.DEV) {
           console.warn('[resultsComplete] Snapshot capture failed', err)

--- a/src/canvas/stores/analysisEnrichmentShape.ts
+++ b/src/canvas/stores/analysisEnrichmentShape.ts
@@ -1,0 +1,157 @@
+/**
+ * The ONE reader of an analysis enrichment envelope, shared by every caller
+ * that rebuilds an `AnalysisSnapshot` from one.
+ *
+ * ⚠ WHY THIS MODULE EXISTS AT ALL (CLAUDE.md trap 12 — derive, don't mirror).
+ * There are now TWO sources of the same material:
+ *
+ *   1. a persisted `v5_handler_facts` `run_analysis` row's
+ *      `payload.result.enrichment`  (`persistedRunSnapshotFactory`)
+ *   2. a live V5 turn's `analysis_result` block's own `enrichment`
+ *      (`v5RunSnapshotFactory`, ROADMAP 2.350)
+ *
+ * They are the SAME bytes at two moments — (1) is (2) after CEE persisted it.
+ * Giving each its own guards would be a mirror of exactly the estate's
+ * hard-won absence-preserving logic, and the two copies would drift: the
+ * enrichment-root sibling extractors already had to be fixed twice
+ * (ROADMAP 2.173 / 2.177) because a compensation lived in one caller and not
+ * the other, so the SAME Compare surface rendered values or `[]` depending on
+ * which caller built the snapshot. This module is the un-mirrorable half.
+ *
+ * It does NOT re-derive anything. It validates, then reshapes into the
+ * `V2RunResponse` slot the ONE factory (`buildAnalysisSnapshot`) already
+ * consumes.
+ */
+import type { V2RunResponse } from '../../adapters/plot/v2/types'
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function isNonEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length > 0
+}
+
+/**
+ * A readable analysis envelope. `null` from the parser means "this cannot be
+ * read as a completed analysis", and the caller DROPS it rather than
+ * defaulting it.
+ */
+export interface ParsedAnalysisEnrichment {
+  enrichment: Record<string, unknown>
+  /**
+   * The two arrays every DECIDING snapshot field comes from, carried out of
+   * the parser already proven non-empty, so `toV2ResponseShape` has no `?? []`
+   * arm that reads like sanctioned defaulting. Readability only — see that
+   * function's header for why this is NOT a second line of defence.
+   */
+  optionComparison: unknown[]
+  factorSensitivity: unknown[]
+}
+
+/**
+ * Read an untrusted enrichment envelope.
+ *
+ * ⚠ A PRESENT ENVELOPE IS NOT A READABLE RUN. Found by the adversarial review
+ * of PR #523 (finding 1) and closed here.
+ *
+ * Until this guard existed, callers accepted any object with an `enrichment`
+ * key and `toV2ResponseShape` DEFAULTED a missing or empty `option_comparison`
+ * to `[]`. `buildAnalysisSnapshot`'s pre-existing `winner?.win_probability ?? 0`
+ * then produced a fully renderable snapshot. The reviewer's probe, reproduced
+ * verbatim:
+ *
+ *   RESULT:  {"winnerId":"","winnerLabel":"","winnerProbability":0,
+ *             "goalProbability":null,"runnerUpProbability":null}
+ *   FACTORS: {"topElasticity":0,"rankFlipRate":0,
+ *             "influenceConcentration":0,"topCalibrationFactor":""}
+ *
+ * i.e. a run plotted on the trajectory at 0% with an empty winner label, and a
+ * hero inviting the user to "Calibrate " at "0% influence" — three fabricated
+ * measurements in one sentence.
+ *
+ * Both arrays are non-empty in 773/773 live persisted facts AND in both
+ * `analysis_result` blocks captured off the live guest wire on the 2026-08-04b
+ * walk (4 options / 6 factors each), so this costs nothing on real data — it
+ * is a guard against PRODUCER DRIFT, and it makes that drift loud by omission
+ * (a run vanishes from the journey) instead of silently publishing zeros the
+ * engine never measured.
+ *
+ * Every OTHER producer field stays absence-preserving rather than drop-worthy
+ * (`recommendation_stability` is legitimately absent in 426/773 runs and must
+ * render "Not assessed", not delete the run).
+ */
+export function parseAnalysisEnrichment(value: unknown): ParsedAnalysisEnrichment | null {
+  const enrichment = asRecord(value)
+  // No envelope ⇒ nothing to render. A payload that carries none is a producer
+  // change, and the honest response is to omit the run from the journey, not
+  // to render a run with every field blank.
+  if (!enrichment) return null
+
+  if (!isNonEmptyArray(enrichment.option_comparison)) return null
+  if (!isNonEmptyArray(enrichment.factor_sensitivity)) return null
+
+  return {
+    enrichment,
+    optionComparison: enrichment.option_comparison,
+    factorSensitivity: enrichment.factor_sensitivity,
+  }
+}
+
+/**
+ * The `robustness` slot, read off the untrusted envelope.
+ *
+ * This was `composeRobustness`, the root→robustness fold — deleted as
+ * redundant once all three sibling extractors adopted the root-wins dual read
+ * (ROADMAP 2.173 / 2.177). What remains is only the slot read, with `{}` — not
+ * undefined — preserved for an absent or malformed `robustness`, exactly as
+ * the fold-era code behaved.
+ */
+function readRobustnessSlot(enrichment: Record<string, unknown>): V2RunResponse['robustness'] {
+  // Double cast, deliberately: the object is untrusted JSONB, not a validated
+  // V2RobustnessActual. The factory's extractors already re-read every field
+  // off it defensively (`as Record<string, unknown>` + type guards), so
+  // widening through `unknown` is honest about what is known — asserting the
+  // nominal type directly would claim a validation nobody did.
+  return (asRecord(enrichment.robustness) ?? {}) as unknown as V2RunResponse['robustness']
+}
+
+/**
+ * Shape the parsed envelope into the `V2RunResponse` slot the factory
+ * consumes. No value is invented: absent producer fields stay absent, and the
+ * factory's own absence-preserving branches then fire.
+ *
+ * It takes the PARSED envelope rather than the raw enrichment so that the two
+ * deciding arrays arrive already proven non-empty and this function has no
+ * `Array.isArray(...) : []` arm that READS like sanctioned defaulting.
+ *
+ * ⚠ BE CLEAR ABOUT WHAT THIS IS NOT. It is **not** a second line of defence.
+ * `buildAnalysisSnapshot` has its own `rawV2Response.option_comparison ?? []`
+ * and `factor_sensitivity ?? []` (analysisSnapshotFactory.ts:250,257), so
+ * deleting the `parseAnalysisEnrichment` guards would re-create finding 1
+ * exactly, whatever this function passes through. Mutation-checked: restoring
+ * the defaulting arm here with the guards intact REDs nothing (M13), while
+ * deleting either guard REDs immediately (M10/M11). **The guards in
+ * `parseAnalysisEnrichment` are the whole fix; this is readability, and it
+ * must not be mistaken for a guarantee.**
+ *
+ * `responseHash` is threaded in because `buildAnalysisSnapshot` reads run
+ * identity off `rawV2Response.response_hash` (analysisSnapshotFactory.ts:500).
+ * Persisted facts carry it inside the enrichment (773/773 live rows); the live
+ * V5 block does NOT — the applicator derives it — so that caller passes it
+ * explicitly. Omitting it leaves the enrichment's own value in place.
+ */
+export function enrichmentToV2ResponseShape(
+  parsed: ParsedAnalysisEnrichment,
+  responseHash?: string | null,
+): V2RunResponse {
+  return {
+    ...parsed.enrichment,
+    option_comparison: parsed.optionComparison,
+    factor_sensitivity: parsed.factorSensitivity,
+    robustness: readRobustnessSlot(parsed.enrichment),
+    ...(responseHash ? { response_hash: responseHash } : {}),
+  } as unknown as V2RunResponse
+}

--- a/src/canvas/stores/analysisSnapshotStore.ts
+++ b/src/canvas/stores/analysisSnapshotStore.ts
@@ -6,12 +6,19 @@
  *
  * ROADMAP 2.113a slice 1 changed WHERE those runs come from. The store itself
  * is still in-memory — it is not written to localStorage or Supabase — but it
- * is now SEEDED from Supabase (`hydrateFromPersisted`), which is what makes
- * the journey survive a reload and, on the deployed V5 path, exist at all:
- * the session capture gate at `canvas/store.ts` `resultsComplete` requires a
- * `rawV2Response`, and the live results-hydration applicator passes null for
- * it (`v5/applyV5State.ts:1023`, "V5 carries no V2 envelope"), so that gate
- * never opened on the real wire.
+ * is now SEEDED from Supabase (`hydrateFromPersisted`).
+ *
+ * ⚠ CORRECTED BY ROADMAP 2.350. This header used to say that seeding "is what
+ * makes the journey ... on the deployed V5 path, exist at all", because the
+ * session capture gate required a `rawV2Response` the V5 applicator passes as
+ * null. The first half of that was true; the conclusion was too generous.
+ * `hydrateFromPersisted` is reached only through
+ * `useCompareHistoryHydration`, which skips guests before any read — and
+ * staging serves every session as guest — so on the deployed walks NEITHER
+ * feed ever wrote, and the tab was empty within a session as well as across a
+ * reload. 2.350 revived the session capture from the V5 block's own
+ * enrichment, so THIS store now has a live writer at guest tier.
+ * Cross-reload lineage at guest tier remains open (ROADMAP 2.312 / Track 2).
  */
 import { create } from 'zustand'
 import type { AnalysisSnapshot } from '../compare-tab/types'
@@ -53,8 +60,38 @@ export const useAnalysisSnapshotStore = create<AnalysisSnapshotStoreState & Anal
   (set, get) => ({
     snapshots: [],
 
+    /**
+     * Append a session-captured run.
+     *
+     * ⭐ IDENTITY-IDEMPOTENT (ROADMAP 2.350). A run already in the journey is
+     * NOT appended again.
+     *
+     * Why this is needed here and not left to the caller's own guard: the V5
+     * applicator's dedupe (`hash !== prevHash`) is CONSECUTIVE-ONLY. On the
+     * real wire a turn sequence re-delivers an earlier analysis verbatim —
+     * measured on the 2026-08-04b walk, where run 2's turn re-delivered run
+     * 1's `analysis_result` block BYTE-IDENTICALLY before the genuinely new
+     * analysis arrived. A consecutive re-delivery is caught upstream, but the
+     * order A, B, A is not: after B, `prevHash` is B's, so a re-delivered A
+     * passes that guard and would become a third "run" in a two-run journey.
+     * Putting the check on the store makes it un-bypassable by any caller
+     * rather than a rule each capture site has to remember.
+     *
+     * `hydrateFromPersisted` already dedupes on the same `runIdentity`, so the
+     * two writers now agree on what "the same run" means.
+     *
+     * ⚠ A SNAPSHOT WITH NO `responseHash` IS NEVER MERGED INTO ANOTHER — the
+     * identity falls back to the per-capture `runId`, which is a fresh uuid,
+     * so an unhashed run still appends. That is deliberate (silently dropping
+     * a run we cannot identify would be worse than showing it twice) and it
+     * preserves the pre-2.350 behaviour of the V2 capture path exactly.
+     */
     addSnapshot: (snapshot) => {
       set(state => {
+        const identity = runIdentity(snapshot)
+        if (state.snapshots.some(s => runIdentity(s) === identity)) {
+          return state
+        }
         // Enforce sequential 1-indexed runNumber regardless of caller
         const enforced = { ...snapshot, runNumber: state.snapshots.length + 1 }
         return { snapshots: [...state.snapshots, enforced] }

--- a/src/canvas/stores/persistedRunSnapshotFactory.ts
+++ b/src/canvas/stores/persistedRunSnapshotFactory.ts
@@ -47,11 +47,15 @@
  * PHASE0-EVIDENCE-2026-07-28/sibling-extractors-fix.md. The nested-only and
  * both-absent classes stay pinned in this module's spec.
  */
-import type { V2RunResponse } from '../../adapters/plot/v2/types'
 import type { ScenarioEvent } from '../../types/scenario'
 import type { AnalysisSnapshot } from '../compare-tab/types'
 import type { PersistedAnalysisRunRow } from '../../services/analysisRunHistoryService'
 import { buildAnalysisSnapshot } from './analysisSnapshotFactory'
+import {
+  parseAnalysisEnrichment,
+  enrichmentToV2ResponseShape,
+  type ParsedAnalysisEnrichment,
+} from './analysisEnrichmentShape'
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -59,25 +63,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
-function isNonEmptyArray(value: unknown): value is unknown[] {
-  return Array.isArray(value) && value.length > 0
-}
-
 /**
  * The CEE-owned half of the fact, plus the PLoT envelope it wraps.
  * Everything here is untrusted JSONB — `null` means "this row cannot be read
  * as a completed analysis", and the caller DROPS it rather than defaulting it.
+ *
+ * ⚠ THE ENVELOPE HALF NOW LIVES IN `analysisEnrichmentShape.ts`, SHARED WITH
+ * THE LIVE V5 CAPTURE PATH (ROADMAP 2.350). A persisted fact's enrichment and
+ * a live `analysis_result` block's enrichment are the same bytes at two
+ * moments, so they get ONE reader — see that module's header for why a second
+ * copy of these guards would be the mirror defect this estate has already paid
+ * for twice (2.173 / 2.177). What stays here is only what is genuinely
+ * fact-ROW-shaped: the `fact_type` filter and the two row-level timestamps.
  */
-interface ParsedRunFact {
-  enrichment: Record<string, unknown>
-  /**
-   * The two arrays every DECIDING snapshot field comes from, carried out of the
-   * parser already proven non-empty, so `toV2ResponseShape` has no `?? []` arm
-   * that reads like sanctioned defaulting. Readability only — see that
-   * function's header for why this is NOT a second line of defence.
-   */
-  optionComparison: unknown[]
-  factorSensitivity: unknown[]
+interface ParsedRunFact extends ParsedAnalysisEnrichment {
   computedAt: string | null
   graphHashAtRun: string | null
 }
@@ -92,107 +91,22 @@ function parseRunFact(payload: unknown): ParsedRunFact | null {
   const result = asRecord(root.result)
   if (!result) return null
 
-  const enrichment = asRecord(result.enrichment)
-  // No envelope ⇒ nothing to render. 773/773 live rows carry one; a row that
-  // does not is a producer change, and the honest response is to omit the run
-  // from the journey, not to render a run with every field blank.
-  if (!enrichment) return null
-
-  // ⚠ A PRESENT ENVELOPE IS NOT A READABLE RUN. Found by the adversarial
-  // review of PR #523 (finding 1) and closed here pre-merge.
-  //
-  // Until this guard existed, `parseRunFact` accepted any row with
-  // {object, fact_type, result, enrichment} and `toV2ResponseShape` DEFAULTED a
-  // missing or empty `option_comparison` to `[]`. `buildAnalysisSnapshot`'s
-  // pre-existing `winner?.win_probability ?? 0` then produced a fully
-  // renderable snapshot. The reviewer's probe, reproduced verbatim here before
-  // the fix:
-  //
-  //   RESULT:  {"winnerId":"","winnerLabel":"","winnerProbability":0,
-  //             "goalProbability":null,"runnerUpProbability":null}
-  //   FACTORS: {"topElasticity":0,"rankFlipRate":0,
-  //             "influenceConcentration":0,"topCalibrationFactor":""}
-  //
-  // i.e. a run plotted on the trajectory at 0% with an empty winner label, and
-  // a hero inviting the user to "Calibrate " at "0% influence" — three
-  // fabricated measurements in one sentence. That is the absent≠zero class, on
-  // the very path this module documents as "dropped, never defaulted": the
-  // original three drop tests (non-object payload / wrong fact_type / no
-  // enrichment) could not see this shape.
-  //
-  // Both arrays are non-empty in 773/773 live facts, so this costs nothing on
-  // real data — it is a guard against PRODUCER DRIFT, and it makes that drift
-  // loud by omission (a run vanishes from the journey) instead of silently
-  // publishing zeros the engine never measured. The write surface is
-  // service-role-only, so this was never reachable by a client.
-  //
-  // These are the two arrays the snapshot's DECIDING fields come from —
-  // `option_comparison` for winner/runner-up/probabilities/goal, and
-  // `factor_sensitivity` for the whole top-factor and calibration block. Every
-  // OTHER producer field stays absence-preserving rather than drop-worthy
-  // (`recommendation_stability` is legitimately absent in 426/773 runs and must
-  // render "Not assessed", not delete the run).
-  if (!isNonEmptyArray(enrichment.option_comparison)) return null
-  if (!isNonEmptyArray(enrichment.factor_sensitivity)) return null
+  // Envelope validation + the two deciding-array guards: ONE reader, shared
+  // with the live V5 capture path. 773/773 live rows carry a readable
+  // envelope; a row that does not is a producer change, and the honest
+  // response is to omit the run from the journey, not to render a run with
+  // every field blank.
+  const parsed = parseAnalysisEnrichment(result.enrichment)
+  if (!parsed) return null
 
   return {
-    enrichment,
-    optionComparison: enrichment.option_comparison,
-    factorSensitivity: enrichment.factor_sensitivity,
+    ...parsed,
     computedAt: typeof result.computed_at === 'string' ? result.computed_at : null,
     graphHashAtRun:
       typeof result.graph_hash_at_run === 'string' && result.graph_hash_at_run.length > 0
         ? result.graph_hash_at_run
         : null,
   }
-}
-
-/**
- * The `robustness` slot, read off the untrusted envelope.
- *
- * This was `composeRobustness`, the root→robustness fold — deleted as
- * redundant once all three extractors adopted the root-wins dual read
- * (ROADMAP 2.173 / 2.177; see the module header's HISTORY block for the full
- * story and the byte-identity proof). What remains is only the slot read,
- * with `{}` — not undefined — preserved for an absent or malformed
- * `robustness`, exactly as the fold-era code behaved.
- */
-function readRobustnessSlot(enrichment: Record<string, unknown>): V2RunResponse['robustness'] {
-  // Double cast, deliberately: the object is untrusted JSONB, not a validated
-  // V2RobustnessActual. The factory's extractors already re-read every field
-  // off it defensively (`as Record<string, unknown>` + type guards), so
-  // widening through `unknown` is honest about what is known — asserting the
-  // nominal type directly would claim a validation nobody did.
-  return (asRecord(enrichment.robustness) ?? {}) as unknown as V2RunResponse['robustness']
-}
-
-/**
- * Shape the parsed fact into the `V2RunResponse` slot the factory consumes. No
- * value is invented: absent producer fields stay absent, and the factory's own
- * absence-preserving branches then fire.
- *
- * It takes the PARSED fact rather than the raw enrichment so that the two
- * deciding arrays arrive already proven non-empty and this function has no
- * `Array.isArray(...) : []` arm that READS like sanctioned defaulting.
- *
- * ⚠ BE CLEAR ABOUT WHAT THIS IS NOT. It is **not** a second line of defence,
- * and the earlier draft of this comment implied it was. `buildAnalysisSnapshot`
- * has its own `rawV2Response.option_comparison ?? []` and
- * `factor_sensitivity ?? []` (analysisSnapshotFactory.ts:250,257), so deleting
- * the `parseRunFact` guards would re-create finding 1 exactly, whatever this
- * function passes through. Mutation-checked: restoring the defaulting arm here
- * with the guards intact REDs nothing (28/28 green — M13), while deleting
- * either guard REDs immediately (M10/M11). **The guards in `parseRunFact` are
- * the whole fix; this is readability, and it must not be mistaken for a
- * guarantee.**
- */
-function toV2ResponseShape(fact: ParsedRunFact): V2RunResponse {
-  return {
-    ...fact.enrichment,
-    option_comparison: fact.optionComparison,
-    factor_sensitivity: fact.factorSensitivity,
-    robustness: readRobustnessSlot(fact.enrichment),
-  } as unknown as V2RunResponse
 }
 
 export interface BuildPersistedSnapshotParams {
@@ -216,7 +130,7 @@ export function buildSnapshotFromPersistedRun(
   if (!fact) return null
 
   const base = buildAnalysisSnapshot({
-    rawV2Response: toV2ResponseShape(fact),
+    rawV2Response: enrichmentToV2ResponseShape(fact),
     // No graph-at-run in a run_analysis fact. Passing null (not []) is what
     // makes graphHash / nodeCount / edgeCount / evidenceCoverage report
     // honest absence instead of a fabricated empty graph.

--- a/src/canvas/stores/v5RunSnapshotFactory.ts
+++ b/src/canvas/stores/v5RunSnapshotFactory.ts
@@ -1,0 +1,87 @@
+/**
+ * V5 session-capture snapshot factory — build an `AnalysisSnapshot` from a
+ * LIVE `analysis_result` block's own enrichment.
+ *
+ * ROADMAP 2.350. This is the sibling of `persistedRunSnapshotFactory`, and the
+ * two share their whole envelope reader (`analysisEnrichmentShape.ts`) because
+ * they read the SAME bytes at two different moments: a persisted
+ * `v5_handler_facts` `run_analysis` row IS this enrichment after CEE wrote it.
+ *
+ * ⚠ WHY THIS PATH HAD TO EXIST — the defect it closes.
+ * The Compare tab's in-session capture (`canvas/store.ts` `resultsComplete`)
+ * was gated on `rawV2Response`, and the deployed V5 applicator passes that as
+ * `null` EXPLICITLY ("V5 carries no V2 envelope", `v5/applyV5State.ts`). So the
+ * gate never opened on the live wire — for ANY tier — and Compare's only other
+ * feed (`useCompareHistoryHydration`) skips guests by design. Staging serves
+ * every session as guest, so a guest with two completed runs saw
+ * `compare-empty-state` and zero run-pickers: witnessed on the 2026-08-04b
+ * walk (`p3b/P3b-compare-before.json`, `runPickerCount: 0`). Diagnosis of
+ * record: `PHASE0-EVIDENCE-2026-07-28/diagnosis-2350-compare-pickers.md`.
+ *
+ * ⚠ SCOPE — WITHIN-SESSION ONLY. This revives the SESSION feed. It writes
+ * nothing to localStorage or Supabase, so the journey still does NOT survive a
+ * reload at guest tier: that half is the run list arriving over the
+ * CEE-mediated scenario-addressed read route (ROADMAP 2.312 / Track 2) and is
+ * deliberately untouched here. `useCompareHistoryHydration`'s guest skip is
+ * unchanged.
+ *
+ * ⚠ RUN IDENTITY IS DERIVED, NOT PRODUCER-SUPPLIED. Neither `analysis_result`
+ * block captured off the live guest wire carries a `model_card`, so
+ * `mapV5AnalysisToReport` derives `response_hash` itself (fnv1a-64 over
+ * summary + leading_option_id + win_probabilities + canonical-serialised
+ * enrichment). That derived value is what the applicator ALREADY uses to
+ * decide "is this a new analysis" (`hash !== prevHash`), and reusing it here
+ * is what makes the Compare tab and the Results panel agree on what "the same
+ * run" means — and what lets a later sign-in merge dedupe a session run
+ * against its own persisted row (`analysisSnapshotStore.runIdentity`).
+ */
+import type { Node, Edge } from '@xyflow/react'
+import type { ScenarioEvent } from '../../types/scenario'
+import type { AnalysisSnapshot } from '../compare-tab/types'
+import { buildAnalysisSnapshot } from './analysisSnapshotFactory'
+import { parseAnalysisEnrichment, enrichmentToV2ResponseShape } from './analysisEnrichmentShape'
+
+export interface BuildV5SessionSnapshotParams {
+  /** The `analysis_result` block's own `enrichment` record, untrusted. */
+  enrichment: unknown
+  /**
+   * The analysis response hash the applicator computed for this run — the same
+   * value it wrote to `results.hash`.
+   */
+  responseHash: string
+  /** The graph the analysis was computed over. Present on this path, unlike
+   *  the persisted rebuild, so graphHash / counts / evidence coverage are real. */
+  nodes: Node[] | null
+  edges: Edge[] | null
+  runNumber: number
+  events: ScenarioEvent[]
+  previousSnapshotTimestamp: string | null
+}
+
+/**
+ * Build one session snapshot. Returns null when the block cannot be read as a
+ * completed analysis — the caller omits it from the journey rather than
+ * publishing a run of zeros nobody measured.
+ */
+export function buildSnapshotFromV5Analysis(
+  params: BuildV5SessionSnapshotParams,
+): AnalysisSnapshot | null {
+  const { enrichment, responseHash, nodes, edges, runNumber, events, previousSnapshotTimestamp } =
+    params
+
+  const parsed = parseAnalysisEnrichment(enrichment)
+  if (!parsed) return null
+
+  // `source` stays the factory's default `'session'`, and `graphHash` stays the
+  // UI's own `generateGraphHash` regime — which is exactly right and is what
+  // stops `detectStructureChange` comparing it against a persisted snapshot's
+  // CEE `aag_v1` hash. See `compare-tab/types.ts` `SnapshotSource`.
+  return buildAnalysisSnapshot({
+    rawV2Response: enrichmentToV2ResponseShape(parsed, responseHash),
+    nodes,
+    edges,
+    runNumber,
+    events,
+    previousSnapshotTimestamp,
+  })
+}

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -154,6 +154,10 @@ export interface V5ApplicatorStore {
     resultsSource?: 'direct' | 'conversation'
     enrichment?: unknown
     rawV2Response?: unknown
+    /** ROADMAP 2.350: the analysis_result block's own enrichment, for the
+     *  Compare tab's in-session snapshot capture. NOT the V2-shaped
+     *  `enrichment` slot above, which this path clears. */
+    v5Enrichment?: unknown
   }) => void
   /**
    * Current results hash for dedupe. When the new analysis hash matches
@@ -1070,6 +1074,24 @@ export function applyV5State(
           // cleared rather than left to a stale prior write.
           enrichment: null,
           rawV2Response: null,
+          // ROADMAP 2.350 — the block's OWN enrichment, for the Compare tab's
+          // in-session capture ONLY.
+          //
+          // ⚠ THIS IS DELIBERATELY A SEPARATE PARAM FROM `enrichment` ABOVE,
+          // AND MUST STAY ONE. That slot is V2-SHAPED and is being cleared on
+          // purpose — folding this value into it would repopulate a V2 slot
+          // the V5 path has explicitly emptied since it shipped, and every
+          // consumer reading it would start seeing a shape it was never
+          // written for. This param is read by exactly one thing: the snapshot
+          // capture at the bottom of `resultsComplete`.
+          //
+          // Why it is needed at all: that capture was gated on
+          // `rawV2Response`, which this call passes as null — so the gate
+          // never opened on the live wire, for any tier, and Compare's only
+          // other feed skips guests by design. A guest with two completed runs
+          // saw an empty state telling them to run an analysis they had
+          // already run twice. See `canvas/stores/v5RunSnapshotFactory.ts`.
+          v5Enrichment: analysisBlock.enrichment ?? null,
         })
         applied.push('analysis_result:results_hydrated')
         // Reliable run identity: a NEW analysis_result response_hash (hash !==


### PR DESCRIPTION
## What this closes

**PC1 step 6 — "see two versions side by side" — for the guest tier the walks actually walk.** Within one session, a guest who runs the analysis twice now gets the run pickers instead of an empty state.

**Side effect, PC2 / N6:** the empty state's copy — *"Refine your model and run the analysis again"*, instructing a run the user has already performed twice — no longer renders at ≥2 runs.

ROADMAP **2.350**, the INDEPENDENT half. Diagnosis of record: `PHASE0-EVIDENCE-2026-07-28/diagnosis-2350-compare-pickers.md` (L29, read-only).

---

## The defect

The Compare tab's in-session capture (`canvas/store.ts` `resultsComplete`) was gated on `rawV2Response`:

```ts
if (isCompareTabEnabled() && rawV2Response && report) {
```

The deployed analyse path is V5, and its applicator calls that action with `rawV2Response: null` **explicitly** — *"V5 carries no V2 envelope"*. **So the capture never executed on a real turn, for any tier.** The tab's only other feed, `useCompareHistoryHydration`, skips guests before any read by design — and staging serves every session as guest (`VITE_AUTH_MODE=guest`).

Both feeds closed ⇒ `snapshots.length` is 0 ⇒ `CompareTabBody.tsx:204` paints the empty state. Witnessed on the 2026-08-04b walk, `p3b/P3b-compare-before.json`:

```json
{ "runPickerCount": 0, "runAgainCopy": 1,
  "compareTestids": ["…", "compare-tab-body", "compare-empty-state"] }
```

This was never a regression. #526's parity was real but **signed-in only, in its own words** — guest tier was designed out of slice 1 deliberately. 2.350 is the scope gap surfacing.

---

## The premise, verified at the bytes — not inherited

The fix rests on "the V5 block's enrichment carries the same material the persisted rebuild parses". I measured that on **the actual guest walk that produced the 0-picker capture**, not from a code comment:

| capture | `option_comparison` | `factor_sensitivity` | at |
|---|---|---|---|
| `p3b/wire-run1-4-res.txt` | 4 | 6 | enrichment **root** |
| `p3b/wire-run2-8-res.txt` | 4 | 6 | enrichment **root** |

Two further findings from the same measurement, both load-bearing:

1. **Neither block carries a `model_card`** — so `response_hash` is *derived* by `mapV5AnalysisToReport` (fnv1a-64 over summary + leading_option_id + win_probabilities + enrichment). Run identity on this path is content-derived. That derived value is what the applicator *already* uses for `hash !== prevHash`, so reusing it keeps Compare and the Results panel agreeing on "the same run".
2. **`p3b/wire-run2-4-res.txt` is a byte-identical re-delivery of run 1's block** inside run 2's turn sequence. The wire really does replay analyses. This is why the dedupe below is identity-bound and not left to the applicator's guard.

---

## The fix

- **`stores/analysisEnrichmentShape.ts` (new)** — the envelope reader, **extracted and shared**, not copied. A persisted `run_analysis` fact *is* this enrichment after CEE wrote it, so the two callers get one reader. A second set of guards would be the mirror defect this estate already paid for twice (2.173 / 2.177, where a compensation lived in one caller and not the other and the same Compare surface rendered values or `[]` depending on who built the snapshot).
- **`stores/v5RunSnapshotFactory.ts` (new)** — sibling of `persistedRunSnapshotFactory`; hands the shaped envelope to the **one** `buildAnalysisSnapshot`. Re-derives nothing.
- **`applyV5State.ts`** — passes the block's own enrichment as a **new, separate `v5Enrichment` param**. Deliberately *not* folded into `enrichment`: that slot is V2-shaped and is being cleared on purpose. Pinned by a spec.
- **`store.ts`** — gate becomes `report && (rawV2Response || v5Enrichment)`; V2 callers unchanged. A null from the reader ⇒ the run is **omitted**, never published as zeros.
- **`analysisSnapshotStore.ts`** — `addSnapshot` is now **identity-idempotent** on `responseHash`. The applicator's dedupe is *consecutive-only*: after A, B, a re-delivered A passes `hash !== prevHash` and would become a third "run". Putting the check on the store makes it un-bypassable rather than a rule each capture site must remember. `hydrateFromPersisted` already deduped on the same identity, so the two writers now agree.

### Scope — read this before scoring the walk

**Within-session only.** No persistence, no Feed B change, no RLS or tier change. **The run list still does NOT survive a reload at guest tier** — that half couples to the CEE-mediated scenario-addressed read route (ROADMAP 2.312 / Track 2) and is untouched here. Please don't score the session half as the lineage half.

---

## Evidence

**RED-first.** Both specs drive the **real applicator against the real canvas store**, wired exactly as `useConversation.ts:4532-4537` wires it, from the captured wire bytes. This matters: the existing `CompareTabBody.pickTwoRuns.spec.tsx` and `analysisSnapshotStore.spec.ts` are already green and prove nothing here — they *seed* the store, and the defect is that nothing on the wire ever writes to it.

At tip, before the fix: applicator spec **6 failed / 2 passed**, render spec **3 failed / 1 passed**. The passing ones are the deliberate controls (harness genuinely drives the applicator; 1-run still shows the empty state).

**Mutants — all bite** (throwaway worktree *outside* the repo root, trap 9c; applied-check scoped to `src/` and asserted **exactly 1** file changed each time, trap 12e; control reads exactly 0):

| # | mutation | result |
|---|---|---|
| M1 | re-add the `rawV2Response &&` conjunct — **the shipped defect** | applicator **6 RED**, render **3 RED** |
| M2 | remove the `responseHash` identity dedupe | applicator **1 RED** (the A,B,A replay) |
| M3 | empty state renders at 2 runs — **N6 kill pin** | render **3 RED** |
| M4a | delete the `option_comparison` guard from the shared reader | persisted **3 RED** + V5 **2 RED** |
| M4b | delete the `factor_sensitivity` guard from the shared reader | persisted **2 RED** + V5 **1 RED** |
| M5 | drop `responseHash` threading (identity → fresh uuid) | applicator **2 RED** |

**M4 is why there are drop-specs on the V5 caller.** On the first pass M4 RED-ed *only* the persisted spec — sharing the reader made the two callers **agree**, but it did not make the new one **covered**, and a later change giving it its own lenient parse would have shipped green. Five drop cases were added on this caller (CLAUDE.md trap 12d: a shared/derived guard proves agreement, never completeness).

**Gates** (Supabase env vars set for every run):
- Inspector-v2 collection control: **34 files / 355 tests, `SUPABASE_BINDING: real`** — no collect-time failure, so the measured surface is the real one (trap 2b).
- `npm run typecheck` (the repo's own gate): **PASSED**, ratchet **exact** — 623 files / 2507 errors vs baseline 2507. Coverage 3184/3224, derived at this tip. Two real errors of mine were found and **fixed at the source**; the baseline was not touched.
- `eslint` over the changed files: **0 errors**, 9 warnings — all pre-existing in `store.ts` at lines outside my hunks (verified: identical count at the base tip).

- Scoped regression surface (`src/canvas/compare-tab src/canvas/stores src/v5`), run to completion: **103 files / 1526 tests passed**, exit 0.
- **CI at this exact head SHA: 13/13 success**, including the required **Staging Gate**, all four **Full Test Suite** shards, the **Summary**, **TypeScript + Lint**, **Typecheck Gate Self-Test** and **Production Build** (re-queried via `check-runs` for the SHA rather than trusting notifications).
- ⚠ **One thing I did NOT get**: a completed *local* whole-repo `vitest run`. I invoked it ad-hoc rather than via the repo's own `test:full` (which sets `--max-old-space-size=6144`); the parent exited without writing a summary and left orphaned workers. It had reached **932 files with 0 FAIL** at that point, but an unfinished run is not a result and I am not reporting it as one. The sharded CI suite above is the authoritative whole-repo evidence.

### One fixture fixed at the source

`__fixtures__/analysisSnapshot.ts` hardcoded `responseHash: 'abc123'` for **every** snapshot while varying `runId: run-${runNumber}` — i.e. every "distinct" run claimed to be the same run. Invisible until `addSnapshot` became identity-idempotent. Every identity-sensitive test already overrides the field, so only tests that didn't care relied on the collision. Fixed to derive from `runNumber` like `runId` does, rather than absorbed into a baseline.

---

## Not proven here

- **jsdom proves presence, never layout** (trap 3). "The pickers are in the DOM" is the whole claim. Visible, above the fold, reachable on a real screen — **not proven**; the screen witness rides the next walk. Live acceptance is a fresh guest context, 2 runs in one session, Compare tab → `run-pair-picker` with both selects listing Run 1 / Run 2 (`p3b-reload.mjs:133-147` is reusable as-is).
- **Reload survival stays ❌** at guest tier — Track 2, as above.
- No probe was run against staging in this lane.

Second open UI PR alongside #568 — file sets verified **disjoint** (zero overlap, `comm`-checked); rebased cleanly onto the post-#568 tip `8d0f3a76`.
