### PR TITLE
fix(ui): host "Confirm AI estimate" on the arm the deployed flags mount (ROADMAP 2.661 + 2.649 rider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,23 @@ jobs:
           key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
 
+      # ── ROADMAP 2.649 — parity with staging-full-tests.yml ──────────────────
+      # Deliberately placed BEFORE the "Schema contract gate" step below, which
+      # is currently a LANDMINE: it fails any package.json carrying a `"file:`
+      # reference and requires @talchain/schemas to be a registry semver — but
+      # the repo now pins a VENDORED TARBALL
+      # (`file:./vendor/talchain-schemas-<v>.tgz`). That step therefore cannot
+      # pass at today's tip. It has not been red because this workflow runs only
+      # on push/PR to `main`, so it will first fire at the next promotion. Rowed
+      # separately — resolving it is a policy question (vendored vs registry
+      # pin), not a wiring change. Running the vendor checks first means they
+      # still report while that is settled.
+      - name: Vendored schemas tarball integrity
+        run: pnpm run check:vendor
+
+      - name: Vendored schemas version constant is derived, not drifted
+        run: pnpm run ci:guard:schemas-version
+
       - name: Schema contract gate
         run: |
           echo "Checking schema dependency contract..."

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -128,6 +128,22 @@ jobs:
       - name: Starter fixtures match their source captures
         run: pnpm run ci:guard:starters
 
+      # ── ROADMAP 2.649 — the vendored-pin checklist's INVISIBLE fourth item ──
+      # The vendored @talchain/schemas tarball needs a sibling
+      # `vendor/<tarball>.tgz.sha256`. Nothing in CI checked for it: `check:vendor`
+      # ran only from `dev`/`dev:sandbox` and the local pre-push gate, so a missing
+      # or corrupt sidecar passed CI green and first failed at someone's pre-push
+      # (the DSK badge car shipped exactly that omission — caught by a lane, not by
+      # CI). An alarm that only fires on one developer's machine is not an alarm.
+      - name: Vendored schemas tarball integrity
+        run: pnpm run check:vendor
+
+      # The version constant stamped into debug/evidence bundles must be DERIVED
+      # from the package.json pin, never hand-typed (CLAUDE.md trap 12). This reds
+      # if the generated file drifts from the pin.
+      - name: Vendored schemas version constant is derived, not drifted
+        run: pnpm run ci:guard:schemas-version
+
   # ── Typecheck gate self-test (positive control) ──────────────────────
   # The `tsc` job above asserts an ABSENCE ("no new type errors, no invisible
   # files"). That assertion is worth nothing unless the gate can be shown to

--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
     "build-storybook": "storybook build",
     "generate:flag-env": "node scripts/generate-flag-env.mjs",
     "ci:guard:flag-env": "node scripts/generate-flag-env.mjs --check",
-    "ci:guard:bundle-env": "node scripts/ci/assert-bundle-env-allowlist.mjs"
+    "ci:guard:bundle-env": "node scripts/ci/assert-bundle-env-allowlist.mjs",
+    "generate:schemas-version": "node scripts/generate-schemas-version.mjs",
+    "ci:guard:schemas-version": "node scripts/generate-schemas-version.mjs --check"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/scripts/generate-schemas-version.mjs
+++ b/scripts/generate-schemas-version.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * generate-schemas-version.mjs
+ *
+ * Generates `src/lib/talchainSchemasVersion.ts` from the `@talchain/schemas`
+ * vendored-tarball pin in package.json, so the version constant surfaced in
+ * the debug bundle is DERIVED rather than hand-maintained.
+ *
+ * WHY (ROADMAP 2.649). The constant used to be typed by hand, with a spec that
+ * red on drift. That guard worked — the DSK badge car tripped it — but a
+ * value a human must remember to update is the hand-maintained mirror CLAUDE.md
+ * trap 12 is about: the failure mode is silent, and the blast radius is a WRONG
+ * CONTRACT VERSION stamped into evidence bundles. Deriving it removes the
+ * human step entirely.
+ *
+ * WHY NOT `import pkg from '../../package.json'`: that bundles the repo's full
+ * dependency list (names + exact versions) into a client chunk. This repo
+ * deliberately narrows what reaches the bundle (see vite.config.ts's
+ * SECURITY-LOAD-BEARING define block), so generation at source is the
+ * consistent choice — the same shape `generate-flag-env.mjs` already uses.
+ *
+ * WHY NOT a Vite `define`: `vitest.config.ts` does NOT extend `vite.config.ts`
+ * in this repo, so a define would have to be declared in both — two mirrors
+ * instead of one, which is the defect this row exists to remove.
+ *
+ * Usage:
+ *   node scripts/generate-schemas-version.mjs           # write
+ *   node scripts/generate-schemas-version.mjs --check   # CI: red if stale
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const PKG = resolve(ROOT, 'package.json')
+const OUT = resolve(ROOT, 'src/lib/talchainSchemasVersion.ts')
+
+/**
+ * The SAME shape `scripts/check-vendor-sha.mjs` and the drift spec parse, kept
+ * strict on purpose: a pin that is not a vendored tarball is a hard error, not
+ * a silent fallback. A fallback here would let a registry-pin migration ship a
+ * stale constant unnoticed — exactly the silent-drift class this replaces.
+ */
+function deriveVersion(pkgRaw) {
+  const pkg = JSON.parse(pkgRaw)
+  const pin =
+    pkg.dependencies?.['@talchain/schemas'] ??
+    pkg.devDependencies?.['@talchain/schemas']
+  if (!pin) {
+    throw new Error('@talchain/schemas pin missing from package.json')
+  }
+  const match = /talchain-schemas-(\d+\.\d+\.\d+(?:[-+][\w.]+)?)\.tgz$/.exec(pin)
+  if (!match) {
+    throw new Error(
+      `@talchain/schemas pin '${pin}' is not a vendored tarball reference — ` +
+        'update scripts/generate-schemas-version.mjs if the pin format changed on purpose.',
+    )
+  }
+  return match[1]
+}
+
+function renderModule(version) {
+  return `/**
+ * Vendored @talchain/schemas version — the UI's contract pin, surfaced in the
+ * debug bundle's \`schema_versions\` block.
+ *
+ * ⚠ GENERATED FILE — DO NOT EDIT BY HAND (ROADMAP 2.649).
+ * Derived from the \`@talchain/schemas\` vendored-tarball pin in package.json by
+ * \`scripts/generate-schemas-version.mjs\`. Regenerate with:
+ *
+ *     pnpm run generate:schemas-version
+ *
+ * \`pnpm run ci:guard:schemas-version\` reds in CI if this file drifts from
+ * package.json, and \`src/lib/__tests__/talchainSchemasVersion.spec.ts\` reds in
+ * the test suite. Editing this value by hand is how a wrong contract version
+ * gets stamped into evidence bundles.
+ */
+export const TALCHAIN_SCHEMAS_VENDORED_VERSION = '${version}' as const
+`
+}
+
+function main() {
+  const version = deriveVersion(readFileSync(PKG, 'utf8'))
+  const rendered = renderModule(version)
+
+  if (process.argv.includes('--check')) {
+    let current = null
+    try {
+      current = readFileSync(OUT, 'utf8')
+    } catch {
+      /* missing — treated as stale below */
+    }
+    if (current !== rendered) {
+      console.error(
+        `\n❌ src/lib/talchainSchemasVersion.ts is STALE.\n\n` +
+          `   It is generated from the @talchain/schemas pin in package.json, which\n` +
+          `   currently resolves to ${version}. The debug bundle's\n` +
+          `   schema_versions.ui_vendored_talchain_schemas field is populated from this\n` +
+          `   constant, so drift puts a WRONG contract version into evidence bundles.\n\n` +
+          `   Fix:  pnpm run generate:schemas-version\n`,
+      )
+      process.exit(1)
+    }
+    console.log(
+      `✅ src/lib/talchainSchemasVersion.ts is up to date with package.json (${version})`,
+    )
+    return
+  }
+
+  writeFileSync(OUT, rendered)
+  console.log(`✅ wrote ${relative(ROOT, OUT)} (${version})`)
+}
+
+main()

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -29,6 +29,7 @@ import { StressTestSection } from './StressTestSection'
 import { SectionErrorBoundary } from '../../canvas/components/SectionErrorBoundary'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
 import { DecisionConfidencePanel } from './DecisionConfidencePanel'
+import { TriageActionCardsBody } from './TriageActionCardsBody'
 import { AnalysisHeroV17 } from './AnalysisHeroV17'
 import { WhatChangedChip } from '../../canvas/components/WhatChangedChip'
 import { StrengthenContainer } from './strengthen/StrengthenContainer'
@@ -415,6 +416,65 @@ export const ResultsBody = memo(function ResultsBody({
               double-render the grounding line. */}
           <SectionErrorBoundary section="Key question">
             <KeyQuestionCard />
+          </SectionErrorBoundary>
+          {/* ── 2.661 (P4): THE CONFIRM/SET-VALUE AFFORDANCE, ON THE ARM THE
+              DEPLOYED FLAGS ACTUALLY MOUNT ──────────────────────────────────
+              "Confirm AI estimate" + the inline value editor are P4's
+              human-confirms-the-AI affordance. Both are minted by
+              `TriageActionCardsBody` (`mapEvidenceGapsToActions` → `TriageCard`
+              → `InlineValueControls`), and until now that body was composed
+              ONLY by `DecisionConfidencePanel` and `AnalysisHeroV17` — BOTH of
+              which live in the `!isAnalysisHeroPanelEnabled()` arm below.
+              Staging bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`, so on the
+              posture real users load NEITHER mounted and no staging user could
+              confirm an AI estimate after an analysis at all.
+
+              ⚠ WHY NOT "PUT IT ON THE V17 HERO" (the obvious answer, and the
+              wrong one — CLAUDE.md trap 3b, third instance in this estate):
+              `analysisHeroV17` is ALSO "1" on the deployed bundle, but V17 is
+              inside the SAME dark arm, so hosting it there would have shipped
+              the identical invisible feature a third time. Read at the bytes
+              from `assets/flags-*.js`, not from netlify.toml (trap 18).
+
+              ⚠ WHY NOT INSIDE `AnalysisHeroContainer`: that component's
+              contract is "the ONE authorised mount of the analysis hero",
+              read-only and store-free by design (enforced by its own
+              inertness spec), and `AnalysisHeroPanel` has no per-factor row —
+              only quick-links that focus a factor on canvas. Threading write
+              handlers through it would break a deliberate boundary. The triage
+              body is the surface that already IS "the factors whose estimates
+              are weak — act on them", so it mounts as the hero's sibling,
+              exactly where a user inspecting a factor's estimate acts on it.
+
+              ⭐ NO NEW WRITE PATH. Same component, same
+              `runGatedOnConfirmFactor` / `runGatedOnSetFactorValue` the legacy
+              arm passes — so the run-gating semantics #609 shipped are
+              inherited rather than re-derived (a re-derivation here is exactly
+              how the retired `isStale` lock would come back). The wrapper
+              testid makes the MOUNT PATH itself assertable, so a flag move
+              REDs `ResultsBody.confirmEstimateLiveMount.spec.tsx` instead of
+              silently darkening the affordance again. */}
+          <SectionErrorBoundary section="Decision confidence">
+            {/* `space-y-3` is the spacing context this body's ONLY other call
+                site gives it (`DecisionConfidencePanel`'s T1 card) — its root
+                is a Fragment, so without it the sub-sections butt together.
+                `empty:hidden` because that same Fragment root means a run with
+                no gaps, flip risk, conditional winners or result checks renders
+                a genuinely EMPTY div, which would still consume one `gap-4` of
+                the parent flex column. No card chrome is invented here: what
+                this surface should look like framed is a design decision, not
+                a wiring one. */}
+            <div className="space-y-3 empty:hidden" data-testid="hero-arm-triage-actions">
+              <TriageActionCardsBody
+                data={resultsSectionData}
+                onFocusNode={onFocusNode}
+                onConfirm={runGatedOnConfirmFactor}
+                onSetValue={runGatedOnSetFactorValue}
+                nodeValueLookup={nodeValueLookup}
+                onSendMessage={onSendMessage}
+                aiAffordance={aiAffordance}
+              />
+            </div>
           </SectionErrorBoundary>
         </>
       )}

--- a/src/components/results/__tests__/ResultsBody.confirmEstimateLiveMount.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.confirmEstimateLiveMount.spec.tsx
@@ -1,0 +1,374 @@
+/**
+ * ResultsBody — P4's "Confirm AI estimate" MUST RENDER ON THE DEPLOYED FLAG
+ * POSTURE (ROADMAP 2.661; the corrected premise of 2.651).
+ *
+ * ## The defect this file exists to prevent, stated bluntly
+ *
+ * `ResultsBody` mounts BOTH triage-carrying surfaces — `AnalysisHeroV17` and
+ * `DecisionConfidencePanel` — inside its `!isAnalysisHeroPanelEnabled()` arm.
+ * Deployed staging bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"`, so on the
+ * posture real users load, NEITHER mounted and the confirm/set-value
+ * affordance did not exist at all. A user could not confirm an AI estimate
+ * after an analysis.
+ *
+ * ⚠ Note the shape of the trap (CLAUDE.md 3b, third instance in this estate).
+ * `analysisHeroV17` is ALSO `"1"` on staging — so the natural reading, "the
+ * V17 hero is the modern surface, host it there", is WRONG: V17 is inside the
+ * SAME dark arm. Both values were read from the DEPLOYED BUNDLE
+ * (`assets/flags-*.js`: `VITE_FEATURE_ANALYSIS_HERO_PANEL:"1"`,
+ * `VITE_FEATURE_ANALYSIS_HERO_V17:"1"`, `..._COMPARE:void 0`), not from
+ * `netlify.toml` alone — CLAUDE.md trap 18: config is not posture.
+ *
+ * ## Flag injection — through the flag system's own seam, NOT a mock
+ *
+ * `vi.mock('@/flags')` would prove the mock, not the posture. `makeFlag`
+ * (flagFactory.ts) reads localStorage AT CALL TIME ahead of the env snapshot,
+ * and `'1'` resolves through the same truthiness the deployed
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"` uses. So
+ * `localStorage.setItem('feature.analysisHeroPanel', '1')` exercises the real
+ * `isAnalysisHeroPanelEnabled` end to end. Parity assertions below pin that
+ * the injection actually flips the real functions — without them the whole
+ * file could pass while testing the default posture (CLAUDE.md trap 13b: a
+ * guard whose discrimination depends on an unpinned precondition).
+ *
+ * ## Both flags are set, because the DEPLOYED POSTURE sets both
+ *
+ * Reproducing only `analysisHeroPanel` would be a fixture of my own invention
+ * rather than the wire (CLAUDE.md trap 16's inverse). `deployedPosture()`
+ * sets the pair the bundle carries.
+ *
+ * ## Identity binding (CLAUDE.md trap 19)
+ *
+ * Every assertion binds to ONE named factor by its `targetNodeId`, and the
+ * handler-argument checks pin that identity a second time at the call: only
+ * this card can produce this id. Nothing here finds "the first confirm
+ * button" or "a card with an editor".
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): DOM-presence and handler-call assertions only.
+ * jsdom cannot prove visibility, layout, or that anything is above the fold.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  EvidenceGapItem,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+import { isAnalysisHeroPanelEnabled, isAnalysisHeroV17Enabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+/** The one factor this spec is about, named once. */
+const TARGET_NODE_ID = 'node_underinformed_factor'
+const TARGET_LABEL = 'Ramp-up time'
+
+/** The testid of the mount path under test — the hero-arm host, by identity. */
+const LIVE_MOUNT = 'hero-arm-triage-actions'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: 0.3,
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+
+  /**
+   * An evidence gap is what mints a triage card carrying the inline value
+   * editor + "Confirm AI estimate" (`mapEvidenceGapsToActions` → `TriageCard`
+   * → `InlineValueControls`). `targetNodeId` is the id the confirm handler
+   * must receive.
+   */
+  const gap: EvidenceGapItem = {
+    factorId: 'fac_ramp',
+    factorLabel: TARGET_LABEL,
+    confidence: 40,
+    voi: 0.5,
+    suggestion: 'This estimate is the AI’s, not yours.',
+    targetNodeId: TARGET_NODE_ID,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [gap],
+    topEvidenceGaps: [gap],
+    nextActions: [],
+    topNextActions: [],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+interface Handlers {
+  onConfirmFactor: ReturnType<typeof vi.fn>
+  onSetFactorValue: ReturnType<typeof vi.fn>
+}
+
+function renderBody(props: { isStale?: boolean; isRunning?: boolean } = {}): Handlers {
+  const onConfirmFactor = vi.fn()
+  const onSetFactorValue = vi.fn()
+  render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onConfirmFactor={onConfirmFactor}
+      onSetFactorValue={onSetFactorValue}
+      nodeValueLookup={{
+        [TARGET_NODE_ID]: { value: 12, unit: 'weeks', cap: null },
+      }}
+      isStale={props.isStale}
+      isRunning={props.isRunning}
+    />,
+  )
+  return { onConfirmFactor, onSetFactorValue }
+}
+
+/**
+ * The DEPLOYED STAGING posture, through the real flag seam. Both values are
+ * the ones read from the deployed bundle — see the file header.
+ */
+function deployedPosture(): void {
+  localStorage.setItem('feature.analysisHeroPanel', '1')
+  localStorage.setItem('feature.analysisHeroV17', '1')
+  // ⚠ The precondition this whole file's discrimination rests on. Without
+  // these, every assertion below could be measuring the DEFAULT posture and
+  // silently proving nothing (CLAUDE.md trap 13b).
+  expect(isAnalysisHeroPanelEnabled()).toBe(true)
+  expect(isAnalysisHeroV17Enabled()).toBe(true)
+}
+
+/** The default / production posture: the flag is absent, so it reads false. */
+function defaultPosture(): void {
+  localStorage.removeItem('feature.analysisHeroPanel')
+  localStorage.removeItem('feature.analysisHeroV17')
+  expect(isAnalysisHeroPanelEnabled()).toBe(false)
+}
+
+/**
+ * The triage card for THIS factor, by identity, scoped to a named root so a
+ * card mounted by any OTHER arm cannot satisfy the assertion.
+ */
+function targetCardWithin(root: HTMLElement): HTMLElement {
+  const label = within(root).getByText(TARGET_LABEL)
+  const card = label.closest('[data-testid^="unified-triage-"]') as HTMLElement | null
+  expect(card, `no triage card found for "${TARGET_LABEL}"`).not.toBeNull()
+  return card!
+}
+
+/** The live (deployed-posture) host, asserted to BE the mount path. */
+function liveMount(): HTMLElement {
+  return screen.getByTestId(LIVE_MOUNT)
+}
+
+describe('ResultsBody — "Confirm AI estimate" on the DEPLOYED flag posture (2.661)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      draftCoaching: null,
+    })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  /**
+   * CONTROL (CLAUDE.md trap 13). Every claim below is worthless unless this
+   * fixture can render the affordance AT ALL. This proves a PRESENCE on the
+   * arm that always had one, before anything asserts a presence elsewhere.
+   */
+  it('control — on the DEFAULT posture the legacy arm renders the affordance for this factor', () => {
+    defaultPosture()
+    const { onConfirmFactor } = renderBody()
+    const panel = screen.getByTestId('decision-confidence-panel')
+    fireEvent.click(
+      within(targetCardWithin(panel)).getByRole('button', { name: 'Confirm AI estimate' }),
+    )
+    expect(onConfirmFactor).toHaveBeenCalledWith(TARGET_NODE_ID)
+  })
+
+  /**
+   * ⭐ I-A, THE ROW'S CAPABILITY CLAIM. RED at pristine: on the posture real
+   * staging users load, the button did not exist.
+   */
+  it('deployed posture — the affordance RENDERS, inside the live mount path', () => {
+    deployedPosture()
+    renderBody()
+    expect(
+      within(targetCardWithin(liveMount())).getByRole('button', {
+        name: 'Confirm AI estimate',
+      }),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * I-A, second half: it does not merely DRAW — the confirmation LANDS, with
+   * the same argument the default-posture control asserts. A button that
+   * renders but reports nothing satisfies presence and still fails the user.
+   */
+  it('deployed posture — the confirmation LANDS with this factor’s id', () => {
+    deployedPosture()
+    const { onConfirmFactor } = renderBody()
+    fireEvent.click(
+      within(targetCardWithin(liveMount())).getByRole('button', {
+        name: 'Confirm AI estimate',
+      }),
+    )
+    expect(onConfirmFactor).toHaveBeenCalledTimes(1)
+    expect(onConfirmFactor).toHaveBeenCalledWith(TARGET_NODE_ID)
+  })
+
+  /** I-A: the set-value control is the other half of P4 and must also land. */
+  it('deployed posture — the inline value editor commits an override for this factor', () => {
+    deployedPosture()
+    const { onSetFactorValue } = renderBody()
+    const card = targetCardWithin(liveMount())
+    const input = within(card).getByRole('spinbutton', { name: `Value for ${TARGET_LABEL}` })
+    fireEvent.change(input, { target: { value: '20' } })
+    fireEvent.click(within(card).getByRole('button', { name: 'Edit value' }))
+    expect(onSetFactorValue).toHaveBeenCalledWith(TARGET_NODE_ID, 20)
+  })
+
+  /**
+   * ⭐ I-B, limb 1 — the run gate #609 shipped still applies on this surface.
+   * The new host must inherit the gating, not route around it.
+   */
+  it('deployed posture — while a run is IN FLIGHT the affordance stays suppressed', () => {
+    deployedPosture()
+    renderBody({ isRunning: true })
+    const card = targetCardWithin(liveMount())
+    expect(
+      within(card).queryByRole('button', { name: 'Confirm AI estimate' }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(card).queryByRole('spinbutton', { name: `Value for ${TARGET_LABEL}` }),
+    ).not.toBeInTheDocument()
+  })
+
+  /**
+   * ⭐ I-B, limb 2 — staleness must NEVER suppress (Paul's Ruling 3, the lock
+   * #609 retired). This is the limb that would silently come back if someone
+   * re-derived `suppressMutations` on the new host.
+   */
+  it('deployed posture — STALE results still offer the affordance, and it lands', () => {
+    deployedPosture()
+    const { onConfirmFactor } = renderBody({ isStale: true })
+    fireEvent.click(
+      within(targetCardWithin(liveMount())).getByRole('button', {
+        name: 'Confirm AI estimate',
+      }),
+    )
+    expect(onConfirmFactor).toHaveBeenCalledWith(TARGET_NODE_ID)
+  })
+
+  /**
+   * ⚠ I-C — THE MOUNT FORK, ASSERTED IN BOTH DIRECTIONS.
+   *
+   * Not "the affordance exists somewhere" but "it exists on the arm the
+   * deployed flags mount, and NOT twice". A flag move REDs this pair rather
+   * than leaving a green suite pointed at a component no deployment renders.
+   */
+  it('mount fork — deployed posture mounts the hero arm host and NOT the legacy panel', () => {
+    deployedPosture()
+    renderBody()
+    expect(screen.getByTestId('analysis-hero-panel')).toBeInTheDocument()
+    expect(liveMount()).toBeInTheDocument()
+    expect(screen.queryByTestId('decision-confidence-panel')).not.toBeInTheDocument()
+    // Exactly one confirm affordance for this factor — the hero arm must not
+    // double-render what the legacy arm used to own.
+    expect(screen.getAllByRole('button', { name: 'Confirm AI estimate' })).toHaveLength(1)
+  })
+
+  /**
+   * I-D — the legacy arm is UNCHANGED when the flag is off, and the new host
+   * is absent there. Without this direction the fix could have quietly
+   * double-mounted the queue on the default/production posture.
+   */
+  it('mount fork — default posture keeps the legacy panel and does NOT mount the hero arm host', () => {
+    defaultPosture()
+    renderBody()
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId(LIVE_MOUNT)).not.toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Confirm AI estimate' })).toHaveLength(1)
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.staleMutationAffordances.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.staleMutationAffordances.spec.tsx
@@ -23,16 +23,27 @@
  * running limb REDs only the running test.
  *
  * ⚠ SURFACE BINDING (CLAUDE.md trap 3b) — READ BEFORE ADDING A CASE.
- * `netlify.toml` `[context.staging.environment]` sets
- * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"`, and ResultsBody mounts the triage
- * surfaces that carry this affordance (`AnalysisHeroV17` /
- * `DecisionConfidencePanel`) ONLY inside its `!isAnalysisHeroPanelEnabled()`
- * arm. So on DEPLOYED STAGING this affordance does not render at all — the
- * arm under test here is the flag-OFF one (the `defaultValue: false` posture:
- * local dev, and production, which does not inherit the staging context).
- * The last test asserts that mount fork in BOTH directions so this file can
- * never quietly become a test about a component no deployment renders, and so
- * it fails loud the day the flag moves.
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` on deployed staging, and the two
+ * triage surfaces this file drives (`AnalysisHeroV17` /
+ * `DecisionConfidencePanel`) mount ONLY inside `!isAnalysisHeroPanelEnabled()`.
+ * So the arm under test HERE is the flag-OFF one (the `defaultValue: false`
+ * posture: local dev, and production, which does not inherit the staging
+ * context).
+ *
+ * ⭐ UPDATED BY ROADMAP 2.661. This header used to end "so on DEPLOYED STAGING
+ * this affordance does not render at all", and the final test PINNED that
+ * absence as intended. That was a true measurement of a REAL DEFECT — no
+ * staging user could confirm an AI estimate — and pinning it made the defect
+ * look like a decision. 2.661 restored the affordance on the flag-ON arm by
+ * mounting `TriageActionCardsBody` there directly; the final test below now
+ * asserts the fork WITHOUT asserting the absence, and the flag-ON arm's own
+ * behaviour is owned by `ResultsBody.confirmEstimateLiveMount.spec.tsx`.
+ * The lesson kept deliberately visible: a test that pins an absence is a test
+ * that will defend it.
+ *
+ * The final test still asserts the mount fork in BOTH directions so this file
+ * can never quietly become a test about a component no deployment renders,
+ * and so it fails loud the day the flag moves.
  *
  * ⚠ SCOPE (CLAUDE.md trap 3): DOM-presence and handler-call assertions only.
  * Nothing here claims anything about layout, visibility or the fold.
@@ -313,11 +324,8 @@ describe('ResultsBody — staleness never switches off a mutation affordance (2.
    * ⚠ TRAP 3b — THE MOUNT FORK ITSELF, ASSERTED IN BOTH DIRECTIONS.
    *
    * Asserted here so this file states its own scope as an executable fact
-   * rather than a comment that can rot. Flag OFF, the triage surface mounts
-   * and everything above is a real claim. Flag ON — the DEPLOYED STAGING
-   * posture per `netlify.toml` — the analysis-hero arm replaces it and
-   * carries no triage confirm affordance at all, so nothing above describes
-   * what a staging user currently sees.
+   * rather than a comment that can rot: everything above drives the flag-OFF
+   * arm, and these two tests prove WHICH component that arm mounts.
    *
    * If the flag is ever promoted, retired, or inverted, this test goes RED
    * and forces the question rather than leaving a green suite pointed at a
@@ -329,17 +337,33 @@ describe('ResultsBody — staleness never switches off a mutation affordance (2.
     expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
     expect(screen.getByTestId('unified-triage-queue')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Confirm AI estimate' })).toBeInTheDocument()
+    // The flag-OFF arm must not ALSO mount 2.661's hero-arm host, or the
+    // affordance would double-render on the default/production posture.
+    expect(screen.queryByTestId('hero-arm-triage-actions')).not.toBeInTheDocument()
   })
 
-  it('mount fork — flag ON (the DEPLOYED STAGING posture) replaces it with the hero arm, which carries NO confirm affordance', () => {
+  /**
+   * ⭐ REWRITTEN BY ROADMAP 2.661 — see the header. This test previously
+   * asserted `queryByRole('Confirm AI estimate')` was ABSENT on the deployed
+   * posture. That absence was the DEFECT, not the design, and pinning it
+   * would have made restoring P4 look like a regression.
+   *
+   * What it asserts now is the part that was always true and still is: the
+   * flag-ON arm REPLACES the legacy panel. The affordance's presence and
+   * behaviour on that arm is owned by
+   * `ResultsBody.confirmEstimateLiveMount.spec.tsx`, which drives the real
+   * flag seam rather than this file's mock — so the two files cannot drift
+   * into asserting opposite things about the same posture.
+   */
+  it('mount fork — flag ON (the DEPLOYED STAGING posture) replaces the legacy panel with the hero arm', () => {
     vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
     renderBody({ isStale: false, isRunning: false })
     expect(screen.getByTestId('analysis-hero-panel')).toBeInTheDocument()
     expect(screen.queryByTestId('decision-confidence-panel')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('unified-triage-queue')).not.toBeInTheDocument()
-    // The corrected premise of ROADMAP 2.651, as an executable fact: on
-    // staging this affordance does not render, so the U1 lock currently gates
-    // a surface no staging user reaches. Promoting/retiring the flag REDs this.
-    expect(screen.queryByRole('button', { name: 'Confirm AI estimate' })).not.toBeInTheDocument()
+    // 2.661: the hero arm now hosts the affordance itself, so the confirm
+    // button IS present here — asserted by identity of its host, not merely
+    // by existence, and exactly once (no double mount across the two arms).
+    expect(screen.getByTestId('hero-arm-triage-actions')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Confirm AI estimate' })).toHaveLength(1)
   })
 })

--- a/src/lib/talchainSchemasVersion.ts
+++ b/src/lib/talchainSchemasVersion.ts
@@ -1,14 +1,16 @@
 /**
- * Vendored @talchain/schemas version — single source of truth for the UI's
- * contract pin, surfaced in the debug bundle's `schema_versions` block.
+ * Vendored @talchain/schemas version — the UI's contract pin, surfaced in the
+ * debug bundle's `schema_versions` block.
  *
- * Why a hand-maintained constant instead of importing the package's own
- * package.json: the vendored tarball's `exports` map exposes only `.`,
- * `./boundary` and `./orchestrator` (no `./package.json` subpath), so a
- * runtime/bundler import of the version is not portable. The constant is
- * guarded by `src/lib/__tests__/talchainSchemasVersion.spec.ts`, which
- * fails whenever this value drifts from the `file:./vendor/
- * talchain-schemas-<version>.tgz` pin in package.json — update both
- * together when bumping the vendored contract.
+ * ⚠ GENERATED FILE — DO NOT EDIT BY HAND (ROADMAP 2.649).
+ * Derived from the `@talchain/schemas` vendored-tarball pin in package.json by
+ * `scripts/generate-schemas-version.mjs`. Regenerate with:
+ *
+ *     pnpm run generate:schemas-version
+ *
+ * `pnpm run ci:guard:schemas-version` reds in CI if this file drifts from
+ * package.json, and `src/lib/__tests__/talchainSchemasVersion.spec.ts` reds in
+ * the test suite. Editing this value by hand is how a wrong contract version
+ * gets stamped into evidence bundles.
  */
 export const TALCHAIN_SCHEMAS_VENDORED_VERSION = '0.37.0' as const


### PR DESCRIPTION
## ROADMAP 2.661 — P4's "Confirm AI estimate" was dark for every staging user

**The capability gap.** `TriageActionCardsBody` mints "Confirm AI estimate" + the inline set-value editor. It was composed only by `DecisionConfidencePanel` and `AnalysisHeroV17` — and **both** sit inside `ResultsBody`'s `!isAnalysisHeroPanelEnabled()` arm. Staging bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`, so neither mounted. **No staging user could confirm an AI estimate after an analysis at all.**

### Premise re-derived at the deployed bundle (not netlify.toml — trap 18)

`https://staging--olumi.netlify.app/assets/flags-DBpusaUf.js`:

```
VITE_FEATURE_ANALYSIS_HERO_PANEL:"1"
VITE_FEATURE_ANALYSIS_HERO_V17:"1"
VITE_FEATURE_ANALYSIS_HERO_COMPARE:void 0
```

### ⚠ Correction to the row's prescription

Row 2.661 said to host the affordance on *"the V17 hero / its confidence section"*. **That would have shipped the identical invisible feature a third time.** `analysisHeroV17` is *also* `"1"`, but V17 lives in the **same dark arm** — the flag that darkens it is `analysisHeroPanel`, not `analysisHeroV17`. The surface the deployed flags actually mount is `AnalysisHeroContainer` / `KeyQuestionCard`.

### Placement, and why not the alternatives

`TriageActionCardsBody` now mounts **directly in the flag-ON arm**, as the hero's sibling, in the same relative reading position the legacy panel occupied (hero → key question → act on factors → strengthen → options → drivers).

- **Not inside `AnalysisHeroContainer`** — its contract is "the ONE authorised mount of the analysis hero", read-only and store-free by design (enforced by its own inertness spec), and `AnalysisHeroPanel` has **no per-factor row**, only quick-links that focus a factor on canvas. Threading write handlers through it would break a deliberate boundary.
- **Not the inspector** — that is a different surface with a different data source and would need a new write path.

**No new write path.** Same component, same `runGatedOnConfirmFactor` / `runGatedOnSetFactorValue` the legacy arm passes, so #609's run-gating semantics are *inherited* rather than re-derived — a re-derivation here is exactly how the retired `isStale` lock would come back.

### RED-first at pristine

6 failed / 2 passed. The two that passed are the **default-posture control** and the **flag-OFF fork** — proving the fixture *can* render the affordance before anything asserts one elsewhere (trap 13).

### Discriminating mutants (6/6 bit; control applied-check exactly 0, each mutant exactly 1)

| # | Mutation | Result |
|---|---|---|
| M1 | delete the hero-arm mount | 6 live RED |
| M2 | new mount takes raw `onConfirmFactor` (bypass run gate) | **only** "in flight ... suppressed" RED; legacy GREEN |
| M3 | re-introduce the retired `isStale` lock | **only** "STALE still offers" RED; legacy GREEN |
| M4 | drop `onSetValue` | set-value half RED |
| M5 | mount twice | exactly-one guards RED |
| M6 | mount unconditionally (outside the flag arm) | **only** the flag-OFF direction RED |

M2/M3 fail on **different assertions** — the two gating limbs are independently bound on the new host. M6 is the fork-binding discriminator: it proves the tests bind to the **fork**, not merely to "the affordance exists somewhere".

Isolation proven by **writing** (trap 9g): distinct inodes, sentinel write landed in the worktree, source hash unchanged. My first isolation probe reported "OK" *vacuously* (the append had failed) and was rewritten to assert the write actually happened.

### A pinned-defect test, corrected

`ResultsBody.staleMutationAffordances.spec.tsx` asserted the affordance was **absent** on the deployed posture. That absence was the **defect, not the design**, and pinning it would have made restoring P4 look like a regression. Rewritten to assert the fork without asserting the absence; header records why. Both forks still asserted both directions, plus exactly-one-mount checks so neither posture can double-render.

---

## Rider — ROADMAP 2.649 (separate commit)

1. **`check:vendor` never ran in CI** — wired only into `dev*` scripts and the local pre-push gate (zero references across `.github/workflows/`). A missing `vendor/<tarball>.tgz.sha256` sidecar passed CI green. Now a step in the staging gate's `tsc` job and in `ci.yml`.
2. **`TALCHAIN_SCHEMAS_VENDORED_VERSION` was hand-typed** — now generated from the package.json pin by `scripts/generate-schemas-version.mjs`, with `ci:guard:schemas-version` red on drift (same shape as `generate-flag-env.mjs`). Value unchanged (0.37.0) — no behaviour change. Guard proven both ways.

Rejected and recorded: importing `package.json` bundles the full dependency list into a client chunk; a Vite `define` would need declaring in **both** `vite.config.ts` and `vitest.config.ts` (which does not extend it) — two mirrors instead of one.

### ⚠ Found, not fixed — `ci.yml`'s "Schema contract gate" is a landmine

It fails any `package.json` containing `"file:` and requires `@talchain/schemas` to be a registry semver — but the repo pins `file:./vendor/talchain-schemas-0.37.0.tgz`. **That step cannot pass at today's tip.** It is not red only because `ci.yml` runs on `main` alone, so it will first fire at the next promotion. New vendor steps placed *before* it so they still report meanwhile. Resolving it is a policy question (vendored vs registry pin), not a wiring change — rowed separately.
