### PR TITLE
fix(results): stop rendering the fabricated goal-fit number (L60 obs 1, UI half)

### DIFF
--- a/src/canvas/components/DecisionSummary.tsx
+++ b/src/canvas/components/DecisionSummary.tsx
@@ -306,7 +306,13 @@ export function DecisionSummary({
                 threshold: goalThreshold ?? undefined,
                 // Read off the same decision the number came from — never
                 // re-derived, and never inferred from the value.
-                isSubstitutedJoint: decision.basis === 'joint_goal_substituted',
+                //
+                // ⭐ L62: reads the owner's published PERMISSION rather than a
+                // basis literal. Since the substitution is now withheld
+                // outright (no number on that basis), every number that
+                // reaches this branch earns the possessive and this is false —
+                // by construction, not by assertion.
+                isSubstitutedJoint: !decision.mayUsePossessiveGoalFraming,
               }
             : null
       }

--- a/src/canvas/components/__tests__/DecisionSummary.possessiveGate.spec.tsx
+++ b/src/canvas/components/__tests__/DecisionSummary.possessiveGate.spec.tsx
@@ -123,7 +123,10 @@ describe('DecisionSummary — possessive gate on a substituted joint goal figure
   it('control: each fixture drives the REAL selector to the basis this suite claims for it', () => {
     // Anti-vacuity (trap 13): the absence assertions below are worthless if a
     // fixture stopped reaching its branch.
-    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_substituted')
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_withheld')
+    // ⭐ L62: and it carries no number, which is what turns "the possessive is
+    // withheld" below into "no goal claim renders at all".
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).goalProbability).toBeNull()
     expect(selectGoalProbability(REAL_GOAL_OPTION).basis).toBe('goal_probability')
     expect(selectGoalProbability(CONSTRAINED_OPTION).basis).toBe('joint_goal_constrained')
   })
@@ -136,12 +139,18 @@ describe('DecisionSummary — possessive gate on a substituted joint goal figure
     expect(textOf()).toContain('chance of achieving')
   })
 
-  it('WITHHOLDS the possessive on the witnessed substituted run', () => {
+  /**
+   * ⭐ AMENDED BY L62. 2.283 kept the number and swapped the voice; L60 showed
+   * the number is the untruth (a structural zero from a frame-blind
+   * comparison), so this card states no goal claim at all on that basis. The
+   * possessive assertions are unchanged and still load-bearing; the
+   * "renders the withheld phrase" half is inverted.
+   */
+  it('L62: states NO goal claim on the witnessed substituted run — neither voice', () => {
     setStore(SUBSTITUTED_OPTION)
     const text = textOf()
-    // The register's phrase form verbatim — no copy invented at this site.
-    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
-    // Neither possessive arm survives: both named the user's own goal.
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    // Neither possessive arm survives either: both named the user's own goal.
     expect(text).not.toContain('chance of achieving')
     expect(text).not.toContain(`achieving ${GOAL_LABEL}`)
   })

--- a/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
@@ -146,7 +146,23 @@ describe('Model-tab goal card — per-option goal fit (real ModelTabBody→GoalS
     expect(rows).toHaveTextContent('2% chance of hitting your goal')
   })
 
-  it('substituted-joint basis withholds the possessive and renders the modelled-basis caveat', () => {
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04). THIS IS THE SCREENSHOT-05 SURFACE.
+   *
+   * 2.282 pinned that this card kept the substituted numbers and swapped to
+   * the non-possessive register. That is exactly what the user was looking at
+   * in L60's screenshot 05: "< 1% chance of meeting every target this run
+   * scored" four times, directly under "Target: 250,000" — for a target the
+   * engine had never even received, scored from a frame-blind comparison that
+   * forces P ~ 0 for every option.
+   *
+   * `buildGoalFitRows` calls `selectGoalProbability` and returns `null` the
+   * moment any option has no admissible figure (its complete-field rule). With
+   * the substitution withheld that is now every option, so the block does not
+   * render — the honest-absence state for this card, and the same rule the
+   * "one option without a figure" test below already pinned.
+   */
+  it('L62: a joint-only run renders NO goal-fit block at all — neither register, no caveat', () => {
     // The witnessed 2.282 shape: goal_probability absent, joint present,
     // scored from the modelled outcome distribution.
     setResults({
@@ -168,15 +184,21 @@ describe('Model-tab goal card — per-option goal fit (real ModelTabBody→GoalS
       },
     })
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
-    const rows = screen.getByTestId('goal-fit-parity')
-    // The possessive claim names a question the substituted number does not
-    // answer — the register's withheld arm renders instead.
-    expect(rows).not.toHaveTextContent('chance of hitting your goal')
-    expect(rows).toHaveTextContent('chance of meeting every target this run scored')
-    // Doctrine B: the caveat must sit adjacent to the number.
-    expect(screen.getByTestId('goal-fit-modelled-caveat')).toHaveTextContent(
-      "Modelled from the target's projected outcome distribution",
-    )
+
+    // Control first: the card ITSELF still renders, so the absences below are
+    // about the goal-fit claim and not about a blank tab.
+    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
+
+    // The block is gone entirely — no rows, so neither register can appear.
+    expect(screen.queryByTestId('goal-fit-parity')).toBeNull()
+    const section = screen.getByTestId('model-goal-section')
+    expect(section).not.toHaveTextContent('chance of hitting your goal')
+    expect(section).not.toHaveTextContent('chance of meeting every target this run scored')
+    // Doctrine B in the only form left: with no number displayed there is
+    // nothing for the modelled-basis caveat to qualify, so it must not render
+    // either. A caveat beside no figure is a hedge about a value the user
+    // cannot see.
+    expect(screen.queryByTestId('goal-fit-modelled-caveat')).toBeNull()
   })
 })
 

--- a/src/canvas/components/model-tab/buildGoalFitRows.ts
+++ b/src/canvas/components/model-tab/buildGoalFitRows.ts
@@ -81,7 +81,11 @@ export function buildGoalFitRows(
       id: node.id,
       label: typeof data?.label === 'string' ? data.label : node.id,
       probability: decision.goalProbability,
-      isSubstitutedJoint: decision.basis === 'joint_goal_substituted',
+      // ⭐ L62: always false — the row only exists when a number survived line
+      // 75, and every surviving number earns the possessive now that the joint
+      // substitution is withheld at source. Read off the owner's permission,
+      // never a basis literal.
+      isSubstitutedJoint: !decision.mayUsePossessiveGoalFraming,
       modelledBasis: decision.goalFitIsModelledBasis,
       nValidSamples: positiveIntegerOrNull(outcome?.n_valid_samples),
     })

--- a/src/canvas/hooks/__tests__/goalProbabilityIdentity.parity.spec.tsx
+++ b/src/canvas/hooks/__tests__/goalProbabilityIdentity.parity.spec.tsx
@@ -76,6 +76,23 @@ const JOINT_ONLY_RECORD: GoalProbabilityInput & Record<string, unknown> = {
   goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
 }
 
+/**
+ * ⭐ L62 — the record this file's AGREEMENT tests now anchor on.
+ *
+ * `JOINT_ONLY_RECORD` above no longer produces a number (the substitution is
+ * withheld — L60 §5–§8), and "both consumers returned null" is exactly the
+ * vacuous agreement this file's positive control exists to forbid. The
+ * CONSTRAINED basis is the remaining one that carries a joint number AND the
+ * modelled-basis caveat, so it is the shape that keeps the parity claim
+ * non-vacuous: same number, same caveat, both surfaces.
+ */
+const CONSTRAINED_JOINT_RECORD: GoalProbabilityInput & Record<string, unknown> = {
+  probability_of_joint_goal: 0.62,
+  constraint_analysis: { constraints: [{ id: 'c1' }] },
+  confidence: 0.5,
+  goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+}
+
 /** Control: the run carries the true per-option goal quantity. */
 const GOAL_QUANTITY_RECORD: GoalProbabilityInput & Record<string, unknown> = {
   goal_probability: 0.41,
@@ -152,26 +169,29 @@ const renderGoalNode = () =>
 
 beforeEach(() => {
   vi.clearAllMocks()
-  useStore(JOINT_ONLY_RECORD)
+  // ⭐ L62: was `JOINT_ONLY_RECORD`. Tests that need the WITHHELD shape now
+  // switch to it explicitly, so the default state of this file is one where a
+  // number genuinely exists and "agreement" means something.
+  useStore(CONSTRAINED_JOINT_RECORD)
 })
 
 describe('goal-probability identity — the two consumers agree', () => {
   it('POSITIVE CONTROL: the single source of truth really does show a number and a caveat here', () => {
     // Fixes the decision before anything asserts agreement with it, so a
     // "both surfaces returned null" state can never satisfy this file.
-    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    const decision = selectGoalProbability(CONSTRAINED_JOINT_RECORD)
     expect(decision.goalProbability).toBe(0.62)
     expect(decision.goalFitIsModelledBasis).toBe(true)
   })
 
   it('the canvas consumer returns the SAME value as the results-panel selector', () => {
-    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    const decision = selectGoalProbability(CONSTRAINED_JOINT_RECORD)
     const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
     expect(result.current.achievementProbability).toBe(decision.goalProbability)
   })
 
   it('the canvas consumer returns the SAME provenance caveat as the results-panel selector', () => {
-    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    const decision = selectGoalProbability(CONSTRAINED_JOINT_RECORD)
     const { result } = renderHook(() => useNodeDisplayMetadata('goal-1', 'goal'))
     expect(result.current.achievementProbabilityIsModelledBasis).toBe(
       decision.goalFitIsModelledBasis,
@@ -218,24 +238,67 @@ describe('goal-probability identity — the rendered canvas text matches the dec
     // a hard-coded `true` would keep demanding the withheld wording and the
     // parity claim would quietly become a fiction. Asking the selector makes
     // the comparison self-contained.
+    // ⭐ AMENDED BY L62 (2026-08-04). 2.283's version derived the VOICE from
+    // the selector and asserted the node still stated 62% in the withheld
+    // register — parity of the NUMBER across canvas and panel. L60 showed
+    // that number is a structural zero from comparing a level/count threshold
+    // to change-frame samples, so the selector now publishes NO number for
+    // this record and the parity claim becomes parity of the ABSENCE: neither
+    // surface states a figure.
+    //
+    // The derivation discipline the original insisted on is kept — nothing
+    // here is hard-coded, everything is asked of the selector — because that
+    // is what stops this test drifting into a fiction if the basis moves again.
+    // ⚠ The store must be pointed at the WITHHELD record explicitly: this
+    // file's `beforeEach` now anchors on `CONSTRAINED_JOINT_RECORD` so the
+    // agreement tests are non-vacuous, and without this line the render below
+    // would be of a run that legitimately carries 62%.
+    useStore(JOINT_ONLY_RECORD)
     const decision = selectGoalProbability(JOINT_ONLY_RECORD)
-    const substituted = decision.basis === 'joint_goal_substituted'
 
-    // Anti-vacuity (trap 13): pin that the derivation actually yields the
-    // WITHHELD arm here, so the assertion below cannot pass by having silently
-    // flipped to the permitted one.
-    expect(substituted).toBe(true)
+    // Anti-vacuity (trap 13): pin that this record really does reach the
+    // withheld arm, so the absences below cannot pass by having quietly
+    // flipped to a basis that never had a figure to begin with.
+    expect(decision.basis).toBe('joint_goal_withheld')
+    expect(decision.jointSubstitutionWithheld).toBe(true)
+    expect(decision.goalProbability).toBeNull()
     expect(decision.mayUsePossessiveGoalFraming).toBe(false)
+    // The quantity itself is still published — withheld from the goal-fit
+    // slot, not deleted from the payload.
+    expect(decision.jointGoalProbability).toBe(0.62)
 
-    renderGoalNode()
-    expect(screen.getByText(GOAL_ANCHOR_COPY.phrase('62%', substituted))).toBeDefined()
-    // And the possessive voice is gone, on this basis, at this surface.
+    const { container } = renderGoalNode()
+    const text = container.textContent ?? ''
+    // Neither voice, and no percentage: the withheld register had exactly one
+    // job, captioning a substituted number, and there is no such number now.
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('62%', true))
+    expect(text).not.toContain('62%')
     expect(screen.queryByText(/chance of reaching target/)).toBeNull()
   })
 
   it('GoalNode does not simultaneously deny that a goal probability exists', () => {
+    // Anchored on the CONSTRAINED record (see its header): a run that DOES
+    // carry a figure. On the withheld run the node SHOULD deny — that is the
+    // honest state, and it is pinned as such in the test below rather than
+    // being conflated with this one.
     renderGoalNode()
     expect(screen.queryByText(/did not produce a goal probability/)).toBeNull()
+  })
+
+  it('⭐ L62: on a WITHHELD run the node denies a figure, and the panel agrees — no contradiction in the other direction either', () => {
+    // The mirror of the test above, and the reason this file exists. ROADMAP
+    // 2.275 recorded the two surfaces disagreeing on the substituted run — the
+    // node denying a probability while the Goal-fit sub-tab rendered "< 1%"
+    // four times from the same report. Both now deny, and the SELECTOR is
+    // asserted alongside the render so "they agree" cannot mean "both broke".
+    useStore(JOINT_ONLY_RECORD)
+    const decision = selectGoalProbability(JOINT_ONLY_RECORD)
+    expect(decision.basis).toBe('joint_goal_withheld')
+    expect(decision.goalProbability).toBeNull()
+
+    const { container } = renderGoalNode()
+    expect(container.textContent ?? '').toContain('did not produce a goal probability')
+    expect(container.textContent ?? '').not.toContain('62%')
   })
 
   it('GoalNode carries the provenance caveat the results panel carries', () => {
@@ -244,20 +307,31 @@ describe('goal-probability identity — the rendered canvas text matches the dec
       GOAL_FIT_BASIS_CAVEAT_COPY,
     )
   })
+
+  it('⭐ L62: and NO caveat on a withheld run — a hedge beside no number is its own claim', () => {
+    useStore(JOINT_ONLY_RECORD)
+    renderGoalNode()
+    expect(screen.queryByTestId('goal-fit-basis-caveat-node')).toBeNull()
+  })
 })
 
 describe('goal-probability identity — which quantity the number IS', () => {
-  it('names the substituted joint quantity as its own basis', () => {
-    expect(selectGoalProbability(JOINT_ONLY_RECORD).basis).toBe('joint_goal_substituted')
+  it('names the withheld joint quantity as its own basis (L62 — was `joint_goal_substituted`)', () => {
+    expect(selectGoalProbability(JOINT_ONLY_RECORD).basis).toBe('joint_goal_withheld')
   })
 
-  it('withholds the possessive framing when the joint value stands in for an absent goal value', () => {
-    // The NUMBER is still shown — it is real, computed and decision-relevant.
-    // Only "YOUR goal" is withheld, because the number answers a different
-    // question from the one that phrase asserts.
+  it('L62: withholds the NUMBER, not merely the possessive, when the joint value would stand in for an absent goal value', () => {
+    // 2.283's version read: "The NUMBER is still shown — it is real, computed
+    // and decision-relevant. Only 'YOUR goal' is withheld." L60 showed the
+    // number is P(level-or-count threshold >= change-frame sample), i.e. a
+    // structural zero that is neither about the user's goal nor about
+    // anything else they asked. Both are withheld.
     const decision = selectGoalProbability(JOINT_ONLY_RECORD)
-    expect(decision.goalProbability).toBe(0.62)
+    expect(decision.goalProbability).toBeNull()
     expect(decision.mayUsePossessiveGoalFraming).toBe(false)
+    expect(decision.jointSubstitutionWithheld).toBe(true)
+    // Still published for the honestly-labelled joint surface.
+    expect(decision.jointGoalProbability).toBe(0.62)
   })
 
   it('permits the possessive framing when the value IS the goal quantity', () => {

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.goalBasis.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.goalBasis.spec.ts
@@ -121,19 +121,34 @@ describe('useNodeDisplayMetadata — achievementProbabilityBasis (REAL hook)', (
     // because a fixture silently stopped reaching the branch under test — the
     // failure mode that made a PLoT leak test capture 0 bytes and assert
     // nothing.
-    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_substituted')
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_withheld')
     expect(selectGoalProbability(SUBSTITUTED_OPTION).mayUsePossessiveGoalFraming).toBe(false)
+    // ⭐ L62: and it carries NO number — which is what turns the forwarding
+    // test below from "forwards the basis with a value" into "forwards the
+    // basis with the absence".
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).goalProbability).toBeNull()
     expect(selectGoalProbability(REAL_GOAL_OPTION).basis).toBe('goal_probability')
     expect(selectGoalProbability(REAL_GOAL_OPTION).mayUsePossessiveGoalFraming).toBe(true)
     expect(selectGoalProbability(CONSTRAINED_OPTION).basis).toBe('joint_goal_constrained')
     expect(selectGoalProbability(CONSTRAINED_OPTION).mayUsePossessiveGoalFraming).toBe(true)
   })
 
-  it('forwards joint_goal_substituted on the witnessed payload', () => {
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04). 2.283 pinned that the hook forwarded the
+   * substituted basis ALONGSIDE the substituted number, so a render site could
+   * pick the honest voice for it. L60 §5–§8 showed the number is a structural
+   * zero, so the selector withholds it — and the thing the hook must now
+   * forward faithfully is the basis WITH the absence. Forwarding a basis while
+   * inventing a number would be worse than either.
+   */
+  it('L62: forwards joint_goal_withheld — basis AND absence — on the witnessed payload', () => {
     setReport(reportFor(SUBSTITUTED_OPTION))
     const md = renderForGoal()
-    expect(md.achievementProbability).toBe(0.0054)
-    expect(md.achievementProbabilityBasis).toBe('joint_goal_substituted')
+    expect(md.achievementProbability).toBeNull()
+    expect(md.achievementProbabilityBasis).toBe('joint_goal_withheld')
+    // The joint quantity itself still crosses the hop for the panel's own
+    // honestly-labelled row.
+    expect(md.jointGoalProbability).toBe(0.0054)
   })
 
   it('forwards goal_probability when the run carries the real goal quantity', () => {
@@ -150,7 +165,7 @@ describe('useNodeDisplayMetadata — achievementProbabilityBasis (REAL hook)', (
     expect(md.achievementProbabilityBasis).toBe('joint_goal_constrained')
     // The discriminator that matters: the same JOINT quantity, and yet not
     // substituted. A gate widened to "the figure is joint" fails here.
-    expect(md.achievementProbabilityBasis).not.toBe('joint_goal_substituted')
+    expect(md.achievementProbabilityBasis).not.toBe('joint_goal_withheld')
   })
 
   it('INVARIANT: a non-null achievementProbability is NEVER published without a basis', () => {
@@ -161,7 +176,13 @@ describe('useNodeDisplayMetadata — achievementProbabilityBasis (REAL hook)', (
     // possessive. This test is what stops "optional in the type" decaying into
     // "absent in practice": the real hook must populate it whenever it
     // publishes a number. Derived from the hook's own output, not mirrored.
-    for (const option of [SUBSTITUTED_OPTION, REAL_GOAL_OPTION, CONSTRAINED_OPTION]) {
+    // ⭐ L62 narrowed the fixture set, NOT the invariant. `SUBSTITUTED_OPTION`
+    // is removed because it no longer publishes a number, so it cannot
+    // exercise "a non-null probability without a basis" — including it would
+    // make the loop assert `not.toBeNull()` about a legitimately null value
+    // and turn the invariant into a false alarm. The withheld case gets its
+    // own, opposite invariant immediately below, so nothing goes unpinned.
+    for (const option of [REAL_GOAL_OPTION, CONSTRAINED_OPTION]) {
       setReport(reportFor(option))
       const md = renderForGoal()
       expect(md.achievementProbability).not.toBeNull()
@@ -169,6 +190,17 @@ describe('useNodeDisplayMetadata — achievementProbabilityBasis (REAL hook)', (
       expect(md.achievementProbabilityBasis).not.toBeUndefined()
       expect(md.achievementProbabilityBasis).not.toBe('none')
     }
+  })
+
+  it('⭐ L62 INVARIANT (the other direction): a WITHHELD basis is never published WITH a number', () => {
+    // The mirror of the invariant above, and the one that matters after L62:
+    // the whole defect was a basis that said "this is a stand-in" while a
+    // number rode along beside it and got rendered anyway. Absence and basis
+    // must travel together or the render sites are back to guessing.
+    setReport(reportFor(SUBSTITUTED_OPTION))
+    const md = renderForGoal()
+    expect(md.achievementProbabilityBasis).toBe('joint_goal_withheld')
+    expect(md.achievementProbability).toBeNull()
   })
 
   it('control: the pointer gap (ROADMAP 2.275) is the ONLY thing the fixtures add', () => {

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.goalFitAvailable.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.goalFitAvailable.spec.ts
@@ -87,13 +87,47 @@ beforeEach(() => {
 })
 
 describe('useNodeDisplayMetadata — goalFitAvailable (REAL hook)', () => {
-  it('is TRUE on the witnessed payload, where no option is designated', () => {
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04) — AND THE FLIP IS THE USER-VISIBLE WIN.
+   *
+   * ROADMAP 2.275 added `goalFitAvailable` because the canvas goal node denied
+   * a probability while the Goal-fit sub-tab rendered "< 1%" four times from
+   * the same report. The flag made the node point the user AT those per-option
+   * figures ("see Goal fit for each option's chance").
+   *
+   * L60 then established what those figures were: P(level-or-count threshold
+   * >= change-frame sample), structurally ~0 for every option. So the flag was
+   * directing users to a fabrication. `selectGoalProbability` now withholds
+   * them, this scan finds nothing admissible, and the node states the simpler
+   * truth instead. 2.275's contradiction is resolved in the honest direction —
+   * both surfaces deny, rather than both affirming a fiction.
+   *
+   * The flag itself is NOT retired: the positive control below proves it still
+   * fires for a run carrying real per-option goal figures, which is the case
+   * 2.275 was actually built for.
+   */
+  it('L62: is FALSE on the witnessed payload — the per-option figures it used to advertise are withheld', () => {
     setReport(WITNESSED_REPORT)
     const { result } = renderHook(() => useNodeDisplayMetadata('goal_capacity', 'goal'))
 
-    // The pointer the hook needs is genuinely absent, so no node-level number…
     expect(result.current.achievementProbability).toBeNull()
-    // …but the run DID produce per-option goal figures, and the hook says so.
+    expect(result.current.goalFitAvailable).toBe(false)
+  })
+
+  it('⭐ L62 POSITIVE CONTROL: still TRUE when the run carries REAL per-option goal probabilities and no option is designated', () => {
+    // This is 2.275's actual case, and without it the amendment above would be
+    // indistinguishable from deleting the feature (trap 13). Same report
+    // shape, same missing pointer — only the producer channel differs.
+    setReport({
+      ...WITNESSED_REPORT,
+      option_probabilities: {
+        opt_bristol: { probability_of_goal: 0.31 },
+        opt_leeds: { probability_of_goal: 0.12 },
+      },
+    })
+    const { result } = renderHook(() => useNodeDisplayMetadata('goal_capacity', 'goal'))
+
+    expect(result.current.achievementProbability).toBeNull()
     expect(result.current.goalFitAvailable).toBe(true)
   })
 
@@ -114,8 +148,14 @@ describe('useNodeDisplayMetadata — goalFitAvailable (REAL hook)', () => {
   it('a hard zero still counts as a figure the run produced', () => {
     // witness §11c: run 4 returned exactly 0 for all four options. Zero is a
     // result, not an absence — denying it would be the same defect inverted.
+    //
+    // ⭐ L62 changed the CHANNEL, not the principle. The fixture was
+    // `probability_of_joint_goal: 0`, which is now withheld — so the test
+    // would have passed by asserting the withhold rather than the zero-is-a-
+    // result rule it exists for. It uses the honest goal channel instead, and
+    // the rule is pinned exactly as before: an EXACT ZERO is a measurement.
     setReport({
-      option_probabilities: { opt_a: { probability_of_joint_goal: 0 } },
+      option_probabilities: { opt_a: { probability_of_goal: 0 } },
       robustness: {},
     })
     const { result } = renderHook(() => useNodeDisplayMetadata('goal_capacity', 'goal'))
@@ -140,8 +180,24 @@ describe('useNodeDisplayMetadata — goalFitAvailable (REAL hook)', () => {
     // Positive control for the other direction: with a designation the hook
     // reaches selectGoalProbability, gets a number, and goalFitAvailable is
     // not needed. This is what keeps the two branches mutually exclusive.
+    // ⭐ L62: the designated option needs an HONEST figure for this control to
+    // test what it claims. With the witnessed (joint-only) payload the hook
+    // now reaches the selector and correctly gets NOTHING, so both branches
+    // would be false and the mutual exclusivity would hold vacuously.
     setReport({
       ...WITNESSED_REPORT,
+      option_probabilities: {
+        ...WITNESSED_REPORT.option_probabilities,
+        opt_bristol: {
+          probability_of_goal: 0.0002,
+          constraint_analysis: { constraints: [{ id: 'c1' }] },
+          probability_of_joint_goal: 0.0002,
+          goal_fit_basis: {
+            scored_from: 'modelled_outcome_distribution',
+            node_ids: ['goal_capacity'],
+          },
+        },
+      },
       robustness: { recommended_option_id: 'opt_bristol' },
     })
     const { result } = renderHook(() => useNodeDisplayMetadata('goal_capacity', 'goal'))

--- a/src/canvas/hooks/__tests__/useNodeDisplayMetadata.jointGoal.spec.ts
+++ b/src/canvas/hooks/__tests__/useNodeDisplayMetadata.jointGoal.spec.ts
@@ -90,12 +90,25 @@ describe('useNodeDisplayMetadata — jointGoalProbability (REAL hook)', () => {
     expect(md.jointGoalProbability).toBe(0.0054)
   })
 
-  it('under substitution the joint figure IS the achievement figure — the selector identity survives the hop', () => {
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04). This pinned the 2.296 identity: under
+   * substitution `achievementProbability === jointGoalProbability`, because the
+   * achievement figure WAS the joint figure. The substitution is gone (L60 §5:
+   * the joint figure is P(level-or-count threshold >= change-frame sample)), so
+   * the identity that survives the hop is now the OPPOSITE one, and it is the
+   * more important of the two: the joint quantity is still forwarded verbatim
+   * for the separately-labelled inspector row, while the achievement slot is
+   * empty. A gate that deleted the joint quantity too would break the honest
+   * surface, so this pins that it does not.
+   */
+  it('L62 — under withhold the joint figure is still FORWARDED, and the achievement figure is empty', () => {
     setReport(reportFor(SUBSTITUTED_OPTION))
     const md = renderForGoal()
-    expect(md.achievementProbabilityBasis).toBe('joint_goal_substituted')
+    expect(md.achievementProbabilityBasis).toBe('joint_goal_withheld')
+    expect(md.achievementProbability).toBeNull()
+    // Untouched, byte-for-byte: this is what `GoalPanel`'s "chance of hitting
+    // every target" row renders under its own honest label.
     expect(md.jointGoalProbability).toBe(0.0054)
-    expect(md.jointGoalProbability).toBe(md.achievementProbability)
   })
 
   it('no pointer (the 2.275 gap) → no joint figure either — nothing is read outside the owner', () => {

--- a/src/canvas/hooks/useNodeDisplayMetadata.ts
+++ b/src/canvas/hooks/useNodeDisplayMetadata.ts
@@ -98,8 +98,15 @@ interface NodeDisplayMetadata {
    * would be a SECOND copy of a fact the selector already owns — the
    * hand-maintained-mirror defect class (CLAUDE.md trap 12), and the exact
    * shape of the two `generateGraphHash` twins. Consumers narrow it themselves
-   * with `=== 'joint_goal_substituted'`, which is byte-for-byte the expression
-   * `OptionNode` already uses, so the canvas has ONE vocabulary for this test.
+   * with the owner's exported `basisWithholdsPossessive()`, which is
+   * byte-for-byte what `OptionNode`, `GoalNode` and `GoalPanel` all call, so
+   * the canvas has ONE vocabulary for this test.
+   *
+   * ⚠ L62 (2026-08-04): that narrowing used to be an inline
+   * `=== 'joint_goal_substituted'` literal at each of those four sites. The
+   * basis is now `'joint_goal_withheld'` and carries NO number, so every site
+   * evaluates false — and the four literals became one function precisely so
+   * the next change to the rule cannot leave three of them behind.
    *
    * OPTIONAL, for the reason `goalFitAvailable` below is optional (mock churn
    * rewrites printed type strings across unrelated suites). ⚠ Note the polarity

--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -25,6 +25,7 @@ import { typography } from '../../styles/typography'
 import { formatGoalTarget } from '../../components/results/utils/formatGoalTarget'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { GOAL_ANCHOR_COPY } from '../../components/results/utils/goalAnchorCopy'
+import { basisWithholdsPossessive } from '../../components/results/utils/selectGoalProbability'
 import { readInferenceWarnings } from '../../components/results/utils/readInferenceWarnings'
 import { DataBar, type DataBarColour } from '../ui/shared/DataBar'
 import { getStabilityClassification } from '../../lib/stability'
@@ -140,8 +141,17 @@ export const GoalNode = memo((props: NodeProps) => {
   // `joint_goal_constrained` is the user's own goal AND their own limits —
   // the possessive is EARNED there and is untouched (the ROADMAP 1.49 case).
   // The expression is byte-identical to `OptionNode`'s, deliberately.
+  // ⭐ L62 (2026-08-04) — THIS IS NOW ALWAYS FALSE, AND THAT IS THE POINT.
+  // `selectGoalProbability` no longer substitutes the joint figure into the
+  // goal-fit slot at all: on that basis (`'joint_goal_withheld'`) it returns NO
+  // number, so this surface renders nothing to re-voice. The bases that still
+  // carry a number — `'goal_probability'` and `'joint_goal_constrained'` —
+  // both EARN the possessive. The narrowing goes through the owner's exported
+  // `basisWithholdsPossessive` so the four canvas/summary surfaces share ONE
+  // rule instead of four copies of a literal.
   const goalFitSubstituted =
-    displayMetadata.achievementProbabilityBasis === 'joint_goal_substituted'
+    displayMetadata.achievementProbability !== null &&
+    basisWithholdsPossessive(displayMetadata.achievementProbabilityBasis)
   // The readout, built ONCE above both arms so the withheld and permitted
   // wordings can never show different numbers for the same run.
   //

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -20,7 +20,10 @@ import { readFactorDisplayValue } from '../../utils/formatFactorDisplayValue'
 import { detectBaseline } from '../utils/baselineDetection'
 import { usePopoverHover } from '../hooks/usePopoverHover'
 import { NodeChip, ActionIcons, BriefIcon, NodePopover, ScienceIcon } from './shared'
-import { selectGoalProbability } from '../../components/results/utils/selectGoalProbability'
+import {
+  selectGoalProbability,
+  basisWithholdsPossessive,
+} from '../../components/results/utils/selectGoalProbability'
 import { COMPARATIVE_COPY, GOAL_ANCHOR_COPY } from '../../components/results/utils/goalAnchorCopy'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from '../../components/results/utils/goalFitBasisCaveatCopy'
 import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib/decisionVerdict'
@@ -785,7 +788,18 @@ export const OptionNode = memo((props: NodeProps) => {
   // limits, where the possessive is EARNED and stays. `OptionNode.spec.tsx`'s
   // ROADMAP 1.49 positive control is exactly that constrained case and must
   // keep rendering "chance of target."
-  const goalFitSubstituted = goalDecision?.basis === 'joint_goal_substituted'
+  //
+  // ⭐ L62 (2026-08-04) — THIS IS NOW ALWAYS FALSE, AND THAT IS THE FIX.
+  // `selectGoalProbability` no longer substitutes: on that basis it returns NO
+  // number (`'joint_goal_withheld'`, `goalProbability: null`), so a badge is
+  // never rendered in the withheld state and there is nothing left to re-voice.
+  // The bases that still carry a number — `'goal_probability'` and
+  // `'joint_goal_constrained'` — both EARN the possessive, which is why this
+  // reads the owner's own published permission rather than re-testing a basis
+  // literal: if the owner ever re-permits a number it forbids the possessive
+  // for, this lights up again without an edit here.
+  const goalFitSubstituted =
+    goalDecision?.goalProbability != null && basisWithholdsPossessive(goalDecision.basis)
   // The badge readout, built ONCE above both arms so the withheld and
   // permitted wordings cannot show different numbers for the same option.
   // Byte-identical to the literal it replaces (`'< '` + digits + `%`).

--- a/src/canvas/nodes/__tests__/GoalNode.possessiveGate.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.possessiveGate.spec.tsx
@@ -141,16 +141,43 @@ describe('GoalNode — possessive gate on a substituted joint goal figure (ROADM
     // Anti-vacuity (trap 13): an absence assertion must first prove it can see
     // a presence. If a fixture stopped reaching its branch, the withheld/
     // permitted assertions below would pass by testing nothing.
-    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_substituted')
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).basis).toBe('joint_goal_withheld')
     expect(selectGoalProbability(REAL_GOAL_OPTION).basis).toBe('goal_probability')
     expect(selectGoalProbability(CONSTRAINED_OPTION).basis).toBe('joint_goal_constrained')
+    // ⭐ L62: the withheld basis carries NO number, which is what turns the
+    // "withholds the possessive" test below into an absence-of-figure test.
+    expect(selectGoalProbability(SUBSTITUTED_OPTION).goalProbability).toBeNull()
+    expect(selectGoalProbability(CONSTRAINED_OPTION).goalProbability).toBe(0.42)
   })
 
-  it('WITHHOLDS the possessive on the witnessed substituted run', () => {
-    renderGoalWith(SUBSTITUTED_OPTION)
-    // The shared register's phrase form, verbatim — no copy invented here.
-    expect(screen.getByText(GOAL_ANCHOR_COPY.phrase('< 1%', true))).toBeInTheDocument()
+  /**
+   * ⭐ AMENDED BY L62. 2.283 pinned that the node kept the NUMBER and dropped
+   * the possessive. L60 §5–§8 showed the number is the untruth — a structural
+   * zero from comparing a level/count threshold to change-frame samples — so
+   * the node now shows no figure at all. The possessive assertion is retained
+   * verbatim; the "renders the withheld phrase" half is inverted.
+   */
+  it('L62: shows NO figure at all on the witnessed substituted run — neither voice', () => {
+    const { container } = renderGoalWith(SUBSTITUTED_OPTION)
+    expect(screen.queryByText(GOAL_ANCHOR_COPY.phrase('< 1%', true))).not.toBeInTheDocument()
     expect(screen.queryByText(new RegExp(POSSESSIVE))).not.toBeInTheDocument()
+    expect(container.textContent ?? '').not.toContain('< 1%')
+    // The node's own honest-absence line takes over.
+    //
+    // ⭐ AND NOTE WHICH ONE. Before L62 this run rendered "No overall goal
+    // probability for this run — see Goal fit for each option's chance",
+    // because `goalFitAvailable` was true: the per-option scan found the
+    // substituted figures and pointed the user AT them. That is the
+    // cross-surface contradiction ROADMAP 2.275 recorded from the other side —
+    // the node denying a figure while the Goal-fit sub-tab rendered "< 1%" four
+    // times from the same report. With the substitution withheld the scan finds
+    // nothing admissible, so the node states the simpler truth and the two
+    // surfaces finally agree. Pinned by string because the DIFFERENCE between
+    // these two sentences is the user-visible consequence of the fix.
+    expect(container.textContent ?? '').toContain(
+      'Target set. This run did not produce a goal probability.',
+    )
+    expect(container.textContent ?? '').not.toContain('see Goal fit for each option')
   })
 
   it('positive control: a REAL probability_of_goal keeps the possessive', () => {
@@ -169,13 +196,13 @@ describe('GoalNode — possessive gate on a substituted joint goal figure (ROADM
     expect(screen.queryByText(GOAL_ANCHOR_COPY.phrase('42%', true))).not.toBeInTheDocument()
   })
 
-  it('the two arms are MUTUALLY EXCLUSIVE — the run states one voice, never both', () => {
-    // The GoalPanel defect in miniature: under substitution the same number
-    // rendered in two incompatible voices, exactly one of which was true.
+  it('L62: NEITHER voice appears on a withheld run — the mutual-exclusion test, with both arms now empty', () => {
+    // 2.283 pinned exactly-one-voice. Under L62 the honest count is zero of
+    // both: there is no number for either voice to caption. The CONSTRAINED
+    // positive control above is what stops this degenerating into "the gate
+    // silenced everything".
     renderGoalWith(SUBSTITUTED_OPTION)
-    const withheld = screen.queryAllByText(GOAL_ANCHOR_COPY.phrase('< 1%', true))
-    const possessive = screen.queryAllByText(new RegExp(POSSESSIVE))
-    expect(withheld).toHaveLength(1)
-    expect(possessive).toHaveLength(0)
+    expect(screen.queryAllByText(GOAL_ANCHOR_COPY.phrase('< 1%', true))).toHaveLength(0)
+    expect(screen.queryAllByText(new RegExp(POSSESSIVE))).toHaveLength(0)
   })
 })

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -1260,8 +1260,11 @@ describe('OptionNode', () => {
       probability_of_joint_goal: 0.0054,
       goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
     })
-    expect(substituted.basis).toBe('joint_goal_substituted')
+    expect(substituted.basis).toBe('joint_goal_withheld')
     expect(substituted.mayUsePossessiveGoalFraming).toBe(false)
+    // ⭐ L62: and the number is withheld, not merely re-voiced — which is what
+    // makes the render assertion below an ABSENCE rather than a rewording.
+    expect(substituted.goalProbability).toBeNull()
 
     // …and the neighbouring fixture is genuinely the OTHER basis.
     const constrained = selectGoalProbability({
@@ -1272,18 +1275,24 @@ describe('OptionNode', () => {
     expect(constrained.mayUsePossessiveGoalFraming).toBe(true)
   })
 
-  it('RED-first: WITHHOLDS the possessive "chance of target." when the joint figure is SUBSTITUTED for an absent goal probability', () => {
+  /**
+   * ⭐ AMENDED BY L62. ROADMAP 2.282 renamed the badge; L60 showed the VALUE
+   * was the untruth, so the badge is now absent entirely on this basis.
+   * The possessive assertion is kept verbatim — it must still not appear — and
+   * the "renamed, same value" half is replaced by its opposite.
+   */
+  it('L62: renders NO goal badge at all when the only figure is a joint one standing in for an absent goal probability', () => {
     mockTrust.suspect = false
     mockResultsModeMetadata()
     vi.mocked(useCanvasStore).mockImplementation((selector) =>
       selector(makeSubstitutedJointStore() as any)
     )
-    renderOption()
+    const { container } = renderOption()
     expect(screen.queryByText(/chance of target\./)).toBeNull()
-    // The number is NOT suppressed — it is renamed. Same value, honest voice,
-    // in the shared register's sentence form.
-    expect(screen.getByText(new RegExp(GOAL_ANCHOR_COPY.sentence('< 1%', true).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))))
-      .toBeDefined()
+    // Neither voice, and no number — the withheld wording is gone too, because
+    // there is nothing left for it to caption.
+    expect(container.textContent ?? '').not.toContain(GOAL_ANCHOR_COPY.label(true))
+    expect(container.textContent ?? '').not.toContain('< 1%')
   })
 
   it('positive control: the CONSTRAINED joint figure KEEPS the possessive wording (the gate is basis-scoped, not joint-scoped)', () => {

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.possessiveGate.spec.tsx
@@ -61,7 +61,7 @@ import { useCanvasStore } from '../../../store'
 import { useAuth } from '../../../../contexts/AuthContext'
 import { selectGoalProbability } from '../../../../components/results/utils/selectGoalProbability'
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
-import { GOAL_CONSTRAINT_COPY } from '../inspectorStrings'
+import { GOAL_CONSTRAINT_COPY, GOAL_STRINGS } from '../inspectorStrings'
 import { mapV5AnalysisToReport } from '../../../../v5/mapV5AnalysisToReport'
 import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 
@@ -164,9 +164,14 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (2.28
     // Anti-vacuity (trap 13) — and this time the control also proves the REAL
     // mapper writes the owned fields where the panel's read must look.
     const sub = selectGoalProbability(recordOf(SUBSTITUTED_REPORT))
-    expect(sub.basis).toBe('joint_goal_substituted')
+    expect(sub.basis).toBe('joint_goal_withheld')
     expect(sub.mayUsePossessiveGoalFraming).toBe(false)
-    expect(sub.goalProbability).toBe(sub.jointGoalProbability)
+    // ⭐ L62: the identity 2.296 pinned here (`goalProbability ===
+    // jointGoalProbability`) is precisely the substitution, and it is gone.
+    // The joint quantity survives for the panel's own labelled row; the
+    // goal-fit slot is empty.
+    expect(sub.goalProbability).toBeNull()
+    expect(sub.jointGoalProbability).toBe(0.0054)
 
     expect(selectGoalProbability(recordOf(REAL_GOAL_REPORT)).basis).toBe('goal_probability')
     expect(selectGoalProbability(recordOf(CONSTRAINED_REPORT)).basis).toBe(
@@ -174,27 +179,36 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (2.28
     )
   })
 
-  it('RED-first (2.296): the substituted figure RENDERS at all off the real mapper shape — the gate is no longer dark', () => {
+  /**
+   * ⭐ AMENDED BY L62. 2.296 proved the gate was no longer dark by asserting
+   * the substituted figure RENDERED (re-voiced). L60 §5–§8 showed the figure
+   * itself is the untruth, so the panel now renders no goal-fit figure at all
+   * on this basis. Both halves of the original assertion — the possessive one
+   * and the re-voiced one — must now be absent.
+   */
+  it('L62: the substituted figure does not render at all off the real mapper shape', () => {
     setStore(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
     const text = container.textContent ?? ''
 
     expect(text).not.toContain('chance of reaching this target')
-    // Renamed, not removed — the register's compact readout, with the panel's
-    // existing "current model" qualifier kept.
-    expect(text).toContain(`${GOAL_ANCHOR_COPY.phrase('1%', true)}, based on the current model.`)
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    expect(text).not.toContain('1% chance')
   })
 
-  it('RED-first: the Impact readout does NOT say "chance of success" over a substituted joint figure', () => {
+  it('L62: the Impact readout says neither "chance of success" nor the withheld phrase over a joint-only run', () => {
     setStore(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
     const text = container.textContent ?? ''
 
     expect(text).not.toContain('chance of success')
-    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
   })
 
-  it('RED-first — THE SELF-CONTRADICTION: the Impact block states ONE claim about the substituted number, not two incompatible ones', () => {
+  it('L62 — THE SELF-CONTRADICTION, resolved by subtraction: the Impact block states ZERO claims about the withheld number', () => {
+    // 2.283 fixed one-number-two-voices by picking the honest voice. L62 fixes
+    // it by removing the number, so the honest count is zero. The positive
+    // controls below are what stop that reading as "the panel went blank".
     setStore(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
 
@@ -203,10 +217,9 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (2.28
     const text = impact?.textContent ?? ''
 
     expect(text).not.toContain('chance of success')
-    expect(text).not.toContain('Chance of hitting every target')
-
-    const honest = GOAL_ANCHOR_COPY.phrase('1%', true)
-    expect(text.split(honest).length - 1).toBe(1)
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    // The panel's own honest-absence string for this block.
+    expect(text).toContain(GOAL_STRINGS.impactUnavailable)
   })
 
   it('positive control: a REAL probability_of_goal KEEPS the possessive wording on BOTH sites', () => {
@@ -230,15 +243,22 @@ describe('GoalPanel — possessive gate on a substituted joint goal figure (2.28
     expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('42%', true))
   })
 
-  it('techMode: the diagnostic names the field the number ACTUALLY is under substitution', () => {
+  it('L62 — techMode: the diagnostic states NO goal field for a withheld run, and above all does not name `probability_of_goal`', () => {
+    // 2.282's fix was to stop the tech-mode line calling the substituted value
+    // `probability_of_goal` — "the most literally false line in the block, and
+    // the one a tech-mode reader would trust most". With no value to diagnose,
+    // the line is gone. Both false spellings are pinned absent, so a
+    // regression in either direction REDs.
     setStore(SUBSTITUTED_REPORT)
     const { container } = render(
       <GoalPanel nodeId="goal1" techMode onClose={() => {}} onNavigate={() => {}} />,
     )
     const text = container.textContent ?? ''
 
-    expect(text).toContain('probability_of_joint_goal (substituted for absent probability_of_goal)')
     expect(text).not.toContain('System: probability_of_goal:')
+    expect(text).not.toContain(
+      'probability_of_joint_goal (substituted for absent probability_of_goal)',
+    )
   })
 
   it('honest absence: WITHOUT the producer pointer the panel shows no figure (the 2.275 posture, same as the canvas)', () => {
@@ -294,16 +314,32 @@ describe('GoalPanel — the Constraints-section restatement (ROADMAP 2.283, real
     expect(container.textContent ?? '').toContain('Stay under budget')
   })
 
-  it('RED-first: the Constraints section does NOT restate the substituted joint figure', () => {
+  /**
+   * ⭐ AMENDED BY L62, AND THE DIRECTION REVERSES — read this one carefully.
+   *
+   * 2.283 SUPPRESSED this line under substitution, because the Impact block
+   * above was already stating the identical number in the honest voice and two
+   * findings from one measurement is a lie of arithmetic. That reasoning was
+   * entirely contingent on the substitution: `goalProbability ===
+   * jointGoalProbability` BY CONSTRUCTION was the whole argument.
+   *
+   * With the substitution withheld, the Impact block states nothing, so there
+   * is no duplicate — and the joint quantity is exactly the thing this section
+   * is FOR. It is the one surface where the figure is honestly labelled as
+   * what it is: P(all your limits met), not P(you reach your target). So it
+   * comes BACK, and this test pins its presence rather than its absence.
+   */
+  it('L62: the Constraints section DOES state the joint figure under its own honest label — the goal-fit slot is what was withheld, not the quantity', () => {
     setStoreWithConstraints(SUBSTITUTED_REPORT)
     const { container } = renderPanel()
     const text = container.textContent ?? ''
 
     expect(text).toContain('Stay under budget')
-    expect(text).not.toContain(JOINT_LINE)
-    // Paired presence proof (this suite's RED half): the Impact block carries
-    // the ONE honest statement of the number.
-    expect(text).toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    expect(text).toContain(JOINT_LINE)
+    // …and the goal-fit claim it used to be duplicating is gone, so this is
+    // one statement of one measurement, not two.
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
+    expect(text).not.toContain('chance of success')
   })
 
   it('positive control: with constraints defined, a REAL probability_of_goal KEEPS the Constraints line', () => {

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -42,6 +42,7 @@ import { useAuth } from '../../../../contexts/AuthContext'
 import { isPersistenceActive } from '../../../../lib/persistenceActive'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
+import { basisWithholdsPossessive } from '../../../../components/results/utils/selectGoalProbability'
 import { formatGoalTarget } from '../../../../components/results/utils/formatGoalTarget'
 
 export const GoalPanel = memo(function GoalPanel({
@@ -131,8 +132,16 @@ export const GoalPanel = memo(function GoalPanel({
   // construction, so the Impact block was stating one value twice in two
   // different voices: "N% chance of success" over "Chance of hitting every
   // target: N%". One of those was false. They are collapsed to the honest one.
+  // ⭐ L62 (2026-08-04) — THIS IS NOW ALWAYS FALSE, AND THAT IS THE POINT.
+  // `selectGoalProbability` no longer substitutes the joint figure into the
+  // goal-fit slot at all: on that basis (`'joint_goal_withheld'`) it returns NO
+  // number, so this surface renders nothing to re-voice. The bases that still
+  // carry a number — `'goal_probability'` and `'joint_goal_constrained'` —
+  // both EARN the possessive. The narrowing goes through the owner's exported
+  // `basisWithholdsPossessive` so the four canvas/summary surfaces share ONE
+  // rule instead of four copies of a literal.
   const goalFitSubstituted =
-    displayMetadata.achievementProbabilityBasis === 'joint_goal_substituted'
+    probGoal !== null && basisWithholdsPossessive(displayMetadata.achievementProbabilityBasis)
 
   const thresholdUnit = (node?.data as Record<string, unknown>)?.goal_threshold_unit as string | undefined
   const thresholdRaw = (node?.data as Record<string, unknown>)?.goal_threshold_raw as string | number | null | undefined

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -554,7 +554,11 @@ function OptionCard({
   // consumer of a mitigation six sibling surfaces already honour.
   //
   // `selectGoalProbability` publishes `basis`. When it is
-  // `'joint_goal_substituted'` the number in `option.goalProbability` is
+  // ⚠ L62 (2026-08-04): the basis named below was renamed
+  // `'joint_goal_withheld'` AND now carries no number at all, so this card
+  // renders no goal figure in that state and the branch is unreachable. The
+  // paragraph is kept as the record of what it guarded. On the basis
+  // `'joint_goal_withheld'` the number in `option.goalProbability` is
   // P(all constraints jointly satisfied) STANDING IN for an absent
   // `probability_of_goal` — it answers a DIFFERENT question from the one
   // "target" asserts, and the selector's `mayUsePossessiveGoalFraming` is

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -519,6 +519,10 @@ export const ResultsBody = memo(function ResultsBody({
                   // ROADMAP 2.334 — the resolution the goal readouts need.
                   nValidSamples: o.nValidSamples,
                   goalFitIsSubstitutedJoint: o.goalFitIsSubstitutedJoint,
+                  // ⭐ L62 — lets the gauge tell "no target set" apart from
+                  // "a goal figure was withheld from you"; they need different
+                  // sentences and only the producer decision knows which.
+                  goalFitWithheld: o.goalFitWithheld,
                 }))}
               decisionState={vm.decisionState}
               designationsWithheld={

--- a/src/components/results/SuccessTargetRow.tsx
+++ b/src/components/results/SuccessTargetRow.tsx
@@ -75,7 +75,6 @@ function ConstraintRow({ item }: { item: ConstraintItem }) {
   // fallback arm applies and understates rather than inventing a resolution.
   const readout = formatProbabilityWithResolution(item.prob_satisfied, null)
   const colour = constraintConfidenceColour(item.prob_satisfied)
-  const isMissed = item.prob_satisfied < 0.5
 
   return (
     <div
@@ -96,12 +95,38 @@ function ConstraintRow({ item }: { item: ConstraintItem }) {
           </span>
         )}
       </div>
-      {/* Task M.1.2 Step 2: Display failure margin when constraint is missed */}
-      {isMissed && item.failure_margin_median != null && (
-        <p className={`${typography.panelMeta} text-warning ml-6`}>
-          Typically misses by {item.failure_margin_median} {/* TODO: Add unit from parent context if available */}
-        </p>
-      )}
+      {/*
+        ⭐ L62 (2026-08-04) — THE "TYPICALLY MISSES BY {N}" LINE IS REMOVED.
+
+        It rendered `failure_margin_median` as a DISTANCE the user is short of
+        their target. L60 showed at the bytes what that number is: PLoT
+        denormalises the constraint's shortfall by multiplying a CHANGE-frame
+        Monte-Carlo sample by the goal-threshold cap and subtracting it from the
+        LEVEL target — on the captured probe, "£200,678 short" out of
+        250000 − (p50 0.15783 × 312500). The two quantities are not in the same
+        frame, so the subtraction has no meaning, and the result is a precise,
+        confident, fabricated distance. It travelled with the same structurally
+        ≈0 probability this component's sibling surfaces now withhold
+        (`selectGoalProbability`, basis `'joint_goal_withheld'`), and it is the
+        same defect wearing units instead of a percentage.
+
+        It also shipped the number RAW with a standing `TODO: add unit`, so a
+        margin of 0.563 (a fraction) and one of 18.0 (a head-count) both
+        rendered as bare digits with no unit at all.
+
+        REINSTATEMENT TRIGGER — the same one the probability gate carries: a
+        producer-side frame attestation on the constraint channel, such that a
+        shortfall can be shown to be a distance in the user's units rather than
+        an arithmetic artefact. Nothing on the wire supplies that today.
+
+        SCOPE, STATED HONESTLY: this component is not currently mounted (the
+        hero panel supersedes it) and its `ConstraintAnalysis` input is stripped
+        by `responseMapper` while `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT` holds,
+        so this line was NOT reaching users at this tip. It is removed at the
+        source anyway — it is the repo's only render of `failure_margin_median`,
+        and leaving it would mean the fabricated distance returns the moment
+        either of those two conditions changes.
+      */}
     </div>
   )
 }

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -78,6 +78,19 @@ export interface OptionWinShare {
    * asserts, so the A copy drops the possessive. Read, never re-derived.
    */
   goalFitIsSubstitutedJoint?: boolean
+  /**
+   * ⭐ L62 — `OptionResult.goalFitWithheld`. True when the run DID carry a
+   * `probability_of_joint_goal` and `selectGoalProbability` refused to put it
+   * in the goal-fit slot, because nothing on the wire shows the constraint
+   * threshold and the samples it is compared against are in the same frame.
+   *
+   * It exists to tell two silences apart. `goalProbability` being absent is
+   * ALSO how a no-target run looks, and the A5 line for that state — "Set a
+   * success target to see which option is most likely to reach it" — is the
+   * wrong sentence here: the user did set one, or the run did carry limits.
+   * Read, never re-derived.
+   */
+  goalFitWithheld?: boolean
 }
 
 // =============================================================================
@@ -258,6 +271,13 @@ export function WinGauge({
   // for the whole block — the safe direction, and it cannot produce a block
   // that says "your goal" over a number that does not answer it.
   const substituted = goalRows.some((s) => s.goalFitIsSubstitutedJoint === true)
+  // ⭐ L62 — same run-level reasoning as `substituted` above, and derived over
+  // ALL shares rather than `goalRows`: the withheld state is precisely the one
+  // where there ARE no goal rows, so filtering to rows first would make this
+  // permanently false. Any option whose goal figure was withheld puts the whole
+  // block in the withheld state, which is the safe direction: it can never
+  // invite a target the user already set.
+  const goalFitWithheld = shares.some((s) => s.goalFitWithheld === true)
 
   return (
     <div
@@ -326,13 +346,30 @@ export function WinGauge({
       ) : (
         // A5 — an invitation with its route, not a wall. The comparative
         // block below keeps rendering.
-        <p
-          className={`${typography.panelMeta} text-text-light mb-2`}
-          data-testid="win-gauge-no-target"
-        >
-          {GOAL_ANCHOR_COPY.noTarget}{' '}
-          <span className="text-info">{GOAL_ANCHOR_COPY.noTargetCta}</span>
-        </p>
+        // ⭐ L62 — TWO SILENCES, TWO SENTENCES.
+        // Withheld: the run produced a joint-constraints figure and the
+        // selector refused to score it as goal fit. Saying "Set a success
+        // target" here would ask the user for something they already gave and
+        // would imply the blank is their doing. Say what happened instead, and
+        // do NOT offer the unlock CTA — there is nothing for it to unlock.
+        goalFitWithheld ? (
+          <div className="mb-2" data-testid="win-gauge-goal-not-scored">
+            <p className={`${typography.panelMeta} text-text-light`}>
+              {GOAL_ANCHOR_COPY.notScored}
+            </p>
+            <p className={`${typography.panelMeta} text-text-light`}>
+              {GOAL_ANCHOR_COPY.notScoredReason}
+            </p>
+          </div>
+        ) : (
+          <p
+            className={`${typography.panelMeta} text-text-light mb-2`}
+            data-testid="win-gauge-no-target"
+          >
+            {GOAL_ANCHOR_COPY.noTarget}{' '}
+            <span className="text-info">{GOAL_ANCHOR_COPY.noTargetCta}</span>
+          </p>
+        )
       )}
 
       <div data-testid="win-gauge-comparative-block">

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -72,10 +72,17 @@ export interface OptionWinShare {
    */
   nValidSamples?: number | null
   /**
-   * THE POSSESSIVE GATE — `OptionResult.goalFitIsSubstitutedJoint`, i.e.
-   * `selectGoalProbability(...).basis === 'joint_goal_substituted'`. True ⇒
+   * THE POSSESSIVE GATE — `OptionResult.goalFitIsSubstitutedJoint`. True ⇒
    * the number answers a different question from the one "your goal"
    * asserts, so the A copy drops the possessive. Read, never re-derived.
+   *
+   * ⚠ L62 (2026-08-04): this is now ALWAYS FALSE. It was
+   * `basis === 'joint_goal_substituted'`; that basis no longer exists (renamed
+   * `'joint_goal_withheld'`) and carries no number, so nothing reaches this
+   * surface needing a re-voiced caption. See `goalFitWithheld` below, which is
+   * the flag that now carries the state — and `selectGoalProbability`'s L62
+   * block for why. Kept only so the branches still compile; retiring it is a
+   * rowed follow-up.
    */
   goalFitIsSubstitutedJoint?: boolean
   /**

--- a/src/components/results/__tests__/l62GoalFitWithheld.surfaces.spec.tsx
+++ b/src/components/results/__tests__/l62GoalFitWithheld.surfaces.spec.tsx
@@ -1,0 +1,261 @@
+/**
+ * L62 — the withheld state, at the surfaces the user actually reads.
+ *
+ * The selector-level pins live in
+ * `utils/__tests__/selectGoalProbability.l62Withhold.spec.ts`. This file pins
+ * what the screens do with that decision, because a correct selector rendered
+ * by a surface that falls back to a percentage, a placeholder glyph or the
+ * wrong sentence is not a fix.
+ *
+ * Three surfaces, chosen because each was named in the diagnosis:
+ *
+ *  1. `buildGoalFitRows` — the Model tab's goal card. This is the surface in
+ *     L60 screenshot 05, which printed "< 1% chance of meeting every target
+ *     this run scored" four times directly under "Target: 250,000".
+ *  2. `WinGauge` — the results panel's goal block, and the one place where
+ *     "no goal number" previously collapsed into the NO-TARGET invitation.
+ *  3. `SuccessTargetRow` — the only render of `failure_margin_median` in the
+ *     repo: "Typically misses by {N}", the fabricated distance.
+ *
+ * Fixtures are producer bytes (see `utils/__tests__/fixtures/`). Assertions
+ * bind by identity — exact option id, exact test id — never by a value
+ * predicate a sibling option could satisfy (CLAUDE.md trap 19).
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): jsdom proves PRESENCE and ABSENCE of strings and
+ * nodes in the rendered output. It proves nothing about layout or visibility.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { WinGauge } from '../WinGauge'
+import { SuccessTargetRow } from '../SuccessTargetRow'
+import { buildGoalFitRows } from '../../../canvas/components/model-tab/buildGoalFitRows'
+import { GOAL_ANCHOR_COPY } from '../utils/goalAnchorCopy'
+import { selectGoalProbability } from '../utils/selectGoalProbability'
+import {
+  L60_PRICING_OPTIONS,
+  L60_PEOPLE_OPTIONS,
+  L60_PROBE_OPTIONS,
+} from '../utils/__tests__/fixtures/l60ProducerShapes'
+
+const SHAPES = [
+  ['pricing (draft-minted fraction, decision_grade FALSE)', L60_PRICING_OPTIONS],
+  ['people (chat-minted count, decision_grade TRUE)', L60_PEOPLE_OPTIONS],
+  ['probe (goal-target level, decision_grade TRUE)', L60_PROBE_OPTIONS],
+] as const
+
+type ProducerOption = { id: string; label: string; probability_of_joint_goal?: number }
+
+/** `option_probabilities` keyed by node id, exactly as the report carries it. */
+function asOptionProbabilities(options: readonly ProducerOption[]): Record<string, unknown> {
+  return Object.fromEntries(options.map((o) => [o.id, o]))
+}
+
+function asOptionNodes(options: readonly ProducerOption[]): Node[] {
+  return options.map((o) => ({
+    id: o.id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label: o.label },
+  })) as Node[]
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Model tab goal card — the screenshot-05 surface
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('L62 / Model tab goal card (buildGoalFitRows)', () => {
+  for (const [name, options] of SHAPES) {
+    it(`returns NO rows for the witnessed shape — ${name}`, () => {
+      // Control first: the fixture really is the substituting shape, so a
+      // `null` below cannot be an artefact of an empty or malformed input.
+      for (const o of options as readonly ProducerOption[]) {
+        expect(selectGoalProbability(o).jointSubstitutionWithheld, o.id).toBe(true)
+      }
+
+      const rows = buildGoalFitRows(
+        asOptionNodes(options as readonly ProducerOption[]),
+        asOptionProbabilities(options as readonly ProducerOption[]),
+      )
+      // `GoalSection` renders the goal-fit block on
+      // `goalFitRows && goalFitRows.length > 0`, so null is the honest-absence
+      // state: no rows, no percentages, no "chance of meeting every target".
+      expect(rows).toBeNull()
+    })
+  }
+
+  it('POSITIVE CONTROL: an honest goal probability still produces one row per option, bound by id', () => {
+    const honest = (L60_PRICING_OPTIONS as readonly ProducerOption[]).map((o, i) => ({
+      ...o,
+      probability_of_goal: 0.12 + i * 0.17,
+    }))
+    const rows = buildGoalFitRows(asOptionNodes(honest), asOptionProbabilities(honest))
+
+    expect(rows).not.toBeNull()
+    expect(rows).toHaveLength(honest.length)
+    for (const [i, o] of honest.entries()) {
+      // IDENTITY-bound: the row for THIS option, found by id, carries THIS
+      // option's probability. A `rows.find(r => r.probability === x)` would
+      // pass on a builder that scrambled the pairing.
+      const row = rows!.find((r) => r.id === o.id)
+      expect(row, o.id).toBeDefined()
+      expect(row!.probability).toBe(0.12 + i * 0.17)
+      // And it is NOT flagged as a withheld/substituted voice: the possessive
+      // is earned here.
+      expect(row!.isSubstitutedJoint, o.id).toBe(false)
+    }
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. WinGauge — the results panel's goal block
+// ───────────────────────────────────────────────────────────────────────────
+
+function gaugeShares(options: readonly ProducerOption[]) {
+  return options.map((o, i) => {
+    // The hook's mapping, and only the hook's mapping — the flags come out of
+    // the REAL selector, never hand-set, so this pins the producer shape
+    // through the real chooser into the real component.
+    const d = selectGoalProbability(o)
+    return {
+      id: o.id,
+      label: o.label,
+      winProbability: 0.4 - i * 0.05,
+      isWinner: i === 0,
+      goalProbability: d.goalProbability,
+      nValidSamples: 10000,
+      goalFitIsSubstitutedJoint:
+        d.goalProbability != null && !d.mayUsePossessiveGoalFraming,
+      goalFitWithheld: d.jointSubstitutionWithheld,
+    }
+  })
+}
+
+describe('L62 / WinGauge goal block', () => {
+  for (const [name, options] of SHAPES) {
+    it(`renders the honest-absence state, not a percentage and not the no-target invitation — ${name}`, () => {
+      const { container } = render(
+        <WinGauge shares={gaugeShares(options as readonly ProducerOption[])} />,
+      )
+      const text = container.textContent ?? ''
+
+      // The withheld sentence, by test id and verbatim register copy.
+      const block = container.querySelector('[data-testid="win-gauge-goal-not-scored"]')
+      expect(block).not.toBeNull()
+      expect(block!.textContent).toContain(GOAL_ANCHOR_COPY.notScored)
+      expect(block!.textContent).toContain(GOAL_ANCHOR_COPY.notScoredReason)
+
+      // NOT the no-target invitation: the user set a target / the run carried
+      // limits, and asking them to set one would blame them for our silence.
+      expect(container.querySelector('[data-testid="win-gauge-no-target"]')).toBeNull()
+      expect(text).not.toContain(GOAL_ANCHOR_COPY.noTarget)
+      expect(text).not.toContain(GOAL_ANCHOR_COPY.noTargetCta)
+
+      // No goal figure at all — neither the number nor its label.
+      expect(container.querySelector('[data-testid="win-gauge-goal-block"]')).toBeNull()
+      expect(text).not.toContain(GOAL_ANCHOR_COPY.label(true))
+      expect(text).not.toContain('< 1%')
+      for (const o of options as readonly ProducerOption[]) {
+        expect(container.querySelector(`[data-testid="goal-pct-${o.id}"]`), o.id).toBeNull()
+      }
+
+      // The comparative block is untouched — the gate withholds one claim, it
+      // does not blank the panel.
+      expect(container.querySelector('[data-testid="win-gauge-comparative-block"]')).not.toBeNull()
+    })
+  }
+
+  it('POSITIVE CONTROL: an honest goal probability still draws the goal block, per option by id', () => {
+    const honest = (L60_PRICING_OPTIONS as readonly ProducerOption[]).map((o, i) => ({
+      ...o,
+      probability_of_goal: 0.12 + i * 0.17,
+    }))
+    const { container } = render(<WinGauge shares={gaugeShares(honest)} />)
+    const text = container.textContent ?? ''
+
+    expect(container.querySelector('[data-testid="win-gauge-goal-block"]')).not.toBeNull()
+    // The possessive is EARNED here, so the label is the possessive form.
+    expect(text).toContain(GOAL_ANCHOR_COPY.label(false))
+    expect(container.querySelector('[data-testid="win-gauge-goal-not-scored"]')).toBeNull()
+    for (const o of honest) {
+      expect(container.querySelector(`[data-testid="goal-pct-${o.id}"]`), o.id).not.toBeNull()
+    }
+  })
+
+  it('POSITIVE CONTROL: a genuine NO-TARGET run still gets the no-target invitation, not the withheld sentence', () => {
+    // No goal figure AND no joint figure — the ordinary state of a run the
+    // user set no target on. Without this control, wiring every empty goal
+    // block to the withheld copy would pass every test above.
+    const noTarget = (L60_PRICING_OPTIONS as readonly ProducerOption[]).map((o, i) => ({
+      id: o.id,
+      label: o.label,
+      winProbability: 0.4 - i * 0.05,
+      isWinner: i === 0,
+      goalProbability: null,
+      nValidSamples: 10000,
+      goalFitIsSubstitutedJoint: false,
+      goalFitWithheld: false,
+    }))
+    const { container } = render(<WinGauge shares={noTarget} />)
+
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-not-scored"]')).toBeNull()
+    expect(container.textContent ?? '').toContain(GOAL_ANCHOR_COPY.noTarget)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. SuccessTargetRow — the fabricated shortfall
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('L62 / the fabricated "typically misses by" distance', () => {
+  it('does not render a shortfall for a missed constraint, in the user units or otherwise', () => {
+    // The margin values are the producer's own, from the pricing run's
+    // `constraint_margins` (a fraction) and the people run's (a head-count) —
+    // the two cases the removed line rendered as bare, unitless digits.
+    const { container } = render(
+      <SuccessTargetRow
+        goalThreshold={250000}
+        constraintAnalysis={{
+          joint_probability: 0,
+          constraints: [
+            {
+              node_id: 'out_gross_margin',
+              operator: '>=',
+              threshold: 0.8,
+              label: 'Gross Margin',
+              prob_satisfied: 0,
+              failure_margin_median: 0.5630574027128157,
+              near_miss_fraction: 0,
+              binding: true,
+            },
+            {
+              node_id: 'risk_ae_attrition',
+              operator: '<=',
+              threshold: 2,
+              label: 'Account executives lost',
+              prob_satisfied: 0,
+              failure_margin_median: 18.002137272472513,
+              near_miss_fraction: 0,
+              binding: false,
+            },
+          ],
+        }}
+      />,
+    )
+    const text = container.textContent ?? ''
+
+    // Control: the rows themselves DID render, so the absences below are
+    // about the shortfall line and not about an empty component.
+    expect(container.querySelector('[data-testid="constraint-row-out_gross_margin"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="constraint-row-risk_ae_attrition"]')).not.toBeNull()
+
+    // The removed claim, by wording and by value.
+    expect(text).not.toContain('Typically misses by')
+    expect(text).not.toContain('0.5630574027128157')
+    expect(text).not.toContain('18.002137272472513')
+    // …and no rounded rendering of either sneaking back in.
+    expect(text).not.toMatch(/misses by/i)
+  })
+})

--- a/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
+++ b/src/components/results/__tests__/substitutedJointGate.optionCards.spec.tsx
@@ -58,6 +58,31 @@
  * Scope limit (CLAUDE.md trap 3): jsdom proves PRESENCE and ABSENCE of
  * strings in the rendered output. It proves nothing about layout, wrapping
  * or visibility.
+ *
+ * ═════════════════════════════════════════════════════════════════════════
+ * ⭐ SUPERSEDED IN PART BY L62 (2026-08-04) — READ BEFORE EDITING
+ * ═════════════════════════════════════════════════════════════════════════
+ * 2.282's fix was a COPY switch: keep the substituted number, drop the
+ * possessive voice. L60's diagnosis
+ * (`PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md` §5–§8, verified
+ * live at the deployed tips) established that the NUMBER is the untruth. ISL
+ * evaluates the constraint with a bare `value >= threshold`, comparing a
+ * LEVEL or COUNT threshold against CHANGE-frame Monte-Carlo samples with no
+ * conversion — so P ≈ 0 is arithmetically forced for every option in every
+ * decision, and `probability_of_goal` was absent precisely because ISL's frame
+ * guard had honestly refused to guess. 2.282 was re-voicing a fabrication.
+ *
+ * `selectGoalProbability` therefore no longer substitutes at all (basis
+ * `'joint_goal_withheld'`, no number). The tests below that asserted the
+ * WITHHELD WORDING renders are inverted: nothing renders. Their possessive
+ * assertions are unchanged and still load-bearing, and the two positive
+ * controls — a real `probability_of_goal` keeps the possessive — are
+ * untouched, because they are what stops this reading as "the card went
+ * blank".
+ *
+ * The 2.282 narrative above is kept verbatim rather than rewritten: it is the
+ * record of what was believed and fixed at the time, and the amendment is
+ * more legible beside it than in place of it.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -155,7 +180,10 @@ function toOptionResults(
       nValidSamples: 10000,
       goalProbability: goalDecision.goalProbability,
       goalFitIsModelledBasis: goalDecision.goalFitIsModelledBasis,
-      goalFitIsSubstitutedJoint: goalDecision.basis === 'joint_goal_substituted',
+      // L62: the hook's expression, verbatim — the owner's PERMISSION on a
+      // present number, not a basis literal.
+      goalFitIsSubstitutedJoint:
+        goalDecision.goalProbability != null && !goalDecision.mayUsePossessiveGoalFraming,
     } as OptionResult
   })
 }
@@ -176,83 +204,55 @@ describe('OptionCards — possessive gate on a substituted joint goal figure (RO
     const decisions = WITNESSED_PRODUCER_OPTIONS.map((o) => selectGoalProbability(o))
 
     for (const d of decisions) {
-      expect(d.basis).toBe('joint_goal_substituted')
+      expect(d.basis).toBe('joint_goal_withheld')
       expect(d.mayUsePossessiveGoalFraming).toBe(false)
+      expect(d.jointSubstitutionWithheld).toBe(true)
     }
-    // The substituted VALUE is the joint figure, unchanged — the fix is a
-    // copy switch, and this control would catch a "fix" that suppressed the
-    // number instead of the framing.
-    expect(decisions[0].goalProbability).toBe(0.0054)
+    // ⭐ THE INVERSION. 2.282 asserted `goalProbability === 0.0054` here and
+    // said this control "would catch a fix that suppressed the number instead
+    // of the framing". Suppressing the number is exactly what L62 does, on
+    // evidence 2.282 did not have — so the control asserts the opposite now,
+    // and the joint quantity is pinned as still-published beside it.
+    expect(decisions[0].goalProbability).toBeNull()
+    expect(decisions[0].jointGoalProbability).toBe(0.0054)
 
-    // And it survives the hook's mapping into the prop the card reads.
+    // And the withhold survives the hook's mapping into the prop the card reads.
     const mapped = toOptionResults(WITNESSED_PRODUCER_OPTIONS)
-    expect(mapped.every((o) => o.goalFitIsSubstitutedJoint === true)).toBe(true)
-    expect(mapped[0].goalProbability).toBe(0.0054)
+    expect(mapped.every((o) => o.goalFitIsSubstitutedJoint === false)).toBe(true)
+    expect(mapped[0].goalProbability).toBeNull()
   })
 
-  it('RED-first: the low-goal badge does NOT say "likely to reach target" over a substituted joint figure', () => {
+  it('L62: the low-goal badge does not render AT ALL over a withheld joint figure — neither voice, no number', () => {
     const { container } = renderCards(toOptionResults(WITNESSED_PRODUCER_OPTIONS))
     const text = container.textContent ?? ''
 
-    // The witnessed string, verbatim.
+    // The 2.282 assertions, unchanged: the possessive must not appear.
     expect(text).not.toContain('< 1% likely to reach target')
     expect(text).not.toContain(POSSESSIVE_BADGE_TAIL)
 
-    // The badge still renders, still carries the number, and now names the
-    // quantity it actually is — the register's compact readout, verbatim.
-    //
-    // ⭐ AMENDED (ROADMAP 2.334): the readout was `'< 1%'`; it is now `'1%'`.
-    // The fixture carries `nValidSamples: 10000`, so the goal register no
-    // longer floors — it resolves, and 0.0054 renders through the shared
-    // smallest-distinct-precision rule.
-    //
-    // ⚠ NAMING THIS EXPLICITLY BECAUSE IT IS THE ONE BAND WHERE THE NEW
-    // REGISTER READS *HIGHER* THAN THE OLD FLOOR. For values in
-    // [0.005, 0.00999] the resolved string is "1%" where the floor said
-    // "< 1%" — 0.54% presented as 1%. That is ordinary integer rounding and
-    // it is byte-identical to what `formatProbabilityWithResolution` has
-    // rendered for WIN probabilities since ROADMAP 2.236, which is the whole
-    // point of the two registers sharing one rule. It is not a new untruth,
-    // but it IS a direction change, and a reviewer should see it stated
-    // rather than discover it: everywhere else in this slice the change makes
-    // readouts tighter or unchanged; here it makes one coarser.
-    //
-    // Derived by EXECUTING `formatGoalProbability(0.0054, 10000)` at this tip.
-    // Do not hand-edit this string — re-execute if the fixture moves.
-    //
-    // ⚠ BOUND BY IDENTITY AND EXACT EQUALITY, NOT `toContain` — and that is
-    // not stylistic. A `toContain(phrase('1%', true))` here is VACUOUS: the
-    // OLD string "< 1% chance of meeting every target this run scored"
-    // literally CONTAINS the new one as a substring, so the assertion passes
-    // whether or not the fix is present. Caught by mutation (dropping the
-    // nSamples delegation left this test green while the sibling specs went
-    // red), which is the only reason it is written this way.
-    const badge = container.querySelector('[data-testid="low-goal-warning-opt_hybrid"]')
-    expect(badge).not.toBeNull()
-    expect(badge?.textContent).toBe(GOAL_ANCHOR_COPY.phrase('1%', true))
-    // And the floor string is gone from the card entirely, so no substring
-    // relationship can hide a regression.
+    // ⭐ INVERTED. 2.282 required the badge to SURVIVE, carrying the register's
+    // withheld phrase over the same value ("the fix is a copy switch, never a
+    // value transform"). With the value itself withheld there is no badge.
+    expect(container.querySelector('[data-testid="low-goal-warning-opt_hybrid"]')).toBeNull()
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.phrase('1%', true))
     expect(text).not.toContain('< 1%')
   })
 
-  it('RED-first: the goal bar does NOT carry the possessive "Hits target" label over a substituted joint figure', () => {
+  it('L62: the goal bar carries neither the possessive label nor the withheld caption', () => {
     const { container } = renderCards(toOptionResults(WITNESSED_PRODUCER_OPTIONS))
     const text = container.textContent ?? ''
 
+    // 2.282's assertion, unchanged.
     expect(text).not.toContain(POSSESSIVE_BAR_LABEL)
-    // Replaced by the register's label form — the same string `WinGauge`'s
-    // goal block renders for the same state.
-    expect(text).toContain(GOAL_ANCHOR_COPY.label(true))
-    // Exactly one caption per RENDERED card. The count is DERIVED from the
-    // DOM rather than hard-coded to the five fixture options, because
-    // `OptionCards` truncates to `TOP_N` behind a "Show all" toggle — a
-    // literal 5 here would be a hand-maintained mirror of a constant this
-    // spec does not own (CLAUDE.md trap 12), and it would silently become
-    // the wrong number the day that constant moves.
-    const renderedCards = container.querySelectorAll('[data-testid^="option-card-"]')
-    expect(renderedCards.length).toBeGreaterThan(0)
-    expect(container.querySelectorAll('[data-testid^="goal-fit-substituted-label-"]'))
-      .toHaveLength(renderedCards.length)
+    // ⭐ INVERTED: 2.282 required the withheld label to REPLACE it. There is no
+    // number to caption, so neither appears.
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.label(true))
+    expect(
+      container.querySelectorAll('[data-testid^="goal-fit-substituted-label-"]'),
+    ).toHaveLength(0)
+    // Control: the cards themselves DID render, so the absences above are about
+    // the goal claim and not about an empty component.
+    expect(container.querySelectorAll('[data-testid^="option-card-"]').length).toBeGreaterThan(0)
   })
 
   it('positive control: a REAL probability_of_goal KEEPS the possessive "Hits target" label and renders no withheld caption', () => {
@@ -286,19 +286,28 @@ describe('OptionCards — possessive gate on a substituted joint goal figure (RO
       .toHaveLength(1)
   })
 
-  it('the two arms are mutually exclusive: no render shows both voices at once', () => {
-    for (const options of [
-      toOptionResults(WITNESSED_PRODUCER_OPTIONS),
-      toOptionResults(withRealGoalProbability(0.055)),
-    ]) {
+  it('L62: the withheld run shows NEITHER voice, and the honest run shows exactly the possessive one', () => {
+    // 2.282 pinned `possessive === !withheld` — exactly one voice per render.
+    // Under L62 the withheld run has zero of both, so the XOR no longer holds
+    // and asserting it would be false. Each arm is pinned explicitly instead,
+    // which is strictly stronger: the XOR was satisfiable by a card rendering
+    // the WRONG single voice.
+    const cases = [
+      { options: toOptionResults(WITNESSED_PRODUCER_OPTIONS), expectPossessive: false },
+      { options: toOptionResults(withRealGoalProbability(0.055)), expectPossessive: true },
+    ]
+    for (const { options, expectPossessive } of cases) {
       const { container, unmount } = renderCards(options)
       const text = container.textContent ?? ''
       const possessive = text.includes(POSSESSIVE_BADGE_TAIL) || text.includes(POSSESSIVE_BAR_LABEL)
-      const withheld =
+      const withheldVoice =
         text.includes(GOAL_ANCHOR_COPY.label(true)) ||
         text.includes(GOAL_ANCHOR_COPY.phrase('< 1%', true)) ||
         text.includes(GOAL_ANCHOR_COPY.phrase('6%', true))
-      expect(possessive).toBe(!withheld)
+      expect(possessive).toBe(expectPossessive)
+      // The withheld VOICE is retired outright: it existed only to caption a
+      // substituted number, and there is no longer such a number.
+      expect(withheldVoice).toBe(false)
       unmount()
     }
   })

--- a/src/components/results/__tests__/useResultsSectionData.goalProbability.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.goalProbability.spec.ts
@@ -116,6 +116,23 @@ function adaptedSubstitutedFlags(): Record<string, boolean | undefined> {
   return out
 }
 
+/**
+ * ⭐ L62 — the field that now carries the state 2.282's flag used to.
+ * `goalFitIsSubstitutedJoint` meant "the number shown is a substituted joint
+ * figure"; there is no such number any more, so it is false everywhere and
+ * `goalFitWithheld` says what happened instead. Both are read here, by the
+ * same hook render, so a test cannot assert one while the other quietly
+ * disagrees.
+ */
+function adaptedWithheldFlags(): Record<string, boolean | undefined> {
+  const { result } = renderHook(() => useResultsSectionData())
+  const out: Record<string, boolean | undefined> = {}
+  for (const o of result.current.recommendation?.allOptions ?? []) {
+    out[o.id] = o.goalFitWithheld
+  }
+  return out
+}
+
 describe('useResultsSectionData — goalProbability collapse — gate ON (default)', () => {
   beforeEach(() => {
     mockTrust.suspect = true
@@ -189,14 +206,21 @@ describe('useResultsSectionData — goalProbability collapse — POSITIVE CONTRO
     } as any)
   })
 
-  it('falls back to probability_of_joint_goal when goal_probability and constraint_analysis are absent (auto goal threshold)', () => {
+  /**
+   * ⭐ SUPERSEDED BY L62 — kept inverted, so restoring the fallback REDs here
+   * as well as at the selector. This is the hook-level twin of
+   * `selectGoalProbability.spec.ts`'s "does NOT fall back" test: the pair is
+   * what proves the withhold survives the hop into `OptionResult` rather than
+   * being re-derived on the way.
+   */
+  it('L62: does NOT fall back to probability_of_joint_goal when goal_probability and constraint_analysis are absent', () => {
     setStoreWithMappedReport(makeV2Response(
       { probability_of_joint_goal: 0 },
       { probability_of_joint_goal: 0 },
     ))
     const probs = adaptedGoalProbabilities()
-    expect(probs.opt_a).toBe(0)
-    expect(probs.opt_b).toBe(0)
+    expect(probs.opt_a).toBeNull()
+    expect(probs.opt_b).toBeNull()
   })
 
   it('prefers unconstrained goal_probability when no constraint_analysis exists', () => {
@@ -274,7 +298,7 @@ describe('useResultsSectionData — goalFitIsSubstitutedJoint (ROADMAP 2.282, th
     expect(adaptedGoalProbabilities().opt_a).toBeNull()
   })
 
-  it('SUBSTITUTED: joint present, goal_probability absent, no constraint_analysis → flag TRUE', () => {
+  it('L62 — WITHHELD: joint present, goal_probability absent, no constraint_analysis → no number, withheld flag TRUE', () => {
     // The witnessed staging shape (2026-08-01): ISL refused
     // `probability_of_goal` because `goal_threshold_frame` was never
     // stamped, and the auto-materialised constraint's joint figure stands in.
@@ -282,11 +306,19 @@ describe('useResultsSectionData — goalFitIsSubstitutedJoint (ROADMAP 2.282, th
       { probability_of_joint_goal: 0.0054 },
       { probability_of_joint_goal: 0.0018 },
     ))
+    // ⭐ L62. ROADMAP 2.282 pinned `goalFitIsSubstitutedJoint: true` with the
+    // value still published — "the withhold is on the framing only". The
+    // framing was never the problem: L60 showed the VALUE is
+    // P(level-or-count threshold >= change-frame sample), a structural zero.
+    // So the substituted flag is now false (nothing is substituted) and the
+    // withheld flag carries the state.
     const flags = adaptedSubstitutedFlags()
-    expect(flags.opt_a).toBe(true)
-    expect(flags.opt_b).toBe(true)
-    // The VALUE is still published — the withhold is on the framing only.
-    expect(adaptedGoalProbabilities().opt_a).toBe(0.0054)
+    expect(flags.opt_a).toBe(false)
+    expect(flags.opt_b).toBe(false)
+    expect(adaptedWithheldFlags().opt_a).toBe(true)
+    expect(adaptedWithheldFlags().opt_b).toBe(true)
+    // The number the user was shown is gone.
+    expect(adaptedGoalProbabilities().opt_a).toBeNull()
   })
 
   it('CONSTRAINED: the same joint figure WITH constraint_analysis → flag FALSE (possessive earned)', () => {
@@ -300,12 +332,19 @@ describe('useResultsSectionData — goalFitIsSubstitutedJoint (ROADMAP 2.282, th
       },
       { probability_of_joint_goal: 0.2 },
     ))
+    // ⭐ L62: the DISCRIMINATION this test exists for is unchanged and is what
+    // proves the gate is not a blanket ban on joint figures — one payload
+    // shape apart, opposite outcomes. Only the name of opt_b's state moved.
     const flags = adaptedSubstitutedFlags()
-    // opt_a carries its own constraints → 'joint_goal_constrained'.
+    // opt_a carries its own constraints → 'joint_goal_constrained' → the
+    // possessive is EARNED and the number is still shown.
     expect(flags.opt_a).toBe(false)
-    // opt_b has the identical joint number and NO constraints → substituted.
-    // The pair is the discriminator: one payload shape apart, opposite flags.
-    expect(flags.opt_b).toBe(true)
+    expect(adaptedGoalProbabilities().opt_a).toBe(0.2)
+    expect(adaptedWithheldFlags().opt_a).toBe(false)
+    // opt_b has the identical joint number and NO constraints → withheld.
+    expect(flags.opt_b).toBe(false)
+    expect(adaptedWithheldFlags().opt_b).toBe(true)
+    expect(adaptedGoalProbabilities().opt_b).toBeNull()
   })
 
   it('REAL goal probability → flag FALSE', () => {

--- a/src/components/results/__tests__/useResultsSectionData.seamAEnrichmentLift.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.seamAEnrichmentLift.spec.ts
@@ -143,7 +143,18 @@ describe('useResultsSectionData — Seam-A live fixture carrying the 4 lifted fi
     expect(byId.get('opt_b')?.goalFitIsModelledBasis).toBe(false)
   })
 
-  it('POSITIVE CONTROL (gate OFF): goal_fit_basis caveat flag is true ONLY for the option whose displayed number is the modelled joint-goal figure', () => {
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04). This asserted that with the SEAM-1 gate off
+   * the joint-only option (`opt_a`) displayed 0.42 and carried the
+   * modelled-basis caveat. That is now the withheld state: `opt_a` has no
+   * `probability_of_goal`, so its only figure is a joint one standing in for
+   * the absent goal quantity, and `selectGoalProbability` refuses it.
+   *
+   * The test is retained because its DISCRIMINATION still matters and is
+   * pinned below — opt_a and opt_b differ by one field, and the two must not
+   * end up in the same state. What flipped is which state opt_a is in.
+   */
+  it('L62 (gate OFF): the joint-ONLY option is withheld; the option with a real goal probability is untouched', () => {
     mockTrust.suspect = false
     setStoreFromLiveSeamABlock(JOINT_CAVEAT_BLOCK)
 
@@ -151,10 +162,16 @@ describe('useResultsSectionData — Seam-A live fixture carrying the 4 lifted fi
     const byId = new Map(
       (result.current.recommendation?.allOptions ?? []).map((o) => [o.id, o]),
     )
-    expect(byId.get('opt_a')?.goalProbability).toBe(0.42)
-    expect(byId.get('opt_a')?.goalFitIsModelledBasis).toBe(true)
+    // opt_a: joint-only ⇒ withheld. No number, and therefore no caveat to hang
+    // on one.
+    expect(byId.get('opt_a')?.goalProbability).toBeNull()
+    expect(byId.get('opt_a')?.goalFitIsModelledBasis).toBe(false)
+    expect(byId.get('opt_a')?.goalFitWithheld).toBe(true)
+    // opt_b: a real `probability_of_goal` ⇒ untouched. This is what makes the
+    // pair a discriminator rather than a blanket suppression.
     expect(byId.get('opt_b')?.goalProbability).toBe(0.55)
     expect(byId.get('opt_b')?.goalFitIsModelledBasis).toBe(false)
+    expect(byId.get('opt_b')?.goalFitWithheld).toBe(false)
   })
 
   it('a live Seam-A turn WITHOUT the four fields renders honest absence — no invention, no crash', () => {

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -175,15 +175,35 @@ export interface OptionResult {
   goalFitIsModelledBasis?: boolean
   /**
    * Goal-probability IDENTITY: true when the rendered `goalProbability` is
-   * `probability_of_joint_goal` STANDING IN for an absent `goal_probability`
-   * (the ISL-auto-derived-goal-threshold run). The number is real and the
-   * user is entitled to it, but it answers "P(all constraints jointly
-   * satisfied)", not "P(this option clears the goal)" — so prose showing it
-   * must NOT use the possessive "your goal" framing. Set from
-   * `selectGoalProbability(...).basis === 'joint_goal_substituted'`; never
-   * re-derived at a render site.
+   * `probability_of_joint_goal` STANDING IN for an absent `goal_probability`.
+   *
+   * ⚠ L62 (2026-08-04): this is now ALWAYS FALSE on every live payload, and
+   * the field is retained only so the surfaces that branch on it keep
+   * compiling. `selectGoalProbability` no longer substitutes — the joint
+   * figure is withheld from the goal-fit slot entirely (see that module's L62
+   * block for why the wire cannot justify the substitution). A rendered
+   * `goalProbability` is therefore always a quantity that earns the
+   * possessive. Retiring this field and the substituted-voice copy it selects
+   * is a follow-up; it is NOT done here because it touches a dozen surfaces
+   * and this change is a P0 truth fix, not a refactor.
+   *
+   * Set from `!selectGoalProbability(...).mayUsePossessiveGoalFraming` on a
+   * present number; never re-derived at a render site.
    */
   goalFitIsSubstitutedJoint?: boolean
+  /**
+   * ⭐ L62 — true when this run DID carry a `probability_of_joint_goal` and the
+   * selector refused to put it in the goal-fit slot (basis
+   * `'joint_goal_withheld'`).
+   *
+   * The distinction it carries is one no other field can: `goalProbability`
+   * being null means "no goal number", which is ALSO the state of a run where
+   * the user set no target. Those need different sentences — offering "Set a
+   * success target" to someone who set one is its own small untruth. Surfaces
+   * read this to choose `GOAL_ANCHOR_COPY.notScored` over
+   * `GOAL_ANCHOR_COPY.noTarget`.
+   */
+  goalFitWithheld?: boolean
 }
 
 /** Outcome unit type for formatting - from goal node observed_state.unit */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1590,7 +1590,17 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         goalFitIsModelledBasis,
         // Which quantity `goalProbability` actually IS, carried to the render
         // layer so prose can name it honestly (see types.ts).
-        goalFitIsSubstitutedJoint: goalDecision.basis === 'joint_goal_substituted',
+        //
+        // ⭐ L62: reads the owner's published PERMISSION on a present number
+        // rather than testing a basis literal. Always false today — the
+        // substitution is withheld at source, so anything rendered here earns
+        // the possessive.
+        goalFitIsSubstitutedJoint:
+          goalDecision.goalProbability != null && !goalDecision.mayUsePossessiveGoalFraming,
+        // ⭐ L62: "a goal number was WITHHELD" — distinct from "there is no
+        // goal number", which is also the no-target state. Forwarded from the
+        // owner, never re-derived.
+        goalFitWithheld: goalDecision.jointSubstitutionWithheld,
         // Multi-constraint analysis (from ISL when goal_constraints were provided)
         constraintAnalysis: prob.constraint_analysis,
       }

--- a/src/components/results/utils/__tests__/fixtures/l60ProducerShapes.ts
+++ b/src/components/results/utils/__tests__/fixtures/l60ProducerShapes.ts
@@ -1,0 +1,430 @@
+/**
+ * L60 PRODUCER-BYTE FIXTURES — the three witnessed frame-broken shapes.
+ *
+ * ⚠ GENERATED, NOT HAND-WRITTEN. Every object below is a verbatim
+ * `option_comparison[]` entry lifted from L60's captured artefacts in
+ * `PHASE0-EVIDENCE-2026-07-28/l60-artefacts/`. Nothing here was invented to
+ * make a test pass; the numbers are what the deployed producer emitted.
+ *
+ * Source artefacts and their SHA-256 at generation time:
+ *   runfact-04f53491-run1.json  4df65cac576231015281e72bb53400ecb9f4deaa4f64f1f564ea9f217c5153c3
+ *   runfact-7fe412ba-run3.json  e4c24be0d4d46810cc94f72c153f71b5257689fddce09698578f65d3c91edf3d
+ *   probe-plot-response.json    27f438ba25593f0d937fbda67bf84dd7fe05fdeb7616d1fb6af3e17d93875e19
+ *
+ * WHAT EACH SHAPE IS (L60 §6 / §8.2 — all three are the SAME defect):
+ *
+ *  · PRICING  real session, 3 Aug. Draft-minted margin constraint
+ *    `out_gross_margin >= 0.8 'fraction'`, `scale_provenance.source: 'default'`,
+ *    `constraints_decision_grade: FALSE` — and it rendered anyway.
+ *  · PEOPLE   real session, same night. Chat-minted COUNT constraint
+ *    `risk_ae_attrition <= 2 'count'`, `scale_provenance.source: 'explicit_cap'`,
+ *    `constraints_decision_grade: TRUE` — decision-grade-stamped and still
+ *    frame-broken ("≤2 AEs of 8" evaluated as P(risk-score-sample ≤ 0.25)).
+ *    Note it carries NO `goal_fit_basis` at all.
+ *  · PROBE    synthetic run against deployed PLoT/ISL (`_meta.builds` =
+ *    plot 2864b0c / isl 80aa83f). Goal-target constraint
+ *    `goal_mrr >= 250000 'level'`, `goal_threshold_cap`, decision-grade TRUE.
+ *
+ * In all three, `probability_of_goal` / `goal_probability` is ABSENT (the
+ * honest channel failed closed) and `probability_of_joint_goal` is present and
+ * structurally ≈0 — the exact input that drove the substitution.
+ */
+
+/** Verbatim `option_comparison` entries — pricing scenario, run 1. */
+export const L60_PRICING_OPTIONS = [
+  {
+    "id": "opt_hold",
+    "label": "Hold at £49 Per Seat (Status Quo)",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.03613319044678028,
+      "p50": 0.12757593878224927,
+      "p90": 0.2629372109066514,
+      "std": 0.11796575608786203,
+      "mean": 0.12102572420856127,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_hold",
+    "option_label": "Hold at £49 Per Seat (Status Quo)",
+    "goal_fit_basis": {
+      "node_ids": [
+        "out_gross_margin"
+      ],
+      "scored_from": "modelled_outcome_distribution"
+    },
+    "win_probability": 0.020675,
+    "constraint_margins": [
+      {
+        "constraint_id": "constraint_out_gross_margin_min",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 0.5630574027128157
+      }
+    ],
+    "constraint_probabilities": {
+      "constraint_out_gross_margin_min": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": false
+  },
+  {
+    "id": "opt_pilot",
+    "label": "Raise to £59 with 90-Day Grandfathering Pilot",
+    "status": "computed",
+    "outcome": {
+      "p10": 0.00009992473409735536,
+      "p50": 0.17835204350068484,
+      "p90": 0.344992029859525,
+      "std": 0.1366007846593304,
+      "mean": 0.17479962109701008,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_pilot",
+    "option_label": "Raise to £59 with 90-Day Grandfathering Pilot",
+    "goal_fit_basis": {
+      "node_ids": [
+        "out_gross_margin"
+      ],
+      "scored_from": "modelled_outcome_distribution"
+    },
+    "win_probability": 0.423625,
+    "constraint_margins": [
+      {
+        "constraint_id": "constraint_out_gross_margin_min",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 0.5147017706133903
+      }
+    ],
+    "constraint_probabilities": {
+      "constraint_out_gross_margin_min": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": false
+  },
+  {
+    "id": "opt_raise",
+    "label": "Raise to £59 Per Seat",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.03281096682804376,
+      "p50": 0.15424030709835906,
+      "p90": 0.30498816558265374,
+      "std": 0.13214061015506698,
+      "mean": 0.14572138842656235,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_raise",
+    "option_label": "Raise to £59 Per Seat",
+    "goal_fit_basis": {
+      "node_ids": [
+        "out_gross_margin"
+      ],
+      "scored_from": "modelled_outcome_distribution"
+    },
+    "win_probability": 0.17807499999999998,
+    "constraint_margins": [
+      {
+        "constraint_id": "constraint_out_gross_margin_min",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 0.5147017706133903
+      }
+    ],
+    "constraint_probabilities": {
+      "constraint_out_gross_margin_min": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": false
+  },
+  {
+    "id": "opt_tiers",
+    "label": "Introduce £39 / £69 Two-Tier Pricing",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.04372169657168537,
+      "p50": 0.17425489983657472,
+      "p90": 0.3729525314022953,
+      "std": 0.1610180859004306,
+      "mean": 0.16882110388736365,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_tiers",
+    "option_label": "Introduce £39 / £69 Two-Tier Pricing",
+    "goal_fit_basis": {
+      "node_ids": [
+        "out_gross_margin"
+      ],
+      "scored_from": "modelled_outcome_distribution"
+    },
+    "win_probability": 0.377625,
+    "constraint_margins": [
+      {
+        "constraint_id": "constraint_out_gross_margin_min",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 0.538879586663103
+      }
+    ],
+    "constraint_probabilities": {
+      "constraint_out_gross_margin_min": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": false
+  }
+] as const
+
+/** Verbatim `option_comparison` entries — people scenario, run 3. */
+export const L60_PEOPLE_OPTIONS = [
+  {
+    "id": "opt_coach",
+    "label": "Coach VP for 90 Days",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.1389575634478105,
+      "p50": -0.016253818769636996,
+      "p90": 0.13874885280628005,
+      "std": 0.11018187732741158,
+      "mean": -0.006684217345643961,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_coach",
+    "option_label": "Coach VP for 90 Days",
+    "win_probability": 0.2887083333333336,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-e9543857-e145-4ed5-a729-905529d9b0dd",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 18.002137272472513
+      }
+    ],
+    "constraint_probabilities": {
+      "gc-e9543857-e145-4ed5-a729-905529d9b0dd": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": true
+  },
+  {
+    "id": "opt_cro",
+    "label": "Hire CRO Above VP of Sales",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.148624082727891,
+      "p50": 0.03512728507637698,
+      "p90": 0.2182432775177721,
+      "std": 0.1445043548037945,
+      "mean": 0.034499101227603676,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_cro",
+    "option_label": "Hire CRO Above VP of Sales",
+    "win_probability": 0.544441666666666,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-e9543857-e145-4ed5-a729-905529d9b0dd",
+        "near_miss_fraction": 0.00010015022533800701,
+        "failure_margin_median": 31.8966279077316
+      }
+    ],
+    "constraint_probabilities": {
+      "gc-e9543857-e145-4ed5-a729-905529d9b0dd": 0.0015
+    },
+    "probability_of_joint_goal": 0.0015,
+    "constraints_decision_grade": true
+  },
+  {
+    "id": "opt_replace",
+    "label": "Replace VP of Sales Now",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.4095583881241738,
+      "p50": -0.14789361453182195,
+      "p90": 0.10510100578028671,
+      "std": 0.1995890317988956,
+      "mean": -0.15211272555890115,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_replace",
+    "option_label": "Replace VP of Sales Now",
+    "win_probability": 0.10380833333333335,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-e9543857-e145-4ed5-a729-905529d9b0dd",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 51.66854604312486
+      }
+    ],
+    "constraint_probabilities": {
+      "gc-e9543857-e145-4ed5-a729-905529d9b0dd": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": true
+  },
+  {
+    "id": "opt_status_quo",
+    "label": "Continue as-is (Status Quo)",
+    "status": "computed",
+    "outcome": {
+      "p10": -0.1475729164398055,
+      "p50": -0.062381410253707616,
+      "p90": 0.02494799344555471,
+      "std": 0.07007526440098573,
+      "mean": -0.061863238018065474,
+      "n_samples": 10000,
+      "validity_ratio": 1,
+      "n_valid_samples": 10000
+    },
+    "option_id": "opt_status_quo",
+    "option_label": "Continue as-is (Status Quo)",
+    "win_probability": 0.06304166666666666,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-e9543857-e145-4ed5-a729-905529d9b0dd",
+        "near_miss_fraction": 0,
+        "failure_margin_median": 18.002137272472513
+      }
+    ],
+    "constraint_probabilities": {
+      "gc-e9543857-e145-4ed5-a729-905529d9b0dd": 0
+    },
+    "probability_of_joint_goal": 0,
+    "constraints_decision_grade": true
+  }
+] as const
+
+/** Verbatim `option_comparison` entries — synthetic goal-target probe. */
+export const L60_PROBE_OPTIONS = [
+  {
+    "option_id": "option_hold",
+    "option_label": "Hold at £49",
+    "id": "option_hold",
+    "label": "Hold at £49",
+    "outcome": {
+      "mean": 0.027282928494601323,
+      "std": 0.15387841718359827,
+      "p10": -0.18113270723803077,
+      "p50": 0.035861632979633684,
+      "p90": 0.2245363849396803,
+      "n_samples": 2000,
+      "n_valid_samples": 2000,
+      "validity_ratio": 1
+    },
+    "status": "computed",
+    "win_probability": 0.04975,
+    "probability_of_joint_goal": 0,
+    "constraint_probabilities": {
+      "gc-l60-probe": 0
+    },
+    "constraints_decision_grade": true,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-l60-probe",
+        "failure_margin_median": 238793.23969386448,
+        "near_miss_fraction": 0
+      }
+    ],
+    "goal_fit_basis": {
+      "scored_from": "modelled_outcome_distribution",
+      "node_ids": [
+        "goal_mrr"
+      ]
+    }
+  },
+  {
+    "option_id": "option_raise",
+    "option_label": "Raise to £59",
+    "id": "option_raise",
+    "label": "Raise to £59",
+    "outcome": {
+      "mean": 0.14038738666155756,
+      "std": 0.1933410584098391,
+      "p10": -0.14154574157001282,
+      "p50": 0.15782836832512714,
+      "p90": 0.376322484211003,
+      "n_samples": 2000,
+      "n_valid_samples": 2000,
+      "validity_ratio": 1
+    },
+    "status": "computed",
+    "win_probability": 0.95025,
+    "probability_of_joint_goal": 0,
+    "constraint_probabilities": {
+      "gc-l60-probe": 0
+    },
+    "constraints_decision_grade": true,
+    "constraint_margins": [
+      {
+        "constraint_id": "gc-l60-probe",
+        "failure_margin_median": 200678.63489839778,
+        "near_miss_fraction": 0
+      }
+    ],
+    "goal_fit_basis": {
+      "scored_from": "modelled_outcome_distribution",
+      "node_ids": [
+        "goal_mrr"
+      ]
+    }
+  }
+] as const
+
+/** Verbatim run-level `constraint_results` — pricing (decision_grade FALSE). */
+export const L60_PRICING_CONSTRAINT_RESULTS = [
+  {
+    "value": 0.8,
+    "node_id": "out_gross_margin",
+    "operator": ">=",
+    "option_id": "opt_hold",
+    "probability": 0,
+    "constraint_id": "constraint_out_gross_margin_min",
+    "scale_provenance": {
+      "source": "default",
+      "range_unified": true,
+      "decision_grade": false
+    }
+  }
+] as const
+
+/** Verbatim run-level `constraint_results` — people (decision_grade TRUE). */
+export const L60_PEOPLE_CONSTRAINT_RESULTS = [
+  {
+    "value": 2,
+    "node_id": "risk_ae_attrition",
+    "operator": "<=",
+    "option_id": "opt_coach",
+    "probability": 0,
+    "constraint_id": "gc-e9543857-e145-4ed5-a729-905529d9b0dd",
+    "scale_provenance": {
+      "source": "explicit_cap",
+      "range_unified": true,
+      "decision_grade": true
+    }
+  }
+] as const
+
+/** Verbatim run-level `constraint_results` — probe (decision_grade TRUE). */
+export const L60_PROBE_CONSTRAINT_RESULTS = [
+  {
+    "constraint_id": "gc-l60-probe",
+    "node_id": "goal_mrr",
+    "operator": ">=",
+    "value": 250000,
+    "probability": 0,
+    "option_id": "option_hold",
+    "scale_provenance": {
+      "source": "goal_threshold_cap",
+      "range_unified": true,
+      "decision_grade": true
+    }
+  }
+] as const

--- a/src/components/results/utils/__tests__/selectGoalProbability.l62Withhold.spec.ts
+++ b/src/components/results/utils/__tests__/selectGoalProbability.l62Withhold.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * L62 — the joint figure is WITHHELD from the goal-fit slot.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE DEFECT (L60, verified live at the deployed tips 2026-08-04)
+ * ─────────────────────────────────────────────────────────────────────────
+ * ISL evaluates every goal constraint with a bare `value >= threshold` — a
+ * LEVEL or COUNT threshold compared directly against CHANGE-frame Monte-Carlo
+ * samples, with no frame conversion and no refusal path. P ≈ 0 is then
+ * ARITHMETICALLY FORCED for every option regardless of option quality. The
+ * honest channel (`probability_of_goal`) had already failed closed on all
+ * three witnessed runs — ISL's frame guard refusing to guess — and
+ * `selectGoalProbability` was papering over that refusal by substituting
+ * `probability_of_joint_goal`, which the guard does not cover. Every option in
+ * every decision then rendered a confident "< 1% chance of meeting every
+ * target this run scored".
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THE GATE IS TOTAL — read `l62-goalfit-gate.md` §1 for the full table
+ * ─────────────────────────────────────────────────────────────────────────
+ * The narrower gate ("substitute only when decision-grade AND the frames are
+ * compatible") is not available: nothing on the wire states the frame of a
+ * constraint threshold, and `constraints_decision_grade` does not
+ * discriminate — it is TRUE on two of the three fabrications below and FALSE
+ * on the third. Test 2 PROVES that from the fixtures rather than asserting it,
+ * so a reviewer does not have to take the derivation on trust.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * DISCIPLINE
+ * ─────────────────────────────────────────────────────────────────────────
+ * · The fixtures are PRODUCER BYTES, generated from L60's captured artefacts —
+ *   see `fixtures/l60ProducerShapes.ts` for the source files and their
+ *   SHA-256. No number here was invented to make an assertion pass.
+ * · Every assertion binds to its object by IDENTITY (exact option id), never
+ *   by a value predicate another option could satisfy (CLAUDE.md trap 19).
+ *   With four options per run all reporting joint ≈ 0, a `find(o => o.p === 0)`
+ *   would happily assert about the wrong option.
+ * · Test 1 is the anti-vacuity control (trap 13): it proves the fixtures are
+ *   genuinely IN the substituting state — joint present, honest channel absent
+ *   — BEFORE anything asserts a withhold. Without it, a fixture that simply
+ *   carried no numbers at all would make every "is null" pass by testing
+ *   nothing.
+ * · Tests 5–6 are the positive control in the other direction: a genuinely
+ *   honest goal probability must still render. A "fix" that returned null
+ *   unconditionally passes 3 and 4 and fails these.
+ *
+ * RED-first at `bc0e4a98`: tests 3, 4, 7 and 8 fail there (the selector
+ * returns the joint number with basis `'joint_goal_substituted'`).
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  selectGoalProbability,
+  basisWithholdsPossessive,
+  type GoalProbabilityInput,
+} from '../selectGoalProbability'
+import {
+  L60_PRICING_OPTIONS,
+  L60_PEOPLE_OPTIONS,
+  L60_PROBE_OPTIONS,
+  L60_PRICING_CONSTRAINT_RESULTS,
+  L60_PEOPLE_CONSTRAINT_RESULTS,
+  L60_PROBE_CONSTRAINT_RESULTS,
+} from './fixtures/l60ProducerShapes'
+
+type ProducerOption = GoalProbabilityInput & {
+  id: string
+  probability_of_joint_goal?: number
+  constraints_decision_grade?: boolean
+}
+
+/**
+ * The three witnessed shapes, each named by the constraint flavour that drove
+ * it. `expectedJointById` is transcribed from the fixture at read time — not
+ * typed in — so the expectations cannot drift from the bytes.
+ */
+const WITNESSED = [
+  {
+    name: 'pricing — draft-minted fraction constraint (decision_grade FALSE)',
+    options: L60_PRICING_OPTIONS as readonly ProducerOption[],
+    constraintResults: L60_PRICING_CONSTRAINT_RESULTS,
+  },
+  {
+    name: 'people — chat-minted COUNT constraint (decision_grade TRUE)',
+    options: L60_PEOPLE_OPTIONS as readonly ProducerOption[],
+    constraintResults: L60_PEOPLE_CONSTRAINT_RESULTS,
+  },
+  {
+    name: 'probe — goal-target LEVEL constraint (decision_grade TRUE)',
+    options: L60_PROBE_OPTIONS as readonly ProducerOption[],
+    constraintResults: L60_PROBE_CONSTRAINT_RESULTS,
+  },
+] as const
+
+describe('L62 — the joint figure never stands in for an absent goal probability', () => {
+  it('CONTROL (anti-vacuity): every fixture option is genuinely in the substituting state — joint present, honest channel absent', () => {
+    for (const shape of WITNESSED) {
+      expect(shape.options.length, `${shape.name}: fixture must not be empty`).toBeGreaterThan(0)
+      for (const o of shape.options) {
+        // The trigger for substitution: a finite joint figure …
+        expect(
+          typeof o.probability_of_joint_goal === 'number' &&
+            Number.isFinite(o.probability_of_joint_goal),
+          `${shape.name} / ${o.id}: joint figure must be present`,
+        ).toBe(true)
+        // … and NO honest goal quantity, in either wire spelling.
+        expect(o.goal_probability, `${shape.name} / ${o.id}`).toBeUndefined()
+        expect(o.probability_of_goal, `${shape.name} / ${o.id}`).toBeUndefined()
+        // … and no per-option constraint_analysis, so the 'joint_goal_constrained'
+        // branch cannot be what is being exercised.
+        expect(o.constraint_analysis ?? null, `${shape.name} / ${o.id}`).toBeNull()
+      }
+    }
+  })
+
+  it('CONTROL: `constraints_decision_grade` does NOT discriminate these fabrications — which is why the gate is total, not conditional', () => {
+    const grades = WITNESSED.map((s) => ({
+      name: s.name,
+      // Identity-bound: read off the run's OWN options, all of which agree.
+      perOption: s.options.map((o) => o.constraints_decision_grade),
+      perConstraint: (
+        s.constraintResults as readonly { scale_provenance?: { decision_grade?: boolean } }[]
+      ).map((c) => c.scale_provenance?.decision_grade),
+    }))
+
+    // Pricing: FALSE and it rendered anyway.
+    expect(grades[0].perOption.every((g) => g === false)).toBe(true)
+    expect(grades[0].perConstraint.every((g) => g === false)).toBe(true)
+    // People AND probe: TRUE, and both are frame-broken.
+    expect(grades[1].perOption.every((g) => g === true)).toBe(true)
+    expect(grades[1].perConstraint.every((g) => g === true)).toBe(true)
+    expect(grades[2].perOption.every((g) => g === true)).toBe(true)
+    expect(grades[2].perConstraint.every((g) => g === true)).toBe(true)
+
+    // So a `decision_grade === true` gate would have suppressed 1 of 3 and
+    // passed 2 of 3 straight through. This is the measurement behind the
+    // module's "the wire cannot distinguish" claim; it is not an opinion.
+    const suppressedByDecisionGrade = grades.filter((g) =>
+      g.perOption.every((x) => x === false),
+    ).length
+    expect(suppressedByDecisionGrade).toBe(1)
+  })
+
+  for (const shape of WITNESSED) {
+    it(`WITHHOLDS the fabricated figure — ${shape.name}`, () => {
+      for (const o of shape.options) {
+        const d = selectGoalProbability(o)
+        // ⭐ THE PIN. Identity-bound: this option, by its own id.
+        expect(d.goalProbability, `${shape.name} / ${o.id}: goal-fit number`).toBeNull()
+        expect(d.basis, `${shape.name} / ${o.id}: basis`).toBe('joint_goal_withheld')
+        expect(d.jointSubstitutionWithheld, `${shape.name} / ${o.id}`).toBe(true)
+        expect(d.goalProbabilityIsJoint, `${shape.name} / ${o.id}`).toBe(false)
+        // No number ⇒ no possessive, and no modelled-basis caveat to hang on a
+        // number that is not there.
+        expect(d.mayUsePossessiveGoalFraming, `${shape.name} / ${o.id}`).toBe(false)
+        expect(d.goalFitIsModelledBasis, `${shape.name} / ${o.id}`).toBe(false)
+      }
+    })
+
+    it(`leaves the JOINT channel's own labelled value untouched — ${shape.name}`, () => {
+      for (const o of shape.options) {
+        const d = selectGoalProbability(o)
+        // Byte-for-byte the producer's value, per option, bound by id. The gate
+        // governs the goal-fit SLOT; it must not silently delete the quantity
+        // the inspector renders under its own honest label.
+        expect(d.jointGoalProbability, `${shape.name} / ${o.id}: joint passthrough`).toBe(
+          o.probability_of_joint_goal,
+        )
+      }
+    })
+  }
+
+  it('POSITIVE CONTROL: a genuinely honest `probability_of_goal` still renders (wire spelling)', () => {
+    // Minimal, traceable mutation of producer bytes: the pricing options with
+    // the honest channel restored at a value the run could plausibly carry.
+    // Per-option DISTINCT values so the assertions bind to an option rather
+    // than to a shared constant.
+    const honest = L60_PRICING_OPTIONS.map((o, i) => ({
+      ...(o as ProducerOption),
+      probability_of_goal: 0.11 + i * 0.13,
+    }))
+
+    for (const [i, o] of honest.entries()) {
+      const d = selectGoalProbability(o)
+      expect(d.goalProbability, `${o.id}`).toBe(0.11 + i * 0.13)
+      expect(d.basis, `${o.id}`).toBe('goal_probability')
+      expect(d.jointSubstitutionWithheld, `${o.id}`).toBe(false)
+      expect(d.mayUsePossessiveGoalFraming, `${o.id}`).toBe(true)
+      // And the joint value is still carried alongside, unchanged.
+      expect(d.jointGoalProbability, `${o.id}`).toBe(
+        (o as ProducerOption).probability_of_joint_goal,
+      )
+    }
+  })
+
+  it('POSITIVE CONTROL: the mapped `goal_probability` spelling renders too', () => {
+    const honest = L60_PEOPLE_OPTIONS.map((o, i) => ({
+      ...(o as ProducerOption),
+      goal_probability: 0.2 + i * 0.15,
+    }))
+
+    for (const [i, o] of honest.entries()) {
+      const d = selectGoalProbability(o)
+      expect(d.goalProbability, `${o.id}`).toBe(0.2 + i * 0.15)
+      expect(d.basis, `${o.id}`).toBe('goal_probability')
+      expect(d.jointSubstitutionWithheld, `${o.id}`).toBe(false)
+    }
+  })
+
+  it('the modelled-basis caveat cannot be raised over a withheld figure', () => {
+    // The pricing bytes DO carry
+    // `goal_fit_basis.scored_from === 'modelled_outcome_distribution'` — the
+    // exact input that used to set `goalFitIsModelledBasis`. With the number
+    // withheld there is nothing for a caveat to qualify, and a caveat rendered
+    // beside no number reads as a hedge about a value the user cannot see.
+    const withBasis = L60_PRICING_OPTIONS.filter(
+      (o) =>
+        (o as { goal_fit_basis?: { scored_from?: string } }).goal_fit_basis?.scored_from ===
+        'modelled_outcome_distribution',
+    )
+    expect(withBasis.length, 'control: the fixture must carry the modelled basis').toBeGreaterThan(
+      0,
+    )
+    for (const o of withBasis) {
+      expect(selectGoalProbability(o as ProducerOption).goalFitIsModelledBasis).toBe(false)
+    }
+  })
+
+  it('`basisWithholdsPossessive` maps exactly the withheld basis, and nothing else', () => {
+    expect(basisWithholdsPossessive('joint_goal_withheld')).toBe(true)
+    expect(basisWithholdsPossessive('goal_probability')).toBe(false)
+    expect(basisWithholdsPossessive('joint_goal_constrained')).toBe(false)
+    expect(basisWithholdsPossessive('none')).toBe(false)
+    expect(basisWithholdsPossessive(null)).toBe(false)
+    expect(basisWithholdsPossessive(undefined)).toBe(false)
+  })
+
+  it('the constrained basis is UNAFFECTED — this gate is not a blanket ban on joint figures', () => {
+    // `joint_goal_constrained` is the user's own goal AND their own limits,
+    // chosen because the option carries its own constraint analysis. It has
+    // never been the substitution and must keep its number, or this change
+    // would be suppressing a quantity it was never asked to touch.
+    const constrained: GoalProbabilityInput = {
+      ...(L60_PROBE_OPTIONS[0] as ProducerOption),
+      constraint_analysis: { constraints: [{ node_id: 'goal_mrr' }] },
+    }
+    const d = selectGoalProbability(constrained)
+    expect(d.basis).toBe('joint_goal_constrained')
+    expect(d.goalProbability).toBe(
+      (L60_PROBE_OPTIONS[0] as ProducerOption).probability_of_joint_goal,
+    )
+    expect(d.goalProbabilityIsJoint).toBe(true)
+    expect(d.jointSubstitutionWithheld).toBe(false)
+  })
+})

--- a/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
+++ b/src/components/results/utils/__tests__/selectGoalProbability.spec.ts
@@ -29,6 +29,9 @@ describe('selectGoalProbability — gate-independent behaviour', () => {
       basis: 'none' as const,
       goalFitIsModelledBasis: false,
       mayUsePossessiveGoalFraming: false,
+      // L62: nothing was available to withhold here — 'none' means the run
+      // carried no joint figure either.
+      jointSubstitutionWithheld: false,
     }
     // Exact shape, deliberately: the selection is a CONTRACT, and a field that
     // appears (or vanishes) without a decision here is a field some surface will
@@ -65,10 +68,31 @@ describe('selectGoalProbability — CURRENT STATE: seam 1 RESTORED (PLOT_JOINT_H
     expect(result.goalProbabilityIsJoint).toBe(true)
   })
 
-  it('falls back to probability_of_joint_goal when goal_probability is absent (ISL auto-derived goal threshold)', () => {
+  /**
+   * ⭐ SUPERSEDED BY L62 (2026-08-04), AND THE SUPERSESSION IS THE POINT.
+   *
+   * This test pinned the FALLBACK: goal_probability absent ⇒ show the joint
+   * figure instead. L60 established at the bytes that the joint figure on that
+   * path is P(level-or-count threshold ≥ change-frame sample) — a structural
+   * zero forced by arithmetic, not a measurement of anything the user asked —
+   * and that `probability_of_goal` was absent precisely BECAUSE ISL's frame
+   * guard had honestly refused to produce it. The fallback was papering over a
+   * refusal.
+   *
+   * The test is kept, inverted, rather than deleted: it is the record that this
+   * behaviour was deliberate once, and it now fails loudly if the fallback is
+   * ever restored. See `selectGoalProbability.l62Withhold.spec.ts` for the
+   * producer-byte pins.
+   */
+  it('does NOT fall back to probability_of_joint_goal when goal_probability is absent (L62 — was the fallback, now withheld)', () => {
     const result = selectGoalProbability({ probability_of_joint_goal: 0.0 })
-    expect(result.goalProbability).toBe(0)
-    expect(result.goalProbabilityIsJoint).toBe(true)
+    expect(result.goalProbability).toBeNull()
+    expect(result.goalProbabilityIsJoint).toBe(false)
+    expect(result.basis).toBe('joint_goal_withheld')
+    expect(result.jointSubstitutionWithheld).toBe(true)
+    // The quantity itself is still published for the surfaces that label it
+    // honestly — withheld from the goal-fit SLOT, not deleted.
+    expect(result.jointGoalProbability).toBe(0)
   })
 
   it('still uses unconstrained goal_probability when there are no constraints', () => {
@@ -137,20 +161,41 @@ describe('selectGoalProbability — basis and framing permission', () => {
     expect(result.mayUsePossessiveGoalFraming).toBe(true)
   })
 
-  it('a joint figure standing in for an absent goal figure shows the NUMBER but withholds the possessive', () => {
+  it('L62: a joint figure standing in for an absent goal figure is withheld entirely — no number, no voice', () => {
+    // ROADMAP 2.282 withheld only the possessive VOICE and kept showing the
+    // number. That was a copy fix over a value that should never have been
+    // shown; L60 §5–§8 is why. Both are withheld now.
     const result = selectGoalProbability({ probability_of_joint_goal: 0.62 })
-    expect(result.basis).toBe('joint_goal_substituted')
-    expect(result.goalProbability).toBe(0.62)
-    expect(result.goalProbabilityIsJoint).toBe(true)
+    expect(result.basis).toBe('joint_goal_withheld')
+    expect(result.goalProbability).toBeNull()
+    expect(result.goalProbabilityIsJoint).toBe(false)
     expect(result.mayUsePossessiveGoalFraming).toBe(false)
+    expect(result.jointSubstitutionWithheld).toBe(true)
+    expect(result.jointGoalProbability).toBe(0.62)
   })
 
-  it('carries the modelled-basis caveat on a joint figure the producer marked as modelled', () => {
+  it('carries the modelled-basis caveat on a CONSTRAINED joint figure the producer marked as modelled', () => {
+    // ⭐ L62 amended the INPUT, not the rule. The caveat still rides a joint
+    // figure marked `modelled_outcome_distribution` — but only one that is
+    // actually DISPLAYED, which after L62 means the constrained basis. A
+    // caveat rendered beside a withheld number would be a hedge about a value
+    // the user cannot see.
+    const result = selectGoalProbability({
+      probability_of_joint_goal: 0.62,
+      constraint_analysis: { constraints: [{ id: 'c1' }] },
+      goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
+    })
+    expect(result.basis).toBe('joint_goal_constrained')
+    expect(result.goalFitIsModelledBasis).toBe(true)
+  })
+
+  it('L62: no modelled-basis caveat over a WITHHELD figure — there is nothing for it to qualify', () => {
     const result = selectGoalProbability({
       probability_of_joint_goal: 0.62,
       goal_fit_basis: { scored_from: 'modelled_outcome_distribution' },
     })
-    expect(result.goalFitIsModelledBasis).toBe(true)
+    expect(result.basis).toBe('joint_goal_withheld')
+    expect(result.goalFitIsModelledBasis).toBe(false)
   })
 
   it('never applies the caveat to the unconstrained goal quantity, even when the marker is present', () => {
@@ -205,8 +250,12 @@ describe('selectGoalProbability — owned aliases of the goal quantity', () => {
       probability_of_goal: undefined,
       probability_of_joint_goal: 0.5,
     })
-    expect(result.basis).toBe('joint_goal_substituted')
-    expect(result.goalProbability).toBe(0.5)
+    // L62: the ALIAS behaviour under test is unchanged — `undefined` is still
+    // treated as absent rather than coerced. What changed is what an absent
+    // goal quantity plus a present joint one now produces.
+    expect(result.basis).toBe('joint_goal_withheld')
+    expect(result.goalProbability).toBeNull()
+    expect(result.jointGoalProbability).toBe(0.5)
   })
 })
 

--- a/src/components/results/utils/goalAnchorCopy.ts
+++ b/src/components/results/utils/goalAnchorCopy.ts
@@ -117,6 +117,34 @@ export const GOAL_ANCHOR_COPY = {
   noTarget: 'Set a success target to see which option is most likely to reach it.',
   /** Inline unlock action beside `noTarget`. `HERO_COPY` re-exports this. */
   noTargetCta: 'Define success',
+
+  /**
+   * ⭐ L62 — the WITHHELD state. A second no-number state, NOT a third
+   * A-register voice.
+   *
+   * The header above forbids inventing a third voice for a DISPLAYED number,
+   * and this is not one: it is the sentence for when there is no number at
+   * all. It exists because `noTarget` is the wrong sentence in this state and
+   * saying it would be its own small untruth — the user HAS set a target, or
+   * the run DID carry limits; the surface is not asking for one. What
+   * happened is that the only figure available was
+   * `probability_of_joint_goal` standing in for a goal probability the engine
+   * refused to produce, and nothing on the wire lets us check that the
+   * threshold and the samples are even in the same frame
+   * (`selectGoalProbability`, basis `'joint_goal_withheld'`). Scoring it
+   * anyway is what produced "< 1%" for every option on every decision.
+   *
+   * Plain language, no jargon, no number, no blame on the user, and it does
+   * not promise the figure is coming back.
+   */
+  notScored: "This run couldn't score your options against your target.",
+  /**
+   * The one-line reason, rendered beside `notScored` where there is room.
+   * Separate string so a compact surface can take the headline alone rather
+   * than truncate a sentence mid-clause.
+   */
+  notScoredReason:
+    'The analysis produced a figure for your limits, but not one that answers whether an option reaches your target.',
 } as const
 
 /**

--- a/src/components/results/utils/selectGoalProbability.ts
+++ b/src/components/results/utils/selectGoalProbability.ts
@@ -46,17 +46,63 @@
  *                               option carries its own constraint analysis —
  *                               the user's own goal AND the user's own
  *                               limits, which the "and limits" copy names.
- *   • 'joint_goal_substituted'  the joint quantity STANDING IN for an absent
- *                               goal quantity. The number is real and the
- *                               user is entitled to it, but it answers a
- *                               different question from the one the
- *                               possessive framing ("your goal") asserts, so
- *                               `mayUsePossessiveGoalFraming` is false here.
+ *   • 'joint_goal_withheld'     a joint quantity WAS available and is being
+ *                               withheld from the goal-fit slot. No number is
+ *                               returned. See the L62 block below.
  *   • 'none'                    no admissible value.
  *
  * `goalProbability` and `goalProbabilityIsJoint` are DERIVED from `basis`
  * rather than computed alongside it, so the number and the claim about which
  * quantity it is cannot drift apart.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⭐ L62 (2026-08-04) — THE SUBSTITUTION IS WITHHELD, NOT RE-VOICED
+ * ─────────────────────────────────────────────────────────────────────────
+ * This basis used to be `'joint_goal_substituted'`: the joint number WAS
+ * returned, and the fix of the day (ROADMAP 2.282) was to withhold only the
+ * possessive VOICE around it — "chance of meeting every target this run
+ * scored" instead of "chance of hitting your goal". That was a copy fix over
+ * a number that should never have been shown.
+ *
+ * L60's diagnosis (`PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md`
+ * §5–§8, verified live at the deployed tips) establishes why the NUMBER is
+ * the problem, not the wording. `probability_of_joint_goal` is
+ * P(all constraints jointly satisfied), and ISL evaluates every constraint
+ * with `value >= constraint.threshold` — a LEVEL/COUNT threshold compared
+ * directly against CHANGE-frame Monte-Carlo samples, with no frame
+ * conversion and no refusal path. P ≈ 0 is then ARITHMETICALLY FORCED for
+ * every option regardless of option quality. Three flavours were witnessed
+ * producing exactly that: a draft-minted fraction constraint, a chat-minted
+ * COUNT constraint ("≤ 2 account executives" scored as P(risk-score ≤ 0.25)),
+ * and a goal-target LEVEL constraint. The honest channel
+ * (`probability_of_goal`) had already FAILED CLOSED on all three — ISL's
+ * frame guard refusing to guess — and this selector was papering over that
+ * refusal with the unguarded number from the channel the guard does not
+ * cover.
+ *
+ * WHY THE GATE IS TOTAL RATHER THAN CONDITIONAL. The obvious narrower gate
+ * is "substitute only when the producer marked the constraints decision-grade
+ * AND the frames are compatible". The second half is not derivable: NOTHING
+ * on the wire states the frame of a constraint threshold or of the samples it
+ * is compared against (`GoalConstraint` carries no frame field; the frame
+ * attestation exists only on `goal_threshold`, a different channel). And the
+ * first half does not discriminate — measured against the three witnessed
+ * producer captures, `constraints_decision_grade` is TRUE on two of the three
+ * fabrications and FALSE on the third. `goal_fit_basis` and the
+ * `CONSTRAINT_GOALFIT_MODELLED_BASIS` warning are absent entirely from one of
+ * them. There is no field, and no conjunction of fields, that separates a
+ * frame-broken joint figure from a sound one.
+ *
+ * So the strongest gate that is DERIVED rather than assumed is the total one:
+ * the joint figure never stands in for an absent goal probability. It is
+ * still published as `jointGoalProbability` and still rendered, unchanged, by
+ * the surfaces that label it honestly as the joint-constraints channel.
+ *
+ * REINSTATEMENT TRIGGER (do not relax this gate without it): a producer-side
+ * frame attestation on the constraint channel — the ISL/PLoT half of L60's
+ * fix stack — such that a joint figure can be shown to answer the question
+ * the goal-fit slot asks. Until such a field exists and is read here, any
+ * conditional substitution is a guess wearing a guarantee.
  */
 
 import { PLOT_JOINT_HEADLINE_SUSPECT } from '../../../adapters/plot/constraintTrust'
@@ -118,7 +164,16 @@ export type GoalProbabilityBasis =
   | 'none'
   | 'goal_probability'
   | 'joint_goal_constrained'
-  | 'joint_goal_substituted'
+  /**
+   * ⚠ RENAMED FROM `'joint_goal_substituted'` BY L62, DELIBERATELY.
+   *
+   * The rename is the instrument. Every consumer that compared against the
+   * old literal is now a COMPILE error rather than a silently-false branch,
+   * so the compiler enumerates the blast radius instead of a human listing it
+   * (CLAUDE.md trap 12 — derive, never mirror). Do not add the old member back
+   * as an alias.
+   */
+  | 'joint_goal_withheld'
 
 export interface GoalProbabilityInput extends Partial<Record<OwnedField, number>> {
   constraint_analysis?: { constraints?: unknown[] } | null
@@ -161,13 +216,49 @@ export interface GoalProbabilitySelection {
   /**
    * Whether prose may call the thing this number measures "YOUR goal".
    *
-   * False on `joint_goal_substituted`: the value is P(all constraints jointly
-   * satisfied) standing in for an absent goal probability, so the possessive
-   * would attribute to the user a question the number does not answer. The
-   * NUMBER is still shown (it is real, computed, and decision-relevant) —
-   * only the possessive framing is withheld.
+   * False whenever `goalProbability` is null, which now includes every
+   * `joint_goal_withheld` run: there is no number to frame.
    */
   mayUsePossessiveGoalFraming: boolean
+  /**
+   * ⭐ L62. True ⇔ `basis === 'joint_goal_withheld'` — the run DID carry a
+   * joint figure and this selector refused to put it in the goal-fit slot.
+   *
+   * Published because "no goal number" and "a goal number was withheld" need
+   * DIFFERENT copy, and a surface must not have to re-derive which it is
+   * holding. The no-target line ("Set a success target to see which option is
+   * most likely to reach it") is a lie in this state: the user did set a
+   * target, or the run did carry constraints — what failed is that nothing on
+   * the wire lets us score them honestly. Surfaces read this and say so.
+   */
+  jointSubstitutionWithheld: boolean
+}
+
+/**
+ * ⭐ L62 — THE ONE MAPPING from a basis to "must a RENDERED number withhold
+ * the possessive voice".
+ *
+ * Four surfaces (`OptionNode`, `GoalNode`, `GoalPanel`, `DecisionSummary`)
+ * each narrowed the basis with their own inline `=== 'joint_goal_substituted'`
+ * literal. That was one vocabulary while there was one literal to test; the
+ * moment the set of withholding bases changes it becomes four copies of a rule
+ * (CLAUDE.md trap 12). It is a function now, and it lives beside the basis it
+ * reads.
+ *
+ * ⚠ STATE OF THIS FUNCTION TODAY, PLAINLY: it returns true for exactly one
+ * basis, and that basis NEVER carries a number — `selectGoalProbability`
+ * returns `goalProbability: null` for it. Every call site is additionally
+ * gated on a present number, so **no call site can currently take the
+ * withholding arm**. This is deliberately NOT dressed up as a live guard: it
+ * is the seam that keeps the four surfaces speaking one language, and it goes
+ * live again the day a basis both carries a number and forbids the possessive.
+ * It is not evidence that anything is being protected today — what protects
+ * the user today is that the number is withheld at source.
+ */
+export function basisWithholdsPossessive(
+  basis: GoalProbabilityBasis | null | undefined,
+): boolean {
+  return basis === 'joint_goal_withheld'
 }
 
 export function selectGoalProbability(
@@ -217,6 +308,9 @@ export function selectGoalProbability(
       basis: unconstrained != null ? 'goal_probability' : 'none',
       goalFitIsModelledBasis: false,
       mayUsePossessiveGoalFraming: unconstrained != null,
+      // This arm never substitutes either, so nothing is withheld FROM a
+      // substitution here — the L62 gate below is what owns that state.
+      jointSubstitutionWithheld: false,
     }
   }
 
@@ -233,14 +327,19 @@ export function selectGoalProbability(
       : unconstrained != null
         ? 'goal_probability'
         : jointGoalProb != null
-          ? 'joint_goal_substituted'
+          ? // ⭐ L62: was `'joint_goal_substituted'`, and the joint number was
+            // returned here. It is now withheld — see the L62 block in the
+            // module header for the derivation.
+            'joint_goal_withheld'
           : 'none'
 
-  const goalProbabilityIsJoint =
-    basis === 'joint_goal_constrained' || basis === 'joint_goal_substituted'
+  const goalProbabilityIsJoint = basis === 'joint_goal_constrained'
 
   // Derived FROM the basis (never computed in parallel with it), so the
   // number and the statement of which quantity it is cannot diverge.
+  // `joint_goal_withheld` falls through to null by construction: there is no
+  // arm that returns a number for it, so no future edit can reintroduce the
+  // substitution without changing the basis itself.
   const goalProbability = goalProbabilityIsJoint
     ? jointGoalProb
     : basis === 'goal_probability'
@@ -250,10 +349,15 @@ export function selectGoalProbability(
   return {
     goalProbability,
     goalProbabilityIsJoint,
+    // UNCHANGED by the gate, deliberately: the surfaces that render the joint
+    // figure as its OWN, separately-labelled claim ("chance of hitting every
+    // target") are honest and keep their number. The gate governs the GOAL-FIT
+    // slot only.
     jointGoalProbability: jointGoalProb,
     basis,
     goalFitIsModelledBasis:
       goalProbabilityIsJoint && goalFitBasisScoredFrom === 'modelled_outcome_distribution',
-    mayUsePossessiveGoalFraming: goalProbability != null && basis !== 'joint_goal_substituted',
+    mayUsePossessiveGoalFraming: goalProbability != null,
+    jointSubstitutionWithheld: basis === 'joint_goal_withheld',
   }
 }

--- a/src/lib/__tests__/discriminationFallback.spec.ts
+++ b/src/lib/__tests__/discriminationFallback.spec.ts
@@ -216,15 +216,55 @@ describe('fromOptionProbabilities', () => {
   // used to read `goal_probability` directly, with no joint fallback; it now
   // reads `selectGoalProbability`'s choice.
 
-  it('picks up the joint figure when the run carries no goal_probability', () => {
-    // The documented ISL-auto-derived-threshold run. Before routing through the
-    // owner this produced `Math.round(undefined * 100)` = NaN, which then
-    // poisoned the min/max spread the verdict is computed from.
+  /**
+   * ⭐ AMENDED BY L62 (2026-08-04) — AND THIS SURFACE MATTERS MORE THAN MOST.
+   *
+   * The test pinned the joint FALLBACK: no `goal_probability` ⇒ use
+   * `probability_of_joint_goal` and rank on it. `selectGoalProbability` no
+   * longer substitutes (L60 §5–§8: the joint figure on that path is
+   * P(level-or-count threshold >= change-frame sample), a structural zero), so
+   * both options are DROPPED and the discrimination verdict is computed from
+   * an empty set.
+   *
+   * That is the honest outcome and it is worth naming, because this function
+   * does not merely display a number — it feeds the "too close to call"
+   * VERDICT. Ranking options by a quantity that is ~0 for all of them by
+   * arithmetic would have produced a confident discrimination claim about
+   * noise. `analyzeDiscrimination([])` returns `discriminates: false` with
+   * "No predictions available", which is the correct thing to say when nothing
+   * scoreable arrived.
+   *
+   * The original comment's concern — never contribute NaN to the spread — is
+   * unchanged and still pinned by the sibling test below.
+   */
+  it('L62: drops options whose only figure is a withheld joint one — the verdict is not computed from a structural zero', () => {
     const result = fromOptionProbabilities({
       opt_1: { probability_of_joint_goal: 0.6 } as never,
       opt_2: { probability_of_joint_goal: 0.2 } as never,
     })
-    expect(result.map((r) => r.value)).toEqual([60, 20])
+    expect(result).toEqual([])
+
+    // …and the verdict built from that is an honest absence, not a confident
+    // "too close to call" over nothing.
+    const verdict = analyzeDiscrimination(result)
+    expect(verdict.discriminates).toBe(false)
+    expect(verdict.topOption).toBeNull()
+    expect(verdict.spread).toBe(0)
+  })
+
+  it('POSITIVE CONTROL: a real goal_probability still ranks, by identity — the drop above is not a blanket one', () => {
+    // Without this, deleting the body of `fromOptionProbabilities` would pass
+    // the test above (trap 13).
+    const result = fromOptionProbabilities({
+      opt_1: { goal_probability: 0.6 } as never,
+      opt_2: { goal_probability: 0.2 } as never,
+    })
+    // Bound by option id, never by position or value: a builder that paired
+    // the wrong label to the wrong number would satisfy a `.map(r => r.value)`
+    // assertion (CLAUDE.md trap 19).
+    const byId = new Map(result.map((r) => [r.optionId, r.value]))
+    expect(byId.get('opt_1')).toBe(60)
+    expect(byId.get('opt_2')).toBe(20)
     expect(result.every((r) => Number.isFinite(r.value))).toBe(true)
   })
 


### PR DESCRIPTION
## The defect

Every option in every decision rendered a confident **"< 1% chance of meeting every target this run scored"** on the goal-fit surface, beside a fabricated "£200k short" margin.

That number is `probability_of_joint_goal` **substituted** for an absent `probability_of_goal`. L60's diagnosis (`PHASE0-EVIDENCE-2026-07-28/diagnosis-goalfit-untruth.md`, verified live at the deployed tips) established what it is at the bytes: ISL evaluates every goal constraint with a bare `value >= threshold`, comparing a **LEVEL or COUNT** threshold against **CHANGE-frame** Monte-Carlo samples, with no frame conversion and no refusal path. `P ≈ 0` is **arithmetically forced** regardless of option quality.

And `probability_of_goal` was absent *precisely because* ISL's frame guard had honestly refused to guess. **The substitution was papering over a refusal.**

Three flavours were witnessed producing it: a draft-minted fraction constraint, a chat-minted COUNT constraint (`≤ 2 account executives` scored as `P(risk-score ≤ 0.25)`), and a goal-target LEVEL constraint.

## The gate, and why it is total rather than conditional

`selectGoalProbability` — the single chooser — no longer substitutes. The basis is **renamed** `'joint_goal_substituted'` → `'joint_goal_withheld'` and returns **no number**.

The rename is the instrument: every consumer comparing against the old literal became a compile error rather than a silently-false branch, so the compiler enumerated the blast radius instead of me hand-listing it (CLAUDE.md trap 12).

**The obvious narrower gate is not available, and this was measured rather than assumed.** Against L60's three captured producer shapes:

| witnessed shape (all frame-broken) | `constraints_decision_grade` | `scale_provenance.source` | `CONSTRAINT_GOALFIT_MODELLED_BASIS` | `goal_fit_basis` |
|---|---|---|---|---|
| pricing — draft margin, `fraction` | **false** | `default` | present | present |
| people — chat count, `count` | **true** | `explicit_cap` | **absent** | **absent** |
| probe — goal target, `level` | **true** | `goal_threshold_cap` | present | present |

`decision_grade === true` would have suppressed **1 of 3** and passed **2 straight through** — while reading as a frame guarantee it does not provide. No other field discriminates either, because **no field on the wire is about the frame at all** (`GoalConstraint` has no frame field; the attestation exists only on `goal_threshold`, a different channel).

So the strongest gate that is *derived rather than assumed* is the total one. **This is pinned as a test, not asserted in prose** — see the `constraints_decision_grade` control.

**Reinstatement trigger** (documented in the module): a producer-side frame attestation on the constraint channel — the ISL/PLoT half of L60's fix stack, still open.

## Deliberately unchanged

- **`jointGoalProbability`** — published verbatim, so the surfaces that label the quantity honestly keep their number. The GoalPanel Constraints line that ROADMAP 2.283 *suppressed as a duplicate* now **comes back**: there is no longer a duplicate, and that section is the one honest home for it.
- **`'joint_goal_constrained'`** — the user's own goal AND their own limits. Never the substitution; keeps its number. Pinned.
- The comparative channel ("came out ahead in N% of simulated scenarios") everywhere.

## Also: the fabricated shortfall

`Typically misses by {failure_margin_median}` is removed — the repo's only render of that field. It is `250000 − (p50 0.15783 × cap 312500)`: a change-frame sample denormalised as a level fraction, subtracted from a level target. It also shipped raw with a standing `TODO: add unit`, so `0.563` (a fraction) and `18.0` (a head-count) both printed as bare digits.

**Claim-type, stated precisely: this was NOT reaching users.** `SuccessTargetRow` is unmounted and its input is stripped by `responseMapper` while `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT` holds. Removed at source anyway, because leaving it means the fabricated distance returns the moment either condition changes.

## Proof

- **Fixtures are producer bytes**, generated from L60's artefacts with each source file's SHA-256 in the header. Nothing invented to make an assertion pass.
- **Identity-bound throughout** (trap 19) — every assertion keys on the exact option id. Not stylistic: all four options report joint ≈ 0, so a value predicate would happily assert about the wrong option.
- **Anti-vacuity controls first** (trap 13) — the fixtures are proven to be *in* the substituting state before anything asserts a null.
- **Mutation, in worktrees outside the repo root** (traps 9/9c), removed before any gate run; applied-check scoped to `src/`, control asserts **exactly 0** (trap 12e):

| run | applied-check | result |
|---|---|---|
| control | **0 files** | 23/23 pass |
| **M1 — drop the gate** | 1 file | **10 fail** — every fabricated-figure pin |
| **M2 — gate everything** | 1 file | **5 fail** — every positive control |

The two failing sets are **disjoint**. That is the load-bearing property: the pins *discriminate*, rather than merely being sensitive. A suite where M2 ⊆ M1 would be satisfied by a fix that just blanks the goal number — which is the wrong fix.

- `pnpm run typecheck` (the required **Staging Gate** command): **PASSED**, within baseline, **+0**. Baseline NOT regenerated.
- `eslint` over every touched directory: **0 errors**. `lint:hooks-ratchet`: exactly matching baseline.
- Supabase env vars set for every measurement (trap 2b).

## ⚠ TWELVE existing spec files carried the superseded contract

ROADMAP 2.282/2.283 fixed this by withholding only the possessive **voice** over the same number. That was a copy fix over a value that should never have been shown. **Every affected test is repaired in place with the supersession stated at the assertion — none deleted**, and the 2.282 narrative headers kept verbatim beside the amendment.

Worth a reviewer's eye:
- `substitutedJointGate.optionCards.spec.tsx` — its control said it *"would catch a fix that suppressed the number instead of the framing"*. That is exactly what this does, on evidence 2.282 did not have. Control inverted.
- `GoalPanel.possessiveGate.spec.tsx` — **direction reverses**: the Constraints joint line goes from pinned-absent to pinned-**present**.
- `goalProbabilityIdentity.parity.spec.tsx` — its agreement tests would have degenerated into "both returned null", the exact vacuity its own control forbids. Re-anchored on a record that still carries a number.
- `GoalNode.possessiveGate.spec.tsx` — the node's absence line changes from *"see Goal fit for each option's chance"* (pointing the user **at** the fabrications) to *"This run did not produce a goal probability."* The ROADMAP 2.275 cross-surface contradiction resolves in the honest direction.

**⚠ CORRECTED — this said "nine" and it was wrong.** I enumerated the first sweep's failures with `grep -E "^ FAIL "`, which matches vitest's per-TEST lines, not its per-FILE ones: it returned 8 files from a run whose own summary said **14**, and I generalised from it. The compiler could not close the gap either — `.toBe('joint_goal_substituted')` is an argument, not a `===` comparison, so the rename raised no TS2367 in those files. **Two independent instruments, same blind spot, both under-reporting.**

CI's four shards gave the complete manifest at `8094ebc2`: **4 more files / 7 tests** still red, fixed in `28f5cdf4`. Two of them matter beyond bookkeeping:

- `discriminationFallback.spec.ts` **feeds a VERDICT, not a display.** Options are now dropped and `analyzeDiscrimination([])` returns "No predictions available" — the right answer, because ranking options by a quantity that is ≈0 for all of them by arithmetic would have produced a confident *"too close to call"* over noise.
- `useNodeDisplayMetadata.goalFitAvailable.spec.ts` — ROADMAP 2.275 added that flag so the goal node would point users **at** the per-option figures instead of denying them. Those figures were the fabrication, so the flag was signposting it. Now false on that payload; **not retired** — a new positive control proves it still fires for a run with real per-option goal probabilities, which is 2.275's actual case.

Full account, including the corrected manifest table: `l62-goalfit-gate.md` §9.

## What this does NOT fix

1. **The producer still computes and ships the fabrication.** ISL/PLoT frame refusal (L60 fix-stack item 1) is unaffected and still open.
2. `jointGoalProbability` is still ≈0 on a frame-broken run and still renders where honestly labelled. Deliberate — the label there is true — but only the producer fix makes the number right.
3. ~~The V7 goal lens still says "Set a success target" in the withheld state.~~ **WITHDRAWN — I had not read the branch.** `buildV7Lenses.ts:219` picks `producer_gap` whenever a target is set, and that renders *"Goal fit unlocks when the engine returns per-option goal probabilities for this run."* The lens already distinguishes the two silences, from the store's own target. (`WinGauge` still needed the new `goalFitWithheld` flag because it has no `goalThreshold` prop and so cannot make that distinction.) I inferred a file's behaviour from one grep hit without opening it — trap 16, and the row it generated is withdrawn.
4. `goalFitIsSubstitutedJoint` and the substituted-voice register are now permanently unreachable, retained and `@deprecated`. Retiring them touches a dozen surfaces; this is a P0 truth fix, not a refactor.
5. **jsdom scope (trap 3):** every render claim is presence/absence of strings and nodes. None of it proves layout or on-screen visibility. A browser walk is still owed.

Full derivation and evidence: `PHASE0-EVIDENCE-2026-07-28/l62-goalfit-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
