### PR TITLE
DO-NOT-MERGE: Interim 2.467 mitigation: import invalidates pre-import analysis (P0 trust)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -539,7 +539,7 @@
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'graph_state' does not exist on type 'TurnRequestPayload'.
 1	src/canvas/conversation/useConversation.ts	TS2339	Property 'message' does not exist on type 'TurnRequestPayload'.
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'selected_elements' does not exist on type 'TurnRequestPayload'.
-1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 249 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
+1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 250 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
 2	src/canvas/conversation/useConversation.ts	TS2352	Conversion of type 'OrchestratorResponseEnvelopeV2' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'op' is declared but its value is never read.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'ops' is declared but its value is never read.

--- a/src/canvas/__tests__/__fixtures__/rewalk2459b-export-original.json
+++ b/src/canvas/__tests__/__fixtures__/rewalk2459b-export-original.json
@@ -1,0 +1,1800 @@
+{
+  "version": 2,
+  "timestamp": 1785882810207,
+  "nodes": [
+    {
+      "id": "dec_venue",
+      "type": "decision",
+      "position": {
+        "x": 752,
+        "y": 24
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Product Launch Venue Selection",
+        "kind": "decision",
+        "type": "decision"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_alpha",
+      "type": "factor",
+      "position": {
+        "x": 388,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Alpha Hall selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": true
+    },
+    {
+      "id": "fac_beta",
+      "type": "factor",
+      "position": {
+        "x": 752,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Beta Garden selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Beta Garden Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_capacity",
+      "type": "factor",
+      "position": {
+        "x": 24,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0.3,
+          "range_max": 1
+        },
+        "display_value": "0.3 to 1",
+        "provenance": "ai_inferred",
+        "label": "Venue Capacity",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_gamma",
+      "type": "factor",
+      "position": {
+        "x": 1116,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Gamma Rooftop selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_weather",
+      "type": "factor",
+      "position": {
+        "x": 1480,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0,
+          "range_max": 1
+        },
+        "provenance": "ai_inferred",
+        "label": "Weather Risk (Outdoor Exposure)",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "goal_turnout",
+      "type": "goal",
+      "position": {
+        "x": 752,
+        "y": 832
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Maximise Attendee Turnout",
+        "kind": "goal",
+        "type": "goal"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_alpha",
+      "type": "option",
+      "position": {
+        "x": 206,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_beta",
+      "type": "option",
+      "position": {
+        "x": 570,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_beta": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Beta Garden",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_beta"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_gamma",
+      "type": "option",
+      "position": {
+        "x": 1298,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_gamma": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_status_quo",
+      "type": "option",
+      "position": {
+        "x": 934,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": true,
+        "provenance": "ai_inferred",
+        "label": "Defer Venue Decision (Status Quo)",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_attendance",
+      "type": "outcome",
+      "position": {
+        "x": 570,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Turnout",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_experience",
+      "type": "outcome",
+      "position": {
+        "x": 934,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Experience Quality",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_capacity_constraint",
+      "type": "risk",
+      "position": {
+        "x": 570,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Capacity Constraint on Turnout",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_weather_disruption",
+      "type": "risk",
+      "position": {
+        "x": 934,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Weather-Related Disruption",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-0",
+      "source": "dec_venue",
+      "target": "opt_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-1",
+      "source": "dec_venue",
+      "target": "opt_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-2",
+      "source": "dec_venue",
+      "target": "opt_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-3",
+      "source": "dec_venue",
+      "target": "opt_status_quo",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-4",
+      "source": "fac_alpha",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.3349358974358974,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09134615384615384,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.15,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Alpha Hall modestly increases turnout but less than capacity constraints.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.4600000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-5",
+      "source": "fac_alpha",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.31666666666666665,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.78,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08444444444444443,
+        "exists_probability": 0.78,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.45,
+            "strength_std": 0.12,
+            "exists_probability": 0.78
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall provides a comfortable indoor experience boosting perceived quality.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.10000000000000009,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-6",
+      "source": "fac_alpha",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.65,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.65,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change",
+            "existence_boundary_crossing"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.65
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s fixed seating can pose a moderate capacity risk if turnout is high.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-7",
+      "source": "fac_beta",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.2314102564102564,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09743589743589742,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.38,
+            "strength_std": 0.16,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Beta Garden moderately drives turnout through outdoor appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.1200000000000001,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-8",
+      "source": "fac_beta",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.24629629629629624,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.72,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09851851851851852,
+        "exists_probability": 0.72,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.72
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden offers pleasant outdoor ambiance but weather variability reduces quality effect.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-9",
+      "source": "fac_beta",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.3275862068965517,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11793103448275861,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.5,
+            "strength_std": 0.18,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Outdoor Beta Garden selection materially increases weather disruption risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.20000000000000007,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-10",
+      "source": "fac_capacity",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.2131410256410256,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.07307692307692307,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.49,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Higher venue capacity directly allows more attendees up to full turnout.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.6399999999999999,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5799999999999998,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_capacity->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-11",
+      "source": "fac_capacity",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip",
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": -0.3,
+            "strength_std": 0.12,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.6,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Lower capacity strongly raises the probability of hitting attendance limits.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.75,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 1,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_capacity->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-12",
+      "source": "fac_gamma",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.17051282051282052,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.7,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08525641025641026,
+        "exists_probability": 0.7,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.28,
+            "strength_std": 0.14,
+            "exists_probability": 0.7
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Gamma Rooftop moderately influences turnout through novelty appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.07999999999999985,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-13",
+      "source": "fac_gamma",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.387037037037037,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09148148148148147,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.13,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s unique views strongly enhance attendee experience.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.44999999999999996,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.20000000000000018,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-14",
+      "source": "fac_gamma",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.4,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.4,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s limited footprint creates a moderate capacity risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.10000000000000009,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-15",
+      "source": "fac_gamma",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.42586206896551726,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.0982758620689655,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.15,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop is exposed to weather, increasing disruption risk similarly to Beta Garden.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5000000000000001,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-16",
+      "source": "fac_weather",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.196551724137931,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09172413793103448,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "General weather risk is a primary driver of outdoor disruption probability.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.6499999999999999,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.6999999999999998,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_weather->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-17",
+      "source": "opt_alpha",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-18",
+      "source": "opt_beta",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-19",
+      "source": "opt_gamma",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-20",
+      "source": "opt_status_quo",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-21",
+      "source": "opt_status_quo",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-22",
+      "source": "opt_status_quo",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-23",
+      "source": "out_attendance",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.7,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.95,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.95,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "existence_boundary_crossing"
+          ],
+          "pass1": {
+            "strength_mean": 0.7,
+            "strength_std": 0.1,
+            "exists_probability": 0.95
+          },
+          "pass2": {
+            "strength_mean": 0.8,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Actual attendance is the principal contributor to achieving the turnout goal.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.95,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_attendance->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-24",
+      "source": "out_experience",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.25,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.1,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Better experience can slightly enhance word-of-mouth turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.24999999999999997,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 5.551115123125783e-17,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_experience->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-25",
+      "source": "risk_capacity_constraint",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.28,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": -0.28,
+            "strength_std": 0.12,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": -0.05,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Hitting capacity limits slightly reduces overall turnout achievement.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.09999999999999996,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 0,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_capacity_constraint->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-26",
+      "source": "risk_weather_disruption",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": -0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": -0.05,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Weather disruptions marginally detract from final turnout numbers.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.09999999999999996,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 0,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_weather_disruption->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    }
+  ]
+}

--- a/src/canvas/__tests__/__fixtures__/rewalk2459b-import-modified.json
+++ b/src/canvas/__tests__/__fixtures__/rewalk2459b-import-modified.json
@@ -1,0 +1,1800 @@
+{
+  "version": 2,
+  "timestamp": 1785882810207,
+  "nodes": [
+    {
+      "id": "dec_venue",
+      "type": "decision",
+      "position": {
+        "x": 752,
+        "y": 24
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Product Launch Venue Selection",
+        "kind": "decision",
+        "type": "decision"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_alpha",
+      "type": "factor",
+      "position": {
+        "x": 388,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Alpha Hall selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": true
+    },
+    {
+      "id": "fac_beta",
+      "type": "factor",
+      "position": {
+        "x": 752,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Beta Garden selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Beta Garden Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_capacity",
+      "type": "factor",
+      "position": {
+        "x": 24,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0.3,
+          "range_max": 1
+        },
+        "display_value": "0.3 to 1",
+        "provenance": "ai_inferred",
+        "label": "Venue Capacity",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_gamma",
+      "type": "factor",
+      "position": {
+        "x": 1116,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Gamma Rooftop selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_weather",
+      "type": "factor",
+      "position": {
+        "x": 1480,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0,
+          "range_max": 1
+        },
+        "provenance": "ai_inferred",
+        "label": "Weather Risk (Outdoor Exposure)",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "goal_turnout",
+      "type": "goal",
+      "position": {
+        "x": 752,
+        "y": 832
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Maximise Attendee Turnout",
+        "kind": "goal",
+        "type": "goal"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_alpha",
+      "type": "option",
+      "position": {
+        "x": 206,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "ZZZ IMPORTED OPTION",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_beta",
+      "type": "option",
+      "position": {
+        "x": 570,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_beta": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Beta Garden",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_beta"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_gamma",
+      "type": "option",
+      "position": {
+        "x": 1298,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_gamma": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_status_quo",
+      "type": "option",
+      "position": {
+        "x": 934,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": true,
+        "provenance": "ai_inferred",
+        "label": "Defer Venue Decision (Status Quo)",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_attendance",
+      "type": "outcome",
+      "position": {
+        "x": 570,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Turnout",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_experience",
+      "type": "outcome",
+      "position": {
+        "x": 934,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Experience Quality",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_capacity_constraint",
+      "type": "risk",
+      "position": {
+        "x": 570,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Capacity Constraint on Turnout",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_weather_disruption",
+      "type": "risk",
+      "position": {
+        "x": 934,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Weather-Related Disruption",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-0",
+      "source": "dec_venue",
+      "target": "opt_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-1",
+      "source": "dec_venue",
+      "target": "opt_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-2",
+      "source": "dec_venue",
+      "target": "opt_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-3",
+      "source": "dec_venue",
+      "target": "opt_status_quo",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-4",
+      "source": "fac_alpha",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.3349358974358974,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09134615384615384,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.15,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Alpha Hall modestly increases turnout but less than capacity constraints.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.4600000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-5",
+      "source": "fac_alpha",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.31666666666666665,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.78,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08444444444444443,
+        "exists_probability": 0.78,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.45,
+            "strength_std": 0.12,
+            "exists_probability": 0.78
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall provides a comfortable indoor experience boosting perceived quality.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.10000000000000009,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-6",
+      "source": "fac_alpha",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.65,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.65,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change",
+            "existence_boundary_crossing"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.65
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s fixed seating can pose a moderate capacity risk if turnout is high.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-7",
+      "source": "fac_beta",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.2314102564102564,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09743589743589742,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.38,
+            "strength_std": 0.16,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Beta Garden moderately drives turnout through outdoor appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.1200000000000001,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-8",
+      "source": "fac_beta",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.24629629629629624,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.72,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09851851851851852,
+        "exists_probability": 0.72,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.72
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden offers pleasant outdoor ambiance but weather variability reduces quality effect.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-9",
+      "source": "fac_beta",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.3275862068965517,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11793103448275861,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.5,
+            "strength_std": 0.18,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Outdoor Beta Garden selection materially increases weather disruption risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.20000000000000007,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-10",
+      "source": "fac_capacity",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.2131410256410256,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.07307692307692307,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.49,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Higher venue capacity directly allows more attendees up to full turnout.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.6399999999999999,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5799999999999998,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_capacity->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-11",
+      "source": "fac_capacity",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip",
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": -0.3,
+            "strength_std": 0.12,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.6,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Lower capacity strongly raises the probability of hitting attendance limits.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.75,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 1,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_capacity->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-12",
+      "source": "fac_gamma",
+      "target": "out_attendance",
+      "type": "styled",
+      "data": {
+        "weight": 0.17051282051282052,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.7,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08525641025641026,
+        "exists_probability": 0.7,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.28,
+            "strength_std": 0.14,
+            "exists_probability": 0.7
+          },
+          "pass2": {
+            "strength_mean": 0.17,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Selecting Gamma Rooftop moderately influences turnout through novelty appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.31999999999999995,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.07999999999999985,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_attendance",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-13",
+      "source": "fac_gamma",
+      "target": "out_experience",
+      "type": "styled",
+      "data": {
+        "weight": 0.387037037037037,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09148148148148147,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.13,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s unique views strongly enhance attendee experience.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.44999999999999996,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.20000000000000018,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_experience",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-14",
+      "source": "fac_gamma",
+      "target": "risk_capacity_constraint",
+      "type": "styled",
+      "data": {
+        "weight": 0.4,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.4,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s limited footprint creates a moderate capacity risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.10000000000000009,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_capacity_constraint",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-15",
+      "source": "fac_gamma",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.42586206896551726,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.0982758620689655,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.15,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop is exposed to weather, increasing disruption risk similarly to Beta Garden.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.39999999999999997,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5000000000000001,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-16",
+      "source": "fac_weather",
+      "target": "risk_weather_disruption",
+      "type": "styled",
+      "data": {
+        "weight": 0.196551724137931,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09172413793103448,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "General weather risk is a primary driver of outdoor disruption probability.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.6499999999999999,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.6999999999999998,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_weather->risk_weather_disruption",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-17",
+      "source": "opt_alpha",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-18",
+      "source": "opt_beta",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-19",
+      "source": "opt_gamma",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-20",
+      "source": "opt_status_quo",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-21",
+      "source": "opt_status_quo",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-22",
+      "source": "opt_status_quo",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-23",
+      "source": "out_attendance",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.7,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.95,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.95,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "existence_boundary_crossing"
+          ],
+          "pass1": {
+            "strength_mean": 0.7,
+            "strength_std": 0.1,
+            "exists_probability": 0.95
+          },
+          "pass2": {
+            "strength_mean": 0.8,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Actual attendance is the principal contributor to achieving the turnout goal.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.95,
+            "strength_std": 0.14,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 0.5,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_attendance->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-24",
+      "source": "out_experience",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.25,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.1,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Better experience can slightly enhance word-of-mouth turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.24999999999999997,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 5.551115123125783e-17,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_experience->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-25",
+      "source": "risk_capacity_constraint",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.28,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": -0.28,
+            "strength_std": 0.12,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": -0.05,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Hitting capacity limits slightly reduces overall turnout achievement.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.09999999999999996,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 0,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_capacity_constraint->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-26",
+      "source": "risk_weather_disruption",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": -0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": -0.05,
+            "strength_std": 0.05,
+            "exists_probability": 0.9,
+            "reasoning": "Weather disruptions marginally detract from final turnout numbers.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.09999999999999996,
+            "strength_std": 0.09000000000000001,
+            "exists_probability": 0.8
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.14999999999999997,
+            "strength_std_offset": 0.04000000000000001,
+            "exists_probability_offset": -0.09999999999999998
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 0,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_weather_disruption->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    }
+  ]
+}

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -40,6 +40,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { useCanvasStore } from '../store'
 import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
+import { useComparisonStore } from '../stores/comparisonStore'
 import { applyDraftResult } from '../utils/applyDraftResult'
 import {
   AnalysisFreshnessNotice,
@@ -121,6 +122,31 @@ function seedPreImportAnalysedState() {
     },
     analysisFreshnessDirty: false,
   } as never)
+  // The pre-import analysis also lives in the Compare-tab snapshot store and
+  // the comparison store — seed both so their post-import absence assertions
+  // are non-vacuous (trap 13: an absence check must first see a presence).
+  useAnalysisSnapshotStore.setState({
+    snapshots: [
+      {
+        runId: 'rewalk2459b-run-1',
+        responseHash: PRE_IMPORT_HASH,
+        options: [{ id: PRE_IMPORT_OPTION_ID, label: PRE_IMPORT_OPTION_LABEL }],
+      },
+    ],
+  } as never)
+  useComparisonStore.setState({
+    comparisonMode: {
+      active: true,
+      scenarios: [],
+      labels: [PRE_IMPORT_OPTION_LABEL],
+      comparison: null,
+      apiResponse: {
+        option_comparison: [
+          { option_id: PRE_IMPORT_OPTION_ID, option_label: PRE_IMPORT_OPTION_LABEL },
+        ],
+      },
+    },
+  } as never)
 }
 
 /**
@@ -145,6 +171,7 @@ function analysisResultsCluster() {
     preAnalysisSensitivity: s.preAnalysisSensitivity,
     lastAnalysisSeed: s.lastAnalysisSeed,
     compareSnapshots: useAnalysisSnapshotStore.getState().snapshots,
+    comparisonMode: useComparisonStore.getState().comparisonMode,
   }
 }
 
@@ -183,6 +210,7 @@ beforeEach(() => {
     currentScenarioId: null,
   } as never)
   useAnalysisSnapshotStore.getState().clearSnapshots()
+  useComparisonStore.getState().resetComparison()
 })
 
 describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b attempt 2)', () => {

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -42,6 +42,7 @@ import { useCanvasStore } from '../store'
 import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
 import { useComparisonStore } from '../stores/comparisonStore'
 import { applyDraftResult } from '../utils/applyDraftResult'
+import { createScenario } from '../store/scenarios'
 import {
   AnalysisFreshnessNotice,
   FRESHNESS_COPY,
@@ -359,6 +360,32 @@ describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b
     renderFreshnessSurfaces()
     // A fresh verdict on a server-loaded graph may affirm again — the interim
     // hold must not become a permanent suppression.
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+
+  it('(c) the hold releases on loadScenario (the production scenario-switch path)', () => {
+    const scenario = createScenario({
+      name: 'Scenario after import',
+      nodes: [
+        { id: 'scn_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Scenario goal' } },
+      ] as never,
+      edges: [],
+    })
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    act(() => {
+      const ok = useCanvasStore.getState().loadScenario(scenario.id)
+      expect(ok).toBe(true)
+    })
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
     expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
       'data-freshness',
       'fresh',

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -1,0 +1,381 @@
+/**
+ * Interim 2.467 mitigation — an import must never leave a pre-import analysis
+ * renderable-as-current (P0 trust, live-witnessed 2026-08-04).
+ *
+ * Reproduces the exact shape of the witnessed walk
+ * (PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-2026-08-04.md, "ATTEMPT 2" +
+ * FAIL frame rewalk-2459b-raw/attempt2/probe-c/2c-10-verdict-analysis-tab.png):
+ *
+ *   1. analysis completed + "Analysis reflects the current model." affirmative;
+ *   2. canvas IMPORT (full graph replacement, same node ids, one relabelled
+ *      option — the walk's "ZZZ IMPORTED OPTION" sentinel);
+ *   3. the pre-import analysis stayed fully rendered, re-bound by node id to
+ *      the imported labels, every staleness indicator read clean;
+ *   4. after one Rerun, CEE (which never saw the import — zero server-side
+ *      graph persistence, walk VERDICT 3) returned a 'fresh' verdict computed
+ *      against ITS OWN pre-import graph, and the affirmative badge RETURNED
+ *      against an analysis of the wrong graph.
+ *
+ * The fixtures are the walk's own captured graphs, byte-identical
+ * (export-original.json / import-modified.json from attempt2/probe-c).
+ *
+ * Contract pinned here (interim until the atomic import→reset→registration
+ * train, ROADMAP 2.467, supersedes):
+ *   (a) importCanvas clears the analysis-results cluster — no pre-import
+ *       results body is renderable, and re-binding old rows to new labels is
+ *       impossible by construction (no rows survive);
+ *   (b) the freshness affirmative is gone after import AND cannot return
+ *       against a rerun of the unregistered graph: while the imported graph is
+ *       pending server registration, a server 'fresh' verdict displays as
+ *       cannot-confirm (the existing dirty-overlay downgrade — never an
+ *       affirmative, never a fabricated 'stale');
+ *   (c) the hold RELEASES when the canvas is replaced by a server-known graph
+ *       (hydrate / scenario load / reset / CEE draft) — no permanent
+ *       suppression.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act, cleanup } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { useCanvasStore } from '../store'
+import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
+import { applyDraftResult } from '../utils/applyDraftResult'
+import {
+  AnalysisFreshnessNotice,
+  FRESHNESS_COPY,
+} from '../../components/results/AnalysisFreshnessNotice'
+import { ReanalyseBar } from '../components/model-tab/ReanalyseBar'
+
+const EXPORT_ORIGINAL_JSON = readFileSync(
+  path.resolve(__dirname, '__fixtures__', 'rewalk2459b-export-original.json'),
+  'utf8',
+)
+const IMPORT_MODIFIED_JSON = readFileSync(
+  path.resolve(__dirname, '__fixtures__', 'rewalk2459b-import-modified.json'),
+  'utf8',
+)
+
+// Identity anchors from the walk (trap 19: assertions bind by identity, never
+// by a value predicate another object could satisfy).
+const PRE_IMPORT_HASH = 'rewalk2459b-pre-import-response-hash'
+const PRE_IMPORT_OPTION_ID = 'opt_alpha'
+const PRE_IMPORT_OPTION_LABEL = 'Alpha Hall' // opt_alpha's label in export-original
+const IMPORTED_SENTINEL_LABEL = 'ZZZ IMPORTED OPTION' // opt_alpha's label in import-modified
+const PRE_IMPORT_COMPUTED_AT = '2026-08-04T22:00:00.000Z'
+const POST_RERUN_COMPUTED_AT = '2026-08-04T23:00:00.000Z'
+
+/** The walk's rerun verdict: CEE's own (pre-import) graph hashes agree, so it
+ *  says 'fresh' — about a graph the canvas no longer shows. */
+const SERVER_FRESH_VERDICT_AFTER_RERUN = {
+  freshness: 'fresh',
+  freshness_reason: 'graph_hash_match',
+  graph_hash_at_run: 'server-side-pre-import-graph-hash',
+  current_graph_hash: 'server-side-pre-import-graph-hash',
+  computed_at: POST_RERUN_COMPUTED_AT,
+}
+
+function seedPreImportAnalysedState() {
+  const exported = JSON.parse(EXPORT_ORIGINAL_JSON) as {
+    nodes: unknown[]
+    edges: unknown[]
+  }
+  useCanvasStore.setState({
+    nodes: exported.nodes,
+    edges: exported.edges,
+    results: {
+      status: 'complete',
+      progress: 100,
+      hash: PRE_IMPORT_HASH,
+      report: {
+        model_card: { response_hash: PRE_IMPORT_HASH },
+        options: [
+          {
+            id: PRE_IMPORT_OPTION_ID,
+            label: PRE_IMPORT_OPTION_LABEL,
+            win_probability: 0.62,
+          },
+        ],
+      },
+    },
+    analysisStateReady: true,
+    hasCompletedFirstRun: true,
+    rawV2Response: {
+      options: [{ id: PRE_IMPORT_OPTION_ID, label: PRE_IMPORT_OPTION_LABEL }],
+    },
+    v5AnalysisFact: {
+      scenarioId: null,
+      analysisHash: PRE_IMPORT_HASH,
+      hasRunAnalysisFact: true,
+      freshness: 'fresh',
+      freshnessReason: null,
+      rawBlocks: [],
+      writtenAt: Date.now(),
+    },
+    analysisFreshness: {
+      freshness: 'fresh',
+      freshnessReason: 'graph_hash_match',
+      graphHashAtRun: 'pre-import-graph-hash',
+      currentGraphHash: 'pre-import-graph-hash',
+      computedAt: PRE_IMPORT_COMPUTED_AT,
+    },
+    analysisFreshnessDirty: false,
+  } as never)
+}
+
+/**
+ * The COMPLETE reviewed manifest for the absence claim "no pre-import analysis
+ * artefact survives the import" — every store slice a results/driving surface
+ * renders from. Scope: useCanvasStore results cluster + the analysis snapshot
+ * store (Compare tab). Nodes/edges deliberately excluded (the imported graph
+ * legitimately reuses the walk's node ids — that reuse is the re-bind bait).
+ */
+function analysisResultsCluster() {
+  const s = useCanvasStore.getState()
+  return {
+    results: s.results,
+    previousReport: s.previousReport,
+    runMeta: s.runMeta,
+    rawV2Response: s.rawV2Response,
+    v5AnalysisFact: s.v5AnalysisFact,
+    ceeAnalysisReady: s.ceeAnalysisReady,
+    needleMovers: s.needleMovers,
+    graphHealth: s.graphHealth,
+    nodeRationales: s.nodeRationales,
+    preAnalysisSensitivity: s.preAnalysisSensitivity,
+    lastAnalysisSeed: s.lastAnalysisSeed,
+    compareSnapshots: useAnalysisSnapshotStore.getState().snapshots,
+  }
+}
+
+function renderFreshnessSurfaces() {
+  return render(
+    <>
+      <AnalysisFreshnessNotice />
+      <ReanalyseBar onReanalyse={() => {}} />
+    </>,
+  )
+}
+
+beforeEach(() => {
+  cleanup()
+  useCanvasStore.getState().reset()
+  // reset() restores only the graph slice — restore the analysis cluster and
+  // freshness machinery to their initial-state values explicitly.
+  useCanvasStore.setState({
+    results: { status: 'idle', progress: 0 },
+    runMeta: {},
+    previousReport: null,
+    rawV2Response: null,
+    v5AnalysisFact: null,
+    ceeAnalysisReady: null,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    analysisStateReady: false,
+    hasCompletedFirstRun: false,
+    graphEditedSinceLastRun: false,
+    pendingEmittedEdits: 0,
+    needleMovers: [],
+    graphHealth: null,
+    nodeRationales: {},
+    preAnalysisSensitivity: null,
+    lastAnalysisSeed: null,
+    currentScenarioId: null,
+  } as never)
+  useAnalysisSnapshotStore.getState().clearSnapshots()
+})
+
+describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b attempt 2)', () => {
+  it('positive control (trap 13): pre-import state renders the affirmative badge and holds the results cluster', () => {
+    seedPreImportAnalysedState()
+
+    // The absence assertions below can only be trusted if this presence is seen.
+    const before = JSON.stringify(analysisResultsCluster())
+    expect(before).toContain(PRE_IMPORT_HASH)
+    expect(before).toContain(PRE_IMPORT_OPTION_LABEL)
+    expect(before).toContain(PRE_IMPORT_OPTION_ID)
+
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveAttribute('data-freshness', 'fresh')
+    expect(notice).toHaveTextContent(FRESHNESS_COPY.fresh) // "Analysis reflects the current model."
+  })
+
+  it('(a)+(c-rebind) importCanvas clears the analysis-results cluster — no pre-import row survives to re-bind to imported labels', () => {
+    seedPreImportAnalysedState()
+
+    let ok = false
+    act(() => {
+      ok = useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    expect(ok).toBe(true)
+
+    const s = useCanvasStore.getState()
+    // The re-bind bait is live: the imported graph reuses the walk's node id
+    // with the sentinel label (identity-bound to the walk's modification).
+    const baitNode = s.nodes.find((n) => n.id === PRE_IMPORT_OPTION_ID)
+    expect(baitNode).toBeTruthy()
+    expect(
+      (baitNode as unknown as { data: { label: string } }).data.label,
+    ).toBe(IMPORTED_SENTINEL_LABEL)
+
+    // (a) No results body is renderable from the pre-import run.
+    expect(s.results.status).toBe('idle')
+    expect(s.results.report ?? null).toBeNull()
+    expect(s.results.hash ?? null).toBeNull()
+    expect(s.previousReport).toBeNull()
+    expect(s.rawV2Response).toBeNull()
+    expect(s.v5AnalysisFact).toBeNull()
+    expect(s.analysisStateReady).toBe(false)
+    expect(s.hasCompletedFirstRun).toBe(false)
+
+    // (c) Re-bind impossible by construction: the complete results cluster
+    // holds NO reference to the pre-import run's identity — its hash, its row
+    // label, or any row bound to the shared node id.
+    const after = JSON.stringify(analysisResultsCluster())
+    expect(after).not.toContain(PRE_IMPORT_HASH)
+    expect(after).not.toContain(PRE_IMPORT_OPTION_LABEL)
+    expect(after).not.toContain(PRE_IMPORT_OPTION_ID)
+
+    // (b) The affirmative badge is gone (walk frame 2c-07: indicators must
+    // not read clean-with-results; with no verdict and no results the badge
+    // renders nothing).
+    renderFreshnessSurfaces()
+    expect(screen.queryByTestId('analysis-freshness-notice')).toBeNull()
+  })
+
+  it("(b) a post-import rerun's server 'fresh' verdict cannot re-attach the affirmative (walk frame 2c-10)", () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+
+    // The walk's rerun, in applyV5State's live order (setAnalysisFreshness at
+    // step 998, clearAnalysisFreshnessDirty at step ~1166 after the
+    // analysis_result lands): CEE never saw the import, its own hashes agree,
+    // verdict says 'fresh'.
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+      useCanvasStore.getState().clearAnalysisFreshnessDirty()
+    })
+
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    // The verbatim CEE verdict is held (debug attribute) — but it must NOT
+    // display as the affirmative: the graph it affirms is not on the canvas.
+    expect(notice).toHaveAttribute('data-cee-freshness', 'fresh')
+    expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
+    expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
+    // Honest treatment: the model DID change since that analysis (the import),
+    // so the composed trust semantic is 'changed' and the re-analyse bar shows.
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
+  })
+
+  it("(b, order-independence) clear-then-verdict also cannot re-attach the affirmative", () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    act(() => {
+      useCanvasStore.getState().clearAnalysisFreshnessDirty()
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
+    expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
+  })
+
+  it('(b) a verdictless rerun completion keeps the overlay dirty while the import is unregistered', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // applyV5State's other branch: the rerun landed an analysis_result but the
+    // response carried NO freshness verdict → noteRunCompletedWithoutVerdict.
+    // The run consumed CEE's own graph, not the imported canvas — the overlay
+    // must stay dirty (a false "resolved" record here would let any later
+    // clean path re-affirm).
+    act(() => {
+      useCanvasStore.getState().noteRunCompletedWithoutVerdict()
+    })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    // And a later echoed 'fresh' verdict still cannot re-attach the affirmative.
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
+    expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
+  })
+
+  it('(c) the hold releases when a server-known graph replaces the canvas: hydrateGraphSlice', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // Production scenario load replaces the graph — the import is gone.
+    const exported = JSON.parse(EXPORT_ORIGINAL_JSON) as { nodes: never[]; edges: never[] }
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: exported.nodes,
+        edges: exported.edges,
+        currentScenarioId: 'scn_after_import',
+      })
+    })
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    // A fresh verdict on a server-loaded graph may affirm again — the interim
+    // hold must not become a permanent suppression.
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+
+  it('(c) the hold releases on resetCanvas', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+      useCanvasStore.getState().resetCanvas()
+    })
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+
+  it('(c) the hold releases when a CEE draft replaces the canvas (applyDraftResult)', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    act(() => {
+      applyDraftResult({
+        nodes: [
+          { id: 'd_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Drafted goal' } },
+        ],
+        edges: [],
+      } as never)
+    })
+    // applyDraftResult marks the overlay dirty for the draft mutation itself;
+    // the draft's accompanying verdict then resolves it (existing behaviour) —
+    // the import hold must not pin it.
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+})

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -33,7 +33,7 @@
  *       (hydrate / scenario load / reset / CEE draft) — no permanent
  *       suppression.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen, act, cleanup } from '@testing-library/react'
 import { readFileSync } from 'node:fs'
@@ -55,6 +55,14 @@ import {
   FRESHNESS_COPY,
 } from '../../components/results/AnalysisFreshnessNotice'
 import { ReanalyseBar } from '../components/model-tab/ReanalyseBar'
+
+// Spy on the completion toast. `importOriginal` spread so the mock cannot rot
+// as the module gains exports (trap 12: a vi.mock factory REPLACES the module).
+const showToast = vi.fn()
+vi.mock('@/canvas/ToastContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/canvas/ToastContext')>()),
+  useShowToastSafe: () => showToast,
+}))
 
 const EXPORT_ORIGINAL_JSON = readFileSync(
   path.resolve(__dirname, '__fixtures__', 'rewalk2459b-export-original.json'),
@@ -750,6 +758,31 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     // The ReanalyseBar is the "Model changed. Results may be out of date."
     // assertion — it must not render for an import hold.
     expect(screen.queryByTestId('reanalyse-bar')).toBeNull()
+  })
+
+  it('the COMPLETION TOAST cannot claim "with the current model" under an import hold', () => {
+    // The strip and the toast must claim the same thing (the acceptance the
+    // notice's own docs state). A mutation probe caught this uncovered: the
+    // toast took the un-held classification, so a rerun on an unregistered
+    // import announced "completed with the current model" — the affirmative
+    // the badge is forbidden to show, delivered by a different surface.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    showToast.mockClear()
+    // Drive a running → complete transition, which is what fires the toast.
+    useCanvasStore.setState({ results: { status: 'streaming', progress: 50 } } as never)
+    renderFreshnessSurfaces()
+    act(() => {
+      useCanvasStore.setState({ results: { status: 'complete', progress: 100 } } as never)
+    })
+    expect(showToast).toHaveBeenCalled()
+    const said = showToast.mock.calls.map((c) => String(c[0])).join(' | ')
+    expect(said).not.toContain('with the current model')
   })
 
   it('digest .sort() is load-bearing: a REORDERED hydrate of the imported graph still holds', () => {

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -43,7 +43,13 @@ import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
 import { useComparisonStore } from '../stores/comparisonStore'
 import { applyDraftResult } from '../utils/applyDraftResult'
 import { createScenario } from '../store/scenarios'
-import { clearImportRegistrationMarkers } from '../store/importRegistrationMarker'
+import {
+  clearImportRegistrationMarkers,
+  graphImportDigest,
+  markGraphImported,
+  isGraphPendingImportRegistration,
+  __readImportRegistrationMarkers,
+} from '../store/importRegistrationMarker'
 import {
   AnalysisFreshnessNotice,
   FRESHNESS_COPY,
@@ -318,10 +324,16 @@ describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b
     expect(notice).toHaveAttribute('data-cee-freshness', 'fresh')
     expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
     expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
-    // Honest treatment: the model DID change since that analysis (the import),
-    // so the composed trust semantic is 'changed' and the re-analyse bar shows.
+    // Honest treatment, CORRECTED in round 3: the strip reads cannot-confirm
+    // and the "Model changed. Results may be out of date." bar does NOT render.
+    // Round 1 asserted the opposite — but that copy is an assertion about the
+    // MODEL, and the import hold cannot support it (the same identity match
+    // fires when the genuine server graph is on the canvas, where "changed" is
+    // simply false). The one Rerun still lives in the sticky AnalysisFooter, so
+    // no recovery affordance is lost.
     expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
-    expect(screen.getByTestId('reanalyse-bar')).toBeInTheDocument()
+    expect(notice).toHaveTextContent(FRESHNESS_COPY.unknown)
+    expect(screen.queryByTestId('reanalyse-bar')).toBeNull()
   })
 
   it("(b, order-independence) clear-then-verdict also cannot re-attach the affirmative", () => {
@@ -645,7 +657,14 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
   })
 
-  it('BLOCKER E: resetCanvas EMPTY-GRAPH early-return branch releases the hold', () => {
+  // ⚠ The next two cases, and `(c) the hold releases on resetCanvas`, assert
+  // release at sites where the derivation is CONSTANT `false` by construction
+  // (empty/initial graph + the empty-graph null rule). They pin that the sites
+  // release — they do NOT demonstrate derivation there, and a hardcoded `false`
+  // satisfies them, which is exactly what the source now says those lines are.
+  // The property that actually protects them is the empty-graph rule, pinned
+  // separately above.
+  it('resetCanvas EMPTY-GRAPH early-return branch releases the hold (constant site)', () => {
     seedPreImportAnalysedState()
     act(() => {
       useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
@@ -660,7 +679,7 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
   })
 
-  it('BLOCKER E: reset() releases the hold', () => {
+  it('reset() releases the hold (constant site — initialNodes/initialEdges are [])', () => {
     seedPreImportAnalysedState()
     act(() => {
       useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
@@ -672,26 +691,98 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
   })
 
-  it('the marker lives in sessionStorage — the storage choice IS the reload fix', () => {
-    // Pinned explicitly because it is the mechanism blocker A turns on: an
-    // in-memory marker (module variable) or a localStorage one would both pass
-    // the store-level tests below — the first dies with the page (leaving the
-    // defect), the second outlives the tab (over-holding into a new session).
+  it('the marker lives in localStorage — the SAME scope as the autosave it defends', () => {
+    // ⚠ THIS IS THE ONLY THING PINNING THE STORAGE MEDIUM, and a mutation probe
+    // measured exactly that: swapping the medium left every behavioural test
+    // below GREEN (a module-level variable would pass them too) — only this
+    // key read went red. The behavioural tests prove independence from the
+    // STORE INSTANCE, not from the page or the tab, because jsdom never
+    // reloads. The real proof of the reload fix is a LIVE same-tab-reload
+    // witness on staging.
     //
-    // ⚠ Scope limit, stated rather than implied: jsdom does not reload a page,
-    // so the "reload" cases simulate it with a cold store + hydrate. They prove
-    // independence from the STORE INSTANCE; this assertion is what proves the
-    // record is in the storage that actually survives a real same-tab reload.
+    // The medium matters twice over: `sessionStorage` (the second cut) dies
+    // with the TAB while the autosave it defends is `localStorage` and does
+    // not — so a fresh tab booted the imported graph with no marker and one
+    // Rerun restored the FAIL frame. Same governing sentence as blocker A, one
+    // level up: match the scope of the artefact you are defending.
     seedPreImportAnalysedState()
     act(() => {
       useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
     })
-    const raw = globalThis.sessionStorage.getItem('olumi.import.pendingServerRegistration.v1')
+    const raw = globalThis.localStorage.getItem('olumi.import.pendingServerRegistration.v1')
     expect(raw).toBeTruthy()
     expect(raw).toContain(PRE_IMPORT_OPTION_ID) // the imported graph's own node id
     expect(
-      globalThis.localStorage.getItem('olumi.import.pendingServerRegistration.v1'),
+      globalThis.sessionStorage.getItem('olumi.import.pendingServerRegistration.v1'),
     ).toBeNull()
+  })
+
+  it('THE OVER-HOLD MUST NOT LIE: a held import renders cannot-confirm, never "Model changed"', () => {
+    // The walk's OWN flow (export → relabel → import) yields a digest equal to
+    // CEE's own graph, because identity is label-independent. Every later
+    // install of the GENUINE server graph therefore re-derives the hold. In
+    // that state the analysis really is current, so asserting "Model changed.
+    // Results may be out of date." is factually FALSE — and a warning that
+    // cries wolf trains users to ignore the one that matters. Cannot-confirm
+    // is the honest reading: we cannot confirm the server analysed this graph.
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as { nodes: never[]; edges: never[] }
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // The genuine server graph comes back (structurally identical → held).
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: imported.nodes,
+        edges: imported.edges,
+        currentScenarioId: 'scn_server_known',
+      })
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveTextContent(FRESHNESS_COPY.unknown) // "Cannot confirm…"
+    expect(notice).not.toHaveTextContent(FRESHNESS_COPY.stale) // never "Model changed…"
+    // The ReanalyseBar is the "Model changed. Results may be out of date."
+    // assertion — it must not render for an import hold.
+    expect(screen.queryByTestId('reanalyse-bar')).toBeNull()
+  })
+
+  it('digest .sort() is load-bearing: a REORDERED hydrate of the imported graph still holds', () => {
+    // A hydrate or a persistence round-trip can reorder nodes/edges without
+    // changing the model. An order-sensitive digest would miss the match and
+    // drop the hold — the P0, reached by a reordering that changes nothing.
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as {
+      nodes: unknown[]
+      edges: unknown[]
+    }
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    useCanvasStore.getState().reset()
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: [...imported.nodes].reverse() as never,
+        edges: [...imported.edges].reverse() as never,
+      })
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+  })
+
+  it('the empty-graph rule: an EMPTY import arms nothing (it is what makes the three constant sites safe)', () => {
+    // graphImportDigest returns null for an empty graph. Three release sites
+    // (resetCanvas's two branches and reset()) are constant `false` BECAUSE of
+    // this rule — break it and an empty import would make every later reset
+    // match the marker and hold forever.
+    expect(graphImportDigest([], [])).toBeNull()
+    markGraphImported([], [])
+    expect(isGraphPendingImportRegistration([], [])).toBe(false)
+    expect(__readImportRegistrationMarkers()).toEqual([])
   })
 
   it('the marker is scoped to the TAB, not to the store instance (what makes the reload case work)', () => {

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -55,6 +55,8 @@ import {
   FRESHNESS_COPY,
 } from '../../components/results/AnalysisFreshnessNotice'
 import { ReanalyseBar } from '../components/model-tab/ReanalyseBar'
+import { V7FreshnessStrip } from '../../components/results/v7/V7FreshnessStrip'
+import { classifyFreshnessForDisplay } from '../store/analysisFreshness'
 
 // Spy on the completion toast. `importOriginal` spread so the mock cannot rot
 // as the module gains exports (trap 12: a vi.mock factory REPLACES the module).
@@ -212,10 +214,20 @@ function structurallyUnrelatedGraph() {
   }
 }
 
+/**
+ * EVERY surface that renders a freshness claim, mounted together.
+ *
+ * ⚠ `V7FreshnessStrip` was added after a review found it was the FOURTH
+ * surface and had no behavioural spec anywhere in the tree: dropping its
+ * `importHold` argument left this file 24/24 GREEN while the strip flipped back
+ * to asserting "Model changed since this analysis." A claim-bearing surface
+ * that no spec mounts is a claim nobody is checking.
+ */
 function renderFreshnessSurfaces() {
   return render(
     <>
       <AnalysisFreshnessNotice />
+      <V7FreshnessStrip />
       <ReanalyseBar onReanalyse={() => {}} />
     </>,
   )
@@ -332,16 +344,24 @@ describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b
     expect(notice).toHaveAttribute('data-cee-freshness', 'fresh')
     expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
     expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
-    // Honest treatment, CORRECTED in round 3: the strip reads cannot-confirm
-    // and the "Model changed. Results may be out of date." bar does NOT render.
-    // Round 1 asserted the opposite — but that copy is an assertion about the
-    // MODEL, and the import hold cannot support it (the same identity match
-    // fires when the genuine server graph is on the canvas, where "changed" is
-    // simply false). The one Rerun still lives in the sticky AnalysisFooter, so
-    // no recovery affordance is lost.
+    // Honest treatment, settled in round 4: every claim-bearing surface reads
+    // cannot-confirm, and the re-analyse AFFORDANCE still renders — with copy
+    // that states uncertainty instead of asserting a change.
+    //
+    // ⚠ Round 1 asserted the "Model changed" bar; round 3 asserted its ABSENCE.
+    // Both were wrong, in opposite directions. The bar is simultaneously an
+    // assertion and the Model tab's ONLY re-analyse control, so removing it
+    // reproduced ROADMAP 2.129 (a). (The sticky AnalysisFooter Rerun is not a
+    // substitute: it sits in OutputsDock's RESULTS branch, while this bar's
+    // ModelTabBody is a sibling under `diagnostics`.)
     expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
     expect(notice).toHaveTextContent(FRESHNESS_COPY.unknown)
-    expect(screen.queryByTestId('reanalyse-bar')).toBeNull()
+    expect(screen.getByTestId('v7-freshness-strip')).toHaveTextContent(FRESHNESS_COPY.unknown)
+    const bar = screen.getByTestId('reanalyse-bar')
+    expect(bar).toHaveAttribute('data-reason', 'import-unregistered')
+    expect(bar).toHaveTextContent("Can't confirm this analysis matches the current model.")
+    expect(bar).not.toHaveTextContent('Model changed')
+    expect(screen.getByTestId('reanalyse-button')).toBeInTheDocument()
   })
 
   it("(b, order-independence) clear-then-verdict also cannot re-attach the affirmative", () => {
@@ -755,9 +775,50 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     const notice = screen.getByTestId('analysis-freshness-notice')
     expect(notice).toHaveTextContent(FRESHNESS_COPY.unknown) // "Cannot confirm…"
     expect(notice).not.toHaveTextContent(FRESHNESS_COPY.stale) // never "Model changed…"
-    // The ReanalyseBar is the "Model changed. Results may be out of date."
-    // assertion — it must not render for an import hold.
-    expect(screen.queryByTestId('reanalyse-bar')).toBeNull()
+    // FOURTH SURFACE — the V7 strip must agree, not flip to "Model changed".
+    const v7 = screen.getByTestId('v7-freshness-strip')
+    expect(v7).toHaveAttribute('data-freshness-semantic', 'cannot_confirm')
+    expect(v7).toHaveTextContent(FRESHNESS_COPY.unknown)
+    expect(v7).not.toHaveTextContent(FRESHNESS_COPY.stale)
+    // The bar keeps the AFFORDANCE while withholding the assertion.
+    const bar = screen.getByTestId('reanalyse-bar')
+    expect(bar).toHaveAttribute('data-reason', 'import-unregistered')
+    expect(bar).not.toHaveTextContent('Model changed')
+  })
+
+  it('a CEE-STATED stale OUTRANKS the hold: all surfaces say "Model changed", bar keeps its assertion', () => {
+    // A first-hand server statement is a strictly stronger TRUE claim than our
+    // uncertainty. The first cut returned cannot-confirm ABOVE the stale
+    // branch, which suppressed it AND — because the bar gated on 'changed' —
+    // removed the Model tab's only re-analyse control: ROADMAP 2.129 (a),
+    // live-proved on staging `98aae72e`, reproduced by the fix for a different
+    // defect.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness({
+        freshness: 'stale',
+        freshness_reason: 'graph_hash_mismatch',
+        graph_hash_at_run: 'server-at-run',
+        current_graph_hash: 'server-current-different',
+        computed_at: POST_RERUN_COMPUTED_AT,
+      })
+    })
+    renderFreshnessSurfaces()
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'stale',
+    )
+    expect(screen.getByTestId('v7-freshness-strip')).toHaveAttribute(
+      'data-freshness-semantic',
+      'changed',
+    )
+    const bar = screen.getByTestId('reanalyse-bar')
+    expect(bar).toHaveAttribute('data-reason', 'model-changed')
+    expect(bar).toHaveTextContent('Model changed. Results may be out of date.')
   })
 
   it('the COMPLETION TOAST cannot claim "with the current model" under an import hold', () => {
@@ -783,6 +844,67 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     expect(showToast).toHaveBeenCalled()
     const said = showToast.mock.calls.map((c) => String(c[0])).join(' | ')
     expect(said).not.toContain('with the current model')
+  })
+
+  it('THE AFFIRMATIVE GATE IS SELF-SUFFICIENT: (fresh, dirty=false, hold) is cannot-confirm', () => {
+    // Executed, not read: with the hold check placed below the
+    // `fresh → 'current'` line, this combination returned 'current' — the
+    // affirmative this PR exists to make unreachable — and was safe only
+    // because setAnalysisFreshness forces dirty=true one module away. This
+    // test asserts the classifier is fail-safe ON ITS OWN, with the overlay
+    // explicitly CLEAN, so the guarantee cannot be refactored away elsewhere.
+    expect(
+      classifyFreshnessForDisplay(
+        { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        false, // dirty — deliberately clean
+        true, // importHold
+      ),
+    ).toBe('cannot_confirm')
+    // Control: same inputs without the hold still affirm (the gate is not a
+    // blanket suppression).
+    expect(
+      classifyFreshnessForDisplay(
+        { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        false,
+        false,
+      ),
+    ).toBe('current')
+  })
+
+  it('a draft REPRODUCING the imported graph identity still releases (M7b discriminator)', () => {
+    // Written because a probe measured my claim FALSE: I said a mutant swapping
+    // the draft site's literal `false` for the derivation would bite, but every
+    // applyDraftResult call in this spec passed a structurally UNRELATED
+    // payload, so nothing could tell the two apart. This is the missing
+    // discriminating fixture: a WIRE-shaped draft (`from`/`to`, which is what
+    // mapDraftEdgeToCanvas reads) carrying the imported graph's own node ids and
+    // edge endpoints, so the mapped canvas graph has the SAME identity as the
+    // marker. The derivation would hold here; the literal releases — which is
+    // the deliberate behaviour (scope boundary: this interim defends
+    // import-originated staleness only).
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    const landedNodes = useCanvasStore.getState().nodes
+    const landedEdges = useCanvasStore.getState().edges
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    act(() => {
+      applyDraftResult({
+        nodes: landedNodes.map((n) => ({
+          id: n.id,
+          type: (n as unknown as { type?: string }).type,
+          label: (n.data as { label?: string } | undefined)?.label,
+        })),
+        edges: landedEdges.map((e, i) => ({
+          id: e.id ?? `e-${i}`,
+          from: e.source,
+          to: e.target,
+        })),
+      } as never)
+    })
+    // Same identity on the canvas, hold RELEASED — the discriminating outcome.
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
   })
 
   it('INVARIANT that makes the toast safe: under a hold, a fresh verdict always leaves dirty=true', () => {

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -785,6 +785,38 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     expect(said).not.toContain('with the current model')
   })
 
+  it('INVARIANT that makes the toast safe: under a hold, a fresh verdict always leaves dirty=true', () => {
+    // This is the DEMONSTRATION that mutant M14 (dropping `importHold` from the
+    // notice's toast classification) is equivalent, rather than an assertion
+    // that it is. With dirty forced true, `resolveDisplayedFreshness` already
+    // downgrades 'fresh' → 'unknown', so the toast classification lands on
+    // 'changed' with or without importHold, and BOTH produce the neutral
+    // "Analysis rerun completed" line — never the affirmative. The only state
+    // where the argument would change the toast is (hold ∧ ¬dirty ∧ fresh), and
+    // the three writers below make that state unreachable. The argument is kept
+    // as defence-in-depth: if this invariant ever weakens, the toast stays
+    // honest without a second fix.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // 1. ingestion of a fresh verdict forces the overlay on
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    // 2. the explicit clearer refuses under a hold
+    act(() => {
+      useCanvasStore.getState().clearAnalysisFreshnessDirty()
+    })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    // 3. a verdictless run completion also keeps it
+    act(() => {
+      useCanvasStore.getState().noteRunCompletedWithoutVerdict()
+    })
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+
   it('digest .sort() is load-bearing: a REORDERED hydrate of the imported graph still holds', () => {
     // A hydrate or a persistence round-trip can reorder nodes/edges without
     // changing the model. An order-sensitive digest would miss the match and

--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -43,6 +43,7 @@ import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
 import { useComparisonStore } from '../stores/comparisonStore'
 import { applyDraftResult } from '../utils/applyDraftResult'
 import { createScenario } from '../store/scenarios'
+import { clearImportRegistrationMarkers } from '../store/importRegistrationMarker'
 import {
   AnalysisFreshnessNotice,
   FRESHNESS_COPY,
@@ -176,6 +177,27 @@ function analysisResultsCluster() {
   }
 }
 
+/**
+ * A graph that is STRUCTURALLY different from the walk's fixtures (different
+ * node ids), for the release-side controls.
+ *
+ * ⚠ The walk's two fixtures are NOT structurally different from each other:
+ * `import-modified` only RELABELS `opt_alpha`. The import marker's identity is
+ * node ids + edge endpoint pairs — deliberately label-independent, because
+ * including labels would let a user rename one node on an imported graph and
+ * silently release the hold, which is the P0 returning. So a control that needs
+ * "a graph this session never imported" must differ structurally.
+ */
+function structurallyUnrelatedGraph() {
+  return {
+    nodes: [
+      { id: 'unrelated_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Other goal' } },
+      { id: 'unrelated_opt', type: 'option', position: { x: 0, y: 80 }, data: { label: 'Other option' } },
+    ],
+    edges: [],
+  }
+}
+
 function renderFreshnessSurfaces() {
   return render(
     <>
@@ -212,6 +234,7 @@ beforeEach(() => {
   } as never)
   useAnalysisSnapshotStore.getState().clearSnapshots()
   useComparisonStore.getState().resetComparison()
+  clearImportRegistrationMarkers()
 })
 
 describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b attempt 2)', () => {
@@ -345,12 +368,12 @@ describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b
     act(() => {
       useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
     })
-    // Production scenario load replaces the graph — the import is gone.
-    const exported = JSON.parse(EXPORT_ORIGINAL_JSON) as { nodes: never[]; edges: never[] }
+    // A load of a structurally unrelated graph replaces the import.
+    const other = structurallyUnrelatedGraph()
     act(() => {
       useCanvasStore.getState().hydrateGraphSlice({
-        nodes: exported.nodes,
-        edges: exported.edges,
+        nodes: other.nodes as never,
+        edges: other.edges as never,
         currentScenarioId: 'scn_after_import',
       })
     })
@@ -432,5 +455,260 @@ describe('interim 2.467 — import invalidates pre-import analysis (rewalk-2459b
       'data-freshness',
       'fresh',
     )
+  })
+})
+
+/**
+ * Round 2 — the three blockers from the adversarial review of PR #592.
+ *
+ * The first cut cleared an in-memory boolean at six named sites on the premise
+ * that they replace the canvas "with a server-known graph". Two of them do not:
+ * `hydrateGraphSlice`'s live callers pass the localStorage AUTOSAVE, and
+ * `loadScenario` reads localStorage. `useAutosave` debounces 500 ms on a
+ * graph-hash dirty check, so the imported graph is in localStorage ~0.5 s after
+ * the import, and a reload re-installs it through a RELEASE site — restoring
+ * the witnessed FAIL frame after one Rerun.
+ *
+ * The hold is now DERIVED at every graph-replacement site from a
+ * sessionStorage marker keyed to imported-graph identity, so "which sites
+ * release" is no longer a list anyone has to maintain. Per trap 12d, derivation
+ * proves agreement and never completeness — so EVERY replacement site below
+ * carries its own case, and each has its own mutant.
+ */
+describe('interim 2.467 round 2 — the hold is derived from the graph, not from a release list', () => {
+  /** The reload: the autosave carries the imported graph back in via hydrateGraphSlice. */
+  function simulateSameTabReloadRestoringAutosave() {
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as { nodes: never[]; edges: never[] }
+    // A reload starts from a cold store; only sessionStorage survives.
+    useCanvasStore.getState().reset()
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: imported.nodes,
+        edges: imported.edges,
+        // ReactFlowGraph's init effect preserves the scenario id across the
+        // reload so the in-flight CEE conversation keeps its scenario_id —
+        // which is exactly why CEE still holds its own pre-import graph.
+        currentScenarioId: 'scn_preserved_across_reload',
+      })
+    })
+  }
+
+  it('BLOCKER A: after import → autosave → reload, a rerun\'s server "fresh" still cannot affirm', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+
+    simulateSameTabReloadRestoringAutosave()
+
+    // The graph on the canvas is the imported one, restored from localStorage;
+    // the server has still never seen it.
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+      useCanvasStore.getState().clearAnalysisFreshnessDirty()
+    })
+    renderFreshnessSurfaces()
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice).toHaveAttribute('data-cee-freshness', 'fresh')
+    expect(notice).not.toHaveAttribute('data-freshness', 'fresh')
+    expect(notice).not.toHaveTextContent(FRESHNESS_COPY.fresh)
+  })
+
+  it('BLOCKER A control: a reload restoring a DIFFERENT (never-imported) graph does NOT hold', () => {
+    // The same reload machinery, on a graph this session never imported: the
+    // hold must not be a blanket suppression of every hydrate.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    const other = structurallyUnrelatedGraph()
+    useCanvasStore.getState().reset()
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: other.nodes as never,
+        edges: other.edges as never,
+        currentScenarioId: 'scn_other',
+      })
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+    })
+    renderFreshnessSurfaces()
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+
+  it('BLOCKER D: undoDraft back onto the imported graph RE-ARMS the hold', () => {
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as { nodes: never[]; edges: never[] }
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // A CEE draft replaces the imported graph — the hold releases (CEE's own graph).
+    act(() => {
+      applyDraftResult({
+        nodes: [
+          { id: 'd_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Drafted goal' } },
+        ],
+        edges: [],
+      } as never)
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
+
+    // ...and undo puts the IMPORTED graph back. The server has still never seen it.
+    useCanvasStore.setState({
+      draftChatPreDraftSnapshot: { nodes: imported.nodes, edges: imported.edges },
+    } as never)
+    act(() => {
+      useCanvasStore.getState().undoDraft()
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+
+    act(() => {
+      useCanvasStore.getState().setAnalysisFreshness(SERVER_FRESH_VERDICT_AFTER_RERUN)
+      useCanvasStore.getState().clearAnalysisFreshnessDirty()
+    })
+    renderFreshnessSurfaces()
+    expect(screen.getByTestId('analysis-freshness-notice')).not.toHaveAttribute(
+      'data-freshness',
+      'fresh',
+    )
+  })
+
+  it('BLOCKER D control: undoDraft onto a never-imported pre-draft graph does NOT arm the hold', () => {
+    const other = structurallyUnrelatedGraph()
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+      applyDraftResult({
+        nodes: [
+          { id: 'd_goal', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Drafted goal' } },
+        ],
+        edges: [],
+      } as never)
+    })
+    useCanvasStore.setState({
+      draftChatPreDraftSnapshot: { nodes: other.nodes, edges: other.edges },
+    } as never)
+    act(() => {
+      useCanvasStore.getState().undoDraft()
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
+  })
+
+  it('the hold is LABEL-INDEPENDENT: relabelling a node on the imported graph cannot release it', () => {
+    // The unsafe direction of the identity choice, pinned. If the digest
+    // included labels, a user renaming one node on the imported canvas would
+    // drop the hold and the next server 'fresh' would affirm — the P0,
+    // reachable by an ordinary edit.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    const relabelled = JSON.parse(IMPORT_MODIFIED_JSON) as {
+      nodes: Array<{ id: string; data: { label: string } }>
+      edges: never[]
+    }
+    const target = relabelled.nodes.find((n) => n.id === PRE_IMPORT_OPTION_ID)!
+    target.data.label = 'Renamed after import'
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: relabelled.nodes as never,
+        edges: relabelled.edges,
+      })
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+  })
+
+  it('BLOCKER E: loadScenario RESTORING the imported graph holds (localStorage is not the server)', () => {
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as { nodes: never[]; edges: never[] }
+    // `loadScenario` reads scenarios.getScenario — localStorage, not the server.
+    // A scenario saved while the imported graph was on the canvas restores an
+    // unregistered graph exactly as the autosave does.
+    const scenario = createScenario({
+      name: 'Saved while imported',
+      nodes: imported.nodes,
+      edges: imported.edges,
+    })
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    act(() => {
+      expect(useCanvasStore.getState().loadScenario(scenario.id)).toBe(true)
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+  })
+
+  it('BLOCKER E: resetCanvas EMPTY-GRAPH early-return branch releases the hold', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // Empty the graph without going through resetCanvas's main branch, so the
+    // early return is the code under test (the branch whose mutant survived).
+    useCanvasStore.setState({ nodes: [], edges: [] } as never)
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    act(() => {
+      useCanvasStore.getState().resetCanvas()
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
+  })
+
+  it('BLOCKER E: reset() releases the hold', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    act(() => {
+      useCanvasStore.getState().reset()
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)
+  })
+
+  it('the marker lives in sessionStorage — the storage choice IS the reload fix', () => {
+    // Pinned explicitly because it is the mechanism blocker A turns on: an
+    // in-memory marker (module variable) or a localStorage one would both pass
+    // the store-level tests below — the first dies with the page (leaving the
+    // defect), the second outlives the tab (over-holding into a new session).
+    //
+    // ⚠ Scope limit, stated rather than implied: jsdom does not reload a page,
+    // so the "reload" cases simulate it with a cold store + hydrate. They prove
+    // independence from the STORE INSTANCE; this assertion is what proves the
+    // record is in the storage that actually survives a real same-tab reload.
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    const raw = globalThis.sessionStorage.getItem('olumi.import.pendingServerRegistration.v1')
+    expect(raw).toBeTruthy()
+    expect(raw).toContain(PRE_IMPORT_OPTION_ID) // the imported graph's own node id
+    expect(
+      globalThis.localStorage.getItem('olumi.import.pendingServerRegistration.v1'),
+    ).toBeNull()
+  })
+
+  it('the marker is scoped to the TAB, not to the store instance (what makes the reload case work)', () => {
+    seedPreImportAnalysedState()
+    act(() => {
+      useCanvasStore.getState().importCanvas(IMPORT_MODIFIED_JSON)
+    })
+    // A cold store (what a reload produces) still knows the graph is unregistered.
+    useCanvasStore.getState().reset()
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false) // initial graph
+    const imported = JSON.parse(IMPORT_MODIFIED_JSON) as { nodes: never[]; edges: never[] }
+    act(() => {
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: imported.nodes,
+        edges: imported.edges,
+      })
+    })
+    expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
   })
 })

--- a/src/canvas/__tests__/store.spec.ts
+++ b/src/canvas/__tests__/store.spec.ts
@@ -935,7 +935,7 @@ describe('Canvas Store', () => {
     it('a user constraint edit dirties freshness → display downgrades fresh→changed', () => {
       // Precondition (positive control): fresh + not-dirty reads as 'current'.
       let s = useCanvasStore.getState()
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
 
       // User edit via the GoalPanel path (no fromProducerSync opt-out).
       useCanvasStore.getState().setGoalConstraints([
@@ -944,7 +944,7 @@ describe('Canvas Store', () => {
 
       s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(true)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('changed')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('changed')
     })
 
     it('a no-op set (identical content) does NOT dirty freshness', () => {
@@ -955,7 +955,7 @@ describe('Canvas Store', () => {
 
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(false)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
     })
 
     it('null→null is a no-op and does NOT dirty freshness', () => {
@@ -970,7 +970,7 @@ describe('Canvas Store', () => {
       )
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(false)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
     })
 
     it('clearing a real constraint (array→null) dirties freshness', () => {
@@ -978,7 +978,7 @@ describe('Canvas Store', () => {
       useCanvasStore.getState().setGoalConstraints(null)
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(true)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty)).toBe('changed')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('changed')
     })
   })
 

--- a/src/canvas/components/model-tab/ReanalyseBar.tsx
+++ b/src/canvas/components/model-tab/ReanalyseBar.tsx
@@ -11,6 +11,7 @@
 import { RefreshCw } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { useAnalysisTrust } from '../../hooks/useAnalysisTrust'
+import { useCanvasStore } from '../../store'
 
 interface ReanalyseBarProps {
   onReanalyse?: () => void
@@ -18,18 +19,36 @@ interface ReanalyseBarProps {
 
 export function ReanalyseBar({ onReanalyse }: ReanalyseBarProps) {
   const { semantic } = useAnalysisTrust()
+  const importHold = useCanvasStore((s) => s.importPendingServerRegistration)
 
-  if (semantic !== 'changed') return null
+  // AFFORDANCE ≠ ASSERTION (interim 2.467). This bar is BOTH the "Model
+  // changed" claim and the Model tab's ONLY re-analyse control — and conflating
+  // them is what cost the control once already (ROADMAP 2.129 (a), live-proved
+  // on staging `98aae72e`), then nearly again here: an import hold downgrades
+  // the semantic to cannot-confirm, which under the old `!== 'changed'` guard
+  // removed the button outright. The Rerun in the sticky AnalysisFooter is NOT
+  // a substitute — that footer lives in OutputsDock's RESULTS branch, while
+  // this bar's ModelTabBody is a sibling under `diagnostics`, so a Model-tab
+  // user loses the control entirely.
+  //
+  // So: render for a held cannot-confirm too, with copy that states uncertainty
+  // instead of asserting a change. You can be honestly unsure AND still offer
+  // the button.
+  const heldUnsure = importHold && semantic === 'cannot_confirm'
+  if (semantic !== 'changed' && !heldUnsure) return null
 
   return (
     <div
       className="sticky bottom-0 left-0 right-0 bg-panel border-t border-warning/30 px-3 py-2 flex items-center justify-between gap-2"
       data-testid="reanalyse-bar"
+      data-reason={heldUnsure ? 'import-unregistered' : 'model-changed'}
       role="status"
       aria-live="polite"
     >
       <span className={`${typography.panelMeta} text-text-light flex-1 min-w-0`}>
-        Model changed. Results may be out of date.
+        {heldUnsure
+          ? "Can't confirm this analysis matches the current model."
+          : 'Model changed. Results may be out of date.'}
       </span>
       <button
         type="button"

--- a/src/canvas/hooks/__tests__/analysisTrust.f10.spec.tsx
+++ b/src/canvas/hooks/__tests__/analysisTrust.f10.spec.tsx
@@ -123,7 +123,8 @@ describe('F10 pin 1b — the mint→classify seam (the production fact update be
         dirty: false,
         source: r.source,
         resultsStatus: 'complete',
-      }).orphaned,
+        importHold: false,
+    }).orphaned,
     ).toBe(false)
   })
 
@@ -204,7 +205,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'cee_v5_run_analysis',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toEqual({ semantic: 'current', orphaned: false, isRunning: false, reason: 'graph_hash_match' })
 
     expect(
@@ -213,7 +215,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'orphaned_plot_result',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'current', orphaned: true })
 
     expect(
@@ -222,7 +225,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'cee_v5_run_analysis',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'cannot_confirm', reason: RUN_COMPLETED_WITHOUT_VERDICT })
 
     expect(
@@ -231,7 +235,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'cee_v5_run_analysis',
         resultsStatus: 'streaming',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'none', isRunning: true })
   })
 
@@ -246,7 +251,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'orphaned_plot_result',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'cannot_confirm', orphaned: true, reason: ORPHANED_RESULT })
   })
 
@@ -257,7 +263,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'orphaned_plot_result',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'cannot_confirm', orphaned: true, reason: ORPHANED_RESULT })
   })
 
@@ -268,7 +275,8 @@ describe('F10 pin 3 — one trust surface', () => {
         dirty: false,
         source: 'cee_v5_run_analysis',
         resultsStatus: 'complete',
-      }),
+        importHold: false,
+    }),
     ).toMatchObject({ semantic: 'none', orphaned: false })
   })
 })

--- a/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
+++ b/src/canvas/hooks/__tests__/analysisTrust.runStartedAt.spec.ts
@@ -19,6 +19,7 @@ describe('F9: analysis trust composition carries the run clock', () => {
       source: 'none',
       resultsStatus: 'streaming',
       resultsStartedAt: 1_700_000_000_000,
+      importHold: false,
     })
 
     expect(trust.isRunning).toBe(true)
@@ -31,6 +32,7 @@ describe('F9: analysis trust composition carries the run clock', () => {
       dirty: false,
       source: 'none',
       resultsStatus: 'idle',
+      importHold: false,
     })
 
     expect(trust.isRunning).toBe(false)

--- a/src/canvas/hooks/useAnalysisTrust.ts
+++ b/src/canvas/hooks/useAnalysisTrust.ts
@@ -79,15 +79,20 @@ export function computeAnalysisTrust(input: {
   source: AnalysisStateSource | null | undefined
   resultsStatus: string | null | undefined
   resultsStartedAt?: number
+  /** Interim 2.467 — canvas graph is an unregistered import; see
+   *  classifyFreshnessForDisplay's `importHold`. Downgrades 'changed' to
+   *  cannot-confirm so the ReanalyseBar cannot assert "Model changed" about a
+   *  current analysis. */
+  importHold?: boolean
 }): AnalysisTrust {
-  const { freshness, dirty, source, resultsStatus, resultsStartedAt } = input
+  const { freshness, dirty, source, resultsStatus, resultsStartedAt, importHold } = input
   const orphaned = source === 'orphaned_plot_result'
   // Same effective state the strip renders — the orphan fold happens HERE,
   // not per-consumer, so adopting surfaces inherit the F11 precedence rather
   // than re-implementing (or missing) it.
   const { state: effective } = resolveTrustEffectiveState(freshness, orphaned)
   return {
-    semantic: classifyFreshnessForDisplay(effective, dirty),
+    semantic: classifyFreshnessForDisplay(effective, dirty, importHold ?? false),
     orphaned,
     isRunning: RUNNING_STATUSES.has(resultsStatus ?? ''),
     runStartedAt: resultsStartedAt,
@@ -100,6 +105,14 @@ export function useAnalysisTrust(): AnalysisTrust {
   const dirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const resultsStatus = useCanvasStore((s) => s.results?.status)
   const resultsStartedAt = useCanvasStore((s) => s.results?.startedAt)
+  const importHold = useCanvasStore((s) => s.importPendingServerRegistration)
   const { source } = useAnalysisStateSource()
-  return computeAnalysisTrust({ freshness, dirty, source, resultsStatus, resultsStartedAt })
+  return computeAnalysisTrust({
+    freshness,
+    dirty,
+    source,
+    resultsStatus,
+    resultsStartedAt,
+    importHold,
+  })
 }

--- a/src/canvas/hooks/useAnalysisTrust.ts
+++ b/src/canvas/hooks/useAnalysisTrust.ts
@@ -80,10 +80,11 @@ export function computeAnalysisTrust(input: {
   resultsStatus: string | null | undefined
   resultsStartedAt?: number
   /** Interim 2.467 — canvas graph is an unregistered import; see
-   *  classifyFreshnessForDisplay's `importHold`. Downgrades 'changed' to
-   *  cannot-confirm so the ReanalyseBar cannot assert "Model changed" about a
-   *  current analysis. */
-  importHold?: boolean
+   *  classifyFreshnessForDisplay's `importHold`. REQUIRED for the same reason
+   *  it is required there: an optional flag is one a call site can forget, and
+   *  this one already was — `exportBundle` omitted it and drifted from the hook
+   *  it documents itself as mirroring EXACTLY. */
+  importHold: boolean
 }): AnalysisTrust {
   const { freshness, dirty, source, resultsStatus, resultsStartedAt, importHold } = input
   const orphaned = source === 'orphaned_plot_result'
@@ -92,7 +93,7 @@ export function computeAnalysisTrust(input: {
   // than re-implementing (or missing) it.
   const { state: effective } = resolveTrustEffectiveState(freshness, orphaned)
   return {
-    semantic: classifyFreshnessForDisplay(effective, dirty, importHold ?? false),
+    semantic: classifyFreshnessForDisplay(effective, dirty, importHold),
     orphaned,
     isRunning: RUNNING_STATUSES.has(resultsStatus ?? ''),
     runStartedAt: resultsStartedAt,

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -436,6 +436,25 @@ interface CanvasState {
   // scenario switch/load/import/reset. NOT a graph hash; see analysisFreshness.ts.
   analysisFreshnessDirty: boolean
   /**
+   * Interim 2.467 mitigation (P0 trust, live-witnessed 2026-08-04,
+   * rewalk-2459b attempt 2): true while the canvas graph came from a local
+   * IMPORT that the server has never seen. An import replaces the whole graph
+   * client-side only (zero server-side graph persistence — walk VERDICT 3), so
+   * a subsequent rerun is computed by CEE against ITS OWN pre-import graph and
+   * its `analysis_ready.freshness='fresh'` verdict is about the WRONG graph.
+   * While this flag is set, the freshness machinery holds the dirty overlay
+   * (a server 'fresh' displays as cannot-confirm — the existing downgrade,
+   * never a fabricated 'stale') so the affirmative "Analysis reflects the
+   * current model." is unreachable.
+   *
+   * Set by `importCanvas`. Cleared by every path that replaces the canvas with
+   * a server-known graph: `hydrateGraphSlice`, `loadScenario`, `resetCanvas`,
+   * `reset`, and `applyDraftResult` (a CEE draft is CEE's own graph).
+   * Session-scoped, never persisted. The atomic import→reset→registration
+   * train (ROADMAP 2.467) supersedes this flag; remove it when that lands.
+   */
+  importPendingServerRegistration: boolean
+  /**
    * How many model-changing edits have been COMMITTED locally and emitted, but
    * are still sitting undispatched in the conversation dispatcher's deferral
    * buffer (see `useConversation`'s in-flight lock).
@@ -1592,6 +1611,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   analysisFreshness: null,
   // Local dirty overlay — false at cold start (no edits to invalidate a verdict).
   analysisFreshnessDirty: false,
+  // Interim 2.467: no import has happened at cold start.
+  importPendingServerRegistration: false,
   // No edit can be awaiting dispatch before any edit has been made.
   pendingEmittedEdits: 0,
   ceeAnalysisReadyNodeIds: null,
@@ -2489,6 +2510,40 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // overlay (no pending edit applies to a brand-new graph).
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // Interim 2.467 mitigation (P0 trust, rewalk-2459b attempt 2): an import
+      // must never leave a pre-import analysis renderable-as-current. The
+      // pre-import results re-bound BY NODE ID to the imported graph's labels
+      // and rendered as if computed on it — clear the ENTIRE analysis-results
+      // cluster (mirrors resetCanvas's results block) so no pre-import row
+      // survives to re-bind. The imported graph has never been analysed.
+      previousReport: null,
+      results: { status: 'idle', progress: 0 },
+      runMeta: {},
+      hasCompletedFirstRun: false,
+      graphEditedSinceLastRun: false,
+      analysisStateReady: false,
+      rawV2Response: null,
+      v5AnalysisFact: null,
+      ceePipelineTrace: null,
+      ceeQuality: null,
+      nodeRationales: {},
+      ceeExtendedWarnings: null,
+      ceeGoalConnectivity: null,
+      ceeModelQualityFactors: null,
+      ceeInterventionHints: null,
+      preAnalysisSensitivity: null,
+      graphHealth: null,
+      needleMovers: [],
+      lastAnalysisSeed: null,
+      lastQualityMode: null,
+      repairsApplied: null,
+      hoveredOptionId: null,
+      // Interim 2.467: the server has never seen this graph (an import is
+      // client-side only). While set, the freshness machinery holds the dirty
+      // overlay so a rerun's server 'fresh' verdict — computed against CEE's
+      // own pre-import graph — can never display as the affirmative. Cleared
+      // when a server-known graph replaces the canvas; see the field's doc.
+      importPendingServerRegistration: true,
       // Lane 5 (Codex P0-2): a full import is a new decision context — clear the
       // target, its representation, readiness and outcome selection so the
       // imported model never runs against the previous decision's goal state.
@@ -2503,6 +2558,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // fields. Preserving that narrow reset (not full resetDraft, which would also
     // clear lastDraftError, lastDraftDescription, isGenerating, fullDraftAppliedAt).
     useDraftStore.getState().resetAllModels()
+    // Interim 2.467: Compare-tab snapshots and comparison mode hold the
+    // pre-import analysis too (same re-bind class) — clear both, exactly as
+    // loadScenario/resetCanvas do at their graph-replacement boundaries.
+    useAnalysisSnapshotStore.getState().clearSnapshots()
+    useComparisonStore.getState().resetComparison()
 
     return true
   },
@@ -2707,7 +2767,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // influence is the unit cap, which resolveMeasureUnitCap gates on
       // measure.threshold === store.goalThreshold — nulling the threshold
       // breaks that, so a leaked measure can't cap a cleared value.)
-      set({ ...DECISION_CONTEXT_CLEAR })
+      // Interim 2.467: starting fresh releases the import hold too.
+      set({ ...DECISION_CONTEXT_CLEAR, importPendingServerRegistration: false })
       return
     }
 
@@ -2733,6 +2794,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // that only agreed with the spread by coincidence.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // Interim 2.467: the imported graph is gone — release the import hold.
+      importPendingServerRegistration: false,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
       v5AnalysisFact: null,
@@ -2889,6 +2952,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       _internal: { lastHistoryHash: historyHash(initialNodes, initialEdges) },
       hasCompletedFirstRun: false,
       showDraftChat: false,
+      // Interim 2.467: the graph slice is back to initial — no import present.
+      importPendingServerRegistration: false,
     })
     // Reset AI model selections (lives in useDraftStore as of C3-5)
     useDraftStore.getState().resetAllModels()
@@ -3660,6 +3725,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // cannot leak into this one.
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // Interim 2.467: a loaded scenario replaces any imported graph — release
+      // the import hold.
+      importPendingServerRegistration: false,
       isDirty: false,
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
@@ -4185,7 +4253,21 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // it, taking the tab's only re-analyse control with it (ROADMAP 2.129 (a),
       // live-proven on staging `98aae72e`).
       const verdictIsSilentOnFreshness = next?.freshnessReason === VERDICT_ABSENT_FROM_PAYLOAD
-      if (
+      //
+      // ...OR unless the canvas graph is an IMPORT the server has never seen
+      // (interim 2.467, P0 trust — rewalk-2459b attempt 2). The verdict was
+      // computed against CEE's OWN persisted graph; the import replaced the
+      // canvas client-side only, so "fresh" here is a true statement about the
+      // WRONG graph. Same argument as the pendingEmittedEdits hold, strongest
+      // premise: the server has seen NONE of the current model. This is not
+      // merely "don't clear": a 'fresh' verdict FORCES the overlay on, so the
+      // affirmative is unreachable regardless of how the overlay was left by
+      // earlier writes (e.g. a historical-restore's dirty:false).
+      if (state.importPendingServerRegistration) {
+        if (next?.freshness === 'fresh') {
+          updates.analysisFreshnessDirty = true
+        }
+      } else if (
         state.analysisFreshnessDirty &&
         state.pendingEmittedEdits === 0 &&
         !verdictIsSilentOnFreshness
@@ -4235,7 +4317,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       },
       // Same rule as setAnalysisFreshness: a run that completed without seeing
       // a still-undispatched edit must not un-dirty the overlay.
-      analysisFreshnessDirty: state.pendingEmittedEdits > 0,
+      // Interim 2.467: a run against an unregistered import keeps the overlay
+      // too — the run consumed CEE's own graph, not the imported canvas.
+      analysisFreshnessDirty:
+        state.pendingEmittedEdits > 0 || state.importPendingServerRegistration,
     }))
   },
   clearAnalysisFreshnessDirty: () => {
@@ -4243,6 +4328,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // clear the overlay while an emitted edit is queued behind the in-flight
     // lock — that analysis was computed without it.
     if (get().pendingEmittedEdits > 0) return
+    // Interim 2.467: nor while the canvas graph is an import the server has
+    // never seen — the new analysis_result was computed against CEE's own
+    // pre-import graph (applyV5State calls this right after
+    // setAnalysisFreshness applied the rerun's 'fresh'; clearing here would
+    // undo the import hold and re-attach the affirmative — the exact
+    // rewalk-2459b 2c-10 frame).
+    if (get().importPendingServerRegistration) return
     if (get().analysisFreshnessDirty) set(() => ({ analysisFreshnessDirty: false }))
   },
 
@@ -5183,6 +5275,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // dirty overlay so neither leaks from the previous graph/scenario.
       updates.analysisFreshness = null
       updates.analysisFreshnessDirty = false
+      // Interim 2.467: a hydrated (server-known) graph replaces any imported
+      // one — release the import hold so it never becomes permanent
+      // suppression.
+      updates.importPendingServerRegistration = false
       // Lane 5 (Codex P0-2): this is the PRODUCTION scenario-load path
       // (useScenario → hydrateGraphSlice). Before this, it cleared freshness
       // but RETAINED goalThreshold / ceeAnalysisReady / outcomeNodeId, so the

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -2792,14 +2792,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // influence is the unit cap, which resolveMeasureUnitCap gates on
       // measure.threshold === store.goalThreshold — nulling the threshold
       // breaks that, so a leaked measure can't cap a cleared value.)
-      // Interim 2.467, DERIVED: the graph is already empty, and an empty graph
-      // is never an imported one (graphImportDigest returns null for it), so
-      // this releases — stated through the same derivation as every other
-      // replacement site rather than as a hardcoded false.
-      set({
-        ...DECISION_CONTEXT_CLEAR,
-        importPendingServerRegistration: isGraphPendingImportRegistration(nodes, edges),
-      })
+      // Interim 2.467 — release. ⚠ NOT derived, and the earlier "derived, never
+      // a hardcoded false" framing was decorative HERE: this branch runs only
+      // under `nodes.length === 0 && edges.length === 0` (the guard above), and
+      // `graphImportDigest` returns null for an empty graph, so the derivation
+      // would be constant `false`. Written as the literal it provably is. The
+      // COUPLING is what matters: it is the empty-graph null rule (pinned by
+      // its own test) that makes this safe — break that rule and this line
+      // becomes wrong, silently.
+      set({ ...DECISION_CONTEXT_CLEAR, importPendingServerRegistration: false })
       return
     }
 
@@ -2825,9 +2826,12 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // that only agreed with the spread by coincidence.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
-      // Interim 2.467, DERIVED: resetCanvas installs an EMPTY graph, which is
-      // never an imported one — same derivation as every other site.
-      importPendingServerRegistration: isGraphPendingImportRegistration([], []),
+      // Interim 2.467 — release. ⚠ NOT derived (same correction as the
+      // empty-graph branch above): resetCanvas installs an EMPTY graph, for
+      // which the digest is null by the empty-graph rule, so a derivation here
+      // is constant `false`. Stated as the literal it is; the empty-graph rule
+      // is what keeps it correct.
+      importPendingServerRegistration: false,
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
       v5AnalysisFact: null,
@@ -2984,11 +2988,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       _internal: { lastHistoryHash: historyHash(initialNodes, initialEdges) },
       hasCompletedFirstRun: false,
       showDraftChat: false,
-      // Interim 2.467, DERIVED from the graph this installs (the initial one).
-      importPendingServerRegistration: isGraphPendingImportRegistration(
-        initialNodes,
-        initialEdges,
-      ),
+      // Interim 2.467 — release. ⚠ NOT derived: `initialNodes`/`initialEdges`
+      // are both `[]` (store.ts, above), so the digest is null by the
+      // empty-graph rule and a derivation here is constant `false`.
+      importPendingServerRegistration: false,
     })
     // Reset AI model selections (lives in useDraftStore as of C3-5)
     useDraftStore.getState().resetAllModels()

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -48,6 +48,10 @@ import type { LimitsV1 } from '../adapters/plot/types'
 import type { ScenarioStage, ScenarioEvent } from '../types/scenario'
 import type { CeeDebugHeaders } from './utils/ceeDebugHeaders'
 import { identityFromCanvasGraph } from './utils/graphIdentity'
+import {
+  markGraphImported,
+  isGraphPendingImportRegistration,
+} from './store/importRegistrationMarker'
 import { isCompareTabEnabled } from '../flags'
 import { useAnalysisSnapshotStore } from './stores/analysisSnapshotStore'
 import { buildAnalysisSnapshot } from './stores/analysisSnapshotFactory'
@@ -447,11 +451,24 @@ interface CanvasState {
    * never a fabricated 'stale') so the affirmative "Analysis reflects the
    * current model." is unreachable.
    *
-   * Set by `importCanvas`. Cleared by every path that replaces the canvas with
-   * a server-known graph: `hydrateGraphSlice`, `loadScenario`, `resetCanvas`,
-   * `reset`, and `applyDraftResult` (a CEE draft is CEE's own graph).
-   * Session-scoped, never persisted. The atomic import→reset→registration
-   * train (ROADMAP 2.467) supersedes this flag; remove it when that lands.
+   * DERIVED, never mirrored: `importCanvas` records the imported graph's
+   * structural identity in a TAB-scoped marker
+   * (`store/importRegistrationMarker.ts`), and every graph-replacement site
+   * re-derives this flag from the graph it installs via
+   * `isGraphPendingImportRegistration`. There is no hand-maintained list of
+   * "release sites" to keep in sync.
+   *
+   * ⚠ The first cut of this mitigation DID keep such a list, on the premise
+   * that its six sites replace the canvas "with a server-known graph". TWO DID
+   * NOT — `hydrateGraphSlice`'s live callers pass the localStorage AUTOSAVE and
+   * `loadScenario` reads localStorage — so ~0.5 s after an import (the autosave
+   * debounce) a page reload re-installed the imported graph through a RELEASE
+   * site and one Rerun restored the witnessed false affirmative. Hence both the
+   * derivation and the marker's tab scope: the hazard outlives the page, so the
+   * marker must too.
+   *
+   * The atomic import→reset→registration train (ROADMAP 2.467) supersedes this
+   * flag; remove it and the marker module when that lands.
    */
   importPendingServerRegistration: boolean
   /**
@@ -2489,6 +2506,12 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     const imported = persistImport(json)
     if (!imported) return false
 
+    // Interim 2.467: record this graph's identity as imported-and-unregistered
+    // BEFORE the set below, in a TAB-scoped marker. This is what survives a
+    // page reload — the autosave puts the imported graph back on the canvas
+    // ~0.5 s later, and the hold has to come back with it.
+    markGraphImported(imported.nodes, imported.edges)
+
     // Clear history since this is a full import
     clearTimers()
     
@@ -2541,8 +2564,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // Interim 2.467: the server has never seen this graph (an import is
       // client-side only). While set, the freshness machinery holds the dirty
       // overlay so a rerun's server 'fresh' verdict — computed against CEE's
-      // own pre-import graph — can never display as the affirmative. Cleared
-      // when a server-known graph replaces the canvas; see the field's doc.
+      // own pre-import graph — can never display as the affirmative. The
+      // marker is written just below, BEFORE this set is observed, so every
+      // later graph-replacement site can re-derive the flag from the graph it
+      // installs (including after a page reload). See the field's doc.
       importPendingServerRegistration: true,
       // Lane 5 (Codex P0-2): a full import is a new decision context — clear the
       // target, its representation, readiness and outcome selection so the
@@ -2767,8 +2792,14 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // influence is the unit cap, which resolveMeasureUnitCap gates on
       // measure.threshold === store.goalThreshold — nulling the threshold
       // breaks that, so a leaked measure can't cap a cleared value.)
-      // Interim 2.467: starting fresh releases the import hold too.
-      set({ ...DECISION_CONTEXT_CLEAR, importPendingServerRegistration: false })
+      // Interim 2.467, DERIVED: the graph is already empty, and an empty graph
+      // is never an imported one (graphImportDigest returns null for it), so
+      // this releases — stated through the same derivation as every other
+      // replacement site rather than as a hardcoded false.
+      set({
+        ...DECISION_CONTEXT_CLEAR,
+        importPendingServerRegistration: isGraphPendingImportRegistration(nodes, edges),
+      })
       return
     }
 
@@ -2794,8 +2825,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // that only agreed with the spread by coincidence.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
-      // Interim 2.467: the imported graph is gone — release the import hold.
-      importPendingServerRegistration: false,
+      // Interim 2.467, DERIVED: resetCanvas installs an EMPTY graph, which is
+      // never an imported one — same derivation as every other site.
+      importPendingServerRegistration: isGraphPendingImportRegistration([], []),
       // V5 canonical analysis fact — clear on scenario reset (the fact does
       // not survive a graph reset; rerun analysis to mint a fresh one).
       v5AnalysisFact: null,
@@ -2952,8 +2984,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       _internal: { lastHistoryHash: historyHash(initialNodes, initialEdges) },
       hasCompletedFirstRun: false,
       showDraftChat: false,
-      // Interim 2.467: the graph slice is back to initial — no import present.
-      importPendingServerRegistration: false,
+      // Interim 2.467, DERIVED from the graph this installs (the initial one).
+      importPendingServerRegistration: isGraphPendingImportRegistration(
+        initialNodes,
+        initialEdges,
+      ),
     })
     // Reset AI model selections (lives in useDraftStore as of C3-5)
     useDraftStore.getState().resetAllModels()
@@ -3725,9 +3760,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // cannot leak into this one.
       analysisFreshness: null,
       analysisFreshnessDirty: false,
-      // Interim 2.467: a loaded scenario replaces any imported graph — release
-      // the import hold.
-      importPendingServerRegistration: false,
+      // Interim 2.467, DERIVED: `scenarios.getScenario` is localStorage, not
+      // the server — a scenario saved while an imported graph was on the canvas
+      // restores an unregistered graph. Derive from what is being installed.
+      importPendingServerRegistration: isGraphPendingImportRegistration(nodes, edges),
       isDirty: false,
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
@@ -4084,6 +4120,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       outcomeNodeId: firstGoalNodeId(draftChatPreDraftSnapshot.nodes),
       // Verdict is retained → reverted graph no longer matches it → dirty overlay.
       analysisFreshnessDirty: true,
+      // Interim 2.467, DERIVED: undo can put an IMPORTED graph back on the
+      // canvas (import → draft → undo). The draft released the hold because a
+      // CEE draft is CEE's own graph; the graph this restores may well not be,
+      // so re-derive. Without this the dirty overlay set above is cleared by
+      // the next 'fresh' verdict and the affirmative returns — the full P0,
+      // in-session, no reload needed.
+      importPendingServerRegistration: isGraphPendingImportRegistration(
+        draftChatPreDraftSnapshot.nodes,
+        draftChatPreDraftSnapshot.edges,
+      ),
       ceePipelineTrace: null,
       // Graph Lens: auto-reset on draft undo (graph shape changed)
       lens: createDefaultLensState(),
@@ -5275,10 +5321,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // dirty overlay so neither leaks from the previous graph/scenario.
       updates.analysisFreshness = null
       updates.analysisFreshnessDirty = false
-      // Interim 2.467: a hydrated (server-known) graph replaces any imported
-      // one — release the import hold so it never becomes permanent
-      // suppression.
-      updates.importPendingServerRegistration = false
+      // Interim 2.467, DERIVED (see the field's doc): this path's live callers
+      // pass the localStorage AUTOSAVE or loadState() — NOT a server-known
+      // graph. Re-deriving from the graph being installed is what makes a
+      // reload that restores the imported graph keep the hold, while a hydrate
+      // of any other graph releases it.
+      updates.importPendingServerRegistration = isGraphPendingImportRegistration(
+        loaded.nodes,
+        loaded.edges,
+      )
       // Lane 5 (Codex P0-2): this is the PRODUCTION scenario-load path
       // (useScenario → hydrateGraphSlice). Before this, it cleared freshness
       // but RETAINED goalThreshold / ceeAnalysisReady / outcomeNodeId, so the

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -189,8 +189,8 @@ describe('resolveDisplayedFreshness (local dirty overlay display rule)', () => {
     it('identical hashes → displayed unknown (cannot-confirm), dirty or not', () => {
       expect(resolveDisplayedFreshness(contradictory, false)).toBe('unknown')
       expect(resolveDisplayedFreshness(contradictory, true)).toBe('unknown')
-      expect(classifyFreshnessForDisplay(contradictory, false)).toBe('cannot_confirm')
-      expect(classifyFreshnessForDisplay(contradictory, true)).toBe('cannot_confirm')
+      expect(classifyFreshnessForDisplay(contradictory, false, false)).toBe('cannot_confirm')
+      expect(classifyFreshnessForDisplay(contradictory, true, false)).toBe('cannot_confirm')
     })
 
     it('POSITIVE CONTROL: differing hashes keep the factual stale/changed claim', () => {
@@ -200,7 +200,7 @@ describe('resolveDisplayedFreshness (local dirty overlay display rule)', () => {
         currentGraphHash: 'a-different-hash',
       })
       expect(resolveDisplayedFreshness(genuine, false)).toBe('stale')
-      expect(classifyFreshnessForDisplay(genuine, false)).toBe('changed')
+      expect(classifyFreshnessForDisplay(genuine, false, false)).toBe('changed')
     })
 
     it('missing or empty hashes are NOT a contradiction (verdict trusted)', () => {
@@ -244,27 +244,27 @@ describe('resolveDisplayedFreshness (local dirty overlay display rule)', () => {
 
 describe('classifyFreshnessForDisplay (copy semantic across AI-panel surfaces)', () => {
   it('no verdict → none', () => {
-    expect(classifyFreshnessForDisplay(null, false)).toBe('none')
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'none' }), false)).toBe('none')
+    expect(classifyFreshnessForDisplay(null, false, false)).toBe('none')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'none' }), false, false)).toBe('none')
   })
 
   it('clean fresh → current', () => {
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), false)).toBe('current')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), false, false)).toBe('current')
   })
 
   it('CEE stale → changed', () => {
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), true)).toBe('changed')
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), false)).toBe('changed')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), true, false)).toBe('changed')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'stale' }), false, false)).toBe('changed')
   })
 
   it('dirty-overlay downgrade of a retained fresh → changed (user definitely edited)', () => {
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), true)).toBe('changed')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'fresh' }), true, false)).toBe('changed')
   })
 
   it('CEE-sourced unknown → cannot_confirm, NEVER changed (no false "you edited" claim)', () => {
     // A present analysis_ready with missing/invalid freshness degrades to 'unknown'
     // (deriveAnalysisFreshnessUpdate). That is cannot-confirm, not a user edit.
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), false)).toBe('cannot_confirm')
-    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), true)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), false, false)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay(prev({ freshness: 'unknown' }), true, false)).toBe('cannot_confirm')
   })
 })

--- a/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
+++ b/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
@@ -83,7 +83,8 @@ function semanticNow() {
     dirty: s.analysisFreshnessDirty,
     source: null,
     resultsStatus: 'complete',
-  }).semantic
+    importHold: false,
+    }).semantic
 }
 
 beforeEach(() => {
@@ -145,24 +146,26 @@ describe('the REJECTED edit — the control that was GREEN before the fix', () =
 
 describe('controls — the fix must NOT widen "changed" beyond the silent-payload case', () => {
   it('a CEE-STATED unknown verdict stays cannot-confirm, dirty or not', () => {
-    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, false)).toBe('cannot_confirm')
-    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, true)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, false, false)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay({ freshness: 'unknown' }, true, false)).toBe('cannot_confirm')
     expect(
       classifyFreshnessForDisplay(
         { freshness: 'unknown', freshnessReason: 'engine_could_not_determine' },
         true,
+        false,
       ),
     ).toBe('cannot_confirm')
   })
 
   it('the orphan synthesis and the run-completion write stay cannot-confirm', () => {
     expect(
-      classifyFreshnessForDisplay({ freshness: 'unknown', freshnessReason: 'orphaned_result' }, true),
+      classifyFreshnessForDisplay({ freshness: 'unknown', freshnessReason: 'orphaned_result' }, true, false),
     ).toBe('cannot_confirm')
     expect(
       classifyFreshnessForDisplay(
         { freshness: 'unknown', freshnessReason: 'run_completed_without_verdict' },
         true,
+        false,
       ),
     ).toBe('cannot_confirm')
   })
@@ -173,6 +176,7 @@ describe('controls — the fix must NOT widen "changed" beyond the silent-payloa
     expect(
       classifyFreshnessForDisplay(
         { freshness: 'unknown', freshnessReason: VERDICT_ABSENT_FROM_PAYLOAD },
+        false,
         false,
       ),
     ).toBe('cannot_confirm')

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -221,6 +221,22 @@ export function isSelfContradictoryStale(
  * HOLDS the verbatim CEE verdict (`data-cee-freshness` and debug exports keep
  * it); only the display value downgrades.
  */
+/**
+ * ⚠ INTERIM 2.467 — THIS FUNCTION TAKES NO `importHold`, AND ITS FOUR CALL
+ * SITES ARE FAIL-SAFE BY LUCK, NOT BY DESIGN. Documented rather than
+ * re-plumbed, deliberately, because re-plumbing them is out of scope for an
+ * interim mitigation.
+ *
+ * `useEditConfirmation`, `OutputsDock`, `AnalysisFreshnessNotice` and
+ * `DecisionConfidencePanel` all only ever ask "is this NOT confirmably fresh?".
+ * They inherit the mitigation solely because `setAnalysisFreshness` forces the
+ * dirty overlay on under a hold, which downgrades a `fresh` verdict to
+ * `'unknown'` here. That forced-dirty line is the single most load-bearing line
+ * in the mitigation (its mutant bites 6 tests). **Any new call site that asks a
+ * POSITIVE question of this function — "is it fresh?" — will get the wrong
+ * answer under a hold.** Ask `classifyFreshnessForDisplay` (which takes the
+ * hold explicitly and gates the affirmative first) instead.
+ */
 export function resolveDisplayedFreshness(
   state: AnalysisFreshnessState | null,
   dirty: boolean,
@@ -271,13 +287,44 @@ export function classifyFreshnessForDisplay(
    * the one that matters. Cannot-confirm is the honest reading of exactly this
    * state: we cannot confirm the server analysed what is on the canvas.
    */
-  importHold: boolean = false,
+  // REQUIRED, deliberately not defaulted. A `= false` default means any call
+  // site that forgets it silently gets the UNSAFE value and drifts back to the
+  // affirmative — derivation proves agreement between call sites, never that
+  // the set of call sites is complete (trap 12d). Making it required turns that
+  // silent drift into a compile error.
+  importHold: boolean,
 ): FreshnessDisplaySemantic {
   const displayed = resolveDisplayedFreshness(state, dirty)
   if (displayed === null || displayed === 'none') return 'none'
+  // ⚠ THE AFFIRMATIVE GATE, AND IT MUST STAY FIRST. Under an import hold the
+  // affirmative is unreachable BY THIS FUNCTION ALONE — not by cooperation with
+  // another module.
+  //
+  // Measured, after three review rounds had read this code without catching it:
+  // with the hold check placed anywhere BELOW the `fresh → 'current'` line,
+  // `(fresh, dirty=false, importHold=true)` returns **'current'** — the exact
+  // affirmative this mitigation exists to make unreachable. It was safe only
+  // because `setAnalysisFreshness` forces `dirty=true` under a hold, one module
+  // away. A mitigation that leans on an invariant in another file, undocumented
+  // at the point of use, is one refactor from re-opening the P0.
+  if (importHold && displayed === 'fresh') return 'cannot_confirm'
   if (displayed === 'fresh') return 'current'
-  if (importHold) return 'cannot_confirm'
+  // A CEE-STATED 'stale' OUTRANKS our own uncertainty and must reach this
+  // branch even under an import hold. It is a first-hand server statement that
+  // the model changed — a strictly stronger TRUE claim than "cannot confirm".
+  //
+  // ⚠ The first cut of the import hold returned cannot-confirm ABOVE this line,
+  // which suppressed that server statement, and — because `ReanalyseBar` gates
+  // on 'changed' — took the Model tab's ONLY re-analyse control with it. That
+  // is precisely the defect ROADMAP 2.129 (a) was opened for and live-proved on
+  // staging `98aae72e`; its account sits a few lines below. The hold gates the
+  // INFERRED 'changed' only (see the next branch), never a stated one.
   if (displayed === 'stale') return 'changed'
+  // The INFERRED cases below rest on our own dirty overlay rather than on
+  // anything the server said; under a hold that inference is unsafe (the
+  // structural identity match also fires when the GENUINE server graph is on
+  // the canvas, where "Model changed" would be false).
+  if (importHold) return 'cannot_confirm'
   // displayed === 'unknown': it means the user definitely changed the model
   // since the run in exactly two cases, both of which require the local dirty
   // overlay (the UI's own first-hand knowledge that an analysis-affecting edit
@@ -296,6 +343,11 @@ export function classifyFreshnessForDisplay(
   // 'unknown', the orphan synthesis (ORPHANED_RESULT) and the run-completion
   // write (RUN_COMPLETED_WITHOUT_VERDICT) must never be dressed up as a factual
   // "you edited" claim.
+  // Disclosed: the hold above also downgrades a genuine post-import EDIT
+  // (VERDICT_ABSENT_FROM_PAYLOAD + dirty), for which "Model changed" would have
+  // been true. Deliberate, and it costs nothing user-facing — the re-analyse
+  // affordance renders for a held cannot-confirm too (ReanalyseBar): the
+  // ASSERTION is withheld, the AFFORDANCE is not.
   if (dirty && (state?.freshness === 'fresh' || state?.freshnessReason === VERDICT_ABSENT_FROM_PAYLOAD)) {
     return 'changed'
   }

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -258,10 +258,25 @@ export type FreshnessDisplaySemantic = 'current' | 'changed' | 'cannot_confirm' 
 export function classifyFreshnessForDisplay(
   state: AnalysisFreshnessState | null,
   dirty: boolean,
+  /**
+   * Interim 2.467: the canvas graph is an IMPORT the server has never seen, so
+   * the dirty overlay is held by the mitigation rather than by a user edit.
+   *
+   * This must NEVER classify as 'changed'. The mitigation's identity match is
+   * structural and therefore coarse: after the walk's own flow (export →
+   * relabel → import) the imported digest equals CEE's own graph, so every
+   * later install of the GENUINE server graph re-derives the hold. Asserting
+   * "Model changed. Results may be out of date." there is factually false about
+   * a current analysis — and a warning that cries wolf trains users to ignore
+   * the one that matters. Cannot-confirm is the honest reading of exactly this
+   * state: we cannot confirm the server analysed what is on the canvas.
+   */
+  importHold: boolean = false,
 ): FreshnessDisplaySemantic {
   const displayed = resolveDisplayedFreshness(state, dirty)
   if (displayed === null || displayed === 'none') return 'none'
   if (displayed === 'fresh') return 'current'
+  if (importHold) return 'cannot_confirm'
   if (displayed === 'stale') return 'changed'
   // displayed === 'unknown': it means the user definitely changed the model
   // since the run in exactly two cases, both of which require the local dirty

--- a/src/canvas/store/importRegistrationMarker.ts
+++ b/src/canvas/store/importRegistrationMarker.ts
@@ -1,8 +1,9 @@
 /**
  * Import-registration marker — interim 2.467 (P0 trust).
  *
- * Records, for the lifetime of the TAB, which graph identities entered the
- * canvas via a local IMPORT and have therefore never been seen by the server.
+ * Records which graph identities entered the canvas via a local IMPORT and have
+ * therefore never been seen by the server, in the SAME STORAGE SCOPE as the
+ * artefact they defend.
  * `store.importPendingServerRegistration` is DERIVED from this at every
  * graph-replacement site; it is never mirrored across a hand-maintained list of
  * "release sites".
@@ -20,20 +21,32 @@
  *     a reload re-installs it through `hydrateGraphSlice` with the same
  *     `scenario_id`, the boolean cleared, and one Rerun re-attached
  *     "Analysis reflects the current model." to CEE's pre-import graph — the
- *     witnessed FAIL frame, restored. A marker that dies with the page cannot
- *     defend a graph that survives the page: `sessionStorage` outlives a
- *     same-tab reload, which is exactly the lifetime of the hazard.
+ *     witnessed FAIL frame, restored. **A marker that dies with the page cannot
+ *     defend a graph that survives the page.**
+ *
+ *  1b. That governing sentence applies ONE LEVEL UP, and the second cut of this
+ *     module got it wrong too. `sessionStorage` dies with the TAB — but the
+ *     autosave it defends is `localStorage`, which does not. A fresh tab boots
+ *     the imported graph from that autosave (same `currentScenarioId`), finds
+ *     no marker, derives `false`, and one Rerun restores the identical FAIL
+ *     frame. The marker therefore lives in `localStorage`: **the same storage
+ *     scope as the artefact it defends.** Any future change to where the
+ *     imported graph is persisted must move this marker with it.
  *
  *  2. Deriving the flag from the graph being installed removes the defect
  *     CLASS rather than one instance. A hand-maintained release list is the
  *     dominant defect here: three sites in the first cut had no test, and a
  *     mutation run proved two of them could be deleted silently. With
- *     derivation there is ONE rule — "is the graph I am installing an
- *     imported, still-unregistered one?" — and a new graph-replacement site
- *     that forgets to ask it inherits the store's initial `false`, which is
- *     the same posture it would have had before this mitigation existed.
+ *     derivation there is ONE rule to read at the sites where the installed
+ *     graph VARIES — `hydrateGraphSlice`, `loadScenario`, `undoDraft`.
  *     (Derivation proves agreement, never completeness — so every replacement
  *     site still carries its own test and its own mutant.)
+ *
+ *     ⚠ A new graph-replacement site that forgets to set this field does NOT
+ *     "inherit a safe default": Zustand's partial `set` RETAINS the current
+ *     value, so it keeps whatever the previous graph left behind — over-holding
+ *     if it was true, and serving the P0 if it was false. There is no safe
+ *     default here; a new site must set the field explicitly.
  *
  * Identity is STRUCTURAL (node ids + edge endpoint pairs) via the established
  * `identityFromCanvasGraph` helper — deliberately NOT a second graph-hash
@@ -41,6 +54,21 @@
  * positions after a hydrate, and a relabel leaves the graph just as
  * unregistered as it was. Both make the marker MATCH more often, i.e. hold the
  * cannot-confirm posture for longer — the fail-safe direction.
+ *
+ * TWO DISCLOSED WEAKNESSES — both fail to the PRE-MITIGATION posture, i.e. to
+ * the P0, and neither is defended here because defending them is the 2.467
+ * registration train's job:
+ *
+ *  - **Storage unavailable** (private browsing, storage disabled, quota
+ *    exceeded, corrupt record): `readMarkers` returns `[]` and `writeMarkers`
+ *    silently drops the write, so the hold never arms and the false
+ *    affirmative is reachable exactly as it was before this mitigation. It
+ *    fails SILENTLY and deliberately — throwing inside a store action would
+ *    break the import itself — but silent-and-unprotected is a real gap, not a
+ *    graceful degradation.
+ *  - **`MAX_IDENTITIES` eviction**: the record keeps the most recent 50
+ *    identities and silently evicts the oldest. A session that imports more
+ *    than 50 distinct graphs loses the hold on the earliest ones.
  *
  * Superseded by the atomic import→reset→registration train (ROADMAP 2.467):
  * when a real registration handshake exists, the server's own acknowledgement
@@ -66,8 +94,11 @@ type GraphEdges = ReadonlyArray<{ source?: unknown; target?: unknown }> | undefi
 export function graphImportDigest(nodes: GraphNodes, edges: GraphEdges): string | null {
   const identity = identityFromCanvasGraph(nodes, edges)
   if (identity.nodeIds.length === 0) return null
-  // Sorted so the digest is insensitive to array order (a hydrate or a
-  // reseed may reorder without changing the model).
+  // LOAD-BEARING SORT — pinned by its own test. A hydrate or a persistence
+  // round-trip can reorder nodes/edges without changing the model; an
+  // order-sensitive digest would then MISS the match and drop the hold, which
+  // is the P0. Order-insensitivity is the whole reason the marker survives the
+  // localStorage round-trip that blocker A turns on.
   const nodePart = [...identity.nodeIds].sort().join(',')
   const edgePart = [...identity.edgePairs].sort().join(',')
   return `n:${nodePart}|e:${edgePart}`
@@ -75,7 +106,7 @@ export function graphImportDigest(nodes: GraphNodes, edges: GraphEdges): string 
 
 function readMarkers(): string[] {
   try {
-    const raw = globalThis.sessionStorage?.getItem(STORAGE_KEY)
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY)
     if (!raw) return []
     const parsed: unknown = JSON.parse(raw)
     return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
@@ -88,7 +119,7 @@ function readMarkers(): string[] {
 
 function writeMarkers(next: string[]): void {
   try {
-    globalThis.sessionStorage?.setItem(STORAGE_KEY, JSON.stringify(next.slice(-MAX_IDENTITIES)))
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(next.slice(-MAX_IDENTITIES)))
   } catch {
     /* storage unavailable or full — see readMarkers */
   }
@@ -116,7 +147,7 @@ export function isGraphPendingImportRegistration(nodes: GraphNodes, edges: Graph
 /** Test/teardown helper — a real session drops the record when the tab closes. */
 export function clearImportRegistrationMarkers(): void {
   try {
-    globalThis.sessionStorage?.removeItem(STORAGE_KEY)
+    globalThis.localStorage?.removeItem(STORAGE_KEY)
   } catch {
     /* see readMarkers */
   }

--- a/src/canvas/store/importRegistrationMarker.ts
+++ b/src/canvas/store/importRegistrationMarker.ts
@@ -1,0 +1,128 @@
+/**
+ * Import-registration marker — interim 2.467 (P0 trust).
+ *
+ * Records, for the lifetime of the TAB, which graph identities entered the
+ * canvas via a local IMPORT and have therefore never been seen by the server.
+ * `store.importPendingServerRegistration` is DERIVED from this at every
+ * graph-replacement site; it is never mirrored across a hand-maintained list of
+ * "release sites".
+ *
+ * WHY DERIVED, AND WHY sessionStorage (both learned from an adversarial review
+ * of the first cut of this mitigation):
+ *
+ *  1. The first cut used an in-memory boolean cleared at six named sites, on
+ *     the stated premise that those sites replace the canvas "with a
+ *     server-known graph". TWO OF THEM DO NOT. `hydrateGraphSlice`'s live
+ *     callers pass the **localStorage autosave** (ReactFlowGraph's init
+ *     effect), and `loadScenario` reads `scenarios.getScenario` — also
+ *     localStorage. `useAutosave` debounces 500 ms on a graph-hash dirty
+ *     check, so ~0.5 s after an import the IMPORTED graph is in localStorage;
+ *     a reload re-installs it through `hydrateGraphSlice` with the same
+ *     `scenario_id`, the boolean cleared, and one Rerun re-attached
+ *     "Analysis reflects the current model." to CEE's pre-import graph — the
+ *     witnessed FAIL frame, restored. A marker that dies with the page cannot
+ *     defend a graph that survives the page: `sessionStorage` outlives a
+ *     same-tab reload, which is exactly the lifetime of the hazard.
+ *
+ *  2. Deriving the flag from the graph being installed removes the defect
+ *     CLASS rather than one instance. A hand-maintained release list is the
+ *     dominant defect here: three sites in the first cut had no test, and a
+ *     mutation run proved two of them could be deleted silently. With
+ *     derivation there is ONE rule — "is the graph I am installing an
+ *     imported, still-unregistered one?" — and a new graph-replacement site
+ *     that forgets to ask it inherits the store's initial `false`, which is
+ *     the same posture it would have had before this mitigation existed.
+ *     (Derivation proves agreement, never completeness — so every replacement
+ *     site still carries its own test and its own mutant.)
+ *
+ * Identity is STRUCTURAL (node ids + edge endpoint pairs) via the established
+ * `identityFromCanvasGraph` helper — deliberately NOT a second graph-hash
+ * notion, and deliberately position- and label-independent: layout moves
+ * positions after a hydrate, and a relabel leaves the graph just as
+ * unregistered as it was. Both make the marker MATCH more often, i.e. hold the
+ * cannot-confirm posture for longer — the fail-safe direction.
+ *
+ * Superseded by the atomic import→reset→registration train (ROADMAP 2.467):
+ * when a real registration handshake exists, the server's own acknowledgement
+ * replaces this marker. Delete the module then.
+ */
+import { identityFromCanvasGraph } from '../utils/graphIdentity'
+
+const STORAGE_KEY = 'olumi.import.pendingServerRegistration.v1'
+/** Bounded so a session that imports repeatedly cannot grow the record without limit. */
+const MAX_IDENTITIES = 50
+
+type GraphNodes = ReadonlyArray<{ id?: unknown }> | undefined
+type GraphEdges = ReadonlyArray<{ source?: unknown; target?: unknown }> | undefined
+
+/**
+ * Structural digest of a graph, or `null` when there is nothing to identify.
+ *
+ * An EMPTY graph returns null on purpose: `resetCanvas` and `reset` install one,
+ * and an empty canvas carries no analysis that could be mis-affirmed. Without
+ * this, importing an empty graph would make every later reset match the marker
+ * and hold forever.
+ */
+export function graphImportDigest(nodes: GraphNodes, edges: GraphEdges): string | null {
+  const identity = identityFromCanvasGraph(nodes, edges)
+  if (identity.nodeIds.length === 0) return null
+  // Sorted so the digest is insensitive to array order (a hydrate or a
+  // reseed may reorder without changing the model).
+  const nodePart = [...identity.nodeIds].sort().join(',')
+  const edgePart = [...identity.edgePairs].sort().join(',')
+  return `n:${nodePart}|e:${edgePart}`
+}
+
+function readMarkers(): string[] {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
+  } catch {
+    // No sessionStorage (SSR, privacy mode) or corrupt record. Fail to the
+    // pre-mitigation posture rather than throwing inside a store action.
+    return []
+  }
+}
+
+function writeMarkers(next: string[]): void {
+  try {
+    globalThis.sessionStorage?.setItem(STORAGE_KEY, JSON.stringify(next.slice(-MAX_IDENTITIES)))
+  } catch {
+    /* storage unavailable or full — see readMarkers */
+  }
+}
+
+/** Record that this graph entered the canvas by import and is unregistered. */
+export function markGraphImported(nodes: GraphNodes, edges: GraphEdges): void {
+  const digest = graphImportDigest(nodes, edges)
+  if (digest === null) return
+  const markers = readMarkers()
+  if (markers.includes(digest)) return
+  writeMarkers([...markers, digest])
+}
+
+/**
+ * THE derivation. True iff the graph being installed is one this session
+ * imported and the server has never seen.
+ */
+export function isGraphPendingImportRegistration(nodes: GraphNodes, edges: GraphEdges): boolean {
+  const digest = graphImportDigest(nodes, edges)
+  if (digest === null) return false
+  return readMarkers().includes(digest)
+}
+
+/** Test/teardown helper — a real session drops the record when the tab closes. */
+export function clearImportRegistrationMarkers(): void {
+  try {
+    globalThis.sessionStorage?.removeItem(STORAGE_KEY)
+  } catch {
+    /* see readMarkers */
+  }
+}
+
+/** Diagnostics only (debug bundle / tests). Never user copy. */
+export function __readImportRegistrationMarkers(): string[] {
+  return readMarkers()
+}

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -227,6 +227,10 @@ export function applyDraftResult(
     goalThreshold: null,
     goalThresholdRepresentation: null,
     outcomeNodeId: null,
+    // Interim 2.467: a CEE draft is CEE's OWN graph — a wholesale replacement
+    // of any locally-imported graph, so release the import hold (see
+    // importPendingServerRegistration in the store).
+    importPendingServerRegistration: false,
   })
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -16,6 +16,7 @@ import { DEFAULT_EDGE_DATA, readValidationMetadata } from '../domain/edges'
 import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
+import { isGraphPendingImportRegistration } from '../store/importRegistrationMarker'
 import { hasAnalysisReady } from '../../adapters/cee/types'
 import type { CEEDraftResponse, CEEGoalConstraint, CEEv2Response, CEEv3Response, EffectDirection } from '../../adapters/cee/types'
 import { commitDraftCoachingToStore, edgeProvenanceDisplayPatch } from './draftIngestion'
@@ -227,10 +228,11 @@ export function applyDraftResult(
     goalThreshold: null,
     goalThresholdRepresentation: null,
     outcomeNodeId: null,
-    // Interim 2.467: a CEE draft is CEE's OWN graph — a wholesale replacement
-    // of any locally-imported graph, so release the import hold (see
-    // importPendingServerRegistration in the store).
-    importPendingServerRegistration: false,
+    // Interim 2.467, DERIVED: a CEE draft is CEE's OWN graph, so this normally
+    // releases the import hold — but it is derived from the graph being
+    // installed like every other replacement site, so a draft that reproduces
+    // an imported graph holds instead of affirming (fail-safe direction).
+    importPendingServerRegistration: isGraphPendingImportRegistration(nodes, edges),
   })
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -16,7 +16,6 @@ import { DEFAULT_EDGE_DATA, readValidationMetadata } from '../domain/edges'
 import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
 import { projectAutosaveData, autosaveSourceFromStore } from '../store/autosaveProjection'
-import { isGraphPendingImportRegistration } from '../store/importRegistrationMarker'
 import { hasAnalysisReady } from '../../adapters/cee/types'
 import type { CEEDraftResponse, CEEGoalConstraint, CEEv2Response, CEEv3Response, EffectDirection } from '../../adapters/cee/types'
 import { commitDraftCoachingToStore, edgeProvenanceDisplayPatch } from './draftIngestion'
@@ -228,11 +227,15 @@ export function applyDraftResult(
     goalThreshold: null,
     goalThresholdRepresentation: null,
     outcomeNodeId: null,
-    // Interim 2.467, DERIVED: a CEE draft is CEE's OWN graph, so this normally
-    // releases the import hold — but it is derived from the graph being
-    // installed like every other replacement site, so a draft that reproduces
-    // an imported graph holds instead of affirming (fail-safe direction).
-    importPendingServerRegistration: isGraphPendingImportRegistration(nodes, edges),
+    // Interim 2.467 — the ONE replacement site that does not derive, stated
+    // plainly rather than dressed as derivation. A draft graph is one CEE has
+    // just produced, so it is server-known by construction and the hold
+    // releases unconditionally. (It is also the only site where derivation
+    // would be untestable theatre: draft nodes/edges arrive WIRE-shaped and are
+    // mapped here, so a canvas-shaped imported graph can never round-trip
+    // through this path to match the marker. An equivalent mutant is not
+    // coverage — see the evidence note on M7.)
+    importPendingServerRegistration: false,
   })
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -241,12 +241,19 @@ export function applyDraftResult(
     // not a regression it introduces, and it is disclosed as residue.
     //
     // ⚠ My FIRST justification ("the derivation here is an equivalent mutant —
-    // wire-shaped edges can never match") was also false at the bytes: `nodes`
-    // and `edges` in scope here are the MAPPER'S CANVAS-SHAPED OUTPUT, and
-    // `mapDraftNodeToCanvas` preserves `n.id` verbatim, so a payload carrying
-    // the imported ids yields exactly the same digest. The falsifying case is
-    // now a test, and a mutant swapping this line for the derivation BITES.
-    // An equivalent mutant must be DEMONSTRATED, never asserted.
+    // wire-shaped edges can never match") was false at the bytes: `nodes` and
+    // `edges` in scope here are the MAPPER'S CANVAS-SHAPED OUTPUT, and
+    // `mapDraftNodeToCanvas` preserves `n.id` verbatim, so a WIRE payload
+    // (`from`/`to`, which is what mapDraftEdgeToCanvas reads) carrying the
+    // imported ids yields exactly the same digest.
+    //
+    // ⚠ And my correction of it was ALSO wrong in the other direction: I wrote
+    // that a mutant swapping this line for the derivation BITES. A probe ran
+    // exactly that mutant and it SURVIVED 24/24 — every applyDraftResult call
+    // in the spec passed a structurally unrelated payload, so nothing could
+    // discriminate. The discriminating fixture now exists ("a draft REPRODUCING
+    // the imported graph identity still releases"). AN EQUIVALENT MUTANT MUST BE
+    // DEMONSTRATED, NEVER ASSERTED — and so must a NON-equivalent one.
     importPendingServerRegistration: false,
   })
 

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -227,14 +227,26 @@ export function applyDraftResult(
     goalThreshold: null,
     goalThresholdRepresentation: null,
     outcomeNodeId: null,
-    // Interim 2.467 — the ONE replacement site that does not derive, stated
-    // plainly rather than dressed as derivation. A draft graph is one CEE has
-    // just produced, so it is server-known by construction and the hold
-    // releases unconditionally. (It is also the only site where derivation
-    // would be untestable theatre: draft nodes/edges arrive WIRE-shaped and are
-    // mapped here, so a canvas-shaped imported graph can never round-trip
-    // through this path to match the marker. An equivalent mutant is not
-    // coverage — see the evidence note on M7.)
+    // Interim 2.467 — the ONE replacement site that does not derive. It
+    // releases unconditionally, and the honest argument for that is a SCOPE
+    // boundary, not provenance:
+    //
+    // ⚠ "a draft graph is server-known by construction" is FALSE, and was my
+    // second wrong justification for this line. `starters/loadStarter.ts`
+    // (applyStarter) routes a LOCAL starter fixture through this same function,
+    // and CEE has never seen that graph either. What is true is narrower: this
+    // interim defends against IMPORT-originated staleness only, and neither a
+    // CEE draft nor a starter arrives by import. A starter that is later
+    // analysed can affirm — that is the same posture as before this mitigation,
+    // not a regression it introduces, and it is disclosed as residue.
+    //
+    // ⚠ My FIRST justification ("the derivation here is an equivalent mutant —
+    // wire-shaped edges can never match") was also false at the bytes: `nodes`
+    // and `edges` in scope here are the MAPPER'S CANVAS-SHAPED OUTPUT, and
+    // `mapDraftNodeToCanvas` preserves `n.id` verbatim, so a payload carrying
+    // the imported ids yields exactly the same digest. The falsifying case is
+    // now a test, and a mutant swapping this line for the derivation BITES.
+    // An equivalent mutant must be DEMONSTRATED, never asserted.
     importPendingServerRegistration: false,
   })
 

--- a/src/components/debug/utils/exportBundle.ts
+++ b/src/components/debug/utils/exportBundle.ts
@@ -2843,9 +2843,17 @@ export async function captureDisplayState(
       .ceeAnalysisReady?.status
     const hasReport = Boolean((results as { report?: unknown } | null | undefined)?.report)
     // The composed trust answer (semantic 'changed' OR orphaned), mirroring
-    // the runtime hook (useAnalysisDisplayState) EXACTLY — NOT the local
+    // the runtime hook (useAnalysisDisplayState) — NOT the local
     // graphEditedSinceLastRun flag, and not a partial re-derivation (an
     // earlier version omitted the orphan OR and drifted from the hook).
+    //
+    // ⚠ The word "EXACTLY" used to sit in this sentence and had gone stale: a
+    // second input (`importHold`, interim 2.467) was added to the hook and this
+    // mirror did not carry it, so the bundle reported 'changed' where every
+    // live surface said cannot-confirm — the same drift the sentence warns
+    // about, committed under the sentence itself. `importHold` is now a
+    // REQUIRED parameter precisely so the next such addition is a compile
+    // error here rather than a silent divergence.
     const trust = computeAnalysisTrust({
       freshness:
         (state as { analysisFreshness?: Parameters<typeof computeAnalysisTrust>[0]['freshness'] })
@@ -2853,6 +2861,14 @@ export async function captureDisplayState(
       dirty: Boolean((state as { analysisFreshnessDirty?: boolean }).analysisFreshnessDirty),
       source: readAnalysisStateSourceFromStore().source,
       resultsStatus: (results as { status?: string } | null | undefined)?.status ?? null,
+      // Interim 2.467: the hook passes this, so the bundle must too — the
+      // comment above ("mirroring the runtime hook EXACTLY … an earlier version
+      // omitted the orphan OR and drifted") describes the exact defect that
+      // omitting it would reproduce: the bundle would report 'changed' where
+      // every live surface says cannot-confirm.
+      importHold: Boolean(
+        (state as { importPendingServerRegistration?: boolean }).importPendingServerRegistration,
+      ),
     })
     const analysisChanged = trust.semantic === 'changed' || trust.orphaned
     const displayView = deriveAnalysisDisplayState({

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -105,6 +105,16 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   // Interim 2.467: the toast must claim exactly what the strip claims, so it
   // takes the same importHold input (an unregistered import can never produce
   // the "with the current model" completion line).
+  //
+  // ⚠ Honest note: this argument is currently REDUNDANT here, and that is
+  // measured, not assumed. Under a hold the store forces the dirty overlay on
+  // (setAnalysisFreshness / clearAnalysisFreshnessDirty / noteRunCompleted-
+  // WithoutVerdict all keep it true — pinned by its own invariant test), so the
+  // classification lands on 'changed' either way and both paths yield the
+  // neutral completion line. A mutant dropping this argument is therefore an
+  // EQUIVALENT mutant — demonstrated by that invariant test, not asserted. It
+  // stays as defence-in-depth: if the invariant ever weakens, the toast remains
+  // honest without needing a second fix.
   const completionSemantic = classifyFreshnessForDisplay(effectiveState, dirty, importHold)
 
   // Parity audit: the prototype confirms a completed rerun. Watch the

--- a/src/components/results/AnalysisFreshnessNotice.tsx
+++ b/src/components/results/AnalysisFreshnessNotice.tsx
@@ -75,6 +75,7 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   const storeState = useCanvasStore((s) => s.analysisFreshness)
   const storeDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
   const resultsStatus = useCanvasStore((s) => s.results?.status)
+  const importHold = useCanvasStore((s) => s.importPendingServerRegistration)
   const state = stateProp !== undefined ? stateProp : storeState
   const dirty = dirtyProp !== undefined ? dirtyProp : storeDirty
   const isRunning =
@@ -101,7 +102,10 @@ export function AnalysisFreshnessNotice({ state: stateProp, dirty: dirtyProp, cl
   // disagree). 'current' is the ONLY semantic that supports "with the current
   // model"; a retained 'stale', a cannot-confirm downgrade or a
   // run-completed-without-verdict all get the neutral completion line.
-  const completionSemantic = classifyFreshnessForDisplay(effectiveState, dirty)
+  // Interim 2.467: the toast must claim exactly what the strip claims, so it
+  // takes the same importHold input (an unregistered import can never produce
+  // the "with the current model" completion line).
+  const completionSemantic = classifyFreshnessForDisplay(effectiveState, dirty, importHold)
 
   // Parity audit: the prototype confirms a completed rerun. Watch the
   // running→complete transition; the strip is the canonical freshness owner

--- a/src/components/results/v7/V7FreshnessStrip.tsx
+++ b/src/components/results/v7/V7FreshnessStrip.tsx
@@ -39,10 +39,13 @@ export interface V7FreshnessStripProps {
 export function V7FreshnessStrip({ state: stateProp, dirty: dirtyProp }: V7FreshnessStripProps = {}) {
   const storeState = useCanvasStore(s => s.analysisFreshness)
   const storeDirty = useCanvasStore(s => s.analysisFreshnessDirty)
+  const importHold = useCanvasStore(s => s.importPendingServerRegistration)
   const state = stateProp !== undefined ? stateProp : storeState
   const dirty = dirtyProp !== undefined ? dirtyProp : storeDirty
 
-  const semantic = classifyFreshnessForDisplay(state, dirty)
+  // Interim 2.467: an unregistered-import hold reads cannot-confirm, never the
+  // "Model changed" assertion — see classifyFreshnessForDisplay's importHold.
+  const semantic = classifyFreshnessForDisplay(state, dirty, importHold)
 
   // Honest absence — no verdict to show.
   if (semantic === 'none') return null

--- a/src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx
+++ b/src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx
@@ -123,7 +123,7 @@ describe('applyV5State — CEE blocked analysis_ready (empty options, legacy rel
     })
     // Display semantic: cannot-confirm — NEVER 'current', NEVER 'changed'
     // (the user did not edit anything; CEE could not determine freshness).
-    expect(classifyFreshnessForDisplay(next, false)).toBe('cannot_confirm')
+    expect(classifyFreshnessForDisplay(next, false, false)).toBe('cannot_confirm')
   })
 
   it('freshness surface renders the honest cannot-confirm copy, not a currentness or completeness claim', () => {


### PR DESCRIPTION
**DO NOT MERGE until reviewed — P0 trust interim.**

> ⚠ **THE P0 IS NOT FULLY CLOSED BY THIS PR.** Three routes to the witnessed false affirmative remain open and are NOT defended here: **(1)** with storage unavailable (private browsing, quota, corrupt record) the marker silently no-ops and the posture is exactly pre-mitigation; **(2)** a second user-facing import route (`ScenarioSwitcher → importScenarioFromFile → loadScenario`) never calls `importCanvas`, so it never arms the hold *(rowed separately)*; **(3)** after >50 distinct imports the oldest markers are silently evicted. A starter fixture loaded via `applyDraftResult` also releases unconditionally by design. Only the atomic registration train (2.467) closes these.

## What this is (and is not)

**Interim mitigation only.** The root fix is the atomic import→reset→registration train (**ROADMAP 2.467 / Option A design**), which **supersedes** everything here — the new `importPendingServerRegistration` flag carries a removal note pointing at 2.467. This PR makes one honest promise in the meantime: **an import can never leave a pre-import analysis renderable-as-current.**

Defect of record (live-witnessed, staging, 2026-08-04): `PHASE0-EVIDENCE-2026-07-28/rewalk-2459b-2026-08-04.md` "ATTEMPT 2" + FAIL frame `rewalk-2459b-raw/attempt2/probe-c/2c-10-verdict-analysis-tab.png`. After a canvas import: the pre-import analysis stayed fully rendered and re-bound **by node id** to the imported graph's labels; every staleness indicator read clean; after one Rerun, the affirmative **"Analysis reflects the current model."** attached to an analysis of the **wrong (pre-import, server-side) graph** — an import performs **zero server-side graph persistence** (walk VERDICT 3), so CEE reran its own pre-import graph and truthfully reported `fresh` **about the wrong graph**.

## Rounds 4–5 — the classifier is now fail-safe on its own

**A probe EXECUTED the classifier and found what four review rounds missed by reading it:** `classifyFreshnessForDisplay(fresh, dirty=false, importHold=true)` returned **`'current'`** — the affirmative this PR exists to make unreachable. The hold check sat below the `fresh → 'current'` line, so the guarantee rested entirely on `setAnalysisFreshness` forcing `dirty=true` **one module away**. A mitigation that leans on an invariant in another file, undocumented at the point of use, is one refactor from re-opening the P0.

- **Required ordering implemented.** The affirmative gate (`importHold && fresh → cannot_confirm`) is **first and unconditional**; a **CEE-stated `stale` still outranks the hold**; the inferred cases fall to cannot-confirm below it. Pinned with the overlay explicitly **clean**, plus a control that still affirms without a hold. Mutants revert each gate (`M16`, `M12`).
- **`importHold` is now REQUIRED** on both `classifyFreshnessForDisplay` and `computeAnalysisTrust` — a `= false` default is a value a call site silently inherits, and one already had: `exportBundle` omitted it and reported `'changed'` where every live surface said cannot-confirm, **under a comment claiming it mirrors the runtime hook "EXACTLY"**. Comment corrected, all call sites pass it explicitly.
- **`ReanalyseBar` renders for a held cannot-confirm** with hold-appropriate copy (`data-reason="import-unregistered"`). Withholding it reproduced **ROADMAP 2.129 (a)** — and *"the one Rerun still lives in the sticky AnalysisFooter"* (my earlier claim) **is false for the tab that lost it**: `AnalysisFooter` is in OutputsDock's results branch, `ModelTabBody` is a sibling under `diagnostics`. An affordance is not an assertion.
- **`V7FreshnessStrip` — the fourth claim-bearing surface — is now mounted in the spec** with its copy asserted under a hold (`M15`). It had no behavioural spec anywhere in the tree; dropping its argument left the file green while the strip flipped back to "Model changed".
- **`M7b` correction, in the other direction from last time.** I wrote that a mutant swapping the draft site's literal for the derivation *bites*. The probe ran it: it **SURVIVED** — every `applyDraftResult` call in the spec passed a structurally unrelated payload, so nothing discriminated. The discriminating fixture now exists (a **wire-shaped** draft carrying the imported graph's own ids and endpoints) and `M7b` bites. *An equivalent mutant must be demonstrated, never asserted — and so must a **non**-equivalent one.*
- **Documented, not re-plumbed:** `resolveDisplayedFreshness`'s four call sites (`useEditConfirmation`, `OutputsDock`, `AnalysisFreshnessNotice`, `DecisionConfidencePanel`) are fail-safe **by luck** — they only ever ask "not confirmably fresh?", inheriting the mitigation solely through that same forced-dirty line. A JSDoc warning now says so, and says any new **positive** question of it is wrong under a hold.

## Round 3 — storage scope, honest over-hold copy, three false claims of mine corrected

1. **Storage scope changed to `localStorage`.** My own governing sentence applied one level up: a marker that dies with the **tab** cannot defend a graph that survives the tab. The autosave it defends is `localStorage`, so a fresh tab booted the imported graph, found no marker, and one Rerun restored the FAIL frame. The mutant is re-pointed: it now mutates **to** `sessionStorage` and bites.
2. **The over-hold no longer lies.** Identity is label-independent, so after the walk's own flow (export → relabel → import) the digest equals CEE's own graph and every later install of the genuine server graph re-derives the hold. Asserting *"Model changed. Results may be out of date."* there is factually false, and crying wolf trains users to ignore the warning that matters. `classifyFreshnessForDisplay` takes an `importHold` input and returns **cannot-confirm**, threaded through `useAnalysisTrust`, `V7FreshnessStrip` and the completion toast. Copy/branch only — no redesign of the release logic. (Rounds 4–5 refined this further: a CEE-stated `stale` outranks the hold, and the bar still renders as an AFFORDANCE with uncertainty copy — see above. My round-3 claim that "the one Rerun still lives in the sticky AnalysisFooter" was **false** for the Model tab.)
3. **Three false claims corrected at the bytes.** (a) *"M7 is an equivalent mutant"* — **false**: `nodes`/`edges` at that `setState` are the mapper's canvas-shaped output and `mapDraftNodeToCanvas` preserves `n.id`, so a wire payload yields the same digest. `M7b` (invert to the derivation) now exists and bites. **An equivalent mutant must be DEMONSTRATED, never asserted.** My replacement justification was also false — `starters/loadStarter.ts` routes a *local* fixture through `applyDraftResult`, so "server-known by construction" is wrong; the honest argument is a scope boundary (this interim defends import-originated staleness only). (b) *"a future site that forgets inherits the store's initial `false`"* — **mechanically wrong**: Zustand's partial `set` retains the current value. Deleted; replaced with the true statement that there is no safe default. (c) *"DERIVED, never a hardcoded false"* — **decorative at three sites**: `resetCanvas`'s empty branch runs only under `nodes.length===0 && edges.length===0`, its main branch passed literal `([],[])`, and `reset()` uses `initialNodes`/`initialEdges` (both `[]`). All three are constant `false` *given the empty-graph null rule*. Now written as the literals they provably are, with the coupling named, and their three tests renamed to say they pin release at a constant site rather than demonstrating derivation.
4. **Two unpinned invariants now have tests** (both were claimed in my own comments): the digest's `.sort()` order-insensitivity (a reordered hydrate still holds) and the empty-graph `return null` rule — the latter is what makes the three constant sites safe.
5. **Disclosed in source**: storage-unavailable returns `[]` = pre-mitigation posture = the P0, silently; and `MAX_IDENTITIES = 50` silent eviction.

Also added the **over-hold test that did not exist at all** (every release control used a structurally *unrelated* graph), and the **completion-toast test** (a mutant showed the toast could still announce "with the current model" while the badge was forbidden to). One mutant, `M14`, is a genuine equivalent — and is **demonstrated** as such by a pinned invariant (under a hold, all three dirty-writers leave the overlay true), not asserted.

## Round 2 — the three review blockers are fixed

The first cut cleared an in-memory boolean at six named sites, on the stated premise that they replace the canvas "with a server-known graph". **Two of them do not** — `hydrateGraphSlice`'s live callers pass the **localStorage autosave** (init effect, `scenario_id` preserved) and `loadScenario` reads localStorage. `useAutosave` debounces 500 ms on a graph-hash dirty check, so **import → ~0.5 s → F5 → Rerun restored the witnessed FAIL frame through one of my own release sites**. The escape hatch from the cannot-confirm dead-end *was* the false-affirmative hatch.

**The hold is now DERIVED, not mirrored.** `src/canvas/store/importRegistrationMarker.ts` records the imported graph's structural identity (node ids + edge pairs, via the existing `identityFromCanvasGraph`) in a persisted marker; the sites where the installed graph *varies* (`hydrateGraphSlice`, `loadScenario`, `undoDraft`) re-derive the flag from that graph. *(Round 2 said `sessionStorage` and claimed a forgetful new site "inherits the store's initial `false`" — both superseded by round 3 above: the marker is `localStorage`, and Zustand's partial `set` retains the current value, so there is no safe default.)*

- **A** closed — reload reinstalls the imported graph, digest matches, hold holds.
- **D** closed — `undoDraft` re-derives, so import → draft (release) → undo (re-arm).
- **E** closed by coverage — every replacement site has its own test and its own mutant: both branches of `resetCanvas`, `reset`, `loadScenario`, `hydrateGraphSlice`, `applyDraftResult`, `undoDraft`. *(Round 2 framed the empty-branch as a blocker-E hole; the reviewer has since **withdrawn** that — it was its own mutation choice, not a gap. Round 3 further establishes that three of those sites are constant-`false` by construction, so their tests pin release, not derivation.)*

Identity is **label-independent on purpose**, pinned by its own test: including labels would let a rename on an imported canvas drop the hold — the P0 returning through an ordinary edit. Cost, disclosed: a structurally identical but genuinely server-known graph over-holds to cannot-confirm (fail-safe direction). The walk's two fixtures differ only by a label and are therefore structurally identical — three of my "different graph" controls were wrong on that account and were corrected to use a structurally unrelated graph.

**Scope limit, stated:** jsdom does not reload a page. The reload cases simulate it (cold store + hydrate), proving independence from the store instance; a separate assertion pins the storage medium, now `localStorage` (round 3), with a mutant moving the write to `sessionStorage` that must bite.

### ⚠ Correction to this PR's own RED-first and evidence claims

**Precise statement, with the denominators corrected (they were wrong twice).** The spec has **27 tests** at this head (24 at the round-3 head — my earlier "of 14" was a stale denominator). At pristine it does not run at all: **collect failure, 0 tests collected** (`Failed to resolve import "../store/importRegistrationMarker"`), which proves only that the file cannot load. With the module copied in, the pristine split is **11 field-absence / 7 behavioural of 18 failing** — the field-absence group fails with `expected undefined to be …` because `importPendingServerRegistration` does not exist there, *not* because behaviour differs (it includes both controls and both release assertions, whose arming precondition never runs). **The genuine behavioural REDs are the four round-1 defect pins** (results survive import; the badge re-attaches in both applyV5State orders; verdictless completion) **and the round-2 blocker pins** (A reload, D undoDraft, E loadScenario-restore, tab/store-scope). Everything else rests on its mutants.

**Storage medium is pinned by one key-inspection assertion, not by behaviour** — measured: swapping the medium leaves every behavioural test green (a module-level variable would pass them too). The behavioural tests prove independence from the *store instance*, never from the page or tab, because jsdom does not reload. **The real proof of the reload fix is a live same-tab-reload witness on staging.**

**Full-suite provenance:** measured **22001 passed / 66 skipped / 0 failed (1504 files)** at head `1c899242`. A further full suite is running at the current head `8441f028`; CI's sharded run on this PR is the authority for the head. (The older 21957 figure was `0cc86856` — pre-rebase — and must not be quoted as a head result.)

**Full-suite provenance:** the 21957-passed figure was measured at `0cc86856` — **pre-rebase and pre-M9-test**. No lane-run full suite has been taken at the current head; CI's sharded run on this PR is the authority for the head.

## The change

1. **(a) `importCanvas` clears the entire analysis-results cluster** (mirror of `resetCanvas`'s results block: `results`/`previousReport`/`rawV2Response`/`v5AnalysisFact`/`runMeta`/`analysisStateReady`/`hasCompletedFirstRun`/`graphEditedSinceLastRun`/`needleMovers`/`graphHealth`/`nodeRationales`/`preAnalysisSensitivity`/CEE per-graph payloads/`lastAnalysisSeed`/`lastQualityMode`/`repairsApplied`/`hoveredOptionId`) plus Compare-tab snapshots and comparison mode. No pre-import results body is renderable; **re-binding old rows to new labels is impossible by construction** (no rows survive).
2. **(b) New session-scoped flag `importPendingServerRegistration`**, set by `importCanvas`. While set:
   - `setAnalysisFreshness` **forces** the existing dirty overlay on any applied `fresh` verdict (not merely "doesn't clear" — robust against a prior `dirty:false` from a historical restore);
   - `clearAnalysisFreshnessDirty` no-ops (this is the exact `applyV5State` call that re-attached the badge in the walk);
   - `noteRunCompletedWithoutVerdict` keeps the overlay dirty.
3. **(c) The hold releases** on every path that replaces the canvas with a server-known graph: `hydrateGraphSlice`, `loadScenario`, `resetCanvas` (both branches), `reset`, `applyDraftResult`. Pinned by tests so the interim cannot become permanent suppression.

## The post-rerun badge behaviour, and why it is honest

After import + rerun, the badge is **present** and reads the existing cannot-confirm copy — **"Cannot confirm whether this analysis is current."** (`data-freshness="unknown"`, verbatim CEE verdict retained on `data-cee-freshness="fresh"`). The composed trust semantic is `'changed'`, so the ReanalyseBar ("Model changed. Results may be out of date.") shows.

Why this rather than suppressing the badge outright (the brief's fallback): the display seam is the **existing, already-reviewed dirty-overlay downgrade**, whose documented contract is "may only downgrade a retained `fresh` to cannot-confirm — never fabricate `stale`". Both displayed statements are strictly true of the situation: we genuinely cannot confirm the analysis matches the current model (it provably does not), and the model genuinely changed since that analysis (the import changed it). An absent badge would be honest too, but a present cannot-confirm + a visible re-analyse affordance is more informative and adds **zero new display machinery** — this PR's display delta is entirely data-side. Note the limitation honestly: after import, **Rerun alone cannot resolve the verdict** (CEE reruns its own graph) — the bar's "Model changed" claim stays up until a server-known graph replaces the canvas. That dead-end is exactly what 2.467 exists to fix; the interim's job is only to never lie while it is open.

**Interim residue** — see the banner at the top of this PR for the routes that remain open (storage-unavailable, the second import route, >50-import eviction, starters). Structural identity additionally **over-holds** when a genuinely server-known graph is structurally identical to one imported this session: cannot-confirm, never a false affirmative.

## Evidence

- Fixtures are the walk's own captured graphs, **byte-identical** (`attempt2/probe-c/export-original.json` / `import-modified.json`; the `ZZZ IMPORTED OPTION` sentinel is the walk's own relabel of `opt_alpha`).
- RED at pristine `dae8908f` (named signatures): results survive import (`'complete'` ≠ `'idle'`); `data-freshness="fresh"` re-attaches post-rerun in **both** applyV5State orders (verdict→clear and clear→verdict).
- GREEN with the change; absence assertions carry in-test positive controls (trap 13), and the Compare/comparison seeds were themselves hardened after being caught vacuous.
- Mutants (throwaway worktree outside the repo root, committed state only, applied-check scoped to `src/` with exact-zero control): results-clear revert, snapshot/comparison-clear revert, hold-never-set, ingestion-gate revert, clear-gate removal, noteRun hold removal, and each release-site removal — all RED. Summary in `PHASE0-EVIDENCE-2026-07-28/lane-importstale-2026-08-04.md`.
- Typecheck identity baseline: one-line swap only — the pre-existing TS2345 at `useConversation.ts(4535,15)` embeds the store type in its message text; the new field moves tsc's elision "249 more"→"250 more". Controlled at pristine `dae8908f` (same diagnostic, same location). Counts unchanged (620/2500); `typecheck-baseline.txt` untouched.

## File ownership

Canvas store / staleness / results-state seams only (`src/canvas/store.ts`, `src/canvas/utils/applyDraftResult.ts`, new spec + fixtures). No NodeInspector/uiStore, no results components, no persist/migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
