### PR TITLE
2.581 — the downside tail was never lost; two controls are both called "Expert"

### DIFF
--- a/src/canvas/compare-tab/CompareTabBody.tsx
+++ b/src/canvas/compare-tab/CompareTabBody.tsx
@@ -27,11 +27,36 @@ import type { RunPair, RunPreset, Transition } from './types'
 
 interface CompareTabBodyProps {
   onRunAnalysis: () => void
+  /**
+   * ROADMAP 2.581 — THE PRODUCT HAS ONE EXPERT MODE, AND THIS TAB DOES NOT
+   * OWN IT.
+   *
+   * Until this change there were TWO independent expert states: OutputsDock's
+   * (`olumi.expertMode`, `'true'`/`'false'`, the one that gates the Results
+   * option cards' range bar, downside tail and tail caveat) and this tab's own
+   * `useState` behind `feature.compareExpert` (`'1'`/`'0'`). Different keys,
+   * different encodings, no relationship — and this tab's pill was the ONLY
+   * control in the product whose visible text read "Expert". The Results
+   * control is an unlabelled `</>` glyph.
+   *
+   * That is not a hypothetical. It is the measured cause of the 2.581 report:
+   * `expert-session-2026-08-05-raw/run5/driver.log` shows Compare clicked at
+   * 16:02:54, the button matching /^Expert$/i (this pill) at 16:02:57, then
+   * the Analysis tab at 16:02:59 — `</>` never touched. The Results panel
+   * stayed in simple mode, so the entire ExpertBlock (range bar AND tail AND
+   * caveat) never mounted, while the run's own payload carried the complete
+   * downside object for all five options. The tester reasonably read that as
+   * the feature being unreliable.
+   *
+   * CONTROLLED, not merely re-keyed. The state is hoisted to OutputsDock — the
+   * single owner — so there is no second copy to drift (trap 12: the fix for a
+   * mirror is to delete it, not to synchronise it).
+   */
+  expertMode: boolean
+  onToggleExpert: (value: boolean) => void
 }
 
-const EXPERT_STORAGE_KEY = 'feature.compareExpert'
-
-export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
+export function CompareTabBody({ onRunAnalysis, expertMode, onToggleExpert }: CompareTabBodyProps) {
   // ROADMAP 2.113a slice 1: seed the journey from PERSISTED `run_analysis`
   // facts. The session capture gate (canvas/store.ts `resultsComplete`)
   // requires a `rawV2Response`, and the deployed V5 results-hydration path
@@ -60,14 +85,10 @@ export function CompareTabBody({ onRunAnalysis }: CompareTabBodyProps) {
    * choice the user could still get back. `pair` below is the resolved value.
    */
   const [requestedPair, setRequestedPair] = useState<RunPair | null>(null)
-  const [showExpert, setShowExpert] = useState(() => {
-    try { return localStorage.getItem(EXPERT_STORAGE_KEY) === '1' } catch { return false }
-  })
-
-  const handleToggleExpert = useCallback((val: boolean) => {
-    setShowExpert(val)
-    try { localStorage.setItem(EXPERT_STORAGE_KEY, val ? '1' : '0') } catch { /* */ }
-  }, [])
+  // 2.581 — the product's single expert mode, owned by OutputsDock. No local
+  // state and no storage key here: a second copy is the defect.
+  const showExpert = expertMode
+  const handleToggleExpert = onToggleExpert
 
   // State machine
   const compareState = useMemo(

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.freshness.spec.tsx
@@ -61,34 +61,34 @@ beforeEach(() => {
 describe('CompareTabBody — freshness drives the stale compare state (CEE-sourced)', () => {
   it('CEE stale verdict → compareState "stale"', () => {
     mockCanvasState.analysisFreshness = { freshness: 'stale' }
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(stateText()).toBe('stale')
   })
 
   it('fresh verdict dirtied by a local edit (changed) → compareState "stale"', () => {
     mockCanvasState.analysisFreshness = { freshness: 'fresh' }
     mockCanvasState.analysisFreshnessDirty = true
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(stateText()).toBe('stale')
   })
 
   it('CEE-sourced unknown (cannot-confirm) → NOT "stale" (no fabrication)', () => {
     mockCanvasState.analysisFreshness = { freshness: 'unknown' }
     mockCanvasState.analysisFreshnessDirty = true
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(stateText()).not.toBe('stale')
   })
 
   it('confirmed-fresh verdict (clean) → NOT "stale"', () => {
     mockCanvasState.analysisFreshness = { freshness: 'fresh' }
     mockCanvasState.analysisFreshnessDirty = false
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(stateText()).not.toBe('stale')
   })
 
   it('no freshness verdict (null) → NOT "stale"', () => {
     mockCanvasState.analysisFreshness = null
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(stateText()).not.toBe('stale')
   })
 })

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.oneExpertMode.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.oneExpertMode.spec.tsx
@@ -1,0 +1,142 @@
+/**
+ * ROADMAP 2.581 — THE PRODUCT HAS EXACTLY ONE EXPERT MODE.
+ *
+ * ## The measured failure this exists to make impossible
+ *
+ * The 2.581 report — "the downside tail renders in one expert session and not
+ * in another, on the same builds" — was not a producer defect. The failing
+ * session's own `/proxy/v5/turn` payload carried the complete
+ * `downside{cvar_10, p05, expected_regret}` block for all five options
+ * (`expert-session-2026-08-05-raw/run5/wire.json`, entry 14). What differed
+ * was which "Expert" control had been pressed.
+ *
+ * Until this change the product shipped TWO unrelated expert states:
+ *
+ *   · `OutputsDock` — `olumi.expertMode`, `'true'`/`'false'`. This is the one
+ *     that gates the Results option cards' range bar, downside tail and tail
+ *     caveat. Its control is an unlabelled `</>` glyph (its accessible name is
+ *     "Enable expert mode"; its VISIBLE text is `</>`).
+ *   · `CompareTabBody` — a local `useState` behind `feature.compareExpert`,
+ *     `'1'`/`'0'`, scoped to the Refinement-journey tab. Its control was the
+ *     ONLY thing in the product whose visible text read "Expert".
+ *
+ * `run5/driver.log`: Compare clicked 16:02:54 → the button matching
+ * `/^Expert$/i` clicked 16:02:57 → Analysis tab 16:02:59. `</>` never touched.
+ * A reader who goes looking for expert mode finds the word, presses it, and
+ * gets a different mode from the one they were looking for — with nothing on
+ * screen to say so.
+ *
+ * ## Why the fix is a DELETION and not a synchronisation
+ *
+ * Two states kept in step is a hand-maintained mirror, and a mirror drifts
+ * silently (trap 12). So the second state is gone: `CompareTabBody` is now a
+ * controlled consumer of the single `OutputsDock` state, and the
+ * `feature.compareExpert` key no longer exists. The tests below pin BOTH the
+ * controlled-ness (behaviour) and the absence of a second key (a derived
+ * drift alarm that fails loud rather than assuming good).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { TabHeader } from '../TabHeader'
+
+const ROOT = path.resolve(__dirname, '../../../..')
+
+/**
+ * Every non-test source file, enumerated from disk so the sweep cannot go
+ * stale as files are added — the completeness problem a hand-listed manifest
+ * has and a derived one does not.
+ */
+function sourceFiles(): string[] {
+  const out: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') continue
+        walk(p)
+      } else if (/\.tsx?$/.test(entry.name) && !/\.spec\.tsx?$/.test(entry.name)) {
+        out.push(p)
+      }
+    }
+  }
+  walk(path.join(ROOT, 'src'))
+  return out
+}
+
+describe('2.581 — one expert mode, one storage key', () => {
+  it('the Compare pill is CONTROLLED: pressing it reports up and changes nothing on its own', () => {
+    const onToggleExpert = vi.fn()
+    const { rerender } = render(
+      <TabHeader showExpert={false} onToggleExpert={onToggleExpert} />,
+    )
+
+    const pill = screen.getByRole('button', { name: /expert/i })
+    // Identity: this is the control whose visible text is the word a reader
+    // searches for. If that text moves, this suite must be re-pointed rather
+    // than silently start testing a different button.
+    expect(pill.textContent).toContain('Expert')
+
+    pill.click()
+    expect(onToggleExpert).toHaveBeenCalledTimes(1)
+    expect(onToggleExpert).toHaveBeenCalledWith(true)
+
+    // The owner did not update, so the pill must NOT have flipped itself.
+    // A component that re-grew its own state would show the pressed styling
+    // here without anyone having granted it.
+    expect(pill.className).not.toMatch(/bg-info\/10/)
+
+    // And when the owner DOES grant it, the pressed styling appears — the
+    // positive control that proves the assertion above can see the difference.
+    rerender(<TabHeader showExpert onToggleExpert={onToggleExpert} />)
+    expect(screen.getByRole('button', { name: /expert/i }).className).toMatch(/bg-info\/10/)
+  })
+
+  it('CompareTabBody owns no expert state and no storage key of its own', () => {
+    const source = fs.readFileSync(
+      path.join(ROOT, 'src/canvas/compare-tab/CompareTabBody.tsx'),
+      'utf-8',
+    )
+    // Required props, not optional-with-a-default: a default would silently
+    // reintroduce a second behaviour at any call site that forgot to pass it.
+    expect(source).toMatch(/expertMode:\s*boolean/)
+    expect(source).toMatch(/onToggleExpert:\s*\(value:\s*boolean\)\s*=>\s*void/)
+    // The deleted key stays deleted. Comments are stripped first so the
+    // historical account of the defect, which necessarily names the key,
+    // cannot satisfy or defeat this assertion.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+    expect(code).not.toContain('feature.compareExpert')
+    expect(code).not.toMatch(/useState[^\n]*[Ss]howExpert/)
+  })
+
+  it('OutputsDock passes its single expert state down to the Compare tab', () => {
+    const source = fs.readFileSync(
+      path.join(ROOT, 'src/canvas/components/OutputsDock.tsx'),
+      'utf-8',
+    )
+    expect(source).toMatch(
+      /<CompareTabBodyV2[\s\S]{0,300}?expertMode=\{expertMode\}[\s\S]{0,300}?onToggleExpert=\{setExpertMode\}/,
+    )
+  })
+
+  it('exactly ONE expert-mode storage key exists across all non-test source', () => {
+    const keys = new Set<string>()
+    for (const file of sourceFiles()) {
+      const text = fs.readFileSync(file, 'utf-8')
+      // Strip comments before scanning: this file's own prose, and
+      // CompareTabBody's, name the retired key on purpose.
+      const code = text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+      for (const m of code.matchAll(/['"`]([A-Za-z0-9_.-]*[Ee]xpert[A-Za-z0-9_.-]*)['"`]/g)) {
+        // Only string literals that look like a persisted key (dotted
+        // namespace), not copy, class names or aria labels.
+        if (m[1].includes('.')) keys.add(m[1])
+      }
+    }
+    // POSITIVE CONTROL: the sweep must be able to SEE the key that does exist,
+    // or "exactly one" would be satisfied by a scan that found nothing.
+    expect(keys, 'the sweep must see the real key').toContain('olumi.expertMode')
+    expect([...keys].sort()).toEqual(['olumi.expertMode'])
+  })
+})

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.oneExpertMode.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.oneExpertMode.spec.tsx
@@ -1,5 +1,35 @@
 /**
- * ROADMAP 2.581 — THE PRODUCT HAS EXACTLY ONE EXPERT MODE.
+ * ROADMAP 2.581 — THE RESULTS SURFACE HAS EXACTLY ONE EXPERT MODE, AND THE
+ * PRODUCT HAS EXACTLY TWO.
+ *
+ * ⚠ AN EARLIER VERSION OF THIS FILE CLAIMED "THE PRODUCT HAS EXACTLY ONE
+ * EXPERT MODE", AND ITS LAST TEST CLAIMED "exactly ONE expert-mode storage key
+ * exists across all non-test source". **Both were false as written**, and the
+ * test passed only because its sweep matched on the WORD "expert" in a key
+ * NAME. There is a third mode — the second surviving one — which the sweep was
+ * structurally unable to see:
+ *
+ *   · `canvasStore.viewMode`, persisted at `sessionStorage['canvas.viewMode']`,
+ *     typed `'standard' | 'expert'` (`canvas/store.ts:669`, read at `:1709`,
+ *     written at `:4992`). Its controls are labelled **"Detailed"/"Standard"**
+ *     — the LeftSidebar eye toggle (`components/layout/LeftSidebar.tsx:158`,
+ *     accessible name "Detailed view"/"Standard view") and the canvas context
+ *     menu item "Switch to Detailed"/"Switch to Standard"
+ *     (`canvas/contextMenu/useMenuItems.ts:222`). It gates canvas NODE detail
+ *     (`nodes/*.tsx`'s `isDetailed`), post-analysis node filtering
+ *     (`ReactFlowGraph.tsx:340`) and edge-label visibility — **it does not gate
+ *     the downside tail, the range bar or the tail caveat.**
+ *
+ * The key is named for its VALUES, not for the word, so a name-based sweep is
+ * blind to it. This file now sweeps BOTH ways (see the last two tests), and
+ * the claim it makes is the true one: **two expert-bearing persisted modes
+ * exist; exactly one of them reaches the Results option cards.** That the
+ * canvas mode does not reach them is pinned behaviourally, on the real mount
+ * path, in `components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx`.
+ *
+ * This correction matters for the row's own thesis: 2.581 was reported because
+ * a reader pressed a control that says "Expert" and got a different mode. A
+ * document that then under-counts the modes is the same defect in the record.
  *
  * ## The measured failure this exists to make impossible
  *
@@ -66,7 +96,28 @@ function sourceFiles(): string[] {
   return out
 }
 
-describe('2.581 — one expert mode, one storage key', () => {
+/**
+ * Every persisted key in non-test source, with the character offset of each
+ * occurrence — so a caller can ask a question about a key's NEIGHBOURHOOD
+ * rather than only about its name.
+ */
+function persistedKeyOccurrences(): Array<{ key: string; file: string; code: string; at: number }> {
+  const out: Array<{ key: string; file: string; code: string; at: number }> = []
+  for (const file of sourceFiles()) {
+    const code = fs
+      .readFileSync(file, 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+    for (const m of code.matchAll(
+      /(?:local|session)Storage\.(?:get|set|remove)Item\(\s*['"`]([A-Za-z0-9_.:-]+)['"`]/g,
+    )) {
+      out.push({ key: m[1], file, code, at: m.index ?? 0 })
+    }
+  }
+  return out
+}
+
+describe('2.581 — the expert modes, counted both ways', () => {
   it('the Compare pill is CONTROLLED: pressing it reports up and changes nothing on its own', () => {
     const onToggleExpert = vi.fn()
     const { rerender } = render(
@@ -121,7 +172,7 @@ describe('2.581 — one expert mode, one storage key', () => {
     )
   })
 
-  it('exactly ONE expert-mode storage key exists across all non-test source', () => {
+  it('exactly ONE storage key is NAMED for expert mode — sweeping by name', () => {
     const keys = new Set<string>()
     for (const file of sourceFiles()) {
       const text = fs.readFileSync(file, 'utf-8')
@@ -138,5 +189,74 @@ describe('2.581 — one expert mode, one storage key', () => {
     // or "exactly one" would be satisfied by a scan that found nothing.
     expect(keys, 'the sweep must see the real key').toContain('olumi.expertMode')
     expect([...keys].sort()).toEqual(['olumi.expertMode'])
+    // ⚠ AND THIS IS THE WHOLE CLAIM — no more. `canvas.viewMode` stores the
+    // VALUE 'expert' and is invisible here by construction. The next test is
+    // what notices it; deleting either leaves a whole class unobserved.
+  })
+
+  it('exactly TWO persisted modes can hold the VALUE "expert" — sweeping by value, which is what the name sweep cannot see', () => {
+    // A key is expert-BEARING if the literal 'expert' appears in its immediate
+    // neighbourhood — i.e. it is written from, compared against, or typed as a
+    // union containing that value. Naming-independent, so it catches a mode
+    // that never spells the word in its key.
+    //
+    // WINDOW, and why this number: measured across all 34 persisted keys in
+    // non-test source at 120 / 200 / 400 characters, every window returns the
+    // SAME single key. 200 is therefore not a tuned threshold sitting on a
+    // cliff edge — it is the middle of a plateau, and the two `canvas.viewMode`
+    // sites (`store.ts:1709` reading inside a `(): 'standard' | 'expert' =>`
+    // initialiser, `:4992` writing `mode`) are both inside it.
+    const WINDOW = 200
+    const valueBorne = new Set<string>()
+    for (const { key, code, at } of persistedKeyOccurrences()) {
+      const near = code.slice(Math.max(0, at - WINDOW), at + WINDOW)
+      if (/['"`]expert['"`]/.test(near)) valueBorne.add(key)
+    }
+
+    // POSITIVE CONTROL, and the correction of this file's original claim: the
+    // sweep must SEE the mode the name sweep is blind to, or "exactly two"
+    // would be satisfied by a scan that found nothing.
+    expect(
+      valueBorne,
+      'the value sweep must see canvas.viewMode — if this fails the sweep is broken, not the product',
+    ).toContain('canvas.viewMode')
+
+    // The full manifest of expert-bearing persisted modes: the name sweep's
+    // one key, unioned with the value sweep's one key. HAND-PINNED, because a
+    // derived guard proves the copies agree and can never notice the list is
+    // short (trap 12d) — this line is what a reviewer reads to learn how many
+    // expert modes the product has.
+    const allExpertModes = new Set<string>([...valueBorne, 'olumi.expertMode'])
+    expect([...allExpertModes].sort()).toEqual(['canvas.viewMode', 'olumi.expertMode'])
+  })
+
+  it('the second mode is a CANVAS-DETAIL mode: the Results option cards never read it', () => {
+    // Scope, stated by consumer. `canvas.viewMode` is read by canvas node
+    // renderers, the post-analysis node filter and edge-label visibility. It
+    // is NOT read anywhere under `src/components/results`, which is where the
+    // range bar, the downside tail and the tail caveat live — so pressing
+    // "Detailed" can never reveal or hide them. (The behavioural proof, on the
+    // real mount path, is in ResultsBody.downsideTailMountPath.spec.tsx; this
+    // is the structural one that fails the moment a results file starts
+    // reading it.)
+    const offenders = sourceFiles()
+      .filter((f) => f.includes(`${path.sep}components${path.sep}results${path.sep}`))
+      .filter((f) => {
+        const code = fs
+          .readFileSync(f, 'utf-8')
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .replace(/^\s*\/\/.*$/gm, '')
+        return /\bviewMode\b/.test(code) || code.includes('canvas.viewMode')
+      })
+      .map((f) => path.relative(ROOT, f))
+
+    // POSITIVE CONTROL: the sweep must actually be looking at files. A filter
+    // that matched nothing would make the emptiness above meaningless.
+    expect(
+      sourceFiles().filter((f) => f.includes(`${path.sep}components${path.sep}results${path.sep}`))
+        .length,
+      'the results-surface file sweep must find files to look at',
+    ).toBeGreaterThan(20)
+    expect(offenders).toEqual([])
   })
 })

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.persistedHydration.spec.tsx
@@ -121,7 +121,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
       }),
     ])
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     // POSITIVE CONTROL: real content, from rows, not "no error".
     expect(await screen.findByTestId('compare-hero')).toBeTruthy()
@@ -149,7 +149,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
       makePersistedRunFactRow({ id: 'f3', createdAt: '2026-07-20T12:00:00.000Z', responseHash: 'h3' }),
     ])
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     await waitFor(() => {
       expect(useAnalysisSnapshotStore.getState().snapshots).toHaveLength(3)
@@ -162,7 +162,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
   it('GUEST UNCHANGED: no signed-in session ⇒ no read attempted, existing empty state, never an error', async () => {
     getSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     await waitFor(() => expect(getSessionIdentity).toHaveBeenCalled())
     expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()
@@ -174,7 +174,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
   it('an owner whose scenario has no persisted runs sees the SAME empty state', async () => {
     listPersistedAnalysisRuns.mockResolvedValue([])
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     await waitFor(() => expect(listPersistedAnalysisRuns).toHaveBeenCalled())
     expect(emptyState()).toBeTruthy()
@@ -186,7 +186,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
       new Error('permission denied for table v5_handler_facts'),
     )
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     await waitFor(() => expect(listPersistedAnalysisRuns).toHaveBeenCalled())
     expect(emptyState()).toBeTruthy()
@@ -209,7 +209,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
 
     render(
       <StrictMode>
-        <CompareTabBody onRunAnalysis={vi.fn()} />
+        <CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />
       </StrictMode>,
     )
 
@@ -222,7 +222,7 @@ describe('Compare tab hydrates from persisted analysis runs (2.113a slice 1)', (
   it('a guest scenario id of null makes no read at all', async () => {
     mockCanvasState.currentScenarioId = null
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
 
     await waitFor(() => expect(emptyState()).toBeTruthy())
     expect(getSessionIdentity).not.toHaveBeenCalled()

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
@@ -94,7 +94,7 @@ const run = (
 
 async function renderWithRuns(rows: unknown[]) {
   listPersistedAnalysisRuns.mockResolvedValue(rows)
-  render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+  render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
   await waitFor(() => {
     expect(useAnalysisSnapshotStore.getState().snapshots.length).toBe(rows.length)
   })
@@ -297,7 +297,7 @@ describe('pick-two-runs side-by-side (2.113a slice 2)', () => {
   it('GUEST UNCHANGED: no session ⇒ no read, no picker, no side-by-side, no error', async () => {
     getSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
 
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     await waitFor(() => expect(getSessionIdentity).toHaveBeenCalled())
 
     expect(listPersistedAnalysisRuns).not.toHaveBeenCalled()

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.rerunProp.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.rerunProp.spec.tsx
@@ -26,7 +26,10 @@ describe('CompareTabBody rerun prop wiring (correction 5)', () => {
       path.join(ROOT, 'src/canvas/components/OutputsDock.tsx'),
       'utf-8',
     )
-    expect(source).toContain('<CompareTabBodyV2 onRunAnalysis={handleRunAnalysis} />')
+    // ROADMAP 2.581 reshaped this mount from a single-prop self-closing tag to
+    // a multi-line element (expert mode is now owned by OutputsDock and passed
+    // down), so the pin is on the wiring rather than on one line's whitespace.
+    expect(source).toMatch(/<CompareTabBodyV2[\s\S]{0,200}?onRunAnalysis=\{handleRunAnalysis\}/)
   })
 
   it('CompareTabBody.onRunAnalysis prop signature is still a single callback', () => {

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.runState.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.runState.spec.tsx
@@ -86,7 +86,7 @@ beforeEach(() => {
 
 describe('F9: CompareTabBody run-state coverage', () => {
   it('positive control: idle with no snapshots shows the empty state and no run treatment', () => {
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(screen.getByTestId('compare-empty-state')).toBeInTheDocument()
     expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
     expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
@@ -94,7 +94,7 @@ describe('F9: CompareTabBody run-state coverage', () => {
 
   it('run in flight with nothing retained: skeleton replaces the empty state', () => {
     setRun('streaming', Date.now())
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(screen.getByTestId('analysis-run-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('compare-empty-state')).not.toBeInTheDocument()
   })
@@ -102,7 +102,7 @@ describe('F9: CompareTabBody run-state coverage', () => {
   it('run in flight with snapshots retained: banner above content, content marked busy, never blanked', () => {
     mockSnapshots = TWO_SNAPSHOTS
     setRun('streaming', Date.now())
-    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(screen.getByTestId('analysis-running-banner')).toBeInTheDocument()
     expect(screen.getByTestId('compare-content')).toBeInTheDocument()
     expect(container.querySelector('[aria-busy="true"]')).not.toBeNull()
@@ -112,7 +112,7 @@ describe('F9: CompareTabBody run-state coverage', () => {
   it('settle: the treatment is gone and retained content is unmarked', () => {
     mockSnapshots = TWO_SNAPSHOTS
     setRun('complete')
-    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(screen.queryByTestId('analysis-running-banner')).not.toBeInTheDocument()
     expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
     expect(screen.getByTestId('compare-content')).toBeInTheDocument()
@@ -121,7 +121,7 @@ describe('F9: CompareTabBody run-state coverage', () => {
 
   it('error with nothing retained: honest empty state, never skeleton-forever', () => {
     setRun('error')
-    render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(screen.queryByTestId('analysis-run-skeleton')).not.toBeInTheDocument()
     expect(screen.getByTestId('compare-empty-state')).toBeInTheDocument()
   })
@@ -129,7 +129,7 @@ describe('F9: CompareTabBody run-state coverage', () => {
   it('contributes no aria-live region of its own (the dock announcer is the single voice)', () => {
     mockSnapshots = TWO_SNAPSHOTS
     setRun('streaming', Date.now())
-    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} />)
+    const { container } = render(<CompareTabBody onRunAnalysis={vi.fn()} expertMode={false} onToggleExpert={vi.fn()} />)
     expect(container.querySelectorAll('[aria-live]')).toHaveLength(0)
   })
 })

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.v5GuestSession.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.v5GuestSession.spec.tsx
@@ -91,7 +91,7 @@ describe('ROADMAP 2.350 — guest, two runs in one session, Compare tab', () => 
   // gone" assertions would be passing for the wrong reason.
   it('CONTROL: with ONE run the guest still sees the empty state and no pickers', () => {
     applyTurn(runA)
-    render(<CompareTabBody onRunAnalysis={() => {}} />)
+    render(<CompareTabBody onRunAnalysis={() => {}} expertMode={false} onToggleExpert={() => {}} />)
 
     expect(screen.getByTestId('compare-empty-state')).toBeTruthy()
     expect(screen.getByText(EMPTY_STATE_COPY)).toBeTruthy()
@@ -104,7 +104,7 @@ describe('ROADMAP 2.350 — guest, two runs in one session, Compare tab', () => 
     applyTurn(runA)
     applyTurn(runB)
 
-    render(<CompareTabBody onRunAnalysis={() => {}} />)
+    render(<CompareTabBody onRunAnalysis={() => {}} expertMode={false} onToggleExpert={() => {}} />)
 
     // The `Pick two runs` preset is what mounts the pair picker
     // (RunSelector.tsx:73); the tab opens on `prev`.
@@ -126,7 +126,7 @@ describe('ROADMAP 2.350 — guest, two runs in one session, Compare tab', () => 
     applyTurn(runA)
     applyTurn(runB)
 
-    render(<CompareTabBody onRunAnalysis={() => {}} />)
+    render(<CompareTabBody onRunAnalysis={() => {}} expertMode={false} onToggleExpert={() => {}} />)
     fireEvent.click(screen.getByText('Pick two runs'))
 
     const captured = useAnalysisSnapshotStore.getState().snapshots
@@ -160,7 +160,7 @@ describe('ROADMAP 2.350 — guest, two runs in one session, Compare tab', () => 
     applyTurn(runA)
     applyTurn(runB)
 
-    render(<CompareTabBody onRunAnalysis={() => {}} />)
+    render(<CompareTabBody onRunAnalysis={() => {}} expertMode={false} onToggleExpert={() => {}} />)
 
     expect(screen.queryByTestId('compare-empty-state')).toBeNull()
     expect(screen.queryByText(EMPTY_STATE_COPY)).toBeNull()

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2548,7 +2548,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
               </div>
             )}
             {effectiveActiveTab === 'compare' && (
-              <CompareTabBodyV2 onRunAnalysis={handleRunAnalysis} />
+              // 2.581 — ONE expert mode for the product. The Compare pill used
+              // to own a separate `feature.compareExpert` state, so the only
+              // control in the UI whose visible text says "Expert" turned on a
+              // different thing from the `</>` toggle beside it — the measured
+              // cause of the "downside tail is scenario-dependent" report.
+              <CompareTabBodyV2
+                onRunAnalysis={handleRunAnalysis}
+                expertMode={expertMode}
+                onToggleExpert={setExpertMode}
+              />
             )}
             {effectiveActiveTab === 'diagnostics' && (
               <ModelTabBody

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -46,6 +46,7 @@ import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
 import {
   DOWNSIDE_HEADING_COPY,
   DOWNSIDE_TAIL_CAVEAT_COPY,
+  DOWNSIDE_UNAVAILABLE_COPY,
   downsideSummaryCopy,
 } from './utils/downsideCopy'
 import { formatRangeValue } from './utils/formatRangeValue'
@@ -834,11 +835,15 @@ function OptionCard({
               Progressive disclosure (P5) — depth for the reader who asked for
               depth, nothing added to the default card.
 
-              HONEST ABSENCE: `option.downside` is undefined whenever the
-              engine could not compute the block honestly, and this renders
-              NOTHING in that case — no zero, no dash, no "not available".
-              A zero here would read as "there is no downside", which is the
-              most damaging thing this surface could say.
+              HONEST ABSENCE — ⚠ AMENDED BY ROADMAP 2.581. `option.downside` is
+              undefined whenever the engine could not compute the block
+              honestly. This used to render NOTHING in that case. It now
+              renders a STATED absence (`DOWNSIDE_UNAVAILABLE_COPY`) and still
+              never a number: a zero here would read as "there is no downside",
+              which is the most damaging thing this surface could say, but
+              silence is what let 2.581 be reported as the feature "appearing
+              in some sessions and not others". A reader who asked for depth
+              and cannot have it is told so.
 
               ⛔ `downside.expectedRegret` is deliberately NOT rendered. It is
               the per-option limb of the value-of-information family (the
@@ -847,7 +852,7 @@ function OptionCard({
               magnitudes there — the same doctrine that removed the EVPI
               percentage-point pill from TriageCard. Showing it is a doctrine
               ruling, not a wiring gap. */}
-          {option.downside !== undefined && (
+          {option.downside !== undefined ? (
             <div className="mt-1" data-testid={`option-downside-${option.id}`}>
               <p className={`${typography.panelMeta} text-text-light`}>
                 <span className="font-medium">{DOWNSIDE_HEADING_COPY}</span>{' '}
@@ -863,6 +868,16 @@ function OptionCard({
                 {DOWNSIDE_TAIL_CAVEAT_COPY}
               </p>
             </div>
+          ) : (
+            /* 2.581 — the stated absence. Same expert block, same option
+               identity, so a reader who opened this card for the tail learns
+               that there is not one rather than scanning a gap. */
+            <p
+              className={`${typography.panelMeta} text-text-light mt-1`}
+              data-testid={`option-downside-unavailable-${option.id}`}
+            >
+              {DOWNSIDE_UNAVAILABLE_COPY}
+            </p>
           )}
         </ExpertBlock>
       )}

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -836,14 +836,18 @@ function OptionCard({
               depth, nothing added to the default card.
 
               HONEST ABSENCE — ⚠ AMENDED BY ROADMAP 2.581. `option.downside` is
-              undefined whenever the engine could not compute the block
-              honestly. This used to render NOTHING in that case. It now
-              renders a STATED absence (`DOWNSIDE_UNAVAILABLE_COPY`) and still
-              never a number: a zero here would read as "there is no downside",
-              which is the most damaging thing this surface could say, but
-              silence is what let 2.581 be reported as the feature "appearing
-              in some sessions and not others". A reader who asked for depth
-              and cannot have it is told so.
+              undefined for reasons this component CANNOT distinguish: a
+              producer (ISL or PLoT) omitted the block with no reason on the
+              wire, OR our own `normaliseDownside` dropped a partially-arrived
+              block, OR schema-pin skew ate the field before it got here. The
+              copy therefore attributes the absence to nobody — see the long
+              note on `DOWNSIDE_UNAVAILABLE_COPY`. This used to render NOTHING
+              in that case. It now renders a STATED absence and still never a
+              number: a zero here would read as "there is no downside", which
+              is the most damaging thing this surface could say, but silence is
+              what let 2.581 be reported as the feature "appearing in some
+              sessions and not others". A reader who asked for depth and cannot
+              have it is told so.
 
               ⛔ `downside.expectedRegret` is deliberately NOT rendered. It is
               the per-option limb of the value-of-information family (the

--- a/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
@@ -97,6 +97,7 @@ import {
   downsideSummaryCopy,
 } from '../utils/downsideCopy'
 import { formatRangeValue } from '../utils/formatRangeValue'
+import { useCanvasStore } from '../../../canvas/store'
 import liveDownsideTurn from '../../../v5/__tests__/fixtures/live-analysis-turn-downside-2026-08-05.json'
 
 /**
@@ -315,6 +316,9 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
   afterEach(() => {
     cleanup()
     localStorage.removeItem('feature.analysisHeroPanel')
+    // The canvas mode is a module singleton; leaving it flipped would leak into
+    // every later file in the same worker.
+    useCanvasStore.setState({ viewMode: 'standard' })
   })
 
   // ── LAYER 1: the wire actually carried it ────────────────────────────────
@@ -433,7 +437,7 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
 
   // ── The stated absence ───────────────────────────────────────────────────
 
-  it('an option the producers omitted the tail for gets a STATED reason, while its siblings keep their values', () => {
+  it('an option arriving with no tail block gets a STATED absence, while its siblings keep their values', () => {
     const withheld = 'opt_retrofit'
     renderBody(optionsFromWire([withheld]), true)
     showAllOptions()
@@ -464,6 +468,86 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
     for (const id of FIXTURE_OPTION_IDS) {
       const line = within(cardByIdentity(id)).getByTestId(`option-downside-unavailable-${id}`)
       expect(line.textContent ?? '').not.toMatch(/[0-9]/)
+    }
+  })
+
+  it('the stated absence BLAMES NOBODY — it cannot, because three causes are indistinguishable here', () => {
+    // `option.downside === undefined` is reached by (1) a producer omitting the
+    // block with no reason on the wire, (2) our own all-or-nothing
+    // `normaliseDownside` dropping a partially-arrived block, or (3) schema-pin
+    // skew eating the field. An earlier draft said "The engine did not return
+    // one", which attributes to the producer a fault that may be ours — the
+    // exact unearned-claim failure this whole surface exists to prevent, made
+    // by the surface itself. Rendered text is asserted (not just the constant),
+    // so a regrown attribution reds here even if it arrives via a new string.
+    renderBody(optionsFromWire([...FIXTURE_OPTION_IDS]), true)
+    showAllOptions()
+    const ATTRIBUTIONS = [
+      /\bengine\b/i,
+      /\bserver\b/i,
+      /\bfailed\b/i,
+      /\berror\b/i,
+      /\bdid not return\b/i,
+      /\bcould not (?:compute|calculate)\b/i,
+    ]
+    for (const id of FIXTURE_OPTION_IDS) {
+      const text = within(cardByIdentity(id)).getByTestId(
+        `option-downside-unavailable-${id}`,
+      ).textContent ?? ''
+      // POSITIVE CONTROL: prove we are reading the real line before asserting
+      // an absence over it — an empty string would satisfy every clause below.
+      expect(text.length, `the absence line for ${id} must have text to scan`).toBeGreaterThan(20)
+      for (const pattern of ATTRIBUTIONS) {
+        expect(text, `${id}: the absence line must not attribute a cause (${pattern})`).not.toMatch(
+          pattern,
+        )
+      }
+      // ...and the honest remainder is still there: no promise about a rerun.
+      expect(text).toMatch(/whether running it again would produce one/i)
+    }
+  })
+
+  // ── The OTHER expert mode does not reach here (2.581's second half) ──────
+
+  it('the canvas "Detailed" mode is a DIFFERENT mode: canvas.viewMode="expert" reveals no tail', () => {
+    // The product has two expert-bearing persisted modes (enumerated by both
+    // sweeps in canvas/compare-tab/__tests__/CompareTabBody.oneExpertMode.spec.tsx):
+    // `olumi.expertMode` — the Results one — and `canvas.viewMode`, typed
+    // `'standard' | 'expert'`, whose controls read "Detailed"/"Standard".
+    // A reader who presses "Detailed" looking for depth must not be told the
+    // tail is unavailable, and must not be shown it either: that control has
+    // nothing to do with this surface. Binding by IDENTITY: the canvas store's
+    // own `viewMode` field is set to the same literal the canvas nodes gate on.
+    useCanvasStore.setState({ viewMode: 'expert' })
+    // Precondition PINNED in-test: if the field is ever renamed or retyped this
+    // reds here, rather than silently degrading into a test of nothing.
+    expect(useCanvasStore.getState().viewMode, 'the canvas mode must actually be set').toBe(
+      'expert',
+    )
+
+    renderBody(optionsFromWire(), false)
+    showAllOptions()
+    for (const id of FIXTURE_OPTION_IDS) {
+      const card = cardByIdentity(id)
+      expect(within(card).queryByTestId(`option-downside-${id}`)).toBeNull()
+      expect(within(card).queryByTestId(`option-downside-unavailable-${id}`)).toBeNull()
+    }
+
+    // DISCRIMINATING CONTROL: the same render with the RESULTS expert mode on
+    // does show the tail — so the emptiness above is the canvas mode failing to
+    // reach this surface, not the harness failing to render one.
+    cleanup()
+    renderBody(optionsFromWire(), true)
+    showAllOptions()
+    for (const id of FIXTURE_OPTION_IDS) {
+      expect(
+        within(cardByIdentity(id)).getByTestId(`option-downside-${id}`).textContent,
+      ).toContain(
+        downsideSummaryCopy(
+          formatRangeValue(CAPTURED_DOWNSIDE[id].p05),
+          formatRangeValue(CAPTURED_DOWNSIDE[id].cvar_10),
+        ),
+      )
     }
   })
 })

--- a/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
@@ -60,12 +60,22 @@
  *
  * Every assertion addresses a card by `option-card-<exact option id>` and
  * re-asserts that card's own label from the fixture, so no assertion can be
- * satisfied by a sibling (trap 19). Every magnitude is DERIVED by calling the
- * product's own `formatRangeValue` / `downsideSummaryCopy` on the fixture's
- * numbers rather than transcribed, so a formatter change cannot make this
- * suite pass against a display it no longer describes. Absence arms always run
- * in a tree where at least one sibling carries the surface, so the harness is
- * demonstrably able to see what it claims is missing (trap 13).
+ * satisfied by a sibling (trap 19).
+ *
+ * The MAGNITUDES are pinned by hand in `CAPTURED_DOWNSIDE` while the WORDING
+ * around them is derived by calling the product's own `formatRangeValue` /
+ * `downsideSummaryCopy`. That split is deliberate and was arrived at the hard
+ * way — see the note on `CAPTURED_DOWNSIDE`: the first version of this file
+ * derived both sides from the same helper, and a mutant that swapped two
+ * options' tail values on the wire left it entirely GREEN. Deriving the
+ * expectation from the input proves consistency and can never prove
+ * correctness (trap 12d). Pinning the numbers catches a mis-join; deriving the
+ * copy stops a formatter change leaving the suite passing against a display it
+ * no longer describes.
+ *
+ * Absence arms always run in a tree where at least one sibling carries the
+ * surface, so the harness is demonstrably able to see what it claims is
+ * missing (trap 13).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
@@ -104,6 +114,36 @@ const FIXTURE_OPTION_IDS = [
 ] as const
 
 type DownsideOnWire = { cvar_10: number; p05: number; expected_regret: number }
+
+/**
+ * ⚠ THE CAPTURE'S OWN NUMBERS, TRANSCRIBED ON PURPOSE — and this constant is
+ * the correction of a defect this suite shipped with, caught by its own
+ * mutant kit.
+ *
+ * The first version of this file derived BOTH the rendered input and the
+ * expected output from `reportDownsideByOptionId()`. Every assertion was
+ * addressed by option id, so it read as identity-bound — but a mutant that
+ * SWAPPED `opt_oven`'s and `opt_vans`' tail values on the wire left the whole
+ * suite GREEN, because the oracle moved with the input. A guard whose
+ * expectation comes from the thing it is checking agrees with itself and can
+ * never notice a mis-join (trap 13b; trap 19's value-vs-identity form).
+ *
+ * So the magnitudes are pinned here, by hand, to the historical capture — the
+ * hand-written corpus that a derived guard structurally cannot replace
+ * (trap 12d). `expected_regret` is pinned too even though it is deliberately
+ * never displayed, so a producer-side change to it is visible rather than
+ * silent.
+ *
+ * PINNED TO 2026-08-05, NEVER REFRESHED TO TRACK A CURRENT PAYLOAD. Its whole
+ * evidential value is that it is the run the tester reported as broken.
+ */
+const CAPTURED_DOWNSIDE: Record<string, DownsideOnWire> = {
+  opt_oven: { cvar_10: -0.3079481799761663, p05: -0.2887558172745903, expected_regret: 0.20736548448233388 },
+  opt_packing: { cvar_10: -0.11219224064218787, p05: -0.10250235969033479, expected_regret: 0.1090488788556412 },
+  opt_retrofit: { cvar_10: -0.061314212185777095, p05: -0.05386777652540353, expected_regret: 0.09474318805872213 },
+  opt_status_quo: { cvar_10: -0.06891378031696103, p05: -0.059642932930203396, expected_regret: 0.2383033608647882 },
+  opt_vans: { cvar_10: -0.15563313781808016, p05: -0.145890584682423, expected_regret: 0.20068539228044652 },
+}
 
 /** The capture's `analysis_result` block, verbatim. */
 function liveAnalysisBlock(): AnalysisResultBlock {
@@ -295,12 +335,16 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
 
     const mapped = reportDownsideByOptionId()
     for (const row of block.enrichment.option_comparison) {
-      expect(row.downside, `wire: ${row.option_id} must carry a downside block`).toBeDefined()
-      expect(mapped[row.option_id], `mapper: ${row.option_id} must survive to the report`).toEqual({
-        cvar_10: row.downside!.cvar_10,
-        p05: row.downside!.p05,
-        expected_regret: row.downside!.expected_regret,
-      })
+      // The wire matches the CAPTURE — an independently pinned corpus, so a
+      // payload whose tail values moved (or were swapped between options)
+      // fails here rather than sliding through as "derived and consistent".
+      expect(row.downside, `wire: ${row.option_id} must carry a downside block`).toEqual(
+        CAPTURED_DOWNSIDE[row.option_id],
+      )
+      // ...and the mapper delivers THAT option's block to THAT option's key.
+      expect(mapped[row.option_id], `mapper: ${row.option_id} must survive to the report`).toEqual(
+        CAPTURED_DOWNSIDE[row.option_id],
+      )
     }
     expect(Object.keys(mapped).sort()).toEqual([...FIXTURE_OPTION_IDS].sort())
   })
@@ -312,7 +356,7 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
     renderBody(options, true)
     showAllOptions()
 
-    const wire = reportDownsideByOptionId()
+    const wire = CAPTURED_DOWNSIDE
     for (const id of FIXTURE_OPTION_IDS) {
       const card = cardByIdentity(id)
       const surface = within(card).getByTestId(`option-downside-${id}`)
@@ -362,7 +406,7 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
     )
     showAllOptions()
 
-    const wire = reportDownsideByOptionId()
+    const wire = CAPTURED_DOWNSIDE
     for (const id of FIXTURE_OPTION_IDS) {
       const card = cardByIdentity(id)
       expect(within(card).getByTestId(`option-downside-${id}`).textContent).toContain(
@@ -403,7 +447,7 @@ describe('2.581 — the downside tail on the mount path, fed by the reported-bro
     // POSITIVE CONTROL, both directions: the siblings in the same tree still
     // carry the real surface, so the absence above is a fact about this card
     // and not about the harness.
-    const wire = reportDownsideByOptionId()
+    const wire = CAPTURED_DOWNSIDE
     for (const id of FIXTURE_OPTION_IDS) {
       if (id === withheld) continue
       const card = cardByIdentity(id)

--- a/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.downsideTailMountPath.spec.tsx
@@ -1,0 +1,425 @@
+/**
+ * ROADMAP 2.581 — THE DOWNSIDE TAIL, ON THE MOUNT PATH, FED BY THE SESSION
+ * THAT WAS REPORTED AS BROKEN.
+ *
+ * ## What was actually wrong, because it was not what the row assumed
+ *
+ * The row opened on "the downside tail is scenario-dependent on the same
+ * builds" and prescribed a typed versioned contract across every producer,
+ * on the theory that PLoT's 0.31 passthrough was losing the object.
+ *
+ * That premise is false, and this file's fixture is the refutation. The
+ * fixture IS the failing session's `/proxy/v5/turn` response, byte-for-byte
+ * (`expert-session-2026-08-05-raw/run5/wire.json`, wire entry 14) — the run
+ * whose option cards the tester opened one by one and found "no tail values
+ * and no caveat". That payload carries
+ * `blocks[0].enrichment.option_comparison[i].downside{cvar_10, p05,
+ * expected_regret}` for ALL FIVE options, with
+ * `option_comparison_status: "computed"`, `n_samples: 10000` and
+ * `validity_ratio: 1`. Nothing was lost by ISL, by PLoT, or by CEE. The tail
+ * was on the wire and never reached the reader.
+ *
+ * What differed between the tester's two sessions was the Results panel's
+ * EXPERT MODE. `OptionCards` gates the whole `ExpertBlock` — range bar AND
+ * tail AND caveat — on `expertMode`, and in the failing session it was off:
+ * `run5/driver.log` shows the harness click Compare (16:02:54), then the only
+ * button in the product whose visible text reads "Expert" (16:02:57 — the
+ * Compare tab's own pill, `compare-tab/TabHeader.tsx`), then return to the
+ * Analysis tab. The Results control is an unlabelled `</>` glyph and was never
+ * touched. The passing session's accessibility snapshot carries the string
+ * `Disable expert mode`, which `OutputsDock` renders only when `expertMode`
+ * is true. The 10th/median/90th the tester still saw comes from the V7
+ * "Likely outcome" lens, which is not expert-gated at all.
+ *
+ * ## What this file therefore pins
+ *
+ *  1. WIRE → REPORT, on the real capture. The real mapper, given the real
+ *     failing-session payload, must produce a downside for every option id at
+ *     the fixture's exact magnitudes. No hand-written payload: a fixture you
+ *     write yourself encodes your model of the producer, not the producer.
+ *
+ *  2. REPORT → PIXELS, on the MOUNT PATH. Assertions render `<ResultsBody>`
+ *     (the single production parent of `OptionCards`, ResultsBody.tsx:549) at
+ *     the DEPLOYED flag posture, not `<OptionCards>` in isolation. Row 2.491
+ *     shipped a badge dark past a full mutant kit because every instrument was
+ *     pointed at a component the deployed flags do not mount; the deployed
+ *     posture here is read off a DOM census of the same capture — run5's
+ *     button list carries `hero-lens-tab-*` (hero panel mounted) alongside
+ *     `option-card-*`, so both surfaces are live together.
+ *
+ *  3. EXPERT BEFORE **AND** AFTER THE ANALYSIS, REOPENING EVERY OPTION CARD
+ *     WITHOUT A RERUN — the row's literal acceptance gate. The "after" arm is
+ *     a rerender with the SAME data object, which is what "without a rerun"
+ *     means at this seam.
+ *
+ *  4. THE STATED ABSENCE. When the producers genuinely omit the block — which
+ *     they do, across at least five branches, all silent — the reader is told,
+ *     and is still never shown a number.
+ *
+ * ## Binding, and what would defeat it
+ *
+ * Every assertion addresses a card by `option-card-<exact option id>` and
+ * re-asserts that card's own label from the fixture, so no assertion can be
+ * satisfied by a sibling (trap 19). Every magnitude is DERIVED by calling the
+ * product's own `formatRangeValue` / `downsideSummaryCopy` on the fixture's
+ * numbers rather than transcribed, so a formatter change cannot make this
+ * suite pass against a display it no longer describes. Absence arms always run
+ * in a tree where at least one sibling carries the surface, so the harness is
+ * demonstrably able to see what it claims is missing (trap 13).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+import {
+  DOWNSIDE_HEADING_COPY,
+  DOWNSIDE_TAIL_CAVEAT_COPY,
+  DOWNSIDE_UNAVAILABLE_COPY,
+  downsideSummaryCopy,
+} from '../utils/downsideCopy'
+import { formatRangeValue } from '../utils/formatRangeValue'
+import liveDownsideTurn from '../../../v5/__tests__/fixtures/live-analysis-turn-downside-2026-08-05.json'
+
+/**
+ * The five option ids the failing session actually carried, in the payload's
+ * own order. Named here so a fixture that silently lost an option fails loudly
+ * rather than shrinking the suite (a shrunk corpus reads exactly like a green
+ * one — the collect-time failure class).
+ */
+const FIXTURE_OPTION_IDS = [
+  'opt_oven',
+  'opt_packing',
+  'opt_retrofit',
+  'opt_status_quo',
+  'opt_vans',
+] as const
+
+type DownsideOnWire = { cvar_10: number; p05: number; expected_regret: number }
+
+/** The capture's `analysis_result` block, verbatim. */
+function liveAnalysisBlock(): AnalysisResultBlock {
+  const blocks = (liveDownsideTurn as { blocks: Array<Record<string, unknown>> }).blocks
+  const analysis = blocks.find((b) => b.type === 'analysis_result')
+  if (!analysis) throw new Error('fixture no longer carries an analysis_result block')
+  return JSON.parse(JSON.stringify(analysis)) as unknown as AnalysisResultBlock
+}
+
+/** `option_id → option_label`, read from the capture. */
+function fixtureLabels(): Record<string, string> {
+  const block = liveAnalysisBlock() as unknown as {
+    enrichment: { option_comparison: Array<{ option_id: string; option_label: string }> }
+  }
+  const out: Record<string, string> = {}
+  for (const row of block.enrichment.option_comparison) out[row.option_id] = row.option_label
+  return out
+}
+
+/**
+ * LAYER 1 — the real mapper on the real capture. Everything below consumes
+ * THIS, so the rendered magnitudes trace to the wire rather than to a literal
+ * typed into a test.
+ */
+function reportDownsideByOptionId(): Record<string, DownsideOnWire> {
+  const report = mapV5AnalysisToReport(liveAnalysisBlock()) as ReturnType<
+    typeof mapV5AnalysisToReport
+  > & { option_probabilities?: Record<string, { downside?: DownsideOnWire }> }
+  const out: Record<string, DownsideOnWire> = {}
+  for (const [id, entry] of Object.entries(report.option_probabilities ?? {})) {
+    if (entry.downside) out[id] = entry.downside
+  }
+  return out
+}
+
+/**
+ * LAYER 2 input — `OptionResult`s built FROM layer 1, at the hook's unscaled
+ * decision (`scale === 1`, which is the branch the capture itself lands in:
+ * no goal threshold was set in that session, so `capValid` is false). The
+ * scaled branch is covered by `useResultsSectionData.downside.spec.ts`; this
+ * file is about whether the surface renders at all and for which cards.
+ */
+function optionsFromWire(omitDownsideFor: readonly string[] = []): OptionResult[] {
+  const downside = reportDownsideByOptionId()
+  const labels = fixtureLabels()
+  return FIXTURE_OPTION_IDS.map((id, i) => {
+    const d = downside[id]
+    const withTail = !omitDownsideFor.includes(id) && d !== undefined
+    return {
+      id,
+      label: labels[id],
+      expected: 0.1,
+      outcome: { mean: 0.1, p10: -0.2, p50: 0.05, p90: 0.3 },
+      p10: -0.2,
+      p50: 0.05,
+      p90: 0.3,
+      isRecommended: i === 0,
+      winProbability: 0.2,
+      goalProbability: undefined,
+      nValidSamples: 10000,
+      rank: i + 1,
+      ...(withTail ? { downside: { cvar10: d.cvar_10, p05: d.p05, expectedRegret: d.expected_regret } } : {}),
+    } as unknown as OptionResult
+  })
+}
+
+function makeData(options: OptionResult[]): ResultsSectionDataReturn {
+  const recommendation = {
+    recommendedOption: options[0],
+    allOptions: options,
+    goalLabel: 'Raise Operating Profit by 8% Within 18 Months',
+    goalThreshold: null,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.9,
+    robustnessLevel: 'medium',
+    isNormalised: true,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.6, robustness: 0.6, clarity: 0.6 },
+    verdict: { hasLeadingOption: true },
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'fair', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 60,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Raise Operating Profit by 8% Within 18 Months',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+/** The MOUNT PATH: OptionCards' only production parent. */
+function renderBody(options: OptionResult[], expertMode: boolean) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(options)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      expertMode={expertMode}
+    />,
+  )
+}
+
+/**
+ * Select a card by IDENTITY — the option id addresses it and the capture's own
+ * label is re-asserted, so a card carrying the right numbers under the wrong
+ * identity satisfies nothing.
+ */
+function cardByIdentity(optionId: string): HTMLElement {
+  const card = screen.getByTestId(`option-card-${optionId}`)
+  const label = fixtureLabels()[optionId]
+  expect(card.textContent, `identity: card ${optionId} must show "${label}"`).toContain(label)
+  return card
+}
+
+/**
+ * Reveal every option card — the row's "reopening every option card without a
+ * rerun". `OptionCards` collapses past the first two, which is exactly what
+ * the tester had to click through; a suite that only ever saw the top two
+ * would be reporting coverage it never had.
+ */
+function showAllOptions(): void {
+  const toggle = screen.queryByTestId('option-cards-toggle')
+  if (toggle && /show all/i.test(toggle.textContent ?? '')) fireEvent.click(toggle)
+  // Every option in the fixture must now be addressable, or the arms below
+  // would silently assert over a subset.
+  for (const id of FIXTURE_OPTION_IDS) {
+    expect(
+      screen.queryByTestId(`option-card-${id}`),
+      `all five option cards must be revealed; ${id} was not`,
+    ).not.toBeNull()
+  }
+}
+
+describe('2.581 — the downside tail on the mount path, fed by the reported-broken session', () => {
+  beforeEach(() => {
+    // Deployed posture, read from the same capture's DOM census (its button
+    // list carries `hero-lens-tab-*`). Injected through the flag system's own
+    // localStorage seam rather than a module mock, so the real predicate runs.
+    localStorage.setItem('feature.analysisHeroPanel', '1')
+  })
+  afterEach(() => {
+    cleanup()
+    localStorage.removeItem('feature.analysisHeroPanel')
+  })
+
+  // ── LAYER 1: the wire actually carried it ────────────────────────────────
+
+  it('the failing session\'s own payload yields a downside for EVERY option id, at its exact magnitudes', () => {
+    const block = liveAnalysisBlock() as unknown as {
+      enrichment: {
+        option_comparison_status: string
+        option_comparison: Array<{ option_id: string; downside?: DownsideOnWire }>
+      }
+    }
+    // The capture's own health, asserted so a future fixture swap that quietly
+    // degrades the run cannot make the rest of this suite vacuous.
+    expect(block.enrichment.option_comparison_status).toBe('computed')
+    expect(block.enrichment.option_comparison.map((r) => r.option_id)).toEqual([
+      ...FIXTURE_OPTION_IDS,
+    ])
+
+    const mapped = reportDownsideByOptionId()
+    for (const row of block.enrichment.option_comparison) {
+      expect(row.downside, `wire: ${row.option_id} must carry a downside block`).toBeDefined()
+      expect(mapped[row.option_id], `mapper: ${row.option_id} must survive to the report`).toEqual({
+        cvar_10: row.downside!.cvar_10,
+        p05: row.downside!.p05,
+        expected_regret: row.downside!.expected_regret,
+      })
+    }
+    expect(Object.keys(mapped).sort()).toEqual([...FIXTURE_OPTION_IDS].sort())
+  })
+
+  // ── LAYER 2: expert BEFORE the analysis ──────────────────────────────────
+
+  it('expert mode on at first render: every option card shows its own tail values AND the caveat', () => {
+    const options = optionsFromWire()
+    renderBody(options, true)
+    showAllOptions()
+
+    const wire = reportDownsideByOptionId()
+    for (const id of FIXTURE_OPTION_IDS) {
+      const card = cardByIdentity(id)
+      const surface = within(card).getByTestId(`option-downside-${id}`)
+      expect(surface.textContent).toContain(DOWNSIDE_HEADING_COPY)
+      // Derived from the wire through the product's own formatter — never
+      // transcribed, so a formatter change cannot leave this passing against a
+      // display it no longer describes.
+      expect(surface.textContent).toContain(
+        downsideSummaryCopy(formatRangeValue(wire[id].p05), formatRangeValue(wire[id].cvar_10)),
+      )
+      expect(
+        within(card).getByTestId(`option-downside-caveat-${id}`).textContent,
+      ).toBe(DOWNSIDE_TAIL_CAVEAT_COPY)
+      // The caveat travels WITH the values by construction — they share one
+      // conditional — so neither can arrive without the other.
+      expect(within(card).queryByTestId(`option-downside-unavailable-${id}`)).toBeNull()
+    }
+  })
+
+  // ── LAYER 2: expert AFTER the analysis, no rerun ─────────────────────────
+
+  it('expert mode switched on AFTER the analysis, with no new data, reveals the tail on every card', () => {
+    const options = optionsFromWire()
+    const data = makeData(options)
+    const { rerender } = render(
+      <ResultsBody
+        resultsSectionData={data}
+        tornadoData={{ rows: [], expectedOutcome: null }}
+        onSendMessage={() => {}}
+        expertMode={false}
+      />,
+    )
+    showAllOptions()
+    // Pre-condition, so the reveal below is provably the toggle's doing.
+    for (const id of FIXTURE_OPTION_IDS) {
+      expect(screen.queryByTestId(`option-downside-${id}`)).toBeNull()
+    }
+
+    // The SAME data object — this is what "without a rerun" means here.
+    rerender(
+      <ResultsBody
+        resultsSectionData={data}
+        tornadoData={{ rows: [], expectedOutcome: null }}
+        onSendMessage={() => {}}
+        expertMode
+      />,
+    )
+    showAllOptions()
+
+    const wire = reportDownsideByOptionId()
+    for (const id of FIXTURE_OPTION_IDS) {
+      const card = cardByIdentity(id)
+      expect(within(card).getByTestId(`option-downside-${id}`).textContent).toContain(
+        downsideSummaryCopy(formatRangeValue(wire[id].p05), formatRangeValue(wire[id].cvar_10)),
+      )
+      expect(within(card).getByTestId(`option-downside-caveat-${id}`).textContent).toBe(
+        DOWNSIDE_TAIL_CAVEAT_COPY,
+      )
+    }
+  })
+
+  // ── Simple mode stays simple (P5), and says nothing rather than lying ────
+
+  it('expert mode off: no tail surface and no absence line on any card — depth is opt-in, not withheld', () => {
+    renderBody(optionsFromWire(), false)
+    showAllOptions()
+    for (const id of FIXTURE_OPTION_IDS) {
+      const card = cardByIdentity(id)
+      expect(within(card).queryByTestId(`option-downside-${id}`)).toBeNull()
+      expect(within(card).queryByTestId(`option-downside-unavailable-${id}`)).toBeNull()
+      expect(card.textContent).not.toMatch(/worst 1 in 20/i)
+    }
+  })
+
+  // ── The stated absence ───────────────────────────────────────────────────
+
+  it('an option the producers omitted the tail for gets a STATED reason, while its siblings keep their values', () => {
+    const withheld = 'opt_retrofit'
+    renderBody(optionsFromWire([withheld]), true)
+    showAllOptions()
+
+    const withheldCard = cardByIdentity(withheld)
+    expect(within(withheldCard).queryByTestId(`option-downside-${withheld}`)).toBeNull()
+    expect(
+      within(withheldCard).getByTestId(`option-downside-unavailable-${withheld}`).textContent,
+    ).toBe(DOWNSIDE_UNAVAILABLE_COPY)
+
+    // POSITIVE CONTROL, both directions: the siblings in the same tree still
+    // carry the real surface, so the absence above is a fact about this card
+    // and not about the harness.
+    const wire = reportDownsideByOptionId()
+    for (const id of FIXTURE_OPTION_IDS) {
+      if (id === withheld) continue
+      const card = cardByIdentity(id)
+      expect(within(card).queryByTestId(`option-downside-unavailable-${id}`)).toBeNull()
+      expect(within(card).getByTestId(`option-downside-${id}`).textContent).toContain(
+        downsideSummaryCopy(formatRangeValue(wire[id].p05), formatRangeValue(wire[id].cvar_10)),
+      )
+    }
+  })
+
+  it('the stated absence contains no numeral — an absent tail must never read as a measured one', () => {
+    renderBody(optionsFromWire([...FIXTURE_OPTION_IDS]), true)
+    showAllOptions()
+    for (const id of FIXTURE_OPTION_IDS) {
+      const line = within(cardByIdentity(id)).getByTestId(`option-downside-unavailable-${id}`)
+      expect(line.textContent ?? '').not.toMatch(/[0-9]/)
+    }
+  })
+})

--- a/src/components/results/utils/downsideCopy.ts
+++ b/src/components/results/utils/downsideCopy.ts
@@ -69,30 +69,48 @@ export const DOWNSIDE_TAIL_CAVEAT_COPY =
   'Where we cut off "the worst" is a working choice we have not settled yet.'
 
 /**
- * ROADMAP 2.581 — what a reader in expert mode gets when the tail is genuinely
- * absent, instead of the silence that used to be there.
+ * ROADMAP 2.581 — what a reader in expert mode gets when the tail is absent,
+ * instead of the silence that used to be there.
  *
- * WHY IT DOES NOT NAME A CAUSE, AND WHY IT DOES NOT PROMISE A RERUN. The
- * producers omit this block across at least five distinct branches and send NO
- * reason with the omission:
+ * ── WHY IT NAMES NO CAUSE AT ALL, NOT EVEN "the engine" ──────────────────────
+ * An earlier draft of this sentence read "The engine did not return one and
+ * does not say why". That was itself an unearned claim, and it is exactly the
+ * defect this surface exists to prevent — one level up, in our own copy.
  *
- *   ISL (`DownsideV2`, enforced by `OptionResultV2._downside_requires_samples`)
- *     · `outcome.percentiles_source != 'samples'` — necessary condition unmet
- *     · the threaded pre-noise joint regret absent or non-finite
- *     · `cvar_10`/`p05` non-finite on an extreme finite population
- *   PLoT (`buildDownside`, routes/v2/numeric-egress-guards.ts)
- *     · the whole `outcome` object dropped (a required stat non-finite)
- *     · any component non-finite, or `expected_regret` negative
+ * At the point this string renders, the option's `downside` is `undefined`.
+ * **That single observation has at least three causes the UI cannot tell
+ * apart:**
  *
- * A rerun with a different seed could plausibly clear the non-finite branches
- * and cannot clear the percentiles-source one — and nothing on the wire says
- * which applied. Writing "try running it again" would therefore be a claim we
- * have not earned, which is the exact failure this whole surface exists to
- * avoid. So the sentence states the absence, states that the reason is not
- * disclosed to us, and stops. Making it able to say more is producer-side work
- * (an omission-reason channel through ISL → PLoT → CEE), not a wording choice.
+ *   1. A PRODUCER omitted the block. ISL omits it (`DownsideV2`, enforced by
+ *      `OptionResultV2._downside_requires_samples`) when
+ *      `outcome.percentiles_source != 'samples'`, when the threaded pre-noise
+ *      joint regret is absent or non-finite, or when `cvar_10`/`p05` are
+ *      non-finite. PLoT omits it (`buildDownside`,
+ *      `routes/v2/numeric-egress-guards.ts`) when the whole `outcome` object
+ *      was dropped, when any component is non-finite, or when
+ *      `expected_regret` is negative. None of these puts a reason on the wire.
+ *   2. OUR OWN MAPPER dropped it. `normaliseDownside` is all-or-nothing: a
+ *      block that arrives with one component missing or non-finite becomes
+ *      `undefined` here, indistinguishable from one that never arrived.
+ *   3. SCHEMA-PIN SKEW ate it. A consumer on an older `@talchain/schemas`
+ *      silently drops fields it does not know; this repo has lost coaching,
+ *      evidence and enrichment fields that way before.
+ *
+ * Cases 2 and 3 are OUR failures, not the engine's. Saying "the engine did not
+ * return one" would attribute a fault we have not established, and would read
+ * to the user as "the compute is flaky" when the code between the compute and
+ * their screen is an equally live suspect.
+ *
+ * ── WHY IT STILL PROMISES NOTHING ABOUT A RERUN ──────────────────────────────
+ * A rerun with a different seed could plausibly clear some non-finite branches
+ * and cannot clear the percentiles-source one — and nothing anywhere says which
+ * applied. Writing "try running it again" would be a second unearned claim. So
+ * the sentence states the absence, states that we cannot account for it, and
+ * stops. Making it able to say more is producer-side work (an omission-reason
+ * channel through ISL → PLoT → CEE) plus a mapper-side one, not a wording
+ * choice.
  *
  * CONTAINS NO NUMERAL, deliberately: see rule 3 above.
  */
 export const DOWNSIDE_UNAVAILABLE_COPY =
-  'No worst-case view for this option in this run. The engine did not return one and does not say why, so we cannot tell you whether running it again would produce one.'
+  'No worst-case view for this option in this run. We cannot tell you why, or whether running it again would produce one.'

--- a/src/components/results/utils/downsideCopy.ts
+++ b/src/components/results/utils/downsideCopy.ts
@@ -22,10 +22,23 @@
  *    claim we have not earned. {@link DOWNSIDE_TAIL_CAVEAT_COPY} is therefore
  *    NOT decoration: it ships wherever the number ships.
  *
- * 3. ABSENCE IS BLANK. There is deliberately no "no downside data" placeholder
- *    and no zero: when the engine could not compute the tail honestly, the
- *    whole surface is simply not rendered. A zero in a downside statistic does
- *    not read as "unknown" — it reads as "there is no downside".
+ * 3. ⚠ RULE 3 IS SUPERSEDED BY ROADMAP 2.581 — ABSENCE IS NOW *STATED*, AND
+ *    STILL NEVER A NUMBER. The original rule read: "ABSENCE IS BLANK. There is
+ *    deliberately no 'no downside data' placeholder and no zero: when the
+ *    engine could not compute the tail honestly, the whole surface is simply
+ *    not rendered."
+ *
+ *    The half of that rule which was right is kept and hardened: a zero, a
+ *    dash, or any other numeral in a downside statistic is forbidden, because
+ *    a zero here does not read as "unknown", it reads as "there is no
+ *    downside".
+ *
+ *    The half that was wrong is this: rendering NOTHING makes an absent tail
+ *    indistinguishable from a tail the reader simply failed to find, which is
+ *    exactly how 2.581 was reported — a depth feature that "appears in some
+ *    sessions and not others" teaches a reader not to trust the depth. So a
+ *    reader who has asked for depth and cannot have it is TOLD, in words, that
+ *    there is nothing here. See {@link DOWNSIDE_UNAVAILABLE_COPY}.
  */
 
 /** Section label for the tail-risk lines on an option card. */
@@ -54,3 +67,32 @@ export function downsideSummaryCopy(p05Display: string, cvar10Display: string): 
  */
 export const DOWNSIDE_TAIL_CAVEAT_COPY =
   'Where we cut off "the worst" is a working choice we have not settled yet.'
+
+/**
+ * ROADMAP 2.581 — what a reader in expert mode gets when the tail is genuinely
+ * absent, instead of the silence that used to be there.
+ *
+ * WHY IT DOES NOT NAME A CAUSE, AND WHY IT DOES NOT PROMISE A RERUN. The
+ * producers omit this block across at least five distinct branches and send NO
+ * reason with the omission:
+ *
+ *   ISL (`DownsideV2`, enforced by `OptionResultV2._downside_requires_samples`)
+ *     · `outcome.percentiles_source != 'samples'` — necessary condition unmet
+ *     · the threaded pre-noise joint regret absent or non-finite
+ *     · `cvar_10`/`p05` non-finite on an extreme finite population
+ *   PLoT (`buildDownside`, routes/v2/numeric-egress-guards.ts)
+ *     · the whole `outcome` object dropped (a required stat non-finite)
+ *     · any component non-finite, or `expected_regret` negative
+ *
+ * A rerun with a different seed could plausibly clear the non-finite branches
+ * and cannot clear the percentiles-source one — and nothing on the wire says
+ * which applied. Writing "try running it again" would therefore be a claim we
+ * have not earned, which is the exact failure this whole surface exists to
+ * avoid. So the sentence states the absence, states that the reason is not
+ * disclosed to us, and stops. Making it able to say more is producer-side work
+ * (an omission-reason channel through ISL → PLoT → CEE), not a wording choice.
+ *
+ * CONTAINS NO NUMERAL, deliberately: see rule 3 above.
+ */
+export const DOWNSIDE_UNAVAILABLE_COPY =
+  'No worst-case view for this option in this run. The engine did not return one and does not say why, so we cannot tell you whether running it again would produce one.'

--- a/src/v5/__tests__/fixtures/live-analysis-turn-downside-2026-08-05.json
+++ b/src/v5/__tests__/fixtures/live-analysis-turn-downside-2026-08-05.json
@@ -1,0 +1,1785 @@
+{
+  "__source__": "PHASE0-EVIDENCE-2026-07-28/expert-session-2026-08-05-raw/run5/wire.json \u2014 wire entry 14, verbatim resBody",
+  "__captured_at__": "2026-08-05T16:02:25Z (ts 1785945745944)",
+  "__captured_against__": "UI 5f066967e0a78d715b1594dc021810a3b400bd36 / CEE build e82738b (staging), POST https://cee-staging.onrender.com/proxy/v5/turn, chip_action_run_analysis",
+  "__notes__": "ROADMAP 2.581 trigger evidence. THIS IS THE SESSION THE TESTER RECORDED AS \"no tail values and no caveat\". The payload nevertheless carries blocks[0].enrichment.option_comparison[i].downside {cvar_10, p05, expected_regret} for ALL FIVE options, option_comparison_status=\"computed\", n_samples=10000, validity_ratio=1. The tail was on the wire and never reached the reader. Pinned to this historical capture \u2014 NEVER refresh it to track a current payload (trap 12b).",
+  "response_version": 2,
+  "assistant_text": "Energy-Efficiency Retrofit currently leads by 2 percentage points, but the analysis treats this as a close call. The result is not yet robust \u2014 no single factor we tested would change the order on its own, but the margin is not settled.\n\nYour first analysis is ready. Take a moment to explore the leading option and the factors shaping it before acting on the result.",
+  "blocks": [
+    {
+      "type": "analysis_result",
+      "summary": "Energy-Efficiency Retrofit currently leads by 2 percentage points, but the analysis treats this as a close call. The result is not yet robust \u2014 no single factor we tested would change the order on its own, but the margin is not settled.",
+      "leading_option_id": "opt_retrofit",
+      "win_probabilities": {
+        "Second Production Oven Line": 0.17681833333333333,
+        "Automated Packing Cell": 0.3417683333333333,
+        "Energy-Efficiency Retrofit": 0.35866,
+        "No Capital Investment (Status Quo)": 0.008476666666666669,
+        "Refrigerated Delivery Vans": 0.11427666666666669
+      },
+      "enrichment": {
+        "option_comparison": [
+          {
+            "option_id": "opt_oven",
+            "option_label": "Second Production Oven Line",
+            "id": "opt_oven",
+            "label": "Second Production Oven Line",
+            "outcome": {
+              "mean": 0.03090832875457821,
+              "std": 0.1911138874141677,
+              "p10": -0.22108546726196782,
+              "p50": 0.03848460062326184,
+              "p90": 0.27347830876477364,
+              "n_samples": 10000,
+              "n_valid_samples": 10000,
+              "validity_ratio": 1
+            },
+            "status": "computed",
+            "win_probability": 0.17681833333333333,
+            "downside": {
+              "cvar_10": -0.3079481799761663,
+              "p05": -0.2887558172745903,
+              "expected_regret": 0.20736548448233388
+            }
+          },
+          {
+            "option_id": "opt_packing",
+            "option_label": "Automated Packing Cell",
+            "id": "opt_packing",
+            "label": "Automated Packing Cell",
+            "outcome": {
+              "mean": 0.12922493438127092,
+              "std": 0.14221849261302802,
+              "p10": -0.06954822534073672,
+              "p50": 0.14052271414688144,
+              "p90": 0.30828944768838695,
+              "n_samples": 10000,
+              "n_valid_samples": 10000,
+              "validity_ratio": 1
+            },
+            "status": "computed",
+            "win_probability": 0.3417683333333333,
+            "downside": {
+              "cvar_10": -0.11219224064218787,
+              "p05": -0.10250235969033479,
+              "expected_regret": 0.1090488788556412
+            }
+          },
+          {
+            "option_id": "opt_retrofit",
+            "option_label": "Energy-Efficiency Retrofit",
+            "id": "opt_retrofit",
+            "label": "Energy-Efficiency Retrofit",
+            "outcome": {
+              "mean": 0.14353062517818996,
+              "std": 0.11470436451590488,
+              "p10": -0.020321726245321088,
+              "p50": 0.15433467612552765,
+              "p90": 0.2853265499017002,
+              "n_samples": 10000,
+              "n_valid_samples": 10000,
+              "validity_ratio": 1
+            },
+            "status": "computed",
+            "win_probability": 0.35866,
+            "downside": {
+              "cvar_10": -0.061314212185777095,
+              "p05": -0.05386777652540353,
+              "expected_regret": 0.09474318805872213
+            }
+          },
+          {
+            "option_id": "opt_status_quo",
+            "option_label": "No Capital Investment (Status Quo)",
+            "id": "opt_status_quo",
+            "label": "No Capital Investment (Status Quo)",
+            "outcome": {
+              "mean": -2.9547627876107274e-05,
+              "std": 0.036327506115315725,
+              "p10": -0.040692250422174364,
+              "p50": 0,
+              "p90": 0.040525775970530684,
+              "n_samples": 10000,
+              "n_valid_samples": 10000,
+              "validity_ratio": 1
+            },
+            "status": "computed",
+            "win_probability": 0.008476666666666669,
+            "downside": {
+              "cvar_10": -0.06891378031696103,
+              "p05": -0.059642932930203396,
+              "expected_regret": 0.2383033608647882
+            }
+          },
+          {
+            "option_id": "opt_vans",
+            "option_label": "Refrigerated Delivery Vans",
+            "id": "opt_vans",
+            "label": "Refrigerated Delivery Vans",
+            "outcome": {
+              "mean": 0.037588420956465585,
+              "std": 0.13273738836591753,
+              "p10": -0.1155601921387401,
+              "p50": 0.013261104631707061,
+              "p90": 0.2210427753996403,
+              "n_samples": 10000,
+              "n_valid_samples": 10000,
+              "validity_ratio": 1
+            },
+            "status": "computed",
+            "win_probability": 0.11427666666666669,
+            "downside": {
+              "cvar_10": -0.15563313781808016,
+              "p05": -0.145890584682423,
+              "expected_regret": 0.20068539228044652
+            }
+          }
+        ],
+        "factor_sensitivity": [
+          {
+            "factor_id": "fac_flour_price",
+            "factor_label": "Wholesale Flour Price",
+            "influence_score": 1,
+            "influence_rank": 1,
+            "sensitivity_score": -0.24750000000000003,
+            "elasticity": 1,
+            "direction": "negative",
+            "importance_rank": 1,
+            "value_of_information": 0,
+            "confidence": 0.446,
+            "confidence_source": "plot_unified_from_isl_bootstrap",
+            "confidence_provenance": {
+              "computation_source": "plot_unified_from_isl_bootstrap",
+              "formula_version": "plot_unified_v3",
+              "is_provisional": true,
+              "calibration_status": "provisional_pending_pilot_calibration",
+              "input_quality": "standard"
+            },
+            "confidence_components": {
+              "structural_certainty": 0.5,
+              "sampling_stability": 0.25
+            },
+            "source": "graph",
+            "flip_risk_category": "correlated",
+            "attribution_stability": "low",
+            "elasticity_std": 0.0411048,
+            "rank_flip_rate": 0.2,
+            "stability_method": "bootstrap_20",
+            "value_defaulted": true,
+            "importance_basis": "graph_structural",
+            "driver_label": "biggest",
+            "evpi_percentage_points": 0,
+            "evpi_method": "heuristic",
+            "evidence_hint": false
+          },
+          {
+            "factor_id": "fac_retrofit",
+            "factor_label": "Energy-Efficiency Retrofit Deployment",
+            "influence_score": 0.6693602693602693,
+            "influence_rank": 2,
+            "sensitivity_score": 0,
+            "elasticity": 0,
+            "direction": "positive",
+            "importance_rank": 2,
+            "value_of_information": 0,
+            "confidence": 0.3,
+            "confidence_source": "plot_unified_from_isl_bootstrap",
+            "confidence_provenance": {
+              "computation_source": "plot_unified_from_isl_bootstrap",
+              "formula_version": "plot_unified_v3",
+              "is_provisional": true,
+              "calibration_status": "provisional_pending_pilot_calibration",
+              "input_quality": "standard"
+            },
+            "confidence_components": {
+              "structural_certainty": 0.5,
+              "sampling_stability": 0
+            },
+            "zero_reason": "intervention_override",
+            "source": "graph",
+            "flip_risk_category": "isolated",
+            "attribution_stability": "negligible",
+            "elasticity_std": 0,
+            "rank_flip_rate": 0,
+            "stability_method": "bootstrap_20",
+            "value_source": "cee_inference",
+            "value_extraction_type": "inferred",
+            "importance_basis": "graph_structural",
+            "driver_label": "strong",
+            "range_derivation_source": "default"
+          },
+          {
+            "factor_id": "fac_packing",
+            "factor_label": "Automated Packing Cell Deployment",
+            "influence_score": 0.6562289562289562,
+            "influence_rank": 3,
+            "sensitivity_score": 0,
+            "elasticity": 0,
+            "direction": "positive",
+            "importance_rank": 3,
+            "value_of_information": 0,
+            "confidence": 0.3,
+            "confidence_source": "plot_unified_from_isl_bootstrap",
+            "confidence_provenance": {
+              "computation_source": "plot_unified_from_isl_bootstrap",
+              "formula_version": "plot_unified_v3",
+              "is_provisional": true,
+              "calibration_status": "provisional_pending_pilot_calibration",
+              "input_quality": "standard"
+            },
+            "confidence_components": {
+              "structural_certainty": 0.5,
+              "sampling_stability": 0
+            },
+            "zero_reason": "intervention_override",
+            "source": "graph",
+            "flip_risk_category": "isolated",
+            "attribution_stability": "negligible",
+            "elasticity_std": 0,
+            "rank_flip_rate": 0,
+            "stability_method": "bootstrap_20",
+            "value_source": "cee_inference",
+            "value_extraction_type": "inferred",
+            "importance_basis": "graph_structural",
+            "driver_label": "strong",
+            "range_derivation_source": "default"
+          },
+          {
+            "factor_id": "fac_vans",
+            "factor_label": "Refrigerated Van Fleet Deployment",
+            "influence_score": 0.3488215488215487,
+            "influence_rank": 4,
+            "sensitivity_score": 0,
+            "elasticity": 0,
+            "direction": "positive",
+            "importance_rank": 4,
+            "value_of_information": 0,
+            "confidence": 0.3,
+            "confidence_source": "plot_unified_from_isl_bootstrap",
+            "confidence_provenance": {
+              "computation_source": "plot_unified_from_isl_bootstrap",
+              "formula_version": "plot_unified_v3",
+              "is_provisional": true,
+              "calibration_status": "provisional_pending_pilot_calibration",
+              "input_quality": "standard"
+            },
+            "confidence_components": {
+              "structural_certainty": 0.5,
+              "sampling_stability": 0
+            },
+            "zero_reason": "intervention_override",
+            "source": "graph",
+            "flip_risk_category": "correlated",
+            "attribution_stability": "negligible",
+            "elasticity_std": 0,
+            "rank_flip_rate": 0,
+            "stability_method": "bootstrap_20",
+            "value_source": "cee_inference",
+            "value_extraction_type": "inferred",
+            "importance_basis": "graph_structural",
+            "driver_label": "moderate",
+            "range_derivation_source": "default"
+          },
+          {
+            "factor_id": "fac_oven",
+            "factor_label": "Second Oven Line Deployment",
+            "influence_score": 0.14377104377104385,
+            "influence_rank": 5,
+            "sensitivity_score": 0,
+            "elasticity": 0,
+            "direction": "positive",
+            "importance_rank": 5,
+            "value_of_information": 0,
+            "confidence": 0.3,
+            "confidence_source": "plot_unified_from_isl_bootstrap",
+            "confidence_provenance": {
+              "computation_source": "plot_unified_from_isl_bootstrap",
+              "formula_version": "plot_unified_v3",
+              "is_provisional": true,
+              "calibration_status": "provisional_pending_pilot_calibration",
+              "input_quality": "standard"
+            },
+            "confidence_components": {
+              "structural_certainty": 0.5,
+              "sampling_stability": 0
+            },
+            "zero_reason": "intervention_override",
+            "source": "graph",
+            "flip_risk_category": "isolated",
+            "attribution_stability": "negligible",
+            "elasticity_std": 0,
+            "rank_flip_rate": 0,
+            "stability_method": "bootstrap_20",
+            "value_source": "cee_inference",
+            "value_extraction_type": "inferred",
+            "importance_basis": "graph_structural",
+            "driver_label": "minor",
+            "range_derivation_source": "default"
+          }
+        ],
+        "robustness": {
+          "fragile_edges": [
+            {
+              "edge_id": "out_energy_saving->goal_profit",
+              "from_id": "out_energy_saving",
+              "to_id": "goal_profit",
+              "switch_probability": 0.4848,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Energy Cost Saving",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_packing->risk_capex_payback",
+              "from_id": "fac_packing",
+              "to_id": "risk_capex_payback",
+              "switch_probability": 0.434,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Automated Packing Cell Deployment",
+              "to_label": "Slow Capex Payback",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_retrofit->out_energy_saving",
+              "from_id": "fac_retrofit",
+              "to_id": "out_energy_saving",
+              "switch_probability": 0.4252,
+              "marginal_switch_probability": 0.25,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Energy-Efficiency Retrofit Deployment",
+              "to_label": "Energy Cost Saving",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "out_throughput->goal_profit",
+              "from_id": "out_throughput",
+              "to_id": "goal_profit",
+              "switch_probability": 0.3992,
+              "marginal_switch_probability": 0.12,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Production Throughput Uplift",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_oven->out_throughput",
+              "from_id": "fac_oven",
+              "to_id": "out_throughput",
+              "switch_probability": 0.3868,
+              "marginal_switch_probability": 0.08,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Second Oven Line Deployment",
+              "to_label": "Production Throughput Uplift",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "out_revenue_reach->goal_profit",
+              "from_id": "out_revenue_reach",
+              "to_id": "goal_profit",
+              "switch_probability": 0.3864,
+              "marginal_switch_probability": 0.08,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Revenue from Expanded Distribution",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_vans->out_revenue_reach",
+              "from_id": "fac_vans",
+              "to_id": "out_revenue_reach",
+              "switch_probability": 0.3774104683195592,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Refrigerated Van Fleet Deployment",
+              "to_label": "Revenue from Expanded Distribution",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "risk_flour_cost->goal_profit",
+              "from_id": "risk_flour_cost",
+              "to_id": "goal_profit",
+              "switch_probability": 0.358,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Flour Input Cost Pressure",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_flour_price->risk_flour_cost",
+              "from_id": "fac_flour_price",
+              "to_id": "risk_flour_cost",
+              "switch_probability": 0.3348,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Wholesale Flour Price",
+              "to_label": "Flour Input Cost Pressure",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "risk_capex_payback->goal_profit",
+              "from_id": "risk_capex_payback",
+              "to_id": "goal_profit",
+              "switch_probability": 0.3232,
+              "marginal_switch_probability": 0.13,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Slow Capex Payback",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_oven->risk_capex_payback",
+              "from_id": "fac_oven",
+              "to_id": "risk_capex_payback",
+              "switch_probability": 0.3152,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Second Oven Line Deployment",
+              "to_label": "Slow Capex Payback",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_vans->risk_capex_payback",
+              "from_id": "fac_vans",
+              "to_id": "risk_capex_payback",
+              "switch_probability": 0.3128,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Refrigerated Van Fleet Deployment",
+              "to_label": "Slow Capex Payback",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "fac_oven->risk_flour_cost",
+              "from_id": "fac_oven",
+              "to_id": "risk_flour_cost",
+              "switch_probability": 0.31,
+              "marginal_switch_probability": 0,
+              "alternative_winner_id": "opt_oven",
+              "from_label": "Second Oven Line Deployment",
+              "to_label": "Flour Input Cost Pressure",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Second Production Oven Line"
+            },
+            {
+              "edge_id": "fac_retrofit->risk_capex_payback",
+              "from_id": "fac_retrofit",
+              "to_id": "risk_capex_payback",
+              "switch_probability": 0.3096,
+              "alternative_winner_id": "opt_packing",
+              "from_label": "Energy-Efficiency Retrofit Deployment",
+              "to_label": "Slow Capex Payback",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Automated Packing Cell"
+            },
+            {
+              "edge_id": "out_labour_saving->goal_profit",
+              "from_id": "out_labour_saving",
+              "to_id": "goal_profit",
+              "switch_probability": 0.2352,
+              "alternative_winner_id": "opt_oven",
+              "from_label": "Labour Cost Saving",
+              "to_label": "Raise Operating Profit by 8% Within 18 Months",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Second Production Oven Line"
+            },
+            {
+              "edge_id": "fac_packing->out_labour_saving",
+              "from_id": "fac_packing",
+              "to_id": "out_labour_saving",
+              "switch_probability": 0.2292,
+              "marginal_switch_probability": 0.45,
+              "alternative_winner_id": "opt_oven",
+              "from_label": "Automated Packing Cell Deployment",
+              "to_label": "Labour Cost Saving",
+              "severity": "warning",
+              "visible": true,
+              "alternative_winner_label": "Second Production Oven Line"
+            }
+          ],
+          "robust_edges": [],
+          "is_robust": false,
+          "level": "very_low",
+          "confidence": 0.35866,
+          "confidence_basis": "recommendation_stability_uncalibrated",
+          "recommended_option_id": "opt_retrofit",
+          "recommended_option_label": "Energy-Efficiency Retrofit",
+          "near_tie": {
+            "is_tie": true,
+            "top_option_id": "opt_retrofit",
+            "second_option_id": "opt_packing",
+            "tied_option_ids": [
+              "opt_retrofit",
+              "opt_packing"
+            ],
+            "gap": 0.016891666666666694,
+            "threshold": 0.1
+          },
+          "display_verdict": "fragile",
+          "display_verdict_reason": "none of the factors we could test changed which option leads on its own, but this result scored low on our other robustness checks"
+        },
+        "decision_review": {
+          "narrative_summary": "The Energy-Efficiency Retrofit leads by a narrow margin of about 2 percentage points, but there is substantial uncertainty around this result. That lead could change if key assumptions about energy cost savings or flour price prove off target.",
+          "story_headlines": {
+            "opt_retrofit": "Energy-Efficiency Retrofit is ahead, contingent on expected energy savings reliably boosting profits under current price and tariff assumptions.",
+            "opt_packing": "Automated Packing Cell could come out ahead if capital payback accelerates or energy savings from retrofit fall short.",
+            "opt_vans": "Refrigerated Van Fleet stands out mainly if expanded distribution turns into substantial new revenue quickly.",
+            "opt_oven": "Second Oven Line's position depends on whether throughput growth will translate to profit fast enough under uncertain input costs."
+          },
+          "robustness_explanation": {
+            "summary": "The ordering holds in about 36% of variations, with several plausible scenarios where the Automated Packing Cell overtakes.",
+            "primary_risk": "The greatest risk is that the link from Energy Cost Saving to raising operating profit is weaker than assumed.",
+            "stability_factors": [
+              "Known tariffs and contracted costs limit some unknowns."
+            ],
+            "fragility_factors": [
+              "The link from Energy Cost Saving to Raise Operating Profit by 8% Within 18 Months could flip the outcome.",
+              "The connection from Energy-Efficiency Retrofit Deployment to Energy Cost Saving is a potential point where results could change."
+            ]
+          },
+          "readiness_rationale": "The narrow lead for the Energy-Efficiency Retrofit is unsettled because the result is highly contingent on energy savings translating into profit and the uncertain future flour price.",
+          "evidence_enhancements": {
+            "fac_flour_price": {
+              "specific_action": "Gather independent forecasts or procurement data on wholesale flour pricing for the coming year.",
+              "rationale": "Flour price is the main uncertainty and could significantly change which project most reliably boosts profit.",
+              "evidence_type": "market_research",
+              "decision_hygiene": "Estimate flour price impacts before reviewing new data."
+            }
+          },
+          "scenario_contexts": {
+            "out_energy_saving->goal_profit": {
+              "trigger_description": "If the effect of Energy Cost Saving on raising operating profit is less strong than modelled...",
+              "consequence": "Automated Packing Cell then overtakes Energy-Efficiency Retrofit."
+            },
+            "fac_retrofit->out_energy_saving": {
+              "trigger_description": "If Energy-Efficiency Retrofit Deployment does not deliver the anticipated Energy Cost Saving...",
+              "consequence": "then Automated Packing Cell overtakes Energy-Efficiency Retrofit."
+            }
+          },
+          "flip_thresholds": [],
+          "bias_findings": [],
+          "key_assumptions": [
+            "The link from Energy Cost Saving to Raise Operating Profit by 8% Within 18 Months takes historical energy cost savings as a guide.",
+            "Wholesale Flour Price is assumed within a plausible range, but large swings could upset this order.",
+            "Production Throughput Uplift is presumed to convert reliably into profit within the 18-month window."
+          ],
+          "decision_quality_prompts": [
+            {
+              "question": "What evidence would change your confidence in the Energy-Efficiency Retrofit leading over Automated Packing Cell?",
+              "principle": "Consider-the-opposite",
+              "applies_because": "The margin between options is slim and subject to overturn if assumptions about energy savings or flour price shift.",
+              "dsk_grounding": "general"
+            },
+            {
+              "question": "What is the base rate for energy-efficiency retrofits delivering the promised profit uplift on similar projects?",
+              "principle": "Outside view and reference class forecasting",
+              "applies_because": "Current uncertainty about whether energy savings will translate robustly into profit calls for a reality check from similar historical projects.",
+              "dsk_claim_id": "DSK-T-002",
+              "evidence_strength": "strong",
+              "dsk_protocol_id": "DSK-P-002",
+              "dsk_grounding": "resolved"
+            }
+          ],
+          "produced_at": "2026-08-05T16:02:40.998Z"
+        },
+        "option_comparison_status": "computed",
+        "edge_e_values": [
+          {
+            "edge_id": "fac_oven::out_throughput",
+            "from_id": "fac_oven",
+            "to_id": "out_throughput",
+            "from_label": "Second Oven Line Deployment",
+            "to_label": "Production Throughput Uplift",
+            "e_value": 1.4921,
+            "flip_direction": "increase",
+            "current_mean": 0.65,
+            "flip_mean": 0.969868,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 2,
+              "band_min": 0.679657,
+              "band_median": 0.740361,
+              "band_max": 0.801066,
+              "band_width": 0.121409,
+              "seed_flip_means": [
+                null,
+                null,
+                null,
+                0.801066,
+                null,
+                null,
+                0.679657,
+                null,
+                null,
+                null
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_oven::risk_capex_payback",
+            "from_id": "fac_oven",
+            "to_id": "risk_capex_payback",
+            "from_label": "Second Oven Line Deployment",
+            "to_label": "Slow Capex Payback",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.34833333333333333,
+            "flip_mean": -0.067979,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 6,
+              "band_min": -0.487762,
+              "band_median": -0.203493,
+              "band_max": 0.371483,
+              "band_width": 0.859245,
+              "seed_flip_means": [
+                null,
+                null,
+                -0.487762,
+                null,
+                0.371483,
+                null,
+                -0.032066,
+                -0.37492,
+                0.103613,
+                -0.473828
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_oven::risk_flour_cost",
+            "from_id": "fac_oven",
+            "to_id": "risk_flour_cost",
+            "from_label": "Second Oven Line Deployment",
+            "to_label": "Flour Input Cost Pressure",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.3,
+            "flip_mean": -0.031158,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 8,
+              "band_min": -0.312546,
+              "band_median": -0.149184,
+              "band_max": 0.406733,
+              "band_width": 0.719279,
+              "seed_flip_means": [
+                null,
+                -0.20963,
+                -0.312546,
+                -0.123756,
+                0.406733,
+                null,
+                0.271348,
+                -0.153874,
+                -0.144493,
+                -0.311569
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_packing::out_labour_saving",
+            "from_id": "fac_packing",
+            "to_id": "out_labour_saving",
+            "from_label": "Automated Packing Cell Deployment",
+            "to_label": "Labour Cost Saving",
+            "e_value": 1.0873,
+            "flip_direction": "increase",
+            "current_mean": 0.6,
+            "flip_mean": 0.652388,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 6,
+              "band_min": 0.503256,
+              "band_median": 0.659981,
+              "band_max": 0.988935,
+              "band_width": 0.485679,
+              "seed_flip_means": [
+                0.988935,
+                null,
+                0.505426,
+                0.503256,
+                0.716381,
+                null,
+                null,
+                0.603581,
+                null,
+                0.945462
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_packing::risk_capex_payback",
+            "from_id": "fac_packing",
+            "to_id": "risk_capex_payback",
+            "from_label": "Automated Packing Cell Deployment",
+            "to_label": "Slow Capex Payback",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.22166666666666665,
+            "flip_mean": 0.158223,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 6,
+              "band_min": -0.408105,
+              "band_median": 0.052262,
+              "band_max": 0.579313,
+              "band_width": 0.987418,
+              "seed_flip_means": [
+                null,
+                null,
+                0.579313,
+                null,
+                0.19182,
+                null,
+                -0.217782,
+                0.396974,
+                -0.408105,
+                -0.087296
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_retrofit::out_energy_saving",
+            "from_id": "fac_retrofit",
+            "to_id": "out_energy_saving",
+            "from_label": "Energy-Efficiency Retrofit Deployment",
+            "to_label": "Energy Cost Saving",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.7,
+            "flip_mean": 0.635413,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 5,
+              "band_min": 0.300676,
+              "band_median": 0.484554,
+              "band_max": 0.893327,
+              "band_width": 0.592651,
+              "seed_flip_means": [
+                null,
+                0.484554,
+                0.893327,
+                null,
+                null,
+                0.674005,
+                0.425643,
+                null,
+                0.300676,
+                null
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_retrofit::risk_capex_payback",
+            "from_id": "fac_retrofit",
+            "to_id": "risk_capex_payback",
+            "from_label": "Energy-Efficiency Retrofit Deployment",
+            "to_label": "Slow Capex Payback",
+            "e_value": 1.5322,
+            "flip_direction": "increase",
+            "current_mean": 0.12666666666666668,
+            "flip_mean": 0.194076,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 5,
+              "band_min": -0.435217,
+              "band_median": -0.141388,
+              "band_max": 0.585551,
+              "band_width": 1.020768,
+              "seed_flip_means": [
+                null,
+                null,
+                -0.141388,
+                null,
+                -0.435217,
+                null,
+                0.534946,
+                null,
+                0.585551,
+                -0.157888
+              ]
+            }
+          },
+          {
+            "edge_id": "fac_vans::risk_capex_payback",
+            "from_id": "fac_vans",
+            "to_id": "risk_capex_payback",
+            "from_label": "Refrigerated Van Fleet Deployment",
+            "to_label": "Slow Capex Payback",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.25333333333333335,
+            "flip_mean": -0.163554,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 5,
+              "band_min": -0.42138,
+              "band_median": -0.408105,
+              "band_max": 0.574216,
+              "band_width": 0.995596,
+              "seed_flip_means": [
+                null,
+                null,
+                -0.42138,
+                null,
+                -0.409617,
+                null,
+                -0.217782,
+                null,
+                -0.408105,
+                0.574216
+              ]
+            }
+          },
+          {
+            "edge_id": "out_energy_saving::goal_profit",
+            "from_id": "out_energy_saving",
+            "to_id": "goal_profit",
+            "from_label": "Energy Cost Saving",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 1,
+            "flip_direction": "decrease",
+            "current_mean": 0.3,
+            "flip_mean": 0.27232,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 8,
+              "band_min": 0.100478,
+              "band_median": 0.394549,
+              "band_max": 0.598683,
+              "band_width": 0.498205,
+              "seed_flip_means": [
+                0.482101,
+                0.385583,
+                0.598683,
+                0.383551,
+                null,
+                0.477831,
+                0.100478,
+                null,
+                0.182272,
+                0.403515
+              ]
+            }
+          },
+          {
+            "edge_id": "out_labour_saving::goal_profit",
+            "from_id": "out_labour_saving",
+            "to_id": "goal_profit",
+            "from_label": "Labour Cost Saving",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 1.0873,
+            "flip_direction": "increase",
+            "current_mean": 0.4,
+            "flip_mean": 0.434926,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 9,
+              "band_min": 0.124096,
+              "band_median": 0.415844,
+              "band_max": 0.720515,
+              "band_width": 0.596419,
+              "seed_flip_means": [
+                null,
+                0.692477,
+                0.355424,
+                0.331912,
+                0.415844,
+                0.720515,
+                0.124096,
+                0.418205,
+                0.39618,
+                0.621677
+              ]
+            }
+          },
+          {
+            "edge_id": "out_revenue_reach::goal_profit",
+            "from_id": "out_revenue_reach",
+            "to_id": "goal_profit",
+            "from_label": "Revenue from Expanded Distribution",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 2.0297,
+            "flip_direction": "increase",
+            "current_mean": 0.35,
+            "flip_mean": 0.71041,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 7,
+              "band_min": 0.196827,
+              "band_median": 0.703281,
+              "band_max": 0.841658,
+              "band_width": 0.644831,
+              "seed_flip_means": [
+                0.196827,
+                0.819737,
+                null,
+                0.521855,
+                0.709864,
+                0.841658,
+                null,
+                null,
+                0.703281,
+                0.285807
+              ]
+            }
+          },
+          {
+            "edge_id": "out_throughput::goal_profit",
+            "from_id": "out_throughput",
+            "to_id": "goal_profit",
+            "from_label": "Production Throughput Uplift",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 1.4921,
+            "flip_direction": "increase",
+            "current_mean": 0.45,
+            "flip_mean": 0.671447,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 8,
+              "band_min": 0.549286,
+              "band_median": 0.681924,
+              "band_max": 0.927879,
+              "band_width": 0.378593,
+              "seed_flip_means": [
+                0.927879,
+                0.687999,
+                0.865054,
+                null,
+                0.628585,
+                null,
+                0.675849,
+                0.549286,
+                0.739821,
+                0.551762
+              ]
+            }
+          },
+          {
+            "edge_id": "risk_capex_payback::goal_profit",
+            "from_id": "risk_capex_payback",
+            "to_id": "goal_profit",
+            "from_label": "Slow Capex Payback",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 1,
+            "flip_direction": "increase",
+            "current_mean": -0.35,
+            "flip_mean": -0.133259,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 6,
+              "band_min": -0.532791,
+              "band_median": -0.067385,
+              "band_max": 0.648378,
+              "band_width": 1.181169,
+              "seed_flip_means": [
+                null,
+                0.645215,
+                null,
+                -0.343824,
+                -0.527123,
+                0.648378,
+                -0.532791,
+                null,
+                0.209055,
+                null
+              ]
+            }
+          },
+          {
+            "edge_id": "risk_flour_cost::goal_profit",
+            "from_id": "risk_flour_cost",
+            "to_id": "goal_profit",
+            "from_label": "Flour Input Cost Pressure",
+            "to_label": "Raise Operating Profit by 8% Within 18 Months",
+            "e_value": 1,
+            "flip_direction": "increase",
+            "current_mean": -0.45,
+            "flip_mean": 0.046737,
+            "stability": {
+              "n_seeds": 10,
+              "n_seeds_flipped": 7,
+              "band_min": -0.580165,
+              "band_median": 0.211803,
+              "band_max": 0.801203,
+              "band_width": 1.381368,
+              "seed_flip_means": [
+                null,
+                null,
+                0.444692,
+                0.140254,
+                -0.580165,
+                0.801203,
+                -0.491214,
+                null,
+                0.211803,
+                0.754222
+              ]
+            }
+          }
+        ],
+        "inference_warnings": [
+          {
+            "code": "EDGE_E_VALUE_NON_FINITE_DROPPED",
+            "message": "2 edge E-value entries were omitted from edge_e_values: 2 carried no finite E-value from the analysis engine (an unflippable edge, whose current and flip means coincide, has no evidence ratio). edge_e_values is shorter because those entries could not be represented, not because they were computed empty. All other analyses are unaffected.",
+            "severity": "info"
+          }
+        ],
+        "confidence_tier": "fair",
+        "flip_thresholds": [
+          {
+            "factor_id": "fac_flour_price",
+            "factor_label": "Wholesale Flour Price",
+            "current_value": 0,
+            "flip_value": null,
+            "alternative_winner_id": null,
+            "alternative_winner_label": null,
+            "flip_reason": "structurally_invariant",
+            "iterations_used": 0,
+            "probes_used": 0,
+            "no_flip_in_range": true
+          },
+          {
+            "factor_id": "fac_oven",
+            "factor_label": "Second Oven Line Deployment",
+            "current_value": 0,
+            "flip_value": null,
+            "alternative_winner_id": null,
+            "alternative_winner_label": null,
+            "flip_reason": "structurally_invariant",
+            "iterations_used": 0,
+            "probes_used": 0,
+            "no_flip_in_range": true
+          },
+          {
+            "factor_id": "fac_packing",
+            "factor_label": "Automated Packing Cell Deployment",
+            "current_value": 0,
+            "flip_value": null,
+            "alternative_winner_id": null,
+            "alternative_winner_label": null,
+            "flip_reason": "structurally_invariant",
+            "iterations_used": 0,
+            "probes_used": 0,
+            "no_flip_in_range": true
+          },
+          {
+            "factor_id": "fac_retrofit",
+            "factor_label": "Energy-Efficiency Retrofit Deployment",
+            "current_value": 0,
+            "flip_value": null,
+            "alternative_winner_id": null,
+            "alternative_winner_label": null,
+            "flip_reason": "structurally_invariant",
+            "iterations_used": 0,
+            "probes_used": 0,
+            "no_flip_in_range": true
+          },
+          {
+            "factor_id": "fac_vans",
+            "factor_label": "Refrigerated Van Fleet Deployment",
+            "current_value": 0,
+            "flip_value": null,
+            "alternative_winner_id": null,
+            "alternative_winner_label": null,
+            "flip_reason": "structurally_invariant",
+            "iterations_used": 0,
+            "probes_used": 0,
+            "no_flip_in_range": true
+          }
+        ],
+        "decision_brief": {
+          "brief_id": "d37be10b-1d40-48e8-b6ed-60fb567b904e",
+          "version": "1",
+          "created_at": "2026-08-05T16:02:32.831Z",
+          "headline": "Energy-Efficiency Retrofit currently leads, but the outcome is highly uncertain. However, the 36% recommendation stability indicates the decision could shift with new information. Define tie-breaker criteria or gather additional evidence.",
+          "options": [
+            {
+              "option_id": "opt_retrofit",
+              "label": "Energy-Efficiency Retrofit",
+              "win_probability": 0.35866,
+              "rank": 1
+            },
+            {
+              "option_id": "opt_packing",
+              "label": "Automated Packing Cell",
+              "win_probability": 0.3417683333333333,
+              "rank": 2
+            },
+            {
+              "option_id": "opt_oven",
+              "label": "Second Production Oven Line",
+              "win_probability": 0.17681833333333333,
+              "rank": 3
+            },
+            {
+              "option_id": "opt_vans",
+              "label": "Refrigerated Delivery Vans",
+              "win_probability": 0.11427666666666669,
+              "rank": 4
+            },
+            {
+              "option_id": "opt_status_quo",
+              "label": "No Capital Investment (Status Quo)",
+              "win_probability": 0.008476666666666669,
+              "rank": 5
+            }
+          ],
+          "top_drivers": [
+            {
+              "factor_label": "Wholesale Flour Price",
+              "sensitivity": 1,
+              "direction": "negative"
+            }
+          ],
+          "key_assumptions": [
+            "Wholesale Flour Price"
+          ],
+          "what_would_change": [
+            "Energy Cost Saving \u2192 Raise Operating Profit by 8% Within 18 Months",
+            "Production Throughput Uplift \u2192 Raise Operating Profit by 8% Within 18 Months",
+            "Revenue from Expanded Distribution \u2192 Raise Operating Profit by 8% Within 18 Months",
+            "Flour Input Cost Pressure \u2192 Raise Operating Profit by 8% Within 18 Months",
+            "Wholesale Flour Price \u2192 Flour Input Cost Pressure",
+            "Slow Capex Payback \u2192 Raise Operating Profit by 8% Within 18 Months",
+            "Labour Cost Saving \u2192 Raise Operating Profit by 8% Within 18 Months"
+          ],
+          "robustness": "fragile",
+          "warnings": [
+            {
+              "code": "DOMINANT_FACTOR",
+              "message": "One factor dominates. What would change if Wholesale Flour Price had less influence?",
+              "severity": "warning"
+            },
+            {
+              "code": "INFLUENTIAL_EXTERNALS",
+              "message": "External factors Wholesale Flour Price significantly affect your outcome but are inherently uncertain. How might you bound these?",
+              "severity": "warning"
+            },
+            {
+              "code": "M2_UNAVAILABLE",
+              "message": "Decision review was unavailable; brief uses deterministic coaching fallback",
+              "severity": "warning"
+            },
+            {
+              "code": "MARGINAL_SWITCH_TRUNCATED",
+              "message": "Marginal switch probability was computed for the 10 most elastic fragile edge(s) of 16; the remaining 6 carry marginal_switch_probability=null. Each edge's sweep costs 100 isolated re-evaluations per option, so the set is bounded to keep the analysis inside its compute-admission budget. Retained values are unaffected \u2014 each is computed independently of the others",
+              "severity": "warning"
+            }
+          ],
+          "headline_banded": {
+            "text": "Energy-Efficiency Retrofit leads, but the top options are very close.",
+            "band": "very_close",
+            "leader_option_id": "opt_retrofit",
+            "leader_label": "Energy-Efficiency Retrofit",
+            "runner_up_option_id": "opt_packing",
+            "runner_up_label": "Automated Packing Cell",
+            "win_probability_gap": 0.016891666666666694,
+            "robustness_gated": false,
+            "doctrine": "provisional_doctrine_v0"
+          },
+          "defaulted_assumptions": [
+            {
+              "factor_label": "Wholesale Flour Price",
+              "note": "No starting value was provided for \"Wholesale Flour Price\" \u2014 the analysis used a default. Setting a real value or range would make this result more trustworthy.",
+              "source": "value_defaulted",
+              "doctrine": "provisional_doctrine_v0"
+            }
+          ],
+          "robustness_caveat": {
+            "text": "This ranking was fragile under the perturbations tested \u2014 small changes to assumptions could change which option leads.",
+            "basis": "is_robust",
+            "doctrine": "provisional_doctrine_v0"
+          },
+          "warning_codes": [],
+          "analysis_summary": {
+            "leading_option": "Energy-Efficiency Retrofit",
+            "win_probability": 0.35866,
+            "robustness_band": "fragile"
+          }
+        },
+        "factor_evppi": [
+          {
+            "factor_id": "fac_flour_price",
+            "evppi": 8e-06,
+            "evppi_raw": 8e-06,
+            "baseline_max_expected_utility": 0.143531,
+            "conditional_max_expected_utility": 0.143539,
+            "units": "outcome",
+            "method": "regression_evppi_v1",
+            "regression_degree": 4,
+            "n_samples": 10000,
+            "clamped_low": false,
+            "clamped_high": false,
+            "noise_floor": 0.000144,
+            "status": "below_resolution",
+            "correlation_active": false
+          }
+        ],
+        "decision_evpi": 0.09474318805872213,
+        "p_win_sensitivity": [
+          {
+            "factor_id": "fac_flour_price",
+            "p_win_delta": 0.032683,
+            "p_win_delta_percentage_points": 3.27,
+            "current_metric": 0.334375,
+            "perfect_metric": 0.367058,
+            "metric_type": "p_win_recommended",
+            "method": "p_win_delta_at_mean_v1",
+            "n_samples": 2000,
+            "status": "resolved",
+            "clamped": false,
+            "noise_floor": 0.03099,
+            "noise_floor_method": "z95_worst_case_bernoulli_diff",
+            "labelling_doctrine": "provisional_doctrine_v0"
+          },
+          {
+            "factor_id": "fac_oven",
+            "p_win_delta": 0.031208,
+            "p_win_delta_percentage_points": 3.12,
+            "current_metric": 0.334375,
+            "perfect_metric": 0.365583,
+            "metric_type": "p_win_recommended",
+            "method": "p_win_delta_at_mean_v1",
+            "n_samples": 2000,
+            "status": "resolved",
+            "clamped": false,
+            "noise_floor": 0.03099,
+            "noise_floor_method": "z95_worst_case_bernoulli_diff",
+            "labelling_doctrine": "provisional_doctrine_v0"
+          },
+          {
+            "factor_id": "fac_vans",
+            "p_win_delta": 0.029892,
+            "p_win_delta_percentage_points": 2.99,
+            "current_metric": 0.334375,
+            "perfect_metric": 0.364267,
+            "metric_type": "p_win_recommended",
+            "method": "p_win_delta_at_mean_v1",
+            "n_samples": 2000,
+            "status": "below_resolution",
+            "clamped": false,
+            "noise_floor": 0.03099,
+            "noise_floor_method": "z95_worst_case_bernoulli_diff",
+            "labelling_doctrine": "provisional_doctrine_v0"
+          },
+          {
+            "factor_id": "fac_retrofit",
+            "p_win_delta": 0.018475,
+            "p_win_delta_percentage_points": 1.85,
+            "current_metric": 0.334375,
+            "perfect_metric": 0.35285,
+            "metric_type": "p_win_recommended",
+            "method": "p_win_delta_at_mean_v1",
+            "n_samples": 2000,
+            "status": "below_resolution",
+            "clamped": false,
+            "noise_floor": 0.03099,
+            "noise_floor_method": "z95_worst_case_bernoulli_diff",
+            "labelling_doctrine": "provisional_doctrine_v0"
+          },
+          {
+            "factor_id": "fac_packing",
+            "p_win_delta": 0.009975,
+            "p_win_delta_percentage_points": 1,
+            "current_metric": 0.334375,
+            "perfect_metric": 0.34435,
+            "metric_type": "p_win_recommended",
+            "method": "p_win_delta_at_mean_v1",
+            "n_samples": 2000,
+            "status": "below_resolution",
+            "clamped": false,
+            "noise_floor": 0.03099,
+            "noise_floor_method": "z95_worst_case_bernoulli_diff",
+            "labelling_doctrine": "provisional_doctrine_v0"
+          }
+        ]
+      },
+      "computed_against_hash": "5bdc3229419438f1"
+    },
+    {
+      "block_id": "d0fc6072-03c7-5ad0-b6c2-b6edd7ded96e",
+      "signal_id": "review:narrative:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "narrative",
+      "title": "How the analysis reads",
+      "body": "The Energy-Efficiency Retrofit leads by a narrow margin of about 2 percentage points, but there is substantial uncertainty around this result. That lead could change if key assumptions about energy cost savings or flour price prove off target.",
+      "severity": "info",
+      "target_refs": [],
+      "priority_rank": 10,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ANALYSIS_NARRATIVE"
+    },
+    {
+      "block_id": "46031ca5-756c-5271-bfdb-fd105a1701e5",
+      "signal_id": "review:robustness:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "robustness",
+      "title": "How robust is this?",
+      "body": "The ordering holds in about 36% of variations, with several plausible scenarios where the Automated Packing Cell overtakes.",
+      "severity": "warning",
+      "target_refs": [],
+      "priority_rank": 50,
+      "category": "should_fix",
+      "priority": 70,
+      "signal_code": "FRAGILE_RESULT"
+    },
+    {
+      "block_id": "04b1791a-063a-565e-893d-fd51c4c528d1",
+      "signal_id": "review:evidence_priority:fac_flour_price:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "evidence_priority",
+      "title": "Highest-leverage evidence gap: Wholesale Flour Price",
+      "body": "Flour price is the main uncertainty and could significantly change which project most reliably boosts profit.",
+      "severity": "info",
+      "target_refs": [
+        {
+          "id": "fac_flour_price",
+          "label": "Wholesale Flour Price",
+          "kind": "factor"
+        }
+      ],
+      "priority_rank": 60,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "EVIDENCE_GAP",
+      "action_intent": "gather_evidence",
+      "action_label": "Strengthen this evidence"
+    },
+    {
+      "block_id": "39956c8f-ab18-5a93-928b-6d7234d4e28d",
+      "signal_id": "review:assumption:1:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "body": "The link from Energy Cost Saving to Raise Operating Profit by 8% Within 18 Months takes historical energy cost savings as a guide.",
+      "severity": "info",
+      "target_refs": [],
+      "priority_rank": 71,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK"
+    },
+    {
+      "block_id": "0de5672a-bec0-56b3-abdf-119e34af841b",
+      "signal_id": "review:assumption:2:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "body": "Wholesale Flour Price is assumed within a plausible range, but large swings could upset this order.",
+      "severity": "info",
+      "target_refs": [],
+      "priority_rank": 72,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK"
+    },
+    {
+      "block_id": "1bb9f8d4-4ffc-5a85-84b3-aa47617ef015",
+      "signal_id": "review:assumption:3:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "review_card",
+      "card_kind": "assumption",
+      "title": "A load-bearing assumption",
+      "body": "Production Throughput Uplift is presumed to convert reliably into profit within the 18-month window.",
+      "severity": "info",
+      "target_refs": [],
+      "priority_rank": 73,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK"
+    },
+    {
+      "block_id": "85e2055f-cabf-5fd6-8fe9-f4b6a07a53c0",
+      "signal_id": "coach:assumption:1:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "body": "The link from Energy Cost Saving to Raise Operating Profit by 8% Within 18 Months takes historical energy cost savings as a guide.",
+      "source": "decision_review",
+      "target_refs": [
+        {
+          "id": "goal_profit",
+          "label": "Raise Operating Profit by 8% Within 18 Months",
+          "kind": "goal"
+        },
+        {
+          "id": "out_energy_saving",
+          "label": "Energy Cost Saving",
+          "kind": "outcome"
+        }
+      ],
+      "priority_rank": 101,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK",
+      "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
+      "action_prompt": "Help me pressure-test this assumption before I rely on it."
+    },
+    {
+      "block_id": "bf971f03-f893-5eb0-bc89-9ae9392a7a76",
+      "signal_id": "coach:assumption:2:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "body": "Wholesale Flour Price is assumed within a plausible range, but large swings could upset this order.",
+      "source": "decision_review",
+      "target_refs": [
+        {
+          "id": "fac_flour_price",
+          "label": "Wholesale Flour Price",
+          "kind": "factor"
+        }
+      ],
+      "priority_rank": 102,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK",
+      "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
+      "action_prompt": "Help me pressure-test this assumption before I rely on it."
+    },
+    {
+      "block_id": "9d510413-9d23-501b-99a0-37ee2b2f9e5a",
+      "signal_id": "coach:assumption:3:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "assumption_check",
+      "title": "An assumption to check",
+      "body": "Production Throughput Uplift is presumed to convert reliably into profit within the 18-month window.",
+      "source": "decision_review",
+      "target_refs": [
+        {
+          "id": "out_throughput",
+          "label": "Production Throughput Uplift",
+          "kind": "outcome"
+        }
+      ],
+      "priority_rank": 103,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "ASSUMPTION_CHECK",
+      "action_intent": "confirm_factor",
+      "action_label": "Confirm this assumption",
+      "action_prompt": "Help me pressure-test this assumption before I rely on it."
+    },
+    {
+      "block_id": "42819885-affd-563e-a61d-d378222889ee",
+      "signal_id": "coach:calibration:1:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "calibration_prompt",
+      "title": "Consider-the-opposite prompt",
+      "body": "What evidence would change your confidence in the Energy-Efficiency Retrofit leading over Automated Packing Cell?",
+      "source": "decision_review",
+      "target_refs": [
+        {
+          "id": "opt_packing",
+          "label": "Automated Packing Cell",
+          "kind": "option"
+        },
+        {
+          "id": "opt_retrofit",
+          "label": "Energy-Efficiency Retrofit",
+          "kind": "option"
+        }
+      ],
+      "priority_rank": 201,
+      "category": "technique",
+      "priority": 30,
+      "signal_code": "CALIBRATION_PROMPT",
+      "action_intent": "start_guided_chat",
+      "action_label": "Try this prompt",
+      "action_prompt": "What evidence would change your confidence in the Energy-Efficiency Retrofit leading over Automated Packing Cell?"
+    },
+    {
+      "block_id": "352d0818-d743-5aaf-ad7c-e4474291d705",
+      "signal_id": "coach:calibration:2:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "calibration_prompt",
+      "title": "Outside view and reference class forecasting prompt",
+      "body": "What is the base rate for energy-efficiency retrofits delivering the promised profit uplift on similar projects?",
+      "source": "decision_review",
+      "target_refs": [],
+      "priority_rank": 202,
+      "category": "technique",
+      "priority": 30,
+      "signal_code": "CALIBRATION_PROMPT",
+      "action_intent": "start_guided_chat",
+      "action_label": "Try this prompt",
+      "action_prompt": "What is the base rate for energy-efficiency retrofits delivering the promised profit uplift on similar projects?"
+    },
+    {
+      "block_id": "06566f60-e722-5efc-8ca8-36eccafe886e",
+      "signal_id": "evidence:fac_flour_price:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "evidence",
+      "factor_label": "Wholesale Flour Price",
+      "factor_ref": {
+        "id": "fac_flour_price",
+        "label": "Wholesale Flour Price",
+        "kind": "factor"
+      },
+      "target_refs": [
+        {
+          "id": "fac_flour_price",
+          "label": "Wholesale Flour Price",
+          "kind": "factor"
+        }
+      ],
+      "current_confidence": "medium",
+      "evidence_gap": "Flour price is the main uncertainty and could significantly change which project most reliably boosts profit.",
+      "suggested_technique": "Market research: Gather independent forecasts or procurement data on wholesale flour pricing for the coming year.",
+      "impact_if_gathered": "Estimate flour price impacts before reviewing new data.",
+      "priority_rank": 1,
+      "severity": "info",
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "EVIDENCE_GAP",
+      "action_intent": "gather_evidence",
+      "action_label": "Strengthen this evidence"
+    },
+    {
+      "block_id": "59e81edf-31a4-579e-8441-08a667dfff3b",
+      "signal_id": "coach:lens:sensitivity_flip_risk:sensitivity_flip_risk:5bdc3229419438f1",
+      "created_at": "2026-08-05T16:02:41.010Z",
+      "source_handler": "decision_review_enricher",
+      "graph_hash_at_generation": "5bdc3229419438f1",
+      "freshness": "fresh",
+      "type": "coaching",
+      "coaching_kind": "strengthen",
+      "title": "Strengthen your model: size up the key driver",
+      "body": "This factor moves the result more than any other. The analysis swept its whole tested range and the ranking never changed, so what is still open is the size of the gap, not the order. Pressure-testing this factor tells you how much of the margin rests on it.",
+      "source": "deterministic_signal",
+      "target_refs": [],
+      "priority_rank": 15,
+      "category": "could_fix",
+      "priority": 50,
+      "signal_code": "STRENGTHEN_ITEM"
+    },
+    {
+      "type": "ui_directive",
+      "verb": "focus",
+      "targets": [
+        {
+          "id": "fac_retrofit",
+          "label": "Energy-Efficiency Retrofit Deployment",
+          "kind": "factor"
+        }
+      ]
+    }
+  ],
+  "suggested_actions": [
+    {
+      "id": "chip_action_explain_results",
+      "label": "Explain the result",
+      "message": "Please explain the analysis result in plain language.",
+      "action_type": "explain_results"
+    },
+    {
+      "id": "chip_action_what_would_flip",
+      "label": "What could change the outcome?",
+      "message": "What could change the outcome of this analysis?",
+      "action_type": "what_would_flip"
+    },
+    {
+      "id": "chip_prompt_validate_decision",
+      "label": "What should we validate?",
+      "message": "What should we validate or research to build confidence in this decision?"
+    }
+  ],
+  "insights": [],
+  "stage_indicator": "analyse",
+  "analysis_ready": {
+    "options": [
+      {
+        "option_id": "opt_oven",
+        "label": "Second Production Oven Line",
+        "status": "ready",
+        "interventions": {
+          "fac_oven": 1,
+          "fac_vans": 0,
+          "fac_packing": 0,
+          "fac_retrofit": 0
+        },
+        "is_baseline": false
+      },
+      {
+        "option_id": "opt_packing",
+        "label": "Automated Packing Cell",
+        "status": "ready",
+        "interventions": {
+          "fac_oven": 0,
+          "fac_vans": 0,
+          "fac_packing": 1,
+          "fac_retrofit": 0
+        },
+        "is_baseline": false
+      },
+      {
+        "option_id": "opt_retrofit",
+        "label": "Energy-Efficiency Retrofit",
+        "status": "ready",
+        "interventions": {
+          "fac_oven": 0,
+          "fac_vans": 0,
+          "fac_packing": 0,
+          "fac_retrofit": 1
+        },
+        "is_baseline": false
+      },
+      {
+        "option_id": "opt_status_quo",
+        "label": "No Capital Investment (Status Quo)",
+        "status": "ready",
+        "interventions": {
+          "fac_oven": 0,
+          "fac_vans": 0,
+          "fac_packing": 0,
+          "fac_retrofit": 0
+        },
+        "is_baseline": true
+      },
+      {
+        "option_id": "opt_vans",
+        "label": "Refrigerated Delivery Vans",
+        "status": "ready",
+        "interventions": {
+          "fac_oven": 0,
+          "fac_vans": 1,
+          "fac_packing": 0,
+          "fac_retrofit": 0
+        },
+        "is_baseline": false
+      }
+    ],
+    "goal_node_id": "goal_profit",
+    "status": "ready",
+    "computed_at": "2026-08-05T16:02:27.804Z",
+    "freshness": "fresh",
+    "freshness_reason": "graph_hash_match",
+    "graph_hash_at_run": "5bdc3229419438f1",
+    "current_graph_hash": "5bdc3229419438f1"
+  },
+  "graph_hash": "5bdc3229419438f1",
+  "_diagnostic_trace": {
+    "llm_calls": [
+      {
+        "role": "decision_review",
+        "provider": "openai",
+        "model": "gpt-4.1",
+        "input_tokens": 10801,
+        "output_tokens": 822,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "latency_ms": 8064,
+        "stop_reason": null,
+        "thinking_enabled": false,
+        "error": null
+      }
+    ],
+    "prompt_identity": [],
+    "zone2_assembly": null,
+    "tool_policy": null,
+    "provider_resolution": [],
+    "structured_output_config": null,
+    "streaming_metrics": null,
+    "fallback_trace": [],
+    "benchmarking": {
+      "total_duration_ms": 15129,
+      "substage_timings": {
+        "finalisation_ms": 3
+      }
+    },
+    "correlation_ids": {
+      "request_id": "49a1ed85-575a-4df5-8e5e-0ef500ef4e13",
+      "scenario_id": "9657b1ab-78c6-4482-b9fe-a221bd53129e",
+      "turn_id": "26bb6e1b-a5fa-41cc-9e83-53959f848afc",
+      "graph_hash": "c095805a48f0f585",
+      "response_hash": "bd52554478e3"
+    },
+    "environment": {
+      "build_sha": "e82738b",
+      "environment": "staging"
+    },
+    "exit_path": "chip_click",
+    "trace_version": 1,
+    "claim_safety": {
+      "may_name_leading_option": true,
+      "verdict_provenance": null,
+      "withheld_projection_reason": null
+    }
+  }
+}


### PR DESCRIPTION
## ⚠ THE ROW'S PREMISE IS WRONG, AND THE MEASUREMENT IS THE MAIN DELIVERABLE

ROADMAP 2.581 opened on *"the downside tail is scenario-dependent on the same builds"* and prescribed **a typed versioned contract across every producer**, on the theory that PLoT's 0.31 passthrough was losing the object.

**Nothing was lost by ISL, PLoT or CEE.** The payload of the reproduction run carried the complete downside block for **all five options**.

> ⚠ **CORRECTION (adversarial review, applied before merge).** An earlier version of this sentence said *"the tester's own failing session"*. **That is not what run5 is.** `run5` is a **scripted reproduction** driven on the same UI/CEE builds; its `driver.log` records a **regex text match** on a button (`/^Expert$/i`), not a human click. **No capture of the originally-described failing session exists anywhere in the evidence set.** The reproduction is not weaker evidence for the *mechanism* — it is stronger, because it is controlled and repeatable and the control that was pressed is recorded at the bytes. But it is **not** the reported session, and describing it as such would attribute to a human tester an action a script performed. Every claim below is a claim about the controlled reproduction.

### The producer-payload comparison the tester said was needed

`PHASE0-EVIDENCE-2026-07-28/expert-session-2026-08-05-raw/run5/wire.json`, wire entry 14 — `POST https://cee-staging.onrender.com/proxy/v5/turn`, `chip_action_run_analysis`, UI `5f066967`, CEE build `e82738b`. This is the run whose option cards the tester opened one by one and found *"no tail values and no caveat"*:

```
blocks[0].enrichment.option_comparison[0..4].downside
  opt_oven        { cvar_10: -0.3079481799761663, p05: -0.2887558172745903, expected_regret: 0.2073... }
  opt_packing     { cvar_10: -0.1121922406421878, p05: -0.1025023596903347, ... }
  opt_retrofit    { cvar_10: -0.0613142121857770, p05: -0.0538677765254035, ... }
  opt_status_quo  { cvar_10: -0.0689137803169610, p05: -0.0596429329302033, ... }
  opt_vans        { cvar_10: -0.1556331378180801, p05: -0.1458905846824230, ... }
option_comparison_status: "computed"   n_samples: 10000   validity_ratio: 1
```

Runs 2, 3 and 4 of the same evidence set also carry `downside` on the wire, and none of the five rendered it. The deployed commit `5f066967` contains the whole 2.449 chain (`downsideCopy.ts` present, `normaliseDownside` present, `option-downside-` render present) — **verified with `git cat-file` at that SHA.**

### The trigger

**There are two independent things called "Expert", and the tester pressed the wrong one — because it is the only one that says the word.**

| | control | state | scope |
|---|---|---|---|
| Results / OutputsDock | unlabelled **`</>`** glyph (aria-label "Enable expert mode") | `olumi.expertMode` = `'true'`/`'false'` | gates `OptionCards`' whole `ExpertBlock`: range bar **and** tail **and** caveat |
| Compare tab | pill whose visible text is **"Expert"** (`compare-tab/TabHeader.tsx:27`) | `feature.compareExpert` = `'1'`/`'0'` | Refinement-journey rows only |

`run5/driver.log`, at the bytes:

```
16:02:54.598  compare  {"text":"Compare"}
16:02:57.104  expert   {"text":"Expert"}      ← the COMPARE pill
16:02:59.193  analysis-tab {"text":"Analysis"}
```

`</>` is present in run5's button list at 02 and 04 and was **never clicked**. The Analysis tab therefore stayed in simple mode, and the `10th/median/90th` the tester still saw is the V7 *Likely outcome* lens (`Cautious (p10) / Middle (p50) / Optimistic (p90)`), which is not expert-gated at all — exactly matching the report.

**Positive proof of the other arm:** the PASSING session's a11y snapshot (`codex-simulated-user-2026-08-05-raw/root/03-analysis-expert.snapshot.yml:345`) contains the string **`Disable expert mode`**, which `OutputsDock` renders *only* when `expertMode === true`.

## What this PR changes

1. **One expert mode.** `CompareTabBody` becomes a controlled consumer of OutputsDock's single state; `feature.compareExpert` and its `useState` are **deleted**, not synchronised (trap 12: the fix for a mirror is to remove it).
2. **The stated absence.** `downsideCopy.ts` rule 3 ("ABSENCE IS BLANK") is amended under this row's authority: when expert mode is on and the producers genuinely omitted the block, the reader is **told**, and is still never shown a number. The sentence deliberately does **not** promise a rerun would help — see below.
3. **The row's acceptance gate**, bound to the real mount path (`<ResultsBody>`, not `<OptionCards>` in isolation) at the deployed flag posture, fed by the failing session's own payload: expert **before** and **after** the analysis, every option card reopened without a rerun.

## Why NOT the typed contract, and what actually needs building

A typed versioned `downside` would fix nothing here — the object already arrives complete, and PLoT's own egress is *already* typed (`DownsideStatsV3` + `buildDownside`, an all-or-nothing finiteness guard). The passthrough in the shared 0.31 schema is what **lets the field through** while the contract lags; ISL's own drift baseline records `DownsideV2` as *"ISL emits ahead of contract adoption"*.

The real producer-side gap is different and is **not fixed by this PR**: the tail is omitted behind a set of gates that is **mostly, but not entirely, silent**.

> ⚠ **CORRECTION (adversarial review, applied before merge).** This previously read *"nine silent gates with no reason channel"*. Narrowed on three counts:
> 1. **A reason channel partly EXISTS and is thrown away in transit.** ISL emits `outcome.percentiles_source`, and the value `"unavailable"` **discriminates gates 1–3**. It is **dropped before it reaches the UI**, so the honest-unavailable work is at least as much about *stopping the discard* as about inventing a new channel — a materially cheaper and differently-shaped job than the original framing implied.
> 2. **ISL gate 7 is unreachable as a failure mode**, so it should not be counted among the live omission causes.
> 3. **PLoT does not merely drop the `downside`** — it drops the **whole `outcome` object** when any of `mean`/`p10`/`p50`/`p90` is non-finite, which is a larger blast radius than "the tail is omitted" and is not a gate on the tail at all.
>
> The honest statement: the omission causes that actually reach a user are fewer than nine, one family of them is already discriminable at the source, and the follow-on row should be scoped to **plumbing `percentiles_source` through PLoT → CEE → UI first**, not to designing a channel from scratch.

*ISL `src/api/robustness.py:974-1050` @ `c25836f7` — all seven must hold:* `finite_samples is not None` · `len(finite_cleaned) > 0` · `percentiles_source == 'samples'` (an extreme mixed-sign population overflows `np.percentile` → `'unavailable'`) · `pre_noise_expected_regret is not None` · `isfinite(pre_noise_regret)` · `isfinite(cvar_val)` · `isfinite(p05_val)`.
*PLoT `routes/v2/run.ts:2661` + `numeric-egress-guards.ts:89` @ `e52c0335`:* `outcome !== undefined` · all three components finite with `expected_regret >= 0`.

Every failure omits the key with **no reason on the wire**, so the UI cannot say which case applied or whether a rerun would help. **That is the honest-unavailable-reason work, and it belongs in ISL + PLoT + the contract — rowed as a follow-on, deliberately not attempted here.**

## ⚠ CODE CHANGED ON REVIEW (`f0261513`) — two claims this PR itself had not earned

The review that produced the corrections above also found the PR making, in its own product surface, the exact class of unearned claim the row exists to eliminate. Both are fixed here, RED-first, with mutants.

**1. `DOWNSIDE_UNAVAILABLE_COPY` named a culprit the UI cannot identify.**

```
was: "…The engine did not return one and does not say why, so we cannot tell
      you whether running it again would produce one."
now: "…We cannot tell you why, or whether running it again would produce one."
```

At the point that string renders, `option.downside` is `undefined` — and that **one** observation has **three** causes this component cannot tell apart: a producer omitted it (no reason on the wire); **our own `normaliseDownside` dropped a partially-arrived block** (it is all-or-nothing); or **schema-pin skew ate the field** before it arrived (this estate has lost coaching, evidence and enrichment fields exactly that way). Two of the three are **ours**. "The engine did not return one" attributed a fault we had not established, on the one surface whose whole purpose is to not do that. The honest no-promise remainder — which the review called the best thing in the PR — is kept.

New guard on the real mount path, `the stated absence BLAMES NOBODY`: asserts the **rendered** text (not the constant) carries none of `engine` / `server` / `failed` / `error` / "did not return" / "could not compute", with a positive control on the line's length so an empty string cannot satisfy it, and re-asserts the no-promise clause survives.

**2. A spec claimed "exactly ONE expert-mode storage key exists across all non-test source". False as written — and it passed only because its sweep matched the WORD "expert" in a key NAME.**

There is a **third** state, and it is the second surviving one:

| | key | values | controls | gates the tail? |
|---|---|---|---|---|
| Results | `olumi.expertMode` | `'true'`/`'false'` | `</>` glyph | **yes** |
| Canvas detail | **`canvas.viewMode`** (`store.ts:669/1709/4992`) | **`'standard'` \| `'expert'`** | **"Detailed"/"Standard"** — `LeftSidebar.tsx:158`, `useMenuItems.ts:222` | **no** |

It is named for its **values**, so a name-based sweep is structurally blind to it — trap 12d landing inside the file whose entire subject is two controls being mistaken for each other. The spec now sweeps **both ways** and claims what is true: by NAME exactly one key; by VALUE exactly one key holds the literal `'expert'` (window measured at 120/200/400 characters across **all 34** persisted keys in non-test source — every window returns the same single key, so 200 is the middle of a plateau, not a threshold on a cliff edge); hand-pinned union `['canvas.viewMode', 'olumi.expertMode']`. Scope is pinned **structurally** (no file under `src/components/results` reads `viewMode`) **and behaviourally** (`canvas.viewMode='expert'` with results expert mode OFF reveals no tail, with a discriminating control — same render, results expert ON — proving the harness can show one).

**Mutants for the review fixes** (same isolation discipline; each asserts its own mutated text is present before running, and is restored from git, never from the other copy):

| | mutation | measured |
|---|---|---|
| C0 | baseline, no mutation | **14/14 green** |
| N1 | regrow the causal attribution | **RED — only `BLAMES NOBODY`** |
| N2 | value sweep's window → 0 | **RED — only the by-VALUE sweep, at its positive control** |
| N3 | rename `canvas.viewMode` → `canvas.displayDepth` | **RED — only the by-VALUE sweep** |
| N4 | wire the canvas mode into `OptionCards`' expert gate | **RED — exactly the two new scope tests, nothing else** |

## Evidence

**Mutants** — throwaway worktree at an absolute path outside the repo root; isolation proven **by writing** a sentinel and asserting the source sha was unchanged, inodes compared (`545547550` vs `545602218`, not hard-linked); applied-check scoped to `src/`, control **exactly 0** at both ends.

| | mutation | expected | measured |
|---|---|---|---|
| control | pristine | GREEN | **10/10 passed**, applied-check 0 |
| M1 | delete the stated-absence branch | RED | **2 failed / 4 passed** |
| M2 | `normaliseDownside` always returns `undefined` | RED | **4 failed / 2 passed** |
| M3 | `CompareTabBody` regrows its own expert state | RED | **2 failed / 2 passed** |
| M4 | OutputsDock stops passing expert mode down | RED | **1 failed / 3 passed** |
| M5a | **swap** `opt_oven`'s and `opt_vans`' tail values on the wire | RED | **4 failed / 2 passed** |
| M5b | perturb `expected_regret` (deliberately never displayed) | RED | **1 failed / 5 passed** |

**⚠ M5a SURVIVED on the first kit run, and the fix is in this PR.** The first version of the spec drew both the rendered input and the expected output from the same derivation, so swapping two options' tail values moved both together and the whole suite stayed green — a guard agreeing with itself (trap 13b), wearing identity-binding's clothes. The magnitudes are now pinned by hand in `CAPTURED_DOWNSIDE` (trap 12d: derivation proves consistency, a corpus is what notices a mis-join) while the *wording* stays derived from the product's own formatter.

> ⚠ **CORRECTION (adversarial review, re-measured at `d4bd1c28` before merge).** This section previously recorded **M5b as GREEN — an equivalent mutant — and called M5a/M5b "the discriminating pair"**. Both statements are withdrawn. **M5b bites: 1 failed / 5 passed.** Re-run in an isolated worktree (inodes distinct, isolation proven by writing a sentinel and asserting the source SHA-256 unchanged), applied-check scoped to `src/` reading exactly 1 file, pristine control 6/6 green. Perturbing `opt_oven`'s `expected_regret` on the wire reds *the failing session's own payload yields a downside for EVERY option id, at its exact magnitudes* — because that test asserts the **whole wire object** against `CAPTURED_DOWNSIDE`, `expected_regret` included, which is exactly what the file's own comment says it does ("`expected_regret` is pinned too even though it is deliberately never displayed, so a producer-side change to it is visible rather than silent"). The original **GREEN / "3 passed / 3 skipped"** figure came from a **filtered run that never collected that test**. **Both mutants bite; there is no discriminating pair here, and none is needed** — M5a alone is the binding proof, and an equivalent mutant must be *demonstrated*, never asserted.

**Gates, at my tip**
- `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**; coverage 3249/3289 tracked files, ratchet 620 files / 2491 errors against baseline 2491.
- `npx vitest run src/components/results src/canvas/compare-tab` — **252 files / 4455 tests passed**, with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` set (`SUPABASE_BINDING: real`, no collect shrink).
- Eight pre-existing `CompareTabBody` spec render sites were updated at source for the now-required props — **not absorbed into any baseline**.

**Not established / not done here**
- No live witness on a deployed build — this is a fresh-clone lane.
- The passing session has no wire capture, only its a11y snapshot; its expert state is proven, its payload is not.
- ISL and PLoT were read only (no install, no gate run) — this PR touches neither.
- The two other sessions' drivers (runs 2 and 4) were not traced to a specific control click; only run5's driver log names it.


---

### Gates at the review-fix head `f0261513`

- `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**. Coverage 3249 / 3289 tracked TS files (40 declared out of scope); ratchet **620 files / 2491 errors against baseline 2491 — 0 new**.
- `pnpm run lint` — **PASSED**, 0 errors (1261 pre-existing warnings); `lint:hooks-ratchet` **234 known violations across 16 files, exactly at baseline**.
- Affected suites (`src/components/results`, `src/canvas/compare-tab`, `src/components/layout`) run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported — `SUPABASE_BINDING: real`, no collect shrink.
- The two directly-edited specs: **14/14 green** (was 10; +4 new guards).
