### PR TITLE
fix(pre-run): truthful un-encoded-option copy + non-destructive remedy (ROADMAP 2.924)

### DIFF
--- a/src/canvas/components/pre-analysis/__tests__/blockerEnrichment.nonDestructiveRemedy.spec.ts
+++ b/src/canvas/components/pre-analysis/__tests__/blockerEnrichment.nonDestructiveRemedy.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * ROADMAP 2.924 — a blocker that names a NON-DESTRUCTIVE remedy must not also
+ * render the destructive one.
+ *
+ * Why this file exists at all: `BlockersSection` gates its "Retry Draft" button
+ * on `display.supportsRetry`, which `enrichBlocker` keys off the blocker CODE —
+ * NOT off the blocker's own `action`. So changing the producer's action from
+ * `retry_draft` to `configure_option` (see
+ * `usePreRunValidation.unencodedOptionCopy.spec.ts`) would have left the
+ * destructive button rendering unchanged. Both halves are needed; this pins the
+ * second half.
+ *
+ * The suppression is deliberately narrow — ANALYSIS_NOT_READY *and* a
+ * `configure_option` action — so the paths where re-drafting genuinely is the
+ * remedy keep their button. The tests below are a DISCRIMINATING PAIR: the
+ * suppression must fire for the targeted shape and must NOT fire for its
+ * neighbours (verification trap 19).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ValidationBlocker } from '@talchain/schemas'
+import { enrichBlocker } from '../blockerEnrichment'
+
+const CONFIGURE_LABEL = 'Configure "Grow via partnerships"'
+
+/** The 2.924 shape: soft status, un-encoded option, non-destructive remedy. */
+const configureBlocker: ValidationBlocker = {
+  code: 'ANALYSIS_NOT_READY',
+  message: '"Grow via partnerships" needs its values set as numbers before analysis can run.',
+  action: { type: 'configure_option', label: CONFIGURE_LABEL, optionId: 'opt_partnerships' },
+}
+
+/** Its twin: the unrecognised-status / needs_user_input shape, still retryable. */
+const retryBlocker: ValidationBlocker = {
+  code: 'ANALYSIS_NOT_READY',
+  message: 'Analysis not ready',
+  action: { type: 'retry_draft', label: 'Retry Draft' },
+}
+
+describe('ROADMAP 2.924 — enrichBlocker suppresses the destructive remedy', () => {
+  it('turns supportsRetry OFF when the blocker names configure_option', () => {
+    const enriched = enrichBlocker(configureBlocker)
+
+    // supportsRetry === false is what stops BlockersSection rendering the
+    // "Retry Draft" button that would discard the user's chat-added option.
+    expect(enriched.display.supportsRetry).toBe(false)
+  })
+
+  it('replaces the re-draft prescriptions with the non-destructive action', () => {
+    const enriched = enrichBlocker(configureBlocker)
+
+    expect(enriched.display.suggestedActions).toEqual([CONFIGURE_LABEL])
+    // The static BLOCKER_DISPLAY bullets for this code are ['Retry draft',
+    // 'Edit brief'] — both prescribe replacing the model.
+    expect(enriched.display.suggestedActions).not.toContain('Retry draft')
+    expect(enriched.display.suggestedActions).not.toContain('Edit brief')
+  })
+
+  it('still passes the producer message through as the description', () => {
+    const enriched = enrichBlocker(configureBlocker)
+
+    expect(enriched.display.description).toBe(configureBlocker.message)
+    expect(enriched.display.description.toLowerCase()).not.toContain('categorical')
+  })
+
+  // ---- the discriminating half: the suppression must NOT leak ----
+
+  it('leaves supportsRetry ON for an ANALYSIS_NOT_READY blocker that asks for a re-draft', () => {
+    const enriched = enrichBlocker(retryBlocker)
+
+    expect(enriched.display.supportsRetry).toBe(true)
+    expect(enriched.display.suggestedActions).toEqual(['Retry draft', 'Edit brief'])
+  })
+
+  it('leaves other codes untouched even when they carry configure_option', () => {
+    // OPTIONS_NEED_MAPPING and EMPTY_INTERVENTIONS already emit configure_option.
+    // 2.924 must not silently change their retry affordance.
+    const needsMapping: ValidationBlocker = {
+      code: 'OPTIONS_NEED_MAPPING',
+      message: '1 option(s) need intervention values',
+      affectedIds: ['opt_partnerships'],
+      action: { type: 'configure_option', label: 'Configure options', optionId: 'opt_partnerships' },
+    }
+    const emptyInterventions: ValidationBlocker = {
+      code: 'EMPTY_INTERVENTIONS',
+      message: '1 option(s) have no interventions',
+      affectedIds: ['opt_partnerships'],
+      action: { type: 'configure_option', label: 'Add interventions', optionId: 'opt_partnerships' },
+    }
+
+    expect(enrichBlocker(needsMapping).display.supportsRetry).toBe(true)
+    expect(enrichBlocker(emptyInterventions).display.supportsRetry).toBe(true)
+  })
+})

--- a/src/canvas/components/pre-analysis/__tests__/blockerEnrichment.spec.ts
+++ b/src/canvas/components/pre-analysis/__tests__/blockerEnrichment.spec.ts
@@ -111,14 +111,18 @@ describe('enrichBlocker', () => {
   it('passes through status-specific message for ANALYSIS_NOT_READY', () => {
     const blocker: ValidationBlocker = {
       code: 'ANALYSIS_NOT_READY',
-      message: 'Some options have categorical values that need encoding',
+      // ROADMAP 2.924 — this fixture used to carry the false "categorical
+      // values" sentence. The test is about PASSTHROUGH, so the string is
+      // incidental; it now carries the truthful copy so the repo no longer
+      // re-seeds the wrong wording to anyone grepping for it.
+      message: '"Grow via partnerships" needs its values set as numbers before analysis can run.',
       action: { type: 'retry_draft', label: 'Retry Draft' },
     }
 
     const enriched = enrichBlocker(blocker)
 
     // Description should be the specific message, not the generic BLOCKER_DISPLAY description
-    expect(enriched.display.description).toBe('Some options have categorical values that need encoding')
+    expect(enriched.display.description).toBe('"Grow via partnerships" needs its values set as numbers before analysis can run.')
     expect(enriched.display.title).toBe('Analysis not ready')
   })
 

--- a/src/canvas/components/pre-analysis/blockerEnrichment.ts
+++ b/src/canvas/components/pre-analysis/blockerEnrichment.ts
@@ -242,11 +242,30 @@ export function enrichBlocker(blocker: ValidationBlocker): EnrichedBlocker {
   }
 
   // ANALYSIS_NOT_READY: pass through status-specific message from validation
-  // (e.g., "Some options have categorical values that need encoding")
+  // (e.g., '"Grow via partnerships" needs its values set as numbers before
+  // analysis can run.')
   if (blocker.code === 'ANALYSIS_NOT_READY' && blocker.message) {
     display = {
       ...display,
       description: blocker.message,
+    }
+  }
+
+  // ROADMAP 2.924 — when the producer named a NON-DESTRUCTIVE remedy, the card
+  // must not also offer "Retry Draft": BlockersSection gates that button on
+  // `display.supportsRetry` (keyed by CODE), not on the blocker's own action, so
+  // changing the action alone would leave the destructive button rendering.
+  // Re-drafting discards options the user added in chat.
+  //
+  // Narrow by construction: this fires only on ANALYSIS_NOT_READY blockers that
+  // carry `configure_option`. The unrecognised-status and needs_user_input paths
+  // still emit `retry_draft` and keep their retry button, and no other blocker
+  // code is touched.
+  if (blocker.code === 'ANALYSIS_NOT_READY' && blocker.action?.type === 'configure_option') {
+    display = {
+      ...display,
+      supportsRetry: false,
+      suggestedActions: [blocker.action.label],
     }
   }
 

--- a/src/canvas/hooks/__tests__/usePreRunValidation.unencodedOptionCopy.spec.ts
+++ b/src/canvas/hooks/__tests__/usePreRunValidation.unencodedOptionCopy.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * ROADMAP 2.924 — pre-run validation copy must name the REAL state, and its
+ * remedy must not destroy the user's work.
+ *
+ * Measured by the 2.427 diagnosis lane against deployed `bc997f50`: a user adds
+ * an option in chat, CEE returns `analysis_ready.status = 'needs_encoding'` with
+ * that option at `status: 'needs_encoding'` and `interventions: {}`. The shipped
+ * build then produced:
+ *   (1) "Some options have categorical values that need encoding" — there are no
+ *       categorical values; there are no values at all;
+ *   (2) an `action` of `retry_draft` / "Retry Draft" — which would DISCARD the
+ *       option the user had just added.
+ *
+ * The fixture below IS that capture state. Assertions bind to the blocker by its
+ * CODE and to the option by its ID/label — never by a value predicate another
+ * option could satisfy (verification trap 19).
+ *
+ * Reachability, stated honestly: under the DEPLOYED staging flag posture
+ * (`VITE_FEATURE_PRE_ANALYSIS_V3=1`) the surfaces that render this blocker's
+ * message are NOT mounted — see the reachability note in the PR. These tests pin
+ * the producer's behaviour; they are not evidence of a user-visible change.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node } from '@xyflow/react'
+import type { CEEAnalysisReady } from '../../../adapters/cee/types'
+import { validateBeforeRun } from '../usePreRunValidation'
+
+// ---------------------------------------------------------------------------
+// Fixtures — the measured capture state
+// ---------------------------------------------------------------------------
+
+const GOAL_ID = 'goal_revenue'
+
+/** The option the user added in chat. Deliberately carries NO baseline keyword. */
+const CHAT_ADDED_ID = 'opt_partnerships'
+const CHAT_ADDED_LABEL = 'Grow via partnerships'
+
+/** "Do nothing" is a baseline keyword, so this option is legitimately empty. */
+const BASELINE_ID = 'opt_status_quo'
+const BASELINE_LABEL = 'Do nothing'
+
+function nodes(): Node[] {
+  return [
+    { id: GOAL_ID, type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Revenue', kind: 'goal' } },
+    { id: CHAT_ADDED_ID, type: 'option', position: { x: 0, y: 0 }, data: { label: CHAT_ADDED_LABEL, kind: 'option' } },
+    { id: BASELINE_ID, type: 'option', position: { x: 0, y: 0 }, data: { label: BASELINE_LABEL, kind: 'option' } },
+  ]
+}
+
+/**
+ * The capture: overall `needs_encoding`, the chat-added option un-encoded with
+ * empty interventions, and a baseline option that is legitimately empty. No
+ * non-baseline option carries interventions, so this reaches the BLOCKER branch.
+ */
+function unEncodedCapture(
+  overallStatus: CEEAnalysisReady['status'] = 'needs_encoding'
+): CEEAnalysisReady {
+  return {
+    options: [
+      { id: BASELINE_ID, label: BASELINE_LABEL, status: 'ready', interventions: {} },
+      { id: CHAT_ADDED_ID, label: CHAT_ADDED_LABEL, status: 'needs_encoding', interventions: {} },
+    ],
+    goal_node_id: GOAL_ID,
+    status: overallStatus,
+  } as CEEAnalysisReady
+}
+
+/** Find the blocker by IDENTITY (its code), asserting it is unambiguous. */
+function theAnalysisNotReadyBlocker(result: ReturnType<typeof validateBeforeRun>) {
+  const matches = result.blockers.filter(b => b.code === 'ANALYSIS_NOT_READY')
+  expect(matches).toHaveLength(1)
+  return matches[0]
+}
+
+// ---------------------------------------------------------------------------
+
+describe('ROADMAP 2.924 — un-encoded option: truthful copy + non-destructive remedy', () => {
+  describe('defect 1: the copy must not assert categorical values that do not exist', () => {
+    it('does not claim "categorical" anything for an option with no values at all', () => {
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], unEncodedCapture())
+      const blocker = theAnalysisNotReadyBlocker(result)
+
+      expect(blocker.message.toLowerCase()).not.toContain('categorical')
+      expect(blocker.message.toLowerCase()).not.toContain('encoding')
+    })
+
+    it('names the real state and the specific un-encoded option by its label', () => {
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], unEncodedCapture())
+      const blocker = theAnalysisNotReadyBlocker(result)
+
+      // Bound to the option by its exact label — the baseline option must not
+      // be the one named, and a generic "some options" sentence must not pass.
+      expect(blocker.message).toContain(`"${CHAT_ADDED_LABEL}"`)
+      expect(blocker.message).not.toContain(BASELINE_LABEL)
+      expect(blocker.message).toContain('values set as numbers')
+    })
+
+    it('uses mapping-specific wording for needs_user_mapping', () => {
+      const capture = unEncodedCapture('needs_user_mapping')
+      capture.options![1].status = 'needs_user_mapping' as CEEAnalysisReady['options'][number]['status']
+
+      const blocker = theAnalysisNotReadyBlocker(
+        validateBeforeRun(GOAL_ID, nodes(), [], capture)
+      )
+
+      expect(blocker.message).toContain(`"${CHAT_ADDED_LABEL}"`)
+      expect(blocker.message).toContain('which factors it affects')
+      // The old copy prescribed the destructive remedy inside the sentence.
+      expect(blocker.message.toLowerCase()).not.toContain('re-draft')
+    })
+  })
+
+  describe('defect 2: the remedy must not discard the option the user just added', () => {
+    it('offers configure_option pointing at the un-encoded option, not retry_draft', () => {
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], unEncodedCapture())
+      const blocker = theAnalysisNotReadyBlocker(result)
+
+      expect(blocker.action?.type).toBe('configure_option')
+      // Identity binding: the remedy must target the chat-added option, not the
+      // baseline one and not "whichever option happened to sort first".
+      expect(blocker.action?.optionId).toBe(CHAT_ADDED_ID)
+      expect(blocker.action?.label).toContain(CHAT_ADDED_LABEL)
+    })
+
+    it('never offers the destructive retry_draft action on this branch', () => {
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], unEncodedCapture())
+      const blocker = theAnalysisNotReadyBlocker(result)
+
+      expect(blocker.action?.type).not.toBe('retry_draft')
+      expect(blocker.action?.label).not.toBe('Retry Draft')
+    })
+  })
+
+  describe('predicate domain: paths where re-drafting IS the right remedy are untouched', () => {
+    it("keeps retry_draft for a recognised-but-unhandled status ('unknown')", () => {
+      const capture = unEncodedCapture('unknown' as CEEAnalysisReady['status'])
+      const blocker = theAnalysisNotReadyBlocker(
+        validateBeforeRun(GOAL_ID, nodes(), [], capture)
+      )
+
+      // 'unknown' is not a soft-bypass status: no option is named, nothing of the
+      // user's is at risk, and re-drafting is the correct move.
+      expect(blocker.action?.type).toBe('retry_draft')
+      expect(blocker.message).toBe('Analysis not ready')
+    })
+
+    it('keeps the brief-editing remedy for needs_user_input', () => {
+      const capture = unEncodedCapture('needs_user_input' as CEEAnalysisReady['status'])
+      const blocker = theAnalysisNotReadyBlocker(
+        validateBeforeRun(GOAL_ID, nodes(), [], capture)
+      )
+
+      expect(blocker.message).toContain('brief needs changes')
+      expect(blocker.action?.type).toBe('retry_draft')
+      expect(blocker.action?.label).toBe('Edit brief')
+    })
+
+    it('still allows the run when the soft status is contradicted by resolved options', () => {
+      const capture = unEncodedCapture()
+      capture.options![1].status = 'ready'
+      capture.options![1].interventions = { fac_reach: { value: 0.4, source: 'brief_extraction' } } as never
+
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], capture)
+
+      expect(result.canRun).toBe(true)
+      expect(result.blockers.some(b => b.code === 'ANALYSIS_NOT_READY')).toBe(false)
+    })
+  })
+
+  describe('warning twin (same copy map; renderer is currently unmounted)', () => {
+    it('carries the truthful message and a non-destructive suggestion', () => {
+      // A third option WITH interventions flips the branch to the warning twin.
+      const capture = unEncodedCapture()
+      capture.options!.push({
+        id: 'opt_direct_sales',
+        label: 'Build a direct sales team',
+        status: 'ready',
+        interventions: { fac_reach: { value: 0.6, source: 'brief_extraction' } },
+      } as never)
+
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], capture)
+      const warnings = result.warnings.filter(w => w.code === 'ANALYSIS_NOT_READY')
+      expect(warnings).toHaveLength(1)
+
+      expect(warnings[0].message.toLowerCase()).not.toContain('categorical')
+      expect(warnings[0].message).toContain(`"${CHAT_ADDED_LABEL}"`)
+      expect(warnings[0].suggestion).toContain(`Configure "${CHAT_ADDED_LABEL}"`)
+      expect(warnings[0].suggestion).toContain('re-drafting would replace')
+    })
+  })
+})

--- a/src/canvas/hooks/usePreRunValidation.ts
+++ b/src/canvas/hooks/usePreRunValidation.ts
@@ -143,6 +143,55 @@ function validateGoalNode(
 }
 
 /**
+ * Whether a CEE option is resolved for run purposes.
+ *
+ * Baseline options ("do nothing") correctly carry empty interventions, so they
+ * are exempt from the intervention requirement.
+ *
+ * ROADMAP 2.924 — this is the SINGLE predicate behind both the soft-bypass gate
+ * and the user-facing copy derived from it. Deriving the sentence from the same
+ * predicate that closed the gate is what stops the two drifting: the message can
+ * never name a different set of options than the one the gate objected to.
+ */
+function isCeeOptionResolved(option: {
+  status?: string
+  label?: string
+  interventions?: Record<string, unknown>
+}): boolean {
+  if (option.status !== 'ready') return false
+  if (detectBaseline(option.label ?? '').isBaseline) return true
+  return Object.keys(option.interventions || {}).length > 0
+}
+
+/**
+ * Truthful description of what the un-resolved options actually need.
+ *
+ * ROADMAP 2.924 — the previous copy asserted a CAUSE it could not know ("Some
+ * options have categorical values that need encoding") on a capture where the
+ * option carried NO values at all (`interventions: {}`, chat-added). These
+ * sentences name the OBSERVABLE state instead, which stays true across the whole
+ * domain that reaches them: an option with no interventions has certainly not had
+ * its values set, whatever upstream reason CEE had for downgrading the status.
+ */
+function describeUnresolvedOptions(
+  status: string,
+  unresolved: Array<{ label?: string }>
+): string {
+  const soleLabel = unresolved.length === 1 ? (unresolved[0]?.label ?? '').trim() : ''
+  const subject = soleLabel ? `"${soleLabel}"` : `${unresolved.length} options`
+  const verb = soleLabel ? 'needs' : 'need'
+
+  if (status === 'needs_user_mapping') {
+    const object = soleLabel ? 'it affects' : 'they affect'
+    return `${subject} ${verb} to say which factors ${object} before analysis can run.`
+  }
+
+  // needs_encoding
+  const possessive = soleLabel ? 'its' : 'their'
+  return `${subject} ${verb} ${possessive} values set as numbers before analysis can run.`
+}
+
+/**
  * Validate overall analysis_ready status.
  *
  * analysis_ready is the SINGLE SOURCE OF TRUTH for run gating.
@@ -200,18 +249,41 @@ function validateOverallStatus(
     // Baseline options correctly have empty interventions ("do nothing").
     // Exclude them from the intervention requirement in the soft bypass check.
     const allOptionsResolved = isSoftStatus && (ceeAnalysisReady.options?.every(
-      o => {
-        if (o.status !== 'ready') return false
-        const isBaseline = detectBaseline(o.label ?? '').isBaseline
-        return isBaseline || Object.keys(o.interventions || {}).length > 0
-      }
+      isCeeOptionResolved
     ) ?? false)
 
     if (!allOptionsResolved) {
-      const statusMessages: Record<string, string> = {
-        needs_user_mapping: 'Options are missing intervention values. Re-draft your model to resolve.',
-        needs_encoding: 'Some options have categorical values that need encoding',
-      }
+      // ROADMAP 2.924 — the options the gate actually objected to, derived from
+      // the SAME predicate as the gate above so the sentence and the gate cannot
+      // disagree about which options are unresolved.
+      const unresolvedOptions = (ceeAnalysisReady.options ?? []).filter(
+        o => !isCeeOptionResolved(o)
+      )
+      const firstUnresolved = unresolvedOptions[0]
+
+      // Truthful copy only for the two soft statuses this branch has words for.
+      // A recognised-but-unhandled status (i.e. 'unknown') keeps the generic
+      // sentence AND the re-draft remedy below — re-drafting is the right move
+      // there, and no option of the user's is named to preserve.
+      const message =
+        isSoftStatus && unresolvedOptions.length > 0
+          ? describeUnresolvedOptions(ceeAnalysisReady.status, unresolvedOptions)
+          : 'Analysis not ready'
+
+      // ROADMAP 2.924 — NON-DESTRUCTIVE REMEDY. This branch fires on options the
+      // user may have just added in chat; `retry_draft` would DISCARD them.
+      // `configure_option` routes to the product's existing working path — the
+      // same action OPTIONS_NEED_MAPPING and EMPTY_INTERVENTIONS already emit,
+      // which opens that option in the inspector instead of replacing the model.
+      const unresolvedLabel = (firstUnresolved?.label ?? '').trim()
+      const remedy: NonNullable<ValidationBlocker['action']> =
+        isSoftStatus && firstUnresolved
+          ? {
+              type: 'configure_option',
+              label: unresolvedLabel ? `Configure "${unresolvedLabel}"` : 'Configure options',
+              optionId: firstUnresolved.id,
+            }
+          : { type: 'retry_draft', label: 'Retry Draft' }
 
       // Layer 1 gate relaxation (amendment #1): When interventions ARE populated
       // but allOptionsResolved failed (e.g. some options still need mapping),
@@ -224,14 +296,17 @@ function validateOverallStatus(
         // Downgrade to warning — interventions exist but status disagrees
         warnings.push({
           code: 'ANALYSIS_NOT_READY',
-          message: statusMessages[ceeAnalysisReady.status] || 'Analysis not ready',
-          suggestion: 'Some options have interventions but the model flagged issues. Consider re-drafting.',
+          message,
+          suggestion:
+            remedy.type === 'configure_option'
+              ? `${remedy.label} to set the values that are still missing — re-drafting would replace the options you already have.`
+              : 'Some options have interventions but the model flagged issues. Consider re-drafting.',
         })
       } else {
         blockers.push({
           code: 'ANALYSIS_NOT_READY',
-          message: statusMessages[ceeAnalysisReady.status] || 'Analysis not ready',
-          action: { type: 'retry_draft', label: 'Retry Draft' },
+          message,
+          action: remedy,
         })
       }
     }


### PR DESCRIPTION
## ROADMAP 2.924 — pre-run validation copy is wrong and its remedy is destructive

Fixes both defects the 2.427 diagnosis lane measured at deployed `bc997f50`, with a chat-added un-encoded option (`analysis_ready.status = 'needs_encoding'`, option `status: 'needs_encoding'`, `interventions: {}`).

### ⚠️ Read this first: the fix is real, the user-visible impact today is ZERO

**Both surfaces that render this blocker are DARK under the deployed staging flag posture.** I derived this before writing code and had it independently re-derived by a second sweep that tried to refute it. Stating it plainly so no one inherits a false reachability claim from this PR:

| Surface | Renders | Mounted on staging? |
|---|---|---|
| `PreAnalysisGuidance.tsx:456-478` (warning branch) | `preRunValidation.warnings` | **NO — zero importers repo-wide** |
| `PreAnalysisPanel` → `BlockersSection` (blocker branch) | `blocker.message`, "Retry Draft" button | **NO — flag-OFF branch only** |

- **Warning branch:** `PreAnalysisGuidance` has **no importer anywhere**. Complete manifest over all tracked files: the definition itself, three *comments* (one in `buildV7Bias.ts`, two in a spec that re-implements the logic rather than importing it), and docs/CI baselines. No dynamic `import()`, no `lazy()`, no barrel. Zero importers ⇒ no flag can mount it. `preRunValidation.warnings` is read **only** by this dead module (3 hits, all in that file).
- **Blocker branch:** `OutputsDock.tsx:2346` is an **exclusive ternary** — `isPreAnalysisV3Enabled() ? <PreAnalysisPanelV3/> : <PreAnalysisPanel/>` — and `netlify.toml:156` sets `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"` under `[context.staging.environment]`. `flagFactory.ts:58-92` resolves `"1"` → `true`. The V3 tree imports **nothing** from `pre-analysis/` and never reads `ValidationBlocker`, `enrichedBlockers`, or `usePreRunValidation`. V3's blocked copy comes from a *different* validator (`graphHealth` → `canRunAnalysis`), which never emits `ANALYSIS_NOT_READY`.
- `useCanRunAnalysis` (exported from the same hook) has **zero consumers** repo-wide.

**Status-ladder rung for this change: TESTED. Not MOUNTED, not witnessed.** The row's premise that the blocker branch "has a live consumer chain" is true in the repo but terminates at a component the deployed flag switches off. The copy is still false wherever it renders (flag-off/local dev, and the documented byte-identical reinstatement path), and `retry_draft` is still destructive — so it is worth fixing where it lives. It is **not** a user-visible change today.

### Defect 1 — the copy asserted a cause it could not know

`usePreRunValidation.ts:213` said *"Some options have categorical values that need encoding"* on a capture with **no values at all**.

The new copy names the **observable** state and the specific option, which stays true across the whole domain that reaches it (trap 22 — predicate breadth): an option with `interventions: {}` has certainly not had its values set, whatever CEE's upstream reason was.

- `needs_encoding` → `"Grow via partnerships" needs its values set as numbers before analysis can run.`
- `needs_user_mapping` → `"Grow via partnerships" needs to say which factors it affects before analysis can run.` (the old text also prescribed *"Re-draft your model to resolve"* — same destructive defect, same push site, fixed together)

Copy and remedy are derived from `isCeeOptionResolved` — **the same per-option predicate that closes the gate** — so the sentence can never name a different set of options than the one the gate objected to.

### Defect 2 — the remedy would have discarded the user's work

`retry_draft` / "Retry Draft" → `configure_option` targeting the un-encoded option: the product's own existing working path, the same action `OPTIONS_NEED_MAPPING` and `EMPTY_INTERVENTIONS` already emit.

**One trap worth naming:** `BlockersSection.tsx:199` gates the destructive button on `display.supportsRetry`, which `enrichBlocker` keys off the blocker **CODE** — *not* off the blocker's action. **Changing the producer's action alone would have left the destructive button rendering unchanged.** So `blockerEnrichment.ts` suppresses `supportsRetry` too — narrowly, on `ANALYSIS_NOT_READY` **and** `configure_option`, so the paths where re-drafting genuinely is the remedy keep their button.

### Predicate domain (review doctrine: audit the domain, not the invariant)

`ANALYSIS_NOT_READY` covers four situations. Only the two soft-status ones change:

| Path | Before | After |
|---|---|---|
| `needs_encoding` / `needs_user_mapping`, options unresolved | false copy + `retry_draft` | truthful copy + `configure_option` |
| `unknown` (recognised, unhandled) | `'Analysis not ready'` + `retry_draft` | **unchanged** — pinned by test |
| `needs_user_input` | brief copy + "Edit brief" | **unchanged** — pinned by test |
| unrecognised status | "Please re-draft" + `retry_draft` | **unchanged** |
| `OPTIONS_NEED_MAPPING` / `EMPTY_INTERVENTIONS` (also carry `configure_option`) | retryable | **unchanged** — pinned by test |

### Evidence

RED-first proven by mutation in a worktree **outside** the repo root, isolation proven by **writing** a sentinel and asserting the source was byte-identical, with distinct inodes checked (APFS hard-link trap). Applied-check scoped to `src/`, control read **exactly 0**. The first isolation check printed OK against a missing file — it was rebuilt to fail loud before any number was trusted.

| Mutant | Result | Reds on |
|---|---|---|
| Control (unmutated) | 14/14 GREEN | — |
| **M1** wrong copy restored | **4 RED** | copy assertions |
| **M2** destructive remedy restored | **3 RED** | *action* assertions — disjoint from M1 |
| **M3** `supportsRetry` suppression deleted | **2 RED** | suppression fires |
| **M4** suppression **broadened** (drop the action conjunct) | **1 RED** | the "does not leak" test |

M3/M4 are a **discriminating pair**: M3 proves the guard fires, M4 proves its narrowness is real and not a tautology — they red on different assertions.

### Gates at this tip

- `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) — ✅ **PASSED**. Coverage 3294/3334. Drift **shrank** 2491 → 2487, **none added**. I did **not** run `--update-baseline`: the 6 baseline diagnostics on this file are pre-existing `ValidationWarning` shape mismatches I did not attribute line-by-line, and banking an unattributed shrink is the trap that entry exists to warn about.
- `vitest` over every suite covering the changed code (`src/canvas/hooks`, `src/canvas/components/pre-analysis`, `src/canvas/components/pre-analysis-v3`, `goldenFixture.spec.ts`) — ✅ **146 files, 1990 tests, 0 failures**. `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported; no shrunk collect.

### Found but NOT fixed (needs its own row)

`src/canvas/hooks/usePreAnalysisData.ts:149` — `TITLE_MAP.ANALYSIS_NOT_READY = 'Draft incomplete — try re-drafting'`. Same destructive prescription, same blocker, doubly-dark path. It is keyed by CODE only, so it cannot distinguish the configure case from the unknown-status case without the same per-blocker treatment the enrichment path got here — more than a copy tweak, so I left it rather than half-do it.

`blockerEnrichment.ts` `GUIDANCE_MAP` / `getBlockerGuidance` confirmed **dark** (zero production callers; only its own definition and its spec) — untouched, per the brief.

### Scope

Pre-run validation seam only. No analysis-display files touched — no overlap with #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
