### PR TITLE
DO-NOT-MERGE: 2.494 + 2.496 — harden four verification instruments left soft by #592 / #591

### DIFF
--- a/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
+++ b/src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx
@@ -41,7 +41,11 @@ import path from 'node:path'
 import { useCanvasStore } from '../store'
 import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
 import { useComparisonStore } from '../stores/comparisonStore'
-import { applyDraftResult } from '../utils/applyDraftResult'
+import {
+  applyDraftResult,
+  mapDraftNodeToCanvas,
+  mapDraftEdgeToCanvas,
+} from '../utils/applyDraftResult'
 import { createScenario } from '../store/scenarios'
 import {
   clearImportRegistrationMarkers,
@@ -889,19 +893,42 @@ describe('interim 2.467 round 2 — the hold is derived from the graph, not from
     const landedNodes = useCanvasStore.getState().nodes
     const landedEdges = useCanvasStore.getState().edges
     expect(useCanvasStore.getState().importPendingServerRegistration).toBe(true)
+    const draftPayload = {
+      nodes: landedNodes.map((n) => ({
+        id: n.id,
+        type: (n as unknown as { type?: string }).type,
+        label: (n.data as { label?: string } | undefined)?.label,
+      })),
+      edges: landedEdges.map((e, i) => ({
+        id: e.id ?? `e-${i}`,
+        from: e.source,
+        to: e.target,
+      })),
+    }
+    // ⚠ PIN THE FIXTURE'S DISCRIMINATING PROPERTY — without this line the test
+    // cannot detect its own fixture rotting. The closing assertion
+    // (`...toBe(false)`) is satisfied by TWO different worlds: the one this
+    // test is about (the draft genuinely reproduces the imported identity, so
+    // only the literal can explain the release) and the one where the fixture
+    // has quietly stopped reproducing it (nothing to discriminate, and the
+    // assertion passes anyway). MEASURED at 2.494: changing `id: n.id` above to
+    // `id: n.id + '_ROTPROBE'` — so the draft reproduces NOTHING — left the
+    // previous version of this test GREEN. Its discriminating power was real
+    // but unguarded at rest, one refactor of `mapDraftNodeToCanvas` /
+    // `mapDraftEdgeToCanvas` or one tidy-up of this builder away from decaying
+    // into exactly the non-discriminating shape it was written to replace.
+    //
+    // So assert, through the SAME mappers `applyDraftResult` runs the payload
+    // through, that the graph we are about to install WOULD hold. The release
+    // below is then provably the literal's doing and not the fixture's failure.
+    expect(
+      isGraphPendingImportRegistration(
+        draftPayload.nodes.map((n) => mapDraftNodeToCanvas(n)),
+        draftPayload.edges.map((e, i) => mapDraftEdgeToCanvas(e, i)),
+      ),
+    ).toBe(true)
     act(() => {
-      applyDraftResult({
-        nodes: landedNodes.map((n) => ({
-          id: n.id,
-          type: (n as unknown as { type?: string }).type,
-          label: (n.data as { label?: string } | undefined)?.label,
-        })),
-        edges: landedEdges.map((e, i) => ({
-          id: e.id ?? `e-${i}`,
-          from: e.source,
-          to: e.target,
-        })),
-      } as never)
+      applyDraftResult(draftPayload as never)
     })
     // Same identity on the canvas, hold RELEASED — the discriminating outcome.
     expect(useCanvasStore.getState().importPendingServerRegistration).toBe(false)

--- a/src/canvas/__tests__/store.spec.ts
+++ b/src/canvas/__tests__/store.spec.ts
@@ -917,6 +917,12 @@ describe('Canvas Store', () => {
   // are sent to PLoT, same class as the goal threshold), so it must dirty the
   // freshness overlay every trust surface reads — otherwise the results keep
   // claiming "Analysis reflects the current model" after a hard constraint change.
+  // The `classifyFreshnessForDisplay` calls below pass `importHold` from the
+  // SAME store snapshot (`s`) as the other two arguments, rather than a
+  // hardcoded `false` (2.494). It resolves to false throughout — this file has
+  // no import scenario — but a literal sitting beside two derived reads is a
+  // mirror of store state that nothing keeps in step. Reading it makes these
+  // assertions measure the composed state the surfaces actually see.
   describe('F2a: constraint edits dirty analysis freshness', () => {
     const FRESH = { freshness: 'fresh' as const, freshnessReason: 'graph_hash_match' }
 
@@ -935,7 +941,7 @@ describe('Canvas Store', () => {
     it('a user constraint edit dirties freshness → display downgrades fresh→changed', () => {
       // Precondition (positive control): fresh + not-dirty reads as 'current'.
       let s = useCanvasStore.getState()
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, s.importPendingServerRegistration)).toBe('current')
 
       // User edit via the GoalPanel path (no fromProducerSync opt-out).
       useCanvasStore.getState().setGoalConstraints([
@@ -944,7 +950,7 @@ describe('Canvas Store', () => {
 
       s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(true)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('changed')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, s.importPendingServerRegistration)).toBe('changed')
     })
 
     it('a no-op set (identical content) does NOT dirty freshness', () => {
@@ -955,7 +961,7 @@ describe('Canvas Store', () => {
 
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(false)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, s.importPendingServerRegistration)).toBe('current')
     })
 
     it('null→null is a no-op and does NOT dirty freshness', () => {
@@ -970,7 +976,7 @@ describe('Canvas Store', () => {
       )
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(false)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('current')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, s.importPendingServerRegistration)).toBe('current')
     })
 
     it('clearing a real constraint (array→null) dirties freshness', () => {
@@ -978,7 +984,7 @@ describe('Canvas Store', () => {
       useCanvasStore.getState().setGoalConstraints(null)
       const s = useCanvasStore.getState()
       expect(s.analysisFreshnessDirty).toBe(true)
-      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, false)).toBe('changed')
+      expect(classifyFreshnessForDisplay(s.analysisFreshness, s.analysisFreshnessDirty, s.importPendingServerRegistration)).toBe('changed')
     })
   })
 

--- a/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
+++ b/src/canvas/store/__tests__/freshnessOnAppliedEdit.spec.ts
@@ -83,7 +83,12 @@ function semanticNow() {
     dirty: s.analysisFreshnessDirty,
     source: null,
     resultsStatus: 'complete',
-    importHold: false,
+    // Read from the SAME store snapshot as the two fields above, rather than a
+    // hardcoded `false` sitting next to the derived values (2.494). It resolves
+    // to false in every scenario here — this file has no import scenario — but
+    // a literal here is a mirror of store state that nothing keeps in step, and
+    // it sits one line from the snapshot that already holds the truth.
+    importHold: s.importPendingServerRegistration,
     }).semantic
 }
 

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -232,10 +232,26 @@ export function isSelfContradictoryStale(
  * They inherit the mitigation solely because `setAnalysisFreshness` forces the
  * dirty overlay on under a hold, which downgrades a `fresh` verdict to
  * `'unknown'` here. That forced-dirty line is the single most load-bearing line
- * in the mitigation (its mutant bites 6 tests). **Any new call site that asks a
- * POSITIVE question of this function — "is it fresh?" — will get the wrong
- * answer under a hold.** Ask `classifyFreshnessForDisplay` (which takes the
- * hold explicitly and gates the affirmative first) instead.
+ * in the mitigation.
+ *
+ * ⚠ NO MUTANT COUNT IS RECORDED HERE, DELIBERATELY. This sentence used to read
+ * "its mutant bites 6 tests" — a hand-written tally no gate derives, i.e. the
+ * hand-maintained mirror this codebase's own doctrine warns about, sitting
+ * inside a comment about load-bearing guarantees. Re-measured at 2.494 it was
+ * wrong AND ill-posed: deleting the assignment bites **5**, flipping it to
+ * `false` bites **7**, so "the" count depends on which mutant you pick and the
+ * number could only ever decay. Derive it instead — every test that can reach
+ * the held branch lives in ONE file,
+ * `src/canvas/__tests__/importCanvas.analysisInvalidation.spec.tsx`, and that
+ * is itself derivable rather than asserted: reaching the branch requires
+ * `importPendingServerRegistration === true`, and every route to it
+ * (`importCanvas`, `markGraphImported`, the marker's storage key, a direct
+ * `setState` of the field) is referenced by that spec alone.
+ *
+ * **Any new call site that asks a POSITIVE question of this function — "is it
+ * fresh?" — will get the wrong answer under a hold.** Ask
+ * `classifyFreshnessForDisplay` (which takes the hold explicitly and gates the
+ * affirmative first) instead.
  */
 export function resolveDisplayedFreshness(
   state: AnalysisFreshnessState | null,

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -245,9 +245,29 @@ export function extractReason(err: BoundaryError | undefined): string {
  *   - `user_jwt` (user-identity.ts, reason `sign_in_required`) describes
  *     SESSION state; "rephrase" is false and "our side is broken" is also
  *     false — recovery is signing in → sign-in copy.
- *   - `OrchestratorTurnPayload` (validators/b1.ts) and `V5RequestExtensions`
- *     (orchestrator-v5/boundary/request-extensions.ts) validate the payload
- *     itself — genuinely input-shaped → rephrase copy (unchanged).
+ *   - `OrchestratorTurnPayload` (validators/b1.ts) validates the turn payload
+ *     itself, the user's `message` included — genuinely input-shaped →
+ *     rephrase copy (unchanged).
+ *   - ⚠ `V5RequestExtensions` (orchestrator-v5/boundary/request-extensions.ts)
+ *     IS NOT IN THAT GROUP — and this line used to say it was, which is why
+ *     the correction is spelled out rather than silently applied (2.496).
+ *     Verified at the PRODUCER's bytes (CEE `request-extensions.ts` module
+ *     header, staging), not from this comment: it parses FOUR OPTIONAL
+ *     app-constructed extension fields — `graph_state`, `analysis_state`,
+ *     `user_id`, `selected_elements` — and carries no user text whatsoever.
+ *     "Rephrase your message" is therefore categorically false for it: the UI
+ *     built the malformed request, not the person typing. It sits in
+ *     `INGRESS_SERVER_STATE_VALIDATORS` below and resolves to the SERVER-FAULT
+ *     copy, pinned by `failureTypeRetryability.test.ts`
+ *     ("V5RequestExtensions → server-fault copy"). That set and that test are
+ *     the authority; this sentence was round-1 text that review F3's pin
+ *     correction superseded and nobody deleted.
+ *
+ *     ⚠ THE DOC WAS CORRECTED, NOT THE BEHAVIOUR. A doc block contradicting
+ *     the executable set is 2.472's own lesson one level up — an expectation
+ *     written from a reader's classification instead of the producer's
+ *     semantics. Left standing, a false one-line description is exactly how a
+ *     correct guard gets "tidied" back into the defect it was written to fix.
  *
  * ⚠ The validator set below is a documented MIRROR of CEE's producer
  * vocabulary (trap 12) with the drift direction chosen deliberately: an


### PR DESCRIPTION
## 🚫 DO-NOT-MERGE — orchestrator merges

**ROADMAP rows: 2.494** (findings a–c) and **2.496** (finding d). Both minted centrally by the orchestrator; this lane minted nothing.

Follow-up to **#592** (interim 2.467 import-staleness P0 mitigation, deployed `6e067e40`) and **#591** (2.472 ingress failure copy). **No product behaviour changes.** All four fixes are to verification machinery or its documentation — instruments that could rot silently while still reading green.

Every claim below was **measured before it was written**, in a throwaway worktree **outside** the repo root, against **committed** state, with the applied-check scoped to `src/` and the control asserting **exactly 0**.

---

### (a) 2.494 — a hand-maintained mutant tally, inside a comment about load-bearing guarantees

`src/canvas/store/analysisFreshness.ts` said the forced-dirty line's *"mutant bites 6 tests"*.

**Reproduced, and the finding is stronger than reported.** Measured over a **derived** scope (21 spec files, 282 tests — the union of every spec calling `importCanvas` or `setAnalysisFreshness`):

| mutant on the forced-dirty line | tests bitten |
|---|---|
| delete `updates.analysisFreshnessDirty = true` | **5** |
| flip it to `= false` | **7** |

So `6` was wrong **and ill-posed** — "the" count depends on which mutant you pick.

**Dropped rather than corrected**, and justified in place: no gate derives the number, so it could only decay (trap 12). Replaced with the **derivation** — every test able to reach the held branch lives in one spec, and *that* is derivable rather than asserted: reaching the branch requires `importPendingServerRegistration === true`, and all four routes to it (`importCanvas`, `markGraphImported`, the marker's storage key, a direct `setState`) are referenced by that spec **alone**. Manifest closed by grep over all four routes, not by generalising from one.

### (b) 2.494 — the M7b discriminator could not detect its own fixture rotting

**Reproduced by execution.** In `importCanvas.analysisInvalidation.spec.tsx`, the closing `expect(...importPendingServerRegistration).toBe(false)` is satisfied by **two different worlds**: the draft genuinely reproducing the imported graph identity (the discriminating case) and the fixture having quietly stopped reproducing it.

Rewriting the builder's `id: n.id` to `id: n.id + '_ROTPROBE'` — so the draft reproduces **nothing** — left the test **GREEN**.

**Fix:** before the `applyDraftResult` act, pin that the payload *would* hold, through the **same mappers** `applyDraftResult` runs it through:

```ts
expect(
  isGraphPendingImportRegistration(
    draftPayload.nodes.map((n) => mapDraftNodeToCanvas(n)),
    draftPayload.edges.map((e, i) => mapDraftEdgeToCanvas(e, i)),
  ),
).toBe(true)
```

The release below it is now provably the literal's doing and not the fixture's failure.

### (c) 2.494 — two hardcoded `false`s sitting beside the derived value

`store.spec.ts` (5 sites) and `freshnessOnAppliedEdit.spec.ts` (`semanticNow`) read live store state but hardcoded `importHold: false`. Now read from the **same snapshot**. Correct today — neither file has an import scenario — but a mirror sitting where the derived value was already in hand.

### (d) 2.496 — a doc block contradicting its own executable set

`src/v5/failureTypeRetryability.ts`'s ingress taxonomy said `V5RequestExtensions` "validate[s] the payload itself — genuinely input-shaped → rephrase copy". The executable `INGRESS_SERVER_STATE_VALIDATORS` **includes** it → **server-fault** copy. The doc and the code said opposite things.

**Direction verified independently before editing** (not inherited):

1. **The producer's bytes** — CEE `orchestrator-v5/boundary/request-extensions.ts` on `staging`: the module parses **four optional app-constructed extension fields** (`graph_state`, `analysis_state`, `user_id`, `selected_elements`). No user text. So "rephrase your message" is categorically false for it.
2. **The behaviour is already pinned** — `failureTypeRetryability.test.ts` carries `it('V5RequestExtensions → server-fault copy: those fields carry no user text')`, above a `⚠ PIN CORRECTED (review F3)` note. The doc line is leftover round-1 text that F3's correction superseded and nobody deleted.

**Doc corrected; behaviour untouched.** This is 2.472's own lesson one level up — a false one-line description is how a correct guard gets "tidied" back into the defect it fixed.

---

## Mutant evidence

| mutant | pristine | with this PR | fails on |
|---|---|---|---|
| **ROTPROBE** (fixture break: `id: n.id` → `id: n.id + '_ROTPROBE'`) | **GREEN** | **RED** | the new guard — `expected false to be true` |
| **M7b** (`applyDraftResult`'s literal `false` → the derivation) | **RED** (1 test) | **RED** (1 test) | the closing assertion — `expected true to be false` |
| finding-(c) **negation probe** (`value` → `!value`, 6 sites) | — | **RED**, 7 tests across both files | proves the derived value genuinely resolves to `false` rather than passing vacuously |

The **ROTPROBE-RED / M7b-still-RED pair** is the deliverable: the guard closes the rot hole **without** swallowing the original discrimination, and the two mutants fail on *different* assertions, which is what shows the discrimination is unchanged in character.

Applied-check: exactly **1** changed file under `src/` per single-file mutation (**2** for the negation probe, which touches two files); control **0** before and after every mutation.

## Gates

- `npm run typecheck` (the repo's named gate) — **PASSED**: 3237/3277 tracked files loaded, 40 declared out of scope; ratchet 2500 = baseline 2500.
- Full local `vitest run` — see the comment below for collected counts (no collect shrink; `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run).
