### PR TITLE
fix(canvas,v7): boot hydration drops server values that equal a UI default; a refused merge records the server identity; the all-below empty state overclaims

### DIFF
--- a/src/canvas/hydrate/__tests__/serverGraphHydration.refusal.spec.ts
+++ b/src/canvas/hydrate/__tests__/serverGraphHydration.refusal.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * L61 ITEM 2 (hydration half) — RED-first. A REFUSED MERGE MUST NOT RECORD THE
+ * SERVER'S IDENTITY TOKEN, AND MUST NOT BE REPORTED AS `'merged'`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE DEFECT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `hydrateCanvasFromServer` discarded the merge's return value, stored CEE's
+ * identity token unconditionally, and returned `'merged'` unconditionally — even
+ * when `mergeServerGraphOnHydrate` had REFUSED the graph outright (zero node-id
+ * overlap, an empty server graph, an unusable shape).
+ *
+ * Two consequences, and they are not equally severe — say so rather than
+ * flattening them:
+ *
+ *   1. UNCONDITIONAL, AND PROVEN HERE: the outcome is FALSE. This module exists
+ *      so that "every boot outcome — including the refusals — is measurable
+ *      without mounting React" (its own docstring). A refusal reported as
+ *      `'merged'` breaks exactly that contract, and the hook logs the false
+ *      value as telemetry.
+ *
+ *   2. THE STORED TOKEN IS A CLAIM THAT WE APPLIED THIS GRAPH, and it HAS A
+ *      READER — the `isSameServerGraph` short-circuit at the top of this very
+ *      function, which returns `'unchanged'` without merging. So a refusal
+ *      recorded as an application makes the NEXT read skip a merge that might by
+ *      then succeed (the guard that refused depends on the CANVAS, which moves;
+ *      the token compares only the SERVER, which has not). This is the opposite
+ *      of a write-only column with no readers: the blast radius is not zero.
+ *
+ * ⚠ HONEST NARROWING. `serverGraphIdentity` is in-memory only and is cleared by
+ * `DECISION_CONTEXT_CLEAR`, and `useServerGraphHydration` attempts once per
+ * scenario id — so today the second read is narrowly reachable. The defect being
+ * fixed is the broken INVARIANT and the false outcome, not a demonstrated
+ * currently-firing wrong number. §2 pins the mechanism at this function's own
+ * seam so the guarantee holds however the hook is later wired.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { hydrateCanvasFromServer } from '../serverGraphHydration'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const CEE_TOKEN = 'c'.repeat(63) + '1'
+
+function envelope(value = CEE_TOKEN, projection = 'identity.v1') {
+  return {
+    kind: 'graph_identity_hash',
+    value,
+    algorithm: 'sha256',
+    projection_version: projection,
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+function body(graph: unknown) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph,
+    graph_present: true,
+    brief_text: null,
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'req-l61',
+  }
+}
+
+function jsonResponse(status: number, b: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => b } as unknown as Response
+}
+
+/** A server graph sharing NO node id with the canvas — the structural guard's case. */
+const UNRELATED_GRAPH = {
+  nodes: [
+    { id: 'unrelated-a', kind: 'factor', label: 'Other' },
+    { id: 'unrelated-b', kind: 'goal', label: 'Elsewhere' },
+  ],
+  edges: [],
+}
+
+/** A server graph that DOES overlap — the acceptance control. */
+const OVERLAPPING_GRAPH = {
+  nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+  edges: [],
+}
+
+function seedCanvas(nodes: unknown[]): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: nodes as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function populatedCanvas() {
+  return [
+    { id: 'factor-1', type: 'factor', position: { x: 10, y: 20 }, data: { label: 'Spend', kind: 'factor', value: 100 } },
+    { id: 'goal-1', type: 'goal', position: { x: 300, y: 400 }, data: { label: 'Profit', kind: 'goal', value: 5 } },
+  ]
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+  seedCanvas(populatedCanvas())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §1 A REFUSAL IS NOT A MERGE
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§1 a refused merge reports itself and records nothing', () => {
+  it('ZERO OVERLAP — the outcome is a refusal, never `merged`', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+  })
+
+  it('ZERO OVERLAP — the identity token is NOT recorded', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(useCanvasStore.getState().serverGraphIdentity).toBeNull()
+  })
+
+  it('ZERO OVERLAP — the canvas is untouched, bound by node identity', async () => {
+    const before = useCanvasStore.getState().nodes
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(useCanvasStore.getState().nodes).toBe(before)
+    const factor = useCanvasStore.getState().nodes.find((n: any) => n.id === 'factor-1') as any
+    expect(factor.data.value).toBe(100)
+  })
+
+  it('an EMPTY server graph is a refusal and records no token', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, body({ nodes: [], edges: [] })))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+    expect(useCanvasStore.getState().serverGraphIdentity).toBeNull()
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §2 THE MECHANISM — a refusal must not suppress the NEXT read
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§2 a refusal leaves the next read free to re-attempt', () => {
+  it('⭐ THE LOAD-BEARING PIN — refuse, then a canvas that CAN merge does merge', async () => {
+    // Read 1: the restored canvas shares no id with the server row, so the
+    // structural guard refuses. The server has NOT moved, so its token is
+    // identical on read 2 — the only thing that changed is the CANVAS, which the
+    // token knows nothing about. Recording the token on the refusal made read 2
+    // return `unchanged` and the server's real graph never landed.
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+
+    // ⚠ MOVE ONLY THE CANVAS. `seedCanvas` would also null `serverGraphIdentity`
+    // and that is precisely the state the defect depends on NOT being reset — a
+    // helper that clears the token would make this pin vacuous by construction
+    // (it would pass with the defect fully present). So the nodes are replaced
+    // directly and whatever read 1 recorded is left exactly where it put it.
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'unrelated-a', type: 'factor', position: { x: 5, y: 5 }, data: { label: 'Stale', kind: 'factor' } },
+      ] as never,
+    } as never)
+
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(outcome, 'the same server graph now overlaps and must merge').toBe('merged')
+    const merged = useCanvasStore.getState().nodes.find((n: any) => n.id === 'unrelated-b')
+    expect(merged, 'the server node the first read refused must now be on the canvas').toBeTruthy()
+  })
+
+  it('IDENTITY-BOUND — the token stored after read 1 does not classify read 2 as unchanged', async () => {
+    // Same idea, stated against the token directly: after a refusal there is no
+    // stored token, so `isSameServerGraph` cannot short-circuit read 2.
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(useCanvasStore.getState().serverGraphIdentity).toBeNull()
+
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(UNRELATED_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).not.toBe('unchanged')
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §3 THE ACCEPTANCE PATH IS UNCHANGED
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§3 acceptance behaves exactly as before', () => {
+  it('an overlapping graph merges, records the token and returns `merged`', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(OVERLAPPING_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(useCanvasStore.getState().serverGraphIdentity).toEqual({
+      value: CEE_TOKEN,
+      projectionVersion: 'identity.v1',
+    })
+    const factor = useCanvasStore.getState().nodes.find((n: any) => n.id === 'factor-1') as any
+    expect(factor.data.value).toBe(250)
+  })
+
+  it('AN IDEMPOTENT ACCEPTED MERGE STILL RECORDS THE TOKEN', async () => {
+    // ⭐ The anti-overcorrection pin. Gating the token on `changed` instead of on
+    // `accepted` would ALSO make §1 green while breaking the common boot — the
+    // one where the server matches the canvas — into a permanent re-merge. The
+    // gate is ACCEPTANCE, not movement.
+    seedCanvas([
+      { id: 'factor-1', type: 'factor', position: { x: 10, y: 20 }, data: { label: 'Spend', kind: 'factor', value: 250 } },
+    ])
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(OVERLAPPING_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(useCanvasStore.getState().serverGraphIdentity?.value).toBe(CEE_TOKEN)
+  })
+
+  it('an accepted merge still short-circuits the NEXT identical read', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, body(OVERLAPPING_GRAPH)))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('unchanged')
+  })
+})

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -29,6 +29,13 @@ export type HydrationOutcome =
   | 'unchanged'
   /** 200 with no graph yet — a normal empty scenario. Canvas untouched. */
   | 'absent'
+  /**
+   * A graph arrived and the MERGE refused it — unusable shape, an empty server
+   * graph, or zero node-id overlap with a non-empty canvas. Canvas untouched and
+   * NO identity token recorded, so the next read re-attempts. Distinct from
+   * `'refused'`, which is a TRANSPORT refusal (401/403/429).
+   */
+  | 'mergeRefused'
   /** 404 — not readable. NEVER deletion. Canvas untouched. */
   | 'notReadable'
   /** 503 through every attempt. Canvas untouched. */
@@ -137,7 +144,43 @@ export async function hydrateCanvasFromServer(
     return 'unchanged'
   }
 
-  mergeServerGraphOnHydrate(result.graph)
+  const merge = mergeServerGraphOnHydrate(result.graph)
+
+  // ── A REFUSED MERGE IS NOT A MERGE, AND MUST NOT BE RECORDED AS ONE (L61) ──
+  //
+  // `mergeServerGraphOnHydrate` refuses on an unusable shape, an empty server
+  // graph, and — the load-bearing one — zero node-id overlap with a non-empty
+  // canvas. Every refusal used to return the same all-zero counts an idempotent
+  // merge returns, this function discarded the return value entirely, and both
+  // the identity token and the `'merged'` outcome were recorded unconditionally.
+  //
+  // Two things were wrong with that, and they are not equally severe:
+  //
+  //   1. THE OUTCOME WAS FALSE, always. This module exists so that every boot
+  //      outcome INCLUDING THE REFUSALS is measurable without mounting React
+  //      (see the header). A refusal reported as `'merged'` breaks exactly that,
+  //      and `useServerGraphHydration` logs the false value as telemetry.
+  //
+  //   2. THE TOKEN IS A CLAIM THAT WE APPLIED THIS GRAPH, and it has a READER —
+  //      the `isSameServerGraph` short-circuit above, which returns `'unchanged'`
+  //      WITHOUT merging. The zero-overlap guard's verdict depends on the CANVAS,
+  //      which moves; the token compares only the SERVER, which has not. So a
+  //      refusal recorded as an application can suppress a later merge that
+  //      would by then succeed. (Narrow today: the token is in-memory only, is
+  //      cleared by `DECISION_CONTEXT_CLEAR`, and the hook attempts once per
+  //      scenario id. The invariant is fixed here regardless of that wiring —
+  //      a guarantee that depends on a caller's current shape is not one.)
+  //
+  // Gated on `accepted`, NEVER on `changed`: an idempotent boot — the server
+  // matched the canvas — is the most common accepted case, and gating on
+  // movement would turn it into a permanent re-merge.
+  if (!merge.accepted) {
+    logger.warn('server_graph_hydration.merge_refused', {
+      scenarioId,
+      reason: merge.refusedReason,
+    })
+    return 'mergeRefused'
+  }
 
   // Store CEE's token VERBATIM — after the merge, so a throw could not leave a
   // token recorded for a graph that was never applied. `null` when CEE issued

--- a/src/canvas/utils/__tests__/mergeServerGraph.acceptance.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.acceptance.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * L61 ITEM 2 (merge half) — RED-first. A REFUSAL MUST BE DISTINGUISHABLE FROM
+ * AN IDEMPOTENT MERGE.
+ *
+ * `mergeServerGraphOnHydrate` has three refusal exits — unusable shape, an empty
+ * server graph, and the zero-node-id-overlap structural guard — and every one of
+ * them returned the SAME all-zero counts an ACCEPTED-but-idempotent merge
+ * returns. The caller therefore could not tell "I read the server's graph and it
+ * matched" from "I refused to look at it", and went on to record CEE's identity
+ * token for a graph it had just thrown away.
+ *
+ * The decision this pins: `accepted` is TRUE exactly when the merge reached the
+ * body that records `lastAuthoritativeGraph` and writes. That is a STRUCTURAL
+ * definition, not a second flag someone has to remember to set — the two identity
+ * records (`lastAuthoritativeGraph` here, `serverGraphIdentity` in the hydration
+ * caller) now answer to ONE rule instead of drifting apart.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+function seed(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      { id: 'factor-1', type: 'factor', position: { x: 10, y: 20 }, data: { label: 'Spend', kind: 'factor', value: 100 } },
+      { id: 'goal-1', type: 'goal', position: { x: 300, y: 400 }, data: { label: 'Profit', kind: 'goal', value: 5 } },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+beforeEach(seed)
+
+describe('§1 the three refusals report themselves', () => {
+  it('ZERO OVERLAP is a refusal, not an idempotent merge', () => {
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'unrelated-a', kind: 'factor', label: 'Other' },
+        { id: 'unrelated-b', kind: 'goal', label: 'Elsewhere' },
+      ],
+      edges: [],
+    })
+    expect(res.accepted).toBe(false)
+    expect(res.refusedReason).toBe('zeroOverlap')
+    expect(res.changed).toBe(false)
+  })
+
+  it('an EMPTY server graph is a refusal — nothing was observed', () => {
+    const res = mergeServerGraphOnHydrate({ nodes: [], edges: [] })
+    expect(res.accepted).toBe(false)
+    expect(res.refusedReason).toBe('emptyServerGraph')
+  })
+
+  it('an UNUSABLE shape is a refusal', () => {
+    expect(mergeServerGraphOnHydrate(null).accepted).toBe(false)
+    expect(mergeServerGraphOnHydrate(null).refusedReason).toBe('unusableShape')
+    expect(mergeServerGraphOnHydrate('not a graph').refusedReason).toBe('unusableShape')
+  })
+})
+
+describe('§2 acceptance is reported for BOTH a changing and an idempotent merge', () => {
+  it('a merge that MOVED a value is accepted AND changed', () => {
+    const res = mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(res.accepted).toBe(true)
+    expect(res.refusedReason).toBeNull()
+    expect(res.changed).toBe(true)
+    expect(res.updatedNodeCount).toBe(1)
+  })
+
+  it('THE DISCRIMINATING CASE — an IDEMPOTENT merge is accepted but NOT changed', () => {
+    // ⭐ This is the case the old all-zero return conflated with a refusal, and
+    // it is the reason `changed` cannot simply be read off the counts by the
+    // caller: "nothing moved" and "I refused to look" are different facts and
+    // only one of them licenses recording an identity token.
+    const res = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+      ],
+      edges: [],
+    })
+    expect(res.accepted, 'the server graph WAS read and it matched').toBe(true)
+    expect(res.changed).toBe(false)
+    expect(res.updatedNodeCount).toBe(0)
+    expect(res.addedNodeCount).toBe(0)
+  })
+})
+
+describe('§3 `accepted` agrees with the OTHER identity record — one rule, not two', () => {
+  it('accepted ⇒ lastAuthoritativeGraph recorded', () => {
+    const res = mergeServerGraphOnHydrate({
+      nodes: [{ id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 }],
+      edges: [],
+    })
+    expect(res.accepted).toBe(true)
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).not.toBeNull()
+  })
+
+  it.each([
+    ['zeroOverlap', { nodes: [{ id: 'unrelated-a', kind: 'factor', label: 'X' }], edges: [] }],
+    ['emptyServerGraph', { nodes: [], edges: [] }],
+    ['unusableShape', null as unknown],
+  ])('refused (%s) ⇒ lastAuthoritativeGraph NOT recorded', (_reason, graph) => {
+    const res = mergeServerGraphOnHydrate(graph)
+    expect(res.accepted).toBe(false)
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+  })
+})

--- a/src/canvas/utils/__tests__/mergeServerGraph.edgePresence.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.edgePresence.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * L61 ITEM 1 — RED-first. BOOT HYDRATION MUST APPLY A SERVER EDGE VALUE THAT
+ * HAPPENS TO EQUAL A UI DEFAULT.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE DEFECT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `overlayEdge` decided "the wire supplied this field" by comparing the mapped
+ * edge against a SYNTHETIC DEFAULT edge (`mapDraftEdgeToCanvas({from,to})`) and
+ * dropping every key that matched. `DEFAULT_EDGE_DATA.weight` is `0.5`, so a
+ * server edge carrying `strength.mean: 0.5` mapped to `weight: 0.5`, compared
+ * equal to the synthetic default, and was discarded — leaving the user's local
+ * `0.7` on screen while the NEXT analysis is computed from the server's `0.5`.
+ *
+ * That is a screen-vs-compute divergence: the number the user is looking at is
+ * not the number the recommendation came from. Under-application is a defensible
+ * default on the RECEIPT path (a receipt is an echo of an edit the user just
+ * made). At BOOT it is not: the server row IS what the next turn rebases from.
+ *
+ * The same shape hits `direction` — the synthetic baseline's direction is
+ * `'positive'` (derived from the default weight `0.5 >= 0`), so an EXPLICIT
+ * server `effect_direction: 'positive'` was dropped and a local `'negative'`
+ * survived. A sign is not a rounding difference.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE FIX THIS SPEC PINS — presence, not equality, and DERIVED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `mapDraftEdgeToCanvas` ALREADY proves which fields the wire carried, for
+ * exactly the fields that matter. It derives `wireSuppliedStrength` from the
+ * same three probes its priority chain uses and hands it to
+ * `edgeValueSourcePatch`, which OMITS any key it cannot justify. So:
+ *
+ *     `weightSource` present on the mapped edge  ⟺  the wire carried a strength
+ *
+ * The hydrate path therefore reads presence off the mapper's own stamps rather
+ * than inferring it from default-equality. Nothing is hand-listed: the field set
+ * is `EDGE_PROVENANCED_FIELDS` and the stamp key is `edgeSourceKey(field)`.
+ *
+ * ⚠ AND BECAUSE DERIVATION CANNOT PROVE COMPLETENESS (the second face of the
+ * mirror trap), §4 below is a HAND-WRITTEN corpus + a union assertion. A guard
+ * derived from the registry proves the consumers agree with the registry; only a
+ * corpus notices the registry is SHORT. Both are shipped, neither supersedes the
+ * other.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+import { overlayEdge } from '../mergeAppliedGraph'
+import { mapDraftEdgeToCanvas } from '../applyDraftResult'
+import {
+  EDGE_PROVENANCED_FIELDS,
+  edgeSourceKey,
+  type EdgeProvenancedField,
+} from '../../domain/edgeValueProvenance'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+/** The synthetic baseline the OLD detection compared against. Derived here the
+ *  same way the implementation derives it, so this spec cannot drift from it. */
+function mapperBaseline(): Record<string, unknown> {
+  return (mapDraftEdgeToCanvas({ from: '__b_src__', to: '__b_tgt__' }, 0).data ??
+    {}) as Record<string, unknown>
+}
+
+function seedGraph(edgeData: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      { id: 'factor-1', type: 'factor', position: { x: 10, y: 20 }, data: { label: 'Spend', kind: 'factor' } },
+      { id: 'goal-1', type: 'goal', position: { x: 300, y: 400 }, data: { label: 'Profit', kind: 'goal' } },
+    ] as never,
+    edges: [
+      {
+        id: 'local-edge-1',
+        source: 'factor-1',
+        target: 'goal-1',
+        type: 'styled',
+        data: { ...edgeData },
+      },
+    ] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+/** Identity-bound: the edge is found by its OWN id, never by a value predicate
+ *  (a value predicate is how a spec ends up passing on a different object). */
+function theEdge(): any {
+  const e = useCanvasStore.getState().edges.find((x: any) => x.id === 'local-edge-1')
+  expect(e, 'the fixture edge must still exist, bound by id').toBeTruthy()
+  return e
+}
+
+const NODES = [
+  { id: 'factor-1', kind: 'factor', label: 'Spend' },
+  { id: 'goal-1', kind: 'goal', label: 'Profit' },
+]
+
+beforeEach(() => {
+  seedGraph({ weight: 0.7, direction: 'negative' })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §1 THE TWO REACHABLE COLLISIONS
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§1 a server edge value that equals a UI default still lands at boot', () => {
+  it('THE HEADLINE PIN — server strength.mean 0.5 overwrites the local weight 0.7', () => {
+    // 0.5 is DEFAULT_EDGE_DATA.weight. Asserted here rather than assumed, so
+    // this pin cannot quietly stop testing the collision if the default moves.
+    expect(mapperBaseline().weight, 'fixture must actually collide with the default').toBe(0.5)
+
+    const res = mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.5 } }],
+    })
+
+    expect(theEdge().data.weight).toBe(0.5)
+    expect(res.updatedEdgeCount).toBe(1)
+  })
+
+  it('the flat `strength_mean` spelling collides identically and lands', () => {
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength_mean: 0.5 }],
+    })
+    expect(theEdge().data.weight).toBe(0.5)
+  })
+
+  it('the bare `weight` spelling collides identically and lands', () => {
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', weight: 0.5 }],
+    })
+    expect(theEdge().data.weight).toBe(0.5)
+  })
+
+  it('THE SIGN PIN — an EXPLICIT server default-positive direction overwrites a local negative', () => {
+    expect(mapperBaseline().direction, 'fixture must actually collide with the default').toBe(
+      'positive',
+    )
+
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [
+        { from: 'factor-1', to: 'goal-1', strength: { mean: 0.9 }, effect_direction: 'positive' },
+      ],
+    })
+    expect(theEdge().data.direction).toBe('positive')
+  })
+
+  it('the provenance stamp rides with the value it describes, never alone', () => {
+    // #570 A1 semantics: a `*Source` stamp must not outlive or precede its value.
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.5 } }],
+    })
+    const data = theEdge().data
+    expect(data.weight).toBe(0.5)
+    expect(data.weightSource).toBe('cee')
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §2 WHAT MUST NOT CHANGE
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§2 the no-op and no-overwrite guarantees survive the fix', () => {
+  it('a server value EQUAL to the local value is still a STRICT no-op', () => {
+    seedGraph({ weight: 0.5, direction: 'positive' })
+    const before = useCanvasStore.getState().edges
+    const res = mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.5 } }],
+    })
+    expect(res.updatedEdgeCount).toBe(0)
+    expect(useCanvasStore.getState().edges).toBe(before)
+  })
+
+  it('a field the wire did NOT carry keeps its local value', () => {
+    // The wire carries a strength and nothing else — the local direction and a
+    // local-only key must both survive. "Server wins" is per-FIELD, not wholesale.
+    seedGraph({ weight: 0.7, direction: 'negative', userReviewedStrength: true, curvature: 0.9 })
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.5 } }],
+    })
+    const data = theEdge().data
+    expect(data.weight).toBe(0.5)
+    expect(data.direction, 'wire stated no direction — local sign survives').toBe('negative')
+    expect(data.curvature, 'a local-only field the wire never mentions survives').toBe(0.9)
+  })
+
+  it('layout/root fields and the edge id survive the overlay', () => {
+    mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.5 } }],
+    })
+    const e = theEdge()
+    expect(e.id).toBe('local-edge-1')
+    expect(e.source).toBe('factor-1')
+    expect(e.target).toBe('goal-1')
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §3 RECEIPT-PATH PARITY — the change is SCOPED
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§3 the RECEIPT path is byte-unchanged', () => {
+  it('overlayEdge with NO options still under-applies a default-equal value', () => {
+    // The receipt path's declared, accepted under-application (mergeAppliedGraph
+    // :177-179). If this flips, the change leaked out of the hydrate path and
+    // the #570 provenance semantics are no longer the ones that were reviewed.
+    const existing = { id: 'e1', source: 'a', target: 'b', data: { weight: 0.7 } }
+    const next = overlayEdge(existing, { from: 'a', to: 'b', strength: { mean: 0.5 } })
+    expect(next, 'default-equal weight is not "supplied" on the receipt path').toBe(existing)
+    expect(next.data.weight).toBe(0.7)
+  })
+
+  it('overlayEdge with NO options still drops an explicit default-positive direction', () => {
+    const existing = { id: 'e1', source: 'a', target: 'b', data: { direction: 'negative' } }
+    const next = overlayEdge(existing, {
+      from: 'a',
+      to: 'b',
+      strength: { mean: 0.5 },
+      effect_direction: 'positive',
+    })
+    expect(next).toBe(existing)
+    expect(next.data.direction).toBe('negative')
+  })
+
+  it('overlayEdge with NO options still applies a value that DIFFERS from the default', () => {
+    // Positive control: the receipt path is not simply inert.
+    const existing = { id: 'e1', source: 'a', target: 'b', data: { weight: 0.7 } }
+    const next = overlayEdge(existing, { from: 'a', to: 'b', strength: { mean: 0.91 } })
+    expect(next).not.toBe(existing)
+    expect(next.data.weight).toBe(0.91)
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §4 COMPLETENESS — a derived guard AND a hand-written corpus
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * HAND-WRITTEN, ON PURPOSE. The wire spelling that supplies each provenanced
+ * field cannot be derived from the registry — the registry names canvas fields,
+ * not wire fields. This is the corpus half: it is what would notice that the
+ * registry is SHORT of a field the wire actually carries.
+ */
+const WIRE_SPELLING_FOR_FIELD: Record<EdgeProvenancedField, Record<string, unknown>> = {
+  weight: { strength: { mean: 0.5 } },
+  direction: { effect_direction: 'positive' },
+  beliefExists: { belief_exists: 0.8 },
+  strengthStd: { strength: { mean: 0.42, std: 0.25 } },
+}
+
+describe('§4 completeness — derived agreement AND a corpus that can notice a short list', () => {
+  it('UNION ASSERTION — the corpus covers EXACTLY the provenanced registry', () => {
+    // Adding a field to EDGE_PROVENANCED_FIELDS without a corpus entry RED-fails
+    // here, instead of silently going untested. This is the assertion that makes
+    // the derived guard below non-vacuous.
+    expect(Object.keys(WIRE_SPELLING_FOR_FIELD).sort()).toEqual(
+      [...EDGE_PROVENANCED_FIELDS].sort(),
+    )
+  })
+
+  it.each([...EDGE_PROVENANCED_FIELDS])(
+    'DERIVED — a wire-supplied `%s` lands at boot regardless of default-equality',
+    (field) => {
+      seedGraph({ weight: 0.7, direction: 'negative', beliefExists: 0.1, strengthStd: 0.99 })
+      const wireEdge = { from: 'factor-1', to: 'goal-1', ...WIRE_SPELLING_FOR_FIELD[field] }
+
+      // What the mapper says the wire carried — the fix's own input.
+      const mapped = mapDraftEdgeToCanvas(wireEdge, 0).data as Record<string, unknown>
+      expect(
+        edgeSourceKey(field) in mapped,
+        `corpus entry for ${field} must actually make the mapper stamp it`,
+      ).toBe(true)
+
+      mergeServerGraphOnHydrate({ nodes: NODES, edges: [wireEdge] })
+      expect(theEdge().data[field]).toEqual(mapped[field])
+    },
+  )
+
+  it('CORPUS — every mapper-baseline key with a real default is either presence-covered or reviewed', () => {
+    // ⚠ THIS IS THE GUARD THAT NOTICES THE REGISTRY IS SHORT.
+    //
+    // The presence rule covers the PROVENANCED fields. Any OTHER key the mapper
+    // always emits with a non-undefined default is still detected by equality,
+    // and so is still droppable if the wire ever starts supplying it. That set
+    // is enumerated here BY HAND and reviewed; a new always-emitted defaulted
+    // mapper field makes this RED rather than silently joining the blind spot.
+    const presenceCovered = new Set<string>(EDGE_PROVENANCED_FIELDS)
+    const stillEqualityDetected = Object.entries(mapperBaseline())
+      .filter(([k, v]) => v !== undefined && !presenceCovered.has(k))
+      .map(([k]) => k)
+      .sort()
+
+    expect(stillEqualityDetected).toEqual(
+      [
+        // None of these is settable from a CEE wire edge by `mapDraftEdgeToCanvas`
+        // — they arrive only via the `...DEFAULT_EDGE_DATA` spread or a literal.
+        // Reviewed 2026-08-04 (L61). If this list grows, check whether the new
+        // field CAN come off the wire before adding it.
+        'beliefStrength',
+        'curvature',
+        'functionType',
+        'kind',
+        'pathType',
+        'schemaVersion',
+        'style',
+      ].sort(),
+    )
+  })
+})

--- a/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.spec.ts
@@ -185,6 +185,13 @@ describe('mergeServerGraphOnHydrate — honest absence', () => {
   it('an EMPTY server graph is a strict no-op — the canvas stands untouched', () => {
     const before = useCanvasStore.getState().nodes
     const res = mergeServerGraphOnHydrate({ nodes: [], edges: [] })
+    // ⚠ EXHAUSTIVE ON PURPOSE — kept `toEqual`, not relaxed to `toMatchObject`.
+    // This assertion is what caught L61's decision fields being added, and that
+    // is the behaviour we want: a new field on this result reaches a caller that
+    // may act on it, so it should have to be declared here rather than arriving
+    // silently. `accepted: false` is the L61 addition — an empty server graph is
+    // a REFUSAL (nothing was observed), which is the same rule that already
+    // governs `lastAuthoritativeGraph` on the line below.
     expect(res).toEqual({
       addedNodeCount: 0,
       addedEdgeCount: 0,
@@ -192,6 +199,9 @@ describe('mergeServerGraphOnHydrate — honest absence', () => {
       updatedEdgeCount: 0,
       removedNodeCount: 0,
       removedEdgeCount: 0,
+      accepted: false,
+      refusedReason: 'emptyServerGraph',
+      changed: false,
     })
     expect(useCanvasStore.getState().nodes).toBe(before)
     expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -275,6 +275,17 @@ export function overlayNode(existing: any, wireNode: any): any {
   return { ...existing, type: nextType, data: nextData }
 }
 
+export interface OverlayEdgeOptions {
+  /**
+   * Determine "the wire supplied this field" from the mapper's PROVENANCE
+   * STAMPS rather than from "the mapped value differs from the mapper default".
+   *
+   * OFF by default, so the RECEIPT path is byte-unchanged. Boot hydration turns
+   * it ON — see the block below for why the two paths differ.
+   */
+  presenceFromProvenanceStamps?: boolean
+}
+
 /**
  * Overlay a wire edge's analytical fields onto an existing canvas edge.
  * Returns the SAME reference when nothing changed.
@@ -283,8 +294,50 @@ export function overlayNode(existing: any, wireNode: any): any {
  * applied — see EDGE_MAPPER_DEFAULTS. Without that filter every receipt would
  * splat DEFAULT_EDGE_DATA over locally-tuned edges and churn history on every
  * turn.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠ EQUALITY-WITH-DEFAULT IS NOT PRESENCE, AND AT BOOT THAT COSTS A NUMBER (L61)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `DEFAULT_EDGE_DATA.weight` is `0.5`. So a server edge carrying
+ * `strength.mean: 0.5` maps to `weight: 0.5`, compares EQUAL to the synthetic
+ * baseline, and is discarded as "not supplied" — leaving a local `0.7` on screen
+ * while the next analysis is computed from the server's `0.5`. The synthetic
+ * baseline's `direction` is `'positive'` for the same reason (default weight
+ * `0.5 >= 0`), so an EXPLICIT server `effect_direction: 'positive'` is dropped
+ * and a local `'negative'` survives — a SIGN, not a rounding difference.
+ *
+ * Those are the only two reachable collisions: `beliefExists` resolves to
+ * `undefined` in the baseline (the explicit assignment overrides the
+ * `DEFAULT_EDGE_DATA` spread) and `strengthStd` is omitted, so both already
+ * differ from anything the wire sends.
+ *
+ * On the RECEIPT path the under-application is defensible and stays: a receipt
+ * echoes an edit the user just made, and over-applying defaults across every
+ * turn is the worse failure. At BOOT it is not defensible — the server row IS
+ * what the next turn rebases from, so a dropped value is screen-vs-compute
+ * divergence.
+ *
+ * THE FIX IS DERIVED, NOT A SECOND LIST. `mapDraftEdgeToCanvas` already proves
+ * which fields the wire carried: it computes `wireSuppliedStrength` from the
+ * same three probes its priority chain uses and passes it to
+ * `edgeValueSourcePatch`, which OMITS any stamp it cannot justify. Hence
+ * `weightSource` present on the mapped edge ⟺ the wire carried a strength. The
+ * field set is `EDGE_PROVENANCED_FIELDS`; the stamp key is `edgeSourceKey`.
+ *
+ * ⚠ WHAT THIS DOES NOT FIX, NAMED RATHER THAN GLOSSED. Presence is only
+ * recoverable for the PROVENANCED fields. Any other key the mapper always emits
+ * with a non-undefined default is still equality-detected, and would still be
+ * dropped if the wire ever started supplying it at exactly the default. That set
+ * is enumerated and reviewed in a corpus assertion in
+ * `mergeServerGraph.edgePresence.spec.ts` §4, which goes RED when it grows —
+ * because a guard derived from a registry can prove its consumers agree with the
+ * registry and can never prove the registry is complete.
  */
-export function overlayEdge(existing: any, wireEdge: any): any {
+export function overlayEdge(
+  existing: any,
+  wireEdge: any,
+  opts?: OverlayEdgeOptions,
+): any {
   const mapped = mapDraftEdgeToCanvas(wireEdge, 0)
   const mappedData = (mapped.data ?? {}) as Record<string, unknown>
 
@@ -292,6 +345,17 @@ export function overlayEdge(existing: any, wireEdge: any): any {
   const supplied: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(mappedData)) {
     if (!sameValue(v, defaults[k])) supplied[k] = v
+  }
+
+  // Presence beats equality on the paths that ask for it. Runs BEFORE the stamp
+  // coupling below, so a value promoted here keeps its own stamp rather than
+  // having it stripped as orphaned.
+  if (opts?.presenceFromProvenanceStamps) {
+    for (const field of EDGE_PROVENANCED_FIELDS) {
+      if (edgeSourceKey(field) in mappedData && field in mappedData) {
+        supplied[field] = mappedData[field]
+      }
+    }
   }
 
   // A provenance stamp must never outlive or precede the value it describes.

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -87,6 +87,18 @@ function deepEqual(a: unknown, b: unknown): boolean {
   }
 }
 
+/**
+ * Why a merge REFUSED the server's graph. Each value corresponds to one guard
+ * below; `null` on the accepted path.
+ */
+export type MergeServerGraphRefusal =
+  /** Not an object — nothing that could be a graph arrived. */
+  | 'unusableShape'
+  /** An object with no nodes AND no edges. Nothing was observed. */
+  | 'emptyServerGraph'
+  /** Zero node-id overlap with a non-empty canvas — two unrelated graphs. */
+  | 'zeroOverlap'
+
 export interface MergeServerGraphResult {
   addedNodeCount: number
   addedEdgeCount: number
@@ -99,9 +111,32 @@ export interface MergeServerGraphResult {
    */
   removedNodeCount: number
   removedEdgeCount: number
+  /**
+   * ⚠ WHETHER THE SERVER'S GRAPH WAS READ AT ALL — NOT WHETHER IT MOVED ANYTHING.
+   *
+   * Every refusal below used to return the SAME all-zero counts an ACCEPTED but
+   * idempotent merge returns, so the caller could not distinguish "I read the
+   * server's graph and it already matched" from "I refused to look at it". The
+   * hydration caller then recorded CEE's identity token — a claim that we have
+   * APPLIED that graph — on graphs it had just thrown away.
+   *
+   * The definition is STRUCTURAL, not a flag someone must remember to set:
+   * `accepted` is true exactly when control reaches the body that records
+   * `lastAuthoritativeGraph`. The two identity records therefore answer to ONE
+   * rule and cannot drift apart.
+   */
+  accepted: boolean
+  /** The guard that refused. `null` when `accepted`. */
+  refusedReason: MergeServerGraphRefusal | null
+  /**
+   * Whether the store was actually written. Distinct from `accepted`: an
+   * idempotent boot is `accepted: true, changed: false`, and that combination is
+   * exactly the case a caller must NOT treat as a refusal.
+   */
+  changed: boolean
 }
 
-const NO_CHANGE: MergeServerGraphResult = Object.freeze({
+const NO_CHANGE = Object.freeze({
   addedNodeCount: 0,
   addedEdgeCount: 0,
   updatedNodeCount: 0,
@@ -110,8 +145,8 @@ const NO_CHANGE: MergeServerGraphResult = Object.freeze({
   removedEdgeCount: 0,
 })
 
-function noChange(): MergeServerGraphResult {
-  return { ...NO_CHANGE }
+function refused(reason: MergeServerGraphRefusal): MergeServerGraphResult {
+  return { ...NO_CHANGE, accepted: false, refusedReason: reason, changed: false }
 }
 
 /**
@@ -125,7 +160,7 @@ function noChange(): MergeServerGraphResult {
 export function mergeServerGraphOnHydrate(
   serverGraph: unknown,
 ): MergeServerGraphResult {
-  if (serverGraph === null || typeof serverGraph !== 'object') return noChange()
+  if (serverGraph === null || typeof serverGraph !== 'object') return refused('unusableShape')
 
   const g = serverGraph as Record<string, unknown>
   const rawNodes: any[] = Array.isArray(g.nodes) ? g.nodes : []
@@ -134,7 +169,7 @@ export function mergeServerGraphOnHydrate(
   // Honest absence: nothing to merge, so nothing is written and no identity is
   // recorded. A server graph with no elements must not authorise later
   // deletions either.
-  if (rawNodes.length === 0 && rawEdges.length === 0) return noChange()
+  if (rawNodes.length === 0 && rawEdges.length === 0) return refused('emptyServerGraph')
 
   const store = useCanvasStore.getState()
   const existingNodeIds = new Set(store.nodes.map((n: any) => n.id))
@@ -157,7 +192,7 @@ export function mergeServerGraphOnHydrate(
         canvasNodeCount: store.nodes.length,
         serverNodeCount: rawNodes.length,
       })
-      return noChange()
+      return refused('zeroOverlap')
     }
   }
 
@@ -218,7 +253,15 @@ export function mergeServerGraphOnHydrate(
     const serverEdge = key ? serverEdgeByPair.get(key) : undefined
     if (!serverEdge) return e
 
-    const overlaid = overlayEdge(e, serverEdge)
+    // ⚠ PRESENCE, NOT EQUALITY-WITH-DEFAULT (L61). The receipt path infers "the
+    // wire supplied this" from "it differs from the mapper's default edge",
+    // which silently drops a server `strength.mean: 0.5` (== the default weight)
+    // and an explicit default-positive `effect_direction`. That under-
+    // application is fine for a receipt and wrong at boot: the server row is
+    // what the NEXT analysis rebases from, so a dropped value leaves the screen
+    // and the compute disagreeing. The mapper's own provenance stamps prove what
+    // the wire carried — see `overlayEdge`.
+    const overlaid = overlayEdge(e, serverEdge, { presenceFromProvenanceStamps: true })
     if (overlaid === e) return e
 
     // `userReviewedStrength` is UI-only and never on the wire, so the overlay
@@ -286,6 +329,10 @@ export function mergeServerGraphOnHydrate(
     return { ...mapped, id }
   })
 
+  // Past every guard: the server's graph WAS read. That is what `accepted`
+  // means, and it is the same fact that licenses the `setLastAuthoritativeGraph`
+  // record twelve lines below — one rule, asserted in
+  // `mergeServerGraph.acceptance.spec.ts` §3 so the two cannot drift apart.
   const result: MergeServerGraphResult = {
     addedNodeCount: addedNodes.length,
     addedEdgeCount: addedEdges.length,
@@ -294,6 +341,9 @@ export function mergeServerGraphOnHydrate(
     // Structural, not incidental: this path has no removal branch at all.
     removedNodeCount: 0,
     removedEdgeCount: 0,
+    accepted: true,
+    refusedReason: null,
+    changed: false, // set below, once the counts are known
   }
 
   // The server graph IS CEE's view of this scenario, so everything in it is an
@@ -319,7 +369,13 @@ export function mergeServerGraphOnHydrate(
     result.addedEdgeCount > 0 ||
     result.updatedNodeCount > 0 ||
     result.updatedEdgeCount > 0
+  result.changed = changed
 
+  // ⚠ ACCEPTED, NOT CHANGED. This early return is an IDEMPOTENT boot — the
+  // server's graph was read and it already matched — and it must stay
+  // distinguishable from the refusals above, because it is the ONE case that
+  // both looks like a refusal in the counters and legitimately licenses
+  // recording an identity token.
   if (!changed) return result
 
   // ── A PRE-MERGE SNAPSHOT, WHENEVER AN EXISTING VALUE MOVES (review A3) ─────

--- a/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
+++ b/src/components/results/v7/__tests__/V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx
@@ -28,9 +28,14 @@
  *
  * THE HONESTY BOUNDARY THIS SUITE POLICES (both directions — trap 13)
  * ──────────────────────────────────────────────────────────────────
- * The empty state is a CLAIM: it says the analysis assessed the unknowns and
- * none of them would change the recommendation. That claim is only true when the
- * rows ARRIVED. So:
+ * The empty state is a CLAIM: it says the analysis ASSESSED the unknowns and
+ * this run could not tell them apart. That claim is only true when the rows
+ * ARRIVED. So:
+ *
+ * (⚠ This paragraph used to say the sentence claimed "none of them would change
+ * the recommendation" — which is what the sentence then said, and what L61
+ * removed as an overclaim: below-resolution licenses CANNOT-RANK, never
+ * NO-EFFECT. §5 now pins that distinction.)
  *
  *   · rows arrived, none resolved  → the sentence renders          (§1, §2)
  *   · `factor_evppi` ABSENT        → the sentence must NOT render, the
@@ -374,5 +379,102 @@ describe('§4 NEGATIVE CONTROL — a resolved row present means there IS somethi
     expect(resolveNext!.resolved.map((r) => r.factorId)).toEqual([first.factor_id])
     expect(screen.queryByTestId('v7-resolve-next-none-above-resolution')).toBeNull()
     expect(text).not.toContain(E.resolveNextNoneAboveResolution)
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * §5 THE CLAIM ITSELF — L61, and this section is the one that was missing
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('§5 the empty state states CANNOT-RANK, never NO-EFFECT', () => {
+  /**
+   * ⚠ WHY THIS SECTION EXISTS AT ALL.
+   *
+   * Every pin in §1–§4 binds the SYMBOL `E.resolveNextNoneAboveResolution` and
+   * never its words — deliberately, so re-wording is not a test rewrite. The
+   * cost of that choice is that the WORDING had no guard whatsoever, and one
+   * shipped that overclaimed: *"at this precision, no single unknown would
+   * change the recommendation"*. That sentence asserts EVIDENCE OF NO EFFECT.
+   *
+   * Below-resolution licenses no such thing. It means the estimator could not
+   * distinguish these factors from noise AT THIS RUN'S RESOLUTION — a statement
+   * about the RUN'S PRECISION, not about the factors' influence. "None of them
+   * would change the recommendation" is a conclusion the estimator did not
+   * establish and cannot, from rows it could not resolve. The file's own
+   * doctrine says so (`v7LensCopy.ts`: below-resolution "NEVER 'zero value' and
+   * never 'not worth resolving'"), and the SIBLING line on the same surface,
+   * `resolveNextBelow`, already speaks the honest register — so the empty state
+   * was contradicting the line directly beneath it.
+   *
+   * These pins bind the DOCTRINE, not a preferred phrasing: any wording that
+   * stays in the cannot-rank register passes, and the specific overclaim cannot
+   * come back unnoticed.
+   */
+
+  const BANNED_NO_EFFECT_PHRASES = [
+    // The exact shipped overclaim and its near neighbours.
+    'would change the recommendation',
+    'no single unknown',
+    "wouldn't change",
+    'would not change',
+    'makes no difference',
+    // Already banned by v7LensCopy's own doctrine for `resolveNextBelow`;
+    // the empty state answers to the same rule.
+    'not worth',
+    'no value',
+    'zero value',
+  ]
+
+  it.each(BANNED_NO_EFFECT_PHRASES)(
+    'the copy constant does not claim no-effect: %s',
+    (phrase) => {
+      expect(E.resolveNextNoneAboveResolution.toLowerCase()).not.toContain(phrase)
+    },
+  )
+
+  it.each(BANNED_NO_EFFECT_PHRASES)(
+    'the RENDERED empty state does not claim no-effect: %s',
+    (phrase) => {
+      // Asserted at the DOM as well as at the constant: the constant is what we
+      // wrote, the DOM is what the user reads, and only the second is the claim.
+      const { text } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+      expect(text.toLowerCase()).not.toContain(phrase)
+    },
+  )
+
+  it('POSITIVE CONTROL — the banned-phrase sweep can actually SEE the rendered sentence', () => {
+    // ⚠ Without this, every assertion above could be passing because the empty
+    // state never rendered at all (trap 13: an absence assertion must first
+    // prove it can detect a presence). Bind to the sentence by its own testid
+    // and confirm the sweep's haystack contains it.
+    const { text } = renderResolveNext(ALL_BELOW_ENRICHMENT)
+    const node = screen.getByTestId('v7-resolve-next-none-above-resolution')
+    expect(node).toHaveTextContent(E.resolveNextNoneAboveResolution)
+    expect(text).toContain(E.resolveNextNoneAboveResolution)
+    // And the sweep would have caught the historical wording, had it still been
+    // there — proven against the literal, pinned here permanently rather than
+    // against "whatever we ship now" (a control pinned to current is a tautology).
+    const HISTORICAL_OVERCLAIM =
+      'Nothing stands out to resolve yet — at this precision, no single unknown would change the recommendation.'
+    expect(
+      BANNED_NO_EFFECT_PHRASES.some((p) => HISTORICAL_OVERCLAIM.toLowerCase().includes(p)),
+      'the sweep must be capable of failing the sentence it was written to remove',
+    ).toBe(true)
+    expect(E.resolveNextNoneAboveResolution).not.toBe(HISTORICAL_OVERCLAIM)
+  })
+
+  it('keeps the below-resolution ≠ worthless doctrine — the sentence still says YET', () => {
+    // The honest reading is "this run could not tell", which leaves open that a
+    // longer run resolves something. A sentence that dropped that would swap one
+    // overclaim for another in the opposite direction.
+    expect(E.resolveNextNoneAboveResolution.toLowerCase()).toContain('yet')
+  })
+
+  it('speaks the same register as its sibling `resolveNextBelow`', () => {
+    // Both lines sit on the same surface with no expert affordance between them.
+    // `resolveNextBelow` attributes the shortfall to THIS RUN'S precision; the
+    // empty state must not attribute it to the factors.
+    expect(E.resolveNextBelow('X').toLowerCase()).toContain('precision')
+    expect(E.resolveNextNoneAboveResolution.toLowerCase()).toContain('precision')
   })
 })

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -229,18 +229,36 @@ export const V7_LENS_COPY = {
      * LICENSED BY: a NON-NULL ranking whose `resolved` band is empty — i.e. the
      * estimator ran, rows arrived and were label-resolved, and not one of them
      * cleared its noise floor. It is NOT licensed by absent/empty/unusable
-     * `factor_evppi`: that is `resolveNextGate` above, and saying "no single
-     * unknown would change the recommendation" about factors nothing assessed
-     * would fabricate the assessment. The two are mutually exclusive by
-     * construction — `buildVoiRanking` returns `null` for exactly the gate's
-     * cases — and both directions are pinned in
+     * `factor_evppi`: that is `resolveNextGate` above, and claiming anything at
+     * all about factors nothing assessed would fabricate the assessment. The two
+     * are mutually exclusive by construction — `buildVoiRanking` returns `null`
+     * for exactly the gate's cases — and both directions are pinned in
      * `V7EvidenceDisclosure.resolveNextAllBelowResolution.spec.tsx` §2/§3.
      *
+     * ⚠ CORRECTED BY L61 — THIS SENTENCE OVERCLAIMED, AND IT WAS MY OWN.
+     * It read: *"Nothing stands out to resolve yet — at this precision, no
+     * single unknown would change the recommendation."* The second clause states
+     * EVIDENCE OF NO EFFECT, and the estimator established no such thing.
+     * Below-resolution means the run could not distinguish these factors FROM
+     * NOISE at its own resolution — a fact about THIS RUN'S PRECISION, not about
+     * the factors' influence. You cannot conclude "none of them would change the
+     * recommendation" from rows you could not resolve; that is precisely the
+     * inference the `resolveNextBelow` doctrine three blocks up forbids ("NEVER
+     * 'zero value' and never 'not worth resolving'"), and the empty state was
+     * contradicting the line rendered directly beneath it.
+     *
+     * The replacement stays in the CANNOT-RANK register: it says the run lacked
+     * the precision to tell the unknowns apart, which is what happened. The
+     * doctrine is now pinned rather than merely written down — §5 of the spec
+     * sweeps the constant AND the rendered DOM for no-effect phrasing, with a
+     * positive control proving the sweep can see the sentence and would have
+     * failed the historical wording (pinned to that literal, permanently, not to
+     * "whatever we ship now").
+     *
      * PLAIN LANGUAGE, DELIBERATELY. "below_resolution", "noise floor" and
-     * "EVPPI" are the producer's vocabulary, not the user's. "at this
-     * precision" is what carries the honest caveat that a longer run could
-     * resolve something — the sentence says nothing stands out YET, never that
-     * nothing matters.
+     * "EVPPI" are the producer's vocabulary, not the user's. "precision" is
+     * what carries the honest caveat that a longer run could resolve something —
+     * the sentence says nothing stands out YET, never that nothing matters.
      *
      * ⚠ THIS PARAGRAPH USED TO SAY the one jargon-adjacent line on this surface
      * (`resolveNextBelow`) was "left exactly where it was". That was true when
@@ -254,7 +272,7 @@ export const V7_LENS_COPY = {
      * The em dash is deliberate and matches `resolveNextNote` above.
      */
     resolveNextNoneAboveResolution:
-      'Nothing stands out to resolve yet — at this precision, no single unknown would change the recommendation.',
+      'Nothing stands out to resolve yet — this run does not have the precision to tell these unknowns apart.',
     /** Conditional-winner narration — all values are producer-supplied
      * (factor label, split value/unit, winner labels); nothing invented. */
     tradeOffSplit: (factor: string, value: string, high: string, low: string) =>


### PR DESCRIPTION
Three Codex-found, orchestrator-adjudicated items. **Every claim re-verified at my tip before any change — nothing inherited.** Two line references in the dispatch brief had drifted and are corrected below.

Base: rebased onto `bc0e4a98` (staging moved under the lane; L58's #577). **Zero file overlap** with L58's five files.

---

## ITEM 1 — wrong-number: a server edge value equal to a UI default was silently dropped

`overlayEdge` inferred "the wire supplied this field" by comparing the mapped edge against a **synthetic default edge** and discarding every key that matched. `DEFAULT_EDGE_DATA.weight` is `0.5`, so a server `strength.mean: 0.5` mapped to `weight: 0.5`, compared equal, and was thrown away — leaving the user's local `0.7` **on screen** while the next analysis is computed from the server's `0.5`. Same shape on `direction`: the synthetic baseline resolves to `'positive'` (default weight `0.5 >= 0`), so an **explicit** server `effect_direction: 'positive'` was dropped and a local `'negative'` survived. A sign, not a rounding difference.

**Derived, not assumed — exactly 2 of the 4 provenanced fields are reachable.** `beliefExists` resolves to `undefined` in the baseline (the explicit assignment overrides the `DEFAULT_EDGE_DATA` 0.8 spread) and `strengthStd` is omitted, so neither can collide. The negative is recorded so nobody later "fixes" a non-defect.

**The fix reuses machinery that already exists.** `mapDraftEdgeToCanvas` already derives `wireSuppliedStrength` from the same three probes its priority chain uses and hands it to `edgeValueSourcePatch`, which **omits** any stamp it cannot justify. So `weightSource` present on the mapped edge ⟺ the wire carried a strength. The hydrate path reads presence off those stamps. Field set is `EDGE_PROVENANCED_FIELDS`, key is `edgeSourceKey()` — nothing hand-listed, no second mirror.

**Scoped.** Opt-in via `overlayEdge(..., { presenceFromProvenanceStamps: true })`, **off by default**, so the receipt path is byte-unchanged and the #570 A1 provenance semantics are exactly the ones that were reviewed. Proven by mutant 2 below.

## ITEM 2 — silent-corruption: a refused boot merge still recorded the server identity token

`mergeServerGraphOnHydrate` refuses on three guards (unusable shape, empty server graph, zero node-id overlap) and **every refusal returned the same all-zero counts an accepted-but-idempotent merge returns**. `hydrateCanvasFromServer` discarded the return value, stored CEE's identity token unconditionally, and returned `'merged'` unconditionally.

**Unconditional and proven: the outcome was false.** This module exists so every boot outcome *"including the refusals"* is measurable without mounting React (its own docstring). A refusal reported as `'merged'` breaks exactly that, and the hook logs the false value as telemetry.

**The token half is real but narrower, and is stated that way rather than inflated.** The poisoned value *does* have a reader — the `isSameServerGraph` short-circuit returns `'unchanged'` without merging — so unlike a write-only column the blast radius is not zero: the zero-overlap verdict depends on the **canvas**, which moves, while the token compares only the **server**, which has not. But `serverGraphIdentity` is in-memory only, is cleared by `DECISION_CONTEXT_CLEAR`, and the hook attempts once per scenario id, so a second read without an intervening clear is narrowly reachable today. **No claim is made of a currently-firing user-visible wrong number for this item.**

The merge now returns `{ accepted, refusedReason, changed }`. `accepted` is defined **structurally** — true exactly when control reaches the body that records `lastAuthoritativeGraph` — so the two identity records answer to one rule instead of drifting apart, and that agreement is itself pinned.

Gated on `accepted`, **never** on `changed`: gating on movement would also make every refusal pin green while turning the most common boot (server matches canvas) into a permanent re-merge. That over-correction has its own dedicated pin, and mutant 4 shows it is the **only** thing that catches it.

## ITEM 3 — trust-surface copy: the all-below-resolution empty state claimed no-effect

Was: *"Nothing stands out to resolve yet — at this precision, no single unknown would change the recommendation."*

The second clause states **evidence of no effect**. `status: 'below_resolution'` means the run could not distinguish those factors **from noise at its own resolution** — a fact about this run's precision, not about the factors' influence. That inference is already forbidden by the file's own doctrine three blocks up, and the sibling line rendered directly beneath it (`resolveNextBelow`, *"Not enough precision this run to rank"*) already speaks the honest register.

Now: *"Nothing stands out to resolve yet — this run does not have the precision to tell these unknowns apart."* Cannot-rank register, keeps "yet" so the below-resolution-≠-worthless doctrine is unchanged.

**The more useful finding is why this was invisible.** All eleven existing pins bind the *symbol* `E.resolveNextNoneAboveResolution` and never its words — deliberately, so re-wording is not a test rewrite. The cost was that the **wording had no guard at all**. §5 closes that: the constant *and* the rendered DOM are swept for no-effect phrasing, with register pins, and a **positive control** proving the sweep can see the sentence and would have failed the historical wording — pinned to that literal permanently, never to "whatever we ship now".

---

## Verification

**RED-first:** 27 named failures before implementation. §3 (receipt parity) was green before the fix, as it must be.

**Mutants** — throwaway worktree a *sibling of* the repo root, never inside it; applied-check scoped to `src/` with the control proven to read **exactly 0**; worktree removed before every gate run.

| # | mutant | result |
|---|---|---|
| 1 | delete the presence block (revert ITEM 1) | **8 RED** |
| 2 | make the presence rule unconditional (scope leak into receipt path) | **4 RED** — my 2 parity pins **plus the 2 pre-existing #570 provenance specs** |
| 3 | delete the refusal gate (restore the ITEM 2 defect) | **5 RED** |
| 3b | keep the honest outcome, still store the token on refusal | **4 RED**, incl. the load-bearing pin failing `expected 'unchanged' to be 'merged'` |
| 4 | gate the token on `changed` instead of `accepted` | **1 RED** — only the anti-overcorrection pin |
| 5 | restore the historical overclaim verbatim | **5 RED** |
| 6 | remove `weight` from `EDGE_PROVENANCED_FIELDS` | **7 RED** — union + corpus |

Three worth reading twice:

- **3b proves the mechanism.** Mutant 3 failed at the first assertion so it never exercised the suppression. 3b keeps the honest outcome and stores the token anyway — the load-bearing pin then fails at its *second* assertion with `the same server graph now overlaps and must merge: expected 'unchanged' to be 'merged'`. The suppression path executes. The defect is real, not inferred.
- **4 is caught by exactly one pin and nothing else** — the entire 16-test pre-existing hydration spec passes under it. Without that pin the over-correction ships looking like a valid fix.
- **6 is trap 12d reproduced exactly.** Removing `weight` from the canonical registry made the *derived* guard for `weight` **silently disappear** (17 tests → 16) — derivation is structurally blind to a missing key. Only the hand-written corpus and the union assertion went RED. That is why both kinds of guard shipped: derivation stops consumers drifting from the list; only a corpus notices the list is short.

**Gates** (derived from `package.json` at this tip, not inherited — `typecheck` is `bash scripts/ci/typecheck-gate.sh`):

| gate | result |
|---|---|
| `pnpm run typecheck` | **PASSED** — coverage 3212/3252 tracked TS files (40 out of scope, unchanged; the 3 new specs loaded), ratchet 620 files / 2502 errors vs baseline 2502 — **no new errors** |
| `vitest src/canvas/{utils,hydrate,hooks,domain,conversation} src/components/results` | **498 files / 8367 passed**, 22 skipped, 0 failed |
| `vitest src/canvas/ui/inspector-v2` (trap 2b collect sanity) | **35 files / 372 collected and passed** — no collect-time failure |

⚠ Worth knowing for other lanes: **phase 1 of the typecheck gate derives from `git ls-files`, so untracked files are invisible to it.** My first run (before `git add`) reported 3207/3247 and did not check the new specs at all. The numbers above are from post-staging runs.

Evidence: `PHASE0-EVIDENCE-2026-07-28/l61-hydrate-integrity.md`

**Not merged — targeted review follows.**