### PR TITLE
feat(results): honest empty state when VOI arrived but nothing clears resolution

### DIFF
--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -385,6 +385,45 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
               {resolveNext ? (
                 <>
                   <EvidenceNote>{E.resolveNextNote}</EvidenceNote>
+                  {/*
+                    ⭐ L51 — THE ARRIVED-AND-ALL-SUB-RESOLUTION EMPTY STATE.
+
+                    WHY THIS CONDITION IS THE HONEST ONE, EXACTLY. We are inside
+                    the `resolveNext != null` branch, and `buildVoiRanking`
+                    returns `null` for every case where the estimator did not
+                    deliver usable rows — absent, null, empty, all-invalid,
+                    all-unlabelable, unusable rank 1 (`voiRanking.ts:186,290,292`).
+                    So reaching here at all means rows ARRIVED, validated and
+                    label-resolved. `voiRanking.ts:292` then guarantees a
+                    non-null ranking has at least one row in some band, so
+                    `resolvedRows.length === 0` here means every surviving row is
+                    below-resolution — the precise condition the sentence claims.
+
+                    That is why the test is `resolvedRows.length === 0` and NOT
+                    `belowResolution.length > 0`: the two are equivalent at this
+                    point, and the former says what the sentence is about (there
+                    is nothing to rank) rather than restating the band split.
+
+                    THE BOUNDARY THIS MUST NOT CROSS. The sentence asserts the
+                    analysis LOOKED. On absent/unusable VOI that assertion would
+                    be fabricated, so those cases must keep the pre-existing
+                    `resolveNextGate` in the `else` below and must never reach
+                    here. Both directions are pinned in
+                    `__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx`
+                    (§2 renders it, §3 proves absent/empty/invalid/unlabelable do
+                    not, §4 proves a single resolved row does not).
+
+                    It sits ABOVE the below-resolution line so the plain-language
+                    outcome is read before the factor list that occasioned it.
+                  */}
+                  {resolvedRows.length === 0 && (
+                    <p
+                      className={`${typography.panelBody} text-text-body`}
+                      data-testid="v7-resolve-next-none-above-resolution"
+                    >
+                      {E.resolveNextNoneAboveResolution}
+                    </p>
+                  )}
                   {resolvedRows.length > 0 && (
                     <ol className="ml-4 list-decimal space-y-1.5 marker:text-text-light">
                       {visibleResolveNext.map((r, i) => {

--- a/src/components/results/v7/V7EvidenceDisclosure.tsx
+++ b/src/components/results/v7/V7EvidenceDisclosure.tsx
@@ -477,7 +477,21 @@ export function V7EvidenceDisclosure({ evidence, onFocusNode }: V7EvidenceDisclo
                   />
                   {/* Demoted, never ranked. Below-resolution means
                       indistinguishable from noise AT THIS RUN'S RESOLUTION —
-                      not zero value, and not "not worth resolving". */}
+                      not zero value, and not "not worth resolving".
+
+                      ⭐ L51 review: the COPY here is no longer the design's
+                      "Below resolution on this run: …". It was reworded to the
+                      plain class ("Not enough precision this run to rank: …")
+                      because this line is behind NO expert affordance —
+                      `expertMode` is never passed into `V7TopMatter`, so it
+                      never reaches this component and every user who opens the
+                      accordion on an all-below run reads it.
+
+                      THE DOCTRINE ABOVE IS UNCHANGED and still constrains the
+                      wording: the shortfall is attributed to THIS RUN'S
+                      precision, never to the factors' worth. Any future
+                      rewording that implies "no value" or "not worth
+                      resolving" breaks it, whatever it does to the prose. */}
                   {resolveNext.belowResolution.length > 0 && (
                     <p
                       className={`${typography.panelMeta} text-text-light`}

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
@@ -11,6 +11,11 @@
  * bare `Below resolution on this run: …` line — and never once told the user the
  * actual outcome. This suite pins the sentence that says it.
  *
+ * (That quoted line is the BEFORE state, kept for the record. The same PR's
+ * review also reworded it to the plain class — see `v7LensCopy.ts`. Every
+ * assertion here goes through `E.resolveNextBelow(...)` or a fixture label, so
+ * no pin in this file spells either wording.)
+ *
  * THE FIXTURE IS CAPTURED PRODUCER BYTES, NOT A HAND-WRITTEN SHAPE.
  * `ALL_BELOW_RESOLUTION_ROWS` is the `enrichment.factor_evppi` array copied
  * VERBATIM out of

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
@@ -1,0 +1,373 @@
+/**
+ * Resolve next — THE ARRIVED-AND-ALL-SUB-RESOLUTION EMPTY STATE (L51).
+ *
+ * WHAT THIS SUITE EXISTS FOR
+ * ──────────────────────────
+ * The 3-Aug witness walk ran an analysis whose per-factor EVPPI came back with
+ * EVERY row `status: 'below_resolution'` — the honest "nothing cleared the noise
+ * floor on this run" condition, with `decision_evpi` present, so the estimator
+ * unambiguously RAN. At staging tip `42cbd0d4` the view rendered a note claiming
+ * the factors were "Ranked by value of information" above an empty list, then a
+ * bare `Below resolution on this run: …` line — and never once told the user the
+ * actual outcome. This suite pins the sentence that says it.
+ *
+ * THE FIXTURE IS CAPTURED PRODUCER BYTES, NOT A HAND-WRITTEN SHAPE.
+ * `ALL_BELOW_RESOLUTION_ROWS` is the `enrichment.factor_evppi` array copied
+ * VERBATIM out of
+ * `PHASE0-EVIDENCE-2026-07-28/journey-witness-2026-08-04c-raw/w7/wire-final-5-res.txt`,
+ * audit legs and all. `FIXTURE_LABELS` is the canvas id→label map read out of the
+ * SAME response's graph, and both ids are confirmed present as `rf__node-*` in
+ * that walk's painted manifest (`w7/W7-manifests.json`) — so label resolution
+ * genuinely succeeds and no row is dropped. A hand-rolled fixture could have got
+ * the honest condition wrong in either direction; these bytes cannot.
+ *
+ * THE HONESTY BOUNDARY THIS SUITE POLICES (both directions — trap 13)
+ * ──────────────────────────────────────────────────────────────────
+ * The empty state is a CLAIM: it says the analysis assessed the unknowns and
+ * none of them would change the recommendation. That claim is only true when the
+ * rows ARRIVED. So:
+ *
+ *   · rows arrived, none resolved  → the sentence renders          (§1, §2)
+ *   · `factor_evppi` ABSENT        → the sentence must NOT render, the
+ *     pre-existing honest gate does instead                        (§3)
+ *   · rows arrived, one resolved   → the sentence must NOT render, the ranking
+ *     does                                                          (§4)
+ *
+ * §3 is the negative control and it is the load-bearing one: an empty state on
+ * absent data would fabricate the claim that the analysis assessed anything at
+ * all. It is asserted against the COPY CONSTANT, not a paraphrase, so it cannot
+ * drift into passing against a sentence that is no longer the one we ship.
+ *
+ * IDENTITY-BOUND, NEVER VALUE-MATCHED (trap 19). Every label assertion resolves
+ * through `FIXTURE_LABELS[row.factor_id]` off the fixture's own rows rather than
+ * naming a string inline, so a test cannot pass on a different factor than the
+ * one it was written for, and re-capturing the walk cannot leave a stale literal
+ * silently asserting nothing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { V7EvidenceDisclosure } from '../V7EvidenceDisclosure'
+import type { V7EvidenceModel } from '../buildV7Lenses'
+import { V7_LENS_COPY } from '../v7LensCopy'
+import { buildVoiRanking } from '../../voi/voiRanking'
+import { mapV5AnalysisToReport } from '../../../../v5/mapV5AnalysisToReport'
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+import { openDisclosureHeader, switchEvidenceView } from '../../../../test/helpers/resolveNextView'
+
+const E = V7_LENS_COPY.evidence
+
+/**
+ * VERBATIM producer bytes — `enrichment.factor_evppi` from
+ * `journey-witness-2026-08-04c-raw/w7/wire-final-5-res.txt`. Both rows
+ * `below_resolution`, both `evppi: 0`, audit legs intact. Not trimmed: the
+ * reader's `.pick()` is supposed to survive the full row, and a trimmed copy
+ * would be testing a shape the wire never sends.
+ */
+const ALL_BELOW_RESOLUTION_ROWS = [
+  {
+    factor_id: 'fac_churn_rate',
+    evppi: 0,
+    evppi_raw: 0,
+    baseline_max_expected_utility: 0.154582,
+    conditional_max_expected_utility: 0.154582,
+    units: 'outcome',
+    method: 'regression_evppi_v1',
+    regression_degree: 4,
+    n_samples: 10000,
+    clamped_low: false,
+    clamped_high: false,
+    noise_floor: 6e-6,
+    status: 'below_resolution',
+    correlation_active: false,
+  },
+  {
+    factor_id: 'fac_market_demand',
+    evppi: 0,
+    evppi_raw: 0,
+    baseline_max_expected_utility: 0.154582,
+    conditional_max_expected_utility: 0.154582,
+    units: 'outcome',
+    method: 'regression_evppi_v1',
+    regression_degree: 4,
+    n_samples: 10000,
+    clamped_low: false,
+    clamped_high: false,
+    noise_floor: 1.8e-5,
+    status: 'below_resolution',
+    correlation_active: false,
+  },
+] as const
+
+/** Canvas id→label, read from the same captured response's graph nodes. */
+const FIXTURE_LABELS: Record<string, string> = {
+  fac_churn_rate: 'Customer Churn Rate',
+  fac_market_demand: 'Enterprise Market Demand',
+}
+
+/** `decision_evpi` from the same capture — the estimator demonstrably RAN. */
+const CAPTURED_DECISION_EVPI = 0.044601096202867174
+
+/**
+ * ⚠ WHY THE NEGATIVE CONTROLS NEED A DRIVER (found by this suite's own RED run).
+ *
+ * `V7EvidenceDisclosure` returns `null` outright when NOTHING is disclosable
+ * (`:178` — "Nothing to disclose at all → render nothing"). So on absent VOI with
+ * no other evidence the whole section unmounts and `not.toContain(copy)` passes
+ * against an EMPTY BODY — a textbook trap-13 vacuous absence: the assertion could
+ * never have seen a presence.
+ *
+ * Passing one driver keeps the disclosure, the tab strip and the Resolve-next
+ * view all MOUNTED, so the negative control asserts what it claims to: the
+ * surface is on screen, the user is looking at the Resolve-next view, and the
+ * sentence still is not there. Every §3/§4 case asserts `v7-evidence-resolve-next`
+ * is present for exactly this reason.
+ */
+const ONE_DRIVER = [
+  { factorKey: 'fac_sales_capacity', label: 'Enterprise Sales Capacity', direction: 'positive' as const, isEstimate: false, focusId: 'fac_sales_capacity' },
+]
+
+function renderResolveNext(
+  enrichment: Record<string, unknown>,
+  { drivers = [] }: { drivers?: V7EvidenceModel['drivers'] } = {},
+) {
+  const block = {
+    type: 'analysis_result',
+    summary: 'A summary',
+    leading_option_id: 'opt_sales',
+    win_probabilities: { opt_sales: 0.57, opt_hybrid: 0.26 },
+    enrichment,
+  } as unknown as AnalysisResultBlock
+  const report = mapV5AnalysisToReport(block) as unknown as Record<string, unknown>
+  const resolveNext = buildVoiRanking({
+    rows: report.factor_evppi,
+    inferenceWarnings: report.inference_warnings,
+    resolveLabel: (id) =>
+      FIXTURE_LABELS[id] ? { label: FIXTURE_LABELS[id], canFocus: true } : null,
+  })
+  render(
+    <V7EvidenceDisclosure
+      evidence={{
+        drivers,
+        flipRisks: [],
+        tradeOffs: [],
+        resolveNext,
+        designationsWithheld: false,
+      }}
+    />,
+  )
+  openDisclosureHeader()
+  switchEvidenceView('resolveNext')
+  return { report, resolveNext, text: document.body.textContent ?? '' }
+}
+
+/** As `renderResolveNext`, with the disclosure guaranteed to stay mounted. */
+function renderResolveNextMounted(enrichment: Record<string, unknown>) {
+  const out = renderResolveNext(enrichment, { drivers: ONE_DRIVER })
+  // NON-VACUITY: prove the absence assertions below can SEE a presence.
+  expect(screen.getByTestId('v7-evidence-resolve-next')).toBeTruthy()
+  return out
+}
+
+/**
+ * The nothing-at-all case: no evidence of any kind, so the disclosure never
+ * mounts and there is no header to click. Cannot go through `renderResolveNext`,
+ * which opens the section.
+ */
+function renderResolveNextNoDisclosure(enrichment: Record<string, unknown>) {
+  const block = {
+    type: 'analysis_result',
+    summary: 'A summary',
+    leading_option_id: 'opt_sales',
+    win_probabilities: { opt_sales: 0.57, opt_hybrid: 0.26 },
+    enrichment,
+  } as unknown as AnalysisResultBlock
+  const report = mapV5AnalysisToReport(block) as unknown as Record<string, unknown>
+  const resolveNext = buildVoiRanking({
+    rows: report.factor_evppi,
+    inferenceWarnings: report.inference_warnings,
+    resolveLabel: (id) =>
+      FIXTURE_LABELS[id] ? { label: FIXTURE_LABELS[id], canFocus: true } : null,
+  })
+  render(
+    <V7EvidenceDisclosure
+      evidence={{
+        drivers: [],
+        flipRisks: [],
+        tradeOffs: [],
+        resolveNext,
+        designationsWithheld: false,
+      }}
+    />,
+  )
+  return { resolveNext }
+}
+
+const ALL_BELOW_ENRICHMENT = {
+  factor_evppi: ALL_BELOW_RESOLUTION_ROWS,
+  decision_evpi: CAPTURED_DECISION_EVPI,
+}
+
+describe('§1 POSITIVE CONTROL — the fixture really is the arrived-and-all-sub-resolution condition', () => {
+  it('carries every captured row through the mapper with status below_resolution', () => {
+    // Without this, §2 could pass on an empty fixture — proving nothing.
+    const { report } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    const carried = report.factor_evppi as Array<Record<string, unknown>>
+    expect(carried).toHaveLength(ALL_BELOW_RESOLUTION_ROWS.length)
+    expect(carried.map((r) => r.status)).toEqual(
+      ALL_BELOW_RESOLUTION_ROWS.map(() => 'below_resolution'),
+    )
+    // The estimator ran: a magnitude for the decision as a whole came back.
+    expect(report.decision_evpi).toBe(CAPTURED_DECISION_EVPI)
+  })
+
+  it('the reader returns a NON-NULL ranking whose resolved band is empty', () => {
+    // This is the fact the dispatched hypothesis got backwards: the reader does
+    // NOT filter below-resolution rows away, so the section does not skip.
+    const { resolveNext } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    expect(resolveNext).not.toBeNull()
+    expect(resolveNext!.resolved).toEqual([])
+    expect(resolveNext!.belowResolution.map((r) => r.factorId)).toEqual(
+      ALL_BELOW_RESOLUTION_ROWS.map((r) => r.factor_id),
+    )
+    // Nothing was dropped — so the empty state is not standing in for a gap.
+    expect(resolveNext!.someFactorsUnassessed).toBe(false)
+  })
+
+  it('renders no ranked rows at all', () => {
+    renderResolveNext(ALL_BELOW_ENRICHMENT)
+    expect(screen.queryAllByTestId('v7-resolve-next-row')).toHaveLength(0)
+    expect(screen.queryByTestId('v7-resolve-next-lead')).toBeNull()
+  })
+})
+
+describe('§2 the honest empty state renders when rows arrived and none cleared resolution', () => {
+  it('states the outcome in plain language', () => {
+    const { text } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    const node = screen.getByTestId('v7-resolve-next-none-above-resolution')
+    expect(node).toHaveTextContent(E.resolveNextNoneAboveResolution)
+    expect(text).toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('does NOT render the "wasn\'t produced" gate — the ranking WAS produced', () => {
+    const { text } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    expect(screen.queryByTestId('v7-evidence-resolve-next-gate')).toBeNull()
+    expect(text).not.toContain(E.resolveNextGate)
+  })
+
+  it('carries no magnitude from the captured audit legs into the DOM', () => {
+    // The empty state is a new sentence on a surface whose whole doctrine is
+    // "no magnitude has a licensed rendering here". It must not become the leak.
+    const { text } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    for (const magnitude of ['0.154582', '0.0446', '10000', '0.000006', '6e-6', '1.8e-5']) {
+      expect(text, `magnitude ${magnitude} must not render`).not.toContain(magnitude)
+    }
+  })
+
+  it('renders whatever OTHER evidence the disclosure happens to carry', () => {
+    // ⚠ ANTI-CORRELATION PIN. Every other case in this suite renders the
+    // all-below payload with NO drivers and every non-rendering case WITH one,
+    // so a condition wrongly sourced from `evidence.drivers.length === 0` —
+    // a field with nothing to do with EVPPI status — would satisfy all of them
+    // and survive. It correlates with the real condition across the fixtures,
+    // not with the thing the sentence claims. This case breaks the correlation:
+    // same all-below payload, driver present, sentence still required.
+    renderResolveNextMounted(ALL_BELOW_ENRICHMENT)
+    expect(screen.getByTestId('v7-resolve-next-none-above-resolution')).toHaveTextContent(
+      E.resolveNextNoneAboveResolution,
+    )
+  })
+
+  it('names the below-resolution factors by fixture identity, not by a value predicate', () => {
+    renderResolveNext(ALL_BELOW_ENRICHMENT)
+    const below = screen.getByTestId('v7-resolve-next-below')
+    for (const row of ALL_BELOW_RESOLUTION_ROWS) {
+      expect(below).toHaveTextContent(FIXTURE_LABELS[row.factor_id])
+    }
+  })
+})
+
+describe('§3 NEGATIVE CONTROL — VOI absent from the payload stays silent', () => {
+  // ⭐ THE LOAD-BEARING PIN. The empty state claims the analysis ASSESSED the
+  // unknowns. On a payload that carried no `factor_evppi` at all, that claim is
+  // fabricated. Absent must keep the pre-existing honest gate and nothing else.
+  it('renders the pre-existing gate and NOT the empty state', () => {
+    const { resolveNext, text } = renderResolveNextMounted({
+      decision_evpi: CAPTURED_DECISION_EVPI,
+    })
+    expect(resolveNext).toBeNull()
+    expect(screen.getByTestId('v7-evidence-resolve-next-gate')).toHaveTextContent(
+      E.resolveNextGate,
+    )
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('an explicitly EMPTY producer array also stays silent', () => {
+    // `[]` is an honest "no factor survived upstream" — still not an assessment
+    // of anything, so still not the empty state's claim to make.
+    const { resolveNext, text } = renderResolveNextMounted({ factor_evppi: [] })
+    expect(resolveNext).toBeNull()
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('rows that all FAIL validation stay silent — unusable is not "assessed"', () => {
+    const { resolveNext, text } = renderResolveNextMounted({
+      factor_evppi: ALL_BELOW_RESOLUTION_ROWS.map((r) => ({ ...r, factor_id: '' })),
+    })
+    expect(resolveNext).toBeNull()
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('rows whose LABELS do not resolve stay silent — unnameable is not "assessed"', () => {
+    // The live-path drop: a producer factor id with no canvas node. All rows are
+    // below-resolution, so `sawFirstResolvedRow` is never set and the reader
+    // collapses to the gate (`voiRanking.ts:237`). Still not the empty state.
+    const { resolveNext, text } = renderResolveNextMounted({
+      factor_evppi: ALL_BELOW_RESOLUTION_ROWS.map((r) => ({
+        ...r,
+        factor_id: `${r.factor_id}_not_on_canvas`,
+      })),
+    })
+    expect(resolveNext).toBeNull()
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('with NO other evidence either, the whole disclosure stays unmounted', () => {
+    // The genuinely-silent case the brief asks for, pinned explicitly so the
+    // driver-mounted controls above are not mistaken for the only absent shape.
+    const { resolveNext } = renderResolveNextNoDisclosure({})
+    expect(resolveNext).toBeNull()
+    expect(screen.queryByTestId('v7-evidence-disclosure')).toBeNull()
+    expect(document.body.textContent ?? '').not.toContain(E.resolveNextNoneAboveResolution)
+  })
+})
+
+describe('§4 NEGATIVE CONTROL — a resolved row present means there IS something to resolve', () => {
+  it('does not render the empty state when the SAME captured rows carry a resolved status', () => {
+    // Mutant (c) as a standing pin: the copy must be sourced from the real
+    // statuses. Flip the captured rows' `status` and the sentence must vanish.
+    const { resolveNext, text } = renderResolveNextMounted({
+      factor_evppi: ALL_BELOW_RESOLUTION_ROWS.map((r) => ({ ...r, evppi: 0.9, status: 'resolved' })),
+      decision_evpi: CAPTURED_DECISION_EVPI,
+    })
+    expect(resolveNext!.resolved).toHaveLength(ALL_BELOW_RESOLUTION_ROWS.length)
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+
+  it('does not render the empty state when only ONE row resolves', () => {
+    const [first, ...rest] = ALL_BELOW_RESOLUTION_ROWS
+    const { resolveNext, text } = renderResolveNextMounted({
+      factor_evppi: [{ ...first, evppi: 0.9, status: 'resolved' }, ...rest],
+      decision_evpi: CAPTURED_DECISION_EVPI,
+    })
+    // Identity-bound: the surviving rank-1 is the row we promoted, not "some row".
+    expect(resolveNext!.resolved.map((r) => r.factorId)).toEqual([first.factor_id])
+    expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
+    expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+})

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -202,6 +202,31 @@ export const V7_LENS_COPY = {
     resolveNextBelow: (labels: string) => `Below resolution on this run: ${labels}`,
     resolveNextPartial: "Some factors couldn't be assessed for this ranking.",
     resolveNextGate: "Value-of-information ranking wasn't produced for this run.",
+    /**
+     * ⭐ L51 — THE ARRIVED-AND-ALL-SUB-RESOLUTION EMPTY STATE. Paul's ruling.
+     *
+     * LICENSED BY: a NON-NULL ranking whose `resolved` band is empty — i.e. the
+     * estimator ran, rows arrived and were label-resolved, and not one of them
+     * cleared its noise floor. It is NOT licensed by absent/empty/unusable
+     * `factor_evppi`: that is `resolveNextGate` above, and saying "no single
+     * unknown would change the recommendation" about factors nothing assessed
+     * would fabricate the assessment. The two are mutually exclusive by
+     * construction — `buildVoiRanking` returns `null` for exactly the gate's
+     * cases — and both directions are pinned in
+     * `V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx` §2/§3.
+     *
+     * PLAIN LANGUAGE, DELIBERATELY. "below_resolution", "noise floor" and
+     * "EVPPI" are the producer's vocabulary, not the user's; the one
+     * jargon-adjacent line on this surface (`resolveNextBelow`) is pre-existing
+     * ratified design copy and is left exactly where it was rather than
+     * relocated by this lane. "at this precision" is what carries the honest
+     * caveat that a longer run could resolve something — the sentence says
+     * nothing stands out YET, never that nothing matters.
+     *
+     * The em dash is deliberate and matches `resolveNextNote` above.
+     */
+    resolveNextNoneAboveResolution:
+      'Nothing stands out to resolve yet — at this precision, no single unknown would change the recommendation.',
     /** Conditional-winner narration — all values are producer-supplied
      * (factor label, split value/unit, winner labels); nothing invented. */
     tradeOffSplit: (factor: string, value: string, high: string, low: string) =>

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -167,9 +167,24 @@ export const V7_LENS_COPY = {
     // ── Resolve next (V7-C slice 1, ROADMAP 2.141) ───────────────────────
     //
     // The five licensed sentences of V7C-EVPPI-RANKING-DESIGN-2026-07-30 §4,
-    // plus that table's honest gate, reproduced VERBATIM. Paul's sign-off is
-    // pending (design §8 Q2); verbatim use is what keeps his review meaningful,
-    // so a deviation here gets flagged in the PR, never silently improved.
+    // plus that table's honest gate. Paul's sign-off on the design was pending
+    // (design §8 Q2), and the rule was: reproduce them VERBATIM, because
+    // verbatim use is what keeps his review meaningful — so a deviation gets
+    // flagged in the PR, never silently improved.
+    //
+    // ⚠ ONE SENTENCE IS NO LONGER VERBATIM, BY RULING RATHER THAN BY DRIFT.
+    // `resolveNextBelow` was reworded off the design's "Below resolution on
+    // this run: …" onto the plain-language form below, per the orchestrator
+    // copy ruling carried by L51's review (the design doc §4 now carries a
+    // dated delta note recording the supersession). The reason it could not
+    // stay: it is NOT behind any expert affordance. `expertMode` is never
+    // passed into `V7TopMatter` and so never reaches this disclosure, so every
+    // user who opens the accordion on an all-below run reads it — producer
+    // vocabulary in the one place a lay reader lands.
+    //
+    // This paragraph previously said all six were verbatim full stop. Left
+    // alone it would have become exactly the trap-14 defect this deck's own
+    // rule exists to prevent: an honest label overwritten by a false one.
     //
     // WHAT LICENSES EACH SENTENCE (design §4):
     //   · resolveNextLead  ← rank-1 of the `status: 'resolved'` rows, in wire
@@ -178,6 +193,12 @@ export const V7_LENS_COPY = {
     //   · resolveNextBelow ← `status: 'below_resolution'`. NEVER "zero value"
     //     and never "not worth resolving": below-resolution means
     //     indistinguishable from noise AT THIS RUN'S RESOLUTION.
+    //     ⭐ REWORDED BY L51 (see the supersession note above). The doctrine in
+    //     the two lines above is unchanged and is what constrains the wording:
+    //     "Not enough precision this run to rank" attributes the shortfall to
+    //     THIS RUN'S precision, which is the honest cause, and never to the
+    //     factors' worth. A phrasing like "not worth resolving" or "no value"
+    //     would state the opposite and is still banned.
     //   · resolveNextNote  ← `method: 'regression_evppi_v1'` on every row. The
     //     honesty disclosure IS that we name the basis and the restraint. The
     //     em dash is the design's, kept against this file's own no-em-dash rule
@@ -199,7 +220,7 @@ export const V7_LENS_COPY = {
       'Ranked by value of information — what a run says it is worth learning before deciding. No amounts shown.',
     resolveNextLead: 'Most worth resolving next',
     resolveNextThen: 'then',
-    resolveNextBelow: (labels: string) => `Below resolution on this run: ${labels}`,
+    resolveNextBelow: (labels: string) => `Not enough precision this run to rank: ${labels}`,
     resolveNextPartial: "Some factors couldn't be assessed for this ranking.",
     resolveNextGate: "Value-of-information ranking wasn't produced for this run.",
     /**
@@ -216,12 +237,19 @@ export const V7_LENS_COPY = {
      * `V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx` §2/§3.
      *
      * PLAIN LANGUAGE, DELIBERATELY. "below_resolution", "noise floor" and
-     * "EVPPI" are the producer's vocabulary, not the user's; the one
-     * jargon-adjacent line on this surface (`resolveNextBelow`) is pre-existing
-     * ratified design copy and is left exactly where it was rather than
-     * relocated by this lane. "at this precision" is what carries the honest
-     * caveat that a longer run could resolve something — the sentence says
-     * nothing stands out YET, never that nothing matters.
+     * "EVPPI" are the producer's vocabulary, not the user's. "at this
+     * precision" is what carries the honest caveat that a longer run could
+     * resolve something — the sentence says nothing stands out YET, never that
+     * nothing matters.
+     *
+     * ⚠ THIS PARAGRAPH USED TO SAY the one jargon-adjacent line on this surface
+     * (`resolveNextBelow`) was "left exactly where it was". That was true when
+     * written and is now false: the review ruled it be reworded to the same
+     * plain class, on the finding that it sits behind NO expert affordance
+     * (`expertMode` never reaches this disclosure). The two sentences now speak
+     * one register, which is the point — an empty state in plain English
+     * directly above a producer-vocabulary line would have been the same
+     * mismatch this lane was sent to fix, moved down one element.
      *
      * The em dash is deliberate and matches `resolveNextNote` above.
      */


### PR DESCRIPTION
## What

When the per-factor EVPPI estimator runs and **every** factor comes back `below_resolution`, the "Resolve next" view now says so in plain language:

> Nothing stands out to resolve yet — at this precision, no single unknown would change the recommendation.

Before this PR it said nothing at all about the outcome: a note claiming the factors were "Ranked by value of information" above an empty list, then a bare `Below resolution on this run: …` line naming seven factors with no explanation.

## ⚠ Two corrections to the brief I was given — both derived at the bytes

**1. The dispatched hypothesis was false.** The brief's hypothesis was *"the ranking filters `below_resolution` rows → empty list → the conditional render skips the section entirely."* It does not. `voiRanking.ts:284-286` pushes those rows into a second `belowResolution` band, and `:292` requires **both** bands empty before returning `null`. The section never skipped — it rendered without ever stating the outcome.

**2. The walk's "no surface at all" is a probe-scope artefact, not a vanishing section.** The disclosure is a collapsed accordion (`V7EvidenceDisclosure.tsx:100,211`) and **no walk phase ever expanded it**. Measured across the whole raw evidence directory:

- `v7-evidence-disclosure` (the always-mounted `<section>` shell) → **4 hits**
- `v7-evidence-tab-` (the four tab chips, which only exist when open) → **0 hits**

`w2/driver.log:15` shows T7 running a testid/text scan with no expand step. The absence manifest measured a closed accordion. *A capture proves what it was pointed at* — trap 16. **The defect survives the correction** (the empty state genuinely did not exist), but the severity framing "the UI silently vanishes the surface" should be revised in the walk record.

## The honesty boundary

The sentence is a **claim**: it asserts the analysis assessed the unknowns and none would change the recommendation. That is only true when rows actually arrived, so the condition is `resolveNext != null && resolvedRows.length === 0`.

That is exact, not a proxy. `buildVoiRanking` returns `null` for every not-arrived case (`voiRanking.ts:186` absent/null/empty/non-array, `:290` unusable rank 1, `:292` all rows dropped), so reaching the line at all means rows arrived, validated and label-resolved; `:292` then guarantees at least one survivor, so an empty `resolved` band means every survivor is below-resolution.

**Absent VOI keeps the pre-existing gate, unchanged.** An empty state on absent data would fabricate the claim that anything was assessed. Both directions are pinned.

## Proof

**Fixture is captured producer bytes**, not a hand-written shape: `enrichment.factor_evppi` copied verbatim from `PHASE0-EVIDENCE-2026-07-28/journey-witness-2026-08-04c-raw/w7/wire-final-5-res.txt` (2 rows, both `below_resolution`, `evppi: 0`, audit legs intact, `decision_evpi: 0.0446` present so the estimator demonstrably ran). The id→label map is read from the same response's graph, and both ids are confirmed present as `rf__node-*` in that walk's painted manifest — so label resolution genuinely succeeds and no row is dropped. The deployed commit in `version-in-probe.json` is `42cbd0d4`, **the same commit this PR branches from**.

**RED-first at the tip.** Copy constant added first, so the RED isolates the missing render rather than a `toContain(undefined)` throw:

```
Tests  4 failed | 8 passed (12)
→ §2 "states the outcome in plain language": v7-resolve-next-none-above-resolution absent from the DOM
```

**Mutants — all four bite.** Worktree outside the repo root, detached at the committed SHA, applied-check scoped to `src/`; clean control read **exactly 0**, each mutant exactly 1, final control back to 0.

| mutant | red | what died |
|---|---|---|
| delete the empty state | 2 | §2 both render pins |
| **render-on-absent-data** | **4** | **every §3 negative control** |
| condition sourced from `someFactorsUnassessed` | 2 | §2 both render pins |
| condition sourced from `evidence.drivers.length` | 1 | §2 anti-correlation pin |

⚠ **The last one is worth a reviewer's attention.** Before I added the anti-correlation case, every rendering fixture had no drivers and every non-rendering fixture had one — so `evidence.drivers.length === 0`, a field with nothing to do with EVPPI status, satisfied all 14 assertions and **would have survived**. I found it by reading the fixtures, not by running them. This is trap 19 one level up: not a test binding to the wrong object, but a suite whose fixtures let an unrelated field impersonate the real condition.

**The RED run also caught three of its own negative controls being vacuous.** `V7EvidenceDisclosure.tsx:178` unmounts the whole section when nothing is disclosable, so `not.toContain(copy)` was asserting against an **empty body** — trap 13. Fixed by mounting the controls with one driver plus an explicit non-vacuity assertion; the genuinely-silent nothing-at-all case is now pinned separately.

**Gates at my tip:**
- `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) → **PASSED**. Coverage 3199/3239 files; ratchet within baseline (621 files / 2505 errors, baseline 2507).
- Full derived blast radius (every spec importing `V7EvidenceDisclosure` / `v7LensCopy` / `V7_LENS_COPY` / the shared `resolveNextView` helper) → **11 files, 206 tests, all pass**.

⚠ **The gate offered `--update-baseline` ("drift shrank 2507 → 2505") and I declined.** This PR cannot fix two pre-existing diagnostics, so the shrink is attribution churn in files it never touched (trap 2b); and both baseline files are in **#572's** changed-file list, so banking them would collide with a sibling lane.

## Review amendment (`c89dd9d7`)

Review verdict on `34fb5ba9` was FIX-FIRST solely on the copy. The reviewer measured the thing I had only inferred: **`resolveNextBelow` is behind no expert affordance at all** — `expertMode` is never passed into `V7TopMatter`, so it never reaches this disclosure, and every user who opens the accordion on an all-below run reads it. My scope note below described an affordance that does not exist on this surface.

| | |
|---|---|
| was | `Below resolution on this run: {labels}` |
| **now** | **`Not enough precision this run to rank: {labels}`** |

**The doctrine is unchanged and is what constrains the wording**: below-resolution ≠ zero value ≠ not-worth-resolving. The new form attributes the shortfall to *this run's precision* — the honest cause — never to the factors' worth.

Also in this commit, and half its point: **three comments de-staled**. Each described the line as verbatim / ratified / left-exactly-as-shipped, and each would have become a false label the instant the string changed — trap 14, in the file whose own rule ("a deviation gets flagged in the PR, never silently improved") exists to prevent precisely that. One of them was mine.

**Zero test edits, derived not assumed**: grepped both spellings across every spec — the sole assertion goes through `E.resolveNextBelow(...)` (`V7EvidenceDisclosure.resolveNext.spec.tsx:182`). Blast radius re-run after the reword: **11 files / 206 tests, identical to before**.

Estate docs updated alongside (not in this repo): `V7C-EVPPI-RANKING-DESIGN-2026-07-30` §4 now carries a dated delta recording both the supersession **and** the empty-state sentence §4 never had a row for — the original table had a row for "nothing produced" and rows for a populated ranking, but none for "produced, and nothing cleared the floor", which is the gap that let this defect ship. §3's mock is marked as-designed-not-as-shipped. My evidence doc's §2 said "7 rows"; corrected to 2 (a windowed regex had run past the array and swept in `p_win_sensitivity` — the PR body was always right).

## Scope notes

- **jsdom presence only.** No screen witness — that rides walk phase 2. jsdom cannot prove visibility (trap 3), so nothing here claims the sentence is on screen, only that it is in the DOM.
- **Expert-mode detail deliberately NOT added.** `V7EvidenceDisclosure` takes only `{ evidence, onFocusNode }` and nothing under `results/v7/` reads an `expertMode` prop — there is no existing pattern to reuse, and the brief said derive, don't invent.
- **For Paul:** the pre-existing `Below resolution on this run: …` line is left exactly as shipped (ratified design copy, `V7C-EVPPI-RANKING-DESIGN-2026-07-30` §4). It is the one jargon-adjacent string on this surface. Relocating it behind an expert affordance is a copy decision, flagged rather than silently made.
- No collision: this PR is 3 files, all `src/components/results/v7/**`. #572 is `src/canvas/**` + `src/adapters/**`; L50 is pre-analysis-v3.

Evidence: `PHASE0-EVIDENCE-2026-07-28/l51-voi-empty-state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
