### PR TITLE
DO-NOT-MERGE (orchestrator merges) — Lane (P1): mark ungrounded coaching prompts as general guidance (2.491)

### DIFF
--- a/src/components/results/__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx
@@ -229,6 +229,90 @@ describe('2.466 mount-path proof — deployed posture (analysisHeroPanel=1), liv
     expect(document.querySelectorAll('[data-testid="dsk-grounding"]')).toHaveLength(1)
   })
 
+  /**
+   * ── 2.491: the badge's NEGATIVE TWIN, on the same mount path ──────────────
+   *
+   * This spec exists because 2.466's badge shipped dark on the V17 hero. The
+   * 2.491 lane then wrote its marker's render tests against that SAME
+   * switched-off component — the identical defect, one feature later, past this
+   * very file. These cases bind the marker to the deployed posture so it cannot
+   * happen a third time: if someone re-hosts the marker on the `!flag` arm,
+   * `DEPLOYED POSTURE` below goes RED.
+   *
+   * The walk fixture predates CEE #825, so it carries no `dsk_grounding`. The
+   * verdicts are injected into a CLONE of the real captured turn — the payload
+   * shape stays the live one, only the new key is added, exactly as #825 emits.
+   */
+  function walkTurnWithVerdicts(verdicts: readonly string[]): Record<string, unknown> {
+    const turn = structuredClone(walkTurn())
+    const blocks = turn.blocks as Record<string, unknown>[]
+    const dr = (blocks[0].enrichment as Record<string, unknown>)
+      .decision_review as Record<string, unknown>
+    const prompts = dr.decision_quality_prompts as Record<string, unknown>[]
+    // Precondition: the fixture must have the shape we think it has, or the
+    // injection silently lands nowhere and every assertion below goes vacuous.
+    if (prompts.length !== verdicts.length) {
+      throw new Error(`fixture has ${prompts.length} DQPs, got ${verdicts.length} verdicts`)
+    }
+    prompts.forEach((p, i) => {
+      p.dsk_grounding = verdicts[i]
+      if (verdicts[i] === 'general') {
+        delete p.dsk_claim_id
+        delete p.dsk_protocol_id
+        delete p.evidence_strength
+      }
+    })
+    return turn
+  }
+
+  function applyTurnToRealStore(turn: Record<string, unknown>): void {
+    const s = useCanvasStore.getState()
+    applyV5State(turn as never, {
+      ...s,
+      currentResultsHash: (s as unknown as { currentResultsHash?: string }).currentResultsHash,
+    } as never)
+  }
+
+  it('DEPLOYED POSTURE: a GENERAL verdict renders the marker on the mounted surface', () => {
+    localStorage.setItem('feature.analysisHeroPanel', '1')
+    applyTurnToRealStore(walkTurnWithVerdicts(['general', 'general']))
+    renderBody()
+
+    // The surface that actually mounts on staging.
+    expect(screen.getByTestId('key-question-card')).toBeInTheDocument()
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent(WALK_Q1)
+
+    expect(screen.getByTestId('dsk-general-guidance').textContent).toBe(
+      'General guidance — not drawn from our attested evidence base.',
+    )
+    // The property that makes the marker meaningful, on the real tree.
+    expect(document.querySelectorAll('[data-testid="dsk-grounding"]')).toHaveLength(0)
+    expect(document.querySelectorAll('[data-testid="dsk-general-guidance"]')).toHaveLength(1)
+  })
+
+  it('DEPLOYED POSTURE, POSITIVE CONTROL: an ATTESTED verdict renders the badge and NO marker', () => {
+    // Same posture, same fixture, same queries — so the case above cannot be
+    // passing because the harness renders nothing.
+    localStorage.setItem('feature.analysisHeroPanel', '1')
+    applyTurnToRealStore(walkTurnWithVerdicts(['attested', 'attested']))
+    renderBody()
+
+    expect(screen.getByTestId('dsk-grounding')).toHaveAttribute('data-dsk-claim-id', 'DSK-T-002')
+    expect(document.querySelectorAll('[data-testid="dsk-general-guidance"]')).toHaveLength(0)
+  })
+
+  it('MOUNT-PATH GUARD: the marker never renders on the flag-OFF arm', () => {
+    // If a future lane moves the marker to the V17 hero (the 2.466 defect,
+    // and the 2.491 lane's first attempt), this goes RED.
+    localStorage.setItem('feature.analysisHeroPanel', '0')
+    applyTurnToRealStore(walkTurnWithVerdicts(['general', 'general']))
+    renderBody()
+
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('key-question-card')).toBeNull()
+    expect(document.querySelectorAll('[data-testid="dsk-general-guidance"]')).toHaveLength(0)
+  })
+
   it('INVERSE CONTROL: flag OFF ⇒ the V17/legacy arm mounts and this surface does not', () => {
     localStorage.setItem('feature.analysisHeroPanel', '0')
     applyWalkTurnToRealStore()

--- a/src/components/results/__tests__/dskGeneralGuidance.spec.tsx
+++ b/src/components/results/__tests__/dskGeneralGuidance.spec.tsx
@@ -1,0 +1,192 @@
+/**
+ * 2.491 — the grounding badge's NEGATIVE TWIN.
+ *
+ * ## RED-first signature at pristine (UI e01dbd4a)
+ *
+ * At pristine there is no `dsk-general-guidance` testid anywhere in the repo,
+ * so every "renders the marker" case below fails with
+ * `Unable to find an element by: [data-testid="dsk-general-guidance"]`.
+ *
+ * The product statement of that failure, which is the defect: a prompt with no
+ * `dsk_claim_id` rendered its question and NOTHING else. Absence-of-badge is
+ * silent, and no user reads silence as "this one is improvised" — so an
+ * unattested science-flavoured question was indistinguishable from an attested
+ * one. Measured live 2026-08-05: 44% of decision-quality prompts.
+ *
+ * ## Why the positive control is mandatory here (trap 13)
+ *
+ * "The marker appears" is an ABSENCE-shaped claim about the other arm: it only
+ * means something if the harness can also SEE the grounded case rendering
+ * WITHOUT it. Every describe below therefore asserts both arms from the same
+ * render, and the mixed-fixture test renders both in one tree.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HeroKeyQuestion } from '../analysisHeroV17/HeroKeyQuestion'
+import {
+  mapDecisionQualityPrompts,
+  isGeneralGuidance,
+  deriveDskGrounding,
+} from '../utils/decisionQualityPrompts'
+import type { KeyQuestion } from '../analysisHeroV17/analysisHeroVM.types'
+
+const noop = () => {}
+
+function renderKQ(kq: KeyQuestion) {
+  return render(<HeroKeyQuestion keyQuestion={kq} onPrefillChat={noop} chatPrefillAvailable />)
+}
+
+const BASE = { chips: [] as string[], extras: [] as string[] }
+
+// ============================================================================
+// The mapper — wire verdict → view flag
+// ============================================================================
+
+describe('mapDecisionQualityPrompts carries the 2.491 verdict', () => {
+  it('carries general, attested and resolved; ignores an unknown value', () => {
+    const mapped = mapDecisionQualityPrompts([
+      { question: 'q-general', principle: 'Consider-the-opposite', dsk_grounding: 'general' },
+      {
+        question: 'q-attested',
+        principle: 'Outside view and reference class forecasting',
+        dsk_claim_id: 'DSK-T-002',
+        evidence_strength: 'strong',
+        dsk_grounding: 'attested',
+      },
+      {
+        question: 'q-resolved',
+        principle: 'Pre-mortem and prospective hindsight',
+        dsk_claim_id: 'DSK-T-001',
+        evidence_strength: 'medium',
+        dsk_grounding: 'resolved',
+      },
+      { question: 'q-bogus', principle: 'x', dsk_grounding: 'definitely-grounded-trust-me' },
+      { question: 'q-absent', principle: 'x' },
+    ])
+
+    expect(mapped.map(m => m.groundingState)).toEqual([
+      'general',
+      'attested',
+      'resolved',
+      undefined, // outside the closed vocabulary ⇒ fails closed
+      undefined, // no verdict on the wire ⇒ no verdict in the view
+    ])
+
+    // Identity-bound (trap 19): assert per named question, not "some entry".
+    expect(isGeneralGuidance(mapped.find(m => m.question === 'q-general')!)).toBe(true)
+    // POSITIVE CONTROL — the harness sees the other three states as NOT general.
+    expect(isGeneralGuidance(mapped.find(m => m.question === 'q-attested')!)).toBe(false)
+    expect(isGeneralGuidance(mapped.find(m => m.question === 'q-resolved')!)).toBe(false)
+    expect(isGeneralGuidance(mapped.find(m => m.question === 'q-absent')!)).toBe(false)
+  })
+
+  it('a RESOLVED prompt gets the ordinary grounding badge — it is genuinely cited', () => {
+    // The whole point of `resolved`: CEE recovered the id from the bundle, so
+    // this is attested science and must NOT be disclaimed.
+    const [m] = mapDecisionQualityPrompts([
+      {
+        question: 'q',
+        principle: 'Pre-mortem and prospective hindsight',
+        dsk_claim_id: 'DSK-T-001',
+        dsk_protocol_id: 'DSK-P-001',
+        evidence_strength: 'medium',
+        dsk_grounding: 'resolved',
+      },
+    ])
+    expect(deriveDskGrounding(m)?.claimId).toBe('DSK-T-001')
+    expect(isGeneralGuidance(m)).toBe(false)
+  })
+
+  it('ABSENCE of the verdict is not general — a payload with no verdict is not disclaimed', () => {
+    // Fail-closed the other way. A pre-2.491 CEE, DSK disabled, or a bundle
+    // load failure must render NOTHING, not a disclaimer we cannot support.
+    const [m] = mapDecisionQualityPrompts([{ question: 'q', principle: 'Consider-the-opposite' }])
+    // Precondition (trap 13b): the fixture must genuinely lack the key, or this
+    // test rots silently the day someone tidies it.
+    expect(m.groundingState).toBeUndefined()
+    expect(isGeneralGuidance(m)).toBe(false)
+  })
+})
+
+// ============================================================================
+// The render — both arms, from the same harness
+// ============================================================================
+
+describe('HeroKeyQuestion renders the general-guidance marker', () => {
+  const COPY = 'General guidance — not drawn from our attested evidence base.'
+
+  it('renders the marker and NO grounding badge for a general prompt', () => {
+    renderKQ({ ...BASE, text: 'What would make you switch?', generalGuidance: true })
+
+    expect(screen.getByTestId('dsk-general-guidance').textContent).toBe(COPY)
+    // The property that makes the marker meaningful.
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: renders the badge and NO marker for a grounded prompt', () => {
+    // This is the assertion that stops the test above from passing vacuously:
+    // it proves the harness CAN see a grounded render, in the same component,
+    // with the same query.
+    renderKQ({
+      ...BASE,
+      text: 'What is the base rate?',
+      grounding: {
+        principle: 'Outside view and reference class forecasting',
+        claimId: 'DSK-T-002',
+        strength: 'strong',
+      },
+    })
+
+    expect(screen.getByTestId('dsk-grounding').textContent).toBe(
+      'Grounded in: Outside view and reference class forecasting · strong evidence',
+    )
+    expect(screen.queryByTestId('dsk-general-guidance')).toBeNull()
+  })
+
+  it('renders NEITHER when there is no verdict at all', () => {
+    renderKQ({ ...BASE, text: 'A question with no DSK verdict' })
+    expect(screen.queryByTestId('dsk-general-guidance')).toBeNull()
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('binds the marker to the general question, not merely to "a question"', () => {
+    // DISCRIMINATING PAIR, render-side: two hero cards in one tree, one general
+    // and one grounded. Exactly one marker must exist, and it must sit in the
+    // general card's subtree — a marker rendered for every question would pass
+    // a naive "the marker exists" assertion and fail this one.
+    const { container } = render(
+      <div>
+        <div data-testid="host-general">
+          <HeroKeyQuestion
+            keyQuestion={{ ...BASE, text: 'general question', generalGuidance: true }}
+            onPrefillChat={noop}
+            chatPrefillAvailable
+          />
+        </div>
+        <div data-testid="host-grounded">
+          <HeroKeyQuestion
+            keyQuestion={{
+              ...BASE,
+              text: 'grounded question',
+              grounding: { principle: 'Outside view and reference class forecasting', claimId: 'DSK-T-002' },
+            }}
+            onPrefillChat={noop}
+            chatPrefillAvailable
+          />
+        </div>
+      </div>,
+    )
+
+    expect(container.querySelectorAll('[data-testid="dsk-general-guidance"]')).toHaveLength(1)
+    expect(
+      screen.getByTestId('host-general').querySelector('[data-testid="dsk-general-guidance"]'),
+    ).not.toBeNull()
+    expect(
+      screen.getByTestId('host-grounded').querySelector('[data-testid="dsk-general-guidance"]'),
+    ).toBeNull()
+    expect(
+      screen.getByTestId('host-grounded').querySelector('[data-testid="dsk-grounding"]'),
+    ).not.toBeNull()
+  })
+})

--- a/src/components/results/__tests__/dskGeneralGuidance.spec.tsx
+++ b/src/components/results/__tests__/dskGeneralGuidance.spec.tsx
@@ -1,43 +1,40 @@
 /**
- * 2.491 — the grounding badge's NEGATIVE TWIN.
+ * 2.491 — the grounding badge's NEGATIVE TWIN: the MAPPER layer.
+ *
+ * ## Scope of this file, and where the render proof lives
+ *
+ * This file covers `mapDecisionQualityPrompts` / `isGeneralGuidance` only —
+ * the wire→view rule. **The render proof is deliberately NOT here**, because
+ * this lane's first attempt put it against `HeroKeyQuestion`, which does not
+ * mount on staging (`netlify.toml:78` sets `VITE_FEATURE_ANALYSIS_HERO_PANEL
+ * = "1"`, and `ResultsBody` hosts `KeyQuestionCard` in that flag-ON arm while
+ * the V17 hero lives in the `!flag` arm). Deleting the deployed marker left
+ * those tests green — the same dark-ship row 2.466 was opened for.
+ *
+ * The render tests now live at
+ * `analysis-hero/__tests__/KeyQuestionCard.generalGuidance.spec.tsx` (the
+ * mounted host) and the mount-path guard at
+ * `__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx` (the real ResultsBody
+ * under the real flag seam).
  *
  * ## RED-first signature at pristine (UI e01dbd4a)
  *
- * At pristine there is no `dsk-general-guidance` testid anywhere in the repo,
- * so every "renders the marker" case below fails with
- * `Unable to find an element by: [data-testid="dsk-general-guidance"]`.
+ * `TypeError: isGeneralGuidance is not a function`, and
+ * `expected [undefined, …] to deeply equal ['general', 'attested', …]`.
  *
- * The product statement of that failure, which is the defect: a prompt with no
- * `dsk_claim_id` rendered its question and NOTHING else. Absence-of-badge is
- * silent, and no user reads silence as "this one is improvised" — so an
- * unattested science-flavoured question was indistinguishable from an attested
- * one. Measured live 2026-08-05: 44% of decision-quality prompts.
- *
- * ## Why the positive control is mandatory here (trap 13)
- *
- * "The marker appears" is an ABSENCE-shaped claim about the other arm: it only
- * means something if the harness can also SEE the grounded case rendering
- * WITHOUT it. Every describe below therefore asserts both arms from the same
- * render, and the mixed-fixture test renders both in one tree.
+ * The product statement of that failure: a prompt with no `dsk_claim_id`
+ * rendered its question and NOTHING else. Absence-of-badge is silent, and no
+ * user reads silence as "this one is improvised" — so an unattested
+ * science-flavoured question was indistinguishable from an attested one.
+ * Measured live 2026-08-05: **52% of decision-quality prompts (16 of 31)**.
  */
 
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { HeroKeyQuestion } from '../analysisHeroV17/HeroKeyQuestion'
 import {
   mapDecisionQualityPrompts,
   isGeneralGuidance,
   deriveDskGrounding,
 } from '../utils/decisionQualityPrompts'
-import type { KeyQuestion } from '../analysisHeroV17/analysisHeroVM.types'
-
-const noop = () => {}
-
-function renderKQ(kq: KeyQuestion) {
-  return render(<HeroKeyQuestion keyQuestion={kq} onPrefillChat={noop} chatPrefillAvailable />)
-}
-
-const BASE = { chips: [] as string[], extras: [] as string[] }
 
 // ============================================================================
 // The mapper — wire verdict → view flag
@@ -109,84 +106,3 @@ describe('mapDecisionQualityPrompts carries the 2.491 verdict', () => {
   })
 })
 
-// ============================================================================
-// The render — both arms, from the same harness
-// ============================================================================
-
-describe('HeroKeyQuestion renders the general-guidance marker', () => {
-  const COPY = 'General guidance — not drawn from our attested evidence base.'
-
-  it('renders the marker and NO grounding badge for a general prompt', () => {
-    renderKQ({ ...BASE, text: 'What would make you switch?', generalGuidance: true })
-
-    expect(screen.getByTestId('dsk-general-guidance').textContent).toBe(COPY)
-    // The property that makes the marker meaningful.
-    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
-  })
-
-  it('POSITIVE CONTROL: renders the badge and NO marker for a grounded prompt', () => {
-    // This is the assertion that stops the test above from passing vacuously:
-    // it proves the harness CAN see a grounded render, in the same component,
-    // with the same query.
-    renderKQ({
-      ...BASE,
-      text: 'What is the base rate?',
-      grounding: {
-        principle: 'Outside view and reference class forecasting',
-        claimId: 'DSK-T-002',
-        strength: 'strong',
-      },
-    })
-
-    expect(screen.getByTestId('dsk-grounding').textContent).toBe(
-      'Grounded in: Outside view and reference class forecasting · strong evidence',
-    )
-    expect(screen.queryByTestId('dsk-general-guidance')).toBeNull()
-  })
-
-  it('renders NEITHER when there is no verdict at all', () => {
-    renderKQ({ ...BASE, text: 'A question with no DSK verdict' })
-    expect(screen.queryByTestId('dsk-general-guidance')).toBeNull()
-    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
-  })
-
-  it('binds the marker to the general question, not merely to "a question"', () => {
-    // DISCRIMINATING PAIR, render-side: two hero cards in one tree, one general
-    // and one grounded. Exactly one marker must exist, and it must sit in the
-    // general card's subtree — a marker rendered for every question would pass
-    // a naive "the marker exists" assertion and fail this one.
-    const { container } = render(
-      <div>
-        <div data-testid="host-general">
-          <HeroKeyQuestion
-            keyQuestion={{ ...BASE, text: 'general question', generalGuidance: true }}
-            onPrefillChat={noop}
-            chatPrefillAvailable
-          />
-        </div>
-        <div data-testid="host-grounded">
-          <HeroKeyQuestion
-            keyQuestion={{
-              ...BASE,
-              text: 'grounded question',
-              grounding: { principle: 'Outside view and reference class forecasting', claimId: 'DSK-T-002' },
-            }}
-            onPrefillChat={noop}
-            chatPrefillAvailable
-          />
-        </div>
-      </div>,
-    )
-
-    expect(container.querySelectorAll('[data-testid="dsk-general-guidance"]')).toHaveLength(1)
-    expect(
-      screen.getByTestId('host-general').querySelector('[data-testid="dsk-general-guidance"]'),
-    ).not.toBeNull()
-    expect(
-      screen.getByTestId('host-grounded').querySelector('[data-testid="dsk-general-guidance"]'),
-    ).toBeNull()
-    expect(
-      screen.getByTestId('host-grounded').querySelector('[data-testid="dsk-grounding"]'),
-    ).not.toBeNull()
-  })
-})

--- a/src/components/results/analysis-hero/KeyQuestionCard.tsx
+++ b/src/components/results/analysis-hero/KeyQuestionCard.tsx
@@ -41,6 +41,7 @@ import { useCanvasStore } from '../../../canvas/store'
 import { typography } from '@/styles/typography'
 import {
   deriveDskGrounding,
+  isGeneralGuidance,
   mapDecisionQualityPrompts,
 } from '../utils/decisionQualityPrompts'
 import { containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
@@ -83,6 +84,18 @@ export function KeyQuestionCard() {
         >
           Grounded in: {grounding.principle}
           {grounding.strength ? ` · ${grounding.strength} evidence` : ''}
+        </p>
+      )}
+      {/* 2.491: the badge's negative twin. Absence of a grounding line used to
+          be SILENT, so an unattested prompt read exactly like an attested one.
+          Rendered only on CEE's positive `general` verdict — never inferred
+          from missing grounding (see isGeneralGuidance). */}
+      {isGeneralGuidance(main) && (
+        <p
+          className={`${typography.panelMeta} text-text-light break-words`}
+          data-testid="dsk-general-guidance"
+        >
+          General guidance — not drawn from our attested evidence base.
         </p>
       )}
     </section>

--- a/src/components/results/analysis-hero/__tests__/KeyQuestionCard.generalGuidance.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/KeyQuestionCard.generalGuidance.spec.tsx
@@ -1,0 +1,174 @@
+/**
+ * KeyQuestionCard — the DSK grounding badge's NEGATIVE TWIN (ROADMAP 2.491, P1).
+ *
+ * ## Why this file is HERE and not next to the V17 hero
+ *
+ * The first version of this lane's render tests targeted `HeroKeyQuestion`
+ * (analysisHeroV17). **That component does not mount on staging.**
+ * `netlify.toml:78` sets `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"`, and
+ * `ResultsBody` hosts `KeyQuestionCard` INSIDE that flag-ON arm while
+ * `HeroKeyQuestion` lives in the `!flag` arm — the two are mutually exclusive
+ * by the same fork. A deployed-DOM census found `key-question-card` in 14
+ * captures and `hero-v17-key-question` in ZERO.
+ *
+ * That is the SAME defect row 2.466 was opened for: lane 1's DSK grounding
+ * badge shipped DARK on the V17 hero for exactly this reason. Reproducing it
+ * with the same badge's negative twin, in the same feature, past a spec written
+ * to prevent it, is why these tests now bind to the surface the deployed flags
+ * actually mount. The mount-path proof itself lives in
+ * `results/__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx`, which renders
+ * the real `ResultsBody` under the real flag seam.
+ *
+ * This spec lives INSIDE the analysis-hero module because the module's
+ * inertness guard allow-lists only ResultsBody/HeroGallery as external
+ * importers.
+ *
+ * ## RED-first signature at pristine (UI e01dbd4a)
+ *
+ * `Unable to find an element by: [data-testid="dsk-general-guidance"]` — the
+ * testid appears in 0 files at pristine.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { useCanvasStore } from '../../../../canvas/store'
+import { readDecisionReviewWireState } from '../../../../v5/decisionReviewAdapter'
+import { KeyQuestionCard } from '../KeyQuestionCard'
+
+const MARKER = 'dsk-general-guidance'
+const COPY = 'General guidance — not drawn from our attested evidence base.'
+
+/** Seed through the REAL adapter, as `applyV5State` does. */
+function seedRawPrompts(prompts: unknown[]): void {
+  const state = readDecisionReviewWireState({
+    decision_review: {
+      produced_at: '2026-08-05T13:00:00.000Z',
+      decision_quality_prompts: prompts,
+    },
+  })
+  if (state.kind !== 'v0_30') throw new Error(`synthetic payload did not classify v0_30: ${state.kind}`)
+  useCanvasStore.setState(s => ({
+    runMeta: { ...s.runMeta, decisionReview030: state.review },
+  }))
+}
+
+// The two live shapes, from the walk of 2026-08-05, with the verdicts CEE
+// #825 now attaches. Identity anchors: the exact question strings.
+const GENERAL_Q = 'What would make you shift from Add Permanent Night Shift to Lease Second Depot?'
+const GENERAL_PROMPT = {
+  question: GENERAL_Q,
+  principle: 'Consider-the-opposite',
+  applies_because: 'Add Permanent Night Shift leads with a high margin.',
+  dsk_grounding: 'general',
+}
+const ATTESTED_Q = 'What is the base rate for UK parcel depots needing emergency capacity expansion?'
+const ATTESTED_PROMPT = {
+  question: ATTESTED_Q,
+  principle: 'Outside view and reference class forecasting',
+  applies_because: 'Volume risk is the main uncertainty.',
+  dsk_claim_id: 'DSK-T-002',
+  dsk_protocol_id: 'DSK-P-002',
+  evidence_strength: 'strong',
+  dsk_grounding: 'attested',
+}
+
+describe('KeyQuestionCard — general-guidance marker (the DEPLOYED host)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState(s => ({ runMeta: { ...s.runMeta, decisionReview030: null } }))
+  })
+  afterEach(() => {
+    useCanvasStore.setState(s => ({ runMeta: { ...s.runMeta, decisionReview030: null } }))
+    cleanup()
+  })
+
+  it('renders the marker, and NO grounding badge, for a general prompt', () => {
+    // Precondition (trap 13b): the fixture must genuinely carry the verdict and
+    // genuinely lack an id, or this test proves nothing.
+    expect(GENERAL_PROMPT.dsk_grounding).toBe('general')
+    expect('dsk_claim_id' in GENERAL_PROMPT).toBe(false)
+
+    seedRawPrompts([GENERAL_PROMPT])
+    render(<KeyQuestionCard />)
+
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent(GENERAL_Q)
+    expect(screen.getByTestId(MARKER).textContent).toBe(COPY)
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: renders the badge, and NO marker, for an attested prompt', () => {
+    // Without this, "the marker appears" would be an assertion about an empty
+    // tree. It proves the harness CAN see the grounded render, same component,
+    // same queries.
+    seedRawPrompts([ATTESTED_PROMPT])
+    render(<KeyQuestionCard />)
+
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent(ATTESTED_Q)
+    expect(screen.getByTestId('dsk-grounding')).toHaveAttribute('data-dsk-claim-id', 'DSK-T-002')
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+  })
+
+  it('a RESOLVED prompt gets the ordinary badge — it is genuinely cited', () => {
+    // The whole point of `resolved`: CEE recovered the id from the bundle, so
+    // this is attested science and must NOT be disclaimed.
+    seedRawPrompts([
+      {
+        question: 'How could this fail?',
+        principle: 'Pre-mortem and prospective hindsight',
+        dsk_claim_id: 'DSK-T-001',
+        dsk_protocol_id: 'DSK-P-001',
+        evidence_strength: 'medium',
+        dsk_grounding: 'resolved',
+      },
+    ])
+    render(<KeyQuestionCard />)
+
+    expect(screen.getByTestId('dsk-grounding')).toHaveAttribute('data-dsk-claim-id', 'DSK-T-001')
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+  })
+
+  it('ABSENCE of a verdict renders NEITHER — a payload with no verdict is not disclaimed', () => {
+    // Fail-closed the other way: DSK off, bundle load failure, or a CEE build
+    // predating #825 must render nothing, not a disclaimer we cannot support.
+    const noVerdict = { question: 'A question with no verdict', principle: 'Consider-the-opposite' }
+    expect('dsk_grounding' in noVerdict).toBe(false)
+
+    seedRawPrompts([noVerdict])
+    render(<KeyQuestionCard />)
+
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent('A question with no verdict')
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('an unrecognised verdict fails closed to no marker', () => {
+    seedRawPrompts([
+      { question: 'q', principle: 'x', dsk_grounding: 'definitely-grounded-trust-me' },
+    ])
+    render(<KeyQuestionCard />)
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('binds to the SELECTED question: the card shows one prompt, and marks THAT one', () => {
+    // The card renders the first glossary-safe question. With a general prompt
+    // first and an attested one second, the marker must appear; swapping the
+    // order must make it disappear. A marker keyed to "any prompt in the list
+    // is general" would pass the first and fail the second.
+    seedRawPrompts([GENERAL_PROMPT, ATTESTED_PROMPT])
+    const first = render(<KeyQuestionCard />)
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent(GENERAL_Q)
+    expect(screen.getByTestId(MARKER)).toBeInTheDocument()
+    first.unmount()
+
+    seedRawPrompts([ATTESTED_PROMPT, GENERAL_PROMPT])
+    render(<KeyQuestionCard />)
+    expect(screen.getByTestId('key-question-text')).toHaveTextContent(ATTESTED_Q)
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+    expect(screen.getByTestId('dsk-grounding')).toBeInTheDocument()
+  })
+
+  it('exactly one marker in the document — no double render', () => {
+    seedRawPrompts([GENERAL_PROMPT])
+    render(<KeyQuestionCard />)
+    expect(document.querySelectorAll(`[data-testid="${MARKER}"]`)).toHaveLength(1)
+  })
+})

--- a/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
+++ b/src/components/results/analysisHeroV17/HeroKeyQuestion.tsx
@@ -72,6 +72,18 @@ export function HeroKeyQuestion({ keyQuestion, onPrefillChat, chatPrefillAvailab
           {keyQuestion.grounding.strength ? ` · ${keyQuestion.grounding.strength} evidence` : ''}
         </p>
       )}
+      {/* 2.491: the badge's negative twin. Absence of a grounding line used to
+          be SILENT, so an unattested prompt read exactly like an attested one.
+          Rendered only on CEE's positive `general` verdict — never inferred
+          from missing grounding (see isGeneralGuidance). */}
+      {keyQuestion.generalGuidance && (
+        <p
+          className={`${typography.panelMeta} text-text-light break-words`}
+          data-testid="dsk-general-guidance"
+        >
+          General guidance — not drawn from our attested evidence base.
+        </p>
+      )}
       {/* Chips are prefill-only. The whole card is hidden upstream when
           chat is unavailable (see the early return above), so chips are
           always meaningfully clickable when this block renders. */}

--- a/src/components/results/analysisHeroV17/__tests__/HeroKeyQuestion.generalGuidance.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/HeroKeyQuestion.generalGuidance.spec.tsx
@@ -1,0 +1,98 @@
+/**
+ * 2.491 — the general-guidance marker on the V17 hero: the FLAG-OFF arm.
+ *
+ * ## Read this before assuming these tests are the proof of anything
+ *
+ * `HeroKeyQuestion` does **not** mount on staging. `netlify.toml:78` sets
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` in the staging context block, and
+ * `ResultsBody.tsx:383` mounts `KeyQuestionCard` inside
+ * `{isAnalysisHeroPanelEnabled() && …}` while `:412` opens the `{!…&& (` arm
+ * where this hero lives. The DEPLOYED proof is
+ * `analysis-hero/__tests__/KeyQuestionCard.generalGuidance.spec.tsx` plus the
+ * mount-path guard in `__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx`.
+ *
+ * This file exists because the marker was shipped on BOTH hosts (matching
+ * 2.466's badge, which is also on both), and an unmounted host with a live
+ * render path still needs its branch pinned — otherwise deleting either the
+ * render or the view-model join is a silent no-op in the suite. Both of those
+ * deletions were demonstrated to SURVIVE before this file existed.
+ *
+ * The two mutants this file must make bite:
+ *   A. delete `{keyQuestion.generalGuidance && (…)}` from HeroKeyQuestion.tsx
+ *   B. delete `...(generalGuidance ? { generalGuidance: true } : {})` from
+ *      buildAnalysisHeroViewModel.ts  ← the JOIN, invisible to any render
+ *      test. Pinned in `buildAnalysisHeroViewModel.spec.ts` (which owns the
+ *      VM fixture builder) rather than mirrored here.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HeroKeyQuestion } from '../HeroKeyQuestion'
+import type { KeyQuestion } from '../analysisHeroVM.types'
+
+const MARKER = 'dsk-general-guidance'
+const COPY = 'General guidance — not drawn from our attested evidence base.'
+const noop = () => {}
+const BASE = { chips: [] as string[], extras: [] as string[] }
+
+function renderKQ(kq: KeyQuestion) {
+  return render(<HeroKeyQuestion keyQuestion={kq} onPrefillChat={noop} chatPrefillAvailable />)
+}
+
+describe('HeroKeyQuestion (flag-OFF arm) — marker render', () => {
+  it('renders the marker, and NO badge, when the VM says general', () => {
+    renderKQ({ ...BASE, text: 'What would make you switch?', generalGuidance: true })
+    expect(screen.getByTestId(MARKER).textContent).toBe(COPY)
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: renders the badge, and NO marker, when the VM says grounded', () => {
+    renderKQ({
+      ...BASE,
+      text: 'What is the base rate?',
+      grounding: {
+        principle: 'Outside view and reference class forecasting',
+        claimId: 'DSK-T-002',
+        strength: 'strong',
+      },
+    })
+    expect(screen.getByTestId('dsk-grounding').textContent).toBe(
+      'Grounded in: Outside view and reference class forecasting · strong evidence',
+    )
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+  })
+
+  it('renders NEITHER when the VM carries no verdict', () => {
+    renderKQ({ ...BASE, text: 'A question with no verdict' })
+    expect(screen.queryByTestId(MARKER)).toBeNull()
+    expect(screen.queryByTestId('dsk-grounding')).toBeNull()
+  })
+
+  it('DISCRIMINATING PAIR: exactly one marker, in the general card only', () => {
+    const { container } = render(
+      <div>
+        <div data-testid="host-general">
+          <HeroKeyQuestion
+            keyQuestion={{ ...BASE, text: 'general question', generalGuidance: true }}
+            onPrefillChat={noop}
+            chatPrefillAvailable
+          />
+        </div>
+        <div data-testid="host-grounded">
+          <HeroKeyQuestion
+            keyQuestion={{
+              ...BASE,
+              text: 'grounded question',
+              grounding: { principle: 'Outside view and reference class forecasting', claimId: 'DSK-T-002' },
+            }}
+            onPrefillChat={noop}
+            chatPrefillAvailable
+          />
+        </div>
+      </div>,
+    )
+    expect(container.querySelectorAll(`[data-testid="${MARKER}"]`)).toHaveLength(1)
+    expect(screen.getByTestId('host-general').querySelector(`[data-testid="${MARKER}"]`)).not.toBeNull()
+    expect(screen.getByTestId('host-grounded').querySelector(`[data-testid="${MARKER}"]`)).toBeNull()
+  })
+})

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -496,6 +496,108 @@ describe('buildAnalysisHeroViewModel', () => {
       expect(vm.keyQuestion?.text).toBe('What evidence would change your view?')
     })
 
+    /**
+     * ── 2.491: the `generalGuidance` JOIN ────────────────────────────────
+     *
+     * `buildKeyQuestion` maps the selected prompt's `groundingState` onto the
+     * VM's `generalGuidance` flag. That join is invisible to any render test —
+     * deleting `...(generalGuidance ? { generalGuidance: true } : {})` was
+     * demonstrated to SURVIVE the whole suite. These cases are what make that
+     * deletion bite.
+     *
+     * (The V17 hero is the flag-OFF arm and does not mount on staging; the
+     * DEPLOYED proof is KeyQuestionCard.generalGuidance.spec.tsx plus the
+     * mount-path guard in ResultsBody.keyQuestionLiveMount.spec.tsx. This join
+     * still needs pinning: an unpinned branch is an unpinned branch.)
+     */
+    it('2.491 — sets generalGuidance from the SELECTED prompt\'s general verdict', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          stability: 0.7,
+          dqpFull: [
+            {
+              principle: 'Consider-the-opposite',
+              appliesBecause: 'x',
+              question: 'What would make you switch?',
+              groundingState: 'general',
+            },
+          ] as never,
+        }),
+        vm: makeVm({ decisionState: 'sensitive' }),
+      })
+      // POSITIVE CONTROL for the join: prove a card exists before asserting a
+      // flag on it, or a null card passes vacuously.
+      expect(vm.keyQuestion).not.toBeNull()
+      expect(vm.keyQuestion?.text).toBe('What would make you switch?')
+      expect(vm.keyQuestion?.generalGuidance).toBe(true)
+      expect(vm.keyQuestion?.grounding).toBeUndefined()
+    })
+
+    it('2.491 — does NOT set generalGuidance for an attested prompt (discriminating half)', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          stability: 0.7,
+          dqpFull: [
+            {
+              principle: 'Outside view and reference class forecasting',
+              appliesBecause: 'x',
+              question: 'What is the base rate?',
+              dskClaimId: 'DSK-T-002',
+              evidenceStrength: 'strong',
+              groundingState: 'attested',
+            },
+          ] as never,
+        }),
+        vm: makeVm({ decisionState: 'sensitive' }),
+      })
+      expect(vm.keyQuestion?.generalGuidance).toBeUndefined()
+      expect(vm.keyQuestion?.grounding?.claimId).toBe('DSK-T-002')
+    })
+
+    it('2.491 — no verdict on the wire ⇒ no flag (absence is not "general")', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          stability: 0.7,
+          dqpFull: [
+            { principle: 'Consider-the-opposite', appliesBecause: 'x', question: 'A question' },
+          ] as never,
+        }),
+        vm: makeVm({ decisionState: 'sensitive' }),
+      })
+      expect(vm.keyQuestion).not.toBeNull()
+      expect(vm.keyQuestion?.generalGuidance).toBeUndefined()
+    })
+
+    it('2.491 — binds to prompt[0], not to "any prompt in the list"', () => {
+      const vm = buildAnalysisHeroViewModel({
+        ...STD_ARGS,
+        data: makeData({
+          stability: 0.7,
+          dqpFull: [
+            {
+              principle: 'Outside view and reference class forecasting',
+              appliesBecause: 'x',
+              question: 'attested first',
+              dskClaimId: 'DSK-T-002',
+              groundingState: 'attested',
+            },
+            {
+              principle: 'Consider-the-opposite',
+              appliesBecause: 'x',
+              question: 'general second',
+              groundingState: 'general',
+            },
+          ] as never,
+        }),
+        vm: makeVm({ decisionState: 'sensitive' }),
+      })
+      expect(vm.keyQuestion?.text).toBe('attested first')
+      expect(vm.keyQuestion?.generalGuidance).toBeUndefined()
+    })
+
     it('hides the card when reviewStatus !== "complete" even if a clean DQP is present (in-progress / stale guard)', () => {
       // Upstream selector exposes m2DecisionQualityPrompts even during a
       // partial review. Without the reviewStatus gate the card would

--- a/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
+++ b/src/components/results/analysisHeroV17/analysisHeroVM.types.ts
@@ -82,6 +82,12 @@ export interface KeyQuestion {
   chips: string[]
   /** DSK provenance for `text`'s source prompt — see DskGrounding. */
   grounding?: DskGrounding
+  /**
+   * 2.491 — true when CEE positively verdicted the source prompt as `general`
+   * (unattested). Renders the badge's negative twin so absence-of-badge stops
+   * being silent. Never inferred from `!grounding`: see `isGeneralGuidance`.
+   */
+  generalGuidance?: boolean
 }
 
 export interface AlsoLink {

--- a/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
+++ b/src/components/results/analysisHeroV17/buildAnalysisHeroViewModel.ts
@@ -59,7 +59,7 @@ import { rankHeroRows } from './rowRanking'
 // AND the test scanner so what production guards against == what tests
 // catch. (Per P1.1 review feedback.)
 import { containsBannedTerm, safeInterpolatedLabel as safeLabel } from './glossaryCheck'
-import { deriveDskGrounding } from '../utils/decisionQualityPrompts'
+import { deriveDskGrounding, isGeneralGuidance } from '../utils/decisionQualityPrompts'
 // Genuine Structure + Coverage signal derivation (P1.1 round-3 review).
 import {
   deriveStructureScore,
@@ -312,11 +312,15 @@ function selectKeyQuestion(
     // attested dskClaimId ⇒ NO grounding object; strength/protocol carried
     // only when present upstream, never defaulted.
     const grounding: DskGrounding | undefined = deriveDskGrounding(dqps[0])
+    // 2.491: the same source prompt's positive `general` verdict, carried so
+    // the host can mark an unattested question instead of saying nothing.
+    const generalGuidance = isGeneralGuidance(dqps[0])
     return {
       text: dqp,
       extras: dqps.slice(1, 4).map(p => p.question).filter(q => q && !containsBannedTerm(q)),
       chips: ['High', 'Some', 'Not sure', 'Add note'],
       ...(grounding ? { grounding } : {}),
+      ...(generalGuidance ? { generalGuidance: true } : {}),
     }
   }
 

--- a/src/components/results/utils/decisionQualityPrompts.ts
+++ b/src/components/results/utils/decisionQualityPrompts.ts
@@ -37,6 +37,27 @@ import { containsBannedTerm } from '../analysisHeroV17/glossaryCheck'
 export const DSK_EVIDENCE_STRENGTHS = ['weak', 'medium', 'strong'] as const
 export type DskEvidenceStrength = (typeof DSK_EVIDENCE_STRENGTHS)[number]
 
+/**
+ * 2.491 — CEE's explicit grounding verdict for a prompt (`dsk_grounding` on the
+ * wire). Closes the 2.456 asymmetry, in which a PRESENT-but-unknown claim id
+ * hard-rejected while an OMITTED id passed unvalidated AND unmarked, so an
+ * ungrounded prompt reached the user indistinguishable from an attested one
+ * (44% of live prompts, walk of 2026-08-05).
+ *
+ *  - `attested`  — the model cited a claim that resolves in the DSK bundle.
+ *  - `resolved`  — the id was omitted but the principle is byte-identical to a
+ *                  bundle claim title, so CEE resolved it FROM the bundle.
+ *                  Carries a real `dsk_claim_id`; renders the normal badge.
+ *  - `general`   — genuinely unattested. Surfaces must say so POSITIVELY.
+ *
+ * ⚠ ABSENCE IS NOT `general`. A payload with no verdict (DSK disabled, bundle
+ * load failure, or a CEE build predating 2.491) means "no verdict was made" —
+ * rendering a disclaimer there would be its own false statement. The general
+ * marker is therefore gated on the POSITIVE value, never on missing grounding.
+ */
+export const DSK_GROUNDING_STATES = ['attested', 'resolved', 'general'] as const
+export type DskGroundingState = (typeof DSK_GROUNDING_STATES)[number]
+
 export interface MappedDecisionQualityPrompt {
   principle: string
   appliesBecause: string
@@ -47,6 +68,13 @@ export interface MappedDecisionQualityPrompt {
   dskProtocolId?: string
   /** Closed-vocabulary strength, verbatim. Only ever present alongside dskClaimId. */
   evidenceStrength?: DskEvidenceStrength
+  /**
+   * 2.491 — CEE's explicit grounding verdict, carried ONLY when it is a member
+   * of the closed vocabulary above. Unlike the provenance triple this is NOT
+   * id-gated: `general` is precisely the case with no id, and it is the value
+   * that lets a surface mark the prompt honestly instead of silently.
+   */
+  groundingState?: DskGroundingState
 }
 
 function nonEmptyString(v: unknown): v is string {
@@ -102,6 +130,26 @@ export function deriveDskGrounding(
 }
 
 /**
+ * 2.491 — should this prompt be marked to the user as general guidance rather
+ * than attested decision science?
+ *
+ * TRUE only on CEE's POSITIVE `general` verdict. Deliberately NOT `!grounding`:
+ * that would fire on every payload with no verdict at all (DSK disabled, bundle
+ * load failure, pre-2.491 CEE), printing a disclaimer we have no basis for —
+ * the mirror-image of the defect this closes. Both halves must be honest, so
+ * the marker fails closed in both directions.
+ *
+ * What would have to be true for this to return TRUE while the prompt IS
+ * grounded? Only if CEE emitted `general` alongside a resolving claim id —
+ * which its policy makes unconstructible (`attested`/`resolved` are the only
+ * verdicts that can accompany an id). The pairing is pinned in CEE's
+ * `dsk-grounding-policy.test.ts` and re-pinned here against a mixed fixture.
+ */
+export function isGeneralGuidance(p: MappedDecisionQualityPrompt): boolean {
+  return p.groundingState === 'general'
+}
+
+/**
  * Map raw wire prompt entries to the UI shape. Preserves the historical
  * behaviour for the three copy fields exactly (truthy check → sanitise,
  * else '') and adds the id-gated provenance carry.
@@ -126,6 +174,14 @@ export function mapDecisionQualityPrompts(raw: ReadonlyArray<unknown>): MappedDe
       if (typeof s === 'string' && (DSK_EVIDENCE_STRENGTHS as readonly string[]).includes(s)) {
         mapped.evidenceStrength = s as DskEvidenceStrength
       }
+    }
+    // 2.491 — the grounding verdict, closed-vocabulary gated. NOT id-gated:
+    // `general` is by definition the no-id case. Anything outside the
+    // vocabulary fails closed to absent, so an unrecognised wire value renders
+    // nothing rather than an unintended claim.
+    const g = p.dsk_grounding
+    if (typeof g === 'string' && (DSK_GROUNDING_STATES as readonly string[]).includes(g)) {
+      mapped.groundingState = g as DskGroundingState
     }
     return mapped
   })


### PR DESCRIPTION
**DO-NOT-MERGE — orchestrator merges.** Pillar: **P1 scientific coaching**. ROADMAP **2.491**. Merge **after** CEE #825 (the producer half).

> **Revised after an independent UI verifier DEMONSTRATED that my tests covered a component staging does not render.** It was right, it is fixed, and both mutants it named now bite. Several of my original claims were wrong and are corrected below. **The rate is 52% (16/31), not 44%.**

## What a user now sees

Under a decision-quality question with no attested science behind it:

> **General guidance — not drawn from our attested evidence base.**

Previously that case rendered the question and **nothing else**. The `dsk-grounding` badge was honest — it correctly stayed silent — but **silence is not a signal**.

## 🔴 The blocker: my tests targeted the switched-off host

`netlify.toml:78` sets `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` in the staging context. `ResultsBody.tsx:383` mounts `KeyQuestionCard` inside `{isAnalysisHeroPanelEnabled() && …}`; `:412` opens the `{!… && (` arm where the V17 `HeroKeyQuestion` lives. **My 7 render tests and all 5 mutants targeted the V17 hero — the flag-OFF arm.** A deployed-DOM census: `key-question-card` in 14 captures, `hero-v17-key-question` in **zero**.

Both named mutants were demonstrated to **survive**. Root cause was structural: no test anywhere constructed a payload carrying `dsk_grounding` and pushed it through the adapter, the view model, or ResultsBody, so both branches were unreachable from the suite by construction.

**This is the same dark-ship row 2.466 exists for** — lane 1's badge shipped dark on the V17 hero for exactly this reason — reproduced with the same badge's negative twin, past the spec written to prevent it.

### Fix, and the acceptance criteria met

| mutant | before | now |
|---|---|---|
| **A** — delete the marker block from `analysis-hero/KeyQuestionCard.tsx` (applied=1, 0 refs left) | GREEN, survived | **RED — 4 failed / 118 passed** ✓ |
| **B** — delete `...(generalGuidance ? { generalGuidance: true } : {})` from `buildAnalysisHeroViewModel.ts` (applied=1) | GREEN, survived | **RED — 1 failed / 121 passed** ✓ |

Control: pristine **122 passed**, applied-check exactly **0** before and after each mutant.

- `analysis-hero/__tests__/KeyQuestionCard.generalGuidance.spec.tsx` — the **deployed** host.
- `analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts` — the VM join (mutant B), added to the spec that **owns** the `makeData`/`dqpFull` fixture rather than mirroring the builder.
- `__tests__/ResultsBody.keyQuestionLiveMount.spec.tsx` — **mount-path guard**, extended as the verifier suggested: real `ResultsBody`, real flag seam (`localStorage` through `makeFlag`, not a mock), real captured turn with verdicts injected into a clone. Re-hosting the marker on the `!flag` arm now goes RED.
- `analysisHeroV17/__tests__/HeroKeyQuestion.generalGuidance.spec.tsx` — the flag-OFF host, explicitly labelled as such.
- `__tests__/dskGeneralGuidance.spec.tsx` — now mapper-only, with its scope stated.

## The design decision that matters: ABSENCE IS NOT `general`

The marker is gated on CEE's **positive** `general` verdict, never on `!grounding`. Inferring it from missing grounding would fire on every payload with no verdict — DSK disabled, bundle load failure, or any CEE build predating #825 — printing a disclaimer we have no basis for. **Fails closed in both directions.** A `resolved` prompt is genuinely cited and correctly gets the ordinary badge.

## Corrections to my own earlier claims

- **My typecheck evidence — re-measured in a clean clone, as instructed.** Same fresh clone, same `node_modules`, both sides:
  - pristine `e01dbd4a`: 3238/3278 loaded · **616 files / 2485 errors** · RATCHET FAILED
  - my head `ca9d73ee`: 3240/3280 loaded · **616 files / 2485 errors** · RATCHET FAILED
  **Byte-identical both sides ⇒ delta from this PR is ZERO**, and loaded files rise by exactly +2 (my new specs, covered without exception). ⚠ This does **not** reproduce the verifier's PASS/rc=0 — but note the **loaded count is identical to theirs (3238/3278)**, so it is *not* a shrunk measurement as they inferred. `package-lock.json` is **not tracked upstream**, so `npm install` resolves different transitive versions on different machines; the errors that move are all in `.stories.tsx` (Storybook types). **CI is the authoritative environment and `TypeScript + Lint` is GREEN on my SHA.** Declining `--update-baseline` was right.
- **My RED-first "headline signature" overstated its reach.** The full split at pristine was: 1 mapper `AssertionError`, **2 × `TypeError: isGeneralGuidance is not a function`** (a missing export, not a behavioural failure), 1 testid-absence, 1 length assertion. Still a real RED-first — now stated as what it is.
- **"`decision_quality_prompts` is untyped in schemas (zero hits in `src/`)" was false as written** — it appears in 19 files under `src/`. The correct claim: **0 hits in `node_modules/@talchain/schemas`**; it rides the enrichment passthrough, and the adapter carries it verbatim (`decisionReviewAdapter.ts:557`).
- **Pin parity (both `0.34.0`) is a cross-service observation**, not something settleable from this repo alone.
- **U1/U5 disclosure stands**: the anchor has no trailing semicolon, my regexes missed, the applied-check caught it, both bite after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)