### PR TITLE
fix(2.928): one formatter arm, one direction resolver, one badge register — the #623 residuals

### DIFF
--- a/src/canvas/__tests__/unsetNonTextChannels.spec.tsx
+++ b/src/canvas/__tests__/unsetNonTextChannels.spec.tsx
@@ -40,6 +40,8 @@ import { USER_EDGE_DEFAULTS } from '../domain/edges'
 import {
   resolveEdgeValueDisplay,
   resolveEdgeSignedStrengthDisplay,
+  resolveEdgeDirectionDisplay,
+  type EdgeDirectionDisplay,
   compareEdgeValueDisplays,
   compareEdgeValueAggregates,
   aggregateEdgeSignedStrength,
@@ -211,12 +213,24 @@ describe('AGGREGATE — a rank built from nothing is not a rank', () => {
 })
 
 describe('STROKE COLOUR — computeDirectionStroke', () => {
+  // ⭐ ROADMAP 2.928 member b — the first parameter is now an
+  // `EdgeDirectionDisplay`, resolved by `resolveEdgeDirectionDisplay`, not the
+  // raw `direction` field. `stated()` below is the only way to express a
+  // licensed claim; a defaulted `'positive'` is no longer expressible.
+  const stated = (direction: 'positive' | 'negative'): EdgeDirectionDisplay => ({
+    show: true,
+    direction,
+    source: 'user',
+  })
+
   it('gives an edge drawn through the product NO verdict colour', () => {
     const data = drawEdgeThroughProduct()
-    const display = resolveEdgeSignedStrengthDisplay(data)
     const stroke = computeDirectionStroke(
-      data.direction as 'positive' | 'negative' | undefined,
-      display,
+      // Both channels resolved from the SAME edge data the product produced —
+      // no hand-supplied direction, which is what let the old call site pass
+      // the fabricated default in.
+      resolveEdgeDirectionDisplay(data),
+      resolveEdgeSignedStrengthDisplay(data),
       false,
     )
     // The defaulted `direction: 'positive'` must NOT reach the green.
@@ -224,14 +238,28 @@ describe('STROKE COLOUR — computeDirectionStroke', () => {
     expect(stroke).toBe('var(--edge-neutral)')
   })
 
+  it('gives NO verdict colour even once the STRENGTH has been set', () => {
+    // ROADMAP 2.928: the reachable half-fix state. Setting the strength in the
+    // inspector stamps `weightSource` and leaves `direction` unstamped, which
+    // used to unlock the green while the glyph stayed correctly hidden.
+    const data = { ...drawEdgeThroughProduct(), weightSource: 'user' }
+    const stroke = computeDirectionStroke(
+      resolveEdgeDirectionDisplay(data),
+      resolveEdgeSignedStrengthDisplay(data),
+      false,
+    )
+    expect(resolveEdgeSignedStrengthDisplay(data).show).toBe(true) // precondition
+    expect(stroke).toBe('var(--edge-neutral)')
+  })
+
   it('still discriminates when the strength IS sourced', () => {
     const set: EdgeValueDisplay = { show: true, value: 0.6, source: 'user' }
-    expect(computeDirectionStroke('positive', set, false)).toBe('var(--edge-positive)')
-    expect(computeDirectionStroke('negative', set, false)).toBe('var(--edge-negative)')
-    expect(computeDirectionStroke('positive', set, true)).toBe('var(--edge-positive-dark)')
+    expect(computeDirectionStroke(stated('positive'), set, false)).toBe('var(--edge-positive)')
+    expect(computeDirectionStroke(stated('negative'), set, false)).toBe('var(--edge-negative)')
+    expect(computeDirectionStroke(stated('positive'), set, true)).toBe('var(--edge-positive-dark)')
     // weight 0 is a valid user choice → neutral, unchanged.
     expect(
-      computeDirectionStroke('positive', { show: true, value: 0, source: 'user' }, false),
+      computeDirectionStroke(stated('positive'), { show: true, value: 0, source: 'user' }, false),
     ).toBe('var(--edge-neutral)')
   })
 })

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -215,11 +215,16 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   const confidence = edgeData?.confidence
   const belief = edgeData?.belief      // v1.2
   const provenance = edgeData?.provenance  // v1.2
-  const direction = edgeData?.direction as 'positive' | 'negative' | undefined  // v2.2
-
   // ⭐ ROADMAP 2.580 member 2 — THE POLARITY GLYPH'S OWN, GATED, DIRECTION.
   //
-  // `direction` above is the RAW field and it defaults: `USER_EDGE_DEFAULTS`
+  // ⭐⭐ ROADMAP 2.928 member b — AND THE STROKE'S. The raw read that used to
+  // sit here (`const direction = edgeData?.direction`) is GONE: after the
+  // stroke moved onto the resolver it had no remaining reader on this surface,
+  // and leaving it would be an invitation to wire a third channel to the
+  // fabricated default. Outbound adapters and persistence still read
+  // `edge.data.direction` from the store; nothing on screen does.
+  //
+  // The RAW field defaults: `USER_EDGE_DEFAULTS`
   // writes `'positive'` with no source stamp, and the template/blueprint/CEE
   // -apply paths build from `DEFAULT_EDGE_DATA`, which has no `direction` key
   // at all. Reading it raw made the canvas draw a green "+" — a positive
@@ -231,12 +236,20 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // stated" while the graph beside it drew a "+". The hover popover below
   // (:1010) was already gated and its comment names this exact hazard.
   //
-  // Kept SEPARATE from `direction` deliberately: the raw field still drives
-  // the stroke colour and the outbound adapters, and changing those is a
-  // different decision with different consumers. This constant is the DISPLAY
-  // CLAIM only.
-  const directionDisplay = resolveEdgeDirectionDisplay(
-    edgeData as Record<string, unknown> | undefined,
+  // ⚠ CORRECTED 2026-08-08 (ROADMAP 2.928 member b). This comment used to say
+  // the constant was "kept SEPARATE from `direction` deliberately: the raw
+  // field still drives the stroke colour". That separation was the DEFECT, not
+  // a design: it left the green polarity STROKE on edges whose glyph this very
+  // resolver had just suppressed. The raw `direction` still drives the outbound
+  // ADAPTERS and the persisted bytes — that part stands, and is why ingestion
+  // is untouched — but it no longer drives anything on screen.
+  //
+  // Memoised on `edgeData` for the same reason `edgeSignedStrength` below is:
+  // the resolver returns a fresh object each call, and the stroke memo now
+  // depends on this one. Same identity discipline, same dependency.
+  const directionDisplay = useMemo(
+    () => resolveEdgeDirectionDisplay(edgeData as Record<string, unknown> | undefined),
+    [edgeData],
   )
   const statedDirection = directionDisplay.show ? directionDisplay.direction : null
 
@@ -281,9 +294,14 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // F.2 + E1: direction-based stroke colour (see directionStroke.ts for the
   // CVD-aware polarity palette and the ΔE rationale). Applies pre-run and
   // post-run; one source of truth shared with directionColour.spec.
+  //
+  // ⭐ ROADMAP 2.928 member b — this takes `directionDisplay`, the SAME resolved
+  // value the glyph reads, not the raw `direction` field. The glyph and the
+  // stroke are now two renderings of one answer; there is no second read of the
+  // fabricated default left on this surface.
   const directionStroke = useMemo(
-    () => computeDirectionStroke(direction, edgeSignedStrength, isDark),
-    [direction, edgeSignedStrength, isDark],
+    () => computeDirectionStroke(directionDisplay, edgeSignedStrength, isDark),
+    [directionDisplay, edgeSignedStrength, isDark],
   )
 
   // Decision Graph Display v2: Existence certainty line style

--- a/src/canvas/edges/__tests__/StyledEdge.directionStrokeProvenance.2928.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.directionStrokeProvenance.2928.spec.tsx
@@ -1,0 +1,369 @@
+/**
+ * ROADMAP 2.928 member (b) — THE STROKE MUST OBEY THE SAME RESOLVER AS THE GLYPH.
+ *
+ * WHAT #623 LEFT HALF-FIXED, AND WHY IT IS VISIBLE
+ * -----------------------------------------------
+ * ROADMAP 2.580 member 2 stopped the canvas drawing a green `+` on edges whose
+ * direction nobody stated: `StyledEdge` began resolving the DISPLAY CLAIM
+ * through `resolveEdgeDirectionDisplay` (ROADMAP 2.263, "ONE OWNER. This
+ * resolver is it."). Its spec said so explicitly in its scope note — "this pins
+ * the GLYPH and its `aria-label` … The stroke COLOUR is a separate channel and
+ * is unchanged here; see the PR body for the rowed residual."
+ *
+ * This is that residual. `computeDirectionStroke` kept taking the RAW
+ * `edgeData.direction`, which `USER_EDGE_DEFAULTS` fabricates as `'positive'`
+ * with no source stamp. So on any edge whose STRENGTH is set but whose
+ * DIRECTION is not, the glyph correctly disappeared and the edge kept its
+ * **green polarity stroke** — the same false causal claim, in the channel
+ * `directionStroke.ts`'s own header calls "the primary" cue:
+ *
+ *     "The +/− glyph is the second cue; these hues are the primary."
+ *
+ * Removing the second cue while leaving the primary one asserting is strictly
+ * worse than the state before #623 for a red-green dichromat, for whom the
+ * glyph was the ONLY reliable polarity channel (same header, the CVD note).
+ *
+ * REACHABILITY — DERIVED FROM THE WRITER MANIFEST, NOT IMAGINED
+ * ------------------------------------------------------------
+ * The divergence needs `weight` STAMPED and `direction` NOT. Both cases below
+ * are real states from `edgeValueProvenance.ts`'s writer manifest:
+ *   1. A user draws an edge (`USER_EDGE_DEFAULTS`: `direction: 'positive'`,
+ *      unstamped) and then sets its strength in the inspector → `weightSource:
+ *      'user'`, direction still unstamped.
+ *   2. CEE sends `effect_direction: 'unknown'` — a declared 0.30.0 contract
+ *      member, the producer EXPLICITLY declining — beside the ingestion-time
+ *      `direction: 'positive'` collapse, with `weightSource: 'cee'`.
+ * Case 2 is the sharper one: the producer said "I will not tell you the
+ * direction" and the canvas painted it green anyway.
+ *
+ * WHAT THIS SPEC ASSERTS, AND WHY IT IS NOT TWO SEPARATE PINS
+ * ----------------------------------------------------------
+ * The last describe block binds the two channels to ONE resolved value: for
+ * every fixture, `a polarity glyph is rendered` ⟺ `the stroke is a polarity
+ * hue`. Pinning them separately would let them drift apart again and stay
+ * green; the biconditional is what REDs on drift, in either direction.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { StyledEdge } from '../StyledEdge'
+import {
+  resolveEdgeDirectionDisplay,
+  resolveEdgeSignedStrengthDisplay,
+} from '../../domain/edgeValueProvenance'
+import { Position } from '@xyflow/react'
+
+const nodeKinds: Record<string, string> = {}
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: 'idle', report: null },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: 'standard',
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// ⛔ importOriginal-SPREAD, never a hand-listed replacement (CLAUDE.md trap 12).
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: (p: number | undefined) => (p !== undefined && p < 0.7 ? '6,4' : undefined),
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+const baseProps = {
+  id: 'e1', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: false,
+}
+
+/** The polarity hues, by token. Light mode — `useIsDark` is mocked false. */
+const POSITIVE = 'var(--edge-positive)'
+const NEGATIVE = 'var(--edge-negative)'
+const NEUTRAL = 'var(--edge-neutral)'
+const POLARITY_HUES = [POSITIVE, NEGATIVE]
+
+/** The rendered stroke, read off the one path BaseEdge draws. */
+function strokeOf(container: HTMLElement): string {
+  const edge = container.querySelector('[data-testid="base-edge"]') as SVGPathElement | null
+  expect(edge, 'BaseEdge did not render').not.toBeNull()
+  return (edge as unknown as HTMLElement).style.stroke
+}
+
+/** Any polarity glyph at all, whichever sign — bound by its own aria-label. */
+const anyGlyph = (container: HTMLElement) =>
+  container.querySelector('[aria-label^="Effect direction:"]')
+
+/**
+ * The fixture table. Each entry is a real edge shape from the writer manifest,
+ * and `stated` is what the ONE OWNER (`resolveEdgeDirectionDisplay`) says about
+ * it — asserted, not assumed, in the biconditional block below.
+ */
+const FIXTURES: Array<{ name: string; data: Record<string, unknown> }> = [
+  {
+    name: 'user stated positive, strength set',
+    data: { weight: 0.6, weightSource: 'user', direction: 'positive', directionSource: 'user', beliefExists: 0.8 },
+  },
+  {
+    name: 'user stated negative, strength set',
+    data: { weight: 0.6, weightSource: 'user', direction: 'negative', directionSource: 'user', beliefExists: 0.8 },
+  },
+  {
+    name: 'CEE raw effect_direction positive, strength set',
+    data: { weight: 0.6, weightSource: 'cee', direction: 'positive', effect_direction: 'positive', beliefExists: 0.8 },
+  },
+  {
+    name: 'DEFAULTED direction, strength set by the user',
+    data: { weight: 0.6, weightSource: 'user', direction: 'positive', beliefExists: 0.8 },
+  },
+  {
+    name: 'producer EXPLICITLY declined (effect_direction: unknown), strength set',
+    data: { weight: 0.6, weightSource: 'cee', direction: 'positive', effect_direction: 'unknown', beliefExists: 0.8 },
+  },
+  {
+    name: 'no direction key at all (DEFAULT_EDGE_DATA paths), strength set',
+    data: { weight: 0.6, weightSource: 'template', beliefExists: 0.8 },
+  },
+  {
+    name: 'unrecognised direction value with a source stamp',
+    data: { weight: 0.6, weightSource: 'user', direction: 'sideways', directionSource: 'user', beliefExists: 0.8 },
+  },
+  {
+    name: 'strength NOT set either',
+    data: { weight: 0.6, direction: 'positive', directionSource: 'user', beliefExists: 0.8 },
+  },
+]
+
+describe('StyledEdge — the stroke is provenance-gated (ROADMAP 2.928 member b)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  // ── The named defects ────────────────────────────────────────────────────
+
+  it('DOES NOT paint the positive green when `direction` is the unstated UI default', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{ weight: 0.6, weightSource: 'user', direction: 'positive', beliefExists: 0.8 }}
+      />
+    )
+    expect(strokeOf(container)).toBe(NEUTRAL)
+    expect(strokeOf(container)).not.toBe(POSITIVE)
+  })
+
+  it('DOES NOT paint the positive green when the producer EXPLICITLY declined', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'cee',
+          direction: 'positive', effect_direction: 'unknown', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(strokeOf(container)).toBe(NEUTRAL)
+    expect(strokeOf(container)).not.toBe(POSITIVE)
+  })
+
+  it('DOES NOT paint a polarity hue for an unrecognised direction, even with a source stamp', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'user',
+          direction: 'sideways', directionSource: 'user', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(POLARITY_HUES).not.toContain(strokeOf(container))
+  })
+
+  // ── The licensed claims still paint ──────────────────────────────────────
+
+  it('still paints the positive green when a USER stated the direction', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'user',
+          direction: 'positive', directionSource: 'user', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(strokeOf(container)).toBe(POSITIVE)
+  })
+
+  it('still paints the negative rose when a USER stated the direction', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'user',
+          direction: 'negative', directionSource: 'user', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(strokeOf(container)).toBe(NEGATIVE)
+  })
+
+  it('still paints the positive green on the CEE back-compat evidence (raw effect_direction)', () => {
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'cee',
+          direction: 'positive', effect_direction: 'positive', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(strokeOf(container)).toBe(POSITIVE)
+  })
+
+  // ── ONE RESOLVED VALUE, TWO CHANNELS ─────────────────────────────────────
+  //
+  // ⚠ THE TWO CHANNELS ARE NOT INTERCHANGEABLE, AND A BICONDITIONAL HERE WOULD
+  // BE WRONG (CLAUDE.md trap 21 — write down the question each authority
+  // answers before reconciling them). The GLYPH answers "did anyone state a
+  // direction?". The STROKE answers "did anyone state a direction AND set a
+  // strength?" — grey is `directionStroke.ts`'s NO-VERDICT colour and it
+  // already, correctly, covers "strength nobody has set". So a stated
+  // direction on an unset strength legitimately renders a glyph over a grey
+  // stroke, and the last fixture in the table is exactly that case. This spec
+  // was first written with a biconditional; that fixture is what refuted it.
+  //
+  // The two claims that ARE binding:
+  //   1. SAFETY — the stroke may never assert a polarity the resolver did not
+  //      license: `strokeIsPolarity ⟹ glyphRendered`. This is the direction
+  //      the defect ran in, and it is the one that must never regress.
+  //   2. AGREEMENT — where the strength IS set, the two channels are the same
+  //      resolved value and must match exactly.
+  // Both are DERIVED per fixture from the two owning resolvers, so a fixture
+  // added to the table extends the coverage without anyone updating a list.
+
+  describe('glyph and stroke derive from the SAME resolved direction', () => {
+    it.each(FIXTURES)('$name', ({ data }) => {
+      const directionShown = resolveEdgeDirectionDisplay(data).show
+      const strengthShown = resolveEdgeSignedStrengthDisplay(data).show
+      const { container } = render(<StyledEdge {...(baseProps as any)} data={data} />)
+
+      const glyphRendered = anyGlyph(container) !== null
+      const strokeIsPolarity = POLARITY_HUES.includes(strokeOf(container))
+
+      // The glyph is bound to the ONE OWNER's verdict (ROADMAP 2.580 member 2).
+      expect(glyphRendered).toBe(directionShown)
+
+      // The stroke is bound to the SAME verdict, conjoined with the strength
+      // gate it already owned. Nothing here re-derives either answer.
+      expect(strokeIsPolarity).toBe(directionShown && strengthShown)
+
+      // Claim 1, stated separately so a regression names itself: the primary
+      // colour cue can never out-claim the secondary glyph cue.
+      if (strokeIsPolarity) expect(glyphRendered).toBe(true)
+    })
+  })
+
+  it('the table is not vacuous: it produces BOTH outcomes on BOTH channels', () => {
+    // Without this, a change that suppressed every glyph and every polarity hue
+    // would satisfy every row above (false === false) — a guard agreeing with
+    // itself (CLAUDE.md trap 13b). Pin the discriminations the table must make.
+    const rows = FIXTURES.map(({ data }) => {
+      const { container, unmount } = render(<StyledEdge {...(baseProps as any)} data={data} />)
+      const row = {
+        polarity: POLARITY_HUES.includes(strokeOf(container)),
+        glyph: anyGlyph(container) !== null,
+      }
+      unmount()
+      return row
+    })
+    expect(rows.map(r => r.polarity)).toContain(true)
+    expect(rows.map(r => r.polarity)).toContain(false)
+    expect(rows.map(r => r.glyph)).toContain(true)
+    expect(rows.map(r => r.glyph)).toContain(false)
+    // …and the two channels genuinely DIVERGE somewhere, so the "different
+    // questions" reading above is measured rather than asserted.
+    expect(rows.some(r => r.glyph !== r.polarity)).toBe(true)
+  })
+
+  it('a structural edge keeps its structural grey and no glyph, gate or not', () => {
+    nodeKinds.src = 'decision'
+    nodeKinds.tgt = 'option'
+    const { container } = render(
+      <StyledEdge
+        {...(baseProps as any)}
+        data={{
+          weight: 0.6, weightSource: 'user',
+          direction: 'positive', directionSource: 'user', beliefExists: 0.8,
+        }}
+      />
+    )
+    expect(anyGlyph(container)).toBeNull()
+    expect(POLARITY_HUES).not.toContain(strokeOf(container))
+  })
+})

--- a/src/canvas/edges/__tests__/directionColour.spec.ts
+++ b/src/canvas/edges/__tests__/directionColour.spec.ts
@@ -11,43 +11,65 @@
  */
 import { describe, it, expect } from 'vitest'
 import { computeDirectionStroke } from '../directionStroke'
-import type { EdgeValueDisplay } from '../../domain/edgeValueProvenance'
+import type {
+  EdgeDirectionDisplay,
+  EdgeValueDisplay,
+} from '../../domain/edgeValueProvenance'
 
 const set = (value: number): EdgeValueDisplay => ({ show: true, value, source: 'user' })
 const NOT_SET: EdgeValueDisplay = { show: false, reason: 'not_set' }
 const ABSENT: EdgeValueDisplay = { show: false, reason: 'absent' }
 
+// ⭐ SECOND SIGNATURE CHANGE (ROADMAP 2.928 member b): the FIRST parameter is
+// now an `EdgeDirectionDisplay` too. The old `'positive' | 'negative' |
+// undefined` could not express "this says 'positive' but nobody stated it" —
+// the exact shape `USER_EDGE_DEFAULTS` fabricates — so the raw field reached
+// the green even after ROADMAP 2.580 gated the glyph. `stated()` is the only
+// way to express a licensed claim; the unlicensed ones are the three below,
+// and they are DIFFERENT REASONS for the same neutral answer.
+const stated = (direction: 'positive' | 'negative'): EdgeDirectionDisplay => ({
+  show: true,
+  direction,
+  source: 'user',
+})
+/** `direction` present but nobody stamped it — the UI default. */
+const DIR_NOT_SET: EdgeDirectionDisplay = { show: false, reason: 'not_set' }
+/** No direction on the edge at all. */
+const DIR_ABSENT: EdgeDirectionDisplay = { show: false, reason: 'absent' }
+/** The producer explicitly declined (`effect_direction: 'unknown'`). */
+const DIR_UNKNOWN: EdgeDirectionDisplay = { show: false, reason: 'unknown' }
+
 describe('directionStroke colour logic (F.2 + E1)', () => {
   it('weight=0, direction="positive" → grey (neutral), NOT yellow', () => {
-    expect(computeDirectionStroke('positive', set(0), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(stated('positive'), set(0), false)).toBe('var(--edge-neutral)')
   })
 
   it('E1: weight=0.5, direction="positive" → the positive-green token', () => {
-    expect(computeDirectionStroke('positive', set(0.5), false)).toBe('var(--edge-positive)')
+    expect(computeDirectionStroke(stated('positive'), set(0.5), false)).toBe('var(--edge-positive)')
   })
 
   it('E1: weight=0.5, direction="negative" → the negative-rose token (distinct from amber warning + risk node)', () => {
-    expect(computeDirectionStroke('negative', set(0.5), false)).toBe('var(--edge-negative)')
+    expect(computeDirectionStroke(stated('negative'), set(0.5), false)).toBe('var(--edge-negative)')
     // Guard the C2 ruling: negative must NOT be the amber warning hue, and must
     // not be the old #ef4444 that collided with the risk-node border.
-    expect(computeDirectionStroke('negative', set(0.5), false)).not.toBe('#FFA656')
-    expect(computeDirectionStroke('negative', set(0.5), false)).not.toBe('#ef4444')
+    expect(computeDirectionStroke(stated('negative'), set(0.5), false)).not.toBe('#FFA656')
+    expect(computeDirectionStroke(stated('negative'), set(0.5), false)).not.toBe('#ef4444')
   })
 
   it('takes the MAGNITUDE, so a negative signed strength still colours by direction', () => {
-    expect(computeDirectionStroke('negative', set(-0.5), false)).toBe('var(--edge-negative)')
+    expect(computeDirectionStroke(stated('negative'), set(-0.5), false)).toBe('var(--edge-negative)')
   })
 
   it('weight=0, direction="negative" → grey (neutral), NOT the polarity colour', () => {
-    expect(computeDirectionStroke('negative', set(0), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(stated('negative'), set(0), false)).toBe('var(--edge-neutral)')
   })
 
   it('weight=0.5, direction=undefined → grey (no direction set)', () => {
-    expect(computeDirectionStroke(undefined, set(0.5), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(DIR_ABSENT, set(0.5), false)).toBe('var(--edge-neutral)')
   })
 
   it('weight=0, direction=undefined → grey (weight defined, no direction), NOT yellow', () => {
-    expect(computeDirectionStroke(undefined, set(0), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(DIR_ABSENT, set(0), false)).toBe('var(--edge-neutral)')
   })
 
   // ── Provenance gate ──────────────────────────────────────────────────────
@@ -55,26 +77,52 @@ describe('directionStroke colour logic (F.2 + E1)', () => {
   // and never could. `direction` is deliberately 'positive' below: that is the
   // value `USER_EDGE_DEFAULTS` fabricates, and it must not reach the green.
   it('unset strength → grey, even with a defaulted positive direction', () => {
-    expect(computeDirectionStroke('positive', NOT_SET, false)).toBe('var(--edge-neutral)')
-    expect(computeDirectionStroke('positive', NOT_SET, false)).not.toBe('var(--edge-positive)')
+    expect(computeDirectionStroke(stated('positive'), NOT_SET, false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(stated('positive'), NOT_SET, false)).not.toBe('var(--edge-positive)')
   })
 
   it('absent strength → grey too', () => {
-    expect(computeDirectionStroke('negative', ABSENT, false)).toBe('var(--edge-neutral)')
-    expect(computeDirectionStroke('negative', ABSENT, true)).toBe('var(--edge-neutral-dark)')
+    expect(computeDirectionStroke(stated('negative'), ABSENT, false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(stated('negative'), ABSENT, true)).toBe('var(--edge-neutral-dark)')
+  })
+
+  // ── The DIRECTION provenance gate (ROADMAP 2.928 member b) ───────────────
+  // A SET strength is deliberate in all three: it isolates the direction gate.
+  // With the strength unset every case would be grey for the other reason, and
+  // the test would pass while proving nothing about direction at all.
+
+  it('unstated direction (the UI default) → grey, even with a set strength', () => {
+    expect(computeDirectionStroke(DIR_NOT_SET, set(0.6), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(DIR_NOT_SET, set(0.6), false)).not.toBe('var(--edge-positive)')
+  })
+
+  it('producer EXPLICITLY declined (effect_direction: "unknown") → grey, not green', () => {
+    expect(computeDirectionStroke(DIR_UNKNOWN, set(0.6), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(DIR_UNKNOWN, set(0.6), false)).not.toBe('var(--edge-positive)')
+  })
+
+  it('no direction at all → grey, with a set strength and in dark mode', () => {
+    expect(computeDirectionStroke(DIR_ABSENT, set(0.6), false)).toBe('var(--edge-neutral)')
+    expect(computeDirectionStroke(DIR_ABSENT, set(0.6), true)).toBe('var(--edge-neutral-dark)')
+  })
+
+  it('the direction gate DISCRIMINATES: the same strength stated is green', () => {
+    // The positive control for the three cases above. Without it they would all
+    // pass against a function that returned neutral unconditionally.
+    expect(computeDirectionStroke(stated('positive'), set(0.6), false)).toBe('var(--edge-positive)')
   })
 
   // Dark mode variants
   it('E1: dark mode positive → dark green', () => {
-    expect(computeDirectionStroke('positive', set(0.5), true)).toBe('var(--edge-positive-dark)')
+    expect(computeDirectionStroke(stated('positive'), set(0.5), true)).toBe('var(--edge-positive-dark)')
   })
 
   it('E1: dark mode negative → rose #F06595 (distinct from the dark risk border #FF6B6B)', () => {
-    expect(computeDirectionStroke('negative', set(0.5), true)).toBe('var(--edge-negative-dark)')
-    expect(computeDirectionStroke('negative', set(0.5), true)).not.toBe('#FF6B6B')
+    expect(computeDirectionStroke(stated('negative'), set(0.5), true)).toBe('var(--edge-negative-dark)')
+    expect(computeDirectionStroke(stated('negative'), set(0.5), true)).not.toBe('#FF6B6B')
   })
 
   it('dark mode: neutral → zinc-400', () => {
-    expect(computeDirectionStroke('positive', set(0), true)).toBe('var(--edge-neutral-dark)')
+    expect(computeDirectionStroke(stated('positive'), set(0), true)).toBe('var(--edge-neutral-dark)')
   })
 })

--- a/src/canvas/edges/directionStroke.ts
+++ b/src/canvas/edges/directionStroke.ts
@@ -1,4 +1,4 @@
-import type { EdgeValueDisplay } from '../domain/edgeValueProvenance'
+import type { EdgeDirectionDisplay, EdgeValueDisplay } from '../domain/edgeValueProvenance'
 
 /**
  * directionStroke — the single source of truth for a causal edge's polarity
@@ -62,26 +62,56 @@ import type { EdgeValueDisplay } from '../domain/edgeValueProvenance'
  * we are entitled to make. Minting a new "unset" edge hue is a design-system
  * change and belongs to a design owner, not to this lane.
  */
+/**
+ * ⛔⛔ THE DIRECTION IS PROVENANCE-GATED TOO (ROADMAP 2.928 member b).
+ * ------------------------------------------------------------------
+ * This used to take a raw `direction: 'positive' | 'negative' | undefined`,
+ * read straight off `edgeData.direction` — the field `USER_EDGE_DEFAULTS`
+ * fabricates as `'positive'` with no source stamp, and that CEE ingestion
+ * writes as `'positive'` even when the producer sent `effect_direction:
+ * 'unknown'` (an explicit refusal, and a declared 0.30.0 contract member).
+ *
+ * ROADMAP 2.580 member 2 fixed the +/− GLYPH by routing it through
+ * `resolveEdgeDirectionDisplay` — and left this function on the raw field. So
+ * an edge whose direction nobody stated lost its glyph and KEPT ITS GREEN
+ * STROKE: the second cue withdrawn, the primary one still asserting. Read the
+ * header above — "the +/− glyph is the second cue; these hues are the primary"
+ * — and note that for a red-green dichromat the glyph was the RELIABLE channel.
+ * Removing it while the hue kept claiming was worse than either half alone.
+ *
+ * Taking an `EdgeDirectionDisplay` is the same fix the strength parameter
+ * already carries: there is no argument that means "'positive', source
+ * unknown", so the defaulted case cannot be passed by accident and cannot be
+ * forgotten. Drift between the glyph and the stroke is now a TYPE error rather
+ * than a silent repaint.
+ *
+ * ⚠ WHY THIS IS NOT SIMPLY THE GLYPH'S RULE. The two channels answer different
+ * questions and must not be collapsed (CLAUDE.md trap 21). The glyph asks "did
+ * anyone STATE a direction?". The stroke asks that AND "did anyone SET a
+ * strength?", because grey is already this module's no-verdict colour for an
+ * unset strength. A stated direction over an unset strength therefore draws a
+ * glyph on a grey line — correct, not drift, and a guard asserting the two
+ * channels always agree would be wrong. See the spec's fixture table.
+ */
 export function computeDirectionStroke(
-  direction: 'positive' | 'negative' | undefined,
+  direction: EdgeDirectionDisplay,
   strength: EdgeValueDisplay,
   isDark: boolean,
 ): string {
   const neutral = isDark ? 'var(--edge-neutral-dark)' : 'var(--edge-neutral)'
-  // Nobody set this strength → no verdict. Must come FIRST: a defaulted
-  // `direction: 'positive'` would otherwise paint it green below.
+  // Nobody set this strength → no verdict.
   if (!strength.show) return neutral
+  // Nobody STATED this direction — defaulted, absent, explicitly declined, or
+  // an unrecognised value that failed closed. The resolver owns that answer and
+  // this function does not re-derive it.
+  if (!direction.show) return neutral
   const weight = Math.abs(strength.value)
-  // Weight defined but direction not yet set → grey (not yellow)
-  if (direction === undefined) return neutral
-  // Direction set with positive weight → green
-  if (direction === 'positive' && weight > 0) {
+  // Neutral: weight === 0 (a valid user choice, not a missing value)
+  if (weight === 0) return neutral
+  // Direction stated with positive weight → green
+  if (direction.direction === 'positive') {
     return isDark ? 'var(--edge-positive-dark)' : 'var(--edge-positive)'
   }
-  // Direction set with negative weight → rose (E1: distinct from amber warning)
-  if (direction === 'negative' && weight > 0) {
-    return isDark ? 'var(--edge-negative-dark)' : 'var(--edge-negative)'
-  }
-  // Neutral: weight === 0 (valid user choice)
-  return neutral
+  // Direction stated with negative weight → rose (E1: distinct from amber warning)
+  return isDark ? 'var(--edge-negative-dark)' : 'var(--edge-negative)'
 }

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -274,15 +274,45 @@ export function WinGauge({
   // (CLAUDE.md trap 12). So the readouts are built ONCE, here, and both
   // consumers read this array. There is no second call to the formatter.
   //
+  // ⭐⭐ ROADMAP 2.928 member (c) — AND THE ARM IS THE ONE THE DATA SUPPORTS.
+  //
+  // This passed a literal `null` as the sample count, which takes
+  // `formatProbabilityWithResolution`'s FALLBACK arm: `Math.round(v * 100)`.
+  // On a real staging run that printed **"100%"** in the legend for
+  // `win_probability = 0.9995` while the option card immediately below printed
+  // **"99.95%"** — one number, two claims, one screen, and the legend's is a
+  // certainty the simulation never measured. The bottom of the scale split the
+  // same way: "< 1%" here against "0.1%" on the card.
+  //
+  // The legend did NOT lack a sample count. `OptionWinShare.nValidSamples` has
+  // been declared since ROADMAP 2.334, `ResultsBody` populates it from the SAME
+  // `OptionResult.nValidSamples` the card reads, and the goal block twenty
+  // lines below already uses it. The count was in scope and simply unused — so
+  // the honest arm is the resolution arm, and the fix is to take it. Making the
+  // CARD drop to the rounding arm instead would delete a measurement this run
+  // supports and would spread the "100%" over-claim rather than remove it.
+  //
+  // EVERY comparative consumer reads `readoutById` below. The stacked segment's
+  // `aria-label` used to be a SECOND call to the formatter — which is how the
+  // screen-reader channel came to speak "100%" over a legend printing "99.95%".
+  // There is now exactly one evaluation per option, so the two cannot differ.
+  const comparativeEntries = sorted.map((share) => {
+    const clamped = Math.max(0, Math.min(1, share.winProbability))
+    return {
+      share,
+      clamped,
+      displayReadout: formatProbabilityWithResolution(clamped, share.nValidSamples),
+    }
+  })
+
+  /** The one comparative string per option, keyed by id. Total over `sorted`. */
+  const readoutById: Record<string, string> = {}
+  for (const entry of comparativeEntries) readoutById[entry.share.id] = entry.displayReadout
+
   // The `clamped <= 0` skip is the ROADMAP 2.236 rule, moved but unchanged: a
   // genuine zero is omitted from the legend, and it contributes zero to the
   // total, so omitting it cannot move the note's arithmetic.
-  const legendEntries = sorted
-    .map((share) => {
-      const clamped = Math.max(0, Math.min(1, share.winProbability))
-      return { share, clamped, displayReadout: formatProbabilityWithResolution(clamped, null) }
-    })
-    .filter(({ clamped }) => clamped > 0)
+  const legendEntries = comparativeEntries.filter(({ clamped }) => clamped > 0)
 
   const roundingNote = deriveOddsRoundingNote(legendEntries.map(e => e.displayReadout))
 
@@ -467,8 +497,12 @@ export function WinGauge({
                 role="img"
                 // ROADMAP 2.236: a segment that IS drawn is labelled with the
                 // shared floored readout, so the screen reader hears what the
-                // legend below prints.
-                aria-label={`${stripEncodingNotation(share.label)}: ${formatProbabilityWithResolution(clamped, null)}`}
+                // legend below prints. ⭐ 2.928 (c): it now READS that readout
+                // instead of recomputing it — this line was the second
+                // evaluation, and it is why the spoken and printed values
+                // disagreed. `readoutById` is total over `sorted`, so a drawn
+                // segment always has one.
+                aria-label={`${stripEncodingNotation(share.label)}: ${readoutById[share.id]}`}
               />
             )
           })}
@@ -483,7 +517,10 @@ export function WinGauge({
                 aria-hidden="true"
               />
               <span className="truncate max-w-[120px]">{stripEncodingNotation(share.label)}</span>
-              <span className="tabular-nums">{displayReadout}</span>
+              {/* ⭐ 2.928 (c): identified so a parity guard can bind this
+                  readout to ITS OWN option rather than to a value another
+                  option could also render (CLAUDE.md trap 19). */}
+              <span className="tabular-nums" data-testid={`legend-pct-${share.id}`}>{displayReadout}</span>
             </span>
           ))}
         </div>

--- a/src/components/results/__tests__/formatterArmParity.2928.spec.tsx
+++ b/src/components/results/__tests__/formatterArmParity.2928.spec.tsx
@@ -1,0 +1,207 @@
+/**
+ * ROADMAP 2.928 member (c) — ONE FORMATTER ARM PER SCREEN.
+ *
+ * THE DEFECT, AS SEEN BY A USER
+ * -----------------------------
+ * `win_probability = 0.9995` rendered **"100%"** in the WinGauge legend and
+ * **"99.95%"** on the option card directly beneath it — two different claims
+ * about ONE number, both on screen at once, one of them asserting a certainty
+ * the simulation never measured.
+ *
+ * WHY, AT THE BYTES. `formatProbabilityWithResolution` has two arms:
+ *   · `nSamples` present  → the resolution ladder; 0.9995 → "99.95%"
+ *   · `nSamples` null     → `formatPercent(v, {fromDecimal:true})`, i.e.
+ *                           `Math.round(99.95)` → "100%"
+ * The option card passed `option.nValidSamples`; the gauge passed a literal
+ * `null` at BOTH its comparative call sites (the legend readout and the stacked
+ * segment's `aria-label`).
+ *
+ * WHICH CLAIM IS HONEST — DERIVED, NOT CHOSEN
+ * -------------------------------------------
+ * The legend does not "genuinely lack" a sample count. `OptionWinShare` already
+ * declares `nValidSamples` (ROADMAP 2.334, added so the GOAL rows could resolve),
+ * `ResultsBody` already populates it from the SAME `OptionResult.nValidSamples`
+ * the card reads, and the goal block one block above already uses it. The count
+ * was in the props, in scope, one identifier away — the comparative call sites
+ * simply never took it.
+ *
+ * So the honest arm is the resolution arm, and the fix is to take it at every
+ * comparative call site in the gauge. The alternative (make the card drop to
+ * the rounding arm) would DELETE a measurement the run actually supports and
+ * would reintroduce the "100%" over-claim on the card too.
+ *
+ * THE FIXTURE DISCRIMINATES — AND SAYS SO IN-TEST
+ * ----------------------------------------------
+ * 0.9995 at n=10000 is chosen because the two arms DISAGREE there (the #623
+ * lane's 0.995 pattern). A parity assertion on a value where both arms return
+ * the same string is a guard agreeing with itself (CLAUDE.md trap 13b), and it
+ * would stay green with the defect fully restored. The first test therefore
+ * PINS ITS OWN PRECONDITION: it asserts the arms disagree on this exact input
+ * before any parity claim is made, so a later change that flattens the ladder
+ * cannot silently hollow the rest of this file out.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { WinGauge } from '../WinGauge'
+import { OptionCards } from '../OptionCards'
+import { formatProbabilityWithResolution } from '../../../utils/formatPercent'
+import type { OptionResult } from '../types'
+
+/** The run under test: one near-certain leader, one near-zero challenger. */
+const N_VALID_SAMPLES = 10000
+const LEADER_WIN = 0.9995
+const CHALLENGER_WIN = 0.0005
+
+const LEADER: OptionResult = {
+  id: 'opt-leader',
+  label: 'Leader',
+  expected: 50,
+  outcome: { mean: 50, p10: 20, p50: 50, p90: 80 },
+  p10: 20,
+  p50: 50,
+  p90: 80,
+  isRecommended: true,
+  winProbability: LEADER_WIN,
+  nValidSamples: N_VALID_SAMPLES,
+  rank: 1,
+}
+
+const CHALLENGER: OptionResult = {
+  ...LEADER,
+  id: 'opt-challenger',
+  label: 'Challenger',
+  isRecommended: false,
+  winProbability: CHALLENGER_WIN,
+  rank: 2,
+}
+
+const SHARES = [LEADER, CHALLENGER].map((o) => ({
+  id: o.id,
+  label: o.label,
+  winProbability: o.winProbability as number,
+  isWinner: o.isRecommended === true,
+  nValidSamples: o.nValidSamples,
+}))
+
+/**
+ * The stacked segment's accessible name, bound to its option by that option's
+ * own label — never by the value under test, which another segment could match.
+ */
+function segmentAriaFor(container: HTMLElement, label: string): string {
+  const seg = container.querySelector(`[role="img"][aria-label^="${label}: "]`)
+  expect(seg, `no stacked segment for "${label}"`).not.toBeNull()
+  return seg!.getAttribute('aria-label')!.slice(`${label}: `.length)
+}
+
+describe('ROADMAP 2.928 (c) — the fixture actually discriminates the two arms', () => {
+  it('0.9995 renders DIFFERENTLY on the two arms, so parity below is not vacuous', () => {
+    const roundingArm = formatProbabilityWithResolution(LEADER_WIN, null)
+    const resolutionArm = formatProbabilityWithResolution(LEADER_WIN, N_VALID_SAMPLES)
+
+    // Named, so a change to either arm fails HERE with the reason, rather than
+    // quietly turning every parity test below into a tautology.
+    expect(roundingArm).toBe('100%')
+    expect(resolutionArm).toBe('99.95%')
+    expect(roundingArm).not.toBe(resolutionArm)
+  })
+
+  it('the rounding arm is the one that over-claims: it says 100% of a value below 1', () => {
+    expect(LEADER_WIN).toBeLessThan(1)
+    expect(formatProbabilityWithResolution(LEADER_WIN, null)).toBe('100%')
+  })
+})
+
+describe('ROADMAP 2.928 (c) — WinGauge and OptionCards state the SAME string', () => {
+  it('the legend readout equals the option card readout for the same option', () => {
+    const gauge = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    const cards = render(<OptionCards options={[LEADER, CHALLENGER]} winnerId={LEADER.id} />)
+
+    const legend = within(gauge.container).getByTestId(`legend-pct-${LEADER.id}`).textContent
+    const card = within(cards.container).getByTestId(`win-pct-${LEADER.id}`).textContent
+
+    expect(legend).toBe(card)
+    expect(legend).toBe('99.95%')
+  })
+
+  it('the legend does not claim 100% for the near-certain leader', () => {
+    const { container } = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    const legend = within(container).getByTestId(`legend-pct-${LEADER.id}`).textContent
+    expect(legend).not.toBe('100%')
+  })
+
+  it('the challenger row takes the same arm too (below-resolution, not floored)', () => {
+    const gauge = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    const cards = render(<OptionCards options={[LEADER, CHALLENGER]} winnerId={LEADER.id} />)
+
+    const legend = within(gauge.container).getByTestId(`legend-pct-${CHALLENGER.id}`).textContent
+    const card = within(cards.container).getByTestId(`win-pct-${CHALLENGER.id}`).textContent
+
+    expect(legend).toBe(card)
+    // The resolution ladder's smallest non-collapsing precision for 0.0005.
+    // At pristine the legend said "< 1%" here while the card said "0.1%" —
+    // the same split as the leader row, at the other end of the scale.
+    expect(legend).toBe('0.1%')
+  })
+})
+
+describe('ROADMAP 2.928 (c) — the screen-reader channel takes the same arm', () => {
+  it('the stacked segment aria-label states the legend string, not a second evaluation', () => {
+    const { container } = render(<WinGauge shares={SHARES} decisionState="robust" />)
+
+    const aria = segmentAriaFor(container, 'Leader')
+    const legend = within(container).getByTestId(`legend-pct-${LEADER.id}`).textContent
+
+    // The sighted and the screen-reader channel must not disagree about a
+    // probability. Before this row they did: "100%" spoken, "99.95%" printed.
+    expect(aria).toBe(legend)
+    expect(aria).toBe('99.95%')
+  })
+
+  it('the segment aria-label equals the option card readout', () => {
+    const gauge = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    const cards = render(<OptionCards options={[LEADER, CHALLENGER]} winnerId={LEADER.id} />)
+
+    expect(segmentAriaFor(gauge.container, 'Leader')).toBe(
+      within(cards.container).getByTestId(`win-pct-${LEADER.id}`).textContent,
+    )
+  })
+})
+
+describe('ROADMAP 2.928 (c) — the fallback arm is preserved where the count is genuinely absent', () => {
+  it('a run with no nValidSamples still renders the legacy rounding on both surfaces', () => {
+    const noCount = SHARES.map((s) => ({ ...s, nValidSamples: null, winProbability: 0.65 }))
+    const { container } = render(<WinGauge shares={noCount} decisionState="robust" />)
+
+    // 0.65 is unambiguous on either arm; the point of this case is that a
+    // missing count does not throw and does not invent a resolution.
+    expect(within(container).getByTestId(`legend-pct-${LEADER.id}`).textContent).toBe('65%')
+  })
+
+  it('the rounding note still renders when every readout is a whole percent', () => {
+    const wholes = [
+      { ...SHARES[0], winProbability: 0.333, nValidSamples: N_VALID_SAMPLES },
+      { ...SHARES[1], winProbability: 0.333, nValidSamples: N_VALID_SAMPLES },
+    ]
+    const { container } = render(<WinGauge shares={wholes} decisionState="robust" />)
+    // 33% + 33% = 66% ≠ 100 ⇒ the note is derivable and must still appear.
+    expect(within(container).getByTestId('option-odds-rounding-note')).toBeInTheDocument()
+  })
+
+  it('the rounding note stands down when the resolution ladder emits decimals', () => {
+    const { container } = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    // "99.95%" carries decimals ⇒ `deriveOddsRoundingNote` returns null by
+    // design (no whole-percent total is derivable). Fail-closed, unchanged.
+    expect(within(container).queryByTestId('option-odds-rounding-note')).toBeNull()
+  })
+})
+
+describe('ROADMAP 2.928 (c) — mount-path pin', () => {
+  it('the legend readout comes from the comparative block, not some other surface', () => {
+    const { container } = render(<WinGauge shares={SHARES} decisionState="robust" />)
+    const block = screen.getByTestId('win-gauge-comparative-block')
+    // Binds the guard to the MOUNT PATH: if the legend moves out of the
+    // comparative block, this fails loud rather than passing on a stray node.
+    expect(block.contains(within(container).getByTestId(`legend-pct-${LEADER.id}`))).toBe(true)
+  })
+})

--- a/src/components/results/constants.ts
+++ b/src/components/results/constants.ts
@@ -5,17 +5,28 @@
  * Phase 3 Bug Fixes: Threshold and label constants.
  */
 
+import { ROBUSTNESS_BADGE_LABELS } from '../../lib/stability'
+
 // =============================================================================
 // Robustness Level Configuration
 // =============================================================================
 
-/** Robustness level labels for display */
+/**
+ * Robustness level labels for display.
+ *
+ * ⭐ ROADMAP 2.928 member (d) — DERIVED from the one register in
+ * `lib/stability.ts`, not re-typed here. This map, `ROBUSTNESS_LEVEL_DISPLAY`
+ * and `getStabilityClassification().badgeLabel` were three hand-maintained
+ * copies of four words; they happened to agree, which is exactly how that
+ * defect class stays invisible until it doesn't (CLAUDE.md trap 12).
+ * `medium` stays as the legacy alias of `moderate`, derived from the same entry.
+ */
 export const ROBUSTNESS_LEVEL_LABELS = {
-  high: 'Robust',
-  medium: 'Moderate',
-  moderate: 'Moderate',
-  low: 'Sensitive',
-  very_low: 'Highly sensitive',
+  high: ROBUSTNESS_BADGE_LABELS.high,
+  medium: ROBUSTNESS_BADGE_LABELS.moderate,
+  moderate: ROBUSTNESS_BADGE_LABELS.moderate,
+  low: ROBUSTNESS_BADGE_LABELS.low,
+  very_low: ROBUSTNESS_BADGE_LABELS.very_low,
 } as const
 
 /** Robustness level colors for badges */

--- a/src/lib/__tests__/robustnessBadgeRegister.2928.spec.ts
+++ b/src/lib/__tests__/robustnessBadgeRegister.2928.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * ROADMAP 2.928 member (d) — ONE ROBUSTNESS BADGE REGISTER, DERIVED.
+ *
+ * THE STATE THIS REPLACES
+ * -----------------------
+ * The same four badge words lived, hand-copied, in THREE places:
+ *   · `lib/stability.ts`               `getStabilityClassification().badgeLabel`
+ *   · `lib/mappers/constants.ts`       `ROBUSTNESS_LEVEL_DISPLAY[*].label`
+ *   · `components/results/constants.ts` `ROBUSTNESS_LEVEL_LABELS`
+ * `stability.spec.ts` even names the other two in a comment explaining that
+ * ROADMAP 2.580 member 3 deliberately did not touch them. That comment is the
+ * tell: a register whose copies have to be remembered is CLAUDE.md trap 12 —
+ * the hand-maintained mirror — and it drifts silently, in the direction that
+ * always reads green.
+ *
+ * They agreed at `b9b1374e`. That is the point: this row is not repairing a
+ * live divergence, it is removing the mechanism that produces one.
+ *
+ * WHAT THIS FILE GUARDS, AND WHY IT IS TWO KINDS OF GUARD (trap 12d)
+ * -----------------------------------------------------------------
+ * Deriving the siblings from one canonical map proves the copies AGREE. It can
+ * never prove the canonical is COMPLETE — a level missing from the map is
+ * invisible to every derived guard, exactly as `thousand` was invisible to the
+ * magnitude-alphabet guards. So this file ships both:
+ *
+ *   1. AGREEMENT — iterate the canonical map; every sibling must resolve
+ *      identically for every key. Adding a level extends this automatically.
+ *   2. COMPLETENESS — derived from `getStabilityClassification`'s OWN
+ *      behaviour, by sweeping its numeric domain and collecting the levels it
+ *      actually emits. That set comes from the classifier, NOT from the map, so
+ *      a level the map forgot fails here rather than passing everywhere.
+ *
+ * The type system carries a third: the canonical map is typed
+ * `Record<RobustnessLevel, string>`, so a new union member with no label is a
+ * compile error in the named typecheck gate, not a runtime surprise.
+ *
+ * ⚠ SCOPE, STATED SO IT IS NOT OVER-READ. This row makes the register SINGLE.
+ * It does NOT re-adjudicate the WORDS. Whether "Robust" still over-claims now
+ * that ROADMAP 2.580 member 3 scoped the hero family to the RANKING is a copy
+ * ruling with a real argument on both sides, and it is rowed in the PR body —
+ * not taken silently by a lane whose brief was the duplication.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ROBUSTNESS_BADGE_LABELS,
+  getStabilityClassification,
+} from '../stability'
+import { ROBUSTNESS_LEVEL_DISPLAY } from '../mappers/constants'
+import { ROBUSTNESS_LEVEL_LABELS } from '../../components/results/constants'
+import type { RobustnessLevel } from '../mappers/types'
+
+/** The canonical keys, derived from the map itself — never hand-listed. */
+const CANONICAL_LEVELS = Object.keys(ROBUSTNESS_BADGE_LABELS) as RobustnessLevel[]
+
+/**
+ * The levels `getStabilityClassification` can actually emit, derived by
+ * sweeping its numeric domain. This is the COMPLETENESS oracle and it is
+ * deliberately independent of `ROBUSTNESS_BADGE_LABELS`: a level the map
+ * forgot shows up here as a key with no label.
+ */
+function levelsTheClassifierEmits(): Set<string> {
+  const seen = new Set<string>()
+  for (let v = 0; v <= 1.0001; v += 0.001) {
+    const c = getStabilityClassification(Math.min(v, 1))
+    if (c) seen.add(c.level)
+  }
+  return seen
+}
+
+describe('ROADMAP 2.928 (d) — agreement: every sibling map derives from the canonical', () => {
+  it('the canonical register is non-empty (the iteration below is not vacuous)', () => {
+    expect(CANONICAL_LEVELS.length).toBeGreaterThan(0)
+    for (const level of CANONICAL_LEVELS) {
+      expect(typeof ROBUSTNESS_BADGE_LABELS[level]).toBe('string')
+      expect(ROBUSTNESS_BADGE_LABELS[level].length).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(CANONICAL_LEVELS.map((level) => ({ level })))(
+    'ROBUSTNESS_LEVEL_DISPLAY.$level.label matches the canonical',
+    ({ level }) => {
+      expect(ROBUSTNESS_LEVEL_DISPLAY[level].label).toBe(ROBUSTNESS_BADGE_LABELS[level])
+    },
+  )
+
+  it.each(CANONICAL_LEVELS.map((level) => ({ level })))(
+    'ROBUSTNESS_LEVEL_LABELS.$level matches the canonical',
+    ({ level }) => {
+      expect(ROBUSTNESS_LEVEL_LABELS[level]).toBe(ROBUSTNESS_BADGE_LABELS[level])
+    },
+  )
+
+  it('getStabilityClassification().badgeLabel matches the canonical at every level', () => {
+    // Bound to the level the classifier itself reports — never to a numeric
+    // threshold this spec re-derives, which would be a second mirror.
+    for (let v = 0; v <= 1.0001; v += 0.001) {
+      const c = getStabilityClassification(Math.min(v, 1))
+      if (!c) continue
+      expect(c.badgeLabel).toBe(ROBUSTNESS_BADGE_LABELS[c.level])
+    }
+  })
+})
+
+describe('ROADMAP 2.928 (d) — completeness: the canonical covers every emitted level', () => {
+  it('every level the classifier emits has a canonical label', () => {
+    const emitted = levelsTheClassifierEmits()
+    expect(emitted.size).toBeGreaterThan(1) // the sweep discriminates
+    for (const level of emitted) {
+      expect(
+        Object.prototype.hasOwnProperty.call(ROBUSTNESS_BADGE_LABELS, level),
+        `no canonical badge label for emitted level "${level}"`,
+      ).toBe(true)
+    }
+  })
+
+  it('every key of every sibling map resolves through the canonical', () => {
+    // The UNION assertion (trap 12d). A sibling carrying a key the canonical
+    // does not know is a hand-written entry that escaped the derivation — the
+    // one thing a derived guard is structurally blind to.
+    const siblingKeys = new Set<string>([
+      ...Object.keys(ROBUSTNESS_LEVEL_DISPLAY),
+      ...Object.keys(ROBUSTNESS_LEVEL_LABELS),
+    ])
+    expect(siblingKeys.size).toBeGreaterThan(0)
+
+    const canonical = new Set<string>(CANONICAL_LEVELS)
+    // `medium` is a DECLARED alias of `moderate` carried by both display maps
+    // for legacy producer values. It is derived from the canonical too, so it
+    // is named here rather than silently tolerated.
+    const ALIASES: Record<string, RobustnessLevel> = { medium: 'moderate' }
+
+    for (const key of siblingKeys) {
+      const resolved = canonical.has(key) ? key : ALIASES[key]
+      expect(resolved, `sibling key "${key}" resolves to nothing canonical`).toBeDefined()
+      const expected = ROBUSTNESS_BADGE_LABELS[resolved as RobustnessLevel]
+      if (key in ROBUSTNESS_LEVEL_DISPLAY) {
+        expect(ROBUSTNESS_LEVEL_DISPLAY[key].label).toBe(expected)
+      }
+      if (key in ROBUSTNESS_LEVEL_LABELS) {
+        expect(ROBUSTNESS_LEVEL_LABELS[key as keyof typeof ROBUSTNESS_LEVEL_LABELS]).toBe(expected)
+      }
+    }
+  })
+
+  it('the `medium` alias states the same word as `moderate`, on both maps', () => {
+    expect(ROBUSTNESS_LEVEL_DISPLAY.medium.label).toBe(ROBUSTNESS_BADGE_LABELS.moderate)
+    expect(ROBUSTNESS_LEVEL_LABELS.medium).toBe(ROBUSTNESS_BADGE_LABELS.moderate)
+  })
+})
+
+describe('ROADMAP 2.928 (d) — what this guard can and cannot prove', () => {
+  /**
+   * ⚠ STATED PLAINLY SO NOBODY READS MORE INTO THIS FILE THAN IT PROVES.
+   *
+   * These are VALUE assertions. Two identical string literals are `toBe`-equal,
+   * so no test here can tell "derived from the canonical" apart from "re-typed
+   * and currently identical". A guard that claimed otherwise would be exactly
+   * the guarantee theatre this estate hunts.
+   *
+   * What makes the register SINGLE is the source: `ROBUSTNESS_LEVEL_DISPLAY`
+   * and `ROBUSTNESS_LEVEL_LABELS` reference `ROBUSTNESS_BADGE_LABELS.*` rather
+   * than literals. What this FILE does is narrower and still worth having —
+   * it REDs the moment anyone re-types one, because the re-typed copy has to
+   * differ to be worth typing, and it REDs on a level or alias that escapes the
+   * register entirely. Mutation evidence for both is in the PR body.
+   */
+  it('the sibling labels equal the canonical at every level', () => {
+    for (const level of CANONICAL_LEVELS) {
+      expect(ROBUSTNESS_LEVEL_DISPLAY[level].label).toBe(ROBUSTNESS_BADGE_LABELS[level])
+      expect(ROBUSTNESS_LEVEL_LABELS[level]).toBe(ROBUSTNESS_BADGE_LABELS[level])
+    }
+  })
+
+  it('the COLOUR channel stays local to its map and out of the shared register', () => {
+    // Colour is a per-surface display decision. Folding it into the shared
+    // register would give the register a second owner and a second reason to
+    // change — the way one-owner rules quietly become two.
+    expect(Object.keys(ROBUSTNESS_LEVEL_DISPLAY.high)).toContain('colour')
+    expect(Object.keys(ROBUSTNESS_BADGE_LABELS)).not.toContain('colour')
+    for (const level of CANONICAL_LEVELS) {
+      expect(typeof ROBUSTNESS_BADGE_LABELS[level]).toBe('string')
+    }
+  })
+})

--- a/src/lib/mappers/constants.ts
+++ b/src/lib/mappers/constants.ts
@@ -10,6 +10,10 @@
  * - Use COPY templates for user-facing messages ("assumptions" NOT "edges")
  */
 
+// The badge WORDS live in one place (ROADMAP 2.928 member d). `lib/stability.ts`
+// imports only a type from `./types`, so this import cannot cycle.
+import { ROBUSTNESS_BADGE_LABELS } from '../stability'
+
 // =============================================================================
 // Threshold Constants
 // =============================================================================
@@ -64,13 +68,22 @@ export interface RobustnessDisplayConfig {
 /**
  * Robustness level to display mapping.
  * CRITICAL: Badge MUST derive from robustness.level field, NOT from recommendation_stability.
+ *
+ * ⭐ ROADMAP 2.928 member (d) — THE LABELS ARE DERIVED, NOT COPIED. They used to
+ * be five string literals here, five more in `components/results/constants.ts`
+ * and four more in `lib/stability.ts`: one register, three hand-maintained
+ * mirrors (CLAUDE.md trap 12). The COLOUR stays local — it is a per-surface
+ * display decision and folding it into the shared register would give the
+ * register a second owner. `medium` remains a declared alias of `moderate` for
+ * legacy producer values, and now derives from the same entry, so the alias
+ * cannot drift from what it aliases either.
  */
 export const ROBUSTNESS_LEVEL_DISPLAY: Record<string, RobustnessDisplayConfig> = {
-  high: { label: 'Robust', colour: 'green' },
-  moderate: { label: 'Moderate', colour: 'amber' },
-  medium: { label: 'Moderate', colour: 'amber' }, // Alias for moderate
-  low: { label: 'Sensitive', colour: 'orange' },
-  very_low: { label: 'Highly sensitive', colour: 'red' },
+  high: { label: ROBUSTNESS_BADGE_LABELS.high, colour: 'green' },
+  moderate: { label: ROBUSTNESS_BADGE_LABELS.moderate, colour: 'amber' },
+  medium: { label: ROBUSTNESS_BADGE_LABELS.moderate, colour: 'amber' }, // Alias for moderate
+  low: { label: ROBUSTNESS_BADGE_LABELS.low, colour: 'orange' },
+  very_low: { label: ROBUSTNESS_BADGE_LABELS.very_low, colour: 'red' },
 } as const
 
 // =============================================================================

--- a/src/lib/stability.ts
+++ b/src/lib/stability.ts
@@ -37,6 +37,45 @@
 
 import type { RobustnessLevel } from './mappers/types'
 
+/**
+ * ⭐ THE ROBUSTNESS BADGE REGISTER — ONE MAP, EVERY SURFACE (ROADMAP 2.928 d).
+ * ═══════════════════════════════════════════════════════════════════════════
+ * These four words used to be hand-copied into THREE places:
+ *   · this file's `badgeLabel` arms,
+ *   · `lib/mappers/constants.ts`'s `ROBUSTNESS_LEVEL_DISPLAY[*].label`,
+ *   · `components/results/constants.ts`'s `ROBUSTNESS_LEVEL_LABELS`.
+ * `stability.spec.ts` even carried a comment naming the other two and noting
+ * that ROADMAP 2.580 member 3 had deliberately not touched them — which is the
+ * tell. A register a human must remember to sync is CLAUDE.md trap 12, the
+ * hand-maintained mirror, and it drifts in the direction that reads green.
+ *
+ * They all agreed at `b9b1374e`. This row does not repair a live divergence; it
+ * removes the mechanism that manufactures one. Both display maps now DERIVE
+ * from here, and `robustnessBadgeRegister.2928.spec.ts` carries the agreement
+ * guard, the union assertion over sibling keys, and a completeness check drawn
+ * from `getStabilityClassification`'s OWN emitted levels rather than from this
+ * map — because a derived guard can prove agreement and never completeness
+ * (trap 12d).
+ *
+ * The `Record<RobustnessLevel, string>` annotation is the third guard and the
+ * cheapest: a new union member with no label here is a COMPILE error in the
+ * named typecheck gate, not a runtime surprise on a user's screen.
+ *
+ * ⚠ THIS IS THE REGISTER, NOT A RULING ON THE WORDS. ROADMAP 2.580 member 3
+ * re-scoped the HERO family to the ranking ("Stable result" → "Stable
+ * ranking") because ISL measures the share of sampled scenarios in which the
+ * same option came out on top — a statement about the ORDER. Whether "Robust"
+ * carries the same over-claim on the badge is a live copy question, argued in
+ * the 2.928 PR body and rowed; it is not decided here, and changing a word here
+ * now changes it on every surface at once, which is exactly the point.
+ */
+export const ROBUSTNESS_BADGE_LABELS: Record<RobustnessLevel, string> = {
+  high: 'Robust',
+  moderate: 'Moderate',
+  low: 'Sensitive',
+  very_low: 'Highly sensitive',
+}
+
 export interface StabilityClassification {
   /** Categorical level matching ISL robustness.level enum */
   level: RobustnessLevel
@@ -71,7 +110,7 @@ export function getStabilityClassification(
   if (stability >= 0.85) {
     return {
       level: 'high',
-      badgeLabel: 'Robust',
+      badgeLabel: ROBUSTNESS_BADGE_LABELS.high,
       heroLabel: 'Stable ranking',
       heroShortText: 'Across sampled scenarios',
       heroExpandedText: 'The same option led in nearly every scenario we sampled. Individual estimates can still be off.',
@@ -84,7 +123,7 @@ export function getStabilityClassification(
   if (stability >= 0.70) {
     return {
       level: 'moderate',
-      badgeLabel: 'Moderate',
+      badgeLabel: ROBUSTNESS_BADGE_LABELS.moderate,
       heroLabel: 'Mostly stable ranking',
       heroShortText: 'In most sampled scenarios',
       heroExpandedText: 'The same option led in most of the scenarios we sampled.',
@@ -97,7 +136,7 @@ export function getStabilityClassification(
   if (stability >= 0.40) {
     return {
       level: 'low',
-      badgeLabel: 'Sensitive',
+      badgeLabel: ROBUSTNESS_BADGE_LABELS.low,
       heroLabel: 'Ranking sensitive to assumptions',
       heroShortText: 'Review key inputs',
       heroExpandedText: 'Which option leads changed across the scenarios we sampled. Review key inputs.',
@@ -109,7 +148,7 @@ export function getStabilityClassification(
 
   return {
     level: 'very_low',
-    badgeLabel: 'Highly sensitive',
+    badgeLabel: ROBUSTNESS_BADGE_LABELS.very_low,
     heroLabel: 'Ranking highly sensitive',
     heroShortText: 'Treat as directional',
     heroExpandedText: 'Which option leads changed often across the scenarios we sampled. Treat as directional.',


### PR DESCRIPTION
ROADMAP **2.928** — the #623 residuals. Four members, one seam, all UI. P5 / **DEPTH**.

Three are BUILT (c, b, d). One is **DESIGN-ONLY by brief** (a) and its proposal is at the bottom of this body — no code.

---

## (c) THE USER-VISIBLE ONE — WinGauge/OptionCards formatter-arm split

**The defect.** `win_probability = 0.9995` rendered **`100%`** in the WinGauge legend and **`99.95%`** on the option card directly beneath it. One number, two claims, one screen — and the legend's is a certainty the simulation never measured. The bottom of the scale split the same way: `0.0005` read **`< 1%`** in the legend against **`0.1%`** on the card.

**At the bytes.** `formatProbabilityWithResolution` has two arms:

| arm | 0.9995 → | 0.0005 → |
|---|---|---|
| `nSamples` present — the resolution ladder | `99.95%` | `0.1%` |
| `nSamples` null — `Math.round(v*100)` | `100%` | `< 1%` |

`OptionCards.tsx:637` passed `option.nValidSamples`. `WinGauge.tsx` passed a literal `null` at **both** comparative call sites: the legend readout (`:283`) and the stacked segment's `aria-label` (`:471`) — so the screen-reader channel spoke `100%` over a legend printing `99.95%` as well.

**Which arm is honest — DERIVED, not chosen.** The legend did **not** genuinely lack a sample count:

- `OptionWinShare.nValidSamples` has been declared since ROADMAP 2.334 (`WinGauge.tsx:74`);
- `ResultsBody.tsx:609` populates it from the **same** `OptionResult.nValidSamples` the card reads;
- the goal block twenty lines below already uses it (`WinGauge.tsx:348`).

The count was in the props and in scope. So the resolution arm is the one the data supports, and both surfaces now take it. The alternative — dropping the CARD to the rounding arm — would delete a measurement the run supports and would spread the `100%` over-claim rather than remove it.

**Files.**
- `src/components/results/WinGauge.tsx:270-315` — one evaluation per option (`comparativeEntries` → `readoutById`), threading `share.nValidSamples`.
- `src/components/results/WinGauge.tsx:~500` — the segment `aria-label` now **reads** `readoutById[share.id]`; it used to be a second call to the formatter, which is *how* the two channels came to disagree.
- `src/components/results/WinGauge.tsx:~518` — `data-testid={legend-pct-<id>}` so a parity guard binds by identity, not by a value another option could render (trap 19).

**The fixture discriminates, and says so in-test.** 0.9995 at n=10000 is chosen because the two arms **disagree** there (the #623 lane's 0.995 pattern). The first test in the file PINS ITS OWN PRECONDITION — it asserts `roundingArm === '100%'`, `resolutionArm === '99.95%'`, `roundingArm !== resolutionArm` — before any parity claim is made, so flattening the ladder later cannot silently hollow the file out (trap 13b).

**The rounding note is unaffected and correct.** `deriveOddsRoundingNote` fails closed on decimals by design, so on this run it stands down (no whole-percent total is derivable) and on an ordinary run (`33%`/`33%`) it still renders. Both pinned.

**Not done, deliberately:** `formatProbabilityWithResolution`'s **fallback arm has a floor but no ceiling** — `0.9995 → '100%'` where `0.002675 → '< 1%'`. That asymmetry is the same defect class as UI-SEM-057, mirrored at the top of the scale, and it is still live at five call sites that pass `null` (`SuccessTargetRow.tsx:76,192`, `OptionCards.tsx:969`, `V7Hero.tsx:74,99`, `buildV7Headline.ts:212`). Closing it is a separate change with a different blast radius — **rowed, see Residuals.**

---

## (b) THE STROKE HALF-FIX

**The state #623 left.** ROADMAP 2.580 member 2 routed the polarity **glyph** through `resolveEdgeDirectionDisplay` (2.263, "ONE OWNER. This resolver is it.") and left `computeDirectionStroke` on the raw `edgeData.direction`. Its own spec said so — *"this pins the GLYPH and its `aria-label` … The stroke COLOUR is a separate channel and is unchanged here; see the PR body for the rowed residual."* This is that residual.

So an edge whose direction nobody stated **lost its glyph and kept its green stroke**. `directionStroke.ts`'s own header calls the hues *"the primary"* cue and the glyph *"the second cue"* — and its CVD note records that for a red-green dichromat the glyph was the reliable channel. Withdrawing the second cue while the primary one keeps asserting is worse than either half alone.

**Reachability — derived from the writer manifest, not imagined.** The divergence needs `weight` STAMPED and `direction` NOT:

1. a user draws an edge (`USER_EDGE_DEFAULTS`: `direction: 'positive'`, unstamped) and then sets its strength in the inspector → `weightSource: 'user'`, direction still unstamped;
2. **the sharper one** — CEE sends `effect_direction: 'unknown'` (a declared 0.30.0 member: the producer *explicitly declining*) beside the ingestion-time `direction: 'positive'` collapse, with `weightSource: 'cee'`. The producer said "I will not tell you the direction" and the canvas painted it green.

**The fix is the TYPE, not the call site.** `computeDirectionStroke`'s first parameter is now `EdgeDirectionDisplay` — the same shape its `strength` parameter already carries. There is no argument that means *"'positive', source unknown"*, so the defaulted case is **not expressible** and drift between glyph and stroke is a compile error rather than a silent repaint.

- `src/canvas/edges/directionStroke.ts:65-118` — new signature + gate.
- `src/canvas/edges/StyledEdge.tsx:~295` — passes `directionDisplay`, the same value the glyph reads.
- `src/canvas/edges/StyledEdge.tsx:218` — the raw `const direction = edgeData?.direction` read is **deleted**; it had no remaining on-screen reader, and leaving it is an invitation to wire a third channel to the fabricated default. Outbound adapters and persistence still read `edge.data.direction` from the store — ingestion and the wire are untouched.

**⚠ A BICONDITIONAL WOULD HAVE BEEN WRONG, AND THE SPEC CAUGHT IT.** The brief asked to *"assert glyph and stroke derive from the SAME resolved value"*. Written as `glyph ⟺ polarityStroke`, that **failed** — on a fixture with a *stated* direction and an *unset* strength, the glyph renders over a grey line. That is correct, not drift: the two channels answer **different questions** (trap 21) —

- **glyph:** *did anyone STATE a direction?*
- **stroke:** *that, AND did anyone SET a strength?* — grey is already this module's no-verdict colour for an unset strength.

So the spec asserts the two binding claims instead, both derived per fixture from the two owning resolvers:

1. **safety** — `strokeIsPolarity ⟹ glyphRendered` (the direction the defect ran in);
2. **agreement** — `strokeIsPolarity === (directionShown && strengthShown)`, exactly.

Plus a non-vacuity test asserting the 8-fixture table produces **both** outcomes on **both** channels *and* that the two genuinely diverge somewhere — so the "different questions" reading is measured, not asserted.

---

## (d) THE TWO `badgeLabel` MAPS

Four badge words, hand-copied into **three** places: `lib/stability.ts`'s `badgeLabel` arms, `lib/mappers/constants.ts`'s `ROBUSTNESS_LEVEL_DISPLAY[*].label`, `components/results/constants.ts`'s `ROBUSTNESS_LEVEL_LABELS`. `stability.spec.ts:55-57` even names the other two in a comment explaining that 2.580 member 3 deliberately did not touch them — which is the tell.

They **all agreed at `b9b1374e`**. This is not repairing a live divergence; it removes the mechanism that manufactures one (trap 12).

- `src/lib/stability.ts:72-77` — `ROBUSTNESS_BADGE_LABELS`, typed `Record<RobustnessLevel, string>`, is the register. Both display maps and all four classifier arms derive from it. `medium` stays a declared alias of `moderate` and derives from the same entry, so the alias cannot drift from what it aliases.
- No cycle: `stability.ts` imports only a *type* from `./mappers/types`; both consumers are leaves.

**Three guards, because a derived guard proves agreement and never completeness (trap 12d):**

1. **Agreement** — iterate the canonical map; every sibling must resolve identically. Adding a level extends coverage with no list to update.
2. **Completeness** — derived from `getStabilityClassification`'s **own emitted levels**, by sweeping its numeric domain. That oracle comes from the classifier, *not* from the map, so a level the map forgot fails here rather than passing everywhere. Plus a **union assertion** over every sibling key.
3. **Types** — `Record<RobustnessLevel, string>` makes a new union member with no label a compile error in the named gate.

**What the spec does NOT claim, stated in the file:** these are value assertions, and two identical string literals are `toBe`-equal, so no test here can tell *"derived"* from *"re-typed and currently identical"*. What makes the register single is the source. What the file does is RED the moment anyone re-types one — proven by mutants D1–D5.

**Scope, deliberately not taken:** whether **"Robust"** still over-claims now that 2.580 member 3 re-scoped the hero family to the RANKING (`recommendation_stability` = "P(same recommendation across samples)", a statement about the ORDER) is a live copy question with an argument on both sides. It is a ruling, not a lane decision — **rowed, see Residuals.** The register change makes taking it later a one-line edit in one place, which is the point.

---

## (a) FACTOR-vs-EDGE DIRECTION GRAIN — DESIGN PROPOSAL, NO CODE

Per brief: design-only this lane; a build needs a live capture to size.

**Why this is not a bug to fix by aligning defaults.** The two surfaces answer different questions about different objects — trap 21, and the #623 lane already established it:

| | FACTOR direction | EDGE direction |
|---|---|---|
| source | `factor_sensitivity[].direction`, normalised by `lib/factorDirection.ts` | `edge.data.direction`, gated by `resolveEdgeDirectionDisplay` |
| producer domain | `positive \| negative \| mixed \| unknown \| null` | `positive \| negative \| unknown` + unstamped/absent |
| the claim | **net effect on the OUTCOME**, across every path in the graph | **stated polarity of ONE link**, single hop |
| rendered as | "increases the outcome" / "decreases the outcome" — `V7EvidenceDisclosure.tsx:254`, `HeroEvidenceDisclosure.tsx:117` | green `+` / rose `−` glyph + polarity stroke — `StyledEdge.tsx` |

A factor can raise its immediate neighbour and **lower the outcome overall** — through a second path, or through a negative edge downstream. When those two disagree the product is not inconsistent; it is telling the user something true and non-obvious. Aligning the defaults would delete that information and would re-create exactly the `#709`/`#737` failure: two authorities answering different questions under similar names.

**The proposal — name the concepts apart on screen.**

1. **Qualify the noun in both directions, everywhere.** Neither surface may use the bare word *"direction"*. Factor: **overall effect on the outcome**. Edge: **stated link polarity**. Internally the same split: `outcomeEffectDirection` vs `linkPolarity` — so a future reader cannot conflate them by grep, which is how the two `generateGraphHash` twins happened.
2. **Do not share a visual token.** The `+`/`−` glyph is the EDGE vocabulary and must never appear on a factor row; the factor row keeps sentence form ("raises the outcome overall" / "lowers the outcome overall"), which carries the "overall" scope in the words themselves.
3. **Say "overall" in the factor copy.** Today's string is *"increases the outcome"* — unscoped, and it reads as a claim about every path. The one-word fix is the cheapest half of this whole member.
4. **When both are visible and disagree, disclose the grain rather than reconcile it.** A single line naming the two scopes ("this link is stated as increasing; across all paths this factor lowers the outcome") turns the apparent contradiction into the insight it actually is.
5. **Neither side's absence may be filled from the other.** `factorDirection`'s rules 1-3 and `resolveEdgeDirectionDisplay`'s rules 1-3 already say this per-surface; the risk is a future "helpful" cross-fill.

**Why this is not built here, stated as a sizing blocker rather than a shrug.** The disagreement's reachability must be bounded by what the **producer** can emit (trap 16-inverse) — a fixture I write myself proves nothing about the wire. Sizing needs one live capture of a run where `factor_sensitivity[].direction` is `negative` (or `mixed`) on a factor whose edge to its neighbour carries a *stated* `positive`. That capture rides the next golden-journey walk.

---

## Evidence

**Base:** staging tip `b9b1374e03416e44403749c058c4607fb108b225`, asserted `HEAD ==` before any read. Fresh blobless clone at a unique `/private/tmp` path.

### RED-first (at pristine, before any source change)

| spec | result at pristine |
|---|---|
| `formatterArmParity.2928.spec.tsx` | **7 failed / 4 passed** — DOM dump shows the legend rendering `100%` and `< 1%` while the card renders `99.95%` / `0.1%`. Pure **value** RED: *"the segment aria-label equals the option card readout"*. |
| `StyledEdge.directionStrokeProvenance.2928.spec.tsx` | **4 failed / 12 passed**, all pure value: `expected 'var(--edge-positive)' to be 'var(--edge-neutral)'` ×2, and the two derived-invariant rows (`DEFAULTED direction`, `producer EXPLICITLY declined`). |
| `robustnessBadgeRegister.2928.spec.ts` | **file RED** — `TypeError: Cannot convert undefined or null to object` (no canonical export). Structural, not a value RED; stated plainly. |

*Honest note:* the legend assertions in (c) RED at pristine as **element-not-found** (the `legend-pct-*` testid ships with the fix). The **value** RED for (c) is carried by the segment `aria-label` assertions, which use a locator that already existed.

### GREEN after

`95/95` across the three new specs + the four they touch (`directionColour.spec.ts`, `unsetNonTextChannels.spec.tsx`, `StyledEdge.directionProvenance.spec.tsx`, `stability.spec.ts`).

### Mutants

Isolated clone at a unique `/private/tmp` path, **isolation proven by a SENTINEL WRITE** (trap 9g) — inodes compared (`stat -f %i`, all distinct) and a write into the mutant tree confirmed *not* to reach the lane clone's SHA-256. Mutations applied to **committed** state, restored by `git checkout`, applied-check scoped to `src/` asserting an exact count, control asserting **exactly zero**.

**Control (no mutation): `6 files / 86 tests passed`, exit 0.** Final control: tree restored clean, `applied-check == 0`.

| # | mutation | result |
|---|---|---|
| **C1** | legend back to the `null` (rounding) arm — *the exact defect* | **BITTEN** — 5 failed / 6 passed |
| **C2** | segment `aria-label` recomputes on the `null` arm | **BITTEN** — 2 failed / 9 passed |
| **C3** | legend loses its `data-testid` identity binding | **BITTEN** — 6 failed / 5 passed |
| **C4** | resolution ladder flattened to whole percents (*the vacuity attack — makes both arms agree*) | **BITTEN** — 5 failed / 6 passed |
| **B1** | `if (!direction.show) return neutral` deleted | **BITTEN** — 12 failed / 36 passed |
| **B2** | `if (!strength.show) return neutral` deleted (the other conjunct) | **BITTEN** — 4 failed / 44 passed |
| **B3** | call site re-reads the raw defaulted `direction` | **BITTEN** — 7 failed / 41 passed |
| **B4** | polarity hues swapped (does the table discriminate SIGN, or only presence?) | **BITTEN** — 10 failed / 38 passed |
| **B5** | `weight === 0` neutral arm deleted | **BITTEN** — 4 failed / 44 passed |
| **D1** | mappers map re-hardcodes `high` | **BITTEN** — 3 failed / 24 passed |
| **D2** | results map re-hardcodes `very_low` | **BITTEN** — 3 failed / 24 passed |
| **D3** | `medium` alias re-pointed at another level | **BITTEN** — 2 failed / 25 passed |
| **D4** | classifier arm re-hardcodes its badge | **BITTEN** — 4 failed / 23 passed |
| **D5** | a level DELETED from the canonical register — *the completeness attack; derivation is structurally blind to this, only the classifier-derived oracle and the union assertion can see it* | **BITTEN** — 3 failed / 22 passed |

**14/14 bitten.** C4 and D5 are the two that matter most: C4 attacks the fixture's discriminating power rather than the fix, and D5 attacks the one thing a derived guard cannot see.

### Gates (at this head)

- `pnpm run typecheck` — **PASSED**. 3302/3342 tracked files loaded; ratchet `617 files / 2487 errors` vs baseline 2491, **"none added"**. Drift had already shrunk under #623; baseline **deliberately not regenerated** (unchanged decision, no `--update-baseline`).
- `pnpm run lint` — **0 errors** (1258 pre-existing warnings). `lint:hooks-ratchet`: *232 known violations across 15 files, exactly matching the baseline* — relevant because this PR adds a `useMemo`.
- `pnpm exec vitest run` (full suite) — see below.

`pnpm exec vitest run` (the named gate command, unsharded locally):

```
Test Files  1561 passed | 3 skipped (1564)
      Tests  22652 passed | 66 skipped (22718)
VITEST_EXIT=0
```

Zero failures. Collected file count is healthy (no shrunk collect — `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were exported for every run in this lane).

---

## Residuals (new rows requested)

1. **The fallback arm's missing ceiling.** `formatProbabilityWithResolution(v, null)` floors the bottom (`'< 1%'`) and rounds the top to `'100%'` for any `v < 1`. Five live call sites pass `null`. Same defect class as UI-SEM-057, mirrored. Not fixed here: it changes copy on the V7 hero and headline, and deserves its own RED-first + review.
2. **The badge WORDS.** Does `"Robust"` over-claim now that the hero family is ranking-scoped? A copy ruling. One-line change in one place after this PR.
3. **(a) factor-vs-edge grain** — proposal above; blocked on one live capture.
4. **Pixel witness.** jsdom proves copy and values, never placement or colour *as rendered*. The `99.95%`/`100%` and the grey-vs-green stroke both want a real-browser confirmation on the next golden-journey walk. This PR is **TESTED**, not journey-witnessed.
