### PR TITLE
DO-NOT-MERGE: 2.590 — import parse silently destroyed node.data fields (goal target/unit/cap and 30+ more)

### DIFF
--- a/src/canvas/domain/__tests__/importFieldSurvival.2590.spec.ts
+++ b/src/canvas/domain/__tests__/importFieldSurvival.2590.spec.ts
@@ -1,0 +1,389 @@
+/**
+ * ROADMAP 2.590 — export → import must not silently destroy node.data fields.
+ *
+ * DEFECT: `V2SnapshotSchema` (migrations.ts) parses each node's `data` with a
+ * z.discriminatedUnion of eight per-type object schemas. Zod object schemas
+ * default to `unknownKeys: 'strip'`, so EVERY field outside the ~8-13 keys each
+ * per-type schema declares is discarded on import — silently, with no error.
+ * `exportCanvas` writes them; `importCanvas` eats them.
+ *
+ * The parser discards what the renderers read. `src/canvas/nodes/GoalNode.tsx`
+ * reads `props.data?.goal_threshold_raw` / `goal_threshold_unit` /
+ * `success_threshold` / `threshold_source` — not one of which is declared by any
+ * schema in that union.
+ *
+ * ── Why THREE guards, and what each one alone cannot prove ────────────────────
+ * Trap 12d: a guard derived from a list proves the copies agree, never that the
+ * list is right. Trap 13b: a guard derived from the schema agrees with the
+ * schema and sees nothing. So:
+ *
+ *   GUARD 1 (structural, INPUT-derived) — enumerates the keys actually present
+ *     on a real export fixture and asserts every one survives, per node, BY ID.
+ *     It cannot go short, because it is derived from the data rather than from
+ *     any hand-maintained list. What it CANNOT do: notice a field the fixture
+ *     does not happen to carry (the repo's export fixtures are all PRE-analysis,
+ *     so none carries the goal threshold quad at all — which is exactly how this
+ *     defect survived `roundtrip-2463.spec.ts`).
+ *
+ *   GUARD 2 (READER-derived corpus) — the hand-written completeness check that
+ *     notices Guard 1's fixture is short. Every entry cites the reader that
+ *     depends on the field. Values are producer-shaped (trap 13c: expectations
+ *     derived from the producer, not from my reading of what a field ought to
+ *     mean) — see `backfillGoalThresholdOntoGoalNode` (applyDraftResult.ts:592)
+ *     and CEEAnalysisReady (adapters/cee/types.ts:392-397) for the goal quad.
+ *
+ *   GUARD 3 (union assertion) — `NODE_FIELD_REGISTRY` (analyticalNodeFields.ts)
+ *     is an INDEPENDENT, reader-derived register of analysis/persist-relevant
+ *     `data.*` fields. Asserting registry ⊆ round-trip-covered means a field
+ *     added there can never sit un-round-tripped: the registry growing fails
+ *     THIS test until the corpus covers it. Mirror-free — it is derived from an
+ *     importable list, not hand-copied.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { exportCanvas, importCanvas } from '../../persist'
+import { importSnapshot } from '../migrations'
+import { deepEqual } from '../analyticalChange'
+import { NODE_FIELD_REGISTRY } from '../analyticalNodeFields'
+import pristineExport from '../../__tests__/fixtures/walk582-t2b-export-pristine.json'
+
+type AnyRec = Record<string, unknown>
+
+function cloneFixture(): { nodes: any[]; edges: any[] } {
+  const f = JSON.parse(JSON.stringify(pristineExport)) as { nodes: any[]; edges: any[] }
+  return { nodes: f.nodes, edges: f.edges }
+}
+
+/** The real parse path: persist.exportCanvas → persist.importCanvas. */
+function roundTrip(state: { nodes: any[]; edges: any[] }) {
+  const json = exportCanvas(state as any)
+  const back = importCanvas(json)
+  expect(back, 'importCanvas returned null — the snapshot failed to parse at all').not.toBeNull()
+  return back!
+}
+
+function dataById(result: { nodes: any[] }, id: string): AnyRec {
+  const node = result.nodes.find((n) => n.id === id)
+  expect(node, `node ${id} missing from import result`).toBeDefined()
+  return (node!.data ?? {}) as AnyRec
+}
+
+// ---------------------------------------------------------------------------
+// GUARD 2's corpus — READER-derived. Each row cites the consumer that breaks
+// when the field does not survive. Node ids bind to walk582-t2b-export-pristine.
+// ---------------------------------------------------------------------------
+interface CorpusEntry {
+  nodeId: string
+  field: string
+  value: unknown
+  /** The reader that depends on this field surviving. */
+  reader: string
+}
+
+const READER_CORPUS: readonly CorpusEntry[] = [
+  // --- goal: the analysis-bearing quad + the user-target pair ---------------
+  {
+    nodeId: 'goal_turnout',
+    field: 'goal_threshold_raw',
+    value: 250000,
+    reader: 'canvas/nodes/GoalNode.tsx:88 · adapters/plot/httpV1Adapter.ts:385 · components/results/useResultsSectionData.ts:1355',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'goal_threshold_unit',
+    value: '£',
+    reader: 'canvas/nodes/GoalNode.tsx:90 · canvas/ui/inspector-v2/editors/GoalAdvancedEditor.tsx:22 · canvas/components/model-tab/GoalSection.tsx:79',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'goal_threshold_cap',
+    value: 312500,
+    reader: 'canvas/hooks/useV2Run.ts:191 · components/results/useResultsSectionData.ts:1332 · canvas/ui/inspector-v2/editors/GoalAdvancedEditor.tsx:23',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'goal_threshold',
+    value: 0.8,
+    reader: 'canvas/ui/inspector-v2/editors/GoalAdvancedEditor.tsx:24 · V2 adapter output',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'success_threshold',
+    value: 250000,
+    reader: 'canvas/nodes/GoalNode.tsx:86 · canvas/store.ts:1301 · canvas/components/pre-analysis-v3/selectors/computeSuccessState.ts:111',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'threshold_source',
+    value: 'user',
+    reader: 'canvas/nodes/GoalNode.tsx:85 · canvas/store.ts:1301 · canvas/components/pre-analysis/hooks/usePreAnalysisData.ts:1292',
+  },
+  // --- every kind: BaseNode is the shared wrapper for all eight renderers ---
+  {
+    nodeId: 'dec_venue',
+    field: 'flagged_as_assumption',
+    value: true,
+    reader: 'canvas/nodes/BaseNode.tsx:278 · canvas/contextMenu/actions.ts',
+  },
+  {
+    nodeId: 'out_attendance',
+    field: 'uncertainty',
+    value: 0.7,
+    reader: 'canvas/nodes/BaseNode.tsx:127 (isUncertain badge)',
+  },
+  {
+    nodeId: 'risk_logistics',
+    field: 'unknownKind',
+    value: true,
+    reader: 'canvas/nodes/BaseNode.tsx:417 → UnknownKindWarning',
+  },
+  {
+    nodeId: 'risk_logistics',
+    field: 'originalKind',
+    value: 'lever',
+    reader: 'canvas/nodes/BaseNode.tsx:417-418 · canvas/adapters/backendKinds.ts',
+  },
+  // --- factor: top-level unit outranks observedState.unit ------------------
+  {
+    nodeId: 'fac_capacity',
+    field: 'unit',
+    value: 'people',
+    reader: 'canvas/nodes/OptionNode.tsx:282,519 (`factorNode?.data?.unit ?? obs?.unit`)',
+  },
+  {
+    nodeId: 'fac_capacity',
+    field: 'state_space',
+    value: { '0': 'low', '1': 'high' },
+    reader: 'canvas/contextMenu/useMenuItems.ts:67 · canvas/ui/inspector-v2/editors/FactorControllableEditor.tsx:49',
+  },
+  // --- ephemeral-but-read session state ------------------------------------
+  {
+    nodeId: 'fac_weather',
+    field: '_baseline_snapshot',
+    value: { value: 12 },
+    reader: 'canvas/contextMenu/actions.ts:544 · canvas/store.ts:3878',
+  },
+  // --- added because GUARD 3 named them: NODE_FIELD_REGISTRY carries these
+  //     and the corpus did not cover them. That is the union assertion doing
+  //     its job on its first run, not a post-hoc addition.
+  {
+    nodeId: 'goal_turnout',
+    field: 'goalThreshold',
+    value: 0.8,
+    reader: 'canvas/store.ts:1303 (camelCase derived cache) · analyticalNodeFields NODE_FIELD_REGISTRY',
+  },
+  {
+    nodeId: 'risk_logistics',
+    field: 'probability',
+    value: 0.4,
+    reader: 'canvas/nodes/RiskNode.tsx (props.data?.probability) · RiskPanel setProbability · V2 adapter',
+  },
+  {
+    nodeId: 'risk_logistics',
+    field: 'impact',
+    value: 'high',
+    reader: 'canvas/nodes/RiskNode.tsx (props.data?.impact) · RiskPanel setImpact',
+  },
+  // --- goal cap-fallback spellings. useV2Run reads three in priority order;
+  //     stripping the fallbacks silently swallows %-unit targets (see the
+  //     comment at useV2Run.ts:243-244).
+  {
+    nodeId: 'goal_turnout',
+    field: 'threshold_cap',
+    value: 100,
+    reader: 'canvas/hooks/useV2Run.ts:192 · components/results/useResultsSectionData.ts:1333',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'scale_max',
+    value: 1000,
+    reader: 'canvas/hooks/useV2Run.ts:193 · components/results/useResultsSectionData.ts:1334',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'threshold',
+    value: 0.75,
+    reader: 'canvas/utils/editedSinceRun.ts:31 · components/results/useResultsSectionData.ts:1360',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'goal_confirmed',
+    value: true,
+    reader: 'canvas/components/pre-analysis/hooks/usePreAnalysisData.ts:1471',
+  },
+  {
+    nodeId: 'goal_turnout',
+    field: 'threshold_confirmed',
+    value: true,
+    reader: 'canvas/components/pre-analysis/hooks/usePreAnalysisData.ts:1328',
+  },
+  // --- snake_case observed state is read at the TOP level alongside the
+  //     camelCase one; only the camelCase spelling is declared.
+  {
+    nodeId: 'fac_capacity',
+    field: 'observed_state',
+    value: { value: 400, unit: 'people' },
+    reader: 'canvas/utils/observedStateHelpers.ts:39,53 · components/results/useResultsSectionData.ts:1287',
+  },
+  {
+    nodeId: 'fac_capacity',
+    field: 'uncertainty_drivers',
+    value: ['seasonality'],
+    reader: 'canvas/ui/inspector-v2/editors/FactorControllableEditor.tsx:51 (top-level read)',
+  },
+  {
+    nodeId: 'opt_alpha',
+    field: 'intervention_unit',
+    value: '%',
+    reader: 'canvas/components/InterventionDisplay.tsx:156,198,282',
+  },
+  {
+    nodeId: 'opt_beta',
+    field: 'locked',
+    value: true,
+    reader: 'canvas/store.ts:2751',
+  },
+] as const
+
+describe('2.590 — export → import must not silently destroy node.data fields', () => {
+  // -------------------------------------------------------------------------
+  // GUARD 1 — structural, derived from the INPUT. Cannot go short.
+  // -------------------------------------------------------------------------
+  describe('GUARD 1 (structural, input-derived): every key on every exported node survives, by id', () => {
+    it('preserves every data key present on a real export fixture, per node id', () => {
+      const state = cloneFixture()
+      // Plant a per-node sentinel so the guard has teeth even where the fixture
+      // itself carries only declared fields. NOT prefixed `__` — persist's
+      // deepSanitize drops `__`-prefixed keys by design.
+      for (const n of state.nodes) {
+        n.data = { ...(n.data ?? {}), rt_probe_2590: `probe:${n.id}` }
+      }
+
+      const before = new Map<string, AnyRec>(state.nodes.map((n) => [n.id, { ...(n.data as AnyRec) }]))
+      const result = roundTrip(state)
+
+      const losses: string[] = []
+      for (const [id, beforeData] of before) {
+        const afterData = dataById(result, id)
+        for (const key of Object.keys(beforeData)) {
+          if (!(key in afterData)) {
+            losses.push(`${id}.data.${key} (destroyed)`)
+          } else if (!deepEqual(afterData[key], beforeData[key])) {
+            // deepEqual (domain/analyticalChange.ts) is the repo's own
+            // key-ORDER-insensitive comparator. Order-sensitive comparison would
+            // false-alarm here: a passthrough parse emits declared keys before
+            // undeclared ones, so `observedState` comes back reordered with
+            // identical values. Order carries no meaning on node data.
+            losses.push(
+              `${id}.data.${key} (mutated: ${JSON.stringify(beforeData[key])} → ${JSON.stringify(afterData[key])})`,
+            )
+          }
+        }
+      }
+      expect(losses, `import destroyed or mutated node data:\n  ${losses.join('\n  ')}`).toEqual([])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // GUARD 2 — READER-derived corpus. This is what notices Guard 1's fixture is
+  // short: the repo's export fixtures are all pre-analysis, so none of them
+  // carries the goal threshold quad.
+  // -------------------------------------------------------------------------
+  describe('GUARD 2 (reader-derived corpus): fields real consumers read survive by exact key and value', () => {
+    it.each(READER_CORPUS)(
+      'preserves $nodeId.data.$field (read by $reader)',
+      ({ nodeId, field, value }) => {
+        const state = cloneFixture()
+        const target = state.nodes.find((n) => n.id === nodeId)
+        expect(target, `corpus node id ${nodeId} not in fixture`).toBeDefined()
+        target!.data = { ...(target!.data ?? {}), [field]: value }
+
+        const after = dataById(roundTrip(state), nodeId)
+
+        expect(field in after, `${nodeId}.data.${field} was destroyed by import`).toBe(true)
+        expect(after[field]).toEqual(value)
+      },
+    )
+
+    it('preserves the whole analysis-bearing goal quad together on goal_turnout, by exact key', () => {
+      // The measured defect: a genuine export came back as exactly
+      // {kind,label,provenance,type}. Producer shape per
+      // backfillGoalThresholdOntoGoalNode (applyDraftResult.ts:592) +
+      // CEEAnalysisReady (adapters/cee/types.ts:392-397).
+      const state = cloneFixture()
+      const goal = state.nodes.find((n) => n.id === 'goal_turnout')!
+      goal.data = {
+        ...(goal.data ?? {}),
+        goal_threshold_raw: 250000,
+        goal_threshold_unit: '£',
+        goal_threshold_cap: 312500,
+        threshold_source: 'user',
+      }
+
+      const after = dataById(roundTrip(state), 'goal_turnout')
+
+      expect(after.goal_threshold_raw).toBe(250000)
+      expect(after.goal_threshold_unit).toBe('£')
+      expect(after.goal_threshold_cap).toBe(312500)
+      expect(after.threshold_source).toBe('user')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // OVER-WIDENING CONTROL — the fix must preserve unknown keys WITHOUT
+  // weakening shape validation. Without these, "stop stripping" could silently
+  // become "accept anything", which is a worse defect than the one being fixed.
+  // -------------------------------------------------------------------------
+  describe('over-widening control: shape validation is UNCHANGED', () => {
+    it('still rejects a node whose discriminant is not a known node type', () => {
+      const state = cloneFixture()
+      // All THREE candidates must be invalid: normaliseSnapshotNodes (2.463)
+      // canonicalises from [data.kind, data.type, node.type] and would otherwise
+      // repair the discriminant from the untouched top-level ReactFlow type.
+      // (Verified: leaving node.type='decision' makes this parse succeed — that
+      // is pre-existing normaliser behaviour, unchanged by 2.590.)
+      state.nodes[0].type = 'not_a_node_type'
+      state.nodes[0].data = { ...(state.nodes[0].data as AnyRec), type: 'not_a_node_type', kind: 'not_a_node_type' }
+      expect(importCanvas(exportCanvas(state as any))).toBeNull()
+    })
+
+    it('still rejects a node missing the required label', () => {
+      const state = cloneFixture()
+      const d = { ...(state.nodes[0].data as AnyRec) }
+      delete d.label
+      state.nodes[0].data = d
+      // persist.sanitizeNodeData re-adds a label, so assert against the parser
+      // directly — this control is about the SCHEMA, not the sanitiser.
+      const raw = JSON.parse(exportCanvas(state as any))
+      raw.nodes[0].data = d
+      expect(importSnapshot(raw)).toBeNull()
+    })
+
+    it('still rejects an out-of-range typed field (utility outside -1..1)', () => {
+      const state = cloneFixture()
+      state.nodes[0].data = { ...(state.nodes[0].data as AnyRec), utility: 42 }
+      expect(importCanvas(exportCanvas(state as any))).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // GUARD 3 — union assertion against an INDEPENDENT reader-derived register.
+  // Mirror-free: derived from an importable list, never hand-copied.
+  // -------------------------------------------------------------------------
+  describe('GUARD 3 (union assertion): every analyticalNodeFields registry field is round-trip covered', () => {
+    it('registry node fields ⊆ fields this spec actually round-trips', () => {
+      const covered = new Set<string>(READER_CORPUS.map((e) => e.field))
+      // Guard 1 covers whatever the fixture carries, so count those too.
+      for (const n of (pristineExport as { nodes: any[] }).nodes) {
+        for (const k of Object.keys(n.data ?? {})) covered.add(k)
+      }
+
+      const uncovered = NODE_FIELD_REGISTRY.map((f) => f.field).filter((f) => !covered.has(f))
+      expect(
+        uncovered,
+        `analyticalNodeFields NODE_FIELD_REGISTRY grew but the 2.590 round-trip corpus did not: ` +
+          `${uncovered.join(', ')}. Add each to READER_CORPUS with the reader that depends on it.`,
+      ).toEqual([])
+    })
+  })
+})

--- a/src/canvas/domain/migrations.ts
+++ b/src/canvas/domain/migrations.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod'
-import { AnyNodeDataSchema, NodeTypeEnum } from './nodes'
+import { AnyNodeDataImportSchema, NodeTypeEnum } from './nodes'
 import { EdgeDataSchema, DEFAULT_EDGE_DATA } from './edges'
 import { captureError } from '../../lib/monitoring'
 
@@ -38,7 +38,15 @@ const V2SnapshotSchema = z.object({
     id: z.string(),
     type: z.string(),
     position: z.object({ x: z.number(), y: z.number() }),
-    data: AnyNodeDataSchema,
+    /**
+     * 2.590 — the IMPORT variant of the node-data union (permissive on
+     * undeclared keys). The strict union stripped every field outside each
+     * per-type schema's declared set, silently destroying the goal target /
+     * unit / cap and everything BaseNode reads. Shape validation, the
+     * discriminant and per-field types are unchanged; see the rationale on
+     * AnyNodeDataImportSchema in ./nodes.ts.
+     */
+    data: AnyNodeDataImportSchema,
   })),
   edges: z.array(z.object({
     id: z.string(),

--- a/src/canvas/domain/nodes.ts
+++ b/src/canvas/domain/nodes.ts
@@ -269,9 +269,12 @@ export const ConstraintNodeDataSchema = NodeDataSchema.extend({
 })
 
 /**
- * Discriminated union of all node data types
+ * The eight per-type node-data schemas, in one place. BOTH unions below are
+ * derived from this single array, so adding a node type reaches the strict
+ * union AND the migration-boundary union automatically — there is no second
+ * list to keep in sync (trap 12: derive, don't mirror).
  */
-export const AnyNodeDataSchema = z.discriminatedUnion('type', [
+const NODE_DATA_SCHEMAS = [
   GoalNodeDataSchema,
   DecisionNodeDataSchema,
   OptionNodeDataSchema,
@@ -280,7 +283,65 @@ export const AnyNodeDataSchema = z.discriminatedUnion('type', [
   OutcomeNodeDataSchema,
   ActionNodeDataSchema,
   ConstraintNodeDataSchema,
-])
+] as const
+
+/**
+ * Discriminated union of all node data types.
+ *
+ * STRICT (Zod default `unknownKeys: 'strip'`). This is the shape that backs the
+ * exported `NodeData`/`GoalNodeData`/… types and the warning-only
+ * `validateNodeData` drift check — both want a tight, fully-declared shape.
+ * Do NOT use it to parse a snapshot: see `AnyNodeDataImportSchema`.
+ */
+export const AnyNodeDataSchema = z.discriminatedUnion('type', NODE_DATA_SCHEMAS)
+
+/**
+ * ROADMAP 2.590 — the migration-boundary variant of the union above.
+ *
+ * ── The defect this exists to close ──────────────────────────────────────────
+ * `V2SnapshotSchema` (domain/migrations.ts) parsed node `data` with the STRICT
+ * union. Zod object schemas strip undeclared keys by default, so importing a
+ * real export silently destroyed every field outside the ~8-13 keys each
+ * per-type schema declares. A measured genuine export came back with
+ * `goal_mrr.data` reduced to exactly `{kind, label, provenance, type}` — target,
+ * unit and cap gone, no error anywhere. **The parser was discarding what the
+ * renderers read**: `nodes/GoalNode.tsx` reads `data.goal_threshold_raw`,
+ * `goal_threshold_unit`, `success_threshold` and `threshold_source`; not one of
+ * those is declared by any schema in the union. `nodes/BaseNode.tsx` — the
+ * shared wrapper for ALL eight renderers — reads `flagged_as_assumption`,
+ * `uncertainty`, `unknownKind` and `originalKind`, none of them declared either.
+ *
+ * ── Why permissive HERE and nowhere else ─────────────────────────────────────
+ * An import parser's job at this boundary is SHAPE VALIDATION AND MIGRATION —
+ * check the discriminant, the required fields, the version. Deciding which data
+ * fields are legitimate is not its job; the filtering was a side effect of using
+ * a strict object schema as a validator, never a designed behaviour. Every other
+ * layer of this repo already treats `node.data` as an open bag on purpose:
+ *   • `transformNodeToV2` (adapters/plot/v2/adapter.ts) uses a BLOCKLIST, and
+ *     says so — "all node.data fields pass through to PLoT EXCEPT … This ensures
+ *     V3 fields (goal_threshold_*, prior, etc.) survive without needing explicit
+ *     forwarding."
+ *   • `CanvasNodeData` (same file) declares `[key: string]: unknown`.
+ *   • `computeGraphHash` (hooks/useAutosave.ts) hashes ALL node data by default
+ *     with a small explicit ephemeral denylist.
+ *   • `ObservedStateSchema` and `EdgeDataSchema` are ALREADY `.passthrough()` —
+ *     which is precisely why nested observed state and edge data survived import
+ *     while top-level node data did not.
+ *   • UI CLAUDE.md: "Preserve unknown fields everywhere — that's how
+ *     forward-compatible data survives the version skew."
+ * The strict union was the last allowlist on an otherwise open path, and it was
+ * the only one positioned to destroy user data.
+ *
+ * Discrimination, required fields and per-field types are UNCHANGED — a node
+ * with a bad `type`, a missing `label` or an out-of-range `utility` is still
+ * rejected exactly as before. Only the silent deletion of undeclared keys stops.
+ *
+ * Round-trip survival is pinned by `__tests__/importFieldSurvival.2590.spec.ts`.
+ */
+export const AnyNodeDataImportSchema = z.discriminatedUnion(
+  'type',
+  NODE_DATA_SCHEMAS.map((schema) => schema.passthrough()) as unknown as typeof NODE_DATA_SCHEMAS,
+)
 
 export type NodeData = z.infer<typeof AnyNodeDataSchema>
 export type GoalNodeData = z.infer<typeof GoalNodeDataSchema>


### PR DESCRIPTION
## The defect

`V2SnapshotSchema` (`src/canvas/domain/migrations.ts:41`) parsed each node's `data` with `AnyNodeDataSchema` — a `z.discriminatedUnion` of eight per-type object schemas. **Zod object schemas strip undeclared keys by default**, so every field outside each per-type schema's declared set was discarded on import, silently, with no error. `exportCanvas` writes them; `importCanvas` ate them.

**The parser discarded what the renderers read.** `nodes/GoalNode.tsx` reads `data.goal_threshold_raw` (:88), `goal_threshold_unit` (:90), `success_threshold` (:86), `threshold_source` (:85) — none declared by any schema in the union. `nodes/BaseNode.tsx`, the shared wrapper for **all eight** renderers, reads `flagged_as_assumption` (:278), `uncertainty` (:127), `unknownKind`/`originalKind` (:417) — none declared either.

## Manifest (derived at SHA `c2c56040`)

Derived by **executing** the schemas (`_def.shape()` / `_def.unknownKeys`), not by reading them:

| schema | unknownKeys | declared |
|---|---|---|
| all 8 node-data schemas | **`strip`** | 8–13 keys each |
| `ObservedStateSchema` | `passthrough` | 10 |
| `EdgeDataSchema` | `passthrough` | 31 |

**The blast radius is exactly the eight top-level node-data schemas.** Nested observed state and all edge data already survived — which is why the loss looked goal-specific.

Fields READ off `node.data` in `src/` but declared by **no** schema: `goal_threshold_raw`, `goal_threshold_unit`, `goal_threshold_cap`, `goal_threshold`, `goalThreshold`, `success_threshold`, `threshold_source`, `threshold`, `threshold_cap`, `scale_max`, `goal_confirmed`, `threshold_confirmed`, `flagged_as_assumption`, `uncertainty`, `unknownKind`, `originalKind`, `unit` (on factor), `state_space`, `uncertainty_drivers` (top-level), `observed_state` (snake, top-level), `intervention_unit`, `locked`, `_baseline_snapshot`, `value`, `baseline`, `baseline_value`, `intercept`, `range`, `factorType`, `starterId`, `templateId`, `templateName`, `style`, `confidence`.

## Why the existing round-trip spec was blind

`roundtrip-2463.spec.ts` asserts a hand-picked list of fields — and **every field it names is declared** (`label`, `kind`, `category`, `observedState`, `encoding_map`, `prior`, `is_baseline`, `interventions`, …). It is a guard agreeing with the schema (trap 13b) and could never see an undeclared field destroyed. Second, independent reason: all repo export fixtures are **pre-analysis**, so none carries the goal quad at all.

## The shape chosen — (c), migration-boundary permissive parse

Adds `AnyNodeDataImportSchema`, derived from the **same array** as the strict union, so adding a node type reaches both automatically — no second list to keep in sync (trap 12).

Rejected **(a) declare every field per-type**: the hand-maintained mirror trap; ~30 declarations across all eight types, drifting silently because the failure mode is data loss under a green suite.

Rejected **(b) global `.passthrough()`**: measured the consumer list — `AnyNodeDataSchema` has exactly **one** non-test runtime consumer (`migrations.ts:41`), so "weakens validation everywhere" is largely false. But the per-type schemas back the exported `NodeData`/`GoalNodeData`… **types** and the warning-only `validateNodeData` (3 live callers: `applyPatch`, `applyDraftResult`, `mergeAppliedGraph`); passthrough would add an index signature to all of them. (c) changes only the behaviour that is wrong.

The repo already treats `node.data` as an open bag on purpose — `transformNodeToV2` uses a **blocklist** and says so ("all node.data fields pass through to PLoT EXCEPT … ensures V3 fields (`goal_threshold_*`, prior, etc.) survive"); `CanvasNodeData` declares `[key: string]: unknown`; `computeGraphHash` hashes all node data by default with a small ephemeral denylist; UI `CLAUDE.md`: "Preserve unknown fields everywhere". **The strict union was the last allowlist on an otherwise open path, and the only one positioned to destroy user data.**

Discrimination, required fields and per-field types are **unchanged** — three explicit over-widening controls pin that. Sanitisation is unaffected: `deepSanitize`/`sanitizeLabel` (persist.ts) still run on every import and recurse into the now-preserved keys.

## Guards (three, different failure modes)

1. **Structural, INPUT-derived** — every key on every node of a real export fixture survives, per node **by id**. Cannot go short: derived from the data, not a list.
2. **READER-derived corpus** — 25 rows / 25 distinct fields, each citing the consumer that breaks, values taken from the **producer** (`backfillGoalThresholdOntoGoalNode`, `CEEAnalysisReady`), asserted by exact key and value.
3. **Union assertion** — `NODE_FIELD_REGISTRY` (`analyticalNodeFields.ts`, independent and reader-derived) ⊆ round-trip-covered. **It fired on its first run** and named three fields the corpus had missed.

Guards 1 and 3 are derived; guard 2 is the hand-written corpus that notices the derived lists are short (trap 12d — ship both).

## Evidence

- **RED-first at pristine:** 16/19 failed with named signatures (`goal_turnout.data.goal_threshold_raw was destroyed by import`, …). `probability`/`impact` **passed** — they *are* declared on risk — so the spec discriminates declared vs undeclared rather than failing everything.
- **Mutants** (throwaway worktree at an absolute path outside the repo, **isolation proven by writing a sentinel** and asserting the source SHA unchanged + distinct inodes; applied-check scoped to `src/`, control exactly 0):

| mutant | result |
|---|---|
| M1 revert the fix (strict union) | **25 failed** / 6 passed |
| M2 drop `.passthrough()` | **25 failed** / 6 passed |
| M3 passthrough **only** goal | **12 failed — zero `goal_turnout` rows red** |
| M4 passthrough **all but** goal | **14 failed — only `goal_turnout` rows red** |
| M5 add uncovered field to registry | guard 3 reds, names the field |
| M6 make `label` optional | exactly the label control reds |

M3/M4 are the **discriminating pair** (trap 19): complementary and disjoint, proving every corpus row binds to its named node by identity, not to "something somewhere in the graph".

- **Named gate `npm run typecheck`:** PASSED — 2491 diagnostics, exactly at baseline, **0 new**; coverage 3248/3288 derived at this tip.
- **Affected suites:** 123 files / 1452 tests green. New spec: 31 tests.
- **CI at `fc61c910`: 13/13 checks green, zero reds** (incl. all 4 Full Test Suite shards + Summary, Production Build, TypeScript + Lint, Typecheck Gate Self-Test, Security Audit, Staging Gate). `staging` requires exactly `["Staging Gate"]`. No check named `Typecheck Drift` exists on this repo at this tip.

## Known, NOT fixed (deliberately out of scope — worth a row)

The node/edge **wrapper** objects in `V2SnapshotSchema` are also strict, so top-level node keys outside `{id,type,position,data}` and edge keys outside `{id,source,target,type,label,data}` are stripped too. Measured on real fixtures the only casualty is `selected` (transient RF state that *should* be dropped), and `sourceHandle`/`targetHandle` are currently harmless — the canvas defines **no named handles** and reads them in one place with `?? ''` fallbacks. Benign today, same mechanism.

## Scope / ownership

Touches only `src/canvas/domain/nodes.ts`, `src/canvas/domain/migrations.ts`, and the new spec. **Does not touch** the `importCanvas` action wiring, reset/hold machinery, scenario-graph hooks, `ScenarioSwitcher` or `importScenarioFromFile` (UI #599's files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
