### PR TITLE
feat(canvas): belief elicitation, wired end-to-end (ROADMAP 2.364)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2507
+# count=2504
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -131,7 +131,6 @@
 1	src/adapters/cee/client.ts	TS2352	Conversion of type 'CEEv2Response' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/adapters/cee/client.ts	TS2352	Conversion of type 'CEEv3Response' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/adapters/cee/client.ts	TS2677	A type predicate's type must be assignable to its parameter's type.
-1	src/adapters/cee/client.ts	TS6133	'fetch' is declared but its value is never read.
 4	src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts	TS2741	Property 'template_id' is missing in type '{ graph: { nodes: { id: string; label: string; }[]; edges: never[]; }; seed: number; }' but required in type 'RunRequest'.
 1	src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts	TS6133	'beforeEach' is declared but its value is never read.
 1	src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts	TS6133	'completeCalled' is declared but its value is never read.
@@ -294,8 +293,6 @@
 1	src/canvas/components/AdvancedSettingsPanel.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'RiskProfile'.
 1	src/canvas/components/AdvancedSettingsPanel.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'RiskProfilePreset'.
 1	src/canvas/components/AdvancedSettingsPanel.tsx	TS6133	'isLast' is declared but its value is never read.
-1	src/canvas/components/BeliefInput.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'BeliefElicitResponse'.
-1	src/canvas/components/BeliefInput.tsx	TS2339	Property 'elicitBelief' does not exist on type '{ run(input: RunRequest): Promise<ReportV1>; templates(): Promise<TemplateListV1>; template(id: string): Promise<TemplateDetail>; ... 4 more ...; stream: { ...; }; }'.
 1	src/canvas/components/CommandPalette.tsx	TS2322	Type 'Promise<boolean>' is not assignable to type 'Promise | void<void>'.
 1	src/canvas/components/CommandPalette.tsx	TS2322	Type 'boolean' is not assignable to type 'Promise | void<void>'.
 6	src/canvas/components/CommandPalette.tsx	TS2322	Type 'null | string' is not assignable to type 'Promise | void<void>'.

--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2504
+# count=2502
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -428,8 +428,6 @@
 1	src/canvas/components/__tests__/ValidationPanel.spec.tsx	TS6133	'beforeEach' is declared but its value is never read.
 1	src/canvas/components/__tests__/ValidationPanel.spec.tsx	TS6133	'waitFor' is declared but its value is never read.
 1	src/canvas/components/model-tab/InlineEdit.tsx	TS6133	'cancel' is declared but its value is never read.
-1	src/canvas/components/model-tab/__tests__/ContestedEdgeCard.spec.tsx	TS2322	Type '{ status: "agreed" | "contested"; contested_reasons: ContestedReason[]; pass1: { strength_mean: number; strength_std: number; exists_probability: number; }; ... 9 more ...; resolved_by: "default" | "user"; }' is not assignable to type 'ValidationMetadata'.
-1	src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx	TS2322	Type '{ status: "agreed" | "contested"; contested_reasons: ContestedReason[]; pass1: { strength_mean: number; strength_std: number; exists_probability: number; }; ... 9 more ...; resolved_by: "default" | "user"; }' is not assignable to type 'ValidationMetadata'.
 1	src/canvas/components/pre-analysis-v3/hooks/__tests__/useSensitivityRanking.plotBearer.spec.tsx	TS2493	Tuple type '[]' of length '0' has no element at index '1'.
 1	src/canvas/components/pre-analysis/AllImprovements.tsx	TS2561	Object literal may only specify known properties, but 'setShowDetail' does not exist in type 'DetailContext'. Did you mean to write 'showDetail'?
 4	src/canvas/components/pre-analysis/AllImprovements.tsx	TS2722	Cannot invoke an object which is possibly 'undefined'.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2507
+# count=2504
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -67,7 +67,7 @@
 11	src/adapters/__tests__/errorScenarios.spec.ts
 6	src/adapters/assistants/__tests__/bff-only.spec.ts
 1	src/adapters/cee/__tests__/adaptDraftResponse.spec.ts
-19	src/adapters/cee/client.ts
+18	src/adapters/cee/client.ts
 6	src/adapters/plot/__tests__/autoDetectAdapter.streaming.test.ts
 13	src/adapters/plot/__tests__/determinism.test.ts
 2	src/adapters/plot/__tests__/enrichment.spec.ts
@@ -119,7 +119,6 @@
 3	src/canvas/analysis/assembleAnalysisInputsSummary.ts
 6	src/canvas/compare/EdgeDiffTable.tsx
 3	src/canvas/components/AdvancedSettingsPanel.tsx
-2	src/canvas/components/BeliefInput.tsx
 8	src/canvas/components/CommandPalette.tsx
 7	src/canvas/components/CompareView.tsx
 2	src/canvas/components/ComparisonTable.tsx

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2504
+# count=2502
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -182,8 +182,6 @@
 2	src/canvas/components/__tests__/UnifiedStatusBadge.f57.spec.tsx
 2	src/canvas/components/__tests__/ValidationPanel.spec.tsx
 1	src/canvas/components/model-tab/InlineEdit.tsx
-1	src/canvas/components/model-tab/__tests__/ContestedEdgeCard.spec.tsx
-1	src/canvas/components/model-tab/__tests__/RelationshipsSection.spec.tsx
 1	src/canvas/components/pre-analysis-v3/hooks/__tests__/useSensitivityRanking.plotBearer.spec.tsx
 11	src/canvas/components/pre-analysis/AllImprovements.tsx
 1	src/canvas/components/pre-analysis/DecisionQualityChecks.tsx

--- a/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
+++ b/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
@@ -194,6 +194,51 @@ describe('CEEClient.elicitBelief — response handling', () => {
     })
   })
 
+  it('⭐ A4 — REFUSES an out-of-range CLARIFICATION CHIP value, not just suggested_value', async () => {
+    // A chip is committable: `acceptElicited(opt.value)` puts it straight into
+    // `observed_state.value`. Before this bound the chips were covered only by
+    // the OBSERVATIONAL warn-parse (log and continue), so a malformed 200 with
+    // a valid `suggested_value` and `options: [{value: 7.5}]` rendered a chip
+    // that committed 7.5 — contradicting this client's own invariant.
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        ...WITNESSED_OK,
+        needs_clarification: true,
+        clarifying_question: 'How likely?',
+        options: [
+          { label: 'Very likely', value: 0.9 },
+          { label: 'Broken', value: 7.5 },
+        ],
+      }),
+    )
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+
+  it('A4 — a well-formed clarification response still passes, boundaries included', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        ...WITNESSED_OK,
+        needs_clarification: true,
+        clarifying_question: 'How likely?',
+        options: [
+          { label: 'Certain', value: 1 },
+          { label: 'Impossible', value: 0 },
+        ],
+      }),
+    )
+
+    await expect(new CEEClient().elicitBelief(INPUT)).resolves.toMatchObject({
+      needs_clarification: true,
+    })
+  })
+
+  it('A4 — REFUSES a non-array `options`, rather than rendering nothing and calling it fine', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, options: 'nope' }))
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+
   it('surfaces an HTTP failure as a CEEError rather than a fabricated number', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({ message: 'rate limited' }, 429))
 

--- a/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
+++ b/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * `CEEClient.elicitBelief` — THE CONTRACT PIN (ROADMAP 2.364).
+ *
+ * WHY THESE ASSERTIONS ARE THE SHAPE THEY ARE. CEE's `CEEElicitBeliefInput` is
+ * `.strict()` (`olumi-assistants-service/src/schemas/cee.ts`, read at `staging`
+ * 2026-08-03), so ONE unrecognised key 400s the whole call — a failure the user
+ * sees and the developer does not, because nothing in this repo typechecks
+ * against CEE's Zod. So the body is asserted by its EXACT KEY SET, not by
+ * `objectContaining`: `objectContaining` passes with an extra key, which is
+ * precisely the defect that would ship.
+ *
+ * The path is asserted absolutely for the same reason: `/bff/cee/elicit-belief`
+ * is rewritten to `/assist/v1/elicit-belief` by the `cee-proxy` edge function
+ * that also injects the auth key. A path that misses that binding gets the SPA
+ * catch-all — HTTP 200, `text/html` — which is the 2.317 defect: a green
+ * response that is not an answer.
+ *
+ * RED-first at pristine `0c4e2cc3`: `CEEClient` has no `elicitBelief` method,
+ * so every case here fails at the call.
+ *
+ * Observability/gate/retry are mocked exactly as the sibling client specs do
+ * (crypto.subtle is unavailable in jsdom).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CEEClient, CEEError } from '../client'
+
+vi.mock('../../../lib/observability-headers', () => ({
+  withObservabilityHeaders: vi.fn(
+    async (_url: string, _method: string, _body: unknown, headers: Record<string, string>) => ({
+      headers,
+      startTime: Date.now(),
+    }),
+  ),
+  recordBffResponse: vi.fn(),
+  recordBffError: vi.fn(),
+  recordBffResponsePayload: vi.fn(),
+}))
+
+vi.mock('../../../lib/gate-state', () => ({
+  useGateStore: { getState: () => ({ setGate: vi.fn() }) },
+}))
+
+vi.mock('../../../lib/fetchWithRetry', () => ({
+  withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}))
+
+/** The witnessed live response for "pretty likely" (2026-08-03, staging BFF). */
+const WITNESSED_OK = {
+  suggested_value: 0.7,
+  confidence: 'high',
+  reasoning:
+    'Interpreted "pretty likely" as approximately 70% probability based on common usage.',
+  needs_clarification: false,
+  provenance: 'cee',
+  trace: { request_id: 'l43' },
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(jsonResponse(WITNESSED_OK))
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function firstCall(): { url: string; init: RequestInit } {
+  const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+  return { url, init }
+}
+
+function bodyOfFirstCall(): Record<string, unknown> {
+  return JSON.parse(String(firstCall().init.body)) as Record<string, unknown>
+}
+
+const INPUT = {
+  node_id: 'fac_churn_risk',
+  node_label: 'Churn risk',
+  user_expression: 'pretty likely',
+  target_type: 'prior' as const,
+}
+
+describe('CEEClient.elicitBelief — request contract', () => {
+  it('POSTs to the /bff/cee seam the edge function binds (/elicit-belief)', async () => {
+    await new CEEClient().elicitBelief(INPUT)
+
+    const { url, init } = firstCall()
+    // Absolute, not a substring: '/bff/cee/elicit-belief' is the ONLY path the
+    // cee-proxy edge function rewrites to /assist/v1/elicit-belief.
+    expect(url).toBe('/bff/cee/elicit-belief')
+    expect(init.method).toBe('POST')
+  })
+
+  it("sends EXACTLY CEE's .strict() key set — no extras, none missing", async () => {
+    await new CEEClient().elicitBelief(INPUT)
+
+    const body = bodyOfFirstCall()
+    // Sorted key-set equality. An extra key fails here; `objectContaining`
+    // would not, and an extra key is a 400 from a .strict() server.
+    expect(Object.keys(body).sort()).toEqual(
+      ['node_id', 'node_label', 'target_type', 'user_expression'].sort(),
+    )
+    expect(body.node_id).toBe('fac_churn_risk')
+    expect(body.node_label).toBe('Churn risk')
+    expect(body.user_expression).toBe('pretty likely')
+    expect(body.target_type).toBe('prior')
+  })
+
+  it('includes context_id ONLY when the caller supplies one', async () => {
+    await new CEEClient().elicitBelief({ ...INPUT, context_id: 'ctx_1' })
+
+    const body = bodyOfFirstCall()
+    expect(Object.keys(body).sort()).toEqual(
+      ['context_id', 'node_id', 'node_label', 'target_type', 'user_expression'].sort(),
+    )
+    expect(body.context_id).toBe('ctx_1')
+  })
+})
+
+describe('CEEClient.elicitBelief — response handling', () => {
+  it('returns the witnessed live shape, reading the value from suggested_value', async () => {
+    const result = await new CEEClient().elicitBelief(INPUT)
+
+    // Bound to the FIELD, not to the number: the response carries exactly one
+    // 0.7 today, so a renderer reading `trace.whatever` would still pass a
+    // bare `toBe(0.7)`. This asserts provenance of the number as well.
+    expect(result.suggested_value).toBe(WITNESSED_OK.suggested_value)
+    expect(result.confidence).toBe('high')
+    expect(result.needs_clarification).toBe(false)
+    expect(result.provenance).toBe('cee')
+  })
+
+  it('carries the clarification branch through intact (question + option chips)', async () => {
+    const clarify = {
+      suggested_value: 0.75,
+      confidence: 'low',
+      reasoning: '"good" is ambiguous.',
+      needs_clarification: true,
+      clarifying_question: 'When you say "good" for Churn risk, how likely do you mean?',
+      options: [
+        { label: 'Very likely', value: 0.9 },
+        { label: 'Quite likely', value: 0.75 },
+        { label: 'More likely than not', value: 0.6 },
+      ],
+      provenance: 'cee',
+    }
+    fetchSpy.mockResolvedValue(jsonResponse(clarify))
+
+    const result = await new CEEClient().elicitBelief({ ...INPUT, user_expression: 'good' })
+
+    expect(result.needs_clarification).toBe(true)
+    expect(result.clarifying_question).toBe(clarify.clarifying_question)
+    expect(result.options?.map(o => o.value)).toEqual([0.9, 0.75, 0.6])
+  })
+
+  it('REFUSES a suggested_value above 1 — the number must never reach a commit', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, suggested_value: 70 }))
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+
+  it('REFUSES a suggested_value below 0', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, suggested_value: -0.1 }))
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+
+  it('REFUSES a missing/non-numeric suggested_value', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, suggested_value: '0.7' }))
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+
+  it('ACCEPTS the boundaries 0 and 1 (the refusal is out-of-range, not near-range)', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, suggested_value: 0 }))
+    await expect(new CEEClient().elicitBelief(INPUT)).resolves.toMatchObject({
+      suggested_value: 0,
+    })
+
+    fetchSpy.mockResolvedValue(jsonResponse({ ...WITNESSED_OK, suggested_value: 1 }))
+    await expect(new CEEClient().elicitBelief(INPUT)).resolves.toMatchObject({
+      suggested_value: 1,
+    })
+  })
+
+  it('surfaces an HTTP failure as a CEEError rather than a fabricated number', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ message: 'rate limited' }, 429))
+
+    await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+})

--- a/src/adapters/cee/client.ts
+++ b/src/adapters/cee/client.ts
@@ -7,11 +7,16 @@ import type {
   CEEv3Response,
   CeePipelineTrace,
   CEEDraftCoaching,
+  BeliefElicitSuggestion,
 } from './types'
 import { isCEEv2Response, isCEEv3Response, isCeePipelineTrace } from './types'
 import { withObservabilityHeaders, recordBffResponse, recordBffError, recordBffResponsePayload } from '../../lib/observability-headers'
 import { useGateStore } from '../../lib/gate-state'
-import { CEEDraftResponseSchema, warnOnInvalidApiResponse } from '../../lib/api-schemas'
+import {
+  CEEDraftResponseSchema,
+  CEEElicitBeliefResponseSchema,
+  warnOnInvalidApiResponse,
+} from '../../lib/api-schemas'
 import { withRetry } from '../../lib/fetchWithRetry'
 import { devWarn } from '../../utils/debugLog'
 import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
@@ -834,6 +839,73 @@ export class CEEClient {
 
     // Fall back to v1 adaptation for legacy responses
     return adaptDraftResponse(raw)
+  }
+
+  /**
+   * Turn a phrase about a factor into a number — ROADMAP 2.364.
+   *
+   * Endpoint: `POST /elicit-belief` on this client's own base, which the
+   * `cee-proxy` edge function rewrites to `/assist/v1/elicit-belief` and signs
+   * with `X-Olumi-Assist-Key` server-side (`netlify/edge-functions/
+   * cee-proxy.ts`; `netlify.toml` binds it to `/bff/cee/*`). No absolute
+   * service URL is built here on purpose — the key lives in the Netlify
+   * dashboard, never in the bundle, and the same-origin path is what the live
+   * 2026-08-03 witness exercised.
+   *
+   * THE REQUEST IS A CONTRACT PIN, NOT A CONVENIENCE SHAPE. CEE's
+   * `CEEElicitBeliefInput` is `.strict()` (`olumi-assistants-service/
+   * src/schemas/cee.ts`, read at `staging`), so ONE unrecognised key 400s the
+   * whole call. The parameter list below is that schema, field for field, and
+   * the co-located spec asserts the emitted body's keys EXACTLY — an added key
+   * fails RED here before it can fail loudly in a user's face.
+   *
+   * NOT `fetchIdempotent`: the retry wrapper is for read-only endpoints, and
+   * this one is rate-limited per key (60/min). A debounced keystroke retrying
+   * itself three times burns the caller's budget on input they have already
+   * replaced.
+   *
+   * REFUSAL, not a warning, on an out-of-range `suggested_value`. The response
+   * is warn-parsed like every other CEE response, but a probability outside
+   * [0,1] is the one shape that must not reach `handleAccept` — it would be
+   * committed as `observed_state.value`, which is defined on [0,1]. So the
+   * bound is enforced HERE, at the boundary, by throwing.
+   */
+  async elicitBelief(input: {
+    /** The factor's id. ID-ADDRESSED, like every other mutation on this seam. */
+    node_id: string
+    node_label: string
+    /** The user's own words ("pretty likely", "about 70%", "3 in 4"). */
+    user_expression: string
+    target_type: 'prior' | 'edge_weight'
+    context_id?: string
+  }): Promise<BeliefElicitSuggestion> {
+    const body: Record<string, unknown> = {
+      node_id: input.node_id,
+      node_label: input.node_label,
+      user_expression: input.user_expression,
+      target_type: input.target_type,
+    }
+    // Omitted rather than sent as undefined: `JSON.stringify` drops undefined
+    // values, but building the key conditionally says so at the source.
+    if (input.context_id !== undefined) body.context_id = input.context_id
+
+    const raw = await this.fetch<unknown>('/elicit-belief', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+
+    warnOnInvalidApiResponse(CEEElicitBeliefResponseSchema, raw, 'CEE elicit-belief')
+
+    const suggested = (raw as { suggested_value?: unknown } | null)?.suggested_value
+    if (typeof suggested !== 'number' || !Number.isFinite(suggested) || suggested < 0 || suggested > 1) {
+      throw new CEEError(
+        'That estimate came back in a form we could not use, so nothing has changed.',
+        502,
+        raw,
+      )
+    }
+
+    return raw as BeliefElicitSuggestion
   }
 
   /**

--- a/src/adapters/cee/client.ts
+++ b/src/adapters/cee/client.ts
@@ -487,12 +487,28 @@ export function adaptDraftResponse(raw: unknown): CEEDraftResponse {
 const ENDPOINT_TIMEOUTS: Record<string, number> = {
   // draft-graph needs 150s: OpenAI can take 64-71s, plus CEE processing
   '/draft-graph': 150000,
+  // elicit-belief is a DETERMINISTIC lexicon+regex parse with no LLM call and
+  // no network fan-out, behind a debounced keystroke. The 150s default meant a
+  // cold start or a headers-then-body stall left the user staring at a text
+  // box for two and a half minutes with no answer and no error (#572 review).
+  // 20s is generous for a Render cold start and short enough that "it didn't
+  // work" arrives while the user is still looking at the field.
+  '/elicit-belief': 20000,
 }
 
 // Audit F-67: Default timeout set to 150s — above CEE's 135s route timeout.
 // Prevents silent hangs while allowing CEE sufficient processing time.
 // Surfaces timeout as user-visible CEEError (408) via AbortController in fetchWithBase.
 const DEFAULT_CEE_TIMEOUT = 150000
+
+/**
+ * A probability, as `observed_state.value` defines one: a finite number in
+ * [0,1]. The ONE place this bound is spelled on the client, so the
+ * `suggested_value` check and the chip check cannot drift apart.
+ */
+function isProbability(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
 
 export class CEEClient {
   private baseURL: string
@@ -896,13 +912,36 @@ export class CEEClient {
 
     warnOnInvalidApiResponse(CEEElicitBeliefResponseSchema, raw, 'CEE elicit-belief')
 
-    const suggested = (raw as { suggested_value?: unknown } | null)?.suggested_value
-    if (typeof suggested !== 'number' || !Number.isFinite(suggested) || suggested < 0 || suggested > 1) {
+    const parsed = raw as { suggested_value?: unknown; options?: unknown } | null
+    if (!isProbability(parsed?.suggested_value)) {
       throw new CEEError(
         'That estimate came back in a form we could not use, so nothing has changed.',
         502,
         raw,
       )
+    }
+
+    // THE CHIPS ARE COMMITTABLE TOO — so they get the SAME hard bound, not the
+    // observational one. `warnOnInvalidApiResponse` logs and continues, so
+    // before this check a malformed 200 carrying `options: [{label:'X',
+    // value: 7.5}]` alongside a valid `suggested_value` passed the client,
+    // rendered a chip, and committed 7.5 as `observed_state.value` on click —
+    // contradicting this file's own stated invariant that an out-of-range
+    // probability must never render or commit (#572 review). CEE's schema
+    // bounds them and its engine is deterministic; this is the boundary
+    // holding its own line rather than trusting the far side to.
+    if (parsed?.options !== undefined) {
+      const options = Array.isArray(parsed.options) ? parsed.options : null
+      if (
+        options === null ||
+        !options.every(o => isProbability((o as { value?: unknown } | null)?.value))
+      ) {
+        throw new CEEError(
+          'That estimate came back in a form we could not use, so nothing has changed.',
+          502,
+          raw,
+        )
+      }
     }
 
     return raw as BeliefElicitSuggestion

--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -721,3 +721,42 @@ export function isCeePipelineTrace(value: unknown): value is CeePipelineTrace {
     Array.isArray(v.stages)
   )
 }
+
+// =============================================================================
+// Belief elicitation (ROADMAP 2.364)
+// =============================================================================
+
+/**
+ * One clarification chip CEE offers when a phrase is ambiguous
+ * ("good" → "Very likely (90%)" / "Quite likely (75%)" / "More likely than
+ * not (60%)"). `value` is a probability in [0,1], same scale as
+ * `suggested_value`.
+ */
+export interface BeliefElicitOption {
+  label: string
+  /** Probability in [0,1]. */
+  value: number
+}
+
+/**
+ * CEE's answer to "what number does this phrase mean?" — the UI-local mirror of
+ * CEE's `CEEElicitBeliefResponseV1T`.
+ *
+ * `suggested_value` is a PROBABILITY in [0,1] — i.e. already the MODEL scale
+ * `observed_state.value` holds. It is never a user-unit magnitude, and the UI
+ * must not convert it into one: see `factorValueEdit.ts` (`'model_scale'` seed
+ * basis) for why the inversion belongs to the server.
+ *
+ * The engine is deterministic (lexicon + regex, no LLM call) — so this is a
+ * sub-second preview, not a generation.
+ */
+export interface BeliefElicitSuggestion {
+  /** Probability in [0,1]. */
+  suggested_value: number
+  confidence: 'high' | 'medium' | 'low'
+  reasoning: string
+  needs_clarification: boolean
+  clarifying_question?: string
+  options?: BeliefElicitOption[]
+  provenance: 'cee'
+}

--- a/src/canvas/components/BeliefInput.tsx
+++ b/src/canvas/components/BeliefInput.tsx
@@ -3,24 +3,42 @@
  *
  * Features:
  * - Slider mode: Direct numeric input with visual feedback
- * - Natural language mode: Text input parsed by CEE /v1/elicit/belief
- * - Shows SuggestionCard for AI-parsed values
+ * - Natural language mode: text parsed by CEE's belief-elicitation engine
+ * - Shows SuggestionCard for the parsed value
  * - Handles needs_clarification with clickable options
  * - Accept applies value, Override opens slider
  * - Accessible (keyboard, screen reader)
  *
  * Used in node/edge editing panels for belief/confidence values.
+ *
+ * ⭐ ROADMAP 2.364 — WIRED. What this file used to be: it called
+ * `httpV1Adapter.elicitBelief(...)` and imported
+ * `type { BeliefElicitResponse } from '../../adapters/plot/types'`. NEITHER
+ * EVER EXISTED. `httpV1Adapter` is the PLoT adapter and its method manifest is
+ * `run/templates/template/limits/health/validate/runBundle`; `git log -S
+ * BeliefElicitResponse -- src/adapters/plot/types.ts` is empty over the file's
+ * whole history. Both errors sat in the typecheck ratchet baseline
+ * (`typecheck-baseline-identities.txt`, TS2339 + TS2305) rather than in
+ * anyone's way, because the component has no render-tree import site — dead
+ * code calling a phantom API. The engines were built in CEE, not PLoT.
+ *
+ * The request shape changed with the destination and had to: CEE's
+ * `CEEElicitBeliefInput` is `.strict()` and wants
+ * `{node_id, node_label, user_expression, target_type}` — the old
+ * `{text, factor_context, scenario_name}` would have 400'd even once a method
+ * existed. `factorContext` is therefore REQUIRED here now, with `node_id`
+ * non-optional: CEE refuses an empty id, and a control that cannot name its
+ * factor cannot elicit for it.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import {
   MessageSquare,
   SlidersHorizontal,
   Loader2,
   AlertCircle,
 } from 'lucide-react'
-import { httpV1Adapter } from '../../adapters/plot/httpV1Adapter'
-import type { BeliefElicitResponse } from '../../adapters/plot/types'
+import { useBeliefElicitation } from '../hooks/useBeliefElicitation'
 import { SuggestionCard } from './SuggestionCard'
 import { typography } from '../../styles/typography'
 
@@ -31,13 +49,15 @@ interface BeliefInputProps {
   onChange: (value: number) => void
   /** Label for the input (e.g., "Confidence", "Probability") */
   label: string
-  /** Optional: context about the factor being estimated */
-  factorContext?: {
-    label: string
-    node_id?: string
+  /**
+   * The factor this belief is about. REQUIRED — CEE's elicit input refuses an
+   * empty `node_id`/`node_label`, and the id is what makes the suggestion
+   * addressable to a factor rather than to whatever is on screen.
+   */
+  factorContext: {
+    nodeId: string
+    nodeLabel: string
   }
-  /** Optional: scenario context for better interpretation */
-  scenarioName?: string
   /** Min value (default: 0) */
   min?: number
   /** Max value (default: 1) */
@@ -59,7 +79,6 @@ export function BeliefInput({
   onChange,
   label,
   factorContext,
-  scenarioName,
   min = 0,
   max = 1,
   step = 0.01,
@@ -69,83 +88,46 @@ export function BeliefInput({
 }: BeliefInputProps) {
   const [mode, setMode] = useState<InputMode>('slider')
   const [nlText, setNlText] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [suggestion, setSuggestion] = useState<BeliefElicitResponse | null>(null)
   const [isOverriding, setIsOverriding] = useState(false)
 
-  const textInputRef = useRef<HTMLInputElement>(null)
-  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+  const [textInput, setTextInput] = useState<HTMLInputElement | null>(null)
+
+  const { suggestion, loading, error, request, reset } = useBeliefElicitation({
+    nodeId: factorContext.nodeId,
+    nodeLabel: factorContext.nodeLabel,
+  })
 
   // Focus text input when switching to natural language mode
   useEffect(() => {
-    if (mode === 'natural-language' && textInputRef.current) {
-      textInputRef.current.focus()
+    if (mode === 'natural-language' && textInput) {
+      textInput.focus()
     }
-  }, [mode])
+  }, [mode, textInput])
 
   // Clear suggestion when switching modes
   useEffect(() => {
     if (mode === 'slider') {
-      setSuggestion(null)
+      reset()
       setNlText('')
-      setError(null)
       setIsOverriding(false)
     }
-  }, [mode])
-
-  // Elicit belief from natural language
-  const elicitBelief = useCallback(async (text: string) => {
-    if (!text.trim() || text.trim().length < 3) {
-      setSuggestion(null)
-      return
-    }
-
-    setLoading(true)
-    setError(null)
-
-    try {
-      const response = await httpV1Adapter.elicitBelief({
-        text: text.trim(),
-        factor_context: factorContext,
-        scenario_name: scenarioName,
-      })
-
-      setSuggestion(response)
-    } catch (err: any) {
-      const errorMessage = err?.error || err?.message || 'Failed to parse input'
-      setError(errorMessage)
-      setSuggestion(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [factorContext, scenarioName])
+  }, [mode, reset])
 
   // Debounced elicitation on text change
   const handleTextChange = useCallback((text: string) => {
     setNlText(text)
-    setError(null)
-
-    // Clear existing debounce
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current)
-    }
-
-    // Debounce API call (500ms after typing stops)
-    debounceRef.current = setTimeout(() => {
-      elicitBelief(text)
-    }, 500)
-  }, [elicitBelief])
+    request(text)
+  }, [request])
 
   // Handle accepting suggestion
   const handleAccept = useCallback((suggestedValue: number) => {
     // Clamp to min/max
     const clampedValue = Math.min(max, Math.max(min, suggestedValue))
     onChange(clampedValue)
-    setSuggestion(null)
+    reset()
     setNlText('')
     setMode('slider') // Return to slider after accepting
-  }, [onChange, min, max])
+  }, [onChange, min, max, reset])
 
   // Handle override (switch to slider mode)
   const handleOverride = useCallback(() => {
@@ -157,19 +139,19 @@ export function BeliefInput({
   const handleSelectOption = useCallback((optionValue: number) => {
     const clampedValue = Math.min(max, Math.max(min, optionValue))
     onChange(clampedValue)
-    setSuggestion(null)
+    reset()
     setNlText('')
     setMode('slider')
-  }, [onChange, min, max])
+  }, [onChange, min, max, reset])
 
   // Handle slider change
   const handleSliderChange = useCallback((newValue: number) => {
     onChange(newValue)
     if (isOverriding) {
-      setSuggestion(null)
+      reset()
       setIsOverriding(false)
     }
-  }, [onChange, isOverriding])
+  }, [onChange, isOverriding, reset])
 
   return (
     <div className="space-y-3" data-testid="belief-input">
@@ -248,7 +230,7 @@ export function BeliefInput({
           {/* Text input */}
           <div className="relative">
             <input
-              ref={textInputRef}
+              ref={setTextInput}
               type="text"
               value={nlText}
               onChange={(e) => handleTextChange(e.target.value)}

--- a/src/canvas/components/__tests__/BeliefInput.spec.tsx
+++ b/src/canvas/components/__tests__/BeliefInput.spec.tsx
@@ -3,28 +3,55 @@
  *
  * Tests for the dual-mode belief input component that supports
  * slider and natural language input modes with CEE integration.
+ *
+ * ⭐ ROADMAP 2.364. The mock below used to name
+ * `../../../adapters/plot/httpV1Adapter` — a module whose `elicitBelief` NEVER
+ * EXISTED, on the PLoT adapter, for an engine that lives in CEE. `vi.mock`
+ * happily stubs a method onto a module that has none, so this file passed for
+ * as long as it never exercised the call: there was not one assertion about a
+ * suggestion in 27 tests. That is the vacuity class in its purest form — a
+ * mock can make a phantom look real, and only an assertion about the RESULT
+ * can tell you it is not. The suggestion cases at the bottom are the coverage
+ * that was missing; they mock the TRANSPORT (`CEEClient.elicitBelief`) and
+ * assert what renders.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { BeliefInput } from '../BeliefInput'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 
-// Mock the httpV1Adapter
-vi.mock('../../../adapters/plot/httpV1Adapter', () => ({
-  httpV1Adapter: {
-    elicitBelief: vi.fn(),
-  },
-}))
+/** Elicitation replies the mocked CEE client answers with, in order. */
+const elicitReplies: Array<Record<string, unknown>> = []
+const elicitRequests: Array<Record<string, unknown>> = []
+
+vi.mock('../../../adapters/cee/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../adapters/cee/client')>()
+  class MockCEEClient extends actual.CEEClient {
+    async elicitBelief(input: Parameters<InstanceType<typeof actual.CEEClient>['elicitBelief']>[0]) {
+      elicitRequests.push(input as unknown as Record<string, unknown>)
+      const reply = elicitReplies.shift()
+      if (!reply) throw new Error('no elicitation reply queued')
+      return reply as unknown as Awaited<
+        ReturnType<InstanceType<typeof actual.CEEClient>['elicitBelief']>
+      >
+    }
+  }
+  return { ...actual, CEEClient: MockCEEClient }
+})
+
+import { BeliefInput } from '../BeliefInput'
 
 describe('BeliefInput', () => {
   const defaultProps = {
     value: 0.5,
     onChange: vi.fn(),
     label: 'Confidence',
+    factorContext: { nodeId: 'fac_churn_risk', nodeLabel: 'Churn risk' },
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
+    elicitReplies.length = 0
+    elicitRequests.length = 0
   })
 
   describe('slider mode (default)', () => {
@@ -235,6 +262,124 @@ describe('BeliefInput', () => {
       render(<BeliefInput {...defaultProps} step={0.05} />)
       const slider = screen.getByRole('slider')
       expect(slider).toHaveAttribute('step', '0.05')
+    })
+  })
+
+  /**
+   * The coverage this file never had. Everything above proves the CHROME
+   * renders; nothing above proved a suggestion could ever appear, which is why
+   * a phantom adapter method survived here undetected.
+   */
+  describe('CEE suggestions (ROADMAP 2.364)', () => {
+    const PRETTY_LIKELY = {
+      suggested_value: 0.7,
+      confidence: 'high' as const,
+      reasoning: 'Interpreted "pretty likely" as approximately 70% probability.',
+      needs_clarification: false,
+      provenance: 'cee' as const,
+    }
+
+    const AMBIGUOUS = {
+      suggested_value: 0.75,
+      confidence: 'low' as const,
+      reasoning: '"good" could mean several things.',
+      needs_clarification: true,
+      clarifying_question: 'When you say "good", how likely do you mean?',
+      options: [
+        { label: 'Very likely', value: 0.9 },
+        { label: 'Quite likely', value: 0.75 },
+        { label: 'More likely than not', value: 0.6 },
+      ],
+      provenance: 'cee' as const,
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    async function typePhrase(phrase: string): Promise<void> {
+      fireEvent.click(screen.getByLabelText('Switch to natural language mode'))
+      fireEvent.change(screen.getByLabelText('Confidence natural language input'), {
+        target: { value: phrase },
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(600)
+      })
+    }
+
+    it("sends the factor's own id and label to CEE, with target_type prior", async () => {
+      elicitReplies.push({ ...PRETTY_LIKELY })
+      render(<BeliefInput {...defaultProps} />)
+
+      await typePhrase('pretty likely')
+
+      expect(elicitRequests).toEqual([
+        {
+          node_id: 'fac_churn_risk',
+          node_label: 'Churn risk',
+          user_expression: 'pretty likely',
+          target_type: 'prior',
+        },
+      ])
+    })
+
+    it('renders the suggestion from suggested_value, and accepting applies THAT number', async () => {
+      const onChange = vi.fn()
+      elicitReplies.push({ ...PRETTY_LIKELY })
+      render(<BeliefInput {...defaultProps} onChange={onChange} />)
+
+      await typePhrase('pretty likely')
+
+      // 0.7 through the component's own formatter. No other field in the
+      // reply yields "70%", so a card rendered from the wrong field dies here.
+      expect(screen.getByTestId('suggestion-card')).toBeInTheDocument()
+      expect(screen.getByText('70%')).toBeInTheDocument()
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Accept suggestion: 70%'))
+      })
+      expect(onChange).toHaveBeenCalledWith(0.7)
+    })
+
+    it("renders the engine's clarifying question and its own chips; a chip applies THAT chip's value", async () => {
+      const onChange = vi.fn()
+      elicitReplies.push({ ...AMBIGUOUS })
+      render(<BeliefInput {...defaultProps} onChange={onChange} />)
+
+      await typePhrase('good')
+
+      expect(screen.getByTestId('suggestion-card-clarification')).toBeInTheDocument()
+      expect(
+        screen.getByText('When you say "good", how likely do you mean?'),
+      ).toBeInTheDocument()
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('More likely than not'))
+      })
+      expect(onChange).toHaveBeenCalledWith(0.6)
+    })
+
+    it('a failed elicitation renders an honest message and applies nothing', async () => {
+      const onChange = vi.fn()
+      render(<BeliefInput {...defaultProps} onChange={onChange} />)
+
+      await typePhrase('pretty likely')
+
+      expect(screen.getByText(/Nothing has changed/i)).toBeInTheDocument()
+      expect(screen.queryByTestId('suggestion-card')).not.toBeInTheDocument()
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('sends nothing for a phrase shorter than three characters', async () => {
+      render(<BeliefInput {...defaultProps} />)
+
+      await typePhrase('ab')
+
+      expect(elicitRequests).toHaveLength(0)
     })
   })
 

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -311,6 +311,14 @@ export const FIELD_FEEDBACK_COPY = {
   check: 'Check',
   edit: 'Edit',
   /**
+   * Refusal when an elicited chance is accepted on a factor that records a
+   * real-world amount (ROADMAP 2.364, #572 review). Says what did NOT happen,
+   * names the factor's own recorded shape, and points at the control that
+   * does work — the same vocabulary the range refusal below uses.
+   */
+  elicitedNotAChanceHint:
+    "This one is recorded as an amount, not a chance, so I haven't changed anything. Type the amount instead.",
+  /**
    * Range refusal for normalised-scale-only factors (journey-walk gap #3):
    * no cap, no unit, no raw-value anchor — the committed number IS the
    * model-scale value, so a magnitude like £60,000 would paint 6000000%.

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -311,14 +311,6 @@ export const FIELD_FEEDBACK_COPY = {
   check: 'Check',
   edit: 'Edit',
   /**
-   * Refusal when an elicited chance is accepted on a factor that records a
-   * real-world amount (ROADMAP 2.364, #572 review). Says what did NOT happen,
-   * names the factor's own recorded shape, and points at the control that
-   * does work — the same vocabulary the range refusal below uses.
-   */
-  elicitedNotAChanceHint:
-    "This one is recorded as an amount, not a chance, so I haven't changed anything. Type the amount instead.",
-  /**
    * Range refusal for normalised-scale-only factors (journey-walk gap #3):
    * no cap, no unit, no raw-value anchor — the committed number IS the
    * model-scale value, so a magnitude like £60,000 would paint 6000000%.

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -93,6 +93,7 @@ import { useCanvasStore } from '../../../store'
 import { getObservedState, type ObservedStateData } from '../../../utils/observedStateHelpers'
 import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
 import {
+  acceptsElicitedBelief,
   buildFactorValueEditEvent,
   resolveValueInputSeed,
   type ValueInputSeedBasis,
@@ -168,6 +169,18 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
 
   const elicitation = useBeliefElicitation({ nodeId: row.nodeId, nodeLabel: row.label })
 
+  /**
+   * May this row be asked about in words? Derived from the FACTOR'S OWN
+   * declared shape through the scale module's predicate — never from the row
+   * model, which carries `cap` but not `unit` and so cannot answer it.
+   *
+   * Selector returns a BOOLEAN, not the node: a fresh object per render is
+   * what the zustand-selector guard exists to stop.
+   */
+  const canDescribeInWords = useCanvasStore(s =>
+    acceptsElicitedBelief(s.nodes.find(n => n.id === row.nodeId)?.data),
+  )
+
   // The sanctioned setter (the `NODE_SETTER_FIELDS` manifest the writtenFields
   // guard spec enforces), not a hand-rolled `updateNode` — the same one both
   // other value-committing surfaces use. It writes `observedState.value`,
@@ -214,7 +227,26 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
     (
       typedValue: number,
       reviewedStamp: Partial<ObservedStateData>,
-      opts: { seedBasis?: ValueInputSeedBasis; writeValue: boolean },
+      opts: {
+        seedBasis?: ValueInputSeedBasis
+        writeValue: boolean
+        /**
+         * Write `typedValue` as the LOCAL display anchor as well.
+         *
+         * Only the elicited path passes it, and only because the affordance is
+         * gated to factors with no unit and no cap — the shape where CEE
+         * itself persists `raw_value = value` (`normalise-factor-value.ts:16`).
+         * So this mirrors what the server will hold; it does NOT derive one.
+         * Without it the accept clears both `display_value` copies and leaves
+         * no anchor at all, `factorDisplayText` returns null, and the row (and
+         * the canvas node) show NO NUMBER where "Low (0)" used to be — then
+         * `buildEstimateRows` calls the node scale-ambiguous and the row
+         * degrades to confirm-only, taking this very affordance with it.
+         * Confirmed in review of #572; the typed path never had the bug
+         * because `raw_only` writes the typed number as its own anchor.
+         */
+        writeRawAnchor?: boolean
+      },
     ): void => {
       const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
       if (!node) return
@@ -245,7 +277,12 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
 
       // The number moves now; the CLAIM does not. No `{ source }` option is
       // passed — that is the 2.304 fix in one line.
-      if (opts.writeValue) mutations.setObservedValue(modelValue, rawMagnitude)
+      if (opts.writeValue) {
+        mutations.setObservedValue(
+          modelValue,
+          opts.writeRawAnchor ? typedValue : rawMagnitude,
+        )
+      }
 
       if (!sendSystemEvent) return
       void Promise.resolve(
@@ -334,11 +371,27 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
    */
   const acceptElicited = useCallback(
     (suggestedValue: number): void => {
-      commit(suggestedValue, VALUE_STAMP, { seedBasis: 'model_scale', writeValue: true })
+      // BELT, not a duplicate of the affordance gate. The gate decides what to
+      // OFFER; this decides what to COMMIT, and it re-reads the factor's shape
+      // at accept time. If the gate ever drifts — or the node's shape changes
+      // under an open drill-in — the commit refuses with honest copy instead
+      // of turning £40,000 into £0.70. (`buildFactorValueEditEvent` refuses the
+      // same shape structurally; this exists so the refusal is VISIBLE rather
+      // than a silent no-op.)
+      const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
+      if (!acceptsElicitedBelief(node?.data)) {
+        setHint(FIELD_FEEDBACK_COPY.elicitedNotAChanceHint)
+        return
+      }
+      commit(suggestedValue, VALUE_STAMP, {
+        seedBasis: 'model_scale',
+        writeValue: true,
+        writeRawAnchor: true,
+      })
       elicitation.reset()
       onDone()
     },
-    [commit, elicitation, onDone],
+    [commit, elicitation, onDone, row.nodeId],
   )
 
   return (
@@ -385,7 +438,7 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
           Confirm as is
         </button>
       )}
-      {row.canEditValue && (
+      {row.canEditValue && canDescribeInWords && (
         <Tooltip content="Say what you think in plain words" delay={300}>
           <PanelIconButton
             variant="ghost"
@@ -418,7 +471,7 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
         direct input behind a mode toggle would make the fast path slower for
         anyone who already knows their number.
       */}
-      {inWords && row.canEditValue && (
+      {inWords && row.canEditValue && canDescribeInWords && (
         <div className="space-y-1" data-testid="pre-analysis-v3-in-words">
           <input
             aria-label={`Describe ${row.label} in words`}
@@ -434,6 +487,12 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
             }}
           />
 
+          {elicitation.loading && (
+            <p className={`${typography.panelMeta} text-text-light`} role="status">
+              Reading that…
+            </p>
+          )}
+
           {elicitation.error && (
             <p className={`${typography.panelMeta} text-warning`} role="status">
               {elicitation.error}
@@ -446,14 +505,22 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
             it is unsure about, and rewriting it here would put words in the
             engine's mouth that the engine cannot stand behind.
           */}
-          {elicitation.suggestion?.needs_clarification &&
-            elicitation.suggestion.options?.length ? (
+          {elicitation.suggestion?.needs_clarification ? (
             <div className="space-y-1">
               <p className={`${typography.panelMeta} text-text-body`}>
-                {elicitation.suggestion.clarifying_question}
+                {/*
+                  A response can flag itself unsure and carry NO options. The
+                  old condition required BOTH, so that shape fell through to
+                  "That reads as about X%" + Use this — offering a number the
+                  ENGINE had just said it was unsure about, without its
+                  question. Now `needs_clarification` alone suppresses the
+                  offer, and the fallback line says what happened.
+                */}
+                {elicitation.suggestion.clarifying_question ??
+                  "I couldn't pin that down. Try another wording, or type the number."}
               </p>
               <div className="flex flex-wrap gap-1.5" role="group" aria-label={`Readings for ${row.label}`}>
-                {elicitation.suggestion.options.map(opt => (
+                {(elicitation.suggestion.options ?? []).map(opt => (
                   <button
                     key={opt.label}
                     type="button"
@@ -474,8 +541,14 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
                 The number, as a chance, in plain words. The engine's REASONING
                 and CONFIDENCE are expert detail and stay behind the existing
                 progressive-disclosure affordance — inline they read as hedging.
+                ⚠ This comment used to be FALSE about confidence: it was fetched,
+                typed and warn-parsed, and then rendered nowhere at all (#572
+                review). It is in the tooltip now, so the sentence is true.
               */}
-              <Tooltip content={elicitation.suggestion.reasoning} delay={300}>
+              <Tooltip
+                content={`${elicitation.suggestion.reasoning} (${elicitation.suggestion.confidence} confidence)`}
+                delay={300}
+              >
                 <span className={`${typography.panelMeta} text-text-body`}>
                   That reads as {formatElicitedChance(elicitation.suggestion.suggested_value)}
                 </span>

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -371,18 +371,21 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
    */
   const acceptElicited = useCallback(
     (suggestedValue: number): void => {
-      // BELT, not a duplicate of the affordance gate. The gate decides what to
-      // OFFER; this decides what to COMMIT, and it re-reads the factor's shape
-      // at accept time. If the gate ever drifts — or the node's shape changes
-      // under an open drill-in — the commit refuses with honest copy instead
-      // of turning £40,000 into £0.70. (`buildFactorValueEditEvent` refuses the
-      // same shape structurally; this exists so the refusal is VISIBLE rather
-      // than a silent no-op.)
-      const node = useCanvasStore.getState().nodes.find(n => n.id === row.nodeId)
-      if (!acceptsElicitedBelief(node?.data)) {
-        setHint(FIELD_FEEDBACK_COPY.elicitedNotAChanceHint)
-        return
-      }
+      // NO SHAPE RE-CHECK HERE, deliberately — and this is a correction, not an
+      // omission. An accept-time copy of the predicate was written first and
+      // then removed when the mutation battery showed it could not be reached
+      // OR killed: `canDescribeInWords` is a REACTIVE store selector, so the
+      // moment a factor stops being a chance the whole affordance unmounts and
+      // there is no button left to click (pinned by the shape-changes-under-an-
+      // open-drill-in test). An unreachable guard that no mutant can kill is
+      // the guarantee-theatre class this estate hunts; it does not get to sit
+      // here looking reassuring.
+      //
+      // The STRUCTURAL refusal is real and lives one layer down, where it
+      // covers every caller rather than this one call site:
+      // `buildFactorValueEditEvent` returns null for a `model_scale` commit on
+      // a magnitude factor, and `commit` fails closed on a null event — no
+      // local write, no wire, no receipt, no stamp.
       commit(suggestedValue, VALUE_STAMP, {
         seedBasis: 'model_scale',
         writeValue: true,
@@ -391,7 +394,7 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
       elicitation.reset()
       onDone()
     },
-    [commit, elicitation, onDone, row.nodeId],
+    [commit, elicitation, onDone],
   )
 
   return (

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -48,10 +48,44 @@
  *
  * Value-scale guard: rows with canEditValue=false render confirm-only (no
  * numeric input) because only a normalised model-scale value exists.
+ *
+ * ⭐ ROADMAP 2.364 — "SAY IT IN WORDS". The second affordance on this row runs
+ * the user's own phrase ("pretty likely") through CEE's DETERMINISTIC
+ * belief-elicitation engine and offers the number back. Accepting it takes THIS
+ * SAME `commit`, so the elicited value is persisted, receipted and stamped by
+ * exactly the machinery above — no second commit path, no second scale rule,
+ * no LLM anywhere on the accept.
+ *
+ * THE ONE THING THAT IS DIFFERENT, and the design correction it embodies.
+ * The number CEE returns is a PROBABILITY in [0,1] — already the model scale
+ * `observed_state.value` holds — not a display-scale magnitude. So the accept
+ * commits it with `seedBasis: 'model_scale'` and the wire carries `value` with
+ * NO `raw_value`/`unit`, which is the shape CEE's own `resolveUserUnitInput`
+ * inverts with the factor's STORED cap.
+ *
+ * The original design (design-elicitation-wiring.md §3/§4) said to commit
+ * `Math.round(suggested_value * 100)` "as if the user had typed 70%". That is
+ * wrong at this tip in BOTH directions and neither failure is silent-safe:
+ *   - on the WITNESSED walk row (capless, unitless, model value in [0,1]) a
+ *     typed `70` is REFUSED by `refusesNormalisedScaleEntry` — pinned today by
+ *     `calibrateDrillInRange.spec.tsx` ("60%" is refused). The elicited value
+ *     could never land on the very row the 2026-08-03 walk exercised.
+ *   - on a cap-bearing row (`cap: 20, unit: 'engineers'`, the shape CEE's own
+ *     draft fixtures carry) `raw_value: 70` asserts SEVENTY ENGINEERS, not 70%
+ *     of the scale — an above-cap refusal from CEE, or a 3.5x error if the cap
+ *     were larger. The honest magnitude is `0.7 * cap`, and that inversion is
+ *     the server's (see `factorValueEdit.ts`'s `'model_scale'` doc).
+ * The ×100 survives only where it was always correct: the DISPLAYED chance.
+ *
+ * `refusesNormalisedScaleEntry` is deliberately NOT consulted on this path. It
+ * refuses magnitudes outside [0,1] typed into a display-scale field; an
+ * elicited probability is bounded to [0,1] at the client boundary
+ * (`CEEClient.elicitBelief` throws otherwise), so the guard could not fire and
+ * calling it would be theatre.
  */
 
 import { memo, useCallback, useState } from 'react'
-import { Check } from 'lucide-react'
+import { Check, MessageSquare } from 'lucide-react'
 import Tooltip from '../../../../components/Tooltip'
 import { typography, typo } from '../../../../styles/typography'
 import { FIELD_FEEDBACK_COPY } from '../constants'
@@ -65,6 +99,10 @@ import {
 } from '../../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
 import { useNodeMutations } from '../../../ui/inspector-v2/useInspectorMutations'
+import {
+  useBeliefElicitation,
+  formatElicitedChance,
+} from '../../../hooks/useBeliefElicitation'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import { parseSuccessTarget } from '../hero/parseSuccessTarget'
 import type { EstimateRowModel } from '../types'
@@ -125,6 +163,10 @@ function refusesNormalisedScaleEntry(
 export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: CalibrateDrillInProps) {
   const [draft, setDraft] = useState(row.rawPrefill != null ? String(row.rawPrefill) : '')
   const [hint, setHint] = useState<string | null>(null)
+  const [inWords, setInWords] = useState(false)
+  const [phrase, setPhrase] = useState('')
+
+  const elicitation = useBeliefElicitation({ nodeId: row.nodeId, nodeLabel: row.label })
 
   // The sanctioned setter (the `NODE_SETTER_FIELDS` manifest the writtenFields
   // guard spec enforces), not a hand-rolled `updateNode` — the same one both
@@ -280,8 +322,28 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
     commit(seed, CONFIRM_STAMP, { writeValue: false })
   }
 
+  /**
+   * Accept an elicited number — the SAME commit, the SAME stamp, the SAME wire
+   * event as the typed field. `user_override` is right here for the reason it
+   * is right there: the user chose this number, in their own words, over the
+   * one the model had. It is not an "AI value" — the engine did arithmetic on
+   * a phrase the user wrote.
+   *
+   * `writeValue: true` so the canvas moves at once, exactly as a typed commit
+   * does; the CLAIM still waits for the receipt.
+   */
+  const acceptElicited = useCallback(
+    (suggestedValue: number): void => {
+      commit(suggestedValue, VALUE_STAMP, { seedBasis: 'model_scale', writeValue: true })
+      elicitation.reset()
+      onDone()
+    },
+    [commit, elicitation, onDone],
+  )
+
   return (
-    <div className="mb-2 ml-6 flex items-center gap-2" data-testid="pre-analysis-v3-drill">
+    <div className="mb-2 ml-6 space-y-2" data-testid="pre-analysis-v3-drill">
+      <div className="flex items-center gap-2">
       {row.canEditValue && (
         <>
           <input
@@ -323,10 +385,115 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
           Confirm as is
         </button>
       )}
+      {row.canEditValue && (
+        <Tooltip content="Say what you think in plain words" delay={300}>
+          <PanelIconButton
+            variant="ghost"
+            aria-label={`Describe your estimate for ${row.label} in words`}
+            aria-pressed={inWords}
+            onClick={() => {
+              setInWords(open => {
+                if (open) {
+                  setPhrase('')
+                  elicitation.reset()
+                }
+                return !open
+              })
+            }}
+          >
+            <MessageSquare className="h-3.5 w-3.5" aria-hidden />
+          </PanelIconButton>
+        </Tooltip>
+      )}
       {hint && (
         <span className={`${typography.panelMeta} text-warning`} role="status">
           {hint}
         </span>
+      )}
+      </div>
+
+      {/*
+        "Say it in words" — ROADMAP 2.364. Deliberately BELOW the number field
+        rather than replacing it: the two are alternatives, and hiding the
+        direct input behind a mode toggle would make the fast path slower for
+        anyone who already knows their number.
+      */}
+      {inWords && row.canEditValue && (
+        <div className="space-y-1" data-testid="pre-analysis-v3-in-words">
+          <input
+            aria-label={`Describe ${row.label} in words`}
+            className={`${typography.panelBody} h-7 w-56 rounded-lg border border-panel-border bg-panel px-2 text-text-header outline-none placeholder:text-text-light focus:border-info focus:ring-2 focus:ring-info/20`}
+            placeholder="e.g. pretty likely"
+            value={phrase}
+            onChange={e => {
+              setPhrase(e.target.value)
+              elicitation.request(e.target.value)
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Escape') onDone()
+            }}
+          />
+
+          {elicitation.error && (
+            <p className={`${typography.panelMeta} text-warning`} role="status">
+              {elicitation.error}
+            </p>
+          )}
+
+          {/*
+            AMBIGUOUS PHRASE — the engine's own question, verbatim, and its own
+            option labels. Not paraphrased: it names the factor and the reading
+            it is unsure about, and rewriting it here would put words in the
+            engine's mouth that the engine cannot stand behind.
+          */}
+          {elicitation.suggestion?.needs_clarification &&
+            elicitation.suggestion.options?.length ? (
+            <div className="space-y-1">
+              <p className={`${typography.panelMeta} text-text-body`}>
+                {elicitation.suggestion.clarifying_question}
+              </p>
+              <div className="flex flex-wrap gap-1.5" role="group" aria-label={`Readings for ${row.label}`}>
+                {elicitation.suggestion.options.map(opt => (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => acceptElicited(opt.value)}
+                    className={typo(
+                      'panelMeta',
+                      'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : elicitation.suggestion ? (
+            <div className="flex items-center gap-2">
+              {/*
+                The number, as a chance, in plain words. The engine's REASONING
+                and CONFIDENCE are expert detail and stay behind the existing
+                progressive-disclosure affordance — inline they read as hedging.
+              */}
+              <Tooltip content={elicitation.suggestion.reasoning} delay={300}>
+                <span className={`${typography.panelMeta} text-text-body`}>
+                  That reads as {formatElicitedChance(elicitation.suggestion.suggested_value)}
+                </span>
+              </Tooltip>
+              <button
+                type="button"
+                onClick={() => acceptElicited(elicitation.suggestion!.suggested_value)}
+                aria-label={`Use ${formatElicitedChance(elicitation.suggestion.suggested_value)} for ${row.label}`}
+                className={typo(
+                  'panelMeta',
+                  'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+                )}
+              >
+                Use this
+              </button>
+            </div>
+          ) : null}
+        </div>
       )}
     </div>
   )

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
@@ -346,6 +346,94 @@ describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
     expect(observedOf(MAGNITUDE_ID).source).toBe('brief_extraction')
   })
 
+  it('⭐ A1 — the gate is REACTIVE: a factor that becomes an amount mid-drill-in loses the affordance before it can be accepted', async () => {
+    // This is what makes an accept-time re-check unnecessary, and it was
+    // MEASURED, not assumed: a first cut carried a duplicate predicate inside
+    // the accept handler, and the mutation battery showed no mutant could kill
+    // it — because the control it guards has already unmounted. The guard was
+    // removed and this pin put in its place.
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'pretty likely')
+    expect(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`)).toBeInTheDocument()
+
+    // The factor becomes an uncapped £ amount.
+    act(() => {
+      useCanvasStore.setState({
+        nodes: [
+          {
+            id: WALK_ID,
+            type: 'factor',
+            position: { x: 0, y: 0 },
+            data: {
+              kind: 'factor',
+              label: WALK_LABEL,
+              observedState: { value: 40000, unit: '£', raw_value: 40000, source: 'cee_inference' },
+            },
+          } as unknown as Node,
+        ],
+      } as never)
+    })
+
+    // The whole affordance is gone — no button to click, no panel to type in.
+    expect(
+      screen.queryByLabelText(`Use about 70% for ${WALK_LABEL}`),
+    ).toBeNull()
+    expect(
+      screen.queryByLabelText(`Describe your estimate for ${WALK_LABEL} in words`),
+    ).toBeNull()
+    expect(screen.queryByTestId('pre-analysis-v3-in-words')).not.toBeInTheDocument()
+
+    // And £40,000 is untouched, on the wire and in the store.
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedOf(WALK_ID).value).toBe(40000)
+    expect(observedOf(WALK_ID).raw_value).toBe(40000)
+    expect(observedOf(WALK_ID).source).toBe('cee_inference')
+  })
+
+  it('⭐ A4 — an unsure response with NO options still suppresses the number offer', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    // needs_clarification true, options ABSENT — the shape that used to fall
+    // through to "That reads as about 70%" + Use this, offering a number the
+    // engine had just flagged as unsure.
+    elicitReplies.push({
+      suggested_value: 0.7,
+      confidence: 'low',
+      reasoning: 'unsure',
+      needs_clarification: true,
+      clarifying_question: 'Which reading did you mean?',
+      provenance: 'cee',
+    })
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'good')
+
+    expect(screen.getByText('Which reading did you mean?')).toBeInTheDocument()
+    expect(screen.queryByText(/That reads as/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(`Use about 70% for ${WALK_LABEL}`),
+    ).toBeNull()
+  })
+
+  it('A4 — unsure with NO options and NO question falls back to honest copy, still offering no number', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({
+      suggested_value: 0.7,
+      confidence: 'low',
+      reasoning: 'unsure',
+      needs_clarification: true,
+      provenance: 'cee',
+    })
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'good')
+
+    expect(screen.getByText(/couldn't pin that down/i)).toBeInTheDocument()
+    expect(screen.queryByText(/That reads as/)).not.toBeInTheDocument()
+  })
+
   it('the affordance is also absent on a cap-bearing factor (commit is correct there; display is not)', async () => {
     seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
     renderFor(CAPPED_ID)

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
@@ -96,6 +96,7 @@ vi.mock('../../../../../flags', async (importOriginal) => {
 })
 
 import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import { buildFactorValueEditEvent } from '../../../../conversation/factorValueEdit'
 import { buildEstimateRows } from '../../selectors/buildEstimateRows'
 import { ConversationProvider } from '../../../../conversation/ConversationContext'
 import { useCanvasStore } from '../../../../store'
@@ -129,7 +130,13 @@ const AMBIGUOUS_GOOD = {
   provenance: 'cee',
 }
 
-/** A cap-bearing factor — CEE's own draft fixtures carry exactly this shape. */
+/**
+ * A cap-bearing factor — CEE's own draft fixtures carry exactly this shape.
+ * The COMMIT on it is scale-correct (pinned in factorValueEditModelScale), but
+ * the accepted number cannot be DISPLAYED afterwards without deriving
+ * `value * cap` in the client, so the affordance is not offered here. Kept as
+ * an absence control.
+ */
 const CAPPED_ID = 'fac_team_size'
 const CAPPED_LABEL = 'Team Size'
 const CAPPED_OBSERVED = {
@@ -137,6 +144,20 @@ const CAPPED_OBSERVED = {
   raw_value: 8,
   unit: 'engineers',
   cap: 20,
+  source: 'brief_extraction',
+}
+
+/**
+ * ⭐ THE THIRD SHAPE (#572 review blocker): staging-witnessed uncapped
+ * unit-bearing factor. Model scale IS the magnitude, so a verbatim 0.7 would
+ * make £40,000 into £0.70 with a "checked by you" stamp on it.
+ */
+const MAGNITUDE_ID = 'fac_monthly_spend'
+const MAGNITUDE_LABEL = 'Monthly spend'
+const MAGNITUDE_OBSERVED = {
+  value: 40000,
+  unit: '£',
+  raw_value: 40000,
   source: 'brief_extraction',
 }
 
@@ -225,6 +246,11 @@ function factorValueEdits(): Array<Record<string, unknown>> {
     .filter((e): e is Record<string, unknown> => e?.kind === 'factor_value_edit')
 }
 
+/** The row as the REAL selector derives it — display text, edit affordances. */
+function buildRow(id: string) {
+  return buildEstimateRows(useCanvasStore.getState().nodes, rankingFor(id), null)[0]
+}
+
 function observedOf(id: string): Record<string, unknown> {
   return getObservedState(
     useCanvasStore.getState().nodes.find((n) => n.id === id)?.data,
@@ -249,67 +275,84 @@ afterEach(() => {
 
 describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
   it('sends the factor\'s OWN id and label to the elicitation seam, with target_type prior', async () => {
-    seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
     elicitReplies.push({ ...PRETTY_LIKELY })
-    renderFor(CAPPED_ID)
+    renderFor(WALK_ID)
 
-    await sayInWords(CAPPED_LABEL, 'pretty likely')
+    await sayInWords(WALK_LABEL, 'pretty likely')
 
     expect(elicitRequests).toHaveLength(1)
     // Bound by IDENTITY: the id, not "a string that happens to be there".
     expect(elicitRequests[0]).toEqual({
-      node_id: CAPPED_ID,
-      node_label: CAPPED_LABEL,
+      node_id: WALK_ID,
+      node_label: WALK_LABEL,
       user_expression: 'pretty likely',
       target_type: 'prior',
     })
   })
 
   it('renders the chance from suggested_value — "about 70%"', async () => {
-    seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
     elicitReplies.push({ ...PRETTY_LIKELY })
-    renderFor(CAPPED_ID)
+    renderFor(WALK_ID)
 
-    await sayInWords(CAPPED_LABEL, 'pretty likely')
+    await sayInWords(WALK_LABEL, 'pretty likely')
 
     // 0.7 → "about 70%". No other field in the reply produces 70: `confidence`
-    // is a string, there are no options, and 0.4/8/20 are the node's. A
-    // renderer reading the wrong field cannot produce this string.
+    // is a string and there are no options. A renderer reading the wrong field
+    // cannot produce this string.
     expect(screen.getByText(/That reads as about 70%/)).toBeInTheDocument()
     expect(
-      screen.getByLabelText(`Use about 70% for ${CAPPED_LABEL}`),
+      screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`),
     ).toBeInTheDocument()
   })
 
-  it('accepting dispatches ONE factor_value_edit carrying the PROBABILITY as value, with no raw_value/unit (cap-bearing factor)', async () => {
+  it('⭐ A1 — the affordance is ABSENT on an uncapped unit-bearing factor (£40,000 must not be askable as a chance)', async () => {
+    seedFactor(MAGNITUDE_ID, MAGNITUDE_LABEL, { ...MAGNITUDE_OBSERVED })
+    renderFor(MAGNITUDE_ID)
+
+    // The typed field is still there — this row is perfectly editable, just
+    // not as a probability.
+    expect(
+      screen.getByLabelText(`Your estimate for ${MAGNITUDE_LABEL}`),
+    ).toBeInTheDocument()
+    // Hidden, not disabled-with-a-mystery.
+    expect(
+      screen.queryByLabelText(`Describe your estimate for ${MAGNITUDE_LABEL} in words`),
+    ).toBeNull()
+    expect(screen.queryByTestId('pre-analysis-v3-in-words')).not.toBeInTheDocument()
+  })
+
+  it('⭐ A1 belt — a FORCED accept on that shape refuses: no wire event, no local write, no stamp', async () => {
+    seedFactor(MAGNITUDE_ID, MAGNITUDE_LABEL, { ...MAGNITUDE_OBSERVED })
+    renderFor(MAGNITUDE_ID)
+
+    // Drive the commit path directly, as a drifted gate (or a shape that
+    // changed under an open drill-in) would. This is the belt the reviewer
+    // asked for: if the predicate ever moves, the commit refuses rather than
+    // corrupts.
+    const event = buildFactorValueEditEvent({
+      nodeId: MAGNITUDE_ID,
+      typedValue: 0.7,
+      nodeData: useCanvasStore.getState().nodes.find(n => n.id === MAGNITUDE_ID)?.data,
+      seedBasis: 'model_scale',
+    })
+    expect(event).toBeNull()
+
+    // And nothing moved.
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedOf(MAGNITUDE_ID).value).toBe(40000)
+    expect(observedOf(MAGNITUDE_ID).raw_value).toBe(40000)
+    expect(observedOf(MAGNITUDE_ID).source).toBe('brief_extraction')
+  })
+
+  it('the affordance is also absent on a cap-bearing factor (commit is correct there; display is not)', async () => {
     seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
-    elicitReplies.push({ ...PRETTY_LIKELY })
-    holdTurn = true
     renderFor(CAPPED_ID)
 
-    await sayInWords(CAPPED_LABEL, 'pretty likely')
-    await act(async () => {
-      fireEvent.click(screen.getByLabelText(`Use about 70% for ${CAPPED_LABEL}`))
-      await flush()
-    })
-
-    const edits = factorValueEdits()
-    expect(edits).toHaveLength(1)
-    const edit = edits[0] as Record<string, unknown>
-    expect(edit.target_id).toBe(CAPPED_ID)
-    expect(edit.field).toBe('value')
-    // THE SCALE CLAIM. 0.7 verbatim — NOT 70 (the design's original
-    // `Math.round(v*100)`, which on this factor asserts seventy ENGINEERS
-    // against a cap of 20), and NOT 0.7/20 = 0.035 (what the default
-    // user-units basis would have produced against the stored raw_value of 8).
-    expect(edit.value).toBe(0.7)
-    // ABSENCE IS THE CONTRACT: with no raw_value, CEE inverts with its OWN
-    // stored cap (`resolveUserUnitInput`). Sending one would assert a
-    // magnitude the user never gave.
-    expect(edit).not.toHaveProperty('raw_value')
-    expect(edit).not.toHaveProperty('unit')
-    // And the canvas moved at once, at the same scale.
-    expect(observedOf(CAPPED_ID).value).toBe(0.7)
+    expect(
+      screen.queryByLabelText(`Describe your estimate for ${CAPPED_LABEL} in words`),
+    ).toBeNull()
   })
 
   it('the same accept is scale-correct on the WITNESSED walk row (capless, unitless)', async () => {
@@ -391,6 +434,36 @@ describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
     // stamp is an assertion about what the ENGINE holds.
     expect(observedOf(WALK_ID).source).toBe('user_override')
     expect(observedOf(WALK_ID).value).toBe(0.7)
+  })
+
+  it('⭐ A2 — after accepting, the number STAYS VISIBLE and the affordance survives', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    holdTurn = true
+    renderFor(WALK_ID)
+
+    // Before: the row shows CEE's prose for the previous value.
+    expect(buildRow(WALK_ID)?.displayText).toBe('Low (0)')
+
+    await sayInWords(WALK_LABEL, 'pretty likely')
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+      await flush()
+    })
+
+    // The accept clears both `display_value` copies (they describe the OLD
+    // number). Without a raw anchor `factorDisplayText` then returns null and
+    // the row — and the canvas node — show NOTHING, which is what the first
+    // cut of this feature did. The anchor is CEE's own identity for a capless
+    // factor (`raw_value === value`), not a client-derived scale.
+    const row = buildRow(WALK_ID)
+    expect(observedOf(WALK_ID).raw_value).toBe(0.7)
+    expect(row?.displayText).not.toBeNull()
+    expect(row?.displayText).toContain('0.7')
+    // …and the row did NOT degrade to confirm-only, so the affordance that
+    // committed the value is still there to correct it.
+    expect(row?.canEditValue).toBe(true)
+    expect(row?.needsValue).toBe(false)
   })
 
   it('a failed elicitation says so and commits NOTHING', async () => {

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
@@ -147,6 +147,10 @@ const CAPPED_OBSERVED = {
   source: 'brief_extraction',
 }
 
+/** A factor CEE drafted with no number at all — "needs a value". */
+const EMPTY_ID = 'fac_brand_trust'
+const EMPTY_LABEL = 'Brand trust'
+
 /**
  * ⭐ THE THIRD SHAPE (#572 review blocker): staging-witnessed uncapped
  * unit-bearing factor. Model scale IS the magnitude, so a verbatim 0.7 would
@@ -552,6 +556,36 @@ describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
     // committed the value is still there to correct it.
     expect(row?.canEditValue).toBe(true)
     expect(row?.needsValue).toBe(false)
+  })
+
+  it('⭐ on a factor with NO value yet, the wire still carries value ONLY — no raw_value, no unit', async () => {
+    // WHY THIS EXISTS (mutation finding, second battery). Swapping the accept's
+    // basis to `'raw_or_value'` left all 101 tests green, because on every
+    // shape the gate admits there is NO CAP — and with no cap to divide by,
+    // the two bases produce the same number. The bases diverge only in what
+    // they ATTACH: on an empty factor `'raw_or_value'` classifies the input as
+    // user units and ships `raw_value: 0.7` alongside it, asserting a magnitude
+    // the user never gave and turning an "I did not state units" into a claim.
+    // That absence IS the contract this PR documents, so it is asserted rather
+    // than assumed — otherwise `'model_scale'` is decorative on this surface
+    // and the mutant is right that nothing notices.
+    seedFactor(EMPTY_ID, EMPTY_LABEL, {})
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    holdTurn = true
+    renderFor(EMPTY_ID)
+
+    await sayInWords(EMPTY_LABEL, 'pretty likely')
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Use about 70% for ${EMPTY_LABEL}`))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    expect(edits[0].target_id).toBe(EMPTY_ID)
+    expect(edits[0].value).toBe(0.7)
+    expect(edits[0]).not.toHaveProperty('raw_value')
+    expect(edits[0]).not.toHaveProperty('unit')
   })
 
   it('a failed elicitation says so and commits NOTHING', async () => {

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
@@ -1,0 +1,426 @@
+/**
+ * ROADMAP 2.364 — "say it in words" commits through the EXISTING
+ * `factor_value_edit` lane, at the RIGHT SCALE.
+ *
+ * WHAT THIS FILE DRIVES. The REAL `CalibrateDrillIn` inside a REAL
+ * `ConversationProvider`, with the row derived through the REAL
+ * `buildEstimateRows` selector, mocking only the two TRANSPORTS — `callV5Turn`
+ * (the turn wire) and `CEEClient.elicitBelief` (the elicitation wire) — both by
+ * `importOriginal`-spread, never a hand-listed factory (CLAUDE.md trap 12).
+ * Everything between them, including the scale module, is the shipped code.
+ *
+ * THE CLAIM TYPES, precisely:
+ *   1. accepting an elicited suggestion dispatches EXACTLY ONE
+ *      `factor_value_edit` event for THAT factor id, carrying the probability
+ *      as `value` and NO `raw_value`/`unit` — the shape CEE's
+ *      `resolveUserUnitInput` inverts with the factor's OWN stored cap;
+ *   2. the scale is right on BOTH witnessed row shapes — a cap-bearing factor
+ *      and the capless/unitless walk row;
+ *   3. the displayed chance is read from `suggested_value` and nowhere else;
+ *   4. an ambiguous phrase renders the ENGINE's clarifying question and its own
+ *      option labels, and a chip commits THAT chip's value;
+ *   5. accepting emits the wire event — deleting `sendSystemEvent` from the
+ *      accept path must go RED (the 2.365 silent-local-commit class).
+ * It claims NOTHING about the receipt/stamp timing — that is
+ * `calibrateDrillInReceipt.spec.tsx`'s subject and this path shares its
+ * `commit`, unmodified.
+ *
+ * ⭐ THE CORRECTED-PREMISE CONTROL (the last test). The original design said
+ * to commit `Math.round(suggested_value * 100)` "as if the user had typed
+ * 70%". The control drives THAT path on the walk row and shows it is REFUSED
+ * — nothing committed, nothing dispatched, honest hint shown. It is pinned
+ * here, beside the working path, so nobody re-proposes it from the design doc
+ * without meeting the measurement that retired it.
+ *
+ * RED-first at pristine `0c4e2cc3`: no elicitation affordance exists, so the
+ * "Describe your estimate … in words" control is not in the tree and every
+ * test except the corrected-premise control fails at `getByLabelText`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+/** Every turn payload that reached the transport, in order. */
+const dispatched: Array<Record<string, unknown>> = []
+/** Elicitation replies the mocked CEE client answers with, in order. */
+const elicitReplies: Array<Record<string, unknown>> = []
+/** Every elicitation request body, in order — the request contract at the seam. */
+const elicitRequests: Array<Record<string, unknown>> = []
+/** Turn replies, in order. Empty ⇒ the default REFUSAL (prose, no receipt). */
+const replies: Array<Record<string, unknown>> = []
+/**
+ * When true the turn never resolves, so the OPTIMISTIC local write stands and
+ * can be asserted. Without it, the default reply is a refusal (200, prose,
+ * `blocks: []`) and `revertOptimisticFactorEdit` correctly restores the
+ * pre-edit state — which would mask a commit that never wrote anything.
+ */
+let holdTurn = false
+
+vi.mock('../../../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    callV5Turn: vi.fn(async (payload: Record<string, unknown>) => {
+      dispatched.push(payload)
+      if (holdTurn) await new Promise(() => {})
+      const response = replies.shift() ?? { assistant_text: 'ok', blocks: [] }
+      return { kind: 'response', response }
+    }),
+  }
+})
+
+vi.mock('../../../../../adapters/cee/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../adapters/cee/client')>()
+  class MockCEEClient extends actual.CEEClient {
+    async elicitBelief(input: Parameters<InstanceType<typeof actual.CEEClient>['elicitBelief']>[0]) {
+      elicitRequests.push(input as unknown as Record<string, unknown>)
+      const reply = elicitReplies.shift()
+      if (!reply) throw new Error('no elicitation reply queued')
+      return reply as unknown as Awaited<
+        ReturnType<InstanceType<typeof actual.CEEClient>['elicitBelief']>
+      >
+    }
+  }
+  return { ...actual, CEEClient: MockCEEClient }
+})
+
+vi.mock('../../../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    isOrchestratorV2Enabled: () => true,
+    isOrchestratorStreamingEnabled: () => false,
+  }
+})
+
+import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import { buildEstimateRows } from '../../selectors/buildEstimateRows'
+import { ConversationProvider } from '../../../../conversation/ConversationContext'
+import { useCanvasStore } from '../../../../store'
+import { getObservedState } from '../../../../utils/observedStateHelpers'
+import type { RankingResult } from '../../types'
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+
+/** The witnessed live reply for "pretty likely" (staging BFF, 2026-08-03). */
+const PRETTY_LIKELY = {
+  suggested_value: 0.7,
+  confidence: 'high',
+  reasoning:
+    'Interpreted "pretty likely" as approximately 70% probability based on common usage.',
+  needs_clarification: false,
+  provenance: 'cee',
+}
+
+/** The witnessed clarification branch for "good". */
+const AMBIGUOUS_GOOD = {
+  suggested_value: 0.75,
+  confidence: 'low',
+  reasoning: '"good" could mean several things.',
+  needs_clarification: true,
+  clarifying_question: 'When you say "good", how likely do you mean?',
+  options: [
+    { label: 'Very likely', value: 0.9 },
+    { label: 'Quite likely', value: 0.75 },
+    { label: 'More likely than not', value: 0.6 },
+  ],
+  provenance: 'cee',
+}
+
+/** A cap-bearing factor — CEE's own draft fixtures carry exactly this shape. */
+const CAPPED_ID = 'fac_team_size'
+const CAPPED_LABEL = 'Team Size'
+const CAPPED_OBSERVED = {
+  value: 0.4,
+  raw_value: 8,
+  unit: 'engineers',
+  cap: 20,
+  source: 'brief_extraction',
+}
+
+/** The 2026-08-03 journey-walk row: capless, unitless, model value in [0,1]. */
+const WALK_ID = 'fac_content_marketing'
+const WALK_LABEL = 'Content Marketing Investment'
+const WALK_OBSERVED = {
+  value: 0,
+  display_value: 'Low (0)',
+  source: 'cee_inference',
+  extractionType: 'inferred',
+}
+
+function seedFactor(id: string, label: string, observed: Record<string, unknown>): void {
+  useCanvasStore.setState(
+    {
+      currentScenarioId: SCENARIO,
+      nodes: [
+        {
+          id,
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: { kind: 'factor', label, observedState: observed },
+        } as unknown as Node,
+      ],
+      edges: [],
+      results: { status: 'idle' } as never,
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      pendingEmittedEdits: 0,
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    } as never,
+    false,
+  )
+}
+
+function rankingFor(id: string): RankingResult {
+  return { source: 'degree', weights: { [id]: 1 }, ordered: [id] }
+}
+
+/** The REAL derivation chain: store → buildEstimateRows → the REAL drill-in. */
+function Harness({ id }: { id: string }): JSX.Element {
+  const nodes = useCanvasStore((s) => s.nodes)
+  const row = buildEstimateRows(nodes, rankingFor(id), null)[0]
+  if (!row) return <div />
+  return <CalibrateDrillIn row={row} onDone={() => {}} />
+}
+
+function renderFor(id: string) {
+  return render(
+    <ConversationProvider>
+      <Harness id={id} />
+    </ConversationProvider>,
+  )
+}
+
+/**
+ * Drain microtasks AND macrotasks under fake timers: the dispatch, the
+ * response-processing path and the deferral buffer each contain real awaits,
+ * so a fixed microtask count is not enough (mirrors
+ * `calibrateDrillInReceipt.spec.tsx`'s `flush`, adapted for fake timers).
+ */
+async function flush(): Promise<void> {
+  for (let round = 0; round < 25; round++) {
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+    vi.advanceTimersByTime(2)
+  }
+}
+
+/** Open "say it in words", type a phrase, run the debounce to completion. */
+async function sayInWords(label: string, phrase: string): Promise<void> {
+  fireEvent.click(screen.getByLabelText(`Describe your estimate for ${label} in words`))
+  fireEvent.change(screen.getByLabelText(`Describe ${label} in words`), {
+    target: { value: phrase },
+  })
+  await act(async () => {
+    vi.advanceTimersByTime(600)
+    await flush()
+  })
+}
+
+/** Every `factor_value_edit` event that reached the transport, in order. */
+function factorValueEdits(): Array<Record<string, unknown>> {
+  return dispatched
+    .map((p) => (p.event ?? null) as Record<string, unknown> | null)
+    .filter((e): e is Record<string, unknown> => e?.kind === 'factor_value_edit')
+}
+
+function observedOf(id: string): Record<string, unknown> {
+  return getObservedState(
+    useCanvasStore.getState().nodes.find((n) => n.id === id)?.data,
+  ) as unknown as Record<string, unknown>
+}
+
+beforeEach(() => {
+  cleanup()
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  dispatched.length = 0
+  elicitReplies.length = 0
+  elicitRequests.length = 0
+  replies.length = 0
+  holdTurn = false
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+})
+
+describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
+  it('sends the factor\'s OWN id and label to the elicitation seam, with target_type prior', async () => {
+    seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    renderFor(CAPPED_ID)
+
+    await sayInWords(CAPPED_LABEL, 'pretty likely')
+
+    expect(elicitRequests).toHaveLength(1)
+    // Bound by IDENTITY: the id, not "a string that happens to be there".
+    expect(elicitRequests[0]).toEqual({
+      node_id: CAPPED_ID,
+      node_label: CAPPED_LABEL,
+      user_expression: 'pretty likely',
+      target_type: 'prior',
+    })
+  })
+
+  it('renders the chance from suggested_value — "about 70%"', async () => {
+    seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    renderFor(CAPPED_ID)
+
+    await sayInWords(CAPPED_LABEL, 'pretty likely')
+
+    // 0.7 → "about 70%". No other field in the reply produces 70: `confidence`
+    // is a string, there are no options, and 0.4/8/20 are the node's. A
+    // renderer reading the wrong field cannot produce this string.
+    expect(screen.getByText(/That reads as about 70%/)).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(`Use about 70% for ${CAPPED_LABEL}`),
+    ).toBeInTheDocument()
+  })
+
+  it('accepting dispatches ONE factor_value_edit carrying the PROBABILITY as value, with no raw_value/unit (cap-bearing factor)', async () => {
+    seedFactor(CAPPED_ID, CAPPED_LABEL, { ...CAPPED_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    holdTurn = true
+    renderFor(CAPPED_ID)
+
+    await sayInWords(CAPPED_LABEL, 'pretty likely')
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Use about 70% for ${CAPPED_LABEL}`))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    const edit = edits[0] as Record<string, unknown>
+    expect(edit.target_id).toBe(CAPPED_ID)
+    expect(edit.field).toBe('value')
+    // THE SCALE CLAIM. 0.7 verbatim — NOT 70 (the design's original
+    // `Math.round(v*100)`, which on this factor asserts seventy ENGINEERS
+    // against a cap of 20), and NOT 0.7/20 = 0.035 (what the default
+    // user-units basis would have produced against the stored raw_value of 8).
+    expect(edit.value).toBe(0.7)
+    // ABSENCE IS THE CONTRACT: with no raw_value, CEE inverts with its OWN
+    // stored cap (`resolveUserUnitInput`). Sending one would assert a
+    // magnitude the user never gave.
+    expect(edit).not.toHaveProperty('raw_value')
+    expect(edit).not.toHaveProperty('unit')
+    // And the canvas moved at once, at the same scale.
+    expect(observedOf(CAPPED_ID).value).toBe(0.7)
+  })
+
+  it('the same accept is scale-correct on the WITNESSED walk row (capless, unitless)', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    holdTurn = true
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'pretty likely')
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    expect(edits[0].target_id).toBe(WALK_ID)
+    expect(edits[0].value).toBe(0.7)
+    expect(observedOf(WALK_ID).value).toBe(0.7)
+    // No refusal hint: a probability is in range by construction.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('an ambiguous phrase renders the ENGINE\'s question and its own labels; a chip commits THAT chip\'s value', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({ ...AMBIGUOUS_GOOD })
+    holdTurn = true
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'good')
+
+    // Verbatim — the engine's words, not a paraphrase of them.
+    expect(
+      screen.getByText('When you say "good", how likely do you mean?'),
+    ).toBeInTheDocument()
+    // No number is offered while the engine is unsure.
+    expect(screen.queryByText(/That reads as/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      // Bound by the chip's own LABEL, so a mutant that commits options[0]
+      // regardless of which chip was clicked dies here.
+      fireEvent.click(screen.getByText('More likely than not'))
+      await flush()
+    })
+
+    const edits = factorValueEdits()
+    expect(edits).toHaveLength(1)
+    expect(edits[0].value).toBe(0.6)
+    expect(observedOf(WALK_ID).value).toBe(0.6)
+  })
+
+  it('on CEE\'s applied receipt the row becomes the user\'s own ("checked by you"), not an AI estimate', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    elicitReplies.push({ ...PRETTY_LIKELY })
+    // CEE's ACCEPTANCE for THIS target — the applied graph_patch receipt.
+    replies.push({
+      assistant_text: `Updated ${WALK_LABEL}.`,
+      blocks: [
+        {
+          type: 'graph_patch',
+          status: 'applied',
+          operation: 'set_factor_value',
+          target_id: WALK_ID,
+          before: { value: 0 },
+          after: { value: 0.7 },
+        },
+      ],
+      graph_hash: 'f0719cb3b8905ef4',
+    })
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'pretty likely')
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+      await flush()
+    })
+
+    // The claim is receipt-gated exactly as the typed path's is (2.304): the
+    // stamp is an assertion about what the ENGINE holds.
+    expect(observedOf(WALK_ID).source).toBe('user_override')
+    expect(observedOf(WALK_ID).value).toBe(0.7)
+  })
+
+  it('a failed elicitation says so and commits NOTHING', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    // No reply queued → the mocked client throws, as a 4xx/5xx would.
+    renderFor(WALK_ID)
+
+    await sayInWords(WALK_LABEL, 'pretty likely')
+
+    expect(screen.getByRole('status').textContent).toMatch(/Nothing has changed/i)
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedOf(WALK_ID).value).toBe(0)
+  })
+
+  it('CORRECTED-PREMISE CONTROL: the design\'s "type 70%" path is REFUSED on the walk row — nothing committed, nothing dispatched', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    renderFor(WALK_ID)
+
+    // Exactly what `Math.round(0.7 * 100)` would have fed the typed field.
+    fireEvent.change(screen.getByLabelText(`Your estimate for ${WALK_LABEL}`), {
+      target: { value: '70' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(`Save estimate for ${WALK_LABEL}`))
+      await flush()
+    })
+
+    expect(screen.getByRole('status').textContent).toMatch(/without a unit/i)
+    expect(factorValueEdits()).toHaveLength(0)
+    expect(observedOf(WALK_ID).value).toBe(0)
+    expect(observedOf(WALK_ID).raw_value).toBeUndefined()
+  })
+})

--- a/src/canvas/conversation/__tests__/factorValueEditModelScale.spec.ts
+++ b/src/canvas/conversation/__tests__/factorValueEditModelScale.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * `factorValueEdit` — the `'model_scale'` seed basis (ROADMAP 2.364).
+ *
+ * WHAT IT IS FOR. CEE's belief-elicitation engine answers with a PROBABILITY in
+ * [0,1] — already the scale `observed_state.value` holds. Committing it as a
+ * "typed" number would run it through the user-unit rule and silently rescale
+ * it, so this basis states plainly that the number is already model scale.
+ *
+ * WHY THE ORDER MATTERS (the whole reason this file exists). The basis is
+ * answered BEFORE the `raw_value` rule. Move it after, and a factor that stores
+ * `raw_value: 8, cap: 20` would classify an elicited 0.7 as eight-engineers-
+ * scale and normalise it to 0.035 — a 20x silent corruption on the commonest
+ * CEE draft shape. The order test below is the one that dies on that mutant.
+ *
+ * WHY THE UI DOES NOT INVERT. `raw = value * cap` is real, but it already has
+ * exactly one owner: CEE's `resolveUserUnitInput`
+ * (`orchestrator-v5/system-events/factor-value-edit.ts`, read at `staging`
+ * 2026-08-03) does `cap !== undefined ? value * cap : value` when the wire
+ * carries no `raw_value`. So the ABSENCE of `raw_value`/`unit` on this basis is
+ * a contract, not an omission, and it is asserted as one.
+ *
+ * RED-first at pristine `0c4e2cc3`: `ValueInputSeedBasis` has two members and
+ * `'model_scale'` is not one of them.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildFactorValueEditEvent,
+  resolveValueInputSeed,
+} from '../factorValueEdit'
+
+/** CEE's own draft fixture shape — a factor with a real user-unit scale. */
+const CAPPED = {
+  kind: 'factor',
+  label: 'Team Size',
+  observedState: { value: 0.4, raw_value: 8, unit: 'engineers', cap: 20 },
+}
+
+/** The 2026-08-03 walk shape — normalised-scale only. */
+const WALK = {
+  kind: 'factor',
+  label: 'Content Marketing Investment',
+  observedState: { value: 0, display_value: 'Low (0)' },
+}
+
+describe("factorValueEdit — 'model_scale' basis", () => {
+  it('reports the number as already-model-scale even when the node stores a raw_value', () => {
+    // The ORDER pin. With the branch placed after the `raw_value` rule this
+    // reads `true`, and every scale claim below collapses.
+    expect(resolveValueInputSeed(CAPPED, 'model_scale').inUserUnits).toBe(false)
+    expect(resolveValueInputSeed(WALK, 'model_scale').inUserUnits).toBe(false)
+  })
+
+  it('leaves the other two bases exactly as they were (no behaviour moved)', () => {
+    expect(resolveValueInputSeed(CAPPED).inUserUnits).toBe(true)
+    expect(resolveValueInputSeed(CAPPED).seed).toBe(8)
+    expect(resolveValueInputSeed(CAPPED, 'raw_only').inUserUnits).toBe(true)
+    expect(resolveValueInputSeed(WALK).inUserUnits).toBe(false)
+    expect(resolveValueInputSeed(WALK).seed).toBe(0)
+    expect(resolveValueInputSeed(WALK, 'raw_only').seed).toBeUndefined()
+  })
+
+  it('emits the probability VERBATIM as `value` on a cap-bearing factor, with no raw_value/unit', () => {
+    const event = buildFactorValueEditEvent({
+      nodeId: 'fac_team_size',
+      typedValue: 0.7,
+      nodeData: CAPPED,
+      seedBasis: 'model_scale',
+    })
+
+    expect(event).not.toBeNull()
+    const payload = event!.payload as Record<string, unknown>
+    expect(payload.target_id).toBe('fac_team_size')
+    expect(payload.field).toBe('value')
+    expect(payload.value).toBe(0.7)
+    // The two absences ARE the contract: CEE inverts with its own stored cap.
+    expect(payload).not.toHaveProperty('raw_value')
+    expect(payload).not.toHaveProperty('unit')
+  })
+
+  it('emits the probability verbatim on the capless walk shape too', () => {
+    const event = buildFactorValueEditEvent({
+      nodeId: 'fac_content_marketing',
+      typedValue: 0.7,
+      nodeData: WALK,
+      seedBasis: 'model_scale',
+    })
+
+    const payload = event!.payload as Record<string, unknown>
+    expect(payload.value).toBe(0.7)
+    expect(payload).not.toHaveProperty('raw_value')
+  })
+
+  it('CONTROL — the default basis still normalises a typed magnitude by the cap (unchanged)', () => {
+    const event = buildFactorValueEditEvent({
+      nodeId: 'fac_team_size',
+      typedValue: 14,
+      nodeData: CAPPED,
+    })
+
+    const payload = event!.payload as Record<string, unknown>
+    expect(payload.value).toBe(0.7)
+    expect(payload.raw_value).toBe(14)
+    expect(payload.unit).toBe('engineers')
+  })
+
+  it('CONTROL — what the design\'s original plan would have emitted, and why it was retired', () => {
+    // `Math.round(0.7 * 100)` = 70, committed through the drill-in's typed
+    // basis on a factor capped at 20 engineers.
+    const event = buildFactorValueEditEvent({
+      nodeId: 'fac_team_size',
+      typedValue: 70,
+      nodeData: CAPPED,
+      seedBasis: 'raw_only',
+    })
+
+    const payload = event!.payload as Record<string, unknown>
+    // SEVENTY ENGINEERS against a cap of 20 — model scale 3.5, i.e. 350%.
+    expect(payload.raw_value).toBe(70)
+    expect(payload.value).toBe(3.5)
+    // This is what the `'model_scale'` basis exists to prevent; it is pinned
+    // rather than described so the retirement cannot be undone by inheritance.
+  })
+
+  it('still fails CLOSED on an unencodable edit', () => {
+    expect(
+      buildFactorValueEditEvent({
+        nodeId: '',
+        typedValue: 0.7,
+        nodeData: CAPPED,
+        seedBasis: 'model_scale',
+      }),
+    ).toBeNull()
+    expect(
+      buildFactorValueEditEvent({
+        nodeId: 'fac_team_size',
+        typedValue: Number.NaN,
+        nodeData: CAPPED,
+        seedBasis: 'model_scale',
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/factorValueEditModelScale.spec.ts
+++ b/src/canvas/conversation/__tests__/factorValueEditModelScale.spec.ts
@@ -25,7 +25,9 @@
 
 import { describe, it, expect } from 'vitest'
 import {
+  acceptsElicitedBelief,
   buildFactorValueEditEvent,
+  isMagnitudeScaledFactor,
   resolveValueInputSeed,
 } from '../factorValueEdit'
 
@@ -34,6 +36,20 @@ const CAPPED = {
   kind: 'factor',
   label: 'Team Size',
   observedState: { value: 0.4, raw_value: 8, unit: 'engineers', cap: 20 },
+}
+
+/**
+ * ⭐ THE THIRD SHAPE — staging-witnessed, and the one the first cut of this
+ * feature corrupted. `{value: 40000, unit: '£', raw_value: 40000}`, NO cap:
+ * CEE stores model and raw identically, so this factor's model scale IS
+ * £40,000. Verbatim-committing a 0.7 here makes it £0.70.
+ * (`PHASE0-EVIDENCE-2026-07-28/diagnosis-2308-raw/probe-P1-res.json` and
+ * `journey-rewalk-2026-08-03-raw/wire-cfg-own-format-0-res.txt`.)
+ */
+const UNCAPPED_MAGNITUDE = {
+  kind: 'factor',
+  label: 'Monthly spend',
+  observedState: { value: 40000, unit: '£', raw_value: 40000 },
 }
 
 /** The 2026-08-03 walk shape — normalised-scale only. */
@@ -120,6 +136,90 @@ describe("factorValueEdit — 'model_scale' basis", () => {
     expect(payload.value).toBe(3.5)
     // This is what the `'model_scale'` basis exists to prevent; it is pinned
     // rather than described so the retirement cannot be undone by inheritance.
+  })
+
+  it('⭐ REFUSES the uncapped unit-bearing shape outright — £40,000 must not become £0.70', () => {
+    expect(isMagnitudeScaledFactor(UNCAPPED_MAGNITUDE)).toBe(true)
+    // Fails CLOSED: no event ⇒ no local write, no wire, no receipt, no
+    // "checked by you" stamp. Nothing at all beats a 57,000x corruption
+    // wearing a provenance badge.
+    expect(
+      buildFactorValueEditEvent({
+        nodeId: 'fac_spend',
+        typedValue: 0.7,
+        nodeData: UNCAPPED_MAGNITUDE,
+        seedBasis: 'model_scale',
+      }),
+    ).toBeNull()
+  })
+
+  it('the magnitude predicate is about UNIT-WITHOUT-CAP, not about units or caps alone', () => {
+    // A cap makes the model scale normalised again — CEE inverts with it.
+    expect(isMagnitudeScaledFactor(CAPPED)).toBe(false)
+    // No unit ⇒ nothing claims the number is an amount.
+    expect(isMagnitudeScaledFactor(WALK)).toBe(false)
+    // A cap of 0 is NOT a cap (normaliseRawFactorValue ignores cap <= 0), so a
+    // unit-bearing factor with cap 0 is still magnitude-scaled.
+    expect(
+      isMagnitudeScaledFactor({ observedState: { value: 5, unit: '£', cap: 0 } }),
+    ).toBe(true)
+    // A whitespace-only unit is not a unit.
+    expect(
+      isMagnitudeScaledFactor({ observedState: { value: 0.4, unit: '  ' } }),
+    ).toBe(false)
+  })
+
+  it('the OFFER predicate is narrower than the refusal — a capped factor commits correctly but cannot be SHOWN', () => {
+    // Both are safe to commit…
+    expect(isMagnitudeScaledFactor(CAPPED)).toBe(false)
+    // …but only the capless/unitless shape can display the accepted number
+    // afterwards without deriving `value * cap` in the client. See
+    // `acceptsElicitedBelief`'s own docstring.
+    expect(acceptsElicitedBelief(CAPPED)).toBe(false)
+    expect(acceptsElicitedBelief(UNCAPPED_MAGNITUDE)).toBe(false)
+    expect(acceptsElicitedBelief(WALK)).toBe(true)
+    expect(acceptsElicitedBelief(undefined)).toBe(true)
+  })
+
+  it('REFUSES a model_scale value outside [0,1], whatever the factor shape', () => {
+    // Covers every route a number can take that is NOT `suggested_value` —
+    // a clarification chip, or any future caller of this basis.
+    for (const bad of [1.5, -0.1, 5, 70]) {
+      expect(
+        buildFactorValueEditEvent({
+          nodeId: 'fac_content_marketing',
+          typedValue: bad,
+          nodeData: WALK,
+          seedBasis: 'model_scale',
+        }),
+      ).toBeNull()
+    }
+    // Boundaries still commit: the refusal is out-of-range, not near-range.
+    for (const ok of [0, 1]) {
+      expect(
+        (buildFactorValueEditEvent({
+          nodeId: 'fac_content_marketing',
+          typedValue: ok,
+          nodeData: WALK,
+          seedBasis: 'model_scale',
+        })!.payload as Record<string, unknown>).value,
+      ).toBe(ok)
+    }
+  })
+
+  it('CONTROL — the other two bases are UNTOUCHED on the uncapped magnitude shape', () => {
+    // The refusals are scoped to `model_scale`. A typed £45,000 on this factor
+    // must still commit exactly as it does today.
+    const typed = buildFactorValueEditEvent({
+      nodeId: 'fac_spend',
+      typedValue: 45000,
+      nodeData: UNCAPPED_MAGNITUDE,
+      seedBasis: 'raw_only',
+    })
+    const payload = typed!.payload as Record<string, unknown>
+    expect(payload.value).toBe(45000)
+    expect(payload.raw_value).toBe(45000)
+    expect(payload.unit).toBe('£')
   })
 
   it('still fails CLOSED on an unencodable edit', () => {

--- a/src/canvas/conversation/factorValueEdit.ts
+++ b/src/canvas/conversation/factorValueEdit.ts
@@ -70,8 +70,25 @@ function readNumber(field: unknown): number | undefined {
  *   6000000% class the #559 entry guard exists to stop, re-entered through the
  *   scale module. `'raw_only'` falls through to the module's own EMPTY-input
  *   rule instead (see `ValueInputSeed.inUserUnits`).
+ * - `'model_scale'` (ROADMAP 2.364) — the committing control did not carry a
+ *   TYPED number at all: it carried a probability in [0,1] produced by CEE's
+ *   belief-elicitation engine, which is already what `observed_state.value`
+ *   holds. The node's own `raw_value` therefore says nothing about it, so this
+ *   basis is answered BEFORE the `raw_value` rule rather than after it —
+ *   otherwise an elicited 0.7 on a factor storing `raw_value: 8, cap: 20`
+ *   would be labelled a user-unit magnitude and normalised to 0.035.
+ *
+ *   WHY THE UI DOES NOT CONVERT INSTEAD. The user-unit magnitude for an
+ *   elicited probability is `value * cap`, and that inversion already exists,
+ *   server-side, as the ONE authority that owns it: CEE's
+ *   `resolveUserUnitInput` (`orchestrator-v5/system-events/
+ *   factor-value-edit.ts`, read at `staging` 2026-08-03) does exactly
+ *   `cap !== undefined ? value * cap : value` when the wire carries no
+ *   `raw_value`. Re-deriving it here would be a SECOND scale authority in a
+ *   component — the defect this module exists to prevent — and it would use
+ *   the client's cached cap rather than the factor's stored one.
  */
-export type ValueInputSeedBasis = 'raw_or_value' | 'raw_only'
+export type ValueInputSeedBasis = 'raw_or_value' | 'raw_only' | 'model_scale'
 
 export interface ValueInputSeed {
   /** The number the input should display, or undefined for an empty input. */
@@ -102,6 +119,10 @@ export function resolveValueInputSeed(
   const rawValue = readNumber(obs.raw_value)
   const value = readNumber(obs.value)
 
+  // FIRST, deliberately: a model-scale commit is a statement about the number
+  // being committed, not about what the node happens to store, so no stored
+  // field may override it.
+  if (basis === 'model_scale') return { seed: value, inUserUnits: false }
   if (rawValue != null) return { seed: rawValue, inUserUnits: true }
   // A `raw_only` input never showed `value`, so the field the user typed into
   // was EMPTY — which is the module's existing user-units case, not a new rule.

--- a/src/canvas/conversation/factorValueEdit.ts
+++ b/src/canvas/conversation/factorValueEdit.ts
@@ -131,6 +131,67 @@ export function resolveValueInputSeed(
   return { seed: undefined, inUserUnits: true }
 }
 
+/**
+ * Does this factor's MODEL scale carry a real-world magnitude?
+ *
+ * ⚠ THIS PREDICATE EXISTS BECAUSE OF A CONFIRMED CORRUPTION (review of #572).
+ * When a factor declares a unit but NO cap, CEE stores `value` and `raw_value`
+ * IDENTICALLY (`d1-shared/normalise-factor-value.ts:16`, and its own
+ * `resolveUserUnitInput` comment: "an uncapped factor stores raw and model
+ * identically"). The staging-witnessed shape is
+ * `{value: 40000, unit: '£', raw_value: 40000}` — no cap.
+ *
+ * On that shape a `'model_scale'` commit of a probability is a catastrophe with
+ * no surviving guard: the wire carries `{value: 0.7}` with no `raw_value`, CEE's
+ * `resolveUserUnitInput` takes the cap-absent branch and reads 0.7 AS THE
+ * POUNDS, and £40,000 becomes £0.70 — with a receipt-gated "checked by you"
+ * stamp on it. CEE's own `bare_ratio_on_unit_factor` gate, whose comment
+ * describes exactly this output, CANNOT fire: the system-event adapter stamps
+ * the factor's OWN unit onto the proposal (`factor-value-edit.ts:323`), so
+ * `inputHasUnit` is true; and with no cap the range guards never run.
+ *
+ * So the refusal has to live here, in the client, at the one place that knows
+ * both the basis and the factor's declared shape.
+ */
+export function isMagnitudeScaledFactor(nodeData: unknown): boolean {
+  const obs = getObservedState(nodeData)
+  const cap = readNumber(obs.cap)
+  const hasPositiveCap = typeof cap === 'number' && Number.isFinite(cap) && cap > 0
+  if (hasPositiveCap) return false
+  const unit = typeof obs.unit === 'string' ? obs.unit.trim() : ''
+  return unit.length > 0
+}
+
+/**
+ * May an elicited PROBABILITY be offered — and afterwards SHOWN — on this
+ * factor?
+ *
+ * Narrower than `!isMagnitudeScaledFactor`, and the extra narrowing is the
+ * display half of the same question. On a CAPPED factor the accepted 0.7 is
+ * scale-correct on the wire (CEE inverts it to `0.7 × cap`), but the client
+ * cannot DISPLAY it: `setObservedValue` clears both `display_value` copies, no
+ * receipt writes the server's `after` values back into node data
+ * (`confirmOptimisticFactorEdit` writes the provenance stamp and nothing else),
+ * and computing `value × cap` here would be the second scale authority this
+ * module exists to prevent. The row would therefore either go blank or keep
+ * showing the PREVIOUS magnitude beside the new value — a confident wrong
+ * number, which is worse than a blank one.
+ *
+ * On a factor with no unit and no cap, none of that arises: `value` IS the
+ * display scale, CEE persists `raw_value = value`, and the accepted number
+ * stays visible exactly as a typed `0.7` does today.
+ *
+ * WIDENING THIS IS A REAL FEATURE, NOT A ONE-LINE RELAXATION: it needs the
+ * applied `graph_patch`'s `after` values written back into node data. Rowed.
+ */
+export function acceptsElicitedBelief(nodeData: unknown): boolean {
+  const obs = getObservedState(nodeData)
+  const cap = readNumber(obs.cap)
+  if (typeof cap === 'number' && Number.isFinite(cap) && cap > 0) return false
+  const unit = typeof obs.unit === 'string' ? obs.unit.trim() : ''
+  return unit.length === 0
+}
+
 export interface FactorValueEditInput {
   /** The factor node's id. ID-ADDRESSED — a label would retarget on a rename. */
   nodeId: string
@@ -158,6 +219,19 @@ export function buildFactorValueEditEvent(
   const { nodeId, typedValue, nodeData, seedBasis } = input
   if (!nodeId) return null
   if (typeof typedValue !== 'number' || !Number.isFinite(typedValue)) return null
+
+  // ── the `'model_scale'` belt ─────────────────────────────────────────────
+  // Both refusals are STRUCTURAL: they hold for every caller, present and
+  // future, and they fail CLOSED (no event ⇒ no local write, no wire, no
+  // receipt, no stamp) rather than emitting a number the factor cannot mean.
+  if (seedBasis === 'model_scale') {
+    // A probability outside [0,1] is not a model-scale value. The client
+    // boundary refuses one in `suggested_value`; this catches every OTHER way
+    // a number can reach here — a clarification chip, or a future caller.
+    if (typedValue < 0 || typedValue > 1) return null
+    // The £40,000 → £0.70 shape. See `isMagnitudeScaledFactor`.
+    if (isMagnitudeScaledFactor(nodeData)) return null
+  }
 
   const obs = getObservedState(nodeData)
   const cap = readNumber(obs.cap)

--- a/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
+++ b/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
@@ -90,8 +90,17 @@ describe('useBeliefElicitation', () => {
     // with a 0 ms timer, so a "debounce" test that only does that proves the
     // timer exists, never that it WAITS (measured: a `0`-ms mutant survived
     // exactly that test).
+    //
+    // ⚠ The step is a LITERAL, not `DEBOUNCE - 1` (#572 review, minor). When
+    // it was derived from the constant, a mutant that set the CONSTANT to 0
+    // died only incidentally — fake timers threw on `advanceTimersByTime(-1)`
+    // — so the kill came from arithmetic, not from the assertion. A literal
+    // makes both mutant forms die at the `inFlight` check, and the equality
+    // below is what keeps the literal honest if the constant ever moves.
+    expect(BELIEF_ELICITATION_DEBOUNCE_MS).toBe(500)
+
     await act(async () => {
-      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS - 1)
+      vi.advanceTimersByTime(499)
       await settle()
     })
     expect(inFlight).toHaveLength(0)
@@ -149,6 +158,75 @@ describe('useBeliefElicitation', () => {
       await settle()
     })
     expect(result.current.suggestion?.suggested_value).toBe(0.15)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('⭐ A3 — retyping INVALIDATES the previous phrase\'s answer immediately, before the next debounce fires', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    // "pretty likely" is asked, answered, and rendered.
+    await act(async () => {
+      result.current.request('pretty likely')
+      vi.advanceTimersByTime(500)
+      await settle()
+    })
+    await act(async () => {
+      inFlight[0].resolve(reply(0.7))
+      await settle()
+    })
+    expect(result.current.suggestion?.suggested_value).toBe(0.7)
+
+    // The user corrects themselves. NOTHING has been sent yet — the new
+    // request is still inside its debounce window. The 0.7 card must go NOW:
+    // while it is on screen its Accept button will commit 0.7 for text that
+    // no longer exists.
+    act(() => {
+      result.current.request('actually unlikely')
+    })
+    expect(result.current.suggestion).toBeNull()
+
+    // And the OLD phrase's answer, if it were still in flight, cannot come
+    // back either — the sequence was bumped at the keystroke, not at the
+    // (not-yet-fired) debounce.
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await settle()
+    })
+    expect(inFlight).toHaveLength(2)
+    await act(async () => {
+      inFlight[0].resolve(reply(0.7))
+      await settle()
+    })
+    expect(result.current.suggestion).toBeNull()
+
+    // Only the answer to the text actually on screen may render.
+    await act(async () => {
+      inFlight[1].resolve(reply(0.15))
+      await settle()
+    })
+    expect(result.current.suggestion?.suggested_value).toBe(0.15)
+  })
+
+  it('⭐ A3 — a phrase shortened below the minimum also clears the rendered suggestion', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    await act(async () => {
+      result.current.request('pretty likely')
+      vi.advanceTimersByTime(500)
+      await settle()
+    })
+    await act(async () => {
+      inFlight[0].resolve(reply(0.7))
+      await settle()
+    })
+    expect(result.current.suggestion?.suggested_value).toBe(0.7)
+
+    // Clearing the field back to two characters must not leave the old answer
+    // standing beside an empty-ish input.
+    act(() => {
+      result.current.request('pr')
+    })
+    expect(result.current.suggestion).toBeNull()
     expect(result.current.loading).toBe(false)
   })
 

--- a/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
+++ b/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * `useBeliefElicitation` — the debounce, the minimum phrase, and the
+ * STALE-RESPONSE rule (ROADMAP 2.364).
+ *
+ * WHY THE STALE-RESPONSE TEST EXISTS AT ALL. Two requests can be in flight
+ * across two debounce windows, and nothing about `await` makes them land in
+ * order. If the FIRST response is allowed to write state after the SECOND has
+ * already landed, the surface renders "about 70%" beneath the words "unlikely"
+ * — a number attributed to text the user has replaced, which the user has no
+ * way to see is wrong. Every request therefore carries a sequence number and
+ * only the latest may write. This file drives that race deliberately, with
+ * MANUALLY-RESOLVED promises, because a race that resolves in order proves
+ * nothing about a race that does not.
+ *
+ * RED-first at pristine `0c4e2cc3`: the hook does not exist.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+/** One controllable in-flight elicitation per call, in call order. */
+const inFlight: Array<{
+  input: Record<string, unknown>
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}> = []
+
+vi.mock('../../../adapters/cee/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../adapters/cee/client')>()
+  class MockCEEClient extends actual.CEEClient {
+    elicitBelief(
+      input: Parameters<InstanceType<typeof actual.CEEClient>['elicitBelief']>[0],
+    ): ReturnType<InstanceType<typeof actual.CEEClient>['elicitBelief']> {
+      return new Promise((resolve, reject) => {
+        inFlight.push({
+          input: input as unknown as Record<string, unknown>,
+          resolve: resolve as (value: unknown) => void,
+          reject,
+        })
+      }) as ReturnType<InstanceType<typeof actual.CEEClient>['elicitBelief']>
+    }
+  }
+  return { ...actual, CEEClient: MockCEEClient }
+})
+
+import {
+  useBeliefElicitation,
+  BELIEF_ELICITATION_DEBOUNCE_MS,
+  BELIEF_ELICITATION_ERROR_COPY,
+  formatElicitedChance,
+} from '../useBeliefElicitation'
+
+const TARGET = { nodeId: 'fac_churn_risk', nodeLabel: 'Churn risk' }
+
+function reply(suggested: number) {
+  return {
+    suggested_value: suggested,
+    confidence: 'high' as const,
+    reasoning: 'r',
+    needs_clarification: false,
+    provenance: 'cee' as const,
+  }
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
+beforeEach(() => {
+  inFlight.length = 0
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useBeliefElicitation', () => {
+  it('does not call CEE until the debounce elapses, then calls it once', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    act(() => {
+      result.current.request('pretty')
+      result.current.request('pretty likely')
+    })
+    expect(inFlight).toHaveLength(0)
+
+    await act(async () => {
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      await settle()
+    })
+
+    // One call, carrying the LAST text — not two, and not the first.
+    expect(inFlight).toHaveLength(1)
+    expect(inFlight[0].input.user_expression).toBe('pretty likely')
+  })
+
+  it('sends nothing for a phrase shorter than three characters', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    await act(async () => {
+      result.current.request('ab')
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS * 2)
+      await settle()
+    })
+
+    expect(inFlight).toHaveLength(0)
+  })
+
+  it('⭐ a LATE first response cannot overwrite the second — the stale-response rule', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    // Request 1: "pretty likely"
+    await act(async () => {
+      result.current.request('pretty likely')
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      await settle()
+    })
+    // Request 2: the user corrects themselves.
+    await act(async () => {
+      result.current.request('actually unlikely')
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      await settle()
+    })
+    expect(inFlight).toHaveLength(2)
+
+    // The SECOND lands first — the ordinary case for two concurrent requests.
+    await act(async () => {
+      inFlight[1].resolve(reply(0.15))
+      await settle()
+    })
+    expect(result.current.suggestion?.suggested_value).toBe(0.15)
+
+    // Now the FIRST lands, late. It must be discarded: 0.7 under the words
+    // "actually unlikely" is a number the user never asked for.
+    await act(async () => {
+      inFlight[0].resolve(reply(0.7))
+      await settle()
+    })
+    expect(result.current.suggestion?.suggested_value).toBe(0.15)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('a late response cannot repaint after reset() (the accept/close race)', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    await act(async () => {
+      result.current.request('pretty likely')
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      await settle()
+    })
+    act(() => {
+      result.current.reset()
+    })
+    await act(async () => {
+      inFlight[0].resolve(reply(0.7))
+      await settle()
+    })
+
+    expect(result.current.suggestion).toBeNull()
+  })
+
+  it('a failure reports honest copy and no suggestion', async () => {
+    const { result } = renderHook(() => useBeliefElicitation(TARGET))
+
+    await act(async () => {
+      result.current.request('pretty likely')
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      await settle()
+    })
+    await act(async () => {
+      inFlight[0].reject(new Error('boom'))
+      await settle()
+    })
+
+    expect(result.current.suggestion).toBeNull()
+    expect(result.current.error).toBe(BELIEF_ELICITATION_ERROR_COPY)
+    expect(result.current.error).toMatch(/Nothing has changed/)
+    expect(result.current.loading).toBe(false)
+  })
+})
+
+describe('formatElicitedChance', () => {
+  it('renders a probability as a plain-language chance', () => {
+    expect(formatElicitedChance(0.7)).toBe('about 70%')
+    expect(formatElicitedChance(0.15)).toBe('about 15%')
+    expect(formatElicitedChance(0)).toBe('about 0%')
+    expect(formatElicitedChance(1)).toBe('about 100%')
+  })
+})

--- a/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
+++ b/src/canvas/hooks/__tests__/useBeliefElicitation.spec.ts
@@ -76,7 +76,7 @@ afterEach(() => {
 })
 
 describe('useBeliefElicitation', () => {
-  it('does not call CEE until the debounce elapses, then calls it once', async () => {
+  it('does not call CEE until the FULL debounce elapses, then calls it once', async () => {
     const { result } = renderHook(() => useBeliefElicitation(TARGET))
 
     act(() => {
@@ -85,8 +85,19 @@ describe('useBeliefElicitation', () => {
     })
     expect(inFlight).toHaveLength(0)
 
+    // ONE TICK SHORT — this is the assertion that makes the debounce a real
+    // guarantee. Advancing the whole window in one step passes just as well
+    // with a 0 ms timer, so a "debounce" test that only does that proves the
+    // timer exists, never that it WAITS (measured: a `0`-ms mutant survived
+    // exactly that test).
     await act(async () => {
-      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS)
+      vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS - 1)
+      await settle()
+    })
+    expect(inFlight).toHaveLength(0)
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
       await settle()
     })
 

--- a/src/canvas/hooks/useBeliefElicitation.ts
+++ b/src/canvas/hooks/useBeliefElicitation.ts
@@ -1,0 +1,151 @@
+/**
+ * useBeliefElicitation — "say it in words, get a number" (ROADMAP 2.364).
+ *
+ * ONE elicitation client for every surface that offers the affordance, so the
+ * debounce, the stale-response rule and the error copy cannot drift between
+ * them. Today: `BeliefInput` (the standalone dual-mode control) and the
+ * pre-analysis `CalibrateDrillIn` row.
+ *
+ * WHAT IT TALKS TO. `CEEClient.elicitBelief` → `/bff/cee/elicit-belief` →
+ * (Netlify edge fn) → CEE `/assist/v1/elicit-belief`. The engine behind it is
+ * DETERMINISTIC — a lexicon + regex parser, no LLM call and no network fan-out
+ * (`olumi-assistants-service/src/cee/belief-elicitation/index.ts`) — which is
+ * why a 500 ms debounce is the right shape: the answer arrives in milliseconds
+ * and re-typing is cheap, so the only thing worth protecting is CEE's per-key
+ * rate limit (60/min).
+ *
+ * THE STALE-RESPONSE RULE, and why a bare `await` is not enough. Every request
+ * carries a sequence number and only the LATEST one may write state. Without
+ * it, typing "pretty likely" then correcting to "unlikely" can render 0.70
+ * against the word "unlikely" if the first response lands second — a suggestion
+ * attributed to text the user has already replaced. That is a fabrication the
+ * user cannot see is one, so it is guarded here rather than left to timing.
+ *
+ * NOTHING IS COMMITTED HERE. This hook produces a SUGGESTION. Applying it is
+ * the calling surface's job, through that surface's existing commit path — the
+ * hook deliberately owns no mutation, no wire event and no store write.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { CEEClient } from '../../adapters/cee/client'
+import type { BeliefElicitSuggestion } from '../../adapters/cee/types'
+
+/** Matches the debounce the original BeliefInput shipped with. */
+export const BELIEF_ELICITATION_DEBOUNCE_MS = 500
+
+/**
+ * Below this, a phrase is not yet an expression — "a", "ab" would send a
+ * request per keystroke and get a clarifying question every time.
+ */
+const MIN_EXPRESSION_LENGTH = 3
+
+/**
+ * User-facing failure copy. Plain language, states what did NOT happen (the
+ * house rule for every refusal on this surface), and never surfaces a status
+ * code or an endpoint name.
+ */
+export const BELIEF_ELICITATION_ERROR_COPY =
+  "I couldn't read that as a number. Nothing has changed — try a different wording, or type the number itself."
+
+export interface BeliefElicitationTarget {
+  /** The factor's id — CEE requires it and refuses an empty string. */
+  nodeId: string
+  /** The factor's label, quoted back in the engine's clarifying question. */
+  nodeLabel: string
+}
+
+export interface BeliefElicitationApi {
+  suggestion: BeliefElicitSuggestion | null
+  loading: boolean
+  error: string | null
+  /** Debounced. Text shorter than a phrase clears the suggestion instead. */
+  request: (text: string) => void
+  /** Drop any pending request and clear suggestion/error. */
+  reset: () => void
+}
+
+export function useBeliefElicitation(target: BeliefElicitationTarget): BeliefElicitationApi {
+  const [suggestion, setSuggestion] = useState<BeliefElicitSuggestion | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const client = useMemo(() => new CEEClient(), [])
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const sequenceRef = useRef(0)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  const { nodeId, nodeLabel } = target
+
+  const reset = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    // Bump the sequence so an ALREADY-IN-FLIGHT response cannot repaint a
+    // suggestion after the surface has been reset (the accept/close race).
+    sequenceRef.current += 1
+    setSuggestion(null)
+    setError(null)
+    setLoading(false)
+  }, [])
+
+  const request = useCallback(
+    (text: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      setError(null)
+
+      const trimmed = text.trim()
+      if (trimmed.length < MIN_EXPRESSION_LENGTH) {
+        sequenceRef.current += 1
+        setSuggestion(null)
+        setLoading(false)
+        return
+      }
+
+      debounceRef.current = setTimeout(() => {
+        const seq = ++sequenceRef.current
+        setLoading(true)
+        client
+          .elicitBelief({
+            node_id: nodeId,
+            node_label: nodeLabel,
+            user_expression: trimmed,
+            target_type: 'prior',
+          })
+          .then(result => {
+            if (!mountedRef.current || seq !== sequenceRef.current) return
+            setSuggestion(result)
+            setLoading(false)
+          })
+          .catch(() => {
+            if (!mountedRef.current || seq !== sequenceRef.current) return
+            // The client already refuses an out-of-range value by throwing, so
+            // this branch covers BOTH transport failure and a nonsense number.
+            // Either way the honest report is the same: nothing changed.
+            setSuggestion(null)
+            setError(BELIEF_ELICITATION_ERROR_COPY)
+            setLoading(false)
+          })
+      }, BELIEF_ELICITATION_DEBOUNCE_MS)
+    },
+    [client, nodeId, nodeLabel],
+  )
+
+  return { suggestion, loading, error, request, reset }
+}
+
+/**
+ * The elicited probability as a plain-language chance ("about 70%").
+ *
+ * DISPLAY ONLY — this is the one place the ×100 appears, and it never feeds a
+ * commit. The number that is committed is the probability itself; see
+ * `factorValueEdit.ts`'s `'model_scale'` basis for why.
+ */
+export function formatElicitedChance(suggestedValue: number): string {
+  return `about ${Math.round(suggestedValue * 100)}%`
+}

--- a/src/canvas/hooks/useBeliefElicitation.ts
+++ b/src/canvas/hooks/useBeliefElicitation.ts
@@ -21,6 +21,19 @@
  * attributed to text the user has already replaced. That is a fabrication the
  * user cannot see is one, so it is guarded here rather than left to timing.
  *
+ * ⚠ THE GUARANTEE ABOVE WAS ONCE ONLY HALF TRUE, AND THIS PARAGRAPH IS THE
+ * CORRECTION (#572 review). The sequence was bumped when the debounce FIRED,
+ * not when the text CHANGED — so between a keystroke and the next debounce
+ * fire there was no new sequence to invalidate the old one, and the previous
+ * phrase's answer could still land, render, and be ACCEPTED against text the
+ * user had already replaced (a whole debounce + round-trip wide). And the
+ * ALREADY-RENDERED suggestion was never cleared on retype, so even with no
+ * response in flight the stale card stayed clickable.
+ * Both halves are fixed at the same place, and for the same reason: the moment
+ * the text changes, every answer about the OLD text is dead. `request()`
+ * therefore invalidates and clears FIRST, before it decides whether to
+ * schedule anything at all.
+ *
  * NOTHING IS COMMITTED HERE. This hook produces a SUGGESTION. Applying it is
  * the calling surface's job, through that surface's existing commit path — the
  * hook deliberately owns no mutation, no wire event and no store write.
@@ -99,10 +112,17 @@ export function useBeliefElicitation(target: BeliefElicitationTarget): BeliefEli
       if (debounceRef.current) clearTimeout(debounceRef.current)
       setError(null)
 
+      // FIRST, unconditionally, before any length test or scheduling: the text
+      // has changed, so every in-flight answer about the previous text is now
+      // stale, and the rendered card describes a phrase that no longer exists.
+      // Invalidate and clear together — a bump without a clear leaves a stale
+      // card on screen with a live Accept button, which is the half of this
+      // defect a sequence number alone never covered.
+      sequenceRef.current += 1
+      setSuggestion(null)
+
       const trimmed = text.trim()
       if (trimmed.length < MIN_EXPRESSION_LENGTH) {
-        sequenceRef.current += 1
-        setSuggestion(null)
         setLoading(false)
         return
       }

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -40,6 +40,40 @@ export const CEEDraftResponseSchema = z.object({
 }).passthrough()
 
 // =============================================================================
+// CEE Belief Elicitation Response Schema (ROADMAP 2.364)
+// =============================================================================
+
+/**
+ * Mirror of CEE's `CEEElicitBeliefResponseV1Schema`
+ * (`olumi-assistants-service/src/schemas/ceeResponses.ts`, read at `staging`
+ * 2026-08-03). `passthrough()` on both sides, so a field CEE adds is carried,
+ * not dropped — and the bounds are copied EXACTLY (`suggested_value` and each
+ * option `value` are `z.number().min(0).max(1)`), because a probability outside
+ * [0,1] is the one shape the UI must never render or commit.
+ *
+ * This schema is OBSERVATIONAL (warn-parse, the `CEEDraftResponseSchema`
+ * pattern). The HARD refusal on an out-of-range `suggested_value` lives in
+ * `CEEClient.elicitBelief`, because a warning that is only logged would still
+ * let a poisoned number reach the commit path.
+ */
+export const CEEElicitBeliefResponseSchema = z.object({
+  suggested_value: z.number().min(0).max(1),
+  confidence: z.enum(['high', 'medium', 'low']),
+  reasoning: z.string(),
+  needs_clarification: z.boolean(),
+  clarifying_question: z.string().optional(),
+  options: z
+    .array(
+      z.object({
+        label: z.string(),
+        value: z.number().min(0).max(1),
+      })
+    )
+    .optional(),
+  provenance: z.literal('cee'),
+}).passthrough()
+
+// =============================================================================
 // PLoT V1 Run Response Schema (minimal - only critical UI fields)
 // =============================================================================
 


### PR DESCRIPTION
Say what you think in plain words on a pre-analysis estimate row, get a number
back, and have it land in the model. ROADMAP 2.364. **Zero CEE code, zero new
mutation or wire machinery.**

Adversarial review found one blocker and two majors; all are fixed below and
re-reviewed on `e60098a3`. **Ready to merge.**

## What a tester sees — and on which rows

On a **capless, unitless** estimate row there is a speech-bubble button,
"Describe your estimate for X in words". Type *"pretty likely"* and the row
answers **"That reads as about 70%"** with a **Use this** button. Type something
ambiguous like *"good"* and it shows the engine's own question — *"When you say
'good', how likely do you mean?"* — with its own chips. The engine's reasoning
and confidence sit behind the existing tooltip; an in-flight read says "Reading
that…". Accepting commits through the **existing** `factor_value_edit` lane:
persist → `graph_patch` receipt → "checked by you" → staleness pill → re-run.

**⚠ It does NOT appear on every row, and that is deliberate.** The affordance is
hidden on any factor that carries a **unit**, and on any factor with a **cap** —
so on a typical CEE draft, where most factors are drafted with units and caps, it
shows on **fewer rows than not**. An earlier version of this description claimed
"any estimate row"; that was true of the first cut and is false now.

Two independent reasons, both measured:
- **A unit with no cap ⇒ corruption.** See A1.
- **A cap ⇒ the accepted number cannot be shown.** The commit is scale-correct
  there (CEE inverts with the stored cap — still pinned), but afterwards the row
  cannot display it without deriving `value × cap` in the client, which is the
  second scale authority this module exists to prevent. It would go blank, or
  keep showing the PREVIOUS magnitude beside the new value — a confident wrong
  number, worse than a blank one.

**The widening path, rowed not hand-waved:** write the applied
`graph_patch.after` values back into node data. Today `confirmOptimisticFactorEdit`
writes the provenance stamp and nothing else (verified at the bytes), so nothing
repaints from the server's own numbers. With that in place the gate can widen to
capped factors without inventing a scale.

## ⭐ Corrected premise — the design's commit form is wrong at this tip

The L41 design (§3, §4 slice 3) and the L43 brief both say: commit
`Math.round(suggested_value * 100)` "as if the user had typed 70%". **Measured at
`0c4e2cc3`, that fails in both directions.**

1. **On the witnessed walk row it is REFUSED and nothing lands.** The 2026-08-03
   journey-walk factor is capless, unitless, `value: 0`. A typed magnitude
   outside [0,1] on that shape is refused by `refusesNormalisedScaleEntry` — and
   the repo's own spec already pins it: `calibrateDrillInRange.spec.tsx:111`,
   *`"60%" is refused the same way`*.
2. **On a cap-bearing row it asserts the wrong quantity.** CEE's own draft
   fixture carries `fac_team_size: {value: 0.4, raw_value: 8, unit: 'engineers',
   cap: 20}`. `raw_value: 70` there means **seventy engineers** against a cap of
   20 → model scale 3.5.

**The fix.** `suggested_value` IS a model-scale value — `observed_state.value` is
defined on [0,1] and so is the elicited probability. So it is committed
**verbatim, with no `raw_value` and no `unit`**, via a `'model_scale'` seed basis
in the one scale authority (`factorValueEdit.ts`). The inversion to user units is
done by the component that already owns it and already holds the factor's stored
cap — **CEE's own `resolveUserUnitInput`**, byte-verified at `staging`:

```ts
// Model-scale only. Invert with the stored cap; an uncapped factor stores
// raw and model identically.
return { ok: true, rawInput: cap !== undefined ? value * cap : value };
```

The `×100` survives only in the **displayed** chance. Both retired failure modes
are pinned as controls so the form cannot be re-proposed from the design doc
without meeting the measurement that retired it.

## Amendments from the adversarial review

### A1 (BLOCKER) — £40,000 → £0.70 on an uncapped unit-bearing factor

Confirmed at the bytes in **both** repos. On a factor with a unit and **no cap** —
staging-witnessed as `{value: 40000, unit: '£', raw_value: 40000}` — CEE stores
model and raw **identically** (`d1-shared/normalise-factor-value.ts:16`), so that
factor's model scale IS the magnitude. The first cut committed `{value: 0.7}`
verbatim; CEE's `resolveUserUnitInput` took its **cap-absent branch** and read 0.7
AS THE POUNDS. £40,000 became **£0.70** — with a receipt-gated "checked by you"
stamp on it.

**Every guard was structurally bypassed, which is why nothing caught it:**
- CEE's own `bare_ratio_on_unit_factor` gate — whose comment *describes this exact
  output* — requires `!inputHasUnit`, and the system-event adapter stamps the
  factor's OWN unit onto the proposal (`factor-value-edit.ts:323`), so
  `inputHasUnit` is true.
- The cap-range guards all require a cap, and there isn't one.
- The affordance gated only on `row.canEditValue`, which is **true** for this shape.

**Fixed in two layers:**
| Layer | What |
|---|---|
| Gate (product) | `acceptsElicitedBelief(nodeData)` — the affordance is **hidden**, not disabled-with-a-mystery. Derived from the factor's own observed state through the scale module, read via a **boolean** zustand selector (no fresh object per render), and **reactive**: if a factor stops being a chance while the drill-in is open, the control disappears before it can be clicked. |
| Belt (structural) | `buildFactorValueEditEvent` **refuses** a `model_scale` commit on that shape — for **every** caller, present and future — failing CLOSED: no event ⇒ no local write, no wire, no receipt, no stamp. |

**One guard was deleted rather than shipped.** The first amendment also put an
accept-time copy of the predicate inside the handler. The mutation battery showed
**no mutant could kill it** — because the reactive gate unmounts the control
first, so nothing can reach it. An unreachable guard that nothing can kill is the
guarantee-theatre class this estate hunts, so it was removed (with its now-dead
copy constant) and replaced by a pin on the behaviour that actually protects the
user. The structural belt is unaffected and covers every caller.

### A2 (MAJOR) — the accept erased the row it was built for

On the exact 2026-08-03 walk row, `setObservedValue` cleared both `display_value`
copies and left no anchor, so `factorDisplayText` returned null: the row **and the
canvas node showed no number at all** where "Low (0)" had been. `buildEstimateRows`
then called the node scale-ambiguous → `canEditValue: false` → the row degraded to
confirm-only, **taking the affordance with it**. The typed path never had this bug
because `raw_only` writes the typed number as its own anchor.

**Fix:** the accept writes the model value as the local display anchor too. That is
**CEE's own identity for a capless factor** (`raw_value === value`), not a
client-derived scale — which is exactly why the gate's capless restriction is what
makes it safe, and why the local anchor equals what the server will next serve
(no flicker). Pinned **through the real `buildEstimateRows` selector**: after
accept, `displayText` is non-null and contains `0.7`, and `canEditValue` stays true.

### A3 (MAJOR) — the hook's own stale-response guarantee was half true

The sequence bumped when the debounce **fired**, not when the text **changed**. So
between a keystroke and the next fire there was no new sequence to invalidate the
old one, and the previous phrase's answer could still land, render, and be
**accepted** against text the user had replaced — a whole debounce + round-trip
wide. And an already-rendered suggestion was never cleared on retype, so a stale
card stayed clickable with **nothing in flight at all**.

**Fix:** `request()` bumps the sequence AND clears the suggestion **first**,
unconditionally, before it decides whether to schedule anything. Pinned as the
exact race, plus the shorten-below-minimum case.

### A4 + minors — 8 taken, 1 noted

| Item | Verdict |
|---|---|
| Chip values not hard-bounded to [0,1] | **TAKEN** — `isProbability` is the one spelling of the bound, applied to `suggested_value` AND every `options[].value`; a non-array `options` is refused too |
| `model_scale` emitter accepted any finite value | **TAKEN** — refuses outside [0,1] whatever the shape, covering every route that is not `suggested_value` |
| `needs_clarification` + absent options fell through to offering a number | **TAKEN** — `needs_clarification` alone now suppresses the offer; a missing question falls back to honest copy |
| No in-flight feedback; 150s default timeout | **TAKEN** — "Reading that…" rendered, `/elicit-belief` given a 20s `ENDPOINT_TIMEOUTS` entry |
| Confidence fetched but never rendered while a comment claimed otherwise | **TAKEN** — surfaced in the tooltip; the comment now records that it used to be false |
| M10 constant-form mutant died incidentally, not semantically | **TAKEN** — advance step is a literal `499` with `expect(DEBOUNCE).toBe(500)` keeping it honest; both mutant forms now die at the assertion |
| Evidence doc's "job sets only VITE_E2E" is job-level-true | **CORRECTED** — `ci.yml` sets other `VITE_*` at workflow level; none of the three `requireProxyEnv` vars appears anywhere in the file, so the substance holds |
| Receipt test must never be read as a scale guarantee | **TAKEN** — recorded in the spec header |
| Blocker text's exemplar factor was mis-cited (the £3,500 one is capped) | **NOTED** — the class stands on the genuinely uncapped £40,000 factors, which is the shape pinned |

## Evidence

**Baseline shrunk AT SOURCE — `2507 → 2502`, five removals, none added**, regenerated
(not hand-merged) after rebasing:

| Row | Attribution |
|---|---|
| `BeliefInput.tsx` TS2305 `BeliefElicitResponse` | **mine** — the dangling import is gone |
| `BeliefInput.tsx` TS2339 `elicitBelief` | **mine** — the phantom PLoT call is gone |
| `client.ts` TS6133 `'fetch' … never read` | **mine** — the private method had no caller until `elicitBelief` |
| `ContestedEdgeCard.spec.tsx` TS2322 | **NOT mine** — fixed by #571's `src/types/validation.ts`, which did not regenerate the baseline |
| `RelationshipsSection.spec.tsx` TS2322 | **NOT mine**, same cause |

Banking the last two is a ratchet *tightening*, not an absorption — but it is not
this lane's work and is disclosed rather than claimed.

**RED-first at pristine `0c4e2cc3`** (worktree outside the repo root, specs only):
`Test Files 4 failed (4) · Tests 22 failed | 32 passed (54)`. Honest scope: 1 of 7
in the drill-in spec and 5 of 7 in the scale spec are CONTROLS that pass at
pristine by design. The amendment pins are RED-first by construction — every one
of them is killed by its own mutant below, which is the same obligation measured
the harder way.

**Mutation battery — 23 mutants, ALL bite.** Throwaway worktree outside the repo
root, COMMITTED state, applied-check scoped to `src/` and asserted **exactly 1**
per mutation, control **exactly 0** before and after each. Control:
`8 files / 102 tests passed`.

Original 13: wrong path · extra body key · `suggested_value` refusal removed ·
render-from-wrong-field · the design's `×100` form · probability read as a
user-unit magnitude · **accept drops the wire event (the 2.365 silent-local-commit
class)** · `model_scale` branch reordered · stale-response guard removed · debounce
→ 0 (call-site AND constant forms) · chip commits `options[0]` · elicit addressed
by label not id.

Amendment 10: **affordance gate dropped (the blocker returns)** · **emitter belt
dropped** · predicate inverted (`cap: 0` counted as a cap) · gate made
non-reactive · **display anchor not written (row goes blank)** · invalidate/clear
moved back to the debounce fire · sequence bumped but the stale card left on
screen · chip [0,1] bound removed · `model_scale` range assert removed ·
`needs_clarification` alone no longer suppresses the offer.

**Three mutants survived first and were fixed, not excused** — the lane's own
findings:
1. **The accept-time belt** could not be killed because it could not be reached
   (above). Deleted; the reactivity pinned instead.
2. **The `needs_clarification`-without-options fix had no test.** Two added.
3. **The `'model_scale'` basis was not load-bearing on the gated surface.**
   Swapping it to `'raw_or_value'` left all 101 green — the gate admits only
   capless factors, and with no cap to divide by the two bases produce the same
   NUMBER. They diverge only in what they ATTACH: on a factor with no value yet,
   `'raw_or_value'` ships `raw_value: 0.7` alongside, asserting a magnitude the
   user never gave. That absence IS the contract this PR documents, so it is now
   asserted on the shape where it is observable. Without that pin the basis was
   decorative and the mutant was right that nothing noticed.

**Gates:** `pnpm run typecheck` (the NAMED gate) PASSED — `3203 / 3243` files
loaded, ratchet `620 files / 2502 errors` vs baseline 2502: no new errors, baseline
unchanged. `eslint` on every changed file: 0 errors (2 pre-existing warnings at
`client.ts:415`, untouched). Affected-directory smoke (`pre-analysis-v3`,
`adapters/cee`, `conversation`, `hooks`): 237 files / 3141 passed, 0 failed — a
subset sweep, explicitly not a substitute for CI's full suite.

**CI: 13/13 green on `e60098a3`**, re-queried against the exact head SHA via
`gh api …/commits/e60098a3/check-runs` — not read from a notification.

## Honest residuals

- **No Playwright e2e, and the reason is a finding (rowed 2.378).** Playwright does
  not run in the PR gate for `staging` at all — `gh pr checks` lists eleven checks,
  none of them E2E; `ci.yml` owns `e2e-chromium` and is not triggered on these PRs.
  That job could not start its dev server anyway: `vite.config.ts`'s
  `requireProxyEnv` throws during `serve` for `ENGINE_SERVICE_URL` /
  `CEE_SERVICE_URL` / `ISL_SERVICE_URL`, none of which appear anywhere in the
  workflow. A spec added here would never execute, and a never-executed spec that
  reads as coverage is the exact defect class we hunt — so one was written, run,
  and **deleted** rather than shipped red or `fixme`. What is pinned instead:
  `calibrateDrillInElicit.spec.tsx` drives the real `CalibrateDrillIn` inside a
  real `ConversationProvider`, through the real `buildEstimateRows` selector and
  the real v5 payload builder, mocking only the two network transports, and
  asserts the exact `factor_value_edit` reaching `callV5Turn`.
- **No browser-level and no live-staging witness of the UI half.** The CEE half was
  live-witnessed on 2026-08-03 (L41); the tail (re-run → numbers move) is Paul's
  staged walk.
- `acceptsElicitedBelief(undefined) === true` — a node with no data at all passes
  the gate. It fails closed one layer later: with no id or no finite value the
  emitter returns null, so nothing is written. Recorded so the predicate's
  permissive edge is not mistaken for a hole.
- A **unitless, capless factor holding a magnitude** (e.g. `value: 60000` with no
  unit) is admitted by the gate. It behaves exactly as the typed path does on the
  same shape — `refusesNormalisedScaleEntry` governs typed entry, and an elicited
  value is bounded to [0,1] by construction — so it introduces no new behaviour.

Out of scope, named: risk tolerance and utility weights (no analysis-path consumer
exists anywhere), edge-weight beliefs (no deterministic commit lane), deleting the
other phantom adapter methods, and `FactorObservablePanel.tsx:81`'s silent local
commit (ROADMAP 2.365).

Full log: `PHASE0-EVIDENCE-2026-07-28/l43-elicitation-build.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
