### PR TITLE
fix(deps): bump fast-uri override past GHSA-7p8r-x3mc-p8w7 (stale override ceiling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   "pnpm": {
     "overrides": {
       "protobufjs@>=7.5.0 <7.6.5": "^7.6.5",
-      "fast-uri@<3.1.2": "^3.1.2",
+      "fast-uri@<3.1.5": "^3.1.5",
       "form-data@>=4.0.0 <4.0.6": "^4.0.6",
       "ws@>=8.0.0 <8.21.0": "^8.21.0",
       "dompurify@<3.4.11": "^3.4.11",
@@ -192,7 +192,7 @@
   "//overrides-provenance": {
     "_comment": "Security overrides added for CI audit gate (claude-ui/security-audit-gate). Each entry pins a transitive dep to a patched version. Remove an entry once every dependent ships a fixed range natively. Provenance:",
     "protobufjs": "GHSA-xq3m-2v4x-88gg (critical) + GHSA-66ff/-75px/-jvwf/-685m/-wcpc (high) via posthog-js>@opentelemetry/otlp-transformer. Patched >=7.6.5. Remove when posthog-js bumps its otlp-transformer chain.",
-    "fast-uri": "GHSA-q3j6-qgpj-74h6 + GHSA-v39h-62p7-jpjc (high) via ajv. Patched >=3.1.2. Remove when ajv bumps fast-uri.",
+    "fast-uri": "GHSA-q3j6-qgpj-74h6 + GHSA-v39h-62p7-jpjc (high) via ajv, then GHSA-7p8r-x3mc-p8w7 (high, host confusion via backslash) which moved the floor. Patched >=3.1.5. Remove when ajv bumps fast-uri.",
     "form-data": "GHSA-hmw2-7cc7-3qxx (high) via openai>@types/node-fetch. Patched >=4.0.6. Remove when openai's node-fetch types drop the vulnerable range.",
     "ws": "GHSA-96hv-2xvq-fx4p (high) + GHSA-58qx-3vcg-4xpx (moderate) via @supabase/realtime-js. Patched >=8.21.0. Remove when @supabase/realtime-js bumps ws.",
     "dompurify": "GHSA-cmwh-pvxp-8882 + others (moderate/low) via posthog-js. Patched >=3.4.11. Remove when posthog-js bumps dompurify.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   protobufjs@>=7.5.0 <7.6.5: ^7.6.5
-  fast-uri@<3.1.2: ^3.1.2
+  fast-uri@<3.1.5: ^3.1.5
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   ws@>=8.0.0 <8.21.0: ^8.21.0
   dompurify@<3.4.11: ^3.4.11
@@ -2526,8 +2526,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4265,6 +4265,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5914,7 +5915,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6852,7 +6853,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## What
The `fast-uri` security override's ceiling fell below a newly-published advisory. `fast-uri@<3.1.2 -> ^3.1.2` (added for GHSA-q3j6-qgpj-74h6 + GHSA-v39h-62p7-jpjc via `ajv`) resolved **3.1.4**, which is inside **GHSA-7p8r-x3mc-p8w7** (high, host confusion via backslash, `>=3.0.0 <3.1.5`, published 2026-08-03T19:16:43Z).

## Why it red only now
The advisory DB's clock, not a code change: `Security Audit (pnpm)` is green on `122b847a` (run predates publication) and red on later commits with identical dependency graphs. A standing red teaches lanes to stop looking, so it's fixed now rather than tolerated — and NOT via continue-on-error or a baseline bump.

## Change
- Override: `fast-uri@<3.1.5 -> ^3.1.5` (kept in `package.json` `pnpm.overrides` per the location doctrine — not moved to pnpm-workspace.yaml)
- Provenance comment updated to name the new advisory and the new floor
- Lockfile: resolves `fast-uri@3.1.5` (`ajv` snapshot + package entry); delta is fast-uri-only plus one incidental registry-metadata `deprecated:` annotation on `whatwg-encoding` (no version change)

## Verification (local, pnpm 10.18.0 = the repo's pin)
- `pnpm audit --prod --audit-level high` → **exit 0** (3 moderates remain — below the gate level, pre-existing)
- `pnpm-lock.yaml` resolves `fast-uri@3.1.5` at both entries (:2529 package, :6853 snapshot)
- Full lockfile diff reviewed line-by-line (11 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)