### PR TITLE
DO-NOT-MERGE — 2.449 UI: surface the downside answer, "if this goes badly, how badly?"

### DIFF
--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -43,6 +43,12 @@ import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import { OptionRangeBar, computeOptionScale } from './shared/OptionRangeBar'
 import { formatGoalProbability } from './utils/displayFloors'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
+import {
+  DOWNSIDE_HEADING_COPY,
+  DOWNSIDE_TAIL_CAVEAT_COPY,
+  downsideSummaryCopy,
+} from './utils/downsideCopy'
+import { formatRangeValue } from './utils/formatRangeValue'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { useCanvasStore, selectResultsStatus } from '../../canvas/store'
 import { isGraphLensEnabled } from '../../flags'
@@ -815,6 +821,49 @@ function OptionCard({
               Expected: {option.outcome.mean.toLocaleString()}
             </p>
           ) : null}
+
+          {/* ROADMAP 2.449 — DOWNSIDE / TAIL RISK. "And if this goes badly,
+              how badly?" The engine has computed this since #91/#92; it died
+              in PLoT's option builder and no user has ever seen it.
+
+              Sits inside the SAME expert block as the range bar, immediately
+              below it, because these two numbers extend that exact bar
+              downward: same simulated runs, same units, same axis, same
+              formatter (`formatRangeValue`, so the tail cannot render on a
+              different precision rule than the range it belongs to).
+              Progressive disclosure (P5) — depth for the reader who asked for
+              depth, nothing added to the default card.
+
+              HONEST ABSENCE: `option.downside` is undefined whenever the
+              engine could not compute the block honestly, and this renders
+              NOTHING in that case — no zero, no dash, no "not available".
+              A zero here would read as "there is no downside", which is the
+              most damaging thing this surface could say.
+
+              ⛔ `downside.expectedRegret` is deliberately NOT rendered. It is
+              the per-option limb of the value-of-information family (the
+              whole-decision EVPI is exactly its minimum across options), and
+              the estate's no-EVPI-display doctrine licenses a ranking with NO
+              magnitudes there — the same doctrine that removed the EVPI
+              percentage-point pill from TriageCard. Showing it is a doctrine
+              ruling, not a wiring gap. */}
+          {option.downside !== undefined && (
+            <div className="mt-1" data-testid={`option-downside-${option.id}`}>
+              <p className={`${typography.panelMeta} text-text-light`}>
+                <span className="font-medium">{DOWNSIDE_HEADING_COPY}</span>{' '}
+                {downsideSummaryCopy(
+                  formatRangeValue(option.downside.p05),
+                  formatRangeValue(option.downside.cvar10),
+                )}
+              </p>
+              <p
+                className={`${typography.panelMeta} text-text-light`}
+                data-testid={`option-downside-caveat-${option.id}`}
+              >
+                {DOWNSIDE_TAIL_CAVEAT_COPY}
+              </p>
+            </div>
+          )}
         </ExpertBlock>
       )}
 

--- a/src/components/results/__tests__/OptionCards.downsideTailRisk.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.downsideTailRisk.spec.tsx
@@ -1,0 +1,275 @@
+/**
+ * ROADMAP 2.449 — DOWNSIDE / TAIL-RISK SURFACE on the option card.
+ *
+ * THE CAPABILITY. Olumi could tell a user which option leads and how robust
+ * that is, but not "and if this goes badly, how badly?" — even though ISL has
+ * computed the answer since #91/#92. This suite is the user-visible end of
+ * that train: PLoT now carries `option_comparison[].downside`, the V5 mapper
+ * and the Results hook carry it through, and these are the sentences a reader
+ * actually gets.
+ *
+ * WHAT IS PINNED HERE, and why each pin exists rather than being obvious:
+ *
+ *  1. THE NUMBERS APPEAR, BOUND TO THE OPTION THEY DESCRIBE. Assertions select
+ *     the card by its `data-testid` (option id) and re-assert the exact label,
+ *     and the sibling option carries DELIBERATELY DIFFERENT tail values — so no
+ *     assertion can be satisfied by the wrong card (trap 19: a spec that finds
+ *     an object by a value predicate passes on whichever object happens to
+ *     satisfy it).
+ *
+ *  2. THE MEANING TRAVELS WITH THE NUMBER. A bare figure is not the product's
+ *     standard. Producer jargon — "CVaR", "expected shortfall", "percentile" —
+ *     must never reach the reader.
+ *
+ *  3. THE UN-RATIFIED TAIL CUT-OFF IS DISCLOSED. ISL marks the 0.10 tail mass
+ *     `DOCTRINE-PENDING(Neil)`. A surface that renders the number without
+ *     saying the cut-off is unsettled is making a claim we have not earned, so
+ *     the caveat is asserted to travel with the magnitudes — not merely to
+ *     exist somewhere in the DOM.
+ *
+ *  4. ABSENCE IS BLANK — never a zero. This is the failure this whole feature
+ *     family has shipped repeatedly, most recently a "defensive" 0.0 in the
+ *     regret statistic that collapsed the whole-decision EVPI bound. A zero in
+ *     a downside statistic does not read as "unknown"; it reads as "there is
+ *     no downside".
+ *
+ *  5. POSITIVE CONTROL, BOTH DIRECTIONS. Every absence assertion here renders
+ *     in a tree where a SIBLING card carries the surface, so the harness is
+ *     demonstrably able to see the thing it claims is missing (trap 13). And
+ *     every presence assertion is paired with an absence arm, so it cannot be
+ *     passing on a permanently-rendered element.
+ *
+ *  6. `expectedRegret` IS CARRIED AND NOT DISPLAYED. It is the per-option limb
+ *     of the value-of-information family (whole-decision EVPI is exactly its
+ *     minimum across options), and the estate's no-EVPI-display doctrine
+ *     licenses a ranking with NO magnitudes for that family. Rendering it is a
+ *     doctrine ruling; this suite pins that the ruling has not been quietly
+ *     taken by a render site.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+import {
+  DOWNSIDE_HEADING_COPY,
+  DOWNSIDE_TAIL_CAVEAT_COPY,
+} from '../utils/downsideCopy'
+
+const HEDGE_ID = 'opt_hedge'
+const HEDGE_LABEL = 'Hedge and stage the rollout'
+const BOLD_ID = 'opt_bold'
+const BOLD_LABEL = 'Go big in one step'
+
+/**
+ * The two options carry DIFFERENT tail values on purpose. Every magnitude
+ * asserted below is unique to one card, so a render that put the right numbers
+ * on the wrong card fails here rather than in front of a user.
+ */
+const HEDGE_DOWNSIDE = { cvar10: 12, p05: 18, expectedRegret: 4 }
+const BOLD_DOWNSIDE = { cvar10: -37, p05: -21, expectedRegret: 19 }
+
+function makeOption(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: HEDGE_ID,
+    label: HEDGE_LABEL,
+    expected: 50,
+    outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+    p10: 20,
+    p50: 50,
+    p90: 80,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.7,
+    nValidSamples: 1000,
+    rank: 1,
+    ...overrides,
+  }
+}
+
+/** Both cards, downside present on both unless overridden. */
+function twoOptions(
+  hedge: Partial<OptionResult> = {},
+  bold: Partial<OptionResult> = {},
+): OptionResult[] {
+  return [
+    makeOption({ id: HEDGE_ID, label: HEDGE_LABEL, downside: { ...HEDGE_DOWNSIDE }, ...hedge }),
+    makeOption({
+      id: BOLD_ID,
+      label: BOLD_LABEL,
+      isRecommended: false,
+      rank: 2,
+      winProbability: 0.35,
+      downside: { ...BOLD_DOWNSIDE },
+      ...bold,
+    }),
+  ]
+}
+
+/**
+ * Select a CARD by identity: the option id addresses it, and the visible label
+ * is re-asserted so a card carrying the right numbers under the wrong identity
+ * cannot satisfy anything below.
+ */
+function cardByIdentity(optionId: string, optionLabel: string): HTMLElement {
+  const card = screen.getByTestId(`option-card-${optionId}`)
+  expect(card.textContent, `identity: card ${optionId} must show "${optionLabel}"`).toContain(
+    optionLabel,
+  )
+  return card
+}
+
+describe('2.449 — option card downside/tail-risk surface', () => {
+  // =========================================================================
+  // 1 — the numbers reach the reader, on the right card
+  // =========================================================================
+
+  it('shows EACH option its OWN tail numbers, with the meaning attached', () => {
+    render(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+
+    const hedge = within(cardByIdentity(HEDGE_ID, HEDGE_LABEL)).getByTestId(
+      `option-downside-${HEDGE_ID}`,
+    )
+    const bold = within(cardByIdentity(BOLD_ID, BOLD_LABEL)).getByTestId(
+      `option-downside-${BOLD_ID}`,
+    )
+
+    // The magnitudes, each on its own card and nowhere else.
+    expect(hedge.textContent).toContain('18')
+    expect(hedge.textContent).toContain('12')
+    expect(bold.textContent).toContain('-21')
+    expect(bold.textContent).toContain('-37')
+    // Cross-check the binding explicitly: neither card carries the other's
+    // numbers. Without this, "contains 18" would still pass if both cards
+    // rendered the same block.
+    expect(hedge.textContent).not.toContain('-37')
+    expect(bold.textContent).not.toContain('18')
+
+    // MEANING ATTACHED — the frequency framing, not a bare figure.
+    expect(hedge.textContent).toContain(DOWNSIDE_HEADING_COPY)
+    expect(hedge.textContent).toMatch(/worst 1 in 20 simulated runs/i)
+    expect(hedge.textContent).toMatch(/worst 1 in 10 average/i)
+  })
+
+  it('never puts producer jargon in front of the reader', () => {
+    render(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+    const surface = screen.getByTestId(`option-downside-${HEDGE_ID}`).textContent ?? ''
+    // POSITIVE CONTROL for this assertion: the surface is non-empty and
+    // carries a number, so "contains no jargon" is not passing on empty text.
+    expect(surface.length).toBeGreaterThan(0)
+    expect(surface).toMatch(/\d/)
+    for (const banned of [
+      'CVaR',
+      'cvar',
+      'conditional value at risk',
+      'expected shortfall',
+      'percentile',
+      'p05',
+      'expected_regret',
+      'EVPI',
+      'tail mass',
+      'Monte Carlo',
+    ]) {
+      expect(surface.toLowerCase()).not.toContain(banned.toLowerCase())
+    }
+  })
+
+  // =========================================================================
+  // 2 — the un-ratified cut-off is disclosed WITH the numbers
+  // =========================================================================
+
+  it('ships the unsettled-cut-off caveat on the same card as the numbers', () => {
+    render(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+
+    const card = cardByIdentity(HEDGE_ID, HEDGE_LABEL)
+    const caveat = within(card).getByTestId(`option-downside-caveat-${HEDGE_ID}`)
+    expect(caveat.textContent).toBe(DOWNSIDE_TAIL_CAVEAT_COPY)
+    // It must not read as settled practice.
+    expect(caveat.textContent).toMatch(/not settled|working choice/i)
+    // And it must travel WITH the magnitudes — a caveat rendered on a card
+    // that shows no number is decoration, and a number on a card that shows
+    // no caveat is the claim we have not earned.
+    expect(within(card).getByTestId(`option-downside-${HEDGE_ID}`).textContent).toMatch(/\d/)
+  })
+
+  it('POSITIVE CONTROL — the caveat is absent exactly when the numbers are', () => {
+    // Hedge keeps its block; bold has none. If the caveat were rendered
+    // unconditionally, the second assertion would fail — which is what makes
+    // the first assertion meaningful.
+    render(
+      <OptionCards options={twoOptions({}, { downside: undefined })} winnerId={HEDGE_ID} expertMode />,
+    )
+    expect(screen.getByTestId(`option-downside-caveat-${HEDGE_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`option-downside-caveat-${BOLD_ID}`)).toBeNull()
+  })
+
+  // =========================================================================
+  // 3 — HONEST ABSENCE: blank, never a zero
+  // =========================================================================
+
+  it('renders NOTHING for an option with no downside — no zero, no placeholder', () => {
+    render(
+      <OptionCards options={twoOptions({}, { downside: undefined })} winnerId={HEDGE_ID} expertMode />,
+    )
+
+    // PRECONDITION PIN + POSITIVE CONTROL: the sibling DOES render the
+    // surface, so this harness is demonstrably able to see it. Without this,
+    // "queryByTestId is null" would also pass if the whole feature were gone.
+    expect(screen.getByTestId(`option-downside-${HEDGE_ID}`)).toBeInTheDocument()
+
+    const boldCard = cardByIdentity(BOLD_ID, BOLD_LABEL)
+    expect(within(boldCard).queryByTestId(`option-downside-${BOLD_ID}`)).toBeNull()
+    // No fabricated stand-in of any kind on the card that has no data.
+    expect(boldCard.textContent).not.toContain(DOWNSIDE_HEADING_COPY)
+    expect(boldCard.textContent).not.toMatch(/worst 1 in 20/i)
+    expect(boldCard.textContent).not.toMatch(/not available|no downside|n\/a/i)
+  })
+
+  it('renders a GENUINE negative tail as itself — a measured value, not a floor', () => {
+    // The bold option's tail is negative: the reader must see that the worst
+    // runs lose value, not a clamped 0.
+    render(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+    const bold = screen.getByTestId(`option-downside-${BOLD_ID}`)
+    expect(bold.textContent).toContain('-37')
+    expect(bold.textContent).not.toMatch(/\b0\b(?!\.)/)
+  })
+
+  // =========================================================================
+  // 4 — expected_regret is carried but NOT displayed (doctrine)
+  // =========================================================================
+
+  it('does NOT render the regret magnitude — value-of-information doctrine', () => {
+    // Values chosen so a leaked regret magnitude is unmistakable: 4 and 19
+    // appear nowhere else in these fixtures' rendered tail text.
+    render(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+
+    const hedge = screen.getByTestId(`option-downside-${HEDGE_ID}`)
+    const bold = screen.getByTestId(`option-downside-${BOLD_ID}`)
+
+    // POSITIVE CONTROL first: the surface is rendering numbers at all, so the
+    // absence below is about THIS number and not about an empty element.
+    expect(hedge.textContent).toContain('18')
+    expect(bold.textContent).toContain('-37')
+
+    expect(hedge.textContent).not.toMatch(/\b4\b/)
+    expect(bold.textContent).not.toMatch(/\b19\b/)
+    // And no prose that would make the "worth X" claim by another route.
+    expect(hedge.textContent).not.toMatch(/worth|perfect information|regret/i)
+  })
+
+  // =========================================================================
+  // 5 — progressive disclosure (P5): depth only where depth was asked for
+  // =========================================================================
+
+  it('is expert-mode only — the default card is unchanged', () => {
+    const { rerender } = render(
+      <OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode={false} />,
+    )
+    expect(screen.queryByTestId(`option-downside-${HEDGE_ID}`)).toBeNull()
+
+    // POSITIVE CONTROL: the SAME options in expert mode do render it, so the
+    // assertion above is about the mode and not about missing data.
+    rerender(<OptionCards options={twoOptions()} winnerId={HEDGE_ID} expertMode />)
+    expect(screen.getByTestId(`option-downside-${HEDGE_ID}`)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.downside.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.downside.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * ROADMAP 2.449 — the report→view-model seam for the DOWNSIDE / tail-risk block.
+ *
+ * WHY THIS SEAM NEEDS ITS OWN SUITE, and it is not the plumbing. `cvar_10` and
+ * `p05` are declared by the producer to be in the SAME units and on the SAME
+ * axis as `outcome.mean`/`p10`, with no normalisation of their own. This hook
+ * DENORMALISES the percentile family by a per-option scale (`goalThresholdCap`
+ * when the run is on model scale). A tail that skipped that scale — or took a
+ * different one — would be plotted against a different ruler than the range it
+ * is the tail OF, and "the worst decile sits at or below p10" would stop being
+ * true ON SCREEN while remaining true in the data. That is a display defect
+ * that reads as a science defect, and no amount of plumbing coverage catches
+ * it.
+ *
+ * The scale arms below are therefore written as a DISCRIMINATING PAIR: the
+ * same downside block is driven through a scaled run and an unscaled run, and
+ * the tail is asserted to move exactly with `outcome.p10` in both. A test that
+ * only ever ran at scale 1 would agree with a hook that applied no scale at
+ * all (trap 13b — a guard agreeing with itself).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+
+const OPT_HEDGE = 'opt_hedge'
+const OPT_BOLD = 'opt_bold'
+
+const NODES = [
+  { id: OPT_HEDGE, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Hedge and stage the rollout' } },
+  { id: OPT_BOLD, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Go big in one step' } },
+]
+
+/** Goal node carrying an explicit cap, which is what turns denormalisation on. */
+function goalNode(cap: number | null) {
+  return {
+    id: 'goal',
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'goal',
+      label: 'Programme value',
+      ...(cap !== null ? { goal_threshold_cap: cap } : {}),
+    },
+  }
+}
+
+type Downside = { cvar_10: number; p05: number; expected_regret: number }
+
+/**
+ * Drive the hook from a V5-shaped report. Values are on MODEL scale (0–1) so
+ * the hook's `alreadyDenormalized` heuristic (any |value| > 2) does not fire
+ * and the cap is genuinely applied — otherwise the "scaled" arm would silently
+ * be a second copy of the unscaled arm.
+ */
+function setStore(opts: {
+  cap: number | null
+  downsideByOption: Partial<Record<string, Downside>>
+}) {
+  const mk = (id: string, mean: number, downside?: Downside) => ({
+    confidence: 0.5,
+    win_probability: id === OPT_HEDGE ? 0.65 : 0.35,
+    expected: mean,
+    outcome: { mean, p10: mean - 0.2, p50: mean, p90: mean + 0.2 },
+    ...(downside !== undefined ? { downside } : {}),
+  })
+
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        option_probabilities: {
+          [OPT_HEDGE]: mk(OPT_HEDGE, 0.62, opts.downsideByOption[OPT_HEDGE]),
+          [OPT_BOLD]: mk(OPT_BOLD, 0.41, opts.downsideByOption[OPT_BOLD]),
+        },
+      },
+    } as never,
+    runMeta: {} as never,
+    nodes: [...NODES, goalNode(opts.cap)] as never,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+function optionById(
+  result: ReturnType<typeof renderHook<ReturnType<typeof useResultsSectionData>, unknown>>,
+  id: string,
+) {
+  const opts = result.result.current.recommendation?.allOptions ?? []
+  // HARNESS PRECONDITION. Without this, a store shape the hook cannot read
+  // would produce an empty option list and every assertion below would fail
+  // for a reason that has nothing to do with the code under test — a RED that
+  // comes from the harness rather than from the defect is worth no more than a
+  // GREEN that comes from a vacuous assertion.
+  expect(opts.length, 'harness precondition: the hook must build both options').toBe(2)
+  const found = opts.find((o) => o.id === id)
+  expect(found, `option ${id} must be in the view model`).toBeDefined()
+  return found!
+}
+
+const HEDGE_DOWNSIDE: Downside = { cvar_10: 0.21, p05: 0.29, expected_regret: 0.04 }
+const BOLD_DOWNSIDE: Downside = { cvar_10: -0.37, p05: -0.18, expected_regret: 0.19 }
+
+describe('2.449 — downside/tail-risk at the report→view-model seam', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as never)
+  })
+
+  it('exposes EACH option its OWN tail block on OptionResult', () => {
+    setStore({ cap: null, downsideByOption: { [OPT_HEDGE]: HEDGE_DOWNSIDE, [OPT_BOLD]: BOLD_DOWNSIDE } })
+    const r = renderHook(() => useResultsSectionData())
+
+    // Bound by id; the two fixtures differ so neither assertion can be
+    // satisfied by the other option's block.
+    expect(optionById(r, OPT_HEDGE).downside).toEqual({ cvar10: 0.21, p05: 0.29, expectedRegret: 0.04 })
+    expect(optionById(r, OPT_BOLD).downside).toEqual({ cvar10: -0.37, p05: -0.18, expectedRegret: 0.19 })
+  })
+
+  it('POSITIVE CONTROL — present on one option and absent on its sibling, same render', () => {
+    setStore({ cap: null, downsideByOption: { [OPT_HEDGE]: HEDGE_DOWNSIDE } })
+    const r = renderHook(() => useResultsSectionData())
+
+    // PRESENT arm — the harness can see a block arrive.
+    expect(optionById(r, OPT_HEDGE).downside).toBeDefined()
+    // ABSENT arm — and can see one NOT arrive, on an option that is otherwise
+    // fully built (it still has its outcome and win probability).
+    const bold = optionById(r, OPT_BOLD)
+    expect(bold.downside).toBeUndefined()
+    expect(bold, 'precondition: the absent-arm option is otherwise populated').toHaveProperty('outcome')
+    expect(bold.outcome.p10).not.toBeNull()
+  })
+
+  // =========================================================================
+  // THE SCALE SEAM — a discriminating pair
+  // =========================================================================
+
+  it('UNSCALED RUN: the tail sits on the same axis as p10, untouched', () => {
+    setStore({ cap: null, downsideByOption: { [OPT_HEDGE]: HEDGE_DOWNSIDE } })
+    const hedge = optionById(renderHook(() => useResultsSectionData()), OPT_HEDGE)
+
+    // Precondition: no cap ⇒ scale 1 ⇒ p10 is the raw model value.
+    expect(hedge.outcome.p10).toBeCloseTo(0.42, 6)
+    expect(hedge.downside?.cvar10).toBeCloseTo(0.21, 6)
+    expect(hedge.downside?.p05).toBeCloseTo(0.29, 6)
+  })
+
+  it('SCALED RUN: the tail moves by the SAME factor as p10 — same ruler, one decision', () => {
+    const CAP = 250_000
+    setStore({ cap: CAP, downsideByOption: { [OPT_HEDGE]: HEDGE_DOWNSIDE } })
+    const hedge = optionById(renderHook(() => useResultsSectionData()), OPT_HEDGE)
+
+    // PRECONDITION PIN: denormalisation actually fired on this run. Without
+    // this the two arms would be indistinguishable and the whole pair vacuous.
+    expect(hedge.outcome.p10).toBeCloseTo(0.42 * CAP, 3)
+
+    expect(hedge.downside?.cvar10).toBeCloseTo(0.21 * CAP, 3)
+    expect(hedge.downside?.p05).toBeCloseTo(0.29 * CAP, 3)
+
+    // The relationship the reader depends on survives the scaling: the mean of
+    // the worst decile sits at or below the tenth-percentile boundary.
+    expect(hedge.downside!.cvar10).toBeLessThanOrEqual(hedge.outcome.p10!)
+    // And the ratio is EXACTLY the ratio in the source data — i.e. one scale
+    // decision was applied to both, not two independent ones.
+    expect(hedge.downside!.cvar10 / hedge.outcome.p10!).toBeCloseTo(0.21 / 0.42, 6)
+  })
+
+  it('carries a GENUINE zero through the scale — a measured 0 is not an absence', () => {
+    const winner: Downside = { cvar_10: 0.55, p05: 0.58, expected_regret: 0 }
+    setStore({ cap: 250_000, downsideByOption: { [OPT_HEDGE]: winner } })
+    const hedge = optionById(renderHook(() => useResultsSectionData()), OPT_HEDGE)
+    expect(hedge.downside).toBeDefined()
+    expect(hedge.downside!.expectedRegret).toBe(0)
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -132,6 +132,44 @@ export interface OptionOutcome {
   p90: number | null
 }
 
+/**
+ * ROADMAP 2.449 — the DOWNSIDE / tail-risk view of an option's simulated
+ * outcome distribution, ready for display: both magnitudes have already been
+ * put on the SAME scale as `OptionOutcome.p10/p50/p90`.
+ *
+ * Present only when the whole block survived the producer's all-or-nothing
+ * emission rule and the boundary guards; there is deliberately NO partial
+ * shape, and no field is ever defaulted to 0 — a zero in a tail statistic
+ * reads as "there is no downside".
+ */
+export interface OptionDownside {
+  /**
+   * Mean of the worst 10% of simulated outcomes (a tail average, so it sits
+   * at or below `outcome.p10` by construction).
+   *
+   * ⚠ The 10% cut-off is a WORKING DEFAULT at the producer, explicitly not a
+   * ratified convention. Any surface showing this number must say so — see
+   * `DOWNSIDE_TAIL_CAVEAT_COPY` in OptionCards.
+   */
+  cvar10: number
+  /** 5th percentile — extends the p10/p50/p90 family downward. */
+  p05: number
+  /**
+   * How much better this decision would have gone, on average, had the true
+   * outcome been known in advance and the best option chosen each time.
+   *
+   * ⛔ CARRIED, NOT DISPLAYED. This is the per-option limb of the
+   * value-of-information family (the whole-decision EVPI is exactly the
+   * MINIMUM of these across options), and the estate's standing
+   * no-EVPI-display doctrine licenses a ranking with NO magnitudes for that
+   * family — it is why the EVPI percentage-point pill was removed from
+   * TriageCard. Rendering this magnitude is a doctrine ruling, not a wiring
+   * gap. It is carried here so a licensed surface does not have to re-plumb
+   * four services; every render site must leave it alone until then.
+   */
+  expectedRegret: number
+}
+
 export interface OptionResult {
   id: string
   label: string
@@ -155,6 +193,13 @@ export interface OptionResult {
    * Source value only — display formatting happens at render time.
    */
   nValidSamples?: number
+  /**
+   * ROADMAP 2.449 — tail-risk view of this option's simulated outcomes,
+   * already scaled onto the same axis as `outcome`. ABSENT (undefined) when
+   * the engine could not compute it honestly; render sites must show nothing
+   * at all rather than a zero or a placeholder.
+   */
+  downside?: OptionDownside
   /** Optional goal probability when no distribution data exists. */
   goalProbability?: number | null
   /** Task 2.1: Whether this option is the baseline for comparison */
@@ -1232,6 +1277,15 @@ export interface ResultsOptionProbability extends OptionProbability {
    * UI-BOUNDARY-DATA-INVENTORY.md §5.
    */
   goal_fit_basis?: { scored_from?: string; node_ids?: string[] }
+  /**
+   * ROADMAP 2.449 — per-option tail-risk view from ISL, forwarded by PLoT.
+   * Values are in the SAME units and on the SAME axis as `outcome.mean` /
+   * `outcome.p10` (no normalisation of their own), so any consumer that scales
+   * the percentile family MUST scale these identically. Present only when the
+   * producer emitted all three components as finite numbers; absent otherwise
+   * — never zeroed, never null.
+   */
+  downside?: { cvar_10: number; p05: number; expected_regret: number }
 }
 
 /**

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1533,6 +1533,26 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       const scaledP50 = norm.p50 != null ? norm.p50 * scale : null
       const scaledP90 = norm.p90 != null ? norm.p90 * scale : null
 
+      // ROADMAP 2.449 — tail-risk block. `cvar_10` and `p05` are declared by
+      // the producer to be in the SAME units as outcome.mean/p10 with NO
+      // normalisation of their own, so they ride THIS option's scale decision
+      // — the same one, taken once above. Scaling them independently (or not
+      // at all) would plot the tail against a different ruler than the range
+      // it is the tail OF, and "the worst decile sits below p10" would stop
+      // being readable on screen.
+      //
+      // Absent stays absent: no zero, no placeholder, no partial object. The
+      // mapper has already enforced the producer's all-or-nothing rule.
+      const rawDownside = prob.downside
+      const optionDownside = rawDownside !== undefined
+        ? {
+            cvar10: rawDownside.cvar_10 * scale,
+            p05: rawDownside.p05 * scale,
+            // Carried, never displayed — see OptionDownside.expectedRegret.
+            expectedRegret: rawDownside.expected_regret * scale,
+          }
+        : undefined
+
       // T6 P0-3: Prefer probability_of_joint_goal (constrained) when constraints exist,
       // fall back to goal_probability (unconstrained).
       // Staging trust review: when ISL auto-derives the goal threshold as a
@@ -1587,6 +1607,8 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         isRecommended: false, // Will be set immutably below
         winProbability: prob.win_probability,
         nValidSamples,
+        // 2.449 — omitted entirely when the engine had nothing honest to say.
+        ...(optionDownside !== undefined ? { downside: optionDownside } : {}),
         goalProbability,
         goalFitIsModelledBasis,
         // Which quantity `goalProbability` actually IS, carried to the render

--- a/src/components/results/utils/downsideCopy.ts
+++ b/src/components/results/utils/downsideCopy.ts
@@ -1,0 +1,56 @@
+/**
+ * ROADMAP 2.449 — the words a user actually reads for the tail-risk view of an
+ * option, and the single source of that wording.
+ *
+ * WHY THIS FILE EXISTS AT ALL. Olumi already tells a user which option leads
+ * and how robust that is. It could not answer the question every serious
+ * decision-maker asks next — "and if this goes badly, how badly?" — even though
+ * the engine has computed the answer for months. These sentences ARE the
+ * capability; the plumbing behind them is only how the numbers got here.
+ *
+ * THREE RULES, all of them load-bearing:
+ *
+ * 1. THE NUMBER ARRIVES WITH ITS MEANING ATTACHED. "CVaR 10%" is not a
+ *    user-facing string, and neither is "5th percentile" or "expected
+ *    shortfall". What the reader gets is what the statistic actually says
+ *    about their decision, in their own language: how bad the bad runs were.
+ *
+ * 2. THE TAIL CUT-OFF IS NOT SETTLED SCIENCE, AND WE SAY SO. ISL's source
+ *    marks the 0.10 tail mass `DOCTRINE-PENDING(Neil)` — a risk-modelling
+ *    default awaiting ratification, not a convention this product has adopted.
+ *    Presenting "the worst 10%" as though it were standard practice would be a
+ *    claim we have not earned. {@link DOWNSIDE_TAIL_CAVEAT_COPY} is therefore
+ *    NOT decoration: it ships wherever the number ships.
+ *
+ * 3. ABSENCE IS BLANK. There is deliberately no "no downside data" placeholder
+ *    and no zero: when the engine could not compute the tail honestly, the
+ *    whole surface is simply not rendered. A zero in a downside statistic does
+ *    not read as "unknown" — it reads as "there is no downside".
+ */
+
+/** Section label for the tail-risk lines on an option card. */
+export const DOWNSIDE_HEADING_COPY = 'If it goes badly'
+
+/**
+ * The two magnitudes, each with its meaning attached.
+ *
+ * `p05` is phrased as "1 in 20 … land below" rather than "5th percentile", and
+ * `cvar_10` as "the worst 1 in 10 … average" rather than "expected shortfall".
+ * Both are frequency framings of the SAME simulated runs the range bar
+ * directly above is drawn from, so the reader is being told more about a
+ * picture they are already looking at rather than being handed a second,
+ * unrelated statistic.
+ */
+export function downsideSummaryCopy(p05Display: string, cvar10Display: string): string {
+  return `In the worst 1 in 20 simulated runs this lands below ${p05Display}, and the worst 1 in 10 average ${cvar10Display}.`
+}
+
+/**
+ * The honesty caveat that must accompany the numbers above.
+ *
+ * It names the un-ratified choice WITHOUT implying the numbers are unreliable:
+ * where the tail is cut is a convention question, and the average of whatever
+ * is inside that cut is computed exactly.
+ */
+export const DOWNSIDE_TAIL_CAVEAT_COPY =
+  'Where we cut off "the worst" is a working choice we have not settled yet.'

--- a/src/v5/__tests__/mapV5AnalysisToReport.downside.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.downside.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * ROADMAP 2.449 — the V5 wire→report boundary for the DOWNSIDE / tail-risk block.
+ *
+ * WHY A SEPARATE SUITE. `mapV5AnalysisToReport` reads `option_comparison[]` by
+ * EXPLICIT FIELD SELECTION — there is no spread anywhere in it. That is the
+ * same shape of drop that killed this statistic at PLoT, and it is a live one
+ * in this very file today: `EnrichmentOutcomeStatsSchema` carries
+ * `n_valid_samples`, the V2 mapper forwards it, and the V5 mapper drops it.
+ * A field that is not asserted at THIS boundary is a field that vanishes
+ * silently the next time someone tidies the object literal.
+ *
+ * THE FIXTURE IS A LIVE CAPTURE, NOT ONE THIS LANE INVENTED. The base block is
+ * `live-analysis-turn-walkA-2026-08-04.json` — a real UI-facing CEE turn from
+ * 4 Aug 2026, which is exactly the payload that PROVES the gap: it carries
+ * `decision_evpi` (so ISL computed the regret population on that run) and no
+ * option carries a downside block (so it died in transit). The downside blocks
+ * are then grafted onto that real payload in the shape ISL's `DownsideV2`
+ * declares, rather than a whole payload written from this lane's model of the
+ * producer.
+ *
+ * ALL-OR-NOTHING IS THE PRODUCER'S RULE. ISL declares `cvar_10`, `p05` and
+ * `expected_regret` as REQUIRED floats and omits the block — "Omitted, never
+ * null" — rather than ship a partial one. So a partial block arriving here is
+ * a broken contract, not a half-answer, and absence is its only honest
+ * reading. Never a zero: a fabricated 0 in a tail statistic reads as "there is
+ * no downside".
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+import liveWalkATurn from './fixtures/live-analysis-turn-walkA-2026-08-04.json'
+
+type DownsideOnWire = { cvar_10?: unknown; p05?: unknown; expected_regret?: unknown }
+
+type ReportWithDownside = ReturnType<typeof mapV5AnalysisToReport> & {
+  option_probabilities?: Record<
+    string,
+    { downside?: { cvar_10: number; p05: number; expected_regret: number } }
+  >
+}
+
+/**
+ * The live 4-Aug turn's `analysis_result` block, with per-option downside
+ * blocks grafted on by option id. Passing `undefined` for an option leaves it
+ * exactly as the live capture had it — i.e. with NO downside key, which is the
+ * producer's documented absence shape and the state the live wire is in today.
+ */
+function liveBlockWithDownside(
+  byOptionId: Record<string, DownsideOnWire | undefined>,
+): AnalysisResultBlock {
+  const blocks = (liveWalkATurn as { blocks: Array<Record<string, unknown>> }).blocks
+  const analysis = blocks.find((b) => b.type === 'analysis_result')
+  if (!analysis) throw new Error('live fixture no longer carries an analysis_result block')
+  const cloned = JSON.parse(JSON.stringify(analysis)) as Record<string, unknown>
+  const enrichment = cloned.enrichment as { option_comparison?: Array<Record<string, unknown>> }
+  const rows = enrichment?.option_comparison
+  if (!Array.isArray(rows) || rows.length < 2) {
+    throw new Error('live fixture no longer carries >= 2 option_comparison rows')
+  }
+  for (const row of rows) {
+    const id = (row.option_id ?? row.id) as string
+    const d = byOptionId[id]
+    if (d !== undefined) row.downside = d
+  }
+  return cloned as unknown as AnalysisResultBlock
+}
+
+/** The live capture's own option ids, derived rather than hardcoded. */
+function liveOptionIds(): string[] {
+  const blocks = (liveWalkATurn as { blocks: Array<Record<string, unknown>> }).blocks
+  const analysis = blocks.find((b) => b.type === 'analysis_result') as
+    | { enrichment?: { option_comparison?: Array<Record<string, unknown>> } }
+    | undefined
+  return (analysis?.enrichment?.option_comparison ?? []).map(
+    (r) => (r.option_id ?? r.id) as string,
+  )
+}
+
+describe('2.449 — downside/tail-risk at the V5 wire→report boundary', () => {
+  // =========================================================================
+  // 0 — the gap itself, pinned against the live capture
+  // =========================================================================
+
+  it('THE GAP: the live 4-Aug turn carries decision_evpi and NO option downside', () => {
+    // This is the measurement the whole lane rests on, kept executable so it
+    // cannot quietly stop being true. `decision_evpi` present means ISL
+    // computed the regret population on that run (its own model validator
+    // raises otherwise), so the absent per-option blocks are a DROP in
+    // transit, never a "the engine had nothing to say".
+    const raw = JSON.stringify(liveWalkATurn)
+    expect(raw).toContain('decision_evpi')
+    expect(raw).not.toContain('cvar_10')
+    expect(raw).not.toContain('"downside"')
+    expect(liveOptionIds().length).toBeGreaterThanOrEqual(2)
+  })
+
+  // =========================================================================
+  // 1 — present-in ⇒ present-out, bound to the option by id
+  // =========================================================================
+
+  it('carries EACH option its OWN downside block through to option_probabilities', () => {
+    const [firstId, secondId] = liveOptionIds()
+    const first = { cvar_10: 0.21, p05: 0.29, expected_regret: 0.04 }
+    const second = { cvar_10: -0.37, p05: -0.18, expected_regret: 0.19 }
+
+    const report = mapV5AnalysisToReport(
+      liveBlockWithDownside({ [firstId]: first, [secondId]: second }),
+    ) as ReportWithDownside
+
+    // Bound BY ID, and the two fixtures are deliberately different so neither
+    // assertion could be satisfied by the other option's block.
+    expect(report.option_probabilities?.[firstId]?.downside).toEqual(first)
+    expect(report.option_probabilities?.[secondId]?.downside).toEqual(second)
+    expect(report.option_probabilities?.[secondId]?.downside?.cvar_10).not.toBe(
+      report.option_probabilities?.[firstId]?.downside?.cvar_10,
+    )
+  })
+
+  it('POSITIVE CONTROL — present on one option and absent on its sibling, in ONE report', () => {
+    const [firstId, secondId] = liveOptionIds()
+    const first = { cvar_10: 0.21, p05: 0.29, expected_regret: 0.04 }
+
+    const report = mapV5AnalysisToReport(
+      liveBlockWithDownside({ [firstId]: first }),
+    ) as ReportWithDownside
+
+    // PRESENT arm — the harness can see a block arrive.
+    expect(report.option_probabilities?.[firstId]?.downside).toEqual(first)
+    // ABSENT arm — and can see one NOT arrive, on an option that is otherwise
+    // fully mapped in the same report.
+    expect(report.option_probabilities?.[secondId]).toBeDefined()
+    expect(report.option_probabilities?.[secondId]).not.toHaveProperty('downside')
+  })
+
+  // =========================================================================
+  // 2 — honest absence: never a zero, never a partial block
+  // =========================================================================
+
+  it.each<[string, DownsideOnWire]>([
+    ['a missing p05', { cvar_10: 0.21, expected_regret: 0.04 }],
+    ['a null cvar_10', { cvar_10: null, p05: 0.29, expected_regret: 0.04 }],
+    ['a NaN expected_regret', { cvar_10: 0.21, p05: 0.29, expected_regret: Number.NaN }],
+    ['a string cvar_10', { cvar_10: '0.21', p05: 0.29, expected_regret: 0.04 }],
+    ['an Infinity p05', { cvar_10: 0.21, p05: Number.POSITIVE_INFINITY, expected_regret: 0.04 }],
+    ['an empty object', {}],
+  ])('drops the WHOLE block on %s — never a partial, never a zero', (_name, bad) => {
+    const [firstId, secondId] = liveOptionIds()
+    const good = { cvar_10: -0.37, p05: -0.18, expected_regret: 0.19 }
+
+    const report = mapV5AnalysisToReport(
+      liveBlockWithDownside({ [firstId]: bad, [secondId]: good }),
+    ) as ReportWithDownside
+
+    // PRECONDITION PIN: the good sibling proves this run carried downside
+    // blocks at all, so the assertion below is about the GUARD and not about a
+    // fixture somebody emptied.
+    expect(report.option_probabilities?.[secondId]?.downside).toEqual(good)
+
+    expect(report.option_probabilities?.[firstId]).not.toHaveProperty('downside')
+    expect(report.option_probabilities?.[firstId]?.downside).toBeUndefined()
+  })
+
+  it('carries a GENUINE zero expected_regret — a measured 0 is not an absence', () => {
+    // The option that wins every simulated draw has expected_regret === 0 by
+    // construction at the producer. A truthiness guard would swallow it and
+    // silently delete the whole tail view of the leading option.
+    const [firstId] = liveOptionIds()
+    const winner = { cvar_10: 0.55, p05: 0.58, expected_regret: 0 }
+
+    const report = mapV5AnalysisToReport(
+      liveBlockWithDownside({ [firstId]: winner }),
+    ) as ReportWithDownside
+
+    expect(report.option_probabilities?.[firstId]?.downside).toEqual(winner)
+    expect(report.option_probabilities?.[firstId]?.downside?.expected_regret).toBe(0)
+  })
+
+  it('a genuine zero in EVERY component still survives', () => {
+    const [firstId] = liveOptionIds()
+    const allZero = { cvar_10: 0, p05: 0, expected_regret: 0 }
+    const report = mapV5AnalysisToReport(
+      liveBlockWithDownside({ [firstId]: allZero }),
+    ) as ReportWithDownside
+    expect(report.option_probabilities?.[firstId]?.downside).toEqual(allZero)
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -129,6 +129,37 @@ function normaliseGoalFitBasis(
   }
 }
 
+/**
+ * ROADMAP 2.449 — normalise the per-option DOWNSIDE / tail-risk block.
+ *
+ * ALL-OR-NOTHING, and that is the PRODUCER's rule rather than a local
+ * invention: ISL declares `cvar_10`, `p05` and `expected_regret` as required
+ * floats on `DownsideV2` and omits the whole block — "Omitted, never null" —
+ * rather than ship a partial one; PLoT's `buildDownside` mirrors that at
+ * egress. So a partial block arriving here is a broken contract, not a
+ * half-answer, and the only honest reading of it is absence.
+ *
+ * NEVER substitutes a zero. A fabricated 0 in a tail-risk statistic does not
+ * read as "unknown" — it reads as "there is no downside", which is the most
+ * damaging direction this defect class can take.
+ *
+ * A MEASURED ZERO IS NOT AN ABSENCE: the option that wins every simulated draw
+ * has `expected_regret === 0` by construction, so this tests finiteness, never
+ * truthiness.
+ */
+function normaliseDownside(
+  raw: { cvar_10?: unknown; p05?: unknown; expected_regret?: unknown } | undefined,
+): { cvar_10: number; p05: number; expected_regret: number } | undefined {
+  if (!isPlainObject(raw)) return undefined
+  const cvar10 = safeFiniteNumber(raw.cvar_10)
+  const p05 = safeFiniteNumber(raw.p05)
+  const expectedRegret = safeFiniteNumber(raw.expected_regret)
+  if (cvar10 === undefined || p05 === undefined || expectedRegret === undefined) {
+    return undefined
+  }
+  return { cvar_10: cvar10, p05, expected_regret: expectedRegret }
+}
+
 // ─── Factor sensitivity normalisation ──────────────────────────────────
 
 interface NormalisedFactor {
@@ -369,6 +400,18 @@ interface RawOptionEnrichmentEntry {
    * verbatim, never derived. UI-BOUNDARY-DATA-INVENTORY.md §3.2/§5.
    */
   goal_fit_basis?: { scored_from?: unknown; node_ids?: unknown }
+  /**
+   * ROADMAP 2.449 — per-option DOWNSIDE / tail-risk block. Produced by ISL
+   * (`DownsideV2`) and forwarded verbatim by PLoT. All three values are in the
+   * SAME units as `outcome.mean` / `outcome.p10`, on the same axis and with no
+   * normalisation of their own — so the Results hook must apply the SAME
+   * denormalisation scale it applies to the percentile family, or the tail
+   * would be plotted against a different ruler than the range it belongs to.
+   *
+   * ABSENT (key omitted) whenever the producer could not compute the block
+   * honestly. Never `null`, never zeroed — see `normaliseDownside`.
+   */
+  downside?: { cvar_10?: unknown; p05?: unknown; expected_regret?: unknown }
 }
 
 interface ResolvedOptionEntry {
@@ -829,6 +872,13 @@ export function mapV5AnalysisToReport(
      * per the honesty rule in UI-BOUNDARY-DATA-INVENTORY.md §5.
      */
     goal_fit_basis?: { scored_from?: string; node_ids?: string[] }
+    /**
+     * ROADMAP 2.449 — per-option tail-risk view, in `outcome`'s units.
+     * Present only when the producer emitted all three components as finite
+     * numbers; ABSENT otherwise (never zeroed). Consumers must apply the same
+     * denormalisation scale as the percentile family.
+     */
+    downside?: { cvar_10: number; p05: number; expected_regret: number }
   }
   const option_probabilities: Record<string, ResultsOptionProbability> = {}
 
@@ -876,6 +926,7 @@ export function mapV5AnalysisToReport(
     const p90 = safeFiniteNumber(outcome?.p90) ?? ciHigh
 
     const goalFitBasis = normaliseGoalFitBasis(enriched?.goal_fit_basis)
+    const downside = normaliseDownside(enriched?.downside)
 
     option_probabilities[optionId] = {
       /**
@@ -905,6 +956,10 @@ export function mapV5AnalysisToReport(
       confidence: 0.5,
       ...(winProb !== undefined ? { win_probability: winProb } : {}),
       ...(expected !== undefined ? { expected } : {}),
+      // 2.449 — tail-risk block. Same conditional-spread idiom as every other
+      // optional field here: no silent defaults, the key is simply absent when
+      // the producer had nothing honest to say.
+      ...(downside !== undefined ? { downside } : {}),
       outcome: {
         mean: rawMean ?? null,
         p10: p10 ?? null,


### PR DESCRIPTION
**DO-NOT-MERGE — orchestrator merges.** ROADMAP 2.449 (surfacing legs). Pillar P1 (scientific coaching) / P5 (depth for power users).
Companion, **merge first**: plot-lite-service #314.

## The capability

Olumi could tell a user which option leads and how robust that is. It could not answer the question every serious decision-maker asks next. ISL has computed the answer since #91/#92; nobody could see it.

## What a user now sees

Expert mode, on an option card, directly under the p10–p90 range bar that the tail extends:

> **If it goes badly**
> In the worst 1 in 20 simulated runs this lands below 18, and the worst 1 in 10 average 12.
> Where we cut off "the worst" is a working choice we have not settled yet.

Three deliberate properties, each pinned by a test rather than assumed:

- **The meaning travels with the number.** "CVaR 10%" is not a user-facing string, and neither is "5th percentile" or "expected shortfall". A guard asserts none of them reaches the reader — paired with a positive control proving the surface is non-empty and carries a digit, so "contains no jargon" is not passing on empty text.
- **The un-ratified cut-off is disclosed.** ISL marks the 0.10 tail mass `DOCTRINE-PENDING(Neil)`. Presenting "the worst 10%" as settled practice would be a claim we have not earned. The caveat is asserted to travel **with** the magnitudes on the same card, and to be **absent exactly when they are**.
- **Absence is blank.** No zero, no dash, no "not available". A zero in a downside statistic does not read as "unknown", it reads as *"there is no downside"* — the same failure shape as the "defensive" `0.0` that collapsed the whole-decision EVPI bound. A **measured** zero survives: the option that wins every draw has `expected_regret === 0` by construction.

## ⚠ `expected_regret` is CARRIED and NOT DISPLAYED — a doctrine boundary, not an oversight

It is the per-option limb of the value-of-information family: whole-decision EVPI is *exactly* its minimum across options. The estate's standing no-EVPI-display doctrine licenses a ranking with **no magnitudes** for that family — the same doctrine that physically removed the EVPI percentage-point pill from `TriageCard.tsx:494`. Rendering this magnitude is a **doctrine ruling, not a wiring gap**, so this lane did not take it. The value is carried to the view model so a licensed surface will not have to re-plumb four services, and a test pins that no render site has quietly taken the ruling.

## The scale seam — the non-obvious part

`cvar_10`/`p05` are declared by the producer to be on the SAME axis as `outcome.mean`/`p10`, with no normalisation of their own. `useResultsSectionData` denormalises the percentile family by a per-option scale. A tail that skipped that scale would make *"the worst decile sits at or below p10"* false **on screen** while true in the data — a display defect that reads as a science defect. Pinned by a scaled/unscaled **pair**: a suite that only ever ran at scale 1 would agree with a hook that applied no scale at all.

## Proof

Three seams, 24 tests: wire→report (`mapV5AnalysisToReport`), report→view-model (`useResultsSectionData`), view-model→DOM (`OptionCards`).

**RED-first at pristine `e01dbd4a`: 23/24 fail.** The one that passes is `THE GAP`, which asserts the live 4-Aug capture carries `decision_evpi` and no downside — it documents the defect and must keep passing.

The mapper fixture is the **live capture** `live-analysis-turn-walkA-2026-08-04.json`, not a payload this lane invented, with downside blocks grafted on in the shape ISL's `DownsideV2` declares.

⚠ Disclosure: the hook spec's first RED was a **false RED** — a wrong store accessor meant the harness never reached the code. It now carries an explicit harness precondition (`allOptions.length === 2`) and the RED was re-established honestly before any result was recorded.

Mutants — throwaway worktree at an absolute path outside the repo root, committed state only, applied-check scoped to `src/`, control asserts exactly 0, collected-count asserted at 24 (a short collect is a hard error).

| # | mutation | applied | result |
|---|---|---|---|
| U0 | control | **0** | GREEN 24/24 |
| U1 | mapper drops the field | 1 | RED 10 |
| U2 | mapper fabricates `{0,0,0}` | 1 | RED 6 |
| U3 | mapper truthiness swallows a measured 0 | 1 | RED 2 |
| U4 | mapper emits a partial block | 1 | RED 5 |
| U5 | hook skips the denormalisation scale | 1 | RED 1 |
| U6 | hook drops the field | 1 | RED 5 |
| U7 | render drops the caveat | 1 | RED 2 |
| U8 | render leaks the regret magnitude | 1 | RED 1 |
| U9 | render ignores expert mode | 1 | RED 1 |
| **U10** | **every card shows the FIRST option's tail** | 1 | **RED 3** |
| **U11** | **only a DIFFERENT option's tail is suppressed** | 1 | **GREEN 24** |

U10/U11 are the **discriminating pair** proving the assertions bind to the named card by identity, not to whichever card satisfies a value predicate.

## Gates

- `pnpm run typecheck` — PASS
- `pnpm run lint` — PASS (rules-of-hooks ratchet exactly matches baseline)
- `src/components/results/__tests__/` + `src/v5/__tests__/` — **194 files / 3,512 tests, all passing**
- `scripts/validate-prepush.sh` ran on push and **passed** (the push was not forced)
- Suites run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported

**No `@talchain/schemas` change needed.** `EnrichmentOptionComparisonEntrySchema` is `.passthrough()`, so the contract does not strip the new field; the drop was the mapper's explicit field selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)