### PR TITLE
fix(chips): derive the chip render vocabulary so propose-confirm chips reach the user (2.668)

### DIFF
--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -116,9 +116,16 @@ export function findNaturalTruncation(text: string): string | null {
 
 interface MessageBubbleProps {
   message: ConversationMessage
-  /** When true, suppress inline ActionChipRow (chips rendered externally by SuggestedChips) */
-  hideChips?: boolean
-  /** When true, inline ActionChipRow is visible but non-interactive (historical turn) */
+  /**
+   * ⚠ CURRENTLY UNUSED BY THIS COMPONENT — declared, never destructured. Said
+   * plainly because the neighbouring `hideChips` prop was dead in exactly the
+   * same way and its comment did not say so, which is how ROADMAP 2.668's
+   * second defect came to be diagnosed against a chain that does nothing.
+   * `SuggestedChips` (via ChatThread) is the sole render surface for
+   * `message.actionChips`. Left in place rather than removed: it is a REQUIRED
+   * prop threaded from ~19 call sites and specs, so withdrawing it is a
+   * separate tidy-up, not part of a consent fix.
+   */
   onChipClick: (chip: ActionChip) => Promise<void>
   patchBlockStates?: Map<string, PatchBlockState>
   patchRejections?: Map<string, PatchRejectionInfo>

--- a/src/canvas/conversation/__tests__/chipActionVocabulary.spec.ts
+++ b/src/canvas/conversation/__tests__/chipActionVocabulary.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * ROADMAP 2.668 — the chip render vocabulary is DERIVED, and stays derived.
+ *
+ * These are the agreement guards. They cannot prove the vocabulary is COMPLETE
+ * (trap 12d: derivation moves that risk, it does not remove it) — the corpus in
+ * `proposeConfirmChipRender.spec.tsx` is the instrument for completeness, and
+ * neither file supersedes the other.
+ *
+ * What each guard here is for:
+ *   - "no silent drop" is the anti-regression pin. It is true by construction
+ *     today, which is the point: it goes RED the moment anyone replaces the
+ *     derivation with a hand list that has gone short — the exact failure this
+ *     row exists to close, and the one a green suite hid for months.
+ *   - "no promise without delivery" is the safety direction: nothing renders as
+ *     executable that the wire would strip or the dispatcher would default.
+ *   - the synthetic-registry cases drive the predicate directly so the AND is
+ *     proven to bite, rather than being inferred from a composed result that
+ *     could hold for another reason.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { ActionType } from '@talchain/schemas/boundary'
+
+import {
+  V5_ENABLED_ACTIONS,
+  UI_LOCAL_RENDERABLE_ACTION_TYPES,
+  isHonestlyDispatchableAction,
+} from '../chipActionVocabulary'
+import { ACTION_TO_TURN_TYPE, DISPATCHABLE_ACTION_TYPES } from '../actionTurnTypes'
+import {
+  KNOWN_ACTION_TYPES,
+  CEE_ACCEPTED_ACTION_TYPES,
+  isSendableToken,
+} from '../../../v5/buildPayload'
+
+describe('chip render vocabulary — derived from the wire, never mirrored', () => {
+  it('NO SILENT DROP: every known, CEE-accepted, dispatchable action renders', () => {
+    // The union assertion. If CEE's vocabulary grows a value that this client
+    // both accepts and dispatches, it MUST be renderable — a chip CEE emits and
+    // the UI deletes is the 2.668 defect, whatever the value.
+    const shouldRender = ActionType.options.filter(
+      (t) =>
+        isSendableToken(t, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES) &&
+        DISPATCHABLE_ACTION_TYPES.has(t),
+    )
+    const dropped = shouldRender.filter((t) => !V5_ENABLED_ACTIONS.has(t))
+    expect(dropped, `these would be filtered out of the chip row: ${dropped.join(', ')}`).toEqual([])
+  })
+
+  it('the three graph-mutation actions — the whole propose-confirm channel — render', () => {
+    // Named explicitly because they are the ones that were missing, and because
+    // a derived guard passing says nothing about WHICH values it covered.
+    // `intentToActionType` emits exactly these three.
+    for (const actionType of ['add_constraint', 'set_factor_value', 'adjust_edge_strength']) {
+      expect(V5_ENABLED_ACTIONS.has(actionType), `${actionType} must render`).toBe(true)
+    }
+  })
+
+  it('NO PROMISE WITHOUT DELIVERY: every wire action it renders survives the send gate and has a mapping', () => {
+    for (const actionType of V5_ENABLED_ACTIONS) {
+      if (!KNOWN_ACTION_TYPES.has(actionType as never)) continue // pre-enum carve-out, below
+      expect(
+        isSendableToken(actionType, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES),
+        `${actionType} renders but would be STRIPPED at the wire`,
+      ).toBe(true)
+      expect(
+        DISPATCHABLE_ACTION_TYPES.has(actionType),
+        `${actionType} renders but has no ACTION_TO_TURN_TYPE mapping — it would fall through to the default turn`,
+      ).toBe(true)
+    }
+  })
+
+  it('the pre-enum carve-out is disjoint from the wire vocabulary, so it can never mask drift', () => {
+    // If a wire value could be hand-listed in the carve-out, the derivation
+    // would be bypassable and the mirror would be back. It cannot be.
+    for (const actionType of UI_LOCAL_RENDERABLE_ACTION_TYPES) {
+      expect(
+        KNOWN_ACTION_TYPES.has(actionType as never),
+        `${actionType} is in the wire enum and must be derived, not carved out`,
+      ).toBe(false)
+    }
+  })
+
+  it('excluded enum values are excluded for a DERIVABLE reason, never a remembered one', () => {
+    // The list this replaced pinned six exclusions with prose reasons, three of
+    // which had gone false. Each exclusion must now be explainable by the two
+    // conjuncts alone.
+    const excluded = ActionType.options.filter((t) => !V5_ENABLED_ACTIONS.has(t))
+    for (const actionType of excluded) {
+      const sendable = isSendableToken(actionType, KNOWN_ACTION_TYPES, CEE_ACCEPTED_ACTION_TYPES)
+      const dispatchable = DISPATCHABLE_ACTION_TYPES.has(actionType)
+      expect(
+        sendable && dispatchable,
+        `${actionType} is excluded but satisfies both conjuncts — the exclusion has no derivable reason`,
+      ).toBe(false)
+    }
+  })
+
+  it('DISPATCHABLE_ACTION_TYPES uses own keys only, not prototype members', () => {
+    // `'constructor' in ACTION_TO_TURN_TYPE` is true on any object literal. A
+    // membership test written with `in` would admit every Object.prototype
+    // member as a dispatchable action.
+    expect(DISPATCHABLE_ACTION_TYPES.has('constructor')).toBe(false)
+    expect(DISPATCHABLE_ACTION_TYPES.has('toString')).toBe(false)
+    expect(DISPATCHABLE_ACTION_TYPES.has('add_constraint')).toBe(true)
+    expect(new Set(DISPATCHABLE_ACTION_TYPES)).toEqual(new Set(Object.keys(ACTION_TO_TURN_TYPE)))
+  })
+})
+
+describe('isHonestlyDispatchableAction — the AND bites, proven on synthetic registries', () => {
+  const published = new Set(['alpha', 'beta', 'gamma'])
+  const accepted = new Set(['alpha', 'beta'])
+  const dispatchable = new Set(['alpha', 'gamma'])
+
+  it('admits a token only when all three hold', () => {
+    expect(isHonestlyDispatchableAction('alpha', published, accepted, dispatchable)).toBe(true)
+  })
+
+  it('publication + acceptance alone is not enough — no dispatch mapping', () => {
+    expect(isHonestlyDispatchableAction('beta', published, accepted, dispatchable)).toBe(false)
+  })
+
+  it('publication + dispatchability alone is not enough — CEE does not accept it', () => {
+    expect(isHonestlyDispatchableAction('gamma', published, accepted, dispatchable)).toBe(false)
+  })
+
+  it('an unpublished token is never admitted, however else it is registered', () => {
+    expect(
+      isHonestlyDispatchableAction('delta', published, new Set(['delta']), new Set(['delta'])),
+    ).toBe(false)
+  })
+})

--- a/src/canvas/conversation/__tests__/proposeConfirmChipRender.spec.tsx
+++ b/src/canvas/conversation/__tests__/proposeConfirmChipRender.spec.tsx
@@ -1,0 +1,333 @@
+/**
+ * ROADMAP 2.668 — the propose-confirm consent chip must REACH THE USER.
+ *
+ * ─── The corpus, and why it is the instrument that matters ─────────────────
+ * `chipActionVocabulary.spec.ts` proves the render vocabulary AGREES with the
+ * wire and the dispatcher. Agreement is not enough (trap 12d): a derived guard
+ * is structurally blind to a vocabulary that is SHORT, and the whole 2.668
+ * defect was a vocabulary that was short. Only a corpus written from what CEE
+ * was MEASURED emitting can notice that — so this file is hand-written from
+ * captured producer shapes, deliberately, and must stay that way.
+ *
+ * Capture provenance: CEE #839's full-route probe (recorded in ROADMAP 2.663,
+ * 2026-08-07) on the #836 warrantless-mutation demotion path. CEE's step2 gate
+ * judges the warrant absent, demotes the `add_constraint` op to an OFFER, and
+ * emits it as a `suggested_actions` entry paired with a `pending_actions`
+ * confirmation record. The 2026-08-06 live consent witness saw the other end of
+ * the same turn — `{"event":"v5.turn_executor.mutation_warrant_absent",
+ * "handler_id":"add_constraint","demotion":"offered"}` — and reported "Still NO
+ * propose-confirm CHIP anywhere". The chip was on the wire the whole time.
+ *
+ * The fixture is not trusted on my say-so: every captured action is parsed
+ * through the vendored `ActionSchema` before use, so a shape this suite renders
+ * is provably a shape the contract admits (trap 16 — a fixture you wrote
+ * yourself is not evidence about the wire; parsing it against the producer's
+ * own schema is the closest a unit test gets).
+ *
+ * `pending_actions` is CEE-side state: it is absent from the 0.38.0
+ * `OlumiResponseSchema` (which is `.strict()`) and has no UI consumer. It is
+ * carried in the fixture as the record of the confirmation pair, not as
+ * something the UI reads.
+ *
+ * ─── What is bound, and how ───────────────────────────────────────────────
+ * Rendering is asserted through `ChatThread`, the surface the deployed flags
+ * actually mount (trap 3b): staging serves `VITE_FEATURE_AI_PANEL_V2=true` and
+ * the V5 orchestrator, and the 2026-08-06 witness saw this row live
+ * ("Chat chips offered: [Run analysis] [Review model] …"). Asserting against
+ * `SuggestedChips` in isolation would prove the component works while saying
+ * nothing about whether the thread mounts it.
+ *
+ * Every assertion binds by IDENTITY — the proposal's own `prop_` id and its
+ * verbatim label — never by a value predicate a sibling chip could satisfy
+ * (trap 19). The unknown-action chip in the same render is the discriminating
+ * half: it proves the row is filtering on the named action_type rather than
+ * having simply been switched off.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { ActionSchema } from '@talchain/schemas/boundary'
+
+import { ChatThread } from '../zones/ChatThread'
+import { buildSuggestedActionChips } from '../../../v5/blocks/suggestedActionChips'
+import { buildV5Payload, type BuildV5PayloadInput } from '../../../v5/buildPayload'
+import { ACTION_TO_TURN_TYPE } from '../actionTurnTypes'
+import { useCanvasStore } from '../../store'
+import type { ConversationMessage } from '../types'
+
+// ---------------------------------------------------------------------------
+// Captured producer shapes (CEE #839 full-route probe, ROADMAP 2.663)
+// ---------------------------------------------------------------------------
+
+/** The #836 demotion: a graph mutation held back and offered for confirmation. */
+const DEMOTION_PROPOSAL_ID = 'prop_9f2c41ab'
+const DEMOTION_LABEL = 'Add this limit'
+const DEMOTION_CONFIRM_UTTERANCE =
+  'Yes, add the limit keeping Customer Churn Rate at or below 3%.'
+
+const CAPTURED_DEMOTION_TURN = {
+  suggested_actions: [
+    {
+      id: DEMOTION_PROPOSAL_ID,
+      label: DEMOTION_LABEL,
+      message: DEMOTION_CONFIRM_UTTERANCE,
+      action_type: 'add_constraint',
+    },
+  ],
+  // CEE-side confirmation record for the offered op. No UI consumer; recorded
+  // here because it is what makes the suggested action a CONSENT affordance
+  // rather than a suggestion.
+  pending_actions: [{ kind: 'apply_proposed_change', chip_id: DEMOTION_PROPOSAL_ID }],
+}
+
+/**
+ * The other two members of CEE's registered graph-mutation vocabulary. Same
+ * demotion machinery, same darkness before this fix — `intentToActionType`
+ * emits exactly these three, so a fix that lit only `add_constraint` would
+ * leave two thirds of the channel dark.
+ */
+const CAPTURED_SIBLING_PROPOSALS = [
+  {
+    id: 'prop_setval_01',
+    label: 'Set this value',
+    message: 'Yes, set Customer Churn Rate to 0.03.',
+    action_type: 'set_factor_value',
+  },
+  {
+    id: 'prop_edge_01',
+    label: 'Strengthen this link',
+    message: 'Yes, strengthen the link from Premium Tier Launch to ARPU Uplift.',
+    action_type: 'adjust_edge_strength',
+  },
+]
+
+/**
+ * An action_type outside the wire vocabulary. The allowlist exists partly to
+ * stop these rendering as executable affordances (2.668 I-D) and that must
+ * survive the switch to derivation.
+ */
+const UNKNOWN_ACTION = {
+  id: 'prop_unknown_01',
+  label: 'Do the unknown thing',
+  message: 'Yes, do the unknown thing.',
+  action_type: 'demolish_graph',
+}
+
+function isWireLegal(action: Record<string, unknown>): boolean {
+  return ActionSchema.safeParse(action).success
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: Object.assign((selector: (s: any) => any) => selector({}), {
+    getState: () => ({ setActiveOutputTab: vi.fn() }),
+    setState: vi.fn(),
+  }),
+}))
+
+vi.mock('../../stores/guidanceStore', () => ({
+  useGuidanceStore: Object.assign(
+    (selector: (s: any) => any) => selector({ guidanceItems: [], _dispatchAction: vi.fn() }),
+    {
+      getState: () => ({ guidanceItems: [], _dispatchAction: vi.fn(), dismissItem: vi.fn() }),
+    },
+  ),
+}))
+
+let seq = 0
+function assistantMessage(actionChips: ConversationMessage['actionChips']): ConversationMessage {
+  seq += 1
+  return {
+    id: `msg-${seq}`,
+    role: 'assistant',
+    content: 'You did not ask me to edit the model, so I have not.',
+    timestamp: new Date(),
+    actionChips,
+  }
+}
+
+function renderThread(
+  actions: Array<Record<string, unknown>>,
+  onChipClick = vi.fn().mockResolvedValue(undefined),
+) {
+  const chips = buildSuggestedActionChips([], actions as any)
+  render(
+    <ChatThread
+      messages={[assistantMessage(chips)]}
+      isThinking={false}
+      longRunningHint={null}
+      nodeCount={17}
+      patchBlockStates={new Map()}
+      patchRejections={new Map()}
+      onChipClick={onChipClick}
+      onPatchAccept={vi.fn()}
+      onPatchDismiss={vi.fn()}
+      onFeedback={vi.fn()}
+      onRetry={vi.fn()}
+    />,
+  )
+  return { chips, onChipClick }
+}
+
+beforeEach(() => {
+  // Staging posture: the V5 orchestrator is the exclusive CEE path, which is
+  // what switches the action_type filter on. With V5 off every chip passes
+  // through unfiltered and this suite would prove nothing.
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+  Element.prototype.scrollIntoView = vi.fn()
+  useCanvasStore.setState({ ceeAnalysisReady: null as any })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  useCanvasStore.setState({ ceeAnalysisReady: null as any })
+})
+
+// ---------------------------------------------------------------------------
+// Fixture preconditions — pinned in-test, so the discriminators cannot rot
+// ---------------------------------------------------------------------------
+
+describe('2.668 fixture preconditions', () => {
+  it('every captured proposal is a wire-legal Action the contract admits', () => {
+    // Without this, a typo in a fixture would produce a chip the producer could
+    // never send, and the suite would be measuring a shape that does not exist.
+    for (const action of [
+      CAPTURED_DEMOTION_TURN.suggested_actions[0],
+      ...CAPTURED_SIBLING_PROPOSALS,
+    ]) {
+      expect(isWireLegal(action), `${action.id} must parse as an Action`).toBe(true)
+    }
+  })
+
+  it('the unknown-action fixture is genuinely unpublished — its discriminating power is pinned', () => {
+    // The I-D tests below prove unknown actions drop. That proof is only worth
+    // anything while this fixture is actually unknown: if `demolish_graph` were
+    // ever added to the enum, those tests would keep passing while testing
+    // nothing (trap 13b — a guard whose discrimination depends on a fixture
+    // nothing pins). This is that pin.
+    expect(isWireLegal(UNKNOWN_ACTION)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I-A — the chip renders somewhere the user can click it
+// ---------------------------------------------------------------------------
+
+describe('2.668 I-A — a demoted proposal reaches the user as a clickable chip', () => {
+  it('renders the captured #836 add_constraint demotion chip in the thread', () => {
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0]])
+
+    const chip = screen.getByTestId(`suggested-chip-${DEMOTION_PROPOSAL_ID}`)
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveTextContent(DEMOTION_LABEL)
+    expect(chip.tagName).toBe('BUTTON')
+    expect(chip).not.toBeDisabled()
+  })
+
+  it('renders it EXACTLY ONCE — SuggestedChips is the sole surface for actionChips', () => {
+    // Pins the property that survived removing the dead `hideChips` chain: the
+    // thread has one chip surface, so a re-introduced inline row would show up
+    // here as a duplicate rather than silently doubling the consent affordance.
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0]])
+
+    expect(screen.getAllByRole('button', { name: DEMOTION_LABEL })).toHaveLength(1)
+  })
+
+  it('mounts it through the response-chip-group the deployed thread renders', () => {
+    // Binds to the MOUNT PATH, not just to the component: if ChatThread stops
+    // grouping chips with the last assistant message, this fails loud rather
+    // than passing because SuggestedChips still works in isolation.
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0]])
+
+    const group = screen.getByTestId('response-chip-group')
+    expect(group.contains(screen.getByTestId(`suggested-chip-${DEMOTION_PROPOSAL_ID}`))).toBe(true)
+  })
+
+  it('renders all three of the graph-mutation vocabulary, not just add_constraint', () => {
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0], ...CAPTURED_SIBLING_PROPOSALS])
+
+    expect(screen.getByTestId(`suggested-chip-${DEMOTION_PROPOSAL_ID}`)).toBeInTheDocument()
+    for (const sibling of CAPTURED_SIBLING_PROPOSALS) {
+      expect(screen.getByTestId(`suggested-chip-${sibling.id}`)).toBeInTheDocument()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I-D — unknown actions still drop (the discriminating pair)
+// ---------------------------------------------------------------------------
+
+describe('2.668 I-D — the safety property survives derivation', () => {
+  it('drops an unknown action_type while the proposal in the SAME turn renders', () => {
+    // The discriminating pair, in one render. The proposal rendering proves the
+    // row is live; the unknown chip vanishing proves the filter is keyed on the
+    // named action_type and not merely switched off. Either half alone shows
+    // nothing.
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0], UNKNOWN_ACTION])
+
+    expect(screen.getByTestId(`suggested-chip-${DEMOTION_PROPOSAL_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`suggested-chip-${UNKNOWN_ACTION.id}`)).toBeNull()
+    expect(screen.queryByRole('button', { name: UNKNOWN_ACTION.label })).toBeNull()
+  })
+
+  it('drops an unknown action_type even when it is the only chip on the turn', () => {
+    renderThread([UNKNOWN_ACTION])
+
+    expect(screen.queryByTestId(`suggested-chip-${UNKNOWN_ACTION.id}`)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// I-C — the click drives the EXISTING confirm-resume path
+// ---------------------------------------------------------------------------
+
+describe('2.668 I-C — clicking the chip emits the confirm utterance', () => {
+  it('hands the chip to onChipClick carrying the confirm message and the typed action', () => {
+    const onChipClick = vi.fn().mockResolvedValue(undefined)
+    renderThread([CAPTURED_DEMOTION_TURN.suggested_actions[0]], onChipClick)
+
+    fireEvent.click(screen.getByTestId(`suggested-chip-${DEMOTION_PROPOSAL_ID}`))
+
+    expect(onChipClick).toHaveBeenCalledTimes(1)
+    const clicked = onChipClick.mock.calls[0][0]
+    // Bound by identity: this is the PROPOSAL's chip, not some other chip that
+    // happens to carry a message.
+    expect(clicked.id).toBe(DEMOTION_PROPOSAL_ID)
+    expect(clicked.message).toBe(DEMOTION_CONFIRM_UTTERANCE)
+    expect(clicked.action_type).toBe('add_constraint')
+  })
+
+  it('dispatches through the existing deliberate turn mapping, not the default fallback', () => {
+    // `dispatchAction` resolves the turn type from ACTION_TO_TURN_TYPE. A chip
+    // whose action is absent from that map falls through to 'conversation' by
+    // DEFAULT rather than by decision — the "promises action, delivers default
+    // routing" case. This asserts the mapping is deliberate.
+    expect(ACTION_TO_TURN_TYPE['add_constraint']).toBe('conversation')
+    for (const sibling of CAPTURED_SIBLING_PROPOSALS) {
+      expect(ACTION_TO_TURN_TYPE[sibling.action_type]).toBeDefined()
+    }
+  })
+
+  it('keeps the typed action_type on the wire so CEE sees the confirm as warranted', () => {
+    // The confirm-resume warrant (#839 F-B) is judged on the turn CEE receives.
+    // If `sanitiseActionType` stripped `add_constraint`, CEE would see an
+    // untyped chat turn and the chip would be a promise the transport broke.
+    const input: BuildV5PayloadInput = {
+      turnId: '00000000-0000-4000-8000-000000000001',
+      scenarioId: '00000000-0000-4000-8000-000000000002',
+      stage: 'analyse',
+      turnClass: 'frame',
+      mode: 'user',
+      message: DEMOTION_CONFIRM_UTTERANCE,
+      source: 'chip',
+      chipMeta: { id: DEMOTION_PROPOSAL_ID, action_type: 'add_constraint' },
+    }
+    const build = buildV5Payload(input)
+    if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+    const payload = build.payload as { chip?: { action_type?: string } }
+    expect(payload.chip?.action_type).toBe('add_constraint')
+  })
+})

--- a/src/canvas/conversation/actionTurnTypes.ts
+++ b/src/canvas/conversation/actionTurnTypes.ts
@@ -1,0 +1,60 @@
+/**
+ * actionTurnTypes — the deterministic `action_type` → turn-type dispatch map.
+ *
+ * EXTRACTED from `useConversation.ts` (2026-08-07, ROADMAP 2.668) so that the
+ * chip RENDER gate can be DERIVED from it. `useConversation` re-exports
+ * `ACTION_TO_TURN_TYPE` unchanged, so every existing importer is unaffected.
+ *
+ * Why the extraction was necessary rather than cosmetic: the render gate
+ * (`chipActionVocabulary`) has to answer "would a click on this chip dispatch
+ * to a turn type chosen for it, or fall through to the default?" — and the
+ * only honest source for that is this map. Importing the 6,000-line
+ * `useConversation` hook module into `SuggestedChips` to read one constant
+ * would drag stores, services and React hooks into a leaf component's module
+ * graph. The constant is data; it belongs in a data module.
+ */
+import type { TurnType } from '../../services/turn-request-builder'
+
+/** Deterministic action_type → turn type mapping. Falls back to 'conversation' for unknown actions. Exported for tests. */
+export const ACTION_TO_TURN_TYPE: Record<string, Exclude<TurnType, 'system_event'>> = {
+  run_analysis: 'run_analysis',
+  // V5 backend handler ID is the PLURAL `explain_results` (see backend
+  // `src/orchestrator-v5/handlers/chip-click-dispatch.ts:137-141` whitelist +
+  // `src/orchestrator-v5/compose/chip-generator.ts` chip emission, post-
+  // Phase-2b). Singular `explain_result` retained as a legacy alias because
+  // the chip-generator's `promptChip(...)` used it as a discriminator string
+  // for years and existing chip surfaces still emit it; either form must
+  // reach the same 'explain' turn type so dispatch is consistent and the
+  // deterministic chip-click bypass fires regardless of which alias the
+  // chip carries.
+  explain_result: 'explain',
+  explain_results: 'explain',
+  compare_options: 'explain',
+  what_would_flip: 'explain',
+  // F2 CHANGE B (2026-07-22): the "What changed?" pill is an analytical
+  // comparison — same explanation class as what_would_flip / compare_options,
+  // so it dispatches as an 'explain' turn (correct timeout class + local
+  // handling). The CEE answer is a direct_answer run-over-run delta.
+  what_changed: 'explain',
+  challenge_assumption: 'conversation',
+  set_factor_value: 'conversation',
+  add_factor: 'conversation',
+  add_option: 'conversation',
+  add_constraint: 'conversation',
+  adjust_edge_strength: 'conversation',
+  remove_factor: 'conversation',
+  set_goal_target: 'conversation',
+  run_premortem: 'explain',
+  draft_graph: 'explicit_generate',
+}
+
+/**
+ * The action types this client dispatches DELIBERATELY (own keys only).
+ *
+ * `Object.keys`, not `in`: `'constructor' in ACTION_TO_TURN_TYPE` is `true`
+ * on any object literal, so a membership test written with `in` would silently
+ * treat every `Object.prototype` member as a dispatchable action.
+ */
+export const DISPATCHABLE_ACTION_TYPES: ReadonlySet<string> = new Set(
+  Object.keys(ACTION_TO_TURN_TYPE),
+)

--- a/src/canvas/conversation/chipActionVocabulary.ts
+++ b/src/canvas/conversation/chipActionVocabulary.ts
@@ -1,0 +1,123 @@
+/**
+ * chipActionVocabulary — WHICH `action_type` a CEE-suggested chip may render
+ * with. DERIVED. Never a hand list.
+ *
+ * ─── The defect this module exists to close (ROADMAP 2.668) ────────────────
+ * `V5_ENABLED_ACTIONS` lived in `SuggestedChips.tsx` as a hand-maintained
+ * allowlist of seven strings. It was missing `add_constraint`,
+ * `set_factor_value` and `adjust_edge_strength` — which is to say, ALL THREE
+ * of CEE's registered graph-mutation handlers, i.e. every chip the
+ * propose-confirm channel can mint. Consequence, measured end-to-end on
+ * 2026-08-07 (CEE #839's F-A probe, at UI `d18ac8b9`): CEE emitted the #836
+ * demotion chip correctly — `suggested_actions:[{action_type:'add_constraint',
+ * …}]` with its paired `pending_actions` confirmation — the chip travelled the
+ * whole wire, and the UI's filter deleted it on arrival. The ENTIRE
+ * propose-confirm consent channel was dark UI-side, for every producer, and
+ * the only user-visible symptom was prose where a button should have been:
+ * offer → "yes, please" → "You did not ask me to edit the model".
+ *
+ * The 2026-08-06 live consent witness recorded the same fact from the other
+ * side: "Still NO propose-confirm CHIP anywhere — every demotion so far
+ * arrives as prose". The chip was never missing. It was filtered.
+ *
+ * ─── Why a list could not survive, and what replaces it ────────────────────
+ * The list was the dominant Olumi defect class (trap 12: the hand-maintained
+ * mirror). It drifted silently, and the drift read as green — there was even a
+ * spec PINNING the six exclusions as correct, with prose reasons that had gone
+ * false. Adding three strings would have re-armed exactly the same trap.
+ *
+ * So the set is derived from the two facts that actually decide whether
+ * rendering a chip is HONEST — meaning a click does what the chip's label
+ * promises rather than degrading into an ordinary chat turn:
+ *
+ *   1. THE CLICK REACHES CEE WITH ITS INTENT INTACT.
+ *      `buildPayload.sanitiseActionType` sends an `action_type` only when it is
+ *      BOTH published in the enum we vendored (`KNOWN_ACTION_TYPES`, itself
+ *      derived from `@talchain/schemas`) AND accepted at CEE's ingress
+ *      (`CEE_ACCEPTED_ACTION_TYPES`). A value failing that gate is STRIPPED at
+ *      the wire: CEE would receive the message with no typed action at all, and
+ *      the chip would be a promise the transport already broke.
+ *
+ *   2. THE CLICK DISPATCHES TO A TURN TYPE CHOSEN FOR IT.
+ *      `ACTION_TO_TURN_TYPE` is consulted by `dispatchAction`; an action absent
+ *      from it falls through to the `'conversation'` default. That is the
+ *      "promises action, delivers default routing" case the old spec's own
+ *      comment named as the reason to exclude `explain_from_structure`.
+ *
+ * Both conjuncts are read from live code, so the set cannot drift from them.
+ * The exclusions are now DERIVED and self-repairing: `explain_from_structure`
+ * stays out because nothing maps it — and lights up the moment someone adds
+ * the mapping, which is precisely what that old comment asked a future author
+ * to remember to do by hand.
+ *
+ * ─── The safety property this KEEPS (ROADMAP 2.668 I-D) ────────────────────
+ * The allowlist existed partly so an UNKNOWN action_type never renders as an
+ * executable chip. That still holds, and now holds for a derivable reason: an
+ * action_type CEE has not published in the vendored enum satisfies neither
+ * conjunct, so it is absent from the derived set and `SuggestedChips` drops it.
+ * The change is confined to actions that are known, accepted AND dispatchable —
+ * "known-and-proposed" — which are exactly the ones that were being dropped by
+ * mistake.
+ *
+ * ─── What derivation CANNOT prove, and what is shipped alongside ───────────
+ * Trap 12d: a derived guard proves the copies AGREE; it can never prove the
+ * source list is COMPLETE. If `ActionType` itself were short a member, every
+ * derived guard here would stay green. So this module ships with BOTH kinds of
+ * guard, and neither supersedes the other:
+ *   - derived invariants (`chipActionVocabulary.spec.ts`) — no known,
+ *     accepted, dispatchable action may be dropped, and nothing renders that
+ *     the wire or the dispatcher would degrade;
+ *   - a hand-written CORPUS of real producer-captured response shapes
+ *     (`proposeConfirmChipRender.spec.tsx`) — the only instrument that can
+ *     notice the vocabulary is short, because it is written from what CEE was
+ *     MEASURED emitting, not from our own list.
+ */
+import {
+  KNOWN_ACTION_TYPES,
+  CEE_ACCEPTED_ACTION_TYPES,
+  isSendableToken,
+} from '../../v5/buildPayload'
+import { DISPATCHABLE_ACTION_TYPES } from './actionTurnTypes'
+
+/**
+ * Action types this client renders that are NOT in the wire vocabulary at all.
+ *
+ * `edit_graph` and `draft_graph` predate `ActionType` and are absent from the
+ * vendored enum, so conjunct 1 can never admit them; they are carried here to
+ * preserve existing behaviour rather than silently withdrawn by the switch to
+ * derivation. Being outside the enum is what makes the carve-out safe: it is
+ * provably disjoint from the wire vocabulary (pinned in the spec), so it can
+ * never mask a drift in the derived set — a wire value can never hide here.
+ */
+export const UI_LOCAL_RENDERABLE_ACTION_TYPES: ReadonlySet<string> = new Set<string>([
+  'edit_graph',
+  'draft_graph',
+])
+
+/**
+ * Is this a wire action_type whose click would be honest — reaching CEE typed
+ * (conjunct 1) AND dispatching to a turn type chosen for it (conjunct 2)?
+ *
+ * Exported so the spec can drive it with SYNTHETIC registries and prove the AND
+ * actually bites, rather than only observing the composed result.
+ */
+export function isHonestlyDispatchableAction(
+  actionType: string,
+  published: ReadonlySet<string> = KNOWN_ACTION_TYPES,
+  accepted: ReadonlySet<string> = CEE_ACCEPTED_ACTION_TYPES,
+  dispatchable: ReadonlySet<string> = DISPATCHABLE_ACTION_TYPES,
+): boolean {
+  return isSendableToken(actionType, published, accepted) && dispatchable.has(actionType)
+}
+
+/**
+ * The chip RENDER vocabulary. Chips whose `action_type` is set and absent from
+ * this set are filtered out by `SuggestedChips` when V5 is active.
+ *
+ * Derived at module load from the wire vocabulary + the dispatch map; the only
+ * hand-written contribution is the pre-enum carve-out above.
+ */
+export const V5_ENABLED_ACTIONS: ReadonlySet<string> = new Set<string>([
+  ...[...KNOWN_ACTION_TYPES].filter((t) => isHonestlyDispatchableAction(t)),
+  ...UI_LOCAL_RENDERABLE_ACTION_TYPES,
+])

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -38,6 +38,7 @@ import {
 } from '../../v5/failureTypeRetryability'
 import { mapV5Blocks } from '../../v5/blocks/mapV5Blocks'
 import { buildSuggestedActionChips } from '../../v5/blocks/suggestedActionChips'
+import { ACTION_TO_TURN_TYPE } from './actionTurnTypes'
 import { deriveV5Stage, v5StageToScenarioStage } from '../../v5/stageMapper'
 import { applyV5State } from '../../v5/applyV5State'
 import {
@@ -2088,38 +2089,15 @@ export interface PatchRejectionInfo {
   violations?: string[]
 }
 
-/** Deterministic action_type → turn type mapping. Falls back to 'conversation' for unknown actions. Exported for tests. */
-export const ACTION_TO_TURN_TYPE: Record<string, Exclude<TurnType, 'system_event'>> = {
-  run_analysis: 'run_analysis',
-  // V5 backend handler ID is the PLURAL `explain_results` (see backend
-  // `src/orchestrator-v5/handlers/chip-click-dispatch.ts:137-141` whitelist +
-  // `src/orchestrator-v5/compose/chip-generator.ts` chip emission, post-
-  // Phase-2b). Singular `explain_result` retained as a legacy alias because
-  // the chip-generator's `promptChip(...)` used it as a discriminator string
-  // for years and existing chip surfaces still emit it; either form must
-  // reach the same 'explain' turn type so dispatch is consistent and the
-  // deterministic chip-click bypass fires regardless of which alias the
-  // chip carries.
-  explain_result: 'explain',
-  explain_results: 'explain',
-  compare_options: 'explain',
-  what_would_flip: 'explain',
-  // F2 CHANGE B (2026-07-22): the "What changed?" pill is an analytical
-  // comparison — same explanation class as what_would_flip / compare_options,
-  // so it dispatches as an 'explain' turn (correct timeout class + local
-  // handling). The CEE answer is a direct_answer run-over-run delta.
-  what_changed: 'explain',
-  challenge_assumption: 'conversation',
-  set_factor_value: 'conversation',
-  add_factor: 'conversation',
-  add_option: 'conversation',
-  add_constraint: 'conversation',
-  adjust_edge_strength: 'conversation',
-  remove_factor: 'conversation',
-  set_goal_target: 'conversation',
-  run_premortem: 'explain',
-  draft_graph: 'explicit_generate',
-}
+/**
+ * Deterministic action_type → turn type mapping. Falls back to 'conversation'
+ * for unknown actions.
+ *
+ * MOVED to `./actionTurnTypes` (2026-08-07, ROADMAP 2.668) so the chip RENDER
+ * gate can derive from it without importing this hook module. Re-exported here
+ * unchanged — this is the same object, not a copy, so no mirror exists.
+ */
+export { ACTION_TO_TURN_TYPE }
 
 /** Source surface for action dispatch — used for logging and telemetry */
 export type ActionSource = 'chip' | 'insight' | 'canvas_coaching' | 'pre_analysis' | 'guidance' | 'inspector' | 'base_rate'

--- a/src/canvas/conversation/zones/ChatMessage.tsx
+++ b/src/canvas/conversation/zones/ChatMessage.tsx
@@ -36,9 +36,6 @@ const CATEGORY_BORDER: Record<MessageCategory, string> = {
 interface ChatMessageProps {
   message: ConversationMessage
   isFirst: boolean
-  /** When true, suppress inline ActionChipRow (chips rendered externally by SuggestedChips) */
-  hideChips?: boolean
-  /** When true, inline chips are visible but non-interactive (historical turn) */
   onChipClick: (chip: ActionChip) => Promise<void>
   onRetry: () => void
   patchBlockStates?: Map<string, PatchBlockState>
@@ -61,7 +58,6 @@ interface ChatMessageProps {
 export const ChatMessage = memo(function ChatMessage({
   message,
   isFirst,
-  hideChips,
   onChipClick,
   onRetry,
   patchBlockStates,
@@ -103,7 +99,6 @@ export const ChatMessage = memo(function ChatMessage({
 
       <MessageBubble
         message={message}
-        hideChips={hideChips}
         onChipClick={onChipClick}
         patchBlockStates={patchBlockStates}
         patchRejections={patchRejections}

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -15,7 +15,6 @@ import { ChatMessage } from './ChatMessage'
 import { SessionDivider } from '../primitives/SessionDivider'
 import { ThinkingIndicator } from './ThinkingIndicator'
 import { SuggestedChips } from './SuggestedChips'
-import { isChipRenderable } from '../chipDispatch'
 import type { ConversationMessage, ActionChip, GraphPatchBlock } from '../types'
 import type { PatchBlockState, PatchRejectionInfo } from '../useConversation'
 
@@ -118,14 +117,19 @@ export const ChatThread = memo(function ChatThread({
   const failedSendRetryId =
     lastUserMsg && lastUserMsg.deliveryState === 'failed' ? lastUserMsg.id : null
 
-  // Get suggested chips from last assistant message
+  // Get suggested chips from last assistant message.
+  //
+  // `SuggestedChips` below is the SOLE render surface for `actionChips`
+  // (verified at 4fbc6451: `<ActionChipRow` has zero production render sites,
+  // and `MessageBubble` renders no chips). Until 2026-08-07 this line was
+  // followed by a `suggestedChipsWillRender` predicate feeding a `hideChips`
+  // prop down ChatMessage → MessageBubble to "suppress the inline
+  // ActionChipRow". MessageBubble declared that prop and never destructured
+  // it: the whole chain was inert, and its comments described a suppression
+  // mechanism that no longer had anything to suppress. Removed rather than
+  // re-documented — a dead guard that reads as a live one is how ROADMAP
+  // 2.668's second defect came to be diagnosed against this file at all.
   const suggestedChips = lastAssistantMsg?.actionChips ?? []
-  // Only hide inline chips when SuggestedChips will actually render something.
-  // ROADMAP 2.138: this used to be a THIRD hand-written copy of the render rule
-  // (`!!c.message`) that had already drifted from SuggestedChips' own copy
-  // (`message || prompt`). It now calls the same predicate the row calls, so the
-  // mirror cannot drift again.
-  const suggestedChipsWillRender = suggestedChips.some(isChipRenderable)
 
   return (
     <div
@@ -158,7 +162,6 @@ export const ChatThread = memo(function ChatThread({
             key={msg.id}
             message={msg}
             isFirst={i === 0}
-            hideChips={isLastAssistant && suggestedChipsWillRender}
             onChipClick={onChipClick}
             onRetry={onRetry}
             showFailedSendRetry={msg.id === failedSendRetryId}

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -25,35 +25,20 @@ import { useCanvasStore } from '../../store'
 import { type FreshnessDisplaySemantic } from '../../store/analysisFreshness'
 import { useAnalysisTrust } from '../../hooks/useAnalysisTrust'
 import { isChipRenderable } from '../chipDispatch'
+import { V5_ENABLED_ACTIONS } from '../chipActionVocabulary'
 import type { ActionChip } from '../types'
 
 // Actions that V5 CEE handles end-to-end. Chips whose action_type is set and
-// not in this list are filtered out when V5 is active. On V4 this set is
+// not in this set are filtered out when V5 is active. On V4 the set is
 // unused — all chips pass through unchanged.
 //
-// Phase 2b of the V5 completion plan (2026-05-13): added `explain_results`
-// and `what_would_flip`. Backend PR olumi-assistants-service#170 emits these
-// as executable `action_type` chips and the new
-// `dispatchDeterministicChipClick` path bypasses Sonnet ORIENT (~12s saved
-// per click). Without these entries here, the V5 UI's filter below would
-// HIDE the new executable chips, defeating the latency fix entirely.
-export const V5_ENABLED_ACTIONS = new Set<string>([
-  'run_analysis',
-  'edit_graph',
-  'draft_graph',
-  'explain_results',
-  // V-P0-2 fold: the schema-valid SINGULAR legacy alias dispatches to the
-  // same 'explain' turn (ACTION_TO_TURN_TYPE) — a producer emitting it must
-  // not have its chip silently hidden.
-  'explain_result',
-  'what_would_flip',
-  // F2 CHANGE B (2026-07-22): the typed door for the "What changed?" pill.
-  // A CEE-emitted / product `what_changed` chip must render as an enabled,
-  // dispatchable action; without it the V5 filter below would HIDE it. Its
-  // wire counterpart is CEE_ACCEPTED_ACTION_TYPES in buildPayload.ts and CEE
-  // PR #620 (the accepting service half). See parallel-briefs/F2B-BYTE-CONFIRM.
-  'what_changed',
-])
+// DERIVED, not listed (ROADMAP 2.668). This used to be seven hand-written
+// strings, and the three missing ones were CEE's entire graph-mutation
+// vocabulary — so every propose-confirm consent chip CEE emitted was deleted
+// here on arrival. `chipActionVocabulary` now derives the set from the wire
+// send gate + the dispatch map; read that module for the full account.
+// Re-exported from here because this is where importers have always found it.
+export { V5_ENABLED_ACTIONS }
 
 // Chips whose action_type is in this set require analysis readiness
 // (ceeAnalysisReady.status === 'ready') before they can render. Without it,

--- a/src/v5/__tests__/explainChips.vocabulary.spec.ts
+++ b/src/v5/__tests__/explainChips.vocabulary.spec.ts
@@ -67,27 +67,29 @@ describe('explain-chips vocabulary — parser → filter seam (V-P0-2)', () => {
     expect(V5_ENABLED_ACTIONS.has('explain_results')).toBe(true)
   })
 
-  it('schema-enum values the filter deliberately EXCLUDES are exactly the documented list — a new enum/emitter value forces a decision here', () => {
-    // These are schema-valid on the wire but have no chip affordance:
-    // set_factor_value/add_constraint/adjust_edge_strength/compare_options
-    // have no V5 end-to-end chip handler; explain_from_structure has no
-    // ACTION_TO_TURN_TYPE dispatch mapping yet (rendering it would promise
-    // action and deliver default routing — add filter + mapping together).
-    // analysis_readiness (added to the enum in schemas 0.20.0) is an OUTBOUND
-    // spark-send intent — the UI sends it as a spark's chip.action_type; it is
-    // never a chip CEE SUGGESTS back for us to render, so it deliberately has
-    // no V5_ENABLED_ACTIONS affordance and belongs here.
+  it('schema-enum values the filter EXCLUDES are exactly those with no dispatch mapping', () => {
+    // ⚠ CORRECTED 2026-08-07 (ROADMAP 2.668). This assertion used to pin SIX
+    // exclusions with hand-written reasons, and three of those reasons had gone
+    // FALSE while the test stayed green — the defect this file's own header
+    // warns about, committed inside the guard written to prevent it.
+    //
+    // The false claim was that set_factor_value / add_constraint /
+    // adjust_edge_strength "have no V5 end-to-end chip handler". They are CEE's
+    // three REGISTERED graph-mutation handlers (witnessed in the deployed
+    // handler registry, 2026-08-06) and the entire propose-confirm consent
+    // channel is minted from them. CEE emitted those chips; this filter deleted
+    // them on arrival, and this test certified the deletion as correct.
+    // `compare_options` was excluded on the same false ground.
+    //
+    // Two exclusions remain and both are now DERIVED rather than remembered:
+    // `explain_from_structure` and `analysis_readiness` have no
+    // ACTION_TO_TURN_TYPE mapping, so a click would fall through to the default
+    // turn type — the "promises action, delivers default routing" case the old
+    // comment named. Add the mapping and the chip lights up on its own; nobody
+    // has to remember to edit a list. The general form of this assertion lives
+    // in chipActionVocabulary.spec.ts ("excluded for a DERIVABLE reason").
     const excluded = ActionType.options.filter((t) => !V5_ENABLED_ACTIONS.has(t))
-    expect(new Set(excluded)).toEqual(
-      new Set([
-        'set_factor_value',
-        'add_constraint',
-        'adjust_edge_strength',
-        'compare_options',
-        'explain_from_structure',
-        'analysis_readiness',
-      ]),
-    )
+    expect(new Set(excluded)).toEqual(new Set(['explain_from_structure', 'analysis_readiness']))
   })
 
   it('the debug-bundle turn selector recognises the explain chip vocabulary (review fold)', () => {


### PR DESCRIPTION
## The defect

CEE emits the #836 demotion's propose-confirm chip correctly — the full-route probe (ROADMAP 2.663) showed `suggested_actions:[{action_type:"add_constraint", …}]` with its paired `pending_actions` on the wire. **The UI deleted it on arrival.**

`V5_ENABLED_ACTIONS` (`SuggestedChips.tsx`) was a hand-maintained allowlist of seven strings missing `add_constraint`, `set_factor_value` and `adjust_edge_strength` — CEE's entire registered graph-mutation vocabulary, i.e. every chip the propose-confirm channel can mint, for every producer. **The whole consent channel was dark UI-side**, and the only user-visible symptom was prose where a button should have been:

> offer → "Yes, please rephrase as you offered" → "You did not ask me to edit the model"

The 2026-08-06 live consent witness saw the other end of the same turn (`mutation_warrant_absent … demotion:"offered"`) and reported *"Still NO propose-confirm CHIP anywhere"*. The chip was never missing. It was filtered.

## The fix — derived, not re-listed

Adding three strings would have re-armed the same trap. There was already a spec **pinning the six exclusions as correct**, with prose reasons that had gone false — certifying the deletion.

`chipActionVocabulary.ts` now derives the set from the two facts that decide whether rendering a chip is honest:

1. **the click reaches CEE typed** — `isSendableToken(KNOWN_ACTION_TYPES ∧ CEE_ACCEPTED_ACTION_TYPES)`, the existing wire send gate. A value failing it is *stripped* at the wire.
2. **the click dispatches to a turn type chosen for it** — membership in `ACTION_TO_TURN_TYPE`. Absent ⇒ falls through to the `'conversation'` default: the "promises action, delivers default routing" case the old comment named.

Net vocabulary change: `+add_constraint +set_factor_value +adjust_edge_strength +compare_options`. Exclusions (`explain_from_structure`, `analysis_readiness`) are now **derived and self-repairing** — add the dispatch mapping and the chip lights up; nobody has to remember to edit a list.

**I-D safety kept**: an unknown `action_type` satisfies neither conjunct, so it still drops — now for a derivable reason.

`ACTION_TO_TURN_TYPE` moved to `actionTurnTypes.ts` and re-exported unchanged from `useConversation` (same object, no mirror), so the render gate can read it without dragging a 6,000-line hook module into a leaf component.

## Second defect: falsified at the tip, corrected

Row 2.668 named `ChatThread.tsx:128` as suppressing an inline chip row. **At `4fbc6451` there is no inline chip row.** `<ActionChipRow` has **zero production render sites** and `MessageBubble` declared `hideChips` and never destructured it. The chain was inert while its comments described a live suppression mechanism — which is why the defect was diagnosed against that file. Dead chain removed; `SuggestedChips` as the sole `actionChips` surface is now pinned by test.

## Evidence

- **RED-first at `4fbc6451`** (isolated worktree, write-test isolation proof): 6 failed / 5 passed. The passes are the properties that already held (unknown-drops, wire parity) — an honest baseline, not a rigged one.
- **10 mutants**, applied-check `src/`-scoped, control exactly zero, collected-count asserted equal to pristine (48) on every run:
  - 8 bite: remove `add_constraint` from `CEE_ACCEPTED` (9 RED) · revert to the old hand list (10 RED) · unknowns pass the filter (3 RED) · drop the filter entirely (9 RED) · remove the dispatch mapping (10 RED) · duplicate the chip row (8 RED) · prototype members admitted as dispatchable (1 RED) · test-rot: the unknown fixture becomes published (3 RED, caught by its own precondition pin).
  - **2 discriminating twins stay GREEN** (trap 19 pair): admitting a *different* unknown token leaves I-D green; breaking a *different* wire action leaves the proposal tests green. The tests bind to their named objects, not to "some chip rendered".
- **Trap 12d demonstrated, not asserted**: mutant M1 left the derived "no silent drop" guard **GREEN** while the hand-written corpus went RED. Derivation is structurally blind to a short source list. Both guards ship; neither supersedes the other.
- Gates at my tip: `pnpm run typecheck` ✅ (3276/3316 files, ratchet within baseline) · `pnpm run lint` ✅ (0 errors; hooks ratchet exact) · full suite **1534 files / 22386 passed, 0 failed** (inspector-v2 collected 37 files / 380 tests — no shrink).
- Typecheck baseline `--update-baseline` **declined**: its 3-diagnostic shrink is attribution churn in `BaselineTargetRow.tsx`, a file this PR never touches.

## Owed

Live staging witness of a demotion chip rendering and clicking through — the acceptance for the whole consent chain.