### PR TITLE
fix(ui): retire the two staleness locks Ruling 3 removed (ROADMAP 2.651)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2416,13 +2416,23 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 {/* v1.1 Contract: Engine critique shown post-run only if blockers exist
                     Note: Pre-run validation uses graphHealth, post-run uses engine critique
                     Only show if engine detected blockers that prevented clean results.
-                    RCA-C/F18: freshness-gate the render — an engine critique carries the
-                    limit that was live AT RUN TIME baked into its free-text message (e.g.
-                    "Graph too large: 16 nodes (limit: 12)"). When the analysis is not
-                    confirmed fresh (hydrated/orphaned reload, or edited since the run) that
-                    message can contradict newer live limits, so suppress it and let live
-                    graphHealth speak until a rerun mints a critique against current limits. */}
-                {!isPreRun && !analysisNotConfirmedFresh && report?.run?.critique && report.run.critique.some(c => c.severity === 'BLOCKER') && (
+
+                    ⛔ ROADMAP 2.651 — Paul's Ruling 3. The `!analysisNotConfirmedFresh`
+                    limb of this gate is RETIRED. RCA-C/F18 freshness-gated the render
+                    because an engine critique bakes the run-time limit into its free text
+                    ("Graph too large: 16 nodes (limit: 12)"), which a newer live limit
+                    could contradict. That is an argument about what the display CLAIMS,
+                    and the tab already answers it — AnalysisFreshnessNotice states "Model
+                    changed since this analysis. Re-run to update." directly above. Hiding
+                    it also hid ValidationPanel's Auto-fix, a graph MUTATION affordance,
+                    from the user's first edit onward. Staleness is a property of RESULTS,
+                    never a lock: out-of-date results are labelled, not withheld — the same
+                    doctrine the wrapper below already records ("v6 keeps stale results
+                    fully readable … No dimming, no aria-disabled lockout"). Live
+                    graphHealth still speaks in parallel; it is no longer made to speak
+                    INSTEAD. `!isPreRun` and the BLOCKER filter are untouched — both are
+                    pinned in `OutputsDock.staleEngineCritique.spec.tsx`. */}
+                {!isPreRun && report?.run?.critique && report.run.critique.some(c => c.severity === 'BLOCKER') && (
                   <div data-testid="outputs-engine-critique">
                     <ValidationPanel
                       critique={mapCritiqueToValidation(report.run.critique)}
@@ -2579,11 +2589,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     onSetFactorValue={handleTriageSetValue}
                     expertMode={expertMode}
                     nodeValueLookup={nodeValueLookup}
-                    // Lane 3 review fold: with the body now mounted at
-                    // 'error', the `!isError` escape re-enabled factor
-                    // mutations (suppressMutations = isStale || isRunning)
-                    // against a not-fresh retained display — the exact
-                    // hazard the Brief 4 Task 13 gate exists for.
+                    // ⛔ ROADMAP 2.651 — Paul's Ruling 3. This value NO LONGER
+                    // GATES ANY AFFORDANCE. `ResultsBody`'s suppression is now
+                    // `isRunning` alone; staleness is carried by the display
+                    // (`AnalysisFreshnessNotice`, and `data-freshness-confirmed`
+                    // on the wrapper above), never by withholding a control.
+                    // The prop is kept so this derivation stays visible at the
+                    // seam — re-attaching a lock to it must be a visible diff.
+                    // (The historical Lane 3 note about the `!isError` escape
+                    // "re-enabling factor mutations against a not-fresh display"
+                    // described the retired Brief 4 Task 13 gate and no longer
+                    // applies: mutations are correct on a not-fresh display.)
                     isStale={analysisNotConfirmedFresh}
                   />
                   </div>

--- a/src/canvas/components/__tests__/OutputsDock.staleEngineCritique.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.staleEngineCritique.spec.tsx
@@ -1,0 +1,302 @@
+/**
+ * OutputsDock — a stale analysis does not HIDE the engine critique
+ * (ROADMAP 2.651, the UI half of Paul's Ruling 3; design §3.3.2 lock U2).
+ *
+ * THE RULING. Staleness is a displayed property of RESULTS, never a lock on
+ * an affordance. CEE #834 built that server-side — the graph is always
+ * editable. This dock still carried the retired conflation:
+ *
+ *   {!isPreRun && !analysisNotConfirmedFresh && report?.run?.critique && …}
+ *
+ * `analysisNotConfirmedFresh` is displayed 'stale' OR 'unknown', and ANY
+ * analysis-affecting local edit downgrades a retained 'fresh' verdict to
+ * 'unknown' (`resolveDisplayedFreshness`). So the user's FIRST edit hid the
+ * blocker critique — and with it the ValidationPanel's Auto-fix control, a
+ * graph MUTATION affordance — for the rest of the session.
+ *
+ * WHY HIDING IT WAS THE WRONG ANSWER TO A REAL PROBLEM. The suppressed
+ * rationale (RCA-C/F18) is that a critique bakes the run-time limit into its
+ * free text ("Graph too large: 16 nodes (limit: 12)"), which a newer live
+ * limit could contradict. That is an argument about what the display CLAIMS,
+ * and the tab already answers it: `AnalysisFreshnessNotice` states "Model
+ * changed since this analysis. Re-run to update." above this panel. The
+ * ruling's line is that out-of-date results are labelled, not withheld — the
+ * same doctrine this file's own neighbour already records: "v6 keeps stale
+ * results fully readable … No dimming, no aria-disabled lockout."
+ *
+ * WHAT SURVIVES BYTE-IDENTICALLY. `!isPreRun` (pre-run validation speaks
+ * through live `graphHealth`, not through a critique that does not exist yet)
+ * and the BLOCKER-severity filter. Both are pinned below and both stay GREEN
+ * across the change; the mutants prove each limb is independently bound.
+ *
+ * ⚠ SURFACE BINDING (CLAUDE.md trap 3b). Unlike its sibling lock in
+ * `ResultsBody`, this panel sits on the surface the DEPLOYED FLAGS mount: it
+ * is inside `effectiveIsOpen && effectiveActiveTab === 'results'` with no
+ * feature-flag arm above it. The first test asserts that mount path so this
+ * file fails loud rather than quietly testing something no deployment
+ * renders.
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): DOM-content assertions only. Nothing here
+ * claims visibility, layout, or that anything is above the fold.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen, within } from '@testing-library/react'
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useReadinessStore } from '../../stores/readinessStore'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    // Matches `netlify.toml` VITE_FEATURE_PRE_ANALYSIS_V3 = "1".
+    isPreAnalysisV3Enabled: () => true,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }),
+}))
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+/**
+ * The one critique this spec is about, named once. Assertions bind to this
+ * MESSAGE, not to "a critique" or "the panel is non-empty" (CLAUDE.md trap
+ * 19) — only this item can produce this sentence, so a different critique
+ * leaking in cannot satisfy them.
+ */
+const BLOCKER_MESSAGE = 'Graph too large: 16 nodes (limit: 12)'
+const WARNING_MESSAGE = 'Edge weight normalised on Ramp-up time'
+
+const BLOCKER_CRITIQUE = [
+  { severity: 'BLOCKER', code: 'GRAPH_TOO_LARGE', message: BLOCKER_MESSAGE },
+]
+const WARNING_ONLY_CRITIQUE = [
+  { severity: 'WARNING', code: 'WEIGHTS_NORMALIZED', message: WARNING_MESSAGE },
+]
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+type Freshness = 'fresh' | 'stale' | 'unknown'
+
+interface SeedOpts {
+  /** false ⇒ pre-run: the `!isPreRun` limb, which this change must not touch. */
+  completedFirstRun?: boolean
+  freshness?: Freshness
+  /** The local dirty overlay — what an analysis-affecting edit sets. */
+  dirty?: boolean
+  critique?: unknown[]
+}
+
+/**
+ * A completed run whose results are on screen, with an engine critique
+ * attached — the state a user is in the moment they edit the graph.
+ */
+function seedPostRunCanvas({
+  completedFirstRun = true,
+  freshness = 'fresh',
+  dirty = false,
+  critique = BLOCKER_CRITIQUE,
+}: SeedOpts = {}) {
+  clearInflightCache()
+  // Held in flight: a settling readiness fetch would clear the state under
+  // test mid-assertion (same reason as OutputsDock.staleVerdictCopy.spec).
+  vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+
+  const nodes = [
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'Build or buy?' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Increase delivery output' } },
+    { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Build it in house' } },
+    { id: 'opt_b', type: 'option', position: { x: 10, y: 0 }, data: { kind: 'option', label: 'Buy a vendor platform' } },
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Ramp-up time' } },
+  ]
+
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }] as never,
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    hasCompletedFirstRun: completedFirstRun,
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: { run: { critique } },
+    },
+    showDraftChat: false,
+    v5AnalysisFact: null,
+    analysisFreshness: {
+      freshness,
+      graphHashAtRun: 'hash_at_run',
+      currentGraphHash: dirty || freshness !== 'fresh' ? 'hash_now_different' : 'hash_at_run',
+    },
+    analysisFreshnessDirty: dirty,
+  } as never)
+}
+
+function renderDock() {
+  return render(
+    <ToastProvider>
+      <OutputsDock />
+    </ToastProvider>,
+  )
+}
+
+const findCritiquePanel = () =>
+  screen.findByTestId('outputs-engine-critique', {}, { timeout: 20_000 })
+const queryCritiquePanel = () => screen.queryByTestId('outputs-engine-critique')
+
+beforeAll(async () => {
+  await import('../pre-analysis-v3')
+}, 30_000)
+
+beforeEach(() => {
+  ensureMatchMedia()
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.unstubAllGlobals()
+})
+
+describe('OutputsDock — staleness labels results, it does not hide the engine critique (2.651 / U2)', () => {
+  /**
+   * CONTROL (CLAUDE.md trap 13) + MOUNT PATH (trap 3b). Every assertion that
+   * the panel is PRESENT is vacuous unless this fixture can render it at all,
+   * and every assertion in this file is worthless if the deployment does not
+   * mount this surface. Both are settled here, before anything else is
+   * claimed.
+   */
+  it('control — on CURRENT results the deployed surface mounts and names the blocker', async () => {
+    seedPostRunCanvas({ freshness: 'fresh' })
+    renderDock()
+    const panel = await findCritiquePanel()
+    expect(within(panel).getByText(BLOCKER_MESSAGE)).toBeInTheDocument()
+  }, 40_000)
+
+  /**
+   * RED at pristine — CEE itself says the model changed.
+   */
+  it('a CEE "stale" verdict still shows the blocker critique', async () => {
+    seedPostRunCanvas({ freshness: 'stale' })
+    renderDock()
+    const panel = await findCritiquePanel()
+    expect(within(panel).getByText(BLOCKER_MESSAGE)).toBeInTheDocument()
+  }, 40_000)
+
+  /**
+   * RED at pristine — THE USER'S FIRST EDIT. The realistic path: CEE's
+   * verdict is still 'fresh', the local dirty overlay downgrades the DISPLAY
+   * to cannot-confirm, and the panel vanished. This is the case the ruling is
+   * actually about, and it fires on every session.
+   */
+  it('after the user edits the graph (cannot-confirm) the blocker critique is still shown', async () => {
+    seedPostRunCanvas({ freshness: 'fresh', dirty: true })
+    renderDock()
+    const panel = await findCritiquePanel()
+    expect(within(panel).getByText(BLOCKER_MESSAGE)).toBeInTheDocument()
+  }, 40_000)
+
+  it('a CEE "unknown" verdict still shows the blocker critique', async () => {
+    seedPostRunCanvas({ freshness: 'unknown' })
+    renderDock()
+    const panel = await findCritiquePanel()
+    expect(within(panel).getByText(BLOCKER_MESSAGE)).toBeInTheDocument()
+  }, 40_000)
+
+  /**
+   * The wiring witness (CLAUDE.md trap 16 — a symbol proves presence in the
+   * repo, never presence on the live path). The same `analysisNotConfirmedFresh`
+   * value that gated this panel is also what the dock hands `ResultsBody` as
+   * its `isStale` prop, and it is stamped on the results wrapper. Asserting it
+   * here proves the store → dock derivation is LIVE, so the sibling
+   * prop-level spec (`ResultsBody.staleMutationAffordances.spec.tsx`) is
+   * describing a state the product actually reaches rather than a fixture.
+   *
+   * Deliberately independent of the critique panel: it is GREEN before and
+   * after this change, so it witnesses the derivation itself rather than the
+   * fix. And it is the counterpart invariant — removing the LOCK must not
+   * remove the honest LABEL.
+   */
+  it('the same edit marks the results wrapper not-confirmed — the display still tells the truth', async () => {
+    seedPostRunCanvas({ freshness: 'fresh', dirty: true })
+    renderDock()
+    const wrapper = await screen.findByTestId('results-body-stale-wrapper', {}, { timeout: 20_000 })
+    expect(wrapper).toHaveAttribute('data-freshness-confirmed', 'false')
+  }, 40_000)
+
+  /**
+   * ⭐ LIMB THAT SURVIVES #1 — `!isPreRun`. Before the first run there is no
+   * engine critique to show; pre-run validation speaks through live
+   * `graphHealth`. GREEN before and after; a mutant deleting this limb must
+   * RED here and nowhere else.
+   */
+  it('before the first run no engine critique panel is mounted', async () => {
+    seedPostRunCanvas({ completedFirstRun: false, freshness: 'fresh' })
+    renderDock()
+    // The dock renders its pre-run surface; the critique panel must not exist.
+    await screen.findByTestId('outputs-pre-run-v3', {}, { timeout: 20_000 })
+    expect(queryCritiquePanel()).not.toBeInTheDocument()
+  }, 40_000)
+
+  /**
+   * ⭐ LIMB THAT SURVIVES #2 — BLOCKER severity. Warnings have their own
+   * surface (`WarningBanner`); this panel is the blocked-run story only.
+   */
+  it('a warning-only critique does not mount the blocker panel, stale or fresh', async () => {
+    seedPostRunCanvas({ freshness: 'stale', critique: WARNING_ONLY_CRITIQUE })
+    renderDock()
+    expect(await screen.findByTestId('results-body-stale-wrapper', {}, { timeout: 20_000 })).toBeTruthy()
+    expect(queryCritiquePanel()).not.toBeInTheDocument()
+  }, 40_000)
+})

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -126,18 +126,40 @@ export const ResultsBody = memo(function ResultsBody({
       (i: { severity?: string; code?: string }) => i.code === 'GRAPH_TOO_LARGE' || i.severity === 'blocker',
     ),
   )
-  // Brief 4 Task 13 + Phase 8 P0 #4: suppress mutation affordances while
-  // results are stale so users don't edit a factor based on a display that
-  // no longer matches the analysis. Read-only affordances (focus node,
-  // hover highlights, AI discuss) remain active. Baseline/threshold
-  // handlers are declared on this component but not currently wired to
-  // the children that consume them, so we only gate the two that are.
-  // Lane 3 (SF2): the body now stays MOUNTED through a run — the same
-  // rationale gates factor mutations mid-flight (don't commit edits against
-  // a display whose run is being replaced).
-  const suppressMutations = isStale || isRunning
-  const staleOnConfirmFactor = suppressMutations ? undefined : onConfirmFactor
-  const staleOnSetFactorValue = suppressMutations ? undefined : onSetFactorValue
+  // ⛔ ROADMAP 2.651 — Paul's Ruling 3, the UI half. The `isStale` limb of this
+  // gate is RETIRED. It read `isStale || isRunning`, and because `isStale` is
+  // the dock's `analysisNotConfirmedFresh` (displayed 'stale' OR 'unknown'),
+  // and ANY analysis-affecting edit downgrades a retained 'fresh' verdict to
+  // 'unknown', the user's FIRST edit switched "Confirm AI estimate" — pillar
+  // P4's human-confirms-the-AI affordance — off for the rest of the session.
+  //
+  // The retired rationale (Brief 4 Task 13 / Phase 8 P0 #4) was "don't edit a
+  // factor based on a display that no longer matches the analysis". That is an
+  // argument about what the display CLAIMS, and the tab already answers it:
+  // `AnalysisFreshnessNotice` says "Model changed since this analysis. Re-run
+  // to update." above these cards. **Out-of-date results get labelled, never
+  // withheld — staleness is a property of RESULTS, never a lock on what the
+  // user may do.** CEE #834 built the same ruling server-side: the graph is
+  // always editable. `isStale` stays on the props so the dock's derivation
+  // remains visible at this seam and any re-introduced lock is a diff rather
+  // than a silent addition — but it MUST NOT gate an affordance.
+  //
+  // ⭐ WHAT SURVIVES, byte-identically: `isRunning`. Lane 3 (SF2) keeps the
+  // body MOUNTED through a run, and committing a factor edit against a display
+  // whose run is being replaced is a genuine hazard the ruling does not touch.
+  // Pinned + mutation-proved in `ResultsBody.staleMutationAffordances.spec.tsx`.
+  //
+  // `isStale` is kept on the props and marked INERT here rather than deleted —
+  // the same idiom `OutputsDock` uses for `realMessageCount`. Deleting it would
+  // remove the seam the dock's staleness arrives on, and with it the only
+  // mutant that can prove this lock has not come back: the spec above asserts
+  // that a body TOLD its results are stale still offers the affordance, which
+  // is unprovable if the component can no longer be told. Re-attaching a gate
+  // to this value must be a visible diff that turns those tests RED.
+  void isStale
+  const suppressMutations = isRunning
+  const runGatedOnConfirmFactor = suppressMutations ? undefined : onConfirmFactor
+  const runGatedOnSetFactorValue = suppressMutations ? undefined : onSetFactorValue
 
   // ROADMAP 1.267 — QUOTED, never re-derived. `useResultsSectionData` already
   // resolved the one verdict (`deriveDecisionVerdict`, the same instance the
@@ -257,8 +279,8 @@ export const ResultsBody = memo(function ResultsBody({
       onFocusNode={onFocusNode}
       verifiedCount={verifiedCount}
       influenceCoverage={influenceCoverage}
-      onConfirm={staleOnConfirmFactor}
-      onSetValue={staleOnSetFactorValue}
+      onConfirm={runGatedOnConfirmFactor}
+      onSetValue={runGatedOnSetFactorValue}
       expertMode={expertMode}
       nodeValueLookup={nodeValueLookup}
       onSendMessage={onSendMessage}
@@ -272,8 +294,8 @@ export const ResultsBody = memo(function ResultsBody({
       onFocusNode={onFocusNode}
       verifiedCount={verifiedCount}
       influenceCoverage={influenceCoverage}
-      onConfirm={staleOnConfirmFactor}
-      onSetValue={staleOnSetFactorValue}
+      onConfirm={runGatedOnConfirmFactor}
+      onSetValue={runGatedOnSetFactorValue}
       expertMode={expertMode}
       nodeValueLookup={nodeValueLookup}
       onSendMessage={onSendMessage}

--- a/src/components/results/__tests__/ResultsBody.staleMutationAffordances.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.staleMutationAffordances.spec.tsx
@@ -1,0 +1,345 @@
+/**
+ * ResultsBody — staleness must not switch OFF a mutation affordance
+ * (ROADMAP 2.651, the UI half of Paul's Ruling 3; design §3.3.2 lock U1).
+ *
+ * THE RULING. The graph is always editable. Staleness is a DISPLAYED PROPERTY
+ * of results — "Model changed since this analysis. Re-run to update." — and
+ * never a lock on what the user may do. CEE #834 built that server-side; this
+ * file pins the consumer half.
+ *
+ * WHAT THE LOCK WAS. `ResultsBody` derived
+ *   const suppressMutations = isStale || isRunning
+ * and withheld `onConfirmFactor` / `onSetFactorValue` from the triage cards.
+ * Because `isStale` is OutputsDock's `analysisNotConfirmedFresh` (displayed
+ * 'stale' OR 'unknown'), and ANY analysis-affecting local edit downgrades a
+ * retained 'fresh' verdict to 'unknown' (`resolveDisplayedFreshness`), the
+ * user's FIRST edit switched "Confirm AI estimate" — pillar P4's
+ * human-confirms-the-AI affordance — off for the rest of the session.
+ *
+ * WHAT SURVIVES. The `isRunning` limb. Committing a factor edit against a
+ * display whose run is being replaced is a genuine hazard and is NOT what the
+ * ruling retires. The mutant pair below proves the two limbs are independently
+ * bound: restoring the stale limb REDs only the stale tests; deleting the
+ * running limb REDs only the running test.
+ *
+ * ⚠ SURFACE BINDING (CLAUDE.md trap 3b) — READ BEFORE ADDING A CASE.
+ * `netlify.toml` `[context.staging.environment]` sets
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"`, and ResultsBody mounts the triage
+ * surfaces that carry this affordance (`AnalysisHeroV17` /
+ * `DecisionConfidencePanel`) ONLY inside its `!isAnalysisHeroPanelEnabled()`
+ * arm. So on DEPLOYED STAGING this affordance does not render at all — the
+ * arm under test here is the flag-OFF one (the `defaultValue: false` posture:
+ * local dev, and production, which does not inherit the staging context).
+ * The last test asserts that mount fork in BOTH directions so this file can
+ * never quietly become a test about a component no deployment renders, and so
+ * it fails loud the day the flag moves.
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): DOM-presence and handler-call assertions only.
+ * Nothing here claims anything about layout, visibility or the fold.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  EvidenceGapItem,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import { isAnalysisHeroPanelEnabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+/**
+ * The one factor this spec is about, named once. Every assertion below binds
+ * to THIS id — never to "a card with an editor" or "the first confirm button"
+ * (CLAUDE.md trap 19: an assertion must bind to its object by identity, never
+ * by a predicate another object could satisfy). The handler-call assertions
+ * check the argument, which is the strongest identity binding available: only
+ * this card can produce this id.
+ */
+const TARGET_NODE_ID = 'node_underinformed_factor'
+const TARGET_LABEL = 'Ramp-up time'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: 0.3,
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+
+  /**
+   * An evidence gap is what mints a triage card carrying the inline value
+   * editor + "Confirm AI estimate" (`mapEvidenceGapsToActions` →
+   * `TriageCard` → `InlineValueControls`). `targetNodeId` is the id the
+   * confirm handler must receive.
+   */
+  const gap: EvidenceGapItem = {
+    factorId: 'fac_ramp',
+    factorLabel: TARGET_LABEL,
+    confidence: 40,
+    voi: 0.5,
+    suggestion: 'This estimate is the AI’s, not yours.',
+    targetNodeId: TARGET_NODE_ID,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [gap],
+    topEvidenceGaps: [gap],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+interface Handlers {
+  onConfirmFactor: ReturnType<typeof vi.fn>
+  onSetFactorValue: ReturnType<typeof vi.fn>
+}
+
+function renderBody(props: { isStale?: boolean; isRunning?: boolean } = {}): Handlers {
+  const onConfirmFactor = vi.fn()
+  const onSetFactorValue = vi.fn()
+  render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onConfirmFactor={onConfirmFactor}
+      onSetFactorValue={onSetFactorValue}
+      nodeValueLookup={{
+        [TARGET_NODE_ID]: { value: 12, unit: 'weeks', cap: null },
+      }}
+      isStale={props.isStale}
+      isRunning={props.isRunning}
+    />,
+  )
+  return { onConfirmFactor, onSetFactorValue }
+}
+
+/**
+ * The triage card for THIS factor, by identity — scoped to the triage queue
+ * (the factor's label also appears in the v7 sharpen line, which carries no
+ * affordance) and then narrowed to the enclosing card element. A second card
+ * appearing later cannot satisfy these assertions by accident, and the
+ * handler-argument checks pin the identity a second time at the call.
+ */
+function targetCard(): HTMLElement {
+  const queue = screen.getByTestId('unified-triage-queue')
+  const label = within(queue).getByText(TARGET_LABEL)
+  const card = label.closest('[data-testid^="unified-triage-"]') as HTMLElement | null
+  expect(card, `no triage card found for "${TARGET_LABEL}"`).not.toBeNull()
+  return card!
+}
+
+describe('ResultsBody — staleness never switches off a mutation affordance (2.651 / U1)', () => {
+  beforeEach(() => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
+    useCanvasStore.setState({
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      draftCoaching: null,
+    })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  /**
+   * CONTROL (CLAUDE.md trap 13). Every "the affordance is present" assertion
+   * below is worthless unless this fixture can render the affordance at all.
+   * This proves a PRESENCE before anything asserts one, and it doubles as the
+   * fresh-results baseline invariant (c) compares the stale case against.
+   */
+  it('control — on CURRENT results the affordance renders and confirms this factor by id', () => {
+    const { onConfirmFactor } = renderBody({ isStale: false, isRunning: false })
+    const confirm = within(targetCard()).getByRole('button', { name: 'Confirm AI estimate' })
+    fireEvent.click(confirm)
+    expect(onConfirmFactor).toHaveBeenCalledTimes(1)
+    expect(onConfirmFactor).toHaveBeenCalledWith(TARGET_NODE_ID)
+  })
+
+  /**
+   * RED at pristine. This is the user's first edit: any analysis-affecting
+   * change downgrades the retained 'fresh' verdict to 'unknown', OutputsDock
+   * turns that into `isStale`, and P4's confirm button vanished for the rest
+   * of the session.
+   */
+  it('after an edit makes results stale, "Confirm AI estimate" is STILL offered', () => {
+    renderBody({ isStale: true, isRunning: false })
+    expect(
+      within(targetCard()).getByRole('button', { name: 'Confirm AI estimate' }),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * Invariant (c): it does not merely RENDER — the confirmation LANDS, with
+   * the same argument the fresh-results control asserts. A button that draws
+   * but reports nothing would satisfy presence and still fail the user.
+   */
+  it('on stale results the confirmation lands exactly as it does on fresh results', () => {
+    const { onConfirmFactor } = renderBody({ isStale: true, isRunning: false })
+    fireEvent.click(within(targetCard()).getByRole('button', { name: 'Confirm AI estimate' }))
+    expect(onConfirmFactor).toHaveBeenCalledTimes(1)
+    expect(onConfirmFactor).toHaveBeenCalledWith(TARGET_NODE_ID)
+  })
+
+  /**
+   * The value editor is the same withheld pair (`onSetFactorValue` feeds
+   * `editorConfig`, whose absence removes the whole inline control, not just
+   * the confirm icon). Staleness must not remove the user's ability to
+   * override the AI's number either — that is the other half of P4.
+   */
+  it('on stale results the inline value editor still commits an override', () => {
+    const { onSetFactorValue } = renderBody({ isStale: true, isRunning: false })
+    const card = targetCard()
+    const input = within(card).getByRole('spinbutton', { name: `Value for ${TARGET_LABEL}` })
+    fireEvent.change(input, { target: { value: '20' } })
+    fireEvent.click(within(card).getByRole('button', { name: 'Edit value' }))
+    expect(onSetFactorValue).toHaveBeenCalledWith(TARGET_NODE_ID, 20)
+  })
+
+  /**
+   * ⭐ THE LIMB THAT SURVIVES, byte-identically. Mid-run suppression is not
+   * what the ruling retires: committing a factor edit against a display whose
+   * run is being replaced is a real hazard. This test must be GREEN before
+   * AND after the change, and the mutant pair proves it is bound to the
+   * RUNNING limb specifically rather than passing because everything is open.
+   */
+  it('while a run is IN FLIGHT the mutation affordances stay suppressed', () => {
+    renderBody({ isStale: false, isRunning: true })
+    expect(
+      within(targetCard()).queryByRole('button', { name: 'Confirm AI estimate' }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(targetCard()).queryByRole('spinbutton', { name: `Value for ${TARGET_LABEL}` }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('stale AND running still suppresses — the surviving limb is not weakened by the other', () => {
+    renderBody({ isStale: true, isRunning: true })
+    expect(
+      within(targetCard()).queryByRole('button', { name: 'Confirm AI estimate' }),
+    ).not.toBeInTheDocument()
+  })
+
+  /**
+   * ⚠ TRAP 3b — THE MOUNT FORK ITSELF, ASSERTED IN BOTH DIRECTIONS.
+   *
+   * Asserted here so this file states its own scope as an executable fact
+   * rather than a comment that can rot. Flag OFF, the triage surface mounts
+   * and everything above is a real claim. Flag ON — the DEPLOYED STAGING
+   * posture per `netlify.toml` — the analysis-hero arm replaces it and
+   * carries no triage confirm affordance at all, so nothing above describes
+   * what a staging user currently sees.
+   *
+   * If the flag is ever promoted, retired, or inverted, this test goes RED
+   * and forces the question rather than leaving a green suite pointed at a
+   * component the deployment does not render.
+   */
+  it('mount fork — flag OFF (default / production posture) mounts the triage surface that carries this affordance', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
+    renderBody({ isStale: false, isRunning: false })
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('unified-triage-queue')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm AI estimate' })).toBeInTheDocument()
+  })
+
+  it('mount fork — flag ON (the DEPLOYED STAGING posture) replaces it with the hero arm, which carries NO confirm affordance', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+    renderBody({ isStale: false, isRunning: false })
+    expect(screen.getByTestId('analysis-hero-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('decision-confidence-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('unified-triage-queue')).not.toBeInTheDocument()
+    // The corrected premise of ROADMAP 2.651, as an executable fact: on
+    // staging this affordance does not render, so the U1 lock currently gates
+    // a surface no staging user reaches. Promoting/retiring the flag REDs this.
+    expect(screen.queryByRole('button', { name: 'Confirm AI estimate' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## ROADMAP 2.651 — remove the two UI staleness locks Paul's Ruling 3 retired

**Pillar: P4 (human–AI collaboration) / PC1.** The UI consumer half of CEE #834
(deployed `007f4795`), which built the ruling server-side: **the graph is always
editable; staleness is a displayed property of results, never a lock.**

The three-state honest display already exists and already says the true thing
(`AnalysisFreshnessNotice`: *"Model changed since this analysis. Re-run to
update."*). Nothing was built — two locks were removed.

### The two locks

| # | Lock | Fired on | What it hid |
|---|---|---|---|
| **U1** | `ResultsBody.tsx` — `suppressMutations = isStale \|\| isRunning`, withholding `onConfirmFactor` / `onSetFactorValue` | any edit (a local edit downgrades a retained `fresh` verdict to `unknown`) | **"Confirm AI estimate"** (P4's human-confirms-the-AI affordance) and the inline value editor, for the rest of the session |
| **U2** | `OutputsDock.tsx` — engine-critique panel gated on `!analysisNotConfirmedFresh` | same | the blocker critique **and `ValidationPanel`'s Auto-fix, a graph mutation affordance** |

**`isRunning` survives byte-identically** — committing an edit against a display
whose run is being replaced is a real hazard the ruling does not touch. So do
`!isPreRun` and the BLOCKER-severity filter on U2. All three are pinned and
mutation-proved.

### ⚠ Corrected premise — the row overstates U1's live impact

Re-derived at this tip; **the design's §3.3.2 line citations had already drifted**
(U1 `:144`→`:138`, U2 `:2423`→`:2425`; symbols intact).

U1's consumer surfaces (`AnalysisHeroV17` / `DecisionConfidencePanel`) mount
**only** inside `ResultsBody`'s `!isAnalysisHeroPanelEnabled()` arm — and staging
deploys that flag **ON**. Established three independent ways:

1. **Source** — `ResultsBody.tsx:406` gates the whole arm.
2. **An existing repo spec** already says it: `ResultsBody.heroPlacement.spec.tsx`
   — *"flag ON: hero REPLACES the legacy decision-confidence panel"*, asserting
   `decision-confidence-panel` is null.
3. **The deployed artifact** (trap 18 — not a YAML read): the staging bundle at
   `f00c1cf2` bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL:"1"` into
   `assets/flags-DBpusaUf.js`, and `makeFlag` precedence is localStorage → env →
   default.

**So on deployed staging the U1 lock gates a surface no staging user reaches** —
the post-analysis "Confirm AI estimate" affordance does not render there at all.
U1 is still correct to remove: the flag is documented as a rollback kill switch,
and production does not inherit the staging context, so the `!flag` arm is a live
surface the moment either changes. **U2 is on the live deployed surface** (inside
`effectiveIsOpen && activeTab === 'results'`, no flag arm) — that half is a
user-visible fix on staging today.

Both mount forks are now asserted **in both directions** so a flag move goes RED
rather than leaving a green suite pointed at a component nothing renders (trap 3b
— this estate shipped that defect twice).

### Evidence

**RED-first, per lock, at pristine** (control green first, so no absence
assertion is vacuous — trap 13):

- U1: control ✓ ("Confirm AI estimate" renders on fresh results and confirms by
  id) → 3 RED: `Unable to find an accessible element with the role "button" and
  name "Confirm AI estimate"` ×2, `…role "spinbutton" and name "Value for
  Ramp-up time"` ×1. Running-suppression ✓ throughout.
- U2: control ✓ (panel mounts, names the blocker) → 3 RED: `Unable to find an
  element by: [data-testid="outputs-engine-critique"]`. `!isPreRun` and
  warning-only limbs ✓ throughout.

**Mutants** — isolated worktree outside the repo root, isolation proven by
**writing a sentinel + inode compare** (trap 9g), restore from the git archive,
applied-check scoped to `src/` with the **control reading exactly 0**, and a
collected-count assertion (15) on every run so a swallowed exit code cannot score
a mutant "bitten" on zero output. Re-run in full at the shipped tip.

| Mutant | Bitten | Signature |
|---|---|---|
| CONTROL | 0 | applied-check **exactly 0**, 15/15 green |
| M1 restore the `isStale` limb | **3** | only the 3 stale tests |
| M2 delete the `isRunning` limb | **2** | only the 2 running tests |
| M3 restore `!analysisNotConfirmedFresh` | **3** | only the 3 stale/unknown/edited tests |
| M4 delete `!isPreRun` | **1** | only the pre-run test |
| M5 delete the BLOCKER filter | **1** | only the warning-only test |
| M6 re-point the confirm target id | **3** | only the handler-**argument** tests; presence-only stays green |

**M1/M2 are the discriminating pair**: disjoint RED sets prove the two limbs are
independently bound — removing the stale limb did not weaken the running one.
**M6** is the trap-19 identity proof: assertions bind to the factor by id, not by
a predicate another card could satisfy.

**Gates** — `pnpm run typecheck` ✅ (coverage + ratchet). It first caught the
now-dead `isStale` prop (`TS6133`); **fixed at source, not by a baseline bump**.
The gate then offered an optional tighten (2491→2488) — **declined**: the shrink
is entirely in `BaselineTargetRow.tsx` and its spec, **files this PR never
touches** (trap 2b, derived by regenerating and diffing). `npx eslint` on all
changed files: **0 errors**; the single `exhaustive-deps` warning is byte-identical
at `f00c1cf2` (proven by linting the pristine file). Neighbouring suites: **379
files / 5894 passed, 0 failed**. Collect assertion with a control: **37/37
inspector-v2 files, 380 tests** with the Supabase env vars exported vs **24 files
failing at collect / 237 tests vanishing** without them.

### Note for the record

`staleOnConfirmFactor` / `staleOnSetFactorValue` are renamed
`runGatedOn…` — after this change the old names were false labels, the exact
defect class trap 14 exists for. `isStale` is kept on the props and marked inert
with `void` (the repo's own `realMessageCount` idiom): deleting it would remove
the only seam through which the lock could be proved absent — M1 would become
unapplicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
