### PR TITLE
fix(results): a displayed statistic must be the one it is labelled as (ROADMAP 2.800 a+b)

### DIFF
--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -40,7 +40,7 @@ import {
 import { ExpertBlock } from './ExpertBlock'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
-import { OptionRangeBar, computeOptionScale } from './shared/OptionRangeBar'
+import { OptionRangeBar, computeOptionScale, isFiniteNumber, type OptionScale } from './shared/OptionRangeBar'
 import { formatGoalProbability } from './utils/displayFloors'
 import { GOAL_FIT_BASIS_CAVEAT_COPY } from './utils/goalFitBasisCaveatCopy'
 import {
@@ -463,8 +463,7 @@ function OptionCard({
   stableNumber = null,
   segmentFillColor,
   onClick,
-  globalMin = 0,
-  globalMax = 1,
+  scale = null,
   onSendMessage,
   onFocusNode,
   expertMode = false,
@@ -501,10 +500,14 @@ function OptionCard({
   /** Task 6b: CSS colour string for coloured fill bar (matches wins segment) */
   segmentFillColor?: string
   onClick?: () => void
-  /** Global min p10 across all options for shared range bar scale */
-  globalMin?: number
-  /** Global max p90 across all options for shared range bar scale */
-  globalMax?: number
+  /**
+   * The shared range-bar axis across all options, or `null` when no option
+   * carries a full p10/p90 range. ROADMAP 2.800b — this used to be a
+   * `globalMin = 0, globalMax = 1` pair whose DEFAULTS were themselves invented
+   * numbers: a card rendered without a scale drew its bar against a fabricated
+   * [0, 1] axis. There is no default axis now; absent means no bar.
+   */
+  scale?: OptionScale | null
   onSendMessage?: (text: string) => void
   onFocusNode?: (nodeId: string) => void
   expertMode?: boolean
@@ -809,13 +812,15 @@ function OptionCard({
       {/* Range bar: p10 / p50 / p90 visual — expert mode only */}
       {expertMode && (
         <ExpertBlock>
-          {option.outcome && typeof option.outcome.p10 === 'number' && typeof option.outcome.p90 === 'number' ? (
+          {scale !== null && isFiniteNumber(option.outcome?.p10) && isFiniteNumber(option.outcome?.p90) ? (
             <OptionRangeBar
               p10={option.outcome.p10}
-              p50={option.outcome.p50 ?? option.outcome.mean ?? undefined}
+              // ROADMAP 2.800a — the MEDIAN, or nothing; never `?? mean`. Same
+              // rule as the V7 lens bar, which shares this component.
+              p50={option.outcome.p50 ?? undefined}
               p90={option.outcome.p90}
-              globalMin={globalMin}
-              globalMax={globalMax}
+              globalMin={scale.globalMin}
+              globalMax={scale.globalMax}
             />
           ) : option.outcome?.mean != null ? (
             <p className={`${typography.panelMeta} text-text-light`}>
@@ -1023,10 +1028,11 @@ export function OptionCards({
   // passing the flag here stops this leaf re-imposing the ranking.
   const sorted = sortOptionsForDisplay(options, { designationsWithheld })
 
-  // Range bar global scale: shared [globalMin, globalMax] across all options
-  // so bar widths are visually comparable. Falls back to mean when percentiles
-  // absent (computeOptionScale — the same formula the V7 lens shares).
-  const { globalMin, globalMax } = computeOptionScale(options)
+  // Range bar shared axis across all options so bar widths are visually
+  // comparable — the same `computeOptionScale` the V7 lens uses. `null` when no
+  // option carries a full range, in which case no card draws a bar either
+  // (ROADMAP 2.800b).
+  const scale = computeOptionScale(options)
 
   // Brief 5.8B D3 collapsed the per-rank border palette to a 2-state
   // (winner / non-winner) hierarchy, so `buildSegmentBorderClassMap` /
@@ -1183,8 +1189,7 @@ export function OptionCards({
             sortedRank={rankById.get(option.id) ?? index + 1}
             stableNumber={stableNumbers?.[option.id] ?? null}
             segmentFillColor={segmentFillColor}
-            globalMin={globalMin}
-            globalMax={globalMax}
+            scale={scale}
             onClick={lensEnabled && resultsComplete ? () => handleLensClick(option.id) : undefined}
             cardRef={(el) => {
               const currentMap = refMap.current

--- a/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
+++ b/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
@@ -1,0 +1,405 @@
+/**
+ * ROADMAP 2.800 (a) + (b) — UNDISCLOSED SUBSTITUTION ON THE OPTION-COMPARISON
+ * SURFACE.
+ *
+ * THE INVARIANT: a displayed statistic must be the statistic it is labelled as,
+ * or it must be disclosed, or it must be absent. Those are the only three
+ * honest outcomes. Two substitutions reached a reader, and this file pins the
+ * third outcome for both:
+ *
+ *   (b) `computeOptionScale` folded `?? 0` across every option, so ONE option
+ *       the engine never scored dragged EVERY other option's bar geometry
+ *       toward zero. Not a printed number — a distorted picture across the
+ *       whole comparison, and the most severe limb because it corrupts the
+ *       display of data that IS present.
+ *
+ *   (a) An absent MEDIAN was filled with the MEAN at the render site
+ *       (`p50 ?? mean`). This is not a subtle mislabel: the lens prints a
+ *       standing caption, `V7_LENS_COPY.outcome.caption`, that reads "Dots show
+ *       the median." — so a substituted dot makes the surface state, in words,
+ *       that a number is the median when it is the mean.
+ *
+ * ORACLE — the producer's own declared semantics, not this lane's reading
+ * (trap 13c: a mutant kit validates sensitivity, never correctness). The type
+ * that declares these fields says it itself, `results/types.ts`:
+ *   "p10/p50/p90 are percentiles; mean is the arithmetic average. Note: mean
+ *    (expected) and p50 (median) are semantically different for skewed
+ *    distributions."
+ * A robustness Monte-Carlo distribution is exactly where they diverge.
+ *
+ * ⚠ WHY THESE PINS RENDER `<ResultsBody>` AND BIND TO `v7-range-bar`.
+ * Two components render the same shared `OptionRangeBar`, and only one of them
+ * reaches an ordinary reader on the deployed build:
+ *   · V7LensGroup's bar (`v7-range-bar`) mounts through V7TopMatter, which
+ *     ResultsBody mounts with NO FLAG ("additive, passthrough, no flag").
+ *   · OptionCards' bar (`option-range-bar`) sits inside `{expertMode && ...}`.
+ * DOM census over the real captures in `PHASE0-EVIDENCE-2026-07-28/`:
+ * `v7-range-bar` in 53 capture files, `v7-outcome-row` in 53, `v7-top-matter`
+ * in 81; `option-range-bar` in 1, and that one file is a model inventory rather
+ * than a rendered results DOM. `ResultsBody.downsideTailMountPath.spec.tsx`
+ * reached the same conclusion independently, from a different capture: "the
+ * 10th/median/90th the tester still saw comes from the V7 'Likely outcome'
+ * lens, which is not expert-gated at all."
+ *
+ * So every arm renders the MOUNT PATH (`<ResultsBody>`) rather than a component
+ * in isolation, and the first arm asserts the mount itself — rows 2.466 and
+ * 2.491 shipped the same feature dark TWICE past a full mutant kit, a RED-first
+ * discipline and a positive control, because every instrument was pointed at a
+ * component the deployed flags do not mount. A green suite is not evidence
+ * about a surface the deployment does not render.
+ *
+ * BINDING: every assertion addresses a row by `data-option-id="<exact id>"` and
+ * re-asserts that row's own label, so no assertion can be satisfied by a
+ * sibling (trap 19).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, within } from '@testing-library/react'
+
+import { ResultsBody } from '../ResultsBody'
+import { computeOptionScale } from '../shared/OptionRangeBar'
+import { V7_LENS_COPY } from '../v7/v7LensCopy'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+type Stats = {
+  mean?: number | null
+  p10?: number | null
+  p50?: number | null
+  p90?: number | null
+  win?: number
+}
+
+/**
+ * An option in exactly the shape the hook emits: `outcome` is ALWAYS present
+ * and its four members are `number | null`.
+ *
+ * ⚠ THE UNSCORED OPTION IS NOT AN EXOTIC PRODUCER STATE. `useResultsSectionData`
+ * builds its option list from `nodes.filter(kind === 'option')` — EVERY option
+ * node on the canvas — and looks each one up in `report.option_probabilities`,
+ * which only holds the ones the engine scored (`optionProbs[nodeId] || {}`). An
+ * option added after the last run, or simply not returned, therefore arrives
+ * here as four nulls. That is a mundane, high-frequency state, and it is what
+ * fed the `?? 0` fold.
+ */
+function opt(id: string, label: string, s: Stats = {}): OptionResult {
+  return {
+    id,
+    label,
+    expected: s.mean ?? null,
+    outcome: {
+      mean: s.mean ?? null,
+      p10: s.p10 ?? null,
+      p50: s.p50 ?? null,
+      p90: s.p90 ?? null,
+    },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    winProbability: s.win,
+    goalProbability: undefined,
+    nValidSamples: 10000,
+  } as unknown as OptionResult
+}
+
+function makeData(options: OptionResult[]): ResultsSectionDataReturn {
+  const recommendation = {
+    recommendedOption: options[0],
+    allOptions: options,
+    goalLabel: 'Grow revenue',
+    goalThreshold: null,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.9,
+    robustnessLevel: 'medium',
+    isNormalised: true,
+    verdict: { hasLeadingOption: true },
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'fair', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 60,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+    conditionalWinners: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Grow revenue',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+/** THE MOUNT PATH — V7TopMatter's only production parent. */
+function renderBody(options: OptionResult[], expertMode = false) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(options)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      expertMode={expertMode}
+    />,
+  )
+}
+
+/**
+ * Select an outcome row by IDENTITY — the option id addresses it and the
+ * option's own label is re-asserted, so a row carrying the right geometry under
+ * the wrong identity satisfies nothing.
+ */
+function rowByIdentity(optionId: string, label: string): HTMLElement {
+  const row = document.querySelector<HTMLElement>(
+    `[data-testid="v7-outcome-row"][data-option-id="${optionId}"]`,
+  )
+  expect(row, `no v7-outcome-row rendered for option id "${optionId}"`).not.toBeNull()
+  expect(row!.textContent, `identity: row ${optionId} must show "${label}"`).toContain(label)
+  return row!
+}
+
+function rangeBar(optionId: string, label: string): HTMLElement {
+  const bar = within(rowByIdentity(optionId, label)).queryByTestId('v7-range-bar')
+  expect(bar, `option "${optionId}" rendered no v7-range-bar`).not.toBeNull()
+  return bar as HTMLElement
+}
+
+/** The bar's fill geometry, as percentages of the shared scale. */
+function barGeometry(optionId: string, label: string): { left: string; width: string } {
+  const fill = rangeBar(optionId, label).querySelector<HTMLElement>('.absolute.top-0')
+  expect(fill, `option "${optionId}" range bar rendered no fill element`).not.toBeNull()
+  return { left: fill!.style.left, width: fill!.style.width }
+}
+
+/** The bar's printed labels, in DOM order: [p10, (median), p90]. */
+function barLabels(optionId: string, label: string): string[] {
+  return Array.from(rangeBar(optionId, label).querySelectorAll('span')).map(
+    (s) => s.textContent ?? '',
+  )
+}
+
+beforeEach(() => {
+  // Deployed posture, read from netlify.toml (VITE_FEATURE_ANALYSIS_HERO_PANEL="1")
+  // and injected through the flag system's own localStorage seam rather than a
+  // module mock, so the real predicate runs.
+  localStorage.setItem('feature.analysisHeroPanel', '1')
+})
+afterEach(() => {
+  cleanup()
+  localStorage.removeItem('feature.analysisHeroPanel')
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// MOUNT PATH — the binding every other arm in this file depends on
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.800 — MOUNT PATH: the pinned surface is the one the deployed build renders', () => {
+  it('ResultsBody mounts the V7 lens and its range bar with NO flag and NO expert mode', () => {
+    renderBody([
+      opt('scored', 'Scored option', { p10: 50, p50: 75, p90: 100, win: 0.6 }),
+      opt('other', 'Other option', { p10: 60, p50: 70, p90: 80, win: 0.4 }),
+    ])
+
+    // If a flag is ever placed in front of the lens group, or the bar is
+    // re-hosted on a component the deployed flags leave unmounted, THIS reds —
+    // which is the alarm 2.466 and 2.491 did not have.
+    expect(screen.queryByTestId('v7-top-matter')).not.toBeNull()
+    expect(screen.queryByTestId('v7-lens-group')).not.toBeNull()
+    expect(rangeBar('scored', 'Scored option')).not.toBeNull()
+
+    // ...and the expert-gated twin is NOT what we are pinning: it is absent at
+    // this posture, which is exactly why binding there would have proved
+    // nothing about what a reader sees.
+    expect(screen.queryByTestId('option-range-bar')).toBeNull()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// (b) An absent value must not participate in the shared scale
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.800b — computeOptionScale: an ABSENT value must not participate', () => {
+  it('does not drag globalMin toward zero when one option was never scored', () => {
+    expect(
+      computeOptionScale([
+        opt('scored', 'Scored', { p10: 50, p50: 75, p90: 100 }),
+        opt('unscored', 'Unscored'),
+      ]),
+    ).toEqual({ globalMin: 50, globalMax: 100 })
+  })
+
+  it('does not drag globalMax UP to zero when every scored option is negative', () => {
+    expect(
+      computeOptionScale([
+        opt('scored', 'Scored', { p10: -100, p50: -75, p90: -50 }),
+        opt('unscored', 'Unscored'),
+      ]),
+    ).toEqual({ globalMin: -100, globalMax: -50 })
+  })
+
+  it('spans exactly the options that render a bar, across several scored options', () => {
+    expect(
+      computeOptionScale([
+        opt('a', 'A', { p10: 10, p90: 40 }),
+        opt('b', 'B', { p10: 30, p90: 90 }),
+        opt('unscored', 'Unscored'),
+      ]),
+    ).toEqual({ globalMin: 10, globalMax: 90 })
+  })
+
+  it('a lone MEAN is not a range bound — it is never drawn on this axis', () => {
+    // An option carrying `mean` but no percentiles renders no bar (the bar needs
+    // p10 AND p90), so stretching the shared axis to cover it would move every
+    // OTHER option's geometry to make room for a value nobody can see.
+    expect(
+      computeOptionScale([
+        opt('scored', 'Scored', { p10: 50, p90: 100 }),
+        opt('meanOnly', 'Mean only', { mean: 5 }),
+      ]),
+    ).toEqual({ globalMin: 50, globalMax: 100 })
+  })
+
+  it('returns null — EXPLICITLY degenerate — when no option carries a full range', () => {
+    expect(computeOptionScale([opt('a', 'A'), opt('b', 'B', { mean: 42 })])).toBeNull()
+  })
+
+  it('returns null for an empty option set', () => {
+    expect(computeOptionScale([])).toBeNull()
+  })
+})
+
+describe('2.800b — the rendered comparison is unmoved by an option with no stats', () => {
+  it("an unscored option does not move the SCORED option's bar", () => {
+    renderBody([
+      opt('scored', 'Scored option', { p10: 50, p50: 75, p90: 100, win: 0.6 }),
+      opt('unscored', 'Unscored option'),
+    ])
+
+    // The only option with a range defines the whole scale, so its bar fills it.
+    // Under the `?? 0` fold the unscored option pinned globalMin at 0 and this
+    // bar started halfway across: { left: '50%', width: '50%' }.
+    expect(barGeometry('scored', 'Scored option')).toEqual({ left: '0%', width: '100%' })
+
+    // The unscored option itself still renders its row and still shows NO bar —
+    // absence stays absence, it is not backfilled with a zero-width artefact.
+    expect(
+      within(rowByIdentity('unscored', 'Unscored option')).queryByTestId('v7-range-bar'),
+    ).toBeNull()
+  })
+
+  it('POSITIVE CONTROL — geometry really does vary between two scored options', () => {
+    // Without this, the assertion above could pass on a helper that always reads
+    // 0%/100%: an absence pin is worthless until it has been shown to see a
+    // presence.
+    renderBody([
+      opt('low', 'Low option', { p10: 0, p50: 25, p90: 50, win: 0.5 }),
+      opt('high', 'High option', { p10: 50, p50: 75, p90: 100, win: 0.5 }),
+    ])
+
+    expect(barGeometry('low', 'Low option')).toEqual({ left: '0%', width: '50%' })
+    expect(barGeometry('high', 'High option')).toEqual({ left: '50%', width: '50%' })
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// (a) An absent median must not be filled with the mean
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.800a — median honesty: an absent p50 is NEVER the mean', () => {
+  it('renders no median dot and no median label when the producer sent no p50', () => {
+    renderBody([
+      opt('a', 'Skewed option', { mean: 90, p10: 10, p50: null, p90: 100, win: 0.6 }),
+      opt('b', 'Other option', { mean: 50, p10: 20, p50: 50, p90: 80, win: 0.4 }),
+    ])
+
+    // Only the two range ends are printed for the option with no median. Under
+    // the substitution the MEAN rendered in the median's slot: ['10','90','100'].
+    expect(barLabels('a', 'Skewed option')).toEqual(['10', '100'])
+    // ...and the dot — the glyph that positions the claim on the axis — is
+    // absent rather than sitting at the mean's position.
+    expect(rangeBar('a', 'Skewed option').querySelector('.rounded-full')).toBeNull()
+
+    // POSITIVE CONTROL in the same tree: the sibling that DID get a median still
+    // shows its dot, so the absence above is a fact about that option and not
+    // about the harness (trap 13 — prove the instrument can see a presence).
+    expect(barLabels('b', 'Other option')).toEqual(['20', '50', '80'])
+    expect(rangeBar('b', 'Other option').querySelector('.rounded-full')).not.toBeNull()
+  })
+
+  it('the median dot is the MEDIAN — a present p50 is never displaced by the mean', () => {
+    // Discriminating partner: proves the render reads p50 specifically, not
+    // "whichever central value happens to be around". mean and p50 are far
+    // apart and on opposite sides of the range.
+    renderBody([opt('a', 'Skewed option', { mean: 20, p10: 0, p50: 80, p90: 100, win: 0.6 })])
+
+    expect(barLabels('a', 'Skewed option')).toEqual(['0', '80', '100'])
+  })
+
+  it('the caption that promises a median is only shown over bars that have one', () => {
+    // The lens prints "Dots show the median. Bars show the realistic range
+    // (10th to 90th percentile)." Pinned here so the copy and the substitution
+    // fix cannot drift apart: the sentence is a claim about every dot drawn
+    // above it.
+    renderBody([opt('a', 'Skewed option', { mean: 20, p10: 0, p50: 80, p90: 100, win: 0.6 })])
+
+    expect(screen.getByText(V7_LENS_COPY.outcome.caption)).toBeTruthy()
+    expect(V7_LENS_COPY.outcome.caption).toContain('median')
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// The expert-gated twin shares the same shared helper — pinned so the two
+// surfaces cannot drift back apart
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('2.800a — the expert OptionCards bar holds the same median rule', () => {
+  it('shows no median label when the producer sent no p50, and one when it did', () => {
+    renderBody(
+      [
+        opt('a', 'Skewed option', { mean: 90, p10: 10, p50: null, p90: 100, win: 0.6 }),
+        opt('b', 'Other option', { mean: 50, p10: 20, p50: 50, p90: 80, win: 0.4 }),
+      ],
+      true,
+    )
+
+    const cardA = screen.getByTestId('option-card-a')
+    const barA = within(cardA).getByTestId('option-range-bar')
+    expect(Array.from(barA.querySelectorAll('span')).map((s) => s.textContent)).toEqual(['10', '100'])
+
+    const cardB = screen.getByTestId('option-card-b')
+    const barB = within(cardB).getByTestId('option-range-bar')
+    expect(Array.from(barB.querySelectorAll('span')).map((s) => s.textContent)).toEqual([
+      '20',
+      '50',
+      '80',
+    ])
+  })
+})

--- a/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
+++ b/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
@@ -363,11 +363,21 @@ describe('2.800a — median honesty: an absent p50 is NEVER the mean', () => {
     expect(barLabels('a', 'Skewed option')).toEqual(['0', '80', '100'])
   })
 
-  it('the caption that promises a median is only shown over bars that have one', () => {
-    // The lens prints "Dots show the median. Bars show the realistic range
-    // (10th to 90th percentile)." Pinned here so the copy and the substitution
-    // fix cannot drift apart: the sentence is a claim about every dot drawn
-    // above it.
+  it('the caption still claims the dots ARE the median — which is why the substitution had to go', () => {
+    // This pins the COPY, not a conditional rendering rule. The lens prints
+    // "Dots show the median. Bars show the realistic range (10th to 90th
+    // percentile)." above the rows, and that sentence is what makes a
+    // substituted dot a false statement rather than a mislabelled glyph.
+    //
+    // Pinned so the two cannot drift apart in either direction: if someone
+    // later softens this wording to something a mean could satisfy, this reds
+    // and the reviewer has to decide deliberately rather than by accident.
+    //
+    // ⚠ SCOPE, stated plainly so the name cannot overclaim: this does NOT
+    // assert that the caption is suppressed when no dot is drawn. It is not —
+    // a run where no option carries a p50 still prints the sentence over
+    // dotless bars. That is a cosmetic incoherence, not a false statistic, and
+    // it is left for its own change rather than widened into this one.
     renderBody([opt('a', 'Skewed option', { mean: 20, p10: 0, p50: 80, p90: 100, win: 0.6 })])
 
     expect(screen.getByText(V7_LENS_COPY.outcome.caption)).toBeTruthy()

--- a/src/components/results/__tests__/useResultsSectionData.medianProvenance.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.medianProvenance.spec.ts
@@ -49,8 +49,23 @@ const OPTION_NODES = [
 
 /**
  * A V5 analysis block whose first option carries a MEAN and a full p10/p90 range
- * but NO p50 — ISL's reachable partial-outcome shape — and whose second option
- * carries a real median as the in-tree positive control.
+ * but NO p50, and whose second option carries a real median as the in-tree
+ * positive control.
+ *
+ * ⚠ THIS SHAPE IS CONSTRUCTED TO ISOLATE THE EXPRESSION UNDER TEST, AND IS NOT
+ * CLAIMED TO BE ONE ISL EMITS. ISL populates p10/p50/p90 as a FAMILY — either
+ * all three from the sample set (`percentiles_source: 'samples'`) or none
+ * (`'unavailable'`) — so "p10 and p90 but no p50" is not in the producer's
+ * output domain, and saying otherwise would be exactly the fixture-outside-the-
+ * producer's-domain error this estate keeps paying for.
+ *
+ * What IS reachable, and what this pin is actually about: `p50` absent at all.
+ * The removed `?? rawExpected` fired on that alone, and `OptionResult.outcome
+ * .p50` has consumers far beyond the range bar's dot — `getExpectedValue` (whose
+ * value `goalAnchorCopy` labels "Most likely outcome"), `selectLensOption`,
+ * `useResultCompleteness`, and the p50 sort in this very hook. The mean did not
+ * merely misplace a glyph; it travelled into copy, selection and ordering. The
+ * p10/p90 here just keep the fixture a realistic comparison row.
  */
 const BLOCK = {
   type: 'analysis_result',

--- a/src/components/results/__tests__/useResultsSectionData.medianProvenance.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.medianProvenance.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * ROADMAP 2.800a — THE HOOK LAYER'S MEDIAN SUBSTITUTION.
+ *
+ * `useResultsSectionData` built each option's percentile family as
+ *
+ *     rawP50 = optionOutcome.p50 ?? optionBands.p50 ?? rawExpected
+ *
+ * where `rawExpected` is the MEAN. So a producer that sent no median got one
+ * invented from a different statistic, one hop BEFORE either render site — and
+ * the two render sites then did the same substitution again on top of it.
+ * Removing it at the render sites alone would have left this one live for every
+ * other consumer of `OptionResult.outcome.p50`.
+ *
+ * ⚠ WHY THIS FILE EXISTS AT ALL — it is the answer to a SURVIVING MUTANT, not a
+ * belt-and-braces extra. The first mutant kit for this row reverted this exact
+ * expression and the whole suite stayed GREEN (104/104): every other spec feeds
+ * `OptionResult` objects straight to the components, so nothing executed the
+ * hook's own percentile assembly. A survivor is a claim either way and has to be
+ * settled by a discriminating fixture rather than asserted equivalent (trap 13c);
+ * this is that fixture.
+ *
+ * DRIVEN THROUGH THE LIVE MAPPER. The report is built by the real
+ * `mapV5AnalysisToReport` from a V5 `analysis_result` block, so the input shape
+ * is the producer's rather than this lane's model of it — and `run.bands` is
+ * left genuinely empty (its members derive from `confidence_interval`, which the
+ * V2 producer no longer emits and this block does not carry), so the
+ * `optionBands.p50` step cannot mask the behaviour under test.
+ *
+ * ORACLE — `OptionOutcome`'s own declaration, not this lane's reading:
+ *   "mean (expected) and p50 (median) are semantically different for skewed
+ *    distributions."
+ * The fixture makes them far apart and on opposite sides of the range, so a
+ * substitution cannot coincidentally satisfy the assertion.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV5AnalysisToReport } from '../../../v5/mapV5AnalysisToReport'
+
+const OPTION_NODES = [
+  { id: 'opt_no_median', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'No median' } },
+  { id: 'opt_with_median', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'With median' } },
+]
+
+/**
+ * A V5 analysis block whose first option carries a MEAN and a full p10/p90 range
+ * but NO p50 — ISL's reachable partial-outcome shape — and whose second option
+ * carries a real median as the in-tree positive control.
+ */
+const BLOCK = {
+  type: 'analysis_result',
+  summary: 'Comparison',
+  leading_option_id: 'opt_no_median',
+  win_probabilities: { opt_no_median: 0.6, opt_with_median: 0.4 },
+  enrichment: {
+    option_comparison: [
+      {
+        option_id: 'opt_no_median',
+        option_label: 'No median',
+        win_probability: 0.6,
+        // mean sits at the TOP of the range: if it were substituted into the
+        // median's slot the difference is unmissable, and no ordering rule could
+        // launder it into looking like a median.
+        outcome: { mean: 90, p10: 10, p90: 100 },
+      },
+      {
+        option_id: 'opt_with_median',
+        option_label: 'With median',
+        win_probability: 0.4,
+        outcome: { mean: 70, p10: 20, p50: 50, p90: 80 },
+      },
+    ],
+  },
+} as unknown as AnalysisResultBlock
+
+function seedStore(): void {
+  const report = mapV5AnalysisToReport(BLOCK)
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report },
+    runMeta: {},
+    nodes: OPTION_NODES,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+/** `option id → outcome`, read from a real hook render. Bound by identity. */
+function outcomesById(): Record<string, { mean: number | null; p10: number | null; p50: number | null; p90: number | null }> {
+  const { result } = renderHook(() => useResultsSectionData())
+  const out: Record<string, { mean: number | null; p10: number | null; p50: number | null; p90: number | null }> = {}
+  for (const o of result.current.recommendation?.allOptions ?? []) {
+    out[o.id] = o.outcome as never
+  }
+  return out
+}
+
+beforeEach(() => {
+  seedStore()
+})
+
+describe('useResultsSectionData — a missing median is never filled with the mean (2.800a)', () => {
+  it('leaves p50 null for the option whose producer sent no median', () => {
+    const byId = outcomesById()
+
+    // Precondition PINNED in-test: if the fixture ever stops reproducing the
+    // state under test, this reds here rather than degrading into a test of
+    // nothing (trap 13b — a guard whose discrimination depends on a fixture
+    // that nothing pins).
+    expect(byId.opt_no_median, 'the fixture must produce this option').toBeDefined()
+    expect(byId.opt_no_median.mean, 'the fixture must carry a MEAN to substitute').toBe(90)
+
+    // Under `?? rawExpected` this read 90 — the mean, sitting where the median
+    // belongs, at the top of its own range.
+    expect(byId.opt_no_median.p50).toBeNull()
+    // ...and the range it belongs to is untouched.
+    expect(byId.opt_no_median.p10).toBe(10)
+    expect(byId.opt_no_median.p90).toBe(100)
+  })
+
+  it('POSITIVE CONTROL — the sibling that DID get a median keeps it', () => {
+    // Same hook render, same store: proves the assertion above is a fact about
+    // that option and not about a harness that returns null for everything.
+    const byId = outcomesById()
+
+    expect(byId.opt_with_median.p50).toBe(50)
+    expect(byId.opt_with_median.mean).toBe(70)
+  })
+
+  it('the bands fallback is genuinely empty, so it cannot be masking the result', () => {
+    // `optionBands.p50` sits between the producer's p50 and the removed mean
+    // fallback. If it were populated it would satisfy the pin above for the
+    // wrong reason — the same self-agreeing-guard failure this row is about.
+    const report = mapV5AnalysisToReport(BLOCK) as { run?: { bands?: { p50?: number | null } } }
+    expect(report.run?.bands?.p50 ?? null).toBeNull()
+  })
+})

--- a/src/components/results/shared/OptionRangeBar.tsx
+++ b/src/components/results/shared/OptionRangeBar.tsx
@@ -1,12 +1,19 @@
 /**
  * OptionRangeBar + computeOptionScale — the shared p10→p90 range bar and its
- * [globalMin, globalMax] scale, extracted VERBATIM from OptionCards so the V7
- * lens bars and the option cards below cannot drift.
+ * [globalMin, globalMax] scale, shared by the V7 lens bars and the option cards
+ * below so the two surfaces cannot drift.
  *
  * OptionRangeBar renders a thin 4px bar showing the p10-to-p90 range with a dot
  * at the median. All bars sharing one scale (computeOptionScale over the same
  * option set) makes bar widths visually comparable between options. The bar fill
  * width represents each option's range within the shared scale.
+ *
+ * ⚠ `p50` IS THE MEDIAN AND NOTHING ELSE (ROADMAP 2.800a). Callers must pass the
+ * producer's own p50 or `undefined` — never a mean standing in for it. The lens
+ * prints a standing caption, "Dots show the median.", so every dot drawn here is
+ * covered by an explicit written claim; a mean in that slot makes the surface
+ * state something false in words, not merely mislabel a glyph. Absent p50 ⇒ no
+ * dot and no middle label, which this component already does on its own.
  *
  * `data-testid` defaults to `option-range-bar` (OptionCards' original testid);
  * the V7 lens passes `v7-range-bar`.
@@ -16,21 +23,59 @@ import { typography } from '../../../styles/typography'
 import { formatRangeValue } from '../utils/formatRangeValue'
 import type { OptionResult } from '../types'
 
+/** One shared finiteness predicate, so the scale and every render gate agree. */
+export function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/** The shared display axis, or `null` when there is nothing to draw one over. */
+export type OptionScale = { globalMin: number; globalMax: number }
+
 /**
- * Shared [globalMin, globalMax] display scale — the exact OptionCards formula
- * (`p10 ?? mean ?? 0` / `p90 ?? mean ?? 0`) with the empty-array guard from
- * buildV7Lenses so an empty option set yields the neutral [0, 1] span instead
- * of [Infinity, -Infinity].
+ * Shared [globalMin, globalMax] display axis for the option range bars.
+ *
+ * ⚠ ROADMAP 2.800b — THIS USED TO FOLD `?? o.outcome?.mean ?? 0` OVER EVERY
+ * OPTION, AND THAT ZERO WAS A DISPLAYED FABRICATION.
+ *
+ * An option the engine never scored arrives here with `outcome` present and all
+ * four members `null` — a mundane, high-frequency state, not an exotic producer
+ * degeneracy: `useResultsSectionData` builds its option list from EVERY option
+ * node on the canvas (`nodes.filter(kind === 'option')`) and looks each one up
+ * in `report.option_probabilities`, which only holds the ones the analysis
+ * returned. Add an option after a run and it is in this list, unscored.
+ *
+ * Under the old fold that option contributed `0` to BOTH ends. With options
+ * spanning 50–100 the axis became [0, 100], and every real bar was redrawn at
+ * half its width, starting halfway across. Nothing on screen said so. The
+ * absent value did not merely fail to appear — it silently restated the numbers
+ * that WERE present, which is the more severe fault.
+ *
+ * THE RULE NOW: the axis spans exactly the bars drawn on it. Only options
+ * carrying BOTH a finite p10 and a finite p90 contribute — those are precisely
+ * the options that render a bar (see `OptionRangeBar`'s callers). An option
+ * with only a `mean` renders no bar, so stretching the axis to cover its mean
+ * would move every other option's geometry to make room for a value nobody can
+ * see; a lone mean is therefore not a bound either.
+ *
+ * THE DEGENERATE CASE IS EXPLICIT, NOT ACCIDENTAL: when no option carries a
+ * full range there is no axis, and this returns `null` rather than a
+ * plausible-looking `[0, 0]` or `[0, 1]` that a caller could draw against.
+ * Callers must render no bars — which is already what they do, since a bar
+ * needs the same p10/p90 pair that would have made the axis non-null.
  */
-export function computeOptionScale(options: OptionResult[]): { globalMin: number; globalMax: number } {
-  return {
-    globalMin: options.length
-      ? Math.min(...options.map((o) => o.outcome?.p10 ?? o.outcome?.mean ?? 0))
-      : 0,
-    globalMax: options.length
-      ? Math.max(...options.map((o) => o.outcome?.p90 ?? o.outcome?.mean ?? 0))
-      : 1,
+export function computeOptionScale(options: OptionResult[]): OptionScale | null {
+  const lows: number[] = []
+  const highs: number[] = []
+  for (const o of options) {
+    const p10 = o.outcome?.p10
+    const p90 = o.outcome?.p90
+    if (isFiniteNumber(p10) && isFiniteNumber(p90)) {
+      lows.push(p10)
+      highs.push(p90)
+    }
   }
+  if (lows.length === 0) return null
+  return { globalMin: Math.min(...lows), globalMax: Math.max(...highs) }
 }
 
 /**

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1507,9 +1507,18 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       const rawExpected =
         prob.expected_outcome ?? prob.expected ?? optionOutcome.mean ?? optionBands.p50 ?? null
 
-      // Extract percentiles (p10/p50/p90) — p50 is true median, NOT expected
+      // Extract percentiles (p10/p50/p90) — p50 is the true median, NOT expected.
+      //
+      // ⚠ ROADMAP 2.800a — `rawP50` used to end `?? rawExpected`, i.e. a missing
+      // MEDIAN was filled with the MEAN. The comment above already said they are
+      // different quantities, and the line below it did the substitution anyway.
+      // `OptionOutcome`'s own declaration is explicit: "mean (expected) and p50
+      // (median) are semantically different for skewed distributions" — and a
+      // robustness Monte-Carlo distribution is exactly where they diverge.
+      // The `optionBands.p50` step stays: that is the SAME statistic from a
+      // second source, not a different one wearing its name.
       const rawP10 = optionOutcome.p10 ?? optionBands.p10 ?? null
-      const rawP50 = optionOutcome.p50 ?? optionBands.p50 ?? rawExpected
+      const rawP50 = optionOutcome.p50 ?? optionBands.p50 ?? null
       const rawP90 = optionOutcome.p90 ?? optionBands.p90 ?? null
 
       // Normalize all 4 values together with single scale decision

--- a/src/components/results/v7/V7LensGroup.tsx
+++ b/src/components/results/v7/V7LensGroup.tsx
@@ -31,7 +31,7 @@ import { formatProbabilityWithResolution } from '@/utils/formatPercent'
 import { loadRuns, type StoredRun } from '@/canvas/store/runHistory'
 import * as runsBus from '@/canvas/store/runsBus'
 import type { OptionResult } from '../types'
-import { OptionRangeBar } from '../shared/OptionRangeBar'
+import { OptionRangeBar, isFiniteNumber, type OptionScale } from '../shared/OptionRangeBar'
 import type { V7LensesModel } from './buildV7Lenses'
 import { V7_LENS_COPY } from './v7LensCopy'
 import { formatGoalProbability } from '../utils/displayFloors'
@@ -50,13 +50,12 @@ export interface V7LensGroupProps {
 function OutcomeRow({
   option,
   isWinner,
-  globalMin,
-  globalMax,
+  scale,
 }: {
   option: OptionResult
   isWinner: boolean
-  globalMin: number
-  globalMax: number
+  /** The shared axis, or null when no option in the set carries a full range. */
+  scale: OptionScale | null
 }) {
   const win =
     typeof option.winProbability === 'number' && Number.isFinite(option.winProbability)
@@ -64,7 +63,9 @@ function OutcomeRow({
       : null
   const p10 = option.outcome?.p10
   const p90 = option.outcome?.p90
-  const hasRange = typeof p10 === 'number' && typeof p90 === 'number'
+  // One shared finiteness predicate with the axis, so a value that cannot be a
+  // bound cannot become a bar either (a NaN would otherwise plot as `NaN%`).
+  const hasRange = isFiniteNumber(p10) && isFiniteNumber(p90)
   return (
     <div className="space-y-1" data-testid="v7-outcome-row" data-option-id={option.id}>
       <div className="flex items-baseline justify-between gap-2">
@@ -80,13 +81,19 @@ function OutcomeRow({
           </span>
         )}
       </div>
-      {hasRange && (
+      {hasRange && scale !== null && (
         <OptionRangeBar
-          p10={p10 as number}
-          p50={option.outcome?.p50 ?? option.outcome?.mean ?? undefined}
-          p90={p90 as number}
-          globalMin={globalMin}
-          globalMax={globalMax}
+          p10={p10}
+          // ROADMAP 2.800a — the MEDIAN, or nothing. This read used to be
+          // `p50 ?? mean`, which put the arithmetic mean in the median's slot
+          // whenever the producer sent no p50 — under a caption that tells the
+          // reader "Dots show the median." The two differ exactly where it
+          // matters: on a skewed distribution, which is what a robustness
+          // Monte-Carlo run produces. Absent p50 ⇒ no dot, no middle label.
+          p50={option.outcome?.p50 ?? undefined}
+          p90={p90}
+          globalMin={scale.globalMin}
+          globalMax={scale.globalMax}
           data-testid="v7-range-bar"
         />
       )}
@@ -256,8 +263,7 @@ export function V7LensGroup({ model }: V7LensGroupProps) {
                   key={o.id}
                   option={o}
                   isWinner={o.id === model.outcome.winnerId}
-                  globalMin={model.outcome.globalMin}
-                  globalMax={model.outcome.globalMax}
+                  scale={model.outcome.scale}
                 />
               ))}
               {model.outcome.hasRange && (

--- a/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Lenses.spec.ts
@@ -72,15 +72,24 @@ describe('buildV7Lenses — passthrough lens + evidence model (V7 L5)', () => {
       expect(m.outcome.hasRange).toBe(false)
     })
 
-    it('computes the shared scale exactly like OptionCards (p10/p90 with mean fallback)', () => {
+    it('computes the shared scale exactly like OptionCards, over the options that render a bar', () => {
+      // ROADMAP 2.800b — the axis is now an object or `null`, and it spans only
+      // options carrying BOTH a finite p10 and p90. It used to fold
+      // `?? mean ?? 0` over every option, so an unscored one dragged the axis to
+      // zero and silently rescaled every real bar.
       const m = buildV7Lenses(
         data({
           allOptions: [opt('a', 'A', { p10: 10, p50: 20, p90: 30 }), opt('b', 'B', { p10: 5, p50: 12, p90: 25 })],
         }),
       )
       expect(m.outcome.hasRange).toBe(true)
-      expect(m.outcome.globalMin).toBe(5)
-      expect(m.outcome.globalMax).toBe(30)
+      expect(m.outcome.scale).toEqual({ globalMin: 5, globalMax: 30 })
+    })
+
+    it('has no axis at all when no option carries a full range', () => {
+      const m = buildV7Lenses(data({ allOptions: [opt('a', 'A', { win: 0.7 }), opt('b', 'B', { win: 0.3 })] }))
+      expect(m.outcome.scale).toBeNull()
+      expect(m.outcome.hasRange).toBe(false)
     })
 
     it('is unavailable when no option carries a win probability or a range', () => {

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -30,7 +30,7 @@
 import type { OptionResult, DriverItem, ConditionalWinner } from '../types'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { VoiRanking } from '../voi/voiRanking'
-import { computeOptionScale } from '../shared/OptionRangeBar'
+import { computeOptionScale, type OptionScale } from '../shared/OptionRangeBar'
 import { hasCompleteGoalField, selectGoalLeader } from '../utils/selectGoalLeader'
 
 /** One flip-risk row — the challengeFragileEdges slice, unchanged. */
@@ -76,9 +76,13 @@ export interface V7OutcomeLens {
   available: boolean
   /** Options to render (recommendation.allOptions), unchanged. */
   options: OptionResult[]
-  /** Shared display scale — computed exactly as OptionCards (UI-SEM-free). */
-  globalMin: number
-  globalMax: number
+  /**
+   * Shared display axis — the same `computeOptionScale` the option cards use.
+   * `null` when no option carries a full range, i.e. when there is no axis to
+   * draw against (ROADMAP 2.800b: the degenerate case is stated, never a
+   * plausible-looking `[0, 0]`).
+   */
+  scale: OptionScale | null
   /** True when any option carries a full p10/p90 range (gates the caption). */
   hasRange: boolean
   winnerId?: string
@@ -161,22 +165,24 @@ export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
   const winnerId = designationsWithheld ? undefined : recommendation.recommendedOption?.id
 
   // ── Likely outcome ─────────────────────────────────────────────────────
-  const hasRange = options.some(
-    (o) => typeof o.outcome?.p10 === 'number' && typeof o.outcome?.p90 === 'number',
-  )
   const hasWin = options.some(
     (o) => typeof o.winProbability === 'number' && Number.isFinite(o.winProbability),
   )
-  // Shared [globalMin, globalMax] scale — computeOptionScale is the exact
-  // OptionCards formula (p10/p90 with mean fallback), so the V7 bars and the
-  // cards below share one scale.
-  const { globalMin, globalMax } = computeOptionScale(options)
+  // Shared display axis — the same `computeOptionScale` the option cards use, so
+  // the V7 bars and the cards below cannot land on different rulers.
+  //
+  // ROADMAP 2.800b — `hasRange` is now DERIVED from the axis rather than
+  // re-deriving the same predicate a second time. The two used to be independent
+  // spellings of "some option has both a p10 and a p90" and could drift; a lens
+  // that captioned "Bars show the realistic range" while the axis said there was
+  // no range is exactly the kind of disagreement nobody would notice.
+  const scale = computeOptionScale(options)
+  const hasRange = scale !== null
 
   const outcome: V7OutcomeLens = {
     available: options.length > 0 && (hasRange || hasWin),
     options,
-    globalMin,
-    globalMax,
+    scale,
     hasRange,
     winnerId,
   }

--- a/src/v5/__tests__/mapV5AnalysisToReport.percentileProvenance.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.percentileProvenance.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * ROADMAP 2.800 (a) — A PERCENTILE MUST NOT BE FILLED FROM A CONFIDENCE INTERVAL.
+ *
+ * `p10 = outcome?.p10 ?? ciLow` / `p90 = outcome?.p90 ?? ciHigh` put a
+ * confidence-interval bound into a percentile's slot and rendered it under the
+ * percentile's name, with no disclosure to the reader. A CI and a p10/p90 pair
+ * are different quantities answering different questions: the interval is a
+ * statement about an ESTIMATE's precision, the percentile pair a statement
+ * about the OUTCOME's spread. Substituting one for the other misstates exactly
+ * the thing this surface exists to communicate.
+ *
+ * ⚠ THE REPO ALREADY KNEW, AND ROUTED AROUND IT. `mapV5AnalysisToReport.ts`
+ * keeps `percentiles_source` a SIBLING of `outcome` rather than a member,
+ * reasoning that "a provenance flag sitting INSIDE that object would read as
+ * certifying whichever numbers ended up in it". That is the correct diagnosis
+ * with the wrong remedy: the honesty badge was moved away from the substitution
+ * instead of the substitution being removed. This suite removes it.
+ *
+ * PRODUCER SEMANTICS, derived at the bytes rather than assumed (trap 13c — a
+ * mutant kit proves sensitivity, never correctness, so the expectation has to
+ * come from the producer):
+ *   · PLoT `src/routes/v2/run.ts` builds each `option_comparison` entry by
+ *     explicit field selection and carries NO `confidence_interval`; its own
+ *     note at the builder reads "expected_outcome and confidence_interval (V1
+ *     legacy) removed from V2 response. Use outcome.mean and [outcome.p10,
+ *     outcome.p90] instead."
+ *   · CEE carries no `option_comparison[].confidence_interval` either (its only
+ *     occurrences of the name are counterfactual `{lower, upper}` objects in
+ *     tests — a different field of a different shape).
+ *   · Across every captured payload in `PHASE0-EVIDENCE-2026-07-28/`, the string
+ *     `confidence_interval` appears in ZERO wire captures.
+ * So this substitution is DEAD ON THE LIVE WIRE and ARMED: the contract still
+ * permits the field (`EnrichmentOutcomeStatsSchema.confidence_interval` is an
+ * optional tuple in `@talchain/schemas` 0.38.0), so a producer that re-adds it
+ * would silently start shipping mislabelled percentiles. These tests are what
+ * keeps it disarmed.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+const baseBlock = (overrides: Partial<AnalysisResultBlock> = {}): AnalysisResultBlock =>
+  ({
+    type: 'analysis_result',
+    summary: 'Option A leads',
+    leading_option_id: 'opt_a',
+    ...overrides,
+  }) as AnalysisResultBlock
+
+type MappedOption = {
+  expected?: number
+  outcome?: { mean?: number | null; p10?: number | null; p50?: number | null; p90?: number | null }
+}
+
+function mapOption(entry: Record<string, unknown>, optionId = 'opt_a'): MappedOption {
+  const block = baseBlock({
+    win_probabilities: { [optionId]: 0.5 },
+    enrichment: { option_comparison: [{ option_id: optionId, ...entry }] },
+  } as Partial<AnalysisResultBlock>)
+
+  const report = mapV5AnalysisToReport(block) as ReturnType<typeof mapV5AnalysisToReport> & {
+    option_probabilities?: Record<string, MappedOption>
+  }
+  const mapped = report.option_probabilities?.[optionId]
+  if (mapped === undefined) throw new Error(`mapper produced no entry for option "${optionId}"`)
+  return mapped
+}
+
+describe('mapV5AnalysisToReport — percentiles are the producer\'s or they are absent', () => {
+  it('a confidence_interval does NOT fill an absent p10/p90', () => {
+    const mapped = mapOption({ confidence_interval: [10, 20] })
+
+    // Absent stays absent. Under the substitution these read 10 and 20 — a CI
+    // bound wearing a percentile's name, with nothing on screen to say so.
+    expect(mapped.outcome?.p10).toBeNull()
+    expect(mapped.outcome?.p90).toBeNull()
+  })
+
+  it('POSITIVE CONTROL — real producer percentiles still flow through untouched', () => {
+    // Without this, the pin above could pass on a mapper that dropped p10/p90
+    // unconditionally: an absence assertion is vacuous until it has been shown
+    // it can see a presence.
+    const mapped = mapOption({
+      outcome: { mean: 12.5, p10: 8, p50: 12, p90: 17 },
+    })
+
+    expect(mapped.outcome).toEqual({ mean: 12.5, p10: 8, p50: 12, p90: 17 })
+  })
+
+  it('a confidence_interval never OVERRIDES percentiles the producer did send', () => {
+    // Discriminating pair partner: proves the fix removed the fallback rather
+    // than inverting the precedence.
+    const mapped = mapOption({
+      outcome: { mean: 12.5, p10: 8, p50: 12, p90: 17 },
+      confidence_interval: [10, 20],
+    })
+
+    expect(mapped.outcome?.p10).toBe(8)
+    expect(mapped.outcome?.p90).toBe(17)
+  })
+
+  it('a partial outcome keeps the member the producer sent and nulls the one it did not', () => {
+    // ISL's reachable degenerate shape 2 — `percentiles_source: 'unavailable'`
+    // with `mean` present — must not be topped up from a CI.
+    const mapped = mapOption({
+      outcome: { mean: 12.5 },
+      confidence_interval: [10, 20],
+    })
+
+    expect(mapped.outcome).toEqual({ mean: 12.5, p10: null, p50: null, p90: null })
+  })
+})

--- a/src/v5/__tests__/mapV5AnalysisToReport.test.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.test.ts
@@ -446,7 +446,22 @@ describe('mapV5AnalysisToReport — enrichment.option_comparison hydrates outcom
     expect(opt.outcome).toEqual({ mean: 12.5, p10: 8.0, p50: 12.0, p90: 17.0 })
   })
 
-  it('confidence_interval midpoint fills `expected` when outcome.mean is absent', () => {
+  // ⚠ AMENDED BY ROADMAP 2.800a. This test used to also assert
+  // `outcome.p10 === 10` and `outcome.p90 === 20` — i.e. it pinned the
+  // CONFIDENCE-INTERVAL bounds being written into the PERCENTILE slots as
+  // intended behaviour. That substitution is the defect 2.800a removed: a CI
+  // bounds an estimate's precision, a p10/p90 pair describes the outcome's
+  // spread, and the surface rendered one under the other's name with no
+  // disclosure. The percentile half now lives in
+  // `mapV5AnalysisToReport.percentileProvenance.spec.ts`, asserting null.
+  //
+  // The `expected` half is DELIBERATELY UNCHANGED and still pinned here: a CI
+  // midpoint standing in for the mean is a central-tendency estimate standing in
+  // for another central-tendency estimate — a materially weaker claim than a
+  // percentile wearing a CI's name — and the identical use on the HEADLINE path
+  // (`headlineCI`) is outside 2.800's scope. Changing one and not the other
+  // would leave this file less coherent, not more. Rowed separately.
+  it('confidence_interval midpoint fills `expected` when outcome.mean is absent, but NEVER the percentiles', () => {
     const block = baseBlock({
       win_probabilities: { opt_a: 0.5 },
       enrichment: {
@@ -461,8 +476,8 @@ describe('mapV5AnalysisToReport — enrichment.option_comparison hydrates outcom
     }
     const opt = report.option_probabilities!.opt_a
     expect(opt.expected).toBe(15)
-    expect(opt.outcome?.p10).toBe(10)
-    expect(opt.outcome?.p90).toBe(20)
+    expect(opt.outcome?.p10).toBeNull()
+    expect(opt.outcome?.p90).toBeNull()
   })
 
   it('outcome quantiles are null (not 0) when enrichment has no option_comparison', () => {

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -924,16 +924,23 @@ export function mapV5AnalysisToReport(
      * ROADMAP 2.646 — the producer's PERCENTILE PROVENANCE for this option's
      * enrichment `outcome` block, carried verbatim from the wire.
      *
-     * ⚠ DELIBERATELY A SIBLING OF `outcome`, NOT A MEMBER OF IT, and the
-     * placement is the honest one rather than the tidy one. The `outcome`
-     * object above is NOT a faithful copy of the producer's: `p10` and `p90`
-     * fall back to the confidence interval when the producer sent none (see
-     * the reads below), and the view-model hop after this one falls back again
-     * to `run.bands`. A provenance flag sitting INSIDE that object would read
-     * as certifying whichever numbers ended up in it — including ones the
-     * producer's percentile population had nothing to do with. It certifies
-     * the producer's percentile population and only that, so it rides beside
-     * the object rather than in it.
+     * ⚠ DELIBERATELY A SIBLING OF `outcome`, NOT A MEMBER OF IT.
+     *
+     * ⚠⚠ AND THE ORIGINAL REASON HAS BEEN REMOVED RATHER THAN WORKED AROUND
+     * (ROADMAP 2.800a). This note used to read: "The `outcome` object above is
+     * NOT a faithful copy of the producer's: `p10` and `p90` fall back to the
+     * confidence interval when the producer sent none… A provenance flag
+     * sitting INSIDE that object would read as certifying whichever numbers
+     * ended up in it." That was the right diagnosis with the wrong remedy — the
+     * honesty badge was moved AWAY from the substitution instead of the
+     * substitution being deleted, so the percentile numbers themselves carried
+     * no disclosure to anyone. The CI fallback is now gone (see the reads
+     * below): `outcome.p10/p50/p90` are the producer's own or they are null.
+     *
+     * The sibling placement STANDS on a narrower and still-true ground: the
+     * view-model hop after this one may still source percentiles from
+     * `run.bands`, a second source for the same statistic, and this flag
+     * certifies the producer's percentile POPULATION and only that.
      *
      * NARROWED TO THE CLOSED VOCABULARY, NEVER DEFAULTED: absent in ⇒ absent
      * out. See `downsideUnavailableCopy` for why absence must not be read as
@@ -997,19 +1004,43 @@ export function mapV5AnalysisToReport(
     const rawExpected = safeFiniteNumber(enriched?.expected_outcome)
     const expected = rawMean ?? rawExpected ?? ciMid ?? undefined
 
-    const p10 = safeFiniteNumber(outcome?.p10) ?? ciLow
+    // ⚠ ROADMAP 2.800a — PERCENTILES ARE THE PRODUCER'S OR THEY ARE ABSENT.
+    // These reads used to end `?? ciLow` / `?? ciHigh`, putting a
+    // CONFIDENCE-INTERVAL bound into a percentile's slot, rendered under the
+    // percentile's name with no disclosure to the reader. They are different
+    // quantities answering different questions — an interval is a statement
+    // about an ESTIMATE's precision, a p10/p90 pair a statement about the
+    // OUTCOME's spread — so the substitution misstated exactly what this
+    // surface exists to communicate.
+    //
+    // The producer settles it: PLoT's V2 option builder carries no
+    // `confidence_interval` at all ("expected_outcome and confidence_interval
+    // (V1 legacy) removed from V2 response. Use outcome.mean and [outcome.p10,
+    // outcome.p90] instead."), CEE synthesises none, and the string appears in
+    // ZERO captured payloads. So this fallback was DEAD ON THE LIVE WIRE and
+    // ARMED: the contract still permits the field, so a producer re-adding it
+    // would have silently started shipping mislabelled percentiles.
+    const p10 = safeFiniteNumber(outcome?.p10) ?? null
     const p50 = safeFiniteNumber(outcome?.p50) ?? null
-    const p90 = safeFiniteNumber(outcome?.p90) ?? ciHigh
+    const p90 = safeFiniteNumber(outcome?.p90) ?? null
 
     // ROADMAP 2.646 — percentile provenance, narrowed to the producer's closed
-    // vocabulary and carried verbatim. Note the shape of this read and how it
-    // differs from every other one in this loop: there is NO fallback chain and
-    // NO coercion. `safeFiniteNumber(x) ?? ciLow` is right for a magnitude,
-    // because a missing p10 and a CI bound are two estimates of the same thing.
-    // A provenance CLAIM has no such substitute — the only honest value is the
-    // one the producer stated, so anything outside the vocabulary (absent,
-    // null, a string we do not recognise) leaves the key absent and the render
-    // site falls back to the copy that attributes the gap to nobody.
+    // vocabulary and carried verbatim: NO fallback chain and NO coercion.
+    //
+    // ⚠ CORRECTED BY ROADMAP 2.800a. This note used to justify the surrounding
+    // fallbacks: "`safeFiniteNumber(x) ?? ciLow` is right for a magnitude,
+    // because a missing p10 and a CI bound are two estimates of the same thing."
+    // They are not. A confidence interval bounds an ESTIMATE's precision; a
+    // p10/p90 pair describes the OUTCOME's spread. Treating them as
+    // interchangeable is the substitution this row removed — the percentile
+    // reads above now have no fallback either, so the contrast this comment
+    // once drew no longer exists: NOTHING in this loop substitutes a different
+    // quantity for a missing one.
+    //
+    // The rule that remains, and now covers every field here: the only honest
+    // value is the one the producer stated, so anything outside the vocabulary
+    // (absent, null, a string we do not recognise) leaves the key absent and the
+    // render site falls back to the copy that attributes the gap to nobody.
     const percentilesSource = narrowPercentilesSource(outcome?.percentiles_source)
 
     const goalFitBasis = normaliseGoalFitBasis(enriched?.goal_fit_basis)


### PR DESCRIPTION
## The defect

On the option-comparison surface, an absent producer value was silently replaced by a **different quantity** and rendered in the missing one's slot, with no disclosure to the reader. ROADMAP row 2.800, limbs (a) and (b).

The pattern is worth naming, because it is the reusable part: **the same card is scrupulous about one honesty and silently substitutes around it.** The downside line states its own absence carefully; the percentile family beside it did not. Honesty implemented per-element does not compose into an honest surface.

## The invariant

> A displayed statistic must be the statistic it is labelled as, or it must be disclosed, or it must be absent.

Those are the only three honest outcomes. This PR takes the third in every case, mirroring the dialect the estate already has (the compute layer's `goal_threshold` channel converts against a proper reference **or refuses and omits the field**; `downside` omits the whole block rather than fabricate a component; PLoT gates `percentiles_source` on a two-literal allowlist rather than defaulting).

## What changed

**(b) `?? 0` distorting a shared scale — the most severe limb, because it corrupts data that IS present.**

`computeOptionScale` folded `?? o.outcome?.mean ?? 0` over every option. One option with no stats contributed `0` to **both** ends of the axis. With options spanning 50–100 the axis became `[0, 100]`, and every real bar was redrawn at half its width, starting halfway across. Nothing on screen said so.

**This needs no exotic producer state.** `useResultsSectionData` builds its option list from `nodes.filter(kind === 'option')` — every option node on the **canvas** — and looks each one up in `report.option_probabilities`, which holds only the options the analysis scored (`optionProbs[nodeId] || {}`). Add an option after a run and it is in that list, unscored, with four nulls. It renders no bar of its own and silently rescales everyone else's.

The axis now spans exactly the bars drawn on it: only options carrying **both** a finite `p10` and a finite `p90` contribute — precisely the options that render a bar. A lone `mean` is not a bound either, because stretching the axis to cover a value that is never drawn moves every other option's geometry to make room for something nobody can see.

**(a) A missing median filled with the mean** — removed at all three sites (`useResultsSectionData`, `V7LensGroup`, `OptionCards`).

**(a) Percentiles filled from confidence-interval bounds** — removed in `mapV5AnalysisToReport`.

## How much of this a user will actually notice — stated plainly

The three limbs are not equally live, and the PR should not imply they are:

- **(b) the shared-scale fold is the one users see.** Its trigger is an ordinary product state — an unscored option on the canvas — and its effect is on numbers that ARE present. This is the real fix.
- **(a) the median substitution reaches further than the dot.** Every captured payload carries `percentiles_source: "samples"`, so all three percentiles arrived and the *bar dot* form is latent today. But the hook writes the substituted value onto `OptionResult.outcome.p50`, and that field has consumers well beyond the bar: `getExpectedValue` (whose result `goalAnchorCopy` labels **"Most likely outcome"**), `selectLensOption`, `useResultCompleteness`, and the p50 sort inside the hook itself. A mean standing in for the median therefore travelled into **copy, lens selection, completeness scoring and option ordering** — which is why this is fixed at the hook and not only at the two render sites, and why the surviving mutant M6 mattered rather than being a technicality.

  ⚠ Precision, so this does not overclaim: ISL populates `p10/p50/p90` as a **family** (all three from samples, or none), so "p10 and p90 present but p50 absent" — the shape needed to render a *dotless-vs-mean-dot* bar — is not in the producer's output domain. The reachable trigger is `p50` absent altogether, which is what the removed fallback keyed on.
- **(a) the CI→percentile substitution is dead today** and fixed as disarmament, not as a live repair (see corrected premises).

So: one live display defect fixed, two landmines removed. Where the change is *visible*, it is a bar that no longer moves; where it is latent, it is a number that can no longer appear under the wrong name.

## Judgement calls, with reasoning

### Disclose or omit the substituted percentile? → **Omit.**

I went in expecting to argue for disclosure, on the grounds that users make real decisions on the spread and losing a central value costs them something. The lens copy settled it the other way:

> `V7_LENS_COPY.outcome.caption` — **"Dots show the median.** Bars show the realistic range (10th to 90th percentile)."

That is a standing, printed sentence asserting what every dot on the surface *is*. A mean sitting in that slot does not merely mislabel a glyph — it makes the product **state something false in words**. A disclosure would have to contradict the caption immediately next to it.

Three further reasons omission is right here rather than merely simpler:

1. **A dot is positional.** Its wrongness is in *where it sits*, and a footnote cannot attach to one glyph among six. On a skewed distribution — which is what a robustness Monte Carlo produces, and exactly where mean and median diverge — a mean-dot misplaces the centre of the very spread the reader is reading.
2. **The spread survives intact.** `p10`–`p90` is untouched; only the false centre goes. The bar's main job is unaffected.
3. **The information is not lost where it exists.** `OptionCards` already renders `Expected: {mean}` under its own name when the range is unavailable. The mean was never absent from the product — it was *mislabelled*.

The type's own declaration is the oracle, not my reading of it: *"mean (expected) and p50 (median) are semantically different for skewed distributions."*

### The degenerate case for (b)/(c) → **explicit `null`, not a plausible number.**

`computeOptionScale` returns `OptionScale | null`. `null` means "no option supplied a finite bound, so there is no axis" — as opposed to the old code's `[0, 1]` for an empty set and `[0, 0]` for an all-unscored set, both of which are numbers a caller could draw against. Callers now render no bars, which is already what they did, since a bar needs the same `p10`/`p90` pair that would have made the axis non-null.

`V7OutcomeLens.hasRange` is now **derived** from the axis (`scale !== null`) rather than re-deriving the same predicate a second time. The two used to be independent spellings of the same question and could drift; a lens captioning "Bars show the realistic range" while the axis said there was no range is exactly the disagreement nobody would notice.

The same reasoning removed a second pair of invented numbers: the inner card's props were `globalMin = 0, globalMax = 1`, so a card rendered without a scale drew against a **fabricated default axis**. There is no default axis now.

### No flag, no toggle.

Per the standing no-dark-launches rule, and because the estate has just found an honest-absence renderer sitting behind a per-browser toggle that is false for every new user: **the simple default is the honest one.** No new flag, no expert gate, nothing added to opt into.

## ⚠ Corrected premises

### 1. Limb (c) is FALSIFIED — that `?? 0` is mathematically inert. Not changed.

The brief (and row 2.800) states that at `useResultsSectionData.ts:1524-1527`, "a missing value counts as 0, which can FLIP the denormalisation decision and therefore the `scale` multiplier applied to the values that ARE present."

It cannot. The `?? 0` sits **inside `Math.abs()`, inside a `Math.max()` of non-negative terms**:

```ts
const maxRaw = Math.max(Math.abs(norm.p90 ?? 0), Math.abs(norm.p10 ?? 0), Math.abs(norm.expected ?? 0))
const alreadyDenormalized = maxRaw > 2
```

A zero term cannot change a maximum of non-negative numbers. Settled by exhaustive execution over all 125 presence/sign patterns (`{absent, −5, −0.5, 0.5, 5}³`) against an honest comparator that maxes over present values only: **124 of 125 identical**. The one difference is all-three-absent, where `?? 0` gives `false` and the honest comparator gives "no decision" — and there `norm.p10/p50/p90/expected` are all `null`, so `scale` multiplies nothing. The sibling fold at `:1486-1492` is inert for the same reason.

**No value that IS present can have its scale changed by a value that is ABSENT.** Nothing was changed here; a no-op refactor would have been churn with regression risk and no user benefit.

### 2. The CI→percentile substitution was DEAD on the live wire — but armed. Fixed anyway.

- PLoT's V2 option builder (`src/routes/v2/run.ts`, staging tip `209d971f`) carries **no** `confidence_interval`; its own note: *"expected_outcome and confidence_interval (V1 legacy) removed from V2 response. Use outcome.mean and [outcome.p10, outcome.p90] instead."*
- CEE (staging tip `666f9526`), real grep over `src/`: 3 occurrences, all in tests, all the counterfactual `{lower, upper}` object — a different field of a different shape.
- Wire census over `PHASE0-EVIDENCE-2026-07-28/`: `confidence_interval` in **zero** captured payloads.
- But the contract still permits it (`EnrichmentOutcomeStatsSchema.confidence_interval`, optional tuple, `@talchain/schemas` 0.38.0).

Claim type: **in-repo, dead on the live wire, re-armable by a producer change alone.** Fixed because that is precisely the class that ships silently.

### 3. The repo's own rationale is corrected, not worked around.

`mapV5AnalysisToReport` deliberately kept `percentiles_source` a *sibling* of `outcome` because *"a provenance flag sitting INSIDE that object would read as certifying whichever numbers ended up in it."* Correct diagnosis, wrong remedy — the honesty badge was moved **away** from the substitution instead of the substitution being removed. That comment is now updated to say so; the sibling placement stands on the narrower, still-true ground that `run.bands` remains a second source for the same statistic.

Two other comments that had become false are corrected in place, including one asserting *"a missing p10 and a CI bound are two estimates of the same thing"* — they are not: an interval bounds an **estimate's precision**, a percentile pair describes the **outcome's spread**.

### 4. Minor
- The evidence section is §7 *"Adjacent trust findings"*, not §"incidental findings".
- `V7LensGroup` lives at `src/components/results/v7/`, not `src/v7/`.
- **Out of scope but a posture correction:** limb (d) (`useScenarioComparison`, outright `?? 0` fabrication) is recorded as behind `compareTab` with "deployed posture UNKNOWN". `netlify.toml` at this tip sets `VITE_FEATURE_COMPARE_TAB = "1"`, and for the UI Vite bakes that at build time. Not touched here; it needs its own lane.

## Mount-path binding — why these tests are pointed at the right component

Two components render the same shared `OptionRangeBar`. Only one reaches an ordinary reader:

| Surface | testid | Gate | Real captures |
|---|---|---|---|
| `v7/V7LensGroup` → `OutcomeRow` | `v7-range-bar` | **none** | **53 files** |
| `OptionCards` | `option-range-bar` | `{expertMode && …}` | **1**, and that one is a model inventory, not a rendered results DOM |

- **DOM census** over `PHASE0-EVIDENCE-2026-07-28/`: `v7-range-bar` 53, `v7-outcome-row` 53, `v7-top-matter` 81, `option-range-bar` 1.
- **Static**: `V7TopMatter`, `V7LensGroup`, `buildV7Lenses` and `OptionRangeBar` contain **zero flag reads**. The chain is not "currently enabled" — it is unflagged. `ResultsBody` mounts it "additive, passthrough, no flag".
- **Independent corroboration**: `ResultsBody.downsideTailMountPath.spec.tsx` reached the same conclusion from a different capture — *"the 10th/median/90th the tester still saw comes from the V7 'Likely outcome' lens, which is not expert-gated at all."*

Every arm renders **`<ResultsBody>`** (the production parent), not a component in isolation, and the first test asserts the mount itself, so a flag placed in front of the lens later goes red here. Rows 2.466 and 2.491 shipped the same feature dark twice past a full mutant kit, RED-first, and a positive control, because every instrument was pointed at a component the deployed flags do not mount.

Every assertion binds by `data-option-id="<exact id>"` and re-asserts that option's own label (trap 19).

## Verification

**RED-first at pristine** (`84bb0cb0`), 9 + 2 named failures:

- `does not drag globalMin toward zero when one option was never scored`
- `does not drag globalMax UP to zero when every scored option is negative`
- `spans exactly the options that render a bar, across several scored options`
- `a lone MEAN is not a range bound — it is never drawn on this axis`
- `returns null — EXPLICITLY degenerate — when no option carries a full range`
- `returns null for an empty option set`
- `an unscored option does not move the SCORED option's bar` — *expected `{left:'0%',width:'100%'}`, got `{left:'50%',width:'50%'}`*
- `renders no median dot and no median label when the producer sent no p50` — *got `['10','90','100']`, the mean in the median's slot*
- `shows no median label when the producer sent no p50, and one when it did` (expert surface)
- `a confidence_interval does NOT fill an absent p10/p90` — *expected 10 to be null*
- `a partial outcome keeps the member the producer sent and nulls the one it did not`

The mount-path test and all three positive controls were **GREEN at pristine** — they are alarms and instrument checks, not defect pins.

One spec was **not** RED-first and should not be read as if it were: `useResultsSectionData.medianProvenance.spec.ts` was written *after* the fix, to kill a surviving mutant. Its evidence is the mutation instead, which is the stronger form of the same proof — reverting `rawP50 ?? rawExpected` turns it red (M6 below), so it demonstrably cannot pass with the defect present.

**Mutants — 10/10 bitten**, in a throwaway worktree outside the repo root, mutating committed state only.

*Isolation proven by WRITING, not by locating*: a sentinel written into the mutant tree left the source's SHA-256 unchanged, and inodes were distinct (`557275845` vs `557288728`) — `cp -R` on APFS can preserve hard links and a mutation has written through to a source clone that way. Restores came from a pristine tar archive, never from the other copy. Applied-check scoped to `src/`, **control exactly 0** before and after; control run green.

| Mutant | Result |
|---|---|
| M1 revert scale to `?? mean ?? 0` | BITTEN (10 failed) |
| M2 a lone mean becomes a bound | BITTEN (2) |
| M3 degenerate case fabricates `[0,1]` | BITTEN (5) |
| M4 V7 `p50 ?? mean` (live surface) | BITTEN (1) |
| M5 OptionCards `p50 ?? mean` | BITTEN (1) |
| M6 hook `p50 ?? rawExpected` | BITTEN (1) |
| M7 mapper `p10 ?? ciLow` | BITTEN (3) |
| M8 mapper `p90 ?? ciHigh` | BITTEN (3) |
| D1 identity broken for ALL options | BITTEN (5) |
| D2 identity broken for ONE option | BITTEN (1) |

**M6 survived the first kit** (104/104 green) and that is recorded rather than smoothed over: every other spec feeds `OptionResult` objects straight to the components, so nothing executed the hook's own percentile assembly. A survivor is a claim either way and had to be settled by a discriminating fixture, not asserted equivalent — hence `useResultsSectionData.medianProvenance.spec.ts`, driven through the real `mapV5AnalysisToReport`, with `run.bands` proven empty **in-test** so the intermediate fallback cannot mask the result.

**D1/D2 are a discriminating pair, not two mutants.** Breaking every row's `data-option-id` reds 5 assertions; breaking only `high`'s reds 1, leaving the other four green. A single biting mutant proves sensitivity to *something*; the pair proves sensitivity to *the named object*.

**Gates**, run at this tip by their named commands:
- `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASSED**. 3287/3327 tracked files loaded; drift *shrank* 2491 → 2487, none added. Not banked with `--update-baseline`: the gate passes, and this PR is not the place to move a baseline.
- `pnpm lint` — **0 errors** (1258 pre-existing warnings); rules-of-hooks ratchet exactly at baseline, no new conditional hooks.
- Full `vitest run` — see below. Healthy-collect proof: pristine `staging` measured **1545 files passed / 3 skipped (1548)** and **22457 tests passed / 66 skipped (22523)**, well above the CI floor (`min_total=700`, `max_skipped=50`), with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported. A shrunk collect would have voided these numbers.

## Not in scope

Limb (d) (`useScenarioComparison` fabrication), limb (e) (the dead `nValidSamples` feed), limb (f) (two CEE-side fabricated zeros) — rowed separately, untouched.

Also deliberately **kept**: `expected = rawMean ?? rawExpected ?? ciMid` in the same loop. A CI midpoint standing in for the mean is a central-tendency estimate standing in for another central-tendency estimate — a materially weaker claim than a percentile wearing a CI's name — it carries an explicit blessing test, and the identical use on the **headline** path (`headlineCI`) is outside this row. Changing one and not the other would have left the file less coherent, not more. Worth its own row.

Noted in passing, not acted on: `RangeVisualization.tsx` carries a third, locally-defined range bar. It is already honest (it bails unless `p10`, `p50` and `p90` are all present) and has **no production mount** — its only `<RangeVisualization>` renders are in specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
