### PR TITLE
feat(2.638 S2): disclose and reverse a human confirmation (P4)

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -47,7 +47,7 @@ import { StatusBar } from './model-tab/StatusBar'
 import { EntityBar } from './model-tab/EntityBar'
 import { StreamingDiagnostics } from './model-tab/StreamingDiagnostics'
 import { buildSynthesisedPriorMap } from './model-tab/synthesisedPriorHelpers'
-import { countFactorsToVerify } from './model-tab/utils'
+import { countFactorsToVerify, mapSourceToDisplay } from './model-tab/utils'
 import { ModelAdjustments } from './model-tab/ModelAdjustments'
 import { resolveRawFactorConfidenceDisplay, type FactorConfidenceDisplay } from '../../components/results/driverConfidenceDisplayPolicy'
 
@@ -75,17 +75,13 @@ interface ModelTabBodyProps {
 }
 
 // ── Source mapping ────────────────────────────────────────────────────────────
-
-const SOURCE_LABELS: Record<string, string> = {
-  brief_extraction: 'From brief',
-  cee_inference: 'AI estimate',
-  user: 'User edited',
-}
-
-function mapSourceToDisplay(source: string | undefined): string | null {
-  if (!source) return null
-  return SOURCE_LABELS[source] ?? source
-}
+//
+// ROADMAP 2.638 S2 — this file used to carry its OWN copy of the three-literal
+// `SOURCE_LABELS` map, byte-identical to `model-tab/utils.ts`'s. It feeds
+// `handleCopyText`, so a source outside the three landed in the user's
+// clipboard as the raw wire literal ("user_confirmed"). The duplicate is gone;
+// the one classification authority now serves both (trap 12: derive, do not
+// mirror).
 
 const KIND_ORDER = ['goal', 'decision', 'option', 'factor', 'risk', 'outcome'] as const
 const EMPTY_NODE_IDS = new Set<string>()

--- a/src/canvas/components/model-tab/SourceProvenancePill.tsx
+++ b/src/canvas/components/model-tab/SourceProvenancePill.tsx
@@ -1,14 +1,33 @@
 /**
  * SourceProvenancePill — outlined pill showing factor/goal value provenance.
  *
- * Maps:
- *   'brief_extraction' → "From brief"   (info border)
- *   'cee_inference'    → "AI estimate"  (warning border)
- *   'user'             → "User edited"  (success border)
- *   undefined/other    → "Not set"      (default border)
+ * Maps (by CLASS, not by literal — see below):
+ *   brief      → "From brief"        (info border)
+ *   ai         → "AI estimate"       (warning border)
+ *   confirmed  → "Confirmed by you"  (success border)
+ *   edited     → "User edited"       (success border)
+ *   assumption → "Your assumption"   (success border)
+ *   unknown    → "Not set"           (default border)
+ *
+ * ⭐ ROADMAP 2.638 S2 — WHAT THIS USED TO DO, AND WHY IT MATTERED.
+ * The map was keyed on three literals. `user_confirmed` and `user_override` —
+ * the two stamps the pre-analysis drill-in and the OutputsDock actually write,
+ * and the ones the Model tab is most likely to be looking at — missed the map
+ * and fell to the FALLBACK, so a value the user had explicitly confirmed
+ * rendered **"Not set"** on a live, unflagged surface. The pill was not merely
+ * silent about the confirmation; it asserted its opposite.
+ *
+ * Keying on the canonical CLASS instead means a new source literal is labelled
+ * the moment it is classified once, rather than in each of the surfaces that
+ * happen to render it (CLAUDE.md trap 12). The record is TOTAL over
+ * `ValueProvenanceKind`, so a new kind is a type error here.
+ *
+ * "Confirmed by you" is a STATUS. Confirming does not change the analysis
+ * today — the compute half is S4 — and this copy must not suggest it does.
  */
 
 import { typography } from '../../../styles/typography'
+import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
 
 interface SourceProvenancePillProps {
   source: string | undefined
@@ -16,16 +35,20 @@ interface SourceProvenancePillProps {
   showWhenAbsent?: boolean
 }
 
-const CONFIG: Record<string, { label: string; border: string }> = {
-  brief_extraction: { label: 'From brief', border: 'border-info/30' },
-  cee_inference:    { label: 'AI estimate', border: 'border-warning/30' },
-  user:             { label: 'User edited', border: 'border-success/30' },
+const CONFIG: Record<ValueProvenanceKind, { label: string; border: string }> = {
+  brief:      { label: 'From brief', border: 'border-info/30' },
+  ai:         { label: 'AI estimate', border: 'border-warning/30' },
+  confirmed:  { label: 'Confirmed by you', border: 'border-success/30' },
+  edited:     { label: 'User edited', border: 'border-success/30' },
+  assumption: { label: 'Your assumption', border: 'border-success/30' },
+  human:      { label: 'Set by you', border: 'border-success/30' },
 }
 
 const FALLBACK = { label: 'Not set', border: 'border-panel-border' }
 
 export function SourceProvenancePill({ source, showWhenAbsent = true }: SourceProvenancePillProps) {
-  const config = source ? (CONFIG[source] ?? FALLBACK) : FALLBACK
+  const cls = classifyValueProvenance(source)
+  const config = cls ? CONFIG[cls.kind] : FALLBACK
   if (!source && !showWhenAbsent) return null
 
   return (

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ObservedState } from './types'
+import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
 import type { EdgeDirectionDisplay } from '../../domain/edgeValueProvenance'
 import { selectDriverDisplayModel, extractPolicyRow } from '../../../components/results/driverDisplayModel'
 import {
@@ -72,26 +73,41 @@ export function getPrimaryValue(obs: ObservedState): string | null {
 
 // ── Source mapping ────────────────────────────────────────────────────────────
 
-const SOURCE_LABELS: Record<string, string> = {
-  brief_extraction: 'From brief',
-  cee_inference: 'AI estimate',
-  user: 'User edited',
-}
-
-const SOURCE_TOOLTIPS: Record<string, string> = {
-  brief_extraction: 'Source: brief_extraction',
-  cee_inference: 'Source: cee_inference',
-  user: 'Source: user',
+/**
+ * ROADMAP 2.638 S2 — keyed on the canonical CLASS, not on three literals.
+ *
+ * The old map listed `brief_extraction`, `cee_inference` and `user` only, and
+ * its `?? source` fallback then rendered the RAW WIRE LITERAL to the user:
+ * `mapSourceToDisplay('user_confirmed')` returned the string
+ * `"user_confirmed"`. This feeds the Model tab's copy-to-clipboard text, so the
+ * leak left the estate in what a user pastes into a document.
+ *
+ * TOTAL over `ValueProvenanceKind` — a new kind is a type error, not a silent
+ * pass-through (trap 12).
+ */
+const KIND_LABELS: Record<ValueProvenanceKind, string> = {
+  brief: 'From brief',
+  ai: 'AI estimate',
+  confirmed: 'Confirmed by you',
+  edited: 'User edited',
+  assumption: 'Your assumption',
+  human: 'Set by you',
 }
 
 export function mapSourceToDisplay(source: string | undefined): string | null {
   if (!source) return null
-  return SOURCE_LABELS[source] ?? source
+  const cls = classifyValueProvenance(source)
+  return cls ? KIND_LABELS[cls.kind] : source
 }
 
+/**
+ * The raw literal, for a title attribute. Byte-identical to the map it
+ * replaced: every entry in the old `SOURCE_TOOLTIPS` was `Source: <literal>`,
+ * i.e. exactly what its own fallback produced (2.638 S2).
+ */
 export function mapSourceToTooltip(source: string | undefined): string | undefined {
   if (!source) return undefined
-  return SOURCE_TOOLTIPS[source] ?? `Source: ${source}`
+  return `Source: ${source}`
 }
 
 // ── Factor verification ─────────────────────────────────────────────────────

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -204,7 +204,21 @@ export const ATTRIBUTION_COPY = {
    * brief, so the chip credits them, never Olumi.
    */
   yourTarget: 'Your target',
+  /**
+   * The generic reviewed claim, kept for the rows whose act we cannot name
+   * (no classifiable source, or CEE's act-blind `user_set`).
+   */
   checkedByYou: 'checked by you',
+  /**
+   * ROADMAP 2.638 S2 — the two acts, told apart.
+   *
+   * "confirmed" = the user read Olumi's number and put their name to it;
+   * "edited" = the user supplied the number. Both are STATUS claims: neither
+   * act changes the analysis today (the compute half is S4), and neither
+   * string may grow to imply that it does.
+   */
+  confirmedByYou: 'confirmed by you',
+  editedByYou: 'edited by you',
   needsValue: 'needs a value',
   unchecked: 'not checked yet',
   set: 'set',

--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -99,6 +99,7 @@ import {
   type ValueInputSeedBasis,
 } from '../../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../../conversation/optimisticFactorEdit'
+import { withdrawUserConfirmation } from '../../../utils/hydrateProvenance'
 import { useNodeMutations } from '../../../ui/inspector-v2/useInspectorMutations'
 import { useBeliefElicitation } from '../../../hooks/useBeliefElicitation'
 import {
@@ -361,6 +362,28 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
   }
 
   /**
+   * Withdraw a confirmation — ROADMAP 2.638 S2.
+   *
+   * NO WIRE EVENT, and that is derived, not an omission. The three system
+   * events this surface can send (`factor_value_edit` and its siblings) all
+   * ASSERT a value; none retracts a claim about one, and CEE's own stamp is
+   * act-blind, so a turn here could only re-assert what the user is
+   * withdrawing. The value is untouched — CEE's copy is already correct and
+   * needs no correction.
+   *
+   * Fails CLOSED on a missing node, exactly as `confirmAsIs` does: no node,
+   * nothing to withdraw, nothing written.
+   */
+  const unconfirm = useCallback((): void => {
+    const store = useCanvasStore.getState()
+    const node = store.nodes.find(n => n.id === row.nodeId)
+    if (!node) return
+    const nextData = withdrawUserConfirmation(node.data as Record<string, unknown>)
+    if (nextData === node.data) return
+    store.updateNode(row.nodeId, { data: nextData } as never)
+  }, [row.nodeId])
+
+  /**
    * Accept an elicited number — the SAME commit, the SAME stamp, the SAME wire
    * event as the typed field. `user_override` is right here for the reason it
    * is right there: the user chose this number, in their own words, over the
@@ -442,6 +465,45 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
           Confirm as is
         </button>
       )}
+      {/*
+        ROADMAP 2.638 S2 — UN-CONFIRM. Ruling 1's constraint is that a
+        confirmation is REVERSIBLE PER VALUE, and this is the surface that
+        accepted it, so this is where it is withdrawn.
+
+        SCOPE, derived rather than assumed. Offered for a CONFIRMED value only.
+        "Confirm as is" commits with `writeValue: false`, so it moved no number
+        and the withdrawal restores the pre-confirmation state EXACTLY, with
+        nothing to snapshot. An EDITED value is a different case: the pre-edit
+        number is captured only for the in-flight refusal path
+        (`captureOptimisticFactorEdit`) and is not retained past the receipt, so
+        an "undo" there would promise a restoration the store cannot perform.
+        The honest affordance for an edited value is the number field above.
+
+        LOCAL BY DESIGN, and that is a claim about ownership, not a shortcut.
+        CEE cannot hold this fact: `set_factor_value` stamps the single literal
+        `'user_override'` for a typed value and a confirmation alike
+        (canonicalise-value-ops.ts:280), and no wire action retracts it. The
+        withdrawal is therefore recorded where the confirm/edit distinction
+        already lives — the client — as a POSITIVE marker that survives the boot
+        merge (see `withdrawUserConfirmation`).
+      */}
+      {row.reviewed && row.provenanceKind === 'confirmed' && (
+        <button
+          type="button"
+          onClick={() => {
+            unconfirm()
+            onDone()
+          }}
+          aria-label={`Undo your confirmation of ${row.label}`}
+          className={typo(
+            'panelMeta',
+            'rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+          )}
+          data-testid="pre-analysis-v3-unconfirm"
+        >
+          Undo confirmation
+        </button>
+      )}
       {row.canEditValue && canDescribeInWords && (
         <Tooltip content="Say what you think in plain words" delay={300}>
           <PanelIconButton
@@ -468,6 +530,24 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
         </span>
       )}
       </div>
+
+      {/*
+        ⭐ THE DISCLOSURE, AND THE SENTENCE IT IS NOT ALLOWED TO BECOME.
+        Confirming records WHO STANDS BEHIND the number. It does NOT change the
+        analysis: nothing downstream reads the provenance stamp yet — the blend
+        that would make a confirmation move the maths is S4, and it is gated on
+        a science ruling. Copy that implied an effect here would be the
+        guarantee-theatre class this estate hunts, so the denial is explicit and
+        pinned by a test rather than left to a reviewer's memory.
+      */}
+      {!row.needsValue && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="pre-analysis-v3-confirmation-note"
+        >
+          Confirming records that you stand behind this number. It does not change the analysis.
+        </p>
+      )}
 
       {/*
         "Say it in words" — ROADMAP 2.364. Deliberately BELOW the number field

--- a/src/canvas/components/pre-analysis-v3/model/EstimateRow.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/EstimateRow.tsx
@@ -25,9 +25,28 @@ interface EstimateRowProps {
   onToggle: (nodeId: string) => void
 }
 
+/**
+ * ROADMAP 2.638 S2 — the reviewed pill says WHICH act it is recording.
+ *
+ * "confirmed by you" (the user read Olumi's number and kept it) and "edited by
+ * you" (the user supplied one) are different claims about who authored the
+ * value, and the panel had been collapsing both into "checked by you" — the
+ * blur the consent witness reported (2.663).
+ *
+ * An unknown or machine-owned kind falls back to the generic copy rather than
+ * guessing an act, which is also what a reviewed row with no classifiable
+ * source gets. `human` deliberately keeps the generic copy: CEE's `user_set`
+ * knows a person acted and cannot say which act (see `valueProvenance`).
+ */
+function reviewedPillCopy(kind: EstimateRowModel['provenanceKind']): string {
+  if (kind === 'confirmed') return ATTRIBUTION_COPY.confirmedByYou
+  if (kind === 'edited') return ATTRIBUTION_COPY.editedByYou
+  return ATTRIBUTION_COPY.checkedByYou
+}
+
 export const EstimateRow = memo(function EstimateRow({ row, expanded, onToggle }: EstimateRowProps) {
   const pill = row.reviewed ? (
-    <Pill variant="success" size="small">{ATTRIBUTION_COPY.checkedByYou}</Pill>
+    <Pill variant="success" size="small">{reviewedPillCopy(row.provenanceKind)}</Pill>
   ) : row.needsValue ? (
     <Pill variant="warning" size="small">{ATTRIBUTION_COPY.needsValue}</Pill>
   ) : row.aiSourced ? (

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/calibrateDrillInReceipt.spec.tsx
@@ -354,6 +354,8 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
     // but the completion claim must not.
     expect(factorValueEdits()).toHaveLength(1)
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
     expect(observedNow().source).toBe('cee_inference')
 
     await act(async () => {
@@ -361,7 +363,11 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
       await flush()
     })
 
-    expect(screen.getByText('checked by you')).toBeInTheDocument()
+    // 2.638 S2: the claim now NAMES THE ACT. A typed value is an edit — the
+    // stronger assertion, because a row that said "confirmed" here would be
+    // crediting the user with endorsing a number they replaced.
+    expect(screen.getByText('edited by you')).toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
     expect(observedNow().source).toBe('user_override')
   })
 
@@ -379,7 +385,7 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
     expect(factorValueEdits()).toHaveLength(1)
     expect(observedNow().source).toBe('user_override')
     expect(observedNow().value).toBe(NEW_MODEL)
-    expect(screen.getByText('checked by you')).toBeInTheDocument()
+    expect(screen.getByText('edited by you')).toBeInTheDocument()
   })
 
   it('"Confirm as is" only stamps user_confirmed after its own receipt', async () => {
@@ -392,6 +398,8 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
     })
     expect(observedNow().source).toBe('cee_inference')
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
 
     await act(async () => {
       resolveInFlight?.(undefined)
@@ -399,7 +407,10 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
     })
     expect(observedNow().source).toBe('user_confirmed')
     expect(observedNow().extractionType).toBe('explicit')
-    expect(screen.getByText('checked by you')).toBeInTheDocument()
+    // 2.638 S2: an endorsement of Olumi's own number reads as a CONFIRMATION,
+    // never as an edit — the distinction the consent witness found collapsed.
+    expect(screen.getByText('confirmed by you')).toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
   })
 
   it('a REFUSED commit (200, no receipt) reverts the optimistic number and never claims the row is checked', async () => {
@@ -416,6 +427,8 @@ describe('"checked by you" is gated on the RECEIPT, not on the commit or the dis
     expect(observedNow().raw_value).toBe(PRIOR_OBSERVED.raw_value)
     expect(observedNow().source).toBe('cee_inference')
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
     expect(screen.getByText('Olumi estimate')).toBeInTheDocument()
   })
 })
@@ -478,6 +491,8 @@ describe('controls — the fix must not be satisfiable by something cheaper and 
 
     expect(observedNow().source).toBe('cee_inference')
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
   })
 
   it('an ACCEPTED commit is never reverted (a fix that reverted unconditionally would pass every RED assertion)', async () => {
@@ -529,5 +544,7 @@ describe('typed-error posture on this path — pins CURRENT behaviour, inherited
     // half IS the 2.304 guarantee, and it holds in the failure direction too.
     expect(observedNow().source).toBe('cee_inference')
     expect(screen.queryByText('checked by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).not.toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).not.toBeInTheDocument()
   })
 })

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/unconfirmAffordance.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/unconfirmAffordance.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * ROADMAP 2.638 S2 — the un-confirm affordance, on the surface that accepted
+ * the confirmation.
+ *
+ * TWO CLAIMS, and they are different:
+ *   (a) the row DISCLOSES which act it is recording — "confirmed by you" (the
+ *       user kept Olumi's number) is not "edited by you" (the user supplied
+ *       one). The consent witness saw the two collapsed (ROADMAP 2.663).
+ *   (b) the confirmation is REVERSIBLE from the same drill-in that made it
+ *       (Ruling 1: reversible per value), and the reversal touches no number.
+ *
+ * SCOPE, derived rather than assumed. Un-confirm is offered for a CONFIRMED
+ * value only. A confirm-as-is writes no number (`commit(..., {writeValue:
+ * false})`), so withdrawing it restores the pre-confirmation state EXACTLY,
+ * with nothing to snapshot. An EDITED value is different: the pre-edit number
+ * is captured only for the in-flight refusal path (`captureOptimisticFactorEdit`
+ * → `revertOptimisticFactorEdit`) and is not retained past the receipt, so an
+ * "undo" there would promise a restoration the store cannot perform. The honest
+ * affordance for an edited value is the Edit control that is already on the row.
+ *
+ * The drill-in is the DEPLOYED-MOUNTED host: `preAnalysisV3` is `"1"` on
+ * staging (netlify.toml), OutputsDock mounts `PreAnalysisPanelV3` on that arm,
+ * and `YourDecisionSection` renders `CalibrateDrillIn` for the expanded row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { EstimateRow } from '../EstimateRow'
+import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import type { EstimateRowModel } from '../../types'
+import { useCanvasStore } from '../../../../store'
+import { isReviewedByUser } from '../../../pre-analysis/utils/isReviewedByUser'
+import { isConfirmationWithdrawn } from '../../../../utils/hydrateProvenance'
+
+const NODE_ID = 'fac_pricing_level'
+
+const base: EstimateRowModel = {
+  nodeId: NODE_ID,
+  label: 'Pricing level',
+  rankLabel: 'top',
+  weight: 1,
+  reviewed: true,
+  aiSourced: false,
+  provenanceKind: 'confirmed',
+  attribution: { kind: 'person', displayName: 'You' },
+  displayText: '70%',
+  rawPrefill: 70,
+  cap: 100,
+  canEditValue: true,
+  needsValue: false,
+}
+
+function seedConfirmedNode(): void {
+  useCanvasStore.setState({
+    nodes: [
+      {
+        id: NODE_ID,
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: {
+          label: 'Pricing level',
+          kind: 'factor',
+          provenance: 'user_set',
+          observedState: { value: 0.7, raw_value: 70, cap: 100, source: 'user_confirmed', extractionType: 'explicit' },
+          observed_state: { value: 0.7, raw_value: 70, cap: 100, source: 'user_confirmed', extractionType: 'explicit' },
+        },
+      },
+    ] as never,
+    edges: [] as never,
+  } as never)
+}
+
+beforeEach(() => {
+  cleanup()
+  seedConfirmedNode()
+})
+
+describe('2.638 S2 (a) · the row says WHICH act it recorded', () => {
+  it('a CONFIRMED row reads "confirmed by you"', () => {
+    render(<EstimateRow row={base} expanded={false} onToggle={vi.fn()} />)
+    expect(screen.getByText('confirmed by you')).toBeInTheDocument()
+    expect(screen.queryByText('edited by you')).toBeNull()
+  })
+
+  it('an EDITED row reads "edited by you" — a different claim, same reviewed state', () => {
+    render(<EstimateRow row={{ ...base, provenanceKind: 'edited' }} expanded={false} onToggle={vi.fn()} />)
+    expect(screen.getByText('edited by you')).toBeInTheDocument()
+    expect(screen.queryByText('confirmed by you')).toBeNull()
+  })
+
+  it('a reviewed row of UNKNOWN provenance keeps the generic copy — never a guessed act', () => {
+    const noKind: EstimateRowModel = { ...base }
+    delete noKind.provenanceKind
+    render(<EstimateRow row={noKind} expanded={false} onToggle={vi.fn()} />)
+    expect(screen.getByText('checked by you')).toBeInTheDocument()
+  })
+})
+
+describe('2.638 S2 (b) · the confirmation is reversible from the drill-in', () => {
+  it('a confirmed row offers "Undo confirmation"', () => {
+    render(<CalibrateDrillIn row={base} onDone={vi.fn()} />)
+    const btn = screen.getByTestId('pre-analysis-v3-unconfirm')
+    expect(btn).toHaveTextContent('Undo confirmation')
+    expect(btn).toHaveAccessibleName('Undo your confirmation of Pricing level')
+  })
+
+  it('the copy discloses STATUS, never an effect on the analysis', () => {
+    render(<CalibrateDrillIn row={base} onDone={vi.fn()} />)
+    const note = screen.getByTestId('pre-analysis-v3-confirmation-note')
+    // The one sentence the design allows: who stands behind the number, and an
+    // explicit denial that confirming moved the maths.
+    expect(note).toHaveTextContent(
+      'Confirming records that you stand behind this number. It does not change the analysis.',
+    )
+  })
+
+  it('clicking it clears the claim on THIS node and leaves the number alone', () => {
+    render(<CalibrateDrillIn row={base} onDone={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('pre-analysis-v3-unconfirm'))
+
+    const node = useCanvasStore.getState().nodes.find((n: any) => n.id === NODE_ID) as any
+    expect(isConfirmationWithdrawn(node.data)).toBe(true)
+    expect(isReviewedByUser(node)).toBe(false)
+    expect(node.data.observedState.value).toBe(0.7)
+    expect(node.data.observedState.raw_value).toBe(70)
+  })
+
+  it('an EDITED row is NOT offered an undo — the prior number was never retained', () => {
+    render(<CalibrateDrillIn row={{ ...base, provenanceKind: 'edited' }} onDone={vi.fn()} />)
+    expect(screen.queryByTestId('pre-analysis-v3-unconfirm')).toBeNull()
+  })
+
+  it('an UNREVIEWED row is not offered an undo either', () => {
+    render(
+      <CalibrateDrillIn
+        row={{ ...base, reviewed: false, provenanceKind: 'ai' }}
+        onDone={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('pre-analysis-v3-unconfirm')).toBeNull()
+    // …and the surface that CAN make the claim is still there.
+    expect(screen.getByTestId('pre-analysis-v3-confirm-as-is')).toBeInTheDocument()
+  })
+
+  /** Identity binding (trap 19): the withdrawal must hit the named node only. */
+  it('leaves a sibling confirmed factor untouched', () => {
+    const store = useCanvasStore.getState()
+    const sibling = {
+      id: 'fac_other',
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      data: {
+        label: 'Other',
+        kind: 'factor',
+        observedState: { value: 0.7, raw_value: 70, cap: 100, source: 'user_confirmed' },
+        observed_state: { value: 0.7, raw_value: 70, cap: 100, source: 'user_confirmed' },
+      },
+    }
+    useCanvasStore.setState({ nodes: [...(store.nodes as any[]), sibling] as never } as never)
+
+    render(<CalibrateDrillIn row={base} onDone={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('pre-analysis-v3-unconfirm'))
+
+    const other = useCanvasStore.getState().nodes.find((n: any) => n.id === 'fac_other') as any
+    expect(isConfirmationWithdrawn(other.data)).toBe(false)
+    expect(isReviewedByUser(other)).toBe(true)
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/selectors/buildEstimateRows.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/buildEstimateRows.ts
@@ -15,7 +15,11 @@ import { factorDisplayText } from '../../../../utils/formatFactorDisplayValue'
 import { unwrapInterventionValue } from '../../../utils/labelUtils'
 import { getObservedState } from '../../../utils/observedStateHelpers'
 import { isAiSource } from '../../pre-analysis/utils/isAiSource'
-import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
+import { isReviewedByUser, resolveReviewSource } from '../../pre-analysis/utils/isReviewedByUser'
+import {
+  classifyNodeProvenance,
+  classifyValueProvenance,
+} from '../../../domain/valueProvenance'
 import type { Attribution, EstimateRowModel, RankingResult, RankLabel } from '../types'
 
 function rankLabelFor(position: number): RankLabel {
@@ -50,6 +54,20 @@ export function buildEstimateRows(
       const reviewed = isReviewedByUser(node)
       const aiSourced = isAiSource(typeof observed.source === 'string' ? observed.source : null)
 
+      // ROADMAP 2.638 S2 — WHICH act the reviewed state records.
+      //
+      // Resolved through `resolveReviewSource`, the SAME chain (and the same
+      // precedence) `isReviewedByUser` walks, so the pill can never name an act
+      // the predicate did not see. Falls through to the node-level
+      // `provenance` rung, which classifies to 'human': CEE writes `user_set`
+      // for a typed value and a confirmation alike, so it is honest about not
+      // knowing the act rather than guessing one.
+      const nodeProvenance = typeof data.provenance === 'string' ? data.provenance : null
+      const provenanceKind = (
+        classifyValueProvenance(resolveReviewSource(node)) ??
+        classifyNodeProvenance(nodeProvenance)
+      )?.kind
+
       const needsValue =
         displayText == null && rawUnwrapped == null && valueUnwrapped == null
 
@@ -67,6 +85,7 @@ export function buildEstimateRows(
         rankLabel,
         weight: ranking.weights[id] ?? 0,
         reviewed,
+        ...(provenanceKind ? { provenanceKind } : {}),
         aiSourced,
         attribution: reviewed
           ? currentUser ?? { kind: 'person', displayName: 'You' }

--- a/src/canvas/components/pre-analysis-v3/types.ts
+++ b/src/canvas/components/pre-analysis-v3/types.ts
@@ -9,6 +9,7 @@
 
 import type { ActionTypeLiteral } from '@talchain/schemas/boundary'
 import type { PendingWireActionType } from '../../conversation/chipMeta'
+import type { ValueProvenanceKind } from '../../domain/valueProvenance'
 
 /**
  * A product-authored spark: a prefilled prompt the product sends on the
@@ -102,6 +103,18 @@ export interface EstimateRowModel {
   /** Relative weight used for the Estimates bar movement. */
   weight: number
   reviewed: boolean
+  /**
+   * WHICH act the reviewed state records — ROADMAP 2.638 S2.
+   *
+   * `reviewed` says a person owns the value; it cannot say whether they
+   * SUPPLIED the number ('edited') or read Olumi's and ENDORSED it
+   * ('confirmed'). Those are different claims and the panel had been
+   * collapsing them into one "checked by you" pill (consent witness, 2.663).
+   *
+   * Undefined when the node's source carries no known class — the row then
+   * keeps the generic copy rather than guessing an act.
+   */
+  provenanceKind?: ValueProvenanceKind
   /** True when the value's source is AI-supplied (drives the "Olumi estimate" pill). */
   aiSourced: boolean
   attribution: Attribution

--- a/src/canvas/components/pre-analysis/provenanceUtils.ts
+++ b/src/canvas/components/pre-analysis/provenanceUtils.ts
@@ -1,9 +1,38 @@
 import type { CEEProvenance } from '../../../adapters/cee/types'
+import { classifyNodeProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
+
+/**
+ * Node-level provenance → pill.
+ *
+ * ROADMAP 2.638 S2. `user_set` used to return **null**: the one value in this
+ * vocabulary that says a HUMAN owns the number had no pill, while both
+ * machine-owned values had one. A reader could only conclude the value was
+ * unattributed — the absence read as "nobody's".
+ *
+ * The copy is deliberately "Set by you", not "Confirmed by you". CEE writes
+ * `provenance: 'user_set'` on every applied `set_factor_value`
+ * (`set-factor-value.ts:450`) whether the user typed a number or endorsed the
+ * one already there — so this stamp knows a person acted and cannot say which
+ * act. Naming the act here would be an over-claim; the confirm/edit
+ * distinction is carried by `observed_state.source` and rendered by the
+ * surfaces that read it.
+ *
+ * The map is TOTAL over `ValueProvenanceKind`, so a kind added to the canonical
+ * classification is a type error here rather than a silent fallback (trap 12).
+ */
+const PILL_BY_KIND: Record<ValueProvenanceKind, { label: string; borderClass: string }> = {
+  confirmed: { label: 'Confirmed by you', borderClass: 'border-success/30' },
+  edited: { label: 'Edited by you', borderClass: 'border-success/30' },
+  assumption: { label: 'Your assumption', borderClass: 'border-success/30' },
+  human: { label: 'Set by you', borderClass: 'border-success/30' },
+  brief: { label: 'From brief', borderClass: 'border-success/30' },
+  ai: { label: 'AI estimate', borderClass: 'border-info/30' },
+}
 
 export function provenanceToPill(
   p: CEEProvenance | undefined,
 ): { label: string; borderClass: string } | null {
-  if (p === 'from_brief') return { label: 'From brief', borderClass: 'border-success/30' }
-  if (p === 'ai_inferred') return { label: 'AI estimate', borderClass: 'border-info/30' }
-  return null
+  const cls = classifyNodeProvenance(p)
+  if (!cls) return null
+  return PILL_BY_KIND[cls.kind]
 }

--- a/src/canvas/components/pre-analysis/utils/isReviewedByUser.ts
+++ b/src/canvas/components/pre-analysis/utils/isReviewedByUser.ts
@@ -47,13 +47,21 @@
 
 import type { Edge, Node } from '@xyflow/react'
 
-const REVIEWED_SOURCES = new Set<string>([
+/**
+ * The ordered list, exported so consumers can ITERATE it rather than re-type
+ * it. ROADMAP 2.638 S2: `valueProvenance`'s completeness guard asserts every
+ * member of this list carries a user-owned provenance class — a derived union
+ * assertion, so a source added here can never silently lose its label.
+ */
+export const REVIEWED_SOURCES_LIST: readonly string[] = Object.freeze([
   'user_confirmed',
   'user_assumption',
   'user_override',
   'user',
   'user_edited',
 ])
+
+const REVIEWED_SOURCES = new Set<string>(REVIEWED_SOURCES_LIST)
 
 /**
  * String-level "is this source value user-owned?" check. Single source
@@ -63,13 +71,47 @@ export function isReviewedSource(source: string | undefined | null): boolean {
   return source != null && REVIEWED_SOURCES.has(source)
 }
 
+/**
+ * The `observed_state.source` value this predicate WOULD consult, resolved
+ * through the field-level fallback chain below.
+ *
+ * Exported for ROADMAP 2.638 S2 so the provenance pill classifies the SAME
+ * string the badge was painted from. Re-implementing the chain at the render
+ * site is how a pill ends up naming an act the predicate never saw — the
+ * hand-maintained-mirror class (trap 12), one layer down from the label maps.
+ * Returns null when no source resolves at any rung.
+ */
+export function resolveReviewSource(node: Node): string | null {
+  const data = node.data as {
+    observed_state?: { source?: string }
+    observedState?: { source?: string }
+    source?: string
+  }
+  return (
+    data?.observed_state?.source ?? data?.observedState?.source ?? data?.source ?? null
+  )
+}
+
 export function isReviewedByUser(node: Node): boolean {
   const data = node.data as {
     observed_state?: { source?: string }
     observedState?: { source?: string }
     source?: string
     provenance?: string
+    userConfirmationWithdrawn?: boolean
   }
+
+  // ROADMAP 2.638 S2 — the WITHDRAWAL rung, and it comes FIRST.
+  //
+  // The user un-confirmed this value. That is a claim only the client holds,
+  // and it has to outrank every stamp below: CEE writes
+  // `observed_state.source = 'user_override'` on every applied
+  // `set_factor_value` (canonicalise-value-ops.ts:280) including the
+  // confirm-as-is being withdrawn, so on the next boot merge the server's own
+  // stamp would otherwise resurrect a claim the user explicitly retracted —
+  // silently, and in the OVER-claim direction this file exists to prevent.
+  // See `withdrawUserConfirmation` in `canvas/utils/hydrateProvenance.ts`.
+  if (data?.userConfirmationWithdrawn === true) return false
   // Field-level fallback chain: snake_case → camelCase → top-level. An
   // empty `observed_state: {}` at the snake-case key no longer hides a
   // valid camelCase or top-level source.
@@ -79,10 +121,18 @@ export function isReviewedByUser(node: Node): boolean {
 
   // Final rung — the WIRE-CARRIED claim (L66, final-walk defect 0, P1).
   //
+  // ⚠ CORRECTED 6 Aug 2026 (2.638 S2, read at CEE staging `d5b64246`): the
+  // premise below — "set_factor_value never writes the field" — was true when
+  // written and is now FALSE. 2.396(b) SHIPPED: the handler merges
+  // `source: USER_EDIT_SOURCE` (= the single literal `'user_override'`,
+  // canonicalise-value-ops.ts:280) into the persisted observed_state. What the
+  // server still cannot carry is WHICH ACT it was — confirm and edit collapse
+  // into that one literal — so the rung below remains necessary and the
+  // client-vs-server precedence above remains right; only the reason changed.
+  //
   // The `source` stamps above are CLIENT-side: CEE's `ObservedStateV3` types
   // `observed_state.source` as z.enum(['brief_extraction','cee_inference']) —
-  // no user-owned member exists, and set_factor_value never writes the field
-  // (rowed 2.396(b)). So after a reload that hydrates from the server graph,
+  // no user-owned member exists in the CONTRACT. So after a reload that hydrates from the server graph,
   // every source stamp reads as the producer's and the badge lied in the
   // under-claim direction: a value the USER set (witnessed: runE
   // fac_pricing_level, 0.7 byte-identical across reload) regressed to

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -43,6 +43,7 @@ import { useCanvasStore } from '../store'
 import { saveAutosave } from '../store/scenarios'
 import { autosaveSourceFromStore, projectAutosaveData } from '../store/autosaveProjection'
 import { withObservedStateUpdate, type ObservedStateData } from '../utils/observedStateHelpers'
+import { clearConfirmationWithdrawal } from '../utils/hydrateProvenance'
 import { unwrapInterventionValue, classifyUnit } from '../utils/labelUtils'
 import { formatValueWithUnit, formatNumber } from '../utils/formatValueWithUnit'
 
@@ -507,8 +508,18 @@ export function confirmOptimisticFactorEdit(edit: OptimisticFactorEdit): Confirm
   const obs = (readObservedState(node.data) ?? {}) as Record<string, unknown>
   if (obs.value !== edit.sentValue) return 'value_moved_on'
 
+  // ROADMAP 2.638 S2 — a new receipted claim ENDS any prior withdrawal.
+  //
+  // `withdrawUserConfirmation` records the retraction as a positive top-level
+  // marker so the boot merge cannot resurrect the claim (CEE re-sends its own
+  // `user_override` stamp on the unchanged value). That marker must not outlive
+  // the retraction: this is the one place a user claim is earned, so it is the
+  // one place the door reopens. Clearing it anywhere else — or not at all —
+  // would make a re-confirmation invisible.
   store.updateNode(edit.nodeId, {
-    data: withObservedStateUpdate(node.data, edit.reviewedStamp),
+    data: clearConfirmationWithdrawal(
+      withObservedStateUpdate(node.data, edit.reviewedStamp) as Record<string, unknown>,
+    ),
   } as never)
 
   // Persist the earned stamp NOW (L66, final-walk defect 0, P1). The stamp is

--- a/src/canvas/domain/__tests__/confirmedValueDisclosure.spec.tsx
+++ b/src/canvas/domain/__tests__/confirmedValueDisclosure.spec.tsx
@@ -1,0 +1,110 @@
+/**
+ * ROADMAP 2.638 S2 — CONFIRMED-VALUE DISCLOSURE (P4, human–AI collaboration).
+ *
+ * Three defects, all measured at pristine `fa1f99f1`, all on DEPLOYED-MOUNTED
+ * surfaces (mount census in the lane report; `preAnalysisV3=1`,
+ * `USE_INSPECTOR_V2` hardcoded true, model tab unflagged):
+ *
+ *   D1  `provenanceToPill('user_set')` returns NULL — the one node-level
+ *       provenance value that says a human owns the number has no pill, while
+ *       the two AI-owned values both do.
+ *   D2  `getExtractionLabel('user_confirmed')` returns **'Estimated by Olumi'**
+ *       (default arm) — a value the user explicitly confirmed is labelled as
+ *       the machine's guess, on three live inspector panels.
+ *   D3  `SourceProvenancePill source="user_confirmed"` renders **'Not set'**
+ *       (CONFIG miss → FALLBACK) and `mapSourceToDisplay('user_confirmed')`
+ *       leaks the raw wire literal — on the live Model tab.
+ *
+ * And the blur the consent witness saw (ROADMAP 2.663): **confirmed and edited
+ * are different claims** — edited = the human supplied a number; confirmed =
+ * the human ratified the number that was already there. The client store is
+ * the ONLY place that distinction survives: CEE's `set_factor_value` stamps
+ * `observed_state.source = USER_EDIT_SOURCE = 'user_override'` for BOTH acts
+ * (`canonicalise-value-ops.ts:280`, applied `set-factor-value.ts:421`, read at
+ * CEE staging `d5b64246`), so no echoed `value_source` can tell them apart.
+ *
+ * SCOPE HONESTY, pinned here so the copy cannot drift into an effect claim:
+ * confirming records WHO STANDS BEHIND the number. It does not change the
+ * maths (that is S4, Neil-gated). Every string asserted below is a STATUS.
+ */
+
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+import { provenanceToPill } from '../../components/pre-analysis/provenanceUtils'
+import { getExtractionLabel, getProvenanceLabel } from '../../ui/inspector-v2/inspectorStrings'
+import { SourceProvenancePill } from '../../components/model-tab/SourceProvenancePill'
+import { mapSourceToDisplay } from '../../components/model-tab/utils'
+
+describe('2.638 S2 · D1 — the node-level confirmation pill renders', () => {
+  it('provenanceToPill("user_set") returns a pill, not null', () => {
+    const pill = provenanceToPill('user_set')
+    expect(pill).not.toBeNull()
+    expect(pill!.label).toBe('Set by you')
+  })
+
+  it('leaves the two producer pills exactly as they were', () => {
+    expect(provenanceToPill('from_brief')).toEqual({
+      label: 'From brief',
+      borderClass: 'border-success/30',
+    })
+    expect(provenanceToPill('ai_inferred')).toEqual({
+      label: 'AI estimate',
+      borderClass: 'border-info/30',
+    })
+    expect(provenanceToPill(undefined)).toBeNull()
+  })
+})
+
+describe('2.638 S2 · D2 — the inspector stops calling a confirmed value an Olumi estimate', () => {
+  it('getExtractionLabel("user_confirmed") says confirmed, never "Estimated by Olumi"', () => {
+    expect(getExtractionLabel('user_confirmed')).toBe('Confirmed by you')
+  })
+
+  it('getExtractionLabel distinguishes confirmed from edited', () => {
+    expect(getExtractionLabel('user_override')).toBe('Set by you')
+    expect(getExtractionLabel('user_confirmed')).not.toBe(getExtractionLabel('user_override'))
+  })
+
+  it('getProvenanceLabel stops leaking the raw wire literal for a confirmed value', () => {
+    const label = getProvenanceLabel('user_confirmed')
+    expect(label).toBe('Confirmed by you')
+    expect(label).not.toContain('user_confirmed')
+  })
+
+  it('leaves the pre-existing extraction labels byte-identical', () => {
+    expect(getExtractionLabel(undefined)).toBe('Estimated by Olumi')
+    expect(getExtractionLabel('brief_extraction')).toBe('From your brief')
+    expect(getExtractionLabel('user')).toBe('Set by you')
+    expect(getExtractionLabel('user_calibration')).toBe('Set by you')
+    expect(getExtractionLabel('something_else')).toBe('Estimated by Olumi')
+  })
+})
+
+describe('2.638 S2 · D3 — the Model tab stops rendering a confirmed value as "Not set"', () => {
+  it('SourceProvenancePill("user_confirmed") reads confirmed, not "Not set"', () => {
+    render(<SourceProvenancePill source="user_confirmed" />)
+    expect(screen.getByText('Confirmed by you')).toBeInTheDocument()
+    expect(screen.queryByText('Not set')).toBeNull()
+  })
+
+  it('SourceProvenancePill("user_override") reads edited — a different claim', () => {
+    render(<SourceProvenancePill source="user_override" />)
+    expect(screen.getByText('User edited')).toBeInTheDocument()
+    expect(screen.queryByText('Confirmed by you')).toBeNull()
+  })
+
+  it('mapSourceToDisplay stops leaking the raw literal for the user-owned sources', () => {
+    expect(mapSourceToDisplay('user_confirmed')).toBe('Confirmed by you')
+    expect(mapSourceToDisplay('user_override')).toBe('User edited')
+    expect(mapSourceToDisplay('user_assumption')).toBe('Your assumption')
+  })
+
+  it('leaves the pre-existing Model-tab copy byte-identical', () => {
+    expect(mapSourceToDisplay('brief_extraction')).toBe('From brief')
+    expect(mapSourceToDisplay('cee_inference')).toBe('AI estimate')
+    expect(mapSourceToDisplay('user')).toBe('User edited')
+    expect(mapSourceToDisplay(undefined)).toBeNull()
+  })
+})

--- a/src/canvas/domain/__tests__/valueProvenance.spec.ts
+++ b/src/canvas/domain/__tests__/valueProvenance.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * ROADMAP 2.638 S2 — the canonical value-provenance classification.
+ *
+ * TRAP 12d, both halves, because neither supersedes the other:
+ *   · the DERIVED guard (the union assertion below) proves the consumers agree
+ *     with the canonical list — it can never prove the list is complete;
+ *   · the HAND-WRITTEN CORPUS proves the list is not SHORT. It is written from
+ *     the producers' own bytes, not from this module, which is the only way it
+ *     can notice a literal the module forgot.
+ * Ship both. The `thousand` defect is what happens when only the first exists.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyValueProvenance,
+  classifyNodeProvenance,
+  isUserOwnedKind,
+  VALUE_PROVENANCE_SOURCES,
+  CONFIRMED_SOURCES,
+  EDITED_SOURCES,
+  type ValueProvenanceKind,
+} from '../valueProvenance'
+import { REVIEWED_SOURCES_LIST } from '../../components/pre-analysis/utils/isReviewedByUser'
+
+describe('2.638 S2 · classification', () => {
+  it('classifies the human-confirmation literal as confirmed, not edited', () => {
+    const c = classifyValueProvenance('user_confirmed')
+    expect(c).not.toBeNull()
+    expect(c!.kind).toBe('confirmed')
+    expect(c!.userOwned).toBe(true)
+  })
+
+  it('classifies every typed-value literal as edited, and the two sets are disjoint', () => {
+    expect(EDITED_SOURCES.length).toBeGreaterThan(0)
+    for (const s of EDITED_SOURCES) {
+      expect(classifyValueProvenance(s)!.kind).toBe('edited')
+    }
+    expect(CONFIRMED_SOURCES).toEqual(['user_confirmed'])
+    for (const s of CONFIRMED_SOURCES) {
+      expect(EDITED_SOURCES).not.toContain(s)
+    }
+  })
+
+  it('classifies the producer literals, and returns null rather than guessing', () => {
+    expect(classifyValueProvenance('brief_extraction')!.kind).toBe('brief')
+    expect(classifyValueProvenance('cee_inference')!.kind).toBe('ai')
+    expect(classifyValueProvenance('brief_extraction')!.userOwned).toBe(false)
+    expect(classifyValueProvenance('a_source_nobody_writes')).toBeNull()
+    expect(classifyValueProvenance(undefined)).toBeNull()
+    expect(classifyValueProvenance(null)).toBeNull()
+  })
+
+  /**
+   * `user_set` is the WIRE-carried node-level stamp CEE writes on every applied
+   * `set_factor_value`, for a typed value and a confirm alike. Reading it as
+   * "confirmed" would manufacture the very distinction the wire destroyed.
+   */
+  it('maps the node-level user_set to "human" — an act it cannot name', () => {
+    expect(classifyNodeProvenance('user_set')).toEqual({ kind: 'human', userOwned: true })
+    expect(classifyNodeProvenance('from_brief')!.kind).toBe('brief')
+    expect(classifyNodeProvenance('ai_inferred')!.kind).toBe('ai')
+    expect(classifyNodeProvenance('user_confirmed')).toBeNull()
+    expect(classifyNodeProvenance(undefined)).toBeNull()
+  })
+
+  it('agrees with itself about which kinds a person owns', () => {
+    const owned: ValueProvenanceKind[] = ['confirmed', 'edited', 'assumption', 'human']
+    const notOwned: ValueProvenanceKind[] = ['brief', 'ai']
+    for (const k of owned) expect(isUserOwnedKind(k)).toBe(true)
+    for (const k of notOwned) expect(isUserOwnedKind(k)).toBe(false)
+  })
+})
+
+describe('2.638 S2 · completeness (trap 12d)', () => {
+  /**
+   * DERIVED guard. `REVIEWED_SOURCES` is the predicate that decides whether the
+   * "checked by you" claim is painted at all; it is imported, not copied, so
+   * this cannot drift. A literal that earns the badge but carries no class
+   * would render an unlabelled or falsely-AI pill — which is defect D2.
+   */
+  it('every source isReviewedByUser treats as user-owned carries a user-owned class', () => {
+    expect(REVIEWED_SOURCES_LIST.length).toBeGreaterThan(0)
+    for (const s of REVIEWED_SOURCES_LIST) {
+      const c = classifyValueProvenance(s)
+      expect(c, `REVIEWED_SOURCES member '${s}' has no provenance class`).not.toBeNull()
+      expect(c!.userOwned, `'${s}' earns the reviewed badge but is not classed user-owned`).toBe(
+        true,
+      )
+    }
+  })
+
+  /**
+   * HAND-WRITTEN CORPUS — deliberately NOT derived from the module. Each entry
+   * is a literal read at the site that writes it, named in the comment so a
+   * later reader can re-derive rather than trust this list.
+   */
+  it('the canonical list covers every literal a producer is known to write', () => {
+    const writtenByProducers = [
+      'user_confirmed', // CalibrateDrillIn.tsx:126 · PreAnalysisPanel.tsx:1154 · OutputsDock.tsx:1280
+      'user_override', // CalibrateDrillIn.tsx:125 · PreAnalysisPanel.tsx:1193 · OutputsDock.tsx:1296
+      //                  AND CEE canonicalise-value-ops.ts:280 (USER_EDIT_SOURCE), for BOTH acts
+      'user', // model-tab FactorsSection factor-value edits
+      'user_edited', // OutputsDock transition bridge
+      'user_calibration', // inspector calibration (inspectorStrings.ts:77,90)
+      'user_assumption', // reserved "mark as assumption" (recognised by REVIEWED_SOURCES)
+      'brief_extraction', // CEE ObservedStateV3
+      'cee_inference', // CEE ObservedStateV3
+      'cee_repair', // CEE validation repair (inspectorStrings.ts:74)
+    ]
+    for (const s of writtenByProducers) {
+      expect(
+        VALUE_PROVENANCE_SOURCES,
+        `'${s}' is written by a producer but is unclassified`,
+      ).toContain(s)
+    }
+  })
+})

--- a/src/canvas/domain/valueProvenance.ts
+++ b/src/canvas/domain/valueProvenance.ts
@@ -1,0 +1,177 @@
+/**
+ * valueProvenance — ONE classification authority for "who put this number here".
+ *
+ * ROADMAP 2.638 S2 (P4, human–AI collaboration). Ships the disclosure half of
+ * the confirmed-values design: no maths changes, nothing new crosses the wire.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS EXISTS — CONFIRMED AND EDITED ARE DIFFERENT CLAIMS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * **Edited** = the human supplied a number. **Confirmed** = the human read the
+ * number that was already there and said "that one is right". The second is the
+ * expensive signal — it is a person putting their name to a machine's estimate
+ * — and the estate has been collapsing it into the first (consent witness,
+ * ROADMAP 2.663: a confirmed value labelled "User edited").
+ *
+ * Four live surfaces got it wrong in four different ways, each because the
+ * label lived in a hand-maintained map that nobody extended when the
+ * `user_confirmed` / `user_override` stamps were introduced (CLAUDE.md trap 12):
+ *
+ *   · `SourceProvenancePill`  (Model tab)      → **"Not set"**
+ *   · `getExtractionLabel`    (3 inspector panels) → **"Estimated by Olumi"**
+ *   · `mapSourceToDisplay`    (Model tab, clipboard) → the raw wire literal
+ *   · `provenanceToPill`      (node-level `user_set`)  → **null**
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠ THE ECHO CANNOT SETTLE THIS — derived at the producer's bytes, 6 Aug 2026
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The design brief (§4.2) says to drive the confirmation surface from the
+ * ECHOED `FactorSensitivityV2.value_source` — "what the engine says it computed
+ * with" — rather than from client state. **That premise does not survive
+ * measurement, and this module is deliberately client-driven instead.**
+ *
+ * CEE's `set_factor_value` stamps `observed_state.source = USER_EDIT_SOURCE`,
+ * and `USER_EDIT_SOURCE` is the single literal `'user_override'`
+ * (`orchestrator/canonicalise-value-ops.ts:280`, applied at
+ * `orchestrator-v5/tools/handlers/set-factor-value.ts:421`; read at CEE staging
+ * `d5b64246`). It writes that stamp for a typed value AND for a confirm-as-is,
+ * which CEE receipts as `noop`. So **the server graph — and therefore every
+ * echoed `value_source` — is structurally incapable of distinguishing the two
+ * acts.** Two further ways the echo and the client disagree, both real:
+ *   · TEMPORAL — the echo describes the graph the LAST ANALYSIS ran on; a
+ *     confirmation made after that run has no echo at all.
+ *   · COVERAGE — `factor_sensitivity` carries `value_source` only for
+ *     PU-listed factors (ground-truth correction 5), so a confirmed valued
+ *     factor with no parameter-uncertainty entry has no echo ROW.
+ *
+ * The client stamp is not a weaker signal here, it is the ONLY one: it is
+ * written by `confirmOptimisticFactorEdit` **after CEE's applied `graph_patch`
+ * receipt**, and flushed to the autosave at that moment. It is receipt-backed
+ * evidence that the client alone holds.
+ *
+ * ⚠ RESIDUAL, named rather than hidden: if the local autosave is absent (a
+ * different browser or device), the boot merge lands CEE's collapsed
+ * `user_override` and a confirm-as-is reads as an edit. Closing that needs a
+ * distinct server-side stamp for the confirm act — a CEE change, not a UI one.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * SHAPE — classification here, COPY at each surface
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This module owns the *kind*. Each surface keeps its own register (the Model
+ * tab is terse, the inspector writes sentences) but must be TOTAL over
+ * `ValueProvenanceKind` — a `Record<ValueProvenanceKind, …>` makes a missing
+ * kind a type error rather than a silent fallback. That is the derivation trap
+ * 12 asks for without forcing one voice on every surface.
+ */
+
+/** What act put the number there. */
+export type ValueProvenanceKind =
+  /** The human read the number that was there and endorsed it. */
+  | 'confirmed'
+  /** The human supplied the number. */
+  | 'edited'
+  /** The human recorded it as an explicit assumption. */
+  | 'assumption'
+  /** A human owns it, but the record does not say which act (wire-level `user_set`). */
+  | 'human'
+  /** Extracted from the user's own brief by the model. */
+  | 'brief'
+  /** The model's own estimate. */
+  | 'ai'
+
+export interface ValueProvenanceClass {
+  kind: ValueProvenanceKind
+  /** True when a person, not the model, owns the claim. */
+  userOwned: boolean
+}
+
+/**
+ * Every `observed_state.source` literal any producer in this estate is known to
+ * write. Sources, with the byte read that established each:
+ *
+ *   `user_confirmed`  — client "Confirm as is" (`CalibrateDrillIn.tsx:126`,
+ *                       `PreAnalysisPanel.tsx:1154`, `OutputsDock.tsx:1280`)
+ *   `user_override`   — client typed value (`CalibrateDrillIn.tsx:125`,
+ *                       `PreAnalysisPanel.tsx:1193`, `OutputsDock.tsx:1296`)
+ *                       AND **CEE server-side, for BOTH acts** (see above)
+ *   `user`            — Model-tab factor-value edits
+ *   `user_edited`     — recognised by the OutputsDock transition bridge
+ *   `user_calibration`— inspector calibration (`inspectorStrings.ts`)
+ *   `user_assumption` — reserved "mark as assumption"; recognised, not yet written
+ *   `brief_extraction`/`explicit` — extraction from the user's brief
+ *   `cee_inference`/`inferred`/`cee_repair` — the model's own estimate
+ */
+const SOURCE_CLASSES: Readonly<Record<string, ValueProvenanceKind>> = Object.freeze({
+  user_confirmed: 'confirmed',
+  user_override: 'edited',
+  user: 'edited',
+  user_edited: 'edited',
+  user_calibration: 'edited',
+  user_assumption: 'assumption',
+  brief_extraction: 'brief',
+  explicit: 'brief',
+  cee_inference: 'ai',
+  inferred: 'ai',
+  cee_repair: 'ai',
+})
+
+const USER_OWNED_KINDS: ReadonlySet<ValueProvenanceKind> = new Set<ValueProvenanceKind>([
+  'confirmed',
+  'edited',
+  'assumption',
+  'human',
+])
+
+/** Every classified literal — the completeness corpus checks against this. */
+export const VALUE_PROVENANCE_SOURCES: readonly string[] = Object.freeze(
+  Object.keys(SOURCE_CLASSES),
+)
+
+/** The literals that mean "the human ratified the number that was there". */
+export const CONFIRMED_SOURCES: readonly string[] = Object.freeze(
+  VALUE_PROVENANCE_SOURCES.filter((s) => SOURCE_CLASSES[s] === 'confirmed'),
+)
+
+/** The literals that mean "the human supplied the number". */
+export const EDITED_SOURCES: readonly string[] = Object.freeze(
+  VALUE_PROVENANCE_SOURCES.filter((s) => SOURCE_CLASSES[s] === 'edited'),
+)
+
+/** True when this kind is a claim a PERSON owns. */
+export function isUserOwnedKind(kind: ValueProvenanceKind): boolean {
+  return USER_OWNED_KINDS.has(kind)
+}
+
+/**
+ * Classify an `observed_state.source` literal.
+ *
+ * Returns `null` — never a guessed class — for an unknown literal. A surface
+ * that renders `null` must fall back to its own honest neutral; inventing a
+ * class here is how "Estimated by Olumi" ended up on a confirmed value.
+ */
+export function classifyValueProvenance(
+  source: string | null | undefined,
+): ValueProvenanceClass | null {
+  if (typeof source !== 'string') return null
+  const kind = SOURCE_CLASSES[source]
+  if (kind === undefined) return null
+  return { kind, userOwned: USER_OWNED_KINDS.has(kind) }
+}
+
+/**
+ * Classify the NODE-LEVEL `data.provenance` value, whose vocabulary is a
+ * different, smaller one (`CEEProvenance`).
+ *
+ * `user_set` maps to `'human'`, not to `'confirmed'`: CEE writes it on every
+ * applied `set_factor_value` regardless of act, so it says a person owns the
+ * value and nothing more. Rendering it as "confirmed" would be exactly the
+ * over-claim this module exists to stop.
+ */
+export function classifyNodeProvenance(
+  provenance: string | null | undefined,
+): ValueProvenanceClass | null {
+  if (provenance === 'user_set') return { kind: 'human', userOwned: true }
+  if (provenance === 'from_brief') return { kind: 'brief', userOwned: false }
+  if (provenance === 'ai_inferred') return { kind: 'ai', userOwned: false }
+  return null
+}

--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -4,6 +4,7 @@
  */
 
 import type { NodeType, FactorCategory } from '../../domain/nodes'
+import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
 
 // ─── Section titles (spec §3.1) ────────────────────────────────────
 export const SECTION_TITLES = {
@@ -64,17 +65,54 @@ export const BADGE_TOOLTIPS: Record<string, string> = {
   inferred:     'This value was estimated because it wasn\'t stated explicitly',
 }
 
+/**
+ * ROADMAP 2.638 S2 — the user-owned arm of both label functions, derived.
+ *
+ * These three inspector panels are DEPLOYED-MOUNTED (`USE_INSPECTOR_V2` is a
+ * hardcoded `true`; no flag gates them), and before this both functions sent
+ * every user-owned source they did not literally list to their DEFAULT arm:
+ * `getExtractionLabel('user_confirmed')` returned **"Estimated by Olumi"** —
+ * the machine claiming a number the user had explicitly confirmed — and
+ * `getProvenanceLabel('user_confirmed')` leaked the raw wire literal as
+ * "Source: user_confirmed".
+ *
+ * The map is TOTAL over `ValueProvenanceKind`: adding a kind to the canonical
+ * classification is a type error here, never a silent fallback (trap 12). The
+ * copy register is this surface's own — sentences, not the Model tab's terse
+ * pills — which is why the kind, not the string, is what is shared.
+ *
+ * "Confirmed by you" states a STATUS and nothing else. Confirming does not
+ * change the analysis today (that is the compute slice, S4) and the copy must
+ * not imply it does.
+ */
+const USER_OWNED_LABEL: Record<ValueProvenanceKind, string | null> = {
+  confirmed: 'Confirmed by you',
+  edited: 'Set by you',
+  assumption: 'Your assumption',
+  human: 'Set by you',
+  // Producer kinds keep each function's own pre-existing copy — see below.
+  brief: null,
+  ai: null,
+}
+
+/** The user-owned label for a source, or null when the producer owns it. */
+function userOwnedLabelFor(source: string): string | null {
+  const cls = classifyValueProvenance(source)
+  if (!cls?.userOwned) return null
+  return USER_OWNED_LABEL[cls.kind]
+}
+
 // ─── Provenance labels (spec §3.4) ────────────────────────────────
 export function getProvenanceLabel(source?: string): string {
   if (!source) return 'No evidence yet'
+  const userOwned = userOwnedLabelFor(source)
+  if (userOwned) return userOwned
   switch (source) {
     case 'brief_extraction': return 'Generated from your brief'
     case 'explicit':         return 'From your brief'
     case 'cee_inference':    return 'Estimated by Olumi'
     case 'inferred':         return 'Estimated by Olumi'
     case 'cee_repair':       return 'Generated from your brief (adjusted during validation)'
-    case 'user':             return 'Set by you'
-    case 'user_calibration': return 'Set by you'
     case 'ai-suggested':     return 'Generated from your brief'
     case 'default':          return 'No evidence yet'
     default:                 return source.startsWith('evidence:') ? `Based on ${source.slice(9)}` : `Source: ${source}`
@@ -84,10 +122,10 @@ export function getProvenanceLabel(source?: string): string {
 /** Extraction type user-facing labels */
 export function getExtractionLabel(source?: string): string {
   if (!source) return 'Estimated by Olumi'
+  const userOwned = userOwnedLabelFor(source)
+  if (userOwned) return userOwned
   switch (source) {
     case 'brief_extraction': return 'From your brief'
-    case 'user':             return 'Set by you'
-    case 'user_calibration': return 'Set by you'
     default:                 return 'Estimated by Olumi'
   }
 }

--- a/src/canvas/utils/__tests__/unconfirmValue.spec.ts
+++ b/src/canvas/utils/__tests__/unconfirmValue.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * ROADMAP 2.638 S2 — REVERSIBILITY, PER VALUE (Ruling 1's constraint).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY A LOCAL CLEAR IS NOT A REVERSAL — the derivation this spec pins
+ * ─────────────────────────────────────────────────────────────────────────────
+ * "Confirm as is" writes NO number (`CalibrateDrillIn.commit(..., {writeValue:
+ * false})`), so the value never moved and the reversal is exact by
+ * construction: only the CLAIM has to be withdrawn. There is nothing to
+ * restore, which is why this needs no snapshot.
+ *
+ * But a withdrawal that only deletes the local stamp is UNDONE ON THE NEXT
+ * BOOT, silently. Measured at the bytes on both sides:
+ *   · CEE's `set_factor_value` stamps `observed_state.source = USER_EDIT_SOURCE
+ *     = 'user_override'` server-side on every applied edit — including a
+ *     confirm-as-is, which CEE receipts as `noop`
+ *     (`canonicalise-value-ops.ts:280`, `set-factor-value.ts:421`, CEE staging
+ *     `d5b64246`). ⚠ This falsifies the standing in-repo claim that "CEE's bag
+ *     can never carry a user source"; 2.396(b) landed exactly that write.
+ *   · `mergeServerGraphOnHydrate` restores user stamps only from the snapshot
+ *     the PRE-merge node held (`restoreUserProvenance` writes only locations
+ *     the snapshot carried). A cleared stamp means an EMPTY snapshot, so the
+ *     server's `user_override` survives the overlay untouched and the row is
+ *     "checked by you" again on the next reload.
+ *
+ * So the withdrawal has to be a DURABLE, POSITIVE fact, not an absence — the
+ * same shape as `userReviewedStrength`, the UI-only edge marker this codebase
+ * already sanctions (`hydrateProvenance.ts:159-163`): a top-level `data` key
+ * the wire never carries, which `overlayNode`'s `{...existing.data,
+ * ...mapped.data}` spread therefore cannot clear.
+ *
+ * ⚠ Scope: withdrawing a confirmation changes NO number and NO analysis — the
+ * confirmation never changed one either (that is S4, Neil-gated). This is a
+ * disclosure reversal, and the copy must not promise more.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+import { withdrawUserConfirmation, isConfirmationWithdrawn } from '../hydrateProvenance'
+import { isReviewedByUser } from '../../components/pre-analysis/utils/isReviewedByUser'
+import { confirmOptimisticFactorEdit } from '../../conversation/optimisticFactorEdit'
+
+const SCENARIO = '11111111-2222-4333-8444-555555555555'
+
+function seed(nodes: unknown[]): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: structuredClone(nodes) as never,
+    edges: [] as never,
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function nodeById(id: string): Node {
+  return useCanvasStore.getState().nodes.find((n: any) => n.id === id) as unknown as Node
+}
+
+/** A factor the user CONFIRMED AS IS: the stamp is `user_confirmed`, value untouched. */
+function confirmedNode(value = 0.7) {
+  return {
+    id: 'fac_pricing_level',
+    type: 'factor',
+    position: { x: 10, y: 20 },
+    data: {
+      label: 'Pricing level',
+      kind: 'factor',
+      provenance: 'user_set',
+      observedState: { value, source: 'user_confirmed', extractionType: 'explicit' },
+      observed_state: { value, source: 'user_confirmed', extractionType: 'explicit' },
+    },
+  }
+}
+
+/**
+ * What CEE's persisted graph actually holds after that same confirm turn —
+ * `user_override`, because CEE collapses confirm and edit into one stamp.
+ * The value is IDENTICAL (a confirm-as-is moves nothing), which is exactly the
+ * branch that restores user stamps.
+ */
+function serverNodeAfterConfirm(value = 0.7) {
+  return {
+    id: 'fac_pricing_level',
+    kind: 'factor',
+    label: 'Pricing level',
+    provenance: 'user_set',
+    observed_state: { value, source: 'user_override' },
+  }
+}
+
+beforeEach(() => {
+  seed([confirmedNode()])
+})
+
+describe('2.638 S2 · withdrawUserConfirmation — the reversal is exact', () => {
+  it('clears the claim at every rung isReviewedByUser reads, and leaves the VALUE alone', () => {
+    const before = nodeById('fac_pricing_level')
+    const nextData = withdrawUserConfirmation(before.data as Record<string, unknown>)
+
+    // The claim is gone …
+    const withdrawn = { ...before, data: nextData } as unknown as Node
+    expect(isReviewedByUser(withdrawn)).toBe(false)
+    expect(isConfirmationWithdrawn(nextData)).toBe(true)
+    expect((nextData as any).observedState.source).toBeUndefined()
+    expect((nextData as any).observed_state.source).toBeUndefined()
+    // ⚠ The node-level `provenance` is CEE's field and is deliberately left
+    // standing (the UI never writes it, and a deletion is not even expressible
+    // through the store's shallow-merge `updateNode`). It does not need
+    // clearing: the withdrawal marker is the FIRST rung `isReviewedByUser`
+    // consults, which is why the predicate above already reads false.
+    expect((nextData as any).provenance).toBe('user_set')
+
+    // … and the number is untouched, in both spellings. A confirm-as-is never
+    // moved it, so a withdrawal that moved it would be inventing a revert.
+    expect((nextData as any).observedState.value).toBe(0.7)
+    expect((nextData as any).observed_state.value).toBe(0.7)
+    expect((nextData as any).label).toBe('Pricing level')
+  })
+
+  it('is inert on a node that was never confirmed (returns the same reference)', () => {
+    const data = { label: 'X', observedState: { value: 1, source: 'cee_inference' } }
+    expect(withdrawUserConfirmation(data)).toBe(data)
+    expect(isConfirmationWithdrawn(data)).toBe(false)
+  })
+
+  it('withdraws a node reviewed ONLY through the wire-carried provenance rung', () => {
+    // No `source` stamp anywhere — the badge came from `data.provenance ===
+    // 'user_set'`, the rung CEE writes. The withdrawal must still bite, or a
+    // value confirmed on another device could never be un-confirmed here.
+    const node = {
+      id: 'fac_wire_only',
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      data: { label: 'Wire only', kind: 'factor', provenance: 'user_set', observed_state: { value: 0.4 } },
+    } as unknown as Node
+    expect(isReviewedByUser(node)).toBe(true)
+
+    const next = withdrawUserConfirmation(node.data as Record<string, unknown>)
+    expect(next).not.toBe(node.data)
+    expect(isConfirmationWithdrawn(next)).toBe(true)
+    expect(isReviewedByUser({ ...node, data: next } as unknown as Node)).toBe(false)
+  })
+
+  it('leaves a PRODUCER stamp in place — the server owns those', () => {
+    const data = {
+      label: 'X',
+      provenance: 'ai_inferred',
+      observedState: { value: 1, source: 'user_confirmed' },
+      observed_state: { value: 1, source: 'cee_inference' },
+    }
+    const next = withdrawUserConfirmation(data) as any
+    expect(next.observedState.source).toBeUndefined()
+    expect(next.observed_state.source).toBe('cee_inference')
+    expect(next.provenance).toBe('ai_inferred')
+    expect(next.observedState.value).toBe(1)
+  })
+})
+
+describe('2.638 S2 · the withdrawal SURVIVES the boot merge (the round trip)', () => {
+  it('a confirmation the user did NOT withdraw survives reload — the control', () => {
+    const result = mergeServerGraphOnHydrate({
+      nodes: [serverNodeAfterConfirm()],
+      edges: [],
+    })
+    expect(result.accepted, result.refusedReason ?? '').toBe(true)
+    const after = nodeById('fac_pricing_level')
+    // Identity-bound: this node, still reviewed, still CONFIRMED (not demoted
+    // to the server's collapsed `user_override`).
+    expect(isReviewedByUser(after)).toBe(true)
+    expect((after.data as any).observed_state.source).toBe('user_confirmed')
+  })
+
+  it('a WITHDRAWN confirmation is not resurrected by CEE\'s own user_override stamp', () => {
+    const before = nodeById('fac_pricing_level')
+    useCanvasStore.setState({
+      nodes: [
+        { ...before, data: withdrawUserConfirmation(before.data as Record<string, unknown>) },
+      ] as never,
+    } as never)
+    expect(isReviewedByUser(nodeById('fac_pricing_level'))).toBe(false)
+
+    const result = mergeServerGraphOnHydrate({
+      nodes: [serverNodeAfterConfirm()],
+      edges: [],
+    })
+    expect(result.accepted, result.refusedReason ?? '').toBe(true)
+
+    const after = nodeById('fac_pricing_level')
+    // THE POINT. The server bag lands (it is authoritative for the value), and
+    // it carries `source: 'user_override'` — but the user withdrew the claim,
+    // and the client is the only holder of that fact.
+    expect(isConfirmationWithdrawn(after.data)).toBe(true)
+    expect(isReviewedByUser(after)).toBe(false)
+    // The VALUE still comes from the server, unchanged by the withdrawal.
+    expect((after.data as any).observed_state.value).toBe(0.7)
+  })
+
+  it('a re-confirmation after a withdrawal is honoured — through the REAL receipt path', () => {
+    // Not a hand-rolled clear: this drives `confirmOptimisticFactorEdit`, the
+    // one place a user claim is earned. A withdrawal that outlived a receipted
+    // re-confirmation would make the second confirmation invisible, and only
+    // this path can prove it does not.
+    const before = nodeById('fac_pricing_level')
+    useCanvasStore.setState({
+      nodes: [
+        { ...before, data: withdrawUserConfirmation(before.data as Record<string, unknown>) },
+      ] as never,
+    } as never)
+    expect(isReviewedByUser(nodeById('fac_pricing_level'))).toBe(false)
+
+    const outcome = confirmOptimisticFactorEdit({
+      nodeId: 'fac_pricing_level',
+      sentValue: 0.7,
+      prevObservedState: { value: 0.7 },
+      prevDisplayValue: undefined,
+      reviewedStamp: { source: 'user_confirmed', extractionType: 'explicit' },
+    })
+    expect(outcome).toBe('stamped')
+
+    const after = nodeById('fac_pricing_level')
+    expect(isConfirmationWithdrawn(after.data)).toBe(false)
+    expect(isReviewedByUser(after)).toBe(true)
+    expect((after.data as any).observedState.source).toBe('user_confirmed')
+  })
+})

--- a/src/canvas/utils/hydrateProvenance.ts
+++ b/src/canvas/utils/hydrateProvenance.ts
@@ -6,14 +6,26 @@
  * breaks the review badge in BOTH directions at once.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * WHY THE SERVER CAN NEVER SETTLE THIS BY ITSELF
+ * WHY THE SERVER CANNOT SETTLE THIS BY ITSELF
  * ─────────────────────────────────────────────────────────────────────────────
- * The stamp the UI reads is `observed_state.source`, and CEE's `ObservedStateV3`
- * types that field as `z.enum(['brief_extraction', 'cee_inference'])`. There is
- * no user-owned member, and the set-factor-value path never writes `source` at
- * all. So the server bag is STRUCTURALLY incapable of carrying "the user
- * checked this" — a merge that lets it decide the field is not resolving a
- * conflict, it is discarding evidence only the client holds.
+ * ⚠ CORRECTED 6 Aug 2026 at CEE's bytes (staging `d5b64246`), because the
+ * original reason here has EXPIRED and the conclusion now rests on a different,
+ * narrower fact. This block used to read: *"CEE's `ObservedStateV3` types
+ * `observed_state.source` as `z.enum(['brief_extraction','cee_inference'])`
+ * … the set-factor-value path never writes `source` at all … the server bag is
+ * STRUCTURALLY incapable of carrying 'the user checked this'."* **That is no
+ * longer true.** ROADMAP 2.396(b) landed the write: `set_factor_value` now
+ * merges `source: USER_EDIT_SOURCE` into the persisted `observed_state`
+ * (`orchestrator-v5/tools/handlers/set-factor-value.ts:421`) and stamps
+ * `node.provenance = 'user_set'` beside it.
+ *
+ * The conclusion survives for a SMALLER reason, and the size matters:
+ * `USER_EDIT_SOURCE` is the single literal `'user_override'`
+ * (`orchestrator/canonicalise-value-ops.ts:280`), written for a typed value and
+ * for a "confirm as is" alike. So the server can now say A PERSON TOUCHED THIS
+ * — it still cannot say WHICH ACT, and it cannot say the person later withdrew
+ * the claim. Those two facts live only in the client, so a merge that lets the
+ * server decide them is still discarding evidence only the client holds.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * THE TWO FAILURES, AND WHY THEY ARE ONE BUG
@@ -153,6 +165,101 @@ export function clearUserProvenance(data: Record<string, any>): Record<string, a
   }
   if (snapshot.top !== undefined) delete next.source
   return next
+}
+
+/**
+ * The key that records a WITHDRAWN confirmation.
+ *
+ * Top-level on `node.data`, UI-only, never on the wire — deliberately the same
+ * shape as `userReviewedStrength` below, and for the same reason: `overlayNode`
+ * merges `{...existing.data, ...mapped.data}`, so a key the mapper never emits
+ * survives every merge. An ABSENCE could not do this job (see below).
+ */
+export const CONFIRMATION_WITHDRAWN_KEY = 'userConfirmationWithdrawn'
+
+/** True when the user has withdrawn their confirmation of this node's value. */
+export function isConfirmationWithdrawn(data: unknown): boolean {
+  return (data as Record<string, unknown> | undefined)?.[CONFIRMATION_WITHDRAWN_KEY] === true
+}
+
+/**
+ * Withdraw a confirmation — ROADMAP 2.638 S2, Ruling 1's "reversible per value".
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THE REVERSAL IS EXACT, AND WHY IT NEEDS NO SNAPSHOT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * "Confirm as is" commits with `writeValue: false` — it moves no number, it
+ * only makes a claim about one. So withdrawing it has nothing to restore: the
+ * pre-confirmation state IS the current value with the claim removed. That is
+ * reversal by construction, the same property §4.3 of the design brief asks of
+ * the compute slice.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠ AND WHY A BARE `clearUserProvenance` IS NOT ENOUGH — the measured trap
+ * ─────────────────────────────────────────────────────────────────────────────
+ * CEE now DOES stamp a user-owned source server-side:
+ * `set_factor_value` writes `observed_state.source = USER_EDIT_SOURCE`, and
+ * `USER_EDIT_SOURCE = 'user_override'` (`canonicalise-value-ops.ts:280`,
+ * `set-factor-value.ts:421`, CEE staging `d5b64246`). ⚠ That falsifies this
+ * file's own header claim that "the server bag is STRUCTURALLY incapable of
+ * carrying 'the user checked this'" — true when written (2.312), landed
+ * otherwise by 2.396(b). The header is corrected in place above.
+ *
+ * The consequence for a withdrawal is precise: `restoreUserProvenance` writes
+ * back only the locations the PRE-merge snapshot HELD, so a node whose stamp we
+ * merely deleted yields an EMPTY snapshot, the server's `user_override` rides
+ * the overlay in untouched, and the badge is back on the next boot. A deletion
+ * cannot survive a merge whose default is "the server's stamp stands"; only a
+ * POSITIVE record can. Hence the key.
+ *
+ * Producer stamps are left alone — they are the server's to move, exactly as in
+ * `clearUserProvenance`.
+ *
+ * ⚠ THE NODE-LEVEL `provenance: 'user_set'` IS DELIBERATELY NOT TOUCHED, and
+ * that is a correction to the obvious design. It is CEE's field — the UI never
+ * writes it — so clearing it locally would put the client into disagreement
+ * with the wire on a value the server owns, and it would be undone by the next
+ * merge anyway. It does not need clearing: the withdrawal marker is the FIRST
+ * rung `isReviewedByUser` consults and short-circuits every rung below it,
+ * including that one. (It also cannot be deleted through the store: `updateNode`
+ * merges `{...n.data, ...updates.data}`, so a top-level key removed from the
+ * patch simply survives — a deletion is not expressible on this path. The
+ * NESTED observed-state bags are different: they are whole objects at the top
+ * level, so replacing them does remove their `source`.)
+ *
+ * Returns the SAME reference when there is nothing to withdraw.
+ */
+export function withdrawUserConfirmation(data: Record<string, any>): Record<string, any> {
+  const snapshot = captureUserProvenance(data)
+  const hadUserStamp =
+    snapshot.observed_state !== undefined ||
+    snapshot.observedState !== undefined ||
+    snapshot.top !== undefined
+  const hadNodeStamp = data?.provenance === 'user_set'
+  if (!hadUserStamp && !hadNodeStamp) return data
+
+  return { ...clearUserProvenance(data), [CONFIRMATION_WITHDRAWN_KEY]: true }
+}
+
+/**
+ * End a withdrawal.
+ *
+ * Called wherever a NEW user claim is EARNED, so the withdrawal is not a
+ * one-way door: a re-confirmation has to be believed.
+ *
+ * ⚠ Writes an explicit `false` rather than deleting the key, and the reason is
+ * measured, not stylistic: the store's `updateNode` merges
+ * `data: {...n.data, ...updates.data}`, so a deleted top-level key SURVIVES the
+ * write. A `delete` here left the marker standing and the re-confirmation
+ * invisible — caught by driving the real receipt path rather than a hand-rolled
+ * clear. `isConfirmationWithdrawn` tests `=== true`, so `false` reads exactly
+ * as "not withdrawn".
+ *
+ * Returns the SAME reference when there is no marker.
+ */
+export function clearConfirmationWithdrawal(data: Record<string, any>): Record<string, any> {
+  if (!isConfirmationWithdrawn(data)) return data
+  return { ...data, [CONFIRMATION_WITHDRAWN_KEY]: false }
 }
 
 /**


### PR DESCRIPTION
**ROADMAP 2.638 S2** — the disclosure + reversibility slice of the confirmed-values design.
**Pillar P4** (human–AI collaboration). **Zero maths change; nothing new crosses the wire.**

## The defects, measured at pristine `fa1f99f1`, on DEPLOYED-MOUNTED surfaces

| surface | what a CONFIRMED value rendered | mounts on staging? |
|---|---|---|
| `SourceProvenancePill` (Model tab) | **"Not set"** | yes, unflagged |
| `getExtractionLabel` (3 inspector-v2 factor panels) | **"Estimated by Olumi"** | yes, `USE_INSPECTOR_V2` hardcoded `true` |
| `getProvenanceLabel` / `mapSourceToDisplay` | the raw wire literal (`user_confirmed`) | yes |
| `EstimateRow` (pre-analysis-v3) | "checked by you" — for **both** acts | yes, `preAnalysisV3="1"` |
| `provenanceToPill('user_set')` | **null** | **no — DARK** |

Four different failures, one cause: four hand-maintained label maps nobody extended when the
`user_confirmed` / `user_override` stamps landed (trap 12).

## ⚠ Trap 3b — R-4 on its own would have shipped dark

`provenanceToPill`'s **only** host is `WhatOlumiAddedSection` → `PreAnalysisPanel` (v1), the
**else** arm of `isPreAnalysisV3Enabled()` at `OutputsDock.tsx:2346`. Staging sets
`VITE_FEATURE_PRE_ANALYSIS_V3="1"`, so that whole arm is dark — the 2.466/2.491 defect a third
time. The slice therefore also lands on the four live surfaces above.

## ⚠ Corrected premise — the design brief's §4.2 does not survive measurement

The brief says to drive the confirmation surface from the **echoed** `FactorSensitivityV2.value_source`.
At CEE's bytes (staging `d5b64246`) that cannot work:

* `set_factor_value` merges `source: USER_EDIT_SOURCE` into the persisted `observed_state`
  (`set-factor-value.ts:421`) and **`USER_EDIT_SOURCE = 'user_override'`** — one literal
  (`canonicalise-value-ops.ts:280`) — written for a typed value **and** for a confirm-as-is.
  **The server graph, and therefore every echo, is structurally incapable of naming the act.**
* The echo also describes the graph the *last analysis* ran on, and `value_source` is echoed only
  for PU-listed factors.

So the surface is driven from the **receipt-gated client stamp** — not the weaker signal here but the
only one (written by `confirmOptimisticFactorEdit` *after* CEE's applied `graph_patch` receipt).
The residual — no local autosave ⇒ CEE's collapsed stamp wins — is **named in `valueProvenance.ts`,
not hidden**, and closing it is a CEE change.

## What ships

* **`canvas/domain/valueProvenance.ts`** — one classification authority. Each surface keeps its own
  copy register but is `Record<ValueProvenanceKind, …>`, so a new kind is a **type error**, never a
  silent fallback.
* `user_set` classifies to **`'human'` ("Set by you")**, never `'confirmed'` — CEE writes it for both
  acts, so naming the act would be an over-claim.
* **`withdrawUserConfirmation`** + an **"Undo confirmation"** affordance on the pre-analysis-v3
  drill-in, scoped to CONFIRMED values. A confirm-as-is commits `writeValue: false`, so the reversal
  is exact with nothing to snapshot; an *edited* value's prior number is not retained past the
  receipt, so an undo there would promise what the store cannot do.
* The withdrawal is a **POSITIVE marker, not an absence**: `restoreUserProvenance` writes back only
  what the pre-merge snapshot held, so a merely *deleted* stamp lets CEE's own `user_override`
  resurrect the claim on the next boot merge, silently. Same shape as the sanctioned UI-only
  `userReviewedStrength`.
* Copy pinned as **STATUS, never effect**: *"Confirming records that you stand behind this number.
  It does not change the analysis."* (S4 is Neil-gated.)

## A defect caught by driving the REAL receipt path

`updateNode` merges `data: {...n.data, ...updates.data}` — **a deleted top-level key survives the
write.** The first `clearConfirmationWithdrawal` deleted the marker, so a receipted re-confirmation
left the withdrawal standing and was invisible. Both cleared states are now explicit.

## Record corrections, at the bytes

`hydrateProvenance.ts` and `isReviewedByUser.ts` both asserted CEE *"never writes
`observed_state.source`"* and that the server bag is *"STRUCTURALLY incapable"* of carrying a user
stamp. **2.396(b) shipped that write.** Both corrected in place; the conclusion is restated on the
narrower fact that survives (the server cannot name the ACT, or the retraction).
Also: the design brief records the UI schema pin as `0.34.0`; the vendored tarball at `fa1f99f1` is
**`0.38.0`**.

## Evidence

* **RED-first at pristine**, named signatures: **7/10** disclosure (`expected null not to be null`;
  `expected 'Estimated by Olumi' to be 'Confirmed by you'`; `expected 'Source: user_confirmed' to be
  'Confirmed by you'`; `Unable to find an element with the text: Confirmed by you` ×2), **6/6**
  reversibility, **6/9** affordance. The passing tests are byte-identical controls (trap 13).
* **Mutants: 16, all bite.** Worktree OUTSIDE the repo root, detached at the SHA with `HEAD`
  asserted; isolation proven by **writing** a sentinel (source SHA-256 unchanged) plus distinct
  inodes; restores from a pristine `git archive`; applied-check scoped to `src/` with the control
  reading **exactly 0**; unreadable summary = hard error. Includes the **trap-19 discriminating
  identity pair** (all-objects vs different-object, killing *different* assertions) and the
  **trap-12d corpus mutant** (canonical list goes SHORT → 7 RED, proving the hand-written corpus
  bites where the derived guard is structurally blind).
* **Full suite: 22,422 passed | 66 skipped (1,538 files)**, `VITE_SUPABASE_*` exported.
  **Collect derived 1541 == actual 1541, delta 0.**
* **Typecheck gate PASSED** (coverage + ratchet). The gate reports a 3-diagnostic *shrink* and offers
  `--update-baseline`; **declined**, since attribution to this PR was not measured (trap 2b).
* eslint on the changed files: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)