### PR TITLE
DO-NOT-MERGE: 2.467 leg 2 — the import → reset → server-registration train (UI)

### DIFF
--- a/src/adapters/cee/__tests__/registerScenarioGraph.spec.ts
+++ b/src/adapters/cee/__tests__/registerScenarioGraph.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * ROADMAP 2.467 — the registration client.
+ *
+ * The source-text block at the bottom is not decoration. `VITE_CEE_BFF_BASE` is
+ * unset in this tree but IS set in the Netlify dashboard to a PLoT origin, and
+ * Vite inlines `import.meta.env` at BUILD time — so the house-style
+ * `import.meta.env.VITE_CEE_BFF_BASE || '/bff/cee'` resolves to PLoT in the
+ * deployed bundle and this route would 404 in production while every jsdom test
+ * stayed green. This estate has shipped an invisible feature that way. The pin
+ * reads the module's own bytes, and a second assertion kills the
+ * dead-constant mutant (a literal nothing reads is the same defect renamed).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  SCENARIO_GRAPH_REGISTER_BASE,
+  registerScenarioGraph,
+  scenarioGraphRegisterUrl,
+} from '../registerScenarioGraph'
+
+const SCENARIO = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+const OWNER = '0f8a1b2c-3d4e-4f50-9a6b-7c8d9e0f1a2b'
+const GRAPH = { nodes: [{ id: 'a', kind: 'goal', label: 'A' }], edges: [] }
+
+const ACK = {
+  schema: 'scenario_graph_registration.v1',
+  scenario_id: SCENARIO,
+  registered: true,
+  graph_identity_hash: { value: 'a'.repeat(64), projection_version: 'identity.v1' },
+  node_count: 1,
+  edge_count: 0,
+  request_id: 'req-1',
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('registerScenarioGraph — the acknowledgement', () => {
+  it('POSITIVE CONTROL: a well-formed ack really is recognised (so every refusal below means something)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, ACK))
+    const result = await registerScenarioGraph(SCENARIO, GRAPH)
+    expect(result.status).toBe('registered')
+    if (result.status !== 'registered') throw new Error('unreachable')
+    expect(result.identity).toEqual({ value: 'a'.repeat(64), projectionVersion: 'identity.v1' })
+    expect(result.nodeCount).toBe(1)
+  })
+
+  it('POSTs the graph to the scenario-addressed register path', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, ACK))
+    await registerScenarioGraph(SCENARIO, GRAPH)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`/bff/cee/scenarios/${SCENARIO}/graph/register`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body).graph).toEqual(GRAPH)
+  })
+
+  it('sends a real user id, and NEVER the guest sentinel (CEE requires a UUID)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, ACK))
+
+    await registerScenarioGraph(SCENARIO, GRAPH, { userId: OWNER })
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).user_id).toBe(OWNER)
+
+    fetchMock.mockClear()
+    await registerScenarioGraph(SCENARIO, GRAPH, { userId: 'guest' })
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).not.toHaveProperty('user_id')
+  })
+
+  it.each([
+    ['a 200 with no discriminator', { registered: true }],
+    ['a 200 from a different route', { schema: 'scenario_graph.v1', registered: true }],
+    ['a 200 that does not say registered', { schema: 'scenario_graph_registration.v1' }],
+  ])('does NOT treat %s as an acknowledgement', async (_label, body) => {
+    // An SPA fallback or a proxy interstitial answers 200. Releasing the hold on
+    // a body we never recognised would re-open the P0 with extra steps.
+    fetchMock.mockResolvedValue(jsonResponse(200, body))
+    expect((await registerScenarioGraph(SCENARIO, GRAPH)).status).toBe('unavailable')
+  })
+
+  it('does NOT treat an unreadable 200 body as an acknowledgement', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('not json')
+      },
+    } as unknown as Response)
+    expect((await registerScenarioGraph(SCENARIO, GRAPH)).status).toBe('unavailable')
+  })
+})
+
+describe('registerScenarioGraph — refusals and retries', () => {
+  it('retries a 503 and succeeds on a later attempt', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(503, {}))
+      .mockResolvedValueOnce(jsonResponse(200, ACK))
+    const result = await registerScenarioGraph(SCENARIO, GRAPH, { retryDelayMs: 0 })
+    expect(result.status).toBe('registered')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after three attempts of 503', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(503, {}))
+    expect((await registerScenarioGraph(SCENARIO, GRAPH, { retryDelayMs: 0 })).status).toBe(
+      'unavailable',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('NEVER retries a 409 — re-sending would be the clobber CEE just refused', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(409, {}))
+    expect((await registerScenarioGraph(SCENARIO, GRAPH, { retryDelayMs: 0 })).status).toBe(
+      'conflict',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a 422 refusal with its code and node ids, and does not retry', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(422, {
+        schema: 'error.v1',
+        code: 'BAD_INPUT',
+        message: 'Some nodes declare two different kinds. Fix the file and import again.',
+        details: { code: 'GRAPH_NODE_KIND_DIVERGENT', node_ids: ['opt_alpha'] },
+      }),
+    )
+    const result = await registerScenarioGraph(SCENARIO, GRAPH, { retryDelayMs: 0 })
+    expect(result).toMatchObject({
+      status: 'rejected',
+      code: 'GRAPH_NODE_KIND_DIVERGENT',
+      nodeIds: ['opt_alpha'],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a transport failure as unknown, never as success', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'))
+    expect((await registerScenarioGraph(SCENARIO, GRAPH)).status).toBe('unavailable')
+  })
+
+  it.each([
+    [401, 'refused'],
+    [403, 'refused'],
+    [429, 'refused'],
+    [404, 'notRegistrable'],
+  ])('maps %i to %s without retrying', async (status, expected) => {
+    fetchMock.mockResolvedValue(jsonResponse(status, {}))
+    expect((await registerScenarioGraph(SCENARIO, GRAPH, { retryDelayMs: 0 })).status).toBe(
+      expected,
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the base is a same-origin LITERAL, pinned at the source text', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/adapters/cee/registerScenarioGraph.ts'),
+    'utf8',
+  )
+
+  /**
+   * Comments STRIPPED before the absence assertions: the module's own header
+   * explains why `VITE_CEE_BFF_BASE` is refused, and a naive substring search
+   * over the whole file would fire on the explanation rather than on code —
+   * a guard that reds on its own documentation teaches the next author to
+   * delete the documentation.
+   */
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n')
+
+  it('POSITIVE CONTROL: the source was read AND the comment strip left real code behind', () => {
+    // Trap 13 twice over — a read that returned '' or a strip that ate the
+    // whole file would make both assertions below pass by never firing.
+    expect(source.length).toBeGreaterThan(1000)
+    expect(code).toContain('export async function registerScenarioGraph')
+    expect(code).toContain('fetch(url')
+    // And the strip really did remove the prose that mentions the env var.
+    expect(source).toContain('VITE_CEE_BFF_BASE')
+    expect(code).not.toContain('the header')
+  })
+
+  it('declares the base as the literal `/bff/cee`, never an env lookup', () => {
+    expect(code).toContain("SCENARIO_GRAPH_REGISTER_BASE = '/bff/cee'")
+    expect(code).not.toContain('VITE_CEE_BFF_BASE')
+    expect(code).not.toContain('import.meta.env')
+    expect(SCENARIO_GRAPH_REGISTER_BASE).toBe('/bff/cee')
+  })
+
+  it('BUILDS the url from that constant — a literal nothing reads is the same defect renamed', () => {
+    const builder = code.slice(code.indexOf('export function scenarioGraphRegisterUrl'))
+    const body = builder.slice(0, builder.indexOf('\n}'))
+    expect(body).toContain('SCENARIO_GRAPH_REGISTER_BASE')
+    expect(scenarioGraphRegisterUrl('abc')).toBe('/bff/cee/scenarios/abc/graph/register')
+  })
+})

--- a/src/adapters/cee/registerScenarioGraph.ts
+++ b/src/adapters/cee/registerScenarioGraph.ts
@@ -1,0 +1,222 @@
+/**
+ * ROADMAP 2.467 — the client half of the `register_graph` seam.
+ *
+ * Sibling of `scenarioGraph.ts` (the READ). Same edge path, same identity-in-
+ * the-body convention, same never-throws discriminated result.
+ *
+ * ⚠ THE BASE IS A LITERAL, AND THAT IS LOAD-BEARING. `VITE_CEE_BFF_BASE` is
+ *   unset in this tree but IS set in the Netlify dashboard to a PLoT origin,
+ *   and Vite inlines `import.meta.env` at BUILD time — so the house-style
+ *   `import.meta.env.VITE_CEE_BFF_BASE || '/bff/cee'` resolves to PLoT in the
+ *   deployed bundle, and PLoT serves no CEE scenario routes. The deployed
+ *   chunks carried zero `/bff/cee` literals when that was last crawled. A
+ *   source-text test pins the literal and the builder's use of it, because a
+ *   constant nothing reads is the same defect wearing a different hat.
+ *
+ * ⚠ A REGISTRATION IS NOT IDEMPOTENT-BY-RETRY IN THE WAY A READ IS. Retrying a
+ *   503 is safe (nothing was written), but a 409 means the server graph moved
+ *   under us and MUST NOT be retried — re-sending would be exactly the silent
+ *   clobber CEE's CAS refused. It is surfaced as its own status so the caller
+ *   keeps the honest "cannot confirm" posture rather than looping.
+ */
+
+import { logger } from '../../lib/logger'
+
+/**
+ * The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see the header.
+ * Deliberately a literal.
+ */
+export const SCENARIO_GRAPH_REGISTER_BASE = '/bff/cee'
+
+/** `POST` — scenario in the path, graph and identity in the body. */
+export function scenarioGraphRegisterUrl(scenarioId: string): string {
+  return `${SCENARIO_GRAPH_REGISTER_BASE}/scenarios/${encodeURIComponent(scenarioId)}/graph/register`
+}
+
+/** Total attempts on a retryable (503) answer: the first plus two retries. */
+const MAX_ATTEMPTS = 3
+const DEFAULT_RETRY_DELAY_MS = 400
+
+/**
+ * Per-attempt deadline. CEE staging cold-starts; a registration that lands
+ * long after the user has moved on describes a graph they may already have
+ * changed. Bounding the wait bounds that window.
+ */
+const DEFAULT_TIMEOUT_MS = 10000
+
+/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
+const GUEST_USER_ID = 'guest'
+
+export interface RegisteredGraphIdentity {
+  /** CEE's opaque `identity.v1` token, VERBATIM. Compare CEE-to-CEE only. */
+  readonly value: string
+  readonly projectionVersion: string
+}
+
+export type RegisterScenarioGraphResult =
+  /** 200 — `scenarios.graph` now holds this graph. THE acknowledgement. */
+  | {
+      status: 'registered'
+      identity: RegisteredGraphIdentity | null
+      nodeCount: number
+      edgeCount: number
+      requestId: string | null
+    }
+  /** 422 — CEE refused these bytes. Actionable, and never retried. */
+  | { status: 'rejected'; code: string; message: string; nodeIds: readonly string[] }
+  /** 409 — the server graph moved. NEVER retried; nothing was written. */
+  | { status: 'conflict' }
+  /** 404 — absent ∪ not-yours ∪ oracle-unresolvable. */
+  | { status: 'notRegistrable' }
+  /** 503 after every attempt, or a transport failure. Unknown; try later. */
+  | { status: 'unavailable' }
+  /** 401 / 403 / 429 — a stable refusal; not retried. */
+  | { status: 'refused'; httpStatus: number }
+
+export interface RegisterScenarioGraphOptions {
+  readonly userId?: string | null
+  readonly signal?: AbortSignal
+  readonly timeoutMs?: number
+  readonly retryDelayMs?: number
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function readIdentityEnvelope(raw: unknown): RegisteredGraphIdentity | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const env = raw as Record<string, unknown>
+  const value = env.value
+  const projectionVersion = env.projection_version
+  if (typeof value !== 'string' || value.length === 0) return null
+  if (typeof projectionVersion !== 'string' || projectionVersion.length === 0) return null
+  return { value, projectionVersion }
+}
+
+/**
+ * Register a whole graph as the scenario's server-side model.
+ *
+ * Never throws: every failure mode is a discriminated status, because the one
+ * outcome this must not produce is a caller that cannot tell "the server has my
+ * graph" from "I could not tell". A caller that cannot tell must keep holding.
+ */
+export async function registerScenarioGraph(
+  scenarioId: string,
+  graph: unknown,
+  opts: RegisterScenarioGraphOptions = {},
+): Promise<RegisterScenarioGraphResult> {
+  const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
+
+  // Identity travels in the BODY: with `CEE_REQUIRE_USER_JWT` off, CEE's
+  // ownership pre-flight reads `user_id` from the request extensions, and it
+  // must be a UUID — the guest sentinel is not one and is never sent as one.
+  const body: Record<string, unknown> = { graph }
+  if (
+    typeof opts.userId === 'string' &&
+    opts.userId.length > 0 &&
+    opts.userId !== GUEST_USER_ID
+  ) {
+    body.user_id = opts.userId
+  }
+
+  const url = scenarioGraphRegisterUrl(scenarioId)
+  const payload = JSON.stringify(body)
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const attemptController = new AbortController()
+    const onCallerAbort = () => attemptController.abort()
+    if (opts.signal) {
+      if (opts.signal.aborted) return { status: 'unavailable' }
+      opts.signal.addEventListener('abort', onCallerAbort, { once: true })
+    }
+    const timer = timeoutMs > 0 ? setTimeout(() => attemptController.abort(), timeoutMs) : null
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        signal: attemptController.signal,
+      })
+    } catch (err) {
+      logger.warn('scenario_graph_register.transport_failure', {
+        attempt,
+        error: (err as Error)?.message ?? 'unknown',
+      })
+      return { status: 'unavailable' }
+    } finally {
+      if (timer !== null) clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onCallerAbort)
+    }
+
+    if (response.status === 503) {
+      if (attempt < MAX_ATTEMPTS) {
+        await sleep(retryDelayMs)
+        continue
+      }
+      return { status: 'unavailable' }
+    }
+
+    // NEVER retried: the server graph moved, and re-sending would be the
+    // silent clobber CEE's CAS just refused.
+    if (response.status === 409) return { status: 'conflict' }
+
+    if (response.status === 404) return { status: 'notRegistrable' }
+
+    if (response.status === 401 || response.status === 403 || response.status === 429) {
+      return { status: 'refused', httpStatus: response.status }
+    }
+
+    if (response.status === 422 || response.status === 400) {
+      let code = 'GRAPH_REJECTED'
+      let message = 'This model could not be saved to the server.'
+      let nodeIds: readonly string[] = []
+      try {
+        const b = (await response.json()) as Record<string, unknown>
+        const details = (b.details ?? {}) as Record<string, unknown>
+        if (typeof details.code === 'string') code = details.code
+        if (typeof b.message === 'string') message = b.message
+        if (Array.isArray(details.node_ids)) {
+          nodeIds = details.node_ids.filter((v): v is string => typeof v === 'string')
+        }
+      } catch {
+        /* a refusal we cannot parse is still a refusal — never a success */
+      }
+      logger.warn('scenario_graph_register.rejected', { code, nodeCount: nodeIds.length })
+      return { status: 'rejected', code, message, nodeIds }
+    }
+
+    if (!response.ok) return { status: 'unavailable' }
+
+    let parsed: Record<string, unknown>
+    try {
+      parsed = (await response.json()) as Record<string, unknown>
+    } catch {
+      // A 200 we cannot read is NOT an acknowledgement. Fail to "unknown" so
+      // the caller keeps holding rather than releasing on a body it never saw.
+      return { status: 'unavailable' }
+    }
+
+    // The discriminator is required. A 200 from something that is not this
+    // route (an SPA fallback, a proxy interstitial) must never read as an ack.
+    if (parsed.schema !== 'scenario_graph_registration.v1' || parsed.registered !== true) {
+      logger.warn('scenario_graph_register.unrecognised_envelope', {
+        schema: typeof parsed.schema === 'string' ? parsed.schema : 'absent',
+      })
+      return { status: 'unavailable' }
+    }
+
+    return {
+      status: 'registered',
+      identity: readIdentityEnvelope(parsed.graph_identity_hash),
+      nodeCount: typeof parsed.node_count === 'number' ? parsed.node_count : 0,
+      edgeCount: typeof parsed.edge_count === 'number' ? parsed.edge_count : 0,
+      requestId: typeof parsed.request_id === 'string' ? parsed.request_id : null,
+    }
+  }
+
+  return { status: 'unavailable' }
+}

--- a/src/canvas/components/ScenarioSwitcher.tsx
+++ b/src/canvas/components/ScenarioSwitcher.tsx
@@ -13,6 +13,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { Save, Copy, Edit2, Trash2, ChevronDown, Folder, AlertCircle, Download, Upload } from 'lucide-react'
 import { useCanvasStore } from '../store'
 import { loadScenarios, getScenario, type Scenario, importScenarioFromFile } from '../store/scenarios'
+import { markGraphImported } from '../store/importRegistrationMarker'
 import { SaveStatusPill } from './SaveStatusPill'
 import { exportScenario } from '../export/exportScenario'
 import { useToast } from '../ToastContext'
@@ -176,6 +177,23 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
       const result = importScenarioFromFile(content, nodes, edges)
 
       if (result.success && result.scenario) {
+        // ROADMAP 2.467/2.483 — THE SECOND IMPORT ROUTE, and until now the
+        // unguarded one. This path never touches `store.importCanvas`, so
+        // `markGraphImported` was never called and `loadScenario`'s derivation
+        // returned FALSE: a graph the server has never seen was installed with
+        // the hold OFF, and one Rerun could re-attach an affirmative to CEE's
+        // own pre-import model. Marked HERE, before `loadScenario` derives the
+        // flag from the graph it installs — the ordering is the whole point.
+        //
+        // The graph is read back from the scenario the import just created,
+        // because `importScenarioFromFile` RESEEDS node ids: marking the file's
+        // original ids would compute a digest for a graph that never reaches
+        // the canvas, and the hold would silently never match.
+        const created = getScenario(result.scenario.id)
+        if (created?.graph) {
+          markGraphImported(created.graph.nodes, created.graph.edges)
+        }
+
         // Load the imported scenario
         loadScenario(result.scenario.id)
         showToast(`Imported "${result.scenario.name}" successfully`, 'success')

--- a/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
+++ b/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
@@ -88,6 +88,38 @@ describe('buildRegistrationGraph — the captured canvas file', () => {
     expect(graph.nodes.every((n) => !('position' in n))).toBe(true)
   })
 
+  it('the ReactFlow renderer key NEVER outranks the semantic spelling', () => {
+    // MEASURED: on the captured file all three spellings agree, so a mutant
+    // that flipped the precedence to `node.type ?? data.kind` SURVIVED. That is
+    // a hole in the oracle, not an equivalence — `node.type` is a RENDERER key
+    // and `data.kind` is what the analysis means by the node. This is the case
+    // that discriminates them.
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'opt_alpha')!
+    // POSITIVE CONTROL: the fixture starts with all three agreeing, so the
+    // divergence below is genuinely introduced by this test.
+    expect(node.type).toBe('option')
+    node.type = 'factor'
+
+    const graph = okGraph(buildRegistrationGraph(file.nodes, file.edges))
+    expect(graph.nodes.find((n) => n.id === 'opt_alpha')?.kind).toBe('option')
+  })
+
+  it('drops a position nested INSIDE node.data, not just the top-level one', () => {
+    // MEASURED: deleting `'position'` from the canvas-only key list left every
+    // test green, because the captured file carries `position` only at the top
+    // level (which is dropped structurally, by never being copied). The
+    // blocklist entry exists for the nested case — so the nested case is what
+    // has to be asserted, or the entry is decoration a tidy-up would delete.
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'opt_alpha')!
+    ;(node.data as Record<string, unknown>).position = { x: 1, y: 2 }
+
+    const graph = okGraph(buildRegistrationGraph(file.nodes, file.edges))
+    expect(graph.nodes.find((n) => n.id === 'opt_alpha')).not.toHaveProperty('position')
+    expect(JSON.stringify(graph)).not.toContain('"position"')
+  })
+
   it('emits exactly ONE kind spelling per node — no `type` reaches the wire', () => {
     const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
     expect(graph.nodes.every((n) => typeof n.kind === 'string')).toBe(true)

--- a/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
+++ b/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * ROADMAP 2.467 — canvas → CEE wire, for the registration seam.
+ *
+ * FIXTURE PROVENANCE: `fixtures/walk-import-modified.canvas.json` is a BYTE
+ * COPY of the file a real browser actually imported during the 5 Aug P0 witness
+ * walk (`PHASE0-EVIDENCE-2026-07-28/walk-p0-witness-raw/import-modified.json`).
+ * Nothing about it was written by this lane — it is the producer's own export,
+ * relabelled by the walker on exactly one node. `walk-export-original.canvas.json`
+ * is the same model BEFORE that relabel, so the pair is the real before/after.
+ *
+ * That matters more than usual here: the defect is that CEE analysed a
+ * DIFFERENT graph from the one on screen, so a hand-written fixture would
+ * encode this lane's model of a canvas node rather than the canvas's.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+
+import { buildRegistrationGraph } from '../buildRegistrationGraph'
+
+import IMPORTED_CANVAS from './fixtures/walk-import-modified.canvas.json'
+import ORIGINAL_CANVAS from './fixtures/walk-export-original.canvas.json'
+
+type CanvasFile = { nodes: Node[]; edges: Edge[] }
+
+const IMPORTED = IMPORTED_CANVAS as unknown as CanvasFile
+const ORIGINAL = ORIGINAL_CANVAS as unknown as CanvasFile
+
+function okGraph(result: ReturnType<typeof buildRegistrationGraph>) {
+  if (!result.ok) throw new Error(`expected ok, got refusal: ${result.reason}`)
+  return result.graph
+}
+
+function refusal(result: ReturnType<typeof buildRegistrationGraph>) {
+  if (result.ok) throw new Error('expected a refusal, got ok')
+  return result
+}
+
+/** Deep-clone so a mutation in one case cannot leak into another. */
+function clone(file: CanvasFile): CanvasFile {
+  return JSON.parse(JSON.stringify(file)) as CanvasFile
+}
+
+describe('buildRegistrationGraph — the captured canvas file', () => {
+  it('POSITIVE CONTROL: the fixture is the walk pair, and it carries the shapes this projection must handle', () => {
+    // Trap 13. Everything below about "positions are dropped" and "the sentinel
+    // survives" is vacuous if the fixture never carried a position or a sentinel.
+    expect(IMPORTED.nodes).toHaveLength(14)
+    expect(IMPORTED.edges).toHaveLength(32)
+    expect(IMPORTED.nodes.every((n) => n.position !== undefined)).toBe(true)
+    const sentinel = IMPORTED.nodes.find((n) => n.id === 'opt_alpha')
+    expect((sentinel?.data as Record<string, unknown>)?.label).toBe('ZZZ IMPORTED OPTION')
+    // The before/after pair really is a pair: one label differs, nothing else.
+    expect((ORIGINAL.nodes.find((n) => n.id === 'opt_alpha')?.data as Record<string, unknown>)?.label).toBe(
+      'Alpha Hall',
+    )
+    expect(ORIGINAL.nodes.map((n) => n.id)).toEqual(IMPORTED.nodes.map((n) => n.id))
+    // At least one node carries the canvas spelling CEE renames.
+    expect(
+      IMPORTED.nodes.some((n) => 'observedState' in ((n.data ?? {}) as Record<string, unknown>)),
+    ).toBe(true)
+  })
+
+  it('projects the real import into CEE wire shape, carrying the sentinel', () => {
+    const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    expect(graph.nodes).toHaveLength(14)
+    expect(graph.edges).toHaveLength(32)
+    // Bound BY IDENTITY, never by a value predicate another node could satisfy.
+    const sentinel = graph.nodes.find((n) => n.id === 'opt_alpha')
+    expect(sentinel?.label).toBe('ZZZ IMPORTED OPTION')
+    expect(sentinel?.kind).toBe('option')
+  })
+
+  it('DISCRIMINATES the two captured graphs — the projection is not label-blind', () => {
+    // The whole train exists because two graphs that differ by a label were
+    // treated as one. A projection that flattened that difference would hand
+    // CEE a graph indistinguishable from the one it already has.
+    const after = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    const before = okGraph(buildRegistrationGraph(ORIGINAL.nodes, ORIGINAL.edges))
+    expect(JSON.stringify(after)).not.toBe(JSON.stringify(before))
+    expect(after.nodes.find((n) => n.id === 'opt_alpha')?.label).toBe('ZZZ IMPORTED OPTION')
+    expect(before.nodes.find((n) => n.id === 'opt_alpha')?.label).toBe('Alpha Hall')
+  })
+
+  it('drops layout — `scenarios.graph` carries no positions', () => {
+    const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    const serialised = JSON.stringify(graph)
+    expect(serialised).not.toContain('"position"')
+    expect(graph.nodes.every((n) => !('position' in n))).toBe(true)
+  })
+
+  it('emits exactly ONE kind spelling per node — no `type` reaches the wire', () => {
+    const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    expect(graph.nodes.every((n) => typeof n.kind === 'string')).toBe(true)
+    expect(graph.nodes.every((n) => !('type' in n))).toBe(true)
+  })
+
+  it('renames `observedState` to CEE`s `observed_state` and keeps its contents', () => {
+    const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    const facAlpha = graph.nodes.find((n) => n.id === 'fac_alpha')
+    expect(facAlpha).toBeDefined()
+    expect(facAlpha).not.toHaveProperty('observedState')
+    expect(facAlpha?.observed_state).toEqual(
+      (IMPORTED.nodes.find((n) => n.id === 'fac_alpha')?.data as Record<string, unknown>)
+        .observedState,
+    )
+  })
+
+  it('maps edge endpoints to `from`/`to` — the canvas spells them `source`/`target`', () => {
+    const graph = okGraph(buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges))
+    const first = IMPORTED.edges[0]
+    expect(graph.edges[0]).toMatchObject({ from: first.source, to: first.target })
+    expect(graph.edges.every((e) => !('source' in e) && !('target' in e))).toBe(true)
+  })
+
+  it('signs the edge strength by direction and clamps it to [-1, +1]', () => {
+    const nodes = [
+      { id: 'a', type: 'factor', data: { kind: 'factor', label: 'A' } },
+      { id: 'b', type: 'goal', data: { kind: 'goal', label: 'B' } },
+    ] as unknown as Node[]
+    const negative = [
+      { id: 'e1', source: 'a', target: 'b', data: { weight: 1.5, direction: 'negative' } },
+    ] as unknown as Edge[]
+    const overWeight = [
+      { id: 'e1', source: 'a', target: 'b', data: { weight: 9, direction: 'positive' } },
+    ] as unknown as Edge[]
+
+    expect(okGraph(buildRegistrationGraph(nodes, negative)).edges[0]).toMatchObject({
+      strength: { mean: -1 },
+      effect_direction: 'negative',
+    })
+    expect(okGraph(buildRegistrationGraph(nodes, overWeight)).edges[0]).toMatchObject({
+      strength: { mean: 1 },
+    })
+  })
+})
+
+describe('buildRegistrationGraph — refusals (2.467c: disagreement is refused, absence is resolved)', () => {
+  it('REFUSES a divergent-field file and names the node BY ID', () => {
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'opt_alpha')!
+    ;(node.data as Record<string, unknown>).type = 'factor'
+
+    const r = refusal(buildRegistrationGraph(file.nodes, file.edges))
+    expect(r.reason).toBe('divergent_node_kind')
+    expect(r.nodeIds).toEqual(['opt_alpha'])
+  })
+
+  it('DISCRIMINATING PAIR: diverging a DIFFERENT node names THAT node, not opt_alpha', () => {
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'goal_turnout')!
+    ;(node.data as Record<string, unknown>).type = 'risk'
+
+    const r = refusal(buildRegistrationGraph(file.nodes, file.edges))
+    expect(r.nodeIds).toEqual(['goal_turnout'])
+    expect(r.nodeIds).not.toContain('opt_alpha')
+  })
+
+  it('DISCRIMINATING PAIR: the SAME node with an AGREEING `type` is accepted', () => {
+    // Without this half, the refusals above could be "any node carrying
+    // `data.type` is refused" rather than "a node whose spellings disagree".
+    // The captured file already carries an agreeing `data.type` on all 14
+    // nodes, which is exactly why the accepted case above passes.
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'opt_alpha')!
+    expect((node.data as Record<string, unknown>).type).toBe('option')
+    expect((node.data as Record<string, unknown>).kind).toBe('option')
+    const graph = okGraph(buildRegistrationGraph(file.nodes, file.edges))
+    expect(graph.nodes.find((n) => n.id === 'opt_alpha')?.kind).toBe('option')
+  })
+
+  it('RESOLVES absence: a node with only `data.type` keeps its meaning', () => {
+    const file = clone(IMPORTED)
+    for (const n of file.nodes) delete (n.data as Record<string, unknown>).kind
+    const graph = okGraph(buildRegistrationGraph(file.nodes, file.edges))
+    expect(graph.nodes.find((n) => n.id === 'opt_alpha')?.kind).toBe('option')
+  })
+
+  it('falls back to the ReactFlow renderer key ONLY when no semantic spelling exists', () => {
+    const file = clone(IMPORTED)
+    for (const n of file.nodes) {
+      delete (n.data as Record<string, unknown>).kind
+      delete (n.data as Record<string, unknown>).type
+    }
+    const graph = okGraph(buildRegistrationGraph(file.nodes, file.edges))
+    expect(graph.nodes.find((n) => n.id === 'goal_turnout')?.kind).toBe('goal')
+  })
+
+  it('REFUSES rather than coercing an untypeable node to `factor`', () => {
+    // The legacy turn mapper coerces. This one must not: quietly relabelling a
+    // node during a whole-graph REPLACE is how screen and server diverge.
+    const file = clone(IMPORTED)
+    const node = file.nodes.find((n) => n.id === 'fac_weather')!
+    delete (node.data as Record<string, unknown>).kind
+    delete (node.data as Record<string, unknown>).type
+    node.type = 'not-a-real-kind'
+
+    const r = refusal(buildRegistrationGraph(file.nodes, file.edges))
+    expect(r.reason).toBe('unresolvable_node_kind')
+    expect(r.nodeIds).toEqual(['fac_weather'])
+  })
+
+  it('REFUSES an empty canvas — registering emptiness would erase the server model', () => {
+    const r = refusal(buildRegistrationGraph([], []))
+    expect(r.reason).toBe('empty_graph')
+  })
+
+  it('reports DIVERGENCE ahead of UNRESOLVABLE when a file has both', () => {
+    const file = clone(IMPORTED)
+    ;(file.nodes.find((n) => n.id === 'opt_alpha')!.data as Record<string, unknown>).type = 'factor'
+    const weather = file.nodes.find((n) => n.id === 'fac_weather')!
+    delete (weather.data as Record<string, unknown>).kind
+    delete (weather.data as Record<string, unknown>).type
+    weather.type = 'nonsense'
+
+    expect(refusal(buildRegistrationGraph(file.nodes, file.edges)).reason).toBe(
+      'divergent_node_kind',
+    )
+  })
+
+  it('never mutates the canvas it projects', () => {
+    const before = JSON.stringify(IMPORTED)
+    buildRegistrationGraph(IMPORTED.nodes, IMPORTED.edges)
+    expect(JSON.stringify(IMPORTED)).toBe(before)
+  })
+})

--- a/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
+++ b/src/canvas/registration/__tests__/buildRegistrationGraph.spec.ts
@@ -19,6 +19,7 @@ import { buildRegistrationGraph } from '../buildRegistrationGraph'
 
 import IMPORTED_CANVAS from './fixtures/walk-import-modified.canvas.json'
 import ORIGINAL_CANVAS from './fixtures/walk-export-original.canvas.json'
+import CODEX_EXPORT from './fixtures/codex-export-2026-08-05.canvas.json'
 
 type CanvasFile = { nodes: Node[]; edges: Edge[] }
 
@@ -163,6 +164,70 @@ describe('buildRegistrationGraph — the captured canvas file', () => {
     expect(okGraph(buildRegistrationGraph(nodes, overWeight)).edges[0]).toMatchObject({
       strength: { mean: 1 },
     })
+  })
+})
+
+describe('buildRegistrationGraph — the analysis-bearing fields must reach the server', () => {
+  /**
+   * FIXTURE: the independent reviewer's own export, 5 Aug 2026
+   * (`PHASE0-EVIDENCE-2026-07-28/codex-deep-review-2026-08-05-raw/canvas-export-1785945361783.json`,
+   * SHA-256 `b2c195f16778…`) — 20 nodes, 34 edges, carrying a real
+   * goal-threshold quad (`raw 250000`, `unit £`, `cap 312500`, `frame level`).
+   *
+   * ⚠ WHY THIS FIXTURE IS THE FILE AND NOT THE CANVAS. Measured at these bytes:
+   *   the IMPORT path itself strips this data before the canvas ever sees it —
+   *   `importCanvas` on this exact file returns 20 nodes whose goal `data` is
+   *   reduced to `{kind, label, provenance, type}`, because
+   *   `V2SnapshotSchema`'s `AnyNodeDataSchema` is a strict discriminated union
+   *   and Zod drops undeclared keys. That defect is UPSTREAM of this module and
+   *   is reported, not silently absorbed.
+   *
+   *   This test therefore pins THIS seam's own obligation: given a canvas that
+   *   DOES carry the analysis-bearing fields, the registration projection must
+   *   not become a SECOND strip. Registering a hollowed-out graph would make
+   *   the server agree with a hollowed-out screen — agreement is not the goal,
+   *   carrying the user's model is.
+   */
+  const codex = CODEX_EXPORT as unknown as CanvasFile
+
+  it('POSITIVE CONTROL: the reviewer`s export really carries the goal-threshold quad', () => {
+    const goal = codex.nodes.find((n) => n.id === 'goal_mrr')
+    const data = goal?.data as Record<string, unknown>
+    expect(data.goal_threshold_raw).toBe(250000)
+    expect(data.goal_threshold_unit).toBe('£')
+    expect(data.goal_threshold_cap).toBe(312500)
+    expect(data.goal_threshold_frame).toBe('level')
+    expect(codex.nodes).toHaveLength(20)
+    expect(codex.edges).toHaveLength(34)
+  })
+
+  it('carries the WHOLE goal-threshold quad through to the wire, bound to the goal node by id', () => {
+    const graph = okGraph(buildRegistrationGraph(codex.nodes, codex.edges))
+    const goal = graph.nodes.find((n) => n.id === 'goal_mrr')
+    expect(goal).toMatchObject({
+      kind: 'goal',
+      goal_threshold_raw: 250000,
+      goal_threshold_unit: '£',
+      goal_threshold_cap: 312500,
+      goal_threshold_frame: 'level',
+    })
+  })
+
+  it('carries the baseline-option marker and per-node observed values', () => {
+    const graph = okGraph(buildRegistrationGraph(codex.nodes, codex.edges))
+    // Bound by IDENTITY: this option, not "an option somewhere with is_baseline".
+    expect(graph.nodes.find((n) => n.id === 'opt_status_quo')?.is_baseline).toBe(true)
+    expect(graph.nodes.find((n) => n.id === 'opt_hire_sales')?.is_baseline).toBe(false)
+  })
+
+  it('DISCRIMINATING HALF: a canvas WITHOUT the quad produces a wire node without it — the test is not asserting a constant', () => {
+    const stripped = clone(codex)
+    const goal = stripped.nodes.find((n) => n.id === 'goal_mrr')!
+    for (const k of Object.keys(goal.data as Record<string, unknown>)) {
+      if (k.startsWith('goal_threshold')) delete (goal.data as Record<string, unknown>)[k]
+    }
+    const graph = okGraph(buildRegistrationGraph(stripped.nodes, stripped.edges))
+    expect(graph.nodes.find((n) => n.id === 'goal_mrr')).not.toHaveProperty('goal_threshold_raw')
   })
 })
 

--- a/src/canvas/registration/__tests__/fixtures/codex-export-2026-08-05.canvas.json
+++ b/src/canvas/registration/__tests__/fixtures/codex-export-2026-08-05.canvas.json
@@ -1,0 +1,2122 @@
+{
+  "version": 2,
+  "timestamp": 1785945361781,
+  "nodes": [
+    {
+      "id": "dec_mrr_growth",
+      "type": "decision",
+      "position": {
+        "x": 392,
+        "y": 24
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "MRR Growth Strategy to £250k",
+        "kind": "decision",
+        "type": "decision"
+      }
+    },
+    {
+      "id": "fac_budget_spend",
+      "type": "factor",
+      "position": {
+        "x": 24,
+        "y": 482
+      },
+      "data": {
+        "category": "controllable",
+        "display_value": "£0",
+        "provenance": "from_brief",
+        "label": "Growth Budget Deployed",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "unit": "£",
+          "source": "brief_extraction",
+          "raw_value": 0,
+          "cap": 120000,
+          "extractionType": "explicit",
+          "factor_type": "cost",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_churn_rate",
+      "type": "factor",
+      "position": {
+        "x": 116,
+        "y": 690
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0.25,
+          "range_max": 0.75
+        },
+        "extractionType": "inferred",
+        "display_value": "0.25 to 0.75",
+        "provenance": "ai_inferred",
+        "label": "Monthly Churn Rate",
+        "kind": "factor",
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_conversion_rate",
+      "type": "factor",
+      "position": {
+        "x": 208,
+        "y": 482
+      },
+      "data": {
+        "category": "observable",
+        "display_value": "0.5",
+        "provenance": "ai_inferred",
+        "label": "Conversion Rate",
+        "kind": "factor",
+        "observedState": {
+          "value": 0.5,
+          "source": "cee_inference",
+          "extractionType": "inferred"
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_lead_volume",
+      "type": "factor",
+      "position": {
+        "x": 576,
+        "y": 482
+      },
+      "data": {
+        "category": "observable",
+        "display_value": "0.5",
+        "provenance": "ai_inferred",
+        "label": "Lead Volume",
+        "kind": "factor",
+        "observedState": {
+          "value": 0.5,
+          "source": "cee_inference",
+          "extractionType": "inferred"
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_onboarding_capacity",
+      "type": "factor",
+      "position": {
+        "x": 668,
+        "y": 690
+      },
+      "data": {
+        "category": "observable",
+        "display_value": "0.5",
+        "provenance": "ai_inferred",
+        "label": "Onboarding Capacity",
+        "kind": "factor",
+        "observedState": {
+          "value": 0.5,
+          "source": "cee_inference",
+          "extractionType": "inferred"
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_partner_channel",
+      "type": "factor",
+      "position": {
+        "x": 392,
+        "y": 482
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "No partner programme",
+          "1": "Partner channel active"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Partner Channel Programme",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_sales_headcount",
+      "type": "factor",
+      "position": {
+        "x": 760,
+        "y": 482
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "No new sales hires",
+          "1": "Two new sales reps hired"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Sales Headcount Investment",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_sales_ramp",
+      "type": "factor",
+      "position": {
+        "x": 484,
+        "y": 690
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0.3,
+          "range_max": 0.8
+        },
+        "display_value": "0.3 to 0.8",
+        "provenance": "ai_inferred",
+        "label": "Sales Ramp Time",
+        "kind": "factor",
+        "type": "factor"
+      }
+    },
+    {
+      "id": "fac_self_serve",
+      "type": "factor",
+      "position": {
+        "x": 300,
+        "y": 690
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "No self-serve tier",
+          "1": "Self-serve tier live"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Self-Serve Tier Launch",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      }
+    },
+    {
+      "id": "goal_mrr",
+      "type": "goal",
+      "position": {
+        "x": 392,
+        "y": 1285
+      },
+      "data": {
+        "goal_threshold": 0.8,
+        "goal_threshold_raw": 250000,
+        "goal_threshold_unit": "£",
+        "goal_threshold_cap": 312500,
+        "goal_threshold_frame": "level",
+        "provenance": "ai_inferred",
+        "label": "Reach £250k Monthly Recurring Revenue",
+        "kind": "goal",
+        "observedState": {
+          "value": 0.576,
+          "baseline": 0.576,
+          "unit": "£",
+          "source": "brief_extraction",
+          "raw_value": 180000,
+          "cap": 312500
+        },
+        "type": "goal"
+      }
+    },
+    {
+      "id": "opt_hire_sales",
+      "type": "option",
+      "position": {
+        "x": 300,
+        "y": 204
+      },
+      "data": {
+        "interventions": {
+          "fac_sales_headcount": 1,
+          "fac_budget_spend": 0.83
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Hire Two Sales Reps",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_sales_headcount",
+          "fac_budget_spend"
+        ],
+        "type": "option"
+      }
+    },
+    {
+      "id": "opt_partner",
+      "type": "option",
+      "position": {
+        "x": 116,
+        "y": 204
+      },
+      "data": {
+        "interventions": {
+          "fac_partner_channel": 1,
+          "fac_budget_spend": 0.6
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Invest in Partner Channel",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_partner_channel",
+          "fac_budget_spend"
+        ],
+        "type": "option"
+      }
+    },
+    {
+      "id": "opt_self_serve",
+      "type": "option",
+      "position": {
+        "x": 484,
+        "y": 204
+      },
+      "data": {
+        "interventions": {
+          "fac_self_serve": 1,
+          "fac_budget_spend": 0.5
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Launch Self-Serve Tier",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_self_serve",
+          "fac_budget_spend"
+        ],
+        "type": "option"
+      }
+    },
+    {
+      "id": "opt_status_quo",
+      "type": "option",
+      "position": {
+        "x": 668,
+        "y": 204
+      },
+      "data": {
+        "interventions": {
+          "fac_sales_headcount": 0,
+          "fac_self_serve": 0,
+          "fac_partner_channel": 0,
+          "fac_budget_spend": 0
+        },
+        "is_baseline": true,
+        "provenance": "ai_inferred",
+        "label": "Keep Current Approach (Status Quo)",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_sales_headcount",
+          "fac_self_serve",
+          "fac_partner_channel",
+          "fac_budget_spend"
+        ],
+        "type": "option"
+      }
+    },
+    {
+      "id": "out_mrr_retention",
+      "type": "outcome",
+      "position": {
+        "x": 484,
+        "y": 942
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "MRR Retained from Existing Base",
+        "kind": "outcome",
+        "type": "outcome"
+      }
+    },
+    {
+      "id": "out_new_mrr",
+      "type": "outcome",
+      "position": {
+        "x": 300,
+        "y": 942
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "New MRR Generated",
+        "kind": "outcome",
+        "type": "outcome"
+      }
+    },
+    {
+      "id": "risk_budget_overrun",
+      "type": "risk",
+      "position": {
+        "x": 208,
+        "y": 1116
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Budget Overrun Pressure",
+        "kind": "risk",
+        "type": "risk"
+      }
+    },
+    {
+      "id": "risk_onboarding_failure",
+      "type": "risk",
+      "position": {
+        "x": 576,
+        "y": 1116
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Onboarding Failure Rate",
+        "kind": "risk",
+        "type": "risk"
+      }
+    },
+    {
+      "id": "risk_slow_ramp",
+      "type": "risk",
+      "position": {
+        "x": 392,
+        "y": 1116
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Slow Sales Ramp Delay",
+        "kind": "risk",
+        "type": "risk"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-0",
+      "source": "dec_mrr_growth",
+      "target": "opt_hire_sales",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-1",
+      "source": "dec_mrr_growth",
+      "target": "opt_partner",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-2",
+      "source": "dec_mrr_growth",
+      "target": "opt_self_serve",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-3",
+      "source": "dec_mrr_growth",
+      "target": "opt_status_quo",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-4",
+      "source": "fac_budget_spend",
+      "target": "out_new_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.24358974358974356,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09743589743589742,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.12,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Budget deployed is a core driver of new MRR but must share influence with leads, conversion, and ramp effects.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.28500000000000003,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.029999999999999916,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-5",
+      "source": "fac_budget_spend",
+      "target": "risk_budget_overrun",
+      "type": "styled",
+      "data": {
+        "weight": 0.5,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.5,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.8,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Higher budget spend approaches the £120k limit, raising the probability of overrunning.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.8350000000000001,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.6700000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-6",
+      "source": "fac_churn_rate",
+      "target": "out_mrr_retention",
+      "type": "styled",
+      "data": {
+        "weight": 0.6,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.6,
+            "strength_std": 0.12,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": -0.8,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "Monthly churn is the primary determinant of how much MRR is retained from the existing base.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.765,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.33000000000000007,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-7",
+      "source": "fac_conversion_rate",
+      "target": "out_new_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.20299145299145296,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08119658119658119,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "Conversion rate directly scales new MRR by determining what fraction of leads close.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.33499999999999996,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-8",
+      "source": "fac_lead_volume",
+      "target": "out_new_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.32478632478632474,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08119658119658119,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.4,
+            "strength_std": 0.1,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": 0.35,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "Lead volume is a key lever for new MRR since more leads proportionally drive more sales.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.385,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.030000000000000027,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-9",
+      "source": "fac_onboarding_capacity",
+      "target": "out_mrr_retention",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "Greater onboarding capacity helps ensure smooth customer setup, improving retention.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.23500000000000001,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-10",
+      "source": "fac_onboarding_capacity",
+      "target": "risk_onboarding_failure",
+      "type": "styled",
+      "data": {
+        "weight": 0.55,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": -0.55,
+            "strength_std": 0.12,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": -0.7,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "More onboarding capacity reduces the likelihood of customers failing during setup.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.6649999999999999,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-11",
+      "source": "fac_partner_channel",
+      "target": "fac_conversion_rate",
+      "type": "styled",
+      "data": {
+        "weight": 0.18,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.7,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.7,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.18,
+            "strength_std": 0.1,
+            "exists_probability": 0.7
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.15,
+            "exists_probability": 0.8,
+            "reasoning": "Partner referrals tend to convert slightly above average, boosting overall conversion.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.23500000000000001,
+            "strength_std": 0.15,
+            "exists_probability": 0.74
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.11000000000000004,
+          "distance_to_goal": 2,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-12",
+      "source": "fac_partner_channel",
+      "target": "fac_lead_volume",
+      "type": "styled",
+      "data": {
+        "weight": 0.28,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.78,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.78,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.28,
+            "strength_std": 0.14,
+            "exists_probability": 0.78
+          },
+          "pass2": {
+            "strength_mean": 0.45,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "A partner program can supply a substantial new stream of qualified leads.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.485,
+            "strength_std": 0.15,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.4099999999999999,
+          "distance_to_goal": 2,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-13",
+      "source": "fac_sales_headcount",
+      "target": "fac_lead_volume",
+      "type": "styled",
+      "data": {
+        "weight": 0.45,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.45,
+            "strength_std": 0.12,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": 0.35,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Additional sales hires typically generate more outreach and inbound leads.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.385,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.13,
+          "distance_to_goal": 2,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-14",
+      "source": "fac_sales_headcount",
+      "target": "risk_slow_ramp",
+      "type": "styled",
+      "data": {
+        "weight": 0.4465811965811966,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11367521367521369,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.14,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.4,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Each new hire introduces ramp-up risk, increasing the overall slow-ramp probability.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.43500000000000005,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.22999999999999998,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-15",
+      "source": "fac_sales_ramp",
+      "target": "out_new_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.1786324786324786,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.08119658119658119,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.22,
+            "strength_std": 0.1,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": -0.1,
+            "strength_std": 0.05,
+            "exists_probability": 0.99,
+            "reasoning": "Longer sales ramp delays revenue recognition, slightly reducing new MRR within the horizon.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.065,
+            "strength_std": 0.05,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.31,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-16",
+      "source": "fac_sales_ramp",
+      "target": "risk_slow_ramp",
+      "type": "styled",
+      "data": {
+        "weight": 0.5034188034188034,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11367521367521369,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.62,
+            "strength_std": 0.14,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.6,
+            "strength_std": 0.1,
+            "exists_probability": 0.99,
+            "reasoning": "Longer ramp times directly heighten the risk of overall slow sales ramp.",
+            "basis": "brief_explicit",
+            "needs_user_input": false,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.635,
+            "strength_std": 0.1,
+            "exists_probability": 0.9299999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.030000000000000027,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-17",
+      "source": "fac_self_serve",
+      "target": "fac_lead_volume",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.15,
+            "exists_probability": 0.85,
+            "reasoning": "A self-serve tier typically generates incremental inbound sign-up leads.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.23500000000000001,
+            "strength_std": 0.15,
+            "exists_probability": 0.79
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 2,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-18",
+      "source": "fac_self_serve",
+      "target": "fac_onboarding_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.1,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip",
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": -0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.15,
+            "exists_probability": 0.8,
+            "reasoning": "Self-serve reduces manual onboarding load, effectively freeing capacity.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.535,
+            "strength_std": 0.15,
+            "exists_probability": 0.74
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 2,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": []
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-19",
+      "source": "opt_hire_sales",
+      "target": "fac_budget_spend",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-20",
+      "source": "opt_hire_sales",
+      "target": "fac_sales_headcount",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-21",
+      "source": "opt_partner",
+      "target": "fac_budget_spend",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-22",
+      "source": "opt_partner",
+      "target": "fac_partner_channel",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-23",
+      "source": "opt_self_serve",
+      "target": "fac_budget_spend",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-24",
+      "source": "opt_self_serve",
+      "target": "fac_self_serve",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-25",
+      "source": "opt_status_quo",
+      "target": "fac_budget_spend",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-26",
+      "source": "opt_status_quo",
+      "target": "fac_partner_channel",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-27",
+      "source": "opt_status_quo",
+      "target": "fac_sales_headcount",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-28",
+      "source": "opt_status_quo",
+      "target": "fac_self_serve",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-29",
+      "source": "out_mrr_retention",
+      "target": "goal_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.1,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.18181818181818182,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Retained MRR contributes directly to achieving the revenue goal.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.21681818181818183,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_mrr_retention->goal_mrr",
+              "before": 0.4,
+              "after": 0.18181818181818182
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-30",
+      "source": "out_new_mrr",
+      "target": "goal_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.55,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.95,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.95,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "existence_boundary_crossing"
+          ],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.1,
+            "exists_probability": 0.95
+          },
+          "pass2": {
+            "strength_mean": 0.36363636363636365,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "New MRR is the main driver for reaching the £250k target by the deadline.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.3986363636363637,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_new_mrr->goal_mrr",
+              "before": 0.8,
+              "after": 0.36363636363636365
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-31",
+      "source": "risk_budget_overrun",
+      "target": "goal_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.18,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.08,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.18,
+            "strength_std": 0.08,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": -0.13636363636363635,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Budget overrun risk detracts from the ability to sustain growth investments.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.10136363636363635,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.1572727272727273,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_budget_overrun->goal_mrr",
+              "before": -0.3,
+              "after": -0.13636363636363635
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-32",
+      "source": "risk_onboarding_failure",
+      "target": "goal_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.1,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": -0.3,
+            "strength_std": 0.1,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": -0.18181818181818182,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Onboarding failures undermine retention and thus the overall revenue goal.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.14681818181818182,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_onboarding_failure->goal_mrr",
+              "before": -0.4,
+              "after": -0.18181818181818182
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-33",
+      "source": "risk_slow_ramp",
+      "target": "goal_mrr",
+      "type": "styled",
+      "data": {
+        "weight": 0.25,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.1,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.25,
+            "strength_std": 0.1,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": -0.13636363636363635,
+            "strength_std": 0.1,
+            "exists_probability": 0.9,
+            "reasoning": "Slow ramp risk delays revenue contribution and jeopardizes meeting the target.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.10136363636363635,
+            "strength_std": 0.1,
+            "exists_probability": 0.8400000000000001
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.035,
+            "strength_std_offset": 0,
+            "exists_probability_offset": -0.06
+          },
+          "max_divergence": 0.2972727272727273,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_slow_ramp->goal_mrr",
+              "before": -0.3,
+              "after": -0.13636363636363635
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    }
+  ]
+}

--- a/src/canvas/registration/__tests__/fixtures/walk-export-original.canvas.json
+++ b/src/canvas/registration/__tests__/fixtures/walk-export-original.canvas.json
@@ -1,0 +1,1894 @@
+{
+  "version": 2,
+  "timestamp": 1785927661783,
+  "nodes": [
+    {
+      "id": "dec_venue",
+      "type": "decision",
+      "position": {
+        "x": 570,
+        "y": 24
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Product Launch Venue Selection",
+        "kind": "decision",
+        "type": "decision"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_alpha",
+      "type": "factor",
+      "position": {
+        "x": 24,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Alpha Hall selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": true
+    },
+    {
+      "id": "fac_beta",
+      "type": "factor",
+      "position": {
+        "x": 388,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Beta Garden selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Beta Garden Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_gamma",
+      "type": "factor",
+      "position": {
+        "x": 752,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Gamma Rooftop selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_weather",
+      "type": "factor",
+      "position": {
+        "x": 1116,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0,
+          "range_max": 1
+        },
+        "provenance": "ai_inferred",
+        "label": "Weather Conditions on Event Day",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "goal_turnout",
+      "type": "goal",
+      "position": {
+        "x": 570,
+        "y": 832
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Maximise Attendee Turnout",
+        "kind": "goal",
+        "type": "goal"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_alpha",
+      "type": "option",
+      "position": {
+        "x": 24,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 1,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_beta",
+      "type": "option",
+      "position": {
+        "x": 388,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 1,
+          "fac_gamma": 0
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Beta Garden",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_gamma",
+      "type": "option",
+      "position": {
+        "x": 752,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_status_quo",
+      "type": "option",
+      "position": {
+        "x": 1116,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": true,
+        "provenance": "ai_inferred",
+        "label": "Defer Venue Decision (Status Quo)",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_appeal",
+      "type": "outcome",
+      "position": {
+        "x": 388,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Experience Appeal",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_capacity",
+      "type": "outcome",
+      "position": {
+        "x": 752,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Venue Capacity and Accessibility",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_logistics",
+      "type": "risk",
+      "position": {
+        "x": 388,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Logistics Friction",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_weather_exposure",
+      "type": "risk",
+      "position": {
+        "x": 752,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Weather Disruption Risk",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-0",
+      "source": "dec_venue",
+      "target": "opt_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-1",
+      "source": "dec_venue",
+      "target": "opt_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-2",
+      "source": "dec_venue",
+      "target": "opt_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-3",
+      "source": "dec_venue",
+      "target": "opt_status_quo",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-4",
+      "source": "fac_alpha",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.18999999999999997,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08866666666666667,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Indoor Alpha Hall offers moderate aesthetic appeal compared to more unique venues.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.375,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-5",
+      "source": "fac_alpha",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.5145833333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s indoor space supports the largest attendee capacity with easy accessibility.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.625,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.050000000000000044,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-6",
+      "source": "fac_alpha",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.72,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.72,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.72
+          },
+          "pass2": {
+            "strength_mean": -0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s central location and parking minimize attendee logistics friction.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.175,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.050000000000000044,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-7",
+      "source": "fac_beta",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.34833333333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.10133333333333333,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.16,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": 0.35,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden’s outdoor setting provides above-average aesthetic appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.475,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000013,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-8",
+      "source": "fac_beta",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.2770833333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11875,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.15,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden offers moderate capacity and accessibility outdoors.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-9",
+      "source": "fac_beta",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.25,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.7,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.13,
+        "exists_probability": 0.7,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change",
+            "confidence_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.25,
+            "strength_std": 0.13,
+            "exists_probability": 0.7
+          },
+          "pass2": {
+            "strength_mean": -0.1,
+            "strength_std": 0.08000000000000002,
+            "exists_probability": 0.9,
+            "reasoning": "Outdoor garden may pose slight additional walking but limited navigation issues.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.024999999999999994,
+            "strength_std": 0.060000000000000026,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.45,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_STD_CLAMPED",
+              "edge_key": "fac_beta->risk_logistics",
+              "before": 0.15,
+              "after": 0.08000000000000002
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-10",
+      "source": "fac_beta",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.3677419354838709,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11032258064516128,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.6,
+            "strength_std": 0.18,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden exposes attendees to weather risk without full shelter.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.325,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.5499999999999999,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_weather_exposure",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-11",
+      "source": "fac_gamma",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.4116666666666667,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.15,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.4,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s view provides the highest uniqueness and appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.525,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-12",
+      "source": "fac_gamma",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.15833333333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.78,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.78,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.78
+          },
+          "pass2": {
+            "strength_mean": -0.2,
+            "strength_std": 0.2,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop has limited capacity and more challenging access.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.07500000000000001,
+            "strength_std": 0.18000000000000002,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 1,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-13",
+      "source": "fac_gamma",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Rooftop access typically increases logistics friction for attendees.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-14",
+      "source": "fac_gamma",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.45967741935483863,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09193548387096773,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.75,
+            "strength_std": 0.15,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop is exposed to weather without overhead coverage.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.65,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_weather_exposure",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-15",
+      "source": "fac_weather",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.1225806451612903,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.06129032258064515,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.15,
+            "exists_probability": 0.95,
+            "reasoning": "Actual weather conditions are the primary driver of weather disruption risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.625,
+            "strength_std": 0.13,
+            "exists_probability": 0.8599999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.85,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_weather->risk_weather_exposure",
+              "before": 0.95,
+              "after": 0.95
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-16",
+      "source": "opt_alpha",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-17",
+      "source": "opt_alpha",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-18",
+      "source": "opt_alpha",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-19",
+      "source": "opt_beta",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-20",
+      "source": "opt_beta",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-21",
+      "source": "opt_beta",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-22",
+      "source": "opt_gamma",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-23",
+      "source": "opt_gamma",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-24",
+      "source": "opt_gamma",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-25",
+      "source": "opt_status_quo",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-26",
+      "source": "opt_status_quo",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-27",
+      "source": "opt_status_quo",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-28",
+      "source": "out_appeal",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.2857142857142857,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Higher attendee experience appeal structurally increases likelihood of turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.4107142857142857,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.12142857142857144,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_appeal->goal_turnout",
+              "before": 0.4,
+              "after": 0.2857142857142857
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_appeal->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-29",
+      "source": "out_capacity",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.55,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.1,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.2857142857142857,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Greater venue capacity and accessibility structurally support higher turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.4107142857142857,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.2785714285714287,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_capacity->goal_turnout",
+              "before": 0.4,
+              "after": 0.2857142857142857
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_capacity->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-30",
+      "source": "risk_logistics",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.1,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": -0.21428571428571425,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Increased logistics friction structurally reduces attendee turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.08928571428571425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.22142857142857153,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_logistics->goal_turnout",
+              "before": -0.3,
+              "after": -0.21428571428571425
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_logistics->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-31",
+      "source": "risk_weather_exposure",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": -0.3,
+            "strength_std": 0.12,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": -0.21428571428571425,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Greater weather disruption risk structurally lowers expected turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.08928571428571425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.4214285714285715,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_weather_exposure->goal_turnout",
+              "before": -0.3,
+              "after": -0.21428571428571425
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_weather_exposure->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    }
+  ]
+}

--- a/src/canvas/registration/__tests__/fixtures/walk-import-modified.canvas.json
+++ b/src/canvas/registration/__tests__/fixtures/walk-import-modified.canvas.json
@@ -1,0 +1,1894 @@
+{
+  "version": 2,
+  "timestamp": 1785927661783,
+  "nodes": [
+    {
+      "id": "dec_venue",
+      "type": "decision",
+      "position": {
+        "x": 570,
+        "y": 24
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Product Launch Venue Selection",
+        "kind": "decision",
+        "type": "decision"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_alpha",
+      "type": "factor",
+      "position": {
+        "x": 24,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Alpha Hall selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Alpha Hall Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": true
+    },
+    {
+      "id": "fac_beta",
+      "type": "factor",
+      "position": {
+        "x": 388,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Beta Garden selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Beta Garden Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_gamma",
+      "type": "factor",
+      "position": {
+        "x": 752,
+        "y": 321
+      },
+      "data": {
+        "category": "controllable",
+        "encoding_map": {
+          "0": "Not selected",
+          "1": "Gamma Rooftop selected"
+        },
+        "display_value": "Low (0)",
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop Selected",
+        "kind": "factor",
+        "observedState": {
+          "value": 0,
+          "source": "cee_inference",
+          "extractionType": "inferred",
+          "factor_type": "other",
+          "uncertainty_drivers": [
+            "Not provided"
+          ]
+        },
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "fac_weather",
+      "type": "factor",
+      "position": {
+        "x": 1116,
+        "y": 321
+      },
+      "data": {
+        "category": "external",
+        "prior": {
+          "distribution": "uniform",
+          "range_min": 0,
+          "range_max": 1
+        },
+        "provenance": "ai_inferred",
+        "label": "Weather Conditions on Event Day",
+        "kind": "factor",
+        "type": "factor"
+      },
+      "selected": false
+    },
+    {
+      "id": "goal_turnout",
+      "type": "goal",
+      "position": {
+        "x": 570,
+        "y": 832
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Maximise Attendee Turnout",
+        "kind": "goal",
+        "type": "goal"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_alpha",
+      "type": "option",
+      "position": {
+        "x": 24,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 1,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "ZZZ IMPORTED OPTION",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_beta",
+      "type": "option",
+      "position": {
+        "x": 388,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 1,
+          "fac_gamma": 0
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Beta Garden",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_gamma",
+      "type": "option",
+      "position": {
+        "x": 752,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 1
+        },
+        "is_baseline": false,
+        "provenance": "ai_inferred",
+        "label": "Gamma Rooftop",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "opt_status_quo",
+      "type": "option",
+      "position": {
+        "x": 1116,
+        "y": 155
+      },
+      "data": {
+        "interventions": {
+          "fac_alpha": 0,
+          "fac_beta": 0,
+          "fac_gamma": 0
+        },
+        "is_baseline": true,
+        "provenance": "ai_inferred",
+        "label": "Defer Venue Decision (Status Quo)",
+        "kind": "option",
+        "interventionKeys": [
+          "fac_alpha",
+          "fac_beta",
+          "fac_gamma"
+        ],
+        "type": "option"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_appeal",
+      "type": "outcome",
+      "position": {
+        "x": 388,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Experience Appeal",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "out_capacity",
+      "type": "outcome",
+      "position": {
+        "x": 752,
+        "y": 544
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Venue Capacity and Accessibility",
+        "kind": "outcome",
+        "type": "outcome"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_logistics",
+      "type": "risk",
+      "position": {
+        "x": 388,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Attendee Logistics Friction",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    },
+    {
+      "id": "risk_weather_exposure",
+      "type": "risk",
+      "position": {
+        "x": 752,
+        "y": 688
+      },
+      "data": {
+        "provenance": "ai_inferred",
+        "label": "Weather Disruption Risk",
+        "kind": "risk",
+        "type": "risk"
+      },
+      "selected": false
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-0",
+      "source": "dec_venue",
+      "target": "opt_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-1",
+      "source": "dec_venue",
+      "target": "opt_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-2",
+      "source": "dec_venue",
+      "target": "opt_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-3",
+      "source": "dec_venue",
+      "target": "opt_status_quo",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-4",
+      "source": "fac_alpha",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.18999999999999997,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.08866666666666667,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.3,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.25,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Indoor Alpha Hall offers moderate aesthetic appeal compared to more unique venues.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.375,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-5",
+      "source": "fac_alpha",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.5145833333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s indoor space supports the largest attendee capacity with easy accessibility.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.625,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.050000000000000044,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-6",
+      "source": "fac_alpha",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.72,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.72,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.72
+          },
+          "pass2": {
+            "strength_mean": -0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Alpha Hall’s central location and parking minimize attendee logistics friction.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.175,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.050000000000000044,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_alpha->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-7",
+      "source": "fac_beta",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.34833333333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.82,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.10133333333333333,
+        "exists_probability": 0.82,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.16,
+            "exists_probability": 0.82
+          },
+          "pass2": {
+            "strength_mean": 0.35,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden’s outdoor setting provides above-average aesthetic appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.475,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000013,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-8",
+      "source": "fac_beta",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.2770833333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11875,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.15,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden offers moderate capacity and accessibility outdoors.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-9",
+      "source": "fac_beta",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.25,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.7,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.13,
+        "exists_probability": 0.7,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change",
+            "confidence_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.25,
+            "strength_std": 0.13,
+            "exists_probability": 0.7
+          },
+          "pass2": {
+            "strength_mean": -0.1,
+            "strength_std": 0.08000000000000002,
+            "exists_probability": 0.9,
+            "reasoning": "Outdoor garden may pose slight additional walking but limited navigation issues.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.024999999999999994,
+            "strength_std": 0.060000000000000026,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.45,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_STD_CLAMPED",
+              "edge_key": "fac_beta->risk_logistics",
+              "before": 0.15,
+              "after": 0.08000000000000002
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-10",
+      "source": "fac_beta",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.3677419354838709,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.9,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.11032258064516128,
+        "exists_probability": 0.9,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.6,
+            "strength_std": 0.18,
+            "exists_probability": 0.9
+          },
+          "pass2": {
+            "strength_mean": 0.2,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Beta Garden exposes attendees to weather risk without full shelter.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.325,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.5499999999999999,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_beta->risk_weather_exposure",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-11",
+      "source": "fac_gamma",
+      "target": "out_appeal",
+      "type": "styled",
+      "data": {
+        "weight": 0.4116666666666667,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.65,
+            "strength_std": 0.15,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.4,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop’s view provides the highest uniqueness and appeal.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.525,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.3333333333333333,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_appeal",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-12",
+      "source": "fac_gamma",
+      "target": "out_capacity",
+      "type": "styled",
+      "data": {
+        "weight": 0.15833333333333333,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.78,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09499999999999999,
+        "exists_probability": 0.78,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "sign_flip"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.12,
+            "exists_probability": 0.78
+          },
+          "pass2": {
+            "strength_mean": -0.2,
+            "strength_std": 0.2,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop has limited capacity and more challenging access.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.07500000000000001,
+            "strength_std": 0.18000000000000002,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 1,
+          "distance_to_goal": 1,
+          "sign_unstable": true,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->out_capacity",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-13",
+      "source": "fac_gamma",
+      "target": "risk_logistics",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.75,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.14,
+        "exists_probability": 0.75,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.14,
+            "exists_probability": 0.75
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Rooftop access typically increases logistics friction for attendees.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.15000000000000002,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_logistics",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-14",
+      "source": "fac_gamma",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.45967741935483863,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.09193548387096773,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "strength_band_change"
+          ],
+          "pass1": {
+            "strength_mean": 0.75,
+            "strength_std": 0.15,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.3,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Gamma Rooftop is exposed to weather without overhead coverage.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.65,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_gamma->risk_weather_exposure",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-15",
+      "source": "fac_weather",
+      "target": "risk_weather_exposure",
+      "type": "styled",
+      "data": {
+        "weight": 0.1225806451612903,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.06129032258064515,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": 0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": 0.5,
+            "strength_std": 0.15,
+            "exists_probability": 0.95,
+            "reasoning": "Actual weather conditions are the primary driver of weather disruption risk.",
+            "basis": "domain_prior",
+            "needs_user_input": true,
+            "lint_corrected": false
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.625,
+            "strength_std": 0.13,
+            "exists_probability": 0.8599999999999999
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.85,
+          "distance_to_goal": 1,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "fac_weather->risk_weather_exposure",
+              "before": 0.95,
+              "after": 0.95
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-16",
+      "source": "opt_alpha",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-17",
+      "source": "opt_alpha",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-18",
+      "source": "opt_alpha",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-19",
+      "source": "opt_beta",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-20",
+      "source": "opt_beta",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-21",
+      "source": "opt_beta",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-22",
+      "source": "opt_gamma",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-23",
+      "source": "opt_gamma",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-24",
+      "source": "opt_gamma",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-25",
+      "source": "opt_status_quo",
+      "target": "fac_alpha",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-26",
+      "source": "opt_status_quo",
+      "target": "fac_beta",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-27",
+      "source": "opt_status_quo",
+      "target": "fac_gamma",
+      "type": "styled",
+      "data": {
+        "weight": 1,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 1,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.01,
+        "exists_probability": 1,
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-28",
+      "source": "out_appeal",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.35,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.88,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.12,
+        "exists_probability": 0.88,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.35,
+            "strength_std": 0.12,
+            "exists_probability": 0.88
+          },
+          "pass2": {
+            "strength_mean": 0.2857142857142857,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Higher attendee experience appeal structurally increases likelihood of turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.4107142857142857,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.12142857142857144,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_appeal->goal_turnout",
+              "before": 0.4,
+              "after": 0.2857142857142857
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_appeal->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-29",
+      "source": "out_capacity",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.55,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.92,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "positive",
+        "strengthStd": 0.1,
+        "exists_probability": 0.92,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": 0.55,
+            "strength_std": 0.1,
+            "exists_probability": 0.92
+          },
+          "pass2": {
+            "strength_mean": 0.2857142857142857,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Greater venue capacity and accessibility structurally support higher turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": 0.4107142857142857,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.2785714285714287,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "out_capacity->goal_turnout",
+              "before": 0.4,
+              "after": 0.2857142857142857
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "out_capacity->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-30",
+      "source": "risk_logistics",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.2,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.8,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.1,
+        "exists_probability": 0.8,
+        "validation": {
+          "status": "agreed",
+          "contested_reasons": [],
+          "pass1": {
+            "strength_mean": -0.2,
+            "strength_std": 0.1,
+            "exists_probability": 0.8
+          },
+          "pass2": {
+            "strength_mean": -0.21428571428571425,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Increased logistics friction structurally reduces attendee turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.08928571428571425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.22142857142857153,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_logistics->goal_turnout",
+              "before": -0.3,
+              "after": -0.21428571428571425
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_logistics->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    },
+    {
+      "id": "e-31",
+      "source": "risk_weather_exposure",
+      "target": "goal_turnout",
+      "type": "styled",
+      "data": {
+        "weight": 0.3,
+        "style": "solid",
+        "curvature": 0.15,
+        "pathType": "bezier",
+        "kind": "decision-probability",
+        "functionType": "linear",
+        "beliefExists": 0.85,
+        "beliefStrength": 0.5,
+        "schemaVersion": 4,
+        "direction": "negative",
+        "strengthStd": 0.12,
+        "exists_probability": 0.85,
+        "validation": {
+          "status": "contested",
+          "contested_reasons": [
+            "raw_magnitude"
+          ],
+          "pass1": {
+            "strength_mean": -0.3,
+            "strength_std": 0.12,
+            "exists_probability": 0.85
+          },
+          "pass2": {
+            "strength_mean": -0.21428571428571425,
+            "strength_std": 0.15,
+            "exists_probability": 0.9,
+            "reasoning": "Greater weather disruption risk structurally lowers expected turnout.",
+            "basis": "structural_inference",
+            "needs_user_input": true,
+            "lint_corrected": true
+          },
+          "pass2_adjusted": {
+            "strength_mean": -0.08928571428571425,
+            "strength_std": 0.13,
+            "exists_probability": 0.81
+          },
+          "bias_correction": {
+            "strength_mean_offset": 0.125,
+            "strength_std_offset": -0.01999999999999999,
+            "exists_probability_offset": -0.09000000000000002
+          },
+          "max_divergence": 0.4214285714285715,
+          "distance_to_goal": 0,
+          "sign_unstable": false,
+          "pass2_missing": false,
+          "evoi_rank": null,
+          "evoi_impact": null,
+          "was_shown": false,
+          "user_action": "pending",
+          "resolved_value": null,
+          "resolved_by": "default",
+          "validation_lint_log": [
+            {
+              "code": "LINT_BUDGET_RESCALE",
+              "edge_key": "risk_weather_exposure->goal_turnout",
+              "before": -0.3,
+              "after": -0.21428571428571425
+            },
+            {
+              "code": "WARN_CLUSTERED_EP",
+              "edge_key": "risk_weather_exposure->goal_turnout",
+              "before": 0.9,
+              "after": 0.9
+            }
+          ]
+        },
+        "beliefExistsSource": "cee",
+        "weightSource": "cee",
+        "strengthStdSource": "cee",
+        "directionSource": "cee",
+        "provenanceDisplay": "ai_inferred"
+      }
+    }
+  ]
+}

--- a/src/canvas/registration/__tests__/importRegistrationTrain.spec.ts
+++ b/src/canvas/registration/__tests__/importRegistrationTrain.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * ROADMAP 2.467 + 2.503 — THE ACCEPTANCE CASE, and the release handshake.
+ *
+ * THE CASE, live-witnessed 5 Aug: **import → PLAIN RELOAD (no save) → the
+ * imported value must SURVIVE.** It did not. `mergeServerGraphOnHydrate` applies
+ * server VALUES over the local canvas at boot (`overlayNode` does
+ * `{...existing.data, ...mapped.data}`), so CEE's label won and the user's
+ * import was silently undone. `verdicts.json` recorded `canvasHasSentinel`
+ * **true** at step 2 (post-import) and **false** at steps 4 and 5 (post-reload).
+ *
+ * The fix belongs to THIS train and is not a standalone patch of the merge rule:
+ * server-wins is CORRECT once the server holds the graph, and destructive only
+ * in the window before it does. So the merge refuses while the hold is armed,
+ * and the refusal ENDS at the registration acknowledgement.
+ *
+ * FIXTURE PROVENANCE: byte copies of the walk's own files (see
+ * `buildRegistrationGraph.spec.ts`).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+
+import { useCanvasStore } from '../../store'
+
+/** The store's own edge type — `Edge<EdgeData>`, not the bare `Edge`. */
+type CanvasStoreEdges = ReturnType<typeof useCanvasStore.getState>['edges']
+import { mergeServerGraphOnHydrate } from '../../utils/mergeServerGraph'
+import {
+  clearImportRegistrationMarkers,
+  isGraphPendingImportRegistration,
+  markGraphImported,
+  releaseImportRegistration,
+} from '../../store/importRegistrationMarker'
+
+import IMPORTED_CANVAS from './fixtures/walk-import-modified.canvas.json'
+import ORIGINAL_CANVAS from './fixtures/walk-export-original.canvas.json'
+
+type CanvasFile = { nodes: Node[]; edges: Edge[] }
+const IMPORTED = IMPORTED_CANVAS as unknown as CanvasFile
+const ORIGINAL = ORIGINAL_CANVAS as unknown as CanvasFile
+
+const SENTINEL = 'ZZZ IMPORTED OPTION'
+const SERVER_LABEL = 'Alpha Hall'
+
+/**
+ * The graph CEE holds — the PRE-import model, in wire shape (`from`/`to`, one
+ * kind spelling), derived from the walk's own "original" export so the server
+ * side of the test is the producer's data too.
+ */
+function serverPreImportGraph(): unknown {
+  return {
+    nodes: ORIGINAL.nodes.map((n) => ({
+      id: n.id,
+      kind: (n.data as Record<string, unknown>).kind,
+      label: (n.data as Record<string, unknown>).label,
+    })),
+    edges: ORIGINAL.edges.map((e) => ({ from: e.source, to: e.target })),
+  }
+}
+
+/** Put the imported canvas on the store, exactly as a boot-from-autosave does. */
+function installImportedCanvas(pendingRegistration: boolean): void {
+  useCanvasStore.setState({
+    nodes: JSON.parse(JSON.stringify(IMPORTED.nodes)) as Node[],
+    edges: JSON.parse(JSON.stringify(IMPORTED.edges)) as unknown as CanvasStoreEdges,
+    currentScenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
+    importPendingServerRegistration: pendingRegistration,
+  })
+}
+
+function sentinelOnCanvas(): string | undefined {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === 'opt_alpha')
+  return (node?.data as Record<string, unknown> | undefined)?.label as string | undefined
+}
+
+beforeEach(() => {
+  clearImportRegistrationMarkers()
+  vi.restoreAllMocks()
+})
+
+describe('2.503 acceptance case — import → reload without saving', () => {
+  it('POSITIVE CONTROL: without the hold, the boot merge really does overwrite the imported label', () => {
+    // Trap 13, and it is the load-bearing control of this whole file. If the
+    // merge could not clobber, the refusal below would prove nothing. This is
+    // the WITNESSED defect, reproduced.
+    installImportedCanvas(false)
+    expect(sentinelOnCanvas()).toBe(SENTINEL)
+
+    const result = mergeServerGraphOnHydrate(serverPreImportGraph())
+
+    expect(result.accepted).toBe(true)
+    expect(sentinelOnCanvas()).toBe(SERVER_LABEL)
+  })
+
+  it('THE ACCEPTANCE CASE: under an armed import hold, the imported value SURVIVES the boot merge', () => {
+    installImportedCanvas(true)
+    expect(sentinelOnCanvas()).toBe(SENTINEL)
+
+    const result = mergeServerGraphOnHydrate(serverPreImportGraph())
+
+    expect(result.accepted).toBe(false)
+    expect(result.refusedReason).toBe('importUnregistered')
+    expect(result.changed).toBe(false)
+    // Bound BY IDENTITY (node id), not by "some node still says the sentinel".
+    expect(sentinelOnCanvas()).toBe(SENTINEL)
+  })
+
+  it('the refusal does not record an authoritative identity for a graph it did not apply', () => {
+    installImportedCanvas(true)
+    const before = useCanvasStore.getState().lastAuthoritativeGraph
+    mergeServerGraphOnHydrate(serverPreImportGraph())
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBe(before)
+  })
+
+  it('server-wins RESUMES once the hold is released — the refusal is a window, not a new rule', () => {
+    // This is why 2.503 was folded into this row rather than patched alone: the
+    // fix must not weaken server-wins in general, only defer it until the
+    // server actually holds the user's graph.
+    installImportedCanvas(true)
+    expect(mergeServerGraphOnHydrate(serverPreImportGraph()).refusedReason).toBe(
+      'importUnregistered',
+    )
+
+    useCanvasStore.setState({ importPendingServerRegistration: false })
+    const after = mergeServerGraphOnHydrate(serverPreImportGraph())
+    expect(after.accepted).toBe(true)
+  })
+
+  it('the refusal is scoped to the import hold — an ordinary canvas still merges', () => {
+    // DISCRIMINATING HALF: without this, "refuses" could mean "refuses always".
+    installImportedCanvas(false)
+    expect(mergeServerGraphOnHydrate(serverPreImportGraph()).accepted).toBe(true)
+  })
+})
+
+describe('the marker handshake — armed by import, released only by an acknowledgement', () => {
+  it('POSITIVE CONTROL: the marker really can arm on the captured graph', () => {
+    expect(isGraphPendingImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(false)
+    markGraphImported(IMPORTED.nodes, IMPORTED.edges)
+    expect(isGraphPendingImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(true)
+  })
+
+  it('releases the acknowledged identity, and reports that it did', () => {
+    markGraphImported(IMPORTED.nodes, IMPORTED.edges)
+    expect(releaseImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(true)
+    expect(isGraphPendingImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(false)
+  })
+
+  it('DISCRIMINATING PAIR: releasing one identity leaves ANOTHER held graph held', () => {
+    // The release is bound to the graph that was registered, by identity —
+    // never "clear the hold". A session that imported two graphs and registered
+    // one keeps holding the other.
+    const other: CanvasFile = {
+      nodes: [{ id: 'zzz-only-node', type: 'goal', data: { kind: 'goal', label: 'Z' } }] as unknown as Node[],
+      edges: [],
+    }
+    markGraphImported(IMPORTED.nodes, IMPORTED.edges)
+    markGraphImported(other.nodes, other.edges)
+
+    expect(releaseImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(true)
+    expect(isGraphPendingImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(false)
+    expect(isGraphPendingImportRegistration(other.nodes, other.edges)).toBe(true)
+  })
+
+  it('releasing an identity that was never held is a no-op that SAYS SO', () => {
+    expect(releaseImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(false)
+  })
+
+  it('the release is label-independent, so a relabel after registration does not silently re-arm or mis-release', () => {
+    // The digest is structural on purpose. Registering and then relabelling
+    // must not resurrect a hold, and must not release someone else's.
+    markGraphImported(IMPORTED.nodes, IMPORTED.edges)
+    expect(releaseImportRegistration(ORIGINAL.nodes, ORIGINAL.edges)).toBe(true)
+    expect(isGraphPendingImportRegistration(IMPORTED.nodes, IMPORTED.edges)).toBe(false)
+  })
+})

--- a/src/canvas/registration/buildRegistrationGraph.ts
+++ b/src/canvas/registration/buildRegistrationGraph.ts
@@ -1,0 +1,203 @@
+/**
+ * ROADMAP 2.467 — CANVAS → CEE WIRE, for the registration seam only.
+ *
+ * The canvas and CEE do not speak the same graph. A ReactFlow node is
+ * `{ id, type, position, data: { label, kind, type, … } }`; a CEE node is
+ * `{ id, kind, label, … }`. A canvas edge is `{ source, target, data }`; a CEE
+ * edge is `{ from, to, strength, … }`. `scenarios.graph` carries no layout, so
+ * positions are dropped here rather than sent and ignored.
+ *
+ * ── WHY THIS IS A SECOND PROJECTION, AND WHY THAT IS THE RIGHT CALL ────────
+ * `useConversation.ts` carries an inline canvas→CEE mapper of its own. It is
+ * NOT reused, deliberately: that one builds the legacy `graph_state` field, and
+ * the LIVE V5 turn path sends no graph at all (`buildPayload.ts` — measured
+ * zero `graph_state`/`graph:` hits, ROADMAP 2.506). Coupling a new live seam to
+ * a legacy producer would make one path's coercions the other's contract. The
+ * duplication is real and is rowed for consolidation; it is not pretended away.
+ *
+ * ── DIVERGENCE IS REFUSED, NOT COERCED (2.467c rider) ──────────────────────
+ * A canvas node carries THREE kind spellings: `data.kind`, `data.type`, and the
+ * top-level `node.type` (ReactFlow's renderer key). The UI's own snapshot
+ * normaliser writes `data.kind` and `data.type` to the SAME canonical value, so
+ * a file where they DISAGREE is a hand-edited or third-party file that says two
+ * things about the same node. The legacy turn mapper coerces an unrecognised
+ * kind to `'factor'`. This one must not: a registration REPLACES the server's
+ * model, and quietly relabelling a node during a replace is how the screen and
+ * the server end up describing different graphs — the exact defect 2.467 exists
+ * to close. Disagreement is refused and named; ABSENCE is resolved, because a
+ * node with only one spelling is unambiguous about what it means.
+ *
+ * CEE re-runs an equivalent refusal at the write seam
+ * (`normaliseGraphNodeKindField`). That is not a mirror of this: the two answer
+ * different obligations — this one refuses to SEND an ambiguous graph, CEE's
+ * refuses to STORE one from any caller, including callers that are not this UI.
+ */
+import type { Edge, Node } from '@xyflow/react'
+
+/** The kinds CEE's node schema accepts. Mirrored deliberately — see the note. */
+const CEE_VALID_KINDS = new Set([
+  'decision',
+  'event',
+  'outcome',
+  'goal',
+  'option',
+  'factor',
+  'risk',
+  'action',
+])
+
+/**
+ * ReactFlow internals and canvas-only fields that must never reach
+ * `scenarios.graph`. `label`/`kind`/`type` are listed because they are emitted
+ * EXPLICITLY above the passthrough, not because they are unwanted.
+ */
+const CANVAS_ONLY_NODE_KEYS = new Set([
+  'selected',
+  'dragging',
+  'measured',
+  'resizing',
+  'position',
+  'positionAbsolute',
+  'draggable',
+  'selectable',
+  'deletable',
+  'connectable',
+  'focusable',
+  'parentId',
+  'extent',
+  'expandParent',
+  'ariaLabel',
+  'zIndex',
+  'hidden',
+  'label',
+  'kind',
+  'type',
+  '_baseline_snapshot',
+])
+
+export interface RegistrationGraph {
+  readonly nodes: ReadonlyArray<Record<string, unknown>>
+  readonly edges: ReadonlyArray<Record<string, unknown>>
+}
+
+export type BuildRegistrationGraphResult =
+  | { readonly ok: true; readonly graph: RegistrationGraph }
+  | {
+      readonly ok: false
+      readonly reason: 'divergent_node_kind' | 'unresolvable_node_kind' | 'empty_graph'
+      /** Node ids the caller can name to the user. Capped. */
+      readonly nodeIds: readonly string[]
+    }
+
+const MAX_REPORTED_NODE_IDS = 10
+
+function readKindCandidate(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? null : trimmed
+}
+
+function clamp01(n: number): number {
+  return Math.max(0, Math.min(1, n))
+}
+
+/**
+ * Project the canvas into the graph CEE will persist.
+ *
+ * Pure. Never throws. Returns a refusal rather than a best guess whenever the
+ * canvas cannot be projected without inventing something.
+ */
+export function buildRegistrationGraph(
+  nodes: ReadonlyArray<Node>,
+  edges: ReadonlyArray<Edge>,
+): BuildRegistrationGraphResult {
+  if (nodes.length === 0) {
+    return { ok: false, reason: 'empty_graph', nodeIds: [] }
+  }
+
+  const divergent: string[] = []
+  const unresolvable: string[] = []
+  const wireNodes: Array<Record<string, unknown>> = []
+
+  for (const node of nodes) {
+    const data = (node.data ?? {}) as Record<string, unknown>
+    const dataKind = readKindCandidate(data.kind)
+    const dataType = readKindCandidate(data.type)
+    const rfType = readKindCandidate(node.type)
+
+    // The two SEMANTIC spellings disagreeing is the ambiguity. `node.type` is
+    // ReactFlow's renderer key and is a fallback, never a third opinion to
+    // arbitrate — it is only consulted when neither semantic spelling exists.
+    if (dataKind !== null && dataType !== null && dataKind !== dataType) {
+      divergent.push(node.id)
+      continue
+    }
+
+    const resolved = dataKind ?? dataType ?? rfType
+    if (resolved === null || !CEE_VALID_KINDS.has(resolved)) {
+      // No coercion to 'factor' here — see the header. A node CEE cannot type
+      // is a node whose analysis meaning we would be inventing.
+      unresolvable.push(node.id)
+      continue
+    }
+
+    const out: Record<string, unknown> = {
+      id: node.id,
+      kind: resolved,
+      label: readKindCandidate(data.label) ?? node.id,
+    }
+    for (const [key, value] of Object.entries(data)) {
+      if (CANVAS_ONLY_NODE_KEYS.has(key) || value === undefined) continue
+      // CEE spells the observed-value bundle `observed_state`.
+      if (key === 'observedState') {
+        out.observed_state = value
+        continue
+      }
+      out[key] = value
+    }
+    wireNodes.push(out)
+  }
+
+  if (divergent.length > 0) {
+    return {
+      ok: false,
+      reason: 'divergent_node_kind',
+      nodeIds: divergent.slice(0, MAX_REPORTED_NODE_IDS),
+    }
+  }
+  if (unresolvable.length > 0) {
+    return {
+      ok: false,
+      reason: 'unresolvable_node_kind',
+      nodeIds: unresolvable.slice(0, MAX_REPORTED_NODE_IDS),
+    }
+  }
+
+  const wireEdges = edges.map((edge) => {
+    const data = (edge.data ?? {}) as Record<string, unknown>
+    const weightValue = data.weight
+    const directionValue = data.direction
+    const strengthStdValue = data.strengthStd
+    // Canvas weight [0,2] + direction → the signed mean CEE expects, clamped
+    // to [-1,+1] (UI-SEM-035).
+    const weight = typeof weightValue === 'number' ? Math.max(0, Math.min(weightValue, 2)) : 0.5
+    const direction = directionValue === 'negative' ? -1 : 1
+    const mean = Math.max(-1, Math.min(1, direction * weight))
+    const std = typeof strengthStdValue === 'number' ? Math.max(0, strengthStdValue) : undefined
+    const rawExistsProb = data.beliefExists ?? data.confidence ?? data.belief
+    const existsProbability = typeof rawExistsProb === 'number' ? clamp01(rawExistsProb) : undefined
+    const effectDirection =
+      directionValue === 'positive' || directionValue === 'negative' ? directionValue : undefined
+
+    return {
+      from: edge.source,
+      to: edge.target,
+      strength: { mean, ...(std !== undefined ? { std } : {}) },
+      ...(existsProbability !== undefined ? { exists_probability: existsProbability } : {}),
+      ...(effectDirection ? { effect_direction: effectDirection } : {}),
+      edge_type: typeof data.edge_type === 'string' ? data.edge_type : 'directed',
+    } satisfies Record<string, unknown>
+  })
+
+  return { ok: true, graph: { nodes: wireNodes, edges: wireEdges } }
+}

--- a/src/canvas/registration/useImportRegistration.ts
+++ b/src/canvas/registration/useImportRegistration.ts
@@ -46,8 +46,16 @@ import { releaseImportRegistration } from '../store/importRegistrationMarker'
 import { buildRegistrationGraph } from './buildRegistrationGraph'
 
 /**
- * Why a registration attempt did not end in an acknowledgement. Surfaced so the
- * Run affordance can say something true rather than spinning forever.
+ * Why a registration attempt did not end in an acknowledgement.
+ *
+ * ⚠ DELIBERATELY NOT STORED ON THE CANVAS STORE. A first cut kept it as a
+ *   store field; a complete manifest showed SIX references and ZERO readers —
+ *   a write-only surface, which is the shape trap 10 exists to warn about, and
+ *   which also re-rendered an unrelated pre-existing diagnostic (widening the
+ *   store's state type changes how tsc PRINTS it) and reddened the typecheck
+ *   gate's own self-test. It is a LOG reason until something actually renders
+ *   it; the honest posture the user sees is driven by
+ *   `importPendingServerRegistration` alone.
  */
 export type ImportRegistrationFailure =
   /** The canvas cannot be projected without inventing a node's meaning. */
@@ -106,7 +114,6 @@ export function useImportRegistration(): void {
         reason: projected.reason,
         nodeIds: projected.nodeIds,
       })
-      useCanvasStore.setState({ importRegistrationFailure: 'graph_not_projectable' })
       return
     }
 
@@ -134,7 +141,7 @@ export function useImportRegistration(): void {
         // The hold stays ARMED. This is the whole discipline: anything short of
         // "CEE told us it stored this" leaves the product honest about not
         // knowing, exactly as it was before this hook existed.
-        useCanvasStore.setState({ importRegistrationFailure: failure })
+        void failure
         return
       }
 
@@ -142,10 +149,7 @@ export function useImportRegistration(): void {
       // registered, and re-derive the store flag from the SAME snapshot so the
       // two cannot disagree.
       const released = releaseImportRegistration(nodes, edges)
-      useCanvasStore.setState({
-        importPendingServerRegistration: false,
-        importRegistrationFailure: null,
-      })
+      useCanvasStore.setState({ importPendingServerRegistration: false })
       logger.info('import_registration.acknowledged', {
         scenarioId,
         nodeCount: result.nodeCount,

--- a/src/canvas/registration/useImportRegistration.ts
+++ b/src/canvas/registration/useImportRegistration.ts
@@ -1,0 +1,163 @@
+/**
+ * ROADMAP 2.467 — THE IMPORT → RESET → SERVER-REGISTRATION TRAIN, client half.
+ *
+ * ── WHY ONE HOOK COVERS EVERY IMPORT ROUTE ─────────────────────────────────
+ * This subscribes to `store.importPendingServerRegistration`, which is DERIVED
+ * at every graph-replacement site (`importCanvas`, `hydrateGraphSlice`,
+ * `loadScenario`, `undoDraft`) from a localStorage marker keyed on the graph's
+ * STRUCTURAL identity. So it fires for:
+ *   · the ImportExportDialog import,
+ *   · the SnapshotManager restore (same store action),
+ *   · the ScenarioSwitcher `importScenarioFromFile` route (which now marks too),
+ *   · **hydrate-from-autosave after a reload or in a new tab** — ROADMAP 2.483's
+ *     binding design note, and the reason a per-route call site would have been
+ *     the same defect with a smaller blast radius.
+ * There is no hand-maintained list of "places to register from"; there is one
+ * condition, read from the graph actually on the canvas.
+ *
+ * ── WHAT IT SENDS, AND WHAT IT SNAPSHOTS ───────────────────────────────────
+ * The canvas is projected to CEE's wire shape by `buildRegistrationGraph`, and
+ * the nodes/edges used for that projection are SNAPSHOTTED and carried through
+ * to the release. The marker is structural, so releasing against a canvas the
+ * user has edited in the meantime would release nothing — safe, but silently.
+ * Carrying the snapshot makes the release describe exactly what was registered.
+ *
+ * ── WHAT COUNTS AS AN ACKNOWLEDGEMENT ──────────────────────────────────────
+ * Only `status: 'registered'` — a 200 carrying the `scenario_graph_registration.v1`
+ * discriminator. A transport failure, an unreadable body, a 503, a 409 and a
+ * 404 all leave the hold ARMED, which is the honest posture: the product goes
+ * on saying it cannot confirm, exactly as the interim mitigation made it. This
+ * hook can only ever make the product MORE confident, never less honest.
+ *
+ * ── THE INTERIM MITIGATION IS NOT LEFT FIGHTING THIS ───────────────────────
+ * `importRegistrationMarker` was always specified as superseded by a real
+ * handshake — "when a real registration handshake exists, the server's own
+ * acknowledgement replaces this marker". This is that handshake: the module
+ * stays as the STATE (it is what survives a reload), and its release is now
+ * driven by CEE's ack rather than by nothing at all. One mechanism, two halves.
+ */
+import { useEffect, useRef } from 'react'
+
+import { useAuth } from '../../contexts/AuthContext'
+import { logger } from '../../lib/logger'
+import { registerScenarioGraph } from '../../adapters/cee/registerScenarioGraph'
+import { useCanvasStore } from '../store'
+import { releaseImportRegistration } from '../store/importRegistrationMarker'
+import { buildRegistrationGraph } from './buildRegistrationGraph'
+
+/**
+ * Why a registration attempt did not end in an acknowledgement. Surfaced so the
+ * Run affordance can say something true rather than spinning forever.
+ */
+export type ImportRegistrationFailure =
+  /** The canvas cannot be projected without inventing a node's meaning. */
+  | 'graph_not_projectable'
+  /** CEE refused the bytes (422). Actionable — the file needs fixing. */
+  | 'rejected'
+  /** The server graph moved under us (409). Never retried. */
+  | 'conflict'
+  /** Transport / 503 / unreadable answer. Unknown; a later attempt may work. */
+  | 'unavailable'
+
+/** UUID shape — a non-UUID `currentScenarioId` cannot name a `scenarios` row. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Register the canvas server-side whenever it holds an unregistered import.
+ *
+ * Mounted once, beside the server-graph hydration hook.
+ */
+export function useImportRegistration(): void {
+  const pending = useCanvasStore((s) => s.importPendingServerRegistration)
+  const scenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const { user } = useAuth()
+  const userId = user?.id ?? null
+
+  /**
+   * Attempts already made, keyed by `${scenarioId}:${nodeCount}:${edgeCount}`.
+   *
+   * ⚠ THIS IS AN IN-FLIGHT / NO-RETRY-LOOP GUARD, NOT THE HOLD. The hold lives
+   *   in localStorage and survives the page; this ref dies with it, so a reload
+   *   legitimately re-attempts a registration that failed. Without the guard, a
+   *   failing registration would re-fire on every render for as long as the
+   *   hold stays armed — which is forever, by design.
+   */
+  const attempted = useRef(new Set<string>())
+
+  useEffect(() => {
+    if (!pending) return
+    if (!scenarioId || !UUID_PATTERN.test(scenarioId)) {
+      // No addressable scenario row yet. The hold stays armed and the product
+      // keeps saying it cannot confirm — which is TRUE: there is nowhere to
+      // register this graph.
+      logger.warn('import_registration.no_scenario_id', { scenarioId: scenarioId ?? null })
+      return
+    }
+
+    // Snapshot the exact graph being registered (see the header).
+    const { nodes, edges } = useCanvasStore.getState()
+    const attemptKey = `${scenarioId}:${nodes.length}:${edges.length}`
+    if (attempted.current.has(attemptKey)) return
+    attempted.current.add(attemptKey)
+
+    const projected = buildRegistrationGraph(nodes, edges)
+    if (!projected.ok) {
+      logger.warn('import_registration.not_projectable', {
+        reason: projected.reason,
+        nodeIds: projected.nodeIds,
+      })
+      useCanvasStore.setState({ importRegistrationFailure: 'graph_not_projectable' })
+      return
+    }
+
+    const controller = new AbortController()
+    let cancelled = false
+
+    void (async () => {
+      const result = await registerScenarioGraph(scenarioId, projected.graph, {
+        userId,
+        signal: controller.signal,
+      })
+      if (cancelled) return
+
+      if (result.status !== 'registered') {
+        const failure: ImportRegistrationFailure =
+          result.status === 'rejected'
+            ? 'rejected'
+            : result.status === 'conflict'
+              ? 'conflict'
+              : 'unavailable'
+        logger.warn('import_registration.not_acknowledged', {
+          status: result.status,
+          scenarioId,
+        })
+        // The hold stays ARMED. This is the whole discipline: anything short of
+        // "CEE told us it stored this" leaves the product honest about not
+        // knowing, exactly as it was before this hook existed.
+        useCanvasStore.setState({ importRegistrationFailure: failure })
+        return
+      }
+
+      // THE ACKNOWLEDGEMENT. Release the marker for the identity that was
+      // registered, and re-derive the store flag from the SAME snapshot so the
+      // two cannot disagree.
+      const released = releaseImportRegistration(nodes, edges)
+      useCanvasStore.setState({
+        importPendingServerRegistration: false,
+        importRegistrationFailure: null,
+      })
+      logger.info('import_registration.acknowledged', {
+        scenarioId,
+        nodeCount: result.nodeCount,
+        edgeCount: result.edgeCount,
+        markerReleased: released,
+        identityProjection: result.identity?.projectionVersion ?? null,
+      })
+    })()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [pending, scenarioId, userId])
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -472,6 +472,23 @@ interface CanvasState {
    */
   importPendingServerRegistration: boolean
   /**
+   * ROADMAP 2.467 — why the last registration attempt did NOT end in a server
+   * acknowledgement, or `null` when there is nothing to report.
+   *
+   * ⚠ THIS IS A REASON, NEVER A GATE. `importPendingServerRegistration` alone
+   *   decides whether the product may affirm freshness or offer a Run; this
+   *   field only lets the affordance say something TRUE about why it is
+   *   waiting. A `null` here means "no failure recorded", which is the state
+   *   both before the first attempt and after a successful one — it is not, and
+   *   must never be read as, "the graph is registered".
+   */
+  importRegistrationFailure:
+    | 'graph_not_projectable'
+    | 'rejected'
+    | 'conflict'
+    | 'unavailable'
+    | null
+  /**
    * How many model-changing edits have been COMMITTED locally and emitted, but
    * are still sitting undispatched in the conversation dispatcher's deferral
    * buffer (see `useConversation`'s in-flight lock).
@@ -1630,6 +1647,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   analysisFreshnessDirty: false,
   // Interim 2.467: no import has happened at cold start.
   importPendingServerRegistration: false,
+  // 2.467: no registration has been attempted, so there is nothing to report.
+  importRegistrationFailure: null,
   // No edit can be awaiting dispatch before any edit has been made.
   pendingEmittedEdits: 0,
   ceeAnalysisReadyNodeIds: null,
@@ -2569,6 +2588,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // later graph-replacement site can re-derive the flag from the graph it
       // installs (including after a page reload). See the field's doc.
       importPendingServerRegistration: true,
+      // A new import is a new attempt: whatever the last one failed with no
+      // longer describes anything on screen.
+      importRegistrationFailure: null,
       // Lane 5 (Codex P0-2): a full import is a new decision context — clear the
       // target, its representation, readiness and outcome selection so the
       // imported model never runs against the previous decision's goal state.

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -472,23 +472,6 @@ interface CanvasState {
    */
   importPendingServerRegistration: boolean
   /**
-   * ROADMAP 2.467 — why the last registration attempt did NOT end in a server
-   * acknowledgement, or `null` when there is nothing to report.
-   *
-   * ⚠ THIS IS A REASON, NEVER A GATE. `importPendingServerRegistration` alone
-   *   decides whether the product may affirm freshness or offer a Run; this
-   *   field only lets the affordance say something TRUE about why it is
-   *   waiting. A `null` here means "no failure recorded", which is the state
-   *   both before the first attempt and after a successful one — it is not, and
-   *   must never be read as, "the graph is registered".
-   */
-  importRegistrationFailure:
-    | 'graph_not_projectable'
-    | 'rejected'
-    | 'conflict'
-    | 'unavailable'
-    | null
-  /**
    * How many model-changing edits have been COMMITTED locally and emitted, but
    * are still sitting undispatched in the conversation dispatcher's deferral
    * buffer (see `useConversation`'s in-flight lock).
@@ -1647,8 +1630,6 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   analysisFreshnessDirty: false,
   // Interim 2.467: no import has happened at cold start.
   importPendingServerRegistration: false,
-  // 2.467: no registration has been attempted, so there is nothing to report.
-  importRegistrationFailure: null,
   // No edit can be awaiting dispatch before any edit has been made.
   pendingEmittedEdits: 0,
   ceeAnalysisReadyNodeIds: null,
@@ -2588,9 +2569,6 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // later graph-replacement site can re-derive the flag from the graph it
       // installs (including after a page reload). See the field's doc.
       importPendingServerRegistration: true,
-      // A new import is a new attempt: whatever the last one failed with no
-      // longer describes anything on screen.
-      importRegistrationFailure: null,
       // Lane 5 (Codex P0-2): a full import is a new decision context — clear the
       // target, its representation, readiness and outcome selection so the
       // imported model never runs against the previous decision's goal state.

--- a/src/canvas/store/importRegistrationMarker.ts
+++ b/src/canvas/store/importRegistrationMarker.ts
@@ -144,6 +144,36 @@ export function isGraphPendingImportRegistration(nodes: GraphNodes, edges: Graph
   return readMarkers().includes(digest)
 }
 
+/**
+ * THE RELEASE — ROADMAP 2.467's registration train.
+ *
+ * Called with the graph the SERVER has just acknowledged holding. The hold is
+ * dropped for that structural identity and no other, so a session that imported
+ * two graphs and registered one keeps holding the other.
+ *
+ * ⚠ CALL THIS ONLY ON A SERVER ACKNOWLEDGEMENT. The whole point of the marker
+ *   is that a graph the server has never seen cannot be affirmed as current;
+ *   releasing on anything weaker than "CEE told us it stored this" re-opens the
+ *   P0. An unreadable answer, a transport failure and a 200 whose body did not
+ *   carry the registration envelope are all NOT acknowledgements.
+ *
+ * ⚠ IDENTITY IS STRUCTURAL, so the graph passed here must be the one that was
+ *   REGISTERED, not a later edit of it. Passing a mutated graph would release
+ *   nothing (the digest would not match) — which fails in the SAFE direction
+ *   (still holding), but silently, so callers snapshot before they send.
+ *
+ * Returns whether a marker was actually removed, so a caller can tell a real
+ * release from a no-op instead of assuming one.
+ */
+export function releaseImportRegistration(nodes: GraphNodes, edges: GraphEdges): boolean {
+  const digest = graphImportDigest(nodes, edges)
+  if (digest === null) return false
+  const markers = readMarkers()
+  if (!markers.includes(digest)) return false
+  writeMarkers(markers.filter((m) => m !== digest))
+  return true
+}
+
 /** Test/teardown helper — a real session drops the record when the tab closes. */
 export function clearImportRegistrationMarkers(): void {
   try {

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -98,6 +98,28 @@ export type MergeServerGraphRefusal =
   | 'emptyServerGraph'
   /** Zero node-id overlap with a non-empty canvas — two unrelated graphs. */
   | 'zeroOverlap'
+  /**
+   * ROADMAP 2.467/2.503 — the canvas holds a graph the SERVER HAS NEVER SEEN.
+   *
+   * THE DEFECT THIS CLOSES, live-witnessed 5 Aug: import a file, press F5
+   * WITHOUT saving, and the imported values were silently GONE. This module's
+   * own rule is "VALUES FROM THE SERVER, LAYOUT FROM LOCAL" — `overlayNode`
+   * does `{...existing.data, ...mapped.data}`, so CEE's `label` wins on every
+   * node id it shares. That rule is CORRECT once the server has the graph, and
+   * destructive before it does: nothing had registered the import, so the boot
+   * merge restored the pre-import model over the user's own work, without a
+   * word. Not a trust-of-numbers defect — the freshness posture stayed honestly
+   * cannot-confirm throughout — but the user's EDIT being undone.
+   *
+   * ⚠ THIS IS DELIBERATELY NOT A STANDALONE PATCH OF THE MERGE RULE. Weakening
+   *   server-wins in general would trade one silent divergence for another. The
+   *   refusal is scoped to exactly the window in which the server's copy is
+   *   KNOWN to be the older one, and it ENDS when registration is acknowledged:
+   *   `releaseImportRegistration` drops the hold, the next hydrate finds no
+   *   marker, and server-wins resumes with the server holding the user's graph.
+   *   Symptom and cause are closed by the same train.
+   */
+  | 'importUnregistered'
 
 export interface MergeServerGraphResult {
   addedNodeCount: number
@@ -172,6 +194,25 @@ export function mergeServerGraphOnHydrate(
   if (rawNodes.length === 0 && rawEdges.length === 0) return refused('emptyServerGraph')
 
   const store = useCanvasStore.getState()
+
+  // ROADMAP 2.467/2.503 — refuse while the canvas holds an UNREGISTERED import.
+  // Placed AFTER the shape guards (an unusable or empty server graph is still
+  // that, whatever the canvas holds) and BEFORE anything reads the canvas or
+  // records an identity: a refusal here must not leave `lastAuthoritativeGraph`
+  // claiming we applied a graph we deliberately did not.
+  //
+  // Derived from the store field, which is itself DERIVED at every
+  // graph-replacement site from the localStorage marker — so this covers the
+  // reload, the new tab and the scenario-load paths without a release list to
+  // keep in sync (trap 12).
+  if (store.importPendingServerRegistration) {
+    logger.warn('merge_server_graph.import_unregistered_hold', {
+      scenarioId: store.currentScenarioId ?? null,
+      canvasNodeCount: store.nodes.length,
+      serverNodeCount: rawNodes.length,
+    })
+    return refused('importUnregistered')
+  }
   const existingNodeIds = new Set(store.nodes.map((n: any) => n.id))
   const existingEdgeIds = new Set(store.edges.map((e: any) => e.id))
 

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -18,6 +18,7 @@ import { getScenario } from '../canvas/store/scenarios'
 import { buildShareLink } from '../canvas/utils/shareLink'
 import { useScenario } from '../hooks/useScenario'
 import { useServerGraphHydration } from '../canvas/hooks/useServerGraphHydration'
+import { useImportRegistration } from '../canvas/registration/useImportRegistration'
 
 const TemplatesPanel = lazy(() => import('../canvas/panels/TemplatesPanel').then(m => ({ default: m.TemplatesPanel })))
 
@@ -78,6 +79,12 @@ export default function CanvasMVP() {
   // Supabase writes, whereas this read goes through CEE, which holds the
   // service credential the browser deliberately does not have.
   useServerGraphHydration(scenarioIdFromRoute)
+
+  // ROADMAP 2.467: register a locally-imported graph with CEE so the analysis
+  // describes the model on screen. Mounted BESIDE the hydration hook on
+  // purpose — the two are the same seam read in both directions, and the
+  // hydration merge refuses while this one still has the hold armed.
+  useImportRegistration()
 
   // Track canvas opened event
   useEffect(() => {


### PR DESCRIPTION
**ROADMAP 2.467 — leg 2 of 2.** Leg 1 is `olumi-assistants-service` **#828** (the deterministic `register_graph` route). **Merge order matters: CEE first.** Until #828 is deployed this leg's registration call answers 404, which is handled as `notRegistrable` and leaves the hold armed — i.e. it degrades to exactly today's honest behaviour, never to a false affirmative.

## Plainly: what changes for a user

**Before:** import a file → the canvas shows the imported model, the server still holds the old one, and every Run analyses the old one. The interim mitigation (#592, live-witnessed 5 Aug) stopped the product *claiming* the analysis was current; it did not make the import work.

**After:** the imported graph is POSTed to CEE and becomes `scenarios.graph`. The next Run analyses **the model on screen**. The hold releases on CEE's acknowledgement and the affirmative becomes true again — earned, not asserted.

## What is in it

- **`registerScenarioGraph`** — client for CEE's new route. Base is a same-origin **literal** `/bff/cee`, pinned by a source-text test: `VITE_CEE_BFF_BASE` is dashboard-set to a **PLoT** origin and Vite inlines `import.meta.env` at build time, which is how this estate has shipped an invisible feature before. Only a 200 carrying `scenario_graph_registration.v1` counts as an acknowledgement — an SPA fallback, an unreadable body, a 503, a 409 and a 404 all leave the hold **armed**. A 409 is never retried; re-sending is the clobber CEE's CAS just refused.
- **`useImportRegistration`** — ONE hook, subscribed to `importPendingServerRegistration`, which is **derived at every graph-replacement site** from a structural localStorage marker. So it covers the ImportExportDialog, the SnapshotManager restore, the ScenarioSwitcher route **and hydrate-from-autosave after a reload or in a new tab** — row 2.483's binding design note, and the reason a per-route call site would have been the same defect with a smaller blast radius. No hand-maintained list of registration sites (trap 12).
- **`buildRegistrationGraph`** — canvas → CEE wire. Drops layout, renames `observedState` → `observed_state`, signs edge strength by direction, maps `source`/`target` → `from`/`to`. **2.467c: a divergent `data.kind`/`data.type` file is REFUSED by node id, not coerced to `'factor'`** the way the legacy turn mapper does — quietly relabelling a node during a whole-graph *replace* is how screen and server diverge. Absence is resolved; disagreement is refused.
- **`releaseImportRegistration`** — the hold drops **only** on a server ack, and **only for the identity that was registered**. A session that imported two graphs and registered one keeps holding the other.
- **`ScenarioSwitcher` import** — the second import route, previously **unguarded** (it never touched `store.importCanvas`, so the hold never armed). Now marks the **reseeded** graph the scenario actually holds, before `loadScenario` derives the flag.
- **ROADMAP 2.503 acceptance case** — `mergeServerGraphOnHydrate` refuses under an armed hold. Deliberately a **window, not a new merge rule**: server-wins is correct once the server holds the graph, and destructive only before it does, so the refusal ends at the acknowledgement. Cause and symptom close together, which is why the row said not to patch the boot merge standalone.

## Evidence

**Fixture provenance:** `walk-import-modified.canvas.json` and `walk-export-original.canvas.json` are **byte copies** of the walk's own files (`PHASE0-EVIDENCE-2026-07-28/walk-p0-witness-raw/`). Nothing about the canvas shape was written by this lane.

- **RED-first, measured:** with the merge refusal removed, **3 of the acceptance tests fail at pristine** — including the positive control, which reproduces the witnessed clobber (`opt_alpha` reverts from `ZZZ IMPORTED OPTION` to `Alpha Hall`). Restored → 10/10 green.
- **48 tests** across three specs. Positive control at every absence claim (trap 13, including one on the source-text read and its comment-strip). Assertions bound **by node id** (trap 19). Four discriminating pairs.
- **Mutants: 19/19 BITTEN.** Throwaway worktree at an absolute path outside the repo root, committed state only, applied-check scoped to `src/`, control exactly zero, every mutation asserted applied.
- **Two survivors settled by MEASUREMENT** (trap 13c): flipping kind precedence to `node.type ?? data.kind` survived because all three spellings agree on the captured file; deleting `'position'` from the canvas-only key list survived because that file carries `position` only at the top level (dropped structurally by never being copied), so the blocklist entry was decoration a tidy-up would have deleted. Both now have the case that discriminates them.
- **Gate at this tip:** `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) **PASSED** — coverage 3241/3281, ratchet within baseline. **124 affected test files / 2,369 tests passed, 0 failed** (registration, adapters/cee, canvas/utils, canvas/hydrate, canvas/store, `store.spec.ts` from `SMOKE_FILES`, `importCanvas.analysisInvalidation`, `ScenarioSwitcher`, model-tab). eslint on every changed file: **0 errors**. `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run.
- **One `::notice::` in the gate, investigated rather than waved through:** a diagnostic in `useConversation.ts` (a file this PR does not touch) appeared and one disappeared. **Measured with a pristine control:** same file, same `4535,15`, same `TS2345` — the message text is re-rendered because the canvas store's state type gained a field. A re-rendering, not a new error.

## NOT in this PR, and why

**Run is not refused on an unregistered graph.** The brief asked for it; the UI has **no single run-dispatch chokepoint** (NodeChip `run_analysis`, `ReanalyseBar`, the `AnalysisFooter` rerun, and CEE-emitted chips are separate surfaces). Gating some of them would be a guarantee that covers a subset — the estate's named dominant defect — so it is rowed rather than half-shipped. The honest posture already exists and is witnessed: a Run on an unregistered graph reads *"Cannot confirm whether this analysis is current."* With this PR the unregistered window is one round-trip in the normal case.

**`useConversation.ts`'s inline canvas→CEE mapper is not reused.** It builds the legacy `graph_state` field, and the live V5 turn path sends no graph at all. Coupling a new live seam to a legacy producer would make one path's coercions the other's contract. The duplication is real, disclosed in the module header, and rowed.

## What needs a REAL BROWSER — none of it is claimed here

jsdom cannot prove this class; the original defect and its mitigation both needed a browser.

1. **The headline:** import → Run → the analysis names `ZZZ IMPORTED OPTION` and **not** `Alpha Hall` (the 4 Aug FAIL frame had it 44× the other way).
2. **The 2.503 acceptance case on a real reload:** import → **F5 without saving** → the sentinel is still on the canvas. `canvasHasSentinel` was `true` at step 2 and `false` at steps 4/5 in the walk.
3. **The hold genuinely releases:** post-registration the affirmative *"Analysis reflects the current model."* returns — and is now TRUE.
4. **Registration fires on hydrate-from-autosave**, in a new tab and after a scenario-switcher load (the three derivation sites).
5. **The second import route** (`ScenarioSwitcher → importScenarioFromFile`) arms the hold and registers.
6. **Failure posture:** with CEE unreachable, the hold stays armed and the copy stays *"Cannot confirm…"* — never the affirmative.

## Pin skew (hazard 1)

UI pins `@talchain/schemas@0.34.0`, CEE **0.35.0**. This leg adds no schemas surface — the registration payload is a plain JSON body validated by CEE's own `GraphStateIngressSchema` — so the skew is not load-bearing here. It is stated rather than assumed away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)