### PR TITLE
DO-NOT-MERGE (orchestrator merges) — Lane (P2/P5): the held-proposal consent record must be complete (2.474 residual (a))

### DIFF
--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -370,6 +370,14 @@ export interface V5HeldProposalAction {
   label: string
   /** Message dispatched to CEE when the affordance is taken (the apply turn). */
   message: string
+  /**
+   * 0.19.0 `Action.detail` — the producer's COMPLETE sentence, emitted exactly
+   * when it had to clamp `label` to chip length, and absent when `label`
+   * already says everything. It is the consent record and the accessible name
+   * for a held proposal: a control the user consents through may not be named
+   * by a string that stops mid-word (ROADMAP 2.474 residual (a)).
+   */
+  detail?: string
 }
 
 export interface V5HeldProposalBlock {

--- a/src/v5/blocks/V5HeldProposalBlock.tsx
+++ b/src/v5/blocks/V5HeldProposalBlock.tsx
@@ -13,6 +13,16 @@
  *     fix: no internal-doctrine-prose leak.
  *   - THE USER'S ACTIONS: confirm + dismiss.
  *
+ * CONSENT COMPLETENESS (ROADMAP 2.474 residual (a), witnessed live 5 Aug 2026).
+ * The producer CLAMPS a multi-operation confirm label to 60 characters and
+ * ships the complete sentence in `Action.detail`. Rendering the clamped form
+ * put a sentence that stopped mid-word on the control, into its accessible
+ * name, and — through the chip seam's display text — into the PERMANENT
+ * TRANSCRIPT, so the record of what the user agreed to ended in an ellipsis.
+ * `resolveHeldConfirmCopy` below is the single place that resolves this: the
+ * accessible name and the consent record are always COMPLETE, and the visible
+ * label is never a fragment.
+ *
  * Action routing (EXISTING seams only — single-writer doctrine, post-#364):
  *   - Confirm dispatches the resolved suggested-action `message` through the
  *     guidance store's `_sendChip(label, message)` seam — the SAME chip-send
@@ -42,17 +52,63 @@ import { Hand } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { useGuidanceStore } from '../../canvas/stores/guidanceStore'
 import { CHIP_CLASS } from './chipClass'
-import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../canvas/conversation/types'
+import type {
+  V5HeldProposalBlock as V5HeldProposalBlockType,
+  V5HeldProposalAction,
+} from '../../canvas/conversation/types'
 import {
   heldProposalReasonText,
   HELD_PROPOSAL_HEADING,
   HELD_PROPOSAL_DISMISS_LABEL,
+  HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL,
   HELD_PROPOSAL_CONFIRMED_ACK,
   HELD_PROPOSAL_DISMISSED_ACK,
 } from './heldProposalReasonCopy'
 
 export interface V5HeldProposalBlockProps {
   block: V5HeldProposalBlockType
+}
+
+/** The three strings the confirm affordance needs, resolved together. */
+export interface HeldConfirmCopy {
+  /** Rendered on the control. Always COMPLETE — never a clamped fragment. */
+  readonly visible: string
+  /** The control's accessible name. COMPLETE, and contains `visible`. */
+  readonly accessibleName: string
+  /** Display text handed to the chip seam — the PERMANENT consent record. */
+  readonly record: string
+}
+
+/**
+ * Resolve the confirm affordance's copy from the producer action.
+ *
+ * `detail` (0.19.0 `Action.detail`) is the producer's own signal that it
+ * CLAMPED `label`: CEE emits it exactly when clamping shortened the label, and
+ * omits it when the label already says everything
+ * (`edit-graph-referee-gate.ts :: buildGmHeldPublicCopy`).
+ *
+ *   - No detail (or detail === label) → the label is already complete. Render
+ *     it verbatim, name it verbatim, record it verbatim. Zero behaviour change.
+ *   - Detail present → the label is a fragment. The control carries the
+ *     UI-owned SHORT COMPLETE label; the accessible name and the consent
+ *     record carry the producer's COMPLETE sentence.
+ *
+ * WCAG 2.5.3 "Label in Name" holds in both branches: the accessible name is
+ * either the visible label itself, or the ratified `${visible}: ${detail}`
+ * construction, which contains it. A speech-input user can always activate the
+ * control by the words on screen — which is precisely what the clamped form
+ * made impossible, since its visible words ended mid-word in an ellipsis.
+ */
+export function resolveHeldConfirmCopy(action: V5HeldProposalAction): HeldConfirmCopy {
+  const detail = typeof action.detail === 'string' ? action.detail.trim() : ''
+  if (detail.length === 0 || detail === action.label) {
+    return { visible: action.label, accessibleName: action.label, record: action.label }
+  }
+  return {
+    visible: HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL,
+    accessibleName: `${HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL}: ${detail}`,
+    record: detail,
+  }
 }
 
 export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactElement {
@@ -63,6 +119,9 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
 
   /** Visible dismiss text: the producer's decline label when CEE emits one. */
   const dismissLabel = decline ? decline.label : HELD_PROPOSAL_DISMISS_LABEL
+
+  /** Complete confirm copy — see resolveHeldConfirmCopy. */
+  const confirmCopy = resolveHeldConfirmCopy(confirm)
 
   const handleConfirm = useCallback(() => {
     if (settled) return
@@ -75,9 +134,16 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
     if (!sendChip) return
     // Single-writer apply path: send the producer's confirm message as a turn;
     // CEE applies the held mutation server-side. No client-minted mutation.
-    sendChip(confirm.label, confirm.message)
+    //
+    // Arg 0 is the DISPLAY text — `dispatchAction` passes it as `displayText`,
+    // which becomes the user's bubble in the permanent transcript. That bubble
+    // IS the record of what was consented to, so it carries the COMPLETE
+    // sentence, never the producer's clamped chip label (2.474 residual (a)).
+    // Arg 1 is untouched: CEE's exact-match pre-route resolves a confirm by the
+    // message, so clamping or rewriting it would break hold routing.
+    sendChip(confirmCopy.record, confirm.message)
     setSettled('accepted')
-  }, [settled, sendChip, confirm.label, confirm.message])
+  }, [settled, sendChip, confirmCopy.record, confirm.message])
 
   const handleDismiss = useCallback(() => {
     if (settled) return
@@ -119,11 +185,15 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
           <button
             type="button"
             onClick={handleConfirm}
-            aria-label={confirm.label}
+            // COMPLETE accessible name: a screen-reader user's entire notion of
+            // what this control does is this string, so it names every
+            // operation. Contains the visible label (WCAG 2.5.3).
+            aria-label={confirmCopy.accessibleName}
+            title={confirmCopy.accessibleName}
             className={CHIP_CLASS}
             data-testid="v5-held-proposal-confirm"
           >
-            {confirm.label}
+            {confirmCopy.visible}
           </button>
           <button
             type="button"

--- a/src/v5/blocks/__tests__/heldProposalConsentRecord.spec.tsx
+++ b/src/v5/blocks/__tests__/heldProposalConsentRecord.spec.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment jsdom
+/**
+ * ROADMAP 2.474 residual (a) — THE CONSENT RECORD MUST BE COMPLETE.
+ *
+ * WHAT THE LIVE WITNESS MEASURED (build e82738b, 5 Aug 2026,
+ * `PHASE0-EVIDENCE-2026-07-28/witness-2474-live-2026-08-05.md` + probes D/L):
+ * on every structural hold, the confirm control's VISIBLE LABEL, its
+ * `aria-label`, AND the user bubble echoed into the permanent transcript were
+ * all the SAME string, truncated mid-word with a literal "..." —
+ *   "Add factor 'AWS-Specific Cost Risk', add factor 'Azure-Sp..."
+ * So the record of what the user consented to stops mid-word, and a
+ * screen-reader user's ENTIRE accessible name for the control is that fragment.
+ *
+ * WHY THE PRODUCER IS NOT AT FAULT. CEE clamps the chip label DELIBERATELY
+ * (`edit-graph-referee-gate.ts :: buildGmHeldPublicCopy` — a multi-op subject
+ * ran ~300 chars and rendered as one enormous chip) and emits the COMPLETE
+ * sentence alongside it in `detail` (0.19.0 `Action.detail`, present in the
+ * pinned 0.34.0 `ActionSchema`) precisely so a consumer never has to render
+ * the clamped form as the whole truth. The UI's mapper DROPPED `detail`.
+ * These pins make the UI consume it.
+ *
+ * THE CONTRACT PINNED HERE:
+ *   1. mapper — `detail` reaches the rendered block (positive control: an
+ *      action WITHOUT detail still maps, unchanged).
+ *   2. accessible name — COMPLETE, never the clamped fragment.
+ *   3. stored consent record — the string handed to the `_sendChip` seam as
+ *      display text (which `dispatchAction` passes as `displayText`, i.e. the
+ *      permanent user bubble) is COMPLETE.
+ *   4. WCAG 2.5.3 Label in Name still holds in BOTH the clamped and the
+ *      unclamped case — the accessible name contains the visible label. This
+ *      is why the visible label cannot simply be swapped for `detail`'s text
+ *      while leaving a clamped string on screen, and why it cannot stay
+ *      clamped while the name goes complete: the two must agree.
+ *   5. MOUNT PATH — the surface asserted here is the one the deployed build
+ *      actually renders: `InlineBlocks` case 'v5_held_proposal', reached from
+ *      the real wire → `parseV5Response` → `mapV5Blocks` path, with the
+ *      held-proposal card as the SINGLE confirm owner (the chip row stands
+ *      down). Verified against the witness DOM captures, in which
+ *      `v5-held-proposal-confirm` sits inside `message-assistant`.
+ *
+ * Fixtures are the LIVE WIRE BYTES from probe D-rung0, copied verbatim from
+ * `witness-2474-raw/D/probeD-verdicts.json` — not hand-invented shapes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
+import { SuggestedChips } from '../../../canvas/conversation/zones/SuggestedChips'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import { parseV5Response } from '../../responseParser'
+import { mapV5Blocks } from '../mapV5Blocks'
+import { buildSuggestedActionChips } from '../suggestedActionChips'
+import { HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL } from '../heldProposalReasonCopy'
+
+// ── LIVE WIRE BYTES (probe D-rung0, CEE build e82738b) ─────────────────────
+
+/** The producer's CLAMPED chip label, exactly as it arrived on the wire. */
+const CLAMPED_LABEL = "Add factor 'AWS Pricing Model Flexibility', add factor 'A..."
+
+/** The producer's COMPLETE sentence, exactly as it arrived in `detail`. */
+const FULL_DETAIL =
+  "Add factor 'AWS Pricing Model Flexibility', add factor 'Azure Microsoft Licensing Synergies', " +
+  "add factor 'Hybrid Multi-Cloud Operational Complexity', link 'AWS Pricing Model Flexibility' " +
+  "to 'AWS Platform Selection', link 'Azure Microsoft Licensing Synergies' to 'Azure Platform " +
+  "Selection' and link 'Hybrid Multi-Cloud Operational Complexity' to 'Hidden and Egress Cost " +
+  "Overruns'"
+
+const CONFIRM_MESSAGE = `Yes, ${FULL_DETAIL.charAt(0).toLowerCase()}${FULL_DETAIL.slice(1)}.`
+
+const PROPOSAL_ID = 'gmh_a45b9a7f5255'
+
+/** A producer label that was NOT clamped — the control for every pin below. */
+const UNCLAMPED_LABEL = 'Continue with this change'
+
+function heldTurnBody(opts: { clamped: boolean }): Record<string, unknown> {
+  return {
+    response_version: 2,
+    assistant_text: "I'm holding these changes rather than applying them straight away.",
+    blocks: [
+      {
+        type: 'error',
+        error_code: 'INTERNAL_ERROR',
+        severity: 'warn',
+        details: { source: 'graph_management', verdict: 'held', candidate_id: 'cand_1' },
+      },
+      {
+        type: 'held_proposal',
+        proposal_id: PROPOSAL_ID,
+        summary: `Held for your confirmation: ${FULL_DETAIL}.`,
+        mutation_class: 'structural',
+        reason_code: 'STRUCTURAL_APPLY_HELD',
+        confirm_action_id: PROPOSAL_ID,
+      },
+    ],
+    suggested_actions: [
+      opts.clamped
+        ? { id: PROPOSAL_ID, label: CLAMPED_LABEL, message: CONFIRM_MESSAGE, detail: FULL_DETAIL }
+        : { id: PROPOSAL_ID, label: UNCLAMPED_LABEL, message: CONFIRM_MESSAGE },
+      { id: 'explain_it', label: 'Explain this', message: 'Explain why this is held' },
+    ],
+    insights: [],
+    stage_indicator: 'analyse',
+  }
+}
+
+async function parseTurn(body: unknown) {
+  const result = await parseV5Response(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+  if (result.kind !== 'response') throw new Error(`expected response, got ${result.kind}`)
+  return result.response
+}
+
+/**
+ * Render the turn exactly as production composes it — the mapped blocks
+ * through `InlineBlocks` (the mount path) PLUS the derived chip row, so a
+ * second confirm surface would be visible to these pins.
+ */
+async function renderTurn(opts: { clamped: boolean }) {
+  const response = await parseTurn(heldTurnBody(opts))
+  const mapped = mapV5Blocks(response.blocks, response.suggested_actions)
+  const chips = buildSuggestedActionChips(response.blocks, response.suggested_actions)
+  const view = render(
+    <>
+      <InlineBlocks blocks={mapped} />
+      <SuggestedChips chips={chips} onChipClick={vi.fn().mockResolvedValue(undefined)} />
+    </>,
+  )
+  return { view, mapped, chips }
+}
+
+/** The accessible name of the confirm control, bound BY TESTID (identity). */
+function confirmAccessibleName(): string {
+  const btn = screen.getByTestId('v5-held-proposal-confirm')
+  return btn.getAttribute('aria-label') ?? btn.textContent ?? ''
+}
+
+beforeEach(() => {
+  useGuidanceStore.setState({ _sendChip: null })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. MOUNT PATH — assert the surface these pins bind to is the deployed one.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.474(a) mount path', () => {
+  it('the confirm control is rendered by InlineBlocks case v5_held_proposal, and is the SINGLE confirm owner', async () => {
+    const { view } = await renderTurn({ clamped: true })
+    const card = screen.getByTestId('v5-held-proposal')
+    // The confirm control lives INSIDE the held-proposal card rendered by the
+    // conversation block stream — the host the witness DOM captures show.
+    expect(within(card).getByTestId('v5-held-proposal-confirm')).toBeInTheDocument()
+    // The generic chip row stands down for the consumed id (single owner), so
+    // there is exactly ONE control carrying this consent anywhere in the tree.
+    expect(
+      view.container.querySelectorAll(`[data-testid="suggested-chip-${PROPOSAL_ID}"]`),
+    ).toHaveLength(0)
+    // Positive control: the row itself rendered (the query can see a chip).
+    expect(view.container.querySelector('[data-testid="suggested-chip-explain_it"]')).not.toBeNull()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. MAPPER — the producer's complete sentence reaches the rendered block.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.474(a) mapper carries Action.detail', () => {
+  it('maps the producer detail onto the confirm action', async () => {
+    const response = await parseTurn(heldTurnBody({ clamped: true }))
+    const mapped = mapV5Blocks(response.blocks, response.suggested_actions)
+    const held = mapped.find((b) => b.type === 'v5_held_proposal')
+    expect(held).toBeDefined()
+    if (held?.type !== 'v5_held_proposal') throw new Error('not a held proposal block')
+    expect(held.confirm.label).toBe(CLAMPED_LABEL)
+    expect(held.confirm.detail).toBe(FULL_DETAIL)
+  })
+
+  it('POSITIVE CONTROL: an action with no detail maps unchanged (detail absent, label intact)', async () => {
+    const response = await parseTurn(heldTurnBody({ clamped: false }))
+    const mapped = mapV5Blocks(response.blocks, response.suggested_actions)
+    const held = mapped.find((b) => b.type === 'v5_held_proposal')
+    if (held?.type !== 'v5_held_proposal') throw new Error('not a held proposal block')
+    expect(held.confirm.label).toBe(UNCLAMPED_LABEL)
+    expect(held.confirm.detail).toBeUndefined()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. THE ACCESSIBLE NAME — complete, never the clamped fragment.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.474(a) accessible name of the confirm control', () => {
+  it('names EVERY operation in full — a screen-reader user hears the whole consent', async () => {
+    await renderTurn({ clamped: true })
+    const name = confirmAccessibleName()
+    // Complete by IDENTITY of content: the last operation of the batch, which
+    // the clamped label cut off ~320 characters earlier, is present.
+    expect(name).toContain("link 'Hybrid Multi-Cloud Operational Complexity' to 'Hidden and Egress Cost Overruns'")
+    expect(name).toContain(FULL_DETAIL)
+  })
+
+  it('carries no mid-word truncation marker', async () => {
+    await renderTurn({ clamped: true })
+    expect(confirmAccessibleName()).not.toContain('...')
+    expect(confirmAccessibleName()).not.toContain('…')
+  })
+
+  it('POSITIVE CONTROL: the absence assertion above CAN see a truncation marker', () => {
+    // The producer's clamped label — the exact string the deployed build put in
+    // the accessible name — DOES contain the marker the pin looks for. Without
+    // this, "not.toContain('...')" could pass by testing nothing.
+    expect(CLAMPED_LABEL).toContain('...')
+    expect(CLAMPED_LABEL).not.toContain(
+      "link 'Hybrid Multi-Cloud Operational Complexity' to 'Hidden and Egress Cost Overruns'",
+    )
+  })
+
+  it('POSITIVE CONTROL: an unclamped producer label is still announced verbatim', async () => {
+    await renderTurn({ clamped: false })
+    expect(confirmAccessibleName()).toContain(UNCLAMPED_LABEL)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. THE STORED CONSENT RECORD — what the transcript keeps.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.474(a) stored consent record', () => {
+  it('hands the COMPLETE sentence to the _sendChip seam as display text', async () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    await renderTurn({ clamped: true })
+
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+
+    expect(sendChip).toHaveBeenCalledTimes(1)
+    // arg 0 is the DISPLAY text — `dispatchAction` passes it as `displayText`,
+    // which becomes the permanent user bubble. It is the consent record.
+    const [displayText, message] = sendChip.mock.calls[0] as [string, string]
+    expect(displayText).toBe(FULL_DETAIL)
+    expect(displayText).not.toContain('...')
+    // The routed message is untouched — CEE's exact-match pre-route depends on
+    // it, so this fix must not alter what is sent.
+    expect(message).toBe(CONFIRM_MESSAGE)
+  })
+
+  it('POSITIVE CONTROL: an unclamped label is recorded verbatim (no behaviour change)', async () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+    await renderTurn({ clamped: false })
+
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+
+    expect(sendChip).toHaveBeenCalledWith(UNCLAMPED_LABEL, CONFIRM_MESSAGE)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. WCAG 2.5.3 Label in Name — must hold in BOTH cases.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.474(a) WCAG 2.5.3 Label in Name holds in both cases', () => {
+  it('clamped: the accessible name contains the visible label', async () => {
+    await renderTurn({ clamped: true })
+    const btn = screen.getByTestId('v5-held-proposal-confirm')
+    const visible = btn.textContent ?? ''
+    expect(visible.length).toBeGreaterThan(0)
+    // The visible label must itself be COMPLETE — a control may not show a
+    // sentence that stops mid-word.
+    expect(visible).not.toContain('...')
+    expect(confirmAccessibleName()).toContain(visible)
+  })
+
+  it('unclamped: the accessible name contains the visible label', async () => {
+    await renderTurn({ clamped: false })
+    const btn = screen.getByTestId('v5-held-proposal-confirm')
+    const visible = btn.textContent ?? ''
+    expect(visible).toBe(UNCLAMPED_LABEL)
+    expect(confirmAccessibleName()).toContain(visible)
+  })
+
+  it('clamped: the control carries the SHORT UI-owned label, not the full sentence', async () => {
+    // A deliberate design choice, pinned so a later tidy-up cannot silently
+    // put a ~380-character sentence on a rounded chip: the complete text is
+    // the NAME and the RECORD, the control itself stays short. Without this
+    // pin, swapping the visible label for `detail` passes every other pin here.
+    await renderTurn({ clamped: true })
+    expect(screen.getByTestId('v5-held-proposal-confirm').textContent).toBe(
+      HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL,
+    )
+    // …and the full naming is still on screen, one element above.
+    expect(screen.getByTestId('v5-held-proposal-summary').textContent ?? '').toContain(FULL_DETAIL)
+  })
+})

--- a/src/v5/blocks/heldProposalReasonCopy.ts
+++ b/src/v5/blocks/heldProposalReasonCopy.ts
@@ -65,6 +65,25 @@ export const HELD_PROPOSAL_HEADING = 'Waiting for your go-ahead'
 export const HELD_PROPOSAL_DISMISS_LABEL = 'Not now'
 
 /**
+ * UI-owned confirm label used ONLY when the producer signals that it clamped
+ * its own chip label — i.e. when `Action.detail` is present and differs from
+ * `label` (ROADMAP 2.474 residual (a)).
+ *
+ * WHY THIS CONSTANT EXISTS. CEE clamps a multi-operation confirm label to 60
+ * characters on purpose (`buildGmHeldPublicCopy`: a ~300-character chip is
+ * unusable) and ships the complete sentence in `detail`. Rendering the clamped
+ * form put a sentence that stops mid-word on the control, in its accessible
+ * name, and — via the chip seam's display text — in the PERMANENT TRANSCRIPT,
+ * so the record of what the user agreed to ended in an ellipsis. The complete
+ * sentence goes to the accessible name and the record; the control itself
+ * carries this short, COMPLETE label instead of a fragment.
+ *
+ * It states the user's action and makes no claim about the change's content —
+ * that claim belongs to the producer's `summary`, rendered directly above.
+ */
+export const HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL = 'Confirm these changes'
+
+/**
  * Acknowledgement shown after the user confirms. States the user's action, not
  * the outcome: the change is applied by CEE on the next turn, so the card must
  * not claim it is already applied.

--- a/src/v5/blocks/mapV5Blocks.ts
+++ b/src/v5/blocks/mapV5Blocks.ts
@@ -193,7 +193,21 @@ export function mapV5Block(
         summary: block.summary,
         mutation_class: block.mutation_class,
         reason_code: block.reason_code,
-        confirm: { label: confirm.label, message: confirm.message },
+        // `detail` (0.19.0 Action.detail) is the producer's COMPLETE sentence,
+        // present exactly when it had to clamp `label` to chip length. Dropping
+        // it here is what made the confirm control's accessible name and the
+        // transcript's consent record stop mid-word (ROADMAP 2.474 residual
+        // (a), witnessed live 5 Aug 2026). Carried on `confirm` only: the
+        // producer clamps the confirm label (`buildGmHeldPublicCopy`) and no
+        // decline path emits `detail` today, so a decline field would be an
+        // unread passenger.
+        confirm: {
+          label: confirm.label,
+          message: confirm.message,
+          ...(typeof confirm.detail === 'string' && confirm.detail.length > 0
+            ? { detail: confirm.detail }
+            : {}),
+        },
         ...(decline ? { decline: { label: decline.label, message: decline.message } } : {}),
       }
     }


### PR DESCRIPTION
**ROADMAP 2.474 residual (a).** Pillar **P2/P5**. DO-NOT-MERGE — orchestrator merges.

## The defect, as the live witness measured it

Build `e82738b`, 5 Aug 2026 (`PHASE0-EVIDENCE-2026-07-28/witness-2474-live-2026-08-05.md`, probes D and L). On every structural hold, **three** strings were the same truncated fragment:

| surface | value at the deployed bytes |
|---|---|
| confirm button text | `Add factor 'AWS-Specific Cost Risk', add factor 'Azure-Sp...` |
| confirm button `aria-label` | *identical* |
| **the user bubble in the permanent transcript** | *identical* |

Re-derived from the raw captures rather than inherited: `witness-2474-raw/L/l-rung2-dom.html`, `D/d-rung0-dom.html` (button tag), `L/l-rung2-confirm-dom.html` (transcript echo).

**The transcript is the record of consent.** A user who confirms a change and later asks *"what did I agree to?"* was shown a sentence that stops mid-word. And a screen-reader user's ENTIRE accessible name for the control was that fragment, so they could not know what they were confirming at all.

## The producer is not at fault — the UI dropped the field that fixes it

CEE clamps the chip label **deliberately** (`edit-graph-referee-gate.ts :: buildGmHeldPublicCopy`, `clampLabel` at 60 chars — a multi-op subject ran ~300 characters and rendered as one enormous chip) and emits the COMPLETE sentence alongside it in **`Action.detail`** (0.19.0; present in the pinned `@talchain/schemas@0.34.0` `ActionSchema` as `detail: z.string().min(1).optional()`). Its own comment says why: *the full description still reaches the user, so a short label never hides what a confirm applies.*

Verified on the live wire (`D/probeD-verdicts.json`): `label` was the 59-char fragment, `detail` was the complete 380-char sentence. **`mapV5Blocks` dropped `detail`.**

## What changed

- `mapV5Blocks.ts` — carries `detail` onto the mapped confirm action (confirm only; no decline path emits `detail`, so a decline field would be an unread passenger).
- `V5HeldProposalBlock.tsx` — new `resolveHeldConfirmCopy` resolves the three strings together:
  - **no `detail`** (label already complete) → verbatim label for all three. **Zero behaviour change.**
  - **`detail` present** (producer signals it clamped) → accessible name and consent record carry the COMPLETE sentence; the control carries a short, complete UI-owned label.
- `heldProposalReasonCopy.ts` — `HELD_PROPOSAL_CONFIRM_CLAMPED_LABEL = 'Confirm these changes'`.
- The routed **message is untouched**: CEE's exact-match pre-route resolves a confirm by the message, so clamping or rewriting it would break hold routing.

### Why the visible label could not simply stay clamped

The repo already pins **WCAG 2.5.3 "Label in Name"** on this control (`V5HeldProposalBlock.spec.tsx`: the accessible name must CONTAIN the visible label). A complete accessible name cannot contain a visible string ending in `...`. So making only the name complete would have **regressed a different criterion**. Both branches now satisfy it: unclamped, name == visible label; clamped, the ratified `${visible}: ${detail}` construction, which contains it.

### Why not put the full sentence on the button

Pinned deliberately (`clamped: the control carries the SHORT UI-owned label`): a ~380-character sentence on a `rounded-full` chip is the very thing CEE clamped to avoid. The complete naming is already on screen one element above, in `v5-held-proposal-summary` — which is the carrier CEE's own comment designates.

## Evidence

**Mount path asserted.** The pins render through the real wire → `parseV5Response` → `mapV5Blocks` → **`InlineBlocks` case `v5_held_proposal`** path with the chip row mounted alongside, and assert the card is the SINGLE confirm owner. Matches the witness DOM, where `v5-held-proposal-confirm` sits inside `message-assistant`. Mutant **M8** (delete the `InlineBlocks` case) REDs 9 of 12 — the mount is pinned, not assumed.

**RED-first at pristine `5f066967`** — 5 named failures, 6 passing controls:
```
× 2.474(a) mapper carries Action.detail > maps the producer detail onto the confirm action
× 2.474(a) accessible name > names EVERY operation in full — a screen-reader user hears the whole consent
× 2.474(a) accessible name > carries no mid-word truncation marker
× 2.474(a) stored consent record > hands the COMPLETE sentence to the _sendChip seam as display text
× 2.474(a) WCAG 2.5.3 > clamped: the accessible name contains the visible label
```

**Positive controls at every absence assertion (trap 13):** the `not.toContain('...')` pin is paired with a control proving the producer's clamped label DOES contain the marker and DOES omit the final operation — so the absence assertion cannot pass by testing nothing.

**Mutants** — throwaway worktree at an absolute path OUTSIDE the repo root, committed state only, applied-check scoped to `src/`, each mutation asserted applied, harness hard-errors on a missing summary line or zero collected tests:

| | mutation | expected | measured |
|---|---|---|---|
| CONTROL | pristine, applied-count(`src/`) **exactly 0** | GREEN | `12 passed (12)` |
| M1 | mapper drops `detail` | RED | 6 failed |
| **M2** | confirm `aria-label` ← clamped label | RED | 3 failed |
| M3 | consent record ← clamped label | RED | 1 failed |
| M4 | visible label ← clamped fragment | RED | 2 failed |
| M5 | clamped branch drops the short UI label | RED | 1 failed |
| M6 | resolver ignores `detail` entirely | RED | 5 failed |
| **M7** | **DISMISS** `aria-label` ← clamped fragment | **GREEN** | `12 passed` |
| M8 | `InlineBlocks` stops rendering the card | RED | 9 failed |

**M2/M7 are the discriminating pair** required for identity binding: loosening the **named** object REDs; loosening a **different** object stays GREEN. Every pin binds by `data-testid`, never by a value predicate another element could satisfy.

**Gates at this SHA:** `pnpm typecheck` → `✅ PASSED`, 3246/3286 files, ratchet **at baseline** (2491, no new errors). `vitest src/v5 src/canvas/conversation/__tests__ src/components/results/v7` → **228 files, 3307 passed, 0 failed**. `eslint` on the changed files → clean. `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run.

## Not in this PR — derived, reported, deliberately not landed

`(b)` deliberation leak and `(c)` `INTERNAL_ERROR` envelope are **CEE-side**; `(d)` is **ruled deliberate and already disclosed**. Full derivations, with file:line, are in the lane report — including the one-line CEE clarify-branch bug (`turn-executor.ts:8554-8556` prefers model prose over the structured `clarification.question`) and the fact that `(c)`'s honest fix needs an additive `@talchain/schemas` enum member landed in merge order schemas → UI → CEE, because CEE's own egress validator would destroy the whole turn on an off-enum value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)