### PR TITLE
fix(ui): light the contested-edge pre-analysis panel with a client-side one-per-target cap (ROADMAP 2.146)

### DIFF
--- a/src/canvas/components/pre-analysis/__tests__/contestedCards.spec.ts
+++ b/src/canvas/components/pre-analysis/__tests__/contestedCards.spec.ts
@@ -177,6 +177,14 @@ describe('Contested edge calibration cards', () => {
     }
   })
 
+  // ⚠ THE TWO EDGES MUST HAVE DIFFERENT TARGETS, AND THAT IS LOAD-BEARING FOR THIS TEST.
+  // This spec pins the DISPLAY ordering of contested items (evoi_impact above no-evoi). Both
+  // edges pointed at `goal1` until the client-side one-per-target-node cap landed
+  // (utils/selectSurfacedContestedEdges.ts), which would keep only one of them and leave
+  // nothing to order. Repointing e2 at its own goal keeps BOTH items on screen so the
+  // ordering assertion still has two objects to order — it does not weaken the assertion:
+  // deleting the evoi-presence branch of the verify sort still elects e1 (max_divergence 0.9
+  // beats 0.3) and turns this red.
   it('sorts contested items with evoi_impact above those without', () => {
     const v1 = makeValidation({ max_divergence: 0.9, evoi_impact: null })
     const v2 = makeValidation({ max_divergence: 0.3, evoi_impact: 0.05 })
@@ -185,10 +193,11 @@ describe('Contested edge calibration cards', () => {
         { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor 1' } },
         { id: 'fac2', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor 2' } },
         { id: 'goal1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+        { id: 'goal2', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal 2' } },
       ],
       edges: [
         { id: 'e1', source: 'fac1', target: 'goal1', data: { weight: 0.5, direction: 'positive', validation: v1 } },
-        { id: 'e2', source: 'fac2', target: 'goal1', data: { weight: 0.5, direction: 'positive', validation: v2 } },
+        { id: 'e2', source: 'fac2', target: 'goal2', data: { weight: 0.5, direction: 'positive', validation: v2 } },
       ],
     }))
 

--- a/src/canvas/components/pre-analysis/__tests__/contestedEdgeCap.spec.ts
+++ b/src/canvas/components/pre-analysis/__tests__/contestedEdgeCap.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * CONTESTED-EDGE CLIENT-SIDE CAP — ROADMAP 2.146 residual, orchestrator ruling (c).
+ *
+ * WHY THIS SPEC EXISTS. `ValidationMetadata.surfaced` was specced as "whether CEE
+ * selected this contested edge for user review", with CEE applying a one-per-target-node
+ * cap. CEE never built it — `EdgeValidationMetadata` in olumi-assistants-service
+ * (src/cee/validation-pipeline/types.ts) has no `surfaced` key. The UI declared the field
+ * REQUIRED and gated on it, so every contested edge that actually arrives on the wire was
+ * dropped and the pre-analysis panel stayed dark over live metadata (CEE's validation
+ * pipeline is ON in code since #808).
+ *
+ * Ruling (c): honour `surfaced` when present, treat ABSENT as ELIGIBLE, and apply the
+ * designed one-per-target-node cap CLIENT-SIDE with a deterministic tie-break —
+ * highest `max_divergence` → lowest `distance_to_goal` → lowest edge id.
+ *
+ * EVERY ASSERTION BINDS BY EDGE ID (trap 19). "One edge survives" is not asserted
+ * anywhere; the specific surviving id is. The tie-break fixtures are built so that
+ * deleting ANY ONE of the three keys elects a DIFFERENT, named edge.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { usePreAnalysisData } from '../hooks/usePreAnalysisData'
+import { useCanvasStore } from '../../../store'
+import type { Node, Edge } from '@xyflow/react'
+import type { ValidationMetadata } from '../../../domain/validation'
+
+vi.mock('../../../store', () => ({ useCanvasStore: vi.fn() }))
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { usePreAnalysisData as _useExistingPreAnalysisData } from '../../../hooks/usePreAnalysisData'
+vi.mock('../../../hooks/usePreAnalysisData', () => ({
+  usePreAnalysisData: vi.fn(() => ({
+    canRun: true,
+    hasBlockers: false,
+    allIssues: [],
+    fixFirstIssues: [],
+    remainingCount: 0,
+    limitingFactor: null,
+    quality: null,
+    readyOptionsCount: 0,
+    totalOptionsCount: 0,
+    edgeProvenance: null,
+    isLoading: false,
+  })),
+}))
+
+vi.mock('../../../hooks/usePreRunValidation', () => ({
+  usePreRunValidation: vi.fn(() => ({ blockers: [], informationalBlockers: [] })),
+  SOFT_BYPASS_STATUSES: new Set(),
+}))
+
+const mockUseCanvasStore = useCanvasStore as unknown as ReturnType<typeof vi.fn>
+
+/**
+ * Builds contested validation metadata. `surfaced` is NOT set by default — that is the
+ * shape CEE actually emits today, and the whole point of the change under test.
+ */
+function contested(overrides: Partial<ValidationMetadata> = {}): ValidationMetadata {
+  return {
+    status: 'contested',
+    contested_reasons: ['strength_band_change'],
+    pass1: { strength_mean: 0.3, strength_std: 0.1, exists_probability: 0.9 },
+    pass2: {
+      strength_mean: 0.7,
+      strength_std: 0.1,
+      exists_probability: 0.9,
+      reasoning: 'Independent review disagrees',
+      basis: 'domain_prior',
+      needs_user_input: false,
+    },
+    max_divergence: 0.5,
+    distance_to_goal: 2,
+    evoi_rank: null,
+    evoi_impact: null,
+    was_shown: false,
+    user_action: 'pending',
+    resolved_value: null,
+    resolved_by: 'default',
+    ...overrides,
+  } as ValidationMetadata
+}
+
+const NODES: Node[] = [
+  { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor 1' } },
+  { id: 'fac2', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor 2' } },
+  { id: 'fac3', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Factor 3' } },
+  { id: 'goal1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal 1' } },
+  { id: 'goal2', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal 2' } },
+]
+
+function edge(id: string, source: string, target: string, validation: ValidationMetadata): Edge {
+  return { id, source, target, data: { weight: 0.5, direction: 'positive', validation } }
+}
+
+function mountWith(edges: Edge[], nodes: Node[] = NODES) {
+  mockUseCanvasStore.mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({
+      nodes,
+      edges,
+      ceeAnalysisReady: null,
+      runMeta: null,
+      ceeQuality: null,
+      ceePipelineTrace: null,
+      preAnalysisSensitivity: null,
+    }),
+  )
+  return renderHook(() => usePreAnalysisData())
+}
+
+/** Surviving contested edge ids, in the order the panel would render them. */
+function survivingIds(result: { current: { contestedEdges: Array<{ edge: Edge }> } }): string[] {
+  return result.current.contestedEdges.map(c => c.edge.id)
+}
+
+/** Contested verify-item ids — the OTHER consumer, which must agree with the above. */
+function verifyContestedIds(result: {
+  current: { improvementsByCategory: { verify: Array<{ key: string; subgroup?: string }> } }
+}): string[] {
+  return result.current.improvementsByCategory.verify
+    .filter(i => i.subgroup === 'contested')
+    .map(i => i.key.replace(/^contested_/, ''))
+}
+
+describe('Contested-edge cap — eligibility (`surfaced` optional, absent = eligible)', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('an ABSENT `surfaced` is ELIGIBLE — the shape CEE actually emits reaches the panel', () => {
+    const { result } = mountWith([edge('e_absent', 'fac1', 'goal1', contested())])
+
+    expect(survivingIds(result)).toEqual(['e_absent'])
+    expect(verifyContestedIds(result)).toEqual(['e_absent'])
+  })
+
+  it('CONTROL — `surfaced: false` is STILL excluded, so the change is not a blanket permit', () => {
+    const { result } = mountWith([edge('e_suppressed', 'fac1', 'goal1', contested({ surfaced: false }))])
+
+    expect(survivingIds(result)).toEqual([])
+    expect(verifyContestedIds(result)).toEqual([])
+  })
+
+  it('CONTROL — an explicit `surfaced: true` is still honoured', () => {
+    const { result } = mountWith([edge('e_explicit', 'fac1', 'goal1', contested({ surfaced: true }))])
+
+    expect(survivingIds(result)).toEqual(['e_explicit'])
+  })
+
+  it('CONTROL — a resolved edge (user_action !== pending) is still excluded even with `surfaced` absent', () => {
+    const { result } = mountWith([
+      edge('e_resolved', 'fac1', 'goal1', contested({ user_action: 'accepted_pass1' })),
+    ])
+
+    expect(survivingIds(result)).toEqual([])
+  })
+
+  it('CONTROL — an agreed (non-contested) edge is never surfaced', () => {
+    const { result } = mountWith([edge('e_agreed', 'fac1', 'goal1', contested({ status: 'agreed' }))])
+
+    expect(survivingIds(result)).toEqual([])
+  })
+})
+
+describe('Contested-edge cap — one per target node, deterministic tie-break', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  // KEY 1 — highest max_divergence. Ids are chosen so that DELETING this key elects
+  // `e_aaa_low` (lowest id, equal distance), not the expected `e_zzz_high`.
+  it('KEY 1 — of three contested edges onto ONE target, the highest `max_divergence` survives: e_zzz_high', () => {
+    const { result } = mountWith([
+      edge('e_aaa_low', 'fac1', 'goal1', contested({ max_divergence: 0.2, distance_to_goal: 2 })),
+      edge('e_zzz_high', 'fac2', 'goal1', contested({ max_divergence: 0.9, distance_to_goal: 2 })),
+      edge('e_mmm_mid', 'fac3', 'goal1', contested({ max_divergence: 0.5, distance_to_goal: 2 })),
+    ])
+
+    expect(survivingIds(result)).toEqual(['e_zzz_high'])
+  })
+
+  // KEY 2 — lowest distance_to_goal. Ids are chosen so that DELETING this key elects
+  // `e_alpha_far` (lowest id), not the expected `e_zulu_near`.
+  it('KEY 2 — on a `max_divergence` tie, the LOWEST `distance_to_goal` survives: e_zulu_near', () => {
+    const { result } = mountWith([
+      edge('e_alpha_far', 'fac1', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 5 })),
+      edge('e_zulu_near', 'fac2', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 1 })),
+    ])
+
+    expect(survivingIds(result)).toEqual(['e_zulu_near'])
+  })
+
+  // KEY 3 — lowest edge id. This is the TOTALITY key: without it the winner is decided by
+  // input order, and the panel reorders between renders. `e_zzz_first` is deliberately
+  // FIRST in the array, so deleting the key elects it.
+  it('KEY 3 — on a full tie, the LOWEST EDGE ID survives regardless of input position: e_aaa_second', () => {
+    const { result } = mountWith([
+      edge('e_zzz_first', 'fac1', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 3 })),
+      edge('e_aaa_second', 'fac2', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 3 })),
+    ])
+
+    expect(survivingIds(result)).toEqual(['e_aaa_second'])
+  })
+
+  it('KEY 3 — the same full tie REVERSED elects the same id, proving the cap is input-order-independent', () => {
+    const { result } = mountWith([
+      edge('e_aaa_second', 'fac2', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 3 })),
+      edge('e_zzz_first', 'fac1', 'goal1', contested({ max_divergence: 0.7, distance_to_goal: 3 })),
+    ])
+
+    expect(survivingIds(result)).toEqual(['e_aaa_second'])
+  })
+
+  it('the cap is PER TARGET NODE, not a global top-1 — each target keeps its own winner', () => {
+    const { result } = mountWith([
+      edge('e_g1_hi', 'fac1', 'goal1', contested({ max_divergence: 0.9 })),
+      edge('e_g1_lo', 'fac2', 'goal1', contested({ max_divergence: 0.1 })),
+      edge('e_g2_hi', 'fac2', 'goal2', contested({ max_divergence: 0.8 })),
+      edge('e_g2_lo', 'fac3', 'goal2', contested({ max_divergence: 0.2 })),
+    ])
+
+    expect([...survivingIds(result)].sort()).toEqual(['e_g1_hi', 'e_g2_hi'])
+  })
+
+  it('a `surfaced: false` edge cannot win the cap and does not consume its target slot', () => {
+    const { result } = mountWith([
+      edge('e_suppressed_hi', 'fac1', 'goal1', contested({ max_divergence: 0.99, surfaced: false })),
+      edge('e_eligible_lo', 'fac2', 'goal1', contested({ max_divergence: 0.1 })),
+    ])
+
+    expect(survivingIds(result)).toEqual(['e_eligible_lo'])
+  })
+})
+
+describe('Contested-edge cap — the two consumers derive from ONE selection (trap 12)', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('`contestedEdges` and the contested verify items name EXACTLY the same edge ids', () => {
+    const { result } = mountWith([
+      edge('e_g1_hi', 'fac1', 'goal1', contested({ max_divergence: 0.9 })),
+      edge('e_g1_lo', 'fac2', 'goal1', contested({ max_divergence: 0.1 })),
+      edge('e_g2_hi', 'fac2', 'goal2', contested({ max_divergence: 0.8 })),
+      edge('e_g2_lo', 'fac3', 'goal2', contested({ max_divergence: 0.2 })),
+    ])
+
+    const fromCards = [...survivingIds(result)].sort()
+    const fromVerify = [...verifyContestedIds(result)].sort()
+
+    // Non-vacuity guard: an empty-vs-empty agreement would pass while proving nothing.
+    expect(fromCards).toEqual(['e_g1_hi', 'e_g2_hi'])
+    expect(fromVerify).toEqual(fromCards)
+  })
+})

--- a/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
+++ b/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
@@ -42,6 +42,12 @@ import { diversifyTriageItems } from '../utils/diversifyTriageItems'
 // and the pre-analysis priority-progress counter (`buildPriorityProgress`)
 // share one `observed_state.source ∈ user_*` contract — no drift.
 import { isReviewedByUser } from '../utils/isReviewedByUser'
+// `selectSurfacedContestedEdges` is the SINGLE source of truth for which contested edges
+// this panel shows: eligibility (honouring `surfaced` when CEE sends it, eligible when
+// absent) plus the client-side one-per-target-node cap. Both consumers below derive from
+// it — they used to be two hand-written filters with the same predicate spelled two
+// different ways. See that module for the CEE supersession note.
+import { selectSurfacedContestedEdges } from '../utils/selectSurfacedContestedEdges'
 // `isAiSourceFromNode` extracted to ../utils/isAiSource.ts; mirrors the
 // isReviewedByUser pattern. Field-level fallback fixes the legacy
 // object-level `observed_state ?? observedState` bug that produced
@@ -653,6 +659,11 @@ export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData
     return nodesByKind.goal[0] ?? null
   }, [nodes, ceeAnalysisReady?.goal_node_id, nodesByKind.goal])
 
+  // Contested edges this panel will show: eligible, capped one-per-target-node, deterministic.
+  // Computed ONCE and consumed by both the `verify` improvement items and the `contestedEdges`
+  // calibration cards, so the two surfaces cannot drift apart (trap 12).
+  const surfacedContestedEdges = useMemo(() => selectSurfacedContestedEdges(edges), [edges])
+
   // Build improvements by category
   const improvementsByCategory = useMemo(() => {
     const result: Record<ImprovementCategory, ImprovementItem[]> = {
@@ -878,14 +889,12 @@ export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData
     }
 
     // === CONTESTED EDGES (highest priority in reviewAssumptions) ===
-    // Filter edges with contested validation that CEE surfaced for user review
-    for (const edge of edges) {
+    // Selection (eligibility + one-per-target-node cap) is derived ONCE in
+    // `surfacedContestedEdges`; this loop only renders it. The predicate used to be inlined
+    // here as `if (!validation.surfaced) continue`, which dropped every edge CEE actually
+    // sends — see utils/selectSurfacedContestedEdges.ts.
+    for (const { edge, validation } of surfacedContestedEdges) {
       const data = edge.data as { validation?: ValidationMetadata; label?: string } | undefined
-      const validation = data?.validation
-      if (!validation) continue
-      if (validation.status !== 'contested') continue
-      if (!validation.surfaced) continue
-      if (validation.user_action !== 'pending') continue
 
       const sourceNode = nodes.find(n => n.id === edge.source)
       const targetNode = nodes.find(n => n.id === edge.target)
@@ -1032,20 +1041,11 @@ export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData
     }
 
     return result
-  }, [nodes, edges, nodesByKind, ceeAnalysisReady?.options, ceeAnalysisReady?.verification_prompts, ceeAnalysisReady?.low_confidence_edges, m1ReviewAssumptions, preAnalysisSensitivity])
+  }, [nodes, edges, surfacedContestedEdges, nodesByKind, ceeAnalysisReady?.options, ceeAnalysisReady?.verification_prompts, ceeAnalysisReady?.low_confidence_edges, m1ReviewAssumptions, preAnalysisSensitivity])
 
-  // Contested edges with full validation metadata for calibration card rendering
-  const contestedEdges = useMemo(() => {
-    return edges
-      .filter(e => {
-        const v = (e.data as { validation?: ValidationMetadata } | undefined)?.validation
-        return v?.status === 'contested' && v?.surfaced && v?.user_action === 'pending'
-      })
-      .map(e => ({
-        edge: e,
-        validation: (e.data as { validation: ValidationMetadata }).validation,
-      }))
-  }, [edges])
+  // Contested edges with full validation metadata for calibration card rendering.
+  // Same derived selection the verify items use — see `surfacedContestedEdges` above.
+  const contestedEdges = surfacedContestedEdges
 
   // Total improvements
   const totalImprovements = useMemo(() => {

--- a/src/canvas/components/pre-analysis/utils/selectSurfacedContestedEdges.ts
+++ b/src/canvas/components/pre-analysis/utils/selectSurfacedContestedEdges.ts
@@ -1,0 +1,108 @@
+/**
+ * CONTESTED-EDGE SELECTION FOR THE PRE-ANALYSIS PANEL — eligibility + one-per-target cap.
+ *
+ * ⚠⚠ SUPERSESSION NOTE — THE CAP HERE IS A STAND-IN FOR A CEE FIELD THAT WAS SPECCED AND
+ * NEVER BUILT. DELETE IT WHEN CEE SHIPS `surfaced`. ⚠⚠
+ *
+ * `ValidationMetadata.surfaced` is documented as "whether CEE selected this contested edge
+ * for user review", under the note "CEE applies one-per-target-node cap". CEE's
+ * `EdgeValidationMetadata` (olumi-assistants-service, `src/cee/validation-pipeline/types.ts`)
+ * has **no `surfaced` key** — the cap was designed and never implemented. The UI nevertheless
+ * declared the field REQUIRED and gated on it, so once CEE's validation pipeline went ON in
+ * code (#808), every contested edge on the wire arrived with `surfaced` absent and was
+ * dropped: the pre-analysis panel was dark over live metadata.
+ *
+ * Orchestrator ruling (4 Aug 2026, option (c)): deliver the differentiator now, keeping the
+ * DESIGNED cap semantics, client-side.
+ *   · `surfaced` becomes OPTIONAL on the UI type, and ABSENT means ELIGIBLE.
+ *   · An explicit `surfaced === false` is still honoured — CEE can suppress an edge the day
+ *     it starts emitting the field, without a UI change.
+ *   · The cap is applied here, with a deterministic tie-break.
+ *
+ * WHEN CEE SHIPS `surfaced`: honour it and DROP the client cap — i.e. delete
+ * `capOnePerTargetNode` and its comparator, and KEEP `isEligibleContested` (which is the
+ * part that honours the field). Do not delete the whole module.
+ *
+ * ⚠ THE MODEL TAB DELIBERATELY HAS NO CAP. `RelationshipsSection.tsx::compareContestedPriority`
+ * orders the full contested list there and every pending contested edge stays fully
+ * actionable. That comparator is a DISPLAY ordering (it leads on `evoi_impact` and has no
+ * total-order key); this one is a WINNER SELECTION and must be total. They are deliberately
+ * separate and must not be unified — unifying would either put a cap on the Model tab or
+ * make this selection non-deterministic.
+ */
+
+import type { Edge } from '@xyflow/react'
+import type { ValidationMetadata } from '../../../domain/validation'
+
+export interface SurfacedContestedEdge {
+  edge: Edge
+  validation: ValidationMetadata
+}
+
+/**
+ * Is this edge a contested edge the user should be asked to adjudicate?
+ *
+ * `surfaced` is honoured when CEE sends it and treated as ELIGIBLE when absent. Note the
+ * explicit `!== false` rather than a truthiness test: `!validation.surfaced` was the
+ * original gate, and it is exactly what made the panel dark.
+ */
+export function isEligibleContested(validation: ValidationMetadata | undefined): boolean {
+  if (!validation) return false
+  if (validation.status !== 'contested') return false
+  if (validation.surfaced === false) return false
+  if (validation.user_action !== 'pending') return false
+  return true
+}
+
+/**
+ * Winner-selection order for the cap. TOTAL by construction:
+ *   1. highest `max_divergence`   — the most disagreement is the most worth asking about
+ *   2. lowest `distance_to_goal`  — nearer the goal matters more
+ *   3. lowest edge id             — the TOTALITY key
+ *
+ * Key 3 is not decoration. Without it the winner of a full tie is whichever edge the input
+ * array happened to present first, so the panel reorders between renders whenever the graph
+ * is rebuilt in a different order. Returns <0 when `a` outranks `b`.
+ */
+export function compareContestedCapPriority(a: SurfacedContestedEdge, b: SurfacedContestedEdge): number {
+  if (a.validation.max_divergence !== b.validation.max_divergence) {
+    return b.validation.max_divergence - a.validation.max_divergence
+  }
+  if (a.validation.distance_to_goal !== b.validation.distance_to_goal) {
+    return a.validation.distance_to_goal - b.validation.distance_to_goal
+  }
+  if (a.edge.id === b.edge.id) return 0
+  return a.edge.id < b.edge.id ? -1 : 1
+}
+
+/**
+ * Eligible contested edges, capped at ONE PER TARGET NODE.
+ *
+ * Survivors are returned in INPUT ORDER, not comparator order: the caller applies its own
+ * display sort (the pre-analysis verify sort leads on `evoi_impact`), and imposing an order
+ * here would silently compete with it.
+ *
+ * ⚠ SINGLE SOURCE OF TRUTH. Both pre-analysis consumers — the `verify` improvement items and
+ * the `contestedEdges` calibration cards — call THIS function. They were two hand-written
+ * filters with the same predicate spelled two different ways
+ * (`if (!validation.surfaced) continue` and `v?.surfaced && ...`), which is the trap-12
+ * hand-maintained mirror. Do not re-inline either one.
+ */
+export function selectSurfacedContestedEdges(edges: Edge[]): SurfacedContestedEdge[] {
+  const eligible: SurfacedContestedEdge[] = []
+  for (const edge of edges) {
+    const validation = (edge.data as { validation?: ValidationMetadata } | undefined)?.validation
+    if (!isEligibleContested(validation)) continue
+    eligible.push({ edge, validation: validation as ValidationMetadata })
+  }
+
+  const winnerByTarget = new Map<string, SurfacedContestedEdge>()
+  for (const candidate of eligible) {
+    const incumbent = winnerByTarget.get(candidate.edge.target)
+    if (!incumbent || compareContestedCapPriority(candidate, incumbent) < 0) {
+      winnerByTarget.set(candidate.edge.target, candidate)
+    }
+  }
+
+  return eligible.filter(c => winnerByTarget.get(c.edge.target) === c)
+}

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -86,9 +86,23 @@ export interface ValidationMetadata {
   /** Percentage points of goal probability; null pre-analysis */
   evoi_impact: number | null
 
-  // Visibility control (CEE applies one-per-target-node cap)
-  /** Whether CEE selected this contested edge for user review */
-  surfaced: boolean
+  // Visibility control
+  /**
+   * Whether CEE selected this contested edge for user review.
+   *
+   * ⚠ OPTIONAL, AND ABSENT MEANS ELIGIBLE. This field was specced as "CEE applies a
+   * one-per-target-node cap" and CEE never built it — `EdgeValidationMetadata` in
+   * olumi-assistants-service (`src/cee/validation-pipeline/types.ts`) has no `surfaced` key,
+   * so nothing on the wire ever sets it. Declaring it REQUIRED was a TS-only lie with no
+   * runtime validator, and the pre-analysis panel's `if (!validation.surfaced) continue`
+   * gate consequently dropped every contested edge once the CEE pipeline went live (#808).
+   *
+   * Per the orchestrator ruling of 4 Aug 2026 the designed cap now runs CLIENT-SIDE in
+   * `canvas/components/pre-analysis/utils/selectSurfacedContestedEdges.ts`, which honours an
+   * explicit `false` and treats absent as eligible. When CEE starts emitting this field,
+   * honour it and delete the client cap — see the supersession note in that module.
+   */
+  surfaced?: boolean
 
   // User interaction tracking
   was_shown: boolean


### PR DESCRIPTION
## What this fixes

The pre-analysis contested-edge panel was **dark over live CEE metadata**.

`ValidationMetadata.surfaced` was specced as *"whether CEE selected this contested edge for user review"*, under the comment *"CEE applies one-per-target-node cap"*. **CEE never built it** — `EdgeValidationMetadata` in `olumi-assistants-service` (`src/cee/validation-pipeline/types.ts`) has no `surfaced` key. The UI nevertheless declared the field **required** and gated on it at two sites:

- `usePreAnalysisData.ts:887` — `if (!validation.surfaced) continue`
- `usePreAnalysisData.ts:1042` — `v?.status === 'contested' && v?.surfaced && ...`

Once CEE's validation pipeline went ON in code (#808, deployed staging ~14:14Z 3 Aug), every contested edge on the wire arrived with `surfaced` **absent** and both gates dropped it. A TS-only lie with no runtime validator — the built-not-connected class.

## What this does — orchestrator ruling (4 Aug 2026), option (c)

- **`surfaced` becomes optional; ABSENT means ELIGIBLE.** An explicit `false` is still honoured, so CEE can suppress an edge the day it starts emitting the field, with no UI change.
- **The designed one-per-target-node cap now runs client-side**, with a **total** tie-break: highest `max_divergence` → lowest `distance_to_goal` → **lowest edge id**. The id key is what makes the winner input-order-independent; without it the panel reorders between renders.
- **Both consumers derive from ONE selection function.** They were two hand-written filters spelling the same predicate two different ways — the trap-12 hand-maintained mirror.
- **Supersession note left in-code**: when CEE ships `surfaced`, honour it and delete the client cap (keep the eligibility filter).

The **Model tab deliberately keeps no cap** (`RelationshipsSection::compareContestedPriority`) — that comparator is a *display ordering*, this one is a *winner selection* and must be total. Kept separate on purpose; unifying would either cap the Model tab or make this selection non-deterministic.

## RED-first — named signatures at pristine `0c4e2cc3`, captured before any source edit

`npx vitest run "…/contestedEdgeCap.spec.ts"` → **Tests 8 failed | 4 passed (12)**

RED (8) — the proof obligations:
1. `eligibility > an ABSENT surfaced is ELIGIBLE — the shape CEE actually emits reaches the panel`
2. `tie-break > KEY 1 — of three contested edges onto ONE target, the highest max_divergence survives: e_zzz_high`
3. `tie-break > KEY 2 — on a max_divergence tie, the LOWEST distance_to_goal survives: e_zulu_near`
4. `tie-break > KEY 3 — on a full tie, the LOWEST EDGE ID survives regardless of input position: e_aaa_second`
5. `tie-break > KEY 3 — the same full tie REVERSED elects the same id, proving the cap is input-order-independent`
6. `tie-break > the cap is PER TARGET NODE, not a global top-1 — each target keeps its own winner`
7. `tie-break > a surfaced: false edge cannot win the cap and does not consume its target slot`
8. `trap 12 > contestedEdges and the contested verify items name EXACTLY the same edge ids`

GREEN at pristine (4) — **the controls**, which must stay green across the change (they are what stops this being a blanket permit): `surfaced: false` still excluded · explicit `surfaced: true` still honoured · resolved edge still excluded · agreed edge never surfaced.

**Every assertion binds by edge ID** (trap 19). "One edge survives" is asserted nowhere; the specific surviving id is. The tie-break fixtures are built so deleting **any one** of the three keys elects a *different, named* edge.

## Mutants — throwaway worktree OUTSIDE the repo root, COMMITTED state `b41e28e6`

Applied-check scoped to `src/` (trap 12e); every mutation asserted `APPLIED=1`; control asserted **exactly 0**; a missing totals line is a hard error.

| # | mutation | result |
|---|---|---|
| M0 | CONTROL — pristine committed state | **23 passed (23)**, APPLIED=**0** |
| M1 | revert eligibility to the original `!validation.surfaced` gate | 8 failed / 15 passed — BITES |
| M2 | **delete the tie-break's SECOND key (`distance_to_goal`)** | 1 failed / 22 passed — BITES |
| M3 | delete the tie-break's FIRST key (`max_divergence`) | 1 failed / 22 passed — BITES |
| M4 | delete the tie-break's THIRD key (edge id) → non-total | 1 failed / 22 passed — BITES |
| M5 | remove the cap entirely | 6 failed / 17 passed — BITES |
| M6 | make the cap GLOBAL instead of per-target (overshoot) | 12 failed / 11 passed — BITES |
| M7 | delete the `surfaced === false` exclusion (blanket permit, overshoot) | 3 failed / 20 passed — BITES |
| M8 | delete the `user_action !== 'pending'` exclusion (overshoot) | 2 failed / 21 passed — BITES |
| M9 | re-inline an UNCAPPED filter at one consumer (the drift this refactor removes) | 8 failed / 15 passed — BITES |

**9/9 bite.** M2 is the brief's required tie-break mutant. M6/M7/M8 are the direction-of-error mutants — they catch an activation that **overshoots** (a global cap, a blanket permit) rather than one that under-delivers. M9 proves the anti-drift assertion is not decorative.

## Pre-existing test fixed at source, not absorbed

`contestedCards.spec.ts > sorts contested items with evoi_impact above those without` pointed **both** of its contested edges at one target, so the cap would leave nothing to order. Fixed by giving the second edge its own target. This does **not** weaken it: deleting the evoi-presence branch of the verify sort still elects `e1` (`max_divergence` 0.9 beats 0.3) and still reds. Reasoning left in-code.

## Gates at this tip

- **`pnpm run typecheck`** (= `bash scripts/ci/typecheck-gate.sh`) — **PASSED**. Coverage 3184/3224 tracked TS files. Ratchet: 621 files / 2505 errors vs baseline 2507 — **none added**.
- Derived with a pristine control worktree: pristine `0c4e2cc3` reads **623 files / 2507**, so the **−2 shrink is attributable to this change** — two pre-existing `TS2322` fixture diagnostics in `ContestedEdgeCard.spec.tsx` and `RelationshipsSection.spec.tsx` that making `surfaced` optional resolves.
- **`--update-baseline` deliberately NOT accepted.** The gate is green without it, and `typecheck-baseline*.txt` is a shared generated file that two other in-flight UI lanes could also move. Flagged for the reviewer rather than banked.
- Affected-area sweep: `pre-analysis` + `model-tab` + `inspector-v2` → **143 files, 2076 passed, 13 skipped, 0 failed**.

## Scope note — the OTHER half of this brief was NOT shipped, deliberately

Item 1 (`VITE_FEATURE_COMMENTS` default-on) is **withdrawn on a corrected premise**: the affordance is unreachable in any deployed build. Full reachability manifest in the lane report. No flag was flipped.

## Co-ordination

Base `0c4e2cc3` re-derived immediately before push and **unchanged**. Files disjoint from PR #570 (hydrate) and the L43 elicitation lane.

**NOT merged — adversarial review follows.**

---

## ⚠ SELF-REFUTATION — READ BEFORE ACCEPTING THE M5 CLAIM

**The surface this PR lights is not the one a staging tester currently sees.** Derived from the **deployed bundle** using the repo's own instrument `pnpm flags:check` (`tools/ci-guards/flag-deployment-drift.mjs`), not from `netlify.toml` and not from prose (trap 18). Deploy under test `https://staging--olumi.netlify.app`, asset chain `/` → `/assets/index-Qjl0hhVW.js` → `/assets/flags-DBpusaUf.js`, deployed commit `0c4e2cc3` — the same tip this PR is based on.

| flag | env key | flags.ts | netlify.toml | **DEPLOYED** |
|---|---|---|---|---|
| `preAnalysisV3` | `VITE_FEATURE_PRE_ANALYSIS_V3` | OFF | `"1"` | **ON (`"1"`)** |

`OutputsDock.tsx:2344` branches on `isPreAnalysisV3Enabled()`. It is **ON**, so the live pre-run surface is `PreAnalysisPanelV3`, and the legacy `PreAnalysisPanel` — the one that consumes `usePreAnalysisData().contestedEdges` and renders `ContestedEdgeCard` — is the **flag-off reinstatement branch**.

**`pre-analysis-v3` renders no contested edges at all.** Complete sweep, scope stated: **35 non-test files** under `src/canvas/components/pre-analysis-v3/`, `rg -a` for `contested|ValidationMetadata|\.validation\b|usePreAnalysisData` → **zero hits**. Its signal registry carries no `truth.contested_edge`, and `usePreAnalysisModel.ts` never reads edge validation.

**Therefore:** the defect this PR fixes is real, the fix is correct, and it restores the contested panel on the legacy surface — but **the brief's M5 for this item is NOT achieved on deployed staging by this PR alone**, and I am not claiming it. Closing that gap needs an orchestrator decision: either a V3-side contested surface, or turning the V3 flag off. Rowing it rather than quietly shipping a panel nobody reaches would be the same built-not-connected class this PR exists to fix.

This is the same standard that killed item 1 of the brief, applied to my own work.
