### PR TITLE
fix(analysis): ROADMAP 2.580 coherence pack — rounding note · edge-direction provenance · ranking-scoped stability · downside units

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -844,7 +844,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // premise that is false at this ref — it claimed the footer would carry
   // "duplicate stale messaging", but the footer's label comes from
   // `derivePostFooterStatus(robustnessVerdict)`, which only ever emits
-  // robustness copy ('Stable result' / 'Sensitive to assumptions' /
+  // robustness copy ('Stable ranking' / 'Ranking sensitive to assumptions' /
   // 'Robustness not assessed' / 'Robustness unknown') and never freshness.
   // Its meta is the producer's robustness reason. Neither duplicates the
   // banner's "Refresh analysis · Coaching may be out of date".
@@ -1246,7 +1246,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // The verdict is now the producer's own robustness.display_verdict (PLoT
   // #202, consumed lane 35 fix 3), normalised fail-closed in the hook; when
   // it is absent (older PLoT builds) the footer keeps the neutral
-  // "Robustness unknown" state instead of a green "Stable result" derived
+  // "Robustness unknown" state instead of a green "Stable ranking" derived
   // from raw stability (which contradicted the glyph on the same tab). Raw
   // stability is retained only as neutral metadata in derivePostFooterMeta
   // below. See ./utils/postAnalysisFooter.ts + ROBUSTNESS-VERDICT-CONTRACT.

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -347,7 +347,7 @@ describe('OutputsDock analyse convergence', () => {
     expect(footer).toBeInTheDocument()
     // Robustness trust fix (ROBUSTNESS-VERDICT-CONTRACT): raw
     // recommendation_stability (0.87) with NO display-safe robustnessVerdict no
-    // longer renders a positive "Stable result" verdict — the footer stays
+    // longer renders a positive "Stable ranking" verdict — the footer stays
     // neutral ("Robustness unknown"), matching the certified glyph.
     //
     // cb16e329 ("stop raw-stability robustness overclaims", 2026-06-27)
@@ -356,7 +356,7 @@ describe('OutputsDock analyse convergence', () => {
     // "Robustness unknown · 87% stability" still contradicted itself,
     // and the number is the leader's win probability, not a robustness
     // verdict — so it no longer renders as neutral metadata either.
-    expect(footer).not.toHaveTextContent('Stable result')
+    expect(footer).not.toHaveTextContent('Stable ranking')
     expect(footer).toHaveTextContent('Robustness unknown')
     expect(footer).not.toHaveTextContent('87%')
     expect(screen.queryByText('Compare available in the tab bar')).not.toBeInTheDocument()

--- a/src/canvas/components/__tests__/OutputsDock.anchorRunControl.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.anchorRunControl.spec.tsx
@@ -2,7 +2,7 @@
  * OutputsDock — the bottom anchor keeps the run-analysis control (Paul, 21-Jul).
  *
  * Paul's finding: opening the canvas onto a completed analysis, "the bottom
- * anchor panel shows the robustness verdict ('Sensitive to assumptions…') in
+ * anchor panel shows the robustness verdict ('Ranking sensitive to assumptions…') in
  * the slot where the RUN-ANALYSIS control should be — instead of the
  * functionality to run the analysis."
  *
@@ -103,7 +103,7 @@ function ensureMatchMedia() {
 }
 
 // robustness.recommendation_stability 0.42 → a display-safe 'fragile'/'moderate'
-// verdict → the "Sensitive to assumptions" footer label Paul reported. The exact
+// verdict → the "Ranking sensitive to assumptions" footer label Paul reported. The exact
 // verdict token is derived upstream; the point of THIS pin is that whatever the
 // verdict, the anchor also carries the run control.
 const fakeReport: Record<string, unknown> = {
@@ -170,7 +170,7 @@ describe('OutputsDock — the bottom anchor keeps the run-analysis control (anch
 
     const footer = screen.getByTestId('results-analysis-footer')
     // The robustness verdict still lives in the anchor (never removed)…
-    expect(footer).toHaveTextContent(/Sensitive to assumptions|Stable result|Robustness/)
+    expect(footer).toHaveTextContent(/Ranking sensitive to assumptions|Stable ranking|Robustness/)
     // …ALONGSIDE the run control, not in place of it.
     const action = screen.getByTestId('results-analysis-footer-action')
     expect(action).toBeInTheDocument()

--- a/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
+++ b/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
@@ -19,20 +19,20 @@ describe('derivePostFooterStatus — display-safe verdict only (robustness trust
   // ONLY from the display-safe `robustnessVerdict`, never from raw
   // recommendation_stability. So the helper takes the verdict, not a number.
 
-  it('verdict "robust" → success "Stable result" (the ONLY path to a positive verdict)', () => {
+  it('verdict "robust" → success "Stable ranking" (the ONLY path to a positive verdict)', () => {
     expect(derivePostFooterStatus('robust')).toEqual({
       icon: 'check',
       iconClass: 'text-success',
-      label: 'Stable result',
+      label: 'Stable ranking',
     })
   })
 
-  it('verdict "moderate" | "fragile" → warning "Sensitive to assumptions"', () => {
+  it('verdict "moderate" | "fragile" → warning "Ranking sensitive to assumptions"', () => {
     for (const v of ['moderate', 'fragile'] as const) {
       expect(derivePostFooterStatus(v)).toEqual({
         icon: 'warning',
         iconClass: 'text-warning',
-        label: 'Sensitive to assumptions',
+        label: 'Ranking sensitive to assumptions',
       })
     }
   })
@@ -55,11 +55,11 @@ describe('derivePostFooterStatus — display-safe verdict only (robustness trust
     }
   })
 
-  it('trust fix: an ABSENT display-safe verdict never renders "Stable result" nor a green/check positive icon', () => {
-    // Previously raw stability ≥ 0.85 rendered a green "Stable result" that
+  it('trust fix: an ABSENT display-safe verdict never renders "Stable ranking" nor a green/check positive icon', () => {
+    // Previously raw stability ≥ 0.85 rendered a green "Stable ranking" that
     // contradicted the neutral robustness glyph.
     const status = derivePostFooterStatus(undefined)
-    expect(status.label).not.toBe('Stable result')
+    expect(status.label).not.toBe('Stable ranking')
     expect(status.icon).not.toBe('check')
     expect(status.iconClass).not.toContain('success')
     expect(status.label).toBe('Robustness unknown')
@@ -70,7 +70,7 @@ describe('derivePostFooterStatus — runtime-safe: unexpected values fall NEUTRA
   // Type safety is necessary but NOT sufficient. If a raw stability number
   // (e.g. 0.87), a stringified number, or any malformed value accidentally
   // reaches the helper at runtime, it must fall neutral — NEVER fabricate a
-  // "Sensitive to assumptions"/"Stable result" claim from an uncertified source.
+  // "Ranking sensitive to assumptions"/"Stable ranking" claim from an uncertified source.
   const NEUTRAL = { icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' } as const
   const UNEXPECTED: Array<[string, unknown]> = [
     ['raw number 0.87', 0.87],
@@ -91,8 +91,8 @@ describe('derivePostFooterStatus — runtime-safe: unexpected values fall NEUTRA
   it.each(UNEXPECTED)('%s → neutral "Robustness unknown", no verdict / no positive styling', (_label, value) => {
     const status = derivePostFooterStatus(value as unknown as RobustnessDisplayVerdict)
     expect(status).toEqual(NEUTRAL)
-    expect(status.label).not.toBe('Stable result')
-    expect(status.label).not.toBe('Sensitive to assumptions')
+    expect(status.label).not.toBe('Stable ranking')
+    expect(status.label).not.toBe('Ranking sensitive to assumptions')
     expect(status.icon).not.toBe('check')
     expect(status.icon).not.toBe('warning')
     expect(status.iconClass).not.toContain('success')

--- a/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
+++ b/src/canvas/components/utils/__tests__/robustnessSingleSource.render.spec.tsx
@@ -10,7 +10,7 @@
  * absent (older PLoT builds) the footer renders the neutral "Robustness
  * unknown" state, in lock-step with the certified glyph
  * (TriageActionCardsBody `checks-robust`) — so the Analysis tab can never
- * show a green "Stable result" beside a neutral "Robustness unknown".
+ * show a green "Stable ranking" beside a neutral "Robustness unknown".
  *
  * These render the ACTUAL presentational AnalysisFooter (the live footer
  * component, env-free) the way OutputsDock wires it (metaPlacement="stacked",
@@ -56,7 +56,7 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
     const { container } = renderFooter(undefined)
     const footer = screen.getByTestId('results-analysis-footer')
     expect(footer).toHaveTextContent('Robustness unknown')
-    expect(footer).not.toHaveTextContent('Stable result')
+    expect(footer).not.toHaveTextContent('Stable ranking')
     // No green/check success styling anywhere in the neutral footer.
     expect(container.querySelector('.text-success')).toBeNull()
     expect(container.querySelector('.lucide-check-circle')).toBeNull()
@@ -71,25 +71,25 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
     // signature makes this structural: it accepts only RobustnessDisplayVerdict.
     const status = derivePostFooterStatus(undefined)
     expect(status).toEqual({ icon: 'unknown', iconClass: 'text-text-light', label: 'Robustness unknown' })
-    expect(status.label).not.toBe('Stable result')
+    expect(status.label).not.toBe('Stable ranking')
   })
 
-  it('the ONLY path to a positive green "Stable result" is robustnessVerdict === "robust"', () => {
+  it('the ONLY path to a positive green "Stable ranking" is robustnessVerdict === "robust"', () => {
     const { container } = renderFooter('robust')
     const footer = screen.getByTestId('results-analysis-footer')
-    expect(footer).toHaveTextContent('Stable result')
+    expect(footer).toHaveTextContent('Stable ranking')
     // Positive verdict → success styling is allowed (stacked mode applies
     // statusIconClassName to both icon and label).
     expect(container.querySelector('.text-success')).not.toBeNull()
     expect(container.querySelector('.lucide-check-circle')).not.toBeNull()
   })
 
-  it('sensitive producer verdicts → warning "Sensitive to assumptions" (no success styling)', () => {
+  it('sensitive producer verdicts → warning "Ranking sensitive to assumptions" (no success styling)', () => {
     for (const v of ['moderate', 'fragile'] as const) {
       const { container } = renderFooter(v)
       const footer = screen.getByTestId('results-analysis-footer')
-      expect(footer).toHaveTextContent('Sensitive to assumptions')
-      expect(footer).not.toHaveTextContent('Stable result')
+      expect(footer).toHaveTextContent('Ranking sensitive to assumptions')
+      expect(footer).not.toHaveTextContent('Stable ranking')
       expect(container.querySelector('.text-success')).toBeNull()
       cleanup()
     }
@@ -99,8 +99,8 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
     const { container } = renderFooter('not_assessed')
     const footer = screen.getByTestId('results-analysis-footer')
     expect(footer).toHaveTextContent('Robustness not assessed')
-    expect(footer).not.toHaveTextContent('Stable result')
-    expect(footer).not.toHaveTextContent('Sensitive to assumptions')
+    expect(footer).not.toHaveTextContent('Stable ranking')
+    expect(footer).not.toHaveTextContent('Ranking sensitive to assumptions')
     expect(container.querySelector('.text-success')).toBeNull()
     expect(container.querySelector('.lucide-help-circle')).not.toBeNull()
   })
@@ -108,13 +108,13 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
   it('runtime-safe: a raw stability NUMBER that slips through at runtime → neutral footer, no verdict styling', () => {
     // Defense-in-depth (rendered): even if 0.87 reached the wired helper at
     // runtime, the footer must render neutral "Robustness unknown" — never a
-    // green "Stable result" nor an amber "Sensitive to assumptions" from an
+    // green "Stable ranking" nor an amber "Ranking sensitive to assumptions" from an
     // uncertified raw value.
     const { container } = renderFooter(0.87 as unknown as RobustnessDisplayVerdict)
     const footer = screen.getByTestId('results-analysis-footer')
     expect(footer).toHaveTextContent('Robustness unknown')
-    expect(footer).not.toHaveTextContent('Stable result')
-    expect(footer).not.toHaveTextContent('Sensitive to assumptions')
+    expect(footer).not.toHaveTextContent('Stable ranking')
+    expect(footer).not.toHaveTextContent('Ranking sensitive to assumptions')
     expect(container.querySelector('.text-success')).toBeNull()
     expect(container.querySelector('.lucide-check-circle')).toBeNull()
     expect(container.querySelector('.lucide-help-circle')).not.toBeNull()
@@ -124,7 +124,7 @@ describe('AnalysisFooter — raw stability cannot render a positive robustness v
     const { container } = renderFooter('high' as unknown as RobustnessDisplayVerdict)
     const footer = screen.getByTestId('results-analysis-footer')
     expect(footer).toHaveTextContent('Robustness unknown')
-    expect(footer).not.toHaveTextContent('Stable result')
+    expect(footer).not.toHaveTextContent('Stable ranking')
     expect(container.querySelector('.text-success')).toBeNull()
   })
 })
@@ -136,8 +136,8 @@ describe('footer ↔ certified glyph consistency (single source)', () => {
   //   not_assessed                                                → "Robustness not assessed"
   //   undefined/null                                              → "Robustness unknown"
   // The footer MUST agree: positive iff the glyph is positive; otherwise the
-  // footer must NOT render a positive "Stable result". This proves the two
-  // sibling surfaces can never contradict (e.g. green "Stable result" beside a
+  // footer must NOT render a positive "Stable ranking". This proves the two
+  // sibling surfaces can never contradict (e.g. green "Stable ranking" beside a
   // neutral "Robustness unknown" glyph on the same Analysis tab).
   const ALL: Array<RobustnessDisplayVerdict | null | undefined> = [
     undefined, null, 'robust', 'moderate', 'fragile', 'not_assessed',
@@ -147,11 +147,11 @@ describe('footer ↔ certified glyph consistency (single source)', () => {
     for (const v of ALL) {
       const status = derivePostFooterStatus(v)
       const glyphPositive = v === 'robust'
-      const footerPositive = status.label === 'Stable result' && status.icon === 'check'
+      const footerPositive = status.label === 'Stable ranking' && status.icon === 'check'
       expect(footerPositive).toBe(glyphPositive)
       if (!glyphPositive) {
-        // Glyph neutral/sensitive → footer must not be a positive "Stable result".
-        expect(status.label).not.toBe('Stable result')
+        // Glyph neutral/sensitive → footer must not be a positive "Stable ranking".
+        expect(status.label).not.toBe('Stable ranking')
         expect(status.iconClass).not.toContain('success')
       }
     }

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -12,8 +12,27 @@
  * `ranking_stability`. The verdict is the producer's own
  * `robustness.display_verdict` (PLoT #202, consumed lane 35 fix 3),
  * normalised fail-closed upstream:
- *   - robustnessVerdict 'robust'                → success "Stable result"
- *   - robustnessVerdict 'moderate' | 'fragile'  → warning "Sensitive to assumptions"
+ *   - robustnessVerdict 'robust'                → success "Stable ranking"
+ *   - robustnessVerdict 'moderate' | 'fragile'  → warning "Ranking sensitive to
+ *     assumptions"
+ *
+ * ⭐ ROADMAP 2.580 member 3 — WHY THE LABELS NAME THE RANKING.
+ *
+ * The verdict is derived from `recommendation_stability`, which ISL declares
+ * as "P(same recommendation across samples)" and reports as "{winner} wins in
+ * {x:.0%} of sampled scenarios". What held is the ORDER, in a finite sample —
+ * not "the result". Codex (5 Aug 2026) saw "Stable result" beside 19 sensitive
+ * assumptions and zero stable edges, and the sensitive assumptions were
+ * exactly the numbers that did not hold. The labels now say which claim is
+ * being made; the mapping, the fail-closed allowlist and the verdict source
+ * are untouched.
+ *
+ * ⚠ THE LEADING META SEGMENT IS STILL THE PRODUCER'S, VERBATIM. PLoT authors
+ * "this result held up under the changes we tested"
+ * (`src/routes/v2/robustness-display-verdict.ts:62`), and rewording a
+ * producer-owned display phrase in the consumer is exactly the divergence this
+ * file's single-source rule exists to prevent. That half is a PLoT patch spec,
+ * not a UI change — see the PR body.
  *   - robustnessVerdict 'not_assessed'          → neutral "Robustness not assessed"
  *     (the producer's own stated absence — rendered as stated, not upgraded
  *     and not blurred into the UI's "unknown")
@@ -84,7 +103,7 @@ export interface PostFooterMetaInput {
  * enum values produce a verdict. Type safety alone is not enough — if a raw
  * stability number (e.g. 0.87), a stringified number, or any other malformed
  * value accidentally reaches this helper at runtime, it must fall NEUTRAL,
- * never fabricate a "Sensitive to assumptions"/"Stable result" claim from an
+ * never fabricate a "Ranking sensitive to assumptions"/"Stable ranking" claim from an
  * uncertified source. So the only branches that emit a verdict are the exact
  * enum matches; everything else (undefined, null, unknown string, number,
  * malformed) returns "Robustness unknown".
@@ -93,13 +112,13 @@ export function derivePostFooterStatus(
   robustnessVerdict: RobustnessDisplayVerdict | null | undefined,
 ): PostFooterStatus {
   if (robustnessVerdict === 'robust') {
-    return { icon: 'check', iconClass: 'text-success', label: 'Stable result' }
+    return { icon: 'check', iconClass: 'text-success', label: 'Stable ranking' }
   }
   // Known display-safe sensitive verdicts → warning, mirroring the certified
   // glyph's "Sensitive" label. Explicit allowlist (NOT a non-robust
   // catch-all) so unexpected runtime values cannot reach this branch.
   if (robustnessVerdict === 'moderate' || robustnessVerdict === 'fragile') {
-    return { icon: 'warning', iconClass: 'text-warning', label: 'Sensitive to assumptions' }
+    return { icon: 'warning', iconClass: 'text-warning', label: 'Ranking sensitive to assumptions' }
   }
   // The producer explicitly said robustness was not assessed — state THAT,
   // verbatim in meaning, rather than the vaguer "unknown".

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -30,6 +30,7 @@ import { formatConfidence, shouldShowLabel, getEdgeConfidence } from '../domain/
 import {
   resolveEdgeValueDisplay,
   resolveEdgeSignedStrengthDisplay,
+  resolveEdgeDirectionDisplay,
   compareEdgeValueDisplays,
   type EdgeValueDisplay,
 } from '../domain/edgeValueProvenance'
@@ -215,6 +216,29 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   const belief = edgeData?.belief      // v1.2
   const provenance = edgeData?.provenance  // v1.2
   const direction = edgeData?.direction as 'positive' | 'negative' | undefined  // v2.2
+
+  // ⭐ ROADMAP 2.580 member 2 — THE POLARITY GLYPH'S OWN, GATED, DIRECTION.
+  //
+  // `direction` above is the RAW field and it defaults: `USER_EDGE_DEFAULTS`
+  // writes `'positive'` with no source stamp, and the template/blueprint/CEE
+  // -apply paths build from `DEFAULT_EDGE_DATA`, which has no `direction` key
+  // at all. Reading it raw made the canvas draw a green "+" — a positive
+  // causal claim — on edges whose direction nobody ever stated.
+  //
+  // `resolveEdgeDirectionDisplay` is the one owner of that answer (rule 4 of
+  // its module header, ROADMAP 2.263). It was applied to the three Model-tab
+  // consumers and not to this file, so the Model tab said "direction not
+  // stated" while the graph beside it drew a "+". The hover popover below
+  // (:1010) was already gated and its comment names this exact hazard.
+  //
+  // Kept SEPARATE from `direction` deliberately: the raw field still drives
+  // the stroke colour and the outbound adapters, and changing those is a
+  // different decision with different consumers. This constant is the DISPLAY
+  // CLAIM only.
+  const directionDisplay = resolveEdgeDirectionDisplay(
+    edgeData as Record<string, unknown> | undefined,
+  )
+  const statedDirection = directionDisplay.show ? directionDisplay.direction : null
 
   // Count outgoing edges from source node for visibility logic
   const outgoingEdgeCount = useMemo(() => {
@@ -799,7 +823,11 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           collision-avoids labels exactly as before. Causal lens shows its own
           numeric parameter label instead. Structural edges have no semantic
           direction — excluded defensively. */}
-      {direction && lensMode !== 'causal' && !isStructuralEdge && (
+      {/* ⭐ ROADMAP 2.580 member 2: gated on `statedDirection`, not on the raw
+          `direction` field — see the derivation at the top of this component.
+          An unstated / declined / unrecognised direction renders NOTHING here;
+          the graph says less rather than something it was never told. */}
+      {statedDirection && lensMode !== 'causal' && !isStructuralEdge && (
         <EdgeLabelRenderer>
           <div
             style={{
@@ -808,7 +836,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               pointerEvents: 'none',
               fontSize: '16px',
               fontWeight: 700,
-              color: direction === 'positive' ? '#059669' : '#dc2626',
+              color: statedDirection === 'positive' ? '#059669' : '#dc2626',
               // Chip surface = the panel token, matching the sibling edge-label
               // chips (bg-panel) so it no longer glares on a dark canvas. Inline
               // CSS-var idiom mirrors the other token refs in this file
@@ -818,9 +846,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
               padding: '0 3px',
               borderRadius: '2px',
             }}
-            aria-label={`Effect direction: ${direction}`}
+            aria-label={`Effect direction: ${statedDirection}`}
           >
-            {direction === 'positive' ? '+' : '−'}
+            {statedDirection === 'positive' ? '+' : '−'}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/src/canvas/edges/__tests__/StyledEdge.directionProvenance.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.directionProvenance.spec.tsx
@@ -1,0 +1,276 @@
+/**
+ * ROADMAP 2.580 member 2 — THE GRAPH MUST NOT ENCODE A DIRECTION NOBODY STATED.
+ *
+ * Codex simulated-user review, 5 Aug 2026: "one flip sentence said hiring
+ * would REDUCE a delay while the displayed graph encoded a POSITIVE
+ * relationship to that delay."
+ *
+ * WHAT THE INVESTIGATION FOUND (and it is not what the member's wording
+ * suggests): the two halves are not two readings of one edge object. The
+ * SENTENCE side is a factor-level fact (`factor_sensitivity[].direction` in
+ * the analysis payload, rendered as "increases/decreases the outcome"); the
+ * GRAPH side is an edge-level field in the canvas store (`edge.data.direction`,
+ * rendered as the green `+` / rose `−` glyph at `StyledEdge.tsx:802`). They
+ * answer DIFFERENT QUESTIONS about DIFFERENT OBJECTS, which is CLAUDE.md trap
+ * 21 — and aligning their defaults would be the wrong fix.
+ *
+ * What IS a defect, and is fixed here: `edge.data.direction` DEFAULTS to
+ * `'positive'`. `USER_EDGE_DEFAULTS` sets it with no source stamp, and the
+ * template-insert, blueprint-insert and two CEE-apply paths build from
+ * `DEFAULT_EDGE_DATA`, which defines no `direction` key at all
+ * (`edgeValueProvenance.ts`, THE WRITER MANIFEST). So the canvas drew a green
+ * `+` — "positive relationship" — on edges whose direction nobody ever stated.
+ * That is the fabricated half of the contradiction the reviewer saw, and it is
+ * display-side.
+ *
+ * The gate already exists and already owns this answer:
+ * `resolveEdgeDirectionDisplay` (ROADMAP 2.263). It was applied to the THREE
+ * Model-tab consumers and NOT to the canvas edge — the one surface the
+ * reviewer called "the displayed graph". Its own module header states rule 4,
+ * "ONE OWNER. This resolver is it." This spec makes the canvas obey it.
+ *
+ * The hover popover in the same file was already gated, and its comment names
+ * this exact hazard: "`direction` defaults to 'positive', so 'Positive' is
+ * itself a fabrication on an edge nobody characterised." The glyph 200 lines
+ * above it was not.
+ *
+ * RED-first: the two "does not render" cases below fail at bc997f50.
+ *
+ * ⚠ SCOPE, STATED SO IT IS NOT OVER-READ: this pins the GLYPH and its
+ * `aria-label` — the symbolic/textual polarity claim. The stroke COLOUR is a
+ * separate channel with its own consumers and is unchanged here; see the PR
+ * body for the rowed residual.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import { Position } from '@xyflow/react'
+
+// ── Node kind registry — switched per-test ───────────────────────────────────
+const nodeKinds: Record<string, string> = {}
+
+// ── Mutable store state — overridden per-test ────────────────────────────────
+interface StoreState {
+  viewMode: 'standard' | 'expert'
+  resultsStatus: 'idle' | 'complete'
+  report: unknown
+}
+const storeState: StoreState = { viewMode: 'standard', resultsStatus: 'idle', report: null }
+const setStore = (over: Partial<StoreState>) => Object.assign(storeState, over)
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: storeState.resultsStatus, report: storeState.report },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: storeState.viewMode,
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// Distinct width outputs so an assertion can tell the two formulas apart;
+// dash reflects the real <0.7 rule so the belief-dash pin is meaningful.
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  // ⛔ importOriginal-SPREAD, not a hand-listed replacement. A `vi.mock`
+  // factory REPLACES the module, so every export added after this mock was
+  // written silently vanished — adding `UNSET_EDGE_STROKE_WIDTH` took 49 tests
+  // down across seven files at once. The spread makes the mock derive from the
+  // real module and override only what it means to stub.
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: (p: number | undefined) => (p !== undefined && p < 0.7 ? '6,4' : undefined),
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+const baseProps = {
+  id: 'e1', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: false,
+}
+
+
+
+/** The glyph, found by its own aria-label — bound by identity, not by text. */
+const glyphFor = (container: HTMLElement, direction: 'positive' | 'negative') =>
+  container.querySelector(`[aria-label="Effect direction: ${direction}"]`)
+
+/** Any polarity glyph at all, whichever sign. */
+const anyGlyph = (container: HTMLElement) =>
+  container.querySelector('[aria-label^="Effect direction:"]')
+
+describe('StyledEdge — polarity glyph is provenance-gated (ROADMAP 2.580 member 2)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    setStore({ viewMode: 'standard', resultsStatus: 'idle', report: null })
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  // ── The claim is licensed: someone stated the direction ──────────────────
+
+  it('renders + when a USER stated a positive direction', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'positive', directionSource: 'user', beliefExists: 0.8 }}
+      />
+    )
+    expect(glyphFor(container, 'positive')!.textContent).toBe('+')
+  })
+
+  it('renders − when a USER stated a negative direction', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'negative', directionSource: 'user', beliefExists: 0.8 }}
+      />
+    )
+    expect(glyphFor(container, 'negative')!.textContent).toBe('−')
+  })
+
+  it('renders + on the CEE back-compat evidence (raw effect_direction, no stamp)', () => {
+    // `effect_direction` is the producer wire spelling and nothing in the UI
+    // fabricates it, so its presence PROVES a producer stated a direction.
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'positive', effect_direction: 'positive', beliefExists: 0.8 }}
+      />
+    )
+    expect(glyphFor(container, 'positive')!.textContent).toBe('+')
+  })
+
+  // ── The claim is NOT licensed: these are the fabrications ────────────────
+
+  it('DOES NOT render a glyph when `direction` is the unstated UI default', () => {
+    // `USER_EDGE_DEFAULTS.direction === 'positive'` with no source stamp —
+    // exactly the shape every user-drawn edge carries until someone sets it.
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+    )
+    expect(anyGlyph(container)).toBeNull()
+  })
+
+  it('DOES NOT render a glyph when the producer EXPLICITLY declined (effect_direction: "unknown")', () => {
+    // The declining value sits BESIDE the defaulted `direction: 'positive'`,
+    // which is precisely the pair that used to render a green +.
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'positive', effect_direction: 'unknown', beliefExists: 0.8 }}
+      />
+    )
+    expect(anyGlyph(container)).toBeNull()
+  })
+
+  it('DOES NOT render a glyph when the edge carries no direction at all', () => {
+    // `DEFAULT_EDGE_DATA` defines no `direction` key: the template-insert,
+    // blueprint-insert and CEE-apply paths all land here.
+    const { container } = render(
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, beliefExists: 0.8 }} />
+    )
+    expect(anyGlyph(container)).toBeNull()
+  })
+
+  it('DOES NOT render a glyph for an unrecognised direction value, even with a source stamp', () => {
+    // Rule 3 of the resolver: an unrecognised value fails closed.
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'sideways', directionSource: 'user', beliefExists: 0.8 }}
+      />
+    )
+    expect(anyGlyph(container)).toBeNull()
+  })
+
+  // ── The glyph states the direction that was STATED, not one inferred ─────
+
+  it('does not let a stated NEGATIVE direction be overridden by a positive magnitude', () => {
+    // Rule 1: never infer direction from a magnitude. `weight` is unsigned and
+    // positive here; the stated direction is negative and must win.
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.9, direction: 'negative', directionSource: 'cee', beliefExists: 0.8 }}
+      />
+    )
+    expect(glyphFor(container, 'negative')!.textContent).toBe('−')
+    expect(glyphFor(container, 'positive')).toBeNull()
+  })
+
+  it('still suppresses the glyph on structural edges even when the direction IS stated', () => {
+    // The pre-existing structural exclusion is not weakened by the new gate.
+    nodeKinds.src = 'decision'
+    nodeKinds.tgt = 'option'
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, direction: 'positive', directionSource: 'user', beliefExists: 0.8 }}
+      />
+    )
+    expect(anyGlyph(container)).toBeNull()
+  })
+})

--- a/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.encoding.spec.tsx
@@ -134,6 +134,22 @@ const RESULTS_REPORT = {
 const styleOf = (container: HTMLElement) =>
   ((container.querySelector('[data-testid="base-edge"]') as unknown as HTMLElement).style)
 
+/**
+ * ⚠ FIXTURES UPDATED, ROADMAP 2.580 member 2 (not a baseline absorption).
+ *
+ * These fixtures used to carry `direction` with NO provenance — byte-identical
+ * to the shape an edge NOBODY characterised carries
+ * (`USER_EDGE_DEFAULTS.direction = 'positive'`, no source stamp). So the pins
+ * read "the glyph renders for a directed edge" while in fact also asserting
+ * "the glyph renders for a DEFAULTED one" — the fabrication Codex saw as "the
+ * displayed graph encoded a POSITIVE relationship".
+ *
+ * The item-1 claim these tests exist for — the glyph shows in Standard view
+ * and pre-run, not only Expert+results — is UNCHANGED and still pinned below.
+ * The fixtures now STATE the direction they were always meant to describe.
+ * The unstated cases are pinned separately, and as ABSENCES, in
+ * `StyledEdge.directionProvenance.spec.tsx`.
+ */
 describe('StyledEdge — polarity glyph legibility (item 1)', () => {
   beforeEach(() => {
     for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
@@ -144,7 +160,7 @@ describe('StyledEdge — polarity glyph legibility (item 1)', () => {
 
   it('renders the + glyph in Standard view, pre-run, for a positive causal edge', () => {
     const { container } = render(
-      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', directionSource: 'user', beliefExists: 0.8 }} />
     )
     const glyph = container.querySelector('[aria-label="Effect direction: positive"]')
     expect(glyph).not.toBeNull()
@@ -153,7 +169,7 @@ describe('StyledEdge — polarity glyph legibility (item 1)', () => {
 
   it('renders the − glyph in Standard view, pre-run, for a negative causal edge', () => {
     const { container } = render(
-      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'negative', beliefExists: 0.8 }} />
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'negative', directionSource: 'user', beliefExists: 0.8 }} />
     )
     const glyph = container.querySelector('[aria-label="Effect direction: negative"]')
     expect(glyph).not.toBeNull()
@@ -164,7 +180,7 @@ describe('StyledEdge — polarity glyph legibility (item 1)', () => {
     nodeKinds.src = 'decision'
     nodeKinds.tgt = 'option'
     const { container } = render(
-      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', beliefExists: 0.8 }} />
+      <StyledEdge {...(baseProps as any)} data={{ weight: 0.6, direction: 'positive', directionSource: 'user', beliefExists: 0.8 }} />
     )
     expect(container.querySelector('[aria-label="Effect direction: positive"]')).toBeNull()
   })

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -49,11 +49,11 @@ import {
   downsideSummaryCopy,
   downsideUnavailableCopy,
 } from './utils/downsideCopy'
-import { formatRangeValue } from './utils/formatRangeValue'
+import { formatDownsideValue } from './utils/formatDownsideValue'
 import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpers'
 import { useCanvasStore, selectResultsStatus } from '../../canvas/store'
 import { isGraphLensEnabled } from '../../flags'
-import type { OptionResult, DecisionState, HingeInfo, ConfidenceTier } from './types'
+import type { OptionResult, DecisionState, HingeInfo, ConfidenceTier, OutcomeUnitType } from './types'
 import {
   constraintConfidenceColour,
   jointProbabilityLabel,
@@ -144,6 +144,25 @@ export interface OptionCardsProps {
    * in the lower simulated range.
    */
   leadingOptionDownsideFlag?: boolean
+  /**
+   * ⭐ ROADMAP 2.580 member 4 — THE OUTCOME AXIS'S UNIT, for the downside tail.
+   *
+   * Codex (5 Aug 2026): "downside values were unitless even when the user's
+   * goal was hours". The unit is not in the analysis payload — `downside` is
+   * three bare numbers and `EnrichmentOutcomeStats` declares no unit field —
+   * it comes from the GOAL NODE via `useResultsSectionData`. `ResultsBody`
+   * already threaded it to `DriversSection` and `TornadoChart` and not here.
+   *
+   * `isNormalised` travels WITH the unit and is not optional garnish: when the
+   * run has no `goal_threshold_cap` the magnitudes are PLoT's normalised 0-1
+   * scores, and attaching "hours" to those would be a new false claim rather
+   * than a fix. See `formatDownsideValue`.
+   */
+  outcomeUnit?: OutcomeUnitType
+  /** Currency symbol, or the raw unit string for a `count` unit ("hours"). */
+  outcomeUnitSymbol?: string
+  /** True when option magnitudes are normalised 0-1 scores, not user units. */
+  isNormalised?: boolean
 }
 
 /** Fallback description when no story headline is available */
@@ -471,6 +490,9 @@ function OptionCard({
   recommendationStability,
   leadingOptionDownsideFlag,
   hasLeadingOption,
+  outcomeUnit,
+  outcomeUnitSymbol,
+  isNormalised,
 }: {
   option: OptionResult
   isWinner: boolean
@@ -521,6 +543,10 @@ function OptionCard({
    * in the lower simulated range. Display-only.
    */
   leadingOptionDownsideFlag?: boolean
+  /** ROADMAP 2.580 member 4 - see `OptionCardsProps`. Display-only. */
+  outcomeUnit?: OutcomeUnitType
+  outcomeUnitSymbol?: string
+  isNormalised?: boolean
 }) {
   // Brief 5.8B D3: per-rank palette (success / info / option / panel-border)
   // collapsed to a 2-state hierarchy — winner cards get `border-success/30`,
@@ -875,9 +901,21 @@ function OptionCard({
             <div className="mt-1" data-testid={`option-downside-${option.id}`}>
               <p className={`${typography.panelMeta} text-text-light`}>
                 <span className="font-medium">{DOWNSIDE_HEADING_COPY}</span>{' '}
+                {/* ROADMAP 2.580 member 4: the magnitudes still go through
+                    `formatRangeValue` (unchanged precision); the unit is
+                    attached only when the goal stated one AND the values are
+                    on the goal's scale. */}
                 {downsideSummaryCopy(
-                  formatRangeValue(option.downside.p05),
-                  formatRangeValue(option.downside.cvar10),
+                  formatDownsideValue(option.downside.p05, {
+                    unit: outcomeUnit,
+                    unitSymbol: outcomeUnitSymbol,
+                    isNormalised,
+                  }),
+                  formatDownsideValue(option.downside.cvar10, {
+                    unit: outcomeUnit,
+                    unitSymbol: outcomeUnitSymbol,
+                    isNormalised,
+                  }),
                 )}
               </p>
               <p
@@ -996,6 +1034,9 @@ export function OptionCards({
   recommendationStability,
   leadingOptionDownsideFlag,
   hasLeadingOption,
+  outcomeUnit,
+  outcomeUnitSymbol,
+  isNormalised,
 }: OptionCardsProps) {
   // Internal ref map if none provided externally
   const internalRefMap = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -1206,6 +1247,9 @@ export function OptionCards({
             confidenceTier={confidenceTier}
             recommendationStability={recommendationStability}
             leadingOptionDownsideFlag={leadingOptionDownsideFlag}
+            outcomeUnit={outcomeUnit}
+            outcomeUnitSymbol={outcomeUnitSymbol}
+            isNormalised={isNormalised}
             hasLeadingOption={hasLeadingOption}
           />
         )

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -664,6 +664,14 @@ export const ResultsBody = memo(function ResultsBody({
               confidenceTier={resultsSectionData.confidence.tier.tier}
               recommendationStability={resultsSectionData.recommendation.recommendationStability}
               leadingOptionDownsideFlag={resultsSectionData.recommendation.leadingOptionDownsideFlag}
+              // ROADMAP 2.580 member 4 — the SAME unit trio already threaded to
+              // DriversSection (:693) and TornadoChart (:741), reaching the
+              // option cards' downside tail for the first time. `isNormalised`
+              // travels with it so a normalised 0-1 score cannot be labelled
+              // in the goal's unit.
+              outcomeUnit={resultsSectionData.recommendation.outcomeUnit}
+              outcomeUnitSymbol={resultsSectionData.recommendation.outcomeUnitSymbol}
+              isNormalised={resultsSectionData.recommendation.isNormalised}
             />
             {/* TippingPoints removed — superseded by TornadoChart (Brief 5.4 Phase 1) */}
           </div>

--- a/src/components/results/ResultsFooter.tsx
+++ b/src/components/results/ResultsFooter.tsx
@@ -20,7 +20,7 @@ export interface ResultsFooterProps {
   /**
    * Brief 5.2 Task 1: weak tier forces "Stability sensitive" even at high
    * numeric stability. Without these, an evidence-weak analysis with
-   * stability 0.97 reads as "Stable result · 97%" — over-confident.
+   * stability 0.97 reads as "Stable ranking · 97%" — over-confident.
    */
   confidenceTier?: ConfidenceTier
   coachingReadiness?: M1CoachingReadiness

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -40,6 +40,7 @@ import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY, isFiniteProbability } from './utils/goalAnchorCopy'
 import { formatGoalProbability } from './utils/displayFloors'
 import { formatProbabilityWithResolution } from '../../utils/formatPercent'
+import { deriveOddsRoundingNote, ODDS_ROUNDING_NOTE_TESTID } from './utils/oddsRoundingNote'
 import Tooltip from '../Tooltip'
 import type { DecisionState } from './types'
 
@@ -266,6 +267,25 @@ export function WinGauge({
     colorById[s.id] = colors[Math.min(i, colors.length - 1)]
   })
 
+  // ⭐ ROADMAP 2.580 member 1 — ONE evaluation of the legend readout.
+  //
+  // The legend below and the rounding note beneath it must state the same
+  // numbers, and "compute it the same way twice" is how they stop doing that
+  // (CLAUDE.md trap 12). So the readouts are built ONCE, here, and both
+  // consumers read this array. There is no second call to the formatter.
+  //
+  // The `clamped <= 0` skip is the ROADMAP 2.236 rule, moved but unchanged: a
+  // genuine zero is omitted from the legend, and it contributes zero to the
+  // total, so omitting it cannot move the note's arithmetic.
+  const legendEntries = sorted
+    .map((share) => {
+      const clamped = Math.max(0, Math.min(1, share.winProbability))
+      return { share, clamped, displayReadout: formatProbabilityWithResolution(clamped, null) }
+    })
+    .filter(({ clamped }) => clamped > 0)
+
+  const roundingNote = deriveOddsRoundingNote(legendEntries.map(e => e.displayReadout))
+
   // ── The goal block (question A) ────────────────────────────────────────
   // Ranked by the goal quantity itself, independently of the comparative
   // sort above — the two rankings disagree on real runs, and that
@@ -455,32 +475,37 @@ export function WinGauge({
         </div>
         {/* Legend — coloured dot + truncated name + percentage */}
         <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1.5">
-          {sorted.map((share) => {
-            const clamped = Math.max(0, Math.min(1, share.winProbability))
-            // ⭐ ROADMAP 2.236 — TWO defects on this line, both from rounding
-            // before deciding.
-            //
-            // It read `Math.round(clamped * 100)` and then `if (displayPct <= 0)
-            // return null`. So an option with a real, measured 0.19% chance was
-            // not merely printed as "0%" — it was DELETED from the legend
-            // entirely, while the canvas node beside it said "< 1%". The skip is
-            // now on the RAW value, so only a genuine zero is omitted, and the
-            // readout goes through the shared floored formatter.
-            if (clamped <= 0) return null
-            const displayReadout = formatProbabilityWithResolution(clamped, null)
-            return (
-              <span key={share.id} className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}>
-                <span
-                  className="inline-block w-2 h-2 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: colorById[share.id] }}
-                  aria-hidden="true"
-                />
-                <span className="truncate max-w-[120px]">{stripEncodingNotation(share.label)}</span>
-                <span className="tabular-nums">{displayReadout}</span>
-              </span>
-            )
-          })}
+          {legendEntries.map(({ share, displayReadout }) => (
+            <span key={share.id} className={`inline-flex items-center gap-1 ${typography.panelMeta} text-text-light`}>
+              <span
+                className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: colorById[share.id] }}
+                aria-hidden="true"
+              />
+              <span className="truncate max-w-[120px]">{stripEncodingNotation(share.label)}</span>
+              <span className="tabular-nums">{displayReadout}</span>
+            </span>
+          ))}
         </div>
+        {/* ⭐ ROADMAP 2.580 member 1 — the rounding note.
+            Codex, 5 Aug 2026: the option percentages totalled 99% in one run
+            and 101% in another "with no explanation". Each share is rounded
+            independently, so the partition need not close; that is fine, but
+            printing it silently is the product claiming a set of figures is a
+            distribution when the arithmetic on screen says otherwise.
+            Derived from `legendEntries` — the SAME strings printed above, not
+            a second evaluation of the formatting rule — so the note cannot
+            drift from the numbers it describes. Absent when the wholes total
+            100, and absent when any readout is a bound or carries decimals
+            (see `deriveOddsRoundingNote`: no total is derivable there). */}
+        {roundingNote !== null && (
+          <p
+            className={`${typography.panelMeta} text-text-light mt-1`}
+            data-testid={ODDS_ROUNDING_NOTE_TESTID}
+          >
+            {roundingNote}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/src/components/results/__tests__/AdvancedSection.spec.tsx
+++ b/src/components/results/__tests__/AdvancedSection.spec.tsx
@@ -65,20 +65,20 @@ describe('AdvancedSection', () => {
   // ── B1 receipts: Result-stability row keyed on the display-safe verdict ──
   // (premise 1) — NEVER the deprecated recommendation_stability. The mapping
   // is the shared ROBUSTNESS-VERDICT-CONTRACT (derivePostFooterStatus).
-  it('renders "Stable result" for a robust display verdict', () => {
+  it('renders "Stable ranking" for a robust display verdict', () => {
     render(<AdvancedSection robustnessVerdict="robust" />)
     fireEvent.click(screen.getByText('Advanced and receipts'))
     const row = screen.getByTestId('receipt-result-stability')
     expect(row).toHaveTextContent('Result stability')
-    expect(row).toHaveTextContent('Stable result')
+    expect(row).toHaveTextContent('Stable ranking')
   })
 
-  it('renders "Sensitive to assumptions" for moderate and fragile verdicts', () => {
+  it('renders "Ranking sensitive to assumptions" for moderate and fragile verdicts', () => {
     const { rerender } = render(<AdvancedSection robustnessVerdict="moderate" />)
     fireEvent.click(screen.getByText('Advanced and receipts'))
-    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Sensitive to assumptions')
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Ranking sensitive to assumptions')
     rerender(<AdvancedSection robustnessVerdict="fragile" />)
-    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Sensitive to assumptions')
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Ranking sensitive to assumptions')
   })
 
   it('renders "Robustness not assessed" for the producer not_assessed verdict', () => {
@@ -111,7 +111,7 @@ describe('AdvancedSection', () => {
     // Nor the old "Stability" dt label.
     expect(screen.queryByText('Stability')).not.toBeInTheDocument()
     // The honest verdict row is what shows instead.
-    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable result')
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable ranking')
   })
 
   it('renders convergence sample count', () => {
@@ -275,7 +275,7 @@ describe('AdvancedSection', () => {
     )
     fireEvent.click(screen.getByText('Advanced and receipts'))
 
-    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable result')
+    expect(screen.getByTestId('receipt-result-stability')).toHaveTextContent('Stable ranking')
     expect(screen.getByText('5,000 simulations')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getByText('8')).toBeInTheDocument()

--- a/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
+++ b/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
@@ -8,14 +8,14 @@
  *
  * Matrix expectations (all values derived from §2.7):
  *   - strong + ready + high stability → hero "is the leading option",
- *     footer "Stable result"
+ *     footer "Stable ranking"
  *   - needs_work + high stability → stability override: hero "leads"
- *     (confident fallback), footer "Stable result"
+ *     (confident fallback), footer "Stable ranking"
  *   - strong + weak readiness (any stability) → readiness never softens;
- *     hero "leads", footer "Stable result" at high stability, "Sensitive
+ *     hero "leads", footer "Stable ranking" at high stability, "Sensitive
  *     to assumptions" at low (numeric pass-through)
  *   - fair + high stability → stability override: hero "leads", footer
- *     "Stable result"
+ *     "Stable ranking"
  *   - fair + low stability → soft: hero "currently leads", footer
  *     "Stability sensitive"
  *   - needs_work + low stability → soft: hero "currently leads", footer
@@ -164,19 +164,19 @@ const matrix: MatrixCase[] = [
     // an endorsement noun with no basis and no number. The ROW is unchanged;
     // only the sentence it expects moved to the comparative register.
     expectHeroContains: 'Option A came out ahead',
-    expectFooterContains: 'Stable result',
+    expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
   },
   {
     // §2.7: needs_work + high stability → stability override → confident fallback.
-    // Hero emits "Option A leads" (no "currently"); footer honours numeric "Stable result".
+    // Hero emits "Option A leads" (no "currently"); footer honours numeric "Stable ranking".
     label: '§2.7 — needs_work + high stability: stability override to confident fallback',
     tier: 'needs_work',
     readiness: 'ready',
     stability: 0.97,
     expectHeroContains: 'Option A leads',
     forbidHero: ['currently leads', 'clear leader', 'advantage', 'is the leading option'],
-    expectFooterContains: 'Stable result',
+    expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
   },
   {
@@ -187,7 +187,7 @@ const matrix: MatrixCase[] = [
     stability: 0.95,
     expectHeroContains: 'Option A leads',
     forbidHero: ['currently leads', 'clear leader', 'is the leading option'],
-    expectFooterContains: 'Stable result',
+    expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
   },
   {
@@ -198,7 +198,7 @@ const matrix: MatrixCase[] = [
     stability: 0.90,
     expectHeroContains: 'Option A leads',
     forbidHero: ['Option A currently leads', 'is the leading option'],
-    expectFooterContains: 'Stable result',
+    expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
   },
   {
@@ -210,7 +210,7 @@ const matrix: MatrixCase[] = [
     expectHeroContains: 'Option A currently leads',
     forbidHero: ['is the leading option'],
     expectFooterContains: 'Stability sensitive',
-    forbidFooter: ['Stable result'],
+    forbidFooter: ['Stable ranking'],
   },
   {
     // close_call readiness is orthogonal — definitive copy, stability passes through.
@@ -223,7 +223,7 @@ const matrix: MatrixCase[] = [
     // only the sentence it expects moved to the comparative register.
     expectHeroContains: 'Option A came out ahead',
     forbidHero: ['Option A currently leads'],
-    expectFooterContains: 'Stable result',
+    expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
   },
   {
@@ -233,13 +233,13 @@ const matrix: MatrixCase[] = [
     // end-to-end journey lane caught on staging. The honest pairing is: the
     // hero reports the LEAD (separation), the footer reports the FRAGILITY
     // (robustness) — two different facts, each in its own voice, no denial.
-    label: 'clear lead + low stability: hero must NOT deny a leader; footer still "Sensitive to assumptions"',
+    label: 'clear lead + low stability: hero must NOT deny a leader; footer still "Ranking sensitive to assumptions"',
     tier: 'strong',
     readiness: 'ready',
     stability: 0.55,
     expectHeroContains: 'Option A',
     forbidHero: ['no clear leading option', 'leads slightly more often'],
-    expectFooterContains: 'Sensitive to assumptions',
+    expectFooterContains: 'Ranking sensitive to assumptions',
   },
   {
     label: 'clear lead + very low stability + fair tier: hero must NOT deny a leader; footer "Stability sensitive" via soft gate',
@@ -260,7 +260,7 @@ const matrix: MatrixCase[] = [
     stability: 0.55,
     wins: { winner: 0.52, runnerUp: 0.48 },
     expectHeroContains: 'no clear leading option',
-    expectFooterContains: 'Sensitive to assumptions',
+    expectFooterContains: 'Ranking sensitive to assumptions',
   },
 ]
 
@@ -339,7 +339,7 @@ describe('Hero ↔ Footer alignment — tier × readiness × stability matrix', 
       const footerText = screen.getByTestId('results-footer').textContent ?? ''
       if (expectSoft) {
         expect(footerText).toContain('Stability sensitive')
-        expect(footerText).not.toContain('Stable result')
+        expect(footerText).not.toContain('Stable ranking')
       } else {
         expect(footerText).not.toContain('Stability sensitive')
       }

--- a/src/components/results/__tests__/OptionCards.downsideUnits.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.downsideUnits.spec.tsx
@@ -1,0 +1,181 @@
+/**
+ * ROADMAP 2.580 member 4 — THE DOWNSIDE TAIL CARRIES ITS UNIT.
+ *
+ * Codex simulated-user review, 5 Aug 2026: "downside values were unitless even
+ * when the user's goal was hours". Same report, same session: an explicit
+ * 14-hour baseline "was stored as 'from brief' but displayed as a unitless
+ * normalised range of `0.29–0.87`".
+ *
+ * WHERE THE UNIT COMES FROM (it is NOT in the analysis payload)
+ * ------------------------------------------------------------
+ * `@talchain/schemas@0.38.0` `EnrichmentOutcomeStats` carries no unit, and the
+ * `downside` block is three bare numbers. The unit reaches the UI from the
+ * GOAL NODE via `useResultsSectionData` (`outcomeUnit` / `outcomeUnitSymbol`),
+ * which already threads it to `DriversSection` and `TornadoChart`
+ * (`ResultsBody.tsx:693-694`, `:741-742`) and did NOT thread it to
+ * `OptionCards`. That is the wiring this spec pins.
+ *
+ * THE BREADTH CASE, PINNED AS HARD AS THE HAPPY ONE (CLAUDE.md trap 22)
+ * --------------------------------------------------------------------
+ * On a run with no `goal_threshold_cap` the magnitudes stay on PLoT's
+ * normalised 0–1 scale (`isNormalised === true`). Appending "hours" there
+ * would swap a missing claim for a FALSE one. The `isNormalised` cases below
+ * are therefore not edge-case garnish — they are the half of the member that a
+ * careless fix gets wrong.
+ *
+ * RED-first: every unit assertion fails at bc997f50, where `OptionCards` has
+ * no unit props at all.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+
+/** An option carrying a tail, on the goal's own scale. */
+function optionWithTail(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: 'option-a',
+    label: 'Option A',
+    expected: 50,
+    outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+    p10: 20,
+    p50: 50,
+    p90: 80,
+    isRecommended: true,
+    winProbability: 0.65,
+    goalProbability: 0.7,
+    rank: 1,
+    downside: { p05: 12.4, cvar10: 9.8, expectedRegret: 3 },
+    ...overrides,
+  }
+}
+
+/** The downside sentence text for the leading option, by identity. */
+function downsideText(id = 'option-a'): string {
+  return screen.getByTestId(`option-downside-${id}`).textContent ?? ''
+}
+
+describe('OptionCards — downside tail states its unit (ROADMAP 2.580 member 4)', () => {
+  it('renders an HOURS goal with the unit beside both tail magnitudes', () => {
+    // `useResultsSectionData` classifies a free-text unit as `count` and passes
+    // the raw string through as the symbol — an "hours" goal arrives exactly
+    // like this. This is the reviewer's case.
+    render(
+      <OptionCards
+        options={[optionWithTail()]}
+        winnerId="option-a"
+        expertMode
+        outcomeUnit="count"
+        outcomeUnitSymbol="hours"
+        isNormalised={false}
+      />,
+    )
+
+    const text = downsideText()
+    expect(text).toContain('12.4 hours')
+    expect(text).toContain('9.8 hours')
+  })
+
+  it('renders a CURRENCY goal with the symbol attached to the magnitude', () => {
+    render(
+      <OptionCards
+        options={[optionWithTail({ downside: { p05: 1200, cvar10: 800, expectedRegret: 1 } })]}
+        winnerId="option-a"
+        expertMode
+        outcomeUnit="currency"
+        outcomeUnitSymbol="£"
+        isNormalised={false}
+      />,
+    )
+
+    const text = downsideText()
+    expect(text).toContain('£1,200')
+    expect(text).toContain('£800')
+  })
+
+  it('puts the minus sign OUTSIDE the currency symbol on a negative tail', () => {
+    render(
+      <OptionCards
+        options={[optionWithTail({ downside: { p05: -1200, cvar10: -800, expectedRegret: 1 } })]}
+        winnerId="option-a"
+        expertMode
+        outcomeUnit="currency"
+        outcomeUnitSymbol="£"
+        isNormalised={false}
+      />,
+    )
+
+    const text = downsideText()
+    expect(text).toContain('-£1,200')
+    expect(text).not.toContain('£-1,200')
+  })
+
+  it('renders a PERCENT goal with a % suffix', () => {
+    render(
+      <OptionCards
+        options={[optionWithTail({ downside: { p05: 12.4, cvar10: 9.8, expectedRegret: 1 } })]}
+        winnerId="option-a"
+        expertMode
+        outcomeUnit="percent"
+        isNormalised={false}
+      />,
+    )
+
+    expect(downsideText()).toContain('12.4%')
+  })
+
+  it('DOES NOT attach the goal unit when the magnitudes are NORMALISED', () => {
+    // The `0.29–0.87` state. Writing "0.29 hours" here would be a new false
+    // claim, not a fix — the number is a normalised score, not hours.
+    render(
+      <OptionCards
+        options={[optionWithTail({ downside: { p05: 0.29, cvar10: 0.21, expectedRegret: 0.1 } })]}
+        winnerId="option-a"
+        expertMode
+        outcomeUnit="count"
+        outcomeUnitSymbol="hours"
+        isNormalised
+      />,
+    )
+
+    const text = downsideText()
+    expect(text).toContain('0.29')
+    expect(text).not.toContain('hours')
+  })
+
+  it('DOES NOT attach a unit when the goal never stated one', () => {
+    // Unchanged behaviour: the card prints exactly what it printed before.
+    render(
+      <OptionCards options={[optionWithTail()]} winnerId="option-a" expertMode />,
+    )
+
+    const text = downsideText()
+    expect(text).toContain('12.4')
+    expect(text).toContain('9.8')
+    expect(text).not.toMatch(/hours|£|\$/)
+  })
+
+  it('binds the unit to the tail of the option it belongs to, not to any option with a tail', () => {
+    // Trap 19: an assertion must bind by IDENTITY. Two options, different
+    // tails — the runner-up's numbers must not satisfy the leader's assertion.
+    render(
+      <OptionCards
+        options={[
+          optionWithTail({ id: 'a', label: 'A', winProbability: 0.7, downside: { p05: 12.4, cvar10: 9.8, expectedRegret: 1 } }),
+          optionWithTail({ id: 'b', label: 'B', winProbability: 0.3, isRecommended: false, downside: { p05: 44.4, cvar10: 41.1, expectedRegret: 1 } }),
+        ]}
+        winnerId="a"
+        expertMode
+        outcomeUnit="count"
+        outcomeUnitSymbol="hours"
+        isNormalised={false}
+      />,
+    )
+
+    expect(downsideText('a')).toContain('12.4 hours')
+    expect(downsideText('a')).not.toContain('44.4')
+    expect(downsideText('b')).toContain('44.4 hours')
+    expect(downsideText('b')).not.toContain('12.4')
+  })
+})

--- a/src/components/results/__tests__/ResultsFooter.spec.tsx
+++ b/src/components/results/__tests__/ResultsFooter.spec.tsx
@@ -16,8 +16,8 @@ function getFooterText(): string {
 }
 
 describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
-  describe('strong tier + high numeric stability → "Stable result"', () => {
-    it('97% stability renders "Stable result · 97%"', () => {
+  describe('strong tier + high numeric stability → "Stable ranking"', () => {
+    it('97% stability renders "Stable ranking · 97%"', () => {
       render(
         <ResultsFooter
           stability={0.97}
@@ -26,14 +26,14 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
         />,
       )
       const text = getFooterText()
-      expect(text).toContain('Stable result')
+      expect(text).toContain('Stable ranking')
       expect(text).toContain('97%')
       expect(text).not.toContain('Stability sensitive')
     })
   })
 
   describe('§2.7 stability override — tier ∈ {needs_work, fair} at stability ≥ 0.85 → numeric pass-through', () => {
-    it('needs_work + 97% stability → "Stable result" (stability override)', () => {
+    it('needs_work + 97% stability → "Stable ranking" (stability override)', () => {
       render(
         <ResultsFooter
           stability={0.97}
@@ -42,12 +42,12 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
         />,
       )
       const text = getFooterText()
-      expect(text).toContain('Stable result')
+      expect(text).toContain('Stable ranking')
       expect(text).not.toContain('Stability sensitive')
       expect(text).toContain('97%')
     })
 
-    it('fair + 90% stability → "Stable result" (stability override)', () => {
+    it('fair + 90% stability → "Stable ranking" (stability override)', () => {
       render(
         <ResultsFooter
           stability={0.90}
@@ -56,7 +56,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
         />,
       )
       const text = getFooterText()
-      expect(text).toContain('Stable result')
+      expect(text).toContain('Stable ranking')
       expect(text).not.toContain('Stability sensitive')
     })
   })
@@ -67,7 +67,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
       ['needs_framing' as const],
       ['low' as const],
       ['not_ready' as const],
-    ])('strong + weak readiness %s at 95%% stability → "Stable result" (readiness never softens)', (readiness) => {
+    ])('strong + weak readiness %s at 95%% stability → "Stable ranking" (readiness never softens)', (readiness) => {
       render(
         <ResultsFooter
           stability={0.95}
@@ -76,7 +76,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
         />,
       )
       const text = getFooterText()
-      expect(text).toContain('Stable result')
+      expect(text).toContain('Stable ranking')
       expect(text).not.toContain('Stability sensitive')
     })
   })
@@ -92,7 +92,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
       )
       const text = getFooterText()
       expect(text).toContain('Stability sensitive')
-      expect(text).not.toContain('Stable result')
+      expect(text).not.toContain('Stable ranking')
     })
 
     it('fair + 78% stability → "Stability sensitive" (new per §2.7)', () => {
@@ -109,7 +109,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
   })
 
   describe('passthrough at low numeric stability', () => {
-    it('strong tier + 0.55 stability → "Sensitive to assumptions"', () => {
+    it('strong tier + 0.55 stability → "Ranking sensitive to assumptions"', () => {
       render(
         <ResultsFooter
           stability={0.55}
@@ -118,7 +118,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
         />,
       )
       const text = getFooterText()
-      expect(text).toContain('Sensitive to assumptions')
+      expect(text).toContain('Ranking sensitive to assumptions')
     })
 
     it('weak tier + 0.3 stability still reads "Stability sensitive" (unified wording)', () => {
@@ -137,7 +137,7 @@ describe('ResultsFooter — Brief 5.2 Task 1 tier-aware label', () => {
     it('no tier / no readiness → numeric label', () => {
       render(<ResultsFooter stability={0.9} />)
       const text = getFooterText()
-      expect(text).toContain('Stable result')
+      expect(text).toContain('Stable ranking')
     })
   })
 

--- a/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
+++ b/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
@@ -131,6 +131,40 @@ describe('WinGauge — rounding note (ROADMAP 2.580 member 1)', () => {
     expect(screen.queryByTestId(ODDS_ROUNDING_NOTE_TESTID)).not.toBeInTheDocument()
   })
 
+  it('reads the LEGEND\'s own readouts — not a second call to the formatter', () => {
+    // ⚠ THIS FIXTURE IS A SOURCE-BINDING PROBE, NOT A WIRE-REALISTIC RUN, and
+    // it is labelled so deliberately (CLAUDE.md trap 16-inverse: a fixture you
+    // wrote yourself is not evidence about the wire). Its shares do not sum to
+    // 1; its only job is to make the formatter's two arms DISAGREE, because
+    // that is the one condition under which "note and legend are one source"
+    // is falsifiable at all.
+    //
+    // `formatProbabilityWithResolution(0.995, null)` → '100%'  (the legend's arm)
+    // `formatProbabilityWithResolution(0.995, 4000)` → '99.5%' (any other arm)
+    //
+    // So if the note is ever re-derived from the shares instead of read from
+    // `legendEntries`, it sees a decimal, fails closed, and disappears — while
+    // the legend above it still prints two whole percentages totalling 102.
+    // Without this case the binding is a guard agreeing with itself: a mutant
+    // that swaps the note onto a different formatter arm SURVIVED every other
+    // assertion in this file.
+    render(
+      <WinGauge
+        shares={[
+          { id: 'a', label: 'Option A', winProbability: 0.995, isWinner: true, goalProbability: null },
+          { id: 'b', label: 'Option B', winProbability: 0.02, isWinner: false, goalProbability: null },
+        ]}
+      />,
+    )
+
+    // Precondition pinned IN-TEST: the legend really is printing two wholes.
+    expect(sumRenderedLegendPercents()).toBe(102)
+
+    expect(screen.getByTestId(ODDS_ROUNDING_NOTE_TESTID).textContent).toBe(
+      'These are rounded to whole percentages, so they total 102%, not 100%.',
+    )
+  })
+
   it('lives inside the comparative block, beside the numbers it describes', () => {
     render(<WinGauge shares={sharesTotalling99()} />)
     const block = screen.getByTestId('win-gauge-comparative-block')

--- a/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
+++ b/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
@@ -117,17 +117,34 @@ describe('WinGauge — rounding note (ROADMAP 2.580 member 1)', () => {
   it('FAILS CLOSED when any share prints as a sub-resolution bound', () => {
     // `< 1%` carries no derivable total, so the component must claim nothing
     // rather than state a sum that excludes an unknown quantity.
+    //
+    // ⚠ THE SHARES ARE CHOSEN, NOT ARBITRARY, and the choice is the test.
+    // A real partition summing to 1 with one sub-1% member usually rounds back
+    // to exactly 100 whichever rule you use, so an absence assertion over it
+    // proves nothing: a mutant that swapped the floored readout for a plain
+    // `Math.round` SURVIVED such a fixture (it printed '1%' where the legend
+    // printed '< 1%', and the totals coincided at 100 anyway).
+    //
+    // These four sum to exactly 1.0 and separate the two rules:
+    //   floored (what the legend prints): 34 + 34 + 32 + '< 1%'  → no total
+    //   plain Math.round:                 34 + 34 + 32 +   1     → 101
+    // so the component must render NOTHING while the wrong rule renders a
+    // confident "total 101%". The absence below is now discriminating.
     render(
       <WinGauge
         shares={[
-          { id: 'a', label: 'A', winProbability: 0.5, isWinner: true, goalProbability: null },
-          { id: 'b', label: 'B', winProbability: 0.4949, isWinner: false, goalProbability: null },
-          { id: 'c', label: 'C', winProbability: 0.0051, isWinner: false, goalProbability: null },
+          { id: 'a', label: 'A', winProbability: 0.336, isWinner: true, goalProbability: null },
+          { id: 'b', label: 'B', winProbability: 0.336, isWinner: false, goalProbability: null },
+          { id: 'c', label: 'C', winProbability: 0.322, isWinner: false, goalProbability: null },
+          { id: 'd', label: 'D', winProbability: 0.006, isWinner: false, goalProbability: null },
         ]}
       />,
     )
     const block = screen.getByTestId('win-gauge-comparative-block')
+    // Precondition pinned IN-TEST: the bound really is on screen, and the
+    // three whole percentages really do sum to something other than 100.
     expect(within(block).getByText(/^<\s?1%$/)).toBeInTheDocument()
+    expect(sumRenderedLegendPercents()).toBe(100)
     expect(screen.queryByTestId(ODDS_ROUNDING_NOTE_TESTID)).not.toBeInTheDocument()
   })
 

--- a/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
+++ b/src/components/results/__tests__/WinGauge.roundingNote.spec.tsx
@@ -1,0 +1,139 @@
+/**
+ * ROADMAP 2.580 member 1 — the rounding note on the LIVE odds surface.
+ *
+ * Codex simulated-user review, 5 Aug 2026: "option percentages displayed as
+ * 99% and 101% totals because of rounding, with no explanation".
+ *
+ * WHY THIS SURFACE (CLAUDE.md trap 3b — bind to what the deployed flags mount)
+ * --------------------------------------------------------------------------
+ * `WinGauge` renders the COMPLETE partition — its legend iterates every share
+ * on the run — and `ResultsBody` mounts it unconditionally at the top of the
+ * options section (`ResultsBody.tsx:591`). `OptionCards` beneath it truncates
+ * to the top 2 behind a "Show all (N more)" toggle, so a total taken there
+ * would routinely be a SUBSET total, which is not a rounding artefact and must
+ * not be described as one. `CompactOptionSpread` is not on this route at all
+ * (`ResultsBody.tsx:527-529` states so).
+ *
+ * ONE SOURCE OF TRUTH (trap 12/21)
+ * --------------------------------
+ * The note is derived from the very strings the legend prints — the component
+ * builds `legendEntries` once and both the legend and the note read it. The
+ * assertions below therefore compare the note's total against the SUM OF THE
+ * RENDERED READOUTS, re-read from the DOM, rather than against a number this
+ * spec computed for itself.
+ *
+ * RED-first: every assertion in this file fails at bc997f50.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { WinGauge, type OptionWinShare } from '../WinGauge'
+import { ODDS_ROUNDING_NOTE_TESTID } from '../utils/oddsRoundingNote'
+
+/** Sum the percentages actually printed in the legend, by identity. */
+function sumRenderedLegendPercents(): number {
+  const block = screen.getByTestId('win-gauge-comparative-block')
+  const printed = within(block)
+    .getAllByText(/^\d+%$/)
+    .map(el => Number(el.textContent!.replace('%', '')))
+  return printed.reduce((a, b) => a + b, 0)
+}
+
+/** Three near-equal shares: each rounds to 33%, so the legend totals 99. */
+function sharesTotalling99(): OptionWinShare[] {
+  return [
+    { id: 'a', label: 'Option A', winProbability: 0.334, isWinner: true, goalProbability: null },
+    { id: 'b', label: 'Option B', winProbability: 0.333, isWinner: false, goalProbability: null },
+    { id: 'c', label: 'Option C', winProbability: 0.333, isWinner: false, goalProbability: null },
+  ]
+}
+
+/** Two shares at .335 and one at .330: 34 + 34 + 33 = 101. */
+function sharesTotalling101(): OptionWinShare[] {
+  return [
+    { id: 'a', label: 'Option A', winProbability: 0.335, isWinner: true, goalProbability: null },
+    { id: 'b', label: 'Option B', winProbability: 0.335, isWinner: false, goalProbability: null },
+    { id: 'c', label: 'Option C', winProbability: 0.330, isWinner: false, goalProbability: null },
+  ]
+}
+
+/** A clean partition — nothing to explain. */
+function sharesTotalling100(): OptionWinShare[] {
+  return [
+    { id: 'a', label: 'Option A', winProbability: 0.65, isWinner: true, goalProbability: null },
+    { id: 'b', label: 'Option B', winProbability: 0.35, isWinner: false, goalProbability: null },
+  ]
+}
+
+describe('WinGauge — rounding note (ROADMAP 2.580 member 1)', () => {
+  it('states the shortfall when the printed percentages total 99%', () => {
+    render(<WinGauge shares={sharesTotalling99()} />)
+
+    // Precondition pinned IN-TEST (trap 13b): the note is only meaningful if
+    // the legend really does print a set that misses 100. Assert the defect
+    // condition on the payload under test before asserting the remedy.
+    expect(sumRenderedLegendPercents()).toBe(99)
+
+    const note = screen.getByTestId(ODDS_ROUNDING_NOTE_TESTID)
+    expect(note.textContent).toBe(
+      'These are rounded to whole percentages, so they total 99%, not 100%.',
+    )
+  })
+
+  it('states the overshoot when the printed percentages total 101%', () => {
+    render(<WinGauge shares={sharesTotalling101()} />)
+
+    expect(sumRenderedLegendPercents()).toBe(101)
+
+    expect(screen.getByTestId(ODDS_ROUNDING_NOTE_TESTID).textContent).toBe(
+      'These are rounded to whole percentages, so they total 101%, not 100%.',
+    )
+  })
+
+  it('names the SAME total the legend prints — note and legend are one source', () => {
+    render(<WinGauge shares={sharesTotalling99()} />)
+
+    const rendered = sumRenderedLegendPercents()
+    const note = screen.getByTestId(ODDS_ROUNDING_NOTE_TESTID).textContent!
+    expect(note).toContain(`total ${rendered}%`)
+  })
+
+  it('renders NO note when the printed percentages already total 100%', () => {
+    render(<WinGauge shares={sharesTotalling100()} />)
+
+    expect(sumRenderedLegendPercents()).toBe(100)
+    expect(screen.queryByTestId(ODDS_ROUNDING_NOTE_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('renders no note for a single-option run (not a partition)', () => {
+    render(
+      <WinGauge
+        shares={[{ id: 'a', label: 'Only', winProbability: 0.99, isWinner: true, goalProbability: null }]}
+      />,
+    )
+    expect(screen.queryByTestId(ODDS_ROUNDING_NOTE_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('FAILS CLOSED when any share prints as a sub-resolution bound', () => {
+    // `< 1%` carries no derivable total, so the component must claim nothing
+    // rather than state a sum that excludes an unknown quantity.
+    render(
+      <WinGauge
+        shares={[
+          { id: 'a', label: 'A', winProbability: 0.5, isWinner: true, goalProbability: null },
+          { id: 'b', label: 'B', winProbability: 0.4949, isWinner: false, goalProbability: null },
+          { id: 'c', label: 'C', winProbability: 0.0051, isWinner: false, goalProbability: null },
+        ]}
+      />,
+    )
+    const block = screen.getByTestId('win-gauge-comparative-block')
+    expect(within(block).getByText(/^<\s?1%$/)).toBeInTheDocument()
+    expect(screen.queryByTestId(ODDS_ROUNDING_NOTE_TESTID)).not.toBeInTheDocument()
+  })
+
+  it('lives inside the comparative block, beside the numbers it describes', () => {
+    render(<WinGauge shares={sharesTotalling99()} />)
+    const block = screen.getByTestId('win-gauge-comparative-block')
+    expect(within(block).getByTestId(ODDS_ROUNDING_NOTE_TESTID)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
+++ b/src/components/results/analysisHeroV17/__tests__/accessibility.spec.tsx
@@ -372,8 +372,8 @@ describe('AnalysisHeroV17 — result-context pill copy never returns (post-remov
   const PILL_LABELS = [
     'Fragile result',
     'Moderate stability',
-    'Stable result',
-    'Mostly stable',
+    'Stable ranking',
+    'Mostly stable ranking',
     'Highly stable',
     'Evidence limited',
     'Evidence moderate',

--- a/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
+++ b/src/components/results/analysisHeroV17/__tests__/buildAnalysisHeroViewModel.spec.ts
@@ -1442,7 +1442,7 @@ describe('buildAnalysisHeroViewModel', () => {
   })
 
   // ── Polish pass: grounded stability/sensitivity wording ────────────────
-  // The hero used to show "Stable result" alongside a generic "Sensitive"
+  // The hero used to show "Stable ranking" alongside a generic "Sensitive"
   // footer check at 0.7–0.85 stability, which read contradictory. The
   // grounded rule below ties both labels to whether a fragile/sensitive
   // factor is actually present in the data.

--- a/src/components/results/utils/__tests__/formatDownsideValue.spec.ts
+++ b/src/components/results/utils/__tests__/formatDownsideValue.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * ROADMAP 2.580 member 4 — unit coverage for the downside unit formatter.
+ *
+ * The load-bearing property is NOT "a unit appears". It is that the MAGNITUDE
+ * is byte-identical to what `formatRangeValue` produced before 2.580, so a
+ * units fix cannot smuggle in a precision change. Every case below asserts
+ * against `formatRangeValue` itself rather than against a literal, which makes
+ * that a derived claim rather than a copied one (CLAUDE.md trap 12).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatDownsideValue } from '../formatDownsideValue'
+import { formatRangeValue } from '../formatRangeValue'
+
+/** The magnitudes the reviewer's session and the existing specs actually use. */
+const VALUES = [0.29, 0.21, -0.37, 9.8, 12.4, 800, 1200, -1200, 0]
+
+describe('formatDownsideValue — magnitude parity with formatRangeValue', () => {
+  it.each(VALUES)('%p with no unit is EXACTLY formatRangeValue(v)', (v) => {
+    expect(formatDownsideValue(v)).toBe(formatRangeValue(v))
+    expect(formatDownsideValue(v, {})).toBe(formatRangeValue(v))
+  })
+
+  it.each(VALUES)('%p normalised is EXACTLY formatRangeValue(v), unit ignored', (v) => {
+    // The unit is deliberately supplied AND deliberately not used: a
+    // normalised score is not in the goal's unit.
+    expect(
+      formatDownsideValue(v, { unit: 'count', unitSymbol: 'hours', isNormalised: true }),
+    ).toBe(formatRangeValue(v))
+  })
+
+  it.each(VALUES)('%p as a count keeps the magnitude and appends the unit word', (v) => {
+    expect(formatDownsideValue(v, { unit: 'count', unitSymbol: 'hours' })).toBe(
+      `${formatRangeValue(v)} hours`,
+    )
+  })
+
+  it.each(VALUES)('%p as a percent keeps the magnitude and appends %%', (v) => {
+    expect(formatDownsideValue(v, { unit: 'percent' })).toBe(`${formatRangeValue(v)}%`)
+  })
+})
+
+describe('formatDownsideValue — currency sign placement', () => {
+  it('prefixes the symbol on a non-negative value', () => {
+    expect(formatDownsideValue(1200, { unit: 'currency', unitSymbol: '£' })).toBe(
+      `£${formatRangeValue(1200)}`,
+    )
+    expect(formatDownsideValue(0, { unit: 'currency', unitSymbol: '£' })).toBe(
+      `£${formatRangeValue(0)}`,
+    )
+  })
+
+  it('puts the minus OUTSIDE the symbol on a negative value', () => {
+    const out = formatDownsideValue(-1200, { unit: 'currency', unitSymbol: '£' })
+    expect(out).toBe(`-£${formatRangeValue(1200)}`)
+    expect(out).not.toContain('£-')
+  })
+})
+
+describe('formatDownsideValue — fails closed rather than inventing a unit', () => {
+  it('renders a bare magnitude when a count unit has no symbol to print', () => {
+    expect(formatDownsideValue(12.4, { unit: 'count' })).toBe(formatRangeValue(12.4))
+  })
+
+  it('renders a bare magnitude when a currency unit has no symbol to print', () => {
+    expect(formatDownsideValue(1200, { unit: 'currency' })).toBe(formatRangeValue(1200))
+  })
+
+  it('treats isNormalised === false as "user units", not as "unknown"', () => {
+    expect(
+      formatDownsideValue(12.4, { unit: 'count', unitSymbol: 'hours', isNormalised: false }),
+    ).toBe(`${formatRangeValue(12.4)} hours`)
+  })
+})

--- a/src/components/results/utils/__tests__/getStabilityDisplayLabel.spec.ts
+++ b/src/components/results/utils/__tests__/getStabilityDisplayLabel.spec.ts
@@ -25,11 +25,11 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
 
   describe('pass-through: strong tier retains numeric classification at every stability', () => {
     it.each([
-      [0.97, 'Stable result'],
-      [0.85, 'Stable result'],
-      [0.80, 'Mostly stable'],
-      [0.55, 'Sensitive to assumptions'],
-      [0.30, 'Highly sensitive'],
+      [0.97, 'Stable ranking'],
+      [0.85, 'Stable ranking'],
+      [0.80, 'Mostly stable ranking'],
+      [0.55, 'Ranking sensitive to assumptions'],
+      [0.30, 'Ranking highly sensitive'],
     ])('stability %s → heroLabel "%s" (strong tier, any readiness)', (stability, expected) => {
       const result = getStabilityDisplayLabel({
         classification: getStabilityClassification(stability),
@@ -43,25 +43,25 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
   })
 
   describe('stability override — tier ∈ {needs_work, fair} at stability ≥ 0.85 → pass-through', () => {
-    it('needs_work + stability 0.97 → "Stable result" (stability override)', () => {
+    it('needs_work + stability 0.97 → "Stable ranking" (stability override)', () => {
       const stability = 0.97
       const result = getStabilityDisplayLabel({
         classification: getStabilityClassification(stability),
         confidenceTier: 'needs_work',
         recommendationStability: stability,
       })
-      expect(result?.heroLabel).toBe('Stable result')
+      expect(result?.heroLabel).toBe('Stable ranking')
       expect(result?.overriddenByTier).toBe(false)
     })
 
-    it('fair + stability 0.90 → "Stable result"', () => {
+    it('fair + stability 0.90 → "Stable ranking"', () => {
       const stability = 0.90
       const result = getStabilityDisplayLabel({
         classification: getStabilityClassification(stability),
         confidenceTier: 'fair',
         recommendationStability: stability,
       })
-      expect(result?.heroLabel).toBe('Stable result')
+      expect(result?.heroLabel).toBe('Stable ranking')
       expect(result?.overriddenByTier).toBe(false)
     })
   })
@@ -105,7 +105,7 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
       ['needs_framing' as const],
       ['low' as const],
       ['not_ready' as const],
-    ])('strong tier + weak readiness %s at stability 0.95 → "Stable result" (readiness never overrides)', (readiness) => {
+    ])('strong tier + weak readiness %s at stability 0.95 → "Stable ranking" (readiness never overrides)', (readiness) => {
       const stability = 0.95
       const result = getStabilityDisplayLabel({
         classification: getStabilityClassification(stability),
@@ -113,7 +113,7 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
         coachingReadiness: readiness,
         recommendationStability: stability,
       })
-      expect(result?.heroLabel).toBe('Stable result')
+      expect(result?.heroLabel).toBe('Stable ranking')
       expect(result?.overriddenByTier).toBe(false)
     })
   })
@@ -123,7 +123,7 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
       classification: getStabilityClassification(0.9),
       recommendationStability: 0.9,
     })
-    expect(result?.heroLabel).toBe('Stable result')
+    expect(result?.heroLabel).toBe('Stable ranking')
     expect(result?.overriddenByTier).toBe(false)
   })
 
@@ -133,7 +133,7 @@ describe('getStabilityDisplayLabel — tier × stability gate (Brief 5.5 §2.7)'
       coachingReadiness: 'close_call',
       recommendationStability: 0.9,
     })
-    expect(result?.heroLabel).toBe('Stable result')
+    expect(result?.heroLabel).toBe('Stable ranking')
     expect(result?.overriddenByTier).toBe(false)
   })
 })

--- a/src/components/results/utils/__tests__/oddsRoundingNote.spec.ts
+++ b/src/components/results/utils/__tests__/oddsRoundingNote.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * ROADMAP 2.580 member 1 — unit coverage for the rounding-note derivation.
+ *
+ * The corpus is NOT drawn from what felt plausible: every readout shape below
+ * is one `formatProbabilityWithResolution` can actually emit (CLAUDE.md trap
+ * 22 — a corpus from the author's head cannot see the class the author did not
+ * imagine). The bound and decimal arms are exercised against the real
+ * formatter in `roundingNoteMatchesFormatter` at the bottom, so a change to
+ * the ladder shows up here rather than silently widening the note's domain.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { deriveOddsRoundingNote } from '../oddsRoundingNote'
+import { formatProbabilityWithResolution } from '../../../../utils/formatPercent'
+
+describe('deriveOddsRoundingNote', () => {
+  it('states the actual total when rounded wholes fall short of 100', () => {
+    // 0.334 / 0.333 / 0.333 → 33% 33% 33%
+    expect(deriveOddsRoundingNote(['33%', '33%', '33%'])).toBe(
+      'These are rounded to whole percentages, so they total 99%, not 100%.',
+    )
+  })
+
+  it('states the actual total when rounded wholes overshoot 100', () => {
+    // 0.335 / 0.335 / 0.330 → 34% 34% 33%
+    expect(deriveOddsRoundingNote(['34%', '34%', '33%'])).toBe(
+      'These are rounded to whole percentages, so they total 101%, not 100%.',
+    )
+  })
+
+  it('renders NO note when the displayed wholes already total 100', () => {
+    expect(deriveOddsRoundingNote(['65%', '35%'])).toBeNull()
+    expect(deriveOddsRoundingNote(['80%', '18%', '2%'])).toBeNull()
+  })
+
+  it('renders no note for a single option (not a partition)', () => {
+    expect(deriveOddsRoundingNote(['99%'])).toBeNull()
+    expect(deriveOddsRoundingNote([])).toBeNull()
+  })
+
+  it('FAILS CLOSED on a bounded readout — a bound carries no derivable total', () => {
+    // `< 1%` is the sub-resolution floor: the true share is unknown, so
+    // "they total 99%" would be a claim the data does not support.
+    expect(deriveOddsRoundingNote(['< 1%', '50%', '49%'])).toBeNull()
+    expect(deriveOddsRoundingNote(['>99%', '1%'])).toBeNull()
+  })
+
+  it('FAILS CLOSED on a decimal readout — "rounded to whole percentages" would be false', () => {
+    expect(deriveOddsRoundingNote(['99.95%', '0.05%'])).toBeNull()
+    expect(deriveOddsRoundingNote(['66.7%', '33.3%'])).toBeNull()
+  })
+
+  it('tolerates surrounding whitespace without widening the accepted shapes', () => {
+    expect(deriveOddsRoundingNote([' 33%', '33% ', ' 33% '])).toBe(
+      'These are rounded to whole percentages, so they total 99%, not 100%.',
+    )
+    expect(deriveOddsRoundingNote(['3 3%', '67%'])).toBeNull()
+  })
+})
+
+describe('roundingNoteMatchesFormatter', () => {
+  /**
+   * Pins the note's DOMAIN to the real formatter rather than to this spec's
+   * idea of it: the three-way split below is what the option cards print for
+   * these inputs, and the note is derived from exactly those strings.
+   */
+  it('is derived from strings the live formatter actually produces', () => {
+    const probabilities = [0.334, 0.333, 0.333]
+    const readouts = probabilities.map(p => formatProbabilityWithResolution(p, 4000))
+
+    // Precondition pinned IN-TEST: if the formatter stops emitting whole
+    // percents for these inputs, this assertion fails rather than the note
+    // silently becoming unreachable (CLAUDE.md trap 13b).
+    expect(readouts).toEqual(['33%', '33%', '33%'])
+
+    expect(deriveOddsRoundingNote(readouts)).toBe(
+      'These are rounded to whole percentages, so they total 99%, not 100%.',
+    )
+  })
+
+  it('stays silent on a sub-resolution share the formatter floors', () => {
+    const readouts = [
+      formatProbabilityWithResolution(0.0001, 4000),
+      formatProbabilityWithResolution(0.5, 4000),
+      formatProbabilityWithResolution(0.4999, 4000),
+    ]
+    expect(readouts[0]).not.toMatch(/^\d+%$/)
+    expect(deriveOddsRoundingNote(readouts)).toBeNull()
+  })
+})

--- a/src/components/results/utils/formatDownsideValue.ts
+++ b/src/components/results/utils/formatDownsideValue.ts
@@ -1,0 +1,82 @@
+/**
+ * ROADMAP 2.580 member 4 — "downside values were unitless even when the
+ * user's goal was hours" (Codex simulated-user review, 5 Aug 2026).
+ *
+ * WHY A NEW HELPER RATHER THAN `formatThreshold`
+ * ----------------------------------------------
+ * `formatThreshold` (RangeVisualization.tsx) is the hero's unit-aware
+ * formatter and was the obvious candidate — but its no-unit branch rounds
+ * differently from `formatRangeValue` (`0.29` → `'0.3'`, not `'0.29'`). Using
+ * it here would silently coarsen every unitless downside figure already on
+ * screen, i.e. fix a units defect by shipping a precision regression.
+ *
+ * So the MAGNITUDE keeps going through `formatRangeValue` — byte-identical to
+ * what the card printed before on every run that has no unit — and this helper
+ * only decides what, if anything, may be written beside it.
+ *
+ * WHAT MAY BE WRITTEN BESIDE IT — THE BREADTH QUESTION (CLAUDE.md trap 22)
+ * -----------------------------------------------------------------------
+ * The unit is NOT carried by the analysis payload. `EnrichmentOutcomeStats`
+ * (`@talchain/schemas@0.38.0`) declares `mean/std/p10/p50/p90/n_samples/…` and
+ * no unit field, and the `downside` block is three bare numbers. The only unit
+ * in play comes from the GOAL NODE (`observed_state.unit` →
+ * `useResultsSectionData`'s `outcomeUnit`/`outcomeUnitSymbol`), and it is the
+ * unit of the OUTCOME AXIS.
+ *
+ * That makes `isNormalised` load-bearing rather than incidental. When the run
+ * has no `goal_threshold_cap`, the hook leaves the option magnitudes on PLoT's
+ * normalised 0–1 scale (`useResultsSectionData`'s `scale = 1`,
+ * `isNormalised = true`). Appending "hours" to a normalised score would not fix
+ * the member — it would replace a missing claim with a FALSE one, on the same
+ * screen, in the same sentence. So a normalised run gets no unit, exactly as
+ * today, and the member's residual for that state is recorded on the row
+ * rather than papered over here.
+ *
+ * The unit is appended in exactly one situation: the values are on the goal's
+ * own scale AND someone stated what that scale measures.
+ */
+
+import type { OutcomeUnitType } from '../types'
+import { formatRangeValue } from './formatRangeValue'
+
+export interface DownsideUnitContext {
+  /** Classified goal unit, from `useResultsSectionData`. */
+  unit?: OutcomeUnitType
+  /**
+   * For `'currency'` this is the symbol (`'£'`); for `'count'` it is the RAW
+   * unit string the user typed (`'hours'`), which is why a count unit can be
+   * rendered at all. `'percent'` carries none — the `%` is the unit.
+   */
+  unitSymbol?: string
+  /**
+   * True when the magnitudes are PLoT's normalised 0–1 scores rather than user
+   * units. A unit must NOT be attached in that state; see the header.
+   */
+  isNormalised?: boolean
+}
+
+/**
+ * A downside magnitude, with its unit when — and only when — one applies.
+ *
+ * The number itself is always `formatRangeValue(value)`, unchanged.
+ */
+export function formatDownsideValue(value: number, ctx: DownsideUnitContext = {}): string {
+  const magnitude = formatRangeValue(value)
+
+  // Normalised scores are not in the goal's unit. Say the number and stop.
+  if (ctx.isNormalised === true) return magnitude
+
+  if (ctx.unit === 'currency' && ctx.unitSymbol) {
+    // Negative tails read "-£1,200", not "£-1,200".
+    return value < 0
+      ? `-${ctx.unitSymbol}${formatRangeValue(Math.abs(value))}`
+      : `${ctx.unitSymbol}${magnitude}`
+  }
+
+  if (ctx.unit === 'percent') return `${magnitude}%`
+
+  if (ctx.unit === 'count' && ctx.unitSymbol) return `${magnitude} ${ctx.unitSymbol}`
+
+  // No unit was ever stated for this goal — unchanged from before 2.580.
+  return magnitude
+}

--- a/src/components/results/utils/oddsRoundingNote.ts
+++ b/src/components/results/utils/oddsRoundingNote.ts
@@ -1,0 +1,64 @@
+/**
+ * ROADMAP 2.580 member 1 — "option percentages displayed as 99% and 101%
+ * totals because of rounding, with no explanation" (Codex simulated-user
+ * review, 5 Aug 2026).
+ *
+ * WHAT THIS CLAIMS, AND WHY THE INPUT IS STRINGS
+ * ----------------------------------------------
+ * The note is an arithmetic statement about the figures ON SCREEN. So it is
+ * derived from the READOUT STRINGS the surface is about to print — not from
+ * the underlying probabilities, and not from a second evaluation of the
+ * formatting rule.
+ *
+ * That distinction is the whole point. `formatProbabilityWithResolution` has
+ * two arms (with/without `n_valid_samples`) and a resolution ladder that can
+ * emit decimals; re-deriving "what will be shown" here would be a
+ * hand-maintained mirror of that function (CLAUDE.md trap 12) and would drift
+ * the first time the ladder changes. Passing the rendered strings in makes the
+ * note and the numbers provably the same values — there is only one evaluation.
+ *
+ * FAIL-CLOSED, DELIBERATELY
+ * -------------------------
+ * A readout that is not an exact whole percentage carries no total we are
+ * entitled to state:
+ *   · `'< 1%'` / `'>99%'` are BOUNDS — the true share is unknown, so no sum of
+ *     the visible set is derivable.
+ *   · `'33.3%'` means the resolution ladder chose decimals, so "rounded to
+ *     whole percentages" would be a false description of what is shown.
+ * In both cases this returns `null`: no note beats a note that overstates.
+ *
+ * It also returns `null` when the displayed integers DO total 100 — the note
+ * exists to explain a visible discrepancy, not to decorate a clean partition.
+ *
+ * ⚠ THE CALLER OWNS ONE PRECONDITION THIS FUNCTION CANNOT CHECK: the readouts
+ * must be the COMPLETE partition. A collapsed option list ("Show all (2 more)")
+ * is a subset, and a subset failing to total 100 is expected, not a rounding
+ * artefact. See the `hiddenCount === 0` gate at the call site.
+ */
+
+/** Test id of the rendered note. Exported so specs bind by identity. */
+export const ODDS_ROUNDING_NOTE_TESTID = 'option-odds-rounding-note'
+
+/** Exact whole-percent readout, e.g. `'33%'`. Bounds and decimals do not match. */
+const WHOLE_PERCENT = /^(\d+)%$/
+
+/**
+ * The note to render beneath a complete set of option odds, or `null`.
+ *
+ * @param readouts the percentage strings the surface is printing, in any order
+ */
+export function deriveOddsRoundingNote(readouts: readonly string[]): string | null {
+  // One option is not a partition; nothing to reconcile.
+  if (readouts.length < 2) return null
+
+  let total = 0
+  for (const readout of readouts) {
+    const match = WHOLE_PERCENT.exec(readout.trim())
+    if (match === null) return null
+    total += Number(match[1])
+  }
+
+  if (total === 100) return null
+
+  return `These are rounded to whole percentages, so they total ${total}%, not 100%.`
+}

--- a/src/components/ui/__tests__/bricks.spec.tsx
+++ b/src/components/ui/__tests__/bricks.spec.tsx
@@ -38,8 +38,8 @@ describe('Button — the DS single-treatment button', () => {
 
 describe('Pill — outlined only, ink text (DS law)', () => {
   it('is always bg-transparent with text-text-body, colour only on the border', () => {
-    render(<Pill tone="success" dot>Stable result</Pill>)
-    const p = screen.getByText('Stable result')
+    render(<Pill tone="success" dot>Stable ranking</Pill>)
+    const p = screen.getByText('Stable ranking')
     expect(p.className).toContain('bg-transparent')
     expect(p.className).toContain('text-text-body')
     expect(p.className).toContain('border-success/40')

--- a/src/lib/__tests__/stability.spec.ts
+++ b/src/lib/__tests__/stability.spec.ts
@@ -18,39 +18,42 @@ describe('getStabilityClassification', () => {
     expect(getStabilityClassification(null)).toBeNull()
   })
 
-  it('classifies >= 0.85 as high / "Stable result"', () => {
+  it('classifies >= 0.85 as high / "Stable ranking"', () => {
     const c = getStabilityClassification(0.85)!
     expect(c.level).toBe('high')
-    expect(c.heroLabel).toBe('Stable result')
+    expect(c.heroLabel).toBe('Stable ranking')
     expect(c.badgeLabel).toBe('Robust')
     expect(c.colorClass).toBe('text-success')
     expect(c.borderClass).toBe('border-success/30')
     expect(c.coaching).toBeNull()
   })
 
-  it('classifies 0.70–0.84 as moderate / "Mostly stable"', () => {
+  it('classifies 0.70–0.84 as moderate / "Mostly stable ranking"', () => {
     for (const v of [0.70, 0.75, 0.80, 0.84]) {
       const c = getStabilityClassification(v)!
       expect(c.level).toBe('moderate')
-      expect(c.heroLabel).toBe('Mostly stable')
+      expect(c.heroLabel).toBe('Mostly stable ranking')
       expect(c.badgeLabel).toBe('Moderate')
     }
   })
 
-  it('classifies 0.40–0.69 as low / "Sensitive to assumptions"', () => {
+  it('classifies 0.40–0.69 as low / "Ranking sensitive to assumptions"', () => {
     for (const v of [0.40, 0.50, 0.69]) {
       const c = getStabilityClassification(v)!
       expect(c.level).toBe('low')
-      expect(c.heroLabel).toBe('Sensitive to assumptions')
+      expect(c.heroLabel).toBe('Ranking sensitive to assumptions')
       expect(c.badgeLabel).toBe('Sensitive')
     }
   })
 
-  it('classifies < 0.40 as very_low / "Highly sensitive"', () => {
+  it('classifies < 0.40 as very_low / "Ranking highly sensitive"', () => {
     for (const v of [0.0, 0.15, 0.39]) {
       const c = getStabilityClassification(v)!
       expect(c.level).toBe('very_low')
-      expect(c.heroLabel).toBe('Highly sensitive')
+      expect(c.heroLabel).toBe('Ranking highly sensitive')
+      // ROADMAP 2.580 member 3 scoped the HERO family to the ranking; the
+      // `badgeLabel` register is a separate map (`lib/mappers/constants.ts`,
+      // `components/results/constants.ts`) and is deliberately unchanged here.
       expect(c.badgeLabel).toBe('Highly sensitive')
     }
   })
@@ -59,7 +62,7 @@ describe('getStabilityClassification', () => {
   it('stability=0.72 produces consistent moderate classification', () => {
     const c = getStabilityClassification(0.72)!
     expect(c.level).toBe('moderate')
-    expect(c.heroLabel).toBe('Mostly stable')
+    expect(c.heroLabel).toBe('Mostly stable ranking')
     expect(c.badgeLabel).toBe('Moderate')
     expect(c.colorClass).toBe('text-success')
     expect(c.borderClass).toBe('border-info/30')
@@ -71,7 +74,7 @@ describe('getStabilityClassification', () => {
     const c = getStabilityClassification(0.818)!
     expect(c.level).toBe('moderate')
     expect(c.badgeLabel).toBe('Moderate')
-    expect(c.heroLabel).toBe('Mostly stable')
+    expect(c.heroLabel).toBe('Mostly stable ranking')
   })
 })
 

--- a/src/lib/__tests__/stabilityRankingScope.spec.ts
+++ b/src/lib/__tests__/stabilityRankingScope.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * ROADMAP 2.580 member 3 — STABILITY COPY MUST CLAIM ONLY WHAT WAS TESTED.
+ *
+ * Codex simulated-user review, 5 Aug 2026: "'Stable result' / 'held up under
+ * the changes we tested' appeared alongside 19 sensitive assumptions and zero
+ * stable edges"; and, in its own list of places Olumi claims more than it
+ * knows: "It called an analysis 'Stable' while displaying 19 sensitive
+ * assumptions and zero stable edges; if only the leader survived sampled
+ * perturbations, the label needs to say that."
+ *
+ * THE EXPECTATION IS DERIVED FROM THE PRODUCER, NOT FROM THE UI'S READING
+ * ---------------------------------------------------------------------
+ * CLAUDE.md trap 13c: a mutant kit measures whether a test can DETECT a
+ * change, never whether the expectation is RIGHT — so the oracle comes from
+ * the producer's declared semantics, read at ISL `staging`:
+ *
+ *   `RobustnessResultV2.recommendation_stability`
+ *     — "P(same recommendation across samples)"
+ *       (src/models/robustness_v2.py)
+ *   `_build_robustness_interpretation`
+ *     — "{most_frequent_winner} wins in {recommendation_stability:.0%} of
+ *        sampled scenarios"
+ *       (src/services/robustness_analyzer_v2.py)
+ *
+ * So the quantity is: THE SHARE OF SAMPLED SCENARIOS IN WHICH THE SAME OPTION
+ * CAME OUT ON TOP. It is a statement about the RANKING, over a FINITE SAMPLE.
+ *
+ * The copy at bc997f50 said "Stable result" / "Result stays the same even if
+ * estimates are off" — two over-claims stacked:
+ *   (a) "the result" — every number, not just which option leads. The 19
+ *       sensitive assumptions the reviewer saw are precisely the numbers that
+ *       did NOT stay the same.
+ *   (b) "even if estimates are off" — an unbounded universal over all possible
+ *       estimate errors, from a finite sample of scenarios.
+ *
+ * WHAT THIS SPEC PINS
+ * -------------------
+ * Not one hard-coded sentence — that would pin today's wording and nothing
+ * else. It pins the two PROPERTIES the member is about, at every tier:
+ *   1. the claim is scoped to the RANKING / which option leads, and
+ *   2. it does not assert an unbounded "whatever the estimates" guarantee.
+ * A future copy edit that keeps both properties passes; one that reintroduces
+ * either over-claim fails.
+ *
+ * RED-first: tiers `high` and `moderate` fail both properties at bc997f50.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { getStabilityClassification } from '../stability'
+
+/** The four tier boundaries, one representative stability each. */
+const TIERS = [
+  { name: 'high', stability: 0.97 },
+  { name: 'moderate', stability: 0.78 },
+  { name: 'low', stability: 0.55 },
+  { name: 'very_low', stability: 0.2 },
+] as const
+
+/**
+ * Vocabulary that scopes a claim to the ranking rather than to "the result".
+ * Any ONE of these is enough — this is a property check, not a copy pin.
+ */
+const RANKING_SCOPED = /\branking\b|which option leads|the same option led|the leading option/i
+
+/**
+ * Unbounded guarantees. Each asserts something about estimate error IN
+ * GENERAL, which a finite sample of scenarios cannot establish.
+ */
+const UNBOUNDED_CLAIM = /even if estimates are off|whatever the estimates|regardless of (?:the )?(?:estimates|assumptions)|under any assumptions/i
+
+/** "the result stays the same" — the (a) over-claim, in any tense. */
+const RESULT_LEVEL_CLAIM = /\bresult (?:stays|stayed|remains|remained|is|was) the same\b/i
+
+describe('stability copy is scoped to the RANKING (ROADMAP 2.580 member 3)', () => {
+  it.each(TIERS)('$name — the hero label names the ranking, not "the result"', ({ stability }) => {
+    const cls = getStabilityClassification(stability)!
+    expect(cls.heroLabel).toMatch(RANKING_SCOPED)
+  })
+
+  it.each(TIERS)('$name — the expanded text is scoped to the ranking', ({ stability }) => {
+    const cls = getStabilityClassification(stability)!
+    expect(cls.heroExpandedText).toMatch(RANKING_SCOPED)
+  })
+
+  it.each(TIERS)('$name — no unbounded "even if estimates are off" guarantee anywhere', ({ stability }) => {
+    const cls = getStabilityClassification(stability)!
+    const prose = [cls.heroLabel, cls.heroShortText, cls.heroExpandedText, cls.coaching ?? ''].join(' | ')
+    expect(prose).not.toMatch(UNBOUNDED_CLAIM)
+  })
+
+  it.each(TIERS)('$name — no "the result stays the same" claim anywhere', ({ stability }) => {
+    const cls = getStabilityClassification(stability)!
+    const prose = [cls.heroLabel, cls.heroShortText, cls.heroExpandedText, cls.coaching ?? ''].join(' | ')
+    expect(prose).not.toMatch(RESULT_LEVEL_CLAIM)
+  })
+
+  it.each(TIERS)('$name — the expanded text says the finding came from a SAMPLE', ({ stability }) => {
+    // The quantity is a share of sampled scenarios. Saying so is the whole
+    // difference between "this held" and "this held in what we tried".
+    const cls = getStabilityClassification(stability)!
+    expect(cls.heroExpandedText).toMatch(/sampl/i)
+  })
+
+  it('the tiers stay DISTINGUISHABLE — a rewrite must not collapse them', () => {
+    // Guards the lazy fix: renaming every tier to one ranking-scoped phrase
+    // would satisfy every assertion above while destroying the signal.
+    const labels = TIERS.map(t => getStabilityClassification(t.stability)!.heroLabel)
+    expect(new Set(labels).size).toBe(TIERS.length)
+  })
+
+  it('the tier BOUNDARIES are untouched — this is a copy change, not a threshold change', () => {
+    expect(getStabilityClassification(0.85)!.level).toBe('high')
+    expect(getStabilityClassification(0.8499)!.level).toBe('moderate')
+    expect(getStabilityClassification(0.70)!.level).toBe('moderate')
+    expect(getStabilityClassification(0.6999)!.level).toBe('low')
+    expect(getStabilityClassification(0.40)!.level).toBe('low')
+    expect(getStabilityClassification(0.3999)!.level).toBe('very_low')
+    expect(getStabilityClassification(null)).toBeNull()
+    expect(getStabilityClassification(undefined)).toBeNull()
+  })
+
+  it('only the high tier withholds coaching — unchanged contract', () => {
+    expect(getStabilityClassification(0.97)!.coaching).toBeNull()
+    expect(getStabilityClassification(0.78)!.coaching).not.toBeNull()
+    expect(getStabilityClassification(0.55)!.coaching).not.toBeNull()
+    expect(getStabilityClassification(0.2)!.coaching).not.toBeNull()
+  })
+})

--- a/src/lib/stability.ts
+++ b/src/lib/stability.ts
@@ -8,10 +8,31 @@
  * buildResultsVM (DecisionState), GoalNode (badge).
  *
  * Thresholds align with ISL robustness protocol:
- *   >= 0.85  high      — "Stable result"
- *   >= 0.70  moderate  — "Mostly stable"
- *   >= 0.40  low       — "Sensitive to assumptions"
- *   <  0.40  very_low  — "Highly sensitive"
+ *   >= 0.85  high      — "Stable ranking"
+ *   >= 0.70  moderate  — "Mostly stable ranking"
+ *   >= 0.40  low       — "Ranking sensitive to assumptions"
+ *   <  0.40  very_low  — "Ranking highly sensitive"
+ *
+ * ⭐ ROADMAP 2.580 member 3 — WHAT THIS NUMBER IS, AND WHAT THE COPY MAY CLAIM.
+ *
+ * Read at the producer (ISL `staging`), not inferred here:
+ *   `RobustnessResultV2.recommendation_stability`  →  "P(same recommendation
+ *     across samples)"                        (src/models/robustness_v2.py)
+ *   `_build_robustness_interpretation`          →  "{winner} wins in {x:.0%}
+ *     of sampled scenarios"        (src/services/robustness_analyzer_v2.py)
+ *
+ * So the quantity is THE SHARE OF SAMPLED SCENARIOS IN WHICH THE SAME OPTION
+ * CAME OUT ON TOP: a statement about the RANKING, over a FINITE SAMPLE.
+ *
+ * The copy used to say "Stable result" / "Result stays the same even if
+ * estimates are off". Codex (5 Aug 2026) saw that beside 19 sensitive
+ * assumptions and zero stable edges — two over-claims stacked:
+ *   (a) "the result" — every number, when only the ORDER was measured; the
+ *       sensitive assumptions are exactly the numbers that did NOT hold;
+ *   (b) "even if estimates are off" — an unbounded universal over all possible
+ *       estimate errors, drawn from a finite sample of scenarios.
+ * The wording below states the ranking scope and the sample, and nothing else.
+ * `stabilityRankingScope.spec.ts` pins both properties at every tier.
  */
 
 import type { RobustnessLevel } from './mappers/types'
@@ -21,7 +42,7 @@ export interface StabilityClassification {
   level: RobustnessLevel
   /** User-facing label for trust/robustness badge (e.g., "Robust") */
   badgeLabel: string
-  /** User-facing label for hero stability tier (e.g., "Stable result") */
+  /** User-facing label for hero stability tier (e.g., "Stable ranking") */
   heroLabel: string
   /** Short explanatory text for the hero section */
   heroShortText: string
@@ -51,9 +72,9 @@ export function getStabilityClassification(
     return {
       level: 'high',
       badgeLabel: 'Robust',
-      heroLabel: 'Stable result',
-      heroShortText: 'Even if estimates are off',
-      heroExpandedText: 'Result stays the same even if estimates are off.',
+      heroLabel: 'Stable ranking',
+      heroShortText: 'Across sampled scenarios',
+      heroExpandedText: 'The same option led in nearly every scenario we sampled. Individual estimates can still be off.',
       coaching: null,
       colorClass: 'text-success',
       borderClass: 'border-success/30',
@@ -64,10 +85,10 @@ export function getStabilityClassification(
     return {
       level: 'moderate',
       badgeLabel: 'Moderate',
-      heroLabel: 'Mostly stable',
-      heroShortText: 'Under most assumptions',
-      heroExpandedText: 'Result stays the same under most assumptions.',
-      coaching: 'The analysis is consistent under most assumptions. A few edge cases could shift the outcome.',
+      heroLabel: 'Mostly stable ranking',
+      heroShortText: 'In most sampled scenarios',
+      heroExpandedText: 'The same option led in most of the scenarios we sampled.',
+      coaching: 'The leading option was the same in most of the scenarios we sampled. A few edge cases could change it.',
       colorClass: 'text-success',
       borderClass: 'border-info/30',
     }
@@ -77,10 +98,10 @@ export function getStabilityClassification(
     return {
       level: 'low',
       badgeLabel: 'Sensitive',
-      heroLabel: 'Sensitive to assumptions',
+      heroLabel: 'Ranking sensitive to assumptions',
       heroShortText: 'Review key inputs',
-      heroExpandedText: 'Result changes under different assumptions. Review key inputs.',
-      coaching: 'Result changes under different assumptions. Small changes could shift the result.',
+      heroExpandedText: 'Which option leads changed across the scenarios we sampled. Review key inputs.',
+      coaching: 'Which option leads changed across the scenarios we sampled. Small changes could change it again.',
       colorClass: 'text-warning',
       borderClass: 'border-factor/30',
     }
@@ -89,10 +110,10 @@ export function getStabilityClassification(
   return {
     level: 'very_low',
     badgeLabel: 'Highly sensitive',
-    heroLabel: 'Highly sensitive',
+    heroLabel: 'Ranking highly sensitive',
     heroShortText: 'Treat as directional',
-    heroExpandedText: 'Small changes in assumptions change the result. Treat as directional.',
-    coaching: 'Small changes in assumptions change the result. Consider strengthening key assumptions before committing.',
+    heroExpandedText: 'Which option leads changed often across the scenarios we sampled. Treat as directional.',
+    coaching: 'Which option leads changed often across the scenarios we sampled. Consider strengthening key assumptions before committing.',
     colorClass: 'text-danger',
     borderClass: 'border-factor/30',
   }


### PR DESCRIPTION
ROADMAP **2.580** (P1 DEPTH · PC2 backbone) — the six "claims-more-than-it-knows" coherence defects the **Codex simulated-user review** measured on the deployed product, 5 Aug 2026 (`PHASE0-EVIDENCE-2026-07-28/codex-simulated-user-review-2026-08-05.md`, §"Analysis presentation is richer but not yet internally coherent" and §6).

Per-member the fix direction was **derived**, not assumed: four are display-side and ship here; two are producer-authored prose and ship as **patch specs** below (this lane does not mutate another repo).

| # | Member | Verdict |
|---|---|---|
| 1 | percentages totalling 99% / 101% with no rounding note | **FIXED (display)** |
| 2 | graph encoded a POSITIVE relationship contradicting the sentence | **FIXED (display) — the fabricated half**; the factor-vs-edge residual is rowed below |
| 3 | "Stable result" beside 19 sensitive assumptions, zero stable edges | **FIXED (display)** + **PLoT patch spec** for the producer-owned reason phrase |
| 4 | downside values unitless on an hours goal | **FIXED (display)** |
| 5 | structured dissent called £60,000 "near" a £120,000 ceiling | **PATCH-SPEC (CEE)** — no UI authorship found |
| 6 | coaching claimed known costs/tariffs/labour rates anchored projections | **PATCH-SPEC (CEE)** — no UI authorship found |

---

## M1 — the rounding note

`WinGauge`'s legend rounds every share independently, so a partition need not close. Codex saw 99% in one run and 101% in another with nothing said.

New `deriveOddsRoundingNote` renders a note **derived from the readout STRINGS the legend prints**: `legendEntries` is built once and both the legend and the note read it, so there is no second evaluation of the formatting rule to drift from (trap 12/21). It **fails closed** on bounds (`< 1%`) and decimals — no total is derivable there — and is silent when the wholes already total 100.

**Surface choice is deliberate (trap 3b):** `WinGauge` renders the complete partition and `ResultsBody` mounts it unconditionally. `OptionCards` truncates to the top 2 behind "Show all (N more)", so a total taken there would routinely be a *subset* total and must not be described as a rounding artefact. `CompactOptionSpread` is not on this route (`ResultsBody.tsx:527-529`).

## M2 — the graph must not encode a direction nobody stated

The member's wording implies two readings of one edge. **It is not.** The sentence side is factor-level (`factor_sensitivity[].direction` → "increases/decreases the outcome"); the graph side is edge-level (`edge.data.direction` → the `+`/`−` glyph). Different objects, different questions — **trap 21**, and aligning their defaults would be the wrong fix.

What *is* a defect: `edge.data.direction` **defaults to `'positive'`**. `USER_EDGE_DEFAULTS` writes it with no source stamp, and the template-insert / blueprint-insert / two CEE-apply paths build from `DEFAULT_EDGE_DATA`, which defines no `direction` key at all (`edgeValueProvenance.ts`, THE WRITER MANIFEST). So the canvas drew a green `+` — a positive causal claim — on edges nobody characterised. **That is the fabricated half of the contradiction, and it is display-side.**

`resolveEdgeDirectionDisplay` already owns this answer (ROADMAP 2.263, rule 4: "ONE OWNER. This resolver is it."). It was applied to the three Model-tab consumers and **not** to the canvas edge — the one surface the reviewer called "the displayed graph". The hover popover 200 lines below in the same file was already gated, and its comment names this exact hazard: *"`direction` defaults to 'positive', so 'Positive' is itself a fabrication on an edge nobody characterised."*

**Scope, stated so it is not over-read:** this gates the **glyph and its `aria-label`**. Stroke colour is a separate channel with its own consumers and is unchanged — rowed below.

## M3 — stability copy claims only what was tested

Expectation derived from the **producer**, not from the UI's reading (trap 13c). At ISL `staging`:

- `RobustnessResultV2.recommendation_stability` — *"P(same recommendation across samples)"* (`src/models/robustness_v2.py`)
- `_build_robustness_interpretation` — *"{winner} wins in {x:.0%} of sampled scenarios"* (`src/services/robustness_analyzer_v2.py`)

So what held is the **ranking**, over a **finite sample**. `"Stable result" / "Result stays the same even if estimates are off"` stacked two over-claims: *the result* (every number — the 19 sensitive assumptions are exactly the numbers that did not hold) and *even if estimates are off* (an unbounded universal from a sample). The hero family and the footer status labels now say ranking and sample. **Thresholds, verdict source and the fail-closed allowlist are untouched.**

The spec pins the two **properties** (ranking-scoped; no unbounded guarantee) at every tier rather than one sentence, plus a guard that the tiers stay distinguishable — so a future copy edit that keeps both properties passes, and the lazy "rename everything to one phrase" fix fails.

## M4 — the downside tail carries its unit

The unit is **not in the analysis payload** — `downside` is three bare numbers and `@talchain/schemas@0.38.0` `EnrichmentOutcomeStats` declares no unit field. It comes from the goal node via `useResultsSectionData`, which already threaded `outcomeUnit`/`outcomeUnitSymbol`/`isNormalised` to `DriversSection` and `TornadoChart` and **not** to `OptionCards`.

New `formatDownsideValue` keeps the magnitude **byte-identical to `formatRangeValue`** (using the hero's `formatThreshold` would have coarsened `0.29` → `0.3`, i.e. fixed a units defect by shipping a precision regression) and attaches the unit only when one was stated **and** the values are on the goal's scale.

**The breadth half is the one a careless fix gets wrong (trap 22):** on a run with no `goal_threshold_cap` the magnitudes are PLoT's normalised 0-1 scores. Labelling those "hours" would replace a missing claim with a **false** one. Normalised runs get no unit, and that case is pinned as hard as the happy path.

---

## Evidence

- **RED-first at pristine `bc997f50`:** M1 render spec 4 failed · M2 3 failed (the fabrication cases) · M3 15 failed · M4 5 failed. Unit specs for the two new helpers are covered by the mutant kit rather than by a module-not-found RED.
- **Mutants: 20/20 bitten**, in a worktree at `/private/tmp/ui2580-mutants-*` (outside the repo root), mutating committed state only. Applied-check scoped to `src/`; **control read exactly 0**. **Isolation proven by WRITING** (trap 9g), not by locating: sentinel appended to the worktree copy, source SHA-256 unchanged, inodes distinct.
- **Two mutants SURVIVED on the first pass and were settled, not asserted** (trap 13c corollary):
  - swapping the note onto a different formatter arm left all 7 assertions green — every fixture rounded identically on both arms, so the "one source" claim was *a guard agreeing with itself* (trap 13b). Fixed with a discriminating fixture at the one value where the arms differ (`0.995` → `100%` vs `99.5%`), labelled in-test as a source-binding probe, not a wire-realistic run.
  - re-deriving with a plain `Math.round` instead of the legend's floored formatter also survived: the old fail-closed fixture summed to 100 under **both** rules. Replaced with a partition summing to exactly 1.0 whose rules disagree (floored → no total; plain round → a confident "total 101%").
  - A third `[pair-narrow]` mutant (legend prints one rule while the note reads another) now bites too.
- **Fixtures fixed at the source, not absorbed:** two `StyledEdge.encoding` fixtures carried a direction with **no provenance** — byte-identical to an edge nobody characterised — so they asserted the fabrication. They now state it; the item-1 claim they exist for is unchanged and still pinned.
- **Gates at this head:** `pnpm run typecheck` **PASSED** (coverage 3292/3332 + ratchet; drift *shrank* 2491 → 2487 — **baseline deliberately NOT regenerated**, per the standing rule about accepting `--update-baseline` prompts). ESLint on every changed file: **0 errors** (6 pre-existing warnings in `StyledEdge.tsx`, none introduced). Pre-push fast gate passed on push.
- **jsdom cannot prove visibility.** Every claim here is copy/DOM-state. The note's placement, the missing glyph and the unit suffix need a pixel witness on staging.

---

## PATCH SPECS (not built here)

### PS-1 · PLoT — the verdict reason phrase (M3's producer half)

`plot-lite-service/src/routes/v2/robustness-display-verdict.ts:62`

```ts
robust: 'this result held up under the changes we tested',
```

Rendered **verbatim** by the UI beside the (now ranking-scoped) label, so the pair currently reads *"Stable ranking — this result held up under the changes we tested"*. `this result` is the same over-claim M3 removed on the UI side: what held is which option leads. Suggested, keeping the module's own claim-safety rules (one short phrase, no numbers):

- `robust` → `'the leading option stayed on top under the changes we tested'`
- `moderate` → `'the leading option mostly stayed on top, but could change under some changes'`
- and the `..._ATTESTED_NO_FLIP` variants adjusted in step.

Blast radius: `robustness-display-verdict.{unit,fixture,flip-evidence}.test.ts`, plus UI `postAnalysisFooter.spec.ts` fixtures that quote the phrase.

### PS-2 · CEE — "£60,000 is near a £120,000 ceiling" (M5)

Structured-dissent prose. No UI authorship: the UI renders dissent text as received (`analysisHeroV17/buildAnalysisHeroViewModel.ts`, `stores/guidanceStore.ts`), and no "near"/"approaching"/"close to" template exists on any results surface. **Constraint arithmetic must be computed, not adjectival**: a proximity word may only be emitted when the derived ratio supports it, and the figure and the ceiling must both appear so the reader can check. £60k against a £120k ceiling is 50% of headroom — no vocabulary of nearness applies. Codex's own recommendation: *response-time consistency assertions for … constraint arithmetic*.

### PS-3 · CEE — coaching asserting inputs it was never given (M6)

*"known costs/tariffs/labour rates anchored projections"* when **their values were never supplied to the model**. This is the `keep model FACTS separate from advice/inference` half of Codex's recommendation. The coaching path must not name a quantity class as an input unless that quantity is present in the graph/brief it was handed; guidance about what *would* anchor a projection must be phrased as a request, not as a description of what happened.

---

## RESIDUALS (rowed, not silently dropped)

1. **M2 residual — factor-vs-edge grain.** With the fabricated `+` gone, a *genuine* disagreement can still occur: `factor_sensitivity[].direction` (a factor's net effect in the run) and `edge.data.direction` (one edge's stated polarity) are different quantities and nothing asserts they agree. Per trap 21 the fix is to **name the concepts apart** on screen, not to align defaults. Needs a live capture to size.
2. **M2 residual — stroke colour.** `computeDirectionStroke` still takes the raw `direction`, so an unstated edge keeps its green/rose stroke while the glyph is now absent. Same claim, softer channel, broader test blast radius.
3. **WinGauge/OptionCards formatter-arm split.** The legend passes `null` for `nSamples` while the option card beneath passes `option.nValidSamples`, so `0.9995` renders `100%` in the legend and `99.95%` on the card. Not one of the six, found on the way.
4. **Two `badgeLabel` maps** (`lib/mappers/constants.ts`, `components/results/constants.ts`) still carry the pre-2.580 register; M3 scoped the hero/footer family only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
