### PR TITLE
feat(calibration R0): make the Record-the-decision modal durable

### DIFF
--- a/src/components/results/modals/DecisionRecordModal.tsx
+++ b/src/components/results/modals/DecisionRecordModal.tsx
@@ -1,21 +1,35 @@
 /**
- * Record-the-decision modal (prototype #decisionModal, build-ready v6).
+ * Record-the-decision modal — the elicitation end of the calibration loop
+ * (calibration R0, ROADMAP 2.727).
  *
- * Captures chosen option / confidence 0-100 / concise rationale / key
- * assumption to watch / revisit trigger-or-date into decisionRecordStore
- * (sessionStorage, scenario-keyed, with the analysed graph hash). The
- * chosen-option select is populated READ-ONLY from the live analysed
- * option set (canvas option nodes + the stable optionNumbering map) —
- * never the prototype's four hardcoded fixtures.
+ * Captures chosen option / confidence 0-100 / **what the user expects to
+ * happen** / concise rationale / key assumption to watch / revisit
+ * trigger-or-date. The chosen-option select is populated READ-ONLY from the
+ * live analysed option set (canvas option nodes + the stable optionNumbering
+ * map) — never the prototype's four hardcoded fixtures.
+ *
+ * ⭐ WHAT CHANGED IN R0: THE RECORD IS NOW DURABLE. On save, a signed-in
+ * user's chosen option, stated confidence, expectation and review date are
+ * POSTed to CEE and persisted in `decision_records` with
+ * `committed_by_user: true` and `confidence_source: 'user_stated'` — the
+ * first user-stated calibration population this product has ever had.
+ * Everything still lands in sessionStorage first, so a failed commit
+ * degrades the record from "durable" to "on this device", never to "lost".
+ *
+ * ⭐ WHY AN "EXPECTATION" FIELD RATHER THAN REUSING THE RATIONALE. The
+ * outcome is scored against `prediction.statement`, a FORWARD claim. A
+ * rationale is backward-looking justification for the choice. Scoring one as
+ * the other would be a semantic lie, and every calibration number built on it
+ * would be meaningless — so the user is asked the forward question directly.
  *
  * Fail-closed: with no completed analysis or zero option nodes the form
  * renders disabled with honest copy — capture never fabricates an option
  * set. Validation closes the prototype's Number('')===0 hole: confidence
  * must be NON-EMPTY, finite and 0-100 inclusive.
  *
- * HONESTY: no backend persistence exists (blocked on identity + Model
- * Management) — the note line says the record lives on this device for
- * this scenario.
+ * ⚠ NO ARITHMETIC ON PROBABILITIES HAPPENS HERE. The confidence goes over
+ * the wire as the raw 0–100 number the user typed; CEE owns the /100. A
+ * second place that rescales is a second place the scale can drift.
  *
  * Mount once; open from anywhere via openDecisionRecord() (the commit
  * rec's INTENDED wiring — the spec flags the prototype's 'ask' routing as
@@ -24,6 +38,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { useCanvasStore } from '../../../canvas/store'
+import { commitDecisionRecord } from '../../../services/decisionRecordCommitService'
 import { typography } from '../../../styles/typography'
 import {
   FIELD_INPUT_CLASS,
@@ -44,26 +59,48 @@ import {
 export const DECISION_RECORD_COPY = {
   title: 'Record the decision',
   subtitle: 'Capture the choice and what would justify revisiting it.',
-  prototypeNote:
-    'Prototype only. Saved on this device for this scenario. Durable saving depends on identity and Model Management.',
+  /**
+   * ⚠ THIS NOTE USED TO SAY "Prototype only … Durable saving depends on
+   * identity and Model Management." Leaving it would have been a FALSE
+   * disclosure in the other direction: for a signed-in user the choice, the
+   * confidence, the expectation and the review date now persist to their
+   * account. The note names the split precisely rather than claiming more or
+   * less than is true.
+   */
+  persistenceNote:
+    'Your choice, confidence, expectation and review date are saved to your account. The rationale, assumption and revisit trigger stay on this device for this scenario.',
+  guestNote:
+    'Signed out, so this stays on this device for this scenario and ends with the browser session. Sign in to keep a durable record.',
+  savedRemoteNote: 'Saved to your account.',
   emptyState:
     'Run an analysis first. There are no analysed options to record a decision against yet.',
   chosenOptionLabel: 'Chosen option',
   confidenceLabel: 'Confidence, 0–100',
   confidencePlaceholder: 'e.g. 70',
+  expectationLabel: 'What do you expect to happen?',
+  expectationPlaceholder: 'e.g. runway holds above 9 months through Q1',
+  expectationHelp:
+    'This is the claim we check back against — keep it something you could later call right or wrong.',
   revisitLabel: 'Revisit trigger or date',
-  revisitPlaceholder: 'e.g. runway falls below 9 months',
+  revisitPlaceholder: 'e.g. runway falls below 9 months, or 2026-12-01',
+  revisitHelp:
+    'Give a date and we set your review date to it. Give a trigger and we keep the text here and set the review date 90 days out.',
   rationaleLabel: 'Concise rationale',
   rationalePlaceholder: 'Why this is the best current choice',
   assumptionLabel: 'Key assumption to watch',
   assumptionPlaceholder: 'The assumption most likely to change the choice',
   cancel: 'Cancel',
-  save: 'Capture prototype record',
+  save: 'Record the decision',
+  saving: 'Saving…',
   confidenceError: 'Add a confidence between 0 and 100.',
+  expectationError: 'Add what you expect to happen.',
   rationaleError: 'Add a concise rationale.',
   assumptionError: 'Add the assumption most likely to change the choice.',
   revisitError: 'Add a revisit trigger or date.',
-  toastSaved: 'Prototype decision record captured in this session.',
+  toastSaved: 'Decision recorded and saved to your account.',
+  toastSavedLocal: 'Decision recorded on this device.',
+  toastSavedLocalAfterError:
+    'Decision recorded on this device — we could not save it to your account.',
 } as const
 
 interface AnalysedOption {
@@ -121,21 +158,26 @@ export function DecisionRecordModal() {
   const titleId = useId()
   const optionId = useId()
   const confidenceId = useId()
+  const expectationId = useId()
   const revisitId = useId()
   const rationaleId = useId()
   const assumptionId = useId()
   const confidenceErrorId = useId()
+  const expectationErrorId = useId()
   const revisitErrorId = useId()
   const rationaleErrorId = useId()
   const assumptionErrorId = useId()
 
   const [chosenOptionId, setChosenOptionId] = useState('')
   const [confidence, setConfidence] = useState('')
+  const [expectation, setExpectation] = useState('')
   const [revisit, setRevisit] = useState('')
   const [rationale, setRationale] = useState('')
   const [assumption, setAssumption] = useState('')
+  const [saving, setSaving] = useState(false)
   const [touched, setTouched] = useState<{
     confidence?: boolean
+    expectation?: boolean
     revisit?: boolean
     rationale?: boolean
     assumption?: boolean
@@ -148,6 +190,7 @@ export function DecisionRecordModal() {
   useEffect(() => {
     if (!isOpen) return
     saveFiredRef.current = false
+    setSaving(false)
     const scenarioKey = resolveScenarioKey(useCanvasStore.getState().currentScenarioId)
     const saved = selectDecisionRecord(useDecisionRecordStore.getState(), scenarioKey)
     if (saved) {
@@ -155,12 +198,16 @@ export function DecisionRecordModal() {
         options.some((o) => o.id === saved.optionId) ? saved.optionId : options[0]?.id ?? '',
       )
       setConfidence(String(saved.confidence))
+      // `?? ''` because records persisted before the expectation field
+      // existed are still readable — never a fabricated statement.
+      setExpectation(saved.expectation ?? '')
       setRevisit(saved.revisitTrigger)
       setRationale(saved.rationale)
       setAssumption(saved.assumptionToWatch)
     } else {
       setChosenOptionId(options[0]?.id ?? '')
       setConfidence('')
+      setExpectation('')
       setRevisit('')
       setRationale('')
       setAssumption('')
@@ -174,6 +221,7 @@ export function DecisionRecordModal() {
   const parsedConfidence = parseConfidence(confidence)
   const confidenceValid =
     Number.isFinite(parsedConfidence) && parsedConfidence >= 0 && parsedConfidence <= 100
+  const expectationValid = expectation.trim() !== ''
   const revisitValid = revisit.trim() !== ''
   const rationaleValid = rationale.trim() !== ''
   const assumptionValid = assumption.trim() !== ''
@@ -182,33 +230,94 @@ export function DecisionRecordModal() {
     hasOptions &&
     chosenOption !== null &&
     confidenceValid &&
+    expectationValid &&
     revisitValid &&
     rationaleValid &&
     assumptionValid
 
   const handleSave = () => {
     if (!valid || chosenOption === null) {
-      setTouched({ confidence: true, revisit: true, rationale: true, assumption: true })
+      setTouched({
+        confidence: true,
+        expectation: true,
+        revisit: true,
+        rationale: true,
+        assumption: true,
+      })
       return
     }
     if (saveFiredRef.current) return
     saveFiredRef.current = true
 
-    const scenarioKey = resolveScenarioKey(useCanvasStore.getState().currentScenarioId)
+    const scenarioId = useCanvasStore.getState().currentScenarioId
+    const scenarioKey = resolveScenarioKey(scenarioId)
     const record: DecisionRecord = {
       optionId: chosenOption.id,
       optionLabel: chosenOption.label,
       optionNumber: chosenOption.number,
       confidence: parsedConfidence,
+      expectation: expectation.trim(),
       rationale: rationale.trim(),
       assumptionToWatch: assumption.trim(),
       revisitTrigger: revisit.trim(),
       analysisHash,
       savedAt: Date.now(),
+      remote: null,
     }
+    // LOCAL FIRST, ALWAYS. Whatever happens on the network, the user's input
+    // is already kept — a failed commit degrades the record from "durable" to
+    // "on this device", never to "lost".
     useDecisionRecordStore.getState().saveRecord(scenarioKey, record)
-    close()
-    showToast(DECISION_RECORD_COPY.toastSaved)
+
+    // A stable per-save id: a retry of THIS save replays through CEE's dedupe
+    // branch, while a genuinely new save gets a new id and is never swallowed
+    // by the previous one.
+    const clientCommitId =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${scenarioKey}:${record.savedAt}`
+
+    if (typeof scenarioId !== 'string' || scenarioId === '') {
+      // No persisted scenario ⇒ nothing CEE could anchor an owner to. Local
+      // only, said plainly.
+      close()
+      showToast(DECISION_RECORD_COPY.toastSavedLocal)
+      return
+    }
+
+    setSaving(true)
+    void commitDecisionRecord({
+      scenarioId,
+      chosenOptionId: chosenOption.id,
+      chosenOptionLabel: chosenOption.label,
+      // RAW 0–100 — CEE owns the /100 (no arithmetic on probabilities here).
+      confidence0to100: parsedConfidence,
+      expectationStatement: record.expectation ?? '',
+      revisitTriggerOrDate: record.revisitTrigger,
+      clientCommitId,
+    }).then((result) => {
+      setSaving(false)
+      if (result.status === 'saved') {
+        useDecisionRecordStore.getState().attachRemote(scenarioKey, {
+          recordId: result.recordId,
+          reviewDate: result.reviewDate,
+          reviewDateSource: result.reviewDateSource,
+        })
+        close()
+        showToast(DECISION_RECORD_COPY.toastSaved)
+        return
+      }
+      close()
+      // Two DIFFERENT local outcomes, never merged: a guest was never going
+      // to get a durable record (records require sign-in by design), while an
+      // error means we tried and failed. Telling a signed-in user the guest
+      // story would hide a real failure.
+      showToast(
+        result.status === 'guest'
+          ? DECISION_RECORD_COPY.toastSavedLocal
+          : DECISION_RECORD_COPY.toastSavedLocalAfterError,
+      )
+    })
   }
 
   return (
@@ -225,7 +334,7 @@ export function DecisionRecordModal() {
           data-testid="decision-record-note"
           className={`mt-[10px] rounded-[9px] border border-panel-border bg-panel px-[9px] py-2 ${typography.panelMeta} text-text-light`}
         >
-          {DECISION_RECORD_COPY.prototypeNote}
+          {DECISION_RECORD_COPY.persistenceNote}
         </p>
 
         {!hasOptions && (
@@ -289,7 +398,42 @@ export function DecisionRecordModal() {
             </FieldError>
           </div>
 
-          <div className="flex flex-col gap-1">
+          <div className="col-span-2 flex flex-col gap-1">
+            <FieldLabel htmlFor={expectationId}>
+              {DECISION_RECORD_COPY.expectationLabel}
+            </FieldLabel>
+            <input
+              id={expectationId}
+              data-testid="decision-record-expectation"
+              type="text"
+              placeholder={DECISION_RECORD_COPY.expectationPlaceholder}
+              value={expectation}
+              onChange={(e) => setExpectation(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, expectation: true }))}
+              disabled={!hasOptions}
+              aria-invalid={touched.expectation === true && !expectationValid}
+              aria-describedby={
+                touched.expectation === true && !expectationValid
+                  ? expectationErrorId
+                  : undefined
+              }
+              className={FIELD_INPUT_CLASS}
+            />
+            <p
+              data-testid="decision-record-expectation-help"
+              className={`${typography.panelMeta} text-text-light`}
+            >
+              {DECISION_RECORD_COPY.expectationHelp}
+            </p>
+            <FieldError
+              id={expectationErrorId}
+              show={touched.expectation === true && !expectationValid}
+            >
+              {DECISION_RECORD_COPY.expectationError}
+            </FieldError>
+          </div>
+
+          <div className="col-span-2 flex flex-col gap-1">
             <FieldLabel htmlFor={revisitId}>{DECISION_RECORD_COPY.revisitLabel}</FieldLabel>
             <input
               id={revisitId}
@@ -306,6 +450,12 @@ export function DecisionRecordModal() {
               }
               className={FIELD_INPUT_CLASS}
             />
+            <p
+              data-testid="decision-record-revisit-help"
+              className={`${typography.panelMeta} text-text-light`}
+            >
+              {DECISION_RECORD_COPY.revisitHelp}
+            </p>
             <FieldError id={revisitErrorId} show={touched.revisit === true && !revisitValid}>
               {DECISION_RECORD_COPY.revisitError}
             </FieldError>
@@ -376,10 +526,10 @@ export function DecisionRecordModal() {
             type="button"
             data-testid="decision-record-save"
             onClick={handleSave}
-            disabled={!valid}
+            disabled={!valid || saving}
             className={PRIMARY_BUTTON_CLASS}
           >
-            {DECISION_RECORD_COPY.save}
+            {saving ? DECISION_RECORD_COPY.saving : DECISION_RECORD_COPY.save}
           </button>
         </div>
       </ModalShell>

--- a/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
+++ b/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
@@ -205,6 +205,48 @@ describe('durable commit — the wire', () => {
     )
   })
 
+  it.each([
+    ['an unrecognised rung', 'some_future_rung'],
+    ['a missing rung', undefined],
+    ['a non-string rung', 42],
+  ])(
+    '%s is reported as a DEFAULT rung, NEVER as user_set',
+    async (_label, rung) => {
+      // Found by a surviving mutant, which is the only reason this test
+      // exists: the fallback DIRECTION was uncovered. Claiming `user_set` for
+      // a rung we did not recognise would tell the user they chose a review
+      // date they never chose — the one direction of this error that misleads.
+      fetchMock.mockResolvedValue(
+        okResponse({
+          record_id: RECORD_ID,
+          review_date: '2026-11-04T00:00:00.000Z',
+          review_date_source: rung,
+          deduped: false,
+        }),
+      )
+      await saveModal()
+      const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+      expect(record?.remote?.reviewDateSource).toBe('default_horizon')
+      expect(record?.remote?.reviewDateSource).not.toBe('user_set')
+    },
+  )
+
+  it('a RECOGNISED user_set rung is still carried through (the fallback is not swallowing everything)', async () => {
+    // The other half of the pair: without this, a mutant that hardcoded
+    // 'default_horizon' for every response would survive the test above.
+    fetchMock.mockResolvedValue(
+      okResponse({
+        record_id: RECORD_ID,
+        review_date: '2026-12-01T00:00:00.000Z',
+        review_date_source: 'user_set',
+        deduped: false,
+      }),
+    )
+    await saveModal()
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.remote?.reviewDateSource).toBe('user_set')
+  })
+
   it('a 2xx with no record_id is NOT reported as saved', async () => {
     fetchMock.mockResolvedValue(okResponse({ deduped: false }, 201))
     await saveModal()

--- a/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
+++ b/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
@@ -20,6 +20,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 
 import { DecisionRecordModal, DECISION_RECORD_COPY } from '../DecisionRecordModal'
@@ -30,7 +31,12 @@ import {
 } from '../decisionRecordStore'
 import { useCanvasStore } from '../../../../canvas/store'
 
-const mockGetSessionIdentity = vi.fn(async () => ({
+type SessionIdentity = { userId: string | null; accessToken: string | null }
+
+// The nullable (guest) shape is part of getSessionIdentity's real contract —
+// declared here rather than inferred from the happy-path literal, so the guest
+// case is expressible without a cast.
+const mockGetSessionIdentity = vi.fn<[], Promise<SessionIdentity>>(async () => ({
   userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
   accessToken: 'test-access-token',
 }))
@@ -86,7 +92,8 @@ function okResponse(body: Record<string, unknown>, status = 201): Response {
   } as unknown as Response
 }
 
-let fetchMock: ReturnType<typeof vi.fn>
+type FetchMock = Mock<Parameters<typeof fetch>, Promise<Response>>
+let fetchMock: FetchMock
 
 async function saveModal() {
   render(<DecisionRecordModal />)
@@ -108,7 +115,7 @@ beforeEach(() => {
     userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
     accessToken: 'test-access-token',
   })
-  fetchMock = vi.fn(async () =>
+  fetchMock = vi.fn<Parameters<typeof fetch>, Promise<Response>>(async () =>
     okResponse({
       record_id: RECORD_ID,
       review_date: '2026-12-01T00:00:00.000Z',
@@ -128,7 +135,7 @@ describe('durable commit — the wire', () => {
     await saveModal()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     expect(url).toBe('/bff/cee/decision-records/commit')
     expect(init.method).toBe('POST')
     expect((init.headers as Record<string, string>).Authorization).toBe(
@@ -164,7 +171,7 @@ describe('durable commit — the wire', () => {
 
   it('NEVER sends the local analysisHash as an anchor — that is PLoT\'s response_hash', async () => {
     await saveModal()
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     const raw = init.body as string
     // `results.hash` is annotated `// response_hash` in the canvas store; the
     // record's anchor is the aag_v1 analysis-affecting hash CEE derives from

--- a/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
+++ b/src/components/results/modals/__tests__/DecisionRecordModal.durableCommit.spec.tsx
@@ -1,0 +1,255 @@
+/**
+ * Calibration R0 (UI half) — the "Record the decision" modal now writes a
+ * DURABLE record.
+ *
+ * This file exercises the REAL `decisionRecordCommitService` against a mocked
+ * `fetch`, so the assertions are about the WIRE — the exact path, the exact
+ * header, the exact body — not about the modal calling something.
+ *
+ * Two things it deliberately proves that a runtime test alone cannot:
+ *   1. the seam base is a LITERAL, DERIVED from `netlify.toml`'s cee-proxy
+ *      binding rather than restated here (Vite inlines `import.meta.env` at
+ *      transform time, so an env-resolved base reads correct in vitest and
+ *      can still ship pointed at the wrong origin — how 2.387 and 2.710
+ *      shipped dark);
+ *   2. the confidence crosses the wire as the RAW 0–100 number, because the
+ *      UI performs no arithmetic on probabilities.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import { DecisionRecordModal, DECISION_RECORD_COPY } from '../DecisionRecordModal'
+import {
+  openDecisionRecord,
+  selectDecisionRecord,
+  useDecisionRecordStore,
+} from '../decisionRecordStore'
+import { useCanvasStore } from '../../../../canvas/store'
+
+const mockGetSessionIdentity = vi.fn(async () => ({
+  userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  accessToken: 'test-access-token',
+}))
+
+vi.mock('../../../../lib/supabase', () => ({
+  supabase: {},
+  getSessionIdentity: (...args: unknown[]) =>
+    (mockGetSessionIdentity as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+const SCENARIO_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const RECORD_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+
+function optionNode(id: string, label: string) {
+  return { id, type: 'option', position: { x: 0, y: 0 }, data: { label } }
+}
+
+function seedAnalysedOptions() {
+  useCanvasStore.setState({
+    nodes: [
+      optionNode('opt_b', 'Hire senior technical lead'),
+      optionNode('opt_a', 'Bring on technical co-founder'),
+    ] as never,
+    results: { status: 'complete', progress: 100, hash: 'hash_run_1' } as never,
+    optionNumbering: { opt_a: 1, opt_b: 2 },
+    currentScenarioId: SCENARIO_ID,
+  } as never)
+}
+
+function fillValid() {
+  fireEvent.change(screen.getByTestId('decision-record-confidence'), {
+    target: { value: '70' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-expectation'), {
+    target: { value: 'Runway holds above 9 months through Q1.' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-revisit'), {
+    target: { value: '2026-12-01' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-rationale'), {
+    target: { value: 'Best current choice given hiring constraints.' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-assumption'), {
+    target: { value: 'The hiring market stays open.' },
+  })
+}
+
+function okResponse(body: Record<string, unknown>, status = 201): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+async function saveModal() {
+  render(<DecisionRecordModal />)
+  act(() => openDecisionRecord())
+  fireEvent.change(screen.getByTestId('decision-record-option'), {
+    target: { value: 'opt_b' },
+  })
+  fillValid()
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('decision-record-save'))
+  })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  useDecisionRecordStore.getState()._reset()
+  seedAnalysedOptions()
+  mockGetSessionIdentity.mockResolvedValue({
+    userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    accessToken: 'test-access-token',
+  })
+  fetchMock = vi.fn(async () =>
+    okResponse({
+      record_id: RECORD_ID,
+      review_date: '2026-12-01T00:00:00.000Z',
+      review_date_source: 'user_set',
+      deduped: false,
+    }),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('durable commit — the wire', () => {
+  it('POSTs to the cee-proxy seam with the user token, and the record becomes durable', async () => {
+    await saveModal()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/bff/cee/decision-records/commit')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer test-access-token',
+    )
+
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.scenario_id).toBe(SCENARIO_ID)
+    expect(body.chosen_option_id).toBe('opt_b')
+    expect(body.chosen_option_label).toBe('Hire senior technical lead')
+    expect(body.expectation_statement).toBe('Runway holds above 9 months through Q1.')
+    expect(body.revisit_trigger_or_date).toBe('2026-12-01')
+    expect(typeof body.client_commit_id).toBe('string')
+    expect((body.client_commit_id as string).length).toBeGreaterThan(0)
+
+    // THE RAW 0–100 NUMBER. The server owns the /100; a UI that divides is a
+    // second place the scale can drift.
+    expect(body.confidence_0_100).toBe(70)
+    expect(body.confidence_0_100).not.toBe(0.7)
+
+    // The durable marker is the record id CEE returned — nothing claims
+    // "saved to your account" without it.
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.remote).toEqual({
+      recordId: RECORD_ID,
+      reviewDate: '2026-12-01T00:00:00.000Z',
+      reviewDateSource: 'user_set',
+    })
+    expect(screen.getByTestId('decision-record-toast')).toHaveTextContent(
+      DECISION_RECORD_COPY.toastSaved,
+    )
+  })
+
+  it('NEVER sends the local analysisHash as an anchor — that is PLoT\'s response_hash', async () => {
+    await saveModal()
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const raw = init.body as string
+    // `results.hash` is annotated `// response_hash` in the canvas store; the
+    // record's anchor is the aag_v1 analysis-affecting hash CEE derives from
+    // its own run_analysis fact. Sending this value would anchor the record
+    // to a regime no reviewer can re-derive against.
+    expect(raw).not.toContain('hash_run_1')
+    expect(raw).not.toContain('graph_hash')
+  })
+
+  it('a guest makes NO network call and is told the LOCAL story, never "saved to your account"', async () => {
+    mockGetSessionIdentity.mockResolvedValue({ userId: null, accessToken: null })
+    await saveModal()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.optionId).toBe('opt_b')
+    expect(record?.remote ?? null).toBeNull()
+    expect(screen.getByTestId('decision-record-toast')).toHaveTextContent(
+      DECISION_RECORD_COPY.toastSavedLocal,
+    )
+  })
+
+  it('a FAILED commit keeps the record locally and says the save failed — a distinct message from the guest one', async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({ code: 'not_scenario_owner', message: 'nope' }, 403),
+    )
+    await saveModal()
+
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.confidence).toBe(70)
+    expect(record?.remote ?? null).toBeNull()
+    const toast = screen.getByTestId('decision-record-toast')
+    expect(toast).toHaveTextContent(DECISION_RECORD_COPY.toastSavedLocalAfterError)
+    // The two local outcomes must not be merged: telling a signed-in user the
+    // guest story would hide a real failure.
+    expect(DECISION_RECORD_COPY.toastSavedLocalAfterError).not.toBe(
+      DECISION_RECORD_COPY.toastSavedLocal,
+    )
+  })
+
+  it('a 2xx with no record_id is NOT reported as saved', async () => {
+    fetchMock.mockResolvedValue(okResponse({ deduped: false }, 201))
+    await saveModal()
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.remote ?? null).toBeNull()
+    expect(screen.getByTestId('decision-record-toast')).toHaveTextContent(
+      DECISION_RECORD_COPY.toastSavedLocalAfterError,
+    )
+  })
+
+  it('a network throw degrades to local, never to lost', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'))
+    await saveModal()
+    const record = selectDecisionRecord(useDecisionRecordStore.getState(), SCENARIO_ID)
+    expect(record?.expectation).toBe('Runway holds above 9 months through Q1.')
+    expect(record?.remote ?? null).toBeNull()
+  })
+})
+
+describe('durable commit — base binding (source-level, DERIVED)', () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url))
+  const REPO_ROOT = path.resolve(HERE, '../../../../..')
+  const SERVICE = path.join(REPO_ROOT, 'src/services/decisionRecordCommitService.ts')
+
+  it('uses the base netlify.toml actually binds cee-proxy to — derived, not restated', () => {
+    const toml = readFileSync(path.join(REPO_ROOT, 'netlify.toml'), 'utf8')
+    // Find the [[edge_functions]] block whose function is cee-proxy and take
+    // ITS path. If the binding ever moves, this derives the new value and the
+    // assertion below fails against the source — no hand-maintained mirror.
+    const match = /function\s*=\s*"cee-proxy"[\s\S]{0,200}?path\s*=\s*"([^"]+)"/.exec(toml)
+    expect(match).not.toBeNull()
+    const boundPath = (match as RegExpExecArray)[1]
+    expect(boundPath).toBe('/bff/cee/*')
+
+    const expectedBase = boundPath.replace(/\/\*$/, '')
+    const source = readFileSync(SERVICE, 'utf8')
+    expect(source).toContain(`const CEE_BFF_BASE = '${expectedBase}'`)
+  })
+
+  it('reads NO import.meta.env in the commit service (Vite would inline it at build time)', () => {
+    const source = readFileSync(SERVICE, 'utf8')
+    const withoutComments = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+    expect(withoutComments).not.toMatch(/import\.meta\s*\.\s*env/)
+    expect(withoutComments).not.toMatch(/VITE_/)
+  })
+})

--- a/src/components/results/modals/__tests__/DecisionRecordModal.spec.tsx
+++ b/src/components/results/modals/__tests__/DecisionRecordModal.spec.tsx
@@ -4,8 +4,16 @@
  * the closed Number('')===0 confidence hole, scenario-keyed persistence
  * with the analysed graph hash, and the shared modal a11y contract.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
+
+// The DURABLE half is exercised end-to-end in
+// DecisionRecordModal.durableCommit.spec.tsx (real service, mocked fetch).
+// Here the commit is stubbed to the GUEST result so this file keeps testing
+// exactly what it was written to test: local capture, validation and a11y.
+vi.mock('../../../../services/decisionRecordCommitService', () => ({
+  commitDecisionRecord: vi.fn(async () => ({ status: 'guest' as const })),
+}))
 
 import { DecisionRecordModal, DECISION_RECORD_COPY } from '../DecisionRecordModal'
 import {
@@ -47,6 +55,9 @@ function openModal() {
 function fillValid() {
   fireEvent.change(screen.getByTestId('decision-record-confidence'), {
     target: { value: '70' },
+  })
+  fireEvent.change(screen.getByTestId('decision-record-expectation'), {
+    target: { value: 'Runway holds above 9 months through Q1.' },
   })
   fireEvent.change(screen.getByTestId('decision-record-revisit'), {
     target: { value: 'Runway falls below 9 months' },
@@ -101,12 +112,14 @@ describe('DecisionRecordModal — chrome and a11y', () => {
     expect(document.activeElement).toBe(opener)
   })
 
-  it('shows the honest prototype-persistence note', () => {
+  it('names the durable/local split honestly — never "prototype only" now that the record persists', () => {
     render(<DecisionRecordModal />)
     openModal()
-    expect(screen.getByTestId('decision-record-note')).toHaveTextContent(
-      'Saved on this device for this scenario.',
-    )
+    const note = screen.getByTestId('decision-record-note')
+    // What IS durable, and what is NOT — both stated, neither over-claimed.
+    expect(note).toHaveTextContent('saved to your account')
+    expect(note).toHaveTextContent('stay on this device')
+    expect(note.textContent ?? '').not.toContain('Prototype only')
   })
 })
 
@@ -184,11 +197,12 @@ describe('DecisionRecordModal — validation', () => {
     expect(screen.getByTestId('decision-record-save')).toBeEnabled()
   })
 
-  it('rationale, assumption and revisit trigger are each required with their own errors', () => {
+  it('expectation, rationale, assumption and revisit trigger are each required with their own errors', () => {
     render(<DecisionRecordModal />)
     openModal()
     fillValid()
     for (const [testId, error] of [
+      ['decision-record-expectation', DECISION_RECORD_COPY.expectationError],
       ['decision-record-rationale', DECISION_RECORD_COPY.rationaleError],
       ['decision-record-assumption', DECISION_RECORD_COPY.assumptionError],
       ['decision-record-revisit', DECISION_RECORD_COPY.revisitError],
@@ -206,14 +220,16 @@ describe('DecisionRecordModal — validation', () => {
 })
 
 describe('DecisionRecordModal — capture', () => {
-  it('saves the scenario-keyed record with the analysed graph hash, toasts the spec copy and closes', () => {
+  it('saves the scenario-keyed record with the analysed graph hash, toasts the spec copy and closes', async () => {
     render(<DecisionRecordModal />)
     openModal()
     fireEvent.change(screen.getByTestId('decision-record-option'), {
       target: { value: 'opt_b' },
     })
     fillValid()
-    fireEvent.click(screen.getByTestId('decision-record-save'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('decision-record-save'))
+    })
 
     const record = selectDecisionRecord(useDecisionRecordStore.getState(), 'scn_test')
     expect(record).toMatchObject({
@@ -224,20 +240,25 @@ describe('DecisionRecordModal — capture', () => {
       rationale: 'Best current choice given hiring constraints.',
       assumptionToWatch: 'The hiring market stays open.',
       revisitTrigger: 'Runway falls below 9 months',
+      expectation: 'Runway holds above 9 months through Q1.',
       analysisHash: 'hash_run_1',
     })
 
     expect(screen.queryByTestId('decision-record-modal')).not.toBeInTheDocument()
+    // A GUEST is told the local story, never "saved to your account" — the
+    // two outcomes are never merged.
     expect(screen.getByTestId('decision-record-toast')).toHaveTextContent(
-      DECISION_RECORD_COPY.toastSaved,
+      DECISION_RECORD_COPY.toastSavedLocal,
     )
   })
 
-  it('the selector exposes the record for later "Decision recorded" surfaces, and it survives a simulated reload', () => {
+  it('the selector exposes the record for later "Decision recorded" surfaces, and it survives a simulated reload', async () => {
     render(<DecisionRecordModal />)
     openModal()
     fillValid()
-    fireEvent.click(screen.getByTestId('decision-record-save'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('decision-record-save'))
+    })
 
     useDecisionRecordStore.setState({ byScenario: {} })
     useDecisionRecordStore.getState()._rehydrateForTests()
@@ -246,20 +267,25 @@ describe('DecisionRecordModal — capture', () => {
     expect(record?.analysisHash).toBe('hash_run_1')
   })
 
-  it('reopening prefills from the existing record', () => {
+  it('reopening prefills from the existing record', async () => {
     render(<DecisionRecordModal />)
     openModal()
     fireEvent.change(screen.getByTestId('decision-record-option'), {
       target: { value: 'opt_b' },
     })
     fillValid()
-    fireEvent.click(screen.getByTestId('decision-record-save'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('decision-record-save'))
+    })
 
     openModal()
     expect(screen.getByTestId('decision-record-option')).toHaveValue('opt_b')
     expect(screen.getByTestId('decision-record-confidence')).toHaveValue('70')
     expect(screen.getByTestId('decision-record-rationale')).toHaveValue(
       'Best current choice given hiring constraints.',
+    )
+    expect(screen.getByTestId('decision-record-expectation')).toHaveValue(
+      'Runway holds above 9 months through Q1.',
     )
   })
 })

--- a/src/components/results/modals/decisionRecordStore.ts
+++ b/src/components/results/modals/decisionRecordStore.ts
@@ -1,21 +1,57 @@
 /**
- * decisionRecordStore — the prototype-only decision record captured by the
+ * decisionRecordStore — the decision record captured by the
  * Record-the-decision modal (prototype #decisionModal, build-ready v6).
  *
- * HONESTY CONTRACT: NO backend persistence exists — durable saving is
- * blocked on identity + Model Management (the prototype's own disclaimer).
- * Records live in sessionStorage on THIS device for THIS scenario and die
- * with the browser session. Any surface rendering a "Decision recorded"
- * state from this store must label it accordingly.
+ * ⭐ HONESTY CONTRACT, REWRITTEN FOR CALIBRATION R0 — AND THE OLD ONE WAS
+ * BECOMING FALSE IN THE OTHER DIRECTION. It used to read "NO backend
+ * persistence exists — durable saving is blocked on identity + Model
+ * Management". That is no longer true for a signed-in user: the chosen
+ * option, the user's stated confidence, their expectation and the review date
+ * now persist durably in CEE's `decision_records` under owner-only RLS. What
+ * is STILL local-only is the set of fields the shared contract has no home
+ * for — `rationale`, `assumptionToWatch` and a non-date `revisitTrigger`
+ * (`DecisionRecordDecisionSchema`/`…PredictionSchema` are `.strict()`).
+ *
+ * So the split, exactly:
+ *   DURABLE (signed in)  chosen option · confidence · expectation ·
+ *                        review date · the analysed graph anchor
+ *   THIS DEVICE ONLY     rationale · assumption to watch · the revisit
+ *                        trigger TEXT (a trigger is not a date)
+ *   GUESTS               everything stays local, by design — decision
+ *                        records require sign-in (CEE refuses an unowned
+ *                        scenario with DR001).
+ *
+ * A surface rendering a "Decision recorded" state must label which of those
+ * it is showing; `DecisionRecord.remote` is how it can tell.
  *
  * Persistence mirrors strengthenStore: zustand + manual, version-keyed
- * sessionStorage, keyed per scenario id. The analysed graph hash
- * (results.hash at capture time) is stored so later surfaces can say
- * whether the record still matches the current analysis.
+ * sessionStorage, keyed per scenario id.
+ *
+ * ⚠ `analysisHash` IS NOT THE DURABLE RECORD'S ANCHOR AND MUST NEVER BE SENT
+ * AS ONE. It is `results.hash`, annotated `// response_hash` in the canvas
+ * store — PLoT's response hash, a different regime from the
+ * `aag_v1:sha256:` analysis-affecting graph hash the record is anchored to.
+ * CEE derives that anchor server-side from its OWN run_analysis fact. This
+ * field stays for local "does the record still match what's on screen"
+ * comparisons only.
  */
 import { create } from 'zustand'
 
 import { resolveScenarioKey } from './scenarioKey'
+
+/**
+ * Proof that this record reached CEE — the durable half. `null` while the
+ * record is local-only (guest, offline, or a failed commit), so no surface
+ * can claim "saved to your account" without the record id that says so.
+ */
+export interface DecisionRecordRemote {
+  /** `decision_records.record_id` — the durable identity. */
+  recordId: string
+  /** ISO timestamptz stored on the record. */
+  reviewDate: string
+  /** Which rung of CEE's ladder set it — `user_set` means the user chose it. */
+  reviewDateSource: 'user_set' | 'default_horizon' | 'default_horizon_after_unparsed_trigger'
+}
 
 export interface DecisionRecord {
   /** Canvas node id of the chosen option (from the analysed option set). */
@@ -26,6 +62,17 @@ export interface DecisionRecord {
   optionNumber: number | null
   /** 0-100 inclusive. Validated non-empty at capture (the prototype's Number('')===0 hole is closed). */
   confidence: number
+  /**
+   * The user's FORWARD-LOOKING claim — "What do you expect to happen?" — and
+   * the only field the eventual outcome is scored against.
+   *
+   * ⚠ DELIBERATELY NOT `rationale`. A rationale is backward-looking
+   * justification for the choice; scoring it as if it were a prediction would
+   * be a semantic lie, and a calibration number built on it would be
+   * meaningless. Optional on the type only because records persisted before
+   * this field existed are still readable.
+   */
+  expectation?: string
   rationale: string
   assumptionToWatch: string
   /** Free text: a trigger condition or a date ("Revisit trigger or date"). */
@@ -33,6 +80,8 @@ export interface DecisionRecord {
   /** results.hash of the completed analysis on screen at capture time, if any. */
   analysisHash: string | null
   savedAt: number
+  /** Set once the record is durable in CEE; null while local-only. */
+  remote?: DecisionRecordRemote | null
 }
 
 export interface DecisionRecordState {
@@ -41,6 +90,12 @@ export interface DecisionRecordState {
   open: () => void
   close: () => void
   saveRecord: (scenarioKey: string, record: DecisionRecord) => void
+  /**
+   * Promote an already-saved local record to DURABLE once CEE has confirmed
+   * the write. A no-op when no record exists for the key — a remote marker
+   * with no record behind it would be a claim about nothing.
+   */
+  attachRemote: (scenarioKey: string, remote: DecisionRecordRemote) => void
   /** Test/reset seam — clears memory AND storage. */
   _reset: () => void
   /** Test seam — re-reads sessionStorage (simulates a reload). */
@@ -78,6 +133,14 @@ export const useDecisionRecordStore = create<DecisionRecordState>((set, get) => 
 
   saveRecord: (scenarioKey, record) => {
     const byScenario = { ...get().byScenario, [scenarioKey]: record }
+    persist(byScenario)
+    set({ byScenario })
+  },
+
+  attachRemote: (scenarioKey, remote) => {
+    const existing = get().byScenario[scenarioKey]
+    if (!existing) return
+    const byScenario = { ...get().byScenario, [scenarioKey]: { ...existing, remote } }
     persist(byScenario)
     set({ byScenario })
   },

--- a/src/services/decisionRecordCommitService.ts
+++ b/src/services/decisionRecordCommitService.ts
@@ -1,0 +1,178 @@
+/**
+ * Decision-record COMMIT — the durable half of "Record the decision"
+ * (calibration R0, ROADMAP 2.727).
+ *
+ * The modal has been eliciting the user's chosen option, their confidence and
+ * a revisit trigger since it shipped — and throwing all of it into
+ * `sessionStorage`, where it dies with the browser session. This module is
+ * the one thing standing between that and a durable, personal calibration
+ * record: it POSTs the commit to CEE, which owns the write.
+ *
+ * ⚠ THE BASE IS A LITERAL, AND THAT IS LOAD-BEARING. `import.meta.env.VITE_*`
+ * is inlined by Vite at TRANSFORM time, so an env-resolved base reads correct
+ * in every vitest run and can still ship pointed at the wrong origin — that is
+ * exactly how `elicitBelief` shipped dark for a day (see `adapters/cee/
+ * client.ts`'s corrected header, ROADMAP 2.710), and how 2.387 shipped dark
+ * before it. `/bff/cee` is owned by `netlify/edge-functions/cee-proxy.ts`,
+ * which rewrites the prefix to `/assist/v1` and injects `X-Olumi-Assist-Key`
+ * server-side; `vite.config.ts` proxies the same prefix in dev. The
+ * co-located spec DERIVES this constant's expected value from `netlify.toml`'s
+ * `cee-proxy` binding rather than restating it.
+ *
+ * ⚠ THE `Authorization` HEADER IS THE USER TOKEN, NOT A SERVICE CREDENTIAL.
+ * The edge function forwards `authorization` verbatim as the user-token slot
+ * and sets `X-Olumi-Assist-Key` separately, so the two never collide. No
+ * bearer from this client is ever a PLoT credential — this base is
+ * same-origin, and same-origin `/bff/*` seams get their credential injected
+ * server-side.
+ *
+ * WHAT THIS MODULE DOES NOT DO: arithmetic on probabilities. The user's
+ * confidence goes over the wire as the RAW 0–100 number they typed, and CEE
+ * normalises it to the contract's [0,1] server-side. A UI that divides by 100
+ * is a second place the scale can drift.
+ */
+import { getSessionIdentity } from '../lib/supabase'
+
+/** Same-origin Netlify edge seam for CEE-served routes. A LITERAL — see header. */
+const CEE_BFF_BASE = '/bff/cee'
+
+/** Path under the seam. The edge rewrites `/bff/cee/x` → `/assist/v1/x`. */
+export const DECISION_RECORD_COMMIT_PATH = '/decision-records/commit'
+
+/** Which rung of CEE's review-date ladder produced the stored `review_date`. */
+export type ReviewDateSource =
+  | 'user_set'
+  | 'default_horizon'
+  | 'default_horizon_after_unparsed_trigger'
+
+export interface DecisionRecordCommitInput {
+  scenarioId: string
+  chosenOptionId: string
+  chosenOptionLabel: string
+  /** RAW 0–100, exactly as the user typed it. Normalised server-side. */
+  confidence0to100: number
+  /** The user's forward-looking claim — the thing the outcome is scored against. */
+  expectationStatement: string
+  /** The modal's free-text "Revisit trigger or date", verbatim. */
+  revisitTriggerOrDate?: string
+  /**
+   * Stable per-save id. Makes a network retry replay through CEE's dedupe
+   * branch instead of writing a second record; a NEW save gets a NEW id, so a
+   * genuinely different commit is never swallowed.
+   */
+  clientCommitId: string
+}
+
+export type DecisionRecordCommitResult =
+  | {
+      readonly status: 'saved'
+      readonly recordId: string
+      readonly reviewDate: string
+      readonly reviewDateSource: ReviewDateSource
+      /** true when CEE replayed an existing record rather than writing a new one. */
+      readonly deduped: boolean
+    }
+  /** Not signed in — the record stays honestly local. Guests have no records by design. */
+  | { readonly status: 'guest' }
+  | { readonly status: 'error'; readonly code: string; readonly message: string }
+
+interface CommitResponseBody {
+  record_id?: unknown
+  review_date?: unknown
+  review_date_source?: unknown
+  deduped?: unknown
+  code?: unknown
+  message?: unknown
+}
+
+const REVIEW_DATE_SOURCES: readonly ReviewDateSource[] = [
+  'user_set',
+  'default_horizon',
+  'default_horizon_after_unparsed_trigger',
+]
+
+function readReviewDateSource(raw: unknown): ReviewDateSource {
+  return typeof raw === 'string' && (REVIEW_DATE_SOURCES as readonly string[]).includes(raw)
+    ? (raw as ReviewDateSource)
+    : // An unrecognised rung is reported as the DEFAULT rung, never as
+      // `user_set`: claiming the user set a date they did not set is the one
+      // direction of this error that misleads.
+      'default_horizon'
+}
+
+/**
+ * Commit the decision durably. Never throws — the caller keeps its local copy
+ * either way, so a failure degrades the record from "durable" to "on this
+ * device", never to "lost".
+ */
+export async function commitDecisionRecord(
+  input: DecisionRecordCommitInput,
+): Promise<DecisionRecordCommitResult> {
+  const { accessToken } = await getSessionIdentity()
+  if (!accessToken) {
+    // Guests genuinely have no records: CEE's RPC refuses an unowned scenario
+    // with DR001 by design. Saying "guest" here, rather than attempting the
+    // call and reporting an error, keeps the modal's copy honest.
+    return { status: 'guest' }
+  }
+
+  let response: Response
+  try {
+    response = await fetch(`${CEE_BFF_BASE}${DECISION_RECORD_COMMIT_PATH}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        scenario_id: input.scenarioId,
+        chosen_option_id: input.chosenOptionId,
+        chosen_option_label: input.chosenOptionLabel,
+        // RAW 0–100 — the server owns the /100. See the module header.
+        confidence_0_100: input.confidence0to100,
+        expectation_statement: input.expectationStatement,
+        ...(input.revisitTriggerOrDate !== undefined && input.revisitTriggerOrDate !== ''
+          ? { revisit_trigger_or_date: input.revisitTriggerOrDate }
+          : {}),
+        client_commit_id: input.clientCommitId,
+      }),
+    })
+  } catch (err) {
+    return {
+      status: 'error',
+      code: 'network_error',
+      message: err instanceof Error ? err.message : 'Network error',
+    }
+  }
+
+  const body = (await response.json().catch(() => ({}))) as CommitResponseBody
+
+  if (!response.ok) {
+    return {
+      status: 'error',
+      code: typeof body.code === 'string' ? body.code : `http_${response.status}`,
+      message:
+        typeof body.message === 'string'
+          ? body.message
+          : 'We could not save this decision to your account.',
+    }
+  }
+
+  if (typeof body.record_id !== 'string' || body.record_id === '') {
+    // A 2xx with no record id is not a save. Reporting it as one would be the
+    // exact "we saved it" claim this slice exists to make true.
+    return {
+      status: 'error',
+      code: 'malformed_response',
+      message: 'We could not confirm this decision was saved.',
+    }
+  }
+
+  return {
+    status: 'saved',
+    recordId: body.record_id,
+    reviewDate: typeof body.review_date === 'string' ? body.review_date : '',
+    reviewDateSource: readReviewDateSource(body.review_date_source),
+    deduped: body.deduped === true,
+  }
+}


### PR DESCRIPTION
**Calibration R0 (ROADMAP 2.727) — UI half.** Pairs with CEE PR #850. Design of record: `parallel-briefs/CALIBRATION-RECONCILE-2026-08-08.md`. Pillars **P1 coaching / P4 human–AI collaboration**.

## The finding this PR acts on

**The live product already elicits user confidence and throws it away.** `DecisionRecordModal` is mounted and reachable from the Strengthen ladder today; it collects the chosen option, a 0–100 confidence and a revisit trigger — into `sessionStorage`, where it dies with the browser session. This PR makes both ends durable. No new elicitation surface, no migration, no contract change, no flags.

## What ships

- **new `src/services/decisionRecordCommitService.ts`** — POSTs the commit to `/bff/cee/decision-records/commit` with `Authorization: Bearer <supabase access token>`. The edge function forwards that as the *user-token* slot and injects `X-Olumi-Assist-Key` separately, so the two never collide.
- **one new modal field: "What do you expect to happen?"** → `prediction.statement`. **Deliberately NOT the rationale.** A rationale is backward-looking justification for the choice; `statement` is the forward claim the outcome is scored against. Scoring one as the other would be a semantic lie and every calibration number built on it would be meaningless.
- **the confidence crosses the wire RAW (0–100)** — CEE owns the `/100`. The UI performs no arithmetic on probabilities; a second place that rescales is a second place the scale can drift.
- **local first, always.** The record is written to `sessionStorage` *before* the network call, so a failed commit degrades it from "durable" to "on this device" — never to "lost". Guest / error / success are **three distinct messages**, never merged: telling a signed-in user the guest story would hide a real failure.
- **`DecisionRecord.remote`** — the record id CEE returned. Nothing may claim "saved to your account" without it.

## The honesty note was rewritten — leaving it would have been a FALSE disclosure in the *other* direction

It read *"Prototype only… Durable saving depends on identity and Model Management."* For a signed-in user that is no longer true. The new copy names the split exactly:

| durable (signed in) | this device only |
|---|---|
| chosen option · confidence · expectation · review date · the analysed-graph anchor | rationale · assumption to watch · the revisit-trigger **text** |

The local-only three have no home in the contract (`DecisionRecordDecisionSchema` / `…PredictionSchema` are `.strict()`) — contract candidate, rowed as reconcile R3.

## Corrected premise: `analysisHash` is NOT the record's anchor

The design brief said the modal "already holds [the analysed graph] as `analysisHash`". It does not. `results.hash` is annotated **`// response_hash`** (`src/canvas/store.ts:194`) — PLoT's regime, which CEE's own `store-adapter.ts` forbids by name ("NEVER PLoT's response_hash / hashGraph"). Sending it would anchor every user record to a value no reviewer can re-derive against the graph. **CEE derives the `aag_v1:sha256:` anchor server-side from its own `run_analysis` fact**, and a spec asserts the request body contains neither `hash_run_1` nor a `graph_hash` key at all.

## Verification

- **30 tests over 2 spec files.** The new spec exercises the **real service** against a mocked `fetch`, so the assertions are about the **wire**: exact path, exact header, exact body keys, and `confidence_0_100 === 70` (with an explicit `not.toBe(0.7)`).
- **Source-level base guard, DERIVED not restated.** The spec parses `netlify.toml`, finds the `cee-proxy` edge-function block, takes **its** path, and asserts the service's literal matches — plus that the service reads no `import.meta.env`/`VITE_` at all. Vite inlines `import.meta.env` at transform time, so a runtime test *cannot* see this defect class; this is how 2.387 and 2.710 shipped dark.
- **9 mutants, all scored as required — 8 BITE + 1 required SURVIVE, 0 unexpected** (counted from the harness log at the final commit; an earlier draft of this description said "8 (7+1)", written before the U7 pair was added — a claim about one's own verification is still a claim). Run in a throwaway worktree **outside** the repo root, isolation proven **by writing a sentinel** and comparing inodes (trap 9g), applied-check `src/`-scoped with the control asserting **exactly zero**.
- **⭐ One mutant SURVIVED and that produced a real fix.** `U7 — an unknown review-date rung is reported as user_set` passed against every test: the fallback was correct but its **direction was uncovered** (trap 13b, a guard agreeing with itself). Claiming `user_set` would tell a user they chose a review date they never chose. Commit `031736be` pins both halves as a pair — an unrecognised/missing/non-string rung must report a default rung, **and** a recognised `user_set` must still carry through, without which a hardcoded-default mutant would survive the first assertion.
- `pnpm typecheck` **GREEN** (3 new TS2322s in the new spec were fixed **at the source**; the gate's `--update-baseline` offer was **declined** — none of the four files this PR touches is in the baseline, so its 3-diagnostic shrink is churn in files this PR never touched).
- Suites run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported; collect counts asserted at **every** mutant run (a shrunk collect voids the numbers).
- **Blast radius: `src/components/results/modals` + `src/canvas/components/__tests__` — 146 files / 1,708 tests, all green.** `OutputsDock.tsx` is the only other referencer of the modal/store.
- ESLint clean on all five touched files.
- ⚠ **The mutant harness itself had a defect, caught by its own control.** The first run reported `HARD ERROR: no summary` on a pristine tree — because `npx vitest run $SPECS` in zsh passes the whole string as **one** argv entry, vitest finds no files and exits **0**. Rewritten with an explicit array plus an argument-count assertion. Had the control not existed, every mutant would have scored "bitten" on zero output.

## Sequencing

Ships ON, no flags. The commit call degrades gracefully against a CEE that does not yet have the endpoint (non-2xx → local-only + the "could not save" message), so merge order between this and #850 does not matter for correctness — but #850 first gives the live witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)