### PR TITLE
chore(dependabot): target `staging`, not frozen `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,12 +55,15 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Target the main branch
-    target-branch: "main"
+    # Target the integration branch: `main` is frozen (Netlify deploys run off
+    # `staging`), so dependabot PRs against `main` change nothing the product runs.
+    target-branch: "staging"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Target the integration branch (see npm entry above).
+    target-branch: "staging"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Stop dependabot raising PRs against a branch the product does not run

**This is the root-cause fix for the 50 dependabot PRs closed today.** It changes **only** `target-branch`. No dependency version, no `pnpm.overrides`, no other setting is touched.

### The defect

Dependabot reads `.github/dependabot.yml` **from the repository's DEFAULT branch**, which is `main` here. This repo's config on `main` does not point dependabot at `staging`, so every PR it raises targets `main`.

Measured today: **`staging` is **1,740** commits ahead of `main`.** Per `POC-FOCUS-CHARTER-2026-07-28.md`, **`staging` IS the product and production is out of scope for the POC** — so a dependency bump merged to `main` changes nothing the deployed service runs. **15 such PRs** were open in this repo and have been closed with that reason recorded on each.

Their red checks were an artefact of a base thousands of commits stale, not evidence about the bumps themselves — which is precisely why triaging them one by one would have been work whose entire output is discarded on merge.

> ⚠ **In this repo `target-branch: "main"` was set explicitly** on the npm ecosystem — deliberate-looking, but pointing at the branch the POC does not deploy. The github-actions ecosystem had no `target-branch` at all and defaulted to `main`. Both are now `staging`.

### Why this PR targets `main`

It has to. `main` is the default branch, and the default branch is the only place dependabot reads this file. **This is the one config change that genuinely belongs on `main`** — a copy on `staging` is dark, because dependabot never looks there.

### After merge

Dependabot re-raises only what is **actually outstanding against `staging`** — expected to be a much smaller set than the 50 just closed, since several were already satisfied by existing override floors.

### Standing landmine — deliberately NOT touched

`pnpm 11` ignores `pnpm.overrides` in `package.json`, and `pnpm <10` cannot read them from `pnpm-workspace.yaml`; the `find-my-way@<9.6.1` pin is load-bearing security protection. **This PR does not migrate or modify any override.** Only `target-branch` is set.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)