### PR TITLE
2.578 — Compare derives its change labels from a canonical graph diff, not run metadata

### DIFF
--- a/src/canvas/compare-tab/Hero.tsx
+++ b/src/canvas/compare-tab/Hero.tsx
@@ -72,9 +72,19 @@ function getHeroCopy(
       const narrow = isNarrowFlip(latest)
       return {
         line1: `Run ${latest.runNumber} · Result changed: ${latest.winnerLabel} now leads at ${latest.winnerProbability}%`,
+        // ⚠ THIS USED TO READ 'Structure changed · Review the new result'
+        // (ROADMAP 2.578). The `flipped` state is `previous.winnerId !==
+        // latest.winnerId` and NOTHING ELSE — a change of leading option. It is
+        // not evidence about the model's shape, and no structure signal is in
+        // scope here at all. So the hero was asserting a cause it had never
+        // measured, on the same surface where the transition card states the
+        // structure verdict from the canonical graph diff — the two could, and
+        // would, contradict each other on a wide flip over an unchanged model.
+        // The replacement says only what this branch actually knows: the leader
+        // changed, and not narrowly.
         line2: narrow
           ? 'New leader by a narrow margin · Review the change carefully'
-          : 'Structure changed · Review the new result',
+          : 'Result changed decisively · Review the new result',
         actionPrefix: '',
         actionLink: 'Review what caused the change',
         actionNodeId: null,

--- a/src/canvas/compare-tab/RunPairCompare.tsx
+++ b/src/canvas/compare-tab/RunPairCompare.tsx
@@ -18,6 +18,7 @@ import { typography } from '../../styles/typography'
 import { GraphLink } from '../../components/results/GraphLink'
 import { highlightNode, clearHighlight } from '../utils/highlightHelpers'
 import { runLabel } from './runLabels'
+import { UNCHARACTERISED_CHANGE_SUMMARY, type GraphChangeKind } from './graphChangeDiff'
 import type { AnalysisSnapshot, LeaderClaim, RunPairComparison } from './types'
 
 interface RunPairCompareProps {
@@ -68,9 +69,35 @@ const STRUCTURE_TEXT: Record<RunPairComparison['structure'], string> = {
   not_comparable: 'Not comparable',
 }
 
-const STRUCTURE_DETAIL: Record<RunPairComparison['structure'], string> = {
-  changed: 'The model these runs were computed over is not the same',
+/**
+ * WHY THIS IS KEYED OFF THE VERDICT KIND AND NOT OFF `structure` (2.578 F1).
+ *
+ * `STRUCTURE_TEXT` above answers ONE question — did the shape move? — and three
+ * answers cover it. This sentence answers a different question, "why does it say
+ * that?", and there are five reasons. When 2.578 made `compareStructure` a
+ * projection of the one verdict it WIDENED two of the three preimages, and each
+ * of these sentences went on being printed for cases it was never true of:
+ *
+ *  · `'unchanged'` acquired `value_only`, so "Both runs were computed over the
+ *    same model" appeared beside the list of values that had just changed — the
+ *    +0.50 → +0.80 journey this whole row exists to fix, reappearing one surface
+ *    over.
+ *  · `'not_comparable'` acquired same-regime `uncharacterised_change`, so two
+ *    `aag_v1` hashes that were read and compared successfully were reported as
+ *    "different, incomparable identifiers" — the screen blaming a provenance
+ *    boundary for a change it had in fact measured, while the transition card
+ *    for the same pair said the model changed.
+ *
+ * `uncharacterised_change` quotes the card's own constant rather than restating
+ * it, so the two surfaces cannot drift apart (CLAUDE.md trap 12).
+ */
+const STRUCTURE_DETAIL: Record<GraphChangeKind, string> = {
+  structural: 'The model these runs were computed over is not the same',
   unchanged: 'Both runs were computed over the same model',
+  value_only: 'The model has the same shape in both runs — some of its values changed',
+  uncharacterised_change: UNCHARACTERISED_CHANGE_SUMMARY,
+  // Cross-regime, or a hash absent at one end: nothing was compared, so nothing
+  // is claimed about whether the model moved.
   not_comparable: 'These two runs record their model with different, incomparable identifiers',
 }
 
@@ -219,7 +246,7 @@ export function RunPairCompare({ comparison }: RunPairCompareProps) {
         className={`${typography.panelMeta} px-4 pb-1.5 text-text-light`}
         data-testid="structure-detail"
       >
-        {STRUCTURE_DETAIL[comparison.structure]}
+        {STRUCTURE_DETAIL[comparison.changeKind]}
       </div>
       <Row
         testId="coverage-row"

--- a/src/canvas/compare-tab/TransitionCard.tsx
+++ b/src/canvas/compare-tab/TransitionCard.tsx
@@ -47,6 +47,8 @@ export function TransitionCard({
   const [open, setOpen] = useState(startOpen)
   const cardKey = `${tr.fromRunNumber}-${tr.toRunNumber}`
   const maxAbs = Math.max(20, ...allDeltas.map(d => Math.abs(d)))
+  const hasDetail =
+    tr.changeVerdict.fieldChanges.length > 0 || tr.changeVerdict.membershipChanges.length > 0
 
   // Hover handler for edit area
   const handleEditsHover = () => {
@@ -90,24 +92,44 @@ export function TransitionCard({
             onMouseEnter={handleEditsHover}
             onMouseLeave={clearHighlight}
           >
-            {tr.edits.map((e, i) => (
-              <div key={i} className={typography.panelBody}>• {e}</div>
-            ))}
             {/*
-              ROADMAP 2.578 — the exact changed fields, by element IDENTITY.
-              This is what makes Compare an audit trail: "why did the
-              recommendation change?" is answered with "strength 0.5 → 0.8 on
-              this relationship", not with a magnitude adjective.
+              ROADMAP 2.578 — ONE description of the change, never two.
+              When the canonical diff has detail, IT is the description: the
+              exact element, the exact field, before → after, by IDENTITY. That
+              is what makes Compare an audit trail — "why did the recommendation
+              change?" answered with "strength 0.5 → 0.8 on this relationship"
+              rather than a magnitude adjective.
+              `tr.edits` carries the same facts as prose and is the fallback for
+              the cases with no detail to show (a provably identical rerun, or a
+              run whose graph was never recorded). Rendering both would print
+              every change twice.
             */}
-            {tr.changeVerdict.fieldChanges.map((c) => (
-              <div
-                key={`${c.element}-${c.id}-${c.field}`}
-                className={typography.panelMeta}
-                data-testid={`change-${c.element}-${c.id}-${c.field}`}
-              >
-                {c.label} · {fieldDisplayLabel(c.field)} {formatChangeValue(c.before)} → {formatChangeValue(c.after)}
-              </div>
-            ))}
+            {hasDetail ? (
+              <>
+                {tr.changeVerdict.membershipChanges.map((c) => (
+                  <div
+                    key={`m-${c.element}-${c.id}`}
+                    className={typography.panelBody}
+                    data-testid={`change-${c.element}-${c.id}-${c.op}`}
+                  >
+                    • {c.op === 'added' ? 'Added' : 'Removed'} {c.element} “{c.label}”
+                  </div>
+                ))}
+                {tr.changeVerdict.fieldChanges.map((c) => (
+                  <div
+                    key={`f-${c.element}-${c.id}-${c.field}`}
+                    className={typography.panelBody}
+                    data-testid={`change-${c.element}-${c.id}-${c.field}`}
+                  >
+                    • {c.label} · {fieldDisplayLabel(c.field)} {formatChangeValue(c.before)} → {formatChangeValue(c.after)}
+                  </div>
+                ))}
+              </>
+            ) : (
+              tr.edits.map((e, i) => (
+                <div key={i} className={typography.panelBody}>• {e}</div>
+              ))
+            )}
           </div>
 
           <div className="h-2" />

--- a/src/canvas/compare-tab/TransitionCard.tsx
+++ b/src/canvas/compare-tab/TransitionCard.tsx
@@ -4,6 +4,7 @@ import { typography } from '../../styles/typography'
 import { GraphLink } from '../../components/results/GraphLink'
 import { highlightNode, clearHighlight } from '../utils/highlightHelpers'
 import { useCanvasStore } from '../store'
+import { fieldDisplayLabel, formatChangeValue } from './graphChangeDiff'
 import type { Transition } from './types'
 
 interface TransitionCardProps {
@@ -91,6 +92,21 @@ export function TransitionCard({
           >
             {tr.edits.map((e, i) => (
               <div key={i} className={typography.panelBody}>• {e}</div>
+            ))}
+            {/*
+              ROADMAP 2.578 — the exact changed fields, by element IDENTITY.
+              This is what makes Compare an audit trail: "why did the
+              recommendation change?" is answered with "strength 0.5 → 0.8 on
+              this relationship", not with a magnitude adjective.
+            */}
+            {tr.changeVerdict.fieldChanges.map((c) => (
+              <div
+                key={`${c.element}-${c.id}-${c.field}`}
+                className={typography.panelMeta}
+                data-testid={`change-${c.element}-${c.id}-${c.field}`}
+              >
+                {c.label} · {fieldDisplayLabel(c.field)} {formatChangeValue(c.before)} → {formatChangeValue(c.after)}
+              </div>
             ))}
           </div>
 

--- a/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/CompareTabBody.pickTwoRuns.spec.tsx
@@ -65,8 +65,14 @@ vi.mock('../TransitionsSection', () => ({
   TransitionsSection: ({ transitions }: { transitions: Array<{ fromRunNumber: number; toRunNumber: number; winnerProbDelta: number; edits: string[] }> }) => (
     <div data-testid="transitions-stub">
       {transitions.map(t => (
-        <span key={`${t.fromRunNumber}-${t.toRunNumber}`} data-testid="transition-pair">
-          {t.fromRunNumber}→{t.toRunNumber}:{t.winnerProbDelta}:{t.edits.length}
+        <span key={`${t.fromRunNumber}-${t.toRunNumber}`}>
+          <span data-testid="transition-pair">
+            {t.fromRunNumber}→{t.toRunNumber}:{t.winnerProbDelta}:{t.edits.length}
+          </span>
+          {/* The card's OWN sentence for the same pair, exposed so the F1 case
+              below can assert the two surfaces agree rather than assert two
+              hand-copied strings (CLAUDE.md trap 12 — derive, never mirror). */}
+          <span data-testid="transition-edits">{t.edits.join(' | ')}</span>
         </span>
       ))}
     </div>
@@ -224,6 +230,47 @@ describe('pick-two-runs side-by-side (2.113a slice 2)', () => {
     openPicker()
     expect(within(screen.getByTestId('structure-row')).getByText('Not comparable')).toBeTruthy()
     expect(screen.getByTestId('structure-detail').textContent).toContain('incomparable identifiers')
+  })
+
+  /**
+   * ROADMAP 2.578 F1 (adversarial review of #604) — the COMMON persisted pair.
+   *
+   * Two persisted runs carry `aag_v1` hashes from the SAME regime, and a
+   * `run_analysis` fact stores no graph, so the verdict is
+   * `uncharacterised_change`: the model provably moved, and nothing survives to
+   * say how. 2.578 routed that verdict to structure `'not_comparable'` — which
+   * is right, because "something moved" is not "the SHAPE moved" — but the
+   * sentence underneath still read "different, incomparable identifiers". Both
+   * identifiers are `aag_v1`, both were read, and they compared fine. The screen
+   * blamed a provenance boundary for a change it had actually measured, while
+   * the transition card for the very same pair said the model changed.
+   *
+   * This is the default state for a signed-in user with two persisted runs, so
+   * it is exercised through the whole live chain, not through a hand-built
+   * snapshot (trap 16: a fixture you wrote yourself is not evidence).
+   */
+  it('two persisted runs whose aag hashes DIFFER say the model changed — not that the identifiers are incomparable', async () => {
+    await renderWithRuns([
+      run(1, '10', 0.5, { graphHashAtRun: 'aag-1' }),
+      run(2, '11', 0.62, { graphHashAtRun: 'aag-2' }),
+    ])
+    openPicker()
+
+    // The shape claim is unchanged and correct: nothing licenses one.
+    expect(within(screen.getByTestId('structure-row')).getByText('Not comparable')).toBeTruthy()
+
+    const detail = screen.getByTestId('structure-detail').textContent ?? ''
+    expect(detail).toBe(
+      'The model changed between these runs — the details were not recorded for this run',
+    )
+    // The sentence the widened preimage made false — it belongs to the
+    // cross-regime / absent-hash case pinned in the test above, and only there.
+    expect(detail).not.toContain('incomparable identifiers')
+
+    // DERIVED coherence: the pair view and the card are two labels on one
+    // screen, and 2.578's whole point is that they cannot disagree. Compared,
+    // not hand-copied — so a change to either sentence must change both.
+    expect(screen.getByTestId('transition-edits').textContent).toBe(detail)
   })
 
   it('goal probability and evidence coverage render "Not assessed" on a persisted pair', async () => {

--- a/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
+++ b/src/canvas/compare-tab/__tests__/__fixtures__/analysisSnapshot.ts
@@ -55,6 +55,15 @@ export function makeAnalysisSnapshot(
     graphHash: 'hash-default',
     nodeCount: 5,
     edgeCount: 4,
+    /**
+     * ROADMAP 2.578. Null by default because this fixture does NOT describe a
+     * graph — it describes a run's analysis. A fabricated empty projection would
+     * make every snapshot built here compare EQUAL to every other and silently
+     * assert "no edits" across the whole suite. Specs that mean to exercise the
+     * canonical diff build real nodes/edges through `buildAnalysisSnapshot`
+     * (see `compareChangeCoherence.spec.tsx`) rather than hand-writing one here.
+     */
+    graphProjection: null,
     options: DEFAULT_SNAPSHOT_OPTIONS,
     leaderVerdict: DEFAULT_LEADER_VERDICT,
     winnerId: 'opt-a',

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -264,6 +264,35 @@ describe('ROADMAP 2.578 — absent evidence yields silence, never a confident la
     expect(tr.structureChanged).toBe(false)
   })
 
+  /**
+   * ⚠ ADDED BECAUSE A MUTANT SURVIVED, not because the code looked thin.
+   * Deleting the `from.source !== to.source` guard in `classifyChange` left the
+   * suite 89/89 GREEN. Reading the code explains why — `hashesAreComparable`
+   * enforces the same-source rule independently, and in the product a persisted
+   * rebuild always has `graphProjection === null`, so a cross-regime pair never
+   * reaches the projection comparison. The guard is defence-in-depth.
+   *
+   * That is an argument, and an argument is not a measurement (trap 13c: a
+   * surviving mutant is a claim either way and must be DEMONSTRATED). This test
+   * constructs the one state where the guard is the only thing standing —
+   * both ends carrying a projection, from different regimes — so the mutant now
+   * bites and the reasoning above is pinned rather than believed.
+   */
+  it('two projections from DIFFERENT regimes are not_comparable, even when both exist', () => {
+    const session = runSnapshot(1, STRENGTH_BEFORE)
+    const persistedWithGraph: AnalysisSnapshot = {
+      ...runSnapshot(2, STRENGTH_AFTER),
+      source: 'persisted',
+    }
+    const [tr] = deriveTransitions([session, persistedWithGraph])
+    expect(tr.changeVerdict.kind).toBe('not_comparable')
+    expect(tr.structureChanged).toBe(false)
+    // Control: the SAME pair within one regime IS compared — so the assertion
+    // above cannot pass merely because this fixture compares nothing.
+    const [same] = deriveTransitions([session, runSnapshot(2, STRENGTH_AFTER)])
+    expect(same.changeVerdict.kind).toBe('value_only')
+  })
+
   it('a real structural change IS reported as structural', () => {
     const before = runSnapshot(1, STRENGTH_BEFORE)
     const after = buildAnalysisSnapshot({

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -273,6 +273,16 @@ describe('ROADMAP 2.578 — the labels cannot contradict each other', () => {
     )
   })
 
+  it('describes the change exactly ONCE — no prose bullet duplicating the detail row', () => {
+    const tr = valueOnlyEditTransition()
+    render(
+      <TransitionCard transition={tr} startOpen showExpert allDeltas={[tr.winnerProbDelta]} />,
+    )
+    // The same edit rendered as both a prose bullet and a detail row would make
+    // one change look like two on a surface whose whole job is counting changes.
+    expect(screen.getAllByText(/strength 0\.5 → 0\.8/)).toHaveLength(1)
+  })
+
   it('renders no change row for the untouched edge', () => {
     const tr = valueOnlyEditTransition()
     render(

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -191,6 +191,62 @@ describe('ROADMAP 2.578 — a value-only link edit is reported as exactly that',
 })
 
 // ---------------------------------------------------------------------------
+// Coverage the hash never had.
+//
+// `generateGraphHash` reads exactly three edge fields — `confidence`, `weight`,
+// `belief`. Measured against a REAL captured graph
+// (`PHASE0-EVIDENCE-2026-07-28/codex-deep-review-2026-08-05-raw/canvas-export-1785945361783.json`,
+// 34 edges): `weight` is present on 34/34, and `confidence` and `belief` on
+// 0/34. The live editable fields are `weight`, `direction`, `strengthStd`,
+// `beliefExists`, `beliefStrength`, `exists_probability` — all 34/34, and all in
+// EDGE_FIELD_REGISTRY with purpose 'stale'.
+//
+// So the old signal was blind in BOTH directions: it raised "structure changed"
+// for a weight edit, and saw NOTHING at all for a direction or uncertainty edit.
+// Deriving from the registry fixes the second half too, and these pin it.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 — analysis-affecting edits the old hash could not see', () => {
+  function editedEdgeData(patch: Record<string, unknown>): Edge[] {
+    return edgesWithStrength(STRENGTH_BEFORE).map(e =>
+      e.id === EDITED_EDGE_ID ? { ...e, data: { ...(e.data as object), ...patch } } : e,
+    )
+  }
+
+  function transitionWith(patch: Record<string, unknown>) {
+    const before = runSnapshot(1, STRENGTH_BEFORE)
+    const after = buildAnalysisSnapshot({
+      rawV2Response: { ...RESPONSE, response_hash: 'resp-2' } as V2RunResponse,
+      report: {} as ReportV1,
+      nodes,
+      edges: editedEdgeData(patch),
+      runNumber: 2,
+      events: [],
+      previousSnapshotTimestamp: PREV_RUN_AT,
+    })
+    return deriveTransitions([before, after])[0]
+  }
+
+  it.each([
+    ['direction', 'positive', 'negative'],
+    ['strengthStd', undefined, 0.25],
+    ['beliefExists', undefined, 0.6],
+  ] as const)(
+    'a %s edit is reported as a value change on the edited edge',
+    (field, _before, after) => {
+      const tr = transitionWith({ [field]: after })
+      expect(tr.changeVerdict.kind).toBe('value_only')
+      const match = tr.changeVerdict.fieldChanges.filter(c => c.field === field)
+      expect(match).toHaveLength(1)
+      expect(match[0].id).toBe(EDITED_EDGE_ID)
+      expect(match[0].after).toBe(after)
+      expect(tr.structureChanged).toBe(false)
+      expect(tr.edits).not.toContain('Rerun (no edits)')
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
 // The coherence rule: two labels on one screen must not be able to disagree.
 // ---------------------------------------------------------------------------
 

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -227,6 +227,35 @@ describe('ROADMAP 2.578 — the labels cannot contradict each other', () => {
 })
 
 // ---------------------------------------------------------------------------
+// The THIRD claim on this surface.
+//
+// The transition card is not the only place Compare talks about structure: the
+// hero's `flipped` copy said "Structure changed · Review the new result".
+// `flipped` is derived as `previous.winnerId !== latest.winnerId` and nothing
+// else — a change of leading option — so that sentence asserted a cause nobody
+// measured, and could contradict the card's canonical verdict on the very same
+// screen. Fixing the card while leaving this in place would satisfy the letter
+// of the row and not its point.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 — no surface claims a structure change without structure evidence', () => {
+  it('the hero copy contains no structure claim, in any state', () => {
+    const heroSource = readFileSync(
+      resolve(__dirname, '../../../..', 'src/canvas/compare-tab/Hero.tsx'),
+      'utf8',
+    )
+    // Positive control: prove this read can SEE hero copy before asserting an
+    // absence in it (trap 13 — an absence assertion must first see a presence).
+    expect(heroSource).toContain('Review the new result')
+    // The structure verdict has exactly one owner, and it is not the hero.
+    const claims = heroSource.split('\n').filter(l =>
+      /Structure changed/.test(l) && !l.trimStart().startsWith('//') && !l.trimStart().startsWith('*'),
+    )
+    expect(claims).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // The honesty rule: a claim the data does not support is not shown at all.
 // ---------------------------------------------------------------------------
 

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -35,7 +35,9 @@ import { resolve } from 'node:path'
 import type { Node, Edge } from '@xyflow/react'
 import { buildAnalysisSnapshot } from '../../stores/analysisSnapshotFactory'
 import { deriveTransitions } from '../deriveTransitions'
+import { deriveRunPairComparison } from '../deriveRunPairComparison'
 import { TransitionCard } from '../TransitionCard'
+import { RunPairCompare } from '../RunPairCompare'
 import type { AnalysisSnapshot } from '../types'
 import type { V2RunResponse } from '../../../adapters/plot/v2/types'
 import type { ReportV1 } from '../../../adapters/plot/types'
@@ -149,6 +151,13 @@ describe('mount path — these tests bind to a surface the deployed flags render
     const section = readFileSync(resolve(repoRoot, 'src/canvas/compare-tab/TransitionsSection.tsx'), 'utf8')
     expect(body).toContain('<TransitionsSection')
     expect(section).toContain('<TransitionCard')
+  })
+
+  // The SECOND surface this file now pins. `RunPairCompare` is the pick-two-runs
+  // side-by-side table, and it reaches a user through the same mounted body.
+  it('CompareTabBody renders RunPairCompare, the pair view pinned below', () => {
+    const body = readFileSync(resolve(repoRoot, 'src/canvas/compare-tab/CompareTabBody.tsx'), 'utf8')
+    expect(body).toContain('<RunPairCompare')
   })
 })
 
@@ -406,5 +415,123 @@ describe('ROADMAP 2.578 — absent evidence yields silence, never a confident la
     const removed = tr.changeVerdict.membershipChanges.filter(c => c.op === 'removed')
     expect(removed).toHaveLength(1)
     expect(removed[0].id).toBe(UNTOUCHED_EDGE_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F1 (adversarial review of #604) — THE PAIR VIEW'S MODEL SENTENCE.
+//
+// `compareStructure` became a pure projection of the ONE verdict, which WIDENED
+// the preimage of two of its three values. Measured at the pre-fix parent
+// `af5c5a37`, where the function read:
+//
+//     if (hashComparable && from.graphHash !== to.graphHash) return 'changed'
+//     … if (hashComparable) return 'unchanged'
+//     return 'not_comparable'
+//
+//   · `'unchanged'`      meant ONLY a same-regime hash EQUALITY. It now also
+//                        carries `value_only` — the observed +0.50 → +0.80
+//                        journey, whose CONTENT hash always differed — so the
+//                        screen said "Both runs were computed over the same
+//                        model" beside a list of the values that moved.
+//   · `'not_comparable'` meant ONLY cross-regime or an absent hash. It now also
+//                        carries same-regime `uncharacterised_change`, so the
+//                        screen blamed "different, incomparable identifiers"
+//                        for two runs whose identifiers ARE the same regime and
+//                        WERE compared — while the card said the model changed.
+//
+// Both sentences were true of their old preimage and are false of the new one.
+// The explanatory copy is therefore keyed off the VERDICT KIND, not off the
+// three-valued structure answer: `structure` answers "did the SHAPE move?" and
+// stays as it is; the sentence underneath has to answer "why does it say that?",
+// and that question has five answers, not three.
+//
+// BINDING (trap 19 / trap 13b). Every case below asserts its own PRECONDITION —
+// the comparison's `changeKind` — before asserting the copy, so a fixture that
+// silently stopped reproducing the target state cannot leave the copy assertion
+// passing for the wrong reason. The negative half of each pair names the exact
+// sentence that used to appear, so the case fails loud if the mapping regresses.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 F1 — the pair view explains the model row from the VERDICT, not the structure answer', () => {
+  function pairFor(fromSnap: AnalysisSnapshot, toSnap: AnalysisSnapshot) {
+    return deriveRunPairComparison(fromSnap, toSnap)
+  }
+
+  function renderDetail(comparison: ReturnType<typeof deriveRunPairComparison>): string {
+    render(<RunPairCompare comparison={comparison} />)
+    return screen.getByTestId('structure-detail').textContent ?? ''
+  }
+
+  it('VALUE-ONLY: says the shape held and the values moved — never "the same model" flat', () => {
+    const comparison = pairFor(runSnapshot(1, STRENGTH_BEFORE), runSnapshot(2, STRENGTH_AFTER))
+    // Precondition, pinned in-test: this fixture really does reproduce the
+    // observed journey's verdict. Without it the copy assertion below could pass
+    // because the fixture stopped working, not because the mapping is right.
+    expect(comparison.changeKind).toBe('value_only')
+    expect(comparison.structure).toBe('unchanged')
+
+    const detail = renderDetail(comparison)
+    expect(detail).toBe('The model has the same shape in both runs — some of its values changed')
+    // The sentence the widened preimage made false.
+    expect(detail).not.toContain('Both runs were computed over the same model')
+  })
+
+  it('VALUE-ONLY: the pair view and the card agree — one says values moved, the other names them', () => {
+    const from = runSnapshot(1, STRENGTH_BEFORE)
+    const to = runSnapshot(2, STRENGTH_AFTER)
+    const comparison = pairFor(from, to)
+    expect(comparison.changeKind).toBe('value_only')
+
+    const detail = renderDetail(comparison)
+    const [tr] = deriveTransitions([from, to])
+    // The card lists the exact edit; the pair view must not be denying that any
+    // value moved on the same screen. This is the coherence rule of 2.578
+    // applied to the surface the F1 review found still breaking it.
+    expect(tr.edits.some(l => /strength 0\.5 → 0\.8/.test(l))).toBe(true)
+    expect(detail).toMatch(/values changed/)
+  })
+
+  it('UNCHANGED: a genuinely identical rerun keeps the original "same model" sentence', () => {
+    const comparison = pairFor(runSnapshot(1, STRENGTH_BEFORE), runSnapshot(2, STRENGTH_BEFORE))
+    expect(comparison.changeKind).toBe('unchanged')
+    expect(comparison.structure).toBe('unchanged')
+
+    // The DISCRIMINATING half: `unchanged` and `value_only` both project to
+    // structure `'unchanged'`, so a fix that simply swapped the sentence for the
+    // whole structure value would break this case. They must differ.
+    expect(renderDetail(comparison)).toBe('Both runs were computed over the same model')
+  })
+
+  it('STRUCTURAL: a membership change still says the model is not the same', () => {
+    const before = runSnapshot(1, STRENGTH_BEFORE)
+    const after = buildAnalysisSnapshot({
+      rawV2Response: { ...RESPONSE, response_hash: 'resp-2' } as V2RunResponse,
+      report: {} as ReportV1,
+      nodes,
+      edges: edgesWithStrength(STRENGTH_BEFORE).filter(e => e.id !== UNTOUCHED_EDGE_ID),
+      runNumber: 2,
+      events: [],
+      previousSnapshotTimestamp: PREV_RUN_AT,
+    })
+    const comparison = pairFor(before, after)
+    expect(comparison.changeKind).toBe('structural')
+    expect(comparison.structure).toBe('changed')
+    expect(renderDetail(comparison)).toBe('The model these runs were computed over is not the same')
+  })
+
+  it('CROSS-REGIME: the incomparable-identifiers sentence survives, on its own preimage', () => {
+    const session = runSnapshot(1, STRENGTH_BEFORE)
+    const otherRegime: AnalysisSnapshot = { ...runSnapshot(2, STRENGTH_AFTER), source: 'persisted' }
+    const comparison = pairFor(session, otherRegime)
+    expect(comparison.changeKind).toBe('not_comparable')
+    expect(comparison.structure).toBe('not_comparable')
+
+    // The DISCRIMINATING half for the other widened value: `not_comparable` and
+    // `uncharacterised_change` both project to structure `'not_comparable'`, and
+    // only THIS one is genuinely about incomparable identifiers.
+    expect(renderDetail(comparison)).toBe(
+      'These two runs record their model with different, incomparable identifiers',
+    )
   })
 })

--- a/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareChangeCoherence.spec.tsx
@@ -1,0 +1,286 @@
+/**
+ * ROADMAP 2.578 — Compare must not contradict itself about what changed.
+ *
+ * OBSERVED DEFECT (independent simulated-user review, 2026-08-05, evidence
+ * `PHASE0-EVIDENCE-2026-07-28/codex-deep-review-2026-08-05-raw/compare-misclassification.yml`):
+ * after a visible link-strength edit `+0.50 → +0.80`, one Compare card rendered
+ * BOTH `• Rerun (no edits)` AND `Structure changed — comparison is directional
+ * only`. Staleness and Undo recognised the same edit correctly.
+ *
+ * DIAGNOSIS (both sources read at `af5c5a37`):
+ *  · "Rerun (no edits)" came from `deriveEditSummary`, which reads the persisted
+ *    SCENARIO EVENT LOG. That log cannot contain an in-session direct edit on the
+ *    deployed build — `direct_edit` is appended only under `isJourneyTabEnabled()`
+ *    (unset in netlify.toml ⇒ false), the append is best-effort `.catch(() => {})`,
+ *    and the factory reads `_hydratedEvents`, written ONCE at scenario load.
+ *  · "Structure changed" came from `compareStructure`, which read a **content**
+ *    hash (`generateGraphHash` hashes edge weight/confidence/belief) as if it
+ *    were a **structure** signal. A value-only edit flips that hash.
+ *
+ * Two labels, two unrelated inputs — so they could disagree, and did.
+ *
+ * THE FIX SHAPE: one classifier (`classifyGraphChange`) over a canonical graph
+ * projection built from the SAME field registry Staleness consumes
+ * (`STALE_NODE_FIELDS` / `STALE_EDGE_FIELDS` + `deepEqual`). Every label on the
+ * surface reads that one verdict, so they cannot disagree by construction.
+ *
+ * BINDING (trap 19): every assertion below binds to the EXACT edge id and the
+ * EXACT before/after values. A second, deliberately-unchanged edge is present in
+ * every fixture so a differ that reports "some edge changed" cannot pass.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../../stores/analysisSnapshotFactory'
+import { deriveTransitions } from '../deriveTransitions'
+import { TransitionCard } from '../TransitionCard'
+import type { AnalysisSnapshot } from '../types'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+// ---------------------------------------------------------------------------
+// The identities under test. Named constants, not literals scattered through
+// assertions: every expectation binds to THESE, so a rename cannot silently
+// re-point a test at a different object.
+// ---------------------------------------------------------------------------
+
+/** The edge the user actually edited. */
+const EDITED_EDGE_ID = 'edge-churn-to-mrr'
+/** Present in every fixture and NEVER edited — the discriminator. */
+const UNTOUCHED_EDGE_ID = 'edge-leads-to-mrr'
+
+const STRENGTH_BEFORE = 0.5
+const STRENGTH_AFTER = 0.8
+
+const nodes: Node[] = [
+  { id: 'fac_churn', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Monthly Churn Rate', kind: 'factor' } },
+  { id: 'fac_leads', type: 'factor', position: { x: 0, y: 80 }, data: { label: 'Lead Volume', kind: 'factor' } },
+  { id: 'out_new_mrr', type: 'outcome', position: { x: 200, y: 40 }, data: { label: 'New MRR', kind: 'outcome' } },
+]
+
+function edgesWithStrength(weight: number): Edge[] {
+  return [
+    {
+      id: EDITED_EDGE_ID,
+      source: 'fac_churn',
+      target: 'out_new_mrr',
+      data: { weight, direction: 'positive', confidence: 0.7 },
+    },
+    {
+      id: UNTOUCHED_EDGE_ID,
+      source: 'fac_leads',
+      target: 'out_new_mrr',
+      data: { weight: 0.4, direction: 'positive', confidence: 0.6 },
+    },
+  ]
+}
+
+const RESPONSE = {
+  analysis_status: 'computed',
+  option_comparison_status: 'computed',
+  robustness_status: 'unavailable',
+  drivers_status: 'unavailable',
+  option_comparison: [
+    { option_id: 'opt-a', option_label: 'Option A', win_probability: 0.48, confidence_interval: [0.3, 0.7], expected_outcome: 0.5 },
+    { option_id: 'opt-b', option_label: 'Option B', win_probability: 0.2, confidence_interval: [0.1, 0.4], expected_outcome: 0.3 },
+  ],
+  critiques: [],
+  response_hash: 'resp-1',
+} as unknown as V2RunResponse
+
+const PREV_RUN_AT = '2026-08-05T10:00:00Z'
+
+/**
+ * Build a run snapshot the way the LIVE session path does (store.ts:3396):
+ * real nodes/edges, and — critically — an EMPTY event list, because that is
+ * what `_hydratedEvents` holds for an in-session edit on the deployed build.
+ * A fixture carrying `direct_edit` events would be testing a wire the product
+ * does not produce (trap 16: a fixture you wrote yourself is not evidence).
+ */
+function runSnapshot(runNumber: number, weight: number): AnalysisSnapshot {
+  return buildAnalysisSnapshot({
+    rawV2Response: { ...RESPONSE, response_hash: `resp-${runNumber}` } as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges: edgesWithStrength(weight),
+    runNumber,
+    events: [],
+    previousSnapshotTimestamp: runNumber === 1 ? null : PREV_RUN_AT,
+  })
+}
+
+/** The observed journey: run 1, edit the link +0.50 → +0.80, run 2. */
+function valueOnlyEditTransition() {
+  const snapshots = [
+    runSnapshot(1, STRENGTH_BEFORE),
+    runSnapshot(2, STRENGTH_AFTER),
+  ]
+  const [tr] = deriveTransitions(snapshots)
+  return tr
+}
+
+// ---------------------------------------------------------------------------
+// Mount-path binding (trap 3b).
+//
+// This estate has twice shipped a UI feature DARK because its tests were bound
+// to a component the deployed flags do not mount. These tests bind to
+// TransitionCard; TransitionCard reaches a user only through
+// CompareTabBody → TransitionsSection, and CompareTabBody mounts only when
+// `VITE_FEATURE_COMPARE_TAB` is on. That posture is DERIVED from netlify.toml
+// here rather than assumed, so if the flag ever moves this file goes RED and
+// says why, instead of staying green about a surface nobody loads.
+// ---------------------------------------------------------------------------
+
+describe('mount path — these tests bind to a surface the deployed flags render', () => {
+  const repoRoot = resolve(__dirname, '../../../..')
+  const netlifyToml = readFileSync(resolve(repoRoot, 'netlify.toml'), 'utf8')
+
+  it('netlify.toml enables VITE_FEATURE_COMPARE_TAB, so CompareTabBody mounts', () => {
+    // Positive control: prove we can SEE a setting in this file at all before
+    // asserting anything about the one under test (trap 13).
+    expect(netlifyToml).toMatch(/VITE_FEATURE_ANALYSIS_HERO_PANEL\s*=\s*"1"/)
+    expect(netlifyToml).toMatch(/VITE_FEATURE_COMPARE_TAB\s*=\s*"1"/)
+  })
+
+  it('CompareTabBody renders TransitionsSection, which renders TransitionCard', () => {
+    const body = readFileSync(resolve(repoRoot, 'src/canvas/compare-tab/CompareTabBody.tsx'), 'utf8')
+    const section = readFileSync(resolve(repoRoot, 'src/canvas/compare-tab/TransitionsSection.tsx'), 'utf8')
+    expect(body).toContain('<TransitionsSection')
+    expect(section).toContain('<TransitionCard')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The acceptance gate.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 — a value-only link edit is reported as exactly that', () => {
+  it('does NOT claim "Rerun (no edits)" — the edit is visible in the graph itself', () => {
+    const tr = valueOnlyEditTransition()
+    expect(tr.edits).not.toContain('Rerun (no edits)')
+  })
+
+  it('does NOT claim the structure changed — node and edge sets are identical', () => {
+    const tr = valueOnlyEditTransition()
+    expect(tr.structureChanged).toBe(false)
+  })
+
+  it('classifies the change as value_only', () => {
+    const tr = valueOnlyEditTransition()
+    expect(tr.changeVerdict.kind).toBe('value_only')
+  })
+
+  it('reports the changed edge BY ID, with the exact before/after values', () => {
+    const tr = valueOnlyEditTransition()
+    const changes = tr.changeVerdict.fieldChanges.filter(c => c.field === 'weight')
+    expect(changes).toHaveLength(1)
+    expect(changes[0].id).toBe(EDITED_EDGE_ID)
+    expect(changes[0].element).toBe('edge')
+    expect(changes[0].before).toBe(STRENGTH_BEFORE)
+    expect(changes[0].after).toBe(STRENGTH_AFTER)
+  })
+
+  it('does NOT report the untouched edge — binding is to the edited object, not "an edge"', () => {
+    const tr = valueOnlyEditTransition()
+    const touchedIds = tr.changeVerdict.fieldChanges.map(c => c.id)
+    expect(touchedIds).toContain(EDITED_EDGE_ID)
+    expect(touchedIds).not.toContain(UNTOUCHED_EDGE_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The coherence rule: two labels on one screen must not be able to disagree.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 — the labels cannot contradict each other', () => {
+  it('never renders "no edits" and "Structure changed" together (the observed defect)', () => {
+    const tr = valueOnlyEditTransition()
+    render(
+      <TransitionCard transition={tr} startOpen showExpert allDeltas={[tr.winnerProbDelta]} />,
+    )
+    const noEdits = screen.queryByText(/Rerun \(no edits\)/)
+    const structure = screen.queryByText(/Structure changed/)
+    // The exact pair witnessed in the capture. Either alone would be a
+    // different (possibly correct) statement; TOGETHER they are incoherent.
+    expect(noEdits && structure).toBeFalsy()
+  })
+
+  it('renders the edit as "+0.5 → +0.8" against the edited relationship', () => {
+    const tr = valueOnlyEditTransition()
+    render(
+      <TransitionCard transition={tr} startOpen showExpert allDeltas={[tr.winnerProbDelta]} />,
+    )
+    expect(screen.getByTestId(`change-edge-${EDITED_EDGE_ID}-weight`)).toHaveTextContent(
+      `${STRENGTH_BEFORE} → ${STRENGTH_AFTER}`,
+    )
+  })
+
+  it('renders no change row for the untouched edge', () => {
+    const tr = valueOnlyEditTransition()
+    render(
+      <TransitionCard transition={tr} startOpen showExpert allDeltas={[tr.winnerProbDelta]} />,
+    )
+    expect(screen.queryByTestId(`change-edge-${UNTOUCHED_EDGE_ID}-weight`)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The honesty rule: a claim the data does not support is not shown at all.
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.578 — absent evidence yields silence, never a confident label', () => {
+  /**
+   * The persisted-run rebuild path (`persistedRunSnapshotFactory`) has no graph:
+   * a `run_analysis` fact stores the analysis, not the model. `nodes`/`edges`
+   * are null there by design, so no projection exists and the honest answer is
+   * "we cannot characterise this change".
+   */
+  function rebuiltSnapshot(runNumber: number): AnalysisSnapshot {
+    return buildAnalysisSnapshot({
+      rawV2Response: { ...RESPONSE, response_hash: `resp-${runNumber}` } as V2RunResponse,
+      report: null,
+      nodes: null,
+      edges: null,
+      runNumber,
+      events: [],
+      previousSnapshotTimestamp: runNumber === 1 ? null : PREV_RUN_AT,
+    })
+  }
+
+  it('a graph-less pair is not_comparable, not "no edits" and not "structure changed"', () => {
+    const [tr] = deriveTransitions([rebuiltSnapshot(1), rebuiltSnapshot(2)])
+    expect(tr.changeVerdict.kind).toBe('not_comparable')
+    expect(tr.structureChanged).toBe(false)
+    expect(tr.edits).not.toContain('Rerun (no edits)')
+  })
+
+  it('a genuinely identical rerun DOES say "no edits" — the honest use of that label', () => {
+    const snapshots = [runSnapshot(1, STRENGTH_BEFORE), runSnapshot(2, STRENGTH_BEFORE)]
+    const [tr] = deriveTransitions(snapshots)
+    expect(tr.changeVerdict.kind).toBe('unchanged')
+    expect(tr.edits).toContain('Rerun (no edits)')
+    expect(tr.structureChanged).toBe(false)
+  })
+
+  it('a real structural change IS reported as structural', () => {
+    const before = runSnapshot(1, STRENGTH_BEFORE)
+    const after = buildAnalysisSnapshot({
+      rawV2Response: { ...RESPONSE, response_hash: 'resp-2' } as V2RunResponse,
+      report: {} as ReportV1,
+      nodes,
+      // The untouched edge is REMOVED — a membership change, by identity.
+      edges: edgesWithStrength(STRENGTH_BEFORE).filter(e => e.id !== UNTOUCHED_EDGE_ID),
+      runNumber: 2,
+      events: [],
+      previousSnapshotTimestamp: PREV_RUN_AT,
+    })
+    const [tr] = deriveTransitions([before, after])
+    expect(tr.changeVerdict.kind).toBe('structural')
+    expect(tr.structureChanged).toBe(true)
+    const removed = tr.changeVerdict.membershipChanges.filter(c => c.op === 'removed')
+    expect(removed).toHaveLength(1)
+    expect(removed[0].id).toBe(UNTOUCHED_EDGE_ID)
+  })
+})

--- a/src/canvas/compare-tab/__tests__/deriveRunPairComparison.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveRunPairComparison.spec.ts
@@ -198,9 +198,22 @@ describe('deriveRunPairComparison — factors (same draft-variance rule, on RANK
 
 // ── DEFECT 2: the cross-regime structure claim ────────────────────────────
 describe('deriveRunPairComparison — model structure', () => {
-  it('two PERSISTED runs with different aag hashes: changed', () => {
+  // ⚠ REVERSED BY ROADMAP 2.578, and for the same reason as its twin in
+  // deriveTransitions.spec.ts: `aag_v1` is an ANALYSIS-AFFECTING hash, i.e. a
+  // CONTENT hash, so its inequality proves the model moved and says nothing
+  // about the model's SHAPE. This row is the pair view's half of the defect that
+  // rendered "Structure changed" for a `+0.50 → +0.80` link edit.
+  it('two PERSISTED runs with different aag hashes: not_comparable, NOT changed', () => {
     const from = persisted({ runNumber: 1, graphHash: 'aag-1' })
     const to = persisted({ runNumber: 2, graphHash: 'aag-2' })
+    expect(deriveRunPairComparison(from, to).structure).toBe('not_comparable')
+  })
+
+  // Control: a difference the counts CAN prove is still reported as changed, so
+  // the correction above did not turn the structure row into a permanent shrug.
+  it('two PERSISTED runs with different edge counts: changed', () => {
+    const from = persisted({ runNumber: 1, graphHash: 'aag-1', edgeCount: 4 })
+    const to = persisted({ runNumber: 2, graphHash: 'aag-2', edgeCount: 6 })
     expect(deriveRunPairComparison(from, to).structure).toBe('changed')
   })
 

--- a/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
@@ -145,12 +145,24 @@ describe('deriveTransitions', () => {
   })
 
   describe('structure detection', () => {
-    it('detects graph hash change', () => {
+    // ⚠ REVERSED BY ROADMAP 2.578, DELIBERATELY — this test used to assert
+    // `structureChanged === true` here, and that expectation WAS the defect.
+    // `generateGraphHash` hashes edge weight/confidence/belief, so it is a
+    // CONTENT hash: a value-only edit (`+0.50 → +0.80`) changes it. Reading its
+    // inequality as a STRUCTURE claim is how Compare came to render "Structure
+    // changed — comparison is directional only" for a link-strength edit, on the
+    // same card that said "Rerun (no edits)" (observed 2026-08-05).
+    // A hash inequality is real evidence that SOMETHING changed, and that is
+    // exactly what it is now reported as.
+    it('a hash inequality alone does NOT license a structure claim — it is a content hash', () => {
       const snapshots = [
         makeSnapshot({ runNumber: 1, graphHash: 'hash-1' }),
         makeSnapshot({ runNumber: 2, graphHash: 'hash-2' }),
       ]
-      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(true)
+      const [tr] = deriveTransitions(snapshots)
+      expect(tr.structureChanged).toBe(false)
+      // …but the signal is NOT thrown away.
+      expect(tr.changeVerdict.kind).toBe('uncharacterised_change')
     })
 
     it('detects node count change', () => {
@@ -191,12 +203,29 @@ describe('deriveTransitions', () => {
       expect(deriveTransitions(snapshots)[0].structureChanged).toBe(false)
     })
 
-    it('DOES compare hashes within one regime (the guard is not a blanket off-switch)', () => {
+    // The ORIGINAL INTENT of this test — "the regime guard must not become a
+    // blanket off-switch" — is preserved exactly. What changed (ROADMAP 2.578)
+    // is only WHICH claim a same-regime inequality licenses: it proves the model
+    // moved, not that its SHAPE moved. Asserting the verdict rather than a
+    // boolean is what stops the fix from quietly discarding the signal.
+    it('DOES still compare hashes within one regime (the guard is not a blanket off-switch)', () => {
       const snapshots = [
         makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
         makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2' }),
       ]
-      expect(deriveTransitions(snapshots)[0].structureChanged).toBe(true)
+      const [tr] = deriveTransitions(snapshots)
+      expect(tr.changeVerdict.kind).toBe('uncharacterised_change')
+      expect(tr.structureChanged).toBe(false)
+    })
+
+    // The control for the test above: EQUAL same-regime hashes must still read
+    // as unchanged, so "uncharacterised_change" cannot be reached by any pair.
+    it('same regime, EQUAL hashes ⇒ unchanged (the inequality arm is discriminating)', () => {
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
+        makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-1' }),
+      ]
+      expect(deriveTransitions(snapshots)[0].changeVerdict.kind).toBe('unchanged')
     })
 
     it('an absent hash at either end is no evidence, not a change', () => {
@@ -402,11 +431,16 @@ describe('buildCumulativeTransition', () => {
     )
   })
 
+  // ROADMAP 2.578: the trigger is now a COUNT change — genuine structural
+  // evidence measured at both ends — rather than a hash inequality, which only
+  // ever proved that the model's CONTENT moved. The caveat's own wording
+  // ("Structure changed during this period") is a claim about shape, so it must
+  // be licensed by evidence about shape.
   it('includes structure change caveat', () => {
     const snapshots = [
-      makeSnapshot({ runNumber: 1, graphHash: 'hash-1' }),
-      makeSnapshot({ runNumber: 2, graphHash: 'hash-2' }),
-      makeSnapshot({ runNumber: 3, graphHash: 'hash-2' }),
+      makeSnapshot({ runNumber: 1, nodeCount: 5 }),
+      makeSnapshot({ runNumber: 2, nodeCount: 6 }),
+      makeSnapshot({ runNumber: 3, nodeCount: 6 }),
     ]
     const result = buildCumulativeTransition(snapshots)!
     expect(result.cumulativeCaveats).toContainEqual(
@@ -414,11 +448,17 @@ describe('buildCumulativeTransition', () => {
     )
   })
 
+  // ROADMAP 2.578 — the per-run `graphHash` values are now DISTINCT. They were
+  // all the fixture default, which the new classifier correctly reads as "these
+  // runs analysed an identical model", and an identical model licenses exactly
+  // one sentence ("Rerun (no edits)"), not a logged edit summary. Distinct
+  // hashes reproduce the real situation this test is about — a run that DID
+  // change — so the passthrough it pins is exercised as intended.
   it('collects all edit summaries', () => {
     const snapshots = [
-      makeSnapshot({ runNumber: 1, editSummary: 'Initial analysis' }),
-      makeSnapshot({ runNumber: 2, editSummary: 'Tightened churn' }),
-      makeSnapshot({ runNumber: 3, editSummary: 'Added regulatory risk' }),
+      makeSnapshot({ runNumber: 1, graphHash: 'h-1', editSummary: 'Initial analysis' }),
+      makeSnapshot({ runNumber: 2, graphHash: 'h-2', editSummary: 'Tightened churn' }),
+      makeSnapshot({ runNumber: 3, graphHash: 'h-3', editSummary: 'Added regulatory risk' }),
     ]
     const result = buildCumulativeTransition(snapshots)!
     expect(result.edits).toEqual(['Tightened churn', 'Added regulatory risk'])
@@ -430,10 +470,23 @@ describe('buildCumulativeTransition', () => {
 // ---------------------------------------------------------------------------
 
 describe('compareStructure', () => {
-  it('same regime, different hash ⇒ changed', () => {
+  // ⚠ REVERSED BY ROADMAP 2.578. `compareStructure` answers one question — "did
+  // the STRUCTURE change?" — and a same-regime CONTENT-hash inequality cannot
+  // answer it in either direction. 'not_comparable' is the honest verdict; the
+  // fact that something moved is carried by `changeVerdict`
+  // (`uncharacterised_change`), not smuggled into a shape claim.
+  it('same regime, different hash ⇒ not_comparable (a content hash cannot speak to shape)', () => {
     expect(compareStructure(
       makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1' }),
       makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2' }),
+    )).toBe('not_comparable')
+  })
+
+  // The counts arm is untouched: it IS evidence about shape, measured at both ends.
+  it('same regime, different node counts ⇒ changed (counts are shape evidence)', () => {
+    expect(compareStructure(
+      makeSnapshot({ runNumber: 1, source: 'persisted', graphHash: 'aag-1', nodeCount: 5 }),
+      makeSnapshot({ runNumber: 2, source: 'persisted', graphHash: 'aag-2', nodeCount: 6 }),
     )).toBe('changed')
   })
 
@@ -495,10 +548,13 @@ describe('compareStructure', () => {
 
 describe('buildRangeTransition', () => {
   const four = () => [
-    makeSnapshot({ runNumber: 1, winnerProbability: 50, editSummary: 'Initial analysis' }),
-    makeSnapshot({ runNumber: 2, winnerProbability: 55, editSummary: 'Tightened churn' }),
-    makeSnapshot({ runNumber: 3, winnerProbability: 61, editSummary: 'Added risk' }),
-    makeSnapshot({ runNumber: 4, winnerProbability: 74, editSummary: 'Reweighted price' }),
+    // Distinct per-run graphHash: see the note on 'collects all edit summaries'.
+    // Each leg is therefore a real change, and the logged summary is what the
+    // card shows for a graph-less run — which is what these interval tests pin.
+    makeSnapshot({ runNumber: 1, graphHash: 'h-1', winnerProbability: 50, editSummary: 'Initial analysis' }),
+    makeSnapshot({ runNumber: 2, graphHash: 'h-2', winnerProbability: 55, editSummary: 'Tightened churn' }),
+    makeSnapshot({ runNumber: 3, graphHash: 'h-3', winnerProbability: 61, editSummary: 'Added risk' }),
+    makeSnapshot({ runNumber: 4, graphHash: 'h-4', winnerProbability: 74, editSummary: 'Reweighted price' }),
   ]
 
   it('an ADJACENT pair is exactly the plain pairwise card', () => {

--- a/src/canvas/compare-tab/deriveRunPairComparison.ts
+++ b/src/canvas/compare-tab/deriveRunPairComparison.ts
@@ -34,7 +34,7 @@ import type {
   OptionDelta,
   RunPairComparison,
 } from './types'
-import { compareStructure } from './deriveTransitions'
+import { classifyChange, structureForChangeKind } from './deriveTransitions'
 
 // ---------------------------------------------------------------------------
 // Leader claim — quoted from the run's own verdict
@@ -214,6 +214,11 @@ export function deriveRunPairComparison(
   const fromLeader = deriveLeaderClaim(from)
   const toLeader = deriveLeaderClaim(to)
 
+  // ONE classification for this pair. `structure` is derived from it rather than
+  // re-classified, so the shape answer and the verdict the copy explains cannot
+  // come apart (ROADMAP 2.578 F1).
+  const changeKind = classifyChange(from, to).kind
+
   // A leader CHANGE is only claimable when both runs named one. Two runs that
   // both declined to name a leader have no leader to report as unchanged, and
   // a named-vs-unclaimed pair is a change in what the PRODUCER would say, not
@@ -231,7 +236,8 @@ export function deriveRunPairComparison(
     to,
     options: deriveOptionDeltas(from, to),
     factors: deriveFactorDeltas(from, to),
-    structure: compareStructure(from, to),
+    structure: structureForChangeKind(changeKind),
+    changeKind,
     fromLeader,
     toLeader,
     leaderChange,

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -11,6 +11,18 @@ import type {
   FactorSensitivitySummary,
   StructureComparison,
 } from './types'
+import {
+  classifyGraphProjections,
+  fieldDisplayLabel,
+  formatChangeValue,
+  NOT_COMPARABLE_VERDICT,
+  UNCHARACTERISED_CHANGE_VERDICT,
+  UNDETAILED_STRUCTURAL_VERDICT,
+  NO_EDITS_SUMMARY,
+  UNCHARACTERISED_SUMMARY,
+  UNCHARACTERISED_CHANGE_SUMMARY,
+  type GraphChangeVerdict,
+} from './graphChangeDiff'
 
 // ---------------------------------------------------------------------------
 // Magnitude classification
@@ -148,12 +160,63 @@ export function compareStructure(
   from: AnalysisSnapshot,
   to: AnalysisSnapshot,
 ): StructureComparison {
-  const hashComparable = hashesAreComparable(from, to)
-  if (hashComparable && from.graphHash !== to.graphHash) return 'changed'
-  if (from.nodeCount != null && to.nodeCount != null && from.nodeCount !== to.nodeCount) return 'changed'
-  if (from.edgeCount != null && to.edgeCount != null && from.edgeCount !== to.edgeCount) return 'changed'
-  if (hashComparable) return 'unchanged'
-  return 'not_comparable'
+  // ROADMAP 2.578 — a pure projection of the ONE verdict. This function no
+  // longer holds any evidence rules of its own; that is what stops the pair
+  // view and the transition card answering differently about the same pair.
+  switch (classifyChange(from, to).kind) {
+    case 'structural':
+      return 'changed'
+    case 'value_only':
+    case 'unchanged':
+      // The VALUES moved but the shape did not — and "did the structure change?"
+      // is the only question this function answers.
+      return 'unchanged'
+    default:
+      // `uncharacterised_change` lands here too, and deliberately: knowing that
+      // something moved is not knowing that the SHAPE moved.
+      return 'not_comparable'
+  }
+}
+
+/**
+ * THE ONE CHANGE CLASSIFICATION for a pair of runs. Every label on the Compare
+ * surface reads this, and every piece of evidence is weighed here — there is no
+ * second place that decides what changed.
+ *
+ * Evidence, strongest first:
+ *  1. Cross-regime ⇒ nothing is comparable (the same guard `hashesAreComparable`
+ *     applies to hashes: a session projection and a persisted one describe
+ *     different things).
+ *  2. A projection at BOTH ends ⇒ authoritative, with per-field before/after.
+ *  3. No projection, but node/edge COUNTS measured at both ends and differing
+ *     ⇒ genuinely structural, though we cannot name the elements.
+ *  4. No projection, same-regime hashes that DIFFER ⇒ something changed;
+ *     these are CONTENT hashes, so this is not a claim about shape.
+ *  5. No projection, same-regime hashes that MATCH ⇒ unchanged (equal content
+ *     implies equal shape — the sound direction).
+ *  6. Otherwise ⇒ no claim.
+ */
+export function classifyChange(
+  from: AnalysisSnapshot,
+  to: AnalysisSnapshot,
+): GraphChangeVerdict {
+  if (from.source !== to.source) return NOT_COMPARABLE_VERDICT
+
+  const projected = classifyGraphProjections(from.graphProjection, to.graphProjection)
+  if (projected.kind !== 'not_comparable') return projected
+
+  const countsDiffer =
+    (from.nodeCount != null && to.nodeCount != null && from.nodeCount !== to.nodeCount) ||
+    (from.edgeCount != null && to.edgeCount != null && from.edgeCount !== to.edgeCount)
+  if (countsDiffer) return UNDETAILED_STRUCTURAL_VERDICT
+
+  if (hashesAreComparable(from, to)) {
+    return from.graphHash === to.graphHash
+      ? { kind: 'unchanged', fieldChanges: [], membershipChanges: [] }
+      : UNCHARACTERISED_CHANGE_VERDICT
+  }
+
+  return NOT_COMPARABLE_VERDICT
 }
 
 /**
@@ -229,8 +292,53 @@ function findConditionalWinner(
 // Build a single transition between two consecutive snapshots
 // ---------------------------------------------------------------------------
 
+/**
+ * The card's one-line edit summary, derived from the graph verdict.
+ *
+ * ⚠ THE ASYMMETRY THIS ENCODES (ROADMAP 2.578). The scenario event log is
+ * evidence of PRESENCE and never evidence of ABSENCE — an empty log is its
+ * normal state on the deployed build even after a real edit (see the note in
+ * `deriveEditSummary`). So:
+ *  · "no edits" is published ONLY when the graph projection proves the two runs
+ *    are identical — never because the log was quiet.
+ *  · when the graph proves a change, the change list is authoritative and the
+ *    log is not consulted at all.
+ *  · when no projection exists, a POSITIVE log summary ("Accepted draft
+ *    changes") is still worth showing — it asserts something happened — but the
+ *    fabricated no-edit sentinel is suppressed, and the honest
+ *    "could not be characterised" is shown instead.
+ */
+function deriveEditLines(verdict: GraphChangeVerdict, to: AnalysisSnapshot): string[] {
+  if (verdict.kind === 'unchanged') return [NO_EDITS_SUMMARY]
+
+  if (verdict.kind === 'value_only' || verdict.kind === 'structural') {
+    const lines: string[] = []
+    for (const c of verdict.membershipChanges) {
+      lines.push(`${c.op === 'added' ? 'Added' : 'Removed'} ${c.element} "${c.label}"`)
+    }
+    for (const c of verdict.fieldChanges) {
+      lines.push(
+        `${c.label}: ${fieldDisplayLabel(c.field)} ${formatChangeValue(c.before)} → ${formatChangeValue(c.after)}`,
+      )
+    }
+    return lines
+  }
+
+  // Something moved, but no graph survives to say what.
+  if (verdict.kind === 'uncharacterised_change') {
+    const logged = to.editSummary
+    return logged && logged !== NO_EDITS_SUMMARY ? [logged] : [UNCHARACTERISED_CHANGE_SUMMARY]
+  }
+
+  // not_comparable
+  const logged = to.editSummary
+  if (logged && logged !== NO_EDITS_SUMMARY) return [logged]
+  return [UNCHARACTERISED_SUMMARY]
+}
+
 function buildTransition(from: AnalysisSnapshot, to: AnalysisSnapshot): Transition {
   const delta = to.winnerProbability - from.winnerProbability
+  const changeVerdict = classifyChange(from, to)
   const { ids: affectedFactorIds, labels: affectedFactorLabels } =
     deriveAffectedFactors(from.topFactors, to.topFactors)
   const { resolved, introduced } = deriveWarningDiffs(from, to)
@@ -244,7 +352,7 @@ function buildTransition(from: AnalysisSnapshot, to: AnalysisSnapshot): Transiti
     fromRunNumber: from.runNumber,
     toRunNumber: to.runNumber,
     magnitude: classifyMagnitude(delta),
-    edits: to.editSummary ? [to.editSummary] : [],
+    edits: deriveEditLines(changeVerdict, to),
     winnerProbDelta: delta,
     // T2b: a robustness CHANGE can only be claimed when both ends were
     // actually assessed. Comparing a null against a real label would report
@@ -258,6 +366,9 @@ function buildTransition(from: AnalysisSnapshot, to: AnalysisSnapshot): Transiti
     affectedFactorIds,
     affectedFactorLabels,
     deterministicAnchor: deriveDeterministicAnchor(from, to),
+    changeVerdict,
+    // Derived from the SAME verdict the edits line above reads — that identity
+    // is the fix, not an implementation detail (ROADMAP 2.578).
     structureChanged: detectStructureChange(from, to),
     eValue,
     eValueEdge: edgeLabel,
@@ -335,18 +446,20 @@ export function buildRangeTransition(
     caveats.push(`Result flipped ${flipCount === 1 ? 'once' : `${flipCount} times`}`)
   }
 
-  // Same regime guard as the pairwise case — a cross-source or absent-ended
-  // hash pair is no evidence, not a change.
-  const structureChanged = legs.some((s, i) =>
-    hashesAreComparable(snapshots[fromIndex + i], s) && s.graphHash !== snapshots[fromIndex + i].graphHash
-  )
-  if (structureChanged) {
+  // ROADMAP 2.578 — per-leg, through the ONE classifier. This used to be a
+  // per-leg hash inequality, which is the same content-hash-as-structure defect
+  // the pairwise path carried: every value-only edit in the span raised
+  // "Structure changed during this period".
+  const legVerdicts = legs.map((s, i) => classifyChange(snapshots[fromIndex + i], s))
+  if (legVerdicts.some(v => v.kind === 'structural')) {
     caveats.push('Structure changed during this period')
   }
 
   return {
     ...base,
-    edits: legs.map(s => s.editSummary).filter(Boolean),
+    // Each leg's lines, in span order — the same derivation the pairwise card
+    // uses, so a leg cannot describe itself one way here and another way there.
+    edits: legVerdicts.flatMap((v, i) => deriveEditLines(v, legs[i])),
     isCumulative: true,
     cumulativeCaveats: caveats,
   }

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -21,6 +21,7 @@ import {
   NO_EDITS_SUMMARY,
   UNCHARACTERISED_SUMMARY,
   UNCHARACTERISED_CHANGE_SUMMARY,
+  type GraphChangeKind,
   type GraphChangeVerdict,
 } from './graphChangeDiff'
 
@@ -163,7 +164,25 @@ export function compareStructure(
   // ROADMAP 2.578 — a pure projection of the ONE verdict. This function no
   // longer holds any evidence rules of its own; that is what stops the pair
   // view and the transition card answering differently about the same pair.
-  switch (classifyChange(from, to).kind) {
+  return structureForChangeKind(classifyChange(from, to).kind)
+}
+
+/**
+ * The projection itself, five verdict kinds onto three structure answers.
+ *
+ * Split out (ROADMAP 2.578 F1) so a caller that has already classified a pair
+ * can obtain BOTH the verdict kind and the structure answer from ONE
+ * classification — `deriveRunPairComparison` needs both, and calling
+ * `classifyChange` twice would leave two derivations to keep in step. There is
+ * still exactly one mapping in this file, which is the property that stops the
+ * pair view and the transition card answering differently about the same pair.
+ *
+ * ⚠ THIS FUNCTION IS LOSSY BY DESIGN, and that is what the F1 review found:
+ * two of its three outputs have more than one preimage, so copy written against
+ * its RESULT cannot state a truth condition. Explanatory copy keys off the KIND.
+ */
+export function structureForChangeKind(kind: GraphChangeKind): StructureComparison {
+  switch (kind) {
     case 'structural':
       return 'changed'
     case 'value_only':

--- a/src/canvas/compare-tab/graphChangeDiff.ts
+++ b/src/canvas/compare-tab/graphChangeDiff.ts
@@ -1,0 +1,325 @@
+/**
+ * Canonical graph change classification for the Compare tab (ROADMAP 2.578).
+ *
+ * ⚠ WHY THIS MODULE EXISTS — the defect it removes.
+ *
+ * Compare rendered TWO claims about the same edit from TWO unrelated inputs, and
+ * on 2026-08-05 an independent simulated-user review caught them contradicting
+ * each other: after a link-strength edit `+0.50 → +0.80`, one card said BOTH
+ * `• Rerun (no edits)` AND `Structure changed — comparison is directional only`.
+ *
+ *  · "Rerun (no edits)" came from `deriveEditSummary`, reading the persisted
+ *    SCENARIO EVENT LOG. That log cannot see an in-session direct edit on the
+ *    deployed build: `direct_edit` events are appended only under
+ *    `isJourneyTabEnabled()` (absent from netlify.toml ⇒ false), the append is
+ *    best-effort with a swallowed rejection, and the snapshot factory reads
+ *    `_hydratedEvents`, which is written ONCE at scenario load and never
+ *    refreshed. Three independent reasons, each alone sufficient.
+ *  · "Structure changed" came from comparing `generateGraphHash`, which hashes
+ *    edge `weight`/`confidence`/`belief` — a CONTENT hash. A value-only edit
+ *    flips it, and the flip was being read as a STRUCTURE claim.
+ *
+ * Meanwhile **Staleness and Undo got the same edit right**, because both are
+ * driven by the synchronous store edit chokepoint (`updateEdge` →
+ * `pushToHistory` for Undo, → `invalidateAnalysisReady` for Staleness). They read
+ * the GRAPH; Compare read a report ABOUT the graph that is never written.
+ *
+ * ⚠ THIS IS DELIBERATELY NOT A NEW DIFFER. The field list is NOT invented here:
+ * it is `STALE_NODE_FIELDS` / `STALE_EDGE_FIELDS`, derived from the ratified
+ * `analyticalNodeFields` registry — the SAME list, obtained the SAME way, that
+ * `hasAnalyticalNodeChange` / `hasAnalyticalEdgeChange` use to decide an edit is
+ * analysis-affecting, i.e. the list STALENESS ITSELF consumes. Comparison uses
+ * that module's `deepEqual` for the same reason it does: structured values must
+ * compare by content, so a re-normalised object with identical content is not a
+ * change. Consequence, and the point of the whole exercise: **Compare and
+ * Staleness cannot disagree about what counts as an edit**, and a field added to
+ * the registry reaches both automatically (CLAUDE.md trap 12 — derive, never
+ * mirror).
+ *
+ * IDENTITY. Elements are keyed by their own `id`, because that is the identity
+ * the editor mutates (`updateEdge(id, …)`) and the identity the user sees
+ * selected. `getEdgeKey` ("source->target") is NOT used as the key: it is a
+ * dedup key, and two parallel edges between the same pair would collide into
+ * one row and report a diff between two different relationships.
+ */
+import type { Node, Edge } from '@xyflow/react'
+import {
+  ANALYTICAL_NODE_DATA_FIELDS,
+  ANALYTICAL_EDGE_FIELDS,
+  deepEqual,
+} from '../domain/analyticalChange'
+
+// ---------------------------------------------------------------------------
+// The projection
+// ---------------------------------------------------------------------------
+
+export interface ProjectedElement {
+  /** The element's own id — the identity the editor mutates. */
+  id: string
+  /** Human label for display. Never used for matching. */
+  label: string
+  /** ReactFlow `type` (node kind). Part of identity for nodes: a kind change is structural. */
+  type: string
+  /** For edges only — endpoints. A re-pointed edge is a structural change. */
+  source?: string
+  target?: string
+  /** Analysis-affecting `data.*` values, keyed by field name. */
+  fields: Record<string, unknown>
+}
+
+export interface GraphProjection {
+  nodes: ProjectedElement[]
+  edges: ProjectedElement[]
+}
+
+function projectFields(
+  data: Record<string, unknown> | undefined,
+  fieldNames: readonly string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const field of fieldNames) {
+    if (data && field in data) out[field] = data[field]
+  }
+  return out
+}
+
+/**
+ * A canonical, comparable projection of the graph a run was computed over.
+ *
+ * Sorted by id so the projection is stable regardless of store ordering — two
+ * runs over the same model must project identically or every rerun would read
+ * as a change.
+ */
+export function buildGraphProjection(nodes: Node[], edges: Edge[]): GraphProjection {
+  const projectedNodes = nodes.map((n) => {
+    const data = n.data as Record<string, unknown> | undefined
+    return {
+      id: n.id,
+      label: typeof data?.label === 'string' ? data.label : n.id,
+      type: n.type ?? '',
+      fields: projectFields(data, ANALYTICAL_NODE_DATA_FIELDS),
+    }
+  })
+
+  const projectedEdges = edges.map((e) => {
+    const data = e.data as Record<string, unknown> | undefined
+    return {
+      id: e.id,
+      label: typeof data?.label === 'string' ? data.label : `${e.source} → ${e.target}`,
+      type: e.type ?? '',
+      source: e.source,
+      target: e.target,
+      fields: projectFields(data, ANALYTICAL_EDGE_FIELDS),
+    }
+  })
+
+  const byId = (a: ProjectedElement, b: ProjectedElement) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+  return {
+    nodes: [...projectedNodes].sort(byId),
+    edges: [...projectedEdges].sort(byId),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The verdict
+// ---------------------------------------------------------------------------
+
+export type ElementKind = 'node' | 'edge'
+
+/** One analysis-affecting field that changed value, by element identity. */
+export interface GraphFieldChange {
+  element: ElementKind
+  id: string
+  label: string
+  field: string
+  before: unknown
+  after: unknown
+}
+
+/** One element that entered or left the graph. */
+export interface GraphMembershipChange {
+  element: ElementKind
+  id: string
+  label: string
+  op: 'added' | 'removed'
+}
+
+/**
+ * `not_comparable`         — nothing licenses ANY claim: cross-regime, or no
+ *                            comparable signal at either end. NOT a synonym for
+ *                            "unchanged".
+ * `unchanged`              — identical membership and identical analysis-affecting values.
+ * `value_only`             — same membership, at least one value differs.
+ * `structural`             — membership, endpoints or node kind differ.
+ * `uncharacterised_change` — SOMETHING changed but we cannot say what.
+ *
+ * ⚠ `uncharacterised_change` exists so the persisted-run path does not have to
+ * choose between two false statements. Those runs carry no graph, only a
+ * CONTENT hash (the UI's `generateGraphHash`, CEE's `aag_v1`). A same-regime
+ * inequality there is real evidence that the model moved — but it is NOT
+ * evidence about the model's SHAPE, which is precisely the inference that
+ * produced "Structure changed" for a `+0.50 → +0.80` value edit. Collapsing this
+ * into `structural` re-introduces that defect; collapsing it into
+ * `not_comparable` throws away a true signal. It is its own answer.
+ */
+export type GraphChangeKind =
+  | 'not_comparable'
+  | 'unchanged'
+  | 'value_only'
+  | 'structural'
+  | 'uncharacterised_change'
+
+export interface GraphChangeVerdict {
+  kind: GraphChangeKind
+  fieldChanges: GraphFieldChange[]
+  membershipChanges: GraphMembershipChange[]
+}
+
+export const NOT_COMPARABLE_VERDICT: GraphChangeVerdict = {
+  kind: 'not_comparable',
+  fieldChanges: [],
+  membershipChanges: [],
+}
+
+/** Something changed; no graph is available to say what. */
+export const UNCHARACTERISED_CHANGE_VERDICT: GraphChangeVerdict = {
+  kind: 'uncharacterised_change',
+  fieldChanges: [],
+  membershipChanges: [],
+}
+
+/** A shape change proven by counts alone — the elements involved are unknown. */
+export const UNDETAILED_STRUCTURAL_VERDICT: GraphChangeVerdict = {
+  kind: 'structural',
+  fieldChanges: [],
+  membershipChanges: [],
+}
+
+function indexById(elements: ProjectedElement[]): Map<string, ProjectedElement> {
+  const map = new Map<string, ProjectedElement>()
+  for (const el of elements) map.set(el.id, el)
+  return map
+}
+
+function diffKind(
+  kind: ElementKind,
+  from: ProjectedElement[],
+  to: ProjectedElement[],
+  fieldChanges: GraphFieldChange[],
+  membershipChanges: GraphMembershipChange[],
+): { structural: boolean } {
+  const fromById = indexById(from)
+  const toById = indexById(to)
+  let structural = false
+
+  for (const el of to) {
+    const prev = fromById.get(el.id)
+    if (!prev) {
+      membershipChanges.push({ element: kind, id: el.id, label: el.label, op: 'added' })
+      structural = true
+      continue
+    }
+    // A kind change, or an edge re-pointed to different endpoints, is a change
+    // to the model's SHAPE — not a value edit.
+    if (prev.type !== el.type || prev.source !== el.source || prev.target !== el.target) {
+      structural = true
+    }
+    const fieldNames = new Set([...Object.keys(prev.fields), ...Object.keys(el.fields)])
+    for (const field of [...fieldNames].sort()) {
+      if (!deepEqual(prev.fields[field], el.fields[field])) {
+        fieldChanges.push({
+          element: kind,
+          id: el.id,
+          label: el.label,
+          field,
+          before: prev.fields[field],
+          after: el.fields[field],
+        })
+      }
+    }
+  }
+
+  for (const el of from) {
+    if (!toById.has(el.id)) {
+      membershipChanges.push({ element: kind, id: el.id, label: el.label, op: 'removed' })
+      structural = true
+    }
+  }
+
+  return { structural }
+}
+
+/**
+ * The ONE classifier. Every label on the Compare surface reads this verdict, so
+ * two labels on one screen cannot disagree — they have one input by construction.
+ */
+export function classifyGraphProjections(
+  from: GraphProjection | null,
+  to: GraphProjection | null,
+): GraphChangeVerdict {
+  if (from == null || to == null) return NOT_COMPARABLE_VERDICT
+
+  const fieldChanges: GraphFieldChange[] = []
+  const membershipChanges: GraphMembershipChange[] = []
+
+  const nodeResult = diffKind('node', from.nodes, to.nodes, fieldChanges, membershipChanges)
+  const edgeResult = diffKind('edge', from.edges, to.edges, fieldChanges, membershipChanges)
+
+  if (nodeResult.structural || edgeResult.structural) {
+    return { kind: 'structural', fieldChanges, membershipChanges }
+  }
+  if (fieldChanges.length > 0) {
+    return { kind: 'value_only', fieldChanges, membershipChanges }
+  }
+  return { kind: 'unchanged', fieldChanges: [], membershipChanges: [] }
+}
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+/** Field names as a user would read them. Unknown fields fall back to the raw name. */
+const FIELD_LABELS: Record<string, string> = {
+  weight: 'strength',
+  direction: 'direction',
+  strengthStd: 'uncertainty',
+  confidence: 'confidence',
+  beliefExists: 'likelihood it exists',
+  beliefStrength: 'belief strength',
+  belief: 'belief',
+  exists_probability: 'likelihood it exists',
+  probability: 'probability',
+  impact: 'impact',
+  observedState: 'observed value',
+}
+
+export function fieldDisplayLabel(field: string): string {
+  return FIELD_LABELS[field] ?? field
+}
+
+/**
+ * The one no-edit sentence, defined once and imported by both the producer
+ * (`deriveEditSummary`) and the consumer (`buildTransition`), so the consumer's
+ * "is this the fabricated no-edit claim?" test cannot drift from the producer's
+ * wording (CLAUDE.md trap 12).
+ */
+export const NO_EDITS_SUMMARY = 'Rerun (no edits)'
+
+/** Shown when nothing licenses ANY claim about what changed. */
+export const UNCHARACTERISED_SUMMARY = 'Changes to the model could not be characterised'
+
+/** Shown when the model provably moved but no graph survives to say how. */
+export const UNCHARACTERISED_CHANGE_SUMMARY =
+  'The model changed between these runs — the details were not recorded for this run'
+
+/**
+ * A value as a user would read it. `undefined` (the field was absent at that end)
+ * renders as an em dash — absence is shown as absence, never as a fabricated 0.
+ */
+export function formatChangeValue(value: unknown): string {
+  if (value === undefined || value === null) return '—'
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  return JSON.stringify(value)
+}

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DecisionVerdict } from '../../lib/decisionVerdict'
+import type { GraphProjection, GraphChangeVerdict } from './graphChangeDiff'
 
 // ---------------------------------------------------------------------------
 // Snapshot types
@@ -90,6 +91,24 @@ export interface AnalysisSnapshot {
    */
   nodeCount: number | null
   edgeCount: number | null
+
+  /**
+   * The canonical, comparable projection of the graph this run was computed
+   * over (ROADMAP 2.578) — the analysis-affecting `data.*` values of every node
+   * and edge, keyed by element id, derived from the SAME `analyticalNodeFields`
+   * registry Staleness consumes. See `graphChangeDiff.ts`.
+   *
+   * This is what lets Compare report "strength 0.5 → 0.8 on THIS edge" instead
+   * of inferring an edit from an event log that is never written, or inferring
+   * a *structure* change from a *content* hash.
+   *
+   * T2b absence-preserving, and null under exactly the same rule as
+   * `graphHash` / `nodeCount` / `edgeCount`: null when the graph is not
+   * available (the persisted-run rebuild stores the analysis, not the model).
+   * A fabricated `{ nodes: [], edges: [] }` would make two rebuilt runs compare
+   * EQUAL and assert "no edits" about two models nobody looked at.
+   */
+  graphProjection: GraphProjection | null
 
   /**
    * Every option this run scored, sorted by win probability descending.
@@ -353,7 +372,24 @@ export interface Transition {
   /** Labels for display */
   affectedFactorLabels: string[]
   deterministicAnchor: string
-  /** graphHash OR nodeCount/edgeCount differs */
+  /**
+   * ROADMAP 2.578 — the ONE verdict every label on this card reads.
+   *
+   * `edits` and `structureChanged` below are both DERIVED from this, which is
+   * the whole point: they used to have unrelated inputs (an event log and a
+   * content hash) and were caught rendering "Rerun (no edits)" and "Structure
+   * changed" on the same card for the same edit. Two labels with one input
+   * cannot disagree.
+   */
+  changeVerdict: GraphChangeVerdict
+  /**
+   * TRUE only for a change to the model's SHAPE — an element added or removed,
+   * an edge re-pointed, a node kind changed.
+   *
+   * ⚠ It is NOT a hash inequality. `generateGraphHash` hashes edge
+   * `weight`/`confidence`/`belief`, so reading its inequality as "structure
+   * changed" reported every value-only edit as structural (ROADMAP 2.578).
+   */
   structureChanged: boolean
   /** Lowest E-value among affected edges */
   eValue: number | null

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DecisionVerdict } from '../../lib/decisionVerdict'
-import type { GraphProjection, GraphChangeVerdict } from './graphChangeDiff'
+import type { GraphProjection, GraphChangeVerdict, GraphChangeKind } from './graphChangeDiff'
 
 // ---------------------------------------------------------------------------
 // Snapshot types
@@ -332,7 +332,25 @@ export interface RunPairComparison {
   options: OptionDelta[]
   /** Union of both runs' top factors, ordered by the strongest |elasticity|. */
   factors: FactorDelta[]
+  /**
+   * Did the model's SHAPE move? Three-valued, and a pure projection of
+   * `changeKind` below — `compareStructure` holds the one mapping.
+   */
   structure: StructureComparison
+  /**
+   * The ONE change verdict's kind for this pair (ROADMAP 2.578 F1).
+   *
+   * ⚠ WHY BOTH FIELDS EXIST. `structure` answers exactly one question — "did the
+   * shape move?" — and three answers are enough for it. The sentence the pair
+   * view prints underneath answers a different question, "why does it say that?",
+   * and there are FIVE reasons. Projecting five onto three then writing copy
+   * against the three is what made two sentences false the moment 2.578 widened
+   * the preimages: `'unchanged'` acquired `value_only` (so "the same model" ran
+   * beside a list of changed values) and `'not_comparable'` acquired same-regime
+   * `uncharacterised_change` (so "incomparable identifiers" ran beside a
+   * successful comparison). A surface that explains a verdict needs the verdict.
+   */
+  changeKind: GraphChangeKind
   fromLeader: LeaderClaim
   toLeader: LeaderClaim
   /**

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -12,6 +12,7 @@ import type { ScenarioEvent, ScenarioEventType } from '../../types/scenario'
 import { SYSTEM_MARKER_EVENT_TYPES } from '../../types/scenario'
 import type { AnalysisSnapshot, FactorSensitivitySummary, SnapshotOption } from '../compare-tab/types'
 import { generateGraphHash } from '../utils/graphHash'
+import { buildGraphProjection, NO_EDITS_SUMMARY } from '../compare-tab/graphChangeDiff'
 import { hasObservedData } from '../utils/observedStateHelpers'
 import { deriveDecisionVerdict, type DecisionVerdict } from '../../lib/decisionVerdict'
 import {
@@ -238,7 +239,15 @@ function deriveEditSummary(
       )
     : []
 
-  if (relevant.length === 0) return 'Rerun (no edits)'
+  // ⚠ ROADMAP 2.578 — THIS SENTENCE IS NO LONGER A CLAIM COMPARE WILL PUBLISH
+  // ON ITS OWN. An empty event log is evidence of nothing: on the deployed
+  // build `direct_edit` events are gated behind `isJourneyTabEnabled()` (unset
+  // ⇒ false), appended best-effort, and read from a load-time-only
+  // `_hydratedEvents` snapshot — so "no relevant events" is the log's normal
+  // state after a real edit. `buildTransition` now only surfaces this string
+  // when the GRAPH PROJECTION independently says the two runs are identical.
+  // An event log can witness presence; it can never witness absence.
+  if (relevant.length === 0) return NO_EDITS_SUMMARY
 
   // Try to extract a specific label from a single edit
   if (relevant.length === 1) {
@@ -454,6 +463,10 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     graphHash: nodes != null && edges != null ? generateGraphHash(nodes, edges) : null,
     nodeCount: nodes != null ? nodes.length : null,
     edgeCount: edges != null ? edges.length : null,
+    // ROADMAP 2.578 — same absence rule as the three fields above, stated once
+    // in BuildSnapshotParams.nodes: no graph ⇒ no projection ⇒ Compare says
+    // "cannot characterise" rather than inventing "no edits".
+    graphProjection: nodes != null && edges != null ? buildGraphProjection(nodes, edges) : null,
 
     options: extractOptions(options as V2OptionComparison[]),
     leaderVerdict: deriveRunLeaderVerdict(rawV2Response, options as V2OptionComparison[]),


### PR DESCRIPTION
ROADMAP **2.578** · pillars **P4** (human–AI collaboration) / **P5** (progressive disclosure).

## The defect

After a visible link-strength edit `+0.50 → +0.80`, Compare rendered **both** `• Rerun (no edits)` **and** `Structure changed — comparison is directional only` on one card. Staleness and Undo recognised the same edit correctly.

Evidence: `PHASE0-EVIDENCE-2026-07-28/codex-deep-review-2026-08-05-raw/compare-misclassification.yml` (refs `e5327` / `e5335`).

## Diagnosis — two labels, two unrelated inputs

**"Rerun (no edits)"** ← `deriveEditSummary`, reading the persisted scenario **event log**. That log cannot witness an in-session edit on the deployed build, for **three independent reasons, each alone sufficient**:
1. `direct_edit` is appended only under `isJourneyTabEnabled()` — `journeyTab` has no `defaultValue` (⇒ `false`) and `VITE_FEATURE_JOURNEY_TAB` is **absent from `netlify.toml`**. Live witness: the capture's Outputs nav reads `Olumi · Analysis · Compare · Model` — **no Journey tab**.
2. the append is best-effort, `.catch(() => {})`.
3. the factory reads `_hydratedEvents`, whose sole writer (`useScenario.ts:697`) runs **once at scenario load**.

So "Rerun (no edits)" was not an edge case — it was the **only** answer Compare could give for a same-session rerun after edits. (`Rerun (no edits)` appears in **12** capture files.)

**"Structure changed"** ← `compareStructure`, comparing `generateGraphHash` — which hashes edge `weight`/`confidence`/`belief`, i.e. a **content** hash. A value-only edit flips it, and the flip was read as a claim about the model's **shape**.

**Why Staleness and Undo were right:** both read the graph at the synchronous store chokepoint (`updateEdge` → `pushToHistory` / `invalidateAnalysisReady`) — no flag, no network, no rehydration. Compare read a *report about* the mutation that is never written.

## Shape chosen: reuse, not a new differ

The field list is **not invented**. It is `STALE_NODE_FIELDS` / `STALE_EDGE_FIELDS`, derived from the ratified `analyticalNodeFields` registry — the same list, obtained the same way, that `hasAnalyticalEdgeChange` uses, i.e. **the list Staleness itself consumes**, with that module's `deepEqual`. Compare and Staleness now cannot disagree about what counts as an edit, and a field added to the registry reaches both automatically.

One classifier (`classifyChange`) holds **all** the evidence rules; `compareStructure` is a pure projection of it, and `edits` / `structureChanged` are both derived from it. Two labels with one input cannot disagree.

Verdicts: `unchanged` · `value_only` · `structural` · `uncharacterised_change` (something moved, no graph survives to say what — added so the persisted path need not choose between two false statements) · `not_comparable`.

## Two further defects of the same class, found and fixed

- **`Hero.tsx:77`** said `Structure changed · Review the new result` whenever the winner flipped by a wide margin. `flipped` is `previous.winnerId !== latest.winnerId` and nothing else — a **third** claim that could contradict the card. Corrected and pinned.
- **`TransitionCard`** printed every change twice once the diff had detail.

## Coverage the hash never had

Measured against a **real captured graph** (`canvas-export-1785945361783.json`, 34 edges): `weight` present 34/34, `confidence` **0/34**, `belief` **0/34**. The old signal was blind in both directions — it raised "structure changed" for a weight edit and saw *nothing* for `direction` / `strengthStd` / `beliefExists` edits. Mutant M11 (projection restricted to the old three fields) REDs the three new tests.

## Verification

**RED-first at pristine `af5c5a37`** — 10 failed / 3 passed, including the contradiction itself in rendered DOM: `expected <span …(1)></span> to be falsy`.

**Mutants** — throwaway worktree at an absolute path outside the repo root, isolation proven by **write test** + inode comparison; control applied-check **exactly 0**.

| mutant | result |
|---|---|
| M1 `structureChanged := false` | BITTEN |
| M2 removal drops `structural = true` | BITTEN |
| M3 field guard `:= if(false)` | BITTEN |
| M4 before/after swapped | BITTEN |
| M5 loosen for ALL objects | BITTEN |
| **PAIR-A'** misattribute to a different edge id | **BITTEN (4)** |
| **PAIR-B'** same id, mutated display label | **GREEN (89/89)** |
| M7 `value_only` emits the no-edits sentinel | BITTEN |
| M8 drop cross-regime guard | **SURVIVED** → gap closed with a new test → **BITTEN**, isolated |
| M9 hash inequality `:= structural` (the original defect) | BITTEN (7) |
| M10 `netlify.toml COMPARE_TAB := 0` | BITTEN — mount binding is live |
| M11 projection restricted to the old hash's fields | BITTEN (3) |

PAIR-A'/PAIR-B' are the trap-19 discriminating pair: assertions bind to the edge **identity**, not to display data and not to "an edge".

**Reversed pins are declared, not absorbed.** Four existing tests asserted "same-regime hash inequality ⇒ structure changed". That expectation *was* the defect; each is rewritten with its reasoning, and controls added so the correction did not turn the structure row into a permanent shrug.

**Gates:** typecheck PASSED, 2491 diagnostics = baseline exactly. eslint on changed files: 0 errors, 1 warning (`_report`, pre-existing). compare-tab 15 files/200 tests; every affected spec outside it 23 files/310 tests.

## Named limitation (inherited, not introduced)

`nodes`/`edges` are destructured at **result-application** time (`store.ts:3147`), so the projection describes the graph when the response lands — exactly the pre-existing binding of `graphHash`/`nodeCount`/`edgeCount`. The row's "bind to what was *actually* analysed" is therefore only **partly** satisfied. Whether an edit can land between dispatch and application I did not establish.

## Separate — adjacent claim, NOT folded in

`ModelTabBody.tsx handleResolveContested`: every branch calls `updateEdge(...)` before `emitAdjudication(...)`, which swallows its rejection. Precision: the swallowed send is an **adjudication receipt**, not the graph write — the edge value is persisted by autosave. Not reproduced behaviourally by this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)