### PR TITLE
P0 fix(cee): route elicit-belief over the same-origin /bff/cee seam, not the PLoT base

### DIFF
--- a/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
+++ b/src/adapters/cee/__tests__/client.elicitBelief.spec.ts
@@ -23,6 +23,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { CEEClient, CEEError } from '../client'
 
 vi.mock('../../../lib/observability-headers', () => ({
@@ -243,5 +246,251 @@ describe('CEEClient.elicitBelief — response handling', () => {
     fetchSpy.mockResolvedValue(jsonResponse({ message: 'rate limited' }, 429))
 
     await expect(new CEEClient().elicitBelief(INPUT)).rejects.toBeInstanceOf(CEEError)
+  })
+})
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * BASE RESOLUTION — the guard that catches the defect the suite above CANNOT.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** Drop comments so a guard cannot confuse PROSE about a var with USE of it. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
+    .join('\n')
+}
+
+/**
+ * The `elicitBelief` method BODY — the exact span between the braces that open
+ * and close it.
+ *
+ * ⚠ NOT a regex. The first attempt was `/async elicitBelief\([\s\S]*?\n {2}\}/`,
+ * reasoning that inner blocks close at ≥4-space indent so `\n  }` must be the
+ * method end. That is FALSE for this method: its parameter is an inline object
+ * TYPE whose own closing brace sits at 2-space indent (`  }): Promise<…> {`),
+ * so the regex returned the signature alone and the binding assertion failed
+ * against correct code. An extractor that silently returns the wrong span is a
+ * guard that measures the wrong thing — so it is scanned properly instead, and
+ * the positive controls below exercise the real shapes.
+ *
+ * Walks the parameter list by paren depth first, so braces inside the parameter
+ * type cannot be mistaken for the body; then brace-matches the body. Quoted
+ * strings are skipped so a brace or paren inside a literal cannot unbalance it.
+ */
+function elicitBeliefBodyOf(code: string): string | undefined {
+  const start = code.indexOf('async elicitBelief(')
+  if (start < 0) return undefined
+
+  let i = code.indexOf('(', start)
+  let parens = 0
+  let quote: string | null = null
+  for (; i < code.length; i++) {
+    const c = code[i]
+    if (quote) {
+      if (c === '\\') i++
+      else if (c === quote) quote = null
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') { quote = c; continue }
+    if (c === '(') parens++
+    else if (c === ')') { parens--; if (parens === 0) break }
+  }
+  if (parens !== 0) return undefined
+
+  const bodyStart = code.indexOf('{', i)
+  if (bodyStart < 0) return undefined
+
+  let braces = 0
+  quote = null
+  for (let j = bodyStart; j < code.length; j++) {
+    const c = code[j]
+    if (quote) {
+      if (c === '\\') j++
+      else if (c === quote) quote = null
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') { quote = c; continue }
+    if (c === '{') braces++
+    else if (c === '}') { braces--; if (braces === 0) return code.slice(bodyStart, j + 1) }
+  }
+  return undefined
+}
+
+/** The path netlify.toml binds the `cee-proxy` edge function to. DERIVED. */
+function ceeProxyBoundPath(toml: string): string | undefined {
+  const block = toml
+    .split('[[edge_functions]]')
+    .slice(1)
+    .find((b) => /function\s*=\s*"cee-proxy"/.test(b))
+  return block?.match(/path\s*=\s*"([^"]+)"/)?.[1]
+}
+
+describe('CEEClient.elicitBelief — base resolution (⚠ VITE_CEE_BFF_BASE points at PLoT)', () => {
+  const dir = path.dirname(fileURLToPath(import.meta.url))
+  const repoRoot = path.join(dir, '..', '..', '..', '..')
+  const clientSrc = readFileSync(path.join(dir, '..', 'client.ts'), 'utf8')
+  const code = stripComments(clientSrc)
+
+  /**
+   * ⚠ THIS GUARD READS THE SOURCE, AND THAT IS THE ONLY INSTRUMENT THAT CAN SEE
+   * THE DEFECT — the same finding as PR #570, now MEASURED a second time on the
+   * deployed artefact rather than inherited.
+   *
+   * Vite substitutes `import.meta.env.VITE_*` at TRANSFORM time, so under vitest
+   * BOTH the hazardous form and the safe one evaluate to the `/bff/cee`
+   * fallback. The behavioural pin below (`expect(url).toBe('/bff/cee/elicit-belief')`)
+   * therefore passed for the whole of #572 while the DEPLOYED build sent the
+   * request to `https://plot-lite-service-staging.onrender.com/v1/cee/elicit-belief`
+   * and took a 404 — witnessed on the wire 2026-08-03 (`journey-witness-2026-08-04d.md`
+   * target 1) and re-confirmed at the deployed bytes: the shipped `CEEClient`
+   * constructor reads
+   *   `this.baseURL="https://plot-lite-service-staging.onrender.com/v1/cee"`
+   * (`assets/clipboard-DeNkRSL5.js@44203`, build `122b847a`), and `/bff/cee`
+   * occurs exactly ONCE in the whole 80-chunk bundle — in `scenarioGraph`'s
+   * hardcoded constant, i.e. the #570 fix, and nowhere else.
+   *
+   * A runtime assertion cannot distinguish the two forms. This one can.
+   */
+  it('never RESOLVES the elicit base from VITE_CEE_BFF_BASE (source-level, with positive controls)', () => {
+    // (1) The base is a LITERAL same-origin path, declared here, not resolved.
+    //     This single assertion also forecloses the import-hop refactor: a
+    //     `import { CEE_ELICIT_BASE } from './somewhere'` has no `const … = '…'`
+    //     declaration to match, so the indirection cannot be smuggled in.
+    expect(code).toMatch(/const CEE_ELICIT_BASE = '\/bff\/cee'/)
+
+    // (2) BIND THE GUARD TO WHAT THE REQUEST ACTUALLY USES (#570 review A4).
+    //     A spelling-presence check alone false-passes on a two-step refactor
+    //     that leaves the constant in place but DEAD.
+    const body = elicitBeliefBodyOf(code)
+    expect(body).toBeDefined()
+    expect(body).toContain('CEE_ELICIT_BASE')
+
+    // (3) …and the env-resolved base is not reachable from this method by any
+    //     of its spellings. `this.fetch<T>()` / `this.fetchIdempotent<T>()` both
+    //     close over `this.baseURL`, which IS the hazard — so the call shape is
+    //     forbidden, not merely the variable name.
+    expect(body).not.toContain('this.baseURL')
+    expect(body).not.toContain('CEE_BASE_URL')
+    expect(body).not.toMatch(/this\.fetch(Idempotent)?</)
+    expect(body).not.toMatch(/https?:\/\//)
+
+    // (4) DERIVED, NOT MIRRORED (trap 12). The literal is not trusted because it
+    //     looks right — it is checked against netlify.toml, which is the source
+    //     of truth for the seam. `cee-proxy` is what rewrites /bff/cee/<x> to
+    //     /assist/v1/<x> and injects X-Olumi-Assist-Key server-side; a base that
+    //     misses that binding gets the SPA catch-all (200 text/html, the 2.317
+    //     defect) or leaves the origin entirely (the 404 this fixes).
+    const boundPath = ceeProxyBoundPath(readFileSync(path.join(repoRoot, 'netlify.toml'), 'utf8'))
+    expect(boundPath).toBe('/bff/cee/*')
+    const declared = code.match(/const CEE_ELICIT_BASE = '([^']+)'/)?.[1]
+    expect(declared).toBe(boundPath!.replace(/\/\*$/, ''))
+  })
+
+  /**
+   * POSITIVE CONTROLS (trap 13). Every matcher above must be shown capable of
+   * seeing the thing it forbids — otherwise an absence assertion passes by
+   * testing nothing. Each control is a synthetic artefact, so none of them can
+   * be hollowed out by a later change to the real file (trap 12b).
+   */
+  it('POSITIVE CONTROLS — each matcher can see the defect it forbids', () => {
+    // (i) the spelling matcher can see a presence. Note this is asserted on the
+    //     REAL file: client.ts must KEEP VITE_CEE_BFF_BASE, because biasCheck and
+    //     sensitivityCoach hit genuinely PLoT-REGISTERED routes (measured
+    //     2026-08-03: POST /v1/cee/bias-check and /v1/cee/sensitivity-coach both
+    //     401 "Missing bearer token", while /v1/cee/elicit-belief and a garbage
+    //     control both 404). That is exactly why this guard is METHOD-scoped and
+    //     scenarioGraph's is FILE-scoped — a file-scoped guard is impossible here.
+    expect(clientSrc).toContain('VITE_CEE_BFF_BASE')
+
+    // (ii) THE EXTRACTOR ITSELF IS CONTROLLED FIRST. A guard is only as good as
+    //      the span it reads, and the first version of this extractor silently
+    //      returned the SIGNATURE ONLY (the parameter's inline object type closes
+    //      at 2-space indent). So: the real span must reach the request.
+    const realBody = elicitBeliefBodyOf(code)
+    expect(realBody).toBeDefined()
+    expect(realBody).toContain('JSON.stringify(body)')
+    expect(realBody).toContain("'/elicit-belief'")
+    //      …and must NOT run past the end of the method into its neighbours.
+    expect(realBody).not.toContain('async biasCheck')
+    expect(realBody).not.toContain("'/bias-check'")
+
+    // (iii) the binding matcher can see the absence of the constant, and the
+    //       call-shape matcher can see the pre-fix form. Proven against the
+    //       VERBATIM parameter shape of the real method — multi-line inline
+    //       object type, closing brace at 2-space indent — so the control
+    //       exercises exactly the structure that broke the first extractor.
+    const SIGNATURE = [
+      '',
+      '  async elicitBelief(input: {',
+      '    node_id: string',
+      '    node_label: string',
+      "    target_type: 'prior' | 'edge_weight'",
+      '    context_id?: string',
+      '  }): Promise<BeliefElicitSuggestion> {',
+    ].join('\n')
+    const preFixBody = elicitBeliefBodyOf(
+      SIGNATURE +
+        [
+          '',
+          "    const raw = await this.fetch<unknown>('/elicit-belief', {",
+          "      method: 'POST',",
+          '      body: JSON.stringify(body),',
+          '    })',
+          '    return raw as BeliefElicitSuggestion',
+          '  }',
+        ].join('\n'),
+    )
+    expect(preFixBody).toBeDefined()
+    expect(preFixBody).toContain('JSON.stringify(body)') // extractor reached the body
+    expect(preFixBody).not.toContain('CEE_ELICIT_BASE')
+    expect(preFixBody).toMatch(/this\.fetch(Idempotent)?</)
+
+    // (iv) the dead-constant refactor (#570 A4) is caught: constant present and
+    //      correct at file scope, method silently back on the env base.
+    const deadBody = elicitBeliefBodyOf(
+      SIGNATURE +
+        [
+          '',
+          "    return this.fetchWithBase(this.baseURL, '/elicit-belief', {})",
+          '  }',
+        ].join('\n'),
+    )
+    expect(deadBody).toBeDefined()
+    expect(deadBody).not.toContain('CEE_ELICIT_BASE')
+    expect(deadBody).toContain('this.baseURL')
+
+    // (v) the import-hop refactor has no matching declaration, so (1) reds.
+    expect("import { CEE_ELICIT_BASE } from './bffBase'").not.toMatch(
+      /const CEE_ELICIT_BASE = '\/bff\/cee'/,
+    )
+
+    // (vi) the netlify.toml extractor is not returning a constant — it reads a
+    //     different path out of a synthetic block.
+    expect(
+      ceeProxyBoundPath('[[edge_functions]]\n  function = "cee-proxy"\n  path = "/bff/WRONG/*"\n'),
+    ).toBe('/bff/WRONG/*')
+    //     …and it identifies the block by FUNCTION, not by position.
+    expect(
+      ceeProxyBoundPath(
+        '[[edge_functions]]\n  function = "isl-proxy"\n  path = "/bff/isl/*"\n' +
+          '[[edge_functions]]\n  function = "cee-proxy"\n  path = "/bff/cee/*"\n',
+      ),
+    ).toBe('/bff/cee/*')
+  })
+
+  /**
+   * The behavioural pin, kept — but HONESTLY LABELLED. It proves the composed
+   * URL is same-origin *in this environment*, and it is BLIND to the hazard
+   * above (both forms resolve to the fallback under vitest). It is not the
+   * guard; assertion (1)–(4) above is.
+   */
+  it('composes a RELATIVE url — never a scheme-bearing absolute host (env-blind: see the guard above)', async () => {
+    await new CEEClient().elicitBelief(INPUT)
+    const { url } = firstCall()
+    expect(url).toBe('/bff/cee/elicit-belief')
+    expect(url.startsWith('/')).toBe(true)
+    expect(url).not.toMatch(/^https?:/i)
   })
 })

--- a/src/adapters/cee/client.ts
+++ b/src/adapters/cee/client.ts
@@ -21,10 +21,53 @@ import { withRetry } from '../../lib/fetchWithRetry'
 import { devWarn } from '../../utils/debugLog'
 import { plotAuthHeaders } from '../../lib/plotAuthHeaders'
 
+/**
+ * ⚠ THIS BASE RESOLVES TO **PLoT**, NOT CEE, ON EVERY DEPLOY. Despite the name
+ * and the `/bff/cee` fallback, `VITE_CEE_BFF_BASE` is set in the Netlify
+ * dashboard to `https://plot-lite-service-staging.onrender.com/v1/cee`, and
+ * Vite inlines it at BUILD time — so no test can observe the deployed value.
+ * MEASURED on build `122b847a`: the shipped constructor reads
+ * `this.baseURL="https://plot-lite-service-staging.onrender.com/v1/cee"`
+ * (`assets/clipboard-DeNkRSL5.js@44203`).
+ *
+ * It is correct ONLY for endpoints PLoT actually serves. Measured 2026-08-03,
+ * with a garbage-path control on the same service (a 404 alone proves nothing;
+ * a 401 next to a 404 proves registration):
+ *   REGISTERED (401 "Missing bearer token"): /bias-check · /sensitivity-coach ·
+ *     /graph-readiness · /prompts/warm
+ *   ABSENT (404, same as the garbage control): /elicit-belief · /ask ·
+ *     /suggest-edge-function · /health
+ * So `biasCheck` and `sensitivityCoach` below keep this base deliberately.
+ * Anything CEE-served must use `CEE_ELICIT_BASE`.
+ */
 const CEE_BASE_URL = (import.meta as any).env?.VITE_CEE_BFF_BASE || '/bff/cee'
+
+/**
+ * The same-origin Netlify edge path for **CEE-served** routes. A LITERAL, and
+ * deliberately NOT `CEE_BASE_URL` — see the hazard above.
+ *
+ * `/bff/cee/*` is owned by `netlify/edge-functions/cee-proxy.ts`, which rewrites
+ * the prefix to `/assist/v1` and injects `X-Olumi-Assist-Key` server-side (the
+ * key stays in the Netlify edge runtime and never enters the bundle);
+ * `vite.config.ts` proxies the same prefix the same way in dev.
+ *
+ * WHY A SECOND CONSTANT RATHER THAN A SHARED ONE. `scenarioGraph.ts` solved this
+ * exact hazard for the scenario-graph read (PR #570) with its own literal. The
+ * constant is not shared because the GUARD cannot be: this file must KEEP
+ * `CEE_BASE_URL` for the PLoT-registered routes, so the file-scoped
+ * "no VITE_CEE_BFF_BASE anywhere" assertion that protects `scenarioGraph.ts` is
+ * impossible here and the guard has to be method-scoped either way. Instead of a
+ * second unchecked mirror, the co-located guard DERIVES the expected value from
+ * `netlify.toml`'s `cee-proxy` binding — see
+ * `__tests__/client.elicitBelief.spec.ts`, "base resolution".
+ */
+const CEE_ELICIT_BASE = '/bff/cee'
+
 // CEE Draft Engine base URL
 // On staging, can be set to direct PLoT URL to bypass Netlify proxy (which times out at ~28s)
 // Example: VITE_CEE_DRAFT_BASE=https://plot-lite-service-staging.onrender.com/v1/cee
+// (Measured: it IS so set on staging — draft-graph is a PLoT-served route, so
+// this one is correct as it stands.)
 const CEE_DRAFT_ENGINE_BASE = (import.meta as any).env?.VITE_CEE_DRAFT_BASE || '/bff/engine/v1/cee'
 
 /**
@@ -520,9 +563,20 @@ export class CEEClient {
     this.timeout = config.timeout ?? DEFAULT_CEE_TIMEOUT
   }
 
-  private async fetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-    return this.fetchWithBase<T>(this.baseURL, endpoint, options)
-  }
+  /**
+   * ⚠ THERE IS DELIBERATELY NO BARE `this.fetch(endpoint)` HELPER ANY MORE.
+   *
+   * It existed, it read as "just use this client's base", and that is exactly
+   * how `elicitBelief` shipped pointed at PLoT — `this.baseURL` is
+   * `CEE_BASE_URL`, which the Netlify dashboard sets to the absolute PLoT URL
+   * (see the constant's header). `elicitBelief` was its only caller, so removing
+   * it costs nothing and takes the trap with it: every request on this client
+   * now names its base at the call site, where the choice between "PLoT serves
+   * this" and "CEE serves this" is visible to the person writing it.
+   *
+   * `fetchIdempotent` keeps `this.baseURL` on purpose — its two callers
+   * (`biasCheck`, `sensitivityCoach`) hit PLoT-REGISTERED routes.
+   */
 
   /** Fetch with retry — use only for idempotent/read-only endpoints (not draft-graph) */
   private async fetchIdempotent<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
@@ -860,13 +914,26 @@ export class CEEClient {
   /**
    * Turn a phrase about a factor into a number — ROADMAP 2.364.
    *
-   * Endpoint: `POST /elicit-belief` on this client's own base, which the
-   * `cee-proxy` edge function rewrites to `/assist/v1/elicit-belief` and signs
-   * with `X-Olumi-Assist-Key` server-side (`netlify/edge-functions/
-   * cee-proxy.ts`; `netlify.toml` binds it to `/bff/cee/*`). No absolute
-   * service URL is built here on purpose — the key lives in the Netlify
-   * dashboard, never in the bundle, and the same-origin path is what the live
-   * 2026-08-03 witness exercised.
+   * Endpoint: `POST /elicit-belief` on `CEE_ELICIT_BASE`, which the `cee-proxy`
+   * edge function rewrites to `/assist/v1/elicit-belief` and signs with
+   * `X-Olumi-Assist-Key` server-side (`netlify/edge-functions/cee-proxy.ts`;
+   * `netlify.toml` binds it to `/bff/cee/*`).
+   *
+   * ⚠ THIS PARAGRAPH IS A CORRECTION, AND THE OLD ONE IS WHY THE CAPABILITY WAS
+   * DARK FOR A DAY. It used to read "on this client's own base … no absolute
+   * service URL is built here on purpose". That was true of the SOURCE and false
+   * of the ARTEFACT: the client's own base is `CEE_BASE_URL`, which the Netlify
+   * dashboard sets to the absolute PLoT URL, and PLoT does not serve this route.
+   * Every word a user typed got `POST https://plot-lite-service-staging.onrender.com/v1/cee/elicit-belief`
+   * → 404 → "I couldn't read that as a number." (wire-witnessed 2026-08-03,
+   * `PHASE0-EVIDENCE-2026-07-28/journey-witness-2026-08-04d.md` target 1; the
+   * 404 discriminated from an auth artefact by a garbage-path control on the
+   * same service and by four sibling `/v1/cee/*` routes answering 401.)
+   *
+   * The co-located spec's mock-fetch pin asserted `/bff/cee/elicit-belief` and
+   * PASSED throughout, because Vite inlines `import.meta.env.VITE_*` at
+   * transform time and vitest only ever sees the fallback. A runtime test cannot
+   * see this class of defect; the source-level guard in that spec can.
    *
    * THE REQUEST IS A CONTRACT PIN, NOT A CONVENIENCE SHAPE. CEE's
    * `CEEElicitBeliefInput` is `.strict()` (`olumi-assistants-service/
@@ -905,7 +972,9 @@ export class CEEClient {
     // values, but building the key conditionally says so at the source.
     if (input.context_id !== undefined) body.context_id = input.context_id
 
-    const raw = await this.fetch<unknown>('/elicit-belief', {
+    // `fetchWithBase(CEE_ELICIT_BASE, …)`, NOT `this.fetch(…)`: the latter
+    // closes over `this.baseURL`, which is the PLoT base on every deploy.
+    const raw = await this.fetchWithBase<unknown>(CEE_ELICIT_BASE, '/elicit-belief', {
       method: 'POST',
       body: JSON.stringify(body),
     })


### PR DESCRIPTION
## The defect (walk-witnessed, deployed staging `122b847a`)

The #572 headline capability is **dark**. Every word a user types in the calibrate drill-in returns
*"I couldn't read that as a number."* because the request goes to

```
POST https://plot-lite-service-staging.onrender.com/v1/cee/elicit-belief  ->  404
```

Wire-witnessed in `PHASE0-EVIDENCE-2026-07-28/journey-witness-2026-08-04d.md` (target 1), on a build
where the affordance itself painted on **5 of 5** estimate rows.

**The 404 is route-absence, not auth** — controlled on the same service, re-measured for this PR:

| probe | result |
|---|---|
| `POST /v1/cee/elicit-belief` | **404** |
| `POST /v1/cee/zzz-garbage-control-l55` | 404 (PLoT 404s absent routes) |
| `POST /v1/cee/bias-check` | **401** `Missing bearer token` (PLoT 401s *registered* routes) |
| `POST /v1/cee/sensitivity-coach` · `/graph-readiness` · `/prompts/warm` | **401** (registered) |

## Root cause — confirmed in the source AND in the deployed artefact

`elicitBelief` used `this.fetch(...)`, which closes over `this.baseURL` = `CEE_BASE_URL` =
`VITE_CEE_BFF_BASE || '/bff/cee'`. **Despite the name, that var is set in the Netlify dashboard to
the absolute PLoT URL**, and Vite inlines it at transform time.

Measured in the deployed bundle at `122b847a` (80 chunks, 5,571,032 bytes crawled transitively):

```js
// assets/clipboard-DeNkRSL5.js@44203
class cs{baseURL;timeout;constructor(e={}){
  this.baseURL="https://plot-lite-service-staging.onrender.com/v1/cee", ...
```

and `/bff/cee` occurs **exactly once in the entire bundle** — `$e="/bff/cee"` in
`CanvasMVP-BkK--VSG.js@23278`, i.e. `SCENARIO_GRAPH_BASE`, the PR #570 fix, and nowhere else.

### Why no test caught it

Vite substitutes `import.meta.env.VITE_*` at **transform** time, so under vitest **both the hazardous
and the safe form evaluate to the `/bff/cee` fallback**. #572's mock-fetch pin asserted
`expect(url).toBe('/bff/cee/elicit-belief')` and passed for the whole of its life while the deployed
build 404'd. This is #570's finding, reproduced — a runtime test cannot see this class of defect.

## The fix

- **`CEE_ELICIT_BASE = '/bff/cee'`** — a literal — used via `fetchWithBase`.
- **Removed the bare `private fetch()` helper.** It read as *"just use this client's base"*, and that
  is exactly how this shipped wrong. `elicitBelief` was its only caller, so it costs nothing and takes
  the trap with it: every request now names its base at the call site, where the choice between
  *"PLoT serves this"* and *"CEE serves this"* is visible to whoever writes it.
  (The **typecheck ratchet** caught it as dead — TS6133 — rather than it being spotted by eye.)
- `biasCheck` / `sensitivityCoach` **deliberately keep** the env base: those routes are PLoT-registered.
- Corrected the docstring that asserted the opposite (*"No absolute service URL is built here on
  purpose"*) and is what made the defect invisible.

## The guard (source-level, co-located, with positive controls)

- **DERIVED, not mirrored** (trap 12): the literal is checked against `netlify.toml`'s `cee-proxy`
  edge-function binding — the actual source of truth for the seam — not against a hand-copied twin.
- **Bound to what the request USES** (#570 review A4), not to a spelling: a two-step refactor leaving
  the constant present but dead goes RED.
- **The body extractor is itself controlled.** The first version silently returned the *signature
  only* (the parameter's inline object type closes at 2-space indent) and would have measured the
  wrong span. Fixed to a paren/brace scanner, with a control asserting the extracted span actually
  reaches the request and does not run into `biasCheck`.

### Why not share `scenarioGraph.ts`'s constant

`client.ts` **must keep** `VITE_CEE_BFF_BASE` for the PLoT-registered routes, so the file-scoped
"no `VITE_CEE_BFF_BASE` anywhere" assertion that protects `scenarioGraph.ts` is impossible here — the
guard must be method-scoped whether or not the constant is shared. Sharing buys nothing where the risk
lives, and extracting a third module would mean editing #570's deliberately-hardened guard on a P0.
The derived netlify.toml check is the stronger anti-mirror move.

## Mutation proof — every mutant bites, control reads exactly 0

Run in a throwaway worktree **outside the repo root** (trap 9c), applied-check scoped to `src/`
(trap 12e), baseline and final control both **exactly 0** modified files.

| # | Mutant | Result |
|---|---|---|
| M1 | method back on `this.baseURL`, constant left dead | **guard RED**, 15 others green |
| M2 | **constant becomes env-resolved (the historical defect)** | **guard RED — and it is the ONLY red**; the behavioural pin passes, exactly the vacuity it closes |
| M3 | constant becomes the absolute PLoT URL | guard RED + 2 |
| M4 | `netlify.toml` binding drifts from the code | **guard RED** (the derived check bites) |
| M5 | import-hop smuggle via a sibling module | guard RED + 2 |
| M6 | extractor reverted to the naive regex | **guard RED + its own positive-control test RED** |

## Gates

- `npm run typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**. Coverage 3207/3247 tracked files;
  ratchet 620 files / 2502 errors, **unchanged** (no baseline update, none requested).
- `vitest` across the elicit blast radius (`src/adapters/cee`, `useBeliefElicitation`, `BeliefInput`,
  `calibrateDrillInElicit`, `netlify-bff-route-precedence`): **160/160 in 11 files**. Non-zero
  collection confirmed; `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported (trap 2b).
- `eslint` on both changed files: clean (2 pre-existing warnings on untouched lines).

## Destination verified live, before the fix ships

`POST https://staging--olumi.netlify.app/bff/cee/elicit-belief` with the exact body this client sends
answers **200** `{"suggested_value":0.7,"confidence":"high","provenance":"cee", ...}` for
`"pretty likely"`. Repeating it with a garbage `Authorization` header returns a byte-identical 200,
so the `plotAuthHeaders()` bearer that rides along is harmless today and is **not** touched here
(recorded as a latent hazard if `CEE_REQUIRE_USER_JWT` is ever flipped on).

## Scope — measured, not assumed

A complete manifest of all 6 `VITE_CEE_BFF_BASE` readers is in
`PHASE0-EVIDENCE-2026-07-28/l55-elicit-path-fix.md` §2. Three more endpoints resolve to a
404 host (`/ask`, `/suggest-edge-function`, `/health`) — but **none is in the shipped bundle and none
is walk-reachable** (`useFormRecommendations` has no importer in `src/` at all), so **scope stays
elicit-only** as briefed. Rows that hit PLoT-registered routes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)