### PR TITLE
feat(inspector): belief elicitation reaches the POST-ANALYSIS surface (ROADMAP 2.391)

### DIFF
--- a/src/canvas/components/BeliefElicitationField.tsx
+++ b/src/canvas/components/BeliefElicitationField.tsx
@@ -123,11 +123,20 @@ export function BeliefElicitationField({
   }, [])
 
   /**
-   * Announced SEPARATELY, and set AFTER mount rather than rendered as initial
-   * content: a live region that already contains its text when it enters the
-   * DOM has no CHANGE to announce, so assistive tech stays silent. Separate
-   * effect from the focus one so a label change re-announces without yanking
-   * focus out of a field the user is mid-way through typing into.
+   * Announced SEPARATELY from the focus effect, so a label change re-announces
+   * without yanking focus out of a field the user is mid-way through typing
+   * into. That part IS pinned.
+   *
+   * ⚠ THE SET-AFTER-MOUNT PART IS A CONVENTION, NOT A GUARANTEE, AND SAYING SO
+   * IS THE POINT. The reason for an effect rather than an initial `useState`
+   * value is that a live region which ALREADY contains its text when it enters
+   * the DOM often is not announced at all — the AT has no CHANGE to report.
+   * But **jsdom cannot see the difference**: mutant M16 (move the text into the
+   * initial state) left all 55 tests GREEN. This comment used to assert the
+   * behaviour as though the suite protected it; it does not, and an unpinned
+   * claim dressed as a guarantee is the defect class this estate hunts. It is
+   * verifiable only against a real screen reader — same standing as the
+   * off-screen half of the scroll fix.
    */
   useEffect(() => {
     setAnnouncement(`Describe ${label} in words — for example, "pretty likely".`)

--- a/src/canvas/components/BeliefElicitationField.tsx
+++ b/src/canvas/components/BeliefElicitationField.tsx
@@ -1,0 +1,178 @@
+/**
+ * "Say it in words" — the elicitation FIELD, one implementation, every surface.
+ *
+ * ROADMAP 2.364 shipped this block inside `CalibrateDrillIn`. ROADMAP 2.391
+ * mounts the same affordance on `FactorControllablePanel`, which is where a
+ * user actually is when they want to revise a belief: the pre-analysis
+ * drill-in UNMOUNTS the moment "Analyse first pass" is clicked (measured on
+ * deployed build `1730c6c5`, L55 §10.7 — `[data-testid="pre-analysis-v3"]` is
+ * null post-run and no "… in words" affordance survives anywhere in the
+ * document), so before this file the elicitation loop and a completed analysis
+ * were mutually exclusive in a single session.
+ *
+ * WHY IT IS A COMPONENT AND NOT A SECOND COPY. Two surfaces rendering the same
+ * user-facing sentences and the same three-way branch (loading / ambiguous /
+ * offer) is the hand-maintained mirror CLAUDE.md trap 12 is about: the copy
+ * would drift, and the `needs_clarification`-alone suppression rule — which an
+ * adversarial review had to put in ONCE already (#572, minor 7) — would have to
+ * be remembered twice. The branch logic and every string live here; each
+ * surface supplies only its own chrome and its own commit.
+ *
+ * WHAT THIS COMPONENT DELIBERATELY DOES NOT OWN:
+ *   - the HOOK. `useBeliefElicitation` (debounce, sequence/stale-response
+ *     discipline, error copy) is passed IN. A second instance per surface would
+ *     be a second race to reason about.
+ *   - the GATE. Whether the affordance may be offered at all is
+ *     `acceptsElicitedBelief(nodeData)`, read REACTIVELY by the surface from
+ *     the store — see its docstring for why capless-and-unitless is the
+ *     boundary and why widening it is a real feature.
+ *   - the COMMIT. `onAccept` receives the probability and nothing else; the
+ *     surface routes it through its own existing `factor_value_edit` path, and
+ *     `buildFactorValueEditEvent` carries the structural refusals for every
+ *     caller.
+ */
+
+import Tooltip from '../../components/Tooltip'
+import { typography, typo } from '../../styles/typography'
+import { formatElicitedChance, type BeliefElicitationApi } from '../hooks/useBeliefElicitation'
+
+/**
+ * The toggle's accessible name, and the field's.
+ *
+ * Exported rather than spelled at each call site for the same reason the JSX
+ * below is shared: two surfaces, one sentence. The toggle BUTTON stays with
+ * each surface (they use different icon chrome), so its label is the one thing
+ * that could still drift — deriving it removes that.
+ */
+export const describeInWordsToggleLabel = (label: string): string =>
+  `Describe your estimate for ${label} in words`
+
+export const describeInWordsFieldLabel = (label: string): string =>
+  `Describe ${label} in words`
+
+/**
+ * Shown when the engine flagged itself unsure and offered NO options to choose
+ * between. Before #572's review this shape fell through to "That reads as about
+ * X%" + Use this, offering a number the engine had just said it was unsure
+ * about, without its question.
+ */
+export const BELIEF_ELICITATION_UNSURE_COPY =
+  "I couldn't pin that down. Try another wording, or type the number."
+
+export interface BeliefElicitationFieldProps {
+  /** The factor's label — quoted in every accessible name on this field. */
+  label: string
+  /** The phrase currently in the field (the surface owns the state). */
+  phrase: string
+  /**
+   * Called on every keystroke. The surface is expected to set its own phrase
+   * state AND call `elicitation.request(next)` — the hook's `request` is what
+   * invalidates any in-flight answer about the previous text.
+   */
+  onPhraseChange: (next: string) => void
+  /** Escape in the field. Optional: not every surface has something to close. */
+  onEscape?: () => void
+  elicitation: BeliefElicitationApi
+  /** Accept a probability in [0,1]. The surface owns the commit. */
+  onAccept: (value: number) => void
+  /** Surface-specific test id on the wrapper. */
+  testId: string
+}
+
+export function BeliefElicitationField({
+  label,
+  phrase,
+  onPhraseChange,
+  onEscape,
+  elicitation,
+  onAccept,
+  testId,
+}: BeliefElicitationFieldProps) {
+  return (
+    <div className="space-y-1" data-testid={testId}>
+      <input
+        aria-label={describeInWordsFieldLabel(label)}
+        className={`${typography.panelBody} h-7 w-56 rounded-lg border border-panel-border bg-panel px-2 text-text-header outline-none placeholder:text-text-light focus:border-info focus:ring-2 focus:ring-info/20`}
+        placeholder="e.g. pretty likely"
+        value={phrase}
+        onChange={e => onPhraseChange(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Escape') onEscape?.()
+        }}
+      />
+
+      {elicitation.loading && (
+        <p className={`${typography.panelMeta} text-text-light`} role="status">
+          Reading that…
+        </p>
+      )}
+
+      {elicitation.error && (
+        <p className={`${typography.panelMeta} text-warning`} role="status">
+          {elicitation.error}
+        </p>
+      )}
+
+      {/*
+        AMBIGUOUS PHRASE — the engine's own question, verbatim, and its own
+        option labels. Not paraphrased: it names the factor and the reading it
+        is unsure about, and rewriting it here would put words in the engine's
+        mouth that the engine cannot stand behind.
+      */}
+      {elicitation.suggestion?.needs_clarification ? (
+        <div className="space-y-1">
+          <p className={`${typography.panelMeta} text-text-body`}>
+            {/*
+              A response can flag itself unsure and carry NO options.
+              `needs_clarification` ALONE suppresses the offer; the fallback
+              line says what happened.
+            */}
+            {elicitation.suggestion.clarifying_question ?? BELIEF_ELICITATION_UNSURE_COPY}
+          </p>
+          <div className="flex flex-wrap gap-1.5" role="group" aria-label={`Readings for ${label}`}>
+            {(elicitation.suggestion.options ?? []).map(opt => (
+              <button
+                key={opt.label}
+                type="button"
+                onClick={() => onAccept(opt.value)}
+                className={typo(
+                  'panelMeta',
+                  'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : elicitation.suggestion ? (
+        <div className="flex items-center gap-2">
+          {/*
+            The number, as a chance, in plain words. The engine's REASONING and
+            CONFIDENCE are expert detail and stay behind the tooltip — inline
+            they read as hedging.
+          */}
+          <Tooltip
+            content={`${elicitation.suggestion.reasoning} (${elicitation.suggestion.confidence} confidence)`}
+            delay={300}
+          >
+            <span className={`${typography.panelMeta} text-text-body`}>
+              That reads as {formatElicitedChance(elicitation.suggestion.suggested_value)}
+            </span>
+          </Tooltip>
+          <button
+            type="button"
+            onClick={() => onAccept(elicitation.suggestion!.suggested_value)}
+            aria-label={`Use ${formatElicitedChance(elicitation.suggestion.suggested_value)} for ${label}`}
+            className={typo(
+              'panelMeta',
+              'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+            )}
+          >
+            Use this
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/canvas/components/BeliefElicitationField.tsx
+++ b/src/canvas/components/BeliefElicitationField.tsx
@@ -32,6 +32,7 @@
  *     caller.
  */
 
+import { useEffect, useRef, useState } from 'react'
 import Tooltip from '../../components/Tooltip'
 import { typography, typo } from '../../styles/typography'
 import { formatElicitedChance, type BeliefElicitationApi } from '../hooks/useBeliefElicitation'
@@ -88,9 +89,67 @@ export function BeliefElicitationField({
   onAccept,
   testId,
 }: BeliefElicitationFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  /**
+   * ⚠ THE DEAD END THIS EXISTS TO CLOSE (found live by Codex; confirmed at the
+   * bytes at `122b847a` AND at this lane's tip, on BOTH hosts).
+   *
+   * Revealing the field only flipped `inWords`. The new input had no ref, no
+   * `focus()` and no `scrollIntoView()`, so on a row near the panel's lower
+   * edge **the UI appeared not to change at all**: focus stayed on the icon,
+   * the field was off-screen, and the user typed their phrase INTO THE CHAT —
+   * where it does nothing. The headline feature was a practical dead end for
+   * exactly the users who did what the affordance invited.
+   *
+   * FOCUS ON MOUNT, NOT IN THE CLICK HANDLER, and that is the whole point:
+   * this component only mounts when the field is revealed, so the behaviour is
+   * identical however the reveal happened — pointer, Enter, Space, or a future
+   * caller that reveals it some other way. A handler on the toggle would have
+   * to be duplicated per host and per input modality, which is how the two
+   * hosts drifted in the first place.
+   */
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.focus()
+    // The repo's own guard (InspectorGuidanceSection.tsx:79): jsdom does not
+    // implement scrollIntoView, and an unguarded call turns every test that
+    // renders this field into a TypeError.
+    if (typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [])
+
+  /**
+   * Announced SEPARATELY, and set AFTER mount rather than rendered as initial
+   * content: a live region that already contains its text when it enters the
+   * DOM has no CHANGE to announce, so assistive tech stays silent. Separate
+   * effect from the focus one so a label change re-announces without yanking
+   * focus out of a field the user is mid-way through typing into.
+   */
+  useEffect(() => {
+    setAnnouncement(`Describe ${label} in words — for example, "pretty likely".`)
+  }, [label])
+
   return (
     <div className="space-y-1" data-testid={testId}>
+      {/*
+        `aria-live` WITHOUT `role="status"`, deliberately. `role="status"` is
+        just sugar for an implicit polite live region, and adding a THIRD one to
+        a component that already has two conditional `role="status"` paragraphs
+        ("Reading that…" and the error line) made `getByRole('status')`
+        ambiguous — it broke two existing CalibrateDrillIn tests the moment this
+        landed. Competing status regions are worse for a screen reader too: the
+        announcement, the loading line and the error line would all claim the
+        same role while describing different things.
+      */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
       <input
+        ref={inputRef}
         aria-label={describeInWordsFieldLabel(label)}
         className={`${typography.panelBody} h-7 w-56 rounded-lg border border-panel-border bg-panel px-2 text-text-header outline-none placeholder:text-text-light focus:border-info focus:ring-2 focus:ring-info/20`}
         placeholder="e.g. pretty likely"

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -100,10 +100,11 @@ import {
 } from '../../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
 import { useNodeMutations } from '../../../ui/inspector-v2/useInspectorMutations'
+import { useBeliefElicitation } from '../../../hooks/useBeliefElicitation'
 import {
-  useBeliefElicitation,
-  formatElicitedChance,
-} from '../../../hooks/useBeliefElicitation'
+  BeliefElicitationField,
+  describeInWordsToggleLabel,
+} from '../../BeliefElicitationField'
 import { PanelIconButton } from '../ui/PanelIconButton'
 import { parseSuccessTarget } from '../hero/parseSuccessTarget'
 import type { EstimateRowModel } from '../types'
@@ -445,7 +446,7 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
         <Tooltip content="Say what you think in plain words" delay={300}>
           <PanelIconButton
             variant="ghost"
-            aria-label={`Describe your estimate for ${row.label} in words`}
+            aria-label={describeInWordsToggleLabel(row.label)}
             aria-pressed={inWords}
             onClick={() => {
               setInWords(open => {
@@ -473,103 +474,26 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
         rather than replacing it: the two are alternatives, and hiding the
         direct input behind a mode toggle would make the fast path slower for
         anyone who already knows their number.
+
+        The FIELD itself moved to `BeliefElicitationField` (ROADMAP 2.391) when
+        the inspector panel became a second host: two surfaces spelling the same
+        sentences and re-deciding the same three-way branch is the mirror trap
+        12 is about. Nothing else about this surface changed — the state, the
+        gate and `acceptElicited` are still owned here.
       */}
       {inWords && row.canEditValue && canDescribeInWords && (
-        <div className="space-y-1" data-testid="pre-analysis-v3-in-words">
-          <input
-            aria-label={`Describe ${row.label} in words`}
-            className={`${typography.panelBody} h-7 w-56 rounded-lg border border-panel-border bg-panel px-2 text-text-header outline-none placeholder:text-text-light focus:border-info focus:ring-2 focus:ring-info/20`}
-            placeholder="e.g. pretty likely"
-            value={phrase}
-            onChange={e => {
-              setPhrase(e.target.value)
-              elicitation.request(e.target.value)
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Escape') onDone()
-            }}
-          />
-
-          {elicitation.loading && (
-            <p className={`${typography.panelMeta} text-text-light`} role="status">
-              Reading that…
-            </p>
-          )}
-
-          {elicitation.error && (
-            <p className={`${typography.panelMeta} text-warning`} role="status">
-              {elicitation.error}
-            </p>
-          )}
-
-          {/*
-            AMBIGUOUS PHRASE — the engine's own question, verbatim, and its own
-            option labels. Not paraphrased: it names the factor and the reading
-            it is unsure about, and rewriting it here would put words in the
-            engine's mouth that the engine cannot stand behind.
-          */}
-          {elicitation.suggestion?.needs_clarification ? (
-            <div className="space-y-1">
-              <p className={`${typography.panelMeta} text-text-body`}>
-                {/*
-                  A response can flag itself unsure and carry NO options. The
-                  old condition required BOTH, so that shape fell through to
-                  "That reads as about X%" + Use this — offering a number the
-                  ENGINE had just said it was unsure about, without its
-                  question. Now `needs_clarification` alone suppresses the
-                  offer, and the fallback line says what happened.
-                */}
-                {elicitation.suggestion.clarifying_question ??
-                  "I couldn't pin that down. Try another wording, or type the number."}
-              </p>
-              <div className="flex flex-wrap gap-1.5" role="group" aria-label={`Readings for ${row.label}`}>
-                {(elicitation.suggestion.options ?? []).map(opt => (
-                  <button
-                    key={opt.label}
-                    type="button"
-                    onClick={() => acceptElicited(opt.value)}
-                    className={typo(
-                      'panelMeta',
-                      'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
-                    )}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-          ) : elicitation.suggestion ? (
-            <div className="flex items-center gap-2">
-              {/*
-                The number, as a chance, in plain words. The engine's REASONING
-                and CONFIDENCE are expert detail and stay behind the existing
-                progressive-disclosure affordance — inline they read as hedging.
-                ⚠ This comment used to be FALSE about confidence: it was fetched,
-                typed and warn-parsed, and then rendered nowhere at all (#572
-                review). It is in the tooltip now, so the sentence is true.
-              */}
-              <Tooltip
-                content={`${elicitation.suggestion.reasoning} (${elicitation.suggestion.confidence} confidence)`}
-                delay={300}
-              >
-                <span className={`${typography.panelMeta} text-text-body`}>
-                  That reads as {formatElicitedChance(elicitation.suggestion.suggested_value)}
-                </span>
-              </Tooltip>
-              <button
-                type="button"
-                onClick={() => acceptElicited(elicitation.suggestion!.suggested_value)}
-                aria-label={`Use ${formatElicitedChance(elicitation.suggestion.suggested_value)} for ${row.label}`}
-                className={typo(
-                  'panelMeta',
-                  'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
-                )}
-              >
-                Use this
-              </button>
-            </div>
-          ) : null}
-        </div>
+        <BeliefElicitationField
+          testId="pre-analysis-v3-in-words"
+          label={row.label}
+          phrase={phrase}
+          onPhraseChange={next => {
+            setPhrase(next)
+            elicitation.request(next)
+          }}
+          onEscape={onDone}
+          elicitation={elicitation}
+          onAccept={acceptElicited}
+        />
       )}
     </div>
   )

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInElicit.spec.tsx
@@ -295,6 +295,31 @@ describe('CalibrateDrillIn — "say it in words" (ROADMAP 2.364)', () => {
     })
   })
 
+  /**
+   * ROADMAP 2.391 — THE REVEAL WAS A PRACTICAL DEAD END ON THIS SURFACE TOO.
+   *
+   * Found live by Codex and confirmed at the bytes at `122b847a`: the toggle
+   * only flipped `inWords`; the new input had no ref, no `focus()`, no
+   * `scrollIntoView()`. On a row near the panel's lower edge the UI appeared
+   * not to change, focus stayed on the icon, and the user typed the phrase
+   * into the CHAT instead — where it does nothing.
+   *
+   * This pin lives on BOTH hosts deliberately. The fix is in the shared
+   * `BeliefElicitationField` (mount-driven, so it is identical for pointer and
+   * keyboard), and this is the assertion that proves the ONE fix reaches the
+   * pre-analysis host and not only the inspector panel.
+   */
+  it('revealing the field MOVES FOCUS INTO IT (the reveal was a dead end)', async () => {
+    seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
+    renderFor(WALK_ID)
+
+    fireEvent.click(screen.getByLabelText(`Describe your estimate for ${WALK_LABEL} in words`))
+
+    // IDENTITY-BOUND to this exact input, not "an input is focused".
+    const field = screen.getByLabelText(`Describe ${WALK_LABEL} in words`)
+    expect(document.activeElement).toBe(field)
+  })
+
   it('renders the chance from suggested_value — "about 70%"', async () => {
     seedFactor(WALK_ID, WALK_LABEL, { ...WALK_OBSERVED })
     elicitReplies.push({ ...PRETTY_LIKELY })

--- a/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
@@ -111,6 +111,28 @@ const WALK_OBSERVED = {
   extractionType: 'inferred',
 }
 
+/**
+ * ⭐ A capless/unitless factor that ALREADY CARRIES `raw_value` — the state this
+ * very panel leaves a factor in after ONE accept (the display anchor is written
+ * locally), and therefore the shape a SECOND accept meets.
+ *
+ * It exists because of a VACUITY I found in my own battery. On `WALK_OBSERVED`
+ * there is no `raw_value`, so the DEFAULT seed basis resolves to
+ * `{inUserUnits: false}` and emits exactly the same payload as `'model_scale'`
+ * — deleting `seedBasis: 'model_scale'` from the accept SURVIVED. Here it does
+ * not: with a `raw_value` present the default basis reports `inUserUnits: true`
+ * and attaches a `raw_value` the client has no business asserting. This fixture
+ * is what makes the "no raw_value" assertion bind the BASIS rather than the
+ * fixture's silence.
+ */
+const ANCHORED_ID = 'fac_brand_trust'
+const ANCHORED_LABEL = 'Brand trust'
+const ANCHORED_OBSERVED = {
+  value: 0.3,
+  raw_value: 0.3,
+  source: 'user_override',
+}
+
 /** A cap-bearing factor — CEE's own draft fixtures carry exactly this shape. */
 const CAPPED_ID = 'fac_team_size'
 const CAPPED_LABEL = 'Team Size'
@@ -361,6 +383,31 @@ describe('FactorControllablePanel — belief elicitation post-analysis (ROADMAP 
     expect(events[0].field).toBe('value')
     // The wire is not optional (2.365 class): the transport was actually called.
     expect(sendSystemEvent).toHaveBeenCalledTimes(1)
+
+    // A2 — the accepted number is still DISPLAYED. Without the local display
+    // anchor, `setObservedValue` clears both `display_value` copies, the row and
+    // the canvas node show NO NUMBER where "Low (0)" was, and the factor then
+    // reads as scale-ambiguous — which takes the affordance itself away.
+    expect(screen.getByTestId('factor-display-text')).toHaveTextContent('0.7')
+  })
+
+  it('binds the model_scale BASIS: no raw_value even when the factor already carries one', async () => {
+    seed(ANCHORED_ID, ANCHORED_LABEL, ANCHORED_OBSERVED)
+    renderPanel(ANCHORED_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(ANCHORED_LABEL, 'pretty likely')
+
+    fireEvent.click(screen.getByLabelText(`Use about 70% for ${ANCHORED_LABEL}`))
+
+    const events = eventsFor(ANCHORED_ID)
+    expect(events).toHaveLength(1)
+    expect(events[0].value).toBe(PRETTY_LIKELY.suggested_value)
+    // THE ASSERTION THE WALK FIXTURE COULD NOT MAKE. With a stored `raw_value`,
+    // the DEFAULT basis would read the probability as a user-unit magnitude and
+    // attach `raw_value: 0.7` — a magnitude the user never gave, which CEE would
+    // then take at face value instead of inverting with its own cap.
+    expect(events[0]).not.toHaveProperty('raw_value')
+    expect(events[0]).not.toHaveProperty('unit')
   })
 
   it('a clarification chip commits THAT chip\'s value, not the first one', async () => {

--- a/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
@@ -303,6 +303,57 @@ describe('FactorControllablePanel — belief elicitation post-analysis (ROADMAP 
     expect(elicitRequests[0].target_type).toBe('prior')
   })
 
+  // ── 1b. THE REVEAL IS NOT A DEAD END ─────────────────────────────────────
+
+  it('revealing the field MOVES FOCUS INTO IT (the reveal was a practical dead end)', () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+
+    const toggle = screen.getByLabelText(describeInWordsToggleLabel(WALK_LABEL))
+    expect(document.activeElement).not.toBe(toggle) // nothing focused yet
+    fireEvent.click(toggle)
+
+    // IDENTITY-BOUND: the active element IS this exact input, not "an input".
+    // Without this, focus stayed on the icon and — on a row near the panel's
+    // lower edge, where the new field is off-screen — the user typed their
+    // phrase into the CHAT, which does nothing (Codex hit this live).
+    const field = screen.getByLabelText(describeInWordsFieldLabel(WALK_LABEL))
+    expect(document.activeElement).toBe(field)
+  })
+
+  it('announces the reveal in a live region', () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    fireEvent.click(screen.getByLabelText(describeInWordsToggleLabel(WALK_LABEL)))
+
+    // Scoped to the revealed field: the panel has other role="status" nodes.
+    const region = screen
+      .getByTestId('inspector-in-words')
+      .querySelector('[aria-live="polite"]')
+    expect(region).not.toBeNull()
+    expect(region).toHaveTextContent(`Describe ${WALK_LABEL} in words`)
+  })
+
+  it('scrolls the revealed field into view — CALL-level, jsdom cannot prove layout', () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    // jsdom does not implement scrollIntoView at all, so installing the spy IS
+    // what makes the call observable. ⚠ CLAIM TYPE: this proves the component
+    // ASKS to be scrolled into view. It proves NOTHING about whether the field
+    // is visible on screen — jsdom cannot prove visibility (CLAUDE.md trap 3),
+    // and the off-screen half of the live defect is only witnessable in a real
+    // browser.
+    const spy = vi.fn()
+    ;(window.HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = spy
+
+    fireEvent.click(screen.getByLabelText(describeInWordsToggleLabel(WALK_LABEL)))
+
+    const field = screen.getByLabelText(describeInWordsFieldLabel(WALK_LABEL))
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.instances[0]).toBe(field)
+    delete (window.HTMLElement.prototype as unknown as Record<string, unknown>).scrollIntoView
+  })
+
   // ── 2. THE GATE, both ways ───────────────────────────────────────────────
 
   it('HIDES the affordance on the uncapped unit-bearing MAGNITUDE shape (the #572 blocker)', () => {

--- a/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/FactorControllablePanel.elicit.spec.tsx
@@ -1,0 +1,475 @@
+/**
+ * ROADMAP 2.391 — "say it in words" reaches the POST-ANALYSIS surface.
+ *
+ * WHY THIS FILE EXISTS (the measurement that forced it). ROADMAP 2.364 shipped
+ * the elicitation affordance on `CalibrateDrillIn` only, and that surface
+ * UNMOUNTS the moment "Analyse first pass" is clicked — measured on deployed
+ * build `1730c6c5` (L55 §10.7) and reproduced independently on `33594598`
+ * (L58 §2): post-run, `[data-testid="pre-analysis-v3"]` is null and no "… in
+ * words" affordance survives anywhere in the document. So a staleness pill
+ * (which needs an analysis to already exist) and the elicitation loop (which
+ * needed the pre-run drill-in) were MUTUALLY EXCLUSIVE in one session, and the
+ * chain "elicit in words → Use this → analysis goes stale" could not be
+ * witnessed at all.
+ *
+ * WHAT THIS FILE PINS, and the CLAIM TYPE of each:
+ *   1. REACHABILITY — the affordance renders on the inspector panel while a
+ *      COMPLETED analysis is in the store. This is the claim that is RED at
+ *      pristine: the panel has no such control.
+ *   2. THE GATE, both ways — offered on a capless/unitless factor, HIDDEN (not
+ *      disabled) on the two shapes `acceptsElicitedBelief` refuses: a
+ *      cap-bearing factor, and the uncapped unit-bearing MAGNITUDE shape that
+ *      was the #572 review's BLOCKER (£40,000 → £0.70).
+ *   3. THE GATE IS REACTIVE — changing the factor's shape underneath an OPEN
+ *      field unmounts the affordance. This is what makes the absence of an
+ *      accept-time re-check honest rather than an omission (see
+ *      `CalibrateDrillIn`'s `acceptElicited` comment, and mutant A1-d in
+ *      `l43-elicitation-build.md`).
+ *   4. THE COMMIT — accepting dispatches EXACTLY ONE `factor_value_edit` for
+ *      THAT node id, carrying the probability VERBATIM as `value` with NO
+ *      `raw_value` and NO `unit`: the shape CEE's `resolveUserUnitInput`
+ *      inverts with the factor's own stored cap.
+ *   5. THE WIRE IS NOT OPTIONAL — deleting `sendSystemEvent` from the accept
+ *      path must go RED (the 2.365 silent-local-commit class).
+ *   6. THE EXISTING TYPED PATH IS UNMOVED — on a factor where the affordance is
+ *      not offered at all, a typed commit still emits the 1.346 event with its
+ *      `raw_value` + `unit` + cap-derived model value, unchanged.
+ *   7. THE POST-ACCEPT NUMBER FIELD IS CONSISTENT — after an accept, blurring
+ *      the number input emits NOTHING. Without the draft sync this is a real
+ *      regression, not a nicety: the field still held the PREVIOUS number, so
+ *      the next blur would have committed it and silently undone the accept.
+ *   8. THE STALENESS CHAIN — with a completed-but-not-fresh analysis, accepting
+ *      surfaces the panel's own "Re-run to see how this affects the results"
+ *      prompt. Control: with no analysis in the store, it does not.
+ *
+ * IDENTITY, NOT VALUE (CLAUDE.md trap 19). Every assertion about a dispatched
+ * event binds it by `target_id` to the node under test; no assertion finds an
+ * event "by value" where another event could satisfy the predicate.
+ *
+ * MOCKS: only the two TRANSPORTS — the conversation's `sendSystemEvent` and
+ * `CEEClient.elicitBelief` — and both by `importOriginal`-spread, never a
+ * hand-listed factory (trap 12). The scale module, the gate, the hook and the
+ * panel are the shipped code.
+ *
+ * RED-first at pristine `33594598`: no elicitation affordance exists on this
+ * panel, so every test except the two controls fails at `getByLabelText`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+/** Every system event that reached the conversation transport, in order. */
+const sendSystemEvent = vi.fn()
+/** Elicitation replies the mocked CEE client answers with, in order. */
+const elicitReplies: Array<Record<string, unknown>> = []
+/** Every elicitation request body, in order — the request contract at the seam. */
+const elicitRequests: Array<Record<string, unknown>> = []
+
+vi.mock('../../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    useOptionalConversationContext: () => ({ sendSystemEvent }),
+  }
+})
+
+vi.mock('../../../../adapters/cee/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../adapters/cee/client')>()
+  class MockCEEClient extends actual.CEEClient {
+    async elicitBelief(input: Parameters<InstanceType<typeof actual.CEEClient>['elicitBelief']>[0]) {
+      elicitRequests.push(input as unknown as Record<string, unknown>)
+      const reply = elicitReplies.shift()
+      if (!reply) throw new Error('no elicitation reply queued')
+      return reply as unknown as Awaited<
+        ReturnType<InstanceType<typeof actual.CEEClient>['elicitBelief']>
+      >
+    }
+  }
+  return { ...actual, CEEClient: MockCEEClient }
+})
+
+import { FactorControllablePanel } from '../panels/FactorControllablePanel'
+import { useCanvasStore } from '../../../store'
+import { normaliseRawFactorValue } from '../../../utils/observedStateHelpers'
+import { BELIEF_ELICITATION_DEBOUNCE_MS } from '../../../hooks/useBeliefElicitation'
+import {
+  describeInWordsToggleLabel,
+  describeInWordsFieldLabel,
+} from '../../../components/BeliefElicitationField'
+
+// ── the four witnessed factor shapes (same fixtures as calibrateDrillInElicit) ──
+
+/** The 2026-08-03 journey-walk row: capless, unitless, model value in [0,1]. */
+const WALK_ID = 'fac_content_marketing'
+const WALK_LABEL = 'Content Marketing Investment'
+const WALK_OBSERVED = {
+  value: 0,
+  display_value: 'Low (0)',
+  source: 'cee_inference',
+  extractionType: 'inferred',
+}
+
+/** A cap-bearing factor — CEE's own draft fixtures carry exactly this shape. */
+const CAPPED_ID = 'fac_team_size'
+const CAPPED_LABEL = 'Team Size'
+const CAPPED_CAP = 20
+const CAPPED_OBSERVED = {
+  value: 0.4,
+  raw_value: 8,
+  unit: 'engineers',
+  cap: CAPPED_CAP,
+  source: 'brief_extraction',
+}
+
+/**
+ * ⭐ THE #572 BLOCKER SHAPE: staging-witnessed uncapped unit-bearing factor.
+ * Model scale IS the magnitude here, so a verbatim 0.7 would turn £40,000 into
+ * £0.70 with a "checked by you" stamp on it.
+ */
+const MAGNITUDE_ID = 'fac_monthly_spend'
+const MAGNITUDE_LABEL = 'Monthly spend'
+const MAGNITUDE_OBSERVED = {
+  value: 40000,
+  unit: '£',
+  raw_value: 40000,
+  source: 'brief_extraction',
+}
+
+/** The witnessed live reply for "pretty likely" (staging BFF, 2026-08-03). */
+const PRETTY_LIKELY = {
+  suggested_value: 0.7,
+  confidence: 'high',
+  reasoning:
+    'Interpreted "pretty likely" as approximately 70% probability based on common usage.',
+  needs_clarification: false,
+  provenance: 'cee',
+}
+
+/** The witnessed clarification branch for "good". */
+const AMBIGUOUS_GOOD = {
+  suggested_value: 0.75,
+  confidence: 'low',
+  reasoning: '"good" could mean several things.',
+  needs_clarification: true,
+  clarifying_question: 'When you say "good", how likely do you mean?',
+  options: [
+    { label: 'Very likely', value: 0.9 },
+    { label: 'Quite likely', value: 0.75 },
+    { label: 'More likely than not', value: 0.6 },
+  ],
+  provenance: 'cee',
+}
+
+/** `needs_clarification` with NO options — must suppress the offer entirely. */
+const UNSURE_NO_OPTIONS = {
+  suggested_value: 0.5,
+  confidence: 'low',
+  reasoning: 'ambiguous',
+  needs_clarification: true,
+  provenance: 'cee',
+}
+
+const noop = () => {}
+
+/**
+ * A COMPLETED analysis whose freshness is not confirmably current — the state a
+ * user is in the moment they edit something after a run. `results.status` is
+ * what the panel reads for results mode; `analysisFreshness` is what
+ * `useEditConfirmation` reads for the re-run prompt.
+ */
+const ANALYSED = {
+  results: { status: 'complete', report: null },
+  analysisFreshness: { freshness: 'stale', freshnessReason: 'graph_hash_mismatch' },
+  analysisFreshnessDirty: false,
+}
+
+/** No analysis at all — the control for every "post-analysis" claim. */
+const NOT_ANALYSED = {
+  results: { status: 'idle', report: null },
+  analysisFreshness: null,
+  analysisFreshnessDirty: false,
+}
+
+function seed(
+  id: string,
+  label: string,
+  observed: Record<string, unknown>,
+  phase: Record<string, unknown> = ANALYSED,
+): void {
+  useCanvasStore.setState(
+    {
+      nodes: [
+        {
+          id,
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: { kind: 'factor', label, observedState: observed },
+        } as unknown as Node,
+      ],
+      edges: [],
+      ...phase,
+    } as never,
+    false,
+  )
+}
+
+function renderPanel(id: string) {
+  return render(
+    <FactorControllablePanel nodeId={id} techMode={false} onClose={noop} onNavigate={noop} />,
+  )
+}
+
+/** Open the words field and type a phrase, letting the debounce fire. */
+async function askInWords(label: string, phrase: string): Promise<void> {
+  fireEvent.click(screen.getByLabelText(describeInWordsToggleLabel(label)))
+  fireEvent.change(screen.getByLabelText(describeInWordsFieldLabel(label)), {
+    target: { value: phrase },
+  })
+  await act(async () => {
+    vi.advanceTimersByTime(BELIEF_ELICITATION_DEBOUNCE_MS + 1)
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+/** Every dispatched event for THIS node id — identity-bound, never by value. */
+function eventsFor(nodeId: string): Array<Record<string, unknown>> {
+  return sendSystemEvent.mock.calls
+    .map(c => c[0] as { type: string; payload: Record<string, unknown> })
+    .filter(e => e.type === 'factor_value_edit' && e.payload.target_id === nodeId)
+    .map(e => e.payload)
+}
+
+describe('FactorControllablePanel — belief elicitation post-analysis (ROADMAP 2.391)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sendSystemEvent.mockClear()
+    elicitReplies.length = 0
+    elicitRequests.length = 0
+  })
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  // ── 1. REACHABILITY — the claim that is RED at pristine ──────────────────
+
+  it('offers the "in words" affordance on the inspector panel WITH A COMPLETED ANALYSIS in the store', () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED, ANALYSED)
+    renderPanel(WALK_ID)
+
+    // The affordance exists on the post-analysis surface. Before 2.391 the ONLY
+    // host was pre-analysis-v3, which is unmounted by then.
+    expect(screen.getByLabelText(describeInWordsToggleLabel(WALK_LABEL))).toBeInTheDocument()
+    // …and the panel really is in results mode, not a pre-run panel that merely
+    // happens to render: the store carries a completed analysis.
+    expect(useCanvasStore.getState().results?.status).toBe('complete')
+  })
+
+  it('addresses the elicit request by NODE ID, not by label', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+
+    expect(elicitRequests).toHaveLength(1)
+    expect(elicitRequests[0].node_id).toBe(WALK_ID)
+    expect(elicitRequests[0].node_id).not.toBe(WALK_LABEL)
+    expect(elicitRequests[0].user_expression).toBe('pretty likely')
+    expect(elicitRequests[0].target_type).toBe('prior')
+  })
+
+  // ── 2. THE GATE, both ways ───────────────────────────────────────────────
+
+  it('HIDES the affordance on the uncapped unit-bearing MAGNITUDE shape (the #572 blocker)', () => {
+    seed(MAGNITUDE_ID, MAGNITUDE_LABEL, MAGNITUDE_OBSERVED)
+    renderPanel(MAGNITUDE_ID)
+
+    // Hidden, not disabled: a disabled control with no explanation is a mystery.
+    expect(screen.queryByLabelText(describeInWordsToggleLabel(MAGNITUDE_LABEL))).toBeNull()
+    // POSITIVE CONTROL for the absence — the panel itself IS rendered, so the
+    // null above is the gate refusing, not an empty tree.
+    expect(screen.getByPlaceholderText('Enter value')).toBeInTheDocument()
+  })
+
+  it('HIDES the affordance on a cap-bearing factor (the accepted number could not be displayed)', () => {
+    seed(CAPPED_ID, CAPPED_LABEL, CAPPED_OBSERVED)
+    renderPanel(CAPPED_ID)
+
+    expect(screen.queryByLabelText(describeInWordsToggleLabel(CAPPED_LABEL))).toBeNull()
+    expect(screen.getByPlaceholderText('Enter value')).toBeInTheDocument()
+  })
+
+  // ── 3. THE GATE IS REACTIVE ──────────────────────────────────────────────
+
+  it('is REACTIVE: a factor that stops being a chance loses the affordance underneath an OPEN field', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+    expect(screen.getByText(/That reads as about 70%/)).toBeInTheDocument()
+
+    // The factor acquires a unit (a CEE graph_patch can do exactly this).
+    act(() => {
+      useCanvasStore.setState(
+        {
+          nodes: [
+            {
+              id: WALK_ID,
+              type: 'factor',
+              position: { x: 0, y: 0 },
+              data: {
+                kind: 'factor',
+                label: WALK_LABEL,
+                observedState: { ...WALK_OBSERVED, unit: '£', value: 40000 },
+              },
+            } as unknown as Node,
+          ],
+        } as never,
+        false,
+      )
+    })
+
+    // The whole affordance is gone — there is no "Use this" left to click, which
+    // is WHY an accept-time re-check would be unreachable and is not written.
+    expect(screen.queryByLabelText(describeInWordsToggleLabel(WALK_LABEL))).toBeNull()
+    expect(screen.queryByText(/That reads as/)).toBeNull()
+  })
+
+  // ── 4 + 5. THE COMMIT, and the wire ──────────────────────────────────────
+
+  it('accepting commits the probability VERBATIM through the same factor_value_edit lane', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+
+    fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+
+    const events = eventsFor(WALK_ID)
+    expect(events).toHaveLength(1)
+    // VERBATIM: the elicited probability IS the model-scale value.
+    expect(events[0].value).toBe(PRETTY_LIKELY.suggested_value)
+    // And NOT the design's retired ×100 form, nor a cap-normalised number.
+    expect(events[0].value).not.toBe(70)
+    // ABSENCE IS THE CONTRACT: no client-asserted magnitude, no client-asserted
+    // unit — CEE derives both from `value` and its own stored cap.
+    expect(events[0]).not.toHaveProperty('raw_value')
+    expect(events[0]).not.toHaveProperty('unit')
+    expect(events[0].field).toBe('value')
+    // The wire is not optional (2.365 class): the transport was actually called.
+    expect(sendSystemEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('a clarification chip commits THAT chip\'s value, not the first one', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(AMBIGUOUS_GOOD)
+    await askInWords(WALK_LABEL, 'good')
+
+    // The ENGINE's own question, verbatim.
+    expect(screen.getByText(AMBIGUOUS_GOOD.clarifying_question)).toBeInTheDocument()
+    // The THIRD chip — a handler that always commits options[0] passes if we
+    // click the first one.
+    fireEvent.click(screen.getByText('More likely than not'))
+
+    const events = eventsFor(WALK_ID)
+    expect(events).toHaveLength(1)
+    expect(events[0].value).toBe(0.6)
+    expect(events[0].value).not.toBe(AMBIGUOUS_GOOD.options[0].value)
+    expect(events[0].value).not.toBe(AMBIGUOUS_GOOD.suggested_value)
+  })
+
+  it('needs_clarification with NO options offers no number at all', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(UNSURE_NO_OPTIONS)
+    await askInWords(WALK_LABEL, 'good')
+
+    // No offer of a number the engine just said it was unsure about.
+    expect(screen.queryByText(/That reads as/)).toBeNull()
+    expect(screen.queryByText('Use this')).toBeNull()
+    expect(
+      screen.getByText(/I couldn't pin that down\. Try another wording, or type the number\./),
+    ).toBeInTheDocument()
+    expect(eventsFor(WALK_ID)).toHaveLength(0)
+  })
+
+  // ── 6. THE EXISTING TYPED PATH IS UNMOVED ────────────────────────────────
+
+  it('CONTROL: the existing typed commit is unchanged on a factor where the affordance is not offered', () => {
+    seed(CAPPED_ID, CAPPED_LABEL, CAPPED_OBSERVED)
+    renderPanel(CAPPED_ID)
+
+    const input = screen.getByPlaceholderText('Enter value')
+    fireEvent.change(input, { target: { value: '12' } })
+    fireEvent.blur(input)
+
+    const events = eventsFor(CAPPED_ID)
+    expect(events).toHaveLength(1)
+    // The 1.346 shape, intact: user-unit magnitude + unit + cap-derived model
+    // value, computed from the fixture's OWN cap rather than a hard-coded bound.
+    expect(events[0].raw_value).toBe(12)
+    expect(events[0].unit).toBe('engineers')
+    expect(events[0].value).toBe(normaliseRawFactorValue(12, CAPPED_CAP))
+  })
+
+  it('CONTROL: an unchanged typed value still emits nothing (the negative control survives the mount)', () => {
+    seed(CAPPED_ID, CAPPED_LABEL, CAPPED_OBSERVED)
+    renderPanel(CAPPED_ID)
+
+    const input = screen.getByPlaceholderText('Enter value')
+    fireEvent.change(input, { target: { value: '8' } })
+    fireEvent.blur(input)
+
+    expect(eventsFor(CAPPED_ID)).toHaveLength(0)
+  })
+
+  // ── 7. THE POST-ACCEPT NUMBER FIELD ──────────────────────────────────────
+
+  it('after an accept, blurring the number field emits NOTHING (it would otherwise undo the accept)', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+    fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+    expect(eventsFor(WALK_ID)).toHaveLength(1)
+
+    // The number input was seeded with the PREVIOUS value (0). Blurring it now,
+    // with no typing at all, must not commit that stale 0 back over the 0.7 the
+    // user just accepted.
+    fireEvent.blur(screen.getByPlaceholderText('Enter value'))
+
+    expect(eventsFor(WALK_ID)).toHaveLength(1)
+  })
+
+  // ── 8. THE STALENESS CHAIN ───────────────────────────────────────────────
+
+  it('accepting on a POST-ANALYSIS panel surfaces the re-run prompt', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED, ANALYSED)
+    renderPanel(WALK_ID)
+    // Nothing edited yet: the prompt must be quiet.
+    expect(screen.queryByTestId('inline-rerun')).toBeNull()
+
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+    fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+
+    expect(screen.getByTestId('inline-rerun')).toBeInTheDocument()
+    expect(screen.getByText('Re-run to see how this affects the results')).toBeInTheDocument()
+  })
+
+  it('CONTROL: with NO analysis in the store, accepting surfaces no re-run prompt', async () => {
+    seed(WALK_ID, WALK_LABEL, WALK_OBSERVED, NOT_ANALYSED)
+    renderPanel(WALK_ID)
+    elicitReplies.push(PRETTY_LIKELY)
+    await askInWords(WALK_LABEL, 'pretty likely')
+    fireEvent.click(screen.getByLabelText(`Use about 70% for ${WALK_LABEL}`))
+
+    // The commit still happened — this control is about the PROMPT, not the edit.
+    expect(eventsFor(WALK_ID)).toHaveLength(1)
+    expect(screen.queryByTestId('inline-rerun')).toBeNull()
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -6,7 +6,8 @@
  */
 
 import { memo, useState, useMemo, useCallback } from 'react'
-import { Link } from 'lucide-react'
+import { Link, MessageSquare } from 'lucide-react'
+import Tooltip from '../../../../components/Tooltip'
 import { useCanvasStore } from '../../../store'
 import type { NodeType, ObservedState, FactorNodeData } from '../../../domain/nodes'
 import { useEditConfirmation } from '../useEditConfirmation'
@@ -38,8 +39,18 @@ import { resolveCoaching } from '../coachingConfig'
 import { FactorControllableEditor } from '../editors/FactorControllableEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
-import { buildFactorValueEditEvent, resolveValueInputSeed } from '../../../conversation/factorValueEdit'
+import {
+  acceptsElicitedBelief,
+  buildFactorValueEditEvent,
+  resolveValueInputSeed,
+  type ValueInputSeedBasis,
+} from '../../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
+import { useBeliefElicitation } from '../../../hooks/useBeliefElicitation'
+import {
+  BeliefElicitationField,
+  describeInWordsToggleLabel,
+} from '../../../components/BeliefElicitationField'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -130,54 +141,103 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
   // degrade to "local edit only", never throw. Same pattern as WhatChangedChip.
   const sendSystemEvent = useOptionalConversationContext()?.sendSystemEvent
 
-  const handleValueBlur = useCallback(() => {
-    const parsed = parseFloat(draftValue)
-    // Commit ONCE per genuinely-changed value. `inputDisplayValue` is the
-    // number the field was showing, so a re-blur after a commit — and a commit
-    // of an unchanged number — are both no-ops here. That is the mechanism
-    // behind the negative control (a same-value edit must not claim a change);
-    // CEE's noop dedup is the backstop, not the mechanism.
-    if (isNaN(parsed) || parsed === inputDisplayValue) return
+  // ── "say it in words" (ROADMAP 2.391) ────────────────────────────────────
+  //
+  // The elicitation affordance was pre-analysis-ONLY until this panel got it:
+  // its only host, `pre-analysis-v3`'s CalibrateDrillIn, unmounts on "Analyse
+  // first pass" (measured on deployed `1730c6c5` and again on `33594598`). This
+  // panel is where a user IS when they want to revise a belief — after they
+  // have seen a result — so the loop "elicit → Use this → analysis goes stale"
+  // is only reachable at all from here.
+  const [inWords, setInWords] = useState(false)
+  const [phrase, setPhrase] = useState('')
+  const elicitation = useBeliefElicitation({
+    nodeId: nodeId ?? '',
+    nodeLabel: String(node?.data?.label ?? ''),
+  })
 
-    // ONE derivation feeds BOTH the local store write and the wire, so the two
-    // cannot disagree about the same edit. Building it first (rather than
-    // writing locally and re-deriving for the send) is what makes that
-    // structural instead of a convention someone has to remember.
-    const event = buildFactorValueEditEvent({
-      // `nodeId` is optional on InspectorPanelProps (the router renders the
-      // panel before a selection resolves). An empty id is unencodable and the
-      // builder returns null for it — fail closed rather than emit a mutation
-      // with no target.
-      nodeId: nodeId ?? '',
-      typedValue: parsed,
-      // Read the node as it was BEFORE the local write: the factor's own scale
-      // metadata (cap/unit) is what decides the scale of what the user typed.
-      nodeData: node?.data,
-    })
-    if (!event) return
-    const { value: modelValue, raw_value: rawMagnitude } = event.payload as {
-      value: number
-      raw_value?: number
-    }
+  /**
+   * May this factor be asked about in words? The SAME predicate the pre-analysis
+   * surface uses, read the SAME way: reactively, from the store, returning a
+   * BOOLEAN (a fresh object per render is what the zustand-selector guard
+   * exists to stop). Capless AND unitless only — see `acceptsElicitedBelief`
+   * for why, and for what widening it would actually take.
+   */
+  const canDescribeInWords = useCanvasStore(s =>
+    acceptsElicitedBelief(s.nodes.find(n => n.id === nodeId)?.data),
+  )
 
-    // ROADMAP 2.129 (b) — the undo for the optimistic write, captured from the
-    // pre-write node data. The defect was live-proven on the Model tab, but this
-    // is the same fire-and-forget shape against the same endpoint: a refusal
-    // leaves the panel showing a number the engine declined. Fixing one twin and
-    // leaving the other armed is how this class keeps coming back.
-    const undo = captureOptimisticFactorEdit(nodeId ?? '', modelValue, node?.data)
+  /**
+   * ONE commit path for both affordances on this panel.
+   *
+   * Extracted from `handleValueBlur` verbatim rather than copied beside it: two
+   * handlers building the same event from the same node would be the mirror
+   * that lets an optimistic write and a wire event drift apart on one edit.
+   * `seedBasis` is NOT a second scale rule — it tells the single scale authority
+   * WHICH number the committing control was displaying, the one thing that
+   * authority cannot derive for itself.
+   */
+  const commitValue = useCallback(
+    (
+      typedValue: number,
+      opts: {
+        seedBasis?: ValueInputSeedBasis
+        /**
+         * Write `typedValue` as the LOCAL display anchor too. Only the elicited
+         * path passes it, and only because the affordance is gated to factors
+         * with no unit and no cap — the shape where CEE itself persists
+         * `raw_value = value`. So this MIRRORS what the server will hold; it
+         * does not derive it. Without it, `setObservedValue` clears both
+         * `display_value` copies and leaves no anchor, and the row shows NO
+         * NUMBER where one used to be (#572 review, A2).
+         */
+        writeRawAnchor?: boolean
+      } = {},
+    ): void => {
+      // ONE derivation feeds BOTH the local store write and the wire, so the two
+      // cannot disagree about the same edit. Building it first (rather than
+      // writing locally and re-deriving for the send) is what makes that
+      // structural instead of a convention someone has to remember.
+      const event = buildFactorValueEditEvent({
+        // `nodeId` is optional on InspectorPanelProps (the router renders the
+        // panel before a selection resolves). An empty id is unencodable and the
+        // builder returns null for it — fail closed rather than emit a mutation
+        // with no target.
+        nodeId: nodeId ?? '',
+        typedValue,
+        // Read the node as it was BEFORE the local write: the factor's own scale
+        // metadata (cap/unit) is what decides the scale of what the user typed.
+        nodeData: node?.data,
+        ...(opts.seedBasis ? { seedBasis: opts.seedBasis } : {}),
+      })
+      // Fail CLOSED. This is also where the STRUCTURAL belt lands for the
+      // elicited path: `buildFactorValueEditEvent` refuses a `model_scale`
+      // commit outside [0,1] or on a magnitude-scaled factor, for every caller,
+      // and a null event means no local write, no wire, no receipt.
+      if (!event) return
+      const { value: modelValue, raw_value: rawMagnitude } = event.payload as {
+        value: number
+        raw_value?: number
+      }
 
-    // Local store write first, so the canvas and the freshness overlay reflect
-    // the edit immediately even if the turn is slow or fails. Note this writes
-    // the MODEL-scale number into `value` — the live defect wrote the display
-    // magnitude (300000) there, which is exactly what CEE's validator refuses.
-    mutations.setObservedValue(modelValue, rawMagnitude)
-    confirmEdit('value')
+      // ROADMAP 2.129 (b) — the undo for the optimistic write, captured from the
+      // pre-write node data. The defect was live-proven on the Model tab, but this
+      // is the same fire-and-forget shape against the same endpoint: a refusal
+      // leaves the panel showing a number the engine declined. Fixing one twin and
+      // leaving the other armed is how this class keeps coming back.
+      const undo = captureOptimisticFactorEdit(nodeId ?? '', modelValue, node?.data)
 
-    // Then the wire. Before this, the chain ENDED at the store write: the edit
-    // never reached CEE, its graph_hash never moved, and the rerun the
-    // freshness strip invited could not possibly reflect the change.
-    if (!sendSystemEvent) return
+      // Local store write first, so the canvas and the freshness overlay reflect
+      // the edit immediately even if the turn is slow or fails. Note this writes
+      // the MODEL-scale number into `value` — the live defect wrote the display
+      // magnitude (300000) there, which is exactly what CEE's validator refuses.
+      mutations.setObservedValue(modelValue, opts.writeRawAnchor ? typedValue : rawMagnitude)
+      confirmEdit('value')
+
+      // Then the wire. Before this, the chain ENDED at the store write: the edit
+      // never reached CEE, its graph_hash never moved, and the rerun the
+      // freshness strip invited could not possibly reflect the change.
+      if (!sendSystemEvent) return
     // Fire-and-forget: the response is ingested by the shared turn path
     // (applyV5State applies graph_patch + analysis_ready for system-event turns
     // exactly as it does for message turns). Awaiting here would block the blur
@@ -193,16 +253,57 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
     // buffer, which queues the send and flushes it when the lock clears (and
     // holds the freshness overlay dirty until it does). See
     // `useConversation`'s `deferredSystemSendsRef`.
-    void Promise.resolve(
-      sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
-    ).catch(() => {
-      // Swallowed deliberately: a genuine send failure is already recorded by
-      // the conversation's own failure channel. Re-throwing from a blur handler
-      // would surface as an unhandled rejection and tell the user nothing they
-      // are not already being told. A server REFUSAL is not a failure and never
-      // reaches here — the dispatcher reverts the optimistic write instead.
-    })
-  }, [draftValue, inputDisplayValue, mutations, confirmEdit, sendSystemEvent, nodeId, node?.data])
+      void Promise.resolve(
+        sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
+      ).catch(() => {
+        // Swallowed deliberately: a genuine send failure is already recorded by
+        // the conversation's own failure channel. Re-throwing from a blur handler
+        // would surface as an unhandled rejection and tell the user nothing they
+        // are not already being told. A server REFUSAL is not a failure and never
+        // reaches here — the dispatcher reverts the optimistic write instead.
+      })
+    },
+    [mutations, confirmEdit, sendSystemEvent, nodeId, node?.data],
+  )
+
+  const handleValueBlur = useCallback(() => {
+    const parsed = parseFloat(draftValue)
+    // Commit ONCE per genuinely-changed value. `inputDisplayValue` is the
+    // number the field was showing, so a re-blur after a commit — and a commit
+    // of an unchanged number — are both no-ops here. That is the mechanism
+    // behind the negative control (a same-value edit must not claim a change);
+    // CEE's noop dedup is the backstop, not the mechanism.
+    if (isNaN(parsed) || parsed === inputDisplayValue) return
+    commitValue(parsed)
+  }, [draftValue, inputDisplayValue, commitValue])
+
+  /**
+   * Accept an elicited number — the SAME commit and the SAME wire event as the
+   * typed field, differing only in which SCALE the committed number is in.
+   *
+   * NO SHAPE RE-CHECK HERE, deliberately, and this is a decision rather than an
+   * omission: `canDescribeInWords` is a REACTIVE store selector, so the moment a
+   * factor stops being a chance the whole affordance unmounts and there is no
+   * button left to click (pinned by the reactive-gate test). An accept-time copy
+   * of the predicate would be unreachable — and an unreachable guard that no
+   * mutant can kill is guarantee theatre. The STRUCTURAL refusal lives one layer
+   * down in `buildFactorValueEditEvent`, where it covers every caller.
+   *
+   * The draft sync at the end is NOT cosmetic. The number input was seeded at
+   * mount from the PREVIOUS value and does not re-seed; without this line the
+   * user's next blur on that field would commit the old number straight back
+   * over the value they just accepted.
+   */
+  const acceptElicited = useCallback(
+    (suggestedValue: number): void => {
+      commitValue(suggestedValue, { seedBasis: 'model_scale', writeRawAnchor: true })
+      elicitation.reset()
+      setInWords(false)
+      setPhrase('')
+      setDraftValue(String(suggestedValue))
+    },
+    [commitValue, elicitation],
+  )
 
   // Connections: options that set this + outbound influences
   const setByOptions = useMemo(() => {
@@ -373,7 +474,56 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
             {unit && unit !== '\u00A3' && unit !== '$' && unit !== '\u20AC' && (
               <span className={`${typography.panelMeta} text-text-light`}>{unit}</span>
             )}
+            {/*
+              ON THE VALUE ROW, beside the number rather than replacing it: the
+              two are alternatives, and hiding the direct input behind a mode
+              toggle would make the fast path slower for anyone who already
+              knows their number. HIDDEN, never disabled, when the factor is not
+              a chance \u2014 a disabled control with no explanation is a mystery.
+            */}
+            {canDescribeInWords && (
+              <Tooltip content="Say what you think in plain words" delay={300}>
+                <button
+                  type="button"
+                  aria-label={describeInWordsToggleLabel(String(node.data?.label ?? ''))}
+                  aria-pressed={inWords}
+                  onClick={() => {
+                    setInWords(open => {
+                      if (open) {
+                        setPhrase('')
+                        elicitation.reset()
+                      }
+                      return !open
+                    })
+                  }}
+                  className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-full outline-none transition-colors text-text-light hover:text-text-header hover:bg-panel-hover focus-visible:text-text-header focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40"
+                >
+                  <MessageSquare className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              </Tooltip>
+            )}
           </div>
+
+          {inWords && canDescribeInWords && (
+            <div className="mt-2">
+              <BeliefElicitationField
+                testId="inspector-in-words"
+                label={String(node.data?.label ?? '')}
+                phrase={phrase}
+                onPhraseChange={next => {
+                  setPhrase(next)
+                  elicitation.request(next)
+                }}
+                onEscape={() => {
+                  setInWords(false)
+                  setPhrase('')
+                  elicitation.reset()
+                }}
+                elicitation={elicitation}
+                onAccept={acceptElicited}
+              />
+            </div>
+          )}
           {/* Provenance inline below value (no separate section title) */}
           {source && (
             <div className="flex items-center gap-1 mt-2 pt-2 border-t border-panel-border">


### PR DESCRIPTION
## The decision, and who made it

**Paul's charge (ROADMAP 2.391), and the measurement behind it.** The belief-elicitation
affordance was **pre-analysis-ONLY**. Its single host, `pre-analysis-v3`'s `CalibrateDrillIn`,
**unmounts** on "Analyse first pass" — measured on deployed `1730c6c5` (L55 §10.7) and
reproduced independently by this lane on `33594598`: post-run,
`document.querySelector('[data-testid="pre-analysis-v3"]')` is **null**, zero estimate rows
remain, and no "… in words" affordance survives anywhere in the document.

So the two preconditions were **mutually exclusive in a single session**: a staleness state
needs an analysis to already exist, but running the analysis removed the only entry point to
the elicitation loop. The chain *"elicit in words → Use this → analysis goes stale"* was
therefore **unprovable**, not merely unproven.

**ORCHESTRATOR DECISION — option (a), per Paul: make the affordance reachable post-analysis**,
on the surface the original design already named as its stretch slice
(`design-elicitation-wiring.md` §3 item 2: *"FactorControllablePanel — same choreography
already present at lines 131–205"*). The alternative — leaving it pre-run only — would have
**recorded a lifecycle limitation as a design**. Post-analysis is precisely when a user most
wants to revise a belief: they have just seen what the model concluded.

## This is a MOUNT, not a rebuild

`FactorControllablePanel` already carried the entire choreography, byte-verified at
`33594598` before any code was written:

| inherited | where |
|---|---|
| `buildFactorValueEditEvent` → `captureOptimisticFactorEdit` → `setObservedValue` → `sendSystemEvent` | `FactorControllablePanel.tsx:146,168,174,196` (pre-change line numbers) |
| the shared hook `useBeliefElicitation` — **no new hook logic**, so the A3 stale-response race discipline is inherited, not re-implemented | `hooks/useBeliefElicitation.ts:110-123` |
| the reactive gate `acceptsElicitedBelief`, read as a **boolean** store selector (never a fresh object per render) | `conversation/factorValueEdit.ts:187` |
| the **structural belt** — verified to cover EVERY caller, not just the drill-in: the `model_scale` refusals (`typedValue < 0 \|\| > 1`, `isMagnitudeScaledFactor`) live INSIDE `buildFactorValueEditEvent` before any payload is built, and fail CLOSED | `conversation/factorValueEdit.ts:227-234` |

The commit is the same one event: `factor_value_edit`, probability **verbatim** as `value`,
**no `raw_value` and no `unit`** — the shape CEE's `resolveUserUnitInput` inverts with the
factor's own stored cap.

## The extraction, and why it is in this PR

The field JSX and **every user-facing string** moved to
`src/canvas/components/BeliefElicitationField.tsx`. Two surfaces spelling the same sentences
and re-deciding the same three-way branch (loading / ambiguous / offer) is the
hand-maintained mirror CLAUDE.md trap 12 exists for — and the `needs_clarification`-alone
suppression rule had already cost one adversarial review to get right (#572, minor 7). It
should not have to be remembered twice.

**It is a pure move.** `CalibrateDrillIn`'s state, gate and `acceptElicited` are unchanged,
and its **96 pre-existing tests are the control** — all green. A mutant that stops the
pre-analysis host rendering the shared field takes **11 tests** red (M12), so the extraction
is load-bearing for both hosts, not just the new one.

## One real defect closed on the way

The panel's number input is seeded **once at mount** and never re-seeds. After an accept it
still held the PREVIOUS number, so the user's next blur on that field would have committed it
straight back **over the value they just accepted**. The accept now syncs the draft. Pinned by
its own test; mutant M6 takes it red.

## Honest scope

- **Magnitude rows are still excluded.** The gate is capless-AND-unitless (the #572 A1
  blocker: £40,000 → £0.70). Widening needs the applied `graph_patch`'s `after` values written
  back into node data — **ROADMAP 2.386's receipt-repaint is the widening path**, rowed, not
  hand-waved.
- **Reach is BRIEF-dependent, and the two measurements in the estate disagree until you split
  them by brief.** In the Step-0 witness draft (a £-heavy quantitative brief: ARR, budget,
  spend) **every** factor carried `unit: "£"` and a cap, so the affordance would appear on
  **zero** rows. L54's walk recorded the opposite on a *qualitative* draft — *"5/5 rows carry
  the affordance; capless-unitless is the norm on qualitative drafts"* (`HANDOVER.md`). Both
  are real; they differ by brief, not by build. I first wrote this up as confirming
  `l43-elicitation-build.md` §A1's *"on a typical CEE draft most factors carry a unit"* — that
  over-attributed my own measurement, and §A1's sentence should be narrowed by whoever owns
  it. The Step-2 witness is scripted against a qualitative brief for this reason, and it
  proves the gate precondition from the live store BEFORE claiming anything about the mount.
- **The `staleness-pill` component is not claimed.** The Step-0 witness measured the staleness
  STATE flipping in three places (the panel's own `InlineRerunPrompt`, CEE's narrative
  sentence, and the graph-patch block's "Latest analysis is now out of date."), and
  `[data-testid="staleness-pill"]` was **absent** on that path. Different claims; only the
  first is measured.
- The full deployed witness of the ELICITED accept (as opposed to the typed one) is **owed
  after merge+deploy**, and needs a brief that drafts capless/unitless factors.

## Proof

- **RED-first at pristine `33594598`** (throwaway worktree outside the repo root): **9 failed
  | 4 passed (13)**. The 4 passing are labelled controls; **2 of them pass VACUOUSLY at
  pristine** (nothing is offered anywhere, so "hidden" is trivially true) — the mutation
  battery is what makes them bind after the mount. Disclosed in the spec header.
- **Two vacuities found in my own battery and fixed at source**: the "no `raw_value`"
  assertion did not bind the `model_scale` BASIS (on the walk fixture the DEFAULT basis emits
  an identical payload, so dropping `seedBasis` SURVIVED) — a capless/unitless fixture that
  already carries `raw_value` makes it bite; and nothing pinned the A2 display anchor.
- **13 mutants, ALL BITE.** Throwaway worktree outside the repo root, committed state,
  applied-check scoped to `src/` and asserting **exactly 1**, control **exactly 0** before and
  after, closing control byte-identical to the opening one. Includes gate-drop (3 red),
  wire-drop/2.365 (5 red), delete-mount (10 red), `seedBasis` drop, `writeRawAnchor` drop,
  draft-sync drop, gate-made-non-reactive, elicit-by-label, and the shared field's branch
  rules.
  **One mutant "survived" and was rebuilt, not excused**: it rendered
  `options?.[0]?.value ?? suggested_value`, and on the non-clarification fixture `options` is
  undefined — the mutant evaluated to the original expression. A mutant that cannot change
  behaviour proves nothing. Replaced by two that genuinely differ; both bite.
- **My mutation runner was itself rebuilt mid-battery.** The first (shell) version passed
  multi-line anchors as positional args and summarised vitest with `grep | tail -2`; it
  reported *"Tests 15 passed (15)"* for a mutant that actually produced *"10 failed | 24
  passed (34)"*. Every number above comes from the corrected Python instrument, in one run.
- **Gates, named, at my tip** (`VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported
  throughout — trap 2b; zero collect-time failures):
  - `pnpm run typecheck` (= `bash scripts/ci/typecheck-gate.sh`) — **PASSED**, coverage +
    ratchet. `3207 / 3247` tracked TS files loaded; drift **2502 = baseline 2502** — nothing
    added, nothing absorbed.
  - `npm run ci:guard:zustand` — **PASS** (directly relevant: this PR adds a store selector).
  - `npm run lint:hooks-ratchet` — **PASS**, 234 known violations, exactly the baseline.
  - Regression sweep over `inspector-v2`, `pre-analysis-v3`, `conversation`, `hooks`,
    `components`: **5036 passed | 46 skipped (5082)** across **401** files, zero failures.

## ADDENDUM — the reveal was a practical DEAD END (Codex live; orchestrator fix-now)

**Verified at the bytes, not inherited** — and it is broader than reported. At pin `122b847a`
the toggle's `onClick` is exactly `setInWords(open => {…})` and the revealed input carries no
ref, no `focus()`, no `scrollIntoView()`. **The same is true at my tip on BOTH hosts** (a grep
for `useRef|focus()|scrollIntoView|autoFocus` across the shared field and both hosts returns
one hit — `autoFocus` on the unrelated *description* textarea).

Not cosmetic: on a row near the panel's lower edge the UI appears not to change, focus stays
on the icon, the field is off-screen, and the user types the phrase **into the chat**, where
it does nothing.

**Fixed in the shared `BeliefElicitationField` — one fix, both hosts.** The extraction earning
its keep. Focus happens **on mount, not in a click handler**, so "same behaviour keyboard and
pointer" is a *structural property* rather than a second test someone has to remember;
`scrollIntoView` sits behind the repo's own `typeof … === 'function'` guard
(`InspectorGuidanceSection.tsx:79`); the reveal is announced in a polite live region.

**A regression I caused and fixed at source:** my first live region used `role="status"`, which
made `getByRole('status')` ambiguous (the field already has two conditional ones) and took two
existing `CalibrateDrillIn` tests red. Now `aria-live` **without** the role — the primitive
`role="status"` is sugar for, and better a11y here than three regions claiming one role.

**Proof.** RED at `131b36ff`: `4 failed | 29 passed (33)` — exactly the 4 new pins, failing on
**both** hosts. After: `10 files, 107 passed`. Battery re-run in full at `ec103305`, control
`55 passed (55)`, applied-check exactly 1, control 0 before and after:
**M13 `focus()` dropped → 2 RED (one per host)** · M14 `scrollIntoView` dropped → RED ·
M15 announcement dropped → RED · M1–M12 all still bite.

**⚠ M16 SURVIVED, and I changed the comment rather than the test.** Moving the announcement
into the initial `useState` value left all 55 tests green. The effect exists because a live
region that already holds its text at insertion often is not announced — but **jsdom cannot see
that**, so the suite does not protect it, and the comment claimed otherwise. Rewritten to
separate what is pinned (the separate effect, so a label change cannot steal focus mid-typing)
from what is convention, verifiable only against a real screen reader. M16 stays in the battery
as a disclosed survivor.

**Claim types:** focus-on-reveal is **identity-bound** to that exact input on both hosts ·
`scrollIntoView` is pinned at **CALL level only** — jsdom cannot prove layout (trap 3), so the
**off-screen half of what Codex saw remains browser-only and is not claimed here**.

Gates re-run: typecheck **PASSED** (drift 2502 = baseline) · zustand guard PASS · hooks-ratchet
PASS.

## Base

Branched from `33594598`. **PR #576 (the dependency-only `fast-uri` override bump) merged
underneath this lane mid-session, exactly as the dispatch predicted** — the deployed
`/version.json` caught it before I did. `git diff --stat 1730c6c5 33594598` = `package.json`
+2/−2 and `pnpm-lock.yaml` +6/−5, **zero `src/`**: disjoint by construction, rebased, no
conflict.

Evidence: `PHASE0-EVIDENCE-2026-07-28/l58-post-analysis-elicitation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

