### PR TITLE
ci: Schema contract gate permits the vendored tarball pin, forbids all else (ROADMAP 2.662)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,32 +142,53 @@ jobs:
 
 
       # ── ROADMAP 2.649 — parity with staging-full-tests.yml ──────────────────
-      # Deliberately placed BEFORE the "Schema contract gate" step below, which
-      # is currently a LANDMINE: it fails any package.json carrying a `"file:`
-      # reference and requires @talchain/schemas to be a registry semver — but
-      # the repo now pins a VENDORED TARBALL
-      # (`file:./vendor/talchain-schemas-<v>.tgz`). That step therefore cannot
-      # pass at today's tip. It has not been red because this workflow runs only
-      # on push/PR to `main`, so it will first fire at the next promotion. Rowed
-      # separately — resolving it is a policy question (vendored vs registry
-      # pin), not a wiring change. Running the vendor checks first means they
-      # still report while that is settled.
+      # Placed BEFORE the "Schema contract gate" step below: these two verify
+      # the vendored tarball's BYTES (sha256 sidecar via
+      # scripts/check-vendor-sha.mjs) and the derived version constant, while
+      # the gate asserts the pin's SHAPE. (ROADMAP 2.662 rewrote the gate to
+      # permit the vendored pin — the registry-semver assertion it replaced
+      # could never pass at a vendored tip, and demonstrably failed at
+      # 9907cebd, run 26251187065.)
       - name: Vendored schemas tarball integrity
         run: pnpm run check:vendor
 
       - name: Vendored schemas version constant is derived, not drifted
         run: pnpm run ci:guard:schemas-version
 
+      # ── POLICY (ROADMAP 2.662, ruled 6 Aug 2026): the vendored tarball IS the
+      # contract mechanism — a sha256-asserted `npm pack` from the schemas repo,
+      # pinned as `file:./vendor/talchain-schemas-<semver>.tgz`; registry pins
+      # are NOT permitted (the registry envelope differs from the canonical
+      # npm-pack bytes — see vendor/README.md). This gate permits EXACTLY that
+      # shape and forbids every other `file:` reference. Byte integrity of the
+      # tarball against its .sha256 sidecar is `check:vendor`'s job (run above)
+      # and is deliberately not duplicated here.
       - name: Schema contract gate
         run: |
+          set -euo pipefail
           echo "Checking schema dependency contract..."
 
-          # 1. No file: references for @talchain/schemas
-          if grep -q '"file:' package.json; then
-            echo "FAIL: package.json contains file: dependency links"
-            grep '"file:' package.json
+          ALLOWED_PIN_RE='"@talchain/schemas": "file:\./vendor/talchain-schemas-[0-9]+\.[0-9]+\.[0-9]+\.tgz"'
+
+          # 1. The ONLY file: reference permitted anywhere in package.json is
+          #    the vendored @talchain/schemas pin (exact anchored shape above).
+          #    Both conditions reported separately: (1a) how many references
+          #    match the permitted shape, (1b) every reference that does not.
+          FILE_REFS="$(grep -an '"file:' package.json || true)"
+          if [ -n "$FILE_REFS" ]; then
+            ALLOWED_COUNT="$(printf '%s\n' "$FILE_REFS" | grep -acE "$ALLOWED_PIN_RE" || true)"
+            OTHER_REFS="$(printf '%s\n' "$FILE_REFS" | grep -avE "$ALLOWED_PIN_RE" || true)"
+          else
+            ALLOWED_COUNT=0
+            OTHER_REFS=""
+          fi
+          echo "OK (1a): file: references matching the vendored @talchain/schemas pin shape: $ALLOWED_COUNT"
+          if [ -n "$OTHER_REFS" ]; then
+            echo "FAIL (1b): package.json carries file: reference(s) other than the vendored @talchain/schemas pin:"
+            printf '%s\n' "$OTHER_REFS"
             exit 1
           fi
+          echo "OK (1b): no other file: references in package.json"
 
           # 2. No local fork directory
           if [ -d "packages/olumi-schemas" ]; then
@@ -175,12 +196,30 @@ jobs:
             exit 1
           fi
 
-          # 3. @talchain/schemas must be a semver version (not a path)
-          SCHEMA_VER=$(node -p "require('./package.json').dependencies['@talchain/schemas']")
-          if echo "$SCHEMA_VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "OK: @talchain/schemas = $SCHEMA_VER (registry version)"
+          # 3. @talchain/schemas must be the vendored-tarball pin (NOT a
+          #    registry semver), and the tarball the pin names must be tracked
+          #    in the tree at the exact semver the pin states.
+          SCHEMA_DEP="$(node -p "require('./package.json').dependencies['@talchain/schemas']")"
+          if printf '%s\n' "$SCHEMA_DEP" | grep -aqE '^file:\./vendor/talchain-schemas-[0-9]+\.[0-9]+\.[0-9]+\.tgz$'; then
+            echo "OK (3a): @talchain/schemas = $SCHEMA_DEP (vendored tarball pin — the contract mechanism)"
           else
-            echo "FAIL: @talchain/schemas = $SCHEMA_VER (not a registry version)"
+            echo "FAIL (3a): @talchain/schemas = $SCHEMA_DEP"
+            echo "  Policy: the vendored tarball IS the contract mechanism. The pin must be"
+            echo "  exactly file:./vendor/talchain-schemas-<semver>.tgz. Registry semver"
+            echo "  pins are NOT permitted — the registry envelope differs from the"
+            echo "  canonical npm-pack bytes (see vendor/README.md)."
+            exit 1
+          fi
+          # Internal consistency: extract the pin's semver, rebuild the
+          # filename from it, and assert THAT path is tracked (git ls-files is
+          # NUL-safe where a filesystem grep is not). Deeper tarball integrity
+          # (sha256 sidecar) is check:vendor's job — not duplicated here.
+          PIN_SEMVER="$(printf '%s\n' "$SCHEMA_DEP" | sed -E 's|^file:\./vendor/talchain-schemas-([0-9]+\.[0-9]+\.[0-9]+)\.tgz$|\1|')"
+          PIN_TARBALL="vendor/talchain-schemas-${PIN_SEMVER}.tgz"
+          if git ls-files --error-unmatch -- "$PIN_TARBALL" >/dev/null 2>&1; then
+            echo "OK (3b): pinned tarball $PIN_TARBALL (semver $PIN_SEMVER) is tracked in the tree"
+          else
+            echo "FAIL (3b): the pin names $PIN_TARBALL but that file is not tracked in the tree"
             exit 1
           fi
 


### PR DESCRIPTION
## ROADMAP 2.662 — Schema contract gate rewritten to encode the vendored-tarball policy

**File ownership:** this PR touches `.github/workflows/ci.yml` ONLY (a sibling lane owns `package.json`/`vendor/**`/lockfile/src).

### Policy encoded (ruled 6 Aug 2026 — orchestrator ruling attached to the dispatch)
The vendored tarball IS the intended long-term contract mechanism: a sha256-asserted `npm pack` from the schemas repo (never the registry artifact — the registry envelope was measured different: shasum `45264dc6…` vs canonical `835ab4b8…`), pinned as `file:./vendor/talchain-schemas-<semver>.tgz`, with `.sha256` sidecars, `vendor/README.md` provenance, and the `check:vendor` CI step serving it. The gate now permits EXACTLY that shape and keeps forbidding everything else. **Registry semver pins FAIL hard** (decision: fail, not warn — symmetry with the old gate's strictness), with the policy stated in the failure message so the next reader doesn't "fix" it backwards.

### Verify-first findings (premise checked before editing)
- Current staging tip `d18ac8b9` pins `file:./vendor/talchain-schemas-0.37.0.tgz`; old rule 1 (`grep -q '"file:' → FAIL`) and rule 3 (bare-semver assertion) could not pass there.
- **Has the `tsc` job ever run green at a vendored-pin tip? NO — and the landmine has actually fired.** ci.yml has **0 successful runs out of 700** (workflow level, `gh api …/runs?status=success` → `total_count: 0`). At the most recent run **26251187065** (2026-05-21, tip `9907cebd`, which pinned `file:./vendor/talchain-schemas-0.8.1.tgz`), the **"Schema contract gate" step itself concluded `failure`** and every later step was skipped. In the registry-pin era (run **23215359362**, tip `7b5992fc`, pin `"0.2.0"`), this step passed and the job failed later at Lint. Premise confirmed; no re-derivation needed.

### The rewrite (gate step only)
- **Rule 1** — the ONLY `file:` reference permitted anywhere in `package.json` is the exact anchored shape `"@talchain/schemas": "file:\./vendor/talchain-schemas-[0-9]+\.[0-9]+\.[0-9]+\.tgz"`. Both conditions explicit and separately reported: **1a** counts allowed-shape references, **1b** lists and FAILs on every other `file:` reference (arbitrary local paths stay forbidden).
- **Rule 3** — the pin must BE the vendored-tarball shape (**3a**; registry semver → FAIL with the policy message). Plus internal consistency (**3b**): extract the pin's `<semver>`, rebuild `vendor/talchain-schemas-<semver>.tgz` from it, and assert that exact path is tracked via `git ls-files --error-unmatch` (NUL-safe; no filesystem grep). Deeper byte integrity (tarball vs `.sha256` sidecar) remains `check:vendor`'s job (`scripts/check-vendor-sha.mjs`, run in the step above the gate) — referenced in the comment, not duplicated.
- **Rules 2 and 4** — UNTOUCHED byte-for-byte (no `packages/olumi-schemas` fork dir; no source imports from local schema paths). They still do real work.
- 2.649 rider comment updated (its LANDMINE prose is resolved by this change); step comment now states the policy in one sentence. `set -euo pipefail`; `grep -a` throughout (NUL-blindness, trap 17).

### Controls — executable, all five run against the step text EXTRACTED from this PR's ci.yml via a YAML parser (never a hand copy), in fixture git repos + the real clone

| Control | Expected | Result |
|---|---|---|
| (a) `"@talchain/schemas": "file:../something"` | FAIL | exit 1 at **1b** ✅ |
| (b) `"@talchain/schemas": "0.37.0"` (registry semver) | FAIL | exit 1 at **3a** with policy message ✅ |
| (c) `file:./vendor/talchain-schemas-0.99.0.tgz`, tarball untracked | FAIL | exit 1 at **3b** ✅ |
| (e) valid pin + second dep `"not-schemas": "file:../elsewhere"` | FAIL | exit 1 at **1b** (proves 1b doesn't key on the schemas line only) ✅ |
| (d) real clone at staging tip `d18ac8b9` | PASS | exit 0, all OKs printed ✅ |

Raw outputs (verbatim):

```
CONTROL (a) — exit=1
OK (1a): file: references matching the vendored @talchain/schemas pin shape: 0
FAIL (1b): package.json carries file: reference(s) other than the vendored @talchain/schemas pin:
5:    "@talchain/schemas": "file:../something"

CONTROL (b) — exit=1
OK (1a): ...: 0
OK (1b): no other file: references in package.json
FAIL (3a): @talchain/schemas = 0.37.0
  Policy: the vendored tarball IS the contract mechanism. The pin must be
  exactly file:./vendor/talchain-schemas-<semver>.tgz. Registry semver
  pins are NOT permitted — the registry envelope differs from the
  canonical npm-pack bytes (see vendor/README.md).

CONTROL (c) — exit=1
OK (1a): ...: 1
OK (1b): no other file: references in package.json
OK (3a): @talchain/schemas = file:./vendor/talchain-schemas-0.99.0.tgz (vendored tarball pin — the contract mechanism)
FAIL (3b): the pin names vendor/talchain-schemas-0.99.0.tgz but that file is not tracked in the tree

CONTROL (e) — exit=1
OK (1a): ...: 1
FAIL (1b): package.json carries file: reference(s) other than the vendored @talchain/schemas pin:
5:    "not-schemas": "file:../elsewhere",

CONTROL (d) real clone at d18ac8b9 — exit=0
OK (1a): ...: 1
OK (1b): no other file: references in package.json
OK (3a): @talchain/schemas = file:./vendor/talchain-schemas-0.37.0.tgz (vendored tarball pin — the contract mechanism)
OK (3b): pinned tarball vendor/talchain-schemas-0.37.0.tgz (semver 0.37.0) is tracked in the tree
All schema contract checks passed.
```

### ⚠ Why this PR's own CI cannot prove the step
`ci.yml` runs only on push/PR to **`main`**, so nothing in this PR's checks (Staging Gate etc.) executes the rewritten step. The fixture proofs above are the evidence — which is exactly why they were made executable against the extracted step text rather than prose. The step will first run for real at the next promotion to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
