### PR TITLE
DO-NOT-MERGE — UI batch: honest distribution-prior rendering (2.468a) + dead hover-setter removal (2.457a)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2500
+# count=2491
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -777,16 +777,14 @@
 2	src/canvas/ui/NodeInspector.stories.tsx	TS2353	Object literal may only specify known properties, and 'factor_sensitivity' does not exist in type 'ReportV1'.
 2	src/canvas/ui/NodeInspector.stories.tsx	TS2353	Object literal may only specify known properties, and 'option_comparison' does not exist in type 'ReportV1'.
 13	src/canvas/ui/NodeInspector.stories.tsx	TS7031	Binding element 'canvasElement' implicitly has an 'any' type.
-4	src/canvas/ui/NodeInspector.tsx	TS18047	'node.data.prior' is possibly 'null'.
 6	src/canvas/ui/NodeInspector.tsx	TS18047	'node.data.utility' is possibly 'null'.
 2	src/canvas/ui/NodeInspector.tsx	TS2322	Type 'unknown' is not assignable to type 'ReactNode'.
 1	src/canvas/ui/NodeInspector.tsx	TS2322	Type '{ className: string; style: { left: string; width: string; }; role: "meter"; "aria-valuenow": {} | null; "aria-valuemin": number; "aria-valuemax": number; "aria-valuetext": any; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-1	src/canvas/ui/NodeInspector.tsx	TS2322	Type '{ className: string; style: { width: string; }; role: "progressbar"; "aria-valuenow": {} | null; "aria-valuemin": number; "aria-valuemax": number; "aria-valuetext": string; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
 1	src/canvas/ui/NodeInspector.tsx	TS2322	Type '{}' is not assignable to type 'ReactNode'.
 1	src/canvas/ui/NodeInspector.tsx	TS2339	Property 'robustness' does not exist on type 'ReportV1'.
 2	src/canvas/ui/NodeInspector.tsx	TS2339	Property 'toFixed' does not exist on type '{}'.
 1	src/canvas/ui/NodeInspector.tsx	TS2345	Argument of type '{} | null' is not assignable to parameter of type 'number'.
-5	src/canvas/ui/NodeInspector.tsx	TS2362	The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+1	src/canvas/ui/NodeInspector.tsx	TS2362	The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 3	src/canvas/ui/NodeInspector.tsx	TS2365	Operator '>=' cannot be applied to types '{}' and 'number'.
 1	src/canvas/ui/__tests__/NodeInspector.goalFitBasisCaveat.spec.tsx	TS2741	Property 'progress' is missing in type '{ status: "complete"; report: null; }' but required in type 'ResultsState'.
 1	src/canvas/ui/__tests__/NodeInspector.icon.spec.tsx	TS6192	All imports in import declaration are unused.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2500
+# count=2491
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -324,7 +324,7 @@
 1	src/canvas/stores/resultsStore.ts
 15	src/canvas/ui/EdgeInspector.stories.tsx
 32	src/canvas/ui/NodeInspector.stories.tsx
-27	src/canvas/ui/NodeInspector.tsx
+18	src/canvas/ui/NodeInspector.tsx
 1	src/canvas/ui/__tests__/NodeInspector.goalFitBasisCaveat.spec.tsx
 1	src/canvas/ui/__tests__/NodeInspector.icon.spec.tsx
 10	src/canvas/ui/__tests__/NodeInspector.inspector-fixes.spec.tsx

--- a/src/canvas/ui/NodeInspector.tsx
+++ b/src/canvas/ui/NodeInspector.tsx
@@ -47,16 +47,31 @@ function formatNormalisedRangeEnd(v: number): string {
  * `{distribution, range_min, range_max}` — the object form is live (written
  * by useInspectorMutations.setPriorRange; present in drafted graphs).
  * - number → percent, unchanged.
- * - object with a finite range → the normalised range in plain words. NEVER
- *   percent-coerced: the endpoints are normalised values, not probabilities
+ * - object with a finite range → the range in plain words. NEVER
+ *   percent-coerced: the endpoints are stored bounds, not probabilities
  *   (same refusal as FactorNode's range formatter).
  * - anything else → null → the prior rows do not render.
  * Arithmetic on the object form is what produced the literal "NaN%" this
  * replaces. Finiteness checks, not truthiness: range_min 0 must render.
+ *
+ * ⚠ THE SCALE SUFFIX IS EARNED, NEVER ASSUMED (#589 review F1). Nothing
+ * bounds the object branch: PriorDistributionSchema (nodes.ts:47-52) applies
+ * `.min(0).max(1)` to the NUMERIC branch only, and the object branch is a
+ * `.passthrough()` with no bounds. Out-of-scale endpoints are witnessed — a
+ * real CEE payload in our evidence corpus carries
+ * `fac_price {distribution:'uniform', range_min:10, range_max:30}` — and are
+ * reachable with no CEE at all, because FactorExternalPanel's blur handlers
+ * write any parseFloat-able value through setPriorRange unclamped. Saying
+ * "on 0–1 scale" over £10–£30 trades a visible NaN for a confident falsehood,
+ * which is worse: a user distrusts NaN and believes a sentence. So the suffix
+ * renders ONLY when the endpoints are actually inside [0,1]; otherwise the
+ * bare range is rendered — exactly the restraint FactorNode.tsx:365 shows by
+ * emitting `Range: a to b` with no scale claim, because it too cannot know the
+ * scale without the unit/cap path this component does not have.
  */
 type PriorDisplay =
   | { kind: 'percent'; fraction: number; text: string }
-  | { kind: 'range'; rangeMin: number; rangeMax: number }
+  | { kind: 'range'; rangeMin: number; rangeMax: number; normalised: boolean }
 
 function describePrior(prior: unknown): PriorDisplay | null {
   if (typeof prior === 'number' && Number.isFinite(prior)) {
@@ -68,10 +83,21 @@ function describePrior(prior: unknown): PriorDisplay | null {
       typeof range_min === 'number' && Number.isFinite(range_min) &&
       typeof range_max === 'number' && Number.isFinite(range_max)
     ) {
-      return { kind: 'range', rangeMin: range_min, rangeMax: range_max }
+      return {
+        kind: 'range',
+        rangeMin: range_min,
+        rangeMax: range_max,
+        // Both endpoints must sit inside [0,1] to earn the scale claim.
+        normalised: range_min >= 0 && range_max <= 1,
+      }
     }
   }
   return null
+}
+
+/** The scale suffix, or nothing when the endpoints have not earned it. */
+function scaleSuffix(p: { normalised: boolean }): string {
+  return p.normalised ? ' on 0–1 scale' : ''
 }
 
 interface NodeInspectorProps {
@@ -419,7 +445,7 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
           <span className={`${typography.panelBody} text-text-body tabular-nums`}>
             {priorDisplay.kind === 'percent'
               ? priorDisplay.text
-              : `${formatNormalisedRangeEnd(priorDisplay.rangeMin)} to ${formatNormalisedRangeEnd(priorDisplay.rangeMax)} on 0–1 scale`}
+              : `${formatNormalisedRangeEnd(priorDisplay.rangeMin)} to ${formatNormalisedRangeEnd(priorDisplay.rangeMax)}${scaleSuffix(priorDisplay)}`}
           </span>
         </div>
       )}
@@ -633,7 +659,7 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
             </div>
           ) : (
             <p className={`${typography.panelBody} text-text-body tabular-nums`}>
-              Between {formatNormalisedRangeEnd(priorDisplay.rangeMin)} and {formatNormalisedRangeEnd(priorDisplay.rangeMax)} on 0–1 scale
+              Between {formatNormalisedRangeEnd(priorDisplay.rangeMin)} and {formatNormalisedRangeEnd(priorDisplay.rangeMax)}{scaleSuffix(priorDisplay)}
             </p>
           )}
         </div>

--- a/src/canvas/ui/NodeInspector.tsx
+++ b/src/canvas/ui/NodeInspector.tsx
@@ -88,7 +88,18 @@ function describePrior(prior: unknown): PriorDisplay | null {
         rangeMin: range_min,
         rangeMax: range_max,
         // Both endpoints must sit inside [0,1] to earn the scale claim.
-        normalised: range_min >= 0 && range_max <= 1,
+        // 2.495: this was `range_min >= 0 && range_max <= 1` — a ONE-SIDED
+        // bound wearing a membership test's comment. It bounded min from
+        // below and max from above and checked neither of the other two
+        // limbs, so {30, 1} rendered "30 to 1 on 0–1 scale" and {0.5, -2}
+        // rendered "0.5 to -2 on 0–1 scale". Reachable with no CEE at all:
+        // FactorExternalPanel.handleMinBlur writes
+        // `setPriorRange(parsed, rangeMax ?? parsed)` unclamped, so a user
+        // whose max is 1 typing 30 into min produces the first row verbatim.
+        // Four limbs, because each endpoint needs both bounds.
+        normalised:
+          range_min >= 0 && range_min <= 1 &&
+          range_max >= 0 && range_max <= 1,
       }
     }
   }

--- a/src/canvas/ui/NodeInspector.tsx
+++ b/src/canvas/ui/NodeInspector.tsx
@@ -35,6 +35,45 @@ interface ObservedState {
   source?: string
 }
 
+/** Normalised (0–1) range end for unitless display: ≤2 dp, trailing zeros
+ *  trimmed. Mirrors FactorNode's module-private formatter of the same name. */
+function formatNormalisedRangeEnd(v: number): string {
+  return Number.isInteger(v) ? String(v) : v.toFixed(2).replace(/\.?0+$/, '')
+}
+
+/**
+ * 2.468(a): honest prior display. `data.prior` is a union (PriorSchema,
+ * domain/nodes.ts): a number 0–1 OR a CEE distribution object
+ * `{distribution, range_min, range_max}` — the object form is live (written
+ * by useInspectorMutations.setPriorRange; present in drafted graphs).
+ * - number → percent, unchanged.
+ * - object with a finite range → the normalised range in plain words. NEVER
+ *   percent-coerced: the endpoints are normalised values, not probabilities
+ *   (same refusal as FactorNode's range formatter).
+ * - anything else → null → the prior rows do not render.
+ * Arithmetic on the object form is what produced the literal "NaN%" this
+ * replaces. Finiteness checks, not truthiness: range_min 0 must render.
+ */
+type PriorDisplay =
+  | { kind: 'percent'; fraction: number; text: string }
+  | { kind: 'range'; rangeMin: number; rangeMax: number }
+
+function describePrior(prior: unknown): PriorDisplay | null {
+  if (typeof prior === 'number' && Number.isFinite(prior)) {
+    return { kind: 'percent', fraction: prior, text: `${(prior * 100).toFixed(0)}%` }
+  }
+  if (prior !== null && typeof prior === 'object') {
+    const { range_min, range_max } = prior as { range_min?: unknown; range_max?: unknown }
+    if (
+      typeof range_min === 'number' && Number.isFinite(range_min) &&
+      typeof range_max === 'number' && Number.isFinite(range_max)
+    ) {
+      return { kind: 'range', rangeMin: range_min, rangeMax: range_max }
+    }
+  }
+  return null
+}
+
 interface NodeInspectorProps {
   nodeId: string
   onClose: () => void
@@ -148,6 +187,9 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
   const currentType = (node.type || 'decision') as NodeType
   const metadata = NODE_REGISTRY[currentType] || NODE_REGISTRY.decision
   const isGoalNode = currentType === 'goal'
+
+  // 2.468(a): union-aware prior display. Null = nothing honest to say → no row.
+  const priorDisplay = describePrior(node.data?.prior)
 
 
   // S.4: State for programmatic section opening from Edit button
@@ -369,12 +411,15 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
         </div>
       )}
 
-      {/* KPI row: Prior */}
-      {node.data?.prior !== undefined && (
+      {/* KPI row: Prior — 2.468(a): percent for numeric priors, the normalised
+          range in plain words for distribution priors, no row otherwise. */}
+      {priorDisplay && (
         <div className="flex items-center justify-between mt-2 px-2 py-1 bg-panel rounded border border-panel-border">
           <span className={`${typography.panelMeta} text-text-light`}>Prior</span>
           <span className={`${typography.panelBody} text-text-body tabular-nums`}>
-            {(node.data.prior * 100).toFixed(0)}%
+            {priorDisplay.kind === 'percent'
+              ? priorDisplay.text
+              : `${formatNormalisedRangeEnd(priorDisplay.rangeMin)} to ${formatNormalisedRangeEnd(priorDisplay.rangeMax)} on 0–1 scale`}
           </span>
         </div>
       )}
@@ -561,28 +606,36 @@ export const NodeInspector = memo(({ nodeId, onClose }: NodeInspectorProps) => {
         />
       </div>
 
-      {/* Prior bar */}
-      {node.data?.prior !== undefined && (
+      {/* Prior bar — 2.468(a): the percent bar is only honest for a numeric
+          prior. A distribution prior renders its range in plain words instead
+          (a probability bar for a value range would fake precision). */}
+      {priorDisplay && (
         <div>
           <label className={`block ${typography.panelMeta} text-text-body mb-1`}>
             Prior <span className="text-text-light">(belief before evidence)</span>
           </label>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 h-2 bg-panel-border rounded-full overflow-hidden">
-              <div
-                className="h-full bg-info rounded-full transition-all"
-                style={{ width: `${node.data.prior * 100}%` }}
-                role="progressbar"
-                aria-valuenow={node.data.prior}
-                aria-valuemin={0}
-                aria-valuemax={1}
-                aria-valuetext={`${(node.data.prior * 100).toFixed(0)}%`}
-              />
+          {priorDisplay.kind === 'percent' ? (
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-2 bg-panel-border rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-info rounded-full transition-all"
+                  style={{ width: `${priorDisplay.fraction * 100}%` }}
+                  role="progressbar"
+                  aria-valuenow={priorDisplay.fraction}
+                  aria-valuemin={0}
+                  aria-valuemax={1}
+                  aria-valuetext={priorDisplay.text}
+                />
+              </div>
+              <span className={`${typography.panelMeta} text-text-body tabular-nums w-10 text-right`}>
+                {priorDisplay.text}
+              </span>
             </div>
-            <span className={`${typography.panelMeta} text-text-body tabular-nums w-10 text-right`}>
-              {(node.data.prior * 100).toFixed(0)}%
-            </span>
-          </div>
+          ) : (
+            <p className={`${typography.panelBody} text-text-body tabular-nums`}>
+              Between {formatNormalisedRangeEnd(priorDisplay.rangeMin)} and {formatNormalisedRangeEnd(priorDisplay.rangeMax)} on 0–1 scale
+            </p>
+          )}
         </div>
       )}
 

--- a/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
+++ b/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
@@ -36,6 +36,30 @@ const FAC_CAPACITY = {
   },
 }
 
+/**
+ * fac_price, from the REAL CEE payload
+ * `PHASE0-EVIDENCE-2026-07-28/replay-payload-747.json` → `graph.nodes[2]`:
+ *   { "id": "fac_price", "kind": "factor", "label": "Price",
+ *     "category": "controllable",
+ *     "prior": {"distribution":"uniform","range_min":10,"range_max":30} }
+ * The `prior` object and the id/label/kind/category are byte-copies; the
+ * envelope is re-shaped from the CEE wire form (top-level `prior`) to the
+ * canvas store form (`data.prior`), which is what mapDraftNodeToCanvas does.
+ * Endpoints 10–30 are OUTSIDE [0,1] — the witnessed counter-example to any
+ * hardcoded scale claim (#589 review F1).
+ */
+const FAC_PRICE = {
+  id: 'fac_price',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  data: {
+    category: 'controllable',
+    prior: { distribution: 'uniform', range_min: 10, range_max: 30 },
+    label: 'Price',
+    kind: 'factor',
+  },
+}
+
 /** Byte-copy of the fac_weather node from t2b-export-pristine.json. */
 const FAC_WEATHER = {
   id: 'fac_weather',
@@ -113,6 +137,56 @@ describe('NodeInspector — distribution-form priors render honestly (2.468a)', 
     const bar = screen.getByRole('progressbar')
     expect(bar.getAttribute('aria-valuenow')).toBe('0.72')
     expect(bar.getAttribute('aria-valuetext')).toBe('72%')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('WITNESSED OUT-OF-SCALE payload fac_price ("Price", uniform 10–30): renders the bare range and makes NO scale claim (F1)', () => {
+    setStore([FAC_PRICE])
+    const { container } = render(<NodeInspector nodeId="fac_price" onClose={() => {}} />)
+
+    // Identity: this render is THE fac_price node from replay-payload-747.json.
+    expect(screen.getByText('Price')).toBeDefined()
+
+    // Bare range in both rows — the numbers are the stored bounds, honestly.
+    expect(screen.getByText('10 to 30')).toBeDefined()
+    expect(screen.getByText('Between 10 and 30')).toBeDefined()
+
+    // The claim the endpoints have NOT earned must appear NOWHERE on the surface.
+    expect(container.textContent).not.toContain('0–1 scale')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('a single out-of-scale endpoint is enough to withhold the suffix (range_min -0.5, range_max 0.5)', () => {
+    setStore([
+      {
+        id: 'fac_delta',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Margin Delta', kind: 'factor', prior: { distribution: 'uniform', range_min: -0.5, range_max: 0.5 } },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_delta" onClose={() => {}} />)
+
+    expect(screen.getByText('Margin Delta')).toBeDefined()
+    expect(screen.getByText('-0.5 to 0.5')).toBeDefined()
+    expect(container.textContent).not.toContain('0–1 scale')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('partial range (one bound only): both prior rows are suppressed — pinned as current behaviour, policy rowed (F6)', () => {
+    setStore([
+      {
+        id: 'fac_partial',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Supplier Lead Time', kind: 'factor', prior: { distribution: 'uniform', range_min: 0.3 } },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_partial" onClose={() => {}} />)
+
+    expect(screen.getByText('Supplier Lead Time')).toBeDefined()
+    expect(screen.queryByText('Prior')).toBeNull()
+    expect(screen.queryByText(/belief before evidence/)).toBeNull()
     expect(container.textContent).not.toContain('NaN')
   })
 

--- a/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
+++ b/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
@@ -173,6 +173,90 @@ describe('NodeInspector — distribution-form priors render honestly (2.468a)', 
     expect(container.textContent).not.toContain('NaN')
   })
 
+  /**
+   * 2.495 — the scale predicate is a MEMBERSHIP test, not a one-sided bound.
+   *
+   * The shipped predicate was `range_min >= 0 && range_max <= 1`: it bounded
+   * range_min from BELOW and range_max from ABOVE and checked neither of the
+   * other two limbs. Measured at 91a541a3, before the fix, on this component:
+   *   {range_min: 30,  range_max: 1}   → "30 to 1 on 0–1 scale"
+   *   {range_min: 2,   range_max: 0.5} → "2 to 0.5 on 0–1 scale"
+   *   {range_min: 0.5, range_max: -2}  → "0.5 to -2 on 0–1 scale"
+   * Neither F1 case above catches this: fac_price (10–30) fails `max <= 1`
+   * and fac_delta (-0.5–0.5) fails `min >= 0`, so BOTH are caught by the
+   * one-sided form and the broken branch was never exercised — a guard
+   * agreeing with itself (estate trap 13b).
+   *
+   * ⚠ WHY TWO CASES AND NOT ONE. The predicate was short by two independent
+   * limbs, and a case pinning one of them is silent about the other: a
+   * "fix" adding only `range_min <= 1` renders "30 to 1" honestly while
+   * still emitting "0.5 to -2 on 0–1 scale", and vice versa. One case here
+   * would PASS while the property FAILS. Each case below pins exactly one
+   * missing limb; both are required and neither is redundant (proven by a
+   * discriminating mutant pair — see the 2.495 mutant kit).
+   *
+   * Each case also asserts the bare range is PRESENT, not merely that the
+   * suffix is absent: an absence assertion over an unrendered row passes by
+   * testing nothing (trap 13).
+   *
+   * Reachability, no CEE involved: FactorExternalPanel.handleMinBlur writes
+   * `setPriorRange(parsed, rangeMax ?? parsed)` — unclamped — so a user
+   * whose max is 1 typing 30 into min produces the first row verbatim.
+   */
+  it('2.495 range_min ABOVE 1 (min 30, max 1): the min-upper-bound limb — bare range, NO scale claim', () => {
+    setStore([
+      {
+        id: 'fac_min_above_one',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: {
+          label: 'Ticket Price Multiplier',
+          kind: 'factor',
+          prior: { distribution: 'uniform', range_min: 30, range_max: 1 },
+        },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_min_above_one" onClose={() => {}} />)
+
+    // Identity: this render is THE fac_min_above_one node, by exact label.
+    expect(screen.getByText('Ticket Price Multiplier')).toBeDefined()
+
+    // Both prior rows render the stored bounds and make no scale claim.
+    // Exact strings: under the one-sided predicate these read
+    // "30 to 1 on 0–1 scale" / "Between 30 and 1 on 0–1 scale" and both
+    // exact-match lookups fail.
+    expect(screen.getByText('30 to 1')).toBeDefined()
+    expect(screen.getByText('Between 30 and 1')).toBeDefined()
+
+    expect(container.textContent).not.toContain('0–1 scale')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('2.495 range_max BELOW 0 (min 0.5, max -2): the max-lower-bound limb — bare range, NO scale claim', () => {
+    setStore([
+      {
+        id: 'fac_max_below_zero',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: {
+          label: 'Cost Variance Floor',
+          kind: 'factor',
+          prior: { distribution: 'uniform', range_min: 0.5, range_max: -2 },
+        },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_max_below_zero" onClose={() => {}} />)
+
+    // Identity: this render is THE fac_max_below_zero node, by exact label.
+    expect(screen.getByText('Cost Variance Floor')).toBeDefined()
+
+    expect(screen.getByText('0.5 to -2')).toBeDefined()
+    expect(screen.getByText('Between 0.5 and -2')).toBeDefined()
+
+    expect(container.textContent).not.toContain('0–1 scale')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
   it('partial range (one bound only): both prior rows are suppressed — pinned as current behaviour, policy rowed (F6)', () => {
     setStore([
       {

--- a/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
+++ b/src/canvas/ui/__tests__/NodeInspector.priorDistribution.spec.tsx
@@ -1,0 +1,138 @@
+/**
+ * NodeInspector — 2.468(a): honest rendering of distribution-form priors.
+ *
+ * `data.prior` is a union (PriorSchema, nodes.ts): a number 0–1 OR a CEE
+ * distribution object `{distribution, range_min, range_max}`. The object form
+ * is LIVE: useInspectorMutations.setPriorRange writes it, and drafted graphs
+ * carry it — the fac_capacity / fac_weather nodes below are byte-copies from
+ * the walk-582 export fixture
+ * (PHASE0-EVIDENCE-2026-07-28/walk-582-raw/t2b-export-pristine.json).
+ *
+ * Numeric formatting of the object form (`prior * 100`) renders the literal
+ * "NaN%" on screen. These specs make "NaN" impossible on this surface:
+ * a distribution prior with a finite range renders as its normalised range in
+ * plain words (never percent-coerced — the endpoints are normalised values,
+ * not probabilities); a distribution prior without a finite range renders
+ * nothing; and the numeric-prior positive control proves the surface still
+ * renders percent (so the "no NaN" sweeps are looking at a live surface).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { NodeInspector } from '../NodeInspector'
+import { useCanvasStore } from '../../store'
+
+/** Byte-copy of the fac_capacity node from t2b-export-pristine.json. */
+const FAC_CAPACITY = {
+  id: 'fac_capacity',
+  type: 'factor',
+  position: { x: 24, y: 321 },
+  data: {
+    category: 'external',
+    prior: { distribution: 'uniform', range_min: 0.3, range_max: 1 },
+    display_value: '0.3 to 1',
+    provenance: 'ai_inferred',
+    label: 'Venue Capacity',
+    kind: 'factor',
+  },
+}
+
+/** Byte-copy of the fac_weather node from t2b-export-pristine.json. */
+const FAC_WEATHER = {
+  id: 'fac_weather',
+  type: 'factor',
+  position: { x: 1480, y: 321 },
+  data: {
+    category: 'external',
+    prior: { distribution: 'uniform', range_min: 0, range_max: 1 },
+    provenance: 'ai_inferred',
+    label: 'Weather Conditions on Event Day',
+    kind: 'factor',
+  },
+}
+
+function setStore(nodes: unknown[]) {
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [],
+    goalThreshold: null,
+    confirmedNodeIds: new Set(),
+    results: { status: 'idle', report: null } as never,
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('NodeInspector — distribution-form priors render honestly (2.468a)', () => {
+  it('fixture node fac_capacity ("Venue Capacity", uniform 0.3–1): renders the range in plain words, never "NaN"', () => {
+    setStore([FAC_CAPACITY])
+    const { container } = render(<NodeInspector nodeId="fac_capacity" onClose={() => {}} />)
+
+    // Identity: this render is THE fixture node.
+    expect(screen.getByText('Venue Capacity')).toBeDefined()
+
+    // Summary KPI row: normalised range in the inspector's voice.
+    expect(screen.getByText('0.3 to 1 on 0–1 scale')).toBeDefined()
+    // Assumptions section: plain words, same numbers.
+    expect(screen.getByText('Between 0.3 and 1 on 0–1 scale')).toBeDefined()
+
+    // A distribution prior is not a probability: no percent progressbar.
+    expect(screen.queryByRole('progressbar')).toBeNull()
+
+    // "NaN" is impossible anywhere in the rendered inspector.
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('fixture node fac_weather (uniform 0–1): range_min 0 renders honestly, not suppressed', () => {
+    setStore([FAC_WEATHER])
+    const { container } = render(<NodeInspector nodeId="fac_weather" onClose={() => {}} />)
+
+    expect(screen.getByText('Weather Conditions on Event Day')).toBeDefined()
+    expect(screen.getByText('0 to 1 on 0–1 scale')).toBeDefined()
+    expect(screen.getByText('Between 0 and 1 on 0–1 scale')).toBeDefined()
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('POSITIVE CONTROL — numeric prior still renders percent in both rows (proves the surface renders values the NaN sweep could see)', () => {
+    setStore([
+      {
+        id: 'fac_num',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Adoption Rate', kind: 'factor', prior: 0.72 },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_num" onClose={() => {}} />)
+
+    expect(screen.getByText('Adoption Rate')).toBeDefined()
+    // Summary KPI row + Assumptions bar readout: exactly the two percent renders.
+    expect(screen.getAllByText('72%')).toHaveLength(2)
+    // The Assumptions progressbar keeps its numeric semantics.
+    const bar = screen.getByRole('progressbar')
+    expect(bar.getAttribute('aria-valuenow')).toBe('0.72')
+    expect(bar.getAttribute('aria-valuetext')).toBe('72%')
+    expect(container.textContent).not.toContain('NaN')
+  })
+
+  it('distribution object WITHOUT a finite range: both prior rows are suppressed, never "NaN"', () => {
+    setStore([
+      {
+        id: 'fac_rangeless',
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Regulatory Climate', kind: 'factor', prior: { distribution: 'uniform' } },
+      },
+    ])
+    const { container } = render(<NodeInspector nodeId="fac_rangeless" onClose={() => {}} />)
+
+    expect(screen.getByText('Regulatory Climate')).toBeDefined()
+    // Summary KPI row absent (its label span renders the exact text "Prior").
+    expect(screen.queryByText('Prior')).toBeNull()
+    // Assumptions row absent (its label carries "belief before evidence").
+    expect(screen.queryByText(/belief before evidence/)).toBeNull()
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(container.textContent).not.toContain('NaN')
+  })
+})

--- a/src/stores/__tests__/uiStore.test.ts
+++ b/src/stores/__tests__/uiStore.test.ts
@@ -10,7 +10,6 @@ describe('uiStore', () => {
     // Reset store to default state
     useUIStore.setState({
       activeOutputTab: 'results',
-      hoveredElementId: null,
       activeRightPanel: null,
     })
   })
@@ -29,16 +28,6 @@ describe('uiStore', () => {
       useUIStore.getState().setActiveOutputTab(tab)
       expect(useUIStore.getState().activeOutputTab).toBe(tab)
     }
-  })
-
-  it('setHoveredElementId sets and clears', () => {
-    expect(useUIStore.getState().hoveredElementId).toBeNull()
-
-    useUIStore.getState().setHoveredElementId('node-123')
-    expect(useUIStore.getState().hoveredElementId).toBe('node-123')
-
-    useUIStore.getState().setHoveredElementId(null)
-    expect(useUIStore.getState().hoveredElementId).toBeNull()
   })
 })
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -4,8 +4,6 @@
  * E1: Enables programmatic tab switching from results components
  * (tornado chart, driver rows) to the Model tab.
  *
- * D2: Hover highlight state for bidirectional canvas-panel linking.
- *
  * Task C: Right-panel orchestration — only one right-side panel is visible
  * at a time. Opening a panel auto-closes any other open panel.
  */
@@ -31,8 +29,6 @@ export interface UIStoreState {
    *  tab value didn't change (e.g. global already 'results' but dock had
    *  another tab persisted in localStorage). */
   activeOutputTabVersion: number
-  /** D2: Element ID currently hovered in a panel (for canvas highlight) */
-  hoveredElementId: string | null
   /** Task C: Which right-side panel is currently open (mutual exclusion) */
   activeRightPanel: RightPanelMode
   /**
@@ -50,7 +46,6 @@ export interface UIStoreActions {
    *  auto-dock and Dock-back when we cannot rely on a value-diff to trigger
    *  the sync. */
   forceActivateOutputTab: (tab: OutputTab) => void
-  setHoveredElementId: (id: string | null) => void
   /** Open a right panel (closes any other). Pass null to close all. */
   openRightPanel: (mode: RightPanelMode) => void
   /** Close the active right panel */
@@ -62,14 +57,12 @@ export interface UIStoreActions {
 export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
   activeOutputTab: 'results',
   activeOutputTabVersion: 0,
-  hoveredElementId: null,
   activeRightPanel: null,
   pendingModelTabSection: null,
 
   setActiveOutputTab: (tab) => set({ activeOutputTab: tab }),
   forceActivateOutputTab: (tab) =>
     set((s) => ({ activeOutputTab: tab, activeOutputTabVersion: s.activeOutputTabVersion + 1 })),
-  setHoveredElementId: (id) => set({ hoveredElementId: id }),
   openRightPanel: (mode) => set({ activeRightPanel: mode }),
   closeRightPanel: () => set({ activeRightPanel: null }),
   requestModelTabSection: (sectionId) => set({ pendingModelTabSection: sectionId }),
@@ -77,5 +70,4 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
 
 // Selectors
 export const selectActiveOutputTab = (s: UIStoreState) => s.activeOutputTab
-export const selectHoveredElementId = (s: UIStoreState) => s.hoveredElementId
 export const selectActiveRightPanel = (s: UIStoreState) => s.activeRightPanel

--- a/src/v5/__tests__/applyV5State.uiDirective.test.ts
+++ b/src/v5/__tests__/applyV5State.uiDirective.test.ts
@@ -402,7 +402,6 @@ describe('applyV5State — ui_directive panel verbs (0.32.0, P3)', () => {
     useUIStore.setState({
       activeOutputTab: 'results',
       activeOutputTabVersion: 0,
-      hoveredElementId: null,
       activeRightPanel: null,
       pendingModelTabSection: null,
     })


### PR DESCRIPTION
Build lane, 2026-08-04. **Rebased onto current `staging` `a2c17dcf`** (zero conflicts). Head **`91a541a3`**. Three commits. Pillar: P5/DEPTH honesty + hygiene. Orchestrator merges; this lane does not.

**Round 2 — responds to the adversarial review (`PHASE0-EVIDENCE-2026-07-28/adv-review-ui-589.md`, verdict FIX-FIRST).** The blocker is fixed, the false claim is corrected below, and four findings are rowed.

## Commit 1 — `2a6d6acd` Fix 2.468(a): distribution-form priors no longer render "NaN%"

`data.prior` is a union (PriorSchema): number 0–1 OR a CEE distribution object `{distribution, range_min, range_max}`. The object form is LIVE (written by `useInspectorMutations.setPriorRange`; present in drafted graphs). NodeInspector's two prior render sites (`(prior * 100).toFixed(0)`) rendered the literal **"NaN%"** plus a NaN-width progressbar.

`describePrior()` resolves the union once: number → percent (unchanged, pinned by a positive control); object with a finite range → the range in plain words; anything else (rangeless `{distribution}`, partial range) → no prior row. No coercion to number on any branch. `Number.isFinite`, not truthiness, so `range_min: 0` renders.

**RED-first at pristine:** 3 failed | 1 passed, "NaN" visible in the failing DOM. **Mutants** (throwaway worktree outside repo root, applied-check scoped to `src/`, control exactly 0): M1 revert → 3 failed|1 passed; M2 forced numeric coercion → 2 failed|2 passed; M3 bare `NaN` injected → **4/4 failed, each precisely on its `not.toContain('NaN')` line** (absence sweep non-vacuous, trap 13).

**Typecheck ratchet banked:** 9 diagnostics fixed in NodeInspector.tsx (TS2362 ×4, TS18047 ×4, TS2322 ×1), 2500 → 2491; every regenerated baseline row is that one file.

## Commit 2 — `f652ec87` Chore 2.457(a): delete the dead `setHoveredElementId` uiStore surface

Zero production readers/callers. Deleted state, action declaration, initial value, setter, `selectHoveredElementId` (zero importers) and the self-certifying test block. Cross-highlight lives on `HighlightContext.tsx` LOCAL `useState` (same setter *name* only) — untouched.

**Absence proof, scope stated:** `git grep -a -n` over **all tracked files** — `selectHoveredElementId` zero occurrences repo-wide; `setHoveredElementId` only HighlightContext's local state. **Independently re-derived and confirmed by the review.**

**⚠ Ownership disclosure:** forces one mechanical line removal in `src/v5/__tests__/applyV5State.uiDirective.test.ts:405` (excess-property error in a `setState` reset literal) — outside declared ownership, unavoidable.

## Commit 3 — `91a541a3` Fix F1 (BLOCKER): the "on 0–1 scale" suffix is earned, never assumed

**The review was right and this is the important commit.** Commit 1 traded a visible `NaN%` for a **confident falsehood**: both range sites appended "on 0–1 scale" **unconditionally**, while nothing bounds the object branch — `PriorDistributionSchema` applies `.min(0).max(1)` to the **numeric** branch only; the object branch is a `.passthrough()`.

Out-of-scale endpoints are **witnessed**, two independent ways:
- a real CEE payload in our own corpus — `replay-payload-747.json` `graph.nodes[2]` = `fac_price {distribution:'uniform', range_min:10, range_max:30}` → rendered **"10 to 30 on 0–1 scale"**, a £10–£30 price band presented as a normalised quantity;
- **no CEE required** — `FactorExternalPanel`'s blur handlers write any `parseFloat`-able value through `setPriorRange` **unclamped** (#590's emitter fail-closes on the *wire* event; the local write precedes it and is unguarded).

A user distrusts `NaN` and **believes** a sentence, so the replacement was the worse of the two on the surface this row exists to make trustworthy. **The decisive argument, now reflected in the code:** the sibling formatter this code claimed to mirror, `FactorNode.tsx:365`, emits `Range: a to b` with **no scale claim** precisely because it cannot know the scale without the unit/cap path `describePrior` lacks — **the formatter was imported, its restraint was not.**

**Fix:** `PriorDisplay` carries `normalised = range_min >= 0 && range_max <= 1`; `scaleSuffix()` emits the claim only when earned, else the bare range renders.

**RED-first against the blocker state:** exactly the 2 new F1 cases fail; other 5 pass. Post-fix **7/7 green**. Both bind by IDENTITY (nodeId + exact label + exact rendered string) and assert `"0–1 scale"` appears **nowhere**.

**F1 mutants** (worktree outside repo root, committed state, CONTROL applied-check exactly 0, restored to 0 after each):

| mutant | result |
|---|---|
| **M4** re-hardcode the suffix (restore the blocker) | **2 failed \| 5 passed** — both F1 cases RED |
| **M5** always omit the suffix (opposite direction) | **2 failed \| 5 passed** — both in-range fixture cases RED |
| **M6** boundary `>=`/`<=` → `>`/`<` | **2 failed \| 5 passed** — `fac_weather` (range_min 0) + `fac_capacity` (range_max 1) RED |

Pinned from **both** directions and at the boundary — M4 alone would pass if the suffix never rendered, M5 alone if it always did (trap 13b).

## ⚠ CORRECTION — my "ONLY numeric assumer" claim was FALSE (review F2)

`src/pages/sandbox-guide/components/panel/states/InspectorState.tsx:100-104` does `{Math.round(prior * 100)}%` under a bare `prior !== undefined` guard — **byte-for-byte the same defect**. My manifest filed it under "object-shape guarded (safe both forms)". **It is not guarded at all, and the word "ONLY" is withdrawn** from the PR body and the evidence file. Root cause, stated plainly: I classified it from its destructure line (`:53`) and never read its render site (`:104`), then used the one word that required the complete read.

Not blocking because the surface is **dead** (zero importers outside its own directory; `CopilotLayout`/`GuideLayout` imported nowhere; not routed in `AppPoC.tsx`) — **rowed for retire-or-fix**, not fixed here.

## Rowed, not fixed here (with reasons)

- **F3** — `formatNormalisedRangeEnd` collapses sub-0.005 endpoints to `0` (`0.001–0.004` → "0 to 0"). **Deliberately not fixed in this PR:** it is a byte-identical inherited copy of `FactorNode.tsx:71`, so fixing only my copy would make the two **diverge** — deepening the very trap-12 mirror F4 names. Belongs with the extraction, both copies at once. Unwitnessed (zero sub-0.005 endpoints across 1,478 evidence JSONs).
- **F4** — extract the duplicated `formatNormalisedRangeEnd` to a shared module **with a derived agreement test** (trap 12). Touches `canvas/nodes`, outside this lane's file ownership.
- **F5** — the distribution *shape* is dropped (`normal` renders identically to `uniform`), and CEE's authored `display_value` is a second source of truth for the same string. Policy call.
- **F6** — partial one-bound ranges are silently suppressed. **Now covered by a pinning spec case** so it cannot change unobserved; the *policy* question is rowed, not silently settled.

## Gates on the final head `91a541a3` (env = CI's own structural strings, quoted, pipefail)

- **`pnpm typecheck`**: **PASSED** — 620 files / 2491 errors vs baseline **2491**; the F1 fix adds zero diagnostics.
- **Affected vitest scope, pristine-controlled at the current base:** pristine `a2c17dcf` **544 green** → head **550 green**. Delta **+6 = (+7 new tests) − (1 deleted test)**. Zero-collect never hit.
- **Fast pre-push gate:** checks **1–7 GREEN**; check 8 (DS v5 drift) RED with the two full `--enforce` outputs **`diff`-EMPTY vs pristine** — standing broken alarm, zero violations in any file this PR touches, **not baselined**.
- ⚠ **Post-rebase instrument trap, disclosed:** the first typecheck after rebasing failed (+7 errors in `buildPayload.ts`, untouched by me) purely because `node_modules` predated #590's **vendored schemas tarball** bump. Reinstall → PASSED. A post-rebase gate result is worthless until the install matches the tree.

## ⚠ MERGE ORDER

Shares the **generated** `scripts/ci/typecheck-baseline-identities.txt` with **#592** — whichever lands second must **re-run `pnpm typecheck` and regenerate**, not trust the text merge. Dormant **#116** also touches `uiStore.ts`/`uiStore.test.ts` and would conflict with the 2.457(a) deletion if revived.

Evidence: `PHASE0-EVIDENCE-2026-07-28/lane-ui-batch-2026-08-04.md`. Review: `adv-review-ui-589.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)