### PR TITLE
Lane 1 (P1): render DSK science provenance on the hero key-question card (+ group-4 seam carry)

### DIFF
--- a/src/components/results/__tests__/groupActionItems.spec.ts
+++ b/src/components/results/__tests__/groupActionItems.spec.ts
@@ -586,3 +586,70 @@ describe('groupActionItems', () => {
     })
   })
 })
+
+// ─── Lane 1 (P1): DSK science-provenance carry on Group 4 (premortem) ───────
+//
+// Structured M2DecisionQualityPromptInput entries may carry DSK provenance
+// (dskClaimId / dskProtocolId / evidenceStrength — already id-gated at the
+// data layer). Group 4's mapping must carry it through to the ActionItem so
+// the card can render a grounding line — and must carry NOTHING for entries
+// without a claim id (the honest-absence rule). NOTE (corrected premise,
+// 2026-08-04): no production caller passes `preMortem` today — this is the
+// seam contract, unit-tested here; the wiring decision is the orchestrator's.
+describe('groupActionItems — DSK provenance carry (Lane 1)', () => {
+  // Fixture-identical entries (live captures r1/r3, CEE 76d2e1c); assertions
+  // bind by IDENTITY to the literal DSK ids.
+  const R1_ENTRY = {
+    principle: 'Consider-the-opposite as a debiasing strategy',
+    appliesBecause: 'Keep Current Setup (Status Quo) leads by a wide margin.',
+    question: 'What would make you switch to HubSpot instead of keeping the current setup?',
+    dskClaimId: 'DSK-T-003',
+    dskProtocolId: 'DSK-P-003',
+    evidenceStrength: 'medium' as const,
+  }
+  const R3_NO_ID_ENTRY = {
+    principle: 'Consider-the-opposite',
+    appliesBecause: 'HubSpot is the only challenger under plausible conditions.',
+    question: 'What would make you seriously consider switching from Keep Current Setup (Status Quo) to HubSpot?',
+  }
+
+  it('carries claim id, protocol id, and strength verbatim onto the Group 4 ActionItem (DSK-T-003)', () => {
+    const groups = groupActionItems({
+      fragileEdges: [],
+      evidenceGaps: [],
+      preMortem: [R1_ENTRY],
+    })
+    expect(groups[3].key).toBe('premortem')
+    const item = groups[3].items[0]
+    expect(item.title).toBe('Consider-the-opposite as a debiasing strategy')
+    expect(item.dskClaimId).toBe('DSK-T-003')
+    expect(item.dskProtocolId).toBe('DSK-P-003')
+    expect(item.evidenceStrength).toBe('medium')
+  })
+
+  it('the REAL live no-id entry (r3[0]) carries NO provenance fields — in-suite control: the id-bearing item in the same run', () => {
+    const groups = groupActionItems({
+      fragileEdges: [],
+      evidenceGaps: [],
+      preMortem: [R3_NO_ID_ENTRY, R1_ENTRY],
+    })
+    const negative = groups[3].items[0]
+    expect(negative.title).toBe('Consider-the-opposite') // identity: THE no-id fixture entry
+    expect(negative.dskClaimId).toBeUndefined()
+    expect(negative.dskProtocolId).toBeUndefined()
+    expect(negative.evidenceStrength).toBeUndefined()
+    // Positive control in the SAME run (proves the suite can see provenance):
+    expect(groups[3].items[1].dskClaimId).toBe('DSK-T-003')
+    expect(groups[3].items[1].evidenceStrength).toBe('medium')
+  })
+
+  it('legacy string[] preMortem entries are unaffected and carry no provenance', () => {
+    const groups = groupActionItems({
+      fragileEdges: [],
+      evidenceGaps: [],
+      preMortem: ['What if the market shrinks?'],
+    })
+    expect(groups[3].items[0].title).toBe('What if the market shrinks?')
+    expect(groups[3].items[0].dskClaimId).toBeUndefined()
+  })
+})

--- a/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
+++ b/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
@@ -56,6 +56,22 @@ export function HeroKeyQuestion({ keyQuestion, onPrefillChat, chatPrefillAvailab
       >
         {keyQuestion.text}
       </p>
+      {/* Lane 1 (P1): DSK science-provenance grounding line. Rendered ONLY
+          when the prompt behind the question attested a dsk_claim_id upstream
+          (see selectKeyQuestion) — no grounding object, no badge, no default.
+          Plain DOM text (screen-reader readable, not colour-only); the claim
+          and protocol ids ride as data-* attributes, never as user copy. */}
+      {keyQuestion.grounding && (
+        <p
+          className={`${typography.panelMeta} text-text-light break-words`}
+          data-testid="dsk-grounding"
+          data-dsk-claim-id={keyQuestion.grounding.claimId}
+          data-dsk-protocol-id={keyQuestion.grounding.protocolId}
+        >
+          Grounded in: {keyQuestion.grounding.principle}
+          {keyQuestion.grounding.strength ? ` · ${keyQuestion.grounding.strength} evidence` : ''}
+        </p>
+      )}
       {/* Chips are prefill-only. The whole card is hidden upstream when
           chat is unavailable (see the early return above), so chips are
           always meaningfully clickable when this block renders. */}

--- a/src/components/results/analysisHeroV17/__tests__/HeroKeyQuestion.dskGrounding.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/HeroKeyQuestion.dskGrounding.spec.tsx
@@ -1,0 +1,114 @@
+/**
+ * HeroKeyQuestion — DSK science-provenance grounding line (Lane 1, P1).
+ *
+ * The key-question card is the LIVE surface that consumes
+ * `decision_quality_prompts`. When the prompt behind the main question is
+ * grounded in a Decision Science Knowledge claim (attested by
+ * `dsk_claim_id`), the card renders a compact plain-text grounding line:
+ *
+ *   "Grounded in: <principle> · <strength> evidence"
+ *
+ * Honesty rules under test:
+ *  - grounding absent → NO badge (queryByTestId null). The positive tests in
+ *    this suite are the in-suite control proving the badge CAN render, so the
+ *    absence assertion is not vacuous (trap 13).
+ *  - strength absent → badge renders the principle only; the word "evidence"
+ *    must NOT appear (a forced default strength turns this test RED).
+ *  - The badge is plain DOM text (screen-reader readable), not colour-only.
+ *
+ * Identity binding: literal ids/titles from the committed live fixtures
+ * (DSK-T-002 / DSK-P-002 / "Outside view and reference class forecasting" /
+ * strong; DSK-T-003 / medium).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HeroKeyQuestion } from '../HeroKeyQuestion'
+import type { KeyQuestion } from '../analysisHeroVM.types'
+
+function renderCard(keyQuestion: KeyQuestion) {
+  return render(
+    <HeroKeyQuestion
+      keyQuestion={keyQuestion}
+      onPrefillChat={vi.fn()}
+      chatPrefillAvailable={true}
+    />,
+  )
+}
+
+const BASE: KeyQuestion = {
+  text: 'What is the base rate for user adoption success when mid-size teams move from status quo systems to new CRMs?',
+  extras: [],
+  chips: ['High', 'Some', 'Not sure', 'Add note'],
+}
+
+describe('HeroKeyQuestion — DSK grounding line', () => {
+  it('renders the grounding line with principle + strength as plain text, claim id in data attributes (r3[1] identity)', () => {
+    renderCard({
+      ...BASE,
+      grounding: {
+        principle: 'Outside view and reference class forecasting',
+        claimId: 'DSK-T-002',
+        protocolId: 'DSK-P-002',
+        strength: 'strong',
+      },
+    } as KeyQuestion)
+    const badge = screen.getByTestId('dsk-grounding')
+    expect(badge.textContent).toBe('Grounded in: Outside view and reference class forecasting · strong evidence')
+    expect(badge.getAttribute('data-dsk-claim-id')).toBe('DSK-T-002')
+    expect(badge.getAttribute('data-dsk-protocol-id')).toBe('DSK-P-002')
+  })
+
+  it('renders a medium-strength grounding line (r1[0] identity: DSK-T-003)', () => {
+    renderCard({
+      ...BASE,
+      text: 'What would make you switch to HubSpot instead of keeping the current setup?',
+      grounding: {
+        principle: 'Consider-the-opposite as a debiasing strategy',
+        claimId: 'DSK-T-003',
+        protocolId: 'DSK-P-003',
+        strength: 'medium',
+      },
+    } as KeyQuestion)
+    const badge = screen.getByTestId('dsk-grounding')
+    expect(badge.textContent).toBe('Grounded in: Consider-the-opposite as a debiasing strategy · medium evidence')
+    expect(badge.getAttribute('data-dsk-claim-id')).toBe('DSK-T-003')
+  })
+
+  it('NO grounding → NO badge at all (honest absence; positives above are the in-suite control)', () => {
+    renderCard(BASE)
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+    // The question itself still renders — absence of provenance never hides content.
+    expect(screen.getByTestId('hero-v17-key-question-text').textContent).toBe(BASE.text)
+  })
+
+  it('grounding WITHOUT strength → principle-only line, no "evidence" wording (a defaulted strength REDs this)', () => {
+    renderCard({
+      ...BASE,
+      grounding: {
+        principle: 'Outside view and reference class forecasting',
+        claimId: 'DSK-T-002',
+      },
+    } as KeyQuestion)
+    const badge = screen.getByTestId('dsk-grounding')
+    expect(badge.textContent).toBe('Grounded in: Outside view and reference class forecasting')
+    expect(badge.textContent).not.toContain('evidence')
+    expect(badge.getAttribute('data-dsk-claim-id')).toBe('DSK-T-002')
+  })
+
+  it('accessibility: the grounding is a text node in the document flow, not colour-only signalling', () => {
+    renderCard({
+      ...BASE,
+      grounding: {
+        principle: 'Outside view and reference class forecasting',
+        claimId: 'DSK-T-002',
+        strength: 'strong',
+      },
+    } as KeyQuestion)
+    const badge = screen.getByTestId('dsk-grounding')
+    // Screen readers read text content: the strength must be present as WORDS.
+    expect(badge.textContent).toContain('strong evidence')
+    // And it must be inside the card's accessible region.
+    expect(badge.closest('[aria-label="Key question"]')).not.toBeNull()
+  })
+})

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -33,6 +33,12 @@ function makeData(overrides: {
   bias?: Array<{ type: string; description: string }>
   dqp?: string[]
   /**
+   * Lane 1 (P1): full decision-quality-prompt objects (the mapped UI shape,
+   * incl. optional DSK provenance). Takes precedence over `dqp` when set —
+   * used by the DSK-grounding tests to feed fixture-identical entries.
+   */
+  dqpFull?: ConfidenceSectionData['m2DecisionQualityPrompts']
+  /**
    * Review status surfaced on `data.confidence.reviewStatus`. The Key
    * question card requires `'complete'` to render — defaulted to that
    * value here so existing DQP-present tests behave unchanged.
@@ -107,7 +113,7 @@ function makeData(overrides: {
       affectedElements: [],
       linkedCritiqueCode: '',
     })),
-    m2DecisionQualityPrompts: overrides.dqp?.map(q => ({
+    m2DecisionQualityPrompts: overrides.dqpFull ?? overrides.dqp?.map(q => ({
       principle: 'test',
       appliesBecause: 'test',
       question: q,
@@ -1415,5 +1421,113 @@ describe('buildAnalysisHeroViewModel', () => {
       })
       expect(vm.checkedCount).toBeNull()
     })
+  })
+})
+
+// ─── Lane 1 (P1): DSK science-provenance grounding on the key question ──────
+//
+// `selectKeyQuestion` reads `m2DecisionQualityPrompts[0]`. When that entry is
+// grounded in a Decision Science Knowledge claim (attested by `dskClaimId`),
+// the VM carries a `grounding` object for the card to render; when it is not,
+// the VM carries NONE — never a default, never an inferred strength.
+// Entries are fixture-identical (live captures r1/r3, CEE 76d2e1c) and
+// assertions bind by IDENTITY to the literal DSK ids.
+describe('keyQuestion DSK grounding (Lane 1)', () => {
+  const R1_ENTRY = {
+    principle: 'Consider-the-opposite as a debiasing strategy',
+    appliesBecause: 'Keep Current Setup (Status Quo) leads by a wide margin.',
+    question: 'What would make you switch to HubSpot instead of keeping the current setup?',
+    dskClaimId: 'DSK-T-003',
+    dskProtocolId: 'DSK-P-003',
+    evidenceStrength: 'medium' as const,
+  }
+  // r3[0] — the REAL no-id entry captured from live staging (the negative).
+  const R3_NO_ID_ENTRY = {
+    principle: 'Consider-the-opposite',
+    appliesBecause: 'HubSpot is the only challenger under plausible conditions.',
+    question: 'What would make you seriously consider switching from Keep Current Setup (Status Quo) to HubSpot?',
+  }
+  const R3_ID_ENTRY = {
+    principle: 'Outside view and reference class forecasting',
+    appliesBecause: 'Confidence in adoption risk is provisional.',
+    question: 'What is the base rate for user adoption success when mid-size teams move from status quo systems to new CRMs?',
+    dskClaimId: 'DSK-T-002',
+    dskProtocolId: 'DSK-P-002',
+    evidenceStrength: 'strong' as const,
+  }
+
+  it('r1[0] (DSK-T-003): grounding carried with claim id, protocol id, strength, principle — all verbatim', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({ stability: 0.7, dqpFull: [R1_ENTRY] }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    expect(vm.keyQuestion?.text).toBe(R1_ENTRY.question)
+    expect(vm.keyQuestion?.grounding).toEqual({
+      principle: 'Consider-the-opposite as a debiasing strategy',
+      claimId: 'DSK-T-003',
+      protocolId: 'DSK-P-003',
+      strength: 'medium',
+    })
+  })
+
+  it('r3 in fixture order: main question is the REAL no-id entry → NO grounding (in-suite positive control: reordered run below)', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({ stability: 0.7, dqpFull: [R3_NO_ID_ENTRY, R3_ID_ENTRY] }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    // The question still renders — honesty about provenance never suppresses content.
+    expect(vm.keyQuestion?.text).toBe(R3_NO_ID_ENTRY.question)
+    expect(vm.keyQuestion?.grounding).toBeUndefined()
+  })
+
+  it('positive control for the absence test: DSK-T-002 first → grounding present with strong strength', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({ stability: 0.7, dqpFull: [R3_ID_ENTRY, R3_NO_ID_ENTRY] }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    expect(vm.keyQuestion?.grounding).toEqual({
+      principle: 'Outside view and reference class forecasting',
+      claimId: 'DSK-T-002',
+      protocolId: 'DSK-P-002',
+      strength: 'strong',
+    })
+  })
+
+  it('adversarial mapped shape: strength WITHOUT claim id → no grounding (VM never invents attestation)', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({
+        stability: 0.7,
+        dqpFull: [{ ...R3_NO_ID_ENTRY, evidenceStrength: 'strong' } as never],
+      }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    expect(vm.keyQuestion?.text).toBe(R3_NO_ID_ENTRY.question)
+    expect(vm.keyQuestion?.grounding).toBeUndefined()
+  })
+
+  it('claim id present, strength absent → grounding WITHOUT strength (never defaulted)', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({
+        stability: 0.7,
+        dqpFull: [{ ...R1_ENTRY, evidenceStrength: undefined }],
+      }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    expect(vm.keyQuestion?.grounding?.claimId).toBe('DSK-T-003')
+    expect(vm.keyQuestion?.grounding?.strength).toBeUndefined()
+  })
+
+  it('reviewStatus gate still hides the whole card — grounding never leaks past it', () => {
+    const vm = buildAnalysisHeroViewModel({
+      ...STD_ARGS,
+      data: makeData({ stability: 0.7, dqpFull: [R1_ENTRY], reviewStatus: 'in_progress' }),
+      vm: makeVm({ decisionState: 'sensitive' }),
+    })
+    expect(vm.keyQuestion).toBeNull()
   })
 })

--- a/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
+++ b/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
@@ -10,6 +10,8 @@
  * happen in `buildAnalysisHeroViewModel`.
  */
 
+import type { DskEvidenceStrength } from '../utils/decisionQualityPrompts'
+
 export type HeroState = 'weak' | 'moderate' | 'reflect' | 'strong'
 
 export type RowCategory =
@@ -63,6 +65,24 @@ export interface HeroRow {
   chatPrompt: string
 }
 
+/**
+ * Lane 1 (P1): DSK science provenance for the main key question. Present ONLY
+ * when the prompt behind `KeyQuestion.text` attested a `dsk_claim_id` upstream
+ * (id-gated at the data layer AND re-gated in `selectKeyQuestion`). Absence
+ * means "not grounded in a cited DSK claim" — the card then renders NO badge:
+ * never a default id, never an inferred strength.
+ */
+export interface DskGrounding {
+  /** Sanitised DSK claim title, e.g. "Outside view and reference class forecasting". */
+  principle: string
+  /** DSK claim id verbatim, e.g. "DSK-T-002" — surfaced as a data-* attribute. */
+  claimId: string
+  /** DSK protocol id, e.g. "DSK-P-002", when cited. */
+  protocolId?: string
+  /** Closed-vocabulary evidence strength, verbatim, when attested. */
+  strength?: DskEvidenceStrength
+}
+
 export interface KeyQuestion {
   /** Main question text — glossary-scanned post-interpolation. */
   text: string
@@ -70,6 +90,8 @@ export interface KeyQuestion {
   extras: string[]
   /** Optional reply chips shown beneath the question. */
   chips: string[]
+  /** DSK provenance for `text`'s source prompt — see DskGrounding. */
+  grounding?: DskGrounding
 }
 
 export interface AlsoLink {

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -72,6 +72,7 @@ import type {
   DimensionSegment,
   HeroRow,
   HeroState,
+  DskGrounding,
   KeyQuestion,
   FooterCheck,
   FooterCta,
@@ -303,10 +304,27 @@ function selectKeyQuestion(
   const dqps = data?.confidence?.m2DecisionQualityPrompts ?? []
   const dqp = dqps[0]?.question
   if (dqp && !containsBannedTerm(dqp)) {
+    // Lane 1 (P1): DSK grounding for the main question's source prompt.
+    // Id-gated (defence in depth over the data-layer gate): no attested
+    // dskClaimId ⇒ NO grounding object — the card renders no badge. Strength
+    // is carried only when present upstream, never defaulted. The principle
+    // (the DSK claim title, user-facing badge copy) passes the same glossary
+    // gate as the question text.
+    const first = dqps[0]
+    const grounding: DskGrounding | undefined =
+      first.dskClaimId && first.principle && !containsBannedTerm(first.principle)
+        ? {
+            principle: first.principle,
+            claimId: first.dskClaimId,
+            ...(first.dskProtocolId ? { protocolId: first.dskProtocolId } : {}),
+            ...(first.evidenceStrength ? { strength: first.evidenceStrength } : {}),
+          }
+        : undefined
     return {
       text: dqp,
       extras: dqps.slice(1, 4).map(p => p.question).filter(q => q && !containsBannedTerm(q)),
       chips: ['High', 'Some', 'Not sure', 'Add note'],
+      ...(grounding ? { grounding } : {}),
     }
   }
 

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -15,6 +15,7 @@ import type { DecisionVerdict } from '../../lib/decisionVerdict'
 import type { ReportV1, OptionProbability } from '../../adapters/plot/types'
 import type { V2FactorSensitivity, V2OptionComparison } from '../../adapters/plot/v2/types'
 import type { KnownFlipReason } from './utils/flipReasonVocabulary'
+import type { MappedDecisionQualityPrompt } from './utils/decisionQualityPrompts'
 
 // Re-export M1 coaching type for component use
 export type { M1CoachingReadiness }
@@ -876,12 +877,14 @@ export interface ConfidenceSectionData {
     affectedElements: string[]
     linkedCritiqueCode: string
   }>
-  /** V12: M2 decision quality prompts (structured) */
-  m2DecisionQualityPrompts?: Array<{
-    principle: string
-    appliesBecause: string
-    question: string
-  }>
+  /**
+   * V12: M2 decision quality prompts (structured). Lane 1 (P1): the entry
+   * shape is owned by `utils/decisionQualityPrompts` (single mapping site) and
+   * carries optional id-gated DSK provenance — dskClaimId / dskProtocolId /
+   * evidenceStrength are present ONLY when the wire entry attested a
+   * `dsk_claim_id`; absence means "not grounded", never "unknown default".
+   */
+  m2DecisionQualityPrompts?: MappedDecisionQualityPrompt[]
   /** V12: M2 evidence enhancements per factor_id */
   m2EvidenceEnhancements?: Record<string, { specific_action: string; decision_hygiene: string }>
   /** V12: M2 narrative summary paragraph */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -61,6 +61,7 @@ import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../lib
 import type { FactorEnrichment, NearTieInfo } from '../../lib/mappers/types'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
 import { stripEncodingNotation, sanitizeCoachingText } from './utils/cleanFactorLabel'
+import { mapDecisionQualityPrompts } from './utils/decisionQualityPrompts'
 import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
@@ -3143,11 +3144,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       m2DecisionQualityPrompts: (() => {
         const prompts = safeArray(m1ReviewAssumptions?.decision_quality_prompts)
         if (prompts.length === 0) return undefined
-        return prompts.map((p: any) => ({
-          principle: p.principle ? sanitizeCoachingText(p.principle) : '',
-          appliesBecause: p.applies_because ? sanitizeCoachingText(p.applies_because) : '',
-          question: p.question ? sanitizeCoachingText(p.question) : '',
-        }))
+        // Lane 1 (P1): single mapping site — carries DSK provenance
+        // (dskClaimId/dskProtocolId/evidenceStrength) id-gated, alongside the
+        // historical sanitised copy fields. See utils/decisionQualityPrompts.
+        return mapDecisionQualityPrompts(prompts)
       })(),
       m2EvidenceEnhancements: (() => {
         const raw = m1ReviewAssumptions?.evidence_enhancements as

--- a/src/components/results/utils/__tests__/decisionQualityPrompts.spec.ts
+++ b/src/components/results/utils/__tests__/decisionQualityPrompts.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * decisionQualityPrompts mapper — DSK science-provenance golden tests.
+ *
+ * Lane 1 (P1): the wire entries under
+ * `enrichment.decision_review.decision_quality_prompts[]` carry optional DSK
+ * provenance (`dsk_claim_id`, `dsk_protocol_id`, `evidence_strength`). The
+ * mapper must carry that provenance through to the UI shape — but ONLY when
+ * attested by a real `dsk_claim_id`. An entry with no claim id gets NO
+ * provenance fields at all: never a default, never an inferred strength.
+ *
+ * Golden inputs are the COMMITTED LIVE-CAPTURE fixtures (staging, CEE
+ * 76d2e1c) — assertions bind by IDENTITY to the literal ids and titles in
+ * those fixtures, never by a value predicate another object could satisfy.
+ * r3's prompt[0] is the real no-id entry from live staging: it is this
+ * suite's negative, and the id-bearing entries in the same suite are its
+ * in-suite positive controls (they prove the suite CAN see provenance, so
+ * the absence assertions are not vacuous).
+ */
+
+import { describe, it, expect } from 'vitest'
+import r1Turn from '../../../../v5/__tests__/fixtures/live-decision-review-0_30.r1-cee-76d2e1c.json'
+import r3Turn from '../../../../v5/__tests__/fixtures/live-decision-review-0_30.r3-cee-76d2e1c.json'
+import { mapDecisionQualityPrompts } from '../decisionQualityPrompts'
+
+const r1Prompts = (r1Turn as any).enrichment.decision_review.decision_quality_prompts as unknown[]
+const r3Prompts = (r3Turn as any).enrichment.decision_review.decision_quality_prompts as unknown[]
+
+describe('mapDecisionQualityPrompts — DSK provenance carry (golden, from live fixtures)', () => {
+  it('r1[0] (DSK-T-003): carries claim id, protocol id, and strength VERBATIM alongside sanitized copy', () => {
+    const mapped = mapDecisionQualityPrompts(r1Prompts)
+    expect(mapped).toHaveLength(1)
+    const entry = mapped[0]
+    // Identity binding: the literal fixture strings.
+    expect(entry.principle).toBe('Consider-the-opposite as a debiasing strategy')
+    expect(entry.question).toBe('What would make you switch to HubSpot instead of keeping the current setup?')
+    expect(entry.dskClaimId).toBe('DSK-T-003')
+    expect(entry.dskProtocolId).toBe('DSK-P-003')
+    expect(entry.evidenceStrength).toBe('medium')
+  })
+
+  it('r3[1] (DSK-T-002): second id-bearing golden — "strong" strength carried verbatim', () => {
+    const mapped = mapDecisionQualityPrompts(r3Prompts)
+    expect(mapped).toHaveLength(2)
+    const entry = mapped[1]
+    expect(entry.principle).toBe('Outside view and reference class forecasting')
+    expect(entry.dskClaimId).toBe('DSK-T-002')
+    expect(entry.dskProtocolId).toBe('DSK-P-002')
+    expect(entry.evidenceStrength).toBe('strong')
+  })
+
+  it('r3[0] (the REAL live no-id entry): NO provenance fields at all — honest absence', () => {
+    // NEGATIVE with in-suite positive control: r3[1] in the SAME mapped
+    // array carries DSK-T-002/strong (asserted above and re-asserted here),
+    // proving this suite can see provenance when it is attested. Without
+    // that control this absence assertion would be vacuous (trap 13).
+    const mapped = mapDecisionQualityPrompts(r3Prompts)
+    const negative = mapped[0]
+    expect(negative.principle).toBe('Consider-the-opposite') // identity: THE no-id fixture entry
+    expect(negative.dskClaimId).toBeUndefined()
+    expect(negative.dskProtocolId).toBeUndefined()
+    expect(negative.evidenceStrength).toBeUndefined()
+    // Positive control in the same array/run:
+    expect(mapped[1].dskClaimId).toBe('DSK-T-002')
+    expect(mapped[1].evidenceStrength).toBe('strong')
+  })
+
+  it('strength WITHOUT a claim id is dropped — provenance is id-gated as a unit', () => {
+    const mapped = mapDecisionQualityPrompts([
+      {
+        principle: 'Premortem analysis',
+        applies_because: 'x',
+        question: 'What could make this fail?',
+        evidence_strength: 'strong', // present on the wire, but unattested (no dsk_claim_id)
+      },
+    ])
+    expect(mapped[0].principle).toBe('Premortem analysis')
+    expect(mapped[0].evidenceStrength).toBeUndefined()
+    expect(mapped[0].dskClaimId).toBeUndefined()
+  })
+
+  it('non-canonical strength vocabulary fails closed to absent (id kept)', () => {
+    const mapped = mapDecisionQualityPrompts([
+      {
+        principle: 'Premortem analysis',
+        applies_because: 'x',
+        question: 'q',
+        dsk_claim_id: 'DSK-T-001',
+        evidence_strength: 'overwhelming', // not in the attested weak|medium|strong vocabulary
+      },
+    ])
+    expect(mapped[0].dskClaimId).toBe('DSK-T-001')
+    expect(mapped[0].evidenceStrength).toBeUndefined()
+  })
+
+  it('id present but strength absent: claim id carried, strength stays absent (never defaulted)', () => {
+    const mapped = mapDecisionQualityPrompts([
+      {
+        principle: 'Premortem analysis',
+        applies_because: 'x',
+        question: 'q',
+        dsk_claim_id: 'DSK-T-001',
+        dsk_protocol_id: 'DSK-P-001',
+      },
+    ])
+    expect(mapped[0].dskClaimId).toBe('DSK-T-001')
+    expect(mapped[0].dskProtocolId).toBe('DSK-P-001')
+    expect(mapped[0].evidenceStrength).toBeUndefined()
+  })
+
+  it('non-string / empty dsk_claim_id is not provenance — gate stays closed', () => {
+    const mapped = mapDecisionQualityPrompts([
+      { principle: 'A', applies_because: 'x', question: 'q', dsk_claim_id: '' },
+      { principle: 'B', applies_because: 'x', question: 'q', dsk_claim_id: 42 },
+    ])
+    expect(mapped[0].dskClaimId).toBeUndefined()
+    expect(mapped[1].dskClaimId).toBeUndefined()
+  })
+
+  it('badge-feeding copy goes through sanitizeCoachingText (arrows stripped), preserving current principle/question behaviour', () => {
+    const mapped = mapDecisionQualityPrompts([
+      {
+        principle: 'Cause → effect thinking',
+        applies_because: 'a -> b',
+        question: 'q',
+        dsk_claim_id: 'DSK-T-009',
+        evidence_strength: 'weak',
+      },
+    ])
+    expect(mapped[0].principle).toBe('Cause to effect thinking')
+    expect(mapped[0].appliesBecause).toBe('a to b')
+    expect(mapped[0].evidenceStrength).toBe('weak')
+  })
+})

--- a/src/components/results/utils/decisionQualityPrompts.ts
+++ b/src/components/results/utils/decisionQualityPrompts.ts
@@ -1,0 +1,83 @@
+/**
+ * decisionQualityPrompts — THE wire→UI mapping site for
+ * `enrichment.decision_review.decision_quality_prompts[]` entries.
+ *
+ * Lane 1 (P1, scientific coaching made visible): CEE's Decision Science
+ * Knowledge bundle annotates prompts with provenance — `dsk_claim_id`
+ * (e.g. "DSK-T-003"), `dsk_protocol_id` (e.g. "DSK-P-003") and
+ * `evidence_strength` — when the LLM actually cites a DSK claim. This mapper
+ * carries that provenance through to the UI shape so surfaces can render a
+ * grounding line ("Grounded in: <principle> · <strength> evidence").
+ *
+ * HONESTY RULES (the point of the feature — a provenance badge that can be
+ * wrong is worse than none):
+ *  - Provenance is ID-GATED AS A UNIT: an entry with no non-empty string
+ *    `dsk_claim_id` gets NO provenance fields at all — never a default id,
+ *    never an inferred strength. (The no-id case is REAL on live staging:
+ *    fixture r3[0].)
+ *  - `evidence_strength` is carried VERBATIM only when it is a member of the
+ *    attested closed vocabulary below; anything else fails closed to absent.
+ *    A closed-vocabulary check IS the sanitisation for that field.
+ *  - Free-text fields (and the ids, defensively) go through
+ *    `sanitizeCoachingText` — the same cleanup `principle` has always had.
+ *    No raw wire text reaches the DOM.
+ */
+
+import { sanitizeCoachingText } from './cleanFactorLabel'
+
+/**
+ * The attested DSK evidence-strength vocabulary (derived from the committed
+ * live fixtures `src/v5/__tests__/fixtures/live-decision-review-0_30.*.json`,
+ * which carry "medium" and "strong", plus "weak" per the DSK bundle contract).
+ * Deliberately NOT unioned with `guidanceStore.EvidenceStrength` (which adds
+ * 'mixed'): that vocabulary belongs to a different wire path, and widening
+ * this one would let an unattested word render as a scientific claim.
+ */
+export const DSK_EVIDENCE_STRENGTHS = ['weak', 'medium', 'strong'] as const
+export type DskEvidenceStrength = (typeof DSK_EVIDENCE_STRENGTHS)[number]
+
+export interface MappedDecisionQualityPrompt {
+  principle: string
+  appliesBecause: string
+  question: string
+  /** DSK claim id VERBATIM (post-sanitise), e.g. "DSK-T-003". PRESENCE is the attestation. */
+  dskClaimId?: string
+  /** DSK protocol id, e.g. "DSK-P-003". Only ever present alongside dskClaimId. */
+  dskProtocolId?: string
+  /** Closed-vocabulary strength, verbatim. Only ever present alongside dskClaimId. */
+  evidenceStrength?: DskEvidenceStrength
+}
+
+function nonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0
+}
+
+/**
+ * Map raw wire prompt entries to the UI shape. Preserves the historical
+ * behaviour for the three copy fields exactly (truthy check → sanitise,
+ * else '') and adds the id-gated provenance carry.
+ */
+export function mapDecisionQualityPrompts(raw: unknown[]): MappedDecisionQualityPrompt[] {
+  return raw.map((entry) => {
+    const p = (entry ?? {}) as Record<string, unknown>
+    const mapped: MappedDecisionQualityPrompt = {
+      principle: nonEmptyString(p.principle) ? sanitizeCoachingText(p.principle) : '',
+      appliesBecause: nonEmptyString(p.applies_because) ? sanitizeCoachingText(p.applies_because) : '',
+      question: nonEmptyString(p.question) ? sanitizeCoachingText(p.question) : '',
+    }
+    // Provenance — id-gated as a unit. No claim id ⇒ nothing, regardless of
+    // what else the entry carries (a strength without an attested claim is
+    // not evidence of anything).
+    if (nonEmptyString(p.dsk_claim_id)) {
+      mapped.dskClaimId = sanitizeCoachingText(p.dsk_claim_id)
+      if (nonEmptyString(p.dsk_protocol_id)) {
+        mapped.dskProtocolId = sanitizeCoachingText(p.dsk_protocol_id)
+      }
+      const s = p.evidence_strength
+      if (typeof s === 'string' && (DSK_EVIDENCE_STRENGTHS as readonly string[]).includes(s)) {
+        mapped.evidenceStrength = s as DskEvidenceStrength
+      }
+    }
+    return mapped
+  })
+}

--- a/src/components/results/utils/groupActionItems.ts
+++ b/src/components/results/utils/groupActionItems.ts
@@ -12,6 +12,7 @@
 import type { UncertaintyItem, EvidenceGapItem } from '../types'
 import type { ConstraintAnalysis } from '../../../types/constraints'
 import { stripEncodingNotation, sanitizeCoachingText } from './cleanFactorLabel'
+import type { DskEvidenceStrength } from './decisionQualityPrompts'
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -37,6 +38,14 @@ export interface ActionItem {
   whatToDo?: string
   /** V12 B4: Node IDs for graph links (from M2 bias finding affected_elements) */
   affectedNodeIds?: string[]
+  /**
+   * Lane 1 (P1): DSK science provenance, carried from the source prompt.
+   * Present ONLY when attested upstream by a `dsk_claim_id` — an item without
+   * these fields is "not grounded", and render surfaces must show NO badge.
+   */
+  dskClaimId?: string
+  dskProtocolId?: string
+  evidenceStrength?: DskEvidenceStrength
 }
 
 export interface ActionGroup {
@@ -140,11 +149,20 @@ export interface M2BiasFindingInput {
   linkedCritiqueCode: string
 }
 
-/** V12: M2 decision quality prompt (real PLoT shape) */
+/**
+ * V12: M2 decision quality prompt (real PLoT shape).
+ * Lane 1 (P1): optional DSK provenance — already id-gated at the data layer
+ * (`utils/decisionQualityPrompts`): these fields are present ONLY when the
+ * wire entry attested a `dsk_claim_id`. Group 4 carries them through to the
+ * ActionItem verbatim; absence stays absence (never defaulted here either).
+ */
 export interface M2DecisionQualityPromptInput {
   principle: string
   appliesBecause: string
   question: string
+  dskClaimId?: string
+  dskProtocolId?: string
+  evidenceStrength?: DskEvidenceStrength
 }
 
 /** V12: M2 evidence enhancement per factor */
@@ -323,13 +341,23 @@ export function groupActionItems(input: GroupActionItemsInput): ActionGroup[] {
     if (typeof item === 'string') {
       return { id: `premortem-${i}`, title: sanitizeCoachingText(item), source: 'brief' as const }
     }
-    // Structured M2 decision quality prompt — fields sanitized at data layer
+    // Structured M2 decision quality prompt — fields sanitized at data layer.
+    // Lane 1 (P1): DSK provenance carried verbatim when attested (id-gated
+    // upstream; re-gated here so a malformed caller cannot smuggle a
+    // strength without a claim id).
     return {
       id: `dqp-${i}`,
       title: item.principle,
       subtitle: item.question,
       whatCouldHappen: item.appliesBecause,
       source: 'model' as const,
+      ...(item.dskClaimId
+        ? {
+            dskClaimId: item.dskClaimId,
+            ...(item.dskProtocolId ? { dskProtocolId: item.dskProtocolId } : {}),
+            ...(item.evidenceStrength ? { evidenceStrength: item.evidenceStrength } : {}),
+          }
+        : {}),
     }
   })
 


### PR DESCRIPTION
**DO NOT MERGE — orchestrator merges after adversarial review.**

Pillar: **P1 — scientific coaching made visible** (POC-DONE step 2: the analysis explains itself). UI-only; base `staging` @ `6d5db185`.

## Scope

Carries CEE's Decision Science Knowledge provenance (`dsk_claim_id`, `dsk_protocol_id`, `evidence_strength`) from `enrichment.decision_review.decision_quality_prompts[]` through the results data layer and renders a compact plain-text grounding line on the hero key-question card — the LIVE surface that consumes these prompts:

> Grounded in: Outside view and reference class forecasting · strong evidence

- `src/components/results/utils/decisionQualityPrompts.ts` (NEW) — the single wire→UI mapping site. Provenance is **id-gated as a unit**; `evidence_strength` is closed-vocabulary (`weak|medium|strong`) carried verbatim, anything else fails closed to absent; all badge-feeding copy (and, defensively, the ids) pass `sanitizeCoachingText`.
- `useResultsSectionData.ts` / `types.ts` — `m2DecisionQualityPrompts` now carries the id-gated provenance (behaviour-preserving for the three existing copy fields).
- `analysisHeroVM.types.ts` / `buildAnalysisHeroViewModel.ts` — `KeyQuestion.grounding?: DskGrounding`, attached in `selectKeyQuestion`, re-gated (defence in depth) on `dskClaimId` + the same glossary gate (`containsBannedTerm`) the question text passes.
- `HeroKeyQuestion.tsx` — the grounding line. Plain DOM text (screen-reader readable, not colour-only). Ids ride as data attributes, never as user copy.
- `groupActionItems.ts` — Group-4 (premortem) seam now carries provenance onto `ActionItem` (see corrected premise below).

## The honest-absence rule (the point of the feature)

An entry with **no `dsk_claim_id` gets NO badge** — never a default id, never an inferred strength. The no-id case is REAL on live staging (fixture r3 prompt[0], principle "Consider-the-opposite"): it is the suite's negative, with in-suite positive controls (DSK-T-003/medium, DSK-T-002/strong) proving the absence assertions are not vacuous.

## Test IDs

- `dsk-grounding` — the grounding line on the key-question card
- `data-dsk-claim-id` / `data-dsk-protocol-id` — machine-readable attestation on that element

## Fixtures used (committed live captures, CEE 76d2e1c)

`src/v5/__tests__/fixtures/live-decision-review-0_30.r1-cee-76d2e1c.json` (DSK-T-003 / DSK-P-003 / medium) and `…r3-cee-76d2e1c.json` (prompt[0] = real no-id negative; prompt[1] = DSK-T-002 / DSK-P-002 / strong). All golden assertions bind by IDENTITY to these literal ids/titles.

## RED-first + mutation evidence

- RED at pristine: 9 targeted failures with named signatures (mapper module unresolved; both component positives; VM grounding trio; groupActionItems carry pair) — 118 pre-existing tests in the touched files stayed green.
- GREEN after: target set 15 files / 389 tests (pristine control 13/367 — collect not shrunk); scoped-closeout surface `src/components/results src/canvas/components/pre-analysis src/components/shared`: **5648 passed / 0 failed**.
- Mutations (throwaway worktree outside repo root, committed state, applied-check == 1 per mutant, control == 0): render-wiring revert → 4 RED; forced default strength → 2 RED; mapper invents claim id → 3 RED; Group-4 carry removed → 2 RED; VM invents grounding → 2 RED. **All five bite.**
- `pnpm typecheck` PASSED; `validate-prepush.sh` fails ONLY on pre-existing Check 8 (DS v5 drift) with a violation set **byte-identical** to the pristine-staging control (diff: identical) — zero net-new drift from this PR.

## Corrected premise (deliverable)

The brief stated "the UI already renders `principle` as action-item titles" via `groupActionItems.ts:329`. At `6d5db185` that Group-4 path has **no production caller**: `ConfidenceSection.tsx:640` (the only call site) passes no `preMortem`, so the only LIVE renderer of `decision_quality_prompts` is the hero key-question card. This PR therefore badges the hero card (live) and carries provenance through the Group-4 seam (unit-tested contract); **wiring DQPs into Group 4 is left as an orchestrator decision** — note `decisionReviewAdapter.ts`'s `V0_30_ENRICHER_OWNED_KEYS` doctrine warns the same prompts also arrive as wire coaching blocks, so that wiring is a double-render product call, not a lane call.

## Deferred (reported, not done)

- Typing `dsk_claim_id`/`dsk_protocol_id`/`evidence_strength` in `olumi-schemas` is the hardening half — the schemas seat is lane 2's right now. The UI reads the passthrough fields **tolerantly (all optional)**, so the later typing is additive and non-breaking.
- `GuidanceItem.dsk_claim_id`/`evidence_strength` (guidanceStore:104-105) stay dormant: their populate site is `src/v5/extractPhase3FromV5Response.ts` (outside this lane's file ownership) and no committed fixture attests dsk fields on coaching blocks — dependency reported to the orchestrator.

No new flags or env gates; ships ON; rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)