### PR TITLE
feat(pre-analysis-v3): surface contested connections on the pre-run screen (ROADMAP 2.376)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -19,6 +19,7 @@ import { GoalTargetNudge } from '../pre-analysis/GoalTargetNudge'
 import { PanelHeader } from './header/PanelHeader'
 import { HeroSection, GOAL_INPUT_ID, SUCCESS_INPUT_ID } from './hero/HeroSection'
 import { SharpenSection } from './sharpen/SharpenSection'
+import { ContestedSection } from './contested/ContestedSection'
 import { YourDecisionSection } from './model/YourDecisionSection'
 import { AdvancedSection } from './advanced/AdvancedSection'
 import { PanelFooter } from './footer/PanelFooter'
@@ -148,6 +149,14 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
           onSendPrompt={sendPrompt}
           onAction={handleSignalAction}
         />
+        {/* ROADMAP 2.376 — connections CEE's two validation passes disagreed about.
+            Placed between Sharpen and Your decision on purpose: it is a "worth checking
+            before you run" item like Sharpen's, but it is about the MODEL's connections
+            rather than the framing, so it introduces the model section rather than
+            interrupting the coaching. It is deliberately ABOVE Advanced — a differentiator
+            no other tool shows should not be filed behind a collapsed set-up disclosure.
+            Renders nothing at all when no connection is contested, which is most models. */}
+        <ContestedSection rows={model.contested} />
         <YourDecisionSection model={model} onSendPrompt={sendPrompt} estimateFocus={estimateFocus} />
         <AdvancedSection advanced={model.advanced} />
       </div>

--- a/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
@@ -1,0 +1,325 @@
+/**
+ * ROADMAP 2.376 — the contested-relationship surface in the V3 pre-analysis panel.
+ *
+ * WHY THIS SUITE EXISTS. #571 shipped `selectSurfacedContestedEdges` and wired it into the
+ * LEGACY pre-analysis panel. Deployed staging runs `preAnalysisV3`, whose tree had ZERO
+ * contested consumers — so on the surface a user actually sees, CEE's live validation
+ * metadata (#808) was dark. This suite pins the V3 mount.
+ *
+ * WHAT EACH PIN IS FOR (every assertion is a mutant's tombstone):
+ *  · MOUNT       — deleting `<ContestedSection>` from PreAnalysisPanelV3 must go RED.
+ *  · IDENTITY    — the pins name the SPECIFIC surviving edge id and the SPECIFIC capped-out
+ *                  edge id. Trap 19: never `getAllByTestId(...).toHaveLength(1)`, which a
+ *                  different edge could satisfy.
+ *  · SELECTOR    — three edges that a naive `status === 'contested'` filter WOULD render and
+ *                  the selector does NOT (resolved / suppressed / capped). Rendering from any
+ *                  field other than `selectSurfacedContestedEdges`'s output goes RED here.
+ *  · EMPTY       — no contested edges renders NOTHING, not an empty section.
+ *
+ * jsdom proves PRESENCE, never visibility (trap 3). The on-screen witness rides walk phase 2.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Edge, Node } from '@xyflow/react'
+import { PreAnalysisPanelV3 } from '../PreAnalysisPanelV3'
+import { ToastProvider } from '../../../ToastContext'
+import { useCanvasStore } from '../../../store'
+import { useReadinessStore } from '../../../stores/readinessStore'
+import { useUIStore } from '../../../../stores/uiStore'
+import { makeContestedEdge, makeContestedValidation } from '../../../../__fixtures__/contestedEdge'
+import { CONTESTED_COPY } from '../constants'
+import { getBasisLabel, getContestedReasonLabel } from '../../model-tab/strengthBands'
+import { findBannedTerm } from '../../../../test/glossaryBannedTerms'
+import type { ContestedReason, EstimateBasis } from '../../../domain/validation'
+
+function node(id: string, kind: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+/** Base graph: enough for the panel to render, plus the factors our edges join. */
+const BASE_NODES: Node[] = [
+  node('d1', 'decision', 'Hire a tech lead or two developers?'),
+  node('g1', 'goal', 'Increase delivery output', { goal_threshold: 0.8 }),
+  node('o1', 'option', 'Hire a tech lead'),
+  node('o2', 'option', 'Hire two developers'),
+  node('f_lead', 'factor', 'Tech lead impact'),
+  node('f_cost', 'factor', 'Salary cost'),
+  node('f_speed', 'factor', 'Delivery speed'),
+  node('f_morale', 'factor', 'Team morale'),
+]
+
+function setGraph(edges: Edge[]) {
+  useCanvasStore.setState({
+    nodes: BASE_NODES,
+    edges,
+    preAnalysisSensitivity: null,
+    draftCoaching: null,
+    currentBriefText: null,
+    goalThreshold: 0.8,
+  })
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+  useReadinessStore.setState({
+    readiness: {
+      readiness_score: 72,
+      readiness_level: 'strong',
+      can_run_analysis: true,
+      confidence_explanation: 'Looks consistent.',
+      improvements: [],
+    },
+    loading: false,
+    error: null,
+  })
+  useUIStore.setState({ activeOutputTab: 'results', pendingModelTabSection: null })
+  setGraph([])
+})
+
+function renderPanel() {
+  return render(
+    <ToastProvider>
+      <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun blockedReason={undefined} />
+    </ToastProvider>,
+  )
+}
+
+const SECTION = 'pre-analysis-v3-contested'
+const row = (edgeId: string) => `pre-analysis-v3-contested-row-${edgeId}`
+
+describe('pre-analysis v3 — contested relationships mount', () => {
+  it('renders the section when the selector surfaces a contested connection', () => {
+    setGraph([
+      makeContestedEdge('e_lead_speed', 'f_lead', 'f_speed', makeContestedValidation()),
+    ])
+    renderPanel()
+    expect(screen.getByTestId(SECTION)).toBeInTheDocument()
+    expect(screen.getByText(CONTESTED_COPY.title)).toBeInTheDocument()
+  })
+
+  it('names both ends of the connection in plain language, and why the reviews disagree', () => {
+    setGraph([
+      makeContestedEdge(
+        'e_lead_speed',
+        'f_lead',
+        'f_speed',
+        makeContestedValidation({ contested_reasons: ['sign_flip'] }),
+      ),
+    ])
+    renderPanel()
+    const rowEl = screen.getByTestId(row('e_lead_speed'))
+    // Both node labels render VERBATIM (V3 never rewrites shared graph labels).
+    expect(rowEl).toHaveTextContent('Tech lead impact')
+    expect(rowEl).toHaveTextContent('Delivery speed')
+    // The "why" is the plain-language reason, not a reason enum value.
+    expect(rowEl).toHaveTextContent(
+      'Our reviews disagree on whether this effect is positive or negative',
+    )
+    expect(rowEl.textContent).not.toContain('sign_flip')
+  })
+
+  it('puts the expert detail behind a disclosure, closed by default', () => {
+    setGraph([
+      makeContestedEdge('e_lead_speed', 'f_lead', 'f_speed', makeContestedValidation()),
+    ])
+    renderPanel()
+    const trigger = screen.getByTestId(`pre-analysis-v3-contested-detail-e_lead_speed`)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Based on general domain knowledge')).toBeNull()
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Based on general domain knowledge')).toBeInTheDocument()
+    expect(
+      screen.getByText('Typical B2B ROI shows moderate conversion effects'),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('pre-analysis v3 — contested section renders the SELECTOR output, nothing else', () => {
+  /**
+   * The cap. Two contested connections into the SAME target: the selector keeps exactly one,
+   * by `max_divergence` desc. The pins are IDENTITY-BOUND — a count assertion would pass on
+   * the wrong survivor.
+   */
+  it('the higher-divergence connection into a shared target survives; the other does NOT render', () => {
+    setGraph([
+      makeContestedEdge(
+        'e_lead_speed',
+        'f_lead',
+        'f_speed',
+        makeContestedValidation({ max_divergence: 0.2 }),
+      ),
+      makeContestedEdge(
+        'e_cost_speed',
+        'f_cost',
+        'f_speed',
+        makeContestedValidation({ max_divergence: 0.8 }),
+      ),
+    ])
+    renderPanel()
+    expect(screen.getByTestId(row('e_cost_speed'))).toBeInTheDocument()
+    expect(screen.queryByTestId(row('e_lead_speed'))).toBeNull()
+  })
+
+  it('an ALREADY-RESOLVED contested connection does not render (a raw status filter would show it)', () => {
+    setGraph([
+      makeContestedEdge(
+        'e_resolved',
+        'f_lead',
+        'f_speed',
+        makeContestedValidation({ user_action: 'accepted_pass2' }),
+      ),
+      makeContestedEdge('e_open', 'f_cost', 'f_morale', makeContestedValidation()),
+    ])
+    renderPanel()
+    expect(screen.getByTestId(row('e_open'))).toBeInTheDocument()
+    expect(screen.queryByTestId(row('e_resolved'))).toBeNull()
+  })
+
+  it('an explicit `surfaced: false` from CEE is honoured (absent still means eligible)', () => {
+    setGraph([
+      makeContestedEdge(
+        'e_suppressed',
+        'f_lead',
+        'f_speed',
+        makeContestedValidation({ surfaced: false }),
+      ),
+      // `surfaced` ABSENT — the live wire shape. Must render.
+      makeContestedEdge('e_absent', 'f_cost', 'f_morale', makeContestedValidation()),
+    ])
+    renderPanel()
+    expect(screen.getByTestId(row('e_absent'))).toBeInTheDocument()
+    expect(screen.queryByTestId(row('e_suppressed'))).toBeNull()
+  })
+
+  it('an AGREED connection never renders', () => {
+    setGraph([
+      makeContestedEdge(
+        'e_agreed',
+        'f_lead',
+        'f_speed',
+        makeContestedValidation({ status: 'agreed', contested_reasons: [] }),
+      ),
+    ])
+    renderPanel()
+    expect(screen.queryByTestId(SECTION)).toBeNull()
+  })
+
+  it('orders rows deterministically by the exported cap comparator', () => {
+    setGraph([
+      makeContestedEdge('e_a', 'f_lead', 'f_speed', makeContestedValidation({ max_divergence: 0.2 })),
+      makeContestedEdge('e_b', 'f_cost', 'f_morale', makeContestedValidation({ max_divergence: 0.9 })),
+      makeContestedEdge('e_c', 'f_speed', 'g1', makeContestedValidation({ max_divergence: 0.5 })),
+    ])
+    renderPanel()
+    const ids = [...screen.getByTestId(SECTION).querySelectorAll('[data-contested-edge-id]')].map(
+      el => el.getAttribute('data-contested-edge-id'),
+    )
+    expect(ids).toEqual(['e_b', 'e_c', 'e_a'])
+  })
+})
+
+describe('pre-analysis v3 — contested section empty state', () => {
+  it('renders NOTHING when there are no contested connections (no empty-section noise)', () => {
+    setGraph([makeContestedEdge('e_plain', 'f_lead', 'f_speed')])
+    renderPanel()
+    expect(screen.queryByTestId(SECTION)).toBeNull()
+    expect(screen.queryByText(CONTESTED_COPY.title)).toBeNull()
+  })
+
+  it('renders NOTHING on an edgeless model', () => {
+    setGraph([])
+    renderPanel()
+    expect(screen.queryByTestId(SECTION)).toBeNull()
+  })
+})
+
+describe('pre-analysis v3 — contested section routes to the ONE adjudication surface', () => {
+  /**
+   * DISPLAY-ONLY BY RULING. The legacy pre-analysis panel's contested resolve handler was
+   * deleted in the Brief 4 Task 6 dead-code sweep (`PreAnalysisPanel.tsx:76,1106`), so there
+   * is no pre-analysis write path to reuse; the only live adjudication surface is the Model
+   * tab (`ModelTabBody::handleResolveContested` → `RelationshipsSection` →
+   * `ContestedEdgeCard`). This slice does NOT invent a second one. It reuses the EXISTING,
+   * non-mutating cross-panel handoff the legacy panel already uses for the same destination
+   * (`PreAnalysisPanel.tsx:2304`).
+   */
+  it('the review affordance navigates to the Model tab relationships section and mutates no graph data', () => {
+    const edges = [makeContestedEdge('e_open', 'f_lead', 'f_speed', makeContestedValidation())]
+    setGraph(edges)
+    const edgesBefore = JSON.stringify(useCanvasStore.getState().edges)
+    renderPanel()
+
+    fireEvent.click(screen.getByTestId('pre-analysis-v3-contested-review'))
+
+    expect(useUIStore.getState().pendingModelTabSection).toBe('relationships')
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+    // Display-only: the click must not touch the graph.
+    expect(JSON.stringify(useCanvasStore.getState().edges)).toBe(edgesBefore)
+  })
+})
+
+/**
+ * The borrowed copy is scanned too.
+ *
+ * `CONTESTED_COPY` rides the panel's own banned-terms sweep (registry.spec.ts), but the
+ * sentences a user actually reads as the "why" come from `model-tab/strengthBands.ts`, which
+ * that sweep does not reach. Deliberately reused rather than copied (trap 12) — so the sweep
+ * has to follow them here.
+ *
+ * The maps below are the TYPE's key set, not a hand-kept list: `Record<ContestedReason, true>`
+ * makes a new union member a COMPILE error rather than a silently unscanned sentence. That is
+ * the union-assertion form of trap 12d — derivation alone could not notice a missing key.
+ */
+const ALL_CONTESTED_REASONS: Record<ContestedReason, true> = {
+  sign_flip: true,
+  strength_band_change: true,
+  confidence_band_change: true,
+  existence_boundary_crossing: true,
+  raw_magnitude: true,
+}
+const ALL_BASES: Record<EstimateBasis, true> = {
+  brief_explicit: true,
+  structural_inference: true,
+  domain_prior: true,
+  weak_guess: true,
+}
+
+describe('pre-analysis v3 — the borrowed reason and basis copy passes the same glossary sweep', () => {
+  it.each(Object.keys(ALL_CONTESTED_REASONS) as ContestedReason[])(
+    'reason %s reads as plain language with no banned term',
+    reason => {
+      const label = getContestedReasonLabel(reason)
+      expect(label.length).toBeGreaterThan(0)
+      expect(findBannedTerm(label)).toBeNull()
+      expect(label).not.toContain('—')
+      // Never the enum value itself leaking onto the surface.
+      expect(label).not.toContain(reason)
+    },
+  )
+
+  it.each(Object.keys(ALL_BASES) as EstimateBasis[])(
+    'basis %s reads as plain language with no banned term',
+    basis => {
+      const label = getBasisLabel(basis)
+      expect(label.length).toBeGreaterThan(0)
+      expect(findBannedTerm(label)).toBeNull()
+      expect(label).not.toContain(basis)
+    },
+  )
+})
+
+describe('pre-analysis v3 — contested section respects the panel hierarchy contract', () => {
+  it('owns a single top rule and introduces no second border-b', () => {
+    setGraph([makeContestedEdge('e_open', 'f_lead', 'f_speed', makeContestedValidation())])
+    renderPanel()
+    const section = screen.getByTestId(SECTION)
+    expect(section.classList.contains('border-t')).toBe(true)
+    expect(section.classList.contains('border-b')).toBe(false)
+    const panel = screen.getByTestId('pre-analysis-v3')
+    const borderB = [...panel.querySelectorAll('*')].filter(el => el.classList.contains('border-b'))
+    expect(borderB).toHaveLength(1)
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
@@ -33,6 +33,7 @@ import { CONTESTED_COPY } from '../constants'
 import { getBasisLabel, getContestedReasonLabel } from '../../model-tab/strengthBands'
 import { findBannedTerm } from '../../../../test/glossaryBannedTerms'
 import type { ContestedReason, EstimateBasis } from '../../../domain/validation'
+import type { EdgeData } from '../../../domain/edges'
 
 function node(id: string, kind: string, label: string, data: Record<string, unknown> = {}): Node {
   return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
@@ -53,7 +54,11 @@ const BASE_NODES: Node[] = [
 function setGraph(edges: Edge[]) {
   useCanvasStore.setState({
     nodes: BASE_NODES,
-    edges,
+    // The shared `__fixtures__/contestedEdge` builder returns a plain `Edge` (it is also used
+    // by Model-tab and telemetry suites that never touch the store); the store's slice is
+    // `Edge<EdgeData>`. Narrowing at the boundary rather than forking the fixture — the fields
+    // under test (`data.validation`, `source`, `target`, `id`) are identical either way.
+    edges: edges as Edge<EdgeData>[],
     preAnalysisSensitivity: null,
     draftCoaching: null,
     currentBriefText: null,

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -164,6 +164,36 @@ export const SIGNAL_COPY = {
     'A reflective check from Olumi, based on the structure of your model. Worth a thought, not a verdict.',
 } as const
 
+/**
+ * ROADMAP 2.376 — the contested-relationship surface.
+ *
+ * Plain language by ruling: no "contested", no "validation", no "pass 1/pass 2", no divergence
+ * number. The user is told that Olumi looked twice and the two looks did not agree about one
+ * named connection, and where to settle it. The per-reason sentences are NOT duplicated here:
+ * they are `getContestedReasonLabel` in `model-tab/strengthBands.ts`, the single source of
+ * truth the Model tab's own cards already render (trap 12 — a second copy of five sentences
+ * is a hand-maintained mirror). `contestedReasonsSweep.spec` scans those five through the
+ * same banned-terms matcher this object is scanned with.
+ *
+ * NO RESOLVE COPY HERE, DELIBERATELY. This section is DISPLAY-ONLY: the pre-analysis panel's
+ * contested resolve handler was deleted in the Brief 4 Task 6 dead-code sweep, and the only
+ * live adjudication surface is the Model tab. `reviewCta` therefore promises navigation, not
+ * a fix, and phrases it the way the legacy panel's own model-tab link does.
+ */
+export const CONTESTED_COPY = {
+  title: 'Where our reviews disagree',
+  meta: (n: number) => `${n} ${n === 1 ? 'connection' : 'connections'}`,
+  lead: 'Olumi looked at this model twice and the two looks did not agree here. Your judgement is worth more than either.',
+  /** Row title reads "How <source> affects <target>" — a noun phrase, not a claim. */
+  rowLeadIn: 'How',
+  rowConnective: 'affects',
+  /** Reached only if a connection is flagged with no stated reason. Claims nothing specific. */
+  reasonFallback: 'Our reviews did not settle on the same estimate here.',
+  showDetail: 'Show detail',
+  hideDetail: 'Hide detail',
+  reviewCta: 'Settle these in the model tab',
+} as const
+
 export const ATTRIBUTION_COPY = {
   olumiNoticed: 'Olumi noticed',
   olumiPrefix: 'Olumi:',

--- a/src/canvas/components/pre-analysis-v3/contested/ContestedSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/contested/ContestedSection.tsx
@@ -1,0 +1,129 @@
+/**
+ * ContestedSection — "Where our reviews disagree" (ROADMAP 2.376).
+ *
+ * CEE validates every drafted connection twice and flags the ones the two passes disagree
+ * about. Those cards have been live in the Model tab for some time; this is the same fact,
+ * put in front of the user on the surface they are actually standing on before they run —
+ * the pre-analysis panel. It is an ADDITION to the pre-run screen, not a rescue of the Model
+ * tab, which keeps its own uncapped, fully actionable list.
+ *
+ * ⚠ DISPLAY-ONLY, AND THE COPY SAYS SO. There is no pre-analysis write path to reuse: the
+ * legacy panel's contested resolve handler was deleted in the Brief 4 Task 6 dead-code sweep
+ * (`PreAnalysisPanel.tsx:76,1106`), and the only live adjudication surface is the Model tab
+ * (`ModelTabBody::handleResolveContested` → `RelationshipsSection` → `ContestedEdgeCard`).
+ * This slice does NOT invent a second write path. The one affordance here is the EXISTING,
+ * non-mutating cross-panel handoff the legacy panel already uses for exactly this destination
+ * (`PreAnalysisPanel.tsx:2304`) — two ui-store calls, no graph mutation.
+ *
+ * EMPTY MEANS ABSENT. Nothing renders when no connection is contested — no header, no "0",
+ * no reassurance row. Same rule as SharpenSection.
+ *
+ * HIERARCHY. A single `border-t` and no static `bg-panel-hover` strip: the panel's one neutral
+ * section-header strip belongs to Sharpen and its one `border-b` to the Header
+ * (`hierarchyContract.spec.tsx`).
+ */
+
+import { memo, useCallback, useState } from 'react'
+import { Scale } from 'lucide-react'
+import { typography, typo } from '../../../../styles/typography'
+import { useUIStore } from '../../../../stores/uiStore'
+import { CONTESTED_COPY } from '../constants'
+import type { ContestedRowModel } from '../selectors/computeContestedRows'
+
+/**
+ * One contested connection. The expert detail (what the second look was based on, and its
+ * own sentence) sits behind a per-row reveal, in the panel's existing reveal idiom — an
+ * `aria-expanded` text button, as SharpenSection's "Show N more" uses. Conditional render
+ * rather than `hidden`: PanelDisclosure's always-mounted rule exists so a section-level
+ * `aria-controls` target is valid, and this row-level reveal has no such target.
+ */
+const ContestedRow = memo(function ContestedRow({ row }: { row: ContestedRowModel }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div
+      className="grid grid-cols-[16px_1fr] items-start gap-2 border-t border-panel-border py-2 first:border-t-0"
+      data-testid={`pre-analysis-v3-contested-row-${row.edgeId}`}
+      data-contested-edge-id={row.edgeId}
+    >
+      <Scale className="mt-0.5 h-3.5 w-3.5 flex-none text-text-light" aria-hidden />
+      <div className="min-w-0">
+        <p className={`${typography.panelBody} text-text-body`}>
+          {CONTESTED_COPY.rowLeadIn}{' '}
+          {/* Shared graph labels render VERBATIM — the panel never rewrites them. */}
+          <span className="font-semibold text-text-header">{row.sourceLabel}</span>{' '}
+          {CONTESTED_COPY.rowConnective}{' '}
+          <span className="font-semibold text-text-header">{row.targetLabel}</span>
+        </p>
+        {row.reasons.map(reason => (
+          <p key={reason} className={`${typography.panelMeta} text-text-light`}>
+            {reason}
+          </p>
+        ))}
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen(v => !v)}
+          className={typo(
+            'panelMeta',
+            'mt-1 rounded text-info outline-none transition-colors hover:underline focus-visible:ring-2 focus-visible:ring-info/40',
+          )}
+          data-testid={`pre-analysis-v3-contested-detail-${row.edgeId}`}
+        >
+          {open ? CONTESTED_COPY.hideDetail : CONTESTED_COPY.showDetail}
+        </button>
+        {open && (
+          <div className="mt-1 space-y-0.5">
+            <p className={`${typography.panelMeta} text-text-light`}>{row.basis}</p>
+            {row.reasoning && (
+              <p className={`${typography.panelMeta} text-text-light`}>{row.reasoning}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+})
+
+export const ContestedSection = memo(function ContestedSection({
+  rows,
+}: {
+  rows: ContestedRowModel[]
+}) {
+  // The established pre-analysis → Model tab handoff (PreAnalysisPanel.tsx:2304). Navigation
+  // only: it asks the Model tab to open its relationships section and activates that tab.
+  // Nothing here writes graph data.
+  const openInModelTab = useCallback(() => {
+    useUIStore.getState().requestModelTabSection('relationships')
+    useUIStore.getState().setActiveOutputTab('diagnostics')
+  }, [])
+
+  if (rows.length === 0) return null
+
+  return (
+    <div className="border-t border-panel-border px-4 py-4" data-testid="pre-analysis-v3-contested">
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <h2 className={`${typography.panelHeader} text-text-header`}>{CONTESTED_COPY.title}</h2>
+        <span className={`${typography.panelMeta} flex-none text-text-light`}>
+          {CONTESTED_COPY.meta(rows.length)}
+        </span>
+      </div>
+      <p className={`${typography.panelMeta} mb-2 text-text-light`}>{CONTESTED_COPY.lead}</p>
+      <div>
+        {rows.map(row => (
+          <ContestedRow key={row.edgeId} row={row} />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={openInModelTab}
+        className={typo(
+          'panelMeta',
+          'mt-2 inline-flex items-center gap-1 self-start rounded text-info outline-none hover:underline focus-visible:ring-2 focus-visible:ring-info/40',
+        )}
+        data-testid="pre-analysis-v3-contested-review"
+      >
+        {CONTESTED_COPY.reviewCta} ›
+      </button>
+    </div>
+  )
+})

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -13,6 +13,7 @@ import { useGraphReadiness } from '../../../hooks/useGraphReadiness'
 import { readinessWillScaffold } from '../../../utils/canRunAnalysis'
 import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
 import { computeBars, type BarsModel } from '../selectors/computeBars'
+import { computeContestedRows, type ContestedRowModel } from '../selectors/computeContestedRows'
 import { computeEstimateRanking } from '../selectors/computeEstimateRanking'
 import { computeGraphFacts, computeProvenanceCounts } from '../selectors/graphFacts'
 import { computeInfluenceCoverage } from '../selectors/computeInfluenceCoverage'
@@ -51,6 +52,19 @@ export interface PreAnalysisModel {
   }
   options: Array<{ nodeId: string; label: string }>
   risks: Array<{ nodeId: string; label: string; attribution: Attribution }>
+  /**
+   * ROADMAP 2.376 — connections CEE's two validation passes disagreed about, as words.
+   *
+   * Sourced from `useCanvasStore(s => s.edges)`, the same store slice every other v3 slice
+   * reads and the same one the legacy panel's `usePreAnalysisData` reads. That is not an
+   * assumption: `applyDraftResult` writes CEE's per-edge validation metadata onto
+   * `edge.data.validation` at ingest (`utils/applyDraftResult.ts:139,157`, via
+   * `readValidationMetadata`), so the metadata reaches this tree by construction — there is
+   * no separate legacy-only data path to bridge.
+   *
+   * EMPTY ARRAY IS THE NORMAL CASE and renders nothing at all.
+   */
+  contested: ContestedRowModel[]
   advanced: {
     factorCount: number
     connectionCount: number
@@ -303,6 +317,11 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     [nodes],
   )
 
+  // ROADMAP 2.376 — contested connections. Keyed on the store's own nodes/edges so one
+  // commit (a resolve in the Model tab, a re-draft) updates this section in the same pass as
+  // every other slice.
+  const contested = useMemo(() => computeContestedRows(nodes, edges), [nodes, edges])
+
   // UI-SEM-091: effective runnable ORs the scaffold intent, so advanced.canRun
   // and the footer agree with the run gate (canRunAnalysis util).
   const canRun = readiness ? readiness.can_run_analysis || willScaffoldOptions : null
@@ -416,6 +435,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       estimates,
       options,
       risks,
+      contested,
       advanced,
       footer,
       readinessCheck,
@@ -428,6 +448,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       estimates,
       options,
       risks,
+      contested,
       advanced,
       footer,
       readinessCheck,

--- a/src/canvas/components/pre-analysis-v3/selectors/computeContestedRows.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/computeContestedRows.ts
@@ -1,0 +1,83 @@
+/**
+ * computeContestedRows — the v3 panel's view model for contested connections (ROADMAP 2.376).
+ *
+ * ⚠ THIS MODULE OWNS NO ELIGIBILITY LOGIC, BY DESIGN. Which connections are surfaced is
+ * `selectSurfacedContestedEdges` (#571, orchestrator ruling of 4 Aug 2026) and nothing here
+ * may re-decide it. That module is the SINGLE source of truth for the `surfaced`/pending
+ * predicate and the one-per-target-node cap, and it carries the supersession note for the day
+ * CEE starts emitting `surfaced`. Re-spelling its predicate here — even "just the obvious
+ * half" — is exactly the trap-12 hand-maintained mirror it was created to abolish: the legacy
+ * panel had that predicate written two different ways and one of them made the panel dark.
+ * This module only turns its output into words.
+ *
+ * ORDER. `selectSurfacedContestedEdges` deliberately returns survivors in INPUT order and
+ * tells the caller to apply its own display sort, so this is where the order is chosen. We
+ * sort with the selector's own exported `compareContestedCapPriority`, which is TOTAL (its
+ * third key is the edge id) and therefore renders identically across graph rebuilds.
+ *
+ * ⚠ That is a REUSE for ordering, NOT a unification of the two comparators. The Model tab
+ * keeps its own private `compareContestedPriority`, which leads on `evoi_impact` — a
+ * post-analysis field that is null on every edge on this pre-run surface, so its leading key
+ * is inert here anyway and it is not a total order. Do not replace either with the other.
+ *
+ * COPY. The per-reason and per-basis sentences come from `model-tab/strengthBands.ts` — the
+ * same functions the Model tab's contested cards render — so the two surfaces can never drift
+ * into describing the same disagreement differently. `pass2.reasoning` is CEE-authored text
+ * and goes through the v3 runtime glossary guard like every other CEE string in this panel;
+ * unsafe wording with no safe substitution is dropped rather than shown.
+ *
+ * NUMBERS ARE DELIBERATELY ABSENT. No `max_divergence`, no `strength_mean`, no probability.
+ * Effect-strength values stay gated on this panel until the value-scale work lands
+ * (`YourDecisionSection`'s standing rule); a raw model-scale number here would be the same
+ * defect class in a new place.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import {
+  selectSurfacedContestedEdges,
+  compareContestedCapPriority,
+} from '../../pre-analysis/utils/selectSurfacedContestedEdges'
+import { getBasisLabel, getContestedReasonLabel } from '../../model-tab/strengthBands'
+import { guardCeeTextOrNull } from '../signals/ceeTextGuard'
+import { CONTESTED_COPY } from '../constants'
+
+export interface ContestedRowModel {
+  /** ReactFlow edge id. The identity every pin binds to. */
+  edgeId: string
+  /** Verbatim node labels. v3 never rewrites shared graph labels (labelSafetyAndMutation). */
+  sourceLabel: string
+  targetLabel: string
+  /** Plain-language reasons the two looks disagreed. Never a reason enum value. */
+  reasons: string[]
+  /** What the second look based its estimate on, in plain language. */
+  basis: string
+  /** The second look's own sentence, glossary-guarded. Null when it cannot be made safe. */
+  reasoning: string | null
+}
+
+export function computeContestedRows(
+  nodes: ReadonlyArray<Node>,
+  edges: ReadonlyArray<Edge>,
+): ContestedRowModel[] {
+  const surfaced = selectSurfacedContestedEdges(edges as Edge[])
+  if (surfaced.length === 0) return []
+
+  const labelById = new Map<string, string>()
+  for (const node of nodes) {
+    const label = (node.data as Record<string, unknown> | undefined)?.label
+    labelById.set(node.id, typeof label === 'string' && label !== '' ? label : node.id)
+  }
+
+  return [...surfaced].sort(compareContestedCapPriority).map(({ edge, validation }) => {
+    const reasons = validation.contested_reasons.map(getContestedReasonLabel)
+    const rawReasoning = validation.pass2.reasoning?.trim()
+    return {
+      edgeId: edge.id,
+      sourceLabel: labelById.get(edge.source) ?? edge.source,
+      targetLabel: labelById.get(edge.target) ?? edge.target,
+      reasons: reasons.length > 0 ? reasons : [CONTESTED_COPY.reasonFallback],
+      basis: getBasisLabel(validation.pass2.basis),
+      reasoning: rawReasoning ? guardCeeTextOrNull(rawReasoning) : null,
+    }
+  })
+}

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
@@ -14,6 +14,7 @@ import { SIGNAL_REGISTRY, type SignalDetectionInput } from '../registry'
 import {
   ACTIONS_MENU,
   ATTRIBUTION_COPY,
+  CONTESTED_COPY,
   FOOTER_COPY,
   HERO_COPY,
   LADDER_COPY,
@@ -209,6 +210,9 @@ describe('glossary — every copy string passes the banned-terms scan', () => {
     manyOptions: BLOCKED_REASON_COPY.manyOptions(3, true),
     manyOptionsNoPromise: BLOCKED_REASON_COPY.manyOptions(3, false),
   })
+  // ROADMAP 2.376 — the contested surface's own copy, with its one factory invoked so the
+  // sentence a user is shown is scanned rather than the function that builds it.
+  push('CONTESTED_COPY', { ...CONTESTED_COPY, meta: CONTESTED_COPY.meta(2) })
   push('HERO_COPY', HERO_COPY)
   push('ACTIONS_MENU', ACTIONS_MENU)
   push('SPARK_PROMPTS', SPARK_PROMPTS)


### PR DESCRIPTION
## What this is

ROADMAP 2.376. **The contested-connection surface, mounted in the V3 pre-analysis panel.**

PR #571 shipped `selectSurfacedContestedEdges` and wired it into the **legacy** pre-analysis panel. Deployed staging runs `preAnalysisV3` — a ~35-file tree with **zero** contested consumers. CEE's validation pipeline has been ON since #808, so contested metadata flows on every real draft, and on the surface a user is actually standing on before they run, it was dark. This mounts it there.

The Model tab's contested cards are unchanged and stay uncapped. This is an **addition to the pre-run screen**, not a rescue.

## Where it sits, and why

Between **Sharpen your thinking** and **Your decision**, above **Advanced**.

It is a "worth checking before you run" item like Sharpen's, but it is about the model's *connections* rather than its framing — so it introduces the model section rather than interrupting the coaching. Deliberately **not** behind the Advanced disclosure: a differentiator no other tool shows should not be filed under set-up detail.

## What a user sees

> ### Where our reviews disagree — 2 connections
> Olumi looked at this model twice and the two looks did not agree here. Your judgement is worth more than either.
>
> **How** ***Tech lead impact*** **affects** ***Delivery speed***
> Our reviews disagree on how strong this effect is
> `Show detail` → *Based on general domain knowledge* · *Typical B2B ROI shows moderate conversion effects*
>
> `Settle these in the model tab ›`

No "contested", no "validation", no "pass 1 / pass 2", no divergence number, no strength value. Effect strengths stay gated on this panel (`YourDecisionSection`'s standing rule) — a raw model-scale number here would be the same defect class in a new place. Expert detail sits behind the per-row reveal, in the panel's existing reveal idiom.

## Zero selector edits — as briefed

`selectSurfacedContestedEdges` is consumed **unchanged**. The diff does not touch `src/canvas/components/pre-analysis/` at all. The new `computeContestedRows.ts` owns **no** eligibility logic: re-spelling the surfaced/pending predicate there is exactly the trap-12 mirror #571 exists to abolish (the legacy panel had it written two different ways, and one of them made the panel dark).

Display order is that module's own exported `compareContestedCapPriority`, which is **total** (third key is the edge id), so the list cannot reorder between graph rebuilds. That is a reuse **for ordering**, not a unification with the Model tab's private `compareContestedPriority` — which leads on `evoi_impact`, a post-analysis field that is `null` on every edge on this pre-run surface. Both comparators stay where they are.

## Display-only, and the copy says so

Asked to add a resolve affordance *if an existing action lane is reachable*. Derived:

- **The legacy pre-analysis panel has no resolve affordance to reuse.** Its contested resolve handler was **deleted** in the Brief 4 Task 6 dead-code sweep — `PreAnalysisPanel.tsx:76` (`// removed handleResolveContestedEdge handler`) and `:1106`. The `ContestedEdgeCard` render inside `AllImprovements.tsx:356` is gated on `nodes && onResolveEdge`, and `AllImprovements` has **no non-test mount** anywhere in the tree.
- **The only live adjudication surface is the Model tab** — `ModelTabBody::handleResolveContested` (`:576`) → `RelationshipsSection` (`:763`) → `ContestedEdgeCard`. That handler is a component-local `useCallback` carrying `directionSource` provenance semantics; lifting it would be inventing a second write path, which this slice was told not to do.

So the section is **display-only**. Its single affordance is the **existing, non-mutating** cross-panel handoff the legacy panel already uses for exactly this destination (`PreAnalysisPanel.tsx:2304`):

```ts
useUIStore.getState().requestModelTabSection('relationships')
useUIStore.getState().setActiveOutputTab('diagnostics')
```

A pin asserts the click leaves `useCanvasStore.getState().edges` byte-identical.

## The data path — derived, not assumed (trap 16)

The brief flagged that edge validation metadata might not reach the V3 tree. **It does, by construction** — traced producer → store → consumer, not grepped:

| hop | evidence |
|---|---|
| CEE draft response `e.validation` → `edge.data.validation` | `canvas/utils/applyDraftResult.ts:139,157` via `readValidationMetadata` (`canvas/domain/edges.ts`) |
| store slice legacy reads | `usePreAnalysisData.ts:610` — `useCanvasStore(s => s.edges)` |
| store slice **V3** reads | `usePreAnalysisModel.ts:107` — `useCanvasStore(s => s.edges)`, **the same slice** |

<sub>⚠ Corrected in review: this row cited `:93`, which is the line at **base** `42cbd0d4`. On this branch the same statement is at `:107` (my own additions above it moved it). A line citation is only true against a stated ref — the ref is the branch.</sub>

There is no legacy-only data path and nothing to bridge. The premise that a gap might exist is **withdrawn**, with the bytes above.

## Copy: reused, not copied

The five "why they disagree" sentences and the four basis lines are `getContestedReasonLabel` / `getBasisLabel` from `model-tab/strengthBands.ts` — the same functions the Model tab's own cards render — so the two surfaces cannot drift into describing the same disagreement differently.

That copy sits outside the panel's banned-terms sweep, so the spec drags all nine through `findBannedTerm` over a `Record<ContestedReason, true>` / `Record<EstimateBasis, true>` **key set**: a new union member becomes a **compile error**, not a silently unscanned sentence (the union-assertion form of trap 12d — derivation alone is structurally blind to a missing key). `CONTESTED_COPY` itself is added to `registry.spec.ts`'s existing sweep, with its one factory invoked.

`pass2.reasoning` is CEE-authored and goes through the v3 runtime glossary guard (`guardCeeTextOrNull`) like every other CEE string in this panel; wording with no safe substitution is dropped rather than shown.

## Proof

**RED-first at base `42cbd0d4`** — the FINAL spec against the unmodified V3 tree: **10 failed / 11 passed (21)**. The V3 tree rendered no contested section, by named signature (`pre-analysis-v3-contested`).

<sub>⚠ Corrected in review. This line said **10 failed / 2 passed**, which was a **stale measurement, not a wrong one**: I measured it against the 12-test spec and never re-measured after adding the 9 `it.each` glossary tests, which exercise `strengthBands.ts` labels that already exist at base and therefore pass there. 12 + 9 = 21; 2 + 9 = 11. The arithmetic reconciles exactly, and the substantive claim — **all 10 mount/selector/detail pins RED at base** — is unchanged. The lesson is the general one: a proof figure is pinned to the artefact that produced it, and editing the artefact silently invalidates the figure.</sub>

**Identity-bound pins, never counts** (trap 19 — a `toHaveLength(1)` passes on the wrong survivor). Two contested connections into the same target: the pins name **`e_cost_speed` renders** and **`e_lead_speed` does not**.

**Mutants** — throwaway worktrees outside the repo root, removed before any gate run; control **21/21 green** with an applied-check scoped to `src/` reading **exactly 0**:

| mutant | change | result |
|---|---|---|
| control | none | 21 passed |
| **M1** delete the mount | drop `<ContestedSection>` from `PreAnalysisPanelV3` | **9 failed** |
| **M2** bypass the selector | render from a raw `status === 'contested'` filter instead of the selector's output | **3 failed** — resolved / `surfaced:false` / capped all leak |
| **M3** always render | remove `if (rows.length === 0) return null` | **3 failed** — both empty-state pins + the agreed-connection pin |

**Named gate** `pnpm run typecheck` at this tip: **PASSED** — phase 1 coverage 3201/3241 (both new files loaded), phase 2 ratchet 621 files / 2505 errors vs baseline 2507. It caught a real defect the 21 green tests were blind to (`TS2322` at `contestedSection.spec.tsx:56` — `Edge[]` vs the store's `Edge<EdgeData>[]`), fixed in `0e223005`. **`--update-baseline` deliberately DECLINED**: the 2-error shrink the gate offers to bank is pre-existing on `42cbd0d4` (run 1 measured 2506 *including* my one error, so base is already 2505) and lives in files this PR never touched — banking it here would credit another lane's churn to this one.

**Suites**: `pre-analysis-v3` + `model-tab` — **903 passed / 903**, 53 files, including `hierarchyContract`, `copyHygiene`, `labelSafetyAndMutation` and `registry` (glossary) unchanged-green. Collect was verified un-shrunken (trap 2b): 53 spec files on disk in those trees, 53 collected, with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run. The two legacy contested suites — `contestedEdgeCap.spec.ts`, `contestedCards.spec.ts` — **23 passed / 23**. Lint clean on every changed file.

**⚠ Reported rather than swallowed:** `vitest run src/canvas/components/pre-analysis` (the whole legacy tree) **did not complete** — exit 144, twice, once before any mutation worktree existed. I did not establish whether it does so on pristine `42cbd0d4` too, so I am **not** claiming it is pre-existing. What I can state completely is that it cannot be *this* PR's doing: the full change manifest is 7 files, **all** under `pre-analysis-v3/`, **zero** under `pre-analysis/`, and `selectSurfacedContestedEdges` is byte-identical to base (`git diff` against `42cbd0d4` returns empty for that path).

**This caveat stays OPEN on attribution after review.** The reviewer's base control reached 44 files / 0 failures but produced **no exit code** under host contention, so it neither reproduces nor clears the 144 — a **quiet-host base control is rowed as follow-up**. The *not-PR-caused* half is settled independently, and does not depend on that control: the 7-file manifest above plus 4 green CI shards on this head.

**⚠ jsdom proves presence, never visibility (trap 3).** Nothing here is a claim that the section is on screen, above the fold, or reachable in the deployed panel. **The screen witness rides walk phase 2.**

## Co-ordination

No overlap with L43 (elicitation). L43 owns `CEEClient` / `BeliefInput` / `model/CalibrateDrillIn.tsx`; none is touched here. Shared files this PR edits and L43 might: `constants.ts` (additive block) and `hooks/usePreAnalysisModel.ts` (one import, one `useMemo`, one interface field, two memo-dep entries) — both additive and merge-shaped, but worth a glance if L43 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
