### PR TITLE
fix(results): WinGauge tells "target set, nothing scored" apart from "no target"

### DIFF
--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -528,6 +528,13 @@ export const ResultsBody = memo(function ResultsBody({
               designationsWithheld={
                 resultsSectionData.recommendation.verdict?.hasLeadingOption === false
               }
+              // ⭐ L65 — the same store-derived target signal the V7 goal
+              // lens gates with (`recommendation.goalThreshold`). Lets the
+              // gauge tell "no target set" from "target set, nothing scored":
+              // post-#308 the producer suppresses the frame-broken joint
+              // channel at source, so `goalFitWithheld` (which needs a joint
+              // figure to ARRIVE) can no longer see that state.
+              goalThreshold={resultsSectionData.recommendation.goalThreshold}
             />
             {/* Codex B1: winnerId is ALWAYS the canonical leader — every leader
                 predicate (downside sentence, leader CTA/prompt) keys to it. The

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -209,6 +209,7 @@ export function WinGauge({
   shares,
   decisionState,
   designationsWithheld = false,
+  goalThreshold = null,
 }: {
   shares: OptionWinShare[]
   decisionState?: DecisionState
@@ -226,6 +227,20 @@ export function WinGauge({
    * untouched — this chart is a distribution, and the distribution is data.
    */
   designationsWithheld?: boolean
+  /**
+   * ⭐ L65 — the user's success target, threaded from the same store-derived
+   * source the V7 goal lens discriminates with (`recommendation.goalThreshold`
+   * = `effectiveGoalThreshold` in `useResultsSectionData`; the lens's gate is
+   * `no_target` vs `producer_gap`, `buildV7Lenses.ts`).
+   *
+   * Exists because `goalFitWithheld` cannot see the post-#308 state: that
+   * flag fires only when a joint figure ARRIVED and was refused, but the
+   * producer now suppresses the frame-broken joint channel at source, so on
+   * the witnessed run class nothing arrives at all (basis 'none') — and the
+   * gauge fell back to the no-target invitation for a user who DID set a
+   * target. This prop is what lets it tell those two silences apart.
+   */
+  goalThreshold?: number | null
 }) {
   if (shares.length === 0) return null
 
@@ -353,12 +368,22 @@ export function WinGauge({
       ) : (
         // A5 — an invitation with its route, not a wall. The comparative
         // block below keeps rendering.
-        // ⭐ L62 — TWO SILENCES, TWO SENTENCES.
-        // Withheld: the run produced a joint-constraints figure and the
-        // selector refused to score it as goal fit. Saying "Set a success
-        // target" here would ask the user for something they already gave and
-        // would imply the blank is their doing. Say what happened instead, and
-        // do NOT offer the unlock CTA — there is nothing for it to unlock.
+        // ⭐ L62, EXTENDED BY L65 — THREE SILENCES, THREE SENTENCES.
+        // 1. Withheld: the run produced a joint-constraints figure and the
+        //    selector refused to score it as goal fit. Saying "Set a success
+        //    target" here would ask the user for something they already gave
+        //    and would imply the blank is their doing. Say what happened
+        //    instead, and do NOT offer the unlock CTA — there is nothing for
+        //    it to unlock. Checked FIRST because it is the more specific
+        //    truth: a figure existed, and the sentence pair says so.
+        // 2. Target set, nothing arrived (basis 'none' — the post-#308 norm,
+        //    with the producer suppressing the frame-broken joint channel at
+        //    source): the invitation is equally wrong, and the withheld pair
+        //    would claim a figure that never existed. Same sentence the V7
+        //    goal lens shows for the same run state (its `producer_gap`
+        //    gate), same finite-number guard as its threshold read, one
+        //    register key for both surfaces. No CTA — nothing unlocks it.
+        // 3. Genuinely no target: the invitation, with its route.
         goalFitWithheld ? (
           <div className="mb-2" data-testid="win-gauge-goal-not-scored">
             <p className={`${typography.panelMeta} text-text-light`}>
@@ -368,6 +393,13 @@ export function WinGauge({
               {GOAL_ANCHOR_COPY.notScoredReason}
             </p>
           </div>
+        ) : typeof goalThreshold === 'number' && Number.isFinite(goalThreshold) ? (
+          <p
+            className={`${typography.panelMeta} text-text-light mb-2`}
+            data-testid="win-gauge-goal-producer-gap"
+          >
+            {GOAL_ANCHOR_COPY.producerGap}
+          </p>
         ) : (
           <p
             className={`${typography.panelMeta} text-text-light mb-2`}

--- a/src/components/results/__tests__/ResultsBody.winGaugeGoalThreshold.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.winGaugeGoalThreshold.spec.tsx
@@ -1,0 +1,150 @@
+/**
+ * L65 — the MOUNT SITE carries the target signal to WinGauge.
+ *
+ * `winGauge.targetSetNotScored.spec.tsx` pins the component's discrimination
+ * by mounting WinGauge directly — which proves nothing about ResultsBody.
+ * Without this file, deleting the `goalThreshold` passthrough at the
+ * ResultsBody call site would leave every test green while the shipped panel
+ * regressed to the wrong invitation (the exact unwitnessed-seam class the
+ * mutation discipline exists to catch). Harness mirrors
+ * `ResultsBody.heroPlacement.spec.tsx` (local fixtures; no analysis-hero
+ * imports — its inertness guard allow-lists ResultsBody as sole importer).
+ *
+ * Identity binding (trap 19): exact testids, never value predicates.
+ * jsdom scope (trap 3): presence/absence only, no layout claims.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+/**
+ * Two options, NO goal probabilities anywhere (basis 'none' on every option,
+ * nothing withheld) — the post-#308 shape of a frame-broken run.
+ */
+function makeData(goalThreshold: number | null): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: null,
+    goalFitWithheld: false,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: null,
+    goalFitWithheld: false,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    goalThreshold,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody(goalThreshold: number | null) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(goalThreshold)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+describe('L65 / ResultsBody threads recommendation.goalThreshold into WinGauge', () => {
+  it('target set + no goal numbers → the gauge shows the producer-gap sentence, not the invitation', () => {
+    const { container } = renderBody(250000)
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: no target anywhere → the invitation, not the producer-gap sentence', () => {
+    const { container } = renderBody(null)
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+  })
+})

--- a/src/components/results/__tests__/winGauge.targetSetNotScored.spec.tsx
+++ b/src/components/results/__tests__/winGauge.targetSetNotScored.spec.tsx
@@ -1,0 +1,164 @@
+/**
+ * L65 — WinGauge: target-set-but-not-scored is its OWN state, never the
+ * no-target invitation.
+ *
+ * THE DEFECT THIS PINS (found by #579's reviewer, verified at `da1630e6`).
+ * Post-#308 PLoT suppresses the frame-broken `probability_of_joint_goal` at
+ * source, so on the witnessed run class NOTHING arrives in the goal-fit
+ * slot: `selectGoalProbability` returns basis 'none' and
+ * `jointSubstitutionWithheld: false`. WinGauge's only honest-absence trigger
+ * was `goalFitWithheld` — which fires only when a joint figure ARRIVED and
+ * was refused — so a run where the user DID set a target fell through to the
+ * no-target branch: "Set a success target…" + "Define success", an
+ * invitation to do something already done. Stage-1 of this file pinned that
+ * wrong invitation GREEN at pristine before being flipped to these pins.
+ *
+ * THE FIX. WinGauge reads the same store-derived target signal the V7 goal
+ * lens already discriminates with (`recommendation.goalThreshold` →
+ * `buildV7Lenses.ts` gate `no_target` vs `producer_gap`) as a prop, and for
+ * target-set-plus-basis-'none' renders the SAME producer-gap sentence the
+ * lens shows for the SAME run state — one claim, one register
+ * (`GOAL_ANCHOR_COPY.producerGap`, which `V7_LENS_COPY.goal.gateProducerGap`
+ * delegates to). No CTA beside it: there is nothing a user action unlocks.
+ *
+ * Assertions bind by IDENTITY — exact testid, verbatim register string —
+ * never by a value predicate another element could satisfy (trap 19).
+ * jsdom scope (trap 3): these pins prove presence/absence in the rendered
+ * output, never layout or visibility.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { WinGauge, type OptionWinShare } from '../WinGauge'
+import { GOAL_ANCHOR_COPY } from '../utils/goalAnchorCopy'
+import { V7_LENS_COPY } from '../v7/v7LensCopy'
+
+/** Basis 'none' on every option: no goal figure, nothing withheld. */
+function sharesNothingArrived(): OptionWinShare[] {
+  return [
+    {
+      id: 'opt-a',
+      label: 'Option A',
+      winProbability: 0.7,
+      isWinner: true,
+      goalProbability: null,
+      goalFitIsSubstitutedJoint: false,
+      goalFitWithheld: false,
+    },
+    {
+      id: 'opt-b',
+      label: 'Option B',
+      winProbability: 0.3,
+      isWinner: false,
+      goalProbability: null,
+      goalFitIsSubstitutedJoint: false,
+      goalFitWithheld: false,
+    },
+  ]
+}
+
+describe('L65 / WinGauge — target set, nothing arrived (basis none)', () => {
+  it('renders the producer-gap sentence, not the invitation to set a target', () => {
+    const { container } = render(
+      <WinGauge shares={sharesNothingArrived()} goalThreshold={250000} />,
+    )
+    const text = container.textContent ?? ''
+
+    // The honest-absence state, by testid and verbatim register copy.
+    const gap = container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')
+    expect(gap).not.toBeNull()
+    expect(gap!.textContent).toContain(GOAL_ANCHOR_COPY.producerGap)
+
+    // NOT the no-target invitation: the user already set a target, and the
+    // CTA would offer to unlock something no user action can unlock.
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).toBeNull()
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.noTarget)
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.noTargetCta)
+
+    // NOT the withheld pair: nothing arrived, so "The analysis produced a
+    // figure for your limits" would claim a figure that does not exist.
+    expect(container.querySelector('[data-testid="win-gauge-goal-not-scored"]')).toBeNull()
+    expect(text).not.toContain(GOAL_ANCHOR_COPY.notScoredReason)
+
+    // No goal numbers were fabricated for it either.
+    expect(container.querySelector('[data-testid="win-gauge-goal-block"]')).toBeNull()
+
+    // The comparative block is untouched — the gate withholds one claim, it
+    // does not blank the panel.
+    expect(container.querySelector('[data-testid="win-gauge-comparative-block"]')).not.toBeNull()
+  })
+
+  it('a non-finite target does NOT count as a target (same guard as the V7 lens)', () => {
+    const { container } = render(
+      <WinGauge shares={sharesNothingArrived()} goalThreshold={Number.NaN} />,
+    )
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+  })
+})
+
+describe('L65 / WinGauge — positive controls (the discrimination must not over-fire)', () => {
+  it('genuinely-no-target still gets the invitation and its CTA, never the producer-gap sentence', () => {
+    // No goalThreshold prop at all — the ordinary state of a run the user
+    // set no target on. Without this control, wiring every empty goal block
+    // to the producer-gap copy would pass the tests above.
+    const { container } = render(<WinGauge shares={sharesNothingArrived()} />)
+    const invitation = container.querySelector('[data-testid="win-gauge-no-target"]')
+    expect(invitation).not.toBeNull()
+    expect(invitation!.textContent).toContain(GOAL_ANCHOR_COPY.noTarget)
+    expect(invitation!.textContent).toContain(GOAL_ANCHOR_COPY.noTargetCta)
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-not-scored"]')).toBeNull()
+  })
+
+  it('an explicit null target behaves exactly like an absent one', () => {
+    const { container } = render(
+      <WinGauge shares={sharesNothingArrived()} goalThreshold={null} />,
+    )
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+  })
+
+  it('honest goal numbers with a target still draw the goal block, bound per option by id', () => {
+    const honest: OptionWinShare[] = sharesNothingArrived().map((s, i) => ({
+      ...s,
+      goalProbability: i === 0 ? 0.2 : 0.8,
+    }))
+    const { container } = render(<WinGauge shares={honest} goalThreshold={250000} />)
+
+    expect(container.querySelector('[data-testid="win-gauge-goal-block"]')).not.toBeNull()
+    // IDENTITY-bound: each option's own readout node, found by its id.
+    expect(container.querySelector('[data-testid="goal-pct-opt-a"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="goal-pct-opt-b"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).toBeNull()
+  })
+
+  it('PRECEDENCE: a withheld figure keeps the withheld pair even when the target is set', () => {
+    // Both signals true: a joint figure arrived and was refused (L62) AND the
+    // target is known locally. The withheld pair is the more specific truth —
+    // it explains that a figure existed — and must not be displaced by the
+    // producer-gap sentence.
+    const withheld: OptionWinShare[] = sharesNothingArrived().map((s) => ({
+      ...s,
+      goalFitWithheld: true,
+    }))
+    const { container } = render(<WinGauge shares={withheld} goalThreshold={250000} />)
+
+    const notScored = container.querySelector('[data-testid="win-gauge-goal-not-scored"]')
+    expect(notScored).not.toBeNull()
+    expect(notScored!.textContent).toContain(GOAL_ANCHOR_COPY.notScored)
+    expect(notScored!.textContent).toContain(GOAL_ANCHOR_COPY.notScoredReason)
+    expect(container.querySelector('[data-testid="win-gauge-goal-producer-gap"]')).toBeNull()
+    expect(container.querySelector('[data-testid="win-gauge-no-target"]')).toBeNull()
+  })
+})
+
+describe('L65 / one sentence, two surfaces', () => {
+  it('the V7 goal lens producer-gap gate IS the house register sentence (identity, not equality of copies)', () => {
+    // Delegation pin, same shape as gateNoTarget → GOAL_ANCHOR_COPY.noTarget:
+    // the lens and the gauge render the same state from the same key, so the
+    // two surfaces cannot drift apart under a future copy edit.
+    expect(V7_LENS_COPY.goal.gateProducerGap).toBe(GOAL_ANCHOR_COPY.producerGap)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/goalAttainmentCopy.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/goalAttainmentCopy.spec.tsx
@@ -1,9 +1,22 @@
 /**
  * Goal-attainment copy — ONE claim across THREE hero surfaces.
  *
- * THE DEFECT THIS PINS (family 2, slice −1). On every live V5 analysis the
- * shared selector resolves `basis === 'joint_goal_substituted'`, because both
- * of that branch's discriminating inputs are pinned constants on the wire:
+ * ⚠ CORRECTED BY L65 (2026-08-04): the trace below describes the wire AS IT
+ * WAS when this file was written — the state that PRODUCED the defect — and
+ * is no longer the live state. L62 renamed the substituted basis to
+ * `'joint_goal_withheld'` and it now returns NO number, and PLoT #308
+ * suppresses the frame-broken joint channel at source, so the ordinary live
+ * run lands on basis 'none' with an empty goal slot. These fixtures hand-set
+ * `goalFitIsSubstitutedJoint: true` (see `liveJointOnly`, whose name is now
+ * historical), so they still exercise the copy gates they pin; what changed
+ * is the claim that live runs take this path — today they do not. The pins
+ * stay so the wording cannot regress if a number-bearing substituted basis
+ * ever returns.
+ *
+ * THE DEFECT THIS PINS (family 2, slice −1), as traced at the time. On every
+ * live V5 analysis the shared selector resolved
+ * `basis === 'joint_goal_substituted'`, because both of that branch's
+ * discriminating inputs were pinned constants on the wire:
  *
  *   - `probability_of_goal` never arrives (PLoT synthesises an auto goal
  *     constraint whenever a finite threshold exists and then CLEARS the
@@ -64,9 +77,12 @@ const POSSESSIVE = /your goal/i
 const PLURALITY = /\ball targets\b|\bthe targets\b/i
 
 /**
- * The LIVE record shape, per the trace above: the row's number is the
- * substituted joint figure and NO option carries per-option constraint
- * analysis. Every live analysis produces exactly this.
+ * The record shape that was live when this file was written, per the trace
+ * above: the row's number is the substituted joint figure and NO option
+ * carries per-option constraint analysis. Every live analysis THEN produced
+ * exactly this; none does today (see the L65 correction in the header — the
+ * name is kept because renaming a fixture is a code change outside a prose
+ * correction's scope).
  */
 function liveJointOnly(base: OptionResult): OptionResult {
   return makeOption({

--- a/src/components/results/analysis-hero/buildHeroModel.ts
+++ b/src/components/results/analysis-hero/buildHeroModel.ts
@@ -336,12 +336,20 @@ export function buildHeroModel(
     // "your goal" wording names a question the number does not answer, so the
     // line states the quantity it actually is. The number itself is unchanged
     // and still shown: this is a copy switch, never a value transform.
-    // ⚠ On the live V5 wire this is the ONLY branch that runs: the selector's
-    // basis is `joint_goal_substituted` on every run (both discriminating
-    // inputs are pinned constants — see heroCopy's `noneOnTrack` block), and
-    // `optionHasConstraints` is always false. So this line, the headline and
-    // the caption must state ONE claim in one voice — they are read together,
-    // in a single render, about a single number.
+    // ⚠ CORRECTED BY L65 (2026-08-04) — the claim that used to sit here was
+    // true when written and is now false. It read: "On the live V5 wire this
+    // is the ONLY branch that runs: the selector's basis is
+    // `joint_goal_substituted` on every run". That basis no longer exists:
+    // L62 renamed it `'joint_goal_withheld'` and it returns NO number, so
+    // `goalFitIsSubstitutedJoint` is always false today and the
+    // `goalFitJointBasis` arm below is DEAD pending its rowed retirement
+    // (ROADMAP 2.399(b) — do not delete it here). A live row that has a
+    // number takes the plain `goalFit` arm (or `goalFitWithLimits` when the
+    // option carries its own constraint analysis). The one-voice rule the
+    // old paragraph stated still binds whenever the substituted arm renders:
+    // this line, the headline and the caption must state ONE claim in one
+    // voice — they are read together, in a single render, about a single
+    // number.
     const goalFit =
       goalValue != null
         ? optionHasConstraints(o)

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -156,9 +156,14 @@ export const HERO_COPY = {
      * withheld the possessive while the headline and caption above it asserted
      * it, about the same number, on every live run.
      *
-     * WHY. The number every live V5 run renders here is
-     * `probability_of_joint_goal`. Two live cases produce it and the UI cannot
-     * tell them apart:
+     * WHY (as traced when this wording shipped — ⚠ L65, 2026-08-04: the
+     * every-run part is now history. L62 withholds the substituted joint
+     * figure at the selector, and PLoT #308 suppresses the frame-broken
+     * channel at source, so a number rendered here today is an honest
+     * `goal_probability`. The count/possessive restraint below stays until
+     * the interim-retirement trigger fires). The number every live V5 run
+     * rendered here was `probability_of_joint_goal`. Two live cases produced
+     * it and the UI could not tell them apart:
      *   A. no user constraints — PLoT synthesises ONE constraint from the goal
      *      threshold, on the goal node, `>=`, and ISL evaluates it against the
      *      EXACT goal samples. The figure IS goal attainment, over exactly one
@@ -303,12 +308,18 @@ export const HERO_COPY = {
     goalFit: (readout: string) => GOAL_ANCHOR_COPY.sentence(readout, false),
     goalFitWithLimits: (readout: string) => `${readout} chance of meeting your goal and limits.`,
     /**
-     * Goal-probability IDENTITY: used when the row's number is
+     * Goal-probability IDENTITY: the voice for a row whose number is
      * `probability_of_joint_goal` STANDING IN for an absent
-     * `goal_probability` (flagged by the shared selector as
-     * `basis: 'joint_goal_substituted'` — which, on the live V5 wire, is
-     * EVERY run). The number is shown, unchanged: this is a copy switch,
-     * never a value transform.
+     * `goal_probability`.
+     *
+     * ⚠ CORRECTED BY L65 (2026-08-04): this comment used to add that the
+     * flagging basis (`'joint_goal_substituted'`) "on the live V5 wire, is
+     * EVERY run". True when written; false now. L62 renamed the basis
+     * `'joint_goal_withheld'` and it carries NO number, so this arm renders
+     * on no run today — dead pending the rowed retirement of the
+     * substituted-register surfaces (ROADMAP 2.399(b)); do not delete it
+     * here. When it did render, the number was shown unchanged: a copy
+     * switch, never a value transform.
      *
      * GOAL-ATTAINMENT IDENTITY, interim wording (family 2, slice −1) — the
      * same claim, in the same words, as `headline.goalOnly` /

--- a/src/components/results/utils/goalAnchorCopy.ts
+++ b/src/components/results/utils/goalAnchorCopy.ts
@@ -145,6 +145,29 @@ export const GOAL_ANCHOR_COPY = {
    */
   notScoredReason:
     'The analysis produced a figure for your limits, but not one that answers whether an option reaches your target.',
+
+  /**
+   * ⭐ L65 — the TARGET-SET-BUT-NOT-SCORED state. A third no-number state,
+   * and like `notScored` above it is NOT a third A-register voice: there is
+   * no number to voice.
+   *
+   * LICENSED BY: a user target exists (the store-derived `goalThreshold`
+   * signal the V7 goal lens already gates with, `buildV7Lenses.ts`) and NO
+   * goal-fit figure arrived at all — basis 'none'. Post-#308 the producer
+   * suppresses the frame-broken joint channel at source, so this is the
+   * ordinary shape of that run class, and BOTH existing sentences are wrong
+   * for it: `noTarget` asks the user for something they already gave, and
+   * `notScoredReason` claims "the analysis produced a figure for your
+   * limits" when nothing arrived. This sentence claims only the gap.
+   *
+   * The wording is the V7 goal lens's producer-gap gate, MOVED here verbatim
+   * (byte-identical) so the lens and WinGauge render one claim from one
+   * register — `V7_LENS_COPY.goal.gateProducerGap` now references this key,
+   * the same delegation shape as its `gateNoTarget`. No CTA beside it:
+   * there is nothing a user action currently unlocks.
+   */
+  producerGap:
+    'Goal fit unlocks when the engine returns per-option goal probabilities for this run.',
 } as const
 
 /**

--- a/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
+++ b/src/components/results/v7/__tests__/V7LensGroup.spec.tsx
@@ -132,10 +132,16 @@ describe('V7LensGroup (V7 L5)', () => {
 // gated, because on a substituted-joint basis the number answers a different
 // question from the one "your goal" asserts. The CAPTION directly beneath
 // them was a static string reading "…reaches your success target." So on the
-// live V5 wire — where the basis is `joint_goal_substituted` on EVERY run
-// (`heroCopy`'s own note: "which, on the live V5 wire, is EVERY run") — the
-// lens rendered de-possessed rows under a possessive caption about the same
-// numbers.
+// live V5 wire OF THE TIME — where the basis was `joint_goal_substituted` on
+// EVERY run (per `heroCopy`'s note of the time) — the lens rendered
+// de-possessed rows under a possessive caption about the same numbers.
+//
+// ⚠ CORRECTED BY L65 (2026-08-04): that every-run state is history. L62
+// renamed the basis `'joint_goal_withheld'` and it carries NO number, so no
+// live run reaches the substituted arm today — these fixtures hand-set
+// `goalFitIsSubstitutedJoint: true` and still exercise the gate they pin.
+// The pins stay so the caption cannot regress if a number-bearing
+// substituted basis ever returns.
 //
 // RED-first: the substituted assertions fail on `48adda75`.
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/components/results/v7/v7LensCopy.ts
+++ b/src/components/results/v7/v7LensCopy.ts
@@ -63,10 +63,16 @@ export const V7_LENS_COPY = {
      * the rows directly beneath it printed `hitReadout(formatted,
      * isSubstitutedJoint)` — gated, because on a `joint_goal_substituted`
      * basis the number answers a DIFFERENT question from the one "your"
-     * asserts. On the live V5 wire that basis is EVERY run (`heroCopy`'s own
-     * note on `detail.goalFitJointBasis`), so the lens rendered de-possessed
-     * rows under a possessive caption about the same numbers, on every run a
-     * user has ever seen.
+     * asserts. When this gate was built, that basis WAS every live V5 run
+     * (`heroCopy`'s note of the time on `detail.goalFitJointBasis`), so the
+     * lens rendered de-possessed rows under a possessive caption about the
+     * same numbers, on every run a user had ever seen.
+     *
+     * ⚠ CORRECTED BY L65 (2026-08-04): the every-run claim above is history,
+     * not the present. L62 renamed that basis `'joint_goal_withheld'` and it
+     * now carries NO number, so no live run reaches the substituted arm —
+     * fixtures exercise it. The gate stays: a future number-bearing basis
+     * that withholds the possessive must find the caption already gated.
      *
      * ONE function of the flag, not two sibling constants — the same shape
      * `evidence.flipRisksNote` / `tradeOffsNote` below already use, for the
@@ -86,8 +92,12 @@ export const V7_LENS_COPY = {
         : 'Each value is the chance that option reaches your success target.',
     /** No user target set — user-actionable, distinct from the producer gap. */
     gateNoTarget: GOAL_ANCHOR_COPY.noTarget,
-    /** A target is set but the engine returned no per-option goal probabilities. */
-    gateProducerGap: 'Goal fit unlocks when the engine returns per-option goal probabilities for this run.',
+    /** A target is set but the engine returned no per-option goal
+     * probabilities. Delegates to the house register (L65, byte-identical
+     * move) — WinGauge renders the same run state from the same key, so the
+     * two surfaces cannot drift; the same delegation shape as `gateNoTarget`
+     * above. */
+    gateProducerGap: GOAL_ANCHOR_COPY.producerGap,
     hitReadout: (formatted: string, isSubstitutedJoint: boolean) =>
       GOAL_ANCHOR_COPY.phrase(formatted, isSubstitutedJoint),
     /** Mirrors OptionCards' sub-1% display-honesty affordance (UI-SEM-057). */


### PR DESCRIPTION
## The defect (found by #579's reviewer; mechanism verified at `da1630e6` before any change)

Post-#308, PLoT suppresses the frame-broken `probability_of_joint_goal` at source, so on the witnessed run class NOTHING arrives in the goal-fit slot: `selectGoalProbability` returns basis `'none'` and `jointSubstitutionWithheld: false`. WinGauge's only honest-absence trigger was `goalFitWithheld` — which fires only when a joint figure ARRIVED and was refused — so a run where the user DID set a target fell into the no-target invitation: "Set a success target to see which option is most likely to reach it." + "Define success". An invitation to do something already done, on exactly the surface the P0 stack exists to make honest, and the likeliest shape of tomorrow's user session (non-root un-pinned targets are the witnessed norm).

## The fix (no new channel, no new claim)

- WinGauge gains `goalThreshold?: number | null`, threaded from `recommendation.goalThreshold` at the ResultsBody mount site — the SAME store-derived signal the V7 goal lens already discriminates with (`buildV7Lenses.ts` gate `no_target` vs `producer_gap`), with the lens's own finite-number guard.
- Target set + basis `'none'` now renders the SAME producer-gap sentence the V7 lens shows for the SAME run state: "Goal fit unlocks when the engine returns per-option goal probabilities for this run." Moved verbatim (byte-identical) into the house register as `GOAL_ANCHOR_COPY.producerGap`; `V7_LENS_COPY.goal.gateProducerGap` now delegates to it (same shape as its `gateNoTarget` delegation), so the two surfaces cannot drift. No CTA — nothing a user action currently unlocks.
- Precedence: the L62 withheld pair stays first (a figure existed — the more specific truth). The invitation stays for genuinely-no-target. `notScoredReason` was NOT reused for the new state: "The analysis produced a figure for your limits…" would claim a figure that never arrived.

## Trap-14 prose corrections riding along (comments only; no code retirement — substituted-register deletion is rowed 2.399(b))

`buildHeroModel.ts` ("basis is `joint_goal_substituted` on every run" — false since L62; `goalFitJointBasis` arm noted DEAD pending 2.399(b), not deleted) · `heroCopy.ts` (`goalFitJointBasis` "EVERY run" note, plus the `noneOnTrack` WHY trace — same falsehood in the same file, corrected as a one-paragraph scope extension so the file cannot self-contradict) · `v7LensCopy.ts` caption note · `V7LensGroup.spec.tsx` banner · `goalAttainmentCopy.spec.tsx` header + `liveJointOnly` fixture note. Every correction keeps the original confession and dates the correction.

## Evidence

- **RED-first:** stage-1 spec pinned the WRONG invitation GREEN at pristine `da1630e6`; flipped spec: 2 failed (exactly the fix's claims) / 5 controls green at pristine; all green after the fix.
- **Identity binding (trap 19):** testids + verbatim register strings, no value predicates.
- **Mutants** (worktrees outside repo root, committed state, applied-check src-scoped with control = exactly 0): delete-the-discrimination → 2 RED (component + mount-site pins), controls green · force-discriminate-everything → 4 RED (both no-target controls, NaN guard, null control) · delete-the-ResultsBody-passthrough → 1 RED (mount-site pin). All bite.
- **Gates at `8d11be01`:** full `src/components/results` + claim-ownership walker: 226 files / 4203 tests green. `pnpm run typecheck` (the repo gate): PASSED — coverage 3215/3255 loaded, ratchet 2502/2502 vs baseline (zero new errors). Inspector-v2 collect health with env vars: 39 files / 415 tests (≥ documented healthy floor 33/349 — no collect shrink).
- Evidence file: `PHASE0-EVIDENCE-2026-07-28/l65-wingauge-copy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)