### PR TITLE
2.635 — retire the readiness verdict's three fail-open limbs; stale is never quoted as current

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -83,7 +83,15 @@ import {
 // Lazy: flag-off users never pay the v3 bundle cost.
 const PreAnalysisPanelV3 = lazy(() => import('./pre-analysis-v3'))
 import { useConversation } from '../conversation/useConversation'
-import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip, computeCeeCannotSeeModel } from '../utils/canRunAnalysis'
+import {
+  canRunAnalysis as canRunAnalysisUtil,
+  getRunButtonTooltip,
+  computeCeeCannotSeeModel,
+  readinessObjectsToRun,
+  verdictLicenceSuperseded,
+  RUN_LICENCE_SUPERSEDED_REFUSAL,
+  type ReadinessVerdictLicence,
+} from '../utils/canRunAnalysis'
 import { selectOptionsNeedingValues } from '../utils/composeBlockedReason'
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
@@ -126,6 +134,10 @@ import { verboseDebug } from '../../utils/verboseLog'
 import { AnalysisFooter } from '../shared/AnalysisFooter'
 import { derivePostFooterStatus, derivePostFooterMeta } from './utils/postAnalysisFooter'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
+// ROADMAP 2.635 (I-4) — read at DISPATCH time, not via a render-scope selector:
+// the whole point of the licence barrier is to see the store as it is when the
+// run actually goes out, not as it was when the gate was computed.
+import { useReadinessStore } from '../stores/readinessStore'
 import { AskOlumiDrawer } from '../../components/results/coaching/AskOlumiDrawer'
 import { DefineSuccessModal, DecisionRecordModal, HowComputedModal } from '../../components/results/modals'
 
@@ -824,7 +836,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // rather than kept alongside it.
   const runStatus = runStatusRegion({ isRunning })
 
-  const { readiness } = useGraphReadiness()
+  // ROADMAP 2.635 — `stale` feeds the gate's COPY (I-3) and `verdictAtMs`
+  // identifies WHICH verdict licensed a run (I-4).
+  const { readiness, stale: readinessStale, verdictAtMs: readinessVerdictAtMs } = useGraphReadiness()
 
   // C1 review: the orphan-banner footer suppression is GONE. It rested on a
   // premise that is false at this ref — it claimed the footer would carry
@@ -894,7 +908,14 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     ceeCannotSeeModel: computeCeeCannotSeeModel(nodes),
     draftStreamPhase,
     optionsNeedingValues,
+    readinessStale,
   })
+  // ROADMAP 2.635 (I-4) — the identity of the verdict this gate result was
+  // computed against, captured at the same moment so the two cannot drift.
+  const licensedByVerdict = useMemo<ReadinessVerdictLicence>(
+    () => ({ verdictAtMs: readinessVerdictAtMs, stale: readinessStale }),
+    [readinessVerdictAtMs, readinessStale],
+  )
   const canRunAnalysis = runGateResult.allowed
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)
   const showToast = useShowToastSafe()
@@ -936,6 +957,38 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
         status: 'blocked',
         reason: 'Could not save your latest changes. Check your connection and try again.',
       }
+    }
+    // ── ROADMAP 2.635 (I-4): the run is bound to the verdict that licensed it ──
+    //
+    // The gate above was evaluated during RENDER. This callback dispatches
+    // later, and the `flushPendingSaves()` await immediately above is a real
+    // window — a fresh verdict, or a staleness mark, can land inside it. Until
+    // now nothing tied the click to the assessment that opened the gate, so a
+    // run dispatched against a SUPERSEDED verdict looked exactly like one
+    // dispatched against a current one, and a doomed run was un-attributable.
+    //
+    // The check is deliberately narrow. A moved licence alone does NOT stop the
+    // run: staleness marks flip on ordinary canvas churn, and refusing on that
+    // would hand the user a Run button that fails whenever they touched
+    // anything. It stops only the case that is actually doomed — the licence
+    // moved AND the verdict now on screen OBJECTS. That question is asked of
+    // `readinessObjectsToRun`, the gate's own rung predicate, so there is still
+    // exactly one definition of what a readiness objection is (I-5).
+    const licenceAtDispatch = useReadinessStore.getState()
+    if (
+      verdictLicenceSuperseded(licensedByVerdict, {
+        verdictAtMs: licenceAtDispatch.verdictAtMs,
+        stale: licenceAtDispatch.stale,
+      }) &&
+      readinessObjectsToRun(licenceAtDispatch.readiness)
+    ) {
+      console.warn('[OutputsDock] run licence superseded before dispatch', {
+        licensedByVerdictAtMs: licensedByVerdict.verdictAtMs,
+        licensedByStale: licensedByVerdict.stale,
+        atDispatchVerdictAtMs: licenceAtDispatch.verdictAtMs,
+        atDispatchStale: licenceAtDispatch.stale,
+      })
+      return { status: 'blocked', reason: RUN_LICENCE_SUPERSEDED_REFUSAL }
     }
     // Capture pre-analysis review progress for transition bridge
     const storeState = useCanvasStore.getState()
@@ -1015,7 +1068,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     }
     await runV2Analysis()
     return { status: 'v2' }
-  }, [canRunAnalysis, runBlockedTooltip, isRunning, runV2Analysis, framing, flushPendingSaves])
+  }, [canRunAnalysis, runBlockedTooltip, isRunning, runV2Analysis, framing, flushPendingSaves, licensedByVerdict])
 
   // Expose the canonical runner to other surfaces (canvas shortcut, palette).
   useEffect(() => registerCanonicalRunner(runCanonicalAnalysis), [runCanonicalAnalysis])

--- a/src/canvas/components/PreAnalysisHealth.tsx
+++ b/src/canvas/components/PreAnalysisHealth.tsx
@@ -100,10 +100,11 @@ const tierConfig: Record<GraphReadinessLevel, TierStyle> = {
     ...topBandStyle,
     label: 'Ready',
   },
-  strong: {
-    ...topBandStyle,
-    label: 'Strong',
-  },
+  // ROADMAP 2.635 — the `strong` entry is gone with the level itself. It was
+  // the local heuristic's spelling of the top band; that heuristic and its last
+  // caller (the 429 arm) are deleted, so no writer can produce it. The Record's
+  // exhaustiveness device is what made this a required edit rather than dead
+  // config left to rot — which is exactly why it is typed this way.
 }
 
 // Priority styling

--- a/src/canvas/components/__tests__/OutputsDock.runVerdictLicence.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runVerdictLicence.spec.tsx
@@ -1,0 +1,299 @@
+/**
+ * OutputsDock — a run is bound to the verdict that licensed it
+ * (ROADMAP 2.635, invariant I-4).
+ *
+ * ── The gap ──────────────────────────────────────────────────────────────
+ * The run gate is evaluated during RENDER. The click that acts on it dispatches
+ * later, and `runCanonicalAnalysis` awaits `flushPendingSaves()` in between —
+ * the F1 barrier that persists an in-flight autosave before a canonical V5 run
+ * (which carries a scenario id, not a graph). That await is a real window: a
+ * fresh readiness verdict can land inside it.
+ *
+ * Until 2.635 nothing tied the dispatch to the verdict that opened the gate, so
+ * a run licensed by a verdict that had since been REPLACED BY A REFUSAL looked
+ * exactly like one licensed by a current verdict — and the resulting doomed run
+ * was un-attributable. The user presses Analyse, the run goes out against a
+ * model the server has just said it cannot analyse, and the failure surfaces as
+ * an engine error rather than as the readiness refusal it actually is.
+ *
+ * ── What this file pins, and why it needs a PAIR ─────────────────────────
+ * A single "blocked" assertion would be satisfied by a barrier that refuses
+ * whenever the verdict identity moves at all — which would be a far worse
+ * defect than the one it fixes, because staleness marks flip on ordinary canvas
+ * churn and the Run button would fail whenever the user touched anything. So
+ * the discrimination is proved with a pair (CLAUDE.md trap 19):
+ *
+ *   · licence moved AND the new verdict OBJECTS   ⇒ must refuse
+ *   · licence moved AND the new verdict PERMITS   ⇒ must run
+ *
+ * Neither alone shows the binding. The first proves sensitivity to something;
+ * the second proves it is sensitive to the OBJECTION rather than to the mere
+ * fact of change.
+ *
+ * ⚠ Surface binding (trap 3b): `netlify.toml` sets
+ * `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"`, and the canonical runner under test is
+ * the one `OutputsDock` registers regardless of that flag; the flag mock below
+ * matches the deployment so the component mounts the surface a user loads.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, waitFor } from '@testing-library/react'
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useReadinessStore } from '../../stores/readinessStore'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { getCanonicalRunner } from '../../analysis/canonicalRunRegistry'
+import { RUN_LICENCE_SUPERSEDED_REFUSAL } from '../../utils/canRunAnalysis'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    isPreAnalysisV3Enabled: () => true,
+    // Force the V2 fallback so a permitted run has an observable, local
+    // terminal outcome (`status: 'v2'`) instead of a fire-and-forget V5 stream.
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+const runV2Analysis = vi.fn(async () => {})
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: (...a: unknown[]) => runV2Analysis(...(a as [])), cancelRun: vi.fn() }),
+}))
+
+/**
+ * The seam this file exists to exercise. `flushPendingSaves` is awaited between
+ * the render-time gate and the dispatch, so whatever it does to the readiness
+ * store happens INSIDE the window under test. Each test installs its own.
+ */
+let flushBehaviour: () => void | Promise<void> = () => {}
+
+vi.mock('../../../hooks/useScenario', () => ({
+  useScenario: () => ({
+    setAnalysisRunning: vi.fn(),
+    resetAnalysisStatus: vi.fn(),
+    persistAnalysisSuccess: vi.fn(),
+    persistAnalysisFailure: vi.fn(),
+    isPersistenceActive: false,
+    flushPendingSaves: async () => {
+      await flushBehaviour()
+    },
+  }),
+}))
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+const LICENSING_VERDICT_AT_MS = 1_000_000
+
+/** The verdict that OPENS the gate — the licence the run is issued against. */
+const RUNNABLE_VERDICT = {
+  readiness_score: 90,
+  readiness_level: 'ready' as const,
+  can_run_analysis: true,
+  confidence_explanation: 'Ready to analyse',
+  improvements: [],
+  scaffold_plan: { will_scaffold_options: false },
+  options_ready: 5,
+  options_total: 5,
+  goal_node_valid: true,
+}
+
+/** A LATER verdict that objects — identifiable by its own sentence. */
+const SUPERSEDING_BLOCKED_VERDICT = {
+  ...RUNNABLE_VERDICT,
+  can_run_analysis: false,
+  confidence_explanation: 'One option lost its effect values (verdict D2)',
+  options_ready: 4,
+}
+
+/** A LATER verdict that still permits — the discriminating half. */
+const SUPERSEDING_RUNNABLE_VERDICT = {
+  ...RUNNABLE_VERDICT,
+  confidence_explanation: 'Still ready to analyse (verdict D3)',
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+function seedPreRunCanvas() {
+  const nodes = [
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'Build or buy?' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Increase delivery output' } },
+    { id: 'opt_build', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Build it in house' } },
+    { id: 'opt_buy', type: 'option', position: { x: 10, y: 0 }, data: { kind: 'option', label: 'Buy a vendor platform' } },
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Ramp-up time' } },
+  ]
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }] as never,
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    hasCompletedFirstRun: false,
+    results: { status: 'idle', progress: 0 },
+    showDraftChat: false,
+    v5AnalysisFact: null,
+    analysisFreshness: null,
+    ceeAnalysisReady: {
+      goal_node_id: 'g1',
+      status: 'ready',
+      options: [
+        { id: 'opt_build', status: 'ready' },
+        { id: 'opt_buy', status: 'ready' },
+      ],
+    },
+  } as never)
+}
+
+/** Hold the licensing verdict; the transport never settles so nothing else lands. */
+function seedLicensingVerdict() {
+  clearInflightCache()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise(() => {})),
+  )
+  useReadinessStore.setState({
+    readiness: RUNNABLE_VERDICT,
+    loading: false,
+    error: null,
+    stale: false,
+    verdictAtMs: LICENSING_VERDICT_AT_MS,
+  })
+}
+
+/** Land a NEW verdict, with a NEW timestamp — i.e. supersede the licence. */
+function landVerdict(verdict: typeof RUNNABLE_VERDICT) {
+  useReadinessStore.setState({
+    readiness: verdict,
+    loading: false,
+    error: null,
+    stale: false,
+    verdictAtMs: LICENSING_VERDICT_AT_MS + 5_000,
+  })
+}
+
+async function mountDockAndTakeRunner() {
+  render(
+    <ToastProvider>
+      <OutputsDock />
+    </ToastProvider>,
+  )
+  await waitFor(() => expect(getCanonicalRunner()).not.toBeNull(), { timeout: 20_000 })
+  return getCanonicalRunner()!
+}
+
+beforeAll(async () => {
+  await import('../pre-analysis-v3')
+}, 30_000)
+
+beforeEach(() => {
+  ensureMatchMedia()
+  runV2Analysis.mockClear()
+  flushBehaviour = () => {}
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+  seedPreRunCanvas()
+  seedLicensingVerdict()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.unstubAllGlobals()
+})
+
+describe('OutputsDock — the run is bound to the verdict that licensed it (I-4)', () => {
+  // ── Control (trap 13): the gate is genuinely OPEN and the run genuinely
+  // reaches the pipeline. Without this, "blocked" below could be the gate
+  // refusing for some unrelated reason and the barrier never running at all.
+  it('control — with the licence intact the run reaches the analysis pipeline', async () => {
+    const run = await mountDockAndTakeRunner()
+
+    const outcome = await run()
+
+    expect(outcome).toEqual({ status: 'v2' })
+    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+  }, 40_000)
+
+  // ── The defect ───────────────────────────────────────────────────
+  it('refuses when the licensing verdict is replaced by a refusal mid-dispatch', async () => {
+    const run = await mountDockAndTakeRunner()
+    // The refusal lands INSIDE the persistence-flush await — the real window.
+    flushBehaviour = () => landVerdict(SUPERSEDING_BLOCKED_VERDICT)
+
+    const outcome = await run()
+
+    expect(outcome).toEqual({ status: 'blocked', reason: RUN_LICENCE_SUPERSEDED_REFUSAL })
+    // The point of the barrier: the doomed run never went out.
+    expect(runV2Analysis).not.toHaveBeenCalled()
+  }, 40_000)
+
+  // ── The discriminating half (trap 19) ────────────────────────────
+  it('still runs when the licence moves but the new verdict permits', async () => {
+    const run = await mountDockAndTakeRunner()
+    // Identity moves — a genuinely new verdict, new timestamp — but it does not
+    // object. A barrier keyed on identity ALONE would refuse here, and would
+    // brick the Run button on ordinary re-check churn.
+    flushBehaviour = () => landVerdict(SUPERSEDING_RUNNABLE_VERDICT)
+
+    const outcome = await run()
+
+    expect(outcome).toEqual({ status: 'v2' })
+    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+  }, 40_000)
+
+  it('still runs when a staleness mark lands mid-dispatch on a permitting verdict', async () => {
+    const run = await mountDockAndTakeRunner()
+    // The commonest case by far: the user nudges the canvas, `stale` flips, the
+    // refetch is in flight. Ruling 3 — uncertainty must not lock the user out.
+    flushBehaviour = () => useReadinessStore.setState({ stale: true })
+
+    const outcome = await run()
+
+    expect(outcome).toEqual({ status: 'v2' })
+    expect(runV2Analysis).toHaveBeenCalledTimes(1)
+  }, 40_000)
+})

--- a/src/canvas/components/__tests__/OutputsDock.staleVerdictCopy.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.staleVerdictCopy.spec.tsx
@@ -1,0 +1,279 @@
+/**
+ * OutputsDock — a stale verdict is not quoted as current, THROUGH THE REAL
+ * WIRING (ROADMAP 2.635, invariants I-3 and I-4).
+ *
+ * ⚠ Why this file exists alongside `canRunAnalysis.staleVerdict.spec.ts`.
+ * That spec proves the GATE withholds specific copy when told the verdict is
+ * stale. It proves nothing about whether anything ever tells it. This is the
+ * exact defect shape `OutputsDock.blockedReasonWiring.spec.tsx` was written for
+ * after mutation survivor M3: reverting the dock's wiring hunk alone left the
+ * whole suite green while the headline behaviour silently vanished.
+ *
+ * ⚠ Surface binding (CLAUDE.md trap 3b). The assertions below are bound to the
+ * surface the DEPLOYED FLAGS mount. `netlify.toml` sets
+ * `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"`, so `OutputsDock` renders
+ * `PreAnalysisPanelV3` and the footer under test is `pre-analysis-v3-footer`.
+ * The mock below pins `isPreAnalysisV3Enabled: () => true` to match, and the
+ * first test asserts the MOUNT PATH itself, so this binding fails loud if the
+ * flag ever moves — a green suite is not evidence about a component the
+ * deployment does not render.
+ *
+ * ⚠ Scope (CLAUDE.md trap 3): these are DOM-content assertions, not layout or
+ * visibility claims. Nothing here asserts anything is above the fold.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useReadinessStore } from '../../stores/readinessStore'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    // Matches `netlify.toml` VITE_FEATURE_PRE_ANALYSIS_V3 = "1" — the surface
+    // the deployment actually mounts.
+    isPreAnalysisV3Enabled: () => true,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }),
+}))
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+/** The verdict from the failing journey: one option not ready, gate closed. */
+const BLOCKED_VERDICT = {
+  readiness_score: 90,
+  readiness_level: 'ready' as const,
+  can_run_analysis: false,
+  confidence_explanation: 'V3 analysis not ready: 1 option(s) blocked: opt_extend',
+  improvements: [],
+  scaffold_plan: { will_scaffold_options: false },
+  options_ready: 4,
+  options_total: 5,
+  goal_node_valid: true,
+}
+
+const OPTION_LABELS: Record<string, string> = {
+  opt_build: 'Build it in house',
+  opt_buy: 'Buy a vendor platform',
+  opt_hybrid: 'Hybrid build and buy',
+  opt_wait: 'Wait a year',
+  opt_extend: 'Partner with a consultancy',
+}
+
+const SPECIFIC_SENTENCE = BLOCKED_REASON_COPY.oneOption('Partner with a consultancy', true)
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+function seedPreRunCanvas() {
+  const nodes = [
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'Build or buy?' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Increase delivery output' } },
+    ...Object.entries(OPTION_LABELS).map(([id, label], i) => ({
+      id,
+      type: 'option',
+      position: { x: 10 * i, y: 0 },
+      data: { kind: 'option', label },
+    })),
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Ramp-up time' } },
+  ]
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }] as never,
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    hasCompletedFirstRun: false,
+    results: { status: 'idle', progress: 0 },
+    showDraftChat: false,
+    v5AnalysisFact: null,
+    analysisFreshness: null,
+  } as never)
+}
+
+function seedCeeAnalysisReady(notReadyIds: string[]) {
+  useCanvasStore.setState({
+    ceeAnalysisReady: {
+      goal_node_id: 'g1',
+      status: 'needs_input',
+      options: Object.keys(OPTION_LABELS).map((id) => ({
+        id,
+        status: notReadyIds.includes(id) ? 'needs_encoding' : 'ready',
+      })),
+    },
+  } as never)
+}
+
+/**
+ * Put the store into the exact state under test and HOLD it there.
+ *
+ * The transport is stubbed with a promise that never settles. That is not a
+ * convenience — it IS the state this row is about: a verdict has landed, the
+ * canvas has since moved, the staleness mark is set, and the refetch that will
+ * answer for the new model is IN FLIGHT. The window between those two events is
+ * precisely when a surface can quote an outgrown verdict as current, and it is
+ * the window the user sits in every time they act on a remedy chip.
+ *
+ * A resolving stub cannot express it: the dock's own `startListening()` fetch
+ * lands on mount and clears `stale` (readinessStore `:841`), so the fixture
+ * would silently become the fresh case and every assertion below would be about
+ * the wrong state.
+ */
+function seedVerdict({ stale }: { stale: boolean }) {
+  clearInflightCache()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise(() => {})),
+  )
+  useReadinessStore.setState({
+    readiness: BLOCKED_VERDICT,
+    loading: false,
+    error: null,
+    stale,
+    verdictAtMs: Date.now(),
+  })
+}
+
+beforeAll(async () => {
+  await import('../pre-analysis-v3')
+}, 30_000)
+
+beforeEach(() => {
+  ensureMatchMedia()
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.unstubAllGlobals()
+})
+
+describe('OutputsDock → the blocked footer, when the verdict is stale (I-3)', () => {
+  // ── Control: the mount path, and that specific copy is REACHABLE ──
+  //
+  // Both halves matter. The mount assertion is trap 3b: it fails loud if the
+  // deployed flag ever stops mounting this surface, instead of the whole file
+  // quietly testing a component nobody renders. The copy assertion is trap 13:
+  // it proves the specific sentence can arrive here at all, so the withholding
+  // assertions below cannot pass by testing nothing.
+  it('control — a FRESH verdict mounts the deployed surface and names the option', async () => {
+    seedPreRunCanvas()
+    seedCeeAnalysisReady(['opt_extend'])
+    seedVerdict({ stale: false })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    // The mount path itself — the V3 branch of OutputsDock's flag fork.
+    expect(await screen.findByTestId('outputs-pre-run-v3', {}, { timeout: 20_000 })).toBeTruthy()
+
+    const footer = await screen.findByTestId('pre-analysis-v3-footer', {}, { timeout: 20_000 })
+    expect(footer).toHaveTextContent(SPECIFIC_SENTENCE)
+  }, 40_000)
+
+  it('a stale verdict does not name the option it graded', async () => {
+    seedPreRunCanvas()
+    seedCeeAnalysisReady(['opt_extend'])
+    seedVerdict({ stale: true })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const footer = await screen.findByTestId('pre-analysis-v3-footer', {}, { timeout: 20_000 })
+    // The user may have just described this very option. Naming it again, from
+    // a verdict that was never re-asked, is the false reason PC1 forbids.
+    expect(footer).not.toHaveTextContent('Partner with a consultancy')
+    expect(footer).not.toHaveTextContent(SPECIFIC_SENTENCE)
+  }, 40_000)
+
+  it('a stale verdict says the model changed and the check is being redone', async () => {
+    seedPreRunCanvas()
+    seedCeeAnalysisReady(['opt_extend'])
+    seedVerdict({ stale: true })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const footer = await screen.findByTestId('pre-analysis-v3-footer', {}, { timeout: 20_000 })
+    expect(footer).toHaveTextContent(BLOCKED_REASON_COPY.staleRecheck)
+  }, 40_000)
+
+  it('the Run button carries the same stale sentence — one state, one story', async () => {
+    seedPreRunCanvas()
+    seedCeeAnalysisReady(['opt_extend'])
+    seedVerdict({ stale: true })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    // Still disabled: staleness does not open the gate (that would be inventing
+    // a verdict in the permissive direction). Only the CLAIM changes.
+    expect(analyse).toBeDisabled()
+    expect(analyse).toHaveAttribute('title', BLOCKED_REASON_COPY.staleRecheck)
+  }, 40_000)
+})

--- a/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
@@ -91,7 +91,7 @@ function seedReadiness(canRun = true, explanation = 'Looks consistent.') {
   useReadinessStore.setState({
     readiness: {
       readiness_score: 72,
-      readiness_level: 'strong',
+      readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
       can_run_analysis: canRun,
       confidence_explanation: explanation,
       improvements: [],

--- a/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/contestedSection.spec.tsx
@@ -71,7 +71,7 @@ beforeEach(() => {
   useReadinessStore.setState({
     readiness: {
       readiness_score: 72,
-      readiness_level: 'strong',
+      readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
       can_run_analysis: true,
       confidence_explanation: 'Looks consistent.',
       improvements: [],

--- a/src/canvas/components/pre-analysis-v3/__tests__/headerRow.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/headerRow.spec.tsx
@@ -25,7 +25,7 @@ beforeEach(() => {
   useReadinessStore.setState({
     readiness: {
       readiness_score: 72,
-      readiness_level: 'strong',
+      readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
       can_run_analysis: true,
       confidence_explanation: 'Looks consistent.',
       improvements: [],

--- a/src/canvas/components/pre-analysis-v3/__tests__/hierarchyContract.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/hierarchyContract.spec.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
   useReadinessStore.setState({
     readiness: {
       readiness_score: 72,
-      readiness_level: 'strong',
+      readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
       can_run_analysis: true,
       confidence_explanation: 'Looks consistent.',
       improvements: [],

--- a/src/canvas/components/pre-analysis-v3/__tests__/readinessOutageVisibility.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/readinessOutageVisibility.spec.tsx
@@ -279,15 +279,17 @@ describe('pre-analysis panel — an unchecked model is never presented as a chec
     })
   })
 
-  // ── The 429 limb: a local fallback is never cited as a check ─────
+  // ── The 429 limb: no local fallback exists to cite (ROADMAP 2.635) ─
   //
-  // This slice added a footer arm that fires on ANY non-null store error, and
-  // 429 sets one. Its verdict is the LOCAL heuristic, not a server answer — so
-  // the arm must name the rate limit and must NOT print "Showing the check
-  // from HH:MM" over a number no server produced. That would re-create the
-  // fabrication class one field over, inside the fix for it.
+  // This block used to assert `readiness` was NON-null after a 429 — the local
+  // heuristic's verdict — while insisting the surface not print "Showing the
+  // check from HH:MM" over it. That was the best available compromise while a
+  // fabricated verdict was on screen. 2.635 removed the fabrication instead:
+  // the arm publishes nothing, so the panel reaches the SAME honest
+  // never-checked surface as the transport, 404 and 5xx limbs, and the
+  // timestamp problem cannot arise because there is no local verdict.
   describe('a rate-limited check is named as one, and cites no server time', () => {
-    it('shows the rate-limit reason without claiming a timestamped check', async () => {
+    it('shows the rate-limit reason and publishes no verdict to timestamp', async () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 429,
@@ -299,7 +301,7 @@ describe('pre-analysis panel — an unchecked model is never presented as a chec
       renderPanel()
       await settle()
 
-      expect(useReadinessStore.getState().readiness).not.toBeNull()
+      expect(useReadinessStore.getState().readiness).toBeNull()
       expect(useReadinessStore.getState().verdictAtMs).toBeNull()
 
       const outage = screen.getByTestId('pre-analysis-v3-readiness-outage')

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -130,7 +130,9 @@ export const ConversationPanel = memo(function ConversationPanel({
   const generateInFlightRef = useRef(false)
   const wasThinkingRef = useRef(false)
   const { runV2Analysis, isRunning: isV2RunInFlight } = useV2Run()
-  const { readiness } = useGraphReadiness()
+  // ROADMAP 2.635 (I-3) — `stale` travels with the verdict into the gate, so
+  // a refusal composed here cannot quote a verdict the canvas has outgrown.
+  const { readiness, stale: readinessStale } = useGraphReadiness()
 
   // Track 2: Thread persistence (best-effort, flag-gated)
   const { onBlockAction, onChipTaken } = useThreadPersistence(scenarioId, messages)
@@ -501,7 +503,8 @@ export const ConversationPanel = memo(function ConversationPanel({
     isRunning: isAnalysisRunning,
     ceeCannotSeeModel,
     draftStreamPhase,
-  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel, draftStreamPhase])
+    readinessStale,
+  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel, draftStreamPhase, readinessStale])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain

--- a/src/canvas/hooks/useGraphReadiness.ts
+++ b/src/canvas/hooks/useGraphReadiness.ts
@@ -222,31 +222,40 @@ export const CEE_READINESS_LEVELS = ['needs_work', 'fair', 'ready'] as const
 export type CeeReadinessLevel = (typeof CEE_READINESS_LEVELS)[number]
 
 /**
- * `strong` is NOT a CEE value — no CEE code path assigns it to `readiness_level`.
- * It is emitted only by the UI's own local heuristic,
- * `readinessStore.calculateFallbackReadiness`, when CEE is unreachable, and that
- * value is written straight to the store WITHOUT passing through the normaliser.
- * Accepted here so the field's type covers both writers.
+ * ── ROADMAP 2.635 (I-1): `LOCAL_FALLBACK_READINESS_LEVELS` was DELETED ──
  *
- * @deprecated Local-fallback spelling of the top band. The fallback emitting a
- * BETTER verdict than the producer (CEE down + score 85 => `strong`; CEE up +
- * score 85 => the top band) is tracked separately and deliberately untouched
- * here — see the divergence-2 row on the family-3 readiness design.
+ * It held exactly one member, `'strong'`, and its own docstring said the thing
+ * that eventually retired it: `strong` is NOT a CEE value — no CEE code path
+ * assigns it to `readiness_level`. It existed because the UI's local heuristic
+ * `readinessStore.calculateFallbackReadiness` emitted it, writing straight to
+ * the store WITHOUT passing through the normaliser. That heuristic's last caller
+ * (the 429 arm) was retired in 2.635 and the function is deleted, so `strong`
+ * now has no writer anywhere in this repo.
+ *
+ * It is removed rather than left resident because a level in the accepted set
+ * with no producer is a standing invitation to re-fabricate one — and because
+ * leaving it made the accepted set a UI invention padded onto a producer
+ * vocabulary, which is the shape that caused the original defect this whole
+ * area was opened for (CEE's `ready` silently coerced to `fair`).
+ *
+ * The old `@deprecated` note recorded the sharpest reason of all: the fallback
+ * emitted a BETTER verdict than the producer could (CEE down + score 85 =>
+ * `strong`; CEE up + score 85 => the top band). An unreachable server producing
+ * a more confident answer than a reachable one is the fabrication class
+ * inverted. It is now unreachable by construction.
  */
-export const LOCAL_FALLBACK_READINESS_LEVELS = ['strong'] as const
-export type LocalFallbackReadinessLevel = (typeof LOCAL_FALLBACK_READINESS_LEVELS)[number]
 
 /**
- * Every value `GraphReadiness.readiness_level` may hold — the producer's set
- * plus the local-fallback band. This is what the normaliser accepts; anything
- * else is unrecognised input and degrades to `fair` (loudly, in DEV).
+ * Every value `GraphReadiness.readiness_level` may hold.
+ *
+ * ⚠ This is now EXACTLY the producer's set — see the assertion in
+ * `readinessStore.ceeVocabulary.spec.ts`. Anything else is unrecognised input
+ * and degrades to `fair` (loudly, in DEV). Do not widen this with a value the
+ * UI invents: a level the producer cannot emit has no honest surface.
  */
-export const ACCEPTED_READINESS_LEVELS = [
-  ...CEE_READINESS_LEVELS,
-  ...LOCAL_FALLBACK_READINESS_LEVELS,
-] as const
+export const ACCEPTED_READINESS_LEVELS = CEE_READINESS_LEVELS
 
-export type GraphReadinessLevel = CeeReadinessLevel | LocalFallbackReadinessLevel
+export type GraphReadinessLevel = CeeReadinessLevel
 
 export type ImprovementPriority = 'high' | 'medium' | 'low'
 

--- a/src/canvas/stores/__tests__/readinessStore.ceeVocabulary.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.ceeVocabulary.spec.ts
@@ -34,6 +34,7 @@ import { useCanvasStore } from '../../store'
 import {
   clearInflightCache,
   CEE_READINESS_LEVELS,
+  ACCEPTED_READINESS_LEVELS,
 } from '../../hooks/useGraphReadiness'
 import { canRunAnalysis, getRunButtonTooltip } from '../../utils/canRunAnalysis'
 
@@ -157,10 +158,13 @@ describe('positive controls — the rest of the vocabulary is unchanged', () => 
   it.each([
     ['fair', 55],
     ['needs_work', 20],
-    // Not a CEE value — emitted only by the UI's own CEE-down fallback. Kept
-    // accepted so the fallback path (divergence 2, out of scope here) is not
-    // disturbed by this change.
-    ['strong', 85],
+    // ROADMAP 2.635 — `['strong', 85]` used to sit here, described as "not a CEE
+    // value … kept accepted so the fallback path is not disturbed". The fallback
+    // path is now DELETED (`calculateFallbackReadiness` and its last caller, the
+    // 429 arm), so `strong` has no writer and is no longer accepted. It moved to
+    // the degradation table below, which is where a value the producer cannot
+    // emit belongs.
+    ['ready', 85],
   ])('passes %s through unchanged', async (level, score) => {
     const readiness = await readinessAfterCeeSays({
       ...CEE_READY_RESPONSE,
@@ -192,6 +196,10 @@ describe('positive controls — the rest of the vocabulary is unchanged', () => 
 
   it.each([
     ['an unknown vocabulary member', 'excellent'],
+    // ROADMAP 2.635 — the retired local-fallback band. Nothing emits it now, and
+    // if anything ever did it would be a UI invention, so it degrades like any
+    // other unrecognised input rather than reaching a surface.
+    ['the retired local-fallback band', 'strong'],
     ['a value from a different lifecycle', 'close_call'],
     ['garbage', '<script>'],
     ['a non-string', 42],
@@ -218,5 +226,22 @@ describe('the accepted set is the producer vocabulary', () => {
 
   it('does not treat "strong" as a producer value', () => {
     expect(CEE_READINESS_LEVELS as readonly string[]).not.toContain('strong')
+  })
+
+  // ── ROADMAP 2.635 (I-1): the accepted set may not exceed the producer's ──
+  //
+  // Until 2.635 the accepted set was the producer's set PLUS a UI-invented
+  // member (`strong`), because the UI had a local writer that emitted it. That
+  // writer is deleted. This pins the resulting property, which is stronger than
+  // "strong is absent": the UI accepts EXACTLY what CEE can emit, so no future
+  // arm can quietly widen the vocabulary to make room for another local guess.
+  //
+  // ⚠ Deriving `ACCEPTED_READINESS_LEVELS` from `CEE_READINESS_LEVELS` proves
+  // the two AGREE; it can never prove the producer list is COMPLETE (trap 12d).
+  // Completeness of `CEE_READINESS_LEVELS` against CEE itself is a cross-repo
+  // mirror, and is asserted separately above against the CEE SHA in this file's
+  // header. The two guards are not redundant and neither supersedes the other.
+  it('accepts exactly the producer vocabulary and nothing the UI invented', () => {
+    expect([...ACCEPTED_READINESS_LEVELS].sort()).toEqual([...CEE_READINESS_LEVELS].sort())
   })
 })

--- a/src/canvas/stores/__tests__/readinessStore.malformedOk.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.malformedOk.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * readinessStore — a 200 that does not answer the question is not a "yes"
+ * (ROADMAP 2.635, invariant I-2).
+ *
+ * ── The limb ─────────────────────────────────────────────────────────────
+ * The normaliser defaulted the ONE gating field on the whole response:
+ *
+ *     can_run_analysis:
+ *       typeof data.can_run_analysis === 'boolean' ? data.can_run_analysis : true
+ *
+ * A 2xx whose body carries no `can_run_analysis` boolean — a partial write, a
+ * proxy that rewrote the body, a producer that renamed the field, a CEE
+ * deployment on an older contract — therefore GRANTED the run, and stamped
+ * `verdictAtMs`, and reported `error: null`. Every downstream surface read that
+ * as the server's own assessment. It is the same fabrication class as the 429
+ * arm (I-1), just spelled as a default instead of a heuristic, and it is
+ * strictly harder to notice because nothing about it is labelled.
+ *
+ * ── The chosen fail direction (I-2) ──────────────────────────────────────
+ * A malformed 200 is treated as UNKNOWN, not as `true`, and unknown is the
+ * store's existing state: publish no verdict, retain whatever the server last
+ * actually said, set a truthful `error`. The run gate's own posture on an
+ * unknown verdict is unchanged and is stated in `canRunAnalysis` — a readiness
+ * check that cannot be obtained does not brick the Run button for a healthy
+ * user; it is disclosed. What changes here is only that the store stops
+ * INVENTING the answer.
+ *
+ * ── What these tests pin ─────────────────────────────────────────────────
+ *   1. a 200 without the boolean does not grant the run;
+ *   2. it publishes no verdict at all when there has never been a server one;
+ *   3. it never replaces a server `false` with a local `true`;
+ *   4. it says so — a truthful `error`, and no `verdictAtMs` stamp;
+ *   5. THE DISCRIMINATING HALF: a well-formed 200 still flows through
+ *      byte-identically in BOTH directions. This is not "null everything".
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion here is on store state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+const SERVER_BLOCKED_SENTENCE = 'One option still needs its effect values (server verdict B4)'
+
+function ok(body: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** A well-formed answer that CLOSES the gate, identifiable by its own sentence. */
+function mockBlockedServerResponse() {
+  return ok({
+    readiness_score: 62,
+    readiness_level: 'fair',
+    can_run_analysis: false,
+    confidence_explanation: SERVER_BLOCKED_SENTENCE,
+    improvements: [],
+    options_ready: 1,
+    options_total: 2,
+    goal_node_valid: true,
+  })
+}
+
+/** A well-formed answer that OPENS the gate. */
+function mockOpenServerResponse() {
+  return ok({
+    readiness_score: 88,
+    readiness_level: 'ready',
+    can_run_analysis: true,
+    confidence_explanation: 'Ready to analyse',
+    improvements: [],
+  })
+}
+
+/**
+ * A 200 that is otherwise plausible but carries NO `can_run_analysis` boolean.
+ * Everything else the normaliser reads is present, so the ONLY thing missing is
+ * the answer to the question the request asked.
+ */
+function mockMalformedOkResponse(extra: Record<string, unknown> = {}) {
+  return ok({
+    readiness_score: 88,
+    readiness_level: 'ready',
+    confidence_explanation: 'Ready to analyse',
+    improvements: [],
+    options_ready: 2,
+    options_total: 2,
+    goal_node_valid: true,
+    ...extra,
+  })
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  useCanvasStore.setState({ nodes: nodes as never, edges: edges as never })
+}
+
+function mutateCanvas(tag: string) {
+  const nodes = useCanvasStore.getState().nodes
+  useCanvasStore.setState({
+    nodes: [
+      ...nodes,
+      {
+        id: `extra-${tag}`,
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: `Extra ${tag}`, kind: 'factor' },
+      },
+    ] as never,
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  useCanvasStore.setState({ nodes: [] as never, edges: [] as never, graphHealth: null } as never)
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — malformed 200 (ROADMAP 2.635, I-2)', () => {
+  // ── Positive control + the DISCRIMINATING half (traps 13 / 13b) ───
+  //
+  // These two tests are not decoration. They are what stops the fix being
+  // "treat every 200 as unknown", which would satisfy every RED below while
+  // destroying the feature. A guard that only proves the hole is closed has not
+  // proved it did not swallow the behaviour while closing it.
+  describe('a well-formed 200 is untouched, in both directions', () => {
+    it('still lands can_run_analysis true when the server says true', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+      expect(state.verdictAtMs).not.toBeNull()
+    })
+
+    it('still lands can_run_analysis false when the server says false', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(false)
+      expect(state.readiness?.confidence_explanation).toBe(SERVER_BLOCKED_SENTENCE)
+      expect(state.error).toBeNull()
+    })
+  })
+
+  // ── RED 1 — the default that invented a "yes" ────────────────────
+  describe('a 200 missing can_run_analysis does not grant the run', () => {
+    it('does not set can_run_analysis true', async () => {
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).not.toBe(true)
+    })
+
+    it('publishes no verdict at all when it has never had one from the server', async () => {
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
+    })
+
+    it.each([
+      ['a string "true"', 'true'],
+      ['a number 1', 1],
+      ['null', null],
+      ['an object', {}],
+    ])('treats %s in can_run_analysis as no answer, not as yes', async (_label, value) => {
+      mockFetch.mockResolvedValue(mockMalformedOkResponse({ can_run_analysis: value }))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).not.toBe(true)
+      expect(state.error).not.toBeNull()
+    })
+  })
+
+  // ── RED 2 — never overwrite the server's refusal ─────────────────
+  describe('a malformed 200 never replaces a verdict the server already gave', () => {
+    it('leaves an existing server "cannot run" verdict intact, by identity', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().readiness?.confidence_explanation).toBe(
+        SERVER_BLOCKED_SENTENCE,
+      )
+
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      mutateCanvas('a')
+      await vi.runAllTimersAsync()
+
+      // Bound by the server sentence, not by `can_run_analysis === false`
+      // (trap 19): a fabricated verdict could satisfy the boolean too.
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.confidence_explanation).toBe(SERVER_BLOCKED_SENTENCE)
+      expect(state.readiness?.readiness_score).toBe(62)
+      expect(state.readiness?.can_run_analysis).toBe(false)
+    })
+
+    it('does not re-stamp verdictAtMs for a response that carried no verdict', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      const stampedByRealAnswer = useReadinessStore.getState().verdictAtMs
+      expect(stampedByRealAnswer).not.toBeNull()
+
+      vi.advanceTimersByTime(60_000)
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      mutateCanvas('a')
+      await vi.runAllTimersAsync()
+
+      // The footer cites this timestamp as "showing the check from HH:MM".
+      // Moving it forward for a response that answered nothing would make a
+      // retained verdict look freshly confirmed.
+      expect(useReadinessStore.getState().verdictAtMs).toBe(stampedByRealAnswer)
+    })
+  })
+
+  // ── RED 3 — the copy ─────────────────────────────────────────────
+  describe('the error names the failure honestly', () => {
+    it('says the response could not be read, and never implies an assessment', async () => {
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const error = useReadinessStore.getState().error ?? ''
+      expect(error).toMatch(/could not read|could not check/i)
+      expect(error.length).toBeGreaterThan(0)
+    })
+  })
+
+  // ── The retry must not be sticky ─────────────────────────────────
+  describe('a malformed 200 is recoverable', () => {
+    it('re-requests the identical graph once the service answers properly', async () => {
+      mockFetch.mockResolvedValue(mockMalformedOkResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().readiness).toBeNull()
+
+      // Same graph, no mutation — only a manual refresh, which is the control
+      // the outage surface offers.
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      useReadinessStore.getState().refresh()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+  })
+})

--- a/src/canvas/stores/__tests__/readinessStore.plotBearer.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.plotBearer.spec.ts
@@ -36,7 +36,7 @@ function okReadiness() {
   return new Response(
     JSON.stringify({
       readiness_score: 75,
-      readiness_level: 'strong',
+      readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
       can_run_analysis: true,
       confidence_explanation: 'Good',
       improvements: [],

--- a/src/canvas/stores/__tests__/readinessStore.rateLimited.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.rateLimited.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * readinessStore — a 429 is not a verdict either (ROADMAP 2.635, invariant I-1).
+ *
+ * ── The last fabrication limb ────────────────────────────────────────────
+ * ROADMAP 2.319(a)/2.329/2.339 closed the transport, 404 and 5xx arms: each now
+ * publishes NO verdict and a truthful `error`. The 429 arm was deliberately left
+ * behind ("this arm's BEHAVIOUR is deliberately unchanged … retiring that is a
+ * separate row"). This is that row.
+ *
+ * At pristine the 429 arm published `calculateFallbackReadiness` INTO
+ * `readiness` — a node/edge-count heuristic whose verdict is
+ * `can_run_analysis: blockers.length === 0`, where `blockers` come from
+ * `graphHealth`, which is `null` until an analysis has already completed. So
+ * before the first analysis there are never any blockers to find, and a rate
+ * limit did not merely RISK opening the gate: it ALWAYS granted the run, on the
+ * most common path there is. Worse, it OVERWROTE a `can_run_analysis: false`
+ * the server had already given, with a locally invented `true` no consumer
+ * could distinguish from the server's own answer.
+ *
+ * It could also print `readiness_level: 'strong'` — a level NO CEE code path
+ * assigns to this field (`useGraphReadiness.CEE_READINESS_LEVELS`). A surface
+ * showing `strong` is showing a band its producer cannot emit.
+ *
+ * ── What these tests pin ─────────────────────────────────────────────────
+ *   1. a 429 publishes no locally-invented verdict when there has never been
+ *      a server one (`readiness` stays `null`);
+ *   2. a 429 never REPLACES a server verdict — in particular never flips a
+ *      server `can_run_analysis: false` to a local `true`;
+ *   3. a 429 can never publish `strong`, a level the producer never emits;
+ *   4. the error names rate limiting truthfully rather than implying an
+ *      assessment ("using local validation" implied one);
+ *   5. the backoff the arm exists for still arms — the fix retires the
+ *      FABRICATION, not the rate-limit handling.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion here is on store state. No
+ * claim in this file is a layout or visibility claim.
+ *
+ * Binding note (CLAUDE.md trap 19): the retained-verdict assertions bind to the
+ * server verdict by IDENTITY — its own `confidence_explanation` string and
+ * score — not by a value predicate (`can_run_analysis === false`) that a
+ * locally invented verdict could also satisfy.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore, __test__ } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache, CEE_READINESS_LEVELS } from '../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+/**
+ * A server answer that CLOSES the gate, with an IDENTIFYING sentence and score
+ * the local heuristic cannot produce. `blockers.length === 0` on a null
+ * graphHealth makes the heuristic say `true`; this says `false`.
+ */
+const SERVER_BLOCKED_SENTENCE = 'One option still needs its effect values (server verdict A7)'
+
+function mockBlockedServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: SERVER_BLOCKED_SENTENCE,
+        improvements: [],
+        options_ready: 1,
+        options_total: 2,
+        goal_node_valid: true,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** A server answer that OPENS the gate — the trap-13 positive control. */
+function mockOpenServerResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+/** HTTP 429, the shape `deduplicatedFetch` hands the store. */
+function mockRateLimitedResponse(retryAfterSeconds?: number) {
+  const headers = new Headers()
+  if (retryAfterSeconds !== undefined) headers.set('Retry-After', String(retryAfterSeconds))
+  return {
+    ok: false,
+    status: 429,
+    statusText: 'Too Many Requests',
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve('rate limited'),
+    headers,
+  }
+}
+
+/**
+ * Seed the canvas with the heuristic's MOST PERMISSIVE input: enough nodes and
+ * edges to score >= 70 (which is the `strong` band) with `graphHealth` left at
+ * its initial `null`, so the heuristic finds zero blockers and grants the run.
+ * If the fabrication survives anywhere, this input is what surfaces it.
+ */
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  const edges =
+    count > 1
+      ? [
+          {
+            id: 'edge-0-1',
+            source: 'node-0',
+            target: 'node-1',
+            data: { weight: 0.5, direction: 'positive' },
+          },
+        ]
+      : []
+  useCanvasStore.setState({ nodes: nodes as never, edges: edges as never })
+}
+
+/** Nudge the canvas so the store sees a NEW payload and refetches. */
+function mutateCanvas(tag: string) {
+  const nodes = useCanvasStore.getState().nodes
+  useCanvasStore.setState({
+    nodes: [
+      ...nodes,
+      {
+        id: `extra-${tag}`,
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: `Extra ${tag}`, kind: 'factor' },
+      },
+    ] as never,
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  useCanvasStore.setState({ nodes: [] as never, edges: [] as never, graphHealth: null } as never)
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore — rate limited (ROADMAP 2.635, I-1)', () => {
+  // ── Positive control (CLAUDE.md trap 13) ─────────────────────────
+  // Before asserting what a 429 does NOT publish, prove this harness can SEE
+  // both verdicts arriving from a server that does answer. Without this every
+  // assertion below could pass by testing nothing.
+  describe('positive control — the harness can observe a real server verdict', () => {
+    it('observes can_run_analysis true when the server opens the gate', async () => {
+      mockFetch.mockResolvedValue(mockOpenServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.error).toBeNull()
+    })
+
+    it('observes the identifying server sentence when the server closes the gate', async () => {
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.can_run_analysis).toBe(false)
+      expect(state.readiness?.confidence_explanation).toBe(SERVER_BLOCKED_SENTENCE)
+    })
+  })
+
+  // ── RED 1 — the fabrication, with no prior server answer ─────────
+  describe('a 429 publishes no locally-invented verdict', () => {
+    it('does not grant can_run_analysis on local authority when rate limited', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      // 3 nodes + 1 edge, graphHealth null — the heuristic's most permissive
+      // input: it scores 80 and finds zero blockers.
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).not.toBe(true)
+    })
+
+    it('publishes no verdict at all when it has never had one from the server', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      // `readiness === null` alongside a non-null `error` is the store's own
+      // pre-existing "unknown" state — the same one the transport, 404 and 5xx
+      // arms already use. No third state is invented (trap 12).
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).not.toBeNull()
+      expect(state.loading).toBe(false)
+    })
+
+    it('never publishes a readiness_level the producer does not emit', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      // 5 nodes + an edge scores 85 — squarely in the heuristic's `strong` band.
+      seedCanvasWithNodes(5)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const level = useReadinessStore.getState().readiness?.readiness_level
+      if (level !== undefined) {
+        // Derived from the producer mirror, not a literal: a level added to CEE
+        // tomorrow must not fail this, and `strong` must never pass it.
+        expect(CEE_READINESS_LEVELS as readonly string[]).toContain(level)
+      }
+      expect(level).not.toBe('strong')
+    })
+  })
+
+  // ── RED 2 — the dangerous part: overwriting the server's refusal ──
+  describe('a 429 never replaces a verdict the server already gave', () => {
+    it('leaves an existing server "cannot run" verdict intact, by identity', async () => {
+      // 1. A real server verdict lands and CLOSES the gate.
+      mockFetch.mockResolvedValue(mockBlockedServerResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+      expect(useReadinessStore.getState().readiness?.confidence_explanation).toBe(
+        SERVER_BLOCKED_SENTENCE,
+      )
+
+      // 2. The next fetch is rate limited.
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      mutateCanvas('a')
+      await vi.runAllTimersAsync()
+
+      // 3. The verdict on screen must still be the SERVER's — asserted by its
+      //    own sentence, not by `can_run_analysis === false`, which the
+      //    heuristic could also satisfy on a different input (trap 19).
+      const state = useReadinessStore.getState()
+      expect(state.readiness?.confidence_explanation).toBe(SERVER_BLOCKED_SENTENCE)
+      expect(state.readiness?.readiness_score).toBe(62)
+      expect(state.readiness?.can_run_analysis).toBe(false)
+    })
+
+    it('does not stamp verdictAtMs for a rate-limited attempt', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      // `verdictAtMs` means "when `readiness` was last set from an ANSWER".
+      // A rate limit is not one.
+      expect(useReadinessStore.getState().verdictAtMs).toBeNull()
+    })
+  })
+
+  // ── RED 3 — the copy ─────────────────────────────────────────────
+  describe('the error names the failure honestly', () => {
+    it('says readiness could not be checked, not that local validation was used', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      const error = useReadinessStore.getState().error ?? ''
+      expect(error).toMatch(/could not check/i)
+      // The pristine string was 'Rate limited - using local validation', which
+      // asserts an assessment was made. It was not.
+      expect(error).not.toMatch(/local validation/i)
+    })
+  })
+
+  // ── Preserved behaviour — this row retires the fabrication only ───
+  describe('the rate-limit handling itself is unchanged', () => {
+    it('still arms the backoff on a 429', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse())
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(__test__.getModuleState().backoff.delay).toBeGreaterThan(0)
+    })
+
+    it('still honours a Retry-After header', async () => {
+      mockFetch.mockResolvedValue(mockRateLimitedResponse(7))
+      seedCanvasWithNodes(3)
+      useReadinessStore.getState().startListening()
+      await vi.runAllTimersAsync()
+
+      expect(__test__.getModuleState().backoff.delay).toBe(7000)
+    })
+  })
+})

--- a/src/canvas/stores/__tests__/readinessStore.serverError.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.serverError.spec.ts
@@ -300,37 +300,40 @@ describe('readinessStore — a server error is not a verdict (ROADMAP 2.339)', (
     })
   })
 
-  // ── The one limb deliberately left alone ─────────────────────────
+  // ── The limb 2.339 left alone, RETIRED in ROADMAP 2.635 ──────────
   //
-  // 429 still publishes the local fallback, with an error string that says so.
-  // It is out of scope for 2.339 (named in the PR body and rowed separately);
-  // this pin exists so its behaviour cannot drift silently while the sibling
-  // limbs are being rewritten.
-  describe('the 429 limb is unchanged and still labelled', () => {
-    it('publishes the local fallback with the rate-limit label', async () => {
+  // This block used to be titled "the 429 limb is unchanged and still
+  // labelled", and pinned the arm publishing `calculateFallbackReadiness` with
+  // the error 'Rate limited - using local validation'. 2.339's own note said it
+  // was "out of scope … rowed separately"; 2.635 is that row, and the fallback
+  // is now deleted outright. The pins are updated rather than removed, because
+  // what they were really protecting — that this arm cannot drift into
+  // fabricating a verdict — is exactly the property that now holds absolutely.
+  describe('the 429 limb publishes no verdict (ROADMAP 2.635)', () => {
+    it('reports the rate limit and publishes no verdict at all', async () => {
       mockFetch.mockResolvedValue(mock429Response())
       seedCanvasWithNodes(3)
       useReadinessStore.getState().startListening()
       await vi.runAllTimersAsync()
 
       const state = useReadinessStore.getState()
-      expect(state.readiness).not.toBeNull()
-      expect(state.error).toBe('Rate limited - using local validation')
+      expect(state.readiness).toBeNull()
+      expect(state.error).toMatch(/rate limited/i)
+      // The old string asserted an assessment had been made. It had not.
+      expect(state.error).not.toMatch(/local validation/i)
     })
 
     // ROADMAP 2.332 — `verdictAtMs` means "when `readiness` was last set from
-    // an ANSWER". The 429 arm sets `readiness` from the LOCAL heuristic, so
-    // stamping it would let a surface cite a time for a number no server
-    // produced — the fabrication class this slice closes, re-created one field
-    // over. It is explicitly nulled, and this is the pin.
-    it('does not stamp verdictAtMs on the local rate-limit fallback', async () => {
+    // an ANSWER". A 429 is not one, and there is now no local verdict for it to
+    // timestamp either.
+    it('does not stamp verdictAtMs when a 429 is the first thing that happens', async () => {
       mockFetch.mockResolvedValue(mock429Response())
       seedCanvasWithNodes(3)
       useReadinessStore.getState().startListening()
       await vi.runAllTimersAsync()
 
       const state = useReadinessStore.getState()
-      expect(state.readiness).not.toBeNull()
+      expect(state.readiness).toBeNull()
       expect(state.verdictAtMs).toBeNull()
     })
 
@@ -360,22 +363,38 @@ describe('readinessStore — a server error is not a verdict (ROADMAP 2.339)', (
       expect(state.verdictAtMs).toBeNull()
     })
 
-    it('clears a real verdict timestamp when a later 429 replaces the verdict', async () => {
+    // ⚠ ROADMAP 2.635 INVERTED THIS TEST, AND THE INVERSION IS THE POINT.
+    //
+    // It used to be `clears a real verdict timestamp when a later 429 replaces
+    // the verdict`, and it was RIGHT while the 429 arm overwrote the server's
+    // answer with the local heuristic: the verdict on screen was then a
+    // fabrication, so citing the replaced answer's time would have been false.
+    //
+    // The arm no longer replaces anything. The verdict on screen after a 429 IS
+    // the server's own last answer, so its timestamp is the true time of that
+    // answer and the footer's "Showing the check from HH:MM" is a TRUE
+    // statement. Clearing it now would be the dishonest option — it would hide
+    // the age of the verdict the user is actually looking at.
+    it('retains the real verdict AND its timestamp when a later 429 arrives', async () => {
       mockFetch.mockResolvedValue(mockOpenServerResponse())
       seedCanvasWithNodes(3)
       useReadinessStore.getState().startListening()
       await vi.runAllTimersAsync()
-      expect(useReadinessStore.getState().verdictAtMs).toEqual(expect.any(Number))
+      const stamped = useReadinessStore.getState().verdictAtMs
+      expect(stamped).toEqual(expect.any(Number))
 
-      // The 429 arm OVERWRITES the server verdict with the heuristic (its own
-      // pre-existing defect, rowed separately). What must not survive that is
-      // the timestamp of the answer it replaced.
       clearInflightCache()
       mockFetch.mockResolvedValue(mock429Response())
       useReadinessStore.getState().refresh()
       await vi.runAllTimersAsync()
 
-      expect(useReadinessStore.getState().verdictAtMs).toBeNull()
+      const state = useReadinessStore.getState()
+      // Bound by the server's own verdict, not by a boolean a local guess could
+      // also satisfy (CLAUDE.md trap 19).
+      expect(state.readiness?.can_run_analysis).toBe(true)
+      expect(state.readiness?.confidence_explanation).toBe('Ready to analyse')
+      expect(state.verdictAtMs).toBe(stamped)
+      expect(state.error).toMatch(/rate limited/i)
     })
   })
 })

--- a/src/canvas/stores/__tests__/readinessStore.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.spec.ts
@@ -27,7 +27,7 @@ function mockSuccessResponse(overrides: Record<string, unknown> = {}) {
     json: () =>
       Promise.resolve({
         readiness_score: 75,
-        readiness_level: 'strong',
+        readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
         can_run_analysis: true,
         confidence_explanation: 'Looks good',
         improvements: [],
@@ -320,15 +320,23 @@ describe('readinessStore', () => {
       expect(state.loading).toBe(false)
     })
 
-    it('backs off on 429 and uses fallback', async () => {
+    // ROADMAP 2.635 — was `backs off on 429 and uses fallback`, asserting
+    // `readiness` was non-null and the error read "using local validation".
+    // The fallback it referred to (`calculateFallbackReadiness`) is DELETED:
+    // it always granted the run pre-first-analysis and could overwrite a
+    // server refusal. A 429 is a statement about the SERVICE, so the arm now
+    // publishes no verdict — the backoff, which is what this test is really
+    // about, is unchanged and asserted directly.
+    it('backs off on 429 and publishes no verdict', async () => {
       mockFetch.mockResolvedValue(mock429Response())
       seedCanvasWithNodes(3)
       useReadinessStore.getState().startListening()
       await vi.runAllTimersAsync()
 
       const state = useReadinessStore.getState()
-      expect(state.readiness).not.toBeNull()
-      expect(state.error).toBe('Rate limited - using local validation')
+      expect(state.readiness).toBeNull()
+      expect(state.error).toMatch(/rate limited/i)
+      expect(__test__.getModuleState().backoff.delay).toBeGreaterThan(0)
     })
   })
 

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -330,46 +330,26 @@ export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
 }
 
 /**
- * Calculate fallback readiness from local graph health.
+ * ── ROADMAP 2.635 (I-1): `calculateFallbackReadiness` was DELETED here ──
+ *
+ * It was a node/edge-count heuristic that returned a full `GraphReadiness` —
+ * score, level and `can_run_analysis` — composed entirely from local state. Its
+ * verdict was `can_run_analysis: blockers.length === 0`, where `blockers` came
+ * from `graphHealth`, which is `null` until an analysis has already COMPLETED.
+ * So on the pre-analysis canvas it never found a blocker and always granted the
+ * run, and it was the only writer of `readiness_level: 'strong'` — a band no
+ * CEE code path assigns to this field.
+ *
+ * Its callers were retired one at a time: the transport catch (2.319a), the 404
+ * arm (2.329), the 5xx arm (2.339), and finally the 429 arm (this row). With the
+ * last caller gone the function is deleted rather than left resident, because a
+ * resident fabricator is an invitation: the next failure arm added to this file
+ * would have reached for it exactly as the previous four did.
+ *
+ * The `'strong'` vocabulary went with it — see `useGraphReadiness.ts`. There is
+ * now no code path in this repo that can produce a readiness verdict the server
+ * did not send.
  */
-function calculateFallbackReadiness(
-  nodes: Node[],
-  edges: Edge[],
-  graphHealth: { issues?: Array<{ severity: string }> } | null,
-): GraphReadiness {
-  let score = 50
-
-  if (nodes.length > 0) score += 10
-  if (nodes.length >= 3) score += 10
-  if (nodes.length >= 5) score += 5
-  if (edges.length > 0) score += 10
-  if (edges.length >= nodes.length - 1) score += 5
-
-  const issues = graphHealth?.issues || []
-  const blockers = issues.filter((i) => i.severity === 'error' || i.severity === 'blocker')
-  const warnings = issues.filter((i) => i.severity === 'warning')
-
-  score -= blockers.length * 15
-  score -= warnings.length * 5
-  score = Math.max(0, Math.min(100, score))
-
-  let level: GraphReadiness['readiness_level'] = 'fair'
-  if (score < 40) level = 'needs_work'
-  else if (score >= 70) level = 'strong'
-
-  return {
-    readiness_score: score,
-    readiness_level: level,
-    can_run_analysis: blockers.length === 0,
-    confidence_explanation:
-      level === 'strong'
-        ? 'Your model has good structure and connections'
-        : level === 'fair'
-          ? 'Analysis available - consider improvements for better results'
-          : 'Address critical issues before running analysis',
-    improvements: [],
-  }
-}
 
 // ── Core fetch logic ───────────────────────────────────────────────
 
@@ -394,11 +374,15 @@ async function fetchReadiness(): Promise<void> {
       return
     }
 
+    // ROADMAP 2.635 — `graphHealth` is deliberately NOT destructured here any
+    // more. Its only reader in this module was `calculateFallbackReadiness`,
+    // and reading it into scope was what made a local verdict cheap to compose.
+    // The readiness question is answered by CEE against the payload below;
+    // nothing in this file needs the canvas's own health assessment.
     const canvasState = useCanvasStore.getState()
     const {
       nodes: currentNodes,
       edges: currentEdges,
-      graphHealth,
       ceeAnalysisReady: currentCeeAnalysisReady,
     } = canvasState
 
@@ -606,20 +590,41 @@ async function fetchReadiness(): Promise<void> {
             `[readinessStore] Rate limited (429), backing off for ${backoffDelay / 1000}s`,
           )
 
-          const fallback = calculateFallbackReadiness(currentNodes, currentEdges, graphHealth)
+          // ── ROADMAP 2.635 (I-1): the LAST fabrication limb, retired ──
+          //
+          // ROADMAP 2.332 left this arm publishing `calculateFallbackReadiness`
+          // and said so: "this arm's BEHAVIOUR is deliberately unchanged …
+          // retiring that is a separate row". This is that row, and the arm now
+          // does exactly what its transport / 404 / 5xx siblings do.
+          //
+          // What it used to do: publish a node/edge-count heuristic INTO
+          // `readiness`, whose verdict is `can_run_analysis: blockers.length === 0`
+          // with `blockers` drawn from `graphHealth` — `null` until an analysis
+          // has already COMPLETED. So before the first analysis there were never
+          // any blockers to find, and a rate limit did not merely RISK opening
+          // the gate: it always granted the run. And because it OVERWROTE
+          // `readiness`, it could replace a `can_run_analysis: false` the server
+          // had already given with a locally invented `true` that no consumer
+          // could distinguish from the server's own answer. It could also print
+          // `readiness_level: 'strong'` — a band NO CEE code path assigns to
+          // this field.
+          //
+          // A rate limit is a statement about the SERVICE, not about the model.
+          // So: publish no verdict, and say that. `readiness` is left EXACTLY as
+          // it was — `null` on first load (the store's own "unknown" state,
+          // which already has a rendered surface), otherwise the last answer the
+          // server actually gave, which a local guess is not entitled to
+          // replace. `verdictAtMs` stays untouched for the same reason it was
+          // explicitly nulled here before: it means "when `readiness` was last
+          // set from an ANSWER", and this is not one.
+          //
+          // The backoff above is UNCHANGED — this row retires the fabrication,
+          // not the rate-limit handling. `lastPayloadHash` is likewise still
+          // unset, so the identical graph can be re-asked once the window
+          // clears; a failure here must not be sticky.
           useReadinessStore.setState({
-            readiness: fallback,
-            error: 'Rate limited - using local validation',
+            error: 'Could not check readiness right now — the service is rate limited',
             loading: false,
-            // ROADMAP 2.332 — this arm's BEHAVIOUR is deliberately unchanged
-            // (it still publishes the labelled local fallback; retiring that is
-            // a separate row). But `verdictAtMs` means "when `readiness` was
-            // last set from an ANSWER", and this verdict is not one — it is the
-            // local heuristic. Stamping it would let a surface cite a time for
-            // a number no server produced, which is the fabrication class this
-            // whole slice exists to close. Explicitly null, so the absence is a
-            // decision rather than an oversight.
-            verdictAtMs: null,
           })
           return
         }
@@ -696,14 +701,52 @@ async function fetchReadiness(): Promise<void> {
 
       const data = response.data
 
+      // ── ROADMAP 2.635 (I-2): a 200 that does not answer is not a "yes" ──
+      //
+      // This field used to default to `true`:
+      //
+      //     typeof data.can_run_analysis === 'boolean' ? data.can_run_analysis : true
+      //
+      // `can_run_analysis` is the ONE gating field on the whole response. A 2xx
+      // whose body omits it — a partial write, a proxy that rewrote the body, a
+      // producer that renamed the field, a CEE on an older contract — therefore
+      // GRANTED the run, stamped `verdictAtMs`, and reported `error: null`.
+      // Downstream that is indistinguishable from the server's own assessment.
+      // It is the same fabrication class as the 429 arm above, spelled as a
+      // default rather than a heuristic, and strictly harder to notice because
+      // nothing about it was labelled.
+      //
+      // The fail direction is a stated decision, not a fall-through: a malformed
+      // 200 is UNKNOWN, and unknown is a state this store already has. Publish
+      // no verdict, retain whatever the server last actually said, set a
+      // truthful error. What the run GATE does with an unknown verdict is
+      // `canRunAnalysis`'s decision and is unchanged — a readiness check that
+      // cannot be obtained does not brick the Run button for a healthy user, it
+      // is disclosed. All this branch does is stop INVENTING the answer.
+      //
+      // Note the ordering: this is checked BEFORE `normalized` is built, so no
+      // half-invented verdict can exist even transiently. `lastPayloadHash` is
+      // left unset (as on the other no-verdict arms) so the identical graph can
+      // be re-asked once the service answers properly.
+      if (typeof data.can_run_analysis !== 'boolean') {
+        console.warn(
+          '[readinessStore] Readiness response carried no can_run_analysis boolean — publishing no verdict:',
+          { received: typeof data.can_run_analysis },
+        )
+        useReadinessStore.setState({
+          error: 'Could not read the readiness service response',
+          loading: false,
+        })
+        return
+      }
+
       const normalized: GraphReadiness = {
         readiness_score:
           typeof data.readiness_score === 'number'
             ? Math.max(0, Math.min(100, data.readiness_score))
             : 50,
         readiness_level: normaliseReadinessLevel(data.readiness_level),
-        can_run_analysis:
-          typeof data.can_run_analysis === 'boolean' ? data.can_run_analysis : true,
+        can_run_analysis: data.can_run_analysis,
         confidence_explanation:
           typeof data.confidence_explanation === 'string'
             ? data.confidence_explanation
@@ -1020,7 +1063,6 @@ export const selectReadinessVerdictAtMs = (state: ReadinessStoreState) => state.
 /** @internal — exposed for unit testing. Not part of public API. */
 export const __test__ = {
   fetchReadiness,
-  calculateFallbackReadiness,
   getModuleState: () => ({
     lastObservedPayload,
     lastPayloadHash,

--- a/src/canvas/utils/__tests__/blockedReasonStaleWiring.derived.spec.ts
+++ b/src/canvas/utils/__tests__/blockedReasonStaleWiring.derived.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * DERIVED guard: the staleness mark actually reaches the copy (ROADMAP 2.635, I-3).
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────────
+ * `composeReadinessBlockedReason`'s `verdictIsStale` parameter DEFAULTS to
+ * `false`. That default is the safe one — it reproduces pre-2.635 behaviour for
+ * a caller who omits it — but a safe default is also a silent one: a caller who
+ * stops passing the argument loses the whole invariant and every unit test of
+ * the composer stays green, because they pass it explicitly.
+ *
+ * This is the failure shape `runGateCallSites.derived.spec.ts` was written for
+ * on a different parameter, and its mutation battery proved it real: removing
+ * `draftStreamPhase` from `OutputsDock`'s gate call survived the entire suite.
+ * A gate nobody feeds is a gate that never fires — correct machinery, never
+ * executed.
+ *
+ * So the manifest is DERIVED from source at test time rather than hand-listed
+ * (trap 12): a third run surface added tomorrow is covered without anyone
+ * remembering to add it here, and the file list is a directory walk, not a
+ * literal.
+ *
+ * ── ITS HONEST LIMIT, STATED ─────────────────────────────────────────────
+ * This is a STRUCTURAL check on source text. It proves the argument is passed
+ * and that the value passed is the store's own staleness mark — it does NOT
+ * prove the resulting sentence is right. That is pinned by behaviour, in
+ * `canRunAnalysis.staleVerdict.spec.ts` (the gate's own logic) and
+ * `OutputsDock.staleVerdictCopy.spec.tsx` (the real wiring, through the
+ * deployed-flag surface). The two kinds of guard are not redundant.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+const SRC = join(process.cwd(), 'src')
+
+/** Every `.ts`/`.tsx` file under `src/`, tests and stories excluded. */
+function productionSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      productionSources(full, out)
+    } else if (/\.tsx?$/.test(entry) && !/\.(spec|test|stories)\.tsx?$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/** Read the whole argument list of a call, balancing parens from the `(`. */
+function callArguments(text: string, openParenIndex: number): string {
+  let depth = 1
+  let i = openParenIndex + 1
+  while (i < text.length && depth > 0) {
+    if (text[i] === '(') depth++
+    else if (text[i] === ')') depth--
+    i++
+  }
+  return text.slice(openParenIndex + 1, i - 1)
+}
+
+function composerCallSites(): Array<{ file: string; args: string }> {
+  const found: Array<{ file: string; args: string }> = []
+  const pattern = /\bcomposeReadinessBlockedReason\s*\(/g
+  for (const file of productionSources(SRC)) {
+    // The composer's own module defines it; a definition is not a call site.
+    if (file.endsWith(join('canvas', 'utils', 'composeBlockedReason.ts'))) continue
+    const text = readFileSync(file, 'utf8')
+    let m: RegExpExecArray | null
+    while ((m = pattern.exec(text)) !== null) {
+      // Skip the import statement, which matches the bare identifier.
+      const lineStart = text.lastIndexOf('\n', m.index) + 1
+      const line = text.slice(lineStart, m.index)
+      if (/\bimport\b/.test(line)) continue
+      found.push({ file: relative(SRC, file), args: callArguments(text, m.index + m[0].length - 1) })
+    }
+  }
+  return found
+}
+
+/** Run-gate call sites, matched under the local alias both live callers use. */
+function runGateCallSites(): Array<{ file: string; args: string }> {
+  const found: Array<{ file: string; args: string }> = []
+  const pattern = /\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g
+  for (const file of productionSources(SRC)) {
+    if (file.endsWith(join('canvas', 'utils', 'canRunAnalysis.ts'))) continue
+    const text = readFileSync(file, 'utf8')
+    let m: RegExpExecArray | null
+    while ((m = pattern.exec(text)) !== null) {
+      let depth = 1
+      let i = m.index + m[0].length
+      while (i < text.length && depth > 0) {
+        if (text[i] === '{') depth++
+        else if (text[i] === '}') depth--
+        i++
+      }
+      found.push({ file: relative(SRC, file), args: text.slice(m.index, i) })
+    }
+  }
+  return found
+}
+
+const COMPOSER_SITES = composerCallSites()
+const GATE_SITES = runGateCallSites()
+
+describe('composeReadinessBlockedReason — derived staleness-wiring manifest', () => {
+  it('finds the call site at all (trap 13: prove the matcher sees a presence)', () => {
+    // If this drops to zero every assertion below is vacuous, which is why it is
+    // the first test in the file.
+    expect(COMPOSER_SITES.length).toBeGreaterThan(0)
+    // Reported by name so a reviewer can see what was actually measured.
+    expect(COMPOSER_SITES.map((s) => s.file)).toMatchObject(
+      COMPOSER_SITES.map(() => expect.any(String)),
+    )
+  })
+
+  it('every production caller passes a third (staleness) argument', () => {
+    const offenders = COMPOSER_SITES.filter((site) => {
+      // Count top-level commas: two of them means three arguments.
+      let depth = 0
+      let commas = 0
+      for (const ch of site.args) {
+        if ('([{'.includes(ch)) depth++
+        else if (')]}'.includes(ch)) depth--
+        else if (ch === ',' && depth === 0) commas++
+      }
+      return commas < 2
+    })
+
+    expect(offenders.map((o) => `${o.file}: ${o.args.replace(/\s+/g, ' ').trim()}`)).toEqual([])
+  })
+
+  it('the staleness argument is the readiness verdict’s own mark, not a literal', () => {
+    // `composeReadinessBlockedReason(v, opts, false)` would satisfy the arity
+    // check above while disabling the invariant everywhere — the exact shape a
+    // "just make it compile" edit produces.
+    const offenders = COMPOSER_SITES.filter((site) => /,\s*(false|true)\s*\)?$/.test(site.args.trim()))
+
+    expect(offenders.map((o) => o.file)).toEqual([])
+  })
+})
+
+describe('run-gate call sites — derived staleness manifest', () => {
+  it('finds the run-gate call sites at all', () => {
+    expect(GATE_SITES.length).toBeGreaterThan(0)
+  })
+
+  it('every run-gate call site feeds the readiness staleness mark', () => {
+    // The gate is what forwards staleness to the composer, so a surface that
+    // omits it silently reverts to quoting a stale verdict as current — with no
+    // type error, because the parameter is optional by design (52 existing test
+    // call sites made it impractical to require).
+    const offenders = GATE_SITES.filter((site) => !/\breadinessStale\b/.test(site.args))
+
+    expect(offenders.map((o) => o.file)).toEqual([])
+  })
+})

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -42,7 +42,7 @@ describe('canRunAnalysis', () => {
         ...defaultParams,
         readiness: {
           readiness_score: 70,
-          readiness_level: 'strong',
+          readiness_level: 'ready', // ROADMAP 2.635 — was 'strong', the local heuristic's spelling of the top band; that heuristic is deleted and the level with it. `ready` is the producer's own top band at this score.
           can_run_analysis: true,
           confidence_explanation: 'Model looks good',
           improvements: [],

--- a/src/canvas/utils/__tests__/canRunAnalysis.staleVerdict.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.staleVerdict.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * canRunAnalysis — a stale verdict may not be quoted as current
+ * (ROADMAP 2.635, invariant I-3).
+ *
+ * ── The limb ─────────────────────────────────────────────────────────────
+ * ROADMAP 2.332 gave the store a `stale` flag: true the moment a
+ * payload-affecting mutation is detected, cleared only when a fresh verdict
+ * lands. Its docstring says `stale` "is what stops a surface presenting that
+ * verdict as current".
+ *
+ * The V3 footer honours it. THE GATE DID NOT — `stale` was not an input to
+ * `canRunAnalysis` at all. So when a retained verdict blocks, the gate composed
+ * its refusal from that verdict's STRUCTURED FIELDS (`options_total`,
+ * `options_ready`, the named option labels) as if the fields described the model
+ * now on the canvas. The user follows the named remedy — describes what the
+ * option changes — the canvas mutates, `stale` goes true, and the SAME sentence
+ * naming the SAME option is still on screen, because the verdict behind it has
+ * not been re-asked. That is a false reason, and by POC-DONE's PC1 language a
+ * false reason is exactly what makes a dead end:
+ *
+ *     "a truthful 'can't yet, here's why + the remedy' is not a dead end;
+ *      a false reason is"
+ *
+ * ── The chosen direction ─────────────────────────────────────────────────
+ * Staleness does NOT open or close the gate — it is not evidence about
+ * runnability, and per Ruling 3 uncertainty must not lock the user out. It
+ * changes only what the refusal is allowed to CLAIM: while the verdict is
+ * outgrown, the gate may say that it is re-checking, and may not make a
+ * specific claim (an option name, a count, a missing goal) sourced from a
+ * verdict that was never asked about the current model.
+ *
+ * ── What these tests pin ─────────────────────────────────────────────────
+ *   1. a fresh blocking verdict still names the specific remedy (control);
+ *   2. a STALE blocking verdict names no option, no count, no goal claim;
+ *   3. it says instead that the model changed and the check is being redone;
+ *   4. the gate direction is unchanged by staleness in BOTH directions —
+ *      stale + blocking stays shut, stale + runnable stays open. Staleness is
+ *      not a new blocker.
+ *
+ * Binding note (CLAUDE.md trap 19): the control asserts the EXACT composed
+ * sentence for a NAMED option, so it cannot be satisfied by some other
+ * blocked-copy rung that happens to be non-empty.
+ */
+import { describe, it, expect } from 'vitest'
+import { canRunAnalysis } from '../canRunAnalysis'
+import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
+import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+
+/**
+ * The verdict from Paul's failing journey: five options, four ready, goal
+ * present, `can_run_analysis: false`. Its structured fields are what the
+ * specific copy is composed from — which is precisely why quoting them from a
+ * stale verdict is a factual claim about a model nobody graded.
+ */
+const BLOCKED_VERDICT: GraphReadiness = {
+  readiness_score: 90,
+  readiness_level: 'ready',
+  can_run_analysis: false,
+  confidence_explanation: 'V3 analysis not ready: 1 option(s) blocked: opt_extend',
+  improvements: [],
+  scaffold_plan: { will_scaffold_options: false },
+  options_ready: 4,
+  options_total: 5,
+  goal_node_valid: true,
+} as GraphReadiness
+
+const RUNNABLE_VERDICT: GraphReadiness = {
+  readiness_score: 90,
+  readiness_level: 'ready',
+  can_run_analysis: true,
+  confidence_explanation: 'Ready to analyse',
+  improvements: [],
+} as GraphReadiness
+
+const ONE_OPTION_NEEDING_VALUES = [
+  { id: 'opt_extend', label: 'Partner with a consultancy' },
+] as const
+
+function gate(overrides: Record<string, unknown> = {}) {
+  return canRunAnalysis({
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    readiness: BLOCKED_VERDICT,
+    hasBlockers: false,
+    nodeCount: 8,
+    optionsNeedingValues: ONE_OPTION_NEEDING_VALUES,
+    ...overrides,
+  } as never)
+}
+
+describe('canRunAnalysis — a stale verdict is not quoted as current (I-3)', () => {
+  // ── Control (traps 13 / 13b) ─────────────────────────────────────
+  // Prove the specific sentence is REACHABLE here before asserting it is
+  // withheld. Without this, every assertion below could pass on a gate that
+  // never composes specific copy at all.
+  describe('control — a FRESH blocking verdict still names the remedy', () => {
+    it('composes the exact one-option sentence when the verdict is current', () => {
+      const result = gate({ readinessStale: false })
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe(
+        BLOCKED_REASON_COPY.oneOption('Partner with a consultancy', true),
+      )
+    })
+
+    it('composes the same sentence when staleness is not supplied at all', () => {
+      // Omission must behave as "current", or every existing call site silently
+      // loses its specific copy the day this parameter lands.
+      const result = gate()
+
+      expect(result.reason).toBe(
+        BLOCKED_REASON_COPY.oneOption('Partner with a consultancy', true),
+      )
+    })
+  })
+
+  // ── RED 1 — the specific claim must be withheld while stale ──────
+  describe('a stale blocking verdict makes no specific claim', () => {
+    it('does not name the option the stale verdict graded', () => {
+      const result = gate({ readinessStale: true })
+
+      expect(result.reason ?? '').not.toContain('Partner with a consultancy')
+      expect(result.blockingReasons ?? []).not.toContain(
+        BLOCKED_REASON_COPY.oneOption('Partner with a consultancy', true),
+      )
+    })
+
+    it('does not publish the stale verdict’s count', () => {
+      const result = canRunAnalysis({
+        graphHealth: { status: 'healthy', score: 100, issues: [] },
+        readiness: { ...BLOCKED_VERDICT, options_ready: 1, options_total: 4 } as GraphReadiness,
+        hasBlockers: false,
+        nodeCount: 8,
+        readinessStale: true,
+        optionsNeedingValues: [
+          { id: 'a', label: 'Alpha' },
+          { id: 'b', label: 'Beta' },
+          { id: 'c', label: 'Gamma' },
+        ],
+      } as never)
+
+      expect(result.reason ?? '').not.toMatch(/\b3 options\b/)
+      expect(result.reason ?? '').not.toMatch(/\bhave no effect values yet\b/)
+    })
+
+    it('does not claim the goal is missing from a verdict it never re-asked', () => {
+      const result = canRunAnalysis({
+        graphHealth: { status: 'healthy', score: 100, issues: [] },
+        readiness: { ...BLOCKED_VERDICT, goal_node_valid: false } as GraphReadiness,
+        hasBlockers: false,
+        nodeCount: 8,
+        readinessStale: true,
+      } as never)
+
+      expect(result.reason ?? '').not.toBe(BLOCKED_REASON_COPY.goalMissing)
+    })
+
+    it('does not claim there are too few options from a stale count', () => {
+      const result = canRunAnalysis({
+        graphHealth: { status: 'healthy', score: 100, issues: [] },
+        readiness: { ...BLOCKED_VERDICT, options_total: 1 } as GraphReadiness,
+        hasBlockers: false,
+        nodeCount: 8,
+        readinessStale: true,
+      } as never)
+
+      expect(result.reason ?? '').not.toBe(BLOCKED_REASON_COPY.tooFewOptions)
+    })
+  })
+
+  // ── RED 2 — it must say what it actually knows ───────────────────
+  describe('the stale refusal states the state it is in', () => {
+    it('tells the user the model changed and the check is being redone', () => {
+      const result = gate({ readinessStale: true })
+
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toBe(BLOCKED_REASON_COPY.staleRecheck)
+      // Non-negotiable: it must not be an empty or absent reason. A blocked Run
+      // button with no reason is the dead end PC1 names.
+      expect((result.reason ?? '').length).toBeGreaterThan(0)
+    })
+
+    it('the stale sentence makes no claim about the model', () => {
+      // The whole point of this rung: it describes the CHECK, never the graph.
+      const sentence = BLOCKED_REASON_COPY.staleRecheck
+
+      expect(sentence).not.toMatch(/option|goal|factor|decision/i)
+      expect(sentence).toMatch(/chang/i)
+    })
+  })
+
+  // ── RED 3 — the gate direction is a decision, both ways ──────────
+  describe('staleness does not move the gate', () => {
+    it('stale + blocking stays shut', () => {
+      expect(gate({ readinessStale: true }).allowed).toBe(false)
+    })
+
+    it('stale + runnable stays OPEN — staleness is not a new blocker', () => {
+      // Ruling 3: uncertainty must not lock the user out. A user whose model is
+      // mid-recheck and whose last verdict said "yes" keeps their Run button.
+      const result = canRunAnalysis({
+        graphHealth: { status: 'healthy', score: 100, issues: [] },
+        readiness: RUNNABLE_VERDICT,
+        hasBlockers: false,
+        nodeCount: 8,
+        readinessStale: true,
+      } as never)
+
+      expect(result.allowed).toBe(true)
+    })
+
+    it('stale does not suppress a NON-readiness blocking reason', () => {
+      // Staleness is evidence about the readiness verdict only. A validation
+      // blocker is the canvas's own fact and must survive untouched.
+      const result = canRunAnalysis({
+        graphHealth: {
+          status: 'error',
+          score: 10,
+          issues: [{ severity: 'error', message: 'Cycle detected' }],
+        },
+        readiness: BLOCKED_VERDICT,
+        hasBlockers: true,
+        nodeCount: 8,
+        readinessStale: true,
+      } as never)
+
+      expect(result.allowed).toBe(false)
+      // Bound by the validator's own message (trap 19), not by "some reason
+      // exists" — the stale rung also produces a reason, so a length check
+      // could pass on the wrong object.
+      expect(result.blockingReasons).toContain('Cycle detected')
+      expect(result.reason).toContain('Cycle detected')
+    })
+  })
+})

--- a/src/canvas/utils/__tests__/composeBlockedReason.spec.ts
+++ b/src/canvas/utils/__tests__/composeBlockedReason.spec.ts
@@ -341,6 +341,10 @@ describe('AMENDMENT A1 — the composed sentence is VETTED, never rewritten', ()
       goalMissing: [BLOCKED_REASON_COPY.goalMissing],
       tooFewOptions: [BLOCKED_REASON_COPY.tooFewOptions],
       unspecified: [BLOCKED_REASON_COPY.unspecified],
+      // ROADMAP 2.635 (I-3) — the stale rung. It is a composed sentence like any
+      // other and must classify as composed-safe, or the footer would degrade it
+      // to the non-committal fallback and the staleness disclosure would vanish.
+      staleRecheck: [BLOCKED_REASON_COPY.staleRecheck],
     }
     expect(Object.keys(samples).sort()).toEqual(Object.keys(BLOCKED_REASON_COPY).sort())
 

--- a/src/canvas/utils/__tests__/verdictLicence.spec.ts
+++ b/src/canvas/utils/__tests__/verdictLicence.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * `verdictLicenceSuperseded` — the licence identity is the PAIR
+ * (ROADMAP 2.635, invariant I-4).
+ *
+ * ── Why this file exists: a surviving mutant, settled by demonstration ────
+ * The 2.635 battery ran 14 mutants; 13 bit. The survivor (M12) deleted the
+ * `stale` half of the comparison:
+ *
+ *     licensed.verdictAtMs !== current.verdictAtMs || licensed.stale !== current.stale
+ *  →  licensed.verdictAtMs !== current.verdictAtMs
+ *
+ * CLAUDE.md trap 13c is explicit that a survivor is a claim either way, and
+ * that an equivalent mutant must be DEMONSTRATED rather than asserted. Here is
+ * the demonstration, derived from the store rather than argued:
+ *
+ *   · `readinessStore` has exactly ONE writer of `stale: true` (the canvas
+ *     subscription, `readinessStore.ts:980`), and it sets `stale` AND NOTHING
+ *     ELSE — `readiness` and `verdictAtMs` are untouched.
+ *   · Every path that sets `readiness` from an answer stamps `verdictAtMs` in
+ *     the same `setState`.
+ *
+ * So the store cannot produce "the verdict changed to one that objects while
+ * `verdictAtMs` stayed put". At the CURRENT wiring M12 is therefore equivalent
+ * end-to-end, and writing a component-level fixture for that state would be
+ * exactly the error CLAUDE.md trap 16's inverse names: a fixture I wrote myself
+ * is not evidence about what the producer can emit.
+ *
+ * ── So why pin it at all? ────────────────────────────────────────────────
+ * Because equivalence-today is a property of the STORE, not of this function,
+ * and the function's own contract says the licence is the pair. The day a
+ * second `stale` writer appears — or a verdict lands within the same
+ * millisecond as the one it replaces — the dropped clause becomes a live
+ * fail-open with nothing to catch it. This pins the declared contract at the
+ * unit it belongs to, which is the honest place for it: it does not pretend to
+ * be evidence about a reachable product state.
+ */
+import { describe, it, expect } from 'vitest'
+import { verdictLicenceSuperseded, type ReadinessVerdictLicence } from '../canRunAnalysis'
+
+const AT = 1_000_000
+
+function licence(verdictAtMs: number | null, stale: boolean): ReadinessVerdictLicence {
+  return { verdictAtMs, stale }
+}
+
+describe('verdictLicenceSuperseded — identity is (verdictAtMs, stale)', () => {
+  it('is not superseded when both components are unchanged', () => {
+    expect(verdictLicenceSuperseded(licence(AT, false), licence(AT, false))).toBe(false)
+    expect(verdictLicenceSuperseded(licence(AT, true), licence(AT, true))).toBe(false)
+  })
+
+  it('is superseded when the timestamp moves', () => {
+    expect(verdictLicenceSuperseded(licence(AT, false), licence(AT + 1, false))).toBe(true)
+  })
+
+  // The clause M12 deleted. Without it this case reads "not superseded".
+  it('is superseded when only the staleness mark moves', () => {
+    expect(verdictLicenceSuperseded(licence(AT, false), licence(AT, true))).toBe(true)
+    expect(verdictLicenceSuperseded(licence(AT, true), licence(AT, false))).toBe(true)
+  })
+
+  it('is superseded when both move', () => {
+    expect(verdictLicenceSuperseded(licence(AT, false), licence(AT + 1, true))).toBe(true)
+  })
+
+  // `verdictAtMs: null` is "no answer has ever been received", which is a
+  // licence state in its own right — a run permitted because readiness is
+  // unknown. Moving out of it must count as a supersession.
+  it('treats the never-answered state as a licence like any other', () => {
+    expect(verdictLicenceSuperseded(licence(null, false), licence(null, false))).toBe(false)
+    expect(verdictLicenceSuperseded(licence(null, false), licence(AT, false))).toBe(true)
+    expect(verdictLicenceSuperseded(licence(AT, false), licence(null, false))).toBe(true)
+    expect(verdictLicenceSuperseded(licence(null, false), licence(null, true))).toBe(true)
+  })
+})

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -192,6 +192,26 @@ export interface CanRunAnalysisParams {
    * degrades to count-based copy, which is still true.
    */
   optionsNeedingValues?: readonly OptionNeedingValues[]
+  /**
+   * ROADMAP 2.635 (I-3) — `readinessStore.stale`: true when the model has
+   * changed in a way the CURRENT `readiness` verdict was not asked about.
+   *
+   * ⚠ It affects the REASON, never `allowed`. Staleness is not evidence about
+   * runnability — it is evidence about the EVIDENCE — and per Ruling 3
+   * uncertainty must not lock the user out of their own model. So a stale
+   * verdict that blocks still blocks (its refusal is the last real answer we
+   * have) and a stale verdict that permits still permits; what changes is that
+   * the refusal stops making specific claims sourced from a verdict nobody
+   * asked about the current graph.
+   *
+   * The store has carried this flag since 2.332, and its docstring said it "is
+   * what stops a surface presenting that verdict as current". The V3 footer
+   * honoured it; this gate did not, so the blocked copy quoted a stale
+   * verdict's `options_ready`/`options_total` and option labels as if fresh —
+   * the user completes the named remedy and reads the same refusal until the
+   * refetch lands.
+   */
+  readinessStale?: boolean
 }
 
 /**
@@ -212,13 +232,81 @@ export function readinessWillScaffold(readiness: GraphReadiness | null | undefin
 }
 
 /**
+ * Does the readiness verdict OBJECT to a run? (ROADMAP 2.635, I-5.)
+ *
+ * The single definition of the gate's readiness rung. It exists because I-4
+ * needs the same question answered at DISPATCH time, and the alternative —
+ * re-typing `readiness && !readiness.can_run_analysis && !readinessWillScaffold(...)`
+ * at the dispatch barrier — is the hand-maintained mirror this codebase has been
+ * bitten by repeatedly (trap 12): the day the scaffold clause changes, one copy
+ * moves and the other silently keeps the old answer, in the permissive
+ * direction.
+ *
+ * ⚠ Note what `null` means here, because it is a DECISION and not a
+ * fall-through (I-2). A `null` verdict is UNKNOWN, and unknown does not object.
+ * The run gate stays open and the outage is DISCLOSED (the V3 footer's
+ * "Could not check readiness" rung). Failing closed on an unobtainable readiness
+ * check would brick the Run button for a healthy user whose only problem is that
+ * a side-car service is down — the SHUT dead end witnessed in ROADMAP 2.332, and
+ * exactly what POC-DONE's PC1 forbids. A truthful "we could not check, you can
+ * still run" is not a dead end; a false "you cannot run" is.
+ */
+export function readinessObjectsToRun(readiness: GraphReadiness | null | undefined): boolean {
+  return Boolean(readiness) && !readiness!.can_run_analysis && !readinessWillScaffold(readiness)
+}
+
+/**
+ * The identity of the verdict that licensed a run (ROADMAP 2.635, I-4).
+ *
+ * `verdictAtMs` is stamped only when `readiness` is set from a real ANSWER, so
+ * the pair (`verdictAtMs`, `stale`) identifies WHICH assessment the gate was
+ * computed against — including the case where no assessment exists at all.
+ */
+export interface ReadinessVerdictLicence {
+  verdictAtMs: number | null
+  stale: boolean
+}
+
+/**
+ * Has the verdict that licensed a run been SUPERSEDED since the gate opened?
+ * (ROADMAP 2.635, I-4.)
+ *
+ * The run gate is evaluated during render; the click that acts on it dispatches
+ * later, and `runCanonicalAnalysis` awaits a persistence flush in between. That
+ * await is a real window: a fresh verdict, or a staleness mark, can land inside
+ * it. Today nothing binds the click to the verdict that opened the gate, so a
+ * run dispatched against a superseded assessment is indistinguishable from one
+ * dispatched against a current one — which makes a doomed run un-attributable.
+ *
+ * This answers only the IDENTITY question. Whether a superseded licence should
+ * stop the run is the caller's decision, and it is taken by asking
+ * `readinessObjectsToRun` about the CURRENT verdict — one gate authority, asked
+ * twice, never re-implemented.
+ */
+export function verdictLicenceSuperseded(
+  licensed: ReadinessVerdictLicence,
+  current: ReadinessVerdictLicence,
+): boolean {
+  return licensed.verdictAtMs !== current.verdictAtMs || licensed.stale !== current.stale
+}
+
+/**
+ * The refusal shown when a run was licensed by a verdict that has since been
+ * replaced by a refusal. Transient and actionable by construction: the fresh
+ * verdict is already in the store, so pressing Analyse again re-evaluates
+ * against it and either runs or names the real reason.
+ */
+export const RUN_LICENCE_SUPERSEDED_REFUSAL =
+  'Your model changed while the analysis was starting. Press Analyse again to run the current model.'
+
+/**
  * Determine if analysis can run based on current state
  *
  * @param params - State from store and hooks
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, draftStreamPhase = 'idle', optionsNeedingValues } = params
+  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
 
   const blockingReasons: string[] = []
 
@@ -319,12 +407,15 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   // fields, in the product's own language, with the actual remedy named. It
   // never parses the engine's prose (that would just move the mirror) and never
   // asserts a fact the panel's own counts could contradict.
-  if (
-    readiness &&
-    !readiness.can_run_analysis &&
-    !readinessWillScaffold(readiness)
-  ) {
-    const composed = composeReadinessBlockedReason(readiness, optionsNeedingValues)
+  // ROADMAP 2.635 (I-5) — the rung's predicate is `readinessObjectsToRun`, so
+  // the dispatch barrier can ask the SAME question without re-implementing it.
+  if (readinessObjectsToRun(readiness)) {
+    // ROADMAP 2.635 (I-3) — the staleness mark travels WITH the verdict into
+    // the composer. It is passed through rather than pre-derived here, for the
+    // same reason `draftStreamPhase` is (2.122): a predicate re-derived at each
+    // call site is a hand-maintained mirror, and the mutant that drops one
+    // clause from it survives.
+    const composed = composeReadinessBlockedReason(readiness, optionsNeedingValues, readinessStale)
     if (!blockingReasons.includes(composed)) {
       blockingReasons.push(composed)
     }

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -97,6 +97,28 @@ export const BLOCKED_REASON_COPY = {
    * claim in exactly this position.
    */
   unspecified: 'Olumi is not able to run this yet. Ask in the chat and it will explain what is missing.',
+  /**
+   * ROADMAP 2.635 (I-3) — the verdict on screen was not asked about the model
+   * on screen.
+   *
+   * Every other rung in this object is a claim ABOUT THE MODEL, composed from
+   * the verdict's structured fields. That is only honest while the verdict is
+   * current. The moment a payload-affecting mutation lands, `readinessStore`
+   * marks the verdict `stale` — and those same fields start describing a graph
+   * the user has already changed. The user follows the named remedy, the canvas
+   * mutates, and the SAME sentence naming the SAME option is still on screen,
+   * because nothing has re-asked. That is a false reason, and POC-DONE's PC1 is
+   * explicit that a false reason is what makes a dead end where a truthful
+   * "can't yet, here's why" would not.
+   *
+   * So this rung describes THE CHECK, never the graph. It names no option, no
+   * count, no goal, and it is the only member of this object that is true
+   * independent of the verdict's contents — which is precisely what qualifies
+   * it to stand in for them. It is transient by construction: the refetch it
+   * describes is already debounced and in flight.
+   */
+  staleRecheck:
+    'Your model changed since the last check. Olumi is checking again, which takes a moment.',
 } as const
 
 /** Labels longer than this are elided so the footer stays one line. */
@@ -252,11 +274,39 @@ function promiseIsLicensed(readiness: GraphReadiness | null | undefined): boolea
  * Priority is by SPECIFICITY: name the actual remedy when the structured fields
  * support it, and degrade — never to a different factual claim, only to a less
  * specific true one.
+ *
+ * @param verdictIsStale ROADMAP 2.635 (I-3) — `readinessStore.stale`: the model
+ * has changed in a way this verdict was never asked about. When true, EVERY
+ * rung below is short-circuited, because every one of them is a claim about a
+ * graph this verdict did not grade. See `BLOCKED_REASON_COPY.staleRecheck`.
+ *
+ * ⚠ It defaults to `false` — "treat as current" — which is deliberate and is
+ * the pre-2.635 behaviour, so a caller who omits it gets today's copy rather
+ * than a new one. That default is only safe because the wiring is not left to
+ * memory: `blockedReasonStaleWiring.derived.spec.ts` DERIVES the call-site
+ * manifest from source and REDs if a production caller stops passing it. A
+ * hand-remembered argument is the trap-12 mirror; a derived guard on top of a
+ * safe default is not.
  */
 export function composeReadinessBlockedReason(
   readiness: GraphReadiness | null | undefined,
   optionsNeedingValues: readonly OptionNeedingValues[] = [],
+  verdictIsStale: boolean = false,
 ): string {
+  // ── ROADMAP 2.635 (I-3): a stale verdict is not quoted as current ──
+  //
+  // First, and before any field of `readiness` is read. Each rung below draws a
+  // specific factual claim — an option's name, a count, a missing goal — from
+  // the verdict's structured fields, and those fields describe the graph as it
+  // was when the verdict was taken. Once the canvas has moved on, publishing
+  // them tells the user to do something they may have just done.
+  //
+  // Note this rung short-circuits `unspecified` too. That sentence looks
+  // claim-free, but "Olumi is not able to run this yet" still asserts the
+  // verdict's `can_run_analysis: false` as a present-tense fact about the model
+  // on screen, and that is exactly the assertion staleness invalidates.
+  if (verdictIsStale) return BLOCKED_REASON_COPY.staleRecheck
+
   const trustNames = verifyAgainstVerdict(readiness, optionsNeedingValues)
   const labelled = trustNames
     ? optionsNeedingValues
@@ -362,6 +412,13 @@ function composedPatterns(): RegExp[] {
     BLOCKED_REASON_COPY.goalMissing,
     BLOCKED_REASON_COPY.tooFewOptions,
     BLOCKED_REASON_COPY.unspecified,
+    // ROADMAP 2.635 (I-3). Omitting it here would have been the exact failure
+    // this function's docstring warns about: an unrecognised composed sentence
+    // classifies as `foreign` and the render path degrades it to the surface's
+    // non-committal fallback — so the staleness disclosure would silently
+    // vanish at the very surface it was written for. Caught by the sample-matrix
+    // spec, which is why that spec asserts coverage of every key.
+    BLOCKED_REASON_COPY.staleRecheck,
   ]
   cachedPatterns = templates.map((template) => {
     const source = escapeForRegex(template)


### PR DESCRIPTION
## ROADMAP 2.635 — retire the readiness verdict's three fail-open limbs; stale is never quoted as current

Slices **B1-a + B1-b** of the 6 Aug PC1 seam map (`PHASE0-EVIDENCE-2026-07-28/pc1-seam-map-2026-08-06.md`, Blocker 1). Pillar: **PC1 — no dead ends**. Every limb was re-located **by symbol** at this tip (`fc47b90a`); the seam map's line numbers had moved and are not relied on.

> POC-DONE's PC1 language is the whole rationale: *"a truthful 'can't yet, here's why + the remedy' is not a dead end; a false reason is."* Each limb below produced a **false reason** or a **false permission**.

---

### The per-class fail-direction table — FOR RATIFICATION

The invariant I-2 asks that each failure class have a **stated decision**, not a fall-through. This is the table. **⚠ Fail-closed everywhere is deliberately NOT chosen**: a readiness check that cannot be obtained must not brick the Run button for a healthy user — that is the SHUT dead end witnessed in 2.332, and it trades a false "yes" for a false "no".

| Failure class | Verdict published | Gate posture | Disclosure | Changed here? |
|---|---|---|---|---|
| transport unreachable | none — retain last real answer | unknown ⇒ **does not object** (open); a retained refusal still refuses | `Could not reach the readiness service` | no (2.319a) |
| HTTP 404 | none | same | `Could not find the readiness service` | no (2.329) |
| HTTP 5xx / 401 / 403 | none | same | status-only, body never carried | no (2.339) |
| **HTTP 429** | **none** — was a fabricated heuristic verdict incl. `strong` | same | **`Could not check readiness right now — the service is rate limited`** | **YES (I-1)** |
| **malformed 200** (no `can_run_analysis` boolean) | **none** — was `can_run_analysis: true` | same | **`Could not read the readiness service response`** | **YES (I-2)** |
| null at boot (never checked) | none | **does not object** (open) | footer `Could not check readiness` | no (#564) |
| **stale retained verdict that BLOCKS** | retained, marked stale | **still SHUT** — the refusal is the last real answer | **copy replaced by `staleRecheck`; no option, count or goal claim** | **YES (I-3)** |
| stale retained verdict that PERMITS | retained, marked stale | **still OPEN** — Ruling 3: uncertainty must not lock the user out | footer already discloses staleness | no |
| **licence superseded mid-dispatch by a refusal** | n/a | **run refused, attributably** | `Your model changed while the analysis was starting…` | **YES (I-4)** |

The single organising decision: **an unobtainable verdict is UNKNOWN, unknown does not object, and the outage is disclosed.** Documented on `readinessObjectsToRun` so the next failure arm inherits it rather than re-deciding.

---

### Per-limb evidence

RED measured at pristine with production source **unmodified** (`git status --porcelain src/…` empty for all four production files): **22 RED / 11 control-GREEN of 33 collected** across the three limb specs.

#### I-1 — the 429 arm published `calculateFallbackReadiness` AS the verdict
`readinessStore.ts`. The heuristic's verdict is `can_run_analysis: blockers.length === 0`, blockers drawn from `graphHealth`, which is `null` until an analysis has **already completed** — so before the first analysis it never found a blocker and **always granted the run**, and because it OVERWROTE `readiness` it could replace a `can_run_analysis: false` the server had already given. It could also emit `readiness_level: 'strong'`, a band **no CEE code path assigns**.

RED at pristine (5): does not grant on local authority · publishes no verdict when it never had one · never publishes a level the producer does not emit · leaves an existing server refusal intact **by identity** · error says "could not check", not "using local validation".
Preserved and pinned GREEN throughout: backoff still arms, `Retry-After` still honoured.

With the last caller gone, **`calculateFallbackReadiness` is deleted**, and the `strong` vocabulary with it — `ACCEPTED_READINESS_LEVELS` is now **exactly** `CEE_READINESS_LEVELS`, pinned by a new equality test.

#### I-2 — a 200 without the boolean defaulted to `true`
`can_run_analysis: typeof data.can_run_analysis === 'boolean' ? data.can_run_analysis : true` — the one gating field on the whole response. A partial write, a rewriting proxy, a renamed field or a CEE on an older contract all **granted the run**, stamped `verdictAtMs`, and reported `error: null`. Same fabrication class as I-1, spelled as a default, and strictly harder to notice because nothing about it was labelled.

RED at pristine (10), including a table over `'true'` / `1` / `null` / `{}` — every non-boolean is "no answer", not "yes" — plus: never re-stamps `verdictAtMs` for a response that answered nothing, and the failure is **not sticky** (the identical graph is re-askable).
**Discriminating half, GREEN at pristine and after:** a well-formed 200 flows through byte-identically **in both directions**. This is what stops the fix being "treat every 200 as unknown".

#### I-3 — blocked copy quoted a stale verdict as current
`stale` has existed since 2.332 and its own docstring says it "is what stops a surface presenting that verdict as current". The V3 footer honoured it; **the gate did not — `stale` was not an input to `canRunAnalysis` at all.** So a blocked user read a sentence naming a specific option, composed from `options_ready`/`options_total` of a verdict that had never been asked about the model now on the canvas. They complete the named remedy, the canvas mutates, and **the same sentence naming the same option is still there.**

RED at pristine (6): names no option · publishes no count · claims no missing goal · claims no too-few-options · says the model changed and the check is being redone · the stale sentence itself mentions no model noun.
**Direction pinned both ways:** stale + blocking stays shut; stale + runnable stays **open**; stale never suppresses a non-readiness blocking reason (bound to the validator's own message, not to "some reason exists").

#### I-4 — nothing bound the dispatch to the verdict that licensed it
The gate is evaluated at **render**; `runCanonicalAnalysis` dispatches after an awaited `flushPendingSaves()`. A fresh verdict can land inside that window, and a run licensed by a verdict since **replaced by a refusal** was indistinguishable from a current one.

Bound on the **objection**, never on identity alone — proved with a discriminating pair, because a barrier keyed on identity alone would brick the Run button on ordinary re-check churn:

| mid-dispatch event | required outcome |
|---|---|
| licence intact | runs (control) |
| licence moved **and new verdict objects** | refused |
| licence moved **and new verdict permits** | runs |
| staleness mark lands on a permitting verdict | runs |

#### I-5 — one gate authority
The readiness rung is extracted as **`readinessObjectsToRun`** and asked by both the gate and the dispatch barrier, so there is one definition rather than two copies that drift. Complete non-test manifest of `can_run_analysis` readers at this tip, scope `src/`: `readinessStore.ts` · `canRunAnalysis.ts` · `composeBlockedReason.ts` · `useGraphReadiness.ts` · `usePreAnalysisModel.ts` · `PanelFooter.tsx` · `usePreAnalysisData.ts` · `PreAnalysisHealth.tsx`. Only the first three are on the gate path; the rest are display or dead.
**The dead same-named `canRunAnalysis` twin at `lib/readiness.ts:344` is untouched** (trap 16) — its only importer, `ReadinessIndicator.tsx`, still has zero mounts. Deleting it stays row territory.

**I-6** (the two-input split: the UI verdict grades the canvas, CEE re-grades its persisted graph at run time) belongs to Blocker 2's seat and is **not** claimed here.

---

### Guards against this regressing

- **Derived call-site manifest** (`blockedReasonStaleWiring.derived.spec.ts`). `verdictIsStale` defaults to `false` — safe, and therefore **silent**. This walks `src/` at test time and REDs if any production caller stops passing it, **or passes a literal instead of the store's mark**. Same shape as `runGateCallSites.derived.spec.ts`, which exists because a mutation that dropped `draftStreamPhase` from the dock's gate call once survived the entire suite.
- **Accepted-set = producer-set equality**, so no future arm can widen the vocabulary to make room for another local guess. Its limit is stated in-file: derivation proves *agreement*, never *completeness* (trap 12d) — the cross-repo completeness pin against CEE's SHA is a separate, non-derived guard and neither supersedes the other.
- **Surface binding (trap 3b).** The end-to-end specs assert the **mount path itself** (`outputs-pre-run-v3`) alongside the copy, matching `netlify.toml`'s deployed `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"`. A green suite is not evidence about a component the deployment does not render.
- **Identity binding (trap 19).** Retained-verdict assertions bind to the server's own `confidence_explanation` and score, never to `can_run_analysis === false` — which a fabricated verdict could equally satisfy.

### Mutation battery — 14 of 14 bitten

Throwaway worktree **outside** the repo root, mutating only committed state. Isolation proven **by writing** a sentinel and asserting the source was unchanged, plus an inode compare (trap 9g — `cp -R` can preserve APFS hard links, and locating a path proves nothing). Applied-check scoped to `src/` per mutation; **the control asserts exactly zero** changed lines (trap 12e — the untracked `node_modules` symlink must not offset it). Restores come from the git object store, never from the other copy.

| # | Inv | Mutation | Verdict |
|---|---|---|---|
| M1 | I-1 | 429 arm republishes a locally-invented verdict | BITTEN |
| M2 | I-1 | re-widen the accepted vocabulary with a UI-invented level | BITTEN |
| M3 | I-2 | restore the `: true` default on a 200 without the boolean | BITTEN |
| M4 | I-2 | partial guard — only a *missing* field counts as no answer | BITTEN |
| M5 | I-3 | composer ignores the staleness mark | BITTEN |
| M6 | I-3 | gate stops forwarding staleness to the composer | BITTEN |
| M7 | I-3 | OutputsDock stops feeding the mark (the historic M3-survivor shape) | BITTEN |
| M8 | I-3 | ConversationPanel stops feeding the mark | BITTEN |
| M9 | I-3 | wiring passes a hardcoded `false` instead of the mark | BITTEN |
| M10 | I-4 | delete the dispatch licence barrier | BITTEN |
| M11 | I-4 | barrier fires on identity change **alone** (over-blocking twin) | BITTEN |
| M12 | I-4 | licence identity ignores the staleness component | BITTEN *(see below)* |
| M13 | I-5 | the shared readiness rung stops objecting | BITTEN |
| M14 | I-5 | the shared rung drops its scaffold clause | BITTEN |

**M12 survived the first pass, and how it was settled is worth stating.** Trap 13c requires a survivor to be *demonstrated* equivalent, never asserted. Derived from the store rather than argued: `readinessStore` has exactly **one** writer of `stale: true` (`:980`), and it sets `stale` **and nothing else**; every path that sets `readiness` from an answer stamps `verdictAtMs` in the same `setState`. So the store cannot produce "the verdict changed to one that objects while `verdictAtMs` stayed put", and M12 is equivalent **at the current wiring**. Writing a component fixture for that state would have been trap 16's inverse — *a fixture you wrote yourself is not evidence about what the producer can emit*. It is instead pinned where it belongs, as the declared contract of `verdictLicenceSuperseded` (`verdictLicence.spec.ts`), because equivalence-today is a property of the store, not of the function: a second `stale` writer, or two verdicts landing in the same millisecond, would turn the dropped clause into a live fail-open with nothing to catch it. M12 now bites.

**A harness defect found and disclosed.** The battery's first run indexed the wrong tuple element for its spec list, so it invoked vitest on single *characters* and — with `passWithNoTests: true` — burned 17 minutes measuring nothing. Its own `HARD ERROR: pristine specs are not green` control is what caught it. The harness now asserts the runner's argument shape (every arg a real `src/**.spec.ts(x)` file that exists) and that a non-zero test count was collected, so the same class fails in one second instead of seventeen minutes. Trap 15: your own script is not exempt.

### Typecheck ratchet
Fixed **at source** in six files (five `readiness_level: 'strong'` fixtures → `'ready'`, the producer's own top band at those scores; one copy-sample map gains the new rung). **No baseline update**: the gate reported a shrink of 3, and the attribution is `BaselineTargetRow.tsx` + its spec — **two files this PR never touches**. That is the trap-2b shape, so the update was reverted and the gate re-confirmed passing without it.

### Row-text corrections
`ROADMAP.md` is not edited by this lane, but two line references in row 2.635 have moved and one is imprecise:
- `readinessStore.ts:609-624` (429 arm) and `:705-706` (malformed default) — both shifted; re-locate by symbol.
- `canRunAnalysis.ts:322-331` — the `null`-is-no-objection behaviour is unchanged and **deliberate**; the row reads as if it were a defect to fix. It is now an explicitly documented decision on `readinessObjectsToRun` rather than a fall-through, which is what I-2 actually asks for.
