### PR TITLE
fix(2.737): withdraw the stopped-draft notice's receipt promise — the client promised something the server could not deliver

### DIFF
--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -161,12 +161,30 @@ export const UNSETTLED_DRAFT_NOTICE =
 // the draft's commit) and the sentence became the phantom model's cover story
 // \u2014 fresh-journey P0 diagnosis \u00a72 R2. The current premise (CEE 2.709): the
 // commit is the COMMON case (first-write exemption), it is not knowable from
-// this side of the aborted socket, and a refused/failed commit is surfaced by
-// the SERVER at the start of the next reply on this conversation (the
-// draft-loss notice). The copy states exactly that \u2014 pinned by
+// this side of the aborted socket. The copy states exactly that \u2014 pinned by
 // draftLossPremise.spec.ts, governed by narrationHonesty.
+//
+// \u26a0\u26a0 ROADMAP 2.737 WITHDREW THE RECEIPT PROMISE, and the withdrawal is the
+// lesson. This sentence used to end: "If it didn't, your next reply in this
+// conversation will say so." That is a promise about the SERVER, made
+// unconditionally by the CLIENT \u2014 and the server could not keep it. CEE's
+// draft-loss notice needs columns created by migration 20260806120000, which
+// is deliberately UNEXECUTED, so for every deploy state between #751 and that
+// migration the promise was simply false. Worse, ROADMAP 2.735 then found
+// that when the notice DOES light up it was firing for draft failures that
+// never produced a graph \u2014 so the promised receipt would itself have carried
+// a false claim.
+//
+// Our co-ship rule ("CEE PR then UI PR") was necessary and NOT SUFFICIENT: a
+// merged server PR is not a live server CAPABILITY. The honest fix, and the
+// one that needs no flag (Paul's standing no-env-var-gates rule), is to state
+// the weaker thing that is true at EVERY deploy state and let the receipt be
+// a bonus when it arrives: we cannot confirm the save from here, and here is
+// the action that works regardless. When the migration has executed and the
+// notice is live-witnessed, restoring a stronger sentence is a separate,
+// evidenced change \u2014 not an assumption baked in ahead of the capability.
 export const STOPPED_DRAFT_NOTICE =
-  'Drafting ended before your model\u2019s values arrived, so they are not final \u2014 and we can\u2019t confirm from here whether this draft saved. If it didn\u2019t, your next reply in this conversation will say so. The structure is still on the canvas \u2014 start a new draft to get a model with settled values.'
+  'Drafting ended before your model\u2019s values arrived, so they are not final \u2014 and we can\u2019t confirm from here whether this draft saved. The structure is still on the canvas \u2014 start a new draft to get a model with settled values.'
 
 /**
  * ── THE THREE EARLY-STOP NOTICES ────────────────────────────────────────────

--- a/src/canvas/conversation/__tests__/draftLossPremise.spec.ts
+++ b/src/canvas/conversation/__tests__/draftLossPremise.spec.ts
@@ -30,16 +30,46 @@ import {
 const HERE = path.dirname(fileURLToPath(import.meta.url))
 const USE_CONVERSATION = path.join(HERE, '..', 'useConversation.ts')
 
-describe('2.719 — the stopped-draft notice states the NEW premise', () => {
-  it('tells the user save-state is unconfirmed, and that a loss will be surfaced in the conversation', () => {
+describe('2.719/2.737 — the stopped-draft notice states the NEW premise', () => {
+  it('tells the user save-state is unconfirmed, and offers the action that works', () => {
     // Save-uncertainty: the client aborted the socket the receipt would have
     // arrived on, so asserting either "saved" or "not saved" would be a guess.
     expect(STOPPED_DRAFT_NOTICE).toMatch(/whether (this|your) draft saved/i)
-    // The receipt channel that does NOT depend on that socket: CEE's 2.709
-    // invariant-6 notice, carried in the next reply on this conversation.
-    expect(STOPPED_DRAFT_NOTICE).toMatch(/next reply/i)
     // The retry affordance's promise is unchanged.
     expect(STOPPED_DRAFT_NOTICE).toMatch(/start a new draft/i)
+  })
+
+  /**
+   * ROADMAP 2.737 — THIS PIN WAS INVERTED, AND THE INVERSION IS THE POINT.
+   *
+   * It used to REQUIRE `/next reply/i`: the notice had to promise that CEE
+   * would disclose a loss on the scenario's next turn. That promise was made
+   * unconditionally by the client while the server-side capability was DARK —
+   * CEE's draft-loss notice needs columns created by migration 20260806120000,
+   * which is deliberately unexecuted. So the suite was pinning a sentence the
+   * server could not honour, and it passed because it only ever asked whether
+   * the CLIENT said the words.
+   *
+   * A UI promise about server behaviour is only as true as the deployed
+   * server. Until the capability is live-witnessed, the copy must not assert
+   * it — so this pin now forbids exactly what it used to require.
+   */
+  it('2.737: makes NO unconditional promise about what the server will say next turn', () => {
+    expect(STOPPED_DRAFT_NOTICE).not.toMatch(/next reply/i)
+    expect(STOPPED_DRAFT_NOTICE).not.toMatch(/will say so/i)
+    expect(STOPPED_DRAFT_NOTICE).not.toMatch(/will tell you/i)
+    // DISCRIMINATOR (trap 13b): the pin must be able to SEE such a promise —
+    // otherwise "no promise present" could be true of any string at all. The
+    // exact withdrawn sentence, kept as a fixture, must trip every arm above.
+    const WITHDRAWN_2719_PROMISE =
+      'we can’t confirm from here whether this draft saved. If it didn’t, your next reply in this conversation will say so.'
+    expect(WITHDRAWN_2719_PROMISE).toMatch(/next reply/i)
+    expect(WITHDRAWN_2719_PROMISE).toMatch(/will say so/i)
+    // …and the ONE clause that survived the withdrawal is still present in
+    // both, so this is a narrowing of the sentence rather than a rewrite that
+    // happens to dodge the regexes.
+    expect(WITHDRAWN_2719_PROMISE).toMatch(/whether this draft saved/i)
+    expect(STOPPED_DRAFT_NOTICE).toMatch(/whether this draft saved/i)
   })
 
   it('does not assert the old #751 certainty ("still here" as a durability claim) without the save caveat', () => {


### PR DESCRIPTION
External adversarial audit (Codex, 2026-08-08). Pairs with CEE **#848** (2.735 / 2.736 / 2.738). **DO NOT MERGE — adversarial review precedes.**

## The defect

`STOPPED_DRAFT_NOTICE` ended:

> …we can't confirm from here whether this draft saved. **If it didn't, your next reply in this conversation will say so.**

That second sentence is a promise about the **server**, made **unconditionally** by the **client** — and the server could not keep it. CEE's draft-loss notice needs columns created by migration `20260806120000`, which is deliberately **unexecuted**. So for every deploy state between #751 and that migration, the promise was simply false.

Worse: ROADMAP **2.735** then found that when the notice *does* light up it was firing for draft failures that never produced a graph — so the promised receipt would itself have carried a false claim.

Our co-ship rule ("CEE PR then UI PR") was **necessary and not sufficient**: a merged server PR is not a live server *capability*. Our review passed this copy as "claims only what the client can know" and missed that the server half of the promise was dark.

## The fix

State the weaker thing that is **true at every deploy state**, and let the receipt be a bonus when it arrives. No flag, no env gate (standing rule), no new wire field — the sentence is withdrawn. The clause carrying the real information ("we can't confirm from here whether this draft saved") and the action that works ("start a new draft") both survive **verbatim**. This is a narrowing, not a rewrite.

Restoring a stronger sentence once the migration has executed and the notice is live-witnessed is a separate, evidenced change — not an assumption baked in ahead of the capability.

## Evidence

`draftLossPremise.spec.ts` **required** `/next reply/i`. That pin is inverted — it now forbids exactly what it used to require. Note what the old pin shows about this class of test: **it passed happily, because it only ever asked whether the client said the words.**

RED at pristine (staging `a81121d1`, component reverted, spec kept):

```
× 2.737: makes NO unconditional promise about what the server will say next turn
  AssertionError: expected 'Drafting ended before your model's va…' not to match /next reply/i
```

The new pin carries its own **discriminator** (trap 13b): the exact withdrawn sentence is kept in-test as a fixture and asserted to trip every arm, so "no promise present" cannot be vacuously true of any string — and the surviving save-uncertainty clause is asserted in **both**, so a rewrite that merely dodged the regexes would fail.

**Mutant** — throwaway worktree outside the repo root, isolation proven by **writing a sentinel** and asserting the source was unchanged (inodes compared); applied-check `src/`-scoped, control exactly zero. Restoring the withdrawn clause REDs the new pin, and only that pin.

**Gates:** `pnpm typecheck` **PASSED** (coverage + ratchet; 3284/3324 files loaded, drift 2491 → 2488). With `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported: `draftLossPremise` + `narrationHonesty.invariant` **54/54**; `streamedDraftTurn` + `AIInputBar.stopControl` (the constant's other consumers) **50/50**.

## Ordering

This copy is true whether or not #848 has shipped — which is the whole point of the change. It does not need to be sequenced behind CEE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)