### PR TITLE
fix(compare): an unmeasured probability is never plotted as zero (ROADMAP 2.834)

### DIFF
--- a/src/canvas/compare-tab/DotProgression.tsx
+++ b/src/canvas/compare-tab/DotProgression.tsx
@@ -11,8 +11,68 @@ interface DotProgressionProps {
 interface OptionRow {
   label: string
   nodeId: string | null
-  values: number[]
+  /** null ⇒ not scored in this run. Never coerced to 0 (ROADMAP 2.834). */
+  values: (number | null)[]
   colour: string // Tailwind colour class
+}
+
+/**
+ * What a run that was never scored shows instead of a number.
+ *
+ * The surface already owns this idiom — `NOT_ASSESSED` in TrajectorySection
+ * and RunPairCompare, and `—` on ComparisonCanvasLayout. In this row the cell
+ * is a few characters wide, so it takes the em-dash form, with the full
+ * sentence on the title so the meaning is reachable without widening the row.
+ */
+const NOT_SCORED = '—'
+const NOT_SCORED_TITLE = 'Not scored in this run'
+
+/**
+ * One run's cell in a progression row — the ONE place absence is rendered.
+ *
+ * Both rows (options and target) previously carried their own `?? 0`, so the
+ * fix had to land twice or land inconsistently. Rendering both through this
+ * component means a later row cannot reintroduce the fabrication by omission
+ * (CLAUDE.md trap 12 — derive, don't mirror).
+ *
+ * An unscored run draws a HOLLOW dot: a filled dot on a progression reads as
+ * "measured here", which is the same claim the fabricated number made.
+ */
+function ProgressionCell({
+  value,
+  colour,
+  isLast,
+  showConnector,
+}: {
+  value: number | null
+  colour: string
+  isLast: boolean
+  showConnector: boolean
+}) {
+  const scored = value != null
+  const size = isLast ? 9 : 7
+
+  return (
+    <div className="inline-flex items-center">
+      {showConnector && <div className={`w-6 h-0.5 ${colour} opacity-30`} />}
+      <div
+        className={`rounded-full ${scored ? colour : ''}`}
+        style={{
+          width: size,
+          height: size,
+          opacity: isLast ? 1 : 0.6,
+          ...(scored ? {} : { border: '1px dashed var(--text-muted)' }),
+        }}
+        {...(scored ? {} : { 'data-testid': 'compare-dot-unscored', title: NOT_SCORED_TITLE })}
+      />
+      <span
+        className={`${typography.panelMeta} tabular-nums ml-0.5 mr-0.5`}
+        {...(scored ? {} : { title: NOT_SCORED_TITLE })}
+      >
+        {scored ? `${value}%` : NOT_SCORED}
+      </span>
+    </div>
+  )
 }
 
 export function DotProgression({ snapshots }: DotProgressionProps) {
@@ -33,7 +93,10 @@ export function DotProgression({ snapshots }: DotProgressionProps) {
     rows.push({
       label: latest.runnerUpLabel ?? '',
       nodeId: latest.runnerUpId,
-      values: snapshots.map(s => s.runnerUpProbability ?? 0),
+      // `latest.runnerUpId` gates whether the ROW exists, using the LATEST run
+      // only — it says nothing about the earlier runs plotted along it, which
+      // is how `?? 0` printed "0%" for runs that had no runner-up at all.
+      values: snapshots.map(s => s.runnerUpProbability),
       colour: 'bg-option',
     })
   }
@@ -72,29 +135,15 @@ export function DotProgression({ snapshots }: DotProgressionProps) {
               row.label
             )}
           </span>
-          {row.values.map((val, ri) => {
-            const isLast = ri === snapshots.length - 1
-            return (
-              <div key={ri} className="inline-flex items-center">
-                {ri > 0 && (
-                  <div
-                    className={`w-6 h-0.5 ${row.colour} opacity-30`}
-                  />
-                )}
-                <div
-                  className={`rounded-full ${row.colour}`}
-                  style={{
-                    width: isLast ? 9 : 7,
-                    height: isLast ? 9 : 7,
-                    opacity: isLast ? 1 : 0.6,
-                  }}
-                />
-                <span className={`${typography.panelMeta} tabular-nums ml-0.5 mr-0.5`}>
-                  {val}%
-                </span>
-              </div>
-            )
-          })}
+          {row.values.map((val, ri) => (
+            <ProgressionCell
+              key={ri}
+              value={val}
+              colour={row.colour}
+              isLast={ri === snapshots.length - 1}
+              showConnector={ri > 0}
+            />
+          ))}
         </div>
       ))}
 
@@ -104,28 +153,19 @@ export function DotProgression({ snapshots }: DotProgressionProps) {
           <span className={`${typography.panelBody} font-medium w-[68px] flex-shrink-0 flex items-center gap-0.5`}>
             <Target size={10} className="text-goal" /> Target
           </span>
-          {snapshots.map((s, ri) => {
-            const isLast = ri === snapshots.length - 1
-            const val = s.goalProbability ?? 0
-            return (
-              <div key={ri} className="inline-flex items-center">
-                {ri > 0 && (
-                  <div className="w-6 h-0.5 bg-goal opacity-30" />
-                )}
-                <div
-                  className="rounded-full bg-goal"
-                  style={{
-                    width: isLast ? 9 : 7,
-                    height: isLast ? 9 : 7,
-                    opacity: isLast ? 1 : 0.6,
-                  }}
-                />
-                <span className={`${typography.panelMeta} tabular-nums ml-0.5 mr-0.5`}>
-                  {val}%
-                </span>
-              </div>
-            )
-          })}
+          {snapshots.map((s, ri) => (
+            // `hasGoal` decides whether this ROW is drawn at all; it never said
+            // anything about the individual runs along it, so a run with no
+            // goal assessment used to print a fabricated "0%" inside an
+            // honestly-gated row.
+            <ProgressionCell
+              key={ri}
+              value={s.goalProbability}
+              colour="bg-goal"
+              isLast={ri === snapshots.length - 1}
+              showConnector={ri > 0}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/src/canvas/compare-tab/Hero.tsx
+++ b/src/canvas/compare-tab/Hero.tsx
@@ -52,7 +52,15 @@ function getHeroCopy(
       }
     case 'noWinner':
       return {
-        line1: `Run ${latest.runNumber} · No clear leading option (${latest.winnerLabel} ${latest.winnerProbability}%, ${latest.runnerUpLabel ?? '—'} ${latest.runnerUpProbability ?? 0}%)`,
+        // ROADMAP 2.834: `?? 0` printed "Option B 0%" — a confident measurement
+        // — for a runner-up the engine never scored. `runnerUpProbability` is
+        // declared `number | null` precisely because that absence is expected
+        // (a run with a single option has no runner-up at all).
+        line1: `Run ${latest.runNumber} · No clear leading option (${latest.winnerLabel} ${latest.winnerProbability}%, ${latest.runnerUpLabel ?? '—'} ${
+          latest.runnerUpProbability != null
+            ? `${latest.runnerUpProbability}%`
+            : 'not scored in this run'
+        })`,
         line2: 'Model improving · Result uncertain',
         actionPrefix: 'Calibrate ',
         actionLink: latest.topCalibrationFactor,

--- a/src/canvas/compare-tab/TrajectorySection.tsx
+++ b/src/canvas/compare-tab/TrajectorySection.tsx
@@ -66,15 +66,49 @@ function ExpertTable({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
   )
 }
 
-function TrajectoryChart({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
-  const hasGoal = snapshots.some(s => s.goalProbability != null)
+export interface TrajectoryDatum {
+  run: number
+  winner: number
+  /** null ⇒ this run had no runner-up, or the engine did not score it. */
+  runnerUp: number | null
+  /** null ⇒ goal attainment was not assessed for this run. */
+  goal: number | null
+}
 
-  const data = snapshots.map(s => ({
+/**
+ * The chart series, absence-preserving (ROADMAP 2.834).
+ *
+ * `runnerUp` was `?? 0`, which drew a flat line along the axis for a run whose
+ * runner-up was never scored — a measurement the engine did not make, in the
+ * most credible form the UI has. A reader doubts a printed number; a plotted
+ * series reads as observation. `goal` was already honest (`?? undefined`) two
+ * lines away, so this only brings `runnerUp` to the standard its neighbour
+ * already met.
+ *
+ * Recharts leaves a GAP for a null y-value (`connectNulls` defaults false), so
+ * an unscored run breaks the line instead of pinning it to zero.
+ *
+ * Exported so the series can be asserted directly: jsdom cannot prove anything
+ * about a rendered chart (CLAUDE.md trap 3), and a test that renders recharts
+ * under jsdom would be pinning nothing.
+ */
+export function buildTrajectoryData(snapshots: AnalysisSnapshot[]): TrajectoryDatum[] {
+  return snapshots.map(s => ({
     run: s.runNumber,
     winner: s.winnerProbability,
-    runnerUp: s.runnerUpProbability ?? 0,
-    goal: s.goalProbability ?? undefined,
+    runnerUp: s.runnerUpProbability,
+    goal: s.goalProbability,
   }))
+}
+
+function TrajectoryChart({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
+  const data = buildTrajectoryData(snapshots)
+
+  // Derived from the SERIES rather than re-deriving a predicate over the
+  // snapshots: one source of truth for "is there anything to draw", so a
+  // change to the series cannot leave the line-visibility guard behind.
+  const hasGoal = data.some(d => d.goal != null)
+  const hasRunnerUp = data.some(d => d.runnerUp != null)
 
   // Find flip points
   const flipRuns = snapshots
@@ -114,14 +148,16 @@ function TrajectoryChart({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
           dot={{ r: 3 }}
           activeDot={{ r: 5 }}
         />
-        <Line
-          type="monotone"
-          dataKey="runnerUp"
-          stroke="var(--chart-4)"
-          strokeWidth={2}
-          dot={{ r: 3 }}
-          activeDot={{ r: 5 }}
-        />
+        {hasRunnerUp && (
+          <Line
+            type="monotone"
+            dataKey="runnerUp"
+            stroke="var(--chart-4)"
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+        )}
         {hasGoal && (
           <Line
             type="monotone"

--- a/src/canvas/compare-tab/__tests__/compareAbsenceNotZero.spec.tsx
+++ b/src/canvas/compare-tab/__tests__/compareAbsenceNotZero.spec.tsx
@@ -1,0 +1,220 @@
+/**
+ * Compare tab — an unmeasured probability is never plotted as zero (ROADMAP 2.834).
+ *
+ * WHAT THIS PINS, and why it is not covered by anything already here.
+ *
+ * `runnerUpProbability` and `goalProbability` are both declared `number | null`
+ * (`types.ts:144,195`) — absence is a first-class, EXPECTED state, produced on
+ * two honest paths: a run with a single option has no runner-up at all, and
+ * `selectGoalProbability` legitimately returns null for a withheld basis.
+ * Three display sites silently converted that null to 0:
+ *
+ *   TrajectorySection.tsx:75  runnerUp: s.runnerUpProbability ?? 0   (plotted)
+ *   DotProgression.tsx:36     s.runnerUpProbability ?? 0             (printed)
+ *   DotProgression.tsx:109    s.goalProbability ?? 0                 (printed)
+ *
+ * A fabricated zero on a CHART is worse than a fabricated number in prose: a
+ * reader doubts a number but reads a plotted series as observation. On the
+ * trajectory chart a null runner-up drew a flat line along the axis — a
+ * measurement the engine never made, in the most credible form the UI has.
+ *
+ * ⚠ WHY `parseAnalysisEnrichment` DOES NOT ALREADY COVER THIS.
+ * That guard (analysisEnrichmentShape.ts) works at ENVELOPE grain: it rejects
+ * an envelope whose `option_comparison` or `factor_sensitivity` is missing or
+ * empty, and its own header says every OTHER producer field "stays
+ * absence-preserving rather than drop-worthy". Once both arrays are non-empty
+ * the envelope is ADMITTED and the guard makes no claim about the fields
+ * INSIDE the entries. These defects live entirely on admitted envelopes. So
+ * every fixture below is deliberately one the guard PASSES — otherwise the
+ * test would re-prove the guard instead of the branch it misses.
+ *
+ * Sibling: TrajectorySection.absence.spec.tsx pins the EXPERT TABLE. Its own
+ * fixture carries `runnerUpProbability: null` / `goalProbability: null`, so the
+ * chart and dot row were rendering fabricated zeros inside every one of those
+ * green tests — presence of a guard is not coverage of the branch.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DotProgression } from '../DotProgression'
+import { buildTrajectoryData } from '../TrajectorySection'
+import { Hero } from '../Hero'
+import type { AnalysisSnapshot } from '../types'
+
+function snapshot(overrides: Partial<AnalysisSnapshot> = {}): AnalysisSnapshot {
+  return {
+    runId: 'run-1',
+    runNumber: 1,
+    timestamp: '2026-02-20T10:00:00Z',
+    source: 'session',
+    graphHash: 'hash-1',
+    nodeCount: 2,
+    edgeCount: 1,
+    winnerId: 'opt-1',
+    winnerLabel: 'Option A',
+    winnerProbability: 60,
+    runnerUpId: 'opt-2',
+    runnerUpLabel: 'Option B',
+    runnerUpProbability: 30,
+    recommendationStability: 0.8,
+    stabilityLabel: 'stable',
+    fragileEdgeCount: 2,
+    evidenceCoverage: '3/5',
+    topFactors: [],
+    influenceConcentration: 40,
+    topCalibrationFactor: 'Factor X',
+    topCalibrationFactorId: 'f-1',
+    topElasticity: 12,
+    rankFlipRate: 0,
+    goalProbability: 50,
+    jointGoalProbability: null,
+    edgeEValues: [],
+    seedUsed: 42,
+    responseHash: 'resp-1',
+    editSummary: '',
+    ...overrides,
+  } as AnalysisSnapshot
+}
+
+// ---------------------------------------------------------------------------
+// The trajectory CHART series (pure data, so the assertion does not depend on
+// recharts rendering under jsdom — which cannot prove visibility anyway).
+// ---------------------------------------------------------------------------
+
+describe('buildTrajectoryData — absence is a gap in the series, never a zero', () => {
+  it('runnerUpProbability null → series datum is null, NOT 0', () => {
+    const data = buildTrajectoryData([
+      snapshot({ runId: 'r1', runNumber: 1, runnerUpProbability: 30 }),
+      snapshot({ runId: 'r2', runNumber: 2, runnerUpProbability: null }),
+    ])
+
+    // Bind by IDENTITY: the run whose runner-up was not scored, found by
+    // runNumber, never by a value predicate another datum could satisfy.
+    const unscored = data.find(d => d.run === 2)
+    expect(unscored).toBeDefined()
+    expect(unscored!.runnerUp).toBeNull()
+    expect(unscored!.runnerUp).not.toBe(0)
+
+    // ...and the run that WAS scored is untouched.
+    expect(data.find(d => d.run === 1)!.runnerUp).toBe(30)
+  })
+
+  it('an HONEST zero still plots as zero', () => {
+    // The engine measured the runner-up at 0%. That is a real fact and must
+    // survive — the fix must not turn every low value into a gap.
+    const data = buildTrajectoryData([snapshot({ runNumber: 7, runnerUpProbability: 0 })])
+    expect(data.find(d => d.run === 7)!.runnerUp).toBe(0)
+  })
+
+  it('goalProbability null → series datum is null, NOT 0', () => {
+    const data = buildTrajectoryData([
+      snapshot({ runId: 'r1', runNumber: 1, goalProbability: 80 }),
+      snapshot({ runId: 'r2', runNumber: 2, goalProbability: null }),
+    ])
+    expect(data.find(d => d.run === 2)!.goal).toBeNull()
+    expect(data.find(d => d.run === 1)!.goal).toBe(80)
+  })
+
+  it('an HONEST zero goal probability still plots as zero', () => {
+    const data = buildTrajectoryData([snapshot({ runNumber: 3, goalProbability: 0 })])
+    expect(data.find(d => d.run === 3)!.goal).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The dot progression row (printed text, plain DOM)
+// ---------------------------------------------------------------------------
+
+describe('DotProgression — an unscored run prints a gap, never "0%"', () => {
+  it('runnerUpProbability null on an earlier run → no fabricated "0%"', () => {
+    // `if (latest.runnerUpId)` gates the row on the LATEST run only, so an
+    // earlier run with no runner-up reached `?? 0` and printed "0%".
+    render(
+      <DotProgression
+        snapshots={[
+          snapshot({ runId: 'r1', runNumber: 1, runnerUpProbability: null }),
+          snapshot({ runId: 'r2', runNumber: 2, runnerUpProbability: 45 }),
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+    expect(screen.getByText('45%')).toBeInTheDocument()
+    expect(screen.getAllByTestId('compare-dot-unscored').length).toBe(1)
+  })
+
+  it('goalProbability null on one run → no fabricated "0%" in the Target row', () => {
+    // `hasGoal` is computed honestly (`some(s => s.goalProbability != null)`)
+    // and then the row fabricated `?? 0` for the runs that had none — the guard
+    // decided WHETHER to draw the row, never what to draw in it.
+    render(
+      <DotProgression
+        snapshots={[
+          snapshot({ runId: 'r1', runNumber: 1, goalProbability: 70 }),
+          snapshot({ runId: 'r2', runNumber: 2, goalProbability: null }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('70%')).toBeInTheDocument()
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+  })
+
+  it('an HONEST zero still prints "0%" and is NOT marked unscored', () => {
+    render(
+      <DotProgression
+        snapshots={[snapshot({ runId: 'r1', runNumber: 1, goalProbability: 0, runnerUpProbability: 0 })]}
+      />,
+    )
+
+    expect(screen.getAllByText('0%').length).toBeGreaterThan(0)
+    expect(screen.queryByTestId('compare-dot-unscored')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The hero sentence
+// ---------------------------------------------------------------------------
+
+describe('Hero — an unscored runner-up is not printed as a measured 0%', () => {
+  it('noWinner copy with runnerUpProbability null does not claim "0%"', () => {
+    // Reaching the noWinner branch requires the state machine's own predicate
+    // (|winner - (runnerUp ?? 0)| < 10), so winnerProbability is low here.
+    // deriveCompareState is OUT OF SCOPE and untouched — this pins the COPY.
+    render(
+      <Hero
+        snapshots={[
+          snapshot({ runId: 'r1', runNumber: 1 }),
+          snapshot({
+            runId: 'r2',
+            runNumber: 2,
+            winnerProbability: 5,
+            runnerUpProbability: null,
+            runnerUpLabel: 'Option B',
+          }),
+        ]}
+        state="noWinner"
+        showExpert={false}
+        onRunAnalysis={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText(/Option B 0%/)).not.toBeInTheDocument()
+    expect(screen.getByText(/not scored in this run/)).toBeInTheDocument()
+  })
+
+  it('a present runner-up probability is still printed', () => {
+    render(
+      <Hero
+        snapshots={[
+          snapshot({ runId: 'r1', runNumber: 1 }),
+          snapshot({ runId: 'r2', runNumber: 2, winnerProbability: 35, runnerUpProbability: 30 }),
+        ]}
+        state="noWinner"
+        showExpert={false}
+        onRunAnalysis={() => {}}
+      />,
+    )
+
+    expect(screen.getByText(/Option B 30%/)).toBeInTheDocument()
+  })
+})

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.runnerUpAbsence.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.runnerUpAbsence.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * analysisSnapshotFactory — an unmeasured runner-up win probability is null
+ * (ROADMAP 2.834).
+ *
+ * `runnerUpProbability` had TWO absence paths and only one was honest:
+ *
+ *   runnerUp ? Math.round((runnerUp.win_probability ?? 0) * 100) : null
+ *              └── honest: no runner-up at all ⇒ null ───────────┘
+ *                         └── FABRICATION: a runner-up EXISTS but the
+ *                             producer sent no win_probability ⇒ 0
+ *
+ * The second path publishes a confident "0%" for an option the engine simply
+ * did not score, and the snapshot is a PERSISTENCE surface — the false value
+ * outlives the run that produced it and is replayed on the compare tab for
+ * every later session.
+ *
+ * ⚠ WHY `parseAnalysisEnrichment` DOES NOT ALREADY COVER THIS.
+ * That guard rejects an envelope whose `option_comparison` / `factor_sensitivity`
+ * is missing or empty, and explicitly leaves every other producer field
+ * absence-preserving. An envelope carrying TWO option entries, one of which
+ * omits `win_probability`, is fully ADMITTED by it. Every fixture below is
+ * such an envelope, so these tests exercise the branch the guard misses rather
+ * than re-proving the guard.
+ *
+ * ⚠ OUT OF SCOPE, DELIBERATELY: `winnerProbability` (:477) keeps its `?? 0`.
+ * It is declared non-nullable `number` (types.ts:140) and is consumed
+ * ARITHMETICALLY by `deriveCompareState`, so making it nullable would change
+ * which hero copy fires — a product judgement, not a mechanical honesty swap.
+ * The last test below pins that this change does NOT disturb that machine.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import { deriveCompareState } from '../../compare-tab/deriveCompareState'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+/**
+ * Two options, so `runnerUp` is non-null and the fabricating branch is the one
+ * under test. `factor_sensitivity` is non-empty so the envelope is one
+ * `parseAnalysisEnrichment` ADMITS.
+ */
+function build(optionOverrides: Array<Record<string, unknown>>) {
+  return buildAnalysisSnapshot({
+    rawV2Response: {
+      analysis_status: 'computed',
+      option_comparison_status: 'computed',
+      robustness_status: 'unavailable',
+      drivers_status: 'unavailable',
+      option_comparison: optionOverrides,
+      factor_sensitivity: [{ node_id: 'n1', elasticity: 0.4 }],
+      critiques: [],
+      response_hash: 'resp-1',
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+describe('buildAnalysisSnapshot — runner-up win probability absence', () => {
+  it('runner-up EXISTS but win_probability absent → null, NOT 0', () => {
+    const snap = build([
+      { option_id: 'opt-1', option_label: 'Option A', win_probability: 0.6 },
+      { option_id: 'opt-2', option_label: 'Option B' },
+    ])
+
+    // Bind by IDENTITY: this is the runner-up the factory actually chose.
+    expect(snap.runnerUpId).toBe('opt-2')
+    expect(snap.runnerUpProbability).toBeNull()
+    expect(snap.runnerUpProbability).not.toBe(0)
+  })
+
+  it('an HONEST zero win_probability is preserved as 0', () => {
+    // The engine measured this option at 0% — a real fact, not an absence.
+    const snap = build([
+      { option_id: 'opt-1', option_label: 'Option A', win_probability: 0.6 },
+      { option_id: 'opt-2', option_label: 'Option B', win_probability: 0 },
+    ])
+
+    expect(snap.runnerUpId).toBe('opt-2')
+    expect(snap.runnerUpProbability).toBe(0)
+  })
+
+  it('no runner-up at all → still null (the pre-existing honest path)', () => {
+    const snap = build([
+      { option_id: 'opt-1', option_label: 'Option A', win_probability: 0.6 },
+    ])
+
+    expect(snap.runnerUpId).toBeNull()
+    expect(snap.runnerUpProbability).toBeNull()
+  })
+
+  it('a present win_probability is still rounded to a percentage', () => {
+    const snap = build([
+      { option_id: 'opt-1', option_label: 'Option A', win_probability: 0.62 },
+      { option_id: 'opt-2', option_label: 'Option B', win_probability: 0.31 },
+    ])
+
+    expect(snap.runnerUpProbability).toBe(31)
+  })
+})
+
+describe('the out-of-scope state machine is undisturbed', () => {
+  it('deriveCompareState returns the same verdict for an unscored runner-up', () => {
+    // `deriveCompareState` already coerces null with its own `?? 0`, so
+    // absent → 0 (before this change) and absent → null → 0 (after) are the
+    // SAME input to it. This pins that equivalence rather than asserting it:
+    // if a later edit removes that `?? 0`, this test reds instead of the
+    // hero silently changing state.
+    const unscored = build([
+      { option_id: 'opt-1', option_label: 'Option A', win_probability: 0.05 },
+      { option_id: 'opt-2', option_label: 'Option B' },
+    ])
+    const fabricatedZero = { ...unscored, runnerUpProbability: 0 }
+
+    const previous = { ...unscored, runId: 'run-0', winnerId: 'opt-1' }
+
+    expect(deriveCompareState([previous, unscored], false)).toBe(
+      deriveCompareState([previous, fabricatedZero], false),
+    )
+  })
+})

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -476,7 +476,20 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     winnerProbability: Math.round((winner?.win_probability ?? 0) * 100),
     runnerUpId: runnerUp?.option_id ?? null,
     runnerUpLabel: runnerUp?.option_label ?? null,
-    runnerUpProbability: runnerUp ? Math.round((runnerUp.win_probability ?? 0) * 100) : null,
+    // ROADMAP 2.834 — this line had TWO absence paths and only one was honest.
+    // `runnerUp ? … : null` correctly reports "there is no runner-up", but the
+    // inner `win_probability ?? 0` published a confident 0% for a runner-up
+    // that EXISTS and simply was not scored. The snapshot is a persistence
+    // surface, so that fabricated 0 outlived the run and replayed on the
+    // compare tab in every later session.
+    //
+    // The type is unchanged (`number | null`, types.ts:144) — absence was
+    // already first-class here, so no consumer contract moves. `winnerProbability`
+    // above deliberately keeps its `?? 0`: it is non-nullable and is consumed
+    // ARITHMETICALLY by deriveCompareState, so making it nullable would change
+    // which hero copy fires (out of scope, ROADMAP 2.835).
+    runnerUpProbability:
+      runnerUp?.win_probability != null ? Math.round(runnerUp.win_probability * 100) : null,
 
     recommendationStability: stability,
     stabilityLabel: stability != null ? deriveStabilityLabel(stability) : null,


### PR DESCRIPTION
## The defect

Five sites coerced a first-class `null` to `0` on the **compare tab** — a surface `netlify.toml` ships enabled (`VITE_FEATURE_COMPARE_TAB = "1"`, baked at build) and which renders on the **default, non-expert** path (`TrajectoryChart` at `TrajectorySection.tsx:159` and `DotProgression` at `:161` render unconditionally; only `ExpertTable` is expert-gated).

| Site | What it did |
|---|---|
| `TrajectorySection.tsx:75` | `runnerUp: s.runnerUpProbability ?? 0` — **plotted** a flat line on the axis |
| `DotProgression.tsx:36` | `s.runnerUpProbability ?? 0` — printed `0%` |
| `DotProgression.tsx:109` | `s.goalProbability ?? 0` — printed `0%` |
| `Hero.tsx:55` | `${latest.runnerUpProbability ?? 0}%` — printed a measured-looking `0%` |
| `analysisSnapshotFactory.ts:479` | `runnerUp.win_probability ?? 0` — **persisted** the fabrication |

Both fields are declared `number | null` (`types.ts:144,195`), so absence is a **first-class, expected state**, produced on two honest paths: a run with one option has no runner-up at all, and `selectGoalProbability` legitimately returns null for a withheld basis.

**Why the chart site is the worst of them.** A reader can doubt a printed number, but reads a plotted series as observation. An unscored runner-up drew a flat line along zero — a measurement the engine never made, in the most credible form the UI has.

## Producer vs. site — the reasoning

Both, and they are **not** mirrors of each other.

- **`goalProbability` — site only.** The producer (`analysisSnapshotFactory.ts:438-439`) is *already* absence-preserving. Only the display fabricated. Nothing to decide.
- **`runnerUpProbability` — producer *and* sites.** The producer fix is right because the type **already** permits null, so **no consumer contract moves** — the usual argument against a producer-side fix does not apply here. And the sites still need fixing independently, because null was *already reachable* through the pre-existing honest `: null` branch (no runner-up at all); those sites fabricated that legitimate null to `0` today. So the site fixes close a branch the producer never caused.
- **`winnerProbability` (`:477`) deliberately NOT touched.** It is declared non-nullable `number` (`types.ts:140`) and is consumed **arithmetically** by `deriveCompareState`, which is out of scope. Making it nullable would change *which hero copy fires* — a product judgement, not a mechanical honesty swap. Flagged for a separate row.

**The out-of-scope state machine is provably undisturbed.** `deriveCompareState` already coerces with its own `?? 0`, so absent → `0` (before) and absent → `null` → `0` (after) are the *same* input to it. A test pins that equivalence rather than asserting it, so a later edit removing that `?? 0` reds here instead of silently changing the hero state.

## Why `parseAnalysisEnrichment` did not already cover this

That guard works at **envelope grain**: it rejects an envelope whose `option_comparison` or `factor_sensitivity` is missing or empty, and its own header states every *other* producer field "stays absence-preserving rather than drop-worthy". Once both arrays are non-empty the envelope is **admitted**, and the guard makes no claim about the fields *inside* the entries. These defects live entirely on admitted envelopes.

**Every fixture in these specs is therefore one the guard PASSES** — otherwise the tests would re-prove the guard instead of the branch it misses. Presence of a guard is not coverage of the branch.

The sibling `TrajectorySection.absence.spec.tsx` shows the same thing from the other side: its own fixture carries `runnerUpProbability: null` and `goalProbability: null`, so the chart and dot row were rendering fabricated zeros inside **every one of those green tests**.

## The treatment

Absence renders as a gap, matching the idiom this surface already owns (`NOT_ASSESSED` in `TrajectorySection`/`RunPairCompare`, `—` on `ComparisonCanvasLayout`):

- **Chart** — a `null` breaks the line (recharts `connectNulls` defaults false); the runner-up series is hidden entirely when nothing scored it, via `hasRunnerUp` **derived from the series** rather than a re-derived predicate.
- **Dot row** — em-dash plus a **hollow** dot (a filled dot on a progression makes the same "measured here" claim the number did), with `title="Not scored in this run"`.
- **Hero** — "not scored in this run" instead of `0%`.

Both rows now render through one `ProgressionCell`, so a future row cannot reintroduce the fabrication by omission.

`buildTrajectoryData` is exported so the series is asserted **directly** — jsdom cannot prove anything about a rendered chart, and a test that rendered recharts under jsdom would pin nothing.

## Verification

- **RED-first at pristine: 8 failed / 6 passed (14).** The 6 pre-existing greens are the honest-zero controls and the state-machine pin — they must not move. After the fix: **14/14**.
- **9 mutants, all correct. Control applied-check exactly 0.**
  - 7 proof-obligation mutants re-introducing each `?? 0` (plus a falsy-vs-null mutant turning an **honest** `0` into "unscored") — **all RED**, applied-check 1 each.
  - **Discriminating pair:** breaking a *different* object (goal-only in the chart; winner-only in the producer) left the runner-up assertions **GREEN**, proving they bind to their named object rather than to "some null somewhere".
  - **No survivors**, so nothing is asserted as equivalent.
- **Isolation proven by WRITING**, not by locating: distinct APFS inodes, and a sentinel appended in the worktree left the source file's SHA-256 unchanged. Restores came from a pristine **archive**, never the sibling copy. Source clone ended **0 dirty**, HEAD unchanged.
- **Named gate `pnpm typecheck` PASSED** — 3292/3332 tracked files loaded; drift *shrank* 2491 → 2487, and the `--update-baseline` prompt was **declined** (not this PR's to bank).
- Supabase env vars exported for every measurement; collect health checked against the config's own include globs (1,540 matching files).

Rows: **2.834**. Follow-up flagged: `winnerProbability`'s `?? 0` at `analysisSnapshotFactory.ts:477`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
