### PR TITLE
fix(canvas): "checked by you" survives a reload — persist the stamp when earned + re-earn it from the wire's provenance claim (L66, walk defect 0, P1)

### DIFF
--- a/src/canvas/components/pre-analysis/utils/__tests__/isReviewedByUser.spec.ts
+++ b/src/canvas/components/pre-analysis/utils/__tests__/isReviewedByUser.spec.ts
@@ -93,6 +93,53 @@ describe('isReviewedByUser — field-level fallback (addendum Blocking 2)', () =
   })
 })
 
+describe('isReviewedByUser — wire-carried provenance rung (L66, final-walk defect 0)', () => {
+  // The server graph structurally CANNOT carry a user claim in
+  // observed_state.source (CEE's ObservedStateV3 enum has no user member —
+  // rowed 2.396(b)); what it DOES carry is node-level provenance:'user_set',
+  // written by CEE when it applies the user's edit. On a reload that claim is
+  // the only durable evidence the user checked the value, so the predicate
+  // reads it as the final rung. Witnessed shape: runE post-reload
+  // fac_pricing_level — provenance user_set + observed_state.source
+  // cee_inference — must read as reviewed.
+  it('the exact runE post-reload shape reads as reviewed (provenance user_set beats a producer source)', () => {
+    const node = makeNode({
+      label: 'Paid Tier Price Point',
+      provenance: 'user_set',
+      display_value: '0.7',
+      observedState: {
+        value: 0.7,
+        source: 'cee_inference',
+        raw_value: 0.7,
+        std: 0.006999999999999999,
+        baseline: 0.7,
+      },
+    })
+    expect(isReviewedByUser(node)).toBe(true)
+  })
+
+  it('provenance user_set alone (no observed-state bags at all) reads as reviewed', () => {
+    expect(isReviewedByUser(makeNode({ provenance: 'user_set' }))).toBe(true)
+  })
+
+  it.each(['ai_inferred', 'from_brief'])(
+    'non-user provenance "%s" does NOT paint — the over-claim direction is the serious one',
+    (provenance) => {
+      expect(
+        isReviewedByUser(makeNode({ provenance, observedState: { source: 'cee_inference' } })),
+      ).toBe(false)
+    },
+  )
+
+  it('a user-owned SOURCE still wins regardless of provenance (the in-session receipt stamp path)', () => {
+    const node = makeNode({
+      provenance: 'ai_inferred',
+      observed_state: { source: 'user_override' },
+    })
+    expect(isReviewedByUser(node)).toBe(true)
+  })
+})
+
 describe('isReviewedEdge — edge-level predicate (pre-analysis-power-v2)', () => {
   const makeEdge = (data?: Record<string, unknown>): Edge => ({
     id: 'e1',

--- a/src/canvas/components/pre-analysis/utils/isReviewedByUser.ts
+++ b/src/canvas/components/pre-analysis/utils/isReviewedByUser.ts
@@ -68,13 +68,36 @@ export function isReviewedByUser(node: Node): boolean {
     observed_state?: { source?: string }
     observedState?: { source?: string }
     source?: string
+    provenance?: string
   }
   // Field-level fallback chain: snake_case → camelCase → top-level. An
   // empty `observed_state: {}` at the snake-case key no longer hides a
   // valid camelCase or top-level source.
   const source =
     data?.observed_state?.source ?? data?.observedState?.source ?? data?.source
-  return isReviewedSource(source)
+  if (isReviewedSource(source)) return true
+
+  // Final rung — the WIRE-CARRIED claim (L66, final-walk defect 0, P1).
+  //
+  // The `source` stamps above are CLIENT-side: CEE's `ObservedStateV3` types
+  // `observed_state.source` as z.enum(['brief_extraction','cee_inference']) —
+  // no user-owned member exists, and set_factor_value never writes the field
+  // (rowed 2.396(b)). So after a reload that hydrates from the server graph,
+  // every source stamp reads as the producer's and the badge lied in the
+  // under-claim direction: a value the USER set (witnessed: runE
+  // fac_pricing_level, 0.7 byte-identical across reload) regressed to
+  // "Olumi estimate / check first", re-prompting a check already made. The
+  // 3 Aug rewalk filed the same inversion as N1.
+  //
+  // What the server graph DOES carry is node-level `provenance: 'user_set'`,
+  // written by CEE when it APPLIES the user's edit — a receipt-backed claim,
+  // exactly the evidence class the receipt-gated stamp demands in-session.
+  // Only 'user_set' counts: 'from_brief' is an AI extraction of the user's
+  // text (may err — same reason brief_extraction is not a reviewed source)
+  // and 'ai_inferred' is the producer's own guess. The UI never writes
+  // `data.provenance`; it arrives from the wire, so it cannot be forged by a
+  // local path that skipped the receipt.
+  return data?.provenance === 'user_set'
 }
 
 /**

--- a/src/canvas/conversation/__tests__/optimisticFactorEdit.autosaveFlush.spec.ts
+++ b/src/canvas/conversation/__tests__/optimisticFactorEdit.autosaveFlush.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * "Checked by you" must survive a reload — the persistence half (L66,
+ * final-walk defect 0, P1).
+ *
+ * THE WITNESSED DEFECT (journey-witness-final-2026-08-04-raw/runE, build
+ * 610ed5f7): the reviewed stamp for `fac_pricing_level` ("Paid Tier Price
+ * Point") was earned via CEE's applied receipt at ~02:25:33Z and the page
+ * reloaded ~3 s later. The stamp existed ONLY in the in-memory store: the
+ * receipt path writes no autosave, so the slot the boot restores predated the
+ * stamp, and the row regressed to "Olumi estimate / check first" while the
+ * value survived (CEE holds the value; only the client holds the mark).
+ *
+ * The autosave writers before this fix were: the 30 s useAutosave timer, draft
+ * apply, auto-apply proposal patches, draft undo, resultsComplete, and the
+ * error-boundary crash flush. The one interaction that EARNS the mark was not
+ * on the list — any reload within up to ~30.5 s of a check lost it.
+ *
+ * THE RULE UNDER TEST: `confirmOptimisticFactorEdit`, on the 'stamped'
+ * outcome, flushes the autosave THROUGH THE CANONICAL PROJECTION
+ * (projectAutosaveData — the ci-guarded single constructor), so the earned
+ * stamp is on disk the moment the claim is made on screen.
+ *
+ * Identity binding (trap 19): assertions bind to `fac_pricing_level` and read
+ * the stamp back from the PERSISTED bytes at BOTH spellings —
+ * `observed_state.source` is the key `isReviewedByUser` reads FIRST on
+ * restore, so a camel-only persisted stamp would be read straight past.
+ *
+ * Controls: every non-'stamped' outcome ('no_stamp', 'value_moved_on',
+ * 'node_gone') must leave the slot byte-untouched — a flush on those paths
+ * would persist a claim the receipt did not earn (no_stamp) or a state the
+ * function just declined to write (value_moved_on / node_gone).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import {
+  captureOptimisticFactorEdit,
+  confirmOptimisticFactorEdit,
+} from '../optimisticFactorEdit'
+import { loadAutosave } from '../../store/scenarios'
+
+const NODE_ID = 'fac_pricing_level'
+const LABEL = 'Paid Tier Price Point'
+const AUTOSAVE_KEY = 'olumi-canvas-autosave'
+
+/** The node as it stands AFTER the optimistic write, receipt pending. */
+function pendingNode(value: number): Node {
+  return {
+    id: NODE_ID,
+    type: 'factor',
+    position: { x: 100, y: 200 },
+    data: {
+      label: LABEL,
+      kind: 'factor',
+      provenance: 'ai_inferred',
+      observedState: {
+        value,
+        raw_value: value,
+        source: 'cee_inference',
+        std: 0,
+        baseline: 0,
+      },
+    },
+  } as Node
+}
+
+/** Pre-write node data the wire event/undo snapshot was built from. */
+const PRE_EDIT_DATA = {
+  label: LABEL,
+  kind: 'factor',
+  observedState: { value: 0, source: 'cee_inference', std: 0, baseline: 0 },
+}
+
+function persistedNode(): Record<string, unknown> | undefined {
+  const slot = loadAutosave()
+  if (!slot) return undefined
+  const node = (slot.nodes as Array<{ id?: string }>).find((n) => n?.id === NODE_ID)
+  return node as Record<string, unknown> | undefined
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  useCanvasStore.setState({ nodes: [], edges: [], currentScenarioId: null } as never)
+})
+
+describe('confirmOptimisticFactorEdit — the earned stamp reaches the autosave slot', () => {
+  it("'stamped' flushes the autosave, and the persisted node carries the stamp at BOTH spellings", () => {
+    useCanvasStore.setState({ nodes: [pendingNode(0.7)], edges: [] } as never)
+    const edit = captureOptimisticFactorEdit(NODE_ID, 0.7, PRE_EDIT_DATA, {
+      source: 'user_override',
+    })
+    expect(edit).not.toBeNull()
+
+    expect(confirmOptimisticFactorEdit(edit!)).toBe('stamped')
+
+    const persisted = persistedNode()
+    expect(persisted, 'the stamped node must be in the autosave slot').toBeDefined()
+    const data = (persisted as { data?: Record<string, unknown> }).data ?? {}
+    // Snake first — the key isReviewedByUser resolves FIRST on restore.
+    expect((data.observed_state as { source?: string } | undefined)?.source).toBe('user_override')
+    expect((data.observedState as { source?: string } | undefined)?.source).toBe('user_override')
+    // The value the stamp describes rides in the same write.
+    expect((data.observedState as { value?: number } | undefined)?.value).toBe(0.7)
+  })
+
+  it("CONTROL — 'no_stamp' (Model tab / inspector callers) writes nothing: the slot stays empty", () => {
+    useCanvasStore.setState({ nodes: [pendingNode(0.41)], edges: [] } as never)
+    const edit = captureOptimisticFactorEdit(NODE_ID, 0.41, PRE_EDIT_DATA)
+
+    expect(confirmOptimisticFactorEdit(edit!)).toBe('no_stamp')
+
+    expect(localStorage.getItem(AUTOSAVE_KEY)).toBeNull()
+  })
+
+  it("CONTROL — 'value_moved_on' (late receipt) writes nothing: a stale stamp must not be persisted", () => {
+    // The node has moved to 0.9 since the 0.62 edit was sent.
+    useCanvasStore.setState({ nodes: [pendingNode(0.9)], edges: [] } as never)
+    const edit = captureOptimisticFactorEdit(NODE_ID, 0.62, PRE_EDIT_DATA, {
+      source: 'user_override',
+    })
+
+    expect(confirmOptimisticFactorEdit(edit!)).toBe('value_moved_on')
+
+    expect(localStorage.getItem(AUTOSAVE_KEY)).toBeNull()
+  })
+
+  it("CONTROL — 'node_gone' writes nothing", () => {
+    useCanvasStore.setState({ nodes: [], edges: [] } as never)
+    const edit = captureOptimisticFactorEdit(NODE_ID, 0.53, PRE_EDIT_DATA, {
+      source: 'user_override',
+    })
+
+    expect(confirmOptimisticFactorEdit(edit!)).toBe('node_gone')
+
+    expect(localStorage.getItem(AUTOSAVE_KEY)).toBeNull()
+  })
+})

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -40,6 +40,8 @@
  */
 
 import { useCanvasStore } from '../store'
+import { saveAutosave } from '../store/scenarios'
+import { autosaveSourceFromStore, projectAutosaveData } from '../store/autosaveProjection'
 import { withObservedStateUpdate, type ObservedStateData } from '../utils/observedStateHelpers'
 import { unwrapInterventionValue, classifyUnit } from '../utils/labelUtils'
 import { formatValueWithUnit, formatNumber } from '../utils/formatValueWithUnit'
@@ -508,6 +510,28 @@ export function confirmOptimisticFactorEdit(edit: OptimisticFactorEdit): Confirm
   store.updateNode(edit.nodeId, {
     data: withObservedStateUpdate(node.data, edit.reviewedStamp),
   } as never)
+
+  // Persist the earned stamp NOW (L66, final-walk defect 0, P1). The stamp is
+  // the ONE thing only the client holds — the value round-trips through CEE,
+  // but `observed_state.source` cannot (the server enum has no user member,
+  // rowed 2.396(b)) — and before this flush nothing persisted it at the moment
+  // it was earned: the autosave writers were the 30 s timer, draft apply,
+  // auto-apply patches, draft undo, resultsComplete and the crash flush.
+  // Witnessed cost (runE, build 610ed5f7): a reload ~3 s after the receipt
+  // restored a pre-stamp slot and the row regressed to "Olumi estimate /
+  // check first" with the value intact. Flushing on 'stamped' — and ONLY on
+  // 'stamped': the other outcomes wrote nothing, so persisting on them would
+  // record a claim this function just declined to make — closes that window.
+  // Through the canonical projection, like every other writer (the
+  // autosave-projection-single-source ci-guard derives this list from the
+  // filesystem). Best-effort like its sibling call sites: a quota failure
+  // must not turn a successful receipt into a thrown error.
+  try {
+    saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState())))
+  } catch {
+    // Non-critical: the in-memory stamp is already applied; the periodic
+    // autosave remains the fallback writer.
+  }
   return 'stamped'
 }
 

--- a/src/canvas/utils/__tests__/mergeServerGraph.reviewedRehydrate.spec.tsx
+++ b/src/canvas/utils/__tests__/mergeServerGraph.reviewedRehydrate.spec.tsx
@@ -1,0 +1,213 @@
+/**
+ * "Checked by you" must survive a reload — the boot-merge half (L66, final-walk
+ * defect 0, P1).
+ *
+ * THE WITNESSED DEFECT (journey-witness-final-2026-08-04-raw/runE, build
+ * 610ed5f7, positive-control-backed): the user typed "pretty likely" on
+ * `fac_pricing_level` ("Paid Tier Price Point"), accepted the 0.7 suggestion,
+ * and the row read `0.7 · checked by you` with `data-reviewed=true`
+ * (E-02-marks-pre-reload.json). ~3 s later the page reloaded. The VALUE
+ * survived byte-identical — CEE holds it — but the row regressed to
+ * `0.7 · Olumi estimate · check first` (E-03-marks-post-reload.json,
+ * E-04 verdict `survived: false`). The user is re-prompted to redo a check
+ * they made.
+ *
+ * WHY: the reload restored an autosave written BEFORE the receipt stamp
+ * landed (the stamp is receipt-gated and nothing persists it at stamp time —
+ * see optimisticFactorEdit.autosaveFlush.spec.ts for that half), and the
+ * server graph cannot re-earn the badge through `observed_state.source`:
+ * CEE's ObservedStateV3 types it as z.enum(['brief_extraction',
+ * 'cee_inference']) — no user-owned member exists (rowed 2.396(b)). What the
+ * server graph DOES carry — witnessed on the runE wire — is the node-level
+ * claim `provenance: "user_set"`, which CEE writes when it applies the user's
+ * edit. The UI ignored it; the 3 Aug rewalk filed the same inversion as N1
+ * ("CEE emits provenance:'user_set' correctly — the UI reads the stale
+ * observed_state.source").
+ *
+ * THE RULE UNDER TEST: `isReviewedByUser` treats the server's own
+ * `provenance === 'user_set'` as a reviewed claim, so a boot merge over a
+ * stale autosave re-earns the badge from the wire. Identity binding
+ * (CLAUDE.md trap 19): every assertion binds to `fac_pricing_level` /
+ * "Paid Tier Price Point" — the exact runE node — never to a value predicate
+ * another node could satisfy.
+ *
+ * Controls, each stopping a cheaper wrong fix:
+ *  - the stamped-autosave path (variant A) must STILL work — the rung must not
+ *    replace the hydrateProvenance capture/restore machinery;
+ *  - a server node WITHOUT a user provenance claim must NOT paint — the rung
+ *    fires on 'user_set' only, never on 'ai_inferred'/'from_brief' (the
+ *    over-claim direction is the serious one: a badge on a number the user
+ *    never chose is the #570-A1 orphan-stamp class).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+import { isReviewedByUser } from '../../components/pre-analysis/utils/isReviewedByUser'
+import { buildEstimateRows } from '../../components/pre-analysis-v3/selectors/buildEstimateRows'
+import { EstimateRow } from '../../components/pre-analysis-v3/model/EstimateRow'
+
+const NODE_ID = 'fac_pricing_level'
+const LABEL = 'Paid Tier Price Point'
+
+/** The server node as witnessed on the runE wire (post-merge sensitivity body). */
+function serverGraph(overrides: Record<string, unknown> = {}) {
+  return {
+    nodes: [
+      {
+        id: NODE_ID,
+        kind: 'factor',
+        label: LABEL,
+        provenance: 'user_set',
+        display_value: '0.7',
+        category: 'controllable',
+        observed_state: {
+          value: 0.7,
+          source: 'cee_inference',
+          raw_value: 0.7,
+          factor_type: 'price',
+          extractionType: 'inferred',
+          std: 0.006999999999999999,
+          baseline: 0.7,
+        },
+        ...overrides,
+      },
+    ],
+    edges: [],
+  }
+}
+
+/** A restored-autosave local node. */
+function localNode(observedState: Record<string, unknown>): Node {
+  return {
+    id: NODE_ID,
+    type: 'factor',
+    position: { x: 100, y: 200 },
+    data: {
+      label: LABEL,
+      kind: 'factor',
+      provenance: 'ai_inferred',
+      category: 'controllable',
+      observedState,
+    },
+  } as Node
+}
+
+function mergedNode(): Node {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === NODE_ID)
+  expect(node, `node ${NODE_ID} must survive the merge`).toBeDefined()
+  return node as Node
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ nodes: [], edges: [] } as never)
+})
+
+describe('boot merge re-earns "checked by you" from the server provenance claim (runE shape)', () => {
+  it('autosave written INSIDE the receipt window (0.7 optimistic, source still cee_inference) — the witnessed runE loss', () => {
+    useCanvasStore.setState({
+      nodes: [
+        localNode({ value: 0.7, raw_value: 0.7, source: 'cee_inference', std: 0, baseline: 0 }),
+      ],
+      edges: [],
+    } as never)
+
+    const result = mergeServerGraphOnHydrate(serverGraph())
+    expect(result.accepted).toBe(true)
+
+    const node = mergedNode()
+    // Value survives via the server — the witnessed half that already worked.
+    expect((node.data as { observedState?: { value?: number } }).observedState?.value).toBe(0.7)
+    // The mark survives via the server's own provenance claim — the fix.
+    expect(isReviewedByUser(node)).toBe(true)
+  })
+
+  it('autosave predating the edit entirely (value 0) — value moves to the server 0.7 AND the mark is re-earned', () => {
+    useCanvasStore.setState({
+      nodes: [localNode({ value: 0, source: 'cee_inference', std: 0, baseline: 0 })],
+      edges: [],
+    } as never)
+
+    const result = mergeServerGraphOnHydrate(serverGraph())
+    expect(result.accepted).toBe(true)
+
+    const node = mergedNode()
+    expect((node.data as { observedState?: { value?: number } }).observedState?.value).toBe(0.7)
+    expect(isReviewedByUser(node)).toBe(true)
+  })
+
+  it('renders the witnessed row shape: "checked by you" with data-reviewed, on the runE row testid', () => {
+    useCanvasStore.setState({
+      nodes: [
+        localNode({ value: 0.7, raw_value: 0.7, source: 'cee_inference', std: 0, baseline: 0 }),
+      ],
+      edges: [],
+    } as never)
+    mergeServerGraphOnHydrate(serverGraph())
+
+    const node = mergedNode()
+    const rows = buildEstimateRows(
+      [node],
+      { source: 'sensitivity', ordered: [NODE_ID], weights: { [NODE_ID]: 1 } },
+      null,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.nodeId).toBe(NODE_ID)
+    expect(rows[0]!.reviewed).toBe(true)
+
+    render(<EstimateRow row={rows[0]!} expanded={false} onToggle={() => {}} />)
+    const row = screen.getByTestId(`pre-analysis-v3-estimate-${NODE_ID}`)
+    expect(row.getAttribute('data-reviewed')).toBe('true')
+    expect(row.textContent).toContain('checked by you')
+    // The regression the walk witnessed: the row must NOT re-prompt the check.
+    expect(row.textContent).not.toContain('Olumi estimate')
+    expect(row.textContent).not.toContain('check first')
+  })
+})
+
+describe('controls — what the fix must NOT do', () => {
+  it('CONTROL (stamped autosave, variant A): the existing capture/restore path still carries the stamp and the badge', () => {
+    const stampedBag = {
+      value: 0.7,
+      raw_value: 0.7,
+      source: 'user_override',
+      std: 0.006999999999999999,
+      baseline: 0.7,
+    }
+    const node = localNode(stampedBag)
+    ;(node.data as Record<string, unknown>).observed_state = { ...stampedBag }
+    useCanvasStore.setState({ nodes: [node], edges: [] } as never)
+
+    mergeServerGraphOnHydrate(serverGraph())
+
+    const after = mergedNode()
+    const data = after.data as Record<string, unknown>
+    expect((data.observed_state as { source?: string }).source).toBe('user_override')
+    expect((data.observedState as { source?: string }).source).toBe('user_override')
+    expect(isReviewedByUser(after)).toBe(true)
+  })
+
+  it('OVER-CLAIM GUARD: a server node with provenance ai_inferred does NOT paint the badge', () => {
+    useCanvasStore.setState({
+      nodes: [localNode({ value: 0.7, source: 'cee_inference', std: 0, baseline: 0 })],
+      edges: [],
+    } as never)
+
+    mergeServerGraphOnHydrate(serverGraph({ provenance: 'ai_inferred' }))
+
+    expect(isReviewedByUser(mergedNode())).toBe(false)
+  })
+
+  it('OVER-CLAIM GUARD: from_brief provenance (AI-extracted from the brief, not user-confirmed) does not paint either', () => {
+    useCanvasStore.setState({
+      nodes: [localNode({ value: 0.7, source: 'cee_inference', std: 0, baseline: 0 })],
+      edges: [],
+    } as never)
+
+    mergeServerGraphOnHydrate(serverGraph({ provenance: 'from_brief' }))
+
+    expect(isReviewedByUser(mergedNode())).toBe(false)
+  })
+})


### PR DESCRIPTION
## The defect (witnessed, positive-control-backed)

Final walk runE at `610ed5f7` (`PHASE0-EVIDENCE-2026-07-28/journey-witness-final-2026-08-04-raw/runE/`): user checks `fac_pricing_level` ("pretty likely" → 0.7, applied receipt, row reads `0.7 · checked by you`, `data-reviewed=true`); reload ~3 s later keeps the VALUE byte-identical but the row regresses to `0.7 · Olumi estimate · check first` — the product re-prompts a check the user already made.

## Verdict on Question 1: NOT a #578 regression — PRE-EXISTING (never-persisted-in-time)

Settled by an **executed differential**, not inherited: the runE server graph was run through `mergeServerGraphOnHydrate` at the pre-#578 merge-base (`bc0e4a98`) and at head, over three local-autosave variants, in jsdom. Badge outcomes are **byte-identical on both builds**: a stamped autosave survives on BOTH (the hydrateProvenance guard works); a receipt-window or pre-edit autosave loses the mark on BOTH. #578's diff on this path is edge presence + refusal accounting only. Full table in `PHASE0-EVIDENCE-2026-07-28/l66-checked-marks-reload.md` §4.

Two seams, both fixed here UI-side:

1. **Persistence timing.** The reviewed stamp is receipt-gated (`confirmOptimisticFactorEdit`) and lived only in the in-memory store. The autosave writers were: the 30 s `useAutosave` timer, draft apply, auto-apply patches, draft undo, `resultsComplete`, crash flush — never the interaction that EARNS the mark. Any reload within up to ~30.5 s of a check lost it; runE reloaded ~3 s after. **Fix:** the `'stamped'` outcome flushes the autosave through the canonical projection (ci-guarded single constructor); only `'stamped'` — the other outcomes wrote nothing (three controls pin this).
2. **Rehydration.** The server graph structurally cannot carry the mark in `observed_state.source` (CEE's `ObservedStateV3` enum has no user member; `set_factor_value` never writes `source` — rowed 2.396(b)). What the wire DOES carry — witnessed on the runE sensitivity body; filed as inversion N1 by the 3 Aug rewalk — is node-level `provenance: "user_set"`, written by CEE when it APPLIES the user's edit. **Fix:** `isReviewedByUser` reads that as its final rung, `'user_set'` only (`from_brief`/`ai_inferred` pinned NOT to paint — the over-claim direction is the serious one). Single-source predicate, so the badge, reviewedCount, priority progress, influence coverage and drill-in affordances move together.

## Proof obligations

- **RED-first:** 6 named failures before the fix; all assertions identity-bound to the runE node (`fac_pricing_level` / "Paid Tier Price Point"), incl. the rendered row shape (`data-reviewed`, "checked by you", not "Olumi estimate"/"check first"). 49/49 after.
- **Mutants** (throwaway worktree outside repo root; applied-check src/-scoped, control exactly 0):

| Mutant | Perturbation | RED |
|---|---|---|
| M1 | remove the autosave flush (revert leg 1) | 1 — the stamped-flush pin |
| M2 | drop the provenance rung (revert leg 2) | 5 — boot-merge + predicate pins |
| M3 | rung fires on `from_brief` instead of `user_set` | 7 — incl. BOTH over-claim guards |
| M4 | flush on every outcome, not only `'stamped'` | 3 — all three no-write controls |

- **#578's own pins survive:** `mergeServerGraph.{spec,acceptance,edgePresence,provenance}` + `serverGraphHydration.refusal` all green in the 364-file / 5,609-test blast-radius run.
- **Gates at this tip:** `pnpm run typecheck` PASSED (coverage + ratchet, baseline 620/2502 unchanged — the 3 new specs load clean).

## Remains CEE-side (reported, not written here)

- (a) `ObservedStateV3.source` has no user-owned member — rowed 2.396(b).
- (b) Whether CEE flips provenance to `user_set` on a noop "Confirm as is" is unverified; if not, a confirm-as-is mark still cannot be re-earned on a cleared-storage/new-device session (the flush covers same-device).
- (c) Science-icon pill ("Olumi estimated this value…") reads the string-level source only — rowed L60(c), deliberately untouched.

Evidence file: `PHASE0-EVIDENCE-2026-07-28/l66-checked-marks-reload.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)