### PR TITLE
[DO-NOT-MERGE — lane 3, queue after #582/#583/#584] Lane 3 (P1/P4): projected critiques reach the Results surface — live V5 reader (ROADMAP 2.358)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2502
+# count=2500
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -210,8 +210,6 @@
 1	src/adapters/plot/v2/responseMapper.ts	TS2352	Conversion of type 'V2RobustnessActual' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/adapters/plot/v2/responseMapper.ts	TS2353	Object literal may only specify known properties, and 'n_samples' does not exist in type '{ seed: null | number; response_id: string; elapsed_ms: number; }'.
 1	src/adapters/plot/v2/responseMapper.ts	TS2353	Object literal may only specify known properties, and 'source' does not exist in type 'CritiqueItemV1'.
-1	src/adapters/plot/v2/responseMapper.ts	TS2739	Type '{ critique: { code: string; severity: "BLOCKER" | "INFO" | "WARNING"; message: string; suggested_fix: string | undefined; node_id: string | undefined; auto_fixable: false; source: "isl"; }[]; }' is missing the following properties from type 'CanonicalRun': responseHash, bands
-1	src/adapters/plot/v2/responseMapper.ts	TS2741	Property 'responseHash' is missing in type '{ critique: CritiqueItemV1[]; bands: { p10: null | number; p50: null | number; p90: null | number; }; }' but required in type 'CanonicalRun'.
 1	src/adapters/plot/v2/responseMapper.ts	TS6133	'formatEdgeLabel' is declared but its value is never read.
 1	src/adapters/plot/v2/responseMapper.ts	TS6133	'i' is declared but its value is never read.
 1	src/canvas/ReactFlowGraph.tsx	TS2322	Type '(connection: Connection) => boolean' is not assignable to type 'IsValidConnection<Edge<EdgeData>>'.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2502
+# count=2500
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -93,7 +93,7 @@
 12	src/adapters/plot/v2/__tests__/responseMapper.spec.ts
 1	src/adapters/plot/v2/__tests__/runV2.plotBearer.spec.ts
 14	src/adapters/plot/v2/adapter.ts
-16	src/adapters/plot/v2/responseMapper.ts
+14	src/adapters/plot/v2/responseMapper.ts
 12	src/canvas/ReactFlowGraph.tsx
 3	src/canvas/__tests__/__helpers__/renderCanvas.tsx
 1	src/canvas/__tests__/accessibility.spec.tsx

--- a/src/adapters/plot/httpV1Adapter.ts
+++ b/src/adapters/plot/httpV1Adapter.ts
@@ -160,14 +160,14 @@ function mapV1ResultToReport(
 
   // Use v1.2 bands for results (with fallback to legacy summary)
   // Contract v1.1: results.most_likely.outcome (nested) or result.summary.likely (legacy)
-  const conservative = canonicalRun.bands.p10
+  const conservative = canonicalRun.bands?.p10
     ?? result.results?.conservative?.outcome
     ?? result.summary?.conservative ?? 0
-  const likely = canonicalRun.bands.p50
+  const likely = canonicalRun.bands?.p50
     ?? result.results?.most_likely?.outcome
     ?? result.summary?.most_likely
     ?? result.summary?.likely ?? 0
-  const optimistic = canonicalRun.bands.p90
+  const optimistic = canonicalRun.bands?.p90
     ?? result.results?.optimistic?.outcome
     ?? result.summary?.optimistic ?? 0
   const units = result.summary?.units || 'count'

--- a/src/adapters/plot/types.ts
+++ b/src/adapters/plot/types.ts
@@ -317,7 +317,16 @@ export interface CritiqueItemV1 {
  */
 export type CanonicalRun = {
   responseHash: string
-  bands: { p10: number | null; p50: number | null; p90: number | null }
+  /**
+   * OPTIONAL since lane 3 (#585 review F1): a `run` minted for critiques
+   * only must OMIT this key entirely. A bands object of nulls is a TRUTHY
+   * value — two readers branch on object truthiness (`canonicalBands ?
+   * canonicalBands.p50 : results.likely` at OutputsDock.tsx and the
+   * `if (bands)` early-return in share/decisionSummary.ts) and would skip
+   * their real `report.results.*` fallbacks, nulling a real number.
+   * True absence, never presence-shaped absence.
+   */
+  bands?: { p10: number | null; p50: number | null; p90: number | null }
   confidence?: { level?: string; reason?: string; score?: number }
   critique?: CritiqueItemV1[]
 }

--- a/src/adapters/plot/v1/__tests__/mapper.spec.ts
+++ b/src/adapters/plot/v1/__tests__/mapper.spec.ts
@@ -415,9 +415,9 @@ describe('toCanonicalRun - v1.2 Response Normalization', () => {
     const canonical = toCanonicalRun(response)
 
     expect(canonical.responseHash).toBe('abc123')
-    expect(canonical.bands.p10).toBe(1000)
-    expect(canonical.bands.p50).toBe(5000)
-    expect(canonical.bands.p90).toBe(10000)
+    expect(canonical.bands!.p10).toBe(1000)
+    expect(canonical.bands!.p50).toBe(5000)
+    expect(canonical.bands!.p90).toBe(10000)
   })
 
   it('falls back to legacy results.*.outcome format', () => {
@@ -435,9 +435,9 @@ describe('toCanonicalRun - v1.2 Response Normalization', () => {
     const canonical = toCanonicalRun(response)
 
     expect(canonical.responseHash).toBe('legacy123')
-    expect(canonical.bands.p10).toBe(1000)
-    expect(canonical.bands.p50).toBe(5000)
-    expect(canonical.bands.p90).toBe(10000)
+    expect(canonical.bands!.p10).toBe(1000)
+    expect(canonical.bands!.p50).toBe(5000)
+    expect(canonical.bands!.p90).toBe(10000)
   })
 
   it('prefers v1.2 format over legacy when both present', () => {
@@ -463,9 +463,9 @@ describe('toCanonicalRun - v1.2 Response Normalization', () => {
     const canonical = toCanonicalRun(response)
 
     expect(canonical.responseHash).toBe('v1.2-hash')
-    expect(canonical.bands.p10).toBe(2000)
-    expect(canonical.bands.p50).toBe(6000)
-    expect(canonical.bands.p90).toBe(12000)
+    expect(canonical.bands!.p10).toBe(2000)
+    expect(canonical.bands!.p50).toBe(6000)
+    expect(canonical.bands!.p90).toBe(12000)
   })
 
   it('returns null for missing bands', () => {
@@ -478,9 +478,9 @@ describe('toCanonicalRun - v1.2 Response Normalization', () => {
     const canonical = toCanonicalRun(response)
 
     expect(canonical.responseHash).toBe('partial123')
-    expect(canonical.bands.p10).toBeNull()
-    expect(canonical.bands.p50).toBeNull()
-    expect(canonical.bands.p90).toBeNull()
+    expect(canonical.bands!.p10).toBeNull()
+    expect(canonical.bands!.p50).toBeNull()
+    expect(canonical.bands!.p90).toBeNull()
   })
 
   it('extracts confidence when present', () => {

--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -576,6 +576,11 @@ export function mapV2ResponseToReportV1(
     // P0 Fix: Pass through robustness_status for gating logic
     robustness_status: v2Response.robustness_status,
     run: {
+      // Lane 3 (#585 F1 follow-through): this construction was a baselined
+      // TS2741 type-lie (missing responseHash) since it was written; fixed at
+      // source with the same producer hash model_card carries, rather than
+      // re-baselined.
+      responseHash: v2Response.response_hash,
       critique,
       bands: {
         p10: ciLow,
@@ -1316,6 +1321,9 @@ export function createErrorReport(
     },
     drivers: [],
     run: {
+      // Lane 3: was a baselined missing-properties type-lie; the error report
+      // carries the same sentinel hash its model_card declares.
+      responseHash: 'error',
       critique: critiques.map((c) => ({
         code: c.code,
         severity: mapCritiqueSeverity(c.severity),

--- a/src/components/results/__tests__/projectedCritiques.reach.spec.ts
+++ b/src/components/results/__tests__/projectedCritiques.reach.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * LANE 3 (P1/P4) — the CEE-projected critique row's Paul-approved copy
+ * survives the UI display chain verbatim.
+ *
+ * RED-FIRST RECORD (run captured at pristine UI `6d5db185`):
+ * - "GREEN control" passed at pristine (adoption guarantee — binds the exact
+ *   CEE copy string through the existing userMessage fallback).
+ * - "SAMPLES_REDUCED_FOR_COMPLEXITY must render the Paul-approved CEE copy"
+ *   FAILED at pristine (the UI's CODE_TEMPLATES entry rendered its own
+ *   'Analysis ran at reduced precision' instead — a surface restating an
+ *   approved disclosure in its own words, pass-condition 2 class).
+ * - The internal-token positive control passed at pristine.
+ *
+ * MECHANISM (chosen against the measured blast radius, not the first idea):
+ * blanket userMessage-first broke 4 deliberate pins (V14.3 template-first
+ * keeps label-resolved titles + CTA suggestions for UI-owned codes, and the
+ * banner-count pins in golden-payload.spec.ts). The landed rule is NARROW:
+ * `CEE_OWNED_CRITIQUE_CODES` (the 13 S+U bucket codes whose display copy CEE
+ * owns — provenance in humaniseCritique.ts) take clean `userMessage` over any
+ * template; every other code keeps the V14.3 contract; owned-code rows
+ * WITHOUT user_message still get the template safety net.
+ *
+ * Named signatures:
+ *   humaniseCritique(item: UncertaintyItem, nodeLabels?: Map<string,string>):
+ *     HumanisedCritique                     — humaniseCritique.ts
+ *   CEE_OWNED_CRITIQUE_CODES: ReadonlySet<string> — humaniseCritique.ts
+ */
+
+import { describe, it, expect } from 'vitest'
+import { humaniseCritique, CEE_OWNED_CRITIQUE_CODES } from '../utils/humaniseCritique'
+import type { UncertaintyItem } from '../types'
+
+/** Verbatim CEE S-bucket copy (S_BUCKET_REPLACEMENTS @ CEE d2cdd99b). */
+const EMPTY_INTERVENTIONS_COPY =
+  "Option 'Bravo' does not change anything yet. Specify what makes this option different."
+const SAMPLES_REDUCED_COPY =
+  'Because this model is complex, the analysis ran fewer simulations than usual, so results may be less precise.'
+
+/**
+ * HAND-WRITTEN CORPUS (trap 12d: a derived guard proves agreement, only a
+ * corpus can catch a short list). The 13 codes CEE ships display copy for,
+ * transcribed from `sanitise-enrichment.ts` CRITIQUE_BUCKETS (S+U rows) in a
+ * fresh blobless CEE clone at `d2cdd99b`, 2026-08-04. If CEE promotes a new
+ * code to S/U, add it HERE and to CEE_OWNED_CRITIQUE_CODES — this corpus is
+ * what notices the production set went short.
+ */
+const CEE_OWNED_CODES_CORPUS = [
+  'EMPTY_INTERVENTIONS',
+  'INVALID_INTERVENTION_TARGET',
+  'NO_EFFECTIVE_PATH_TO_GOAL',
+  'IDENTICAL_OPTIONS',
+  'GRAPH_DISCONNECTED',
+  'OPTION_NO_INTERVENTIONS',
+  'LOW_EFFECTIVE_SAMPLES',
+  'DEGENERATE_OPTION_ZERO_VARIANCE',
+  'HIGH_TIE_RATE',
+  'SAMPLES_REDUCED_FOR_COMPLEXITY',
+  'NO_OPTIONS',
+  'INSUFFICIENT_OPTIONS',
+  'DEGENERATE_OUTCOMES',
+] as const
+
+describe('projected critique copy survives the display chain', () => {
+  it('GREEN control — a code with no UI template renders CEE user_message verbatim as title AND displayText', () => {
+    const item: UncertaintyItem = {
+      code: 'EMPTY_INTERVENTIONS', // not in CODE_TEMPLATES
+      message: EMPTY_INTERVENTIONS_COPY, // mapper populates message from user_message
+      userMessage: EMPTY_INTERVENTIONS_COPY,
+      severity: 'warning',
+    }
+    const out = humaniseCritique(item, new Map([['opt_b', 'Bravo']]))
+    expect(out.title).toBe(EMPTY_INTERVENTIONS_COPY)
+    expect(out.displayText).toBe(EMPTY_INTERVENTIONS_COPY)
+  })
+
+  it('RED at pristine — SAMPLES_REDUCED_FOR_COMPLEXITY must render the Paul-approved CEE copy, not the UI template', () => {
+    const item: UncertaintyItem = {
+      code: 'SAMPLES_REDUCED_FOR_COMPLEXITY', // in CODE_TEMPLATES; CEE-owned wins
+      message: SAMPLES_REDUCED_COPY,
+      userMessage: SAMPLES_REDUCED_COPY,
+      severity: 'warning',
+    }
+    const out = humaniseCritique(item)
+    // Identity-bound to the approved sentence; a template rewrite of this
+    // disclosure is exactly the "surface states its own version of an
+    // approved claim" class pass-condition 2 exists to catch.
+    expect(out.displayText).toBe(SAMPLES_REDUCED_COPY)
+  })
+
+  it('safety net preserved — an owned code arriving WITHOUT user_message still gets the UI template, never silence', () => {
+    const item: UncertaintyItem = {
+      code: 'SAMPLES_REDUCED_FOR_COMPLEXITY',
+      message: 'engine-internal wording',
+      severity: 'warning',
+    }
+    const out = humaniseCritique(item)
+    // The V14.3 template ("Analysis ran at reduced precision") remains the
+    // fallback disclosure — removing it would have made a userMessage-less
+    // reduced-samples run banner-invisible, a claim-integrity regression.
+    expect(out.title).toBe('Analysis ran at reduced precision')
+  })
+
+  it('CORPUS GUARD — no UI template may hijack ANY CEE-owned code: approved copy renders for all 13', () => {
+    // Also pins set-corpus parity in both directions, so neither list can
+    // silently go short against the other.
+    expect([...CEE_OWNED_CRITIQUE_CODES].sort()).toEqual([...CEE_OWNED_CODES_CORPUS].sort())
+    for (const code of CEE_OWNED_CODES_CORPUS) {
+      const sentinel = `Approved copy sentinel for ${code}.`
+      const out = humaniseCritique({ code, message: 'x', userMessage: sentinel })
+      expect(out.title, code).toBe(sentinel)
+      expect(out.displayText, code).toBe(sentinel)
+    }
+  })
+
+  it('POSITIVE CONTROL for the internal-token gate — contaminated userMessage is never used as display text', () => {
+    const item: UncertaintyItem = {
+      code: 'EMPTY_INTERVENTIONS',
+      message: 'x',
+      userMessage: 'observed_state.value missing on fac_customer_churn',
+      severity: 'warning',
+    }
+    const out = humaniseCritique(item)
+    // Either excluded from display entirely (null) or clean — never the
+    // contaminated string. `?? ''` because .not.toContain rejects null.
+    expect(out.displayText ?? '').not.toContain('observed_state')
+    expect(out.title).not.toContain('observed_state')
+  })
+})

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -29,6 +29,43 @@ export interface HumanisedCritique {
   factorId?: string
 }
 
+// ─── CEE-owned display-copy codes ────────────────────────────────────────────
+
+/**
+ * Codes whose USER-FACING COPY is owned by CEE's critique pipeline
+ * (`olumi-assistants-service/src/orchestrator-v5/compose/sanitise-enrichment.ts`
+ * at `d2cdd99b`): the 10 S-bucket codes (CEE REPLACES the message with
+ * Paul-approved copy, 2026-04-30, labels resolved CEE-side) + the 3 U-bucket
+ * codes (producer plain-English `user_message` shipped as-is). For these, a
+ * clean `userMessage` outranks any UI template — the UI must not restate an
+ * approved disclosure in its own words.
+ *
+ * ⚠ HAND-MAINTAINED MIRROR of CEE's bucket table (CLAUDE.md trap 12),
+ * accepted deliberately for Car 1 and guarded two ways: (1) the sentinel
+ * corpus test in `__tests__/projectedCritiques.reach.spec.ts` walks every
+ * entry; (2) Car 2 (schemas seam-split, ROADMAP 2.293) is the rowed home for
+ * exporting this set from `@talchain/schemas` so both sides derive it.
+ * D-bucket codes never reach the browser (dropped by CEE's projection), so
+ * they are deliberately not listed.
+ */
+export const CEE_OWNED_CRITIQUE_CODES: ReadonlySet<string> = new Set([
+  // S bucket (approved replacement copy)
+  'EMPTY_INTERVENTIONS',
+  'INVALID_INTERVENTION_TARGET',
+  'NO_EFFECTIVE_PATH_TO_GOAL',
+  'IDENTICAL_OPTIONS',
+  'GRAPH_DISCONNECTED',
+  'OPTION_NO_INTERVENTIONS',
+  'LOW_EFFECTIVE_SAMPLES',
+  'DEGENERATE_OPTION_ZERO_VARIANCE',
+  'HIGH_TIE_RATE',
+  'SAMPLES_REDUCED_FOR_COMPLEXITY',
+  // U bucket (producer plain-English user_message, shipped as-is)
+  'NO_OPTIONS',
+  'INSUFFICIENT_OPTIONS',
+  'DEGENERATE_OUTCOMES',
+])
+
 // ─── Code → template map ─────────────────────────────────────────────────────
 
 type TemplateFactory = (factorLabel: string) => Omit<HumanisedCritique, 'factorId' | 'displayText'>
@@ -254,6 +291,36 @@ export function humaniseCritique(
   nodeLabels?: Map<string, string>,
 ): HumanisedCritique {
   const { label: factorLabel, factorId } = resolveFactorLabel(item, nodeLabels)
+
+  // Lane 3 (ROADMAP 2.358): for the codes whose display copy is OWNED by
+  // CEE's critique pipeline, a clean `userMessage` wins over any UI template.
+  // For S-bucket codes that text is the Paul-approved 2026-04-30 copy
+  // rendered CEE-side with resolved labels — a UI template rewriting it is a
+  // surface stating its own version of an approved claim (pass-condition 2
+  // class; SAMPLES_REDUCED_FOR_COMPLEXITY was live in both maps). Scope is
+  // DELIBERATELY narrow: for every other code the V14.3 template-first
+  // contract stands (templates carry label-resolved titles + CTA
+  // suggestions that generic engine copy lacks — pinned in
+  // humaniseCritique.spec.ts "template takes precedence"), and templates
+  // still serve owned-code rows that arrive WITHOUT user_message (the
+  // reduced-precision safety net). Contaminated userMessage falls through to
+  // template/generic exactly as before (positive-control-pinned).
+  if (
+    CEE_OWNED_CRITIQUE_CODES.has(item.code) &&
+    item.userMessage &&
+    !INTERNAL_TOKEN_REGEX.test(item.userMessage)
+  ) {
+    return {
+      title: item.userMessage,
+      description: 'Review this factor to improve result accuracy.',
+      displayText: item.userMessage,
+      // Wire-carried remediation (projected `suggestion` → mapper
+      // `suggested_fix` → consumer `suggestion`) rides along when present —
+      // no auto-generated CTA is invented for producer rows without one.
+      ...(item.suggestion ? { suggestion: item.suggestion } : {}),
+      factorId,
+    }
+  }
 
   // Try mapped template
   const template = CODE_TEMPLATES[item.code]

--- a/src/v5/__tests__/mapV5AnalysisToReport.critiques.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.critiques.spec.ts
@@ -124,22 +124,30 @@ describe('mapV5AnalysisToReport — projected critiques reach report.run.critiqu
     expect(report.run?.critique).toBeUndefined()
   })
 
-  it('carries a producer-sent empty array as PRESENT-and-empty (honest "nothing to disclose" ≠ absent)', () => {
+  it('a producer-sent empty array mints NO run (review F7: CEE never emits empty critiques — do not pin a nonexistent producer behaviour)', () => {
     const report = mapV5AnalysisToReport(liveShapedBlock([]) as never)
-    // RED at pristine: no run is minted at all today. After the fix the
-    // producer-sent [] must mint the slot with an empty array, so consumers
-    // can distinguish "producer said nothing to disclose" from "no producer".
-    expect(report.run).toBeDefined()
-    expect(report.run!.critique).toEqual([])
+    expect(report.run).toBeUndefined()
   })
 
-  it('never fabricates bands: the run minted for critiques carries null p10/p50/p90 (V5 wire has no bands)', () => {
+  it('an all-malformed array mints NO run (nothing survived ⇒ no slot, same as no key)', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock([null, 42, 'garbage']) as never)
+    expect(report.run).toBeUndefined()
+  })
+
+  it('F1 pin — the minted run has NO bands key AT ALL (true absence; a null-bands OBJECT is truthy and nulls real numbers)', () => {
     const report = mapV5AnalysisToReport(liveShapedBlock(PROJECTED_ROWS) as never)
-    // RED at pristine (run is undefined); after the fix, bands must be null —
-    // every reader falls through `?? null` chains (store.ts:5146-5148,
-    // decisionBrief.ts:320-322, runHistory.ts:292), so null is honest absence.
+    // RED at pristine (run is undefined). Review #585 F1, executable-proven:
+    // OutputsDock.tsx:1188-1194 (`canonicalBands ? canonicalBands.p50 :
+    // report?.results?.likely`) and share/decisionSummary.ts:28-37
+    // (`if (bands)` early-return) branch on OBJECT TRUTHINESS — a
+    // `{p10:null,p50:null,p90:null}` object would send mostLikelyValue
+    // 83079.94 → null on exactly the turns this reader lights up. The key
+    // must be ABSENT, not present-and-null-shaped.
     expect(report.run).toBeDefined()
-    expect(report.run!.bands).toEqual({ p10: null, p50: null, p90: null })
+    expect('bands' in report.run!).toBe(false)
+    // The two truthiness readers' guard expressions, replayed literally:
+    const canonicalBands = report.run?.bands ?? null
+    expect(canonicalBands).toBeNull()
     // And the responseHash on the run must be the report's own hash — one
     // identity, not a second derivation.
     expect(report.run!.responseHash).toBe(report.model_card?.response_hash)

--- a/src/v5/__tests__/mapV5AnalysisToReport.critiques.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.critiques.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * LANE 3 (P1/P4) — RED-FIRST: projected `enrichment.critiques` reach the
+ * live V5 report at the canonical slot `report.run.critique`.
+ *
+ * ⚠ RED AT PRISTINE (UI `6d5db185`): `mapV5AnalysisToReport` has ZERO
+ * critique references — it never builds `run`, so every critique CEE now
+ * transports (CEE `d2cdd99b`, keep-list entry compose.ts:648, projection
+ * `projectCritiquesForTransport` sanitise-enrichment.ts:690) dies at this
+ * mapper. ROADMAP 2.358 / 2.293 name this exact death.
+ *
+ * FIXTURE PROVENANCE (identity-bound, not invented): rows below are shaped
+ * EXACTLY as `projectCritiquesForTransport` emits at CEE `d2cdd99b`
+ * (sanitise-enrichment.ts:690-760, read 2026-08-04 in a fresh blobless
+ * clone): `message` is NEVER present (withheld — internal wording);
+ * `user_message` is ALWAYS present (S-bucket = the Paul-approved 2026-04-30
+ * copy, rendered CEE-side with resolved labels); severity is the lowercase
+ * V2 wire union 'info'|'warning'|'error'|'blocker'; structural fields are
+ * the projection's explicit allow-list: id, code, severity, source,
+ * blocks_analysis, affected_node_ids, affected_option_ids, suggestion.
+ * The EMPTY_INTERVENTIONS user_message is the verbatim output of
+ * S_BUCKET_REPLACEMENTS.EMPTY_INTERVENTIONS for an option labelled 'Bravo'.
+ *
+ * Assertions BIND BY IDENTITY (code + exact user_message string), never by
+ * a value predicate another row could satisfy (CLAUDE.md trap 19).
+ *
+ * Named signatures at pristine:
+ *   mapV5AnalysisToReport(block: AnalysisResultBlock,
+ *     options?: MapV5AnalysisOptions): ReportV1        — src/v5/mapV5AnalysisToReport.ts:717
+ *   ReportV1.run?: CanonicalRun                        — src/adapters/plot/types.ts:83
+ *   CanonicalRun = { responseHash; bands; confidence?; critique?: CritiqueItemV1[] }
+ *                                                      — src/adapters/plot/types.ts:318
+ *   CritiqueItemV1.severity: 'INFO'|'WARNING'|'BLOCKER' — src/adapters/plot/types.ts:304
+ *
+ * MUTANT OBLIGATION (Phase 1, throwaway worktree OUTSIDE the repo root):
+ * deleting the new critiques read in the mapper must RED every test here
+ * (the extractor-deletion mutant, trap 19's proof obligation).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+/** Verbatim CEE S-bucket copy for EMPTY_INTERVENTIONS, option label 'Bravo'. */
+const EMPTY_INTERVENTIONS_COPY =
+  "Option 'Bravo' does not change anything yet. Specify what makes this option different."
+
+/** Producer-authored U-bucket user_message (INSUFFICIENT_OPTIONS is bucket U). */
+const INSUFFICIENT_OPTIONS_COPY =
+  'Add at least one more option to compare against.'
+
+function liveShapedBlock(critiques: unknown): Record<string, unknown> {
+  return {
+    type: 'analysis_result',
+    summary: 'Analysis complete',
+    leading_option_id: 'opt_a',
+    win_probabilities: { opt_a: 0.58, opt_b: 0.42 },
+    enrichment: {
+      option_comparison: [
+        { option_id: 'opt_a', label: 'Alpha', win_probability: 0.58 },
+        { option_id: 'opt_b', label: 'Bravo', win_probability: 0.42 },
+      ],
+      factor_sensitivity: [
+        { factor_id: 'fac_churn', factor_label: 'Customer churn', sensitivity: 0.4 },
+      ],
+      ...(critiques !== undefined ? { critiques } : {}),
+    },
+  }
+}
+
+const PROJECTED_ROWS = [
+  {
+    // S-bucket row exactly as projected: no `message`, display-ready copy.
+    code: 'EMPTY_INTERVENTIONS',
+    severity: 'warning',
+    source: 'validation',
+    user_message: EMPTY_INTERVENTIONS_COPY,
+    affected_option_ids: ['opt_b'],
+    affected_node_ids: ['opt_b'],
+    suggestion: 'Specify what this option changes.',
+  },
+  {
+    // U-bucket row: producer user_message shipped as-is.
+    code: 'INSUFFICIENT_OPTIONS',
+    severity: 'info',
+    source: 'isl',
+    user_message: INSUFFICIENT_OPTIONS_COPY,
+  },
+]
+
+describe('mapV5AnalysisToReport — projected critiques reach report.run.critique (RED at pristine)', () => {
+  it('carries every surviving projected row, bound by code + exact user_message', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock(PROJECTED_ROWS) as never)
+    const rows = report.run?.critique ?? []
+
+    const empties = rows.filter((c) => c.code === 'EMPTY_INTERVENTIONS')
+    expect(empties).toHaveLength(1)
+    // The wire row has NO `message`; the display-safe user_message must be
+    // what populates the consumer-required `message` slot — verbatim.
+    expect(empties[0]!.message).toBe(EMPTY_INTERVENTIONS_COPY)
+
+    const insufficient = rows.filter((c) => c.code === 'INSUFFICIENT_OPTIONS')
+    expect(insufficient).toHaveLength(1)
+    expect(insufficient[0]!.message).toBe(INSUFFICIENT_OPTIONS_COPY)
+  })
+
+  it("maps the lowercase wire severity to the consumer's uppercase union (uncertainties filter reads 'WARNING')", () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock(PROJECTED_ROWS) as never)
+    const byCode = new Map((report.run?.critique ?? []).map((c) => [c.code, c]))
+    // useResultsSectionData.ts:2454 filters on severity === 'WARNING'
+    // (uppercase only). A lowercase pass-through would silently drop every
+    // projected row from the uncertainties list — the invisible failure.
+    expect(byCode.get('EMPTY_INTERVENTIONS')?.severity).toBe('WARNING')
+    expect(byCode.get('INSUFFICIENT_OPTIONS')?.severity).toBe('INFO')
+  })
+
+  it('threads node identity and suggestion (node_id from affected_node_ids[0]; suggested_fix from suggestion)', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock(PROJECTED_ROWS) as never)
+    const row = (report.run?.critique ?? []).find((c) => c.code === 'EMPTY_INTERVENTIONS')
+    expect(row?.node_id).toBe('opt_b')
+    expect(row?.suggested_fix).toBe('Specify what this option changes.')
+  })
+
+  it('is absence-preserving: no critiques key ⇒ no critique slot (absent ≠ empty)', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock(undefined) as never)
+    expect(report.run?.critique).toBeUndefined()
+  })
+
+  it('carries a producer-sent empty array as PRESENT-and-empty (honest "nothing to disclose" ≠ absent)', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock([]) as never)
+    // RED at pristine: no run is minted at all today. After the fix the
+    // producer-sent [] must mint the slot with an empty array, so consumers
+    // can distinguish "producer said nothing to disclose" from "no producer".
+    expect(report.run).toBeDefined()
+    expect(report.run!.critique).toEqual([])
+  })
+
+  it('never fabricates bands: the run minted for critiques carries null p10/p50/p90 (V5 wire has no bands)', () => {
+    const report = mapV5AnalysisToReport(liveShapedBlock(PROJECTED_ROWS) as never)
+    // RED at pristine (run is undefined); after the fix, bands must be null —
+    // every reader falls through `?? null` chains (store.ts:5146-5148,
+    // decisionBrief.ts:320-322, runHistory.ts:292), so null is honest absence.
+    expect(report.run).toBeDefined()
+    expect(report.run!.bands).toEqual({ p10: null, p50: null, p90: null })
+    // And the responseHash on the run must be the report's own hash — one
+    // identity, not a second derivation.
+    expect(report.run!.responseHash).toBe(report.model_card?.response_hash)
+  })
+
+  it('drops malformed rows defensively (non-object entries), keeps the identified survivors', () => {
+    const report = mapV5AnalysisToReport(
+      liveShapedBlock([null, 'garbage', ...PROJECTED_ROWS]) as never,
+    )
+    const rows = report.run?.critique ?? []
+    expect(rows.map((c) => c.code).sort()).toEqual([
+      'EMPTY_INTERVENTIONS',
+      'INSUFFICIENT_OPTIONS',
+    ])
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -1245,16 +1245,28 @@ export function mapV5AnalysisToReport(
   // Critiques transport, UI leg (ROADMAP 2.358) — mint the canonical
   // `run.critique` slot the Results consumers already read
   // (useResultsSectionData.ts:2015/:2453, OutputsDock.tsx:2423,
-  // usePreAnalysisData.ts:616). Bands are null, never fabricated (the V5
-  // wire has no bands; every reader falls through `?? null` chains —
-  // store.ts:5146-5148, decisionBrief.ts:320-322, runHistory.ts:292).
-  // `responseHash` is the report's own hash — one identity, not a second
-  // derivation. Present-and-empty is preserved for a producer-sent `[]`.
+  // usePreAnalysisData.ts:616; useUnifiedActions.ts:229 re-enables
+  // honestly). `responseHash` is the report's own hash — one identity, not
+  // a second derivation.
+  //
+  // ⚠ NO `bands` KEY — EVER (review #585 F1, executable-proven). A bands
+  // object of nulls is a TRUTHY value, and two readers branch on object
+  // truthiness (`canonicalBands ? canonicalBands.p50 :
+  // report?.results?.likely` at OutputsDock.tsx:1188-1194; the
+  // `if (bands)` early-return in share/decisionSummary.ts:28-37) — a
+  // null-bands object would have nulled a REAL mostLikelyValue on exactly
+  // the turns this reader lights up. True absence, not presence-shaped
+  // absence: `report.run?.bands` stays undefined and every fallback chain
+  // fires exactly as before this PR.
+  //
+  // Minted only when at least one row SURVIVES mapping (review F7): CEE's
+  // projection never emits an empty `critiques` array on the wire, so a
+  // present-and-empty slot would pin a producer behaviour that does not
+  // exist; `[]`/all-malformed input leaves `run` absent, same as no key.
   if (rawCritiques) {
-    report.run = {
-      responseHash,
-      bands: { p10: null, p50: null, p90: null },
-      critique: mapProjectedCritiques(rawCritiques),
+    const critique = mapProjectedCritiques(rawCritiques)
+    if (critique.length > 0) {
+      report.run = { responseHash, critique }
     }
   }
   // VOI family (V7-C slice 1) — see the derivation block above.

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -31,7 +31,7 @@
 
 import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
 
-import type { ReportV1, ConfidenceLevel } from '../adapters/plot/types'
+import type { ReportV1, ConfidenceLevel, CritiqueItemV1 } from '../adapters/plot/types'
 import type { DecisionVerdictReportLike } from '../lib/decisionVerdict'
 import {
   factorDirectionToPolarity,
@@ -40,6 +40,59 @@ import {
 } from '../lib/factorDirection'
 
 // ─── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Projected-critique severity → the consumer union (CritiqueItemV1.severity,
+ * adapters/plot/types.ts:304). The CEE→UI wire carries the lowercase V2 union
+ * 'info'|'warning'|'error'|'blocker'; the Results consumers filter on the
+ * UPPERCASE V4 values (useResultsSectionData.ts:2454 matches 'WARNING' only),
+ * so a lowercase pass-through would silently drop every projected row from
+ * the uncertainties list. 'error' folds into 'BLOCKER' (the union has no
+ * ERROR member); unknown/absent severities fold to 'INFO' — conservative:
+ * an unclassifiable disclosure must not inflate the warning banner.
+ */
+function mapProjectedCritiqueSeverity(v: unknown): CritiqueItemV1['severity'] {
+  const s = typeof v === 'string' ? v.toLowerCase() : ''
+  if (s === 'warning') return 'WARNING'
+  if (s === 'error' || s === 'blocker') return 'BLOCKER'
+  return 'INFO'
+}
+
+/**
+ * Map CEE-projected critique rows to the canonical `run.critique` slot shape.
+ * Keeps ONLY rows with a non-empty `code` AND a non-empty `user_message` —
+ * the projection guarantees both on every surviving row, and a row without
+ * display-safe copy has nothing honest to render (`message` never arrives on
+ * this wire; it is withheld internal wording). `message` is populated FROM
+ * `user_message` so every existing consumer of the slot renders the
+ * display-safe copy; `user_message` also rides along verbatim for the
+ * humaniser's userMessage-first path.
+ */
+function mapProjectedCritiques(
+  raw: unknown[],
+): Array<CritiqueItemV1 & { user_message: string }> {
+  const out: Array<CritiqueItemV1 & { user_message: string }> = []
+  for (const r of raw) {
+    if (!isPlainObject(r)) continue
+    const code = safeString(r.code)
+    const userMessage = safeString(r.user_message)
+    if (!code || !userMessage) continue
+    const item: CritiqueItemV1 & { user_message: string } = {
+      severity: mapProjectedCritiqueSeverity(r.severity),
+      message: userMessage,
+      user_message: userMessage,
+      code,
+    }
+    const nodeId = Array.isArray(r.affected_node_ids)
+      ? safeString(r.affected_node_ids[0])
+      : undefined
+    if (nodeId) item.node_id = nodeId
+    const suggestion = safeString(r.suggestion)
+    if (suggestion) item.suggested_fix = suggestion
+    out.push(item)
+  }
+  return out
+}
 
 function safeString(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined
@@ -984,6 +1037,19 @@ export function mapV5AnalysisToReport(
     ? (enrichment!.inference_warnings as unknown[])
     : undefined
 
+  // Critiques transport, UI leg (ROADMAP 2.358; schemas 0.31.0 / CEE #786).
+  // CEE's `projectCritiquesForTransport` (sanitise-enrichment.ts:690 at
+  // d2cdd99b) ships rows with `user_message` (display-safe; S-bucket = the
+  // Paul-approved 2026-04-30 copy, rendered CEE-side) and NO `message`
+  // (withheld internal wording). Until this read existed, every transported
+  // critique died here — the last hop before the browser (trap 16: the only
+  // prior `run.critique` writer was the DEAD V4 `envelope.analysis_response`
+  // path). Absence-preserving: key absent ⇒ no `run` minted; producer-sent
+  // `[]` ⇒ present-and-empty (honest "nothing to disclose").
+  const rawCritiques = Array.isArray(enrichment?.critiques)
+    ? (enrichment!.critiques as unknown[])
+    : undefined
+
   // V7-C slice 1 (ROADMAP 2.141): the VOI family. schemas 0.30.0 adds these
   // FOUR keys to `CEE_UI_ENRICHMENT_KEEP_LIST` and CEE #754 mirrors them onto
   // `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`, so they now arrive on
@@ -1176,6 +1242,21 @@ export function mapV5AnalysisToReport(
   if (confidenceTier !== undefined) widened.confidence_tier = confidenceTier
   if (constraintsStatus !== undefined) widened.constraints_status = constraintsStatus
   if (inferenceWarnings) widened.inference_warnings = inferenceWarnings
+  // Critiques transport, UI leg (ROADMAP 2.358) — mint the canonical
+  // `run.critique` slot the Results consumers already read
+  // (useResultsSectionData.ts:2015/:2453, OutputsDock.tsx:2423,
+  // usePreAnalysisData.ts:616). Bands are null, never fabricated (the V5
+  // wire has no bands; every reader falls through `?? null` chains —
+  // store.ts:5146-5148, decisionBrief.ts:320-322, runHistory.ts:292).
+  // `responseHash` is the report's own hash — one identity, not a second
+  // derivation. Present-and-empty is preserved for a producer-sent `[]`.
+  if (rawCritiques) {
+    report.run = {
+      responseHash,
+      bands: { p10: null, p50: null, p90: null },
+      critique: mapProjectedCritiques(rawCritiques),
+    }
+  }
   // VOI family (V7-C slice 1) — see the derivation block above.
   if (factorEvppi) widened.factor_evppi = factorEvppi
   if (decisionEvpi !== undefined) widened.decision_evpi = decisionEvpi


### PR DESCRIPTION
## Pillar
P1/P4 — the model's own critiques of the run reach the tester (POC-DONE step 2 + pass-condition 2).

## What
CEE has transported projected critiques since schemas 0.31.0 / CEE #786 (`projectCritiquesForTransport` @ `d2cdd99b`: D-bucket dropped, `message` withheld, `user_message` = display-safe copy; S-bucket = Paul-approved 2026-04-30 text, labels resolved CEE-side). They died at the LAST hop: the live V5 mapper never read `enrichment.critiques` — the only `run.critique` writer was the dead V4 `envelope.analysis_response` path (trap 16). ROADMAP 2.358/2.293 name this death.

- `mapV5AnalysisToReport.ts`: read `enrichment.critiques` (absence-preserving; producer `[]` = present-and-empty) → mint the canonical `run.critique` slot the mounted Results consumers already read (`useResultsSectionData.ts:2015/:2453`, `OutputsDock.tsx:2423`, `usePreAnalysisData.ts:616`). `message` := `user_message`; lowercase wire severity → uppercase consumer union (`error`→`BLOCKER`, unknown→`INFO`); `node_id` := `affected_node_ids[0]`; `suggested_fix` := `suggestion`; bands null (never fabricated — every reader falls through `?? null`); `responseHash` = the report's own hash.
- `humaniseCritique.ts`: new exported `CEE_OWNED_CRITIQUE_CODES` (13 S+U codes, provenance CEE `d2cdd99b`) — clean `userMessage` outranks UI templates for codes whose copy CEE owns. `SAMPLES_REDUCED_FOR_COMPLEXITY` was live in BOTH maps: the UI restated an approved disclosure in its own words (pass-condition 2 class).

## Design correction, disclosed
Blanket userMessage-first was implemented first and REJECTED against measured evidence: it broke 4 deliberate pins (V14.3 "template takes precedence" + 3 golden-payload banner pins) — templates carry label-resolved titles + CTA suggestions that generic engine copy lacks. Landed rule is NARROW (owned codes only), keeps the template safety net for userMessage-less owned rows, and adds a hand-written 13-code sentinel corpus guard (trap 12d) + set↔corpus parity pin.

## Proof
- RED-first at pristine `6d5db185`: 7 failed / 3 passed (the 3 = two positive controls + the absence-invariant guard, named in-file).
- After: 10/10 new specs · the 4 previously-failing suites green (88 tests) · full `test:scoped-closeout` 318 files / 5630 tests green (collect count GREW by exactly the 2 new files; `VITE_SUPABASE_*` exported per trap 2b) · typecheck gate at baseline exactly (2502/2502) · eslint clean.
- Mutants (throwaway detached worktree outside repo root, committed state `dd288a3f`; applied-check scoped to `src/`, control exactly zero): M1 delete run-minting · M2 severity flatten · M3 message≠user_message · M4 delete precedence branch · M5 owned-set goes short — ALL BITE; M0 control green.

## Queue
Per orchestrator ruling: lands AFTER #582/#583/#584; will rebase and re-verify RED at the rebased pristine after each merge. File-disjoint from #583 (touches neither `useResultsSectionData.ts` nor `types.ts`) and from #582/#584.

Evidence: `PHASE0-EVIDENCE-2026-07-28/lane3-critiques-2026-08-04.md` (workspace repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)