### PR TITLE
DO-NOT-MERGE — Fix 2.472: honest failure copy — server faults are not the user's wording

### DIFF
--- a/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.v5ErrorRecovery.spec.ts
@@ -269,6 +269,37 @@ describe('V5 live-chain error recovery — non-2xx BoundaryError through the rea
     expect(last.content).not.toMatch(/please retry|try again/i)
   })
 
+  it('2.472: the witnessed server-fault ingress violation (scenario_preflight / ownership unverifiable) renders server-fault guidance through the LIVE chain — never "rephrase"', async () => {
+    // Byte-for-byte the BoundaryError CEE served during the 4 Aug outage
+    // (PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-raw/run2-rewalk-wire.json).
+    // Pre-2.472 this told the user to rephrase a message that was fine.
+    stubFetchWith(422, {
+      error: 'INGRESS_CONTRACT_VIOLATION',
+      boundary: 'B1',
+      direction: 'ingress',
+      validator: 'scenario_preflight',
+      details: {
+        reason: 'scenario_ownership_unverifiable',
+        scenario_id: 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce',
+      },
+      request_id: 'd3daf877-2adb-4dde-babf-daa7d7a30d0b',
+      retryable: false,
+    })
+
+    const { last } = await sendAndGetLastMessage()
+
+    // The honest server-fault guidance, verbatim.
+    expect(last.content).toContain(
+      "Something on our side isn't working — your message was fine. Please try again in a moment.",
+    )
+    // The wording-blame untruth is gone.
+    expect(last.content).not.toMatch(/rephrase/i)
+    // The machine reason never leaks.
+    expect(last.content).not.toContain('scenario_ownership_unverifiable')
+    // Server said non-retryable — no retry chip.
+    expect(last.actionChips ?? []).toHaveLength(0)
+  })
+
   it('no envelope at all (200 with a severity-error block) → client table resolves retryability safely', async () => {
     stubFetchWith(200, {
       response_version: 2,

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -4967,7 +4967,12 @@ export function useConversation(): UseConversationReturn {
               const reasonLayer =
                 recovery.suggestion === undefined && isDisplaySafeReason(reason) ? reason : ''
               const guidance =
-                recovery.suggestion === undefined ? resolveV5ErrorGuidance(target.code) : ''
+                recovery.suggestion === undefined
+                  ? // 2.472: taxonomy-aware — a server-state ingress violation
+                    // (e.g. scenario_preflight/ownership) gets server-fault
+                    // guidance, never "rephrase your message".
+                    resolveV5ErrorGuidance(target.code, target.boundaryError)
+                  : ''
               content = [
                 baseCopy,
                 recovery.suggestion ?? '',

--- a/src/v5/TypedErrorRenderer.tsx
+++ b/src/v5/TypedErrorRenderer.tsx
@@ -62,7 +62,9 @@ export function TypedErrorRenderer(props: TypedErrorRendererProps): ReactElement
   // staleness — same resolution as useConversation's typed_error branch.
   const fenceCopy = code === 'GRAPH_DIVERGED' ? resolveFenceRefusalCopy(boundaryError) : null
   const text = fenceCopy ?? resolveUserText(code)
-  const guidance = resolveGuidance(code)
+  // 2.472: taxonomy-aware — an ingress violation whose validator/reason names
+  // server state gets server-fault guidance, never "rephrase your message".
+  const guidance = resolveGuidance(code, boundaryError)
   const reason = extractReason(boundaryError)
 
   return (

--- a/src/v5/__tests__/TypedErrorRenderer.test.tsx
+++ b/src/v5/__tests__/TypedErrorRenderer.test.tsx
@@ -188,3 +188,57 @@ describe('TypedErrorRenderer — fence-class GRAPH_DIVERGED (journey-walk gap #2
     );
   });
 });
+
+describe('TypedErrorRenderer — ingress-violation guidance branches on wire taxonomy (2.472)', () => {
+  it('the witnessed outage shape (scenario_preflight / ownership unverifiable) renders the server-fault copy, not rephrase', () => {
+    render(
+      <TypedErrorRenderer
+        code="INGRESS_CONTRACT_VIOLATION"
+        boundaryError={{
+          error: 'INGRESS_CONTRACT_VIOLATION',
+          boundary: 'B1',
+          direction: 'ingress',
+          validator: 'scenario_preflight',
+          details: {
+            reason: 'scenario_ownership_unverifiable',
+            scenario_id: 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce',
+          },
+          request_id: 'd3daf877-2adb-4dde-babf-daa7d7a30d0b',
+          retryable: false,
+        }}
+      />,
+    );
+    const guidance = screen.getByTestId('typed-error-guidance').textContent ?? '';
+    expect(guidance).toBe(
+      "Something on our side isn't working — your message was fine. Please try again in a moment.",
+    );
+    expect(guidance).not.toMatch(/rephrase/i);
+  });
+
+  it('without a boundaryError the guidance fails safe to the rephrase copy (positive control)', () => {
+    render(<TypedErrorRenderer code="INGRESS_CONTRACT_VIOLATION" />);
+    expect(screen.getByTestId('typed-error-guidance').textContent).toBe(
+      'Please rephrase your message and try again.',
+    );
+  });
+
+  it('an input-shaped violation (OrchestratorTurnPayload) keeps the rephrase copy (positive control)', () => {
+    render(
+      <TypedErrorRenderer
+        code="INGRESS_CONTRACT_VIOLATION"
+        boundaryError={{
+          error: 'INGRESS_CONTRACT_VIOLATION',
+          boundary: 'B1',
+          direction: 'ingress',
+          validator: 'OrchestratorTurnPayload',
+          details: { reason: 'turn_id must be a UUID v4' },
+          request_id: 'req_input_shaped',
+          retryable: false,
+        }}
+      />,
+    );
+    expect(screen.getByTestId('typed-error-guidance').textContent).toBe(
+      'Please rephrase your message and try again.',
+    );
+  });
+});

--- a/src/v5/__tests__/end-to-end.test.ts
+++ b/src/v5/__tests__/end-to-end.test.ts
@@ -270,10 +270,11 @@ describe('V5 typed error — layered content assembly', () => {
     expect(target.kind).toBe('typed_error');
     if (target.kind !== 'typed_error') return;
 
-    // Reproduce the exact join useConversation performs
+    // Reproduce the exact join useConversation performs (2.472: guidance is
+    // taxonomy-aware, so the boundaryError rides along)
     const canonicalText = FAILURE_USER_TEXT[target.code];
     const reason = extractReason(target.boundaryError);
-    const guidance = resolveGuidance(target.code);
+    const guidance = resolveGuidance(target.code, target.boundaryError);
     const content = [canonicalText, reason, guidance].filter((s) => s.length > 0).join('\n\n');
 
     // Canonical layer — never generic
@@ -286,6 +287,50 @@ describe('V5 typed error — layered content assembly', () => {
     expect(content).toContain(canonicalText);
     expect(content).toContain('turn_id must be a UUID v4');
     expect(content).toContain(guidance);
+  });
+
+  it('2.472: the witnessed server-fault ingress violation never blames the user\'s wording', async () => {
+    // Byte-for-byte the BoundaryError CEE served during the 4 Aug outage
+    // (PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-raw/run2-rewalk-wire.json):
+    // the ownership oracle was down — a pure server fault — and the UI told
+    // the user to rephrase. This pins the transport→router→guidance chain on
+    // that exact shape.
+    const boundaryErr: BoundaryError = {
+      error: 'INGRESS_CONTRACT_VIOLATION',
+      boundary: 'B1',
+      direction: 'ingress',
+      validator: 'scenario_preflight',
+      details: {
+        reason: 'scenario_ownership_unverifiable',
+        scenario_id: 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce',
+      },
+      request_id: 'd3daf877-2adb-4dde-babf-daa7d7a30d0b',
+      retryable: false,
+    };
+
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => boundaryErr,
+      text: async () => JSON.stringify(boundaryErr),
+    } as Response);
+
+    const result = await callV5Turn(VALID_PAYLOAD, { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const target = routeV5Response(result);
+
+    expect(target.kind).toBe('typed_error');
+    if (target.kind !== 'typed_error') return;
+
+    // Identity binding: the taxonomy survived the transport intact.
+    expect(target.boundaryError?.validator).toBe('scenario_preflight');
+    expect(extractReason(target.boundaryError)).toBe('scenario_ownership_unverifiable');
+
+    const guidance = resolveGuidance(target.code, target.boundaryError);
+    expect(guidance).toBe(
+      "Something on our side isn't working — your message was fine. Please try again in a moment.",
+    );
+    expect(guidance).not.toMatch(/rephrase/i);
   });
 
   it('error block in response body (non-2xx path absent) produces typed_error with specific code', async () => {

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -181,9 +181,13 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
     )
   })
 
+  // ⚠ PIN CORRECTED (review F1): this list previously asserted ALL THREE
+  // scenario_preflight reasons → server-fault copy. That was wrong for two of
+  // them and the test agreed with the code because I wrote it from my own
+  // classification instead of the producer's semantics (trap 13b — a guard
+  // agreeing with itself). Only the oracle-down reason is a server fault; the
+  // access-denied pair is routed in its own describe block below.
   it.each([
-    ['scenario_preflight', 'scenario_owned_by_other_user'],
-    ['scenario_preflight', 'scenario_requires_authenticated_owner'],
     ['scenario_preflight', 'scenario_ownership_unverifiable'],
     ['turn_commit', 'state_commit_failed_or_turn_runtime_failure'],
     ['turn_commit', 'graph_write_conflict'],
@@ -209,15 +213,33 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
   })
 
   it('a genuine input-shaped violation keeps the rephrase copy (positive control)', () => {
+    // OrchestratorTurnPayload is the B1 Zod validator over the turn body,
+    // which DOES carry the user's `message` — rephrasing can genuinely help,
+    // so this is the least-wrong copy and stays.
     expect(
       resolveGuidance(
         'INGRESS_CONTRACT_VIOLATION',
         ingressErr('OrchestratorTurnPayload', 'turn_id must be a UUID v4'),
       ),
     ).toBe(REPHRASE_COPY)
+  })
+
+  // ⚠ PIN CORRECTED (review F3): V5RequestExtensions used to be asserted here
+  // as a rephrase positive control. It validates ONLY app-constructed state —
+  // `graph_state`, `analysis_state`, `user_id`, `selected_elements`
+  // (request-extensions.ts:8) — and carries NO user text at all, so telling
+  // the user to rephrase their message is categorically false: the UI built
+  // the bad request, not them.
+  it('V5RequestExtensions → server-fault copy: those fields carry no user text', () => {
     expect(
       resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr('V5RequestExtensions')),
-    ).toBe(REPHRASE_COPY)
+    ).toBe(SERVER_FAULT_COPY)
+    expect(
+      resolveGuidance(
+        'INGRESS_CONTRACT_VIOLATION',
+        ingressErr('V5RequestExtensions', 'graph_state.nodes must be an array'),
+      ),
+    ).not.toMatch(/rephrase/i)
   })
 
   it('absent taxonomy FAILS SAFE to the rephrase copy (no error object)', () => {
@@ -252,6 +274,101 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
     expect(
       resolveGuidance('FEATURE_NOT_ENABLED', ingressErr('scenario_preflight')),
     ).toMatch(/not yet available/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.472 — F1 (review blocker): `scenario_preflight` carries a
+// THREE-member reason union and they do NOT share a copy. Branching on the
+// validator alone collapsed them into "our side is broken, try again in a
+// moment", which for the two access-denied reasons is false in BOTH halves
+// AND prescribes an action that can never work — a worse failure than the
+// bug this lane set out to fix.
+//
+// Semantics read at the CEE bytes (`build-turn-context.ts:1183-1234`,
+// `:1326`, `:1339`, staging tip ac62fd4d), which state the branches
+// explicitly:
+//   - caller ABSENT on an owned scenario → IDOR fail-closed →
+//     `scenario_requires_authenticated_owner`  ⇒ SIGN IN
+//   - caller is a DIFFERENT user → cross-tenant attempt →
+//     `scenario_owned_by_other_user`           ⇒ NO ACCESS
+//   - ownership oracle unavailable →
+//     `scenario_ownership_unverifiable`        ⇒ OUR FAULT
+// CEE's admission NAMES the reason precisely so the UI can distinguish them.
+// ---------------------------------------------------------------------------
+describe('resolveGuidance — scenario_preflight reason union routes three ways (2.472 F1)', () => {
+  const SERVER_FAULT_COPY =
+    "Something on our side isn't working — your message was fine. Please try again in a moment."
+  const SIGN_IN_COPY =
+    "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again."
+  const NO_ACCESS_COPY =
+    "This decision belongs to someone else, so you can't make changes to it — nothing you typed was the problem. Ask its owner to share it with you if you need access."
+
+  const preflightErr = (reason: string): BoundaryError => ({
+    error: 'INGRESS_CONTRACT_VIOLATION',
+    boundary: 'B1',
+    direction: 'ingress',
+    validator: 'scenario_preflight',
+    details: { reason, scenario_id: 'a9224aba-5a15-47b7-8b67-e913fa8f2a14' },
+    request_id: 'req_f1',
+    retryable: false,
+  })
+
+  it('scenario_ownership_unverifiable (the WITNESSED shape) → server-fault copy', () => {
+    expect(
+      resolveGuidance('INGRESS_CONTRACT_VIOLATION', preflightErr('scenario_ownership_unverifiable')),
+    ).toBe(SERVER_FAULT_COPY)
+  })
+
+  it('scenario_requires_authenticated_owner → SIGN-IN copy, never server-fault', () => {
+    const g = resolveGuidance(
+      'INGRESS_CONTRACT_VIOLATION',
+      preflightErr('scenario_requires_authenticated_owner'),
+    )
+    expect(g).toBe(SIGN_IN_COPY)
+    expect(g).not.toBe(SERVER_FAULT_COPY)
+    expect(g).not.toMatch(/rephrase/i)
+  })
+
+  it('scenario_owned_by_other_user → NO-ACCESS copy, never server-fault, never sign-in', () => {
+    const g = resolveGuidance(
+      'INGRESS_CONTRACT_VIOLATION',
+      preflightErr('scenario_owned_by_other_user'),
+    )
+    expect(g).toBe(NO_ACCESS_COPY)
+    expect(g).not.toBe(SERVER_FAULT_COPY)
+    expect(g).not.toBe(SIGN_IN_COPY)
+    expect(g).not.toMatch(/rephrase/i)
+  })
+
+  it('the three reasons produce THREE DISTINCT strings (the collapse this fix removes)', () => {
+    const copies = [
+      'scenario_ownership_unverifiable',
+      'scenario_requires_authenticated_owner',
+      'scenario_owned_by_other_user',
+    ].map((r) => resolveGuidance('INGRESS_CONTRACT_VIOLATION', preflightErr(r)))
+    expect(new Set(copies).size).toBe(3)
+  })
+
+  it('neither access-denied copy prescribes a futile wait-and-retry', () => {
+    for (const reason of ['scenario_requires_authenticated_owner', 'scenario_owned_by_other_user']) {
+      const g = resolveGuidance('INGRESS_CONTRACT_VIOLATION', preflightErr(reason))
+      expect(g).not.toMatch(/try again in a moment/i)
+      expect(g).not.toMatch(/isn't working/i)
+    }
+  })
+
+  it('the no-access copy blames nobody and names a real next step', () => {
+    const g = resolveGuidance('INGRESS_CONTRACT_VIOLATION', preflightErr('scenario_owned_by_other_user'))
+    expect(g).toMatch(/nothing you typed was the problem/i)
+    expect(g).toMatch(/share it with you/i)
+    expect(g).not.toMatch(/you (failed|forgot|should have)|your (mistake|error)/i)
+  })
+
+  it('an UNKNOWN future preflight reason falls back to server-fault, never to blame', () => {
+    const g = resolveGuidance('INGRESS_CONTRACT_VIOLATION', preflightErr('scenario_some_future_reason'))
+    expect(g).toBe(SERVER_FAULT_COPY)
+    expect(g).not.toMatch(/rephrase/i)
   })
 })
 

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -103,8 +103,13 @@ describe('resolveGuidance — shared guidance resolver', () => {
     expect(resolveGuidance(code)).toBe('')
   })
 
+  // ⚠ DELIBERATE PIN CHANGE (ROADMAP 2.472): INGRESS_CONTRACT_VIOLATION left
+  // this table on purpose. Its old row pinned "always /rephrase/i" — the exact
+  // untruth 2.472 removes (a server-side key failure told the user to rephrase,
+  // witnessed live 4 Aug). Its guidance is now taxonomy-branched and pinned in
+  // the dedicated describe block below; the rephrase copy survives ONLY as the
+  // input-shaped / fail-safe branch.
   it.each([
-    ['INGRESS_CONTRACT_VIOLATION', /rephrase/i],
     ['EGRESS_CONTRACT_VIOLATION', /validated/i],
     ['FEATURE_NOT_ENABLED', /not yet available/i],
     ['TURN_BUDGET_EXCEEDED', /turn limit/i],
@@ -112,6 +117,146 @@ describe('resolveGuidance — shared guidance resolver', () => {
     const g = resolveGuidance(code)
     expect(g.length).toBeGreaterThan(0)
     expect(g).toMatch(pattern)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.472 — INGRESS_CONTRACT_VIOLATION guidance branches on the wire's
+// own taxonomy (validator / details.reason) instead of blaming the user's
+// wording for every violation.
+//
+// Witnessed defect (4 Aug outage, capture at
+// PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-raw/run2-rewalk-wire.json): CEE
+// refused the turn with validator 'scenario_preflight',
+// details.reason 'scenario_ownership_unverifiable', retryable:false — a
+// server-side ownership-oracle failure — and the UI said "Please rephrase
+// your message and try again."
+//
+// Class → copy contract (validator vocabulary derived at CEE staging tip
+// ac62fd4d — see PR body):
+//   server-state validators (scenario_preflight, turn_commit,
+//   chip_click_dispatch, draft_graph_pipeline, edit_graph_pipeline) or a
+//   details.reason in the producer's scenario_ownership* family → server-fault
+//   copy · user_jwt → sign-in copy · input-shaped validators
+//   (OrchestratorTurnPayload, V5RequestExtensions), unknown validators, and
+//   absent taxonomy → the rephrase copy (fail-safe: never crash, never blank).
+// ---------------------------------------------------------------------------
+describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching (2.472)', () => {
+  const SERVER_FAULT_COPY =
+    "Something on our side isn't working — your message was fine. Please try again in a moment."
+  const SIGN_IN_COPY =
+    'You need to be signed in for this — your message was fine. Please sign in and try again.'
+  const REPHRASE_COPY = 'Please rephrase your message and try again.'
+
+  /** Byte-for-byte the BoundaryError CEE served during the witnessed outage
+   *  (rewalk run2; run1 identical modulo ids). Identity-bound: this object is
+   *  the witnessed wire shape, not a value-predicate stand-in. */
+  const WITNESSED_OUTAGE_ERROR: BoundaryError = {
+    error: 'INGRESS_CONTRACT_VIOLATION',
+    boundary: 'B1',
+    direction: 'ingress',
+    validator: 'scenario_preflight',
+    details: {
+      reason: 'scenario_ownership_unverifiable',
+      scenario_id: 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce',
+    },
+    request_id: 'd3daf877-2adb-4dde-babf-daa7d7a30d0b',
+    retryable: false,
+  }
+
+  const ingressErr = (validator: string, reason?: string): BoundaryError => ({
+    error: 'INGRESS_CONTRACT_VIOLATION',
+    boundary: 'B1',
+    direction: 'ingress',
+    validator,
+    details: reason === undefined ? {} : { reason },
+    request_id: 'req_2472',
+    retryable: false,
+  })
+
+  it('the witnessed outage wire shape gets the server-fault copy, verbatim', () => {
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', WITNESSED_OUTAGE_ERROR)).toBe(
+      SERVER_FAULT_COPY,
+    )
+  })
+
+  it.each([
+    ['scenario_preflight', 'scenario_owned_by_other_user'],
+    ['scenario_preflight', 'scenario_requires_authenticated_owner'],
+    ['scenario_preflight', 'scenario_ownership_unverifiable'],
+    ['turn_commit', 'state_commit_failed_or_turn_runtime_failure'],
+    ['turn_commit', 'graph_write_conflict'],
+    ['chip_click_dispatch', 'chip_click_suggest_options_handler_failed'],
+    ['draft_graph_pipeline', 'draft_graph_commit_failed'],
+    ['edit_graph_pipeline', 'edit_graph_pipeline_threw'],
+  ] as const)(
+    'server-state validator %s (reason %s) → server-fault copy',
+    (validator, reason) => {
+      expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr(validator, reason))).toBe(
+        SERVER_FAULT_COPY,
+      )
+    },
+  )
+
+  it('a scenario_ownership* reason under an unrecognised validator still → server-fault copy', () => {
+    expect(
+      resolveGuidance(
+        'INGRESS_CONTRACT_VIOLATION',
+        ingressErr('some_future_validator', 'scenario_ownership_unverifiable'),
+      ),
+    ).toBe(SERVER_FAULT_COPY)
+  })
+
+  it('user_jwt (sign_in_required) → sign-in copy, never rephrase, never server-fault', () => {
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr('user_jwt', 'sign_in_required'))).toBe(
+      SIGN_IN_COPY,
+    )
+  })
+
+  it('a genuine input-shaped violation keeps the rephrase copy (positive control)', () => {
+    expect(
+      resolveGuidance(
+        'INGRESS_CONTRACT_VIOLATION',
+        ingressErr('OrchestratorTurnPayload', 'turn_id must be a UUID v4'),
+      ),
+    ).toBe(REPHRASE_COPY)
+    expect(
+      resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr('V5RequestExtensions')),
+    ).toBe(REPHRASE_COPY)
+  })
+
+  it('absent taxonomy FAILS SAFE to the rephrase copy (no error object)', () => {
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION')).toBe(REPHRASE_COPY)
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', undefined)).toBe(REPHRASE_COPY)
+  })
+
+  it('unknown validator + unknown reason FAILS SAFE to the rephrase copy', () => {
+    expect(
+      resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr('brand_new_validator', 'novel_reason')),
+    ).toBe(REPHRASE_COPY)
+  })
+
+  it('malformed taxonomy fields never crash and fail safe to rephrase', () => {
+    const malformed = {
+      ...ingressErr('x'),
+      validator: 42,
+      details: { reason: { nested: true } },
+    } as unknown as BoundaryError
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', malformed)).toBe(REPHRASE_COPY)
+    const nullDetails = { ...ingressErr('x'), details: null } as unknown as BoundaryError
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', nullDetails)).toBe(REPHRASE_COPY)
+  })
+
+  it('the error object changes nothing for retryable codes (early return holds)', () => {
+    expect(
+      resolveGuidance('INTERNAL_ERROR', ingressErr('scenario_preflight', 'anything')),
+    ).toBe('')
+  })
+
+  it('other non-retryable codes ignore the taxonomy (INGRESS-only branch)', () => {
+    expect(
+      resolveGuidance('FEATURE_NOT_ENABLED', ingressErr('scenario_preflight')),
+    ).toMatch(/not yet available/i)
   })
 })
 

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -145,7 +145,7 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
   const SERVER_FAULT_COPY =
     "Something on our side isn't working — your message was fine. Please try again in a moment."
   const SIGN_IN_COPY =
-    'You need to be signed in for this — your message was fine. Please sign in and try again.'
+    "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again."
   const REPHRASE_COPY = 'Please rephrase your message and try again.'
 
   /** Byte-for-byte the BoundaryError CEE served during the witnessed outage
@@ -207,12 +207,6 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
     ).toBe(SERVER_FAULT_COPY)
   })
 
-  it('user_jwt (sign_in_required) → sign-in copy, never rephrase, never server-fault', () => {
-    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', ingressErr('user_jwt', 'sign_in_required'))).toBe(
-      SIGN_IN_COPY,
-    )
-  })
-
   it('a genuine input-shaped violation keeps the rephrase copy (positive control)', () => {
     expect(
       resolveGuidance(
@@ -257,6 +251,124 @@ describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching
     expect(
       resolveGuidance('FEATURE_NOT_ENABLED', ingressErr('scenario_preflight')),
     ).toMatch(/not yet available/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ROADMAP 2.472 — auth class (RATIFIED scope extension, 5 Aug).
+//
+// SOURCE OF THE WIRE SHAPE: **CEE source bytes**, not a live capture —
+// `olumi-assistants-service/src/orchestrator/user-identity.ts`
+// `buildSignInRequiredError()` read at staging tip
+// `ac62fd4d3a3a8657b4bcb58e64b0e91a1454f59f`. (Contrast the
+// scenario_preflight class above, which has BOTH source bytes and two
+// independent live captures. This class is byte-derived only; no capture in
+// PHASE0-EVIDENCE contains a user_jwt refusal. Stated so the evidence grade
+// is not overclaimed.)
+//
+// The producer's own comment declares the contract:
+//   "The stable UI mapping key is `details.code === 'sign_in_required'`
+//    (+ `details.recoverable: true`); `details.auth_reason` carries the
+//    refusal cause … `retryable: false` — retrying the same request
+//    unchanged cannot succeed; recovery is signing in."
+// So the gate below keys on `details.code` FIRST (the producer's declared
+// stable key), with `validator === 'user_jwt'` as a secondary signal.
+//
+// auth_reason is the closed union at user-identity.ts:64-68:
+//   missing_token | invalid_token | expired_token | verification_unavailable
+// The first three are genuinely "sign in". The FOURTH is not: if the
+// verifier itself is unavailable, instructing the user to sign in prescribes
+// an action that cannot work — the same defect class 2.472 exists to kill —
+// so it routes to the server-fault copy.
+// ---------------------------------------------------------------------------
+describe('resolveGuidance — auth class: sign-in copy, and the verifier-down carve-out (2.472)', () => {
+  const SERVER_FAULT_COPY =
+    "Something on our side isn't working — your message was fine. Please try again in a moment."
+  const SIGN_IN_COPY =
+    "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again."
+
+  /** Byte-for-byte `buildSignInRequiredError(reason, requestId)` at ac62fd4d. */
+  const signInRequiredError = (
+    authReason: 'missing_token' | 'invalid_token' | 'expired_token' | 'verification_unavailable',
+  ): BoundaryError => ({
+    error: 'INGRESS_CONTRACT_VIOLATION',
+    boundary: 'B1',
+    direction: 'ingress',
+    validator: 'user_jwt',
+    details: {
+      reason: 'sign_in_required',
+      code: 'sign_in_required',
+      recoverable: true,
+      auth_reason: authReason,
+    },
+    request_id: 'req_signin_2472',
+    retryable: false,
+  })
+
+  it.each(['missing_token', 'invalid_token', 'expired_token'] as const)(
+    'auth_reason %s → sign-in copy, verbatim (never rephrase, never server-fault)',
+    (authReason) => {
+      const g = resolveGuidance('INGRESS_CONTRACT_VIOLATION', signInRequiredError(authReason))
+      expect(g).toBe(SIGN_IN_COPY)
+      expect(g).not.toMatch(/rephrase/i)
+      expect(g).not.toBe(SERVER_FAULT_COPY)
+    },
+  )
+
+  it('auth_reason verification_unavailable → server-fault copy: signing in cannot fix a downed verifier', () => {
+    expect(
+      resolveGuidance('INGRESS_CONTRACT_VIOLATION', signInRequiredError('verification_unavailable')),
+    ).toBe(SERVER_FAULT_COPY)
+  })
+
+  it("keys on the producer's declared stable key: details.code alone routes it, even under an unrecognised validator", () => {
+    const renamedValidator = {
+      ...signInRequiredError('expired_token'),
+      validator: 'user_jwt_v2_renamed',
+    }
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', renamedValidator)).toBe(SIGN_IN_COPY)
+  })
+
+  it('validator user_jwt alone routes it when details.code is absent (secondary signal)', () => {
+    const noCode: BoundaryError = {
+      error: 'INGRESS_CONTRACT_VIOLATION',
+      boundary: 'B1',
+      direction: 'ingress',
+      validator: 'user_jwt',
+      details: { reason: 'sign_in_required' },
+      request_id: 'req_no_code',
+      retryable: false,
+    }
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', noCode)).toBe(SIGN_IN_COPY)
+  })
+
+  it('an unknown future auth_reason still gets the sign-in copy (fail safe WITHIN the class)', () => {
+    const future = {
+      ...signInRequiredError('expired_token'),
+      details: { reason: 'sign_in_required', code: 'sign_in_required', auth_reason: 'novel_cause' },
+    } as unknown as BoundaryError
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', future)).toBe(SIGN_IN_COPY)
+  })
+
+  it('malformed auth fields never crash and stay in the sign-in class', () => {
+    const malformed = {
+      ...signInRequiredError('expired_token'),
+      details: { code: 'sign_in_required', auth_reason: { nested: true } },
+    } as unknown as BoundaryError
+    expect(resolveGuidance('INGRESS_CONTRACT_VIOLATION', malformed)).toBe(SIGN_IN_COPY)
+  })
+
+  // Condition 4 of the ratification, asserted as a property of the string
+  // rather than trusted to review: no blame, and an explicit next action.
+  it('the sign-in copy blames nobody and names what to DO', () => {
+    const g = resolveGuidance('INGRESS_CONTRACT_VIOLATION', signInRequiredError('expired_token'))
+    // Says what to do.
+    expect(g).toMatch(/sign in/i)
+    expect(g).toMatch(/send it again|try again/i)
+    // Explicitly exonerates the message.
+    expect(g).toMatch(/nothing was wrong with your message/i)
+    // Blames nobody: no "you failed/forgot/must", no rephrase instruction.
+    expect(g).not.toMatch(/rephrase|you (failed|forgot|did|should have)|invalid|your (mistake|error)/i)
   })
 })
 

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -375,6 +375,15 @@ describe('resolveGuidance — scenario_preflight reason union routes three ways 
 // ---------------------------------------------------------------------------
 // ROADMAP 2.472 — auth class (RATIFIED scope extension, 5 Aug).
 //
+// ⚠ DORMANT ON THE WIRE TODAY (review F2 — an earlier version of this lane's
+// notes claimed CEE "has emitted sign_in_required since user-identity.ts
+// landed", which is FALSE). All three emitters are gated on
+// CEE_REQUIRE_USER_JWT, config default false, "ships dark"; resolveUserIdentity
+// returns { mode: 'off' } before it can refuse. The DEPLOYED posture is
+// unproven from the repo. These tests therefore pin a class that is correct
+// when the flag flips — the LIVE unauthenticated case today is
+// scenario_requires_authenticated_owner, pinned in the F1 block above.
+//
 // SOURCE OF THE WIRE SHAPE: **CEE source bytes**, not a live capture —
 // `olumi-assistants-service/src/orchestrator/user-identity.ts`
 // `buildSignInRequiredError()` read at staging tip

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -144,9 +144,10 @@ describe('resolveGuidance — shared guidance resolver', () => {
 describe('resolveGuidance — INGRESS_CONTRACT_VIOLATION wire-taxonomy branching (2.472)', () => {
   const SERVER_FAULT_COPY =
     "Something on our side isn't working — your message was fine. Please try again in a moment."
-  const SIGN_IN_COPY =
-    "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again."
   const REPHRASE_COPY = 'Please rephrase your message and try again.'
+  // The auth class (user_jwt / sign_in_required) moved to its own describe
+  // block below when the extension was ratified — its copy constant lives
+  // there, not here.
 
   /** Byte-for-byte the BoundaryError CEE served during the witnessed outage
    *  (rewalk run2; run1 identical modulo ids). Identity-bound: this object is

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -231,6 +231,17 @@ export function extractReason(err: BoundaryError | undefined): string {
  *     `edit_graph_pipeline` — reachable under this code via route-v2.ts's
  *     `errorCode: failureType` passthrough) describe SERVER state. The user's
  *     message played no part → server-fault copy.
+ *   ⚠ DORMANT ON THE WIRE TODAY: every emitter of `buildSignInRequiredError`
+ *     is gated on `CEE_REQUIRE_USER_JWT`, config default `false`, documented
+ *     "ships dark" (`config/index.ts:527`) — `resolveUserIdentity` returns
+ *     `{ mode: 'off' }` before it can refuse, and both browser-proxy emitters
+ *     test `config.auth?.requireUserJwt === true`. The DEPLOYED posture is
+ *     UNPROVEN from the repo (Render dashboard owns staging env; never infer
+ *     it from YAML or from this comment). With the flag down, an
+ *     unauthenticated caller on an owned scenario does NOT yield
+ *     `sign_in_required` — it yields `scenario_requires_authenticated_owner`,
+ *     routed by OWNERSHIP_REASON_GUIDANCE above. That row, not this one, is
+ *     what closes the live case.
  *   - `user_jwt` (user-identity.ts, reason `sign_in_required`) describes
  *     SESSION state; "rephrase" is false and "our side is broken" is also
  *     false — recovery is signing in → sign-in copy.

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -251,8 +251,15 @@ const INGRESS_REPHRASE_GUIDANCE = 'Please rephrase your message and try again.'
 const INGRESS_SERVER_FAULT_GUIDANCE =
   "Something on our side isn't working — your message was fine. Please try again in a moment."
 
+/**
+ * Auth-class copy. Deliberately neutral about WHY: `auth_reason` spans
+ * "never signed in" (missing_token) and "session ended" (expired_token), so
+ * asserting either would be a fresh untruth for the other half. It blames
+ * nobody, exonerates the message explicitly, and names the next action —
+ * pinned as a property of the string, not left to review.
+ */
 const INGRESS_SIGN_IN_GUIDANCE =
-  'You need to be signed in for this — your message was fine. Please sign in and try again.'
+  "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again."
 
 const INGRESS_SERVER_STATE_VALIDATORS: ReadonlySet<string> = new Set([
   'scenario_preflight',
@@ -264,7 +271,37 @@ const INGRESS_SERVER_STATE_VALIDATORS: ReadonlySet<string> = new Set([
 
 const INGRESS_SIGN_IN_VALIDATOR = 'user_jwt'
 
+/**
+ * The producer's DECLARED stable mapping key for the auth class
+ * (user-identity.ts `buildSignInRequiredError`, verbatim: "The stable UI
+ * mapping key is `details.code === 'sign_in_required'`"). Keyed on first, so
+ * a validator rename cannot silently drop this class back to "rephrase";
+ * `validator === 'user_jwt'` stays as a secondary signal for envelopes that
+ * omit the code.
+ */
+const SIGN_IN_REQUIRED_CODE = 'sign_in_required'
+
+/**
+ * The one `auth_reason` in the closed union (user-identity.ts:64-68) that is
+ * NOT the user's to fix: the verifier itself is unavailable. Telling that
+ * user to sign in prescribes an action that cannot work — precisely the
+ * defect class this row exists to remove — so it takes the server-fault copy.
+ */
+const AUTH_REASON_VERIFIER_DOWN = 'verification_unavailable'
+
 const SCENARIO_OWNERSHIP_REASON_PREFIX = 'scenario_ownership'
+
+/** Read `details.code` off a BoundaryError. Fail closed: absent/non-string → ''. */
+function extractDetailsCode(err: BoundaryError): string {
+  const code = (err.details as { code?: unknown } | undefined)?.code
+  return typeof code === 'string' ? code : ''
+}
+
+/** Read `details.auth_reason`. Fail closed: absent/non-string → ''. */
+function extractAuthReason(err: BoundaryError): string {
+  const reason = (err.details as { auth_reason?: unknown } | undefined)?.auth_reason
+  return typeof reason === 'string' ? reason : ''
+}
 
 /**
  * Route an INGRESS_CONTRACT_VIOLATION to guidance that is true for its
@@ -274,7 +311,14 @@ const SCENARIO_OWNERSHIP_REASON_PREFIX = 'scenario_ownership'
 export function resolveIngressViolationGuidance(err: BoundaryError | undefined): string {
   if (!err) return INGRESS_REPHRASE_GUIDANCE
   const validator = typeof err.validator === 'string' ? err.validator : ''
-  if (validator === INGRESS_SIGN_IN_VALIDATOR) return INGRESS_SIGN_IN_GUIDANCE
+  // Auth class first, keyed on the producer's declared stable key.
+  if (extractDetailsCode(err) === SIGN_IN_REQUIRED_CODE || validator === INGRESS_SIGN_IN_VALIDATOR) {
+    // …except when the verifier itself is what failed: that is our fault, and
+    // signing in cannot clear it.
+    return extractAuthReason(err) === AUTH_REASON_VERIFIER_DOWN
+      ? INGRESS_SERVER_FAULT_GUIDANCE
+      : INGRESS_SIGN_IN_GUIDANCE
+  }
   if (
     INGRESS_SERVER_STATE_VALIDATORS.has(validator) ||
     extractReason(err).startsWith(SCENARIO_OWNERSHIP_REASON_PREFIX)

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -248,8 +248,29 @@ export function extractReason(err: BoundaryError | undefined): string {
  */
 const INGRESS_REPHRASE_GUIDANCE = 'Please rephrase your message and try again.'
 
+/**
+ * ⚠ The trailing "Please try again in a moment." is DELIBERATE here, and is
+ * deliberately NOT the same thing as `RETRY_INSTRUCTION_SENTENCE` above.
+ * That regex strips retry language from the CANONICAL FAILURE_USER_TEXT when
+ * the retry CHIP is withheld, so the copy never points at an affordance the
+ * UI is not rendering. This sentence points at no affordance: it tells the
+ * user that the fault is transient and that re-sending later is worth doing,
+ * which is true for an oracle-down / commit-failed class and is the only
+ * honest next step available to them. The live-chain spec asserts zero retry
+ * chips alongside this exact string, pinning that the two coexist on purpose.
+ * It is applied ONLY to genuinely transient server faults — never to the
+ * access-denied or sign-in classes, where waiting cannot help.
+ */
 const INGRESS_SERVER_FAULT_GUIDANCE =
   "Something on our side isn't working — your message was fine. Please try again in a moment."
+
+/**
+ * Access correctly refused: the scenario has a different owner. Blames
+ * nobody, states plainly that the message was not the problem, prescribes no
+ * futile wait, and names the one action that can actually change the outcome.
+ */
+const INGRESS_NO_ACCESS_GUIDANCE =
+  "This decision belongs to someone else, so you can't make changes to it — nothing you typed was the problem. Ask its owner to share it with you if you need access."
 
 /**
  * Auth-class copy. Deliberately neutral about WHY: `auth_reason` spans
@@ -267,7 +288,36 @@ const INGRESS_SERVER_STATE_VALIDATORS: ReadonlySet<string> = new Set([
   'chip_click_dispatch',
   'draft_graph_pipeline',
   'edit_graph_pipeline',
+  // Validates ONLY app-constructed state — graph_state, analysis_state,
+  // user_id, selected_elements (request-extensions.ts:8). It carries no user
+  // text whatsoever, so "rephrase your message" is categorically false here:
+  // the UI built the malformed request, not the person typing.
+  'V5RequestExtensions',
 ])
+
+/**
+ * `scenario_preflight` is NOT one failure. Its reason is a closed 3-member
+ * union (`build-turn-context.ts:1227-1235`) whose members need three
+ * DIFFERENT copies, and CEE names the reason precisely so the UI can tell
+ * them apart:
+ *
+ *   scenario_ownership_unverifiable        the oracle is down      → OUR FAULT
+ *   scenario_requires_authenticated_owner  anonymous caller, owned scenario
+ *                                          (IDOR fail-closed)      → SIGN IN
+ *   scenario_owned_by_other_user           cross-tenant attempt    → NO ACCESS
+ *
+ * Collapsing these into the server-fault copy — as this module did until the
+ * F1 review — tells a user whose access was CORRECTLY refused that our
+ * systems are broken and that waiting will help. Both halves are false, and
+ * the prescribed action can never succeed. That is a worse failure than the
+ * bug this module was written to fix, so each member is routed explicitly and
+ * an unknown future member falls back to the (blameless) server-fault copy.
+ */
+const OWNERSHIP_REASON_GUIDANCE: Record<string, string> = {
+  scenario_ownership_unverifiable: INGRESS_SERVER_FAULT_GUIDANCE,
+  scenario_requires_authenticated_owner: INGRESS_SIGN_IN_GUIDANCE,
+  scenario_owned_by_other_user: INGRESS_NO_ACCESS_GUIDANCE,
+}
 
 const INGRESS_SIGN_IN_VALIDATOR = 'user_jwt'
 
@@ -319,9 +369,15 @@ export function resolveIngressViolationGuidance(err: BoundaryError | undefined):
       ? INGRESS_SERVER_FAULT_GUIDANCE
       : INGRESS_SIGN_IN_GUIDANCE
   }
+  const reason = extractReason(err)
+  // Ownership/access reasons are routed by REASON first: they arrive under a
+  // server-state validator but three of them are not server faults at all.
+  const ownershipCopy = OWNERSHIP_REASON_GUIDANCE[reason]
+  if (ownershipCopy !== undefined) return ownershipCopy
+
   if (
     INGRESS_SERVER_STATE_VALIDATORS.has(validator) ||
-    extractReason(err).startsWith(SCENARIO_OWNERSHIP_REASON_PREFIX)
+    reason.startsWith(SCENARIO_OWNERSHIP_REASON_PREFIX)
   ) {
     return INGRESS_SERVER_FAULT_GUIDANCE
   }

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -211,6 +211,80 @@ export function extractReason(err: BoundaryError | undefined): string {
 }
 
 /**
+ * ── Ingress-violation taxonomy (ROADMAP 2.472) ─────────────────────────────
+ *
+ * CEE rides genuinely different failures on the single wire code
+ * INGRESS_CONTRACT_VIOLATION, carrying the real class in `validator` +
+ * `details.reason`. Until 2.472 the guidance line ignored both and told EVERY
+ * ingress violation "Please rephrase your message and try again." — witnessed
+ * false during the 4 Aug outage, when a server-side ownership-oracle failure
+ * (`validator:'scenario_preflight'`, `reason:'scenario_ownership_unverifiable'`,
+ * `retryable:false`) blamed the user's wording
+ * (PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-raw/run{1,2}-rewalk-wire.json).
+ *
+ * Class → copy, from the complete producer manifest at CEE staging tip
+ * ac62fd4d (every non-test `INGRESS_CONTRACT_VIOLATION` emitter):
+ *   - `scenario_preflight` (route-v2-preflight.ts — reasons are the closed
+ *     union scenario_owned_by_other_user | scenario_requires_authenticated_owner
+ *     | scenario_ownership_unverifiable) and the commit/pipeline validators
+ *     (`turn_commit`, `chip_click_dispatch`, `draft_graph_pipeline`,
+ *     `edit_graph_pipeline` — reachable under this code via route-v2.ts's
+ *     `errorCode: failureType` passthrough) describe SERVER state. The user's
+ *     message played no part → server-fault copy.
+ *   - `user_jwt` (user-identity.ts, reason `sign_in_required`) describes
+ *     SESSION state; "rephrase" is false and "our side is broken" is also
+ *     false — recovery is signing in → sign-in copy.
+ *   - `OrchestratorTurnPayload` (validators/b1.ts) and `V5RequestExtensions`
+ *     (orchestrator-v5/boundary/request-extensions.ts) validate the payload
+ *     itself — genuinely input-shaped → rephrase copy (unchanged).
+ *
+ * ⚠ The validator set below is a documented MIRROR of CEE's producer
+ * vocabulary (trap 12) with the drift direction chosen deliberately: an
+ * unknown or absent validator/reason FAILS SAFE to the rephrase copy —
+ * today's behaviour, never a crash, never a blank. The `scenario_ownership`
+ * reason-prefix gate is derived from the producer's own closed-union naming
+ * (same pattern as the `turn_fence_` prefix above), so the ownership family
+ * routes honestly even under a future validator rename.
+ */
+const INGRESS_REPHRASE_GUIDANCE = 'Please rephrase your message and try again.'
+
+const INGRESS_SERVER_FAULT_GUIDANCE =
+  "Something on our side isn't working — your message was fine. Please try again in a moment."
+
+const INGRESS_SIGN_IN_GUIDANCE =
+  'You need to be signed in for this — your message was fine. Please sign in and try again.'
+
+const INGRESS_SERVER_STATE_VALIDATORS: ReadonlySet<string> = new Set([
+  'scenario_preflight',
+  'turn_commit',
+  'chip_click_dispatch',
+  'draft_graph_pipeline',
+  'edit_graph_pipeline',
+])
+
+const INGRESS_SIGN_IN_VALIDATOR = 'user_jwt'
+
+const SCENARIO_OWNERSHIP_REASON_PREFIX = 'scenario_ownership'
+
+/**
+ * Route an INGRESS_CONTRACT_VIOLATION to guidance that is true for its
+ * actual class. Fail safe: no envelope, unknown validator, or malformed
+ * fields → the rephrase copy (pre-2.472 behaviour).
+ */
+export function resolveIngressViolationGuidance(err: BoundaryError | undefined): string {
+  if (!err) return INGRESS_REPHRASE_GUIDANCE
+  const validator = typeof err.validator === 'string' ? err.validator : ''
+  if (validator === INGRESS_SIGN_IN_VALIDATOR) return INGRESS_SIGN_IN_GUIDANCE
+  if (
+    INGRESS_SERVER_STATE_VALIDATORS.has(validator) ||
+    extractReason(err).startsWith(SCENARIO_OWNERSHIP_REASON_PREFIX)
+  ) {
+    return INGRESS_SERVER_FAULT_GUIDANCE
+  }
+  return INGRESS_REPHRASE_GUIDANCE
+}
+
+/**
  * Guidance text for non-retryable errors. Retryable errors show a Try again
  * chip on the message bubble instead, so guidance is empty for them.
  *
@@ -218,12 +292,16 @@ export function extractReason(err: BoundaryError | undefined): string {
  * that use the full component) and useConversation's V5 typed_error branch
  * (which builds a plain-string message body for MessageBubble). Keeping
  * both paths on the same table prevents drift.
+ *
+ * 2.472: pass the BoundaryError when you have one — INGRESS_CONTRACT_VIOLATION
+ * branches on its wire taxonomy (see resolveIngressViolationGuidance). Callers
+ * without an envelope keep the pre-2.472 copy for every code.
  */
-export function resolveGuidance(code: FailureTypeLiteral): string {
+export function resolveGuidance(code: FailureTypeLiteral, err?: BoundaryError): string {
   if (isRetryable(code)) return ''
   switch (code) {
     case 'INGRESS_CONTRACT_VIOLATION':
-      return 'Please rephrase your message and try again.'
+      return resolveIngressViolationGuidance(err)
     case 'EGRESS_CONTRACT_VIOLATION':
       return 'The response could not be validated. Please try again or contact support.'
     case 'FEATURE_NOT_ENABLED':


### PR DESCRIPTION
**DO NOT MERGE — orchestrator merges.** ROADMAP **2.472 (UI half)** · Pillar: **DEPTH / pass-condition 2** (a surface stating an untruth).

## The defect

`resolveGuidance()` (`src/v5/failureTypeRetryability.ts`) returned **"Please rephrase your message and try again."** for EVERY `INGRESS_CONTRACT_VIOLATION`, ignoring the wire's own `validator`, `details.reason`, and `retryable:false`. Witnessed live during the 4 Aug outage (byte-exact in both captures at `PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-raw/run{1,2}-rewalk-wire.json`): a server-side ownership-oracle failure —

```json
{"error":"INGRESS_CONTRACT_VIOLATION","boundary":"B1","direction":"ingress",
 "validator":"scenario_preflight",
 "details":{"reason":"scenario_ownership_unverifiable","scenario_id":"…"},
 "retryable":false}
```

— told the user their wording was the problem.

## Class → copy table (vocabulary derived from the complete producer manifest at CEE staging tip `ac62fd4d`; contract `validator` is freeform `z.string().min(1)`, so the producer manifest is the authority)

> **Revision 2 (review FIX-FIRST, `98952b74`+):** F1 was a real blocker and my error — the table below is the corrected one. See "What the review changed" at the end.

| Wire taxonomy | Guidance |
|---|---|
| **reason** `scenario_ownership_unverifiable` (the witnessed shape — oracle down) | "Something on our side isn't working — your message was fine. Please try again in a moment." |
| **reason** `scenario_requires_authenticated_owner` (anonymous caller, owned scenario — IDOR fail-closed) | sign-in copy (see auth row) |
| **reason** `scenario_owned_by_other_user` (cross-tenant attempt) | "This decision belongs to someone else, so you can't make changes to it — nothing you typed was the problem. Ask its owner to share it with you if you need access." |
| validator ∈ {`turn_commit`, `chip_click_dispatch`, `draft_graph_pipeline`, `edit_graph_pipeline`, `V5RequestExtensions`}, or an unknown `scenario_preflight` reason | "Something on our side isn't working — your message was fine. Please try again in a moment." |
| auth class — `details.code === 'sign_in_required'` (or validator `user_jwt`), `auth_reason` ∈ {`missing_token`, `invalid_token`, `expired_token`} | "You'll need to sign in to continue — nothing was wrong with your message. Please sign in, then send it again." |
| auth class with `auth_reason: 'verification_unavailable'` | server-fault copy (see row 1) — the verifier is down, so "please sign in" would prescribe an action that cannot work |
| validator `OrchestratorTurnPayload` — the Zod validator over the turn body, which DOES carry the user's `message` | "Please rephrase your message and try again." (unchanged) |
| unknown validator / absent envelope / malformed fields | "Please rephrase your message and try again." (**FAIL-SAFE**: never crash, never blank) |

Producer manifest: `scenario_preflight` reasons are the closed union `scenario_owned_by_other_user | scenario_requires_authenticated_owner | scenario_ownership_unverifiable` (`build-turn-context.ts:1230-1235`); `turn_commit` reaches this code via route-v2.ts:4855's `errorCode: failureType` passthrough; the other three pipeline validators are classified defensively (today they default to `INTERNAL_ERROR`). Note for reviewer: `retryable:false` is NOT a discriminator inside this code — input-shaped violations are also non-retryable — so the branch reads validator + reason only.

## ✅ Auth class — RATIFIED scope extension (approved 5 Aug; conditions met below)

Beyond the brief's two prescribed classes, and approved on the grounds that it is the same file, same function, same defect class, and one separable hunk. ⚠ The ratification also cited "a live untruth today" — **that premise was mine and it was wrong**; see the F2 correction immediately below. The row still belongs in this PR (it is correct the moment the flag flips, and it is where the sign-in copy the F1 fix reuses is defined), but on the corrected grounds, not the ones I supplied.

**The absence claim, with its scope stated.** Sweep: `rg -a` (NUL-safe — trap 17, plain `grep` is blind to NUL-bearing sources) for `sign_in_required|user_jwt` over **all of `src`, tests included**. Result: **zero hits outside this PR's own changes.** Claim type: no-handling-anywhere-in-`src`.

**⚠ CORRECTION (review F2) — my earlier claim here was FALSE.** I wrote that "CEE has emitted `sign_in_required` since `user-identity.ts` landed". It does not. Verified at the bytes: all three emitters are gated on `CEE_REQUIRE_USER_JWT`, config default `false`, documented **"ships dark"** (`config/index.ts:527`); `resolveUserIdentity` returns `{ mode: 'off' }` before it can refuse, and both browser-proxy emitters test `config.auth?.requireUserJwt === true`. The **deployed** posture is UNPROVEN from the repo — staging env lives in the Render dashboard and must not be inferred from YAML (trap 18).

**Consequence, and it matters:** with the flag down, an unauthenticated caller on an owned scenario does **not** produce `sign_in_required` — it produces `scenario_requires_authenticated_owner`. So this auth extension hardened the **dormant** twin, and the F1 fix above is what actually closes the **live** case. The auth row is still worth shipping (it is correct the moment the flag flips), but it must not be described as fixing a live surface.

**Wire-shape provenance — stated so the grade is not overclaimed.** This class is derived from **CEE SOURCE BYTES**, not a live capture: `olumi-assistants-service/src/orchestrator/user-identity.ts` `buildSignInRequiredError()` at staging tip `ac62fd4d`. (Contrast `scenario_preflight`, which has source bytes **and** two independent live captures. No capture in `PHASE0-EVIDENCE` contains a `user_jwt` refusal.)

**Keyed on the producer's own declared contract.** Its comment states verbatim that *"The stable UI mapping key is `details.code === 'sign_in_required'`"* — so the gate keys on `details.code` first, with `validator === 'user_jwt'` as a secondary signal. A validator rename therefore cannot silently drop this class back to "rephrase".

**The verifier-down carve-out.** `auth_reason` is the closed union `missing_token | invalid_token | expired_token | verification_unavailable` (`user-identity.ts:64-68`). The fourth is *not* the user's to fix: telling someone to sign in while the verifier is down prescribes an action that cannot work — the exact defect class this PR removes — so it routes to the server-fault copy instead.

**Copy conditions, asserted as properties of the string rather than left to review:** names the action (`/sign in/`, `/send it again/`), explicitly exonerates the message (`/nothing was wrong with your message/`), and blames nobody (asserted NOT to match `/rephrase|you (failed|forgot|did|should have)|invalid|your (mistake|error)/`). It is deliberately neutral about *why*, because `auth_reason` spans "never signed in" and "session ended" — asserting either would be a fresh untruth for the other half.

**RED-first + mutants for this class specifically:** 9 auth tests RED at the rebased pristine, identity-bound to a byte-for-byte reproduction of `buildSignInRequiredError`. Four dedicated mutants, all **KILLED by their named test**: A6 delete the auth branch · A7 remove the verifier-down carve-out · A8 key only on validator (ignore the producer's declared key) · A9 substitute blameful copy with no next action.

**Deliberate pin change (stated, not absorbed):** the `it.each` row `['INGRESS_CONTRACT_VIOLATION', /rephrase/i]` at `failureTypeRetryability.test.ts:107` pinned the universal-rephrase untruth. It moved into the new taxonomy describe block, where the rephrase copy is re-pinned verbatim as the input-shaped/fail-safe branch only. This is a contract change: INGRESS guidance is no longer unconditional.

Trap-12 note: the validator set and the reason map are documented mirrors of CEE's producer vocabulary; drift direction is deliberate — an unknown validator falls back to the rephrase copy, an unknown `scenario_preflight` reason to the blameless server-fault copy, and neither can crash or blank. **The F1 defect is exactly what trap 12d warns about**: deriving a guard from a list proves the copies agree, never that the list is *right*. What caught it was a human reading the producer's semantics, not any guard I wrote.

## Surfaces

Both live typed-error surfaces resolve through the one function and both now pass the envelope: `TypedErrorRenderer` and `useConversation`'s V5 `typed_error` branch. File surface is disjoint from open sibling PRs.

## Verification

- **RED-first at the REBASED pristine `a2c17dcf`** (throwaway worktree outside the repo root, tests-only patch over untouched source, applied-check confirming only the 4 test files changed): **22 failed | 82 passed** — 13 taxonomy + 9 auth, every one a named 2.472 test. Fail-safe and input-shaped controls pass at pristine by design: they pin unchanged behaviour.
- **GREEN at the head:** target files **104/104** · `pnpm typecheck` PASSED (coverage + ratchet at baseline 2500) · `pnpm lint` PASSED (hooks ratchet 234 = baseline). `VITE_SUPABASE_*` exported for every run; zero-collect treated as a hard error.
- **Mutants — 9/9 KILLED, each by its named test** (throwaway worktrees OUTSIDE the repo root, committed state only, per-mutation applied-check scoped to `src/` with the control asserting exactly zero): M1 revert-the-branch · M2 invert `isRetryable` · M3 invert the fail-safe · M4 sever the renderer call site · M5 sever the useConversation call site · A6–A9 as listed above.
- **Full named suite:** 1499 files / 22,036 tests, **1 failed | 21969 passed**. The single red is `src/signals/__tests__/realtime-signals.test.ts` — a wall-clock perf threshold (8.07ms vs <5ms) in a file this branch does not touch; **re-run in isolation on the same tree: 66/66 PASSED**, the failure being CPU contention from my own concurrent mutant harness. Recorded rather than waved away, and flagged as a separate task rather than absorbed into this PR.
- **A typecheck red was fixed at source, not baselined:** moving the auth case into its own describe block orphaned a `SIGN_IN_COPY` const (TS6133, baseline 2500 → 2501). The gate caught it; I deleted the dead const rather than accepting `--update-baseline`.

Evidence: `PHASE0-EVIDENCE-2026-07-28/lane-2472-copy-2026-08-05.md` (orchestration root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What the review changed (revision 2)

Reviewer verdict on `2d58959c` was **FIX-FIRST**: the engineering replayed exactly, but the derived table was wrong in the direction that matters. All four points accepted and fixed.

- **F1 (BLOCKER, my error).** I branched on `validator` and collapsed `scenario_preflight`'s **three-member** reason union into one copy. For `scenario_requires_authenticated_owner` and `scenario_owned_by_other_user`, "our side isn't working — try again in a moment" is false in *both* halves and prescribes an action that can never work: CEE's IDOR guard fired **correctly**. That inverted the harm direction — from vague-false to confidently-causally-false plus a futile instruction, i.e. worse than the bug this lane set out to fix. Now routed by reason, three ways.
  **The uncomfortable part:** my own test *pinned* the wrong behaviour. I wrote the expectation from my classification instead of the producer's semantics, so the guard agreed with itself — trap 13b, in the exact shape the doctrine describes. Pin corrected and the reason called out in-file.
- **F2.** Corrected a false claim of mine (see the auth section above). The auth class is **dormant**, not live.
- **F3.** `V5RequestExtensions` moved off the rephrase copy — its fields are `graph_state`/`analysis_state`/`user_id`/`selected_elements`, no user text at all, so "rephrase your message" is categorically false. It had been pinned as a rephrase *positive control*; pin corrected. `OrchestratorTurnPayload` keeps rephrase — it does carry the user's `message`.
- **F4.** Documented why the server-fault copy's trailing "Please try again in a moment." is deliberate and distinct from `RETRY_INSTRUCTION_SENTENCE` (that regex strips copy pointing at a retry *chip* the UI isn't rendering; this sentence points at no affordance), and why it is applied only to transient faults — never to the access-denied or sign-in classes, where waiting cannot help.

**New mutants for the corrected rows — 5/5 KILLED by their named tests:** F1a collapse the union · F1b sign-in row → server-fault · F1c no-access row → server-fault · F1d no-access copy → futile wait-and-retry · F3 `V5RequestExtensions` back onto rephrase. Running total **14/14**.

**Harness hardening** (adopting the reviewer's own disclosed near-miss, third instance of this shape tonight): spec paths are passed as a **list**, never a shell-split string; a `Tests` summary line **must** exist or the run is a hard error; and the pristine collected-count is measured first, with **every mutant run required to collect exactly the same number** — all five collected 110/110, so none of these kills came from a silently-empty run.
