### PR TITLE
fix(2.935): edge label words derive direction from the signed effect, not unsigned magnitude (Codex MF5)

### DIFF
--- a/src/canvas/__tests__/canvas.edge-labels.dom.spec.tsx
+++ b/src/canvas/__tests__/canvas.edge-labels.dom.spec.tsx
@@ -5,6 +5,18 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { getEdgeLabel, describeEdge, formatNumericLabel, setEdgeLabelMode, getEdgeLabelMode } from '../domain/edgeLabels'
 import { cleanupCanvas } from './__helpers__/renderCanvas'
+import type { EdgeDirectionDisplay } from '../domain/edgeValueProvenance'
+
+/**
+ * ROADMAP 2.935 — the direction is an ARGUMENT now, never inferred from the
+ * sign of `weight`. See the header of
+ * `src/canvas/domain/__tests__/edgeLabels.spec.ts` for why the signed weights
+ * in this file were never evidence about the product, and
+ * `edges/__tests__/StyledEdge.edgeLabelDirectionWords.2935.spec.tsx` for the
+ * integration-level proof against real CEE capture data.
+ */
+const STATED_POSITIVE: EdgeDirectionDisplay = { show: true, direction: 'positive', source: 'user' }
+const STATED_NEGATIVE: EdgeDirectionDisplay = { show: true, direction: 'negative', source: 'user' }
 
 describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
   beforeEach(() => {
@@ -18,7 +30,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.8   // Strong (>= 0.7)
       const belief = 0.9   // High (>= 0.8)
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
       expect(result.label).not.toContain('uncertain')
@@ -30,7 +42,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5   // Moderate (0.3 <= w < 0.7)
       const belief = 0.4   // Low (< 0.6)
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost (uncertain)')
       expect(result.tooltip).toContain('Weight: 0.50')
@@ -41,7 +53,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.75  // Strong negative
       const belief = 0.85   // High confidence
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Strong drag')
       expect(result.label).not.toContain('uncertain')
@@ -53,7 +65,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.2   // Weak (< 0.3)
       const belief = undefined  // Missing belief → uncertain
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost (uncertain)')
       expect(result.tooltip).toContain('Weight: 0.20')
@@ -64,7 +76,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.5  // Moderate negative
       const belief = 0.5   // Low (< 0.6)
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Moderate drag (uncertain)')
     })
@@ -73,7 +85,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.25  // Weak
       const belief = 0.9    // High
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Weak drag')
     })
@@ -82,7 +94,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6   // Moderate
       const belief = 0.7   // Medium (0.6 <= b < 0.8)
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -98,7 +110,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6
       const belief = 0.85
 
-      const label = formatNumericLabel(weight, belief)
+      const label = formatNumericLabel(weight, belief, STATED_POSITIVE)
 
       expect(label).toBe('w 0.60 • b 85%')
     })
@@ -107,7 +119,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.7
       const belief = 0.9
 
-      const label = formatNumericLabel(weight, belief)
+      const label = formatNumericLabel(weight, belief, STATED_NEGATIVE)
 
       expect(label).toBe('w −0.70 • b 90%') // Proper minus sign
     })
@@ -116,7 +128,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = undefined
 
-      const label = formatNumericLabel(weight, belief)
+      const label = formatNumericLabel(weight, belief, STATED_POSITIVE)
 
       expect(label).toBe('w 0.50')
       expect(label).not.toContain('b')
@@ -126,7 +138,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6
       const belief = 0.85
 
-      const result = getEdgeLabel(weight, belief)
+      const result = getEdgeLabel(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('w 0.60 • b 85%')
     })
@@ -177,7 +189,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0
       const belief = 0.8
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost')
     })
@@ -186,7 +198,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.3
       const belief = 0.8
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
     })
@@ -195,7 +207,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.7
       const belief = 0.8
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
     })
@@ -204,7 +216,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0.6
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -214,7 +226,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0.8
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -224,7 +236,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost (uncertain)')
     })
@@ -233,7 +245,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 1.0
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
     })
@@ -242,7 +254,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.01
       const belief = 0.9
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost')
     })
@@ -251,7 +263,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 1.0
       const belief = 1.0
 
-      const result = describeEdge(weight, belief)
+      const result = describeEdge(weight, belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
     })

--- a/src/canvas/domain/__tests__/edgeLabels.spec.ts
+++ b/src/canvas/domain/__tests__/edgeLabels.spec.ts
@@ -12,6 +12,30 @@ import {
   setEdgeLabelMode,
   type EdgeLabelMode
 } from '../edgeLabels'
+import type { EdgeDirectionDisplay } from '../edgeValueProvenance'
+
+/**
+ * ROADMAP 2.935 — the direction is now an ARGUMENT, not an inference from the
+ * sign of `weight`.
+ *
+ * ⚠ WHY EVERY ASSERTION BELOW USED TO PASS WHILE THE PRODUCT WAS WRONG. This
+ * file called `describeEdge(-0.5, 0.8)` and got "Moderate drag" — with a
+ * NEGATIVE weight the producer cannot emit. Both ingestion paths store
+ * `Math.abs(rawWeight)` (UI-SEM-023), so the only argument the product ever
+ * passed was non-negative and the "drag" branch was unreachable in the live
+ * product while being fully covered here. CLAUDE.md trap 16-inverse: the code
+ * path was live and the DATA could never reach it — a fixture you wrote
+ * yourself is not evidence about the wire.
+ *
+ * The signed weights are KEPT below deliberately, and now prove something
+ * stronger: `describeEdge` uses `weight` for its MAGNITUDE ONLY, so a signed
+ * argument cannot smuggle a direction claim past the gate. The integration-level
+ * proof against real capture data lives in
+ * `edges/__tests__/StyledEdge.edgeLabelDirectionWords.2935.spec.tsx`.
+ */
+const STATED_POSITIVE: EdgeDirectionDisplay = { show: true, direction: 'positive', source: 'user' }
+const STATED_NEGATIVE: EdgeDirectionDisplay = { show: true, direction: 'negative', source: 'user' }
+const NOT_STATED: EdgeDirectionDisplay = { show: false, reason: 'not_set' }
 
 describe('edgeLabels', () => {
   // Clean up localStorage between tests
@@ -26,89 +50,89 @@ describe('edgeLabels', () => {
   describe('describeEdge', () => {
     describe('Positive weights (boost)', () => {
       it('returns "Strong boost" for high positive weight with high belief', () => {
-        const result = describeEdge(0.9, 0.9)
+        const result = describeEdge(0.9, 0.9, STATED_POSITIVE)
         expect(result.label).toBe('Strong boost')
         expect(result.tooltip).toContain('Weight: 0.90')
         expect(result.tooltip).toContain('Belief: 90%')
       })
 
       it('returns "Moderate boost" for medium positive weight', () => {
-        const result = describeEdge(0.5, 0.8)
+        const result = describeEdge(0.5, 0.8, STATED_POSITIVE)
         expect(result.label).toBe('Moderate boost')
       })
 
       it('returns "Weak boost" for low positive weight', () => {
-        const result = describeEdge(0.2, 0.8)
+        const result = describeEdge(0.2, 0.8, STATED_POSITIVE)
         expect(result.label).toBe('Weak boost')
       })
 
       it('adds "(uncertain)" qualifier for low belief', () => {
-        expect(describeEdge(0.9, 0.5).label).toBe('Strong boost (uncertain)')
-        expect(describeEdge(0.5, 0.4).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.2, 0.3).label).toBe('Weak boost (uncertain)')
+        expect(describeEdge(0.9, 0.5, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
+        expect(describeEdge(0.5, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(0.2, 0.3, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
       })
 
       it('handles edge case at 0.7 threshold', () => {
-        expect(describeEdge(0.7, 0.8).label).toBe('Strong boost')
-        expect(describeEdge(0.69, 0.8).label).toBe('Moderate boost')
+        expect(describeEdge(0.7, 0.8, STATED_POSITIVE).label).toBe('Strong boost')
+        expect(describeEdge(0.69, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('handles edge case at 0.3 threshold', () => {
-        expect(describeEdge(0.3, 0.8).label).toBe('Moderate boost')
-        expect(describeEdge(0.29, 0.8).label).toBe('Weak boost')
+        expect(describeEdge(0.3, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(0.29, 0.8, STATED_POSITIVE).label).toBe('Weak boost')
       })
     })
 
     describe('Negative weights (drag)', () => {
       it('returns "Strong drag" for high negative weight', () => {
-        expect(describeEdge(-0.9, 0.9).label).toBe('Strong drag')
+        expect(describeEdge(-0.9, 0.9, STATED_NEGATIVE).label).toBe('Strong drag')
       })
 
       it('returns "Moderate drag" for medium negative weight', () => {
-        expect(describeEdge(-0.5, 0.8).label).toBe('Moderate drag')
+        expect(describeEdge(-0.5, 0.8, STATED_NEGATIVE).label).toBe('Moderate drag')
       })
 
       it('returns "Weak drag" for low negative weight', () => {
-        expect(describeEdge(-0.2, 0.8).label).toBe('Weak drag')
+        expect(describeEdge(-0.2, 0.8, STATED_NEGATIVE).label).toBe('Weak drag')
       })
 
       it('adds "(uncertain)" qualifier for low belief', () => {
-        expect(describeEdge(-0.9, 0.5).label).toBe('Strong drag (uncertain)')
-        expect(describeEdge(-0.5, 0.4).label).toBe('Moderate drag (uncertain)')
-        expect(describeEdge(-0.2, 0.3).label).toBe('Weak drag (uncertain)')
+        expect(describeEdge(-0.9, 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
+        expect(describeEdge(-0.5, 0.4, STATED_NEGATIVE).label).toBe('Moderate drag (uncertain)')
+        expect(describeEdge(-0.2, 0.3, STATED_NEGATIVE).label).toBe('Weak drag (uncertain)')
       })
     })
 
     describe('Belief thresholds', () => {
       it('treats >= 80% as high confidence (no qualifier)', () => {
-        expect(describeEdge(0.5, 0.8).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.85).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 1.0).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 0.85, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 1.0, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('treats 60-80% as medium confidence (no qualifier)', () => {
-        expect(describeEdge(0.5, 0.6).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.7).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.79).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 0.6, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 0.7, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(0.5, 0.79, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('treats < 60% as low confidence (adds uncertain)', () => {
-        expect(describeEdge(0.5, 0.59).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.5, 0.4).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.5, 0.1).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(0.5, 0.59, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(0.5, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(0.5, 0.1, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
       })
     })
 
     describe('Missing belief', () => {
       it('treats undefined belief as uncertain', () => {
-        expect(describeEdge(0.9).label).toBe('Strong boost (uncertain)')
-        expect(describeEdge(0.5).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.2).label).toBe('Weak boost (uncertain)')
-        expect(describeEdge(-0.9).label).toBe('Strong drag (uncertain)')
+        expect(describeEdge(0.9, undefined, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
+        expect(describeEdge(0.5, undefined, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(0.2, undefined, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
+        expect(describeEdge(-0.9, undefined, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
       })
 
       it('provides tooltip even when belief is missing', () => {
-        const result = describeEdge(0.6)
+        const result = describeEdge(0.6, undefined, STATED_POSITIVE)
         expect(result.tooltip).toContain('Weight: 0.60')
         expect(result.tooltip).toContain('not set')
       })
@@ -116,31 +140,31 @@ describe('edgeLabels', () => {
 
     describe('Zero weight', () => {
       it('treats zero weight as weak boost', () => {
-        expect(describeEdge(0, 0.8).label).toBe('Weak boost')
+        expect(describeEdge(0, 0.8, STATED_POSITIVE).label).toBe('Weak boost')
       })
     })
   })
 
   describe('formatNumericLabel', () => {
     it('formats positive weight with belief', () => {
-      expect(formatNumericLabel(0.6, 0.85)).toBe('w 0.60 • b 85%')
+      expect(formatNumericLabel(0.6, 0.85, STATED_POSITIVE)).toBe('w 0.60 • b 85%')
     })
 
     it('formats negative weight with belief using proper minus sign', () => {
-      expect(formatNumericLabel(-0.6, 0.85)).toBe('w −0.60 • b 85%')
+      expect(formatNumericLabel(-0.6, 0.85, STATED_NEGATIVE)).toBe('w −0.60 • b 85%')
     })
 
     it('formats weight without belief', () => {
-      expect(formatNumericLabel(0.6)).toBe('w 0.60')
+      expect(formatNumericLabel(0.6, undefined, STATED_POSITIVE)).toBe('w 0.60')
     })
 
     it('rounds belief to nearest integer percentage', () => {
-      expect(formatNumericLabel(0.5, 0.856)).toBe('w 0.50 • b 86%')
-      expect(formatNumericLabel(0.5, 0.854)).toBe('w 0.50 • b 85%')
+      expect(formatNumericLabel(0.5, 0.856, STATED_POSITIVE)).toBe('w 0.50 • b 86%')
+      expect(formatNumericLabel(0.5, 0.854, STATED_POSITIVE)).toBe('w 0.50 • b 85%')
     })
 
     it('formats weight to 2 decimal places', () => {
-      expect(formatNumericLabel(0.123456, 0.8)).toBe('w 0.12 • b 80%')
+      expect(formatNumericLabel(0.123456, 0.8, STATED_POSITIVE)).toBe('w 0.12 • b 80%')
     })
   })
 
@@ -187,27 +211,27 @@ describe('edgeLabels', () => {
 
   describe('getEdgeLabel', () => {
     it('returns human label when mode is "human"', () => {
-      const result = getEdgeLabel(0.9, 0.9, 'human')
+      const result = getEdgeLabel(0.9, 0.9, STATED_POSITIVE, 'human')
       expect(result.label).toBe('Strong boost')
       expect(result.tooltip).toContain('Weight: 0.90')
     })
 
     it('returns numeric label when mode is "numeric"', () => {
-      const result = getEdgeLabel(0.6, 0.85, 'numeric')
+      const result = getEdgeLabel(0.6, 0.85, STATED_POSITIVE, 'numeric')
       expect(result.label).toBe('w 0.60 • b 85%')
     })
 
     it('uses localStorage mode when mode parameter is not provided', () => {
       setEdgeLabelMode('numeric')
-      expect(getEdgeLabel(0.6, 0.85).label).toBe('w 0.60 • b 85%')
+      expect(getEdgeLabel(0.6, 0.85, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
 
       setEdgeLabelMode('human')
-      expect(getEdgeLabel(0.9, 0.9).label).toBe('Strong boost')
+      expect(getEdgeLabel(0.9, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
     })
 
     it('defaults to human mode when localStorage is empty', () => {
       localStorage.clear()
-      expect(getEdgeLabel(0.9, 0.9).label).toBe('Strong boost')
+      expect(getEdgeLabel(0.9, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
     })
   })
 
@@ -217,27 +241,27 @@ describe('edgeLabels', () => {
       const belief = 0.85
 
       // Start in human mode (default)
-      expect(getEdgeLabel(weight, belief).label).toBe('Moderate boost')
+      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('Moderate boost')
 
       // Switch to numeric
       setEdgeLabelMode('numeric')
-      expect(getEdgeLabel(weight, belief).label).toBe('w 0.60 • b 85%')
+      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
 
       // Switch back to human
       setEdgeLabelMode('human')
-      expect(getEdgeLabel(weight, belief).label).toBe('Moderate boost')
+      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('Moderate boost')
     })
 
     it('persists mode across function calls', () => {
       setEdgeLabelMode('numeric')
 
       expect(getEdgeLabelMode()).toBe('numeric')
-      expect(getEdgeLabel(0.5, 0.8).label).toBe('w 0.50 • b 80%')
+      expect(getEdgeLabel(0.5, 0.8, STATED_POSITIVE).label).toBe('w 0.50 • b 80%')
 
       setEdgeLabelMode('human')
 
       expect(getEdgeLabelMode()).toBe('human')
-      expect(getEdgeLabel(0.5, 0.8).label).toBe('Moderate boost')
+      expect(getEdgeLabel(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
     })
   })
 
@@ -247,47 +271,80 @@ describe('edgeLabels', () => {
       // Strength band: 0.3 ≤ 0.65 < 0.7 → "Moderate"
       // Direction: positive → "boost"
       const weight = 0.65 // as derived from abs(strength.mean)
-      const result = describeEdge(weight, 0.85)
+      const result = describeEdge(weight, 0.85, STATED_POSITIVE)
       expect(result.label).toBe('Moderate boost')
     })
 
     it('strength.mean = 0.70 crosses into "Strong" band', () => {
-      const result = describeEdge(0.70, 0.85)
+      const result = describeEdge(0.70, 0.85, STATED_POSITIVE)
       expect(result.label).toBe('Strong boost')
     })
 
     it('negative strength.mean = -0.65 produces "Moderate drag"', () => {
-      // In canvas store: weight = abs(-0.65) = 0.65, direction = 'negative'
-      // describeEdge receives the signed weight for label purposes
-      const result = describeEdge(-0.65, 0.85)
+      // ⚠ CORRECTED (ROADMAP 2.935). This comment used to read "describeEdge
+      // receives the signed weight for label purposes". THAT WAS FALSE, and it
+      // is the sentence that let the defect live for as long as it did: in the
+      // canvas store `weight = abs(-0.65) = 0.65` and the sign lives in a
+      // SEPARATE `direction` field, so `describeEdge` never received a signed
+      // weight from the product at all. The magnitude and the direction are
+      // passed separately below, exactly as the store holds them.
+      const result = describeEdge(0.65, 0.85, STATED_NEGATIVE)
       expect(result.label).toBe('Moderate drag')
+    })
+
+    it('the same magnitude with the direction UNSTATED asserts no direction', () => {
+      // The case the product actually hits on every edge whose producer sent
+      // `effect_direction: 'unknown'` or omitted it — and the case this file
+      // had no coverage for at all before 2.935.
+      const result = describeEdge(0.65, 0.85, NOT_STATED)
+      expect(result.label).toBe('Moderate effect, direction not stated')
+      expect(result.label).not.toContain('boost')
+      expect(result.label).not.toContain('drag')
+    })
+
+    it('the magnitude alone cannot produce a direction word', () => {
+      // The gate's whole point: a caller passing a signed number does not get a
+      // signed word. Same |w|, opposite signs, direction unstated → identical.
+      expect(describeEdge(-0.65, 0.85, NOT_STATED).label)
+        .toBe(describeEdge(0.65, 0.85, NOT_STATED).label)
+    })
+
+    it('an unstated direction prints no minus in the numeric channel either', () => {
+      expect(formatNumericLabel(-0.65, 0.85, NOT_STATED)).toBe('w 0.65 • b 85%')
+      expect(formatNumericLabel(0.65, 0.85, STATED_NEGATIVE)).toBe('w −0.65 • b 85%')
+    })
+
+    it('the tooltip sign tracks the STATED direction, not the argument sign', () => {
+      expect(describeEdge(0.65, 0.85, STATED_NEGATIVE).tooltip).toContain('Weight: −0.65')
+      expect(describeEdge(-0.65, 0.85, STATED_POSITIVE).tooltip).toContain('Weight: 0.65')
+      expect(describeEdge(-0.65, 0.85, NOT_STATED).tooltip).toContain('Weight: 0.65')
     })
   })
 
   describe('Real-world examples', () => {
     it('handles typical template edge weights', () => {
       // Strong positive influence
-      expect(describeEdge(0.8, 0.9).label).toBe('Strong boost')
+      expect(describeEdge(0.8, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
 
       // Moderate positive influence
-      expect(describeEdge(0.5, 0.8).label).toBe('Moderate boost')
+      expect(describeEdge(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
 
       // Weak negative influence
-      expect(describeEdge(-0.2, 0.7).label).toBe('Weak drag')
+      expect(describeEdge(-0.2, 0.7, STATED_NEGATIVE).label).toBe('Weak drag')
 
       // Strong negative influence with uncertainty
-      expect(describeEdge(-0.9, 0.5).label).toBe('Strong drag (uncertain)')
+      expect(describeEdge(-0.9, 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
     })
 
     it('provides meaningful labels for user-edited weights', () => {
       // User sets high confidence strong influence
-      expect(describeEdge(0.95, 0.95).label).toBe('Strong boost')
+      expect(describeEdge(0.95, 0.95, STATED_POSITIVE).label).toBe('Strong boost')
 
       // User sets low confidence moderate influence
-      expect(describeEdge(0.45, 0.4).label).toBe('Moderate boost (uncertain)')
+      expect(describeEdge(0.45, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
 
       // User sets medium confidence weak drag
-      expect(describeEdge(-0.15, 0.75).label).toBe('Weak drag')
+      expect(describeEdge(-0.15, 0.75, STATED_NEGATIVE).label).toBe('Weak drag')
     })
   })
 })

--- a/src/canvas/domain/edgeLabels.ts
+++ b/src/canvas/domain/edgeLabels.ts
@@ -5,6 +5,8 @@
  * Uses British English and plain language to make edges accessible to non-technical users.
  */
 
+import type { EdgeDirectionDisplay } from './edgeValueProvenance'
+
 export type EdgeLabelMode = 'human' | 'numeric'
 
 const STORAGE_KEY = 'canvas.edge-labels-mode'
@@ -61,15 +63,53 @@ export interface EdgeDescription {
  * - Low: b < 60%
  * - Undefined: treat as uncertain
  *
+ * ⚠⚠ THE DIRECTION IS AN ARGUMENT, NOT AN INFERENCE (ROADMAP 2.935, Codex MF5).
+ * ----------------------------------------------------------------------------
+ * This function used to compute `const isPositive = weight >= 0` and pick
+ * "boost" or "drag" from it. Its only product caller — `StyledEdge` via
+ * `getEdgeLabel` — passes `edgeData.weight`, and BOTH ingestion paths store that
+ * as an UNSIGNED MAGNITUDE beside a separate direction field:
+ *
+ *     const weight = Math.max(0, Math.min(2, Math.abs(rawWeight)))   // UI-SEM-023
+ *
+ * So `weight >= 0` was true for every edge in the product, and every causal edge
+ * on the canvas read "boost" — including the ones CEE sent a NEGATIVE
+ * `strength.mean` for. A factor the model says REDUCES the goal was labelled
+ * "Moderate boost (uncertain)" while the glyph beside it announced "Effect
+ * direction: negative".
+ *
+ * `weight` is now used ONLY for its magnitude — the sign of the argument is
+ * ignored deliberately, so no caller can smuggle a direction claim back in
+ * through a number.
+ *
+ * The parameter is REQUIRED, and typed as `EdgeDirectionDisplay` rather than a
+ * bare `'positive' | 'negative'`, for the same reason `computeDirectionStroke`
+ * (ROADMAP 2.928) and `getDirectionalStrengthLabel` (2.263) take one: there is
+ * no argument that means "positive, source unknown", so an unstated direction
+ * cannot produce a signed word by accident and cannot be forgotten.
+ * `resolveEdgeDirectionDisplay` is the ONE OWNER of that answer for canvas edge
+ * data — do not add a second predicate here (CLAUDE.md trap 21).
+ *
+ * ⚠ Do NOT "fix" a caller by re-signing the weight from
+ * `resolveEdgeSignedStrengthDisplay` instead. That module's header forbids it in
+ * capitals — an unstated direction lands there as `+1`, so a word read off that
+ * sign would fabricate "boost" on exactly the edges this gate exists to protect.
+ *
  * Direction:
- * - Positive weight → boost/increase/push
- * - Negative weight → drag/decrease/hinder
+ * - Direction STATED positive → boost/increase/push
+ * - Direction STATED negative → drag/decrease/hinder
+ * - Direction NOT STATED      → name the magnitude, say the direction was never
+ *   stated. Same vocabulary as `getDirectionalStrengthLabel`, deliberately: one
+ *   phrase for one concept across the canvas and the Model tab.
  *
  * British English spelling throughout
  */
-export function describeEdge(weight: number, belief?: number): EdgeDescription {
+export function describeEdge(
+  weight: number,
+  belief: number | undefined,
+  direction: EdgeDirectionDisplay,
+): EdgeDescription {
   const absWeight = Math.abs(weight)
-  const isPositive = weight >= 0
 
   // Categorize strength
   let strength: 'strong' | 'moderate' | 'weak'
@@ -97,32 +137,59 @@ export function describeEdge(weight: number, belief?: number): EdgeDescription {
 
   // Build human-readable label
   const strengthLabel = strength === 'strong' ? 'Strong' : strength === 'moderate' ? 'Moderate' : 'Weak'
-  const directionLabel = isPositive ? 'boost' : 'drag'
+  // Absence stays absence: name the magnitude, and say plainly that the
+  // direction was never stated rather than picking one.
+  const claim = direction.show
+    ? `${strengthLabel} ${direction.direction === 'positive' ? 'boost' : 'drag'}`
+    : `${strengthLabel} effect, direction not stated`
 
   // Add confidence qualifier if belief is low or missing
   let label: string
   if (confidence === 'low' || confidence === 'uncertain') {
-    label = `${strengthLabel} ${directionLabel} (uncertain)`
+    label = `${claim} (uncertain)`
   } else {
-    label = `${strengthLabel} ${directionLabel}`
+    label = claim
   }
 
-  // Build tooltip with numeric details
-  const sign = weight >= 0 ? '' : '−'
-  const tooltip = belief !== undefined
-    ? `Weight: ${sign}${absWeight.toFixed(2)}, Belief: ${Math.round(belief * 100)}%`
-    : `Weight: ${sign}${absWeight.toFixed(2)}, Belief: not set`
+  return { label, tooltip: buildWeightTooltip(absWeight, belief, direction) }
+}
 
-  return { label, tooltip }
+/**
+ * The numeric half of the tooltip, shared by both label modes so the sign rule
+ * lives once. The minus sign is a DIRECTION CLAIM and is printed only when the
+ * direction was stated; an unstated direction prints the bare magnitude, which
+ * is all we are entitled to say about it.
+ */
+function buildWeightTooltip(
+  absWeight: number,
+  belief: number | undefined,
+  direction: EdgeDirectionDisplay,
+): string {
+  const beliefText = belief !== undefined ? `${Math.round(belief * 100)}%` : 'not set'
+  return `Weight: ${signPrefix(direction)}${absWeight.toFixed(2)}, Belief: ${beliefText}`
+}
+
+/** '−' (U+2212 MINUS SIGN) only for a STATED negative direction; '' otherwise. */
+function signPrefix(direction: EdgeDirectionDisplay): string {
+  return direction.show && direction.direction === 'negative' ? '−' : ''
 }
 
 /**
  * Format edge label in numeric format (legacy)
- * Example: "w 0.60 • b 85%"
+ * Example: "w −0.60 • b 85%"
+ *
+ * Same gate as `describeEdge`, for the same reason: the leading minus is a
+ * direction claim, and `weight` reaches here as an unsigned magnitude. Before
+ * ROADMAP 2.935 this printed `w 0.35` for an edge whose CEE mean was −0.35 —
+ * the numeric channel did not invert the claim, it silently DELETED it.
  */
-export function formatNumericLabel(weight: number, belief?: number): string {
-  const sign = weight >= 0 ? '' : '−' // Use proper minus sign
+export function formatNumericLabel(
+  weight: number,
+  belief: number | undefined,
+  direction: EdgeDirectionDisplay,
+): string {
   const absWeight = Math.abs(weight)
+  const sign = signPrefix(direction)
 
   if (belief !== undefined) {
     return `w ${sign}${absWeight.toFixed(2)} • b ${Math.round(belief * 100)}%`
@@ -132,18 +199,26 @@ export function formatNumericLabel(weight: number, belief?: number): string {
 }
 
 /**
- * Get the appropriate edge label based on current mode
+ * Get the appropriate edge label based on current mode.
+ *
+ * `direction` sits BEFORE the optional `mode` so it cannot be omitted — the
+ * whole point of the ROADMAP 2.935 gate. See `describeEdge`'s header.
  */
-export function getEdgeLabel(weight: number, belief?: number, mode?: EdgeLabelMode): EdgeDescription {
+export function getEdgeLabel(
+  weight: number,
+  belief: number | undefined,
+  direction: EdgeDirectionDisplay,
+  mode?: EdgeLabelMode,
+): EdgeDescription {
   const actualMode = mode ?? getEdgeLabelMode()
 
   if (actualMode === 'numeric') {
-    const numericLabel = formatNumericLabel(weight, belief)
+    const numericLabel = formatNumericLabel(weight, belief, direction)
     return {
       label: numericLabel,
       tooltip: numericLabel
     }
   }
 
-  return describeEdge(weight, belief)
+  return describeEdge(weight, belief, direction)
 }

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -391,7 +391,26 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   const srcTitle = sourceNode?.data?.label || source
   const tgtTitle = targetNode?.data?.label || target
   const confText = confidence !== undefined ? `, confidence ${Math.round(confidence * 100)}%` : ''
-  const ariaLabel = `Edge from ${srcTitle} to ${tgtTitle}${confText}`
+
+  // ⭐ ROADMAP 2.935 (Codex MF5) — THE LABEL'S DIRECTION WORD, FROM THE SAME
+  // RESOLVED VALUE THE GLYPH AND THE STROKE READ.
+  //
+  // `weight` (:209) is an UNSIGNED MAGNITUDE — both ingestion paths store
+  // `Math.abs(rawWeight)` beside a separate `direction` field (UI-SEM-023). It
+  // was passed straight into `getEdgeLabel`, which picked "boost" or "drag" from
+  // `weight >= 0`, so every causal edge on the canvas read "boost" — including
+  // the ones CEE sent a negative `strength.mean` for. The glyph beside it was
+  // already announcing "Effect direction: negative" at the time.
+  //
+  // Computed ONCE here rather than twice inline in the JSX below, because the
+  // accessible name is built from it: `aria-label` REPLACES descendant text for
+  // assistive tech, so a name that omitted the description announced something
+  // different from what was on screen.
+  const edgeDescription = useMemo(
+    () => getEdgeLabel(weight, belief, directionDisplay, labelMode),
+    [weight, belief, directionDisplay, labelMode],
+  )
+  const ariaLabel = `Edge from ${srcTitle} to ${tgtTitle}${confText}, ${edgeDescription.label}`
 
   // P0-9: Handle double-click to open inline editor
   const handleLabelDoubleClick = (event: React.MouseEvent) => {
@@ -967,10 +986,12 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
                 : 'bg-panel/95 text-text-header border-panel-border'
             } ${hasSuggestion ? 'ring-2 ring-info ring-offset-1' : ''} ${isFirstEdge && showEdgeHint ? 'edge-hint-active' : ''}`}
             role="note"
+            data-testid="edge-influence-label"
             aria-label={ariaLabel}
             title={(() => {
-              const desc = getEdgeLabel(weight, belief, labelMode)
-              const baseTooltip = provenance ? `${desc.tooltip} • Source: ${provenance}` : desc.tooltip
+              const baseTooltip = provenance
+                ? `${edgeDescription.tooltip} • Source: ${provenance}`
+                : edgeDescription.tooltip
               return `${baseTooltip}\n\nDouble-click to edit`
             })()}
             onDoubleClick={handleLabelDoubleClick}
@@ -978,7 +999,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             onMouseLeave={handleMouseLeave}
           >
             {(() => {
-              const desc = getEdgeLabel(weight, belief, labelMode)
+              const desc = edgeDescription
               return (
                 <>
                   {/* Weight suggestion indicator */}

--- a/src/canvas/edges/__tests__/StyledEdge.edgeLabelDirectionWords.2935.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.edgeLabelDirectionWords.2935.spec.tsx
@@ -1,0 +1,452 @@
+/**
+ * ROADMAP 2.935 (Codex R4 finding MF5) — THE LABEL'S DIRECTION WORD MUST COME
+ * FROM THE RESOLVER, NOT FROM THE SIGN OF A MAGNITUDE.
+ *
+ * THE DEFECT, IN THE PRODUCT'S OWN WORDS
+ * --------------------------------------
+ * CEE returns a NEGATIVE `strength.mean` for a harmful factor. Ingestion
+ * (`mapDraftEdgeToCanvas`, and its twin in `DraftChat`) deliberately splits that
+ * into two fields — "UI-SEM-023 … store unsigned magnitude":
+ *
+ *     const weight    = Math.max(0, Math.min(2, Math.abs(rawWeight)))
+ *     const direction = directionFromEdge ?? (rawWeight < 0 ? 'negative' : 'positive')
+ *
+ * `StyledEdge` then passed that MAGNITUDE — never negative, by construction —
+ * into `getEdgeLabel`, and `describeEdge` derived the user-facing word from
+ * `weight >= 0`. Every causal edge in the product therefore read **"boost"**,
+ * including the ones the model says REDUCE the goal. Codex captured the exact
+ * string on a live negative edge: "Moderate boost (uncertain)".
+ *
+ * WHY EVERY EXISTING TEST WAS GREEN (this is the load-bearing part)
+ * ----------------------------------------------------------------
+ * `edgeLabels.spec.ts` and `canvas.edge-labels.dom.spec.tsx` DO assert
+ * `describeEdge(-0.5, …) === 'Moderate drag'` — and always passed, because they
+ * call the pure function with a signed number **the producer cannot emit**.
+ * The negative weight exists only in the specs. That is CLAUDE.md trap
+ * 16-inverse exactly: *a fixture you wrote yourself is not evidence about the
+ * wire* — the code path was live and the DATA could never reach it.
+ *
+ * So this spec does not hand-author `data` at all. Every fixture is a REAL edge
+ * from a committed CEE draft capture, pushed through the REAL exported
+ * ingestion mapper, and the resulting `data` is what the component sees. If
+ * ingestion ever stops producing the shape under test, `describes the fixture
+ * preconditions` REDs rather than this file quietly testing nothing.
+ *
+ * WHAT QUESTION DOES THE LABEL ANSWER? (CLAUDE.md trap 21 — write it down
+ * BEFORE reconciling two authorities that look like they disagree)
+ * ----------------------------------------------------------------------
+ *   · GLYPH  (`aria-label="Effect direction: …"`) — "did anyone STATE a
+ *     direction?"                                     → `directionDisplay.show`
+ *   · STROKE (`computeDirectionStroke`)              — "did anyone state a
+ *     direction AND set a strength?" Grey is that module's no-verdict colour and
+ *     already covers an unset STRENGTH, so it answers a COMPOUND question.
+ *     #625 refuted a glyph⟺stroke biconditional on exactly that asymmetry.
+ *   · LABEL WORD (`boost` / `drag`)                  — "did anyone STATE a
+ *     direction?" — the SAME question as the glyph.
+ *
+ * The label word is NOT compound the way the stroke is, and the difference is
+ * structural rather than a judgement call: the label carries its strength claim
+ * in a SEPARATE CLAUSE of the same string ("Moderate …"), so the direction word
+ * never has to double as a strength verdict. Grey has no such spare clause,
+ * which is the whole reason it is overloaded. Hence a glyph⟺word biconditional
+ * IS asserted here, and it is asserted with the refutation of the #625 one
+ * spelled out above so no future reader reconciles the two by symmetry.
+ *
+ * WHAT THIS LANE DOES NOT CLAIM — the residual, stated rather than implied
+ * ----------------------------------------------------------------------
+ * The STRENGTH clause is untouched. `describeEdge` still prints "Moderate" for
+ * a `weight` nobody set (the `DEFAULT_EDGE_DATA` 0.5 / `USER_EDGE_DEFAULTS` 0.3
+ * fallthrough), which is the same fabrication class in the other clause and
+ * belongs to the `resolveEdgeSignedStrengthDisplay` family that gated the
+ * stroke's width and colour. It is NOT fixed here and nothing below asserts it
+ * is. Rowed separately; see the PR body.
+ *
+ * WHY NOT "just re-sign the weight before describeEdge"
+ * ----------------------------------------------------
+ * Because `resolveEdgeSignedStrengthDisplay`'s own header forbids it, in
+ * capitals: "⚠ THIS SIGN IS NOT A DIRECTION CLAIM, AND NOTHING MAY READ IT AS
+ * ONE" — an unstated direction lands there as `+1`, so a boost/drag word read
+ * off that sign would fabricate "boost" on every unstated edge and would ADD a
+ * name to the KNOWN SURVIVORS list in that same header. Passing the resolved
+ * `EdgeDirectionDisplay` is the treatment `getDirectionalStrengthLabel`
+ * (strengthBands.ts, ROADMAP 2.263) and `computeDirectionStroke` (2.928) both
+ * already carry, and it is why the parameter here is REQUIRED: there is no
+ * argument that means "positive, source unknown".
+ *
+ * CLAIM TYPES — nothing here claims more than one of these:
+ *   1. Pure-function return values (`describeEdge`, `getEdgeLabel`,
+ *      `resolveEdgeDirectionDisplay`, `mapDraftEdgeToCanvas`).
+ *   2. Rendered text content and attribute values read off the DOM.
+ * jsdom cannot prove VISIBILITY or layout (platform trap 3). "The label reads
+ * X" below means *this element's textContent is X*, nothing more.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { Position } from '@xyflow/react'
+import { StyledEdge } from '../StyledEdge'
+import { mapDraftEdgeToCanvas } from '../../utils/applyDraftResult'
+import { resolveEdgeDirectionDisplay } from '../../domain/edgeValueProvenance'
+
+const nodeKinds: Record<string, string> = {}
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: { label: id === 'src' ? 'Adoption friction' : 'Bottom-up growth' }, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+// `showLabel` needs `isResultsMode` (results.status === 'complete') and a
+// non-standard view with the edge selected — see edgeLabelVisibility.ts.
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: 'complete', report: null },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: 'detailed',
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// ⛔ importOriginal-SPREAD, never a hand-listed replacement (CLAUDE.md trap 12).
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: () => undefined,
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+const baseProps = {
+  id: 'e-under-test', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: true,
+}
+
+// ── Fixtures: real capture edges, through the real ingestion mapper ──────────
+
+type WireEdge = Record<string, unknown>
+
+/** Read a committed CEE draft capture and return its edge list. */
+function captureEdges(file: string): WireEdge[] {
+  const p = resolve(__dirname, '../../starters/data', file)
+  const j = JSON.parse(readFileSync(p, 'utf8'))
+  const edges = (j.edges ?? j.graph?.edges ?? []) as WireEdge[]
+  expect(edges.length, `${file} carried no edges`).toBeGreaterThan(0)
+  return edges
+}
+
+function findEdge(file: string, from: string, to: string): WireEdge {
+  const hit = captureEdges(file).find(e => e.from === from && e.to === to)
+  expect(hit, `${file} no longer carries ${from} → ${to}`).toBeDefined()
+  return hit as WireEdge
+}
+
+/** The PRODUCER. Whatever ingestion writes is what the component sees. */
+function ingest(wire: WireEdge): Record<string, unknown> {
+  return mapDraftEdgeToCanvas(wire, 0).data as Record<string, unknown>
+}
+
+/**
+ * The headline case Codex captured: a CEE edge whose mean is NEGATIVE and whose
+ * `effect_direction` says so, at a magnitude that lands in the "Moderate" band.
+ */
+const NEGATIVE_WIRE = findEdge('pricing-model.draft.json', 'fac_adoption_friction', 'out_bottom_up_growth')
+/** Same file, a positive sibling — the discriminator for "not just always drag". */
+const POSITIVE_WIRE = captureEdges('pricing-model.draft.json').find(
+  e => e.effect_direction === 'positive' &&
+    Math.abs((e as any).strength?.mean ?? 0) >= 0.3 &&
+    Math.abs((e as any).strength?.mean ?? 0) < 0.7,
+) as WireEdge
+/**
+ * UNSET direction: the producer EXPLICITLY declined. `effect_direction:
+ * 'unknown'` is a declared 0.30.0 contract member. Built by taking the real
+ * negative wire edge and replacing ONLY that one field, so every other byte is
+ * still the producer's.
+ *
+ * ⚠ WHAT THIS FIXTURE ACTUALLY PRODUCES — DERIVED, and not what I first assumed.
+ * `mapDraftEdgeToCanvas` extracts known fields with "no blind spread", so
+ * `effect_direction` does NOT survive into `data` at all; the resolver's
+ * explicit-refusal arm is therefore unreachable on THIS ingestion path and the
+ * verdict arrives as `reason: 'not_set'` rather than `'unknown'`. (Its twin in
+ * `DraftChat` spreads `edgeRest` and DOES carry the field through — a real
+ * divergence between the two ingestion twins, out of this lane's scope and
+ * rowed.) Both paths agree on the only thing a display may act on: `show:
+ * false`.
+ *
+ * ⚠ AND THE FABRICATED VALUE IS `'negative'`, NOT `'positive'`, because the
+ * mapper's fallback infers it from the negative mean. That makes this fixture
+ * strictly sharper than a hand-authored one: an implementation that "fixed" the
+ * defect by reading `data.direction` raw would print "drag" here and look
+ * correct, while asserting a direction the producer refused to state. Only a
+ * resolver-bound implementation passes.
+ */
+const UNSET_WIRE: WireEdge = { ...NEGATIVE_WIRE, effect_direction: 'unknown' }
+
+const NEGATIVE_DATA = ingest(NEGATIVE_WIRE)
+const POSITIVE_DATA = ingest(POSITIVE_WIRE)
+const UNSET_DATA = ingest(UNSET_WIRE)
+
+// ── DOM readers, bound by identity ──────────────────────────────────────────
+
+/**
+ * The human edge label, bound by its own test id — NOT by `[role="note"]`
+ * (three components in this tree carry that role) and NOT by matching text
+ * (CLAUDE.md trap 19: an assertion must bind to its object by identity, never
+ * by a predicate another object could satisfy).
+ */
+function labelEl(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('[data-testid="edge-influence-label"]') as HTMLElement | null
+  expect(el, 'the edge influence label did not render').not.toBeNull()
+  return el as HTMLElement
+}
+
+const labelText = (c: HTMLElement) => labelEl(c).textContent ?? ''
+const labelTooltip = (c: HTMLElement) => labelEl(c).getAttribute('title') ?? ''
+const labelAria = (c: HTMLElement) => labelEl(c).getAttribute('aria-label') ?? ''
+const glyphEl = (c: HTMLElement) => c.querySelector('[aria-label^="Effect direction:"]')
+
+/** Words that assert the edge INCREASES its target. */
+const BOOST_WORDS = ['boost', 'increase', 'raises', 'push']
+/** Words that assert the edge REDUCES its target. */
+const DRAG_WORDS = ['drag', 'reduces', 'decrease', 'hinder']
+
+const hasAny = (s: string, words: string[]) =>
+  words.some(w => s.toLowerCase().includes(w))
+
+function renderEdge(data: Record<string, unknown>) {
+  return render(<StyledEdge {...(baseProps as any)} data={data} />)
+}
+
+describe('StyledEdge edge label — direction words (ROADMAP 2.935 / Codex MF5)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+  })
+
+  // ── PRECONDITIONS. Pin the fixtures in-test so a discriminator can never
+  //    silently stop discriminating (CLAUDE.md trap 13b, third face). If
+  //    ingestion changes shape, THIS block REDs — not a downstream assertion
+  //    that would otherwise pass for the wrong reason.
+  describe('fixture preconditions (derived from the producer, not assumed)', () => {
+    it('the negative fixture really is a negative CEE mean stored as an unsigned magnitude', () => {
+      expect((NEGATIVE_WIRE as any).strength.mean).toBeLessThan(0)
+      expect(NEGATIVE_WIRE.effect_direction).toBe('negative')
+      // The defect's mechanism, asserted rather than described: ingestion strips
+      // the sign, so no downstream reader can recover it from `weight`.
+      expect(NEGATIVE_DATA.weight as number).toBeGreaterThan(0)
+      expect(NEGATIVE_DATA.weight as number).toBe(Math.abs((NEGATIVE_WIRE as any).strength.mean))
+      // …and lands in the "Moderate" band (0.3 ≤ |w| < 0.7), so the expected
+      // strings below are the producer's doing and not a threshold accident.
+      expect(NEGATIVE_DATA.weight as number).toBeGreaterThanOrEqual(0.3)
+      expect(NEGATIVE_DATA.weight as number).toBeLessThan(0.7)
+      // The direction survives, stamped, in its own field.
+      expect(resolveEdgeDirectionDisplay(NEGATIVE_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative' }),
+      )
+    })
+
+    it('the positive fixture is a stated-positive edge in the same strength band', () => {
+      expect(POSITIVE_WIRE, 'no moderate positive edge in the capture').toBeDefined()
+      expect(resolveEdgeDirectionDisplay(POSITIVE_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'positive' }),
+      )
+      expect(POSITIVE_DATA.weight as number).toBeGreaterThanOrEqual(0.3)
+      expect(POSITIVE_DATA.weight as number).toBeLessThan(0.7)
+    })
+
+    it('the unset fixture reaches the resolver as UNSTATED despite a fabricated direction', () => {
+      // Ingestion writes a `direction` value even here — that is the trap, and
+      // the value it fabricates is `'negative'` (inferred from the mean), so a
+      // raw read of this field would LOOK right on this fixture.
+      expect(UNSET_DATA.direction).toBe('negative')
+      // …with no source stamp, so the one owner refuses it. `not_set` rather
+      // than `unknown` because this mapper drops `effect_direction` — derived,
+      // see the fixture note in the header.
+      expect(UNSET_DATA.directionSource).toBeUndefined()
+      expect(resolveEdgeDirectionDisplay(UNSET_DATA)).toEqual({ show: false, reason: 'not_set' })
+    })
+
+    it('the three fixtures differ ONLY in direction, so any rendering difference is direction', () => {
+      expect(NEGATIVE_DATA.weight).toBe(UNSET_DATA.weight)
+      expect(NEGATIVE_DATA.beliefExists).toBe(UNSET_DATA.beliefExists)
+    })
+  })
+
+  // ── THE NAMED DEFECT ──────────────────────────────────────────────────────
+
+  it('does NOT call a negative CEE edge a "boost" [ROADMAP 2.935 / MF5]', () => {
+    const { container } = renderEdge(NEGATIVE_DATA)
+    const text = labelText(container)
+    expect(hasAny(text, BOOST_WORDS), `label read "${text}"`).toBe(false)
+    expect(hasAny(text, DRAG_WORDS), `label read "${text}"`).toBe(true)
+  })
+
+  it('the TOOLTIP channel does not drop the sign of a negative CEE edge', () => {
+    const { container } = renderEdge(NEGATIVE_DATA)
+    const tip = labelTooltip(container)
+    // U+2212 MINUS SIGN — the character `describeEdge` already uses.
+    expect(tip, `tooltip read "${tip}"`).toContain('−')
+  })
+
+  it('the ACCESSIBLE NAME agrees with the visible word (no sighted/AT divergence)', () => {
+    const { container } = renderEdge(NEGATIVE_DATA)
+    const aria = labelAria(container)
+    // `aria-label` REPLACES descendant text for assistive tech, so a label whose
+    // accessible name omits the word announces something different from what is
+    // on screen — and, before this fix, the glyph beside it announced "Effect
+    // direction: negative" while the visible text read "boost". The two channels
+    // must carry the same verdict.
+    expect(hasAny(aria, DRAG_WORDS), `accessible name read "${aria}"`).toBe(true)
+    expect(hasAny(aria, BOOST_WORDS), `accessible name read "${aria}"`).toBe(false)
+  })
+
+  it('does NOT assert any direction word when the producer declined to state one', () => {
+    const { container } = renderEdge(UNSET_DATA)
+    const text = labelText(container)
+    expect(hasAny(text, BOOST_WORDS), `label read "${text}"`).toBe(false)
+    expect(hasAny(text, DRAG_WORDS), `label read "${text}"`).toBe(false)
+    // Absence stays absence — the vocabulary `getDirectionalStrengthLabel`
+    // already established for this exact case (strengthBands.ts, ROADMAP 2.263).
+    expect(text).toContain('direction not stated')
+  })
+
+  // ── THE LICENSED CLAIM STILL RENDERS ──────────────────────────────────────
+
+  it('still calls a stated-positive CEE edge a "boost"', () => {
+    const { container } = renderEdge(POSITIVE_DATA)
+    const text = labelText(container)
+    expect(hasAny(text, BOOST_WORDS), `label read "${text}"`).toBe(true)
+    expect(hasAny(text, DRAG_WORDS), `label read "${text}"`).toBe(false)
+  })
+
+  // ── THE TRIPLE: differ where they must, agree where they must ─────────────
+  //
+  // NON-VACUITY IS ASSERTED, NOT HOPED FOR. The table below must yield BOTH
+  // outcomes — at least one pair that differs and at least one invariant that
+  // holds across all three — or the final assertions in this block RED. A table
+  // that collapsed to one answer for every row (the shape the defect had) can
+  // therefore not pass by agreeing with itself.
+
+  describe('negative / positive / unset render differently where they should', () => {
+    const TRIPLE = [
+      { name: 'stated negative', data: NEGATIVE_DATA },
+      { name: 'stated positive', data: POSITIVE_DATA },
+      { name: 'direction unstated', data: UNSET_DATA },
+    ] as const
+
+    it('the three direction words are pairwise DISTINCT', () => {
+      const texts = TRIPLE.map(({ data }) => labelText(renderEdge(data).container))
+      expect(new Set(texts).size, `labels were ${JSON.stringify(texts)}`).toBe(3)
+    })
+
+    it('the three share the SAME strength clause — only the direction moved', () => {
+      // NEGATIVE and UNSET are byte-identical apart from direction (pinned
+      // above), so their strength adjective must match exactly. This is the
+      // "identically where they should" half: a fix that changed the strength
+      // band as a side effect would RED here.
+      const neg = labelText(renderEdge(NEGATIVE_DATA).container)
+      const unset = labelText(renderEdge(UNSET_DATA).container)
+      expect(neg.startsWith('Moderate')).toBe(true)
+      expect(unset.startsWith('Moderate')).toBe(true)
+    })
+
+    it('the label word is bound to the SAME resolver the glyph reads', () => {
+      // The biconditional this file's header licenses (and that #625 correctly
+      // refused for glyph⟺stroke). DERIVED per row from the one owner, so a row
+      // added to TRIPLE extends the coverage with no list to maintain.
+      for (const { name, data } of TRIPLE) {
+        const { container } = renderEdge(data)
+        const stated = resolveEdgeDirectionDisplay(data).show
+        const glyphRendered = glyphEl(container) !== null
+        const wordAsserted = hasAny(labelText(container), [...BOOST_WORDS, ...DRAG_WORDS])
+        expect(glyphRendered, `${name}: glyph`).toBe(stated)
+        expect(wordAsserted, `${name}: direction word`).toBe(stated)
+      }
+    })
+
+    it('the table is NOT vacuous — it produces both a stated and an unstated row', () => {
+      const shown = TRIPLE.map(({ data }) => resolveEdgeDirectionDisplay(data).show)
+      expect(shown).toContain(true)
+      expect(shown).toContain(false)
+    })
+  })
+
+  // ── IDENTITY BINDING (CLAUDE.md trap 19) ─────────────────────────────────
+  //
+  // The DISCRIMINATING MUTANT PAIR this block supports:
+  //   · loosen the direction word for ALL edges (e.g. make `describeEdge`
+  //     ignore its `direction` argument) → `does NOT call a negative CEE edge a
+  //     "boost"` REDs.
+  //   · loosen it for a DIFFERENT edge only (change the OTHER capture's edge,
+  //     or render `POSITIVE_DATA` here) → this block stays GREEN.
+  // Neither alone proves binding; the RED/GREEN pair does.
+
+  it('reads the word off THE EDGE UNDER TEST, not whichever label rendered first', () => {
+    const { container } = renderEdge(NEGATIVE_DATA)
+    const el = labelEl(container)
+    // Bound to the component instance by the id this render was given.
+    expect(baseProps.id).toBe('e-under-test')
+    // Exactly one influence label exists in this render, so `labelEl` cannot be
+    // reading a sibling edge's chip.
+    expect(container.querySelectorAll('[data-testid="edge-influence-label"]').length).toBe(1)
+    expect(el.textContent).toContain('drag')
+  })
+})


### PR DESCRIPTION
## The defect (Codex R4 / MF5), byte-verified live at `baaabfaa`

CEE returns a **negative** `strength.mean` for a harmful factor. Both ingestion
paths deliberately split that into two fields (UI-SEM-023, "store unsigned
magnitude"):

```ts
const weight    = Math.max(0, Math.min(2, Math.abs(rawWeight)))
const direction = directionFromEdge ?? (rawWeight < 0 ? 'negative' : 'positive')
```

`StyledEdge` then passed that **magnitude** — never negative, by construction —
into `getEdgeLabel`, and `describeEdge` picked its word from `weight >= 0`.
So every causal edge in the product read **"boost"**, including the ones the
model says *reduce* the goal. Reproduced against real committed CEE capture
data: negative, positive and unstated edges all rendered the identical string
**`"Moderate boost (uncertain)"`** — the exact string Codex captured.

The glyph beside it was already announcing `Effect direction: negative`.

## Why every existing test was green

`edgeLabels.spec.ts` and `canvas.edge-labels.dom.spec.tsx` *do* assert
`describeEdge(-0.5, …) === 'Moderate drag'` — and always passed, because they
called the pure function with **a signed number the producer cannot emit**. The
negative weight existed only in the specs. CLAUDE.md trap 16-inverse: the code
path was live and the DATA could never reach it. One comment in the old spec
even asserted the false premise outright — *"describeEdge receives the signed
weight for label purposes"* — now corrected in place.

## The fix — one owner, three channels

The direction is now a **required** `EdgeDirectionDisplay` argument, resolved by
`resolveEdgeDirectionDisplay` — the same one owner the glyph reads and that
#625 (2.928) moved the stroke onto. Same treatment `getDirectionalStrengthLabel`
(2.263) and `computeDirectionStroke` (2.928) already carry: **there is no
argument that means "positive, source unknown"**, so an unstated direction
cannot produce a signed word by accident and cannot be forgotten. `weight` is
now used for its magnitude only, so a caller cannot smuggle a direction claim
back in through a number.

Three channels now derive from that one resolved value:

| channel | before | after (stated negative) | after (unstated) |
|---|---|---|---|
| visible word | `Moderate boost` | `Moderate drag` | `Moderate effect, direction not stated` |
| tooltip | `Weight: 0.35` | `Weight: −0.35` | `Weight: 0.35` |
| accessible name | *description absent* | carries the description | carries the description |

The unset copy is `getDirectionalStrengthLabel`'s existing vocabulary verbatim —
one phrase for one concept across the canvas and the Model tab, not new copy.

**The accessible name mattered.** `aria-label` *replaces* descendant text for
assistive tech, so the label's words were never announced at all — while the
glyph beside it announced the opposite verdict. Sighted "boost" vs AT "Effect
direction: negative" was a live contradiction between two channels of the same
component.

### What question does the label answer? (trap 21, written down before reconciling)

- **glyph** — "did anyone STATE a direction?"
- **stroke** — "did anyone state a direction AND set a strength?" (grey is
  already its no-verdict colour for an unset strength — which is why #625
  correctly **refuted** a glyph⟺stroke biconditional)
- **label word** — "did anyone STATE a direction?" — the same question as the glyph

The label word is not compound the way the stroke is, and the difference is
structural: the label carries its strength claim in a **separate clause** of the
same string, so the direction word never doubles as a strength verdict. Grey has
no spare clause. A glyph⟺word biconditional is therefore asserted here, with
#625's refutation spelled out in the spec so nobody reconciles the two by symmetry.

### Premise corrections found while building

1. **The brief's suggested alternative is forbidden.** Re-signing the weight via
   `resolveEdgeSignedStrengthDisplay` before `describeEdge` would fabricate
   "boost" on every unstated edge — an unstated direction lands there as `+1` —
   and that module's header bans it in capitals: *"THIS SIGN IS NOT A DIRECTION
   CLAIM, AND NOTHING MAY READ IT AS ONE"*, with a KNOWN SURVIVORS list this
   would have joined. Hence the resolver-argument shape instead.
2. **There was no honest unset behaviour to preserve.** The label fabricated
   `boost` on unstated edges too — the same root cause, closed by the same fix.
3. **`mapDraftEdgeToCanvas` drops `effect_direction`** ("no blind spread"), so an
   explicit `'unknown'` refusal arrives as `reason: 'not_set'` rather than
   `'unknown'` on that path, while `DraftChat`'s twin carries it through via
   `edgeRest`. Both agree on `show: false`, so display is unaffected — but the
   twins diverge. Out of scope, flagged for a row.

## Evidence

**RED-first at TRUE pristine** — measured with a throwaway probe bound to
`[role="note"]`, i.e. **zero product change**. 8 failed / 6 passed (14). Headline:

```
AssertionError: labels were ["Moderate boost (uncertain)",
                             "Moderate boost (uncertain)",
                             "Moderate boost (uncertain)"]: expected 1 to be 3
```

All three fixtures identical — trap 20's detection heuristic, where the
uniformity *is* the defect. The 6 that passed were the precondition block, so
the RED was the product's doing and not a broken fixture.

**Fixtures are the producer's, not mine** (trap 16-inverse). Real edges from
committed CEE draft captures, pushed through the exported `mapDraftEdgeToCanvas`.
Preconditions are pinned in-test, so if ingestion changes shape the precondition
block REDs rather than a downstream assertion passing for the wrong reason
(trap 13b). Two assumptions I made were **wrong and corrected by measurement**:
the fabricated direction on the unset fixture is `'negative'` (inferred from the
mean), not `'positive'` — which makes that fixture strictly sharper, since a fix
that read `data.direction` raw would print "drag" and *look* correct while
asserting a direction the producer refused to state. Only a resolver-bound
implementation passes.

**Mutation kit** — isolation proven by **writing** (sentinel write + inode
compare, trap 9g), worktree outside the repo root, committed state only,
applied-check scoped to `src/`, control exactly zero, collected-count asserted
== 14 on every run so an unreadable result is a hard error.

| # | mutant | applied | result | want |
|---|---|---|---|---|
| C0 | control, no mutation | **0** | GREEN | GREEN |
| M1 | REVERT: word back to sign-of-magnitude | 1 | RED | RED |
| M2 | **PAIR-A** fabricate 'positive' for EVERY edge | 1 | RED | RED |
| M3 | **PAIR-B** fabricate for a DIFFERENT edge id only | 1 | **GREEN** | GREEN |
| M4 | always 'drag' when stated | 1 | RED | RED |
| M5 | unset branch emits 'boost' again | 1 | RED | RED |
| M6 | `signPrefix` always '' (tooltip) | 1 | RED | RED |
| M7 | aria-label drops the description | 1 | RED | RED |
| M8 | remove the `data-testid` the reader binds to | 1 | RED | RED |
| M9 | `resolveEdgeDirectionDisplay` always 'positive' | 1 | RED | RED |

**M2 RED / M3 GREEN is the discriminating pair** (trap 19): loosening for all
edges REDs, loosening for a different edge does not. Neither alone shows binding.
**M3's non-equivalence is demonstrated, not asserted** (trap 13c corollary):
re-pointing the spec at the edge M3 targets turns it **7 failed / 7 passed**, so
its GREEN is a statement about identity binding, not about a no-op mutation.
M9 is trap 19's extractor-deletion obligation.

**Gates** (env exported; collect health verified)
- `pnpm run typecheck` — **PASSED**. 3307/3347 files covered; **0 added**
  diagnostics. Drift *shrank* 2491 → 2487; **baseline deliberately NOT
  regenerated** (trap 2b). New spec confirmed loaded by the compiler and absent
  from the exception list.
- `eslint` on all 5 changed files — **0 errors**. The one warning
  (`EdgeLabelMode` unused) is pre-existing, verified against `HEAD`.
- rules-of-hooks ratchet — 232 known violations, exactly matching baseline
  (a `useMemo` was added).
- `src/canvas/edges` + `src/canvas/domain` + `src/canvas/__tests__` —
  **85 files / 1131 tests pass**.
- inspector-v2 family — **37 files / 380 tests**, exactly CLAUDE.md's healthy
  figure, so the numbers are not from a shrunk collect.
- E2E/Playwright blast radius: **zero** references to edge label text or aria.

## Scope — stated, not implied

The **strength clause is untouched**. `describeEdge` still prints "Moderate" for
a `weight` nobody set (the `DEFAULT_EDGE_DATA` 0.5 / `USER_EDGE_DEFAULTS` 0.3
fallthrough) — the same fabrication class in the *other* clause, belonging to the
`resolveEdgeSignedStrengthDisplay` family that gated the stroke's width and
colour. Not fixed here, and nothing in the spec claims it is.

## Status rung

**TESTED** (2026-08-08). Not deployed, not mounted, not wire- or
journey-witnessed. Ceiling for this lane per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
