### PR TITLE
fix(2.932): persist goal constraints through reconcile + guest save (Codex MF2)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -1417,6 +1417,10 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         useCanvasStore.getState().hydrateGraphSlice({
           nodes: autosave.nodes,
           edges: autosave.edges,
+          // ROADMAP 2.932: restore the persisted hard constraints on a guest
+          // reload. `?? null` is load-bearing — an old autosave with no
+          // constraints key must CLEAR, not inherit the previous session's.
+          goalConstraints: autosave.goalConstraints ?? null,
         })
         // Scenario/thread continuity: preserve a UUID-format current-scenario ID across
         // the refresh so the in-flight CEE conversation keeps the same scenario_id. The

--- a/src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts
+++ b/src/canvas/__tests__/analysisSurvivesLeaveAndReturn.spec.ts
@@ -289,6 +289,7 @@ describe('a completed analysis survives leaving the canvas and returning', () =>
         computedAt: new Date().toISOString(),
         report: { summary: 'x' } as unknown as ReportV1,
       },
+      goalConstraints: null,
     })
     saveAutosave(data)
 

--- a/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.hashByDefault.spec.ts
@@ -94,6 +94,7 @@ describe('Codex P1-1 — hash-by-default persists previously-lost user fields', 
           // all-required contract.
           analysis: null,
           selectedGoalNode: null,
+          goalConstraints: null,
         })
         clearAutosave()
         saveAutosave(payload)

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -198,6 +198,9 @@ export function useAutosave() {
               // computeGraphHash(nodes, edges) and a completed analysis changes
               // neither, so it skips. `resultsComplete` does the real write.
               analysis: analysisSnapshotFromStore(useCanvasStore.getState()),
+              // ROADMAP 2.932: read at WRITE time from the store (like analysis
+              // above), so the periodic autosave carries the current constraints.
+              goalConstraints: useCanvasStore.getState().goalConstraints ?? null,
             },
             now,
           ),

--- a/src/canvas/persist/__tests__/autosaveProjectionParity.spec.tsx
+++ b/src/canvas/persist/__tests__/autosaveProjectionParity.spec.tsx
@@ -162,6 +162,11 @@ describe('projectAutosaveData — every source field reaches the payload', () =>
       resultsSource: 'conversation',
       report: { summary: 'parity' } as never,
     },
+    // ROADMAP 2.932 — a NON-EMPTY value so the "every field reaches the payload"
+    // loop below actually exercises the constraint projection (the projection
+    // omits an empty array, which would satisfy toBeDefined() while proving
+    // nothing).
+    goalConstraints: [{ constraint_id: 'c_parity', operator: '<=', value: 5000 }],
   }
 
   it('projects every field of a fully-populated source', () => {

--- a/src/canvas/persist/crashFlush.ts
+++ b/src/canvas/persist/crashFlush.ts
@@ -56,6 +56,13 @@ export interface CrashSnapshot {
    * boundary's "your work is auto-saved" promise now covers.
    */
   analysis: AutosaveData['analysis'] | undefined
+  /**
+   * The scenario's hard constraints (ROADMAP 2.932). Required for the same
+   * REPLACE reason: a crash flush that omitted it would strip the user's
+   * constraints out of the last good autosave. Flows straight through the
+   * `...snapshot` spread in flushWorkToAutosave.
+   */
+  goalConstraints: AutosaveData['goalConstraints'] | undefined
 }
 
 export type CrashSnapshotProvider = () => CrashSnapshot | null

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -48,6 +48,7 @@ import type { LimitsV1 } from '../adapters/plot/types'
 import type { ScenarioStage, ScenarioEvent } from '../types/scenario'
 import type { CeeDebugHeaders } from './utils/ceeDebugHeaders'
 import { identityFromCanvasGraph } from './utils/graphIdentity'
+import { buildPersistedGraph, readPersistedGoalConstraints } from './utils/persistedGraph'
 import {
   markGraphImported,
   isGraphPendingImportRegistration,
@@ -3827,6 +3828,21 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // Restore results from run history if this scenario has a last run
     tryRestoreResultsFromHistory(scenario.last_result_hash, get().resultsLoadHistorical)
 
+    // ROADMAP 2.932: restore the scenario's persisted hard constraints — or
+    // CLEAR them when the record has none, so a previous decision's constraints
+    // never ride the newly-loaded scenario. readPersistedGoalConstraints returns
+    // null for an absent/empty/malformed value (fail-open on the untyped JSONB),
+    // which is exactly the clear signal.
+    //
+    // ⚠ MUST BE THE LAST WORD ON goalConstraints IN THIS METHOD. setCeeAnalysisReady(null)
+    // above runs READINESS_CLEAR_FIELDS, which nulls goalConstraints — so a
+    // restore placed before it is silently clobbered on every scenario whose
+    // ceeAnalysisReady is absent or stale (the common case). fromProducerSync: a
+    // scenario load is not a user edit, and freshness was already nulled above.
+    get().setGoalConstraints(readPersistedGoalConstraints(scenario.graph), {
+      fromProducerSync: true,
+    })
+
     return true
     } finally {
       // A.7: End suppression after hydration is complete (always, even on throw)
@@ -3845,6 +3861,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       currentScenarioLastRunSeed,
       ceeAnalysisReady,
       ceeAnalysisReadyNodeIds,
+      goalConstraints,
     } = get()
 
     // P0-2: Set saving state
@@ -3863,7 +3880,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         // Update existing scenario (ID preserved)
         scenarios.updateScenario(currentScenarioId!, {
           name,
-          graph: { nodes, edges },
+          // ROADMAP 2.932: persist the hard constraints INTO the graph JSONB,
+          // the same shape (and snake-case key) the authenticated DB path uses,
+          // so a guest scenario save round-trips them instead of dropping them.
+          graph: buildPersistedGraph(nodes, edges, goalConstraints),
           framing: currentScenarioFraming || undefined,
           last_result_hash: currentScenarioLastResultHash || undefined,
           last_run_at: currentScenarioLastRunAt || undefined,
@@ -3901,6 +3921,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
           id: currentScenarioId ?? undefined,
           nodes,
           edges,
+          // ROADMAP 2.932: persist the hard constraints on the new record too.
+          goalConstraints,
           framing: currentScenarioFraming || undefined,
           last_result_hash: currentScenarioLastResultHash || undefined,
           last_run_at: currentScenarioLastRunAt || undefined,
@@ -5446,6 +5468,9 @@ registerCrashSnapshotProvider(() => {
     // The answer rides the crash flush too — a crash after a completed analysis
     // must not be the one path that silently drops it.
     analysis: analysisSnapshotFromStore(s),
+    // ROADMAP 2.932: the constraints ride the crash flush too, at parity with
+    // the 30s timer — a crash must not be the one path that drops them.
+    goalConstraints: s.goalConstraints ?? null,
   }
 })
 

--- a/src/canvas/store/__tests__/guestGoalConstraintPersistence.spec.ts
+++ b/src/canvas/store/__tests__/guestGoalConstraintPersistence.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * ROADMAP 2.932 (Codex R4 finding MF2) — guest persistence must round-trip the
+ * user's hard constraints. Before this fix, the guest path stored ONLY
+ * `{ nodes, edges }`, so a reload or a scenario save silently discarded the
+ * constraints and the product then reported "No limits on record".
+ *
+ * Two guest vessels, both covered here:
+ *   - the localStorage AUTOSAVE record (autosaveProjection → saveAutosave),
+ *   - the localStorage SCENARIO record (saveCurrentScenario → loadScenario).
+ *
+ * Plus the migration guard: an OLD record with no constraints field must still
+ * load without error (additive shape change, never breaking).
+ *
+ * Bindings are by IDENTITY (constraint_id + operator + value), never a value
+ * predicate another constraint could satisfy (CLAUDE.md trap 19).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import * as scenarios from '../scenarios'
+import { saveAutosave, loadAutosave, type AutosaveData } from '../scenarios'
+import { projectAutosaveData, autosaveSourceFromStore } from '../autosaveProjection'
+import type { CEEGoalConstraint } from '../../../adapters/cee/types'
+
+const goalNode = (id: string) => ({
+  id,
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { kind: 'goal', label: id },
+})
+const factorNode = (id: string) => ({
+  id,
+  type: 'factor',
+  position: { x: 0, y: 120 },
+  data: { kind: 'factor', label: id },
+})
+
+const CONSTRAINTS: CEEGoalConstraint[] = [
+  { constraint_id: 'c_spend_max', node_id: 'factor-1', operator: '<=', value: 5000, unit: '£' },
+  { constraint_id: 'c_revenue_min', node_id: 'goal-1', operator: '>=', value: 20000, unit: '£' },
+]
+
+/** Assert the restored set matches CONSTRAINTS by identity. */
+function expectRestored(restored: ReturnType<typeof useCanvasStore.getState>['goalConstraints']) {
+  expect(restored).not.toBeNull()
+  expect(restored).toHaveLength(2)
+  const spend = restored!.find((c) => c.constraint_id === 'c_spend_max')
+  expect(spend).toBeDefined()
+  expect(spend!.operator).toBe('<=')
+  expect(spend!.value).toBe(5000)
+  const revenue = restored!.find((c) => c.constraint_id === 'c_revenue_min')
+  expect(revenue).toBeDefined()
+  expect(revenue!.operator).toBe('>=')
+  expect(revenue!.value).toBe(20000)
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  scenarios.clearAutosave() // resets the identical-payload dedupe cache too
+  useCanvasStore.getState().reset()
+})
+
+describe('ROADMAP 2.932 — guest SCENARIO record round-trips constraints', () => {
+  it('saveCurrentScenario persists constraints; loadScenario restores them by identity', () => {
+    useCanvasStore.setState({ nodes: [goalNode('goal-1'), factorNode('factor-1')], edges: [] } as never)
+    useCanvasStore.getState().setGoalConstraints(CONSTRAINTS as never, { fromProducerSync: true })
+
+    const id = useCanvasStore.getState().saveCurrentScenario('MF2 test')
+    expect(id).toBeTruthy()
+
+    // Simulate a fresh session: nothing in memory.
+    useCanvasStore.getState().setGoalConstraints(null, { fromProducerSync: true })
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+
+    const ok = useCanvasStore.getState().loadScenario(id!)
+    expect(ok).toBe(true)
+
+    // RED at pristine (named): saveCurrentScenario stored only { nodes, edges }
+    // and loadScenario never restored constraints — `restored` stays null, so
+    // `expect(restored).not.toBeNull()` fails.
+    expectRestored(useCanvasStore.getState().goalConstraints)
+  })
+
+  it('loadScenario CLEARS a stale in-memory constraint when the loaded record has none (no cross-scenario leak on this path)', () => {
+    // A constraint-free scenario A that DOES carry a valid ceeAnalysisReady.
+    // This is the discriminating setup: the valid-readiness branch of
+    // setCeeAnalysisReady does NOT run READINESS_CLEAR_FIELDS, so the ONLY thing
+    // that can clear the stale constraint on this path is the 2.932 restore.
+    const optionNode = { id: 'opt-1', type: 'option', position: { x: 0, y: 240 }, data: { kind: 'option', label: 'A' } }
+    const recA = scenarios.createScenario({
+      name: 'A',
+      nodes: [goalNode('goal-1'), optionNode] as never,
+      edges: [],
+      ceeAnalysisReady: {
+        goal_node_id: 'goal-1',
+        options: [{ id: 'opt-1', label: 'A', status: 'ready', interventions: {} }],
+      } as never,
+      ceeAnalysisReadyNodeIds: null,
+    })
+    // Decision B's constraints are still in memory.
+    useCanvasStore.getState().setGoalConstraints(CONSTRAINTS as never, { fromProducerSync: true })
+
+    useCanvasStore.getState().loadScenario(recA.id)
+
+    // Guard the discriminator's precondition IN-TEST (trap 13b): the readiness
+    // must have restored valid, or this would test the READINESS_CLEAR path by
+    // accident and pass for the wrong reason.
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+    // RED at pristine: loadScenario left decision B's constraint on scenario A.
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+  })
+})
+
+describe('ROADMAP 2.932 — guest AUTOSAVE record round-trips constraints', () => {
+  it('projectAutosaveData persists constraints; a reload hydrate restores them by identity', () => {
+    useCanvasStore.setState({ nodes: [goalNode('goal-1'), factorNode('factor-1')], edges: [] } as never)
+    useCanvasStore.getState().setGoalConstraints(CONSTRAINTS as never, { fromProducerSync: true })
+
+    saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState())))
+
+    const loaded = loadAutosave()
+    expect(loaded).not.toBeNull()
+
+    // Simulate a fresh session, then replay ReactFlowGraph's autosave-restore
+    // wiring: hydrate with the loaded constraints.
+    useCanvasStore.getState().setGoalConstraints(null, { fromProducerSync: true })
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: loaded!.nodes as never,
+      edges: loaded!.edges as never,
+      goalConstraints:
+        (loaded as { goalConstraints?: typeof CONSTRAINTS }).goalConstraints ?? null,
+    })
+
+    // RED at pristine (named): the projection never emitted `goalConstraints`,
+    // so the loaded record has none, the hydrate resolves it to null, and
+    // `expect(restored).not.toBeNull()` fails.
+    expectRestored(useCanvasStore.getState().goalConstraints)
+  })
+})
+
+describe('ROADMAP 2.932 — migration safety: old records with no constraints still load', () => {
+  it('an OLD autosave with no goalConstraints key loads and hydrates without error', () => {
+    // Old shape — written before this field existed. Compiles at pristine and
+    // post-fix because `goalConstraints` is optional on AutosaveData.
+    saveAutosave({ timestamp: Date.now(), nodes: [goalNode('goal-1')], edges: [] } as AutosaveData)
+
+    const loaded = loadAutosave()
+    expect(loaded).not.toBeNull()
+    expect((loaded as { goalConstraints?: unknown }).goalConstraints).toBeUndefined()
+
+    expect(() =>
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: loaded!.nodes as never,
+        edges: loaded!.edges as never,
+        goalConstraints:
+          (loaded as { goalConstraints?: typeof CONSTRAINTS }).goalConstraints ?? null,
+      }),
+    ).not.toThrow()
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+  })
+
+  it('an OLD scenario record with a bare { nodes, edges } graph loads without error', () => {
+    const rec = scenarios.createScenario({ name: 'old', nodes: [goalNode('goal-1')], edges: [] })
+    // Old shape carries no constraints key on the graph.
+    expect((rec.graph as { goal_constraints?: unknown }).goal_constraints).toBeUndefined()
+
+    expect(() => useCanvasStore.getState().loadScenario(rec.id)).not.toThrow()
+    expect(useCanvasStore.getState().goalConstraints).toBeNull()
+  })
+})

--- a/src/canvas/store/autosaveProjection.ts
+++ b/src/canvas/store/autosaveProjection.ts
@@ -75,6 +75,13 @@ export interface AutosaveProjectionSource {
    * analysis of a graph whose option nodes no longer exist must not survive.
    */
   analysis: AutosaveData['analysis'] | undefined
+  /**
+   * The scenario's hard constraints (ROADMAP 2.932). Required like every other
+   * field here — `saveAutosave` REPLACES, so a caller that omitted constraints
+   * would strip them from the last good autosave, which is the exact silent-loss
+   * this field exists to close. `null` means "persist no constraint".
+   */
+  goalConstraints: AutosaveData['goalConstraints'] | undefined
 }
 
 /**
@@ -110,6 +117,12 @@ export interface AutosaveStoreSlice {
    * — see the PR body; it is not resolved here.
    */
   selectedGoalNode?: string | null
+  /**
+   * The store's hard constraints (ROADMAP 2.932). Camel-case here (the store
+   * spelling); the projection persists it under the same `goalConstraints`
+   * autosave key. Typed off AutosaveData so the two cannot drift.
+   */
+  goalConstraints?: AutosaveData['goalConstraints']
   /**
    * The results slice. Structural and narrow: only what decides whether there
    * is an answer worth persisting, and what identifies it.
@@ -174,6 +187,7 @@ export function autosaveSourceFromStore(
     ceeAnalysisReady: (state.ceeAnalysisReady ?? undefined) as AutosaveData['ceeAnalysisReady'],
     selectedGoalNode: state.selectedGoalNode ?? null,
     analysis: analysisSnapshotFromStore(state),
+    goalConstraints: state.goalConstraints ?? null,
     ...overrides,
   }
 }
@@ -202,5 +216,12 @@ export function projectAutosaveData(
     // key and an explicit null the same on read, but the diff at each call site
     // stays readable.
     analysis: source.analysis ?? null,
+    // ROADMAP 2.932: emit only when non-empty, so a constraint-free autosave is
+    // byte-identical to the historical payload (no new key on every record).
+    // Absent/empty ⇒ omit the key ⇒ the restore resolves it to null (clears).
+    goalConstraints:
+      Array.isArray(source.goalConstraints) && source.goalConstraints.length > 0
+        ? source.goalConstraints
+        : undefined,
   }
 }

--- a/src/canvas/store/scenarios.ts
+++ b/src/canvas/store/scenarios.ts
@@ -13,8 +13,9 @@
  */
 
 import type { Node, Edge } from '@xyflow/react'
-import type { CEEAnalysisReady } from '../../adapters/cee/types'
+import type { CEEAnalysisReady, CEEGoalConstraint } from '../../adapters/cee/types'
 import type { ReportV1 } from '../../adapters/plot/types'
+import { buildPersistedGraph, type PersistedGraph } from '../utils/persistedGraph'
 
 export interface ScenarioFraming {
   title?: string          // Decision or question
@@ -33,10 +34,16 @@ export interface Scenario {
   updatedAt: number // timestamp ms
   source_template_id?: string // template this was created from
   source_template_version?: string // template version
-  graph: {
-    nodes: Node[]
-    edges: Edge[]
-  }
+  /**
+   * The persisted graph. Carries an OPTIONAL top-level `goal_constraints`
+   * (snake_case, the CEE wire spelling — see persistedGraph.ts), mirroring the
+   * authenticated `scenarios.graph` JSONB column so a guest scenario save
+   * round-trips hard constraints instead of silently dropping them
+   * (ROADMAP 2.932). Absent on records written before that shipped — additive,
+   * so an old `{ nodes, edges }` graph still loads (readPersistedGoalConstraints
+   * returns null for an absent key).
+   */
+  graph: PersistedGraph<Node, Edge>
   last_result_hash?: string // Most recent analysis hash for this scenario
   last_run_at?: string // ISO timestamp of last analysis run for this scenario
   last_run_seed?: string // Seed used for last analysis run
@@ -305,6 +312,13 @@ export function createScenario(params: {
   last_run_seed?: string
   ceeAnalysisReady?: CEEAnalysisReady | null
   ceeAnalysisReadyNodeIds?: string[] | null
+  /**
+   * The scenario's hard constraints, persisted into `graph.goal_constraints`
+   * (ROADMAP 2.932). Omitted keeps the historical `{ nodes, edges }` bytes
+   * exactly — buildPersistedGraph only emits the key when there is something to
+   * persist, so a constraint-free scenario is byte-unchanged.
+   */
+  goalConstraints?: CEEGoalConstraint[] | null
 }): Scenario {
   const now = Date.now()
   const { nodes, edges } = deepCloneGraph(params.nodes, params.edges)
@@ -315,10 +329,7 @@ export function createScenario(params: {
     updatedAt: now,
     source_template_id: params.source_template_id,
     source_template_version: params.source_template_version,
-    graph: {
-      nodes,
-      edges
-    },
+    graph: buildPersistedGraph(nodes, edges, params.goalConstraints),
     last_result_hash: params.last_result_hash,
     last_run_at: params.last_run_at,
     last_run_seed: params.last_run_seed,
@@ -351,10 +362,10 @@ export function updateScenario(id: string, updates: Partial<Omit<Scenario, 'id' 
 
   if (updates.graph) {
     const { nodes, edges } = deepCloneGraph(updates.graph.nodes, updates.graph.edges)
-    nextUpdates.graph = {
-      nodes,
-      edges,
-    }
+    // Preserve the constraints the caller put on the graph (ROADMAP 2.932).
+    // buildPersistedGraph emits the key only when non-empty, so a
+    // constraint-free update keeps the historical `{ nodes, edges }` bytes.
+    nextUpdates.graph = buildPersistedGraph(nodes, edges, updates.graph.goal_constraints)
   }
 
   scenarios[index] = {
@@ -608,6 +619,14 @@ export interface AutosaveData {
     user_questions?: string[]
   } | null
   selectedGoalNode?: string | null
+  /**
+   * The scenario's hard constraints (ROADMAP 2.932). Absent on records written
+   * before this shipped — additive, so an old autosave still loads and the
+   * restore resolves an absent value to null (clears rather than throws). The
+   * projection emits this only when non-empty, so a constraint-free autosave is
+   * byte-unchanged.
+   */
+  goalConstraints?: CEEGoalConstraint[] | null
 }
 
 // P2: Track last autosave payload to skip identical writes

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.goalConstraints.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.goalConstraints.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * ROADMAP 2.932 (Codex R4 finding MF2) — reconcileAppliedGraph must commit the
+ * applied-edit receipt's `goal_constraints` into the store.
+ *
+ * THE DEFECT. A populated-canvas (terminal analysis) turn routes to
+ * reconcileAppliedGraph, which before this fix read ONLY nodes and edges. So a
+ * turn on which CEE returned goal_constraints left the store on its previous
+ * value: the completed canvas showed "No limits on record", and the NEXT
+ * analysis (which reads store.goalConstraints) omitted the user's limits.
+ *
+ * Bindings are by IDENTITY (constraint_id + target + frame), never a value
+ * predicate another constraint could satisfy (CLAUDE.md trap 19). The
+ * three-constraint receipt exists so the discriminating mutant pair has a
+ * constraint the identity test does NOT bind to.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { reconcileAppliedGraph } from '../mergeAppliedGraph'
+import { useCanvasStore } from '../../store'
+import { seedCanvas as seedStore } from './__helpers__/mergeAppliedGraphHarness'
+
+const EXISTING_NODES = [
+  { id: 'goal-1', type: 'goal', position: { x: 400, y: 40 }, data: { kind: 'goal', label: 'Revenue' } },
+  { id: 'factor-1', type: 'factor', position: { x: 40, y: 200 }, data: { kind: 'factor', label: 'Spend' } },
+]
+
+// The constraints CEE returned on the terminal turn (the MF2 report shape).
+// A third, un-asserted constraint gives the mutant pair a "different" object.
+const RECEIPT_CONSTRAINTS = [
+  { constraint_id: 'c_spend_max', node_id: 'factor-1', operator: '<=', value: 5000, unit: '£' },
+  { constraint_id: 'c_revenue_min', node_id: 'goal-1', operator: '>=', value: 20000, unit: '£' },
+  { constraint_id: 'c_extra', node_id: 'factor-1', operator: '<=', value: 5000, unit: '£' },
+]
+
+// A receipt whose graph OVERLAPS the canvas (so the zero-overlap guard passes)
+// and is structurally identical to it — the analysis turn does not change the
+// graph, so this is a node/edge NO-OP that nonetheless carries constraints.
+function receipt(constraints: unknown) {
+  return {
+    nodes: [
+      { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+      { id: 'factor-1', kind: 'factor', label: 'Spend' },
+    ],
+    edges: [],
+    goal_constraints: constraints,
+  } as never
+}
+
+beforeEach(() => {
+  useCanvasStore.getState().reset()
+  seedStore(EXISTING_NODES, [])
+  useCanvasStore.getState().setGoalConstraints(null, { fromProducerSync: true })
+})
+
+describe('reconcileAppliedGraph — goal_constraints (ROADMAP 2.932)', () => {
+  it('commits the receipt constraints into the store BY IDENTITY, even on a graph no-op', () => {
+    const before = useCanvasStore.getState().goalConstraints
+    expect(before).toBeNull()
+
+    reconcileAppliedGraph(receipt(RECEIPT_CONSTRAINTS))
+
+    const stored = useCanvasStore.getState().goalConstraints
+    // RED at pristine (named): reconcile never wrote constraints, so `stored`
+    // stays null — `expect(stored).not.toBeNull()` fails.
+    expect(stored).not.toBeNull()
+    expect(stored).toHaveLength(3)
+
+    // Bind by IDENTITY, not by "some constraint with value 5000" (c_extra shares
+    // that value): assert the SPECIFIC constraint_id carries the right frame.
+    const spend = stored!.find((c) => c.constraint_id === 'c_spend_max')
+    expect(spend).toBeDefined()
+    expect(spend!.node_id).toBe('factor-1')
+    expect(spend!.operator).toBe('<=')
+    expect(spend!.value).toBe(5000)
+
+    const revenue = stored!.find((c) => c.constraint_id === 'c_revenue_min')
+    expect(revenue).toBeDefined()
+    expect(revenue!.node_id).toBe('goal-1')
+    expect(revenue!.operator).toBe('>=')
+    expect(revenue!.value).toBe(20000)
+  })
+
+  it('leaves the store untouched when the receipt carries NO goal_constraints (absence never clears)', () => {
+    // A prior turn established the constraints.
+    useCanvasStore
+      .getState()
+      .setGoalConstraints(RECEIPT_CONSTRAINTS as never, { fromProducerSync: true })
+
+    reconcileAppliedGraph(receipt(undefined))
+
+    const stored = useCanvasStore.getState().goalConstraints
+    expect(stored).toHaveLength(3)
+    expect(stored!.map((c) => c.constraint_id).sort()).toEqual([
+      'c_extra',
+      'c_revenue_min',
+      'c_spend_max',
+    ])
+  })
+
+  it('leaves the store untouched when the receipt carries an EMPTY goal_constraints array', () => {
+    useCanvasStore
+      .getState()
+      .setGoalConstraints(RECEIPT_CONSTRAINTS as never, { fromProducerSync: true })
+
+    reconcileAppliedGraph(receipt([]))
+
+    expect(useCanvasStore.getState().goalConstraints).toHaveLength(3)
+  })
+})

--- a/src/canvas/utils/__tests__/mergeAppliedGraph.goalConstraints.spec.ts
+++ b/src/canvas/utils/__tests__/mergeAppliedGraph.goalConstraints.spec.ts
@@ -17,6 +17,8 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { reconcileAppliedGraph } from '../mergeAppliedGraph'
 import { useCanvasStore } from '../../store'
 import { seedCanvas as seedStore } from './__helpers__/mergeAppliedGraphHarness'
+import { saveAutosave, loadAutosave, clearAutosave } from '../../store/scenarios'
+import { projectAutosaveData, autosaveSourceFromStore } from '../../store/autosaveProjection'
 
 const EXISTING_NODES = [
   { id: 'goal-1', type: 'goal', position: { x: 400, y: 40 }, data: { kind: 'goal', label: 'Revenue' } },
@@ -104,5 +106,99 @@ describe('reconcileAppliedGraph — goal_constraints (ROADMAP 2.932)', () => {
     reconcileAppliedGraph(receipt([]))
 
     expect(useCanvasStore.getState().goalConstraints).toHaveLength(3)
+  })
+})
+
+/**
+ * F1 (adversarial review of #626) — THE STORE COMMIT IS NOT ENOUGH: THE
+ * CONSTRAINTS MUST REACH THE AUTOSAVE RECORD ON A GRAPH NO-OP TURN.
+ *
+ * MECHANISM, verified at the bytes. On the PR's own canonical case — a terminal
+ * analysis turn that leaves the graph structurally identical while carrying
+ * constraints — NOTHING persisted the freshly-committed constraints:
+ *   1. `applyV5State` (useConversation.ts:4566) runs BEFORE the reconcile branch
+ *      (:4737), and its resultsComplete hydration triggers the autosave write at
+ *      store.ts:3365 PRE-COMMIT — persisting the store's constraints from before
+ *      the turn.
+ *   2. reconcile's own `saveAutosave` sits AFTER the `!changed` early return, so
+ *      a graph no-op never reaches it.
+ *   3. the 30s timer's dirty check is `computeGraphHash(nodes, edges)` —
+ *      constraint-blind, so it skips (the exact hazard store.ts:3348's comment
+ *      warns about: "IT MUST BE HERE AND NOT LEFT TO THE 30s TIMER").
+ *   4. the complete `saveAutosave` writer manifest (8 sites in src/) has NO
+ *      writer that fires after a no-op commit.
+ * Consequence: the store held the constraints, the autosave did not, and the
+ * guest reload hydrated `?? null` — cleared. Same shape as the ROADMAP 2.932
+ * defect, one layer down.
+ */
+describe('reconcileAppliedGraph — constraints reach the AUTOSAVE on a graph no-op (F1)', () => {
+  beforeEach(() => {
+    clearAutosave() // also resets saveAutosave's identical-payload dedupe cache
+  })
+
+  /** Replay the PRE-COMMIT write that applyV5State/resultsComplete performs. */
+  function preCommitAutosaveWrite() {
+    saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState())))
+  }
+
+  it('persists the receipt constraints into the autosave record on a NO-OP turn', () => {
+    // The turn arrives with no constraints in the store yet.
+    preCommitAutosaveWrite()
+    expect(loadAutosave()?.goalConstraints).toBeUndefined()
+
+    reconcileAppliedGraph(receipt(RECEIPT_CONSTRAINTS))
+
+    const persisted = loadAutosave()?.goalConstraints
+    // RED before the fix: the store held them, the autosave did not.
+    expect(persisted).toBeDefined()
+    expect(persisted).toHaveLength(3)
+    // Bind by IDENTITY, not by a value another constraint could satisfy.
+    const spend = persisted!.find((c) => c.constraint_id === 'c_spend_max')
+    expect(spend).toBeDefined()
+    expect(spend!.operator).toBe('<=')
+    expect(spend!.value).toBe(5000)
+  })
+
+  it('POSITIVE CONTROL — a CHANGED receipt already persisted them (the probe can see a presence)', () => {
+    preCommitAutosaveWrite()
+
+    // Same receipt plus a new node ⇒ `changed` is true ⇒ the post-commit
+    // saveAutosave at the end of reconcile fires. This passed BEFORE the fix,
+    // which is what proves the no-op case above fails for a real reason and not
+    // because the probe cannot observe an autosave at all.
+    reconcileAppliedGraph({
+      nodes: [
+        { id: 'goal-1', kind: 'goal', label: 'Revenue' },
+        { id: 'factor-1', kind: 'factor', label: 'Spend' },
+        { id: 'factor-2', kind: 'factor', label: 'Churn' },
+      ],
+      edges: [],
+      goal_constraints: RECEIPT_CONSTRAINTS,
+    } as never)
+
+    const persisted = loadAutosave()?.goalConstraints
+    expect(persisted).toBeDefined()
+    expect(persisted!.find((c) => c.constraint_id === 'c_spend_max')).toBeDefined()
+  })
+
+  it('a REVISED constraint set on a no-op turn replaces the older set in the autosave (no stale restore)', () => {
+    // A prior turn established constraints, and they are in the autosave.
+    useCanvasStore
+      .getState()
+      .setGoalConstraints(RECEIPT_CONSTRAINTS as never, { fromProducerSync: true })
+    preCommitAutosaveWrite()
+    expect(loadAutosave()?.goalConstraints).toHaveLength(3)
+
+    // The user revises the cap; CEE echoes the revision on a graph no-op turn.
+    const REVISED = [
+      { constraint_id: 'c_spend_max', node_id: 'factor-1', operator: '<=', value: 9000, unit: '£' },
+    ]
+    reconcileAppliedGraph(receipt(REVISED))
+
+    const persisted = loadAutosave()?.goalConstraints
+    expect(persisted).toHaveLength(1)
+    // RED before the fix: the autosave still carried the OLD 5000 cap, so a
+    // reload restored a limit the user had already changed.
+    expect(persisted!.find((c) => c.constraint_id === 'c_spend_max')!.value).toBe(9000)
   })
 })

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -609,9 +609,43 @@ export function reconcileAppliedGraph(
   // freshness verdict the same response already set.
   const receiptGoalConstraints = (draftData as { goal_constraints?: unknown }).goal_constraints
   if (Array.isArray(receiptGoalConstraints) && receiptGoalConstraints.length > 0) {
-    useCanvasStore
-      .getState()
-      .setGoalConstraints(receiptGoalConstraints as CEEGoalConstraint[], { fromProducerSync: true })
+    const constraints = receiptGoalConstraints as CEEGoalConstraint[]
+    useCanvasStore.getState().setGoalConstraints(constraints, { fromProducerSync: true })
+    // R2: the staging MF2 witness traces constraints by these logs; without one
+    // here the reconcile commit is invisible to it. Matches applyDraftResult's
+    // and useV2Run's `[constraint-trace]` shape.
+    logger.info('[constraint-trace] store-write', {
+      source: 'reconcileAppliedGraph',
+      count: constraints.length,
+      constraint_ids: constraints.map((c) => c.constraint_id),
+    })
+
+    // F1 (adversarial review) — PERSIST HERE, AND NOT LEFT TO THE 30s TIMER OR
+    // TO THE COMMIT BELOW. On this module's canonical case — a terminal analysis
+    // turn that leaves the graph structurally identical — `changed` is false and
+    // the early return below is taken, so the post-commit `saveAutosave` at the
+    // end of this function NEVER RUNS. Nothing else covers it either:
+    //   - applyV5State runs BEFORE this reconcile (useConversation.ts:4566 vs
+    //     :4737), so its resultsComplete-driven write at store.ts:3365 persists
+    //     the store's PRE-COMMIT constraints;
+    //   - the 30s timer's dirty check is `computeGraphHash(nodes, edges)`, which
+    //     is constraint-blind and skips (the identical hazard store.ts:3348's
+    //     comment warns about for the analysis payload);
+    //   - the complete saveAutosave writer manifest has no site that fires after
+    //     a no-op commit.
+    // Result before this write: the store held the constraints, the autosave did
+    // not, and the guest reload hydrated `?? null` — cleared. It also keeps a
+    // REVISED set from leaving the superseded one in the record.
+    //
+    // Deliberately unconditional rather than gated on `!changed`: a predicate
+    // here would be one more thing to get wrong, and on the changed path the
+    // post-commit write simply supersedes this one (saveAutosave skips an
+    // identical payload, so the cost is bounded).
+    try {
+      saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState())))
+    } catch {
+      // Non-critical — never let a persistence failure break the reconcile.
+    }
   }
 
   if (!changed) return result

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -136,7 +136,7 @@ import {
   mapDraftEdgeToCanvas,
   mapDraftNodeToCanvas,
 } from './applyDraftResult'
-import type { CEEDraftResponse, CEEv2Response, CEEv3Response } from '../../adapters/cee/types'
+import type { CEEDraftResponse, CEEGoalConstraint, CEEv2Response, CEEv3Response } from '../../adapters/cee/types'
 
 /**
  * Horizontal gap between the current bounding box and the added column.
@@ -581,6 +581,38 @@ export function reconcileAppliedGraph(
     nodeIds: [...wireNodeById.keys()],
     edgePairs: [...wireEdgeByPair.keys()],
   })
+
+  // ROADMAP 2.932 (Codex MF2) — commit the receipt's goal_constraints.
+  //
+  // The receipt's draft_graph carries goal_constraints the same way the
+  // fresh-draft path does — nested per @talchain/schemas, or lifted from the
+  // response root onto this very object by attachAnalysisReadyToInlineDraftGraph
+  // (useConversation), which is the SAME object applyDraftResult reads. Before
+  // this, reconcile committed ONLY nodes and edges, so a populated-canvas turn
+  // that returned constraints left the store on the previous value — the
+  // completed canvas showed "No limits on record" and the NEXT analysis (which
+  // reads store.goalConstraints) omitted them. That is the silent-loss the row
+  // is about.
+  //
+  // Runs BEFORE the `!changed` early-return: a terminal analysis turn typically
+  // leaves the graph structurally identical while still carrying the
+  // constraints, so gating this on a node/edge change would drop exactly the
+  // case the defect describes.
+  //
+  // ABSENCE DOES NOT CLEAR. This module's whole contract is "the wire WINS on
+  // keys it carries, the canvas KEEPS keys the wire omits" (see overlayNode) —
+  // an applied-edit receipt is not the wholesale replacement a fresh draft is,
+  // so a receipt that merely does not re-send constraints must not become a NEW
+  // way to lose them (the exact failure class this row closes). Non-empty array
+  // → adopt; absent / empty / non-array → leave the store as-is. fromProducerSync
+  // because these are CEE's authoritative post-state and must not self-dirty the
+  // freshness verdict the same response already set.
+  const receiptGoalConstraints = (draftData as { goal_constraints?: unknown }).goal_constraints
+  if (Array.isArray(receiptGoalConstraints) && receiptGoalConstraints.length > 0) {
+    useCanvasStore
+      .getState()
+      .setGoalConstraints(receiptGoalConstraints as CEEGoalConstraint[], { fromProducerSync: true })
+  }
 
   if (!changed) return result
 


### PR DESCRIPTION
## ROADMAP 2.932 — Codex R4 finding MF2: goal constraints are silently lost

**Pillar:** P2 whole-POC manipulation + PC1/PC2 trust — the product must not discard a user's constraints and then report "No limits on record".

### The defect (byte-verified at deployed UI head b9b1374e; symbol-located)
CEE returns two `goal_constraints` on a populated-canvas turn, but the completed UI showed "No limits on record" and the next analysis omitted them. The terminal (populated-canvas) turn routes to `reconcileAppliedGraph`, which read and committed only nodes and edges. Guest persistence stored only `{ nodes, edges }`, so reload and scenario-save also dropped constraints.

### What this PR fixes
1. **Reconcile** (`src/canvas/utils/mergeAppliedGraph.ts` → `reconcileAppliedGraph`): commits the applied-edit receipt's `goal_constraints` into the store — runs even on a graph no-op (a terminal analysis turn leaves the graph identical while carrying constraints), so the completed canvas reflects them and the next analysis carries them. **Absence never clears** (the module's "wire wins on keys it carries, canvas keeps the rest" contract) — so this never becomes a *new* way to lose constraints.
2. **Guest autosave** (`store/autosaveProjection.ts` + `store/scenarios.ts` `AutosaveData` + `ReactFlowGraph.tsx` restore): constraints are projected into the autosave (required field, fail-loud on drift) and rehydrated on a guest reload — **including the graph-no-op turn**, which is the canonical MF2 case (see F1 below). Required-field typing forced the other three writers (`crashFlush`, the store's crash provider, the 30s timer) to state it.
3. **Guest scenario record** (`store.ts` `saveCurrentScenario`/`loadScenario` + `scenarios.ts`): constraints ride the scenario `graph` JSONB via `buildPersistedGraph` — the same shape and snake-case key the already-fixed authenticated path uses — restored on `loadScenario`. The restore is the **last word** on `goalConstraints` so the pre-existing `setCeeAnalysisReady(null)` READINESS_CLEAR can't clobber it.
4. **Migration-safe:** an old guest autosave / scenario record with no constraints field still loads (additive shape change). Tests included.

The signed-in DB-reload sub-limb (`persistedGraph.ts`) already persisted/rehydrated constraints and is **not regressed** — its helpers are now the shared implementation.

### F1 — fixed in-PR after adversarial review
The store commit alone did **not** survive a guest reload on the canonical no-op turn. Mechanism, verified at the bytes: `applyV5State` runs before the reconcile branch (`useConversation.ts:4566` vs `:4737`) so its `resultsComplete` write (`store.ts:3365`) persists **pre-commit** constraints; reconcile's own `saveAutosave` sat **after** the `!changed` early return; the 30s timer's dirty check is `computeGraphHash(nodes, edges)` — constraint-blind; and the complete writer manifest has no site firing after a no-op commit. A revised constraint set also left the superseded one in the record. Fixed by a `saveAutosave` inside the constraints-commit block **before** the early return, mirroring `resultsComplete`'s "must be here, not left to the 30s timer" pattern (`store.ts:3348`). **R2:** added the `[constraint-trace]` store-write log the staging MF2 witness traces by.

### Verification
- **RED-first** (source stashed / pre-fix head): reconcile commit, guest scenario round-trip, clear-stale leak, guest autosave round-trip → `expected null not to be null` / `expected [{…},{…}] to be null`. F1: `expected undefined not to be undefined` and `expected [3 items] to have a length of 1 but got 3`, with a **changed-receipt positive control passing throughout** (the probe can see a presence).
- **Discriminating mutant pair** (trap 19) in an isolated worktree (sentinel + inode isolation proof, source SHA-256 unchanged): loosen ALL constraint values → RED (`5001≠5000`); loosen only the un-asserted `c_extra` → GREEN.
- Typecheck gate: **0 added errors** (baseline 2491 unchanged, not regenerated). Lint: 0 errors. Projection ci-guard green.

### Residuals (rowed, NOT built here)
- Export/import round-trip of constraints (`canvas/export/exportScenario.ts`).
- The broader cross-scenario leak (atomic clear/replace with identity on every switch path) — this PR closes the `loadScenario` path only.
- The sibling gap in `applyV5State`'s `add_constraint` merge (`:921`, no autosave writer) — pre-existing, rowed separately, deliberately untouched here.
- The CEE-side merge-precedence bug (`compound-goals.ts`) — a separate CEE lane.

Status ladder rung: **TESTED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)