### PR TITLE
feat(canvas): merge-on-hydrate — server values, local layout (ROADMAP 2.312 piece 3)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -546,7 +546,7 @@
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'graph_state' does not exist on type 'TurnRequestPayload'.
 1	src/canvas/conversation/useConversation.ts	TS2339	Property 'message' does not exist on type 'TurnRequestPayload'.
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'selected_elements' does not exist on type 'TurnRequestPayload'.
-1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 247 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
+1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 249 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
 2	src/canvas/conversation/useConversation.ts	TS2352	Conversion of type 'OrchestratorResponseEnvelopeV2' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'op' is declared but its value is never read.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'ops' is declared but its value is never read.

--- a/src/adapters/cee/__tests__/scenarioGraph.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioGraph.spec.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   SCENARIO_GRAPH_BASE,
   scenarioGraphUrl,
@@ -71,41 +74,52 @@ describe('scenarioGraph — base resolution (⚠ hazard: VITE_CEE_BFF_BASE point
     )
   })
 
-  it('IGNORES VITE_CEE_BFF_BASE — it is dashboard-set to an absolute PLoT URL', async () => {
-    // The deployed bundle carries ZERO `/bff/cee` literals and four absolute
-    // `https://plot-lite-service-staging.onrender.com/v1/cee` bases, because
-    // Vite INLINES this var at build time. Any hydrate call that resolved its
-    // base from it would reach PLoT, which does not serve this route.
-    //
-    // ⚠ THE ENV MUST BE SET BEFORE THE MODULE IS IMPORTED, and the module
-    // RE-IMPORTED, or this control is VACUOUS. The defect being guarded is a
-    // MODULE-LEVEL `env.VITE_CEE_BFF_BASE || '/bff/cee'` const, which is
-    // evaluated once at import time — mutating the env afterwards and calling
-    // the already-imported function could never observe it, so the assertion
-    // would pass against the very code it exists to forbid. Verified by
-    // mutation: with the module const swapped for the env-resolved form, this
-    // case goes RED only in this shape.
-    const PLOT = 'https://plot-lite-service-staging.onrender.com/v1/cee'
-    const prev = (import.meta as any).env.VITE_CEE_BFF_BASE
-    try {
-      ;(import.meta as any).env.VITE_CEE_BFF_BASE = PLOT
-      vi.resetModules()
-      const fresh = await import('../scenarioGraph')
+  /**
+   * ⚠ THIS GUARD READS THE SOURCE, AND THAT IS THE ONLY INSTRUMENT THAT CAN
+   * SEE THE DEFECT. Two behavioural versions of it were written first and BOTH
+   * were vacuous; the second one only looked rigorous.
+   *
+   * MEASURED, not reasoned: a throwaway module containing exactly
+   * `(import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'` was imported
+   * under vitest after setting `import.meta.env.VITE_CEE_BFF_BASE` to a PLoT
+   * URL and calling `vi.resetModules()`. It still resolved to `'/bff/cee'`.
+   * Vite substitutes `import.meta.env.VITE_*` member accesses at TRANSFORM
+   * time from the env loaded at config time, so a runtime mutation is
+   * unobservable to the module no matter when it is imported.
+   *
+   * The consequence is the point: NO runtime assertion in this suite can
+   * distinguish the hazardous form from the safe one — in test, both evaluate
+   * to the fallback. A behavioural pin here would pass against the exact code
+   * it exists to forbid, forever. That is why the original evidence for this
+   * hazard was a crawl of the DEPLOYED BUNDLE and not a test.
+   *
+   * Proven by mutation: with `SCENARIO_GRAPH_BASE` swapped for the env-resolved
+   * form, the behavioural version SURVIVED and this version goes RED.
+   */
+  it('never RESOLVES its base from VITE_CEE_BFF_BASE (source-level, with a positive control)', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url))
+    const moduleSrc = readFileSync(path.join(dir, '..', 'scenarioGraph.ts'), 'utf8')
 
-      // Positive control: the env var really is visible to a fresh import, so a
-      // module that DID read it would see PLoT here.
-      expect((import.meta as any).env.VITE_CEE_BFF_BASE).toBe(PLOT)
+    // Strip comments: this file DISCUSSES the var at length, and a guard that
+    // could not tell prose from code would be unmaintainable.
+    const code = moduleSrc
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
+      .join('\n')
 
-      expect(fresh.SCENARIO_GRAPH_BASE).toBe('/bff/cee')
-      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).toBe(
-        `/bff/cee/scenarios/${SCENARIO_ID}/graph`,
-      )
-      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).not.toContain('plot-lite')
-      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).not.toContain('http')
-    } finally {
-      ;(import.meta as any).env.VITE_CEE_BFF_BASE = prev
-      vi.resetModules()
-    }
+    expect(code).not.toContain('VITE_CEE_BFF_BASE')
+    expect(code).not.toContain('VITE_BFF_BASE')
+    // …and no absolute host, which is the failure the var would cause.
+    expect(code).not.toMatch(/https?:\/\//)
+    expect(code).toContain("SCENARIO_GRAPH_BASE = '/bff/cee'")
+
+    // POSITIVE CONTROL (trap 13): the same read + match, pointed at a sibling
+    // that genuinely DOES resolve from the var. If this ever stops finding it,
+    // the guard above has stopped being able to see a presence and its absence
+    // assertions mean nothing.
+    const siblingSrc = readFileSync(path.join(dir, '..', 'client.ts'), 'utf8')
+    expect(siblingSrc).toContain('VITE_CEE_BFF_BASE')
   })
 
   it('POSTs to the pinned URL with a JSON body', async () => {

--- a/src/adapters/cee/__tests__/scenarioGraph.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioGraph.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * scenarioGraph client — RED-first spec (ROADMAP 2.312 piece 3).
+ *
+ * Pins the CEE scenario-addressed graph read (`scenario_graph.v1`, PR #804)
+ * as the UI consumes it, INCLUDING the four binding consumer notes from that
+ * PR's merged body and the base-resolution hazard that would silently point
+ * this call at the wrong host.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  SCENARIO_GRAPH_BASE,
+  scenarioGraphUrl,
+  fetchScenarioGraph,
+} from '../scenarioGraph'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+/** A 64-hex token no local computation in this repo could reproduce. */
+const CEE_TOKEN = 'a'.repeat(63) + '7'
+
+function envelope(value = CEE_TOKEN, projection = 'identity.v1') {
+  return {
+    kind: 'graph_identity_hash',
+    value,
+    algorithm: 'sha256',
+    projection_version: projection,
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+function okBody(over: Record<string, unknown> = {}) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph: { nodes: [{ id: 'n1', kind: 'factor', label: 'N1' }], edges: [] },
+    graph_present: true,
+    brief_text: 'a brief',
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'req-1',
+    ...over,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('scenarioGraph — base resolution (⚠ hazard: VITE_CEE_BFF_BASE points at PLoT)', () => {
+  it('resolves the SAME-ORIGIN Netlify edge path, never an absolute host', () => {
+    expect(SCENARIO_GRAPH_BASE).toBe('/bff/cee')
+    expect(scenarioGraphUrl(SCENARIO_ID)).toBe(
+      `/bff/cee/scenarios/${SCENARIO_ID}/graph`,
+    )
+  })
+
+  it('IGNORES VITE_CEE_BFF_BASE — it is dashboard-set to an absolute PLoT URL', async () => {
+    // The deployed bundle carries ZERO `/bff/cee` literals and four absolute
+    // `https://plot-lite-service-staging.onrender.com/v1/cee` bases, because
+    // Vite INLINES this var at build time. Any hydrate call that resolved its
+    // base from it would reach PLoT, which does not serve this route.
+    //
+    // ⚠ THE ENV MUST BE SET BEFORE THE MODULE IS IMPORTED, and the module
+    // RE-IMPORTED, or this control is VACUOUS. The defect being guarded is a
+    // MODULE-LEVEL `env.VITE_CEE_BFF_BASE || '/bff/cee'` const, which is
+    // evaluated once at import time — mutating the env afterwards and calling
+    // the already-imported function could never observe it, so the assertion
+    // would pass against the very code it exists to forbid. Verified by
+    // mutation: with the module const swapped for the env-resolved form, this
+    // case goes RED only in this shape.
+    const PLOT = 'https://plot-lite-service-staging.onrender.com/v1/cee'
+    const prev = (import.meta as any).env.VITE_CEE_BFF_BASE
+    try {
+      ;(import.meta as any).env.VITE_CEE_BFF_BASE = PLOT
+      vi.resetModules()
+      const fresh = await import('../scenarioGraph')
+
+      // Positive control: the env var really is visible to a fresh import, so a
+      // module that DID read it would see PLoT here.
+      expect((import.meta as any).env.VITE_CEE_BFF_BASE).toBe(PLOT)
+
+      expect(fresh.SCENARIO_GRAPH_BASE).toBe('/bff/cee')
+      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).toBe(
+        `/bff/cee/scenarios/${SCENARIO_ID}/graph`,
+      )
+      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).not.toContain('plot-lite')
+      expect(fresh.scenarioGraphUrl(SCENARIO_ID)).not.toContain('http')
+    } finally {
+      ;(import.meta as any).env.VITE_CEE_BFF_BASE = prev
+      vi.resetModules()
+    }
+  })
+
+  it('POSTs to the pinned URL with a JSON body', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await fetchScenarioGraph(SCENARIO_ID)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe(`/bff/cee/scenarios/${SCENARIO_ID}/graph`)
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+  })
+
+  it('sends user_id only when supplied, and never the guest sentinel', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await fetchScenarioGraph(SCENARIO_ID)
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({})
+
+    fetchSpy.mockClear()
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await fetchScenarioGraph(SCENARIO_ID, { userId: 'guest' })
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({})
+
+    fetchSpy.mockClear()
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await fetchScenarioGraph(SCENARIO_ID, { userId: 'u-42' })
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({ user_id: 'u-42' })
+  })
+})
+
+describe('scenarioGraph — 200 semantics', () => {
+  it('returns the graph VERBATIM alongside the identity envelope value', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    expect(res.status).toBe('graph')
+    if (res.status !== 'graph') return
+    expect(res.graph).toEqual({
+      nodes: [{ id: 'n1', kind: 'factor', label: 'N1' }],
+      edges: [],
+    })
+    expect(res.briefText).toBe('a brief')
+    expect(res.layoutPresent).toBe(false)
+  })
+
+  it('CONSUMER NOTE 1 — reads `.value` off the envelope, never the object', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    if (res.status !== 'graph') throw new Error('expected graph')
+    expect(res.identity).toEqual({
+      value: CEE_TOKEN,
+      projectionVersion: 'identity.v1',
+    })
+    // The object itself must never end up where the hash is expected.
+    expect(typeof res.identity?.value).toBe('string')
+    expect(res.identity?.value).not.toContain('graph_identity_hash')
+  })
+
+  it('CONSUMER NOTE 2 — stores CEE’s token VERBATIM (no local recomputation)', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    if (res.status !== 'graph') throw new Error('expected graph')
+    // Byte-identical to what CEE issued. Any locally-derived value — a hash of
+    // the graph, a JSON digest, anything — differs from this fixed token.
+    expect(res.identity?.value).toBe(CEE_TOKEN)
+  })
+
+  it('refuses a BARE STRING hash — the envelope trap — rather than adopting it', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ graph_identity_hash: CEE_TOKEN })),
+    )
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    if (res.status !== 'graph') throw new Error('expected graph')
+    expect(res.identity).toBeNull()
+  })
+
+  it('null identity envelope is carried as null, not fabricated', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ graph_identity_hash: null })),
+    )
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    if (res.status !== 'graph') throw new Error('expected graph')
+    expect(res.identity).toBeNull()
+  })
+
+  it('graph_present:false is ABSENT — a normal empty canvas, never an error', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: null, graph_present: false, graph_identity_hash: null }),
+      ),
+    )
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    expect(res.status).toBe('absent')
+  })
+
+  it('graph_present:true with a null graph DISAGREES — fail closed, never a graph', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ graph: null })))
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    expect(res.status).toBe('unusable')
+  })
+
+  it('a wrong schema discriminator is unusable, never adopted', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ schema: 'scenario_graph.v2' })),
+    )
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    expect(res.status).toBe('unusable')
+  })
+})
+
+describe('scenarioGraph — refusal semantics', () => {
+  it('CONSUMER NOTE 3 — 404 is NOT-READABLE, a distinct status from absent', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'NOT_FOUND' }))
+    const res = await fetchScenarioGraph(SCENARIO_ID)
+    expect(res.status).toBe('notReadable')
+    // The two must never collapse: `absent` means "no graph yet" (200),
+    // `notReadable` means "absent ∪ not-yours ∪ oracle-unresolvable".
+    expect(res.status).not.toBe('absent')
+  })
+
+  it('401 / 403 / 429 are refusals and are NOT retried', async () => {
+    for (const code of [401, 403, 429]) {
+      fetchSpy.mockClear()
+      fetchSpy.mockResolvedValue(jsonResponse(code, { error: 'x' }))
+      const res = await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
+      expect(res.status).toBe('refused')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('404 is NOT retried — it is a stable answer, not a blip', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'NOT_FOUND' }))
+    await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('scenarioGraph — 503 retry', () => {
+  it('CONSUMER NOTE 3 — 503 RETRIES and can succeed on a later attempt', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(503, { error: 'INTERNAL' }))
+      .mockResolvedValueOnce(jsonResponse(200, okBody()))
+    const res = await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(res.status).toBe('graph')
+  })
+
+  it('a persistent 503 ends UNAVAILABLE after a bounded number of attempts', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(503, { error: 'INTERNAL' }))
+    const res = await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
+    expect(res.status).toBe('unavailable')
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    // Never degrades into "no graph" — a DB blip must not read as an empty canvas.
+    expect(res.status).not.toBe('absent')
+    expect(res.status).not.toBe('notReadable')
+  })
+
+  it('a transport rejection is unusable, never absent', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'))
+    const res = await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
+    expect(res.status).toBe('unusable')
+  })
+})

--- a/src/adapters/cee/__tests__/scenarioGraph.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioGraph.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
@@ -18,6 +18,27 @@ import {
 } from '../scenarioGraph'
 
 const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+/** Drop comments so a guard cannot confuse PROSE about a var with USE of it. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
+    .join('\n')
+}
+
+/** Relative import specifiers, so the guard can follow one hop of indirection. */
+function relativeImportsOf(code: string): string[] {
+  return [...code.matchAll(/from\s+'(\.[^']+)'/g)].map((m) => m[1])
+}
+
+function resolveTs(base: string): string | null {
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts')]) {
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
 
 /** A 64-hex token no local computation in this repo could reproduce. */
 const CEE_TOKEN = 'a'.repeat(63) + '7'
@@ -98,15 +119,8 @@ describe('scenarioGraph — base resolution (⚠ hazard: VITE_CEE_BFF_BASE point
    */
   it('never RESOLVES its base from VITE_CEE_BFF_BASE (source-level, with a positive control)', () => {
     const dir = path.dirname(fileURLToPath(import.meta.url))
-    const moduleSrc = readFileSync(path.join(dir, '..', 'scenarioGraph.ts'), 'utf8')
-
-    // Strip comments: this file DISCUSSES the var at length, and a guard that
-    // could not tell prose from code would be unmaintainable.
-    const code = moduleSrc
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .split('\n')
-      .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
-      .join('\n')
+    const modulePath = path.join(dir, '..', 'scenarioGraph.ts')
+    const code = stripComments(readFileSync(modulePath, 'utf8'))
 
     expect(code).not.toContain('VITE_CEE_BFF_BASE')
     expect(code).not.toContain('VITE_BFF_BASE')
@@ -114,12 +128,38 @@ describe('scenarioGraph — base resolution (⚠ hazard: VITE_CEE_BFF_BASE point
     expect(code).not.toMatch(/https?:\/\//)
     expect(code).toContain("SCENARIO_GRAPH_BASE = '/bff/cee'")
 
-    // POSITIVE CONTROL (trap 13): the same read + match, pointed at a sibling
-    // that genuinely DOES resolve from the var. If this ever stops finding it,
-    // the guard above has stopped being able to see a presence and its absence
-    // assertions mean nothing.
+    // ⚠ BIND THE GUARD TO WHAT THE URL BUILDER ACTUALLY USES (review A4).
+    // The four assertions above were measured passing 18/18 against a realistic
+    // two-step refactor: import a base from a SIBLING module and leave
+    // `SCENARIO_GRAPH_BASE` in place but DEAD. No `VITE_` and no `http` appears
+    // in this file, so a spelling-presence guard is blind to it. Asserting on
+    // the builder's own body is what closes that: the constant has to be LIVE.
+    const builder = code.match(/export function scenarioGraphUrl[\s\S]*?\n\}/)?.[0]
+    expect(builder).toBeDefined()
+    expect(builder).toContain('SCENARIO_GRAPH_BASE')
+
+    // …and the indirection cannot be smuggled in through an import either.
+    for (const spec of relativeImportsOf(code)) {
+      const resolved = resolveTs(path.join(dir, '..', spec))
+      if (!resolved) continue
+      const importedCode = stripComments(readFileSync(resolved, 'utf8'))
+      expect(
+        importedCode.includes('VITE_CEE_BFF_BASE') || importedCode.includes('VITE_BFF_BASE'),
+        `${spec} resolves a base from an env var; importing it here would reintroduce the hazard`,
+      ).toBe(false)
+    }
+
+    // POSITIVE CONTROL (trap 13), now covering BOTH halves of the guard.
+    // (i) the spelling matcher can see a presence:
     const siblingSrc = readFileSync(path.join(dir, '..', 'client.ts'), 'utf8')
     expect(siblingSrc).toContain('VITE_CEE_BFF_BASE')
+    // (ii) the builder-body matcher can see the absence of the constant — proven
+    // against a synthetic body rather than trusted:
+    const deadConstantBody =
+      "export function scenarioGraphUrl(id: string): string {\n  return `${CEE_BASE_URL}/scenarios/${id}/graph`\n}"
+    expect(
+      deadConstantBody.match(/export function scenarioGraphUrl[\s\S]*?\n\}/)?.[0],
+    ).not.toContain('SCENARIO_GRAPH_BASE')
   })
 
   it('POSTs to the pinned URL with a JSON body', async () => {
@@ -173,7 +213,6 @@ describe('scenarioGraph — 200 semantics', () => {
     })
     // The object itself must never end up where the hash is expected.
     expect(typeof res.identity?.value).toBe('string')
-    expect(res.identity?.value).not.toContain('graph_identity_hash')
   })
 
   it('CONSUMER NOTE 2 — stores CEE’s token VERBATIM (no local recomputation)', async () => {
@@ -233,10 +272,10 @@ describe('scenarioGraph — refusal semantics', () => {
   it('CONSUMER NOTE 3 — 404 is NOT-READABLE, a distinct status from absent', async () => {
     fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'NOT_FOUND' }))
     const res = await fetchScenarioGraph(SCENARIO_ID)
-    expect(res.status).toBe('notReadable')
     // The two must never collapse: `absent` means "no graph yet" (200),
-    // `notReadable` means "absent ∪ not-yours ∪ oracle-unresolvable".
-    expect(res.status).not.toBe('absent')
+    // `notReadable` means "absent ∪ not-yours ∪ oracle-unresolvable" and is a
+    // REFUSAL. M3 in the battery is the mutant that collapses them.
+    expect(res.status).toBe('notReadable')
   })
 
   it('401 / 403 / 429 are refusals and are NOT retried', async () => {
@@ -271,9 +310,6 @@ describe('scenarioGraph — 503 retry', () => {
     const res = await fetchScenarioGraph(SCENARIO_ID, { retryDelayMs: 0 })
     expect(res.status).toBe('unavailable')
     expect(fetchSpy).toHaveBeenCalledTimes(3)
-    // Never degrades into "no graph" — a DB blip must not read as an empty canvas.
-    expect(res.status).not.toBe('absent')
-    expect(res.status).not.toBe('notReadable')
   })
 
   it('a transport rejection is unusable, never absent', async () => {

--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -73,6 +73,18 @@ export function scenarioGraphUrl(scenarioId: string): string {
 const MAX_ATTEMPTS = 3
 const DEFAULT_RETRY_DELAY_MS = 400
 
+/**
+ * Per-attempt deadline (review A3).
+ *
+ * ⚠ THIS IS A CORRECTNESS BOUND, NOT A UX NICETY. CEE staging cold-starts, and
+ * an answer that arrives tens of seconds after boot describes a graph the user
+ * has since edited on screen. Applying it then is not "late hydration", it is a
+ * SILENT ROLLBACK of work done in the window — and the autosave would persist
+ * the rolled-back state moments later, destroying the last copy. Bounding the
+ * wait bounds that window.
+ */
+const DEFAULT_TIMEOUT_MS = 8000
+
 /** The guest sentinel `AuthContext` mints; never a Supabase user id. */
 const GUEST_USER_ID = 'guest'
 
@@ -116,6 +128,8 @@ export interface FetchScenarioGraphOptions {
   signal?: AbortSignal
   /** Backoff between 503 retries. Tests pass 0. */
   retryDelayMs?: number
+  /** Per-attempt deadline. See `DEFAULT_TIMEOUT_MS`. */
+  timeoutMs?: number
 }
 
 function sleep(ms: number): Promise<void> {
@@ -224,22 +238,44 @@ export async function fetchScenarioGraph(
   const url = scenarioGraphUrl(scenarioId)
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    // One deadline per attempt, chained to any caller signal so an unmount
+    // still cancels immediately.
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const attemptController = new AbortController()
+    const onCallerAbort = () => attemptController.abort()
+    if (opts.signal) {
+      if (opts.signal.aborted) return { status: 'unusable' }
+      opts.signal.addEventListener('abort', onCallerAbort, { once: true })
+    }
+    const timer =
+      timeoutMs > 0 ? setTimeout(() => attemptController.abort(), timeoutMs) : null
+
     let response: Response
     try {
       response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-        signal: opts.signal,
+        signal: attemptController.signal,
       })
     } catch (err) {
-      // Transport failure — offline, CORS, TLS, abort. Unknown, never absent.
-      if ((err as Error)?.name === 'AbortError') return { status: 'unusable' }
+      // Transport failure — offline, CORS, TLS, deadline, or caller abort.
+      // Unknown, never absent.
+      if ((err as Error)?.name === 'AbortError') {
+        logger.warn('scenario_graph.aborted', {
+          attempt,
+          timedOut: !opts.signal?.aborted,
+        })
+        return { status: 'unusable' }
+      }
       logger.warn('scenario_graph.transport_failure', {
         attempt,
         error: (err as Error)?.message ?? 'unknown',
       })
       return { status: 'unusable' }
+    } finally {
+      if (timer !== null) clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onCallerAbort)
     }
 
     if (response.status === 503) {

--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -1,0 +1,279 @@
+/**
+ * scenarioGraph — the UI's client for CEE's scenario-addressed graph read.
+ *
+ * ROADMAP 2.312 piece 3. Server contract frozen in olumi-assistants-service
+ * PR #804 (merged `ecdc4cf`): `POST /assist/v1/scenarios/{id}/graph` →
+ * `scenario_graph.v1`, reached from the browser as `/bff/cee/scenarios/{id}/graph`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠ WHY THIS FILE DOES NOT USE `VITE_CEE_BFF_BASE` — READ BEFORE "TIDYING"
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Every other CEE caller in this repo resolves its base as
+ * `import.meta.env.VITE_CEE_BFF_BASE || '/bff/cee'`. That looks like the
+ * house style, and copying it here would send this call to the WRONG SERVICE.
+ *
+ * `VITE_CEE_BFF_BASE` is not set anywhere in this tree, so it reads as the
+ * same-origin `/bff/cee` locally — but it IS set in the Netlify dashboard, to
+ * the absolute PLoT URL `https://plot-lite-service-staging.onrender.com/v1/cee`,
+ * and Vite INLINES it at build time. The deployed bundle therefore contains
+ * ZERO `/bff/cee` literals and four absolute PLoT bases (established by a
+ * recursive crawl of the deployed JS chunks, 4 Aug 2026; the same posture is
+ * recorded at `src/canvas/stores/readinessStore.ts` for the readiness path,
+ * which genuinely is a PLoT-served endpoint).
+ *
+ * PLoT does not serve `scenario_graph.v1`. A hydrate call resolved from that
+ * var would leave the same-origin edge seam entirely, hit PLoT, and 404 — and
+ * a 404 on this route means "not readable", so the failure would be
+ * indistinguishable from a legitimate refusal and the canvas would silently
+ * never hydrate. This is CLAUDE.md trap 18 in its live form: the env posture
+ * is NOT derivable from this repo.
+ *
+ * So the base is a DEDICATED same-origin constant. `/bff/cee/*` is owned by
+ * `netlify/edge-functions/cee-proxy.ts`, which rewrites the prefix to
+ * `/assist/v1` and injects `X-Olumi-Assist-Key` server-side; `vite.config.ts`
+ * proxies the same prefix the same way in dev. Both hops are already in the
+ * tree, so the resolved URL shape is pinned by spec rather than assumed.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE FOUR BINDING CONSUMER NOTES (from the merged PR body)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 1. `graph_identity_hash` is an ENVELOPE OBJECT — read `.value`. A consumer
+ *    that treats the field itself as the hash compares objects and gets a
+ *    permanent false "changed".
+ * 2. The token is OPAQUE and CEE-ISSUED. Store it, compare CEE-to-CEE, gate on
+ *    `.projection_version`, and NEVER recompute it locally — the normalisation
+ *    and strip list are CEE's, are versioned so they can move, and have no
+ *    client-side counterpart.
+ * 3. `404` means NOT READABLE (absent ∪ not-yours ∪ oracle-unresolvable). It is
+ *    NOT authoritative deletion and must never discard the local canvas.
+ *    `503` means retry.
+ * 4. No `updated_at`/`version` by ruling — the hash token is the staleness
+ *    anchor and a "last synced" display is out of scope.
+ *
+ * ⚠ THE RESPONSE CARRIES NO LAYOUT. `scenarios.graph` holds no canvas
+ * geometry, and `layout_present` is MEASURED on the returned bytes rather than
+ * promised — it is `false` for every real graph today. Positions are merged
+ * locally; see `canvas/utils/mergeServerGraph.ts`.
+ */
+
+import { logger } from '../../lib/logger'
+
+/**
+ * The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see the header.
+ * Deliberately a literal: an env-resolved base is exactly the defect above.
+ */
+export const SCENARIO_GRAPH_BASE = '/bff/cee'
+
+/** `POST` — the scenario is addressed in the path, identity travels in the body. */
+export function scenarioGraphUrl(scenarioId: string): string {
+  return `${SCENARIO_GRAPH_BASE}/scenarios/${encodeURIComponent(scenarioId)}/graph`
+}
+
+/** Total attempts on a retryable (503) answer: the first plus two retries. */
+const MAX_ATTEMPTS = 3
+const DEFAULT_RETRY_DELAY_MS = 400
+
+/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
+const GUEST_USER_ID = 'guest'
+
+/**
+ * CEE's `identity.v1` envelope, reduced to the two fields a consumer may act on.
+ * `value` is opaque; `projectionVersion` is the gate that makes a comparison
+ * meaningful. Nothing here is ever computed on this side.
+ */
+export interface ScenarioGraphIdentity {
+  /** CEE's token, VERBATIM. Compare CEE-to-CEE only. */
+  readonly value: string
+  /** `graph_identity_hash.projection_version` — never compare across values. */
+  readonly projectionVersion: string
+}
+
+export type ScenarioGraphResult =
+  /** 200 with a graph. `graph` is `scenarios.graph` verbatim; it carries no layout. */
+  | {
+      status: 'graph'
+      graph: unknown
+      briefText: string | null
+      identity: ScenarioGraphIdentity | null
+      /** MEASURED by CEE on the returned bytes. `false` for every real graph today. */
+      layoutPresent: boolean
+      requestId: string | null
+    }
+  /** 200, `graph_present:false` — the scenario exists and has no graph yet. Normal. */
+  | { status: 'absent'; requestId: string | null }
+  /** 404 — absent ∪ not-yours ∪ oracle-unresolvable. NEVER deletion. */
+  | { status: 'notReadable' }
+  /** 503 after every attempt — unknown, try again. NEVER an empty canvas. */
+  | { status: 'unavailable' }
+  /** 401 / 403 / 429 — a stable refusal; not retried. */
+  | { status: 'refused'; httpStatus: number }
+  /** Transport failure, unparseable body, or a shape that contradicts itself. */
+  | { status: 'unusable' }
+
+export interface FetchScenarioGraphOptions {
+  /** Supabase user id. Omitted for guest/unowned scenarios. */
+  userId?: string | null
+  signal?: AbortSignal
+  /** Backoff between 503 retries. Tests pass 0. */
+  retryDelayMs?: number
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * CONSUMER NOTE 1. Accepts ONLY the envelope object and reads `.value` from it.
+ *
+ * A bare string is REFUSED rather than adopted: if CEE ever regressed to
+ * emitting a naked hash, silently accepting it would make this consumer agree
+ * with a shape the contract does not define, and the `projection_version` gate
+ * — the thing that makes a comparison meaningful at all — would be gone with
+ * no signal. Null is the honest answer, and a null token never suppresses a
+ * merge downstream.
+ */
+function readIdentityEnvelope(raw: unknown): ScenarioGraphIdentity | null {
+  if (raw === null || raw === undefined) return null
+  if (typeof raw !== 'object') {
+    logger.warn('scenario_graph.identity_not_an_envelope', {
+      receivedType: typeof raw,
+    })
+    return null
+  }
+  const env = raw as Record<string, unknown>
+  const value = env.value
+  const projectionVersion = env.projection_version
+  if (typeof value !== 'string' || value.length === 0) return null
+  if (typeof projectionVersion !== 'string' || projectionVersion.length === 0) {
+    return null
+  }
+  return { value, projectionVersion }
+}
+
+function parseOk(body: unknown): ScenarioGraphResult {
+  if (body === null || typeof body !== 'object') return { status: 'unusable' }
+  const b = body as Record<string, unknown>
+
+  // The discriminator is a literal in the contract. A different one means the
+  // route moved under us; adopting it would be guessing at a shape.
+  if (b.schema !== 'scenario_graph.v1') {
+    logger.warn('scenario_graph.unexpected_schema', { schema: String(b.schema) })
+    return { status: 'unusable' }
+  }
+
+  const requestId = typeof b.request_id === 'string' ? b.request_id : null
+
+  // `graph_present` is explicit precisely so presence is never inferred from a
+  // falsy check. It is the authority — but it must AGREE with the bytes.
+  const graphPresent = b.graph_present === true
+  const graph = b.graph
+  const graphIsObject = graph !== null && typeof graph === 'object'
+
+  if (!graphPresent) {
+    // Fail closed on disagreement in either direction: a body claiming no graph
+    // while carrying one is not a shape we can act on.
+    if (graphIsObject) {
+      logger.warn('scenario_graph.presence_disagreement', { graphPresent: false })
+      return { status: 'unusable' }
+    }
+    return { status: 'absent', requestId }
+  }
+
+  if (!graphIsObject) {
+    logger.warn('scenario_graph.presence_disagreement', { graphPresent: true })
+    return { status: 'unusable' }
+  }
+
+  return {
+    status: 'graph',
+    graph,
+    briefText: typeof b.brief_text === 'string' ? b.brief_text : null,
+    identity: readIdentityEnvelope(b.graph_identity_hash),
+    layoutPresent: b.layout_present === true,
+    requestId,
+  }
+}
+
+/**
+ * Read the scenario's server-side graph.
+ *
+ * Never throws: every failure mode is a discriminated status, because the one
+ * outcome this must not produce is a caller that cannot tell "no graph" from
+ * "could not read". A 503 is retried; a 404 and the auth/rate refusals are
+ * stable answers and are not.
+ */
+export async function fetchScenarioGraph(
+  scenarioId: string,
+  opts: FetchScenarioGraphOptions = {},
+): Promise<ScenarioGraphResult> {
+  const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
+
+  // Identity travels in the BODY: with `CEE_REQUIRE_USER_JWT` off (staging),
+  // CEE's ownership pre-flight reads `user_id` from the request extensions.
+  // The guest sentinel is not a Supabase id and must never be sent as one.
+  const body: Record<string, unknown> = {}
+  if (
+    typeof opts.userId === 'string' &&
+    opts.userId.length > 0 &&
+    opts.userId !== GUEST_USER_ID
+  ) {
+    body.user_id = opts.userId
+  }
+
+  const url = scenarioGraphUrl(scenarioId)
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: opts.signal,
+      })
+    } catch (err) {
+      // Transport failure — offline, CORS, TLS, abort. Unknown, never absent.
+      if ((err as Error)?.name === 'AbortError') return { status: 'unusable' }
+      logger.warn('scenario_graph.transport_failure', {
+        attempt,
+        error: (err as Error)?.message ?? 'unknown',
+      })
+      return { status: 'unusable' }
+    }
+
+    if (response.status === 503) {
+      if (attempt < MAX_ATTEMPTS) {
+        await sleep(retryDelayMs)
+        continue
+      }
+      return { status: 'unavailable' }
+    }
+
+    // CONSUMER NOTE 3: this is "not readable", not "deleted". The caller must
+    // leave the canvas alone.
+    if (response.status === 404) return { status: 'notReadable' }
+
+    if (
+      response.status === 401 ||
+      response.status === 403 ||
+      response.status === 429
+    ) {
+      return { status: 'refused', httpStatus: response.status }
+    }
+
+    if (!response.ok) {
+      logger.warn('scenario_graph.unexpected_status', { status: response.status })
+      return { status: 'unusable' }
+    }
+
+    try {
+      return parseOk(await response.json())
+    } catch {
+      return { status: 'unusable' }
+    }
+  }
+
+  /* c8 ignore next -- unreachable: the loop returns on every terminal status */
+  return { status: 'unavailable' }
+}

--- a/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
+++ b/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
@@ -20,11 +20,20 @@ vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({ user }),
 }))
 
-let spy: ReturnType<typeof vi.spyOn>
+/**
+ * Typed through a factory rather than `ReturnType<typeof vi.spyOn>`, which
+ * widens to `MockInstance<unknown[], unknown>` and does not accept the real
+ * spy — the typecheck gate caught that as a genuine new error.
+ */
+function spyOnHydrate() {
+  return vi.spyOn(hydration, 'hydrateCanvasFromServer').mockResolvedValue('merged')
+}
+
+let spy: ReturnType<typeof spyOnHydrate>
 
 beforeEach(() => {
   user = { id: 'guest' }
-  spy = vi.spyOn(hydration, 'hydrateCanvasFromServer').mockResolvedValue('merged')
+  spy = spyOnHydrate()
 })
 
 afterEach(() => {

--- a/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
+++ b/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * useServerGraphHydration — the hook's own guarantees (adversarial review A2/A6).
+ *
+ * Every claim pinned here was COMMENT-ONLY before: the once-per-scenario guard,
+ * the abort on dependency change, and the StrictMode double-mount fix. A
+ * docstring is not a test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { StrictMode } from 'react'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useServerGraphHydration } from '../useServerGraphHydration'
+import * as hydration from '../../hydrate/serverGraphHydration'
+
+const A = '11111111-2222-4333-8444-555555555555'
+const B = '22222222-3333-4444-8555-666666666666'
+
+let user: { id: string } | null = { id: 'guest' }
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user }),
+}))
+
+let spy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  user = { id: 'guest' }
+  spy = vi.spyOn(hydration, 'hydrateCanvasFromServer').mockResolvedValue('merged')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useServerGraphHydration — once per scenario', () => {
+  it('hydrates once for a scenario id and not again on re-render', async () => {
+    const { rerender } = renderHook(({ id }) => useServerGraphHydration(id), {
+      initialProps: { id: A },
+    })
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    rerender({ id: A })
+    rerender({ id: A })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates AGAIN when the scenario id changes', async () => {
+    const { rerender } = renderHook(({ id }) => useServerGraphHydration(id), {
+      initialProps: { id: A },
+    })
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    rerender({ id: B })
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2))
+    expect(spy.mock.calls[1][0]).toBe(B)
+  })
+
+  it('makes NO call without a scenario id', () => {
+    renderHook(() => useServerGraphHydration(null))
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useServerGraphHydration — cancellation', () => {
+  it('ABORTS the in-flight read when the scenario id changes', async () => {
+    const { rerender } = renderHook(({ id }) => useServerGraphHydration(id), {
+      initialProps: { id: A },
+    })
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    const firstSignal = (spy.mock.calls[0][1] as any).signal as AbortSignal
+    expect(firstSignal.aborted).toBe(false)
+
+    rerender({ id: B })
+    expect(firstSignal.aborted).toBe(true)
+  })
+
+  it('aborts on unmount', async () => {
+    const { unmount } = renderHook(() => useServerGraphHydration(A))
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    const signal = (spy.mock.calls[0][1] as any).signal as AbortSignal
+    unmount()
+    expect(signal.aborted).toBe(true)
+  })
+})
+
+describe('useServerGraphHydration — StrictMode (A6)', () => {
+  /**
+   * The defect this pins: the ref was marked "attempted" BEFORE the async call,
+   * so StrictMode's dev double-mount aborted the first attempt and the second
+   * effect early-returned on that same ref. Hydration therefore NEVER ran in
+   * development, while production was fine — so a manual dev check would have
+   * observed "no hydration" and drawn exactly the wrong conclusion about
+   * shipped code.
+   */
+  it('still hydrates under StrictMode double-mount', async () => {
+    renderHook(() => useServerGraphHydration(A), { wrapper: StrictMode })
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    // The surviving mount's read must not be an aborted one.
+    const live = spy.mock.calls.some(
+      (c) => !((c[1] as any).signal as AbortSignal).aborted,
+    )
+    expect(live).toBe(true)
+  })
+})
+
+describe('useServerGraphHydration — identity', () => {
+  it('passes the auth user id through', async () => {
+    user = { id: 'user-42' }
+    renderHook(() => useServerGraphHydration(A))
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect((spy.mock.calls[0][1] as any).userId).toBe('user-42')
+  })
+})

--- a/src/canvas/hooks/useServerGraphHydration.ts
+++ b/src/canvas/hooks/useServerGraphHydration.ts
@@ -1,0 +1,59 @@
+/**
+ * useServerGraphHydration — mounts the boot-time server-graph merge.
+ *
+ * ROADMAP 2.312 piece 3. All of the behaviour lives in
+ * `hydrate/serverGraphHydration.ts`; this hook is only the trigger, so the
+ * outcomes stay measurable without React.
+ *
+ * ORDERING. The canvas restores from the localStorage autosave inside
+ * `ReactFlowGraph`'s init effect, which also sets `currentScenarioId` from the
+ * autosave's own stamp. React runs child effects before parent effects, and
+ * `ReactFlowGraph` is a child of the route that calls this hook — so by the
+ * time this fires the local canvas is already on screen and the scenario id is
+ * in hand. That order is what makes the merge a merge: the server's values are
+ * overlaid onto real local nodes carrying real local positions, rather than
+ * racing an empty store.
+ *
+ * ONCE PER SCENARIO. Keyed on the scenario id, not on mount, so a route change
+ * A→B hydrates B while a re-render of A does not re-request. An in-flight read
+ * is aborted when the id changes: the answer would describe the previous
+ * scenario, and `hydrateCanvasFromServer` refuses it anyway.
+ */
+
+import { useEffect, useRef } from 'react'
+import { useCanvasStore } from '../store'
+import { useAuth } from '../../contexts/AuthContext'
+import { hydrateCanvasFromServer } from '../hydrate/serverGraphHydration'
+import { logger } from '../../lib/logger'
+
+export function useServerGraphHydration(scenarioIdFromRoute?: string | null): void {
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const { user } = useAuth()
+
+  // The store id is the general source — it is what the guest boot path sets
+  // from the autosave, and guest is the tier that actually ships. The route
+  // param is the fallback for a deep link that has not reached the store yet.
+  const scenarioId = currentScenarioId ?? scenarioIdFromRoute ?? null
+
+  const hydratedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!scenarioId) return
+    if (hydratedRef.current === scenarioId) return
+    hydratedRef.current = scenarioId
+
+    const controller = new AbortController()
+
+    // Fire-and-forget by design: hydration is an improvement on what is already
+    // on screen, never a precondition for it. `hydrateCanvasFromServer` never
+    // rejects, so the canvas cannot be left mid-boot by a failure here.
+    void hydrateCanvasFromServer(scenarioId, {
+      userId: user?.id ?? null,
+      signal: controller.signal,
+    }).then((outcome) => {
+      logger.debug('server_graph_hydration.outcome', { scenarioId, outcome })
+    })
+
+    return () => controller.abort()
+  }, [scenarioId, user?.id])
+}

--- a/src/canvas/hooks/useServerGraphHydration.ts
+++ b/src/canvas/hooks/useServerGraphHydration.ts
@@ -35,14 +35,15 @@ export function useServerGraphHydration(scenarioIdFromRoute?: string | null): vo
   // param is the fallback for a deep link that has not reached the store yet.
   const scenarioId = currentScenarioId ?? scenarioIdFromRoute ?? null
 
-  const hydratedRef = useRef<string | null>(null)
+  const attemptedRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!scenarioId) return
-    if (hydratedRef.current === scenarioId) return
-    hydratedRef.current = scenarioId
+    if (attemptedRef.current === scenarioId) return
+    attemptedRef.current = scenarioId
 
     const controller = new AbortController()
+    let settled = false
 
     // Fire-and-forget by design: hydration is an improvement on what is already
     // on screen, never a precondition for it. `hydrateCanvasFromServer` never
@@ -51,9 +52,23 @@ export function useServerGraphHydration(scenarioIdFromRoute?: string | null): vo
       userId: user?.id ?? null,
       signal: controller.signal,
     }).then((outcome) => {
+      settled = true
       logger.debug('server_graph_hydration.outcome', { scenarioId, outcome })
     })
 
-    return () => controller.abort()
+    return () => {
+      controller.abort()
+      // ⚠ AN ABORTED ATTEMPT IS NOT AN ATTEMPT (review A6). React StrictMode
+      // mounts every effect twice in dev: the first run set the ref and was
+      // then torn down and aborted, and the second run early-returned on that
+      // same ref — so hydration NEVER ran in development. Production was
+      // unaffected, which is the trap: any manual dev check would have observed
+      // "no hydration" and drawn exactly the wrong conclusion about shipped
+      // code. Releasing the ref when the attempt did not settle makes the dev
+      // and prod paths agree, and costs nothing in prod, where this cleanup
+      // only fires on a dependency change (which must re-hydrate anyway) or on
+      // unmount (where there is nothing left to guard).
+      if (!settled) attemptedRef.current = null
+    }
   }, [scenarioId, user?.id])
 }

--- a/src/canvas/hydrate/__tests__/serverGraphHydration.spec.ts
+++ b/src/canvas/hydrate/__tests__/serverGraphHydration.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * hydrateCanvasFromServer — RED-first spec (ROADMAP 2.312 piece 3).
+ *
+ * The boot orchestration: read the server's graph for the scenario in hand and
+ * merge its VALUES onto the local canvas, keeping the local LAYOUT. Every
+ * non-200 answer leaves the canvas exactly as it was — a refusal is never a
+ * deletion and a blip is never an empty canvas.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { hydrateCanvasFromServer } from '../serverGraphHydration'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const CEE_TOKEN = 'a'.repeat(63) + '7'
+const CEE_TOKEN_2 = 'b'.repeat(63) + '4'
+
+const A_POS = { x: 10, y: 20 }
+const B_POS = { x: 300, y: 400 }
+
+function envelope(value = CEE_TOKEN, projection = 'identity.v1') {
+  return {
+    kind: 'graph_identity_hash',
+    value,
+    algorithm: 'sha256',
+    projection_version: projection,
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+function okBody(over: Record<string, unknown> = {}) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph: {
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
+      ],
+      edges: [],
+    },
+    graph_present: true,
+    brief_text: null,
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'req-1',
+    ...over,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+function seedCanvas(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { ...A_POS },
+        data: { label: 'Spend', kind: 'factor', value: 100 },
+      },
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { ...B_POS },
+        data: { label: 'Profit', kind: 'goal', value: 5 },
+      },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function nodeById(id: string): any {
+  return useCanvasStore.getState().nodes.find((n: any) => n.id === id)
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+  seedCanvas()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('hydrateCanvasFromServer — boot WITH a server graph', () => {
+  it('hydrates the server’s values and keeps the LOCAL positions', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(outcome).toBe('merged')
+    expect(nodeById('factor-1').data.value).toBe(250)
+    expect(nodeById('goal-1').data.value).toBe(9)
+    expect(nodeById('factor-1').position).toEqual(A_POS)
+    expect(nodeById('goal-1').position).toEqual(B_POS)
+  })
+
+  it('stores CEE’s identity token VERBATIM, envelope fields intact', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(useCanvasStore.getState().serverGraphIdentity).toEqual({
+      value: CEE_TOKEN,
+      projectionVersion: 'identity.v1',
+    })
+  })
+
+  it('MUTANT GUARD — the stored token is CEE’s, never locally recomputed', async () => {
+    // The fixture token is a fixed 64-hex string with no relationship to the
+    // graph bytes. Any local re-derivation (a hash of the graph, a digest of
+    // the JSON, a checksum) produces a different value and fails here.
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(useCanvasStore.getState().serverGraphIdentity?.value).toBe(CEE_TOKEN)
+  })
+})
+
+describe('hydrateCanvasFromServer — CEE-to-CEE token comparison only', () => {
+  it('skips the merge when CEE returns the SAME token at the SAME projection', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+
+    // Local edit after the first hydrate; a second identical read must not
+    // silently roll it back — the token says the server has not moved.
+    useCanvasStore.setState({
+      nodes: useCanvasStore
+        .getState()
+        .nodes.map((n: any) =>
+          n.id === 'factor-1' ? { ...n, data: { ...n.data, value: 777 } } : n,
+        ) as never,
+    })
+
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('unchanged')
+    expect(nodeById('factor-1').data.value).toBe(777)
+  })
+
+  it('re-merges when CEE issues a DIFFERENT token', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({
+          graph_identity_hash: envelope(CEE_TOKEN_2),
+          graph: {
+            nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 42 }],
+            edges: [],
+          },
+        }),
+      ),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(nodeById('factor-1').data.value).toBe(42)
+  })
+
+  it('NEVER compares across projection_version — a version change always re-merges', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+
+    // Same token VALUE, different projection. The values are not comparable
+    // across projections, so equality here must not be trusted.
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({
+          graph_identity_hash: envelope(CEE_TOKEN, 'identity.v2'),
+          graph: {
+            nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 42 }],
+            edges: [],
+          },
+        }),
+      ),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(nodeById('factor-1').data.value).toBe(42)
+    expect(useCanvasStore.getState().serverGraphIdentity).toEqual({
+      value: CEE_TOKEN,
+      projectionVersion: 'identity.v2',
+    })
+  })
+
+  it('a null token never suppresses a merge', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ graph_identity_hash: null })),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(useCanvasStore.getState().serverGraphIdentity).toBeNull()
+  })
+})
+
+describe('hydrateCanvasFromServer — refusals never touch the canvas', () => {
+  it('404 leaves the canvas EXACTLY as it was — never a deletion', async () => {
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'NOT_FOUND' }))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID, { retryDelayMs: 0 })).toBe(
+      'notReadable',
+    )
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    expect(useCanvasStore.getState().nodes).toHaveLength(2)
+    expect(nodeById('factor-1').data.value).toBe(100)
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+  })
+
+  it('200 + graph_present:false leaves the canvas untouched (honest absence)', async () => {
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: null, graph_present: false, graph_identity_hash: null }),
+      ),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('absent')
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
+  it('a persistent 503 RETRIES and then leaves the canvas untouched', async () => {
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockResolvedValue(jsonResponse(503, { error: 'INTERNAL' }))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID, { retryDelayMs: 0 })).toBe(
+      'unavailable',
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
+  it('a 503 that clears on retry DOES hydrate', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(503, { error: 'INTERNAL' }))
+      .mockResolvedValueOnce(jsonResponse(200, okBody()))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID, { retryDelayMs: 0 })).toBe(
+      'merged',
+    )
+    expect(nodeById('factor-1').data.value).toBe(250)
+    expect(nodeById('factor-1').position).toEqual(A_POS)
+  })
+
+  it('401 leaves the canvas untouched', async () => {
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockResolvedValue(jsonResponse(401, { error: 'UNAUTHENTICATED' }))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID, { retryDelayMs: 0 })).toBe(
+      'refused',
+    )
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+})
+
+describe('hydrateCanvasFromServer — guards', () => {
+  it('makes NO request without a scenario id', async () => {
+    expect(await hydrateCanvasFromServer(null)).toBe('skipped')
+    expect(await hydrateCanvasFromServer('')).toBe('skipped')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('makes NO request for a non-UUID scenario id', async () => {
+    expect(await hydrateCanvasFromServer('draft-local-1')).toBe('skipped')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/hydrate/__tests__/serverGraphHydration.spec.ts
+++ b/src/canvas/hydrate/__tests__/serverGraphHydration.spec.ts
@@ -12,6 +12,7 @@ import { useCanvasStore } from '../../store'
 import { hydrateCanvasFromServer } from '../serverGraphHydration'
 
 const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const OTHER_SCENARIO_ID = '99999999-8888-4777-8666-555555555555'
 const CEE_TOKEN = 'a'.repeat(63) + '7'
 const CEE_TOKEN_2 = 'b'.repeat(63) + '4'
 
@@ -268,5 +269,44 @@ describe('hydrateCanvasFromServer — guards', () => {
   it('makes NO request for a non-UUID scenario id', async () => {
     expect(await hydrateCanvasFromServer('draft-local-1')).toBe('skipped')
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('REFUSES a graph whose scenario moved under the in-flight read', async () => {
+    // The request is slower than a route change, so an answer can arrive for a
+    // scenario the user has already left. Applying it would graft decision A's
+    // graph onto decision B's canvas.
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockImplementation(async () => {
+      useCanvasStore.setState({ currentScenarioId: OTHER_SCENARIO_ID } as never)
+      return jsonResponse(200, okBody())
+    })
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('skipped')
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    expect(useCanvasStore.getState().serverGraphIdentity).toBeNull()
+  })
+})
+
+describe('hydrateCanvasFromServer — the late-answer deadline (A3)', () => {
+  it('gives up on a hung read rather than rolling the canvas back later', async () => {
+    // A cold-start answer arriving tens of seconds after boot describes a graph
+    // the user has since edited on screen; applying it then is a silent
+    // rollback, and the autosave would persist it moments later.
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        }),
+    )
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID, {
+      timeoutMs: 5,
+      retryDelayMs: 0,
+    })
+    expect(outcome).toBe('unusable')
+    expect(useCanvasStore.getState().nodes).toBe(before)
   })
 })

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -1,0 +1,152 @@
+/**
+ * serverGraphHydration — the boot orchestration for ROADMAP 2.312 piece 3.
+ *
+ * Reads the scenario's graph from CEE and merges its VALUES onto the restored
+ * canvas, keeping the LOCAL layout. Deliberately a plain async function rather
+ * than logic inside a hook, so every boot outcome — including the refusals —
+ * is measurable without mounting React.
+ *
+ * ⚠ THE ONE INVARIANT: an answer that is not a graph NEVER touches the canvas.
+ * A 404 on this route is "not readable" — the union of absent, not-yours and
+ * ownership-oracle-unresolvable — and is explicitly NOT authoritative deletion;
+ * a 503 is "unknown, try again". Both leave the canvas exactly as the autosave
+ * restored it, with no error surfaced: a user who is offline, or whose guest
+ * scenario the server has never seen, is in a normal state and has nothing to
+ * act on. Rendering a DB blip as an empty canvas over live data is the precise
+ * failure the server's fail-closed 503 exists to prevent, and it would be
+ * reintroduced here by treating any of these as "no graph".
+ */
+
+import { useCanvasStore } from '../store'
+import { logger } from '../../lib/logger'
+import { fetchScenarioGraph } from '../../adapters/cee/scenarioGraph'
+import { mergeServerGraphOnHydrate } from '../utils/mergeServerGraph'
+
+export type HydrationOutcome =
+  /** The server's graph was read and merged onto the canvas. */
+  | 'merged'
+  /** Read fine; CEE's token says the server graph has not moved. No write. */
+  | 'unchanged'
+  /** 200 with no graph yet — a normal empty scenario. Canvas untouched. */
+  | 'absent'
+  /** 404 — not readable. NEVER deletion. Canvas untouched. */
+  | 'notReadable'
+  /** 503 through every attempt. Canvas untouched. */
+  | 'unavailable'
+  /** 401 / 403 / 429. Canvas untouched. */
+  | 'refused'
+  /** Transport failure or a shape we cannot act on. Canvas untouched. */
+  | 'unusable'
+  /** No usable scenario id — nothing was requested. */
+  | 'skipped'
+
+export interface HydrateFromServerOptions {
+  /** Supabase user id, when signed in. Omitted for guests. */
+  userId?: string | null
+  signal?: AbortSignal
+  retryDelayMs?: number
+}
+
+/**
+ * A scenario id CEE can address is a UUID — `scenarios.id` is a uuid column, so
+ * anything else is a local draft id and would spend a request to earn a
+ * guaranteed refusal.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Whether CEE's answer is the SAME graph we already hydrated from.
+ *
+ * ⚠ CEE-TO-CEE, GATED ON `projectionVersion`. Both sides of this comparison are
+ * tokens CEE issued; nothing here is derived locally, and equality is only
+ * meaningful WITHIN one projection. When the projection differs the values are
+ * simply not comparable — the normalisation behind them has changed — so the
+ * answer is "not known to be the same", which re-merges. Comparing across
+ * versions would silently skip a hydration on a coincidence of bytes.
+ */
+function isSameServerGraph(
+  stored: { value: string; projectionVersion: string } | null,
+  fetched: { value: string; projectionVersion: string } | null,
+): boolean {
+  if (!stored || !fetched) return false
+  if (stored.projectionVersion !== fetched.projectionVersion) return false
+  return stored.value === fetched.value
+}
+
+/**
+ * Hydrate the canvas from the server's copy of this scenario's graph.
+ *
+ * Never throws and never rejects — the caller is a boot effect, and an
+ * unhandled rejection at boot is how a canvas ends up in an undefined state.
+ */
+export async function hydrateCanvasFromServer(
+  scenarioId: string | null | undefined,
+  opts: HydrateFromServerOptions = {},
+): Promise<HydrationOutcome> {
+  if (typeof scenarioId !== 'string' || !UUID_RE.test(scenarioId)) {
+    return 'skipped'
+  }
+
+  const result = await fetchScenarioGraph(scenarioId, {
+    userId: opts.userId,
+    signal: opts.signal,
+    retryDelayMs: opts.retryDelayMs,
+  })
+
+  // ── Every non-graph answer: leave the canvas alone, say why, surface nothing.
+  if (result.status !== 'graph') {
+    logger.debug('server_graph_hydration.no_merge', {
+      scenarioId,
+      outcome: result.status,
+    })
+    switch (result.status) {
+      case 'absent':
+        return 'absent'
+      case 'notReadable':
+        return 'notReadable'
+      case 'unavailable':
+        return 'unavailable'
+      case 'refused':
+        return 'refused'
+      default:
+        return 'unusable'
+    }
+  }
+
+  // A canvas whose scenario changed under an in-flight read must not receive
+  // another scenario's graph — the request is slower than a route change.
+  const currentId = useCanvasStore.getState().currentScenarioId
+  if (currentId !== null && currentId !== undefined && currentId !== scenarioId) {
+    logger.warn('server_graph_hydration.scenario_moved', {
+      requestedScenarioId: scenarioId,
+      currentScenarioId: currentId,
+    })
+    return 'skipped'
+  }
+
+  const stored = useCanvasStore.getState().serverGraphIdentity
+  if (isSameServerGraph(stored, result.identity)) {
+    // The server has not moved since we last hydrated, so there is nothing to
+    // apply. Skipping is not merely an optimisation: re-merging would roll a
+    // local edit made since that hydration back to the same server value the
+    // user has already been shown once.
+    return 'unchanged'
+  }
+
+  mergeServerGraphOnHydrate(result.graph)
+
+  // Store CEE's token VERBATIM — after the merge, so a throw could not leave a
+  // token recorded for a graph that was never applied. `null` when CEE issued
+  // none (an identity-empty graph), which never suppresses a later merge.
+  useCanvasStore.getState().setServerGraphIdentity(
+    result.identity
+      ? {
+          value: result.identity.value,
+          projectionVersion: result.identity.projectionVersion,
+        }
+      : null,
+  )
+
+  return 'merged'
+}

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -45,6 +45,8 @@ export interface HydrateFromServerOptions {
   userId?: string | null
   signal?: AbortSignal
   retryDelayMs?: number
+  /** Per-attempt deadline — bounds the silent-rollback window (review A3). */
+  timeoutMs?: number
 }
 
 /**
@@ -92,6 +94,7 @@ export async function hydrateCanvasFromServer(
     userId: opts.userId,
     signal: opts.signal,
     retryDelayMs: opts.retryDelayMs,
+    timeoutMs: opts.timeoutMs,
   })
 
   // ── Every non-graph answer: leave the canvas alone, say why, surface nothing.

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -482,6 +482,17 @@ interface CanvasState {
    * which the reconciler removes nothing.
    */
   lastAuthoritativeGraph: { nodeIds: string[]; edgePairs: string[] } | null
+  /**
+   * ROADMAP 2.312 piece 3 — CEE's `identity.v1` token for the server graph this
+   * canvas was last hydrated from, stored VERBATIM.
+   *
+   * ⚠ OPAQUE AND CEE-ISSUED. Compare CEE-to-CEE only, gated on
+   * `projectionVersion`, and NEVER recompute it locally: the normalisation,
+   * strip list and projection are CEE's and are versioned precisely so they can
+   * move, so no client-side value can be the same thing. It is the staleness
+   * anchor by ruling (there is deliberately no `updated_at` on the read route).
+   */
+  serverGraphIdentity: { value: string; projectionVersion: string } | null
   // CEE Pipeline trace from last draft-graph response (for debug panel)
   ceePipelineTrace: CeePipelineTrace | null
   // CEE V3: Per-node LLM reasoning (node ID → why text) for rationale tooltips
@@ -831,6 +842,10 @@ interface CanvasState {
   /** B2: record the identities of an authoritative CEE graph (see the field). */
   setLastAuthoritativeGraph: (
     graph: { nodeIds: string[]; edgePairs: string[] } | null,
+  ) => void
+  /** 2.312: store CEE's opaque identity token verbatim (see the field). */
+  setServerGraphIdentity: (
+    identity: { value: string; projectionVersion: string } | null,
   ) => void
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => void
   setCeeQuality: (quality: CeeQualityDimensions | null) => void
@@ -1197,6 +1212,10 @@ const DECISION_CONTEXT_CLEAR = {
   // B2: element identities are graph-specific. A previous scenario's set would
   // authorise deleting same-id nodes in the newly loaded graph.
   lastAuthoritativeGraph: null,
+  // 2.312: the token identifies ONE scenario's server graph. Carrying it across
+  // a decision-context change would make the next scenario's first read compare
+  // equal to a graph it has nothing to do with, and skip its own hydration.
+  serverGraphIdentity: null,
 } as const
 
 /**
@@ -1584,6 +1603,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   goalConstraints: null,
   // B2: no authoritative graph seen yet — reconciler removes nothing.
   lastAuthoritativeGraph: null,
+  // 2.312: no server graph read yet — nothing to compare against.
+  serverGraphIdentity: null,
   // CEE Pipeline trace from last draft
   ceePipelineTrace: null,
   // CEE V3: Per-node LLM reasoning for rationale tooltips
@@ -4252,6 +4273,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   setLastAuthoritativeGraph: (graph) => {
     set({ lastAuthoritativeGraph: graph })
+  },
+
+  setServerGraphIdentity: (identity) => {
+    set({ serverGraphIdentity: identity })
   },
 
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => {

--- a/src/canvas/utils/__tests__/mergeServerGraph.disclosure.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.disclosure.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * The DISCLOSURE pin — re-review finding on `eb41fc0f`.
+ *
+ * A3 added a pulse so a value cannot move under the user in silence. It was
+ * pinned by NOTHING: deleting the whole `pulseAppliedTargets` block left all 69
+ * specs green (executed by the reviewer). That is the same class as the
+ * original A2 wiring finding — machinery that reads as a guarantee and whose
+ * removal nothing notices — so revert-must-go-red applies to it too.
+ *
+ * The disclosure is only meaningful if it lands on the RIGHT elements, so both
+ * cases are identity-bound: an unchanged node and an ADDED node must not be
+ * pulsed. Pulsing everything would be as dishonest as pulsing nothing — it
+ * would announce changes that did not happen and bury the one that did.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { pulseSpy } = vi.hoisted(() => ({ pulseSpy: vi.fn() }))
+
+// The factory REPLACES the module, so it must carry the module's whole export
+// surface — a hand-listed subset is the trap 12 mirror that silently drops
+// whatever was added since. Derived from the real module and spread over.
+vi.mock('../appliedEditPulse', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../appliedEditPulse')>()),
+  pulseAppliedTargets: pulseSpy,
+}))
+
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+
+const SCENARIO = '11111111-2222-4333-8444-555555555555'
+
+function seed(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: { label: 'Spend', kind: 'factor', value: 100 },
+      },
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 300, y: 400 },
+        data: { label: 'Profit', kind: 'goal', value: 5 },
+      },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+beforeEach(() => {
+  pulseSpy.mockClear()
+  seed()
+})
+
+describe('mergeServerGraphOnHydrate — the overwrite is DISCLOSED', () => {
+  it('pulses ONCE, and only the node whose value the server changed', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [
+        // changed → must be disclosed
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+        // unchanged → must NOT be disclosed
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+        // an ADDITION is a new arrival, not an overwrite → must NOT be disclosed
+        { id: 'factor-2', kind: 'factor', label: 'Headcount' },
+      ],
+      edges: [],
+    })
+
+    expect(pulseSpy).toHaveBeenCalledTimes(1)
+    const { nodeIds, edgeIds } = pulseSpy.mock.calls[0][0]
+    expect(nodeIds).toEqual(['factor-1'])
+    expect(nodeIds).not.toContain('goal-1')
+    expect(nodeIds).not.toContain('factor-2')
+    expect(edgeIds).toEqual([])
+  })
+
+  it('does NOT pulse when the merge only ADDS — nothing was overwritten', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+        { id: 'factor-2', kind: 'factor', label: 'Headcount' },
+      ],
+      edges: [],
+    })
+
+    // The addition landed…
+    expect(useCanvasStore.getState().nodes).toHaveLength(3)
+    // …and announced nothing, because nothing of the user's was replaced.
+    expect(pulseSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/utils/__tests__/mergeServerGraph.provenance.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.provenance.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Provenance honesty across the boot merge — adversarial-review finding A1.
+ *
+ * The three probes the review reproduced by execution, turned into
+ * identity-bound pins. Every assertion below names its node by ID and asserts
+ * through the SAME predicates the UI paints with (`isReviewedByUser`,
+ * `isReviewedEdge`) rather than by poking at a key a renderer may not read —
+ * a value predicate another object could satisfy is how a test passes on the
+ * wrong object (trap 19).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+import {
+  isReviewedByUser,
+  isReviewedEdge,
+} from '../../components/pre-analysis/utils/isReviewedByUser'
+
+const SCENARIO = '11111111-2222-4333-8444-555555555555'
+
+function seed(nodes: unknown[], edges: unknown[] = []): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: structuredClone(nodes) as never,
+    edges: structuredClone(edges) as never,
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function nodeById(id: string): Node {
+  return useCanvasStore.getState().nodes.find((n: any) => n.id === id) as unknown as Node
+}
+function edgeById(id: string): Edge {
+  return useCanvasStore.getState().edges.find((e: any) => e.id === id) as unknown as Edge
+}
+
+/** A node stamped in the CAMEL key only — the shape probe (a) is about. */
+function camelStampedNode(value: number) {
+  return {
+    id: 'factor-1',
+    type: 'factor',
+    position: { x: 10, y: 20 },
+    data: {
+      label: 'Spend',
+      kind: 'factor',
+      observedState: { value, source: 'user' },
+    },
+  }
+}
+
+/** A node stamped in BOTH keys — what `withObservedStateUpdate` writes. */
+function dualStampedNode(value: number) {
+  return {
+    id: 'factor-1',
+    type: 'factor',
+    position: { x: 10, y: 20 },
+    data: {
+      label: 'Spend',
+      kind: 'factor',
+      observedState: { value, source: 'user' },
+      observed_state: { value, source: 'user' },
+    },
+  }
+}
+
+/** CEE's bag can never carry a user source — the enum has no such member. */
+function serverNode(value: number, source = 'cee_inference') {
+  return {
+    id: 'factor-1',
+    kind: 'factor',
+    label: 'Spend',
+    observed_state: { value, source },
+  }
+}
+
+beforeEach(() => {
+  seed([camelStampedNode(0.6)])
+})
+
+describe('A1 probe 1 — an IDENTICAL round-trip must PRESERVE the stamp', () => {
+  it('keeps "checked by you" when the server returns the same value', () => {
+    seed([camelStampedNode(0.6)])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.6)], edges: [] })
+    expect(isReviewedByUser(nodeById('factor-1'))).toBe(true)
+  })
+
+  it('keeps it on a DUAL-key node too, in both spellings', () => {
+    seed([dualStampedNode(0.6)])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.6)], edges: [] })
+    const data = nodeById('factor-1').data as any
+    expect(data.observedState.source).toBe('user')
+    expect(data.observed_state.source).toBe('user')
+    expect(isReviewedByUser(nodeById('factor-1'))).toBe(true)
+  })
+
+  it('does not INVENT the snake key on a camel-only node', () => {
+    seed([camelStampedNode(0.6)])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.6)], edges: [] })
+    const data = nodeById('factor-1').data as any
+    expect(data.observedState.source).toBe('user')
+    expect(data.observed_state).toBeUndefined()
+  })
+
+  it('a stamp-only round-trip is a STRICT no-op — no store write', () => {
+    seed([camelStampedNode(0.6)])
+    const before = useCanvasStore.getState().nodes
+    const res = mergeServerGraphOnHydrate({ nodes: [serverNode(0.6)], edges: [] })
+    expect(res.updatedNodeCount).toBe(0)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+})
+
+describe('A1 probe 2 — a CHANGED value must kill the review claim in BOTH spellings', () => {
+  it('clears the stamp when the server moves the number', () => {
+    seed([camelStampedNode(0.6)])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.9)], edges: [] })
+    expect(nodeById('factor-1').data).toMatchObject({ observedState: { value: 0.9 } })
+    expect(isReviewedByUser(nodeById('factor-1'))).toBe(false)
+  })
+
+  it('THE FALSE-REVIEW CASE: the SNAKE stamp must not survive a changed value', () => {
+    // `isReviewedByUser` resolves snake BEFORE camel, and the mapper never
+    // emits the snake key — so without an explicit clear the badge claims
+    // "checked by you" over the SERVER'S number. This is the assertion that
+    // goes RED if the snake-clear is dropped.
+    seed([dualStampedNode(0.6)])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.9)], edges: [] })
+
+    const data = nodeById('factor-1').data as any
+    expect(data.observedState.value).toBe(0.9)
+    expect(data.observed_state?.source).toBeUndefined()
+    expect(data.observedState?.source).not.toBe('user')
+    expect(isReviewedByUser(nodeById('factor-1'))).toBe(false)
+  })
+
+  it('clears a TOP-LEVEL data.source user stamp too (the third rung)', () => {
+    seed([
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: {
+          label: 'Spend',
+          kind: 'factor',
+          source: 'user_confirmed',
+          observedState: { value: 0.6 },
+        },
+      },
+    ])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.9)], edges: [] })
+    expect((nodeById('factor-1').data as any).source).toBeUndefined()
+    expect(isReviewedByUser(nodeById('factor-1'))).toBe(false)
+  })
+
+  it('leaves a PRODUCER stamp alone — the server owns that field', () => {
+    seed([
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: {
+          label: 'Spend',
+          kind: 'factor',
+          observedState: { value: 0.6, source: 'brief_extraction' },
+        },
+      },
+    ])
+    mergeServerGraphOnHydrate({ nodes: [serverNode(0.9, 'cee_inference')], edges: [] })
+    expect((nodeById('factor-1').data as any).observedState.source).toBe('cee_inference')
+  })
+})
+
+describe('A1 probe 3 — an edge stamp must not outlive the weight it describes', () => {
+  const edge = (weight: number) => ({
+    id: 'e1',
+    source: 'factor-1',
+    target: 'goal-1',
+    data: { weight, userReviewedStrength: true },
+  })
+
+  const nodes = () => [
+    camelStampedNode(0.6),
+    { id: 'goal-1', type: 'goal', position: { x: 300, y: 40 }, data: { label: 'Profit', kind: 'goal' } },
+  ]
+
+  it('clears userReviewedStrength when the server changes the weight', () => {
+    seed(nodes(), [edge(0.7)])
+    mergeServerGraphOnHydrate({
+      nodes: [serverNode(0.6)],
+      edges: [{ id: 'e1', from: 'factor-1', to: 'goal-1', weight: 0.2 }],
+    })
+    expect((edgeById('e1').data as any).weight).toBe(0.2)
+    expect(isReviewedEdge(edgeById('e1'))).toBe(false)
+  })
+
+  it('KEEPS userReviewedStrength when the weight is unchanged', () => {
+    seed(nodes(), [edge(0.7)])
+    mergeServerGraphOnHydrate({
+      nodes: [serverNode(0.6)],
+      edges: [{ id: 'e1', from: 'factor-1', to: 'goal-1', weight: 0.7 }],
+    })
+    expect(isReviewedEdge(edgeById('e1'))).toBe(true)
+  })
+})

--- a/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
@@ -69,16 +69,29 @@ describe('mergeServerGraphOnHydrate — values from server, layout from local', 
     expect(nodeById('goal-1').data.value).toBe(9)
   })
 
-  it('preserves EACH node’s OWN local position — identity-bound, not positional', () => {
+  it('binds each server node to the node with the SAME ID, never the same INDEX', () => {
+    // The server array is deliberately the REVERSE of the canvas array.
+    //
+    // ⚠ ASSERT THE VALUES, NOT ONLY THE POSITIONS. An index-matched merge was
+    // written as a mutant and SURVIVED a position-only version of this test —
+    // and it survived for a structural reason worth recording: `overlayNode`
+    // spreads the EXISTING node first, so the position is preserved no matter
+    // WHICH server node it is handed. Layout is immune to the mis-binding; the
+    // VALUES are what get crossed. A position-only assertion here was therefore
+    // testing the one property the defect cannot disturb.
     mergeServerGraphOnHydrate({
-      // Deliberately the REVERSE order of the canvas array: a merge that
-      // matched by index rather than by id would swap these two positions.
       nodes: [
         { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
         { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
       ],
       edges: [],
     })
+    // Values land on the node whose ID they name…
+    expect(nodeById('factor-1').data.value).toBe(250)
+    expect(nodeById('factor-1').data.label).toBe('Spend')
+    expect(nodeById('goal-1').data.value).toBe(9)
+    expect(nodeById('goal-1').data.label).toBe('Profit')
+    // …and each node keeps its own layout.
     expect(nodeById('factor-1').position).toEqual(A_POS)
     expect(nodeById('goal-1').position).toEqual(B_POS)
   })

--- a/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * mergeServerGraphOnHydrate — RED-first spec (ROADMAP 2.312 piece 3).
+ *
+ * Merge-on-hydrate: VALUES FROM THE SERVER, LAYOUT FROM LOCAL. The server
+ * response carries no geometry at all (`layout_present` is measured false for
+ * every real `scenarios.graph`), so every position on screen after this merge
+ * must be the one the local canvas already held, bound to the node that held
+ * it — not the first position in the array, not a re-layout, not {0,0}.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+
+const A_POS = { x: 10, y: 20 }
+const B_POS = { x: 300, y: 400 }
+
+function seed(nodes: unknown[], edges: unknown[] = []): void {
+  useCanvasStore.setState({
+    currentScenarioId: '11111111-2222-4333-8444-555555555555',
+    nodes: structuredClone(nodes) as never,
+    edges: structuredClone(edges) as never,
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function localNodes() {
+  return [
+    {
+      id: 'factor-1',
+      type: 'factor',
+      position: { ...A_POS },
+      width: 180,
+      selected: false,
+      data: { label: 'Spend', kind: 'factor', value: 100 },
+    },
+    {
+      id: 'goal-1',
+      type: 'goal',
+      position: { ...B_POS },
+      width: 200,
+      selected: false,
+      data: { label: 'Profit', kind: 'goal', value: 5 },
+    },
+  ]
+}
+
+function nodeById(id: string): any {
+  return useCanvasStore.getState().nodes.find((n: any) => n.id === id)
+}
+
+beforeEach(() => {
+  seed(localNodes())
+})
+
+describe('mergeServerGraphOnHydrate — values from server, layout from local', () => {
+  it('hydrates server VALUES onto the local canvas', () => {
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
+      ],
+      edges: [],
+    })
+    expect(res.updatedNodeCount).toBe(2)
+    expect(nodeById('factor-1').data.value).toBe(250)
+    expect(nodeById('goal-1').data.value).toBe(9)
+  })
+
+  it('preserves EACH node’s OWN local position — identity-bound, not positional', () => {
+    mergeServerGraphOnHydrate({
+      // Deliberately the REVERSE order of the canvas array: a merge that
+      // matched by index rather than by id would swap these two positions.
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+      ],
+      edges: [],
+    })
+    expect(nodeById('factor-1').position).toEqual(A_POS)
+    expect(nodeById('goal-1').position).toEqual(B_POS)
+  })
+
+  it('preserves every other canvas-owned root field (width, selected)', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(nodeById('factor-1').width).toBe(180)
+    expect(nodeById('factor-1').selected).toBe(false)
+  })
+
+  it('MUTANT GUARD — server-supplied positions NEVER clobber local layout', () => {
+    // `scenarios.graph` carries no geometry today; if a future write ever put
+    // some there, it must still lose to the canvas. This is the assertion that
+    // goes RED if the merge is ever rewritten to spread the server node last.
+    mergeServerGraphOnHydrate({
+      nodes: [
+        {
+          id: 'factor-1',
+          kind: 'factor',
+          label: 'Spend',
+          value: 250,
+          position: { x: -999, y: -999 },
+          x: -999,
+          y: -999,
+        },
+      ],
+      edges: [],
+    })
+    expect(nodeById('factor-1').position).toEqual(A_POS)
+  })
+})
+
+describe('mergeServerGraphOnHydrate — additive, never destructive', () => {
+  it('adds a server node the canvas does not have, without re-laying-out the rest', () => {
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Headcount' },
+      ],
+      edges: [],
+    })
+    expect(res.addedNodeCount).toBe(1)
+    expect(nodeById('factor-2')).toBeTruthy()
+    expect(nodeById('factor-1').position).toEqual(A_POS)
+    expect(nodeById('goal-1').position).toEqual(B_POS)
+  })
+
+  it('hydrates a FULLY EMPTY canvas from the server graph', () => {
+    seed([], [])
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'goal-1', kind: 'goal', label: 'Profit' },
+      ],
+      edges: [{ id: 'e1', from: 'factor-1', to: 'goal-1' }],
+    })
+    expect(res.addedNodeCount).toBe(2)
+    expect(res.addedEdgeCount).toBe(1)
+    expect(useCanvasStore.getState().nodes).toHaveLength(2)
+  })
+
+  it('NEVER removes a local-only node — the server graph is not a deletion oracle', () => {
+    // The autosave can legitimately be AHEAD of the server (guest inspector
+    // edits never reach CEE at all — ROADMAP 2.304). Boot hydration removing
+    // them would trade a stale value for lost work.
+    const res = mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(res.removedNodeCount).toBe(0)
+    expect(nodeById('goal-1')).toBeTruthy()
+    expect(useCanvasStore.getState().nodes).toHaveLength(2)
+  })
+
+  it('records the server graph as CEE-acknowledged (authorises LATER receipt deletions)', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend' }],
+      edges: [],
+    })
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toEqual({
+      nodeIds: ['factor-1'],
+      edgePairs: [],
+    })
+  })
+})
+
+describe('mergeServerGraphOnHydrate — honest absence', () => {
+  it('an EMPTY server graph is a strict no-op — the canvas stands untouched', () => {
+    const before = useCanvasStore.getState().nodes
+    const res = mergeServerGraphOnHydrate({ nodes: [], edges: [] })
+    expect(res).toEqual({
+      addedNodeCount: 0,
+      addedEdgeCount: 0,
+      updatedNodeCount: 0,
+      updatedEdgeCount: 0,
+      removedNodeCount: 0,
+      removedEdgeCount: 0,
+    })
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+  })
+
+  it('a null / non-object graph is a strict no-op', () => {
+    const before = useCanvasStore.getState().nodes
+    expect(mergeServerGraphOnHydrate(null).updatedNodeCount).toBe(0)
+    expect(mergeServerGraphOnHydrate(undefined).updatedNodeCount).toBe(0)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+  })
+
+  it('a server graph identical to the canvas writes NOTHING (reference-stable)', () => {
+    const before = useCanvasStore.getState().nodes
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+      ],
+      edges: [],
+    })
+    expect(res.updatedNodeCount).toBe(0)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    // …but the READ still happened, so the acknowledged set is recorded. The
+    // evidence is the read, not the write: gating this on a diff would leave
+    // the set stale after the most common boot of all.
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toEqual({
+      nodeIds: ['factor-1', 'goal-1'],
+      edgePairs: [],
+    })
+  })
+
+  it('ZERO node-id overlap with a NON-EMPTY canvas is dropped, never grafted', () => {
+    const before = useCanvasStore.getState().nodes
+    const res = mergeServerGraphOnHydrate({
+      nodes: [{ id: 'unrelated-9', kind: 'factor', label: 'Other' }],
+      edges: [],
+    })
+    expect(res.addedNodeCount).toBe(0)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    // A graph REFUSED as unrelated was never observed — it must not widen what
+    // a later receipt is permitted to delete.
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+  })
+})
+
+describe('mergeServerGraphOnHydrate — boot is not an edit', () => {
+  it('pushes NO history entry — there is nothing to undo to on boot', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(useCanvasStore.getState().history.past).toHaveLength(0)
+  })
+})

--- a/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
@@ -238,10 +238,42 @@ describe('mergeServerGraphOnHydrate — honest absence', () => {
   })
 })
 
-describe('mergeServerGraphOnHydrate — boot is not an edit', () => {
-  it('pushes NO history entry — there is nothing to undo to on boot', () => {
+describe('mergeServerGraphOnHydrate — an overwrite is recoverable and disclosed (A3)', () => {
+  it('pushes a PRE-MERGE snapshot when an existing value moves', () => {
+    // Not "boot is not an edit" — an earlier version of this file reasoned that
+    // way and it was wrong in the case that matters: when the local autosave is
+    // NEWER than the server row, this merge reverts the user's work, and the
+    // autosave then persists the reverted state ~1.5s later. Without a snapshot
+    // that is silent AND unrecoverable.
     mergeServerGraphOnHydrate({
       nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(useCanvasStore.getState().history.past).toHaveLength(1)
+    // …and the snapshot holds the PRE-merge value, so undo restores the user's.
+    const snapshot = useCanvasStore.getState().history.past[0] as any
+    expect(snapshot.nodes.find((n: any) => n.id === 'factor-1').data.value).toBe(100)
+  })
+
+  it('pushes NO snapshot for a pure ADDITION — nothing is being overwritten', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+        { id: 'factor-2', kind: 'factor', label: 'Headcount' },
+      ],
+      edges: [],
+    })
+    expect(useCanvasStore.getState().nodes).toHaveLength(3)
+    expect(useCanvasStore.getState().history.past).toHaveLength(0)
+  })
+
+  it('pushes NO snapshot on a no-op merge', () => {
+    mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+      ],
       edges: [],
     })
     expect(useCanvasStore.getState().history.past).toHaveLength(0)

--- a/src/canvas/utils/hydrateProvenance.ts
+++ b/src/canvas/utils/hydrateProvenance.ts
@@ -147,8 +147,9 @@ export function clearUserProvenance(data: Record<string, any>): Record<string, a
 
   const next: Record<string, any> = { ...data }
   for (const key of locations) {
-    const { source: _dropped, ...rest } = next[key] as Record<string, unknown>
-    next[key] = rest
+    const bag = { ...(next[key] as Record<string, unknown>) }
+    delete bag.source
+    next[key] = bag
   }
   if (snapshot.top !== undefined) delete next.source
   return next
@@ -170,6 +171,7 @@ export function clearEdgeUserReviewOnValueChange(
   if (afterData?.userReviewedStrength !== true) return afterData
   const before = (beforeData ?? {}) as Record<string, any>
   if (Object.is(before.weight, afterData.weight)) return afterData
-  const { userReviewedStrength: _dropped, ...rest } = afterData
-  return rest
+  const next = { ...afterData }
+  delete next.userReviewedStrength
+  return next
 }

--- a/src/canvas/utils/hydrateProvenance.ts
+++ b/src/canvas/utils/hydrateProvenance.ts
@@ -1,0 +1,175 @@
+/**
+ * hydrateProvenance — keep "checked by you" HONEST across a boot-time merge.
+ *
+ * ROADMAP 2.312 piece 3, adversarial-review finding A1. The overlay primitive
+ * is provenance-BLIND, and on this path that is not a cosmetic problem: it
+ * breaks the review badge in BOTH directions at once.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THE SERVER CAN NEVER SETTLE THIS BY ITSELF
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The stamp the UI reads is `observed_state.source`, and CEE's `ObservedStateV3`
+ * types that field as `z.enum(['brief_extraction', 'cee_inference'])`. There is
+ * no user-owned member, and the set-factor-value path never writes `source` at
+ * all. So the server bag is STRUCTURALLY incapable of carrying "the user
+ * checked this" — a merge that lets it decide the field is not resolving a
+ * conflict, it is discarding evidence only the client holds.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE TWO FAILURES, AND WHY THEY ARE ONE BUG
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `mapDraftNodeToCanvas` emits ONLY the camelCase `observedState` key, and
+ * `overlayNode` replaces that object WHOLESALE. Meanwhile `isReviewedByUser`
+ * resolves `observed_state` (snake) BEFORE `observedState` (camel) — the
+ * opposite precedence to `getObservedState`, which the display uses. Hence:
+ *
+ *   (a) UNDER-CLAIM. A camel-only user stamp is STRIPPED on every boot even
+ *       when the value round-tripped byte-identically. The "User edited" pill
+ *       disappears and the "N to verify" count grows back on every reload — the
+ *       user's work is undone visually while the number is unchanged.
+ *
+ *   (b) OVER-CLAIM, and this is the serious direction. On a dual-key node the
+ *       SNAKE stamp survives (the mapper never emits that key) while the CAMEL
+ *       object is replaced by the server's. The display then shows the SERVER'S
+ *       number wearing the user's "checked by you" badge — a provenance claim
+ *       attached to a number the user never saw, which is the exact defect class
+ *       `overlayEdge`'s own orphan-stamp comment already names.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE RULE — honesty in both directions, and it needs both halves
+ * ─────────────────────────────────────────────────────────────────────────────
+ *   · value UNCHANGED by the merge → PRESERVE the user's stamp (fixes (a));
+ *   · value CHANGED by the merge   → the server wins on the value AND every
+ *     user stamp is cleared in BOTH spellings and at the top level (fixes (b)).
+ *
+ * Only USER-OWNED stamps are touched, and membership is decided by
+ * `isReviewedSource` — the same predicate that paints the badge, so this can
+ * never drift from what the UI actually claims. A producer stamp
+ * (`cee_inference`, `brief_extraction`) is left to the overlay, which is the
+ * correct owner of it.
+ *
+ * The comparison is made on the node BEFORE and AFTER the overlay rather than
+ * on the wire shape, so it asks the only question that matters — *did the number
+ * the user reviewed move?* — without depending on which keys CEE happened to
+ * send.
+ */
+
+import { isReviewedSource } from '../components/pre-analysis/utils/isReviewedByUser'
+import { getObservedState } from './observedStateHelpers'
+
+/** The two spellings of the observed-state bag that carry a `source`. */
+const OBSERVED_STATE_KEYS = ['observed_state', 'observedState'] as const
+
+/**
+ * The user stamp as it was spelled on the pre-merge node.
+ *
+ * Recorded per LOCATION rather than collapsed to one value: restoring has to
+ * reproduce the shape that was there, and a node stamped in only one spelling
+ * must not gain the other (that would silently change which predicate wins).
+ */
+export interface UserProvenanceSnapshot {
+  observed_state?: string
+  observedState?: string
+  /** Top-level `data.source` — the third rung of `isReviewedByUser`'s chain. */
+  top?: string
+}
+
+/**
+ * Capture the USER-owned source stamps on a node's data, at every location
+ * `isReviewedByUser` consults. Producer stamps are deliberately not captured:
+ * they are the server's to move.
+ */
+export function captureUserProvenance(data: unknown): UserProvenanceSnapshot {
+  const d = data as Record<string, any> | undefined
+  const snapshot: UserProvenanceSnapshot = {}
+  for (const key of OBSERVED_STATE_KEYS) {
+    const source = d?.[key]?.source
+    if (typeof source === 'string' && isReviewedSource(source)) {
+      snapshot[key] = source
+    }
+  }
+  if (typeof d?.source === 'string' && isReviewedSource(d.source)) {
+    snapshot.top = d.source
+  }
+  return snapshot
+}
+
+/** True when the observed VALUE the user would see is the same on both nodes. */
+export function observedValueUnchanged(beforeData: unknown, afterData: unknown): boolean {
+  const before = getObservedState(beforeData)
+  const after = getObservedState(afterData)
+  // `Object.is` so a NaN value compares equal to itself rather than forcing a
+  // spurious "changed" verdict that would strip a stamp on every boot.
+  return Object.is(before.value, after.value)
+}
+
+/**
+ * Put the user's stamps back exactly where they were.
+ *
+ * Only writes a location the snapshot actually held, so a camel-only stamp
+ * stays camel-only. Returns the SAME reference when there is nothing to do, so
+ * callers keep their no-op detection.
+ */
+export function restoreUserProvenance(
+  data: Record<string, any>,
+  snapshot: UserProvenanceSnapshot,
+): Record<string, any> {
+  const locations = OBSERVED_STATE_KEYS.filter((k) => snapshot[k] !== undefined)
+  if (locations.length === 0 && snapshot.top === undefined) return data
+
+  const next: Record<string, any> = { ...data }
+  for (const key of locations) {
+    // Only re-create the bag if it already exists post-merge; a stamp with no
+    // observed state to describe would be an orphan of the kind this file
+    // exists to prevent.
+    if (next[key] && typeof next[key] === 'object') {
+      next[key] = { ...next[key], source: snapshot[key] }
+    }
+  }
+  if (snapshot.top !== undefined) next.source = snapshot.top
+  return next
+}
+
+/**
+ * Remove every USER stamp, in both spellings and at the top level.
+ *
+ * Called when the merge moved the number: whatever the user reviewed, it is not
+ * what is on screen now, so no surface may go on claiming they reviewed it.
+ * Clearing ALL THREE is the point — clearing only the camel key would leave the
+ * snake key, which is the one `isReviewedByUser` reads FIRST.
+ *
+ * Returns the SAME reference when there was nothing to clear.
+ */
+export function clearUserProvenance(data: Record<string, any>): Record<string, any> {
+  const snapshot = captureUserProvenance(data)
+  const locations = OBSERVED_STATE_KEYS.filter((k) => snapshot[k] !== undefined)
+  if (locations.length === 0 && snapshot.top === undefined) return data
+
+  const next: Record<string, any> = { ...data }
+  for (const key of locations) {
+    const { source: _dropped, ...rest } = next[key] as Record<string, unknown>
+    next[key] = rest
+  }
+  if (snapshot.top !== undefined) delete next.source
+  return next
+}
+
+/**
+ * The edge counterpart. `userReviewedStrength` is a UI-only boolean set by the
+ * pre-analysis strength quick-select; it never reaches the wire, so the overlay
+ * can never clear it and it outlives any weight the server sends.
+ *
+ * Same rule, same reason: a "user judged this relationship" marker attached to
+ * a strength the server has since moved is a claim about a number the user
+ * never chose. Returns the SAME reference when there is nothing to clear.
+ */
+export function clearEdgeUserReviewOnValueChange(
+  beforeData: unknown,
+  afterData: Record<string, any>,
+): Record<string, any> {
+  if (afterData?.userReviewedStrength !== true) return afterData
+  const before = (beforeData ?? {}) as Record<string, any>
+  if (Object.is(before.weight, afterData.weight)) return afterData
+  const { userReviewedStrength: _dropped, ...rest } = afterData
+  return rest
+}

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -138,10 +138,14 @@ import {
 } from './applyDraftResult'
 import type { CEEDraftResponse, CEEv2Response, CEEv3Response } from '../../adapters/cee/types'
 
-/** Horizontal gap between the current bounding box and the added column. */
-const ADDED_COLUMN_X_GAP = 260
+/**
+ * Horizontal gap between the current bounding box and the added column.
+ * Exported so the boot-hydration merge places added nodes identically —
+ * two placement constants that must agree is a mirror, and mirrors drift.
+ */
+export const ADDED_COLUMN_X_GAP = 260
 /** Vertical spacing between stacked added nodes. */
-const ADDED_COLUMN_Y_STEP = 140
+export const ADDED_COLUMN_Y_STEP = 140
 
 export interface ReconcileAppliedGraphResult {
   addedNodeCount: number
@@ -253,8 +257,14 @@ function sameValue(a: unknown, b: unknown): boolean {
  * backfills (interventions, is_baseline, goal_threshold_*) live in the same
  * `data` bag. The residual is documented and accepted: a value CEE genuinely
  * cleared stays on the canvas until the next full draft.
+ *
+ * ⚠ EXPORTED for `mergeServerGraph.ts` (ROADMAP 2.312 piece 3). Boot hydration
+ * needs exactly this rule — server values win, local layout survives — and a
+ * second implementation of "spread existing first" would be the hand-maintained
+ * mirror this repo keeps getting bitten by. There is ONE definition of the
+ * overlay; its two callers differ only in the semantics around it.
  */
-function overlayNode(existing: any, wireNode: any): any {
+export function overlayNode(existing: any, wireNode: any): any {
   const mapped = mapDraftNodeToCanvas(wireNode)
   const nextData = { ...(existing.data ?? {}), ...(mapped.data ?? {}) }
   const nextType = mapped.type ?? existing.type
@@ -274,7 +284,7 @@ function overlayNode(existing: any, wireNode: any): any {
  * splat DEFAULT_EDGE_DATA over locally-tuned edges and churn history on every
  * turn.
  */
-function overlayEdge(existing: any, wireEdge: any): any {
+export function overlayEdge(existing: any, wireEdge: any): any {
   const mapped = mapDraftEdgeToCanvas(wireEdge, 0)
   const mappedData = (mapped.data ?? {}) as Record<string, unknown>
 

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -1,0 +1,283 @@
+/**
+ * mergeServerGraphOnHydrate — VALUES FROM THE SERVER, LAYOUT FROM LOCAL.
+ *
+ * ROADMAP 2.312 piece 3. On boot, the canvas restores from the localStorage
+ * autosave (`ReactFlowGraph`'s init effect → `hydrateGraphSlice`) and nothing
+ * ever asked the server what it holds for this scenario. The measured
+ * consequence: a persisted edit is forgotten on refresh, and a later edit
+ * REBASES against a value the user was never shown (the server recorded "from
+ * £3,500 to £4,200" where the screen said £4,000).
+ *
+ * This closes that by merging CEE's copy over the restored canvas. The two
+ * sides are authoritative for different things and neither is authoritative
+ * for both:
+ *
+ *   · CEE owns the ANALYTICAL state. `scenarios.graph` is what every turn and
+ *     every analysis is computed from.
+ *   · The CANVAS owns the LAYOUT. `scenarios.graph` carries no geometry at all
+ *     — no `position`, no `x`/`y`, no `layout` — and CEE measures that on the
+ *     bytes it returns (`layout_present`, false for every real graph today).
+ *     The autosave is the only place a position has ever existed.
+ *
+ * ⚠ NEVER go through `hydrateGraphSlice` for this. That path REPLACES the
+ * node array, so the server's layout-free nodes would land at {0,0} and the
+ * user's canvas would scramble on every refresh. The position-preserving
+ * overlay is the only correct write, and it is the SAME `overlayNode` /
+ * `overlayEdge` the applied-edit receipt path uses — imported, not copied.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * SCOPE BOUNDARY — SERVER-WINS-ON-VALUES, AT BOOT, ONCE
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Hydration re-opens last-writer-wins between the server row and the
+ * localStorage autosave, and this merge resolves it ONE way and only at boot:
+ * on a field both sides carry, the server's value wins. That is deliberate —
+ * the server's copy is what the next turn and the next analysis will be
+ * computed against, so showing anything else is the rebase defect again.
+ *
+ * What is NOT in scope, and is NOT silently half-done here:
+ *   · no continuous sync — this runs at boot, not on every change;
+ *   · no compare-and-swap — the UI does not write back through this path;
+ *   · no DELETION. An element the canvas has and the server does not SURVIVES.
+ *     The autosave can legitimately be ahead of the server (guest inspector
+ *     edits never reach CEE at all — ROADMAP 2.304), so reconciling absence to
+ *     deletion would trade a stale value for lost work. Absence is only ever
+ *     authoritative on the applied-edit receipt path, which has a receipt to
+ *     justify it; a boot read has none.
+ *
+ * The residual is therefore named rather than hidden: a local-only edit made
+ * before this boot keeps its node on the canvas, but a field the server also
+ * carries is overwritten by the server's value. That is the ruled behaviour
+ * for this rung; a CAS/merge-policy rung is a separate row if wanted.
+ */
+
+import { useCanvasStore } from '../store'
+import { logger } from '../../lib/logger'
+import { canvasEdgePairKey, wireEdgePairKey } from './graphIdentity'
+import { mapDraftEdgeToCanvas, mapDraftNodeToCanvas } from './applyDraftResult'
+import {
+  ADDED_COLUMN_X_GAP,
+  ADDED_COLUMN_Y_STEP,
+  overlayEdge,
+  overlayNode,
+} from './mergeAppliedGraph'
+
+export interface MergeServerGraphResult {
+  addedNodeCount: number
+  addedEdgeCount: number
+  updatedNodeCount: number
+  updatedEdgeCount: number
+  /**
+   * Always 0. Present so the shape matches the receipt reconciler's and so the
+   * "boot never deletes" invariant is an ASSERTABLE counter rather than a
+   * promise in a comment.
+   */
+  removedNodeCount: number
+  removedEdgeCount: number
+}
+
+const NO_CHANGE: MergeServerGraphResult = Object.freeze({
+  addedNodeCount: 0,
+  addedEdgeCount: 0,
+  updatedNodeCount: 0,
+  updatedEdgeCount: 0,
+  removedNodeCount: 0,
+  removedEdgeCount: 0,
+})
+
+function noChange(): MergeServerGraphResult {
+  return { ...NO_CHANGE }
+}
+
+/**
+ * Merge the server's graph onto the live canvas.
+ *
+ * @param serverGraph `scenarios.graph` VERBATIM, as returned by
+ *   `scenario_graph.v1`. Null / absent / empty is a strict no-op: an empty
+ *   server graph is a normal state (every scenario starts there) and must
+ *   never blank a canvas that has content.
+ */
+export function mergeServerGraphOnHydrate(
+  serverGraph: unknown,
+): MergeServerGraphResult {
+  if (serverGraph === null || typeof serverGraph !== 'object') return noChange()
+
+  const g = serverGraph as Record<string, unknown>
+  const rawNodes: any[] = Array.isArray(g.nodes) ? g.nodes : []
+  const rawEdges: any[] = Array.isArray(g.edges) ? g.edges : []
+
+  // Honest absence: nothing to merge, so nothing is written and no identity is
+  // recorded. A server graph with no elements must not authorise later
+  // deletions either.
+  if (rawNodes.length === 0 && rawEdges.length === 0) return noChange()
+
+  const store = useCanvasStore.getState()
+  const existingNodeIds = new Set(store.nodes.map((n: any) => n.id))
+  const existingEdgeIds = new Set(store.edges.map((e: any) => e.id))
+
+  // Structural guard, same rationale as the receipt path: a scenario's server
+  // graph and its own restored canvas always share node ids. ZERO overlap with
+  // a NON-EMPTY canvas means these are two unrelated graphs (a stale autosave
+  // stamped with a scenario id whose server row has since been redrafted), and
+  // unioning them would produce a graph neither side ever had. Drop and warn.
+  // An EMPTY canvas is the opposite case and the whole point of this feature:
+  // there is nothing to conflict with, so it hydrates in full.
+  if (store.nodes.length > 0 && rawNodes.length > 0) {
+    const hasOverlap = rawNodes.some(
+      (n: any) => n != null && typeof n.id === 'string' && existingNodeIds.has(n.id),
+    )
+    if (!hasOverlap) {
+      logger.warn('merge_server_graph.zero_overlap_drop', {
+        scenarioId: store.currentScenarioId ?? null,
+        canvasNodeCount: store.nodes.length,
+        serverNodeCount: rawNodes.length,
+      })
+      return noChange()
+    }
+  }
+
+  // --- Server indexes. Node identity is the id; EDGE identity is the endpoint
+  // pair (CEE mints composite ids, the draft mapper falls back to positional
+  // ones, so the same edge routinely carries different ids on the two sides).
+  const serverNodeById = new Map<string, any>()
+  for (const n of rawNodes) {
+    if (n != null && typeof n.id === 'string' && n.id.length > 0) {
+      if (!serverNodeById.has(n.id)) serverNodeById.set(n.id, n)
+    }
+  }
+  const serverEdgeByPair = new Map<string, any>()
+  for (const e of rawEdges) {
+    if (e == null) continue
+    const key = wireEdgePairKey(e)
+    if (key && !serverEdgeByPair.has(key)) serverEdgeByPair.set(key, e)
+  }
+
+  // --- Updates. `overlayNode` spreads the EXISTING node first and discards the
+  // mapper's `position`, so every canvas-owned root field — position, width,
+  // height, measured, selected, dragging, style, zIndex, parentId — survives by
+  // construction, bound to the node that owned it. Matching is by id, never by
+  // array index.
+  let updatedNodeCount = 0
+  const mergedNodes = store.nodes.map((n: any) => {
+    const serverNode = serverNodeById.get(n.id)
+    if (!serverNode) return n
+    const next = overlayNode(n, serverNode)
+    if (next !== n) updatedNodeCount += 1
+    return next
+  })
+
+  let updatedEdgeCount = 0
+  const mergedEdges = store.edges.map((e: any) => {
+    const key = canvasEdgePairKey(e)
+    const serverEdge = key ? serverEdgeByPair.get(key) : undefined
+    if (!serverEdge) return e
+    const next = overlayEdge(e, serverEdge)
+    if (next !== e) updatedEdgeCount += 1
+    return next
+  })
+
+  // --- Additions: on the server, not on the canvas.
+  const missingRawNodes = rawNodes.filter(
+    (n: any) =>
+      n != null &&
+      typeof n.id === 'string' &&
+      n.id.length > 0 &&
+      !existingNodeIds.has(n.id),
+  )
+  const addedNodes = missingRawNodes.map((n: any) => mapDraftNodeToCanvas(n))
+
+  // Deterministic placement, right of the existing bounding box — never a
+  // re-layout of nodes the user has already arranged. Same constants as the
+  // receipt path, imported from it.
+  if (addedNodes.length > 0) {
+    const xs = mergedNodes.map((n: any) => n.position?.x ?? 0)
+    const ys = mergedNodes.map((n: any) => n.position?.y ?? 0)
+    const baseX = (xs.length ? Math.max(...xs) : 0) + ADDED_COLUMN_X_GAP
+    const baseY = ys.length ? Math.min(...ys) : 0
+    addedNodes.forEach((n: any, idx: number) => {
+      n.position = { x: baseX, y: baseY + idx * ADDED_COLUMN_Y_STEP }
+    })
+  }
+
+  const unionNodeIds = new Set<string>([
+    ...mergedNodes.map((n: any) => n.id as string),
+    ...addedNodes.map((n: any) => n.id as string),
+  ])
+  const seenEdgePairs = new Set<string>(
+    mergedEdges
+      .map((e: any) => canvasEdgePairKey(e))
+      .filter((k): k is string => k !== null),
+  )
+  const missingRawEdges = rawEdges.filter((e: any) => {
+    if (e == null) return false
+    const key = wireEdgePairKey(e)
+    if (key === null) return false
+    if (typeof e.id === 'string' && existingEdgeIds.has(e.id)) return false
+    if (seenEdgePairs.has(key)) return false
+    // Fail closed: never add a dangling edge.
+    const from = e.from ?? e.source
+    const to = e.to ?? e.target
+    if (!unionNodeIds.has(from) || !unionNodeIds.has(to)) return false
+    seenEdgePairs.add(key)
+    return true
+  })
+  const usedEdgeIds = new Set<string>(existingEdgeIds)
+  const addedEdges = missingRawEdges.map((e: any, i: number) => {
+    const mapped = mapDraftEdgeToCanvas(e, i)
+    let id: string = mapped.id
+    while (usedEdgeIds.has(id)) id = `${id}-a`
+    usedEdgeIds.add(id)
+    return { ...mapped, id }
+  })
+
+  const result: MergeServerGraphResult = {
+    addedNodeCount: addedNodes.length,
+    addedEdgeCount: addedEdges.length,
+    updatedNodeCount,
+    updatedEdgeCount,
+    // Structural, not incidental: this path has no removal branch at all.
+    removedNodeCount: 0,
+    removedEdgeCount: 0,
+  }
+
+  // The server graph IS CEE's view of this scenario, so everything in it is an
+  // element CEE has acknowledged. Recording it is what lets the FIRST applied
+  // -edit receipt after this boot reconcile a deletion; `lastAuthoritativeGraph`
+  // names "DB hydration" as one of its three sources for exactly this reason,
+  // and `loadScenario` already seeds it the same way on the Supabase path.
+  //
+  // ⚠ RECORDED EVEN WHEN THE MERGE CHANGED NOTHING, and that is deliberate: the
+  // evidence is the READ, not the write. A server graph identical to the canvas
+  // is still proof that CEE has seen exactly these elements, and gating the
+  // record on a diff would leave the acknowledged set stale after precisely the
+  // most common boot — the one where nothing has drifted. The receipt path
+  // states the same rule for the same reason. It is recorded only AFTER the
+  // guards above: a graph dropped for zero overlap was refused, not observed.
+  useCanvasStore.getState().setLastAuthoritativeGraph({
+    nodeIds: [...serverNodeById.keys()],
+    edgePairs: [...serverEdgeByPair.keys()],
+  })
+
+  const changed =
+    result.addedNodeCount > 0 ||
+    result.addedEdgeCount > 0 ||
+    result.updatedNodeCount > 0 ||
+    result.updatedEdgeCount > 0
+
+  if (!changed) return result
+
+  // One atomic write. Deliberately NO history entry — boot is not an edit and
+  // there is no prior state a user could meaningfully undo to — and no applied
+  // -edit pulse, which announces a change the user just made rather than the
+  // state their canvas was already in.
+  useCanvasStore.setState({
+    nodes: [...mergedNodes, ...addedNodes] as any,
+    edges: [...mergedEdges, ...addedEdges] as any,
+  })
+
+  logger.info('merge_server_graph.applied', {
+    scenarioId: store.currentScenarioId ?? null,
+    ...result,
+  })
+
+  return result
+}

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -48,11 +48,20 @@
  * before this boot keeps its node on the canvas, but a field the server also
  * carries is overwritten by the server's value. That is the ruled behaviour
  * for this rung; a CAS/merge-policy rung is a separate row if wanted.
+ *
+ * ⚠ AND BECAUSE THAT OVERWRITE IS REAL, IT IS NOT SILENT. Whenever this merge
+ * moves at least one EXISTING value it (1) pushes a pre-merge history snapshot,
+ * so the revert is undoable rather than unrecoverable — the autosave would
+ * otherwise persist the reverted state ~1.5s later and destroy the last copy —
+ * and (2) pulses the changed elements on the existing applied-edit surface, so
+ * a number cannot move under the user unannounced. Neither fires on a pure
+ * addition or a no-op. See the commit block below.
  */
 
 import { useCanvasStore } from '../store'
 import { logger } from '../../lib/logger'
 import { canvasEdgePairKey, wireEdgePairKey } from './graphIdentity'
+import { pulseAppliedTargets } from './appliedEditPulse'
 import { mapDraftEdgeToCanvas, mapDraftNodeToCanvas } from './applyDraftResult'
 import {
   ADDED_COLUMN_X_GAP,
@@ -60,6 +69,23 @@ import {
   overlayEdge,
   overlayNode,
 } from './mergeAppliedGraph'
+import {
+  captureUserProvenance,
+  clearEdgeUserReviewOnValueChange,
+  clearUserProvenance,
+  observedValueUnchanged,
+  restoreUserProvenance,
+} from './hydrateProvenance'
+
+/** Structural equality, matching the overlay's own no-op test. */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
 
 export interface MergeServerGraphResult {
   addedNodeCount: number
@@ -156,12 +182,33 @@ export function mergeServerGraphOnHydrate(
   // height, measured, selected, dragging, style, zIndex, parentId — survives by
   // construction, bound to the node that owned it. Matching is by id, never by
   // array index.
+  //
+  // ⚠ PROVENANCE IS APPLIED ON TOP OF THE OVERLAY, NOT INSIDE IT (review A1).
+  // The overlay is provenance-blind: it replaces the camelCase `observedState`
+  // bag wholesale while the snake_case one — which `isReviewedByUser` reads
+  // FIRST — is never emitted by the mapper and therefore survives. Left alone
+  // that strips honest user stamps on an unchanged value AND leaves a "checked
+  // by you" badge on a number the server just changed. See `hydrateProvenance`.
   let updatedNodeCount = 0
   const mergedNodes = store.nodes.map((n: any) => {
     const serverNode = serverNodeById.get(n.id)
     if (!serverNode) return n
-    const next = overlayNode(n, serverNode)
-    if (next !== n) updatedNodeCount += 1
+
+    const userStamps = captureUserProvenance(n.data)
+    const overlaid = overlayNode(n, serverNode)
+    if (overlaid === n) return n
+
+    const nextData = observedValueUnchanged(n.data, overlaid.data)
+      ? restoreUserProvenance(overlaid.data, userStamps)
+      : clearUserProvenance(overlaid.data)
+    const next = nextData === overlaid.data ? overlaid : { ...overlaid, data: nextData }
+
+    // A merge whose ONLY effect was to strip a user stamp and then put it back
+    // is a no-op, and must stay one — otherwise every boot writes the store and
+    // dirties history for a canvas that did not change.
+    if (next.type === n.type && deepEqual(next.data, n.data)) return n
+
+    updatedNodeCount += 1
     return next
   })
 
@@ -170,8 +217,18 @@ export function mergeServerGraphOnHydrate(
     const key = canvasEdgePairKey(e)
     const serverEdge = key ? serverEdgeByPair.get(key) : undefined
     if (!serverEdge) return e
-    const next = overlayEdge(e, serverEdge)
-    if (next !== e) updatedEdgeCount += 1
+
+    const overlaid = overlayEdge(e, serverEdge)
+    if (overlaid === e) return e
+
+    // `userReviewedStrength` is UI-only and never on the wire, so the overlay
+    // can never clear it — it would outlive the weight it describes.
+    const nextData = clearEdgeUserReviewOnValueChange(e.data, overlaid.data)
+    const next = nextData === overlaid.data ? overlaid : { ...overlaid, data: nextData }
+
+    if (deepEqual(next.data, e.data)) return e
+
+    updatedEdgeCount += 1
     return next
   })
 
@@ -265,14 +322,46 @@ export function mergeServerGraphOnHydrate(
 
   if (!changed) return result
 
-  // One atomic write. Deliberately NO history entry — boot is not an edit and
-  // there is no prior state a user could meaningfully undo to — and no applied
-  // -edit pulse, which announces a change the user just made rather than the
-  // state their canvas was already in.
+  // ── A PRE-MERGE SNAPSHOT, WHENEVER AN EXISTING VALUE MOVES (review A3) ─────
+  //
+  // The earlier version of this file pushed no history entry, reasoning that
+  // "boot is not an edit". That reasoning was wrong in the one case that
+  // matters. When the local autosave is NEWER than the server row — routine,
+  // because guest inspector edits never reach CEE at all (ROADMAP 2.304) — this
+  // merge REVERTS the user's work to the server's older values. Silently, with
+  // no undo, and the `useScenario` autosave then persists the reverted state
+  // ~1.5s later, destroying the last copy that held it.
+  //
+  // So: whenever at least one EXISTING element's value changes, snapshot first.
+  // Additions alone do not qualify — nothing is being overwritten — and a
+  // no-op merge already returned above.
+  const overwroteExistingValues = updatedNodeCount > 0 || updatedEdgeCount > 0
+  if (overwroteExistingValues) {
+    useCanvasStore.getState().pushHistory()
+  }
+
   useCanvasStore.setState({
     nodes: [...mergedNodes, ...addedNodes] as any,
     edges: [...mergedEdges, ...addedEdges] as any,
   })
+
+  // ── DISCLOSURE: never move a number the user is looking at in silence ──────
+  //
+  // The same coalesced highlight the applied-edit path uses, on exactly the
+  // elements whose values this merge changed. It is deliberately NOT applied to
+  // ADDED elements: those are new arrivals, not overwrites, and pulsing them
+  // would dilute the signal that matters. Fails closed downstream against the
+  // canvas.
+  if (overwroteExistingValues) {
+    pulseAppliedTargets({
+      nodeIds: mergedNodes
+        .filter((n: any, i: number) => n !== store.nodes[i])
+        .map((n: any) => n.id as string),
+      edgeIds: mergedEdges
+        .filter((e: any, i: number) => e !== store.edges[i])
+        .map((e: any) => e.id as string),
+    })
+  }
 
   logger.info('merge_server_graph.applied', {
     scenarioId: store.currentScenarioId ?? null,

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -17,6 +17,7 @@ import { TopBar } from '../components/layout/TopBar'
 import { getScenario } from '../canvas/store/scenarios'
 import { buildShareLink } from '../canvas/utils/shareLink'
 import { useScenario } from '../hooks/useScenario'
+import { useServerGraphHydration } from '../canvas/hooks/useServerGraphHydration'
 
 const TemplatesPanel = lazy(() => import('../canvas/panels/TemplatesPanel').then(m => ({ default: m.TemplatesPanel })))
 
@@ -66,6 +67,17 @@ export default function CanvasMVP() {
       })
     }
   }, [scenarioIdFromRoute, isPersistenceActive, loadSupabaseScenario])
+
+  // ROADMAP 2.312 piece 3: merge the SERVER's copy of this scenario's graph
+  // over the locally-restored canvas — values from CEE, layout from local.
+  //
+  // ⚠ NOT gated on `isPersistenceActive`. That flag is false for every guest
+  // session by construction (`lib/persistenceActive.ts`), and guest is the tier
+  // that ships — gating on it would leave this doing nothing for every real
+  // user. It does not apply here in any case: that flag governs the UI's own
+  // Supabase writes, whereas this read goes through CEE, which holds the
+  // service credential the browser deliberately does not have.
+  useServerGraphHydration(scenarioIdFromRoute)
 
   // Track canvas opened event
   useEffect(() => {

--- a/src/routes/__tests__/CanvasMVP.serverGraphHydration.spec.tsx
+++ b/src/routes/__tests__/CanvasMVP.serverGraphHydration.spec.tsx
@@ -1,0 +1,101 @@
+/**
+ * The WIRING pin — adversarial-review finding A2.
+ *
+ * Before this file, deleting the one `useServerGraphHydration(...)` call in
+ * CanvasMVP left every other spec GREEN: the client, the merge and the boot
+ * orchestration were all pinned in isolation while the line that makes the
+ * feature exist at all was pinned by nothing. That is the trap-19 proof
+ * obligation unmet at the mounting layer — delete the producer and the tests
+ * must go red.
+ *
+ * This renders the REAL CanvasMVP (heavy children stubbed) and asserts the hook
+ * is actually invoked. `useServerGraphHydration` is the single module under
+ * spy; everything else is stubbed only to make the route mountable in jsdom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const hydrationSpy = vi.fn()
+
+vi.mock('../../canvas/hooks/useServerGraphHydration', () => ({
+  useServerGraphHydration: (id?: string | null) => hydrationSpy(id),
+}))
+
+// ── Heavy children, stubbed to keep the route mountable in jsdom ────────────
+vi.mock('../../canvas/ReactFlowGraph', () => ({
+  default: () => <div data-testid="rfg-stub" />,
+}))
+vi.mock('../../components/layout/TopBar', () => ({ TopBar: () => <div /> }))
+vi.mock('../../components/DebugTray', () => ({ DebugTray: () => <div /> }))
+vi.mock('../../canvas/hooks/useResultsRun', () => ({
+  useResultsRun: () => ({ run: vi.fn() }),
+}))
+vi.mock('../../canvas/hooks/useDebugShortcut', () => ({
+  useDebugShortcut: () => ({ showDebug: false }),
+}))
+vi.mock('../../canvas/utils/sandboxTelemetry', () => ({ trackCanvasOpened: vi.fn() }))
+vi.mock('../../hooks/useScenario', () => ({
+  useScenario: () => ({
+    loadScenario: vi.fn(),
+    saveStatus: 'saved',
+    lastSavedAt: null,
+    saveError: null,
+    isPersistenceActive: false,
+    createSharedBrief: vi.fn(),
+  }),
+}))
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: ROUTE_ID }),
+}))
+
+const ROUTE_ID = '11111111-2222-4333-8444-555555555555'
+
+import CanvasMVP from '../CanvasMVP'
+
+beforeEach(() => {
+  hydrationSpy.mockClear()
+})
+
+describe('CanvasMVP — the hydration hook is actually mounted (A2)', () => {
+  it('CALLS useServerGraphHydration on render — delete the call and this goes RED', () => {
+    render(<CanvasMVP />)
+    expect(hydrationSpy).toHaveBeenCalled()
+  })
+
+  it('passes the ROUTE scenario id through, not something else', () => {
+    render(<CanvasMVP />)
+    expect(hydrationSpy).toHaveBeenCalledWith(ROUTE_ID)
+  })
+})
+
+describe('CanvasMVP — boot ORDERING invariant (A5)', () => {
+  /**
+   * Restore-before-hydrate is what makes this a MERGE rather than a race: the
+   * canvas is populated by `ReactFlowGraph`'s init effect (child effects run
+   * before parent effects), so the overlay lands on real local nodes carrying
+   * real local positions.
+   *
+   * ⚠ THAT RESTS ENTIRELY ON `ReactFlowGraph` BEING A STATIC IMPORT. A child
+   * behind `lazy()` + `Suspense` does not mount in the same commit, so its init
+   * effect would run AFTER this hook's — and hydration would overlay an EMPTY
+   * store, losing every position with no error anywhere. `TemplatesPanel` is
+   * already `lazy()` one section up in this same file, so the tidy-up that
+   * breaks this is both plausible and silent. Pin the invariant, not the hope.
+   */
+  it('imports ReactFlowGraph STATICALLY (a lazy() here would silently break the merge)', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url))
+    const src = readFileSync(path.join(dir, '..', 'CanvasMVP.tsx'), 'utf8')
+
+    expect(src).toMatch(/^import ReactFlowGraph from '\.\.\/canvas\/ReactFlowGraph'$/m)
+    expect(src).not.toMatch(/lazy\(\s*\(\)\s*=>\s*import\('\.\.\/canvas\/ReactFlowGraph'\)/)
+
+    // POSITIVE CONTROL (trap 13): the same matcher DOES find the lazy form on
+    // the sibling that genuinely uses it, so a green above is an observation
+    // rather than a matcher that can never fire.
+    expect(src).toMatch(/lazy\(\s*\(\)\s*=>\s*import\('\.\.\/canvas\/panels\/TemplatesPanel'\)/)
+  })
+})


### PR DESCRIPTION
# What this fixes

On boot the canvas restored **only** from the `localStorage` autosave and never asked CEE what it holds for the scenario. The measured consequences (ROADMAP 2.312): a 7-request boot in which none fetches the graph, a persisted edit forgotten on refresh, and — the data-integrity one — **a stale-store edit that REBASES silently**: the server recorded *"from £3,500 to £4,200"* where the user had been shown £4,000.

This is **piece 3 of 3**. Piece 1 (transport, ROADMAP 2.317) and piece 2 (CEE's scenario-addressed read, PR #804 → `ecdc4cf`, deployed) are already in.

# The design in one line

**Values from the server, layout from local.**

The two sides are authoritative for different things and neither is authoritative for both. CEE owns the analytical state — `scenarios.graph` is what every turn and every analysis is computed from. The canvas owns the layout — `scenarios.graph` carries **no geometry at all**, and CEE *measures* that on the bytes it returns (`layout_present`, false for every real graph today) rather than promising it.

So the merge goes through the **existing** position-preserving `overlayNode` / `overlayEdge` primitive, imported from `mergeAppliedGraph.ts` rather than re-implemented — a second copy of "spread the existing node first" is the hand-maintained mirror this repo keeps getting bitten by. It never goes through `hydrateGraphSlice`, which replaces the node array and would land every server node at `{0,0}`, scrambling the user's canvas on every refresh.

# ⚠ The base is a dedicated constant, NOT `VITE_CEE_BFF_BASE`

Every other CEE caller in this repo resolves its base as `import.meta.env.VITE_CEE_BFF_BASE || '/bff/cee'`. That looks like house style and **copying it here would have sent this call to the wrong service.**

That var is unset in the tree — so it reads as same-origin locally — but it is **dashboard-set to the absolute PLoT URL** `https://plot-lite-service-staging.onrender.com/v1/cee`, and Vite inlines it at build time. PLoT does not serve `scenario_graph.v1`, so a hydrate call resolved from it would leave the edge seam, hit PLoT, and 404 — and **a 404 on this route means "not readable"**, so the failure would have been indistinguishable from a legitimate refusal and the canvas would simply never have hydrated. (CLAUDE.md trap 18: env posture is not derivable from this repo.)

`SCENARIO_GRAPH_BASE = '/bff/cee'` is therefore a literal. Both hops that make it work were read at this tip: `netlify/edge-functions/cee-proxy.ts` (`path: '/bff/cee/*'`, rewrite → `/assist/v1`, target `cee-staging`, injects `X-Olumi-Assist-Key` server-side) and `vite.config.ts` for dev.

## The pin for that hazard could not be behavioural — measured, not reasoned

The brief asked for "a spec pinning the resolved URL shape". I wrote one, it was vacuous, I rewrote it more carefully, **and it was still vacuous** — the mutation battery is what caught it.

A throwaway module containing exactly `(import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'` was imported under vitest *after* setting `import.meta.env.VITE_CEE_BFF_BASE` to a PLoT URL and calling `vi.resetModules()`. It still resolved to `'/bff/cee'`. **Vite substitutes `import.meta.env.VITE_*` at TRANSFORM time**, so a runtime mutation is unobservable to the module no matter when it is imported.

The consequence is the point: **no runtime assertion in this suite can distinguish the hazardous form from the safe one** — in test, both evaluate to the fallback. A behavioural pin would have passed against the exact code it exists to forbid, forever. This is why the original evidence for the hazard was a crawl of the deployed bundle and not a test. The guard is now source-level, with a positive control that finds the var in a sibling which genuinely does use it (trap 13).

# Scope boundary — stated, not half-done

Hydration re-opens last-writer-wins between the server row and the `localStorage` autosave. This resolves it **one way and only at boot**: on a field both sides carry, the server's value wins, because the server's copy is what the next turn and the next analysis will be computed against — showing anything else *is* the rebase defect.

Explicitly **not** in scope, and not silently attempted:

- **no continuous sync** — this runs at boot, once per scenario id;
- **no CAS** — the UI does not write back through this path;
- **NO DELETION.** An element the canvas has and the server does not **survives**. The autosave can legitimately be ahead of the server (guest inspector edits never reach CEE at all — ROADMAP 2.304), so reconciling absence to deletion would trade a stale value for lost work. Absence is only authoritative on the applied-edit receipt path, which has a receipt to justify it; a boot read has none. `removedNodeCount` is structurally 0 and asserted.

Residual, named rather than hidden: a local-only edit made before this boot keeps its node, but a field the server also carries is overwritten by the server's value. A merge-policy/CAS rung is a separate row if wanted.

# The four binding consumer notes (PR #804)

| note | how it is honoured | mutant |
|---|---|---|
| 1. `graph_identity_hash` is an **envelope** — read `.value` | `readIdentityEnvelope` accepts only the object and reads `.value`; a **bare string is refused**, not adopted (accepting it would silently drop the `projection_version` gate) | M5 |
| 2. token is **opaque, CEE-issued**; compare CEE-to-CEE, gate on `projection_version`, **never recompute** | stored verbatim in `serverGraphIdentity`; comparison returns false across differing `projectionVersion` | M4, M12 |
| 3. **404 = not readable, never deletion**; 503 = retry | 404 → `notReadable`, canvas untouched; 503 retried (3 attempts) then `unavailable`, never degraded to "no graph" | M2, M3, M8, M13 |
| 4. no `updated_at` by ruling | the hash token is the only staleness anchor; no "last synced" surface added | — |

**Also honoured:** `200 + graph_present:false` is `absent` — a normal empty canvas, not an error — and is a *distinct* status from `notReadable`. A 200 whose `graph_present` disagrees with the bytes fails closed as `unusable`.

# Adversarial review — amendments (A1–A6)

Review verdict was FIX-FIRST. All six amended; every one carries a mutant.

**A1 (BLOCKER) — the overlay was provenance-blind, and broke the review badge in BOTH directions.**
`mapDraftNodeToCanvas` emits only the camelCase `observedState` bag and `overlayNode` replaces it wholesale, while `isReviewedByUser` resolves the **snake** key *first* — a key the mapper never emits. CEE cannot settle this: its `ObservedStateV3.source` is `z.enum(['brief_extraction','cee_inference'])`, so the server bag is **structurally incapable** of carrying user provenance. Consequences at every boot were (a) an honest camel-only `user` stamp **stripped even on a byte-identical round-trip** — the pill regresses and "N to verify" grows back every reload; (b) on a dual-key node the snake stamp **survives over the server's new number**, so "checked by you" is painted on a value the user never saw; (c) `overlayEdge` replaces a weight while `userReviewedStrength` survives.

New `hydrateProvenance.ts`: **value unchanged → preserve** the user's stamp; **value changed → server wins on the value AND every user stamp is cleared in both spellings and at the top level**. Edges: clear `userReviewedStrength` when the weight moves. Membership is decided by `isReviewedSource` — the same predicate that paints the badge — so this can never drift from what the UI claims. Producer stamps are left to the overlay, which is their correct owner. The review's three probes are now identity-bound specs asserting through `isReviewedByUser`/`isReviewedEdge` rather than by poking a key (trap 19).

*Scoped to the boot path deliberately:* the receipt path plausibly shares this class, but changing it is an unreviewed behaviour change to shipped code. **Named as a follow-up, not silently altered.**

**A2 — the wiring was unpinned.** Deleting the one call left all 45 specs green. Added a mounting-layer spec that renders the **real** CanvasMVP with only the hydration hook spied (heavy children stubbed), plus hook specs for the once-only guard, abort-on-dep-change, unmount abort, and the scenario-moved guard — all previously comment-only claims. M17 is the deletion mutant.

**A3 — the boot revert was silent and unrecoverable.** Now: (i) a **pre-merge history snapshot** whenever an existing value moves, so the revert is undoable — without it the `useScenario` autosave persists the reverted state ~1.5s later and destroys the last copy; (ii) **disclosure** via the existing applied-edit pulse, on the changed elements only (additions are not overwrites); (iii) a **per-attempt fetch deadline** so a cold-start answer arriving tens of seconds late cannot roll back edits made in the window. Threading `timeoutMs` through the orchestration layer was a **real gap the new test caught** — the option existed on the client and nothing passed it.

**A4 — the base guard false-passed on indirection.** Now bound to what `scenarioGraphUrl` actually **uses** (the constant must be live, not dead-but-present) and it follows one hop of relative imports, with positive controls on **both** halves of the guard.

**A5 — restore-before-hydrate rested on an unstated invariant.** `ReactFlowGraph` must stay a **static** import: behind `lazy()` its init effect runs after this hook's and the overlay would land on an empty store, losing every position silently. `TemplatesPanel` is already `lazy()` in the same file, so the tidy-up is plausible. Pinned, with a positive control proving the matcher can see the lazy form.

**A6 — hydration NEVER ran in development.** StrictMode double-mounts: the ref was marked attempted before the async call, the first attempt was aborted, the second effect early-returned. Production was unaffected — which is the trap, since a manual dev check would have observed "no hydration" and drawn the wrong conclusion about shipped code. An aborted attempt no longer counts as an attempt.

Also removed three assertions that could not fail.

## Known residuals (declared, not fixed — rowed by the orchestrator)

- **Signed-in Supabase-loader race.** `useScenario.loadScenario` and this hydration can both write on an authenticated boot. Guest is the tier that ships, so this is not on the deployed path.
- **Zero-overlap guard is porous to semantic ids.** Two unrelated graphs that happen to share an id like `goal-1` would pass the overlap check. Inherited class, present at **both** sites (this one and the receipt reconciler).
- **Contract debt.** The vendored `@talchain/schemas` 0.31.0 carries no `scenario_graph.v1`, so the hand-written parser in `scenarioGraph.ts` is the **sole** validator of this response. Hazard 1 is not engaged (the shape is CEE-local), but there is no shared type to drift *against* either.
- **Adjacent orphanable stamp.** `threshold_source` / `success_threshold` can be separated by the same mechanism A1 fixes for `observed_state.source`. Outside the badge-predicate class (no review claim rides on it), rowed under the 2.374 family.
- **Hand-mirrored location pair.** The provenance rungs are listed in two places — `isReviewedByUser`'s resolution chain and `hydrateProvenance`'s `OBSERVED_STATE_KEYS`. The *membership* test is derived (`isReviewedSource`), but the *location list* is not, so a fourth rung added to the predicate would not automatically be cleared here. Rowed under the same family.

# Verification

**RED-first at pristine**, before any implementation existed:

```
Test Files  3 failed (3)
     Tests  no tests
Failed to resolve import "../scenarioGraph" / "../mergeServerGraph" / "../serverGraphHydration"
```

Every assertion bound to a named signature that did not resolve.

**Mutation battery — 22/22 KILLED**, 69 specs. Run in a worktree **outside the repo root** (trap 9c) on committed state, applied-check **scoped to `src/`** with the control reading **exactly zero** (trap 12e), every anchor asserted unique, every write asserted to land, and **zero-tests-collected treated as a hard ERROR rather than a kill**.

| # | mutant | result |
|---|---|---|
| M1 | server positions clobber local layout | KILLED (4) |
| M2 | hydrate on 404 **discards the canvas** | KILLED (1) |
| M3 | 404 collapsed into `absent` | KILLED (2) |
| M4 | identity token **recomputed locally** | KILLED (4) |
| M5 | bare-string hash adopted (the envelope trap) | KILLED (1) |
| M6 | server nodes matched **by array index** | KILLED (1) |
| M7 | **THE HAZARD** — base resolved from `VITE_CEE_BFF_BASE` | KILLED (1) |
| M8 | 503 not retried | KILLED (4) |
| M9 | boot **deletes** a local-only node | KILLED (2) |
| M10 | zero-overlap guard removed (two graphs grafted) | KILLED (1) |
| M11 | an empty server graph blanks the canvas | KILLED (1) |
| M12 | token compared **across** `projection_version` | KILLED (1) |
| M13 | persistent 503 degrades into "no graph" | KILLED (2) |
| **M14** | **A1** — drop the equality branch (identical round-trip strips the stamp) | KILLED (4) |
| **M15** | **A1** — drop the snake clear (false "checked by you" survives) | KILLED (1) |
| **M16** | **A1** — edge review stamp outlives its weight | KILLED (1) |
| **M17** | **A2** — **delete the `useServerGraphHydration` call** | KILLED (2) |
| **M18** | **A6** — mark attempted on abort (no hydration under StrictMode) | KILLED (1) |
| **M19** | **A3** — drop the pre-merge snapshot | KILLED (1) |
| **M20** | **A4** — base indirection, constant left dead-but-present | KILLED (1) |
| **M21** | **A5** — `ReactFlowGraph` made `lazy()` | KILLED (1) |
| **M22** | **A3** — no fetch deadline | KILLED (1) |

## ⚠ Two mutants SURVIVED the first pass, and both were defects in MY TESTS

Recorded rather than quietly re-rolled, because the *reasons* generalise.

- **M7 survived** for the transform-time reason above — the pin is now source-level.
- **M6 survived a position-only assertion**, and the reason is structural: `overlayNode` spreads the **existing** node first, so **layout is immune to a mis-binding** and only the **values** get crossed. A position-only "identity-bound per node" test was asserting the one property the defect cannot disturb. It now asserts the values.

Both fixes were re-run through the **full** battery, not just their own mutants: 13/13.

## Gates

- **`pnpm run typecheck`** (the named gate, `scripts/ci/typecheck-gate.sh`) — **PASSED**. Phase 1 coverage at the **committed** state: **3191 / 3231** tracked files loaded (40 declared out of scope) — `+7` tracked and `+7` loaded, i.e. **all seven files this PR adds are loaded by a project**, none invisible to the gate. Phase 2 ratchet: **623 files / 2507 errors, baseline 2507** — unchanged, so the seven new files contribute **zero** errors.
  *(An earlier local run of this gate reported 3184 / 3224. That run was made while the new files were still UNTRACKED, and phase 1 derives its source set from `git ls-files` — so it had not actually measured them. The committed-state numbers above are the ones that count.)*
- **`pnpm lint`** — **0 errors**; `rules-of-hooks` ratchet: 234 known violations across 16 files, exactly matching baseline. The amendment commit introduced two `no-unused-vars` warnings of its own (`hydrateProvenance.ts`) and they were **fixed at source**, not left in.
- **Regression run** over every suite covering a modified file (`canvas/utils`, `canvas/store`, `canvas/hooks`, `canvas/hydrate`, `routes`, `adapters/cee`, both `pre-analysis` trees, and the PoC routing spec): **200 files / 3122 tests, 0 failures** (13 skipped, pre-existing).

### Two gate-caught defects in the amendment commit — fixed at source, not baselined

Recorded because the gates earned it. `let spy: ReturnType<typeof vi.spyOn>` widens to `MockInstance<unknown[], unknown>` and does not accept the real spy: the ratchet caught it as a genuine **new** error (2507 → **2508**, TS2322 on a file with baseline 0) and it is now typed through a factory. And the `const { x: _dropped, ...rest }` idiom raised two new lint warnings, rewritten as a shallow copy + `delete`. **Neither was absorbed into a baseline.**

### ⚠ I called an identity `::notice::` "non-blocking", was wrong, and CI caught it

The typecheck gate reported `1 diagnostic appeared, 1 disappeared` in `src/canvas/conversation/useConversation.ts` — a file this PR does not touch. I diagnosed it correctly but then **misjudged its consequence** and shipped the first push without acting on it. Recording that rather than quietly fixing it, because the mechanism is worth knowing.

The diagnosis (verified against copies of both baselines taken before regeneration):

- the identity baseline already carried that exact TS2345, whose text embeds an **elision counter**: `'{ currentResultsHash: …; ... 247 more ...; }' is not assignable to 'V5ApplicatorStore'`;
- this PR adds **exactly two** members to that store type (`serverGraphIdentity` + `setServerGraphIdentity`), so `247 → 249`;
- `scripts/ci/typecheck-baseline.txt` after regeneration: **NO DIFF** — 623 files / 2507 errors, unchanged;
- `typecheck-baseline-identities.txt`: **exactly two lines**, one out one in, same file, same code, same count of 1, differing only in that counter.

So it is a **message re-render of a pre-existing diagnostic, not a new error** — the message-text instability the gate's own header documents.

**But "reported, not blocking" was wrong.** The gate's own positive control (`typecheck:selftest`, its own CI job) asserts as its **green control** that a clean tree prints *no* added-diagnostics notice. An unregenerated identity baseline therefore fails `Typecheck Gate Self-Test`, and `Staging Gate` fails as a **pure rollup of it** — `tsc`, `vitest`, `vitest-summary` and `build` all reported `success`. That control is the right design: a standing notice nobody clears is exactly how a report rots into noise people learn to skip. Regenerated in `f4c91327`.

*(One observation for whoever owns that script: the rollup's error text reads "the typecheck gate did NOT go red when it should have", while the assertion that actually failed is the opposite — the gate printed a notice when it should not have. Not fixed here; flagged.)*

## What is NOT proven here

**jsdom proves presence, never layout** (trap 3). Every claim above is behavioural and store-level. The reload/lineage **screen witness** — that a refreshed canvas visibly shows the server's values at the user's own positions — rides the next walk with the Track 2 batch, per the brief.

Local measurements were taken on a machine under **load average ~80–150 from unrelated processes**; nothing was run concurrently with a measurement, no timing-shaped result is reported as a defect, and CI is the authoritative run.

# Files

| file | |
|---|---|
| `src/adapters/cee/scenarioGraph.ts` | **new** — the client; dedicated base, envelope reader, 503 retry, discriminated results |
| `src/canvas/utils/mergeServerGraph.ts` | **new** — the merge; reuses `overlayNode`/`overlayEdge`; pre-merge snapshot + pulse |
| `src/canvas/utils/hydrateProvenance.ts` | **new** (A1) — preserve/clear the user's review stamp across the merge |
| `src/canvas/hydrate/serverGraphHydration.ts` | **new** — boot orchestration + CEE-to-CEE token comparison |
| `src/canvas/hooks/useServerGraphHydration.ts` | **new** — the trigger (all logic lives above it) |
| `src/canvas/utils/mergeAppliedGraph.ts` | exports `overlayNode`, `overlayEdge`, placement constants |
| `src/canvas/store.ts` | `serverGraphIdentity` + setter, cleared via `DECISION_CONTEXT_CLEAR` |
| `src/routes/CanvasMVP.tsx` | mounts the hook — **not** gated on `isPersistenceActive` (false for every guest, and guest is the tier that ships) |

Specs: `scenarioGraph.spec.ts`, `mergeServerGraph.spec.ts`, `mergeServerGraph.provenance.spec.ts` (A1), `serverGraphHydration.spec.ts`, `useServerGraphHydration.spec.tsx` (A2/A6), `CanvasMVP.serverGraphHydration.spec.tsx` (A2/A5).

**Do not merge — review follows.**
