### PR TITLE
Lane 4 (P5): reconnect toolbar capabilities + remove lying Export/Replay controls

### DIFF
--- a/src/canvas/components/ImportExportDialog.tsx
+++ b/src/canvas/components/ImportExportDialog.tsx
@@ -27,7 +27,6 @@ export function ImportExportDialog({ isOpen, onClose, mode }: ImportExportDialog
   // React 18 + Zustand v5: use individual selectors instead of object+shallow
   const nodes = useCanvasStore(s => s.nodes)
   const edges = useCanvasStore(s => s.edges)
-  const isDirty = useCanvasStore(s => s.isDirty)
   const { showToast } = useToast()
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -103,12 +102,16 @@ export function ImportExportDialog({ isOpen, onClose, mode }: ImportExportDialog
   const handleImport = (autoFix: boolean) => {
     if (!importPreview) return
 
-    // F1 (PR #582 adversarial review): store.importCanvas replaces the whole
-    // graph AND wipes undo history (past/future emptied), so the clobber is
-    // unrecoverable where localStorage autosave is disabled. Mirror
-    // ScenarioSwitcher's dirty-state confirm (same copy) before the
-    // destructive call.
-    if (isDirty && !window.confirm('You have unsaved changes. Import anyway?')) {
+    // F1 (PR #582 adversarial review, gate corrected by the delta re-review):
+    // store.importCanvas replaces the whole graph AND wipes undo history
+    // (past/future emptied), so the clobber is unrecoverable where
+    // localStorage autosave is disabled. Gate on NON-EMPTY canvas, not
+    // `isDirty` — that flag is hollow (ordinary node/edge edits and CEE
+    // draft-apply never set it), and the copy states what actually happens.
+    if (
+      (nodes.length > 0 || edges.length > 0) &&
+      !window.confirm('Import this file? This will replace your current canvas and clear undo history.')
+    ) {
       return
     }
 

--- a/src/canvas/components/ImportExportDialog.tsx
+++ b/src/canvas/components/ImportExportDialog.tsx
@@ -27,6 +27,7 @@ export function ImportExportDialog({ isOpen, onClose, mode }: ImportExportDialog
   // React 18 + Zustand v5: use individual selectors instead of object+shallow
   const nodes = useCanvasStore(s => s.nodes)
   const edges = useCanvasStore(s => s.edges)
+  const isDirty = useCanvasStore(s => s.isDirty)
   const { showToast } = useToast()
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -101,6 +102,15 @@ export function ImportExportDialog({ isOpen, onClose, mode }: ImportExportDialog
 
   const handleImport = (autoFix: boolean) => {
     if (!importPreview) return
+
+    // F1 (PR #582 adversarial review): store.importCanvas replaces the whole
+    // graph AND wipes undo history (past/future emptied), so the clobber is
+    // unrecoverable where localStorage autosave is disabled. Mirror
+    // ScenarioSwitcher's dirty-state confirm (same copy) before the
+    // destructive call.
+    if (isDirty && !window.confirm('You have unsaved changes. Import anyway?')) {
+      return
+    }
 
     let jsonToImport = importPreview
 

--- a/src/canvas/components/ScenarioSwitcher.tsx
+++ b/src/canvas/components/ScenarioSwitcher.tsx
@@ -18,7 +18,17 @@ import { exportScenario } from '../export/exportScenario'
 import { useToast } from '../ToastContext'
 import { typography } from '../../styles/typography'
 
-export function ScenarioSwitcher() {
+interface ScenarioSwitcherProps {
+  /**
+   * Which side of the trigger the dropdown opens on.
+   * 'above' (default) suits a bottom-anchored toolbar; 'below' is for the
+   * fixed TopBar mount (Lane 4 P5), where opening upward would leave the
+   * viewport.
+   */
+  dropdownPosition?: 'above' | 'below'
+}
+
+export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitcherProps = {}) {
   const currentScenarioId = useCanvasStore(s => s.currentScenarioId)
   const isDirty = useCanvasStore(s => s.isDirty)
   const isSaving = useCanvasStore(s => s.isSaving)
@@ -194,6 +204,7 @@ export function ScenarioSwitcher() {
           type="button"
           aria-expanded={isOpen}
           aria-haspopup="true"
+          data-testid="scenario-switcher-trigger"
         >
           <Folder className="w-4 h-4 text-gray-500" />
           <span className="max-w-[150px] truncate">
@@ -210,8 +221,9 @@ export function ScenarioSwitcher() {
         {/* Dropdown menu */}
         {isOpen && (
           <div
-            className="absolute bottom-full left-0 mb-1 w-72 bg-white border border-gray-200 rounded-lg shadow-panel z-50"
+            className={`absolute ${dropdownPosition === 'below' ? 'top-full mt-1' : 'bottom-full mb-1'} left-0 w-72 bg-white border border-gray-200 rounded-lg shadow-panel z-50`}
             role="menu"
+            data-testid="scenario-switcher-menu"
           >
             {/* Current scenario actions */}
             <div className="p-2 border-b border-gray-200">

--- a/src/canvas/components/SnapshotManager.tsx
+++ b/src/canvas/components/SnapshotManager.tsx
@@ -68,6 +68,13 @@ export function SnapshotManager({ isOpen, onClose }: SnapshotManagerProps) {
   }
 
   const handleRestore = (key: string) => {
+    // F1 (PR #582 adversarial review): restore replaces the whole graph AND
+    // wipes undo history (store.importCanvas empties past/future) even when
+    // the canvas is not dirty — so ALWAYS confirm, matching the codebase's
+    // window.confirm convention (snapshot Delete, ScenarioSwitcher load).
+    if (!window.confirm('Restore this snapshot? This will replace your current canvas and clear undo history.')) {
+      return
+    }
     const data = loadSnapshot(key)
     if (data) {
       const importCanvas = useCanvasStore.getState().importCanvas

--- a/src/canvas/components/__tests__/SnapshotManager.spec.tsx
+++ b/src/canvas/components/__tests__/SnapshotManager.spec.tsx
@@ -164,6 +164,74 @@ describe('SnapshotManager', () => {
     confirmSpy.mockRestore()
   })
 
+  /**
+   * F1 (adversarial review of PR #582): Restore calls store.importCanvas,
+   * which replaces the whole graph AND wipes undo history (store.ts:2467),
+   * even when the canvas is not dirty — so Restore must ALWAYS confirm.
+   * Assertions bind to the confirm's exact copy, and the destructive action
+   * must NOT run until accepted.
+   */
+  it('restore requires confirmation and does nothing when declined (F1)', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const importCanvasMock = vi.fn()
+    ;(store.useCanvasStore as unknown as { getState: () => unknown }).getState =
+      vi.fn(() => ({ importCanvas: importCanvasMock }))
+
+    vi.mocked(persist.listSnapshots).mockReturnValue([
+      { key: 'snap-1', timestamp: 1697500000000, size: 1024 },
+    ])
+    vi.mocked(persist.loadSnapshot).mockReturnValue({
+      version: 1,
+      timestamp: 1697500000000,
+      nodes: [{ id: '1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
+      edges: []
+    })
+    Storage.prototype.getItem = vi.fn(() => 'Test Snapshot')
+
+    renderWithToast(<SnapshotManager isOpen={true} onClose={mockOnClose} />)
+
+    fireEvent.click(screen.getByText('Restore'))
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Restore this snapshot? This will replace your current canvas and clear undo history.'
+    )
+    expect(importCanvasMock).not.toHaveBeenCalled()
+    expect(mockOnClose).not.toHaveBeenCalled()
+
+    confirmSpy.mockRestore()
+  })
+
+  it('restore replaces the canvas after confirmation (F1)', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const importCanvasMock = vi.fn()
+    ;(store.useCanvasStore as unknown as { getState: () => unknown }).getState =
+      vi.fn(() => ({ importCanvas: importCanvasMock }))
+
+    const snapshotData = {
+      version: 1,
+      timestamp: 1697500000000,
+      nodes: [{ id: '1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Node 1' } }],
+      edges: []
+    }
+    vi.mocked(persist.listSnapshots).mockReturnValue([
+      { key: 'snap-1', timestamp: 1697500000000, size: 1024 },
+    ])
+    vi.mocked(persist.loadSnapshot).mockReturnValue(snapshotData)
+    Storage.prototype.getItem = vi.fn(() => 'Test Snapshot')
+
+    renderWithToast(<SnapshotManager isOpen={true} onClose={mockOnClose} />)
+
+    fireEvent.click(screen.getByText('Restore'))
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Restore this snapshot? This will replace your current canvas and clear undo history.'
+    )
+    expect(importCanvasMock).toHaveBeenCalledWith(JSON.stringify(snapshotData))
+    expect(mockOnClose).toHaveBeenCalled()
+
+    confirmSpy.mockRestore()
+  })
+
   it('shows snapshot count indicator', () => {
     const mockSnapshots = [
       { key: 'snap-1', timestamp: 1697500000000, size: 1024 },

--- a/src/components/layout/KebabMenu.tsx
+++ b/src/components/layout/KebabMenu.tsx
@@ -1,9 +1,20 @@
 /**
  * KebabMenu — restructured "More" dropdown menu for the top bar.
  *
- * Groups: Decision (Rename, Export, Reset canvas) | View (Fullscreen) |
- * Help (Replay tour, Keyboard shortcuts, How influence works) |
+ * Groups: Decision (Rename, Export, Import, Snapshots, Reset canvas) |
+ * View (Fullscreen) | Help (Keyboard shortcuts, How influence works) |
  * Canvas settings (flattened toggles).
+ *
+ * Lane 4 (P5): Export routes to the REAL ImportExportDialog (it was a
+ * console.warn stub — a visible control that did nothing). Import ships
+ * alongside it so the export dialog's own "editable and re-importable"
+ * claim stays true, and Snapshots reconnects SnapshotManager (previously
+ * only reachable from the production-unmounted CanvasToolbar). "Replay
+ * tour" was REMOVED: it dispatched into an overlay gated on a flag that is
+ * off in every deploy context, and the tour content itself describes
+ * surfaces that do not exist in the deployed UI.
+ *
+ * Requires ToastProvider in an ancestor (the dialogs use useToast).
  */
 
 import { useState, useCallback } from 'react'
@@ -11,14 +22,17 @@ import {
   MoreVertical,
   Pencil,
   Download,
+  Upload,
+  Camera,
   RotateCcw,
   Maximize,
-  BookOpen,
   Keyboard,
   HelpCircle,
 } from 'lucide-react'
 import Tooltip from '../Tooltip'
 import { ConfirmDialog } from '../../canvas/components/ConfirmDialog'
+import { ImportExportDialog } from '../../canvas/components/ImportExportDialog'
+import { SnapshotManager } from '../../canvas/components/SnapshotManager'
 import { useSettingsStore } from '../../canvas/settingsStore'
 import { useCanvasStore } from '../../canvas/store'
 import styles from './TopBar.module.css'
@@ -28,7 +42,6 @@ interface KebabMenuProps {
   onToggle: () => void
   onClose: () => void
   onStartRename: () => void
-  onShowOnboarding: () => void
   onShowKeyboardLegend: () => void
   onShowInfluenceExplainer: () => void
   menuRef: React.RefObject<HTMLDivElement | null>
@@ -39,12 +52,14 @@ export function KebabMenu({
   onToggle,
   onClose,
   onStartRename,
-  onShowOnboarding,
   onShowKeyboardLegend,
   onShowInfluenceExplainer,
   menuRef,
 }: KebabMenuProps) {
   const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [activeDialog, setActiveDialog] = useState<
+    'export' | 'import' | 'snapshots' | null
+  >(null)
 
   const resetCanvas = useCanvasStore(s => s.resetCanvas)
 
@@ -62,9 +77,21 @@ export function KebabMenu({
   } = useSettingsStore()
 
   const handleExport = useCallback(() => {
-    console.warn('Export')
+    setActiveDialog('export')
     onClose()
   }, [onClose])
+
+  const handleImport = useCallback(() => {
+    setActiveDialog('import')
+    onClose()
+  }, [onClose])
+
+  const handleSnapshots = useCallback(() => {
+    setActiveDialog('snapshots')
+    onClose()
+  }, [onClose])
+
+  const closeDialog = useCallback(() => setActiveDialog(null), [])
 
   const handleResetCanvas = useCallback(() => {
     setShowResetConfirm(true)
@@ -119,9 +146,30 @@ export function KebabMenu({
               role="menuitem"
               className={styles.dropdownMenuButton}
               onClick={handleExport}
+              data-testid="kebab-export"
             >
               <Download size={14} aria-hidden="true" />
               <span>Export</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.dropdownMenuButton}
+              onClick={handleImport}
+              data-testid="kebab-import"
+            >
+              <Upload size={14} aria-hidden="true" />
+              <span>Import</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.dropdownMenuButton}
+              onClick={handleSnapshots}
+              data-testid="kebab-snapshots"
+            >
+              <Camera size={14} aria-hidden="true" />
+              <span>Snapshots</span>
             </button>
             <button
               type="button"
@@ -151,15 +199,6 @@ export function KebabMenu({
 
             {/* Help group */}
             <div className={styles.dropdownMenuLabel}>Help</div>
-            <button
-              type="button"
-              role="menuitem"
-              className={styles.dropdownMenuButton}
-              onClick={onShowOnboarding}
-            >
-              <BookOpen size={14} aria-hidden="true" />
-              <span>Replay tour</span>
-            </button>
             <button
               type="button"
               role="menuitem"
@@ -267,6 +306,23 @@ export function KebabMenu({
           onCancel={() => setShowResetConfirm(false)}
         />
       )}
+
+      {/* Lane 4 (P5): the real capability dialogs, portal-rendered by
+          BottomSheet. Each renders null while closed. */}
+      <ImportExportDialog
+        isOpen={activeDialog === 'export'}
+        onClose={closeDialog}
+        mode="export"
+      />
+      <ImportExportDialog
+        isOpen={activeDialog === 'import'}
+        onClose={closeDialog}
+        mode="import"
+      />
+      <SnapshotManager
+        isOpen={activeDialog === 'snapshots'}
+        onClose={closeDialog}
+      />
     </>
   )
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -6,11 +6,16 @@ import { useAnalysisMetadata } from '../../canvas/hooks/useAnalysisMetadata'
 import { useStagePill } from '../../canvas/hooks/useStagePill'
 import { UserAvatarMenu } from './UserAvatarMenu'
 import { KebabMenu } from './KebabMenu'
+import { ScenarioSwitcher } from '../../canvas/components/ScenarioSwitcher'
 import { MENU_EXCLUSIVE_EVENT } from './LeftSidebar'
 
 // Custom events for help actions (communicated to ReactFlowGraph)
+// Lane 4 (P5): SHOW_ONBOARDING removed — its only dispatcher was the kebab
+// "Replay tour" item, which fired into an overlay gated off in every deploy
+// context (a control that lied). ReactFlowGraph's literal
+// 'topbar:show-onboarding' listener + gated overlay remain as dead code;
+// retire-or-revive is a rowed follow-up.
 export const HELP_EVENTS = {
-  SHOW_ONBOARDING: 'topbar:show-onboarding',
   SHOW_KEYBOARD_LEGEND: 'topbar:show-keyboard-legend',
   SHOW_INFLUENCE_EXPLAINER: 'topbar:show-influence-explainer',
   SHOW_TOAST: 'topbar:show-toast',
@@ -128,11 +133,6 @@ export const TopBar = ({
   }, [])
 
   // Help action handlers - emit custom events for ReactFlowGraph to handle
-  const handleShowOnboarding = useCallback(() => {
-    window.dispatchEvent(new CustomEvent(HELP_EVENTS.SHOW_ONBOARDING))
-    setShowMenu(false)
-  }, [])
-
   const handleShowKeyboardLegend = useCallback(() => {
     window.dispatchEvent(new CustomEvent(HELP_EVENTS.SHOW_KEYBOARD_LEGEND))
     setShowMenu(false)
@@ -205,6 +205,12 @@ export const TopBar = ({
         {!isPersisted && isDirty && saveStatus !== 'saving' && (
           <span className={styles.dirtyIndicator} aria-label="Unsaved changes" />
         )}
+
+        {/* Lane 4 (P5): scenario switching, save-as, duplicate, rename,
+            delete, and scenario export/import (.olumi.json) — previously
+            only reachable from the production-unmounted CanvasToolbar. */}
+        <div className={styles.divider} aria-hidden="true" />
+        <ScenarioSwitcher dropdownPosition="below" />
 
       </div>
 
@@ -359,7 +365,6 @@ export const TopBar = ({
           }}
           onClose={() => setShowMenu(false)}
           onStartRename={() => { setIsEditing(true); setShowMenu(false) }}
-          onShowOnboarding={handleShowOnboarding}
           onShowKeyboardLegend={handleShowKeyboardLegend}
           onShowInfluenceExplainer={handleShowInfluenceExplainer}
           menuRef={menuRef}

--- a/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
@@ -19,11 +19,14 @@
  * jsdom proves presence/wiring only, never pixels (trap 3) — the post-deploy
  * browser walk uses the testids listed in the lane report.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { TopBar } from '../TopBar'
 import { ToastProvider } from '../../../canvas/ToastContext'
+import { ImportExportDialog } from '../../../canvas/components/ImportExportDialog'
+import { useCanvasStore } from '../../../canvas/store'
+import { exportCanvas as exportCanvasData } from '../../../canvas/persist'
 
 function renderTopBar() {
   return render(
@@ -115,5 +118,105 @@ describe('TopBar kebab capabilities (Lane 4 P5)', () => {
     const menu = screen.getByTestId('scenario-switcher-menu')
     expect(menu.className).toContain('top-full')
     expect(menu.className).not.toContain('bottom-full')
+  })
+})
+
+/**
+ * F1 (adversarial review of PR #582): the newly-exposed Import path calls
+ * store.importCanvas, which replaces the whole graph AND wipes undo history
+ * (store.ts:2467 — past/future emptied), with no confirmation. Codebase
+ * convention everywhere else is a confirm (ScenarioSwitcher load/import,
+ * snapshot Delete, kebab Reset). These tests pin the dirty-state confirm,
+ * bound by IDENTITY to ScenarioSwitcher's exact copy, and assert the
+ * destructive action is NOT taken until accepted.
+ */
+describe('ImportExportDialog import confirmation (F1)', () => {
+  const importedNode = {
+    id: 'n-imported-1',
+    type: 'decision',
+    position: { x: 0, y: 0 },
+    // data.type is the discriminant of AnyNodeDataSchema (v2 snapshot Zod) —
+    // without it the import path rejects the file (v2-parse-failed).
+    data: { label: 'Imported node F1', type: 'decision' },
+  }
+  // Build the file with the REAL exporter so the fixture cannot drift from
+  // the format the import path validates.
+  const validImportJson = exportCanvasData({ nodes: [importedNode] as never, edges: [] })
+
+  function resetStore() {
+    useCanvasStore.setState({ nodes: [], edges: [], isDirty: false })
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    resetStore()
+  })
+
+  afterEach(() => {
+    resetStore()
+    vi.restoreAllMocks()
+  })
+
+  async function renderImportDialogWithFile() {
+    const onClose = vi.fn()
+    render(
+      <ToastProvider>
+        <ImportExportDialog isOpen onClose={onClose} mode="import" />
+      </ToastProvider>,
+    )
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input).not.toBeNull()
+    const file = new File([validImportJson], 'canvas.json', { type: 'application/json' })
+    // jsdom 24's File lacks Blob.text(); polyfill on the instance so the
+    // dialog's `await file.text()` resolves to the fixture content.
+    if (typeof (file as { text?: unknown }).text !== 'function') {
+      Object.defineProperty(file, 'text', {
+        value: () => Promise.resolve(validImportJson),
+      })
+    }
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } })
+    })
+    await screen.findByText('Import As-Is')
+    return onClose
+  }
+
+  it('with unsaved changes, declining the confirm leaves the canvas untouched', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    useCanvasStore.setState({ isDirty: true })
+    const onClose = await renderImportDialogWithFile()
+
+    fireEvent.click(screen.getByText('Import As-Is'))
+
+    expect(confirmSpy).toHaveBeenCalledWith('You have unsaved changes. Import anyway?')
+    // Destructive action NOT taken: graph unchanged, dialog still open.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('with unsaved changes, accepting the confirm performs the import', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    useCanvasStore.setState({ isDirty: true })
+    const onClose = await renderImportDialogWithFile()
+
+    fireEvent.click(screen.getByText('Import As-Is'))
+
+    expect(confirmSpy).toHaveBeenCalledWith('You have unsaved changes. Import anyway?')
+    // Identity: the imported node (exact label) is now on the canvas.
+    const labels = useCanvasStore.getState().nodes.map(n => n.data?.label)
+    expect(labels).toContain('Imported node F1')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('with no unsaved changes, import proceeds without a prompt', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onClose = await renderImportDialogWithFile()
+
+    fireEvent.click(screen.getByText('Import As-Is'))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    const labels = useCanvasStore.getState().nodes.map(n => n.data?.label)
+    expect(labels).toContain('Imported node F1')
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
@@ -1,0 +1,119 @@
+/**
+ * Lane 4 (P5): kebab-menu capabilities are REAL, and no kebab control lies.
+ *
+ * POC-DONE pass-condition 2: "no surface states an untruth" — a visible
+ * control that does nothing is an untruth. These tests pin:
+ *   1. Kebab -> Export opens the REAL Export Canvas dialog (was console.warn).
+ *   2. Kebab -> Import opens the REAL Import Canvas dialog (required so the
+ *      export dialog's own "re-importable" claim stays true).
+ *   3. Kebab -> Snapshots opens the REAL Snapshot Manager.
+ *   4. Kebab has NO "Replay tour" control (it dispatched into a flag-gated
+ *      overlay that is off in every deploy context — removed lie).
+ *   5. TopBar mounts the ScenarioSwitcher (scenario switching + scenario
+ *      export/import reachable).
+ *   6. The switcher's dropdown opens BELOW the trigger (TopBar is fixed at
+ *      the top of the viewport; the toolbar-era default opened upward).
+ *
+ * Identity binding: menu items by EXACT accessible name (role=menuitem),
+ * dialogs by their BottomSheet <h2> heading text, switcher by data-testid.
+ * jsdom proves presence/wiring only, never pixels (trap 3) — the post-deploy
+ * browser walk uses the testids listed in the lane report.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TopBar } from '../TopBar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar
+          scenarioTitle="Pricing Decision 2025"
+          onTitleChange={vi.fn()}
+          onSave={vi.fn()}
+          onShare={vi.fn()}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+function openKebab() {
+  fireEvent.click(screen.getByRole('button', { name: 'More options' }))
+}
+
+describe('TopBar kebab capabilities (Lane 4 P5)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('kebab Export opens the real Export Canvas dialog', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    renderTopBar()
+    openKebab()
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Export' }))
+
+    // The REAL dialog: BottomSheet with the exact "Export Canvas" heading
+    // and the real export action button.
+    expect(
+      screen.getByRole('heading', { name: 'Export Canvas' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Export as JSON/ }),
+    ).toBeInTheDocument()
+    // And the old lie is gone: no console.warn('Export') stub.
+    expect(warnSpy).not.toHaveBeenCalledWith('Export')
+    warnSpy.mockRestore()
+  })
+
+  it('kebab has an Import entry that opens the real Import Canvas dialog', () => {
+    renderTopBar()
+    openKebab()
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Import' }))
+
+    expect(
+      screen.getByRole('heading', { name: 'Import Canvas' }),
+    ).toBeInTheDocument()
+  })
+
+  it('kebab has a Snapshots entry that opens the real Snapshot Manager', () => {
+    renderTopBar()
+    openKebab()
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Snapshots' }))
+
+    expect(
+      screen.getByRole('heading', { name: 'Snapshot Manager' }),
+    ).toBeInTheDocument()
+  })
+
+  it('kebab does NOT offer a Replay tour control (removed lie)', () => {
+    renderTopBar()
+    openKebab()
+
+    // The menu itself must be open for this absence assertion to see anything
+    // (positive control against a vacuous pass — trap 13).
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('menuitem', { name: 'Replay tour' }),
+    ).toBeNull()
+  })
+
+  it('TopBar mounts the ScenarioSwitcher', () => {
+    renderTopBar()
+    expect(screen.getByTestId('scenario-switcher-trigger')).toBeInTheDocument()
+  })
+
+  it('ScenarioSwitcher dropdown opens BELOW the trigger in the TopBar', () => {
+    renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-switcher-trigger'))
+
+    const menu = screen.getByTestId('scenario-switcher-menu')
+    expect(menu.className).toContain('top-full')
+    expect(menu.className).not.toContain('bottom-full')
+  })
+})

--- a/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.capabilities.spec.tsx
@@ -122,15 +122,32 @@ describe('TopBar kebab capabilities (Lane 4 P5)', () => {
 })
 
 /**
- * F1 (adversarial review of PR #582): the newly-exposed Import path calls
- * store.importCanvas, which replaces the whole graph AND wipes undo history
- * (store.ts:2467 — past/future emptied), with no confirmation. Codebase
- * convention everywhere else is a confirm (ScenarioSwitcher load/import,
- * snapshot Delete, kebab Reset). These tests pin the dirty-state confirm,
- * bound by IDENTITY to ScenarioSwitcher's exact copy, and assert the
- * destructive action is NOT taken until accepted.
+ * F1 (adversarial review of PR #582, prescription CORRECTED by the delta
+ * re-review): the newly-exposed Import path calls store.importCanvas, which
+ * replaces the whole graph AND wipes undo history (store.ts:2467 —
+ * past/future emptied), with no confirmation.
+ *
+ * The first prescription gated the confirm on `isDirty` — but that flag is
+ * HOLLOW: the complete writer manifest shows ordinary node/edge edits and
+ * CEE draft-apply never set it, so a dirty-gated confirm never fires on a
+ * real drafted graph. Corrected gate: NON-EMPTY canvas
+ * (nodes.length > 0 || edges.length > 0), with copy that states what
+ * actually happens (replace canvas, clear undo) — the "unsaved changes"
+ * copy would itself lie on a non-dirty canvas.
+ *
+ * These tests bind to the confirm's EXACT copy and assert the destructive
+ * action is NOT taken until accepted.
  */
 describe('ImportExportDialog import confirmation (F1)', () => {
+  const IMPORT_CONFIRM_COPY =
+    'Import this file? This will replace your current canvas and clear undo history.'
+
+  const existingNode = {
+    id: 'n-existing-1',
+    type: 'decision',
+    position: { x: 10, y: 10 },
+    data: { label: 'Existing node', type: 'decision' },
+  }
   const importedNode = {
     id: 'n-imported-1',
     type: 'decision',
@@ -181,39 +198,44 @@ describe('ImportExportDialog import confirmation (F1)', () => {
     return onClose
   }
 
-  it('with unsaved changes, declining the confirm leaves the canvas untouched', async () => {
+  it('with existing work on the canvas, declining the confirm leaves the canvas untouched', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
-    useCanvasStore.setState({ isDirty: true })
+    // NOT dirty — the gate must fire on canvas CONTENT, not the hollow
+    // isDirty flag (which real edits and CEE draft-apply never set).
+    useCanvasStore.setState({ nodes: [existingNode] as never })
     const onClose = await renderImportDialogWithFile()
 
     fireEvent.click(screen.getByText('Import As-Is'))
 
-    expect(confirmSpy).toHaveBeenCalledWith('You have unsaved changes. Import anyway?')
-    // Destructive action NOT taken: graph unchanged, dialog still open.
-    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(confirmSpy).toHaveBeenCalledWith(IMPORT_CONFIRM_COPY)
+    // Destructive action NOT taken: the existing graph survives, dialog open.
+    const labels = useCanvasStore.getState().nodes.map(n => n.data?.label)
+    expect(labels).toEqual(['Existing node'])
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('with unsaved changes, accepting the confirm performs the import', async () => {
+  it('with existing work on the canvas, accepting the confirm replaces the graph', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    useCanvasStore.setState({ isDirty: true })
+    useCanvasStore.setState({ nodes: [existingNode] as never })
     const onClose = await renderImportDialogWithFile()
 
     fireEvent.click(screen.getByText('Import As-Is'))
 
-    expect(confirmSpy).toHaveBeenCalledWith('You have unsaved changes. Import anyway?')
-    // Identity: the imported node (exact label) is now on the canvas.
+    expect(confirmSpy).toHaveBeenCalledWith(IMPORT_CONFIRM_COPY)
+    // Identity: the imported node (exact label) replaced the existing graph.
     const labels = useCanvasStore.getState().nodes.map(n => n.data?.label)
     expect(labels).toContain('Imported node F1')
+    expect(labels).not.toContain('Existing node')
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('with no unsaved changes, import proceeds without a prompt', async () => {
+  it('on an EMPTY canvas, import proceeds without a prompt', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const onClose = await renderImportDialogWithFile()
 
     fireEvent.click(screen.getByText('Import As-Is'))
 
+    // Empty canvas = nothing to clobber, no friction.
     expect(confirmSpy).not.toHaveBeenCalled()
     const labels = useCanvasStore.getState().nodes.map(n => n.data?.label)
     expect(labels).toContain('Imported node F1')

--- a/src/components/layout/__tests__/TopBar.test.tsx
+++ b/src/components/layout/__tests__/TopBar.test.tsx
@@ -2,11 +2,17 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { TopBar } from '../TopBar'
+// Lane 4 (P5): TopBar now mounts toast-consuming children (ScenarioSwitcher,
+// KebabMenu's ImportExportDialog/SnapshotManager); useToast throws outside
+// ToastProvider. Production (CanvasMVP) provides it at the route level.
+import { ToastProvider } from '../../../canvas/ToastContext'
 
 function renderTopBar(props: React.ComponentProps<typeof TopBar>) {
   return render(
     <MemoryRouter>
-      <TopBar {...props} />
+      <ToastProvider>
+        <TopBar {...props} />
+      </ToastProvider>
     </MemoryRouter>,
   )
 }


### PR DESCRIPTION
**DO NOT MERGE — orchestrator merges after adversarial review.**

Pillar: **P5 (differentiated, progressively-disclosed UI)** · POC-DONE hook: pass-condition 2 — "no surface states an untruth".

## Scope (5 files, +223/−25, base `6d5db185`)
- **KebabMenu**: Export was `console.warn('Export')` — a live control that did nothing. Now opens the real `ImportExportDialog` (JSON/PNG/SVG). New **Import** item (required so the export dialog's own "editable and re-importable" claim is true — scenario import expects a different format). New **Snapshots** item → `SnapshotManager`. **"Replay tour" REMOVED**: it dispatched into an overlay gated on `VITE_FEATURE_ONBOARDING` (off in every deploy context), and the tour content itself states untruths against the deployed UI ("Using live limits" toolbar chip, Compare-view capture, decision-brief bundle) — wiring it would trade a dead control for a lying surface.
- **TopBar**: mounts `ScenarioSwitcher dropdownPosition="below"` (scenario switching + .olumi.json export/import reachable); `SHOW_ONBOARDING` dispatcher/constant removed. TopBar now requires `ToastProvider` (CanvasMVP already provides it at route level).
- **ScenarioSwitcher**: new `dropdownPosition` prop, default `'above'` preserves the (production-unmounted) CanvasToolbar usage and its existing specs.
- NOT in scope: remounting the whole CanvasToolbar (would duplicate Run/zoom/undo controls the deployed layout already has); reviving CompareView/decisionBrief (EdgeDiffTable's own comment warns it needs re-routing first — follow-up row).

No new flags; ships ON; rollback = code revert.

## testids for the post-deploy browser walk
`kebab-export`, `kebab-import`, `kebab-snapshots`, `scenario-switcher-trigger`, `scenario-switcher-menu` (+ existing `btn-*` unaffected).

## RED-first evidence
New `src/components/layout/__tests__/TopBar.capabilities.spec.tsx` at pristine `6d5db185`: **6/6 FAILED** (named signatures in the evidence file). Post-fix: 6/6 green; touched-surface suites green (`Test Files 6 passed`, 56 passed | 1 skipped; `canvas.run-gating.dom.spec.tsx` is in the vitest exclude list at pristine — never collected).

## Mutation evidence (throwaway worktree outside repo root, committed state only)
Control: zero-diff applied-check, 6/6 green. Six mutants, each applied-check = exactly the one expected file, each **BITTEN**: (A) Export reverted to console.warn, (B) switcher un-mounted, (C) Snapshots item removed, (D) Replay tour re-added, (E) Import item removed, (F) dropdown direction reverted.

## Gates
`pnpm typecheck` (typecheck-gate.sh): PASSED, ratchet 2502/2502 within baseline. eslint changed files: 0 errors (1 pre-existing warning, control-verified at pristine). `validate-prepush.sh`: checks 1–7 green; check 8 (DS v5 drift) red with **byte-identical counts + file list at pristine `6d5db185`** — pre-existing, empty delta, no baseline update accepted.

## Real-browser witness (local dev server, lane branch)
Kebab shows Rename/Export/Import/Snapshots/Reset, no Replay tour; Export → real "Export Canvas" sheet; Snapshots → real "Snapshot Manager"; switcher dropdown opens below, on-screen. Screenshot-verified; deployed-pixels proof remains the orchestrator's post-deploy walk.

Evidence file: `PHASE0-EVIDENCE-2026-07-28/lane4-toolbar-2026-08-04.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)