### PR TITLE
fix(2.950): gate the edge label's strength adjective on provenance (#627 lineage)

### DIFF
--- a/src/canvas/__tests__/canvas.edge-labels.dom.spec.tsx
+++ b/src/canvas/__tests__/canvas.edge-labels.dom.spec.tsx
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { getEdgeLabel, describeEdge, formatNumericLabel, setEdgeLabelMode, getEdgeLabelMode } from '../domain/edgeLabels'
 import { cleanupCanvas } from './__helpers__/renderCanvas'
-import type { EdgeDirectionDisplay } from '../domain/edgeValueProvenance'
+import type { EdgeDirectionDisplay, EdgeValueDisplay } from '../domain/edgeValueProvenance'
 
 /**
  * ROADMAP 2.935 — the direction is an ARGUMENT now, never inferred from the
@@ -17,6 +17,11 @@ import type { EdgeDirectionDisplay } from '../domain/edgeValueProvenance'
  */
 const STATED_POSITIVE: EdgeDirectionDisplay = { show: true, direction: 'positive', source: 'user' }
 const STATED_NEGATIVE: EdgeDirectionDisplay = { show: true, direction: 'negative', source: 'user' }
+// ROADMAP 2.950 — the strength is a resolved display now too, for the same
+// reason. `SET` wraps the historical numeric fixtures unchanged; the unset
+// states are covered in `domain/__tests__/edgeLabels.spec.ts` and, against
+// real capture bytes, `edges/__tests__/StyledEdge.edgeLabelStrengthWords.2950.spec.tsx`.
+const SET = (value: number): EdgeValueDisplay => ({ show: true, value, source: 'user' })
 
 describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
   beforeEach(() => {
@@ -30,7 +35,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.8   // Strong (>= 0.7)
       const belief = 0.9   // High (>= 0.8)
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
       expect(result.label).not.toContain('uncertain')
@@ -42,7 +47,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5   // Moderate (0.3 <= w < 0.7)
       const belief = 0.4   // Low (< 0.6)
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost (uncertain)')
       expect(result.tooltip).toContain('Weight: 0.50')
@@ -53,7 +58,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.75  // Strong negative
       const belief = 0.85   // High confidence
 
-      const result = describeEdge(weight, belief, STATED_NEGATIVE)
+      const result = describeEdge(SET(weight), belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Strong drag')
       expect(result.label).not.toContain('uncertain')
@@ -65,7 +70,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.2   // Weak (< 0.3)
       const belief = undefined  // Missing belief → uncertain
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost (uncertain)')
       expect(result.tooltip).toContain('Weight: 0.20')
@@ -76,7 +81,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.5  // Moderate negative
       const belief = 0.5   // Low (< 0.6)
 
-      const result = describeEdge(weight, belief, STATED_NEGATIVE)
+      const result = describeEdge(SET(weight), belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Moderate drag (uncertain)')
     })
@@ -85,7 +90,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.25  // Weak
       const belief = 0.9    // High
 
-      const result = describeEdge(weight, belief, STATED_NEGATIVE)
+      const result = describeEdge(SET(weight), belief, STATED_NEGATIVE)
 
       expect(result.label).toBe('Weak drag')
     })
@@ -94,7 +99,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6   // Moderate
       const belief = 0.7   // Medium (0.6 <= b < 0.8)
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -110,7 +115,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6
       const belief = 0.85
 
-      const label = formatNumericLabel(weight, belief, STATED_POSITIVE)
+      const label = formatNumericLabel(SET(weight), belief, STATED_POSITIVE)
 
       expect(label).toBe('w 0.60 • b 85%')
     })
@@ -119,7 +124,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = -0.7
       const belief = 0.9
 
-      const label = formatNumericLabel(weight, belief, STATED_NEGATIVE)
+      const label = formatNumericLabel(SET(weight), belief, STATED_NEGATIVE)
 
       expect(label).toBe('w −0.70 • b 90%') // Proper minus sign
     })
@@ -128,7 +133,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = undefined
 
-      const label = formatNumericLabel(weight, belief, STATED_POSITIVE)
+      const label = formatNumericLabel(SET(weight), belief, STATED_POSITIVE)
 
       expect(label).toBe('w 0.50')
       expect(label).not.toContain('b')
@@ -138,7 +143,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.6
       const belief = 0.85
 
-      const result = getEdgeLabel(weight, belief, STATED_POSITIVE)
+      const result = getEdgeLabel(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('w 0.60 • b 85%')
     })
@@ -189,7 +194,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0
       const belief = 0.8
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost')
     })
@@ -198,7 +203,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.3
       const belief = 0.8
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
     })
@@ -207,7 +212,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.7
       const belief = 0.8
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
     })
@@ -216,7 +221,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0.6
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -226,7 +231,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0.8
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
       expect(result.label).not.toContain('uncertain')
@@ -236,7 +241,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 0
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost (uncertain)')
     })
@@ -245,7 +250,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.5
       const belief = 1.0
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Moderate boost')
     })
@@ -254,7 +259,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 0.01
       const belief = 0.9
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Weak boost')
     })
@@ -263,7 +268,7 @@ describe('Canvas: Edge labels (blueprint metadata → UI)', () => {
       const weight = 1.0
       const belief = 1.0
 
-      const result = describeEdge(weight, belief, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), belief, STATED_POSITIVE)
 
       expect(result.label).toBe('Strong boost')
     })

--- a/src/canvas/domain/__tests__/edgeLabels.spec.ts
+++ b/src/canvas/domain/__tests__/edgeLabels.spec.ts
@@ -12,7 +12,7 @@ import {
   setEdgeLabelMode,
   type EdgeLabelMode
 } from '../edgeLabels'
-import type { EdgeDirectionDisplay } from '../edgeValueProvenance'
+import type { EdgeDirectionDisplay, EdgeValueDisplay } from '../edgeValueProvenance'
 
 /**
  * ROADMAP 2.935 — the direction is now an ARGUMENT, not an inference from the
@@ -32,10 +32,22 @@ import type { EdgeDirectionDisplay } from '../edgeValueProvenance'
  * argument cannot smuggle a direction claim past the gate. The integration-level
  * proof against real capture data lives in
  * `edges/__tests__/StyledEdge.edgeLabelDirectionWords.2935.spec.tsx`.
+ *
+ * ROADMAP 2.950 — and the STRENGTH is now a resolved `EdgeValueDisplay`, not a
+ * raw number, closing the same fabrication in the other clause: `weight`
+ * defaults on every edge (`DEFAULT_EDGE_DATA` 0.5 / `USER_EDGE_DEFAULTS` 0.3),
+ * so a raw first argument rendered "Moderate" for strengths nobody set. `SET`
+ * below wraps the historical numeric fixtures — their values and expectations
+ * are unchanged — and the unset states have their own block at the bottom.
+ * Integration-level proof against real capture bytes:
+ * `edges/__tests__/StyledEdge.edgeLabelStrengthWords.2950.spec.tsx`.
  */
 const STATED_POSITIVE: EdgeDirectionDisplay = { show: true, direction: 'positive', source: 'user' }
 const STATED_NEGATIVE: EdgeDirectionDisplay = { show: true, direction: 'negative', source: 'user' }
 const NOT_STATED: EdgeDirectionDisplay = { show: false, reason: 'not_set' }
+const SET = (value: number): EdgeValueDisplay => ({ show: true, value, source: 'user' })
+const STRENGTH_NOT_SET: EdgeValueDisplay = { show: false, reason: 'not_set' }
+const STRENGTH_ABSENT: EdgeValueDisplay = { show: false, reason: 'absent' }
 
 describe('edgeLabels', () => {
   // Clean up localStorage between tests
@@ -50,89 +62,89 @@ describe('edgeLabels', () => {
   describe('describeEdge', () => {
     describe('Positive weights (boost)', () => {
       it('returns "Strong boost" for high positive weight with high belief', () => {
-        const result = describeEdge(0.9, 0.9, STATED_POSITIVE)
+        const result = describeEdge(SET(0.9), 0.9, STATED_POSITIVE)
         expect(result.label).toBe('Strong boost')
         expect(result.tooltip).toContain('Weight: 0.90')
         expect(result.tooltip).toContain('Belief: 90%')
       })
 
       it('returns "Moderate boost" for medium positive weight', () => {
-        const result = describeEdge(0.5, 0.8, STATED_POSITIVE)
+        const result = describeEdge(SET(0.5), 0.8, STATED_POSITIVE)
         expect(result.label).toBe('Moderate boost')
       })
 
       it('returns "Weak boost" for low positive weight', () => {
-        const result = describeEdge(0.2, 0.8, STATED_POSITIVE)
+        const result = describeEdge(SET(0.2), 0.8, STATED_POSITIVE)
         expect(result.label).toBe('Weak boost')
       })
 
       it('adds "(uncertain)" qualifier for low belief', () => {
-        expect(describeEdge(0.9, 0.5, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
-        expect(describeEdge(0.5, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.2, 0.3, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
+        expect(describeEdge(SET(0.9), 0.5, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
+        expect(describeEdge(SET(0.5), 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(SET(0.2), 0.3, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
       })
 
       it('handles edge case at 0.7 threshold', () => {
-        expect(describeEdge(0.7, 0.8, STATED_POSITIVE).label).toBe('Strong boost')
-        expect(describeEdge(0.69, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.7), 0.8, STATED_POSITIVE).label).toBe('Strong boost')
+        expect(describeEdge(SET(0.69), 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('handles edge case at 0.3 threshold', () => {
-        expect(describeEdge(0.3, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
-        expect(describeEdge(0.29, 0.8, STATED_POSITIVE).label).toBe('Weak boost')
+        expect(describeEdge(SET(0.3), 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.29), 0.8, STATED_POSITIVE).label).toBe('Weak boost')
       })
     })
 
     describe('Negative weights (drag)', () => {
       it('returns "Strong drag" for high negative weight', () => {
-        expect(describeEdge(-0.9, 0.9, STATED_NEGATIVE).label).toBe('Strong drag')
+        expect(describeEdge(SET(-0.9), 0.9, STATED_NEGATIVE).label).toBe('Strong drag')
       })
 
       it('returns "Moderate drag" for medium negative weight', () => {
-        expect(describeEdge(-0.5, 0.8, STATED_NEGATIVE).label).toBe('Moderate drag')
+        expect(describeEdge(SET(-0.5), 0.8, STATED_NEGATIVE).label).toBe('Moderate drag')
       })
 
       it('returns "Weak drag" for low negative weight', () => {
-        expect(describeEdge(-0.2, 0.8, STATED_NEGATIVE).label).toBe('Weak drag')
+        expect(describeEdge(SET(-0.2), 0.8, STATED_NEGATIVE).label).toBe('Weak drag')
       })
 
       it('adds "(uncertain)" qualifier for low belief', () => {
-        expect(describeEdge(-0.9, 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
-        expect(describeEdge(-0.5, 0.4, STATED_NEGATIVE).label).toBe('Moderate drag (uncertain)')
-        expect(describeEdge(-0.2, 0.3, STATED_NEGATIVE).label).toBe('Weak drag (uncertain)')
+        expect(describeEdge(SET(-0.9), 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
+        expect(describeEdge(SET(-0.5), 0.4, STATED_NEGATIVE).label).toBe('Moderate drag (uncertain)')
+        expect(describeEdge(SET(-0.2), 0.3, STATED_NEGATIVE).label).toBe('Weak drag (uncertain)')
       })
     })
 
     describe('Belief thresholds', () => {
       it('treats >= 80% as high confidence (no qualifier)', () => {
-        expect(describeEdge(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.85, STATED_POSITIVE).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 1.0, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 0.85, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 1.0, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('treats 60-80% as medium confidence (no qualifier)', () => {
-        expect(describeEdge(0.5, 0.6, STATED_POSITIVE).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.7, STATED_POSITIVE).label).toBe('Moderate boost')
-        expect(describeEdge(0.5, 0.79, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 0.6, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 0.7, STATED_POSITIVE).label).toBe('Moderate boost')
+        expect(describeEdge(SET(0.5), 0.79, STATED_POSITIVE).label).toBe('Moderate boost')
       })
 
       it('treats < 60% as low confidence (adds uncertain)', () => {
-        expect(describeEdge(0.5, 0.59, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.5, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.5, 0.1, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(SET(0.5), 0.59, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(SET(0.5), 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(SET(0.5), 0.1, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
       })
     })
 
     describe('Missing belief', () => {
       it('treats undefined belief as uncertain', () => {
-        expect(describeEdge(0.9, undefined, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
-        expect(describeEdge(0.5, undefined, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
-        expect(describeEdge(0.2, undefined, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
-        expect(describeEdge(-0.9, undefined, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
+        expect(describeEdge(SET(0.9), undefined, STATED_POSITIVE).label).toBe('Strong boost (uncertain)')
+        expect(describeEdge(SET(0.5), undefined, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+        expect(describeEdge(SET(0.2), undefined, STATED_POSITIVE).label).toBe('Weak boost (uncertain)')
+        expect(describeEdge(SET(-0.9), undefined, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
       })
 
       it('provides tooltip even when belief is missing', () => {
-        const result = describeEdge(0.6, undefined, STATED_POSITIVE)
+        const result = describeEdge(SET(0.6), undefined, STATED_POSITIVE)
         expect(result.tooltip).toContain('Weight: 0.60')
         expect(result.tooltip).toContain('not set')
       })
@@ -140,31 +152,31 @@ describe('edgeLabels', () => {
 
     describe('Zero weight', () => {
       it('treats zero weight as weak boost', () => {
-        expect(describeEdge(0, 0.8, STATED_POSITIVE).label).toBe('Weak boost')
+        expect(describeEdge(SET(0), 0.8, STATED_POSITIVE).label).toBe('Weak boost')
       })
     })
   })
 
   describe('formatNumericLabel', () => {
     it('formats positive weight with belief', () => {
-      expect(formatNumericLabel(0.6, 0.85, STATED_POSITIVE)).toBe('w 0.60 • b 85%')
+      expect(formatNumericLabel(SET(0.6), 0.85, STATED_POSITIVE)).toBe('w 0.60 • b 85%')
     })
 
     it('formats negative weight with belief using proper minus sign', () => {
-      expect(formatNumericLabel(-0.6, 0.85, STATED_NEGATIVE)).toBe('w −0.60 • b 85%')
+      expect(formatNumericLabel(SET(-0.6), 0.85, STATED_NEGATIVE)).toBe('w −0.60 • b 85%')
     })
 
     it('formats weight without belief', () => {
-      expect(formatNumericLabel(0.6, undefined, STATED_POSITIVE)).toBe('w 0.60')
+      expect(formatNumericLabel(SET(0.6), undefined, STATED_POSITIVE)).toBe('w 0.60')
     })
 
     it('rounds belief to nearest integer percentage', () => {
-      expect(formatNumericLabel(0.5, 0.856, STATED_POSITIVE)).toBe('w 0.50 • b 86%')
-      expect(formatNumericLabel(0.5, 0.854, STATED_POSITIVE)).toBe('w 0.50 • b 85%')
+      expect(formatNumericLabel(SET(0.5), 0.856, STATED_POSITIVE)).toBe('w 0.50 • b 86%')
+      expect(formatNumericLabel(SET(0.5), 0.854, STATED_POSITIVE)).toBe('w 0.50 • b 85%')
     })
 
     it('formats weight to 2 decimal places', () => {
-      expect(formatNumericLabel(0.123456, 0.8, STATED_POSITIVE)).toBe('w 0.12 • b 80%')
+      expect(formatNumericLabel(SET(0.123456), 0.8, STATED_POSITIVE)).toBe('w 0.12 • b 80%')
     })
   })
 
@@ -211,27 +223,27 @@ describe('edgeLabels', () => {
 
   describe('getEdgeLabel', () => {
     it('returns human label when mode is "human"', () => {
-      const result = getEdgeLabel(0.9, 0.9, STATED_POSITIVE, 'human')
+      const result = getEdgeLabel(SET(0.9), 0.9, STATED_POSITIVE, 'human')
       expect(result.label).toBe('Strong boost')
       expect(result.tooltip).toContain('Weight: 0.90')
     })
 
     it('returns numeric label when mode is "numeric"', () => {
-      const result = getEdgeLabel(0.6, 0.85, STATED_POSITIVE, 'numeric')
+      const result = getEdgeLabel(SET(0.6), 0.85, STATED_POSITIVE, 'numeric')
       expect(result.label).toBe('w 0.60 • b 85%')
     })
 
     it('uses localStorage mode when mode parameter is not provided', () => {
       setEdgeLabelMode('numeric')
-      expect(getEdgeLabel(0.6, 0.85, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
+      expect(getEdgeLabel(SET(0.6), 0.85, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
 
       setEdgeLabelMode('human')
-      expect(getEdgeLabel(0.9, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
+      expect(getEdgeLabel(SET(0.9), 0.9, STATED_POSITIVE).label).toBe('Strong boost')
     })
 
     it('defaults to human mode when localStorage is empty', () => {
       localStorage.clear()
-      expect(getEdgeLabel(0.9, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
+      expect(getEdgeLabel(SET(0.9), 0.9, STATED_POSITIVE).label).toBe('Strong boost')
     })
   })
 
@@ -241,27 +253,27 @@ describe('edgeLabels', () => {
       const belief = 0.85
 
       // Start in human mode (default)
-      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('Moderate boost')
+      expect(getEdgeLabel(SET(weight), belief, STATED_POSITIVE).label).toBe('Moderate boost')
 
       // Switch to numeric
       setEdgeLabelMode('numeric')
-      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
+      expect(getEdgeLabel(SET(weight), belief, STATED_POSITIVE).label).toBe('w 0.60 • b 85%')
 
       // Switch back to human
       setEdgeLabelMode('human')
-      expect(getEdgeLabel(weight, belief, STATED_POSITIVE).label).toBe('Moderate boost')
+      expect(getEdgeLabel(SET(weight), belief, STATED_POSITIVE).label).toBe('Moderate boost')
     })
 
     it('persists mode across function calls', () => {
       setEdgeLabelMode('numeric')
 
       expect(getEdgeLabelMode()).toBe('numeric')
-      expect(getEdgeLabel(0.5, 0.8, STATED_POSITIVE).label).toBe('w 0.50 • b 80%')
+      expect(getEdgeLabel(SET(0.5), 0.8, STATED_POSITIVE).label).toBe('w 0.50 • b 80%')
 
       setEdgeLabelMode('human')
 
       expect(getEdgeLabelMode()).toBe('human')
-      expect(getEdgeLabel(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+      expect(getEdgeLabel(SET(0.5), 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
     })
   })
 
@@ -271,12 +283,12 @@ describe('edgeLabels', () => {
       // Strength band: 0.3 ≤ 0.65 < 0.7 → "Moderate"
       // Direction: positive → "boost"
       const weight = 0.65 // as derived from abs(strength.mean)
-      const result = describeEdge(weight, 0.85, STATED_POSITIVE)
+      const result = describeEdge(SET(weight), 0.85, STATED_POSITIVE)
       expect(result.label).toBe('Moderate boost')
     })
 
     it('strength.mean = 0.70 crosses into "Strong" band', () => {
-      const result = describeEdge(0.70, 0.85, STATED_POSITIVE)
+      const result = describeEdge(SET(0.70), 0.85, STATED_POSITIVE)
       expect(result.label).toBe('Strong boost')
     })
 
@@ -288,7 +300,7 @@ describe('edgeLabels', () => {
       // SEPARATE `direction` field, so `describeEdge` never received a signed
       // weight from the product at all. The magnitude and the direction are
       // passed separately below, exactly as the store holds them.
-      const result = describeEdge(0.65, 0.85, STATED_NEGATIVE)
+      const result = describeEdge(SET(0.65), 0.85, STATED_NEGATIVE)
       expect(result.label).toBe('Moderate drag')
     })
 
@@ -296,7 +308,7 @@ describe('edgeLabels', () => {
       // The case the product actually hits on every edge whose producer sent
       // `effect_direction: 'unknown'` or omitted it — and the case this file
       // had no coverage for at all before 2.935.
-      const result = describeEdge(0.65, 0.85, NOT_STATED)
+      const result = describeEdge(SET(0.65), 0.85, NOT_STATED)
       expect(result.label).toBe('Moderate effect, direction not stated')
       expect(result.label).not.toContain('boost')
       expect(result.label).not.toContain('drag')
@@ -305,46 +317,91 @@ describe('edgeLabels', () => {
     it('the magnitude alone cannot produce a direction word', () => {
       // The gate's whole point: a caller passing a signed number does not get a
       // signed word. Same |w|, opposite signs, direction unstated → identical.
-      expect(describeEdge(-0.65, 0.85, NOT_STATED).label)
-        .toBe(describeEdge(0.65, 0.85, NOT_STATED).label)
+      expect(describeEdge(SET(-0.65), 0.85, NOT_STATED).label)
+        .toBe(describeEdge(SET(0.65), 0.85, NOT_STATED).label)
     })
 
     it('an unstated direction prints no minus in the numeric channel either', () => {
-      expect(formatNumericLabel(-0.65, 0.85, NOT_STATED)).toBe('w 0.65 • b 85%')
-      expect(formatNumericLabel(0.65, 0.85, STATED_NEGATIVE)).toBe('w −0.65 • b 85%')
+      expect(formatNumericLabel(SET(-0.65), 0.85, NOT_STATED)).toBe('w 0.65 • b 85%')
+      expect(formatNumericLabel(SET(0.65), 0.85, STATED_NEGATIVE)).toBe('w −0.65 • b 85%')
     })
 
     it('the tooltip sign tracks the STATED direction, not the argument sign', () => {
-      expect(describeEdge(0.65, 0.85, STATED_NEGATIVE).tooltip).toContain('Weight: −0.65')
-      expect(describeEdge(-0.65, 0.85, STATED_POSITIVE).tooltip).toContain('Weight: 0.65')
-      expect(describeEdge(-0.65, 0.85, NOT_STATED).tooltip).toContain('Weight: 0.65')
+      expect(describeEdge(SET(0.65), 0.85, STATED_NEGATIVE).tooltip).toContain('Weight: −0.65')
+      expect(describeEdge(SET(-0.65), 0.85, STATED_POSITIVE).tooltip).toContain('Weight: 0.65')
+      expect(describeEdge(SET(-0.65), 0.85, NOT_STATED).tooltip).toContain('Weight: 0.65')
     })
   })
 
   describe('Real-world examples', () => {
     it('handles typical template edge weights', () => {
       // Strong positive influence
-      expect(describeEdge(0.8, 0.9, STATED_POSITIVE).label).toBe('Strong boost')
+      expect(describeEdge(SET(0.8), 0.9, STATED_POSITIVE).label).toBe('Strong boost')
 
       // Moderate positive influence
-      expect(describeEdge(0.5, 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
+      expect(describeEdge(SET(0.5), 0.8, STATED_POSITIVE).label).toBe('Moderate boost')
 
       // Weak negative influence
-      expect(describeEdge(-0.2, 0.7, STATED_NEGATIVE).label).toBe('Weak drag')
+      expect(describeEdge(SET(-0.2), 0.7, STATED_NEGATIVE).label).toBe('Weak drag')
 
       // Strong negative influence with uncertainty
-      expect(describeEdge(-0.9, 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
+      expect(describeEdge(SET(-0.9), 0.5, STATED_NEGATIVE).label).toBe('Strong drag (uncertain)')
     })
 
     it('provides meaningful labels for user-edited weights', () => {
       // User sets high confidence strong influence
-      expect(describeEdge(0.95, 0.95, STATED_POSITIVE).label).toBe('Strong boost')
+      expect(describeEdge(SET(0.95), 0.95, STATED_POSITIVE).label).toBe('Strong boost')
 
       // User sets low confidence moderate influence
-      expect(describeEdge(0.45, 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
+      expect(describeEdge(SET(0.45), 0.4, STATED_POSITIVE).label).toBe('Moderate boost (uncertain)')
 
       // User sets medium confidence weak drag
-      expect(describeEdge(-0.15, 0.75, STATED_NEGATIVE).label).toBe('Weak drag')
+      expect(describeEdge(SET(-0.15), 0.75, STATED_NEGATIVE).label).toBe('Weak drag')
+    })
+  })
+
+  describe('ROADMAP 2.950 — an unset strength produces no band adjective', () => {
+    it('direction stated, strength unset: the stated half speaks, the unset half says so', () => {
+      expect(describeEdge(STRENGTH_NOT_SET, 0.85, STATED_POSITIVE).label).toBe('Boost, strength not set')
+      expect(describeEdge(STRENGTH_NOT_SET, 0.85, STATED_NEGATIVE).label).toBe('Drag, strength not set')
+    })
+
+    it('the uncertainty qualifier still rides the direction claim', () => {
+      expect(describeEdge(STRENGTH_NOT_SET, 0.4, STATED_NEGATIVE).label).toBe('Drag, strength not set (uncertain)')
+      expect(describeEdge(STRENGTH_NOT_SET, undefined, STATED_POSITIVE).label).toBe('Boost, strength not set (uncertain)')
+    })
+
+    it('NEITHER set: the ratified popover copy, byte-identical, with no qualifier', () => {
+      // The exact `edge-hover-popover-unset` sentence — one phrase for one
+      // concept across the label and the popover, per the row's brief. No
+      // "(uncertain)" suffix: there is no claim for the belief channel to
+      // qualify.
+      expect(describeEdge(STRENGTH_NOT_SET, undefined, NOT_STATED).label).toBe('Strength and likelihood not set')
+      expect(describeEdge(STRENGTH_NOT_SET, 0.85, NOT_STATED).label).toBe('Strength and likelihood not set')
+    })
+
+    it("the display's REASON does not change the sentence — absent and not_set read alike", () => {
+      expect(describeEdge(STRENGTH_ABSENT, undefined, NOT_STATED).label)
+        .toBe(describeEdge(STRENGTH_NOT_SET, undefined, NOT_STATED).label)
+      expect(describeEdge(STRENGTH_ABSENT, 0.85, STATED_NEGATIVE).label)
+        .toBe(describeEdge(STRENGTH_NOT_SET, 0.85, STATED_NEGATIVE).label)
+    })
+
+    it('the tooltip prints "not set" and NEVER a number or a sign for an unset strength', () => {
+      // No minus even for a stated negative: the sign decorates a number, and
+      // there is no number we are entitled to print.
+      expect(describeEdge(STRENGTH_NOT_SET, 0.85, STATED_NEGATIVE).tooltip).toBe('Weight: not set, Belief: 85%')
+      expect(describeEdge(STRENGTH_NOT_SET, undefined, NOT_STATED).tooltip).toBe('Weight: not set, Belief: not set')
+    })
+
+    it('the numeric channel says "w not set" and never prints the fabricated constant', () => {
+      expect(formatNumericLabel(STRENGTH_NOT_SET, 0.85, STATED_NEGATIVE)).toBe('w not set • b 85%')
+      expect(formatNumericLabel(STRENGTH_NOT_SET, undefined, NOT_STATED)).toBe('w not set')
+    })
+
+    it('getEdgeLabel routes the gate through both modes', () => {
+      expect(getEdgeLabel(STRENGTH_NOT_SET, undefined, NOT_STATED, 'human').label).toBe('Strength and likelihood not set')
+      expect(getEdgeLabel(STRENGTH_NOT_SET, undefined, NOT_STATED, 'numeric').label).toBe('w not set')
     })
   })
 })

--- a/src/canvas/domain/edgeLabels.ts
+++ b/src/canvas/domain/edgeLabels.ts
@@ -5,7 +5,7 @@
  * Uses British English and plain language to make edges accessible to non-technical users.
  */
 
-import type { EdgeDirectionDisplay } from './edgeValueProvenance'
+import type { EdgeDirectionDisplay, EdgeValueDisplay } from './edgeValueProvenance'
 
 export type EdgeLabelMode = 'human' | 'numeric'
 
@@ -50,9 +50,9 @@ export interface EdgeDescription {
 }
 
 /**
- * Describe an edge in human-readable terms based on weight and belief
+ * Describe an edge in human-readable terms based on strength and belief
  *
- * Weight scale:
+ * Weight scale (applied to the RESOLVED strength's magnitude):
  * - Strong: |w| >= 0.7
  * - Moderate: 0.3 <= |w| < 0.7
  * - Weak: |w| < 0.3
@@ -62,6 +62,42 @@ export interface EdgeDescription {
  * - Medium: 60% <= b < 80%
  * - Low: b < 60%
  * - Undefined: treat as uncertain
+ *
+ * ⚠⚠ THE STRENGTH IS A RESOLVED DISPLAY, NOT A RAW NUMBER (ROADMAP 2.950).
+ * ------------------------------------------------------------------------
+ * The direction gate below (2.935) closed one clause of this string and left
+ * the other open: `StyledEdge` passed `edgeData?.weight ?? 0.5`, and the edge
+ * defaults (`DEFAULT_EDGE_DATA.weight = 0.5`, `USER_EDGE_DEFAULTS.weight =
+ * 0.3`) define `weight` on every edge whether anyone set it or not. So an edge
+ * whose strength NOBODY characterised read "Moderate effect, direction not
+ * stated" — the direction half refusing to claim while the strength half
+ * asserted a band derived from a UI constant.
+ *
+ * The parameter is now a required `EdgeValueDisplay`, resolved by
+ * `resolveEdgeSignedStrengthDisplay` — the SAME resolver that already gates
+ * this component's stroke width — for the same reason the direction parameter
+ * is an `EdgeDirectionDisplay`: there is no argument that means "0.5, source
+ * unknown", so a defaulted number cannot produce a band adjective by accident
+ * and cannot be forgotten.
+ *
+ * When the strength resolves `show: false`, the value inside is used for
+ * NOTHING — not the band, not the tooltip number. When it resolves `show:
+ * true`, only its MAGNITUDE is read, exactly as `weight` before it: the sign
+ * of `resolveEdgeSignedStrengthDisplay`'s value is NOT a direction claim (its
+ * header forbids reading it as one, in capitals) — the direction argument
+ * remains the one owner of that word.
+ *
+ * COPY (ratified, ROADMAP 2.950): when NEITHER strength nor direction is set,
+ * the label reuses the hover popover's existing vocabulary — "Strength and
+ * likelihood not set" (`edge-hover-popover-unset` in `StyledEdge`) — one
+ * phrase for one concept, no new copy. When exactly one half has provenance,
+ * that half speaks and the other says only that it was not set.
+ * NOTE the two surfaces gate the same sentence on slightly different pairs:
+ * the popover fires it on (strength unset AND likelihood unset) because it has
+ * no direction line; this label fires it on (strength unset AND direction
+ * unset) because `belief` — its only likelihood channel — is a raw legacy
+ * field with no provenance marker to consult. Both remain silent about the
+ * legacy `belief` value, which the tooltip still reports honestly.
  *
  * ⚠⚠ THE DIRECTION IS AN ARGUMENT, NOT AN INFERENCE (ROADMAP 2.935, Codex MF5).
  * ----------------------------------------------------------------------------
@@ -105,20 +141,36 @@ export interface EdgeDescription {
  * British English spelling throughout
  */
 export function describeEdge(
-  weight: number,
+  strength: EdgeValueDisplay,
   belief: number | undefined,
   direction: EdgeDirectionDisplay,
 ): EdgeDescription {
-  const absWeight = Math.abs(weight)
+  // The magnitude this label is entitled to speak about — null when nothing
+  // proves anyone set a strength. See the header: the display's value is used
+  // for NOTHING in that case.
+  const absWeight = strength.show ? Math.abs(strength.value) : null
 
-  // Categorize strength
-  let strength: 'strong' | 'moderate' | 'weak'
-  if (absWeight >= 0.7) {
-    strength = 'strong'
-  } else if (absWeight >= 0.3) {
-    strength = 'moderate'
+  let claim: string
+  if (absWeight !== null) {
+    // Categorize strength
+    const strengthLabel = absWeight >= 0.7 ? 'Strong' : absWeight >= 0.3 ? 'Moderate' : 'Weak'
+    // Absence stays absence: name the magnitude, and say plainly that the
+    // direction was never stated rather than picking one.
+    claim = direction.show
+      ? `${strengthLabel} ${direction.direction === 'positive' ? 'boost' : 'drag'}`
+      : `${strengthLabel} effect, direction not stated`
+  } else if (!direction.show) {
+    // Neither half has provenance: the ratified popover copy, unqualified —
+    // there is no claim for the belief channel to qualify.
+    return {
+      label: 'Strength and likelihood not set',
+      tooltip: buildWeightTooltip(null, belief, direction),
+    }
   } else {
-    strength = 'weak'
+    // Direction stated, strength not set: the stated half speaks, the unset
+    // half says so — same clause shape as the direction arm above, same
+    // "not set" vocabulary as the popover and the tooltip below.
+    claim = `${direction.direction === 'positive' ? 'Boost' : 'Drag'}, strength not set`
   }
 
   // Categorize confidence (if belief is provided)
@@ -134,14 +186,6 @@ export function describeEdge(
   } else {
     confidence = 'uncertain'
   }
-
-  // Build human-readable label
-  const strengthLabel = strength === 'strong' ? 'Strong' : strength === 'moderate' ? 'Moderate' : 'Weak'
-  // Absence stays absence: name the magnitude, and say plainly that the
-  // direction was never stated rather than picking one.
-  const claim = direction.show
-    ? `${strengthLabel} ${direction.direction === 'positive' ? 'boost' : 'drag'}`
-    : `${strengthLabel} effect, direction not stated`
 
   // Add confidence qualifier if belief is low or missing
   let label: string
@@ -159,14 +203,20 @@ export function describeEdge(
  * lives once. The minus sign is a DIRECTION CLAIM and is printed only when the
  * direction was stated; an unstated direction prints the bare magnitude, which
  * is all we are entitled to say about it.
+ *
+ * `absWeight: null` means NO SET STRENGTH (ROADMAP 2.950): the tooltip prints
+ * "not set" — the same vocabulary its own belief clause has always used — and
+ * no sign, because the minus decorates a number and there is no number.
  */
 function buildWeightTooltip(
-  absWeight: number,
+  absWeight: number | null,
   belief: number | undefined,
   direction: EdgeDirectionDisplay,
 ): string {
   const beliefText = belief !== undefined ? `${Math.round(belief * 100)}%` : 'not set'
-  return `Weight: ${signPrefix(direction)}${absWeight.toFixed(2)}, Belief: ${beliefText}`
+  const weightText =
+    absWeight !== null ? `${signPrefix(direction)}${absWeight.toFixed(2)}` : 'not set'
+  return `Weight: ${weightText}, Belief: ${beliefText}`
 }
 
 /** '−' (U+2212 MINUS SIGN) only for a STATED negative direction; '' otherwise. */
@@ -178,34 +228,41 @@ function signPrefix(direction: EdgeDirectionDisplay): string {
  * Format edge label in numeric format (legacy)
  * Example: "w −0.60 • b 85%"
  *
- * Same gate as `describeEdge`, for the same reason: the leading minus is a
- * direction claim, and `weight` reaches here as an unsigned magnitude. Before
- * ROADMAP 2.935 this printed `w 0.35` for an edge whose CEE mean was −0.35 —
- * the numeric channel did not invert the claim, it silently DELETED it.
+ * Same gates as `describeEdge`, for the same reasons:
+ * - the leading minus is a direction claim, and the magnitude reaches here
+ *   unsigned. Before ROADMAP 2.935 this printed `w 0.35` for an edge whose CEE
+ *   mean was −0.35 — the numeric channel did not invert the claim, it silently
+ *   DELETED it.
+ * - the number itself is a strength claim (ROADMAP 2.950). Before the gate
+ *   this printed `w 0.50` — the `DEFAULT_EDGE_DATA` constant, verbatim — for an
+ *   edge whose strength nobody set. An unset strength now prints `w not set`;
+ *   the sign gate is moot in that state because there is no number to sign.
  */
 export function formatNumericLabel(
-  weight: number,
+  strength: EdgeValueDisplay,
   belief: number | undefined,
   direction: EdgeDirectionDisplay,
 ): string {
-  const absWeight = Math.abs(weight)
-  const sign = signPrefix(direction)
+  const weightText = strength.show
+    ? `${signPrefix(direction)}${Math.abs(strength.value).toFixed(2)}`
+    : 'not set'
 
   if (belief !== undefined) {
-    return `w ${sign}${absWeight.toFixed(2)} • b ${Math.round(belief * 100)}%`
+    return `w ${weightText} • b ${Math.round(belief * 100)}%`
   }
 
-  return `w ${sign}${absWeight.toFixed(2)}`
+  return `w ${weightText}`
 }
 
 /**
  * Get the appropriate edge label based on current mode.
  *
- * `direction` sits BEFORE the optional `mode` so it cannot be omitted — the
- * whole point of the ROADMAP 2.935 gate. See `describeEdge`'s header.
+ * `strength` and `direction` sit BEFORE the optional `mode` so neither can be
+ * omitted — the whole point of the ROADMAP 2.935 + 2.950 gates. See
+ * `describeEdge`'s header.
  */
 export function getEdgeLabel(
-  weight: number,
+  strength: EdgeValueDisplay,
   belief: number | undefined,
   direction: EdgeDirectionDisplay,
   mode?: EdgeLabelMode,
@@ -213,12 +270,12 @@ export function getEdgeLabel(
   const actualMode = mode ?? getEdgeLabelMode()
 
   if (actualMode === 'numeric') {
-    const numericLabel = formatNumericLabel(weight, belief, direction)
+    const numericLabel = formatNumericLabel(strength, belief, direction)
     return {
       label: numericLabel,
       tooltip: numericLabel
     }
   }
 
-  return describeEdge(weight, belief, direction)
+  return describeEdge(strength, belief, direction)
 }

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -164,6 +164,12 @@ export function edgeValueSource(
   //
   // `'unknown'` is deliberately NOT evidence: it is the producer declining to
   // state one, which `resolveEdgeDirectionDisplay` reports as its own reason.
+  // Scope of that arm, derived (ROADMAP 2.950): a wire `'unknown'` reaches this
+  // resolver only via `v5/applyV5State.ts:660`'s verbatim `adjust_edge_strength`
+  // merge or via persisted graphs — all three draft ingestion hops strip the
+  // `effect_direction` key (pinned by `edgeValidationMapperMirror.spec.ts`'s
+  // shared-drop corpus), so on those paths the refusal arrives as an unstamped
+  // `direction` and resolves `not_set` rather than `unknown`.
   if (
     field === 'direction' &&
     (data.effect_direction === 'positive' || data.effect_direction === 'negative')
@@ -518,9 +524,12 @@ export function resolveEdgeSignedStrengthDisplay(
     // Listed by name so the follow-up row is honest about its size rather than
     // implying a single stray call site:
     //   · nodes/shared/EdgePills.tsx:71        `direction: signed >= 0 ? 'up' : 'down'`
-    //   · inspector-v2/inspectorStrings.ts:106 `getStrengthDescription` — builds
-    //     the literal string "Strong positive" from `signedValue >= 0`, and is
-    //     rendered by `edges/StyledEdge.tsx:45`
+    //   · ~~inspector-v2 `getStrengthDescription`~~ — RETIRED (ROADMAP 2.950).
+    //     This entry claimed it was "rendered by `edges/StyledEdge.tsx:45`";
+    //     verified at the bytes, that was STALE — StyledEdge imported it and
+    //     never called it, and no other production caller existed, so the
+    //     function was DELETED rather than gated (see its tombstone in
+    //     inspectorStrings.ts).
     //   · inspector-v2/shared/ConnectionRow.tsx:99   bar tone `signedValue >= 0 ? 'bg-success' : 'bg-danger'`
     //   · inspector-v2/shared/ConnectionRow.tsx:106  `signedValue > 0 ? '+' : ''`
     //   · inspector-v2/shared/ConnectionRow.tsx:110  `signedValue >= 0 ? '+' : '−'`

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -43,7 +43,6 @@ import { isGraphLensEnabled } from '../../flags'
 import { isEdgeFragile as isEdgeFragileFn, getFragileEdgeSwitchProbability, isTopFragileEdge as isTopFragileEdgeFn } from '../utils/fragileEdgeMatch'
 import { existenceCertaintyToLineStyle, calculateEdgeImportance, weightMagnitudeToStrokeWidth, UNSET_EDGE_STROKE_WIDTH } from '../utils/graphDisplayCalculations'
 import { typography } from '../../styles/typography'
-import { getStrengthDescription, getProvenanceLabel } from '../ui/inspector-v2/inspectorStrings'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 
@@ -402,13 +401,21 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // the ones CEE sent a negative `strength.mean` for. The glyph beside it was
   // already announcing "Effect direction: negative" at the time.
   //
+  // ⭐ ROADMAP 2.950 — AND THE LABEL'S STRENGTH ADJECTIVE, FROM THE SAME
+  // RESOLVED VALUE THE STROKE WIDTH READS. `weight` (:209) falls through to
+  // `0.5` — `DEFAULT_EDGE_DATA.weight`, a UI constant — so the label asserted
+  // "Moderate" for edges whose strength nobody set, directly beside the
+  // direction clause that had just learned to refuse. `edgeSignedStrength`
+  // (:283) is the one owner of "may this surface speak a strength?", already
+  // consulted by the stroke width; the label now reads the same answer.
+  //
   // Computed ONCE here rather than twice inline in the JSX below, because the
   // accessible name is built from it: `aria-label` REPLACES descendant text for
   // assistive tech, so a name that omitted the description announced something
   // different from what was on screen.
   const edgeDescription = useMemo(
-    () => getEdgeLabel(weight, belief, directionDisplay, labelMode),
-    [weight, belief, directionDisplay, labelMode],
+    () => getEdgeLabel(edgeSignedStrength, belief, directionDisplay, labelMode),
+    [edgeSignedStrength, belief, directionDisplay, labelMode],
   )
   const ariaLabel = `Edge from ${srcTitle} to ${tgtTitle}${confText}, ${edgeDescription.label}`
 
@@ -422,8 +429,29 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   }
 
   // P0-9: Handle edge data update from popover
+  //
+  // ⭐ ROADMAP 2.950 — the strength stamp, CONDITIONAL on the value moving.
+  // `EdgeEditPopover` live-previews on a 120 ms debounce, INCLUDING an initial
+  // fire with the SEED values the moment it opens. Stamping every fire would
+  // launder the `weight` default into a user claim just by opening the popover
+  // — the exact failure `edgeValueProvenance.ts` exists to prevent — while
+  // never stamping would leave the (now provenance-gated) label saying "not
+  // set" about a strength the user just chose. So: stamp `weightSource:
+  // 'user'` only when the written weight differs from the one on screen, and
+  // clear any producer `strength_mean` with it — the resolver prefers the
+  // pre-signed mean, so a stale one would keep speaking over the user's number
+  // (same shape as `PreAnalysisPanel`'s user override, :1216).
+  //
+  // `belief` is deliberately NOT stamped: it is the legacy confidence field,
+  // not the provenanced `beliefExists` channel, and stamping
+  // `beliefExistsSource` for it would claim a value the beliefExists reader
+  // would then resolve from the DEFAULTED `beliefExists: 0.8` instead.
   const handleEdgeUpdate = (edgeId: string, updatedData: { weight: number; belief: number }) => {
-    updateEdgeData(edgeId, updatedData)
+    if (updatedData.weight !== weight) {
+      updateEdgeData(edgeId, { ...updatedData, strength_mean: undefined, weightSource: 'user' })
+    } else {
+      updateEdgeData(edgeId, updatedData)
+    }
   }
 
   // C1: Handle hover for edge label visibility + T1: delayed hover popover

--- a/src/canvas/edges/__tests__/StyledEdge.edgeLabelStrengthWords.2950.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.edgeLabelStrengthWords.2950.spec.tsx
@@ -1,0 +1,479 @@
+/**
+ * ROADMAP 2.950 — THE LABEL'S STRENGTH ADJECTIVE MUST COME FROM THE RESOLVER,
+ * NOT FROM A RAW `weight` THE UI DEFAULTS FABRICATE.
+ *
+ * THE DEFECT, IN THE PRODUCT'S OWN WORDS
+ * --------------------------------------
+ * #627 (ROADMAP 2.935) gated the label's DIRECTION word: an unstated direction
+ * now renders "…, direction not stated" instead of "boost". But the SAME string's
+ * other clause still read a band adjective off `edgeData?.weight ?? 0.5` — a
+ * number `DEFAULT_EDGE_DATA.weight = 0.5` / `USER_EDGE_DEFAULTS.weight = 0.3`
+ * define on every edge whether anyone set it or not. So an edge whose strength
+ * NOBODY characterised rendered **"Moderate effect, direction not stated"**:
+ * the direction half refuses to claim while the strength half asserts a band
+ * derived from a UI constant. Same fabrication class, other clause.
+ *
+ * THE SHAPE OF THE FIX (parallel to #627, deliberately)
+ * -----------------------------------------------------
+ * `describeEdge` now takes a required `EdgeValueDisplay` resolved by
+ * `resolveEdgeSignedStrengthDisplay` — the SAME resolver that already gates this
+ * component's stroke width — so "0.5, source unknown" is not expressible at the
+ * type level, exactly as `EdgeDirectionDisplay` made "positive, source unknown"
+ * inexpressible.
+ *
+ * COPY (ratified in the row's brief): when NEITHER strength nor direction is
+ * set, the label reuses the hover popover's existing vocabulary —
+ * "Strength and likelihood not set" (`edge-hover-popover-unset`) — no new copy.
+ * When exactly one half has provenance, that half speaks and the other half
+ * says only that it was not set.
+ *
+ * FIXTURES — real capture bytes through the real exported ingestion mapper
+ * -----------------------------------------------------------------------
+ * As in the 2935 template: no hand-authored `data`. Every fixture starts from a
+ * REAL edge in a committed CEE draft capture and goes through
+ * `mapDraftEdgeToCanvas`. The unset variants delete wire KEYS from the real
+ * edge (the template's own technique for `effect_direction: 'unknown'`), so
+ * every remaining byte is the producer's. Derived and pinned below: all five
+ * committed captures carry `strength` + a stated `effect_direction` on every
+ * edge, so the unset-strength states arise from the mapper's DEFAULT arm — the
+ * exact arm the defect fabricated from.
+ *
+ * ⚠ WHAT MAKES THE NO-STRENGTH FIXTURE SHARP: the mapper's fallback weight is
+ * `DEFAULT_EDGE_DATA.weight = 0.5`, which lands in the "Moderate" band — so an
+ * implementation still reading the raw number prints "Moderate" here and the
+ * band assertions RED. A fallback that landed outside every band could not
+ * discriminate. The preconditions block pins this, so the fixture cannot
+ * silently stop discriminating (CLAUDE.md trap 13b, third face).
+ *
+ * CLAIM TYPES — nothing here claims more than one of these:
+ *   1. Pure-function return values (`mapDraftEdgeToCanvas`, the resolvers).
+ *   2. Rendered text content and attribute values read off the DOM.
+ *   3. Arguments captured by a store-boundary spy (`updateEdgeData`).
+ * jsdom cannot prove VISIBILITY or layout (platform trap 3).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { Position } from '@xyflow/react'
+import { StyledEdge } from '../StyledEdge'
+import { mapDraftEdgeToCanvas } from '../../utils/applyDraftResult'
+import {
+  resolveEdgeDirectionDisplay,
+  resolveEdgeSignedStrengthDisplay,
+} from '../../domain/edgeValueProvenance'
+import { DEFAULT_EDGE_DATA } from '../../domain/edges'
+import { useEdgeLabelMode } from '../../store/edgeLabelMode'
+
+const nodeKinds: Record<string, string> = {}
+
+// Stable spy — the store mock must NOT mint a fresh vi.fn per selector call, or
+// the popover-stamp assertions below would capture nothing.
+const { updateEdgeDataSpy } = vi.hoisted(() => ({ updateEdgeDataSpy: vi.fn() }))
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => <path data-testid="base-edge" style={style} />,
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: { label: id === 'src' ? 'Adoption friction' : 'Bottom-up growth' }, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+// `showLabel` needs `isResultsMode` (results.status === 'complete') and a
+// non-standard view with the edge selected — see edgeLabelVisibility.ts.
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: updateEdgeDataSpy,
+      runMeta: { ceeReview: null },
+      results: { status: 'complete', report: null },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: 'detailed',
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// ⛔ importOriginal-SPREAD, never a hand-listed replacement (CLAUDE.md trap 12).
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: () => undefined,
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+
+const baseProps = {
+  id: 'e-under-test', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: true,
+}
+
+// ── Fixtures: real capture edges, through the real ingestion mapper ──────────
+
+type WireEdge = Record<string, unknown>
+
+/** Read a committed CEE draft capture and return its edge list. */
+function captureEdges(file: string): WireEdge[] {
+  const p = resolve(__dirname, '../../starters/data', file)
+  const j = JSON.parse(readFileSync(p, 'utf8'))
+  const edges = (j.edges ?? j.graph?.edges ?? []) as WireEdge[]
+  expect(edges.length, `${file} carried no edges`).toBeGreaterThan(0)
+  return edges
+}
+
+function findEdge(file: string, from: string, to: string): WireEdge {
+  const hit = captureEdges(file).find(e => e.from === from && e.to === to)
+  expect(hit, `${file} no longer carries ${from} → ${to}`).toBeDefined()
+  return hit as WireEdge
+}
+
+/** The PRODUCER. Whatever ingestion writes is what the component sees. */
+function ingest(wire: WireEdge): Record<string, unknown> {
+  return mapDraftEdgeToCanvas(wire, 0).data as Record<string, unknown>
+}
+
+/** Same real negative edge the 2935 template pinned: mean −0.35, stated negative. */
+const SET_WIRE = findEdge('pricing-model.draft.json', 'fac_adoption_friction', 'out_bottom_up_growth')
+
+/**
+ * STRENGTH UNSET, direction still stated: the real edge with its ONE
+ * strength-bearing key deleted. (Pinned below: this wire edge carries no
+ * `strength_mean` / `weight` spellings, so deleting `strength` deletes the
+ * whole strength claim and the mapper takes its DEFAULT arm.)
+ */
+const NO_STRENGTH_WIRE: WireEdge = (() => {
+  const { strength: _s, ...rest } = SET_WIRE as Record<string, unknown> & { strength?: unknown }
+  return rest
+})()
+
+/** NEITHER set: strength key AND the stated direction both deleted. */
+const NEITHER_WIRE: WireEdge = (() => {
+  const { effect_direction: _d, ...rest } = NO_STRENGTH_WIRE as Record<string, unknown> & { effect_direction?: unknown }
+  return rest
+})()
+
+const SET_DATA = ingest(SET_WIRE)
+const NO_STRENGTH_DATA = ingest(NO_STRENGTH_WIRE)
+const NEITHER_DATA = ingest(NEITHER_WIRE)
+
+// ── DOM readers, bound by identity (CLAUDE.md trap 19) ──────────────────────
+
+function labelEl(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('[data-testid="edge-influence-label"]') as HTMLElement | null
+  expect(el, 'the edge influence label did not render').not.toBeNull()
+  return el as HTMLElement
+}
+
+const labelText = (c: HTMLElement) => labelEl(c).textContent ?? ''
+const labelTooltip = (c: HTMLElement) => labelEl(c).getAttribute('title') ?? ''
+const labelAria = (c: HTMLElement) => labelEl(c).getAttribute('aria-label') ?? ''
+
+/** Words that assert a strength BAND for the edge. */
+const BAND_WORDS = ['strong', 'moderate', 'weak']
+
+const hasAny = (s: string, words: string[]) =>
+  words.some(w => s.toLowerCase().includes(w))
+
+function renderEdge(data: Record<string, unknown>) {
+  return render(<StyledEdge {...(baseProps as any)} data={data} />)
+}
+
+/** The ratified copy, byte-for-byte the popover's `edge-hover-popover-unset` text. */
+const RATIFIED_UNSET_COPY = 'Strength and likelihood not set'
+
+describe('StyledEdge edge label — strength words (ROADMAP 2.950, #627 lineage)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+    updateEdgeDataSpy.mockClear()
+    vi.mocked(useEdgeLabelMode).mockImplementation((selector: any) => selector({ mode: 'human' }))
+  })
+
+  // ── PRECONDITIONS. Pin the fixtures in-test so a discriminator can never
+  //    silently stop discriminating (trap 13b). If ingestion changes shape,
+  //    THIS block REDs — not a downstream assertion passing for the wrong
+  //    reason.
+  describe('fixture preconditions (derived from the producer, not assumed)', () => {
+    it('the SET fixture has a producer-sourced strength in the Moderate band, direction stated', () => {
+      expect((SET_WIRE as any).strength.mean).toBeLessThan(0)
+      expect(SET_DATA.weightSource).toBe('cee')
+      expect(resolveEdgeSignedStrengthDisplay(SET_DATA)).toEqual(
+        expect.objectContaining({ show: true, source: 'cee' }),
+      )
+      expect(SET_DATA.weight as number).toBeGreaterThanOrEqual(0.3)
+      expect(SET_DATA.weight as number).toBeLessThan(0.7)
+      expect(resolveEdgeDirectionDisplay(SET_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative' }),
+      )
+    })
+
+    it('the wire edge spells its strength ONLY as `strength`, so deleting that key deletes the claim', () => {
+      // Guards the fixture-construction technique itself: if the capture ever
+      // gains a `strength_mean` / `weight` spelling, NO_STRENGTH_WIRE would
+      // silently stop being strength-free and every assertion on it would test
+      // the wrong state.
+      expect(SET_WIRE).not.toHaveProperty('strength_mean')
+      expect(SET_WIRE).not.toHaveProperty('weight')
+      expect(NO_STRENGTH_WIRE).not.toHaveProperty('strength')
+    })
+
+    it('the NO-STRENGTH fixture lands on the UI default, unstamped — and in the Moderate band', () => {
+      // The defect's mechanism, asserted rather than described: the mapper's
+      // fallback IS the fabricated constant, and it falls in a band, so a raw
+      // read renders a band word. That is what makes this fixture discriminate.
+      expect(NO_STRENGTH_DATA.weight).toBe(DEFAULT_EDGE_DATA.weight)
+      expect(NO_STRENGTH_DATA.weight as number).toBeGreaterThanOrEqual(0.3)
+      expect(NO_STRENGTH_DATA.weight as number).toBeLessThan(0.7)
+      expect(NO_STRENGTH_DATA.weightSource).toBeUndefined()
+      expect(NO_STRENGTH_DATA).not.toHaveProperty('strength_mean')
+      expect(resolveEdgeSignedStrengthDisplay(NO_STRENGTH_DATA)).toEqual({
+        show: false,
+        reason: 'not_set',
+      })
+      // …while the direction is still the producer's, stamped.
+      expect(resolveEdgeDirectionDisplay(NO_STRENGTH_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative', source: 'cee' }),
+      )
+    })
+
+    it('the NEITHER fixture is unset on BOTH halves — including a fabricated direction value', () => {
+      // The mapper writes `direction: 'positive'` even here (its own fallback),
+      // unstamped — the same trap shape the 2935 fixture pinned. A raw read of
+      // either field would look plausible; only resolver-bound rendering passes.
+      expect(NEITHER_DATA.weight).toBe(DEFAULT_EDGE_DATA.weight)
+      expect(NEITHER_DATA.weightSource).toBeUndefined()
+      expect(NEITHER_DATA.direction).toBe('positive')
+      expect(NEITHER_DATA.directionSource).toBeUndefined()
+      expect(resolveEdgeSignedStrengthDisplay(NEITHER_DATA)).toEqual({
+        show: false,
+        reason: 'not_set',
+      })
+      expect(resolveEdgeDirectionDisplay(NEITHER_DATA)).toEqual({ show: false, reason: 'not_set' })
+    })
+
+    it('NO_STRENGTH and NEITHER differ ONLY in the direction keys', () => {
+      const keys = new Set([...Object.keys(NO_STRENGTH_DATA), ...Object.keys(NEITHER_DATA)])
+      const differing = [...keys].filter(
+        (k) => JSON.stringify(NO_STRENGTH_DATA[k]) !== JSON.stringify(NEITHER_DATA[k]),
+      ).sort()
+      expect(differing).toEqual(['direction', 'directionSource'])
+    })
+  })
+
+  // ── THE NAMED DEFECT ──────────────────────────────────────────────────────
+
+  it('does NOT assert a strength band for a strength nobody set [ROADMAP 2.950]', () => {
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    const text = labelText(container)
+    expect(hasAny(text, BAND_WORDS), `label read "${text}"`).toBe(false)
+  })
+
+  it('says the strength was not set, in the popover\'s vocabulary', () => {
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    expect(labelText(container).toLowerCase()).toContain('strength not set')
+  })
+
+  it('still names the stated direction when only the strength is unset', () => {
+    // The half with provenance still speaks: this edge's producer said
+    // "negative" (pinned above), and deleting the strength must not silence it.
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    const text = labelText(container)
+    expect(hasAny(text, ['drag']), `label read "${text}"`).toBe(true)
+    expect(hasAny(text, ['boost']), `label read "${text}"`).toBe(false)
+  })
+
+  it('the TOOLTIP does not print the fabricated number, and says not set', () => {
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    const tip = labelTooltip(container)
+    expect(tip, `tooltip read "${tip}"`).toContain('Weight: not set')
+    expect(tip, `tooltip read "${tip}"`).not.toContain('0.50')
+  })
+
+  it('the ACCESSIBLE NAME agrees with the visible text (no sighted/AT divergence)', () => {
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    const aria = labelAria(container)
+    expect(hasAny(aria, BAND_WORDS), `accessible name read "${aria}"`).toBe(false)
+    expect(hasAny(aria, ['drag']), `accessible name read "${aria}"`).toBe(true)
+  })
+
+  it('NEITHER set → the ratified popover copy, exactly', () => {
+    const { container } = renderEdge(NEITHER_DATA)
+    expect(labelText(container)).toBe(RATIFIED_UNSET_COPY)
+  })
+
+  it('the NUMERIC channel does not print the fabricated number either', () => {
+    vi.mocked(useEdgeLabelMode).mockImplementation((selector: any) => selector({ mode: 'numeric' }))
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    const text = labelText(container)
+    expect(text, `numeric label read "${text}"`).toContain('w not set')
+    expect(text, `numeric label read "${text}"`).not.toContain('0.50')
+  })
+
+  // ── THE LICENSED CLAIM STILL RENDERS (regression pins, green at pristine) ─
+
+  it('still renders the full claim for a producer-sourced strength', () => {
+    const { container } = renderEdge(SET_DATA)
+    // Byte-exact: the same string this edge rendered before this change. The
+    // capture carries no `belief`, so the (uncertain) qualifier applies.
+    expect(labelText(container)).toBe('Moderate drag (uncertain)')
+  })
+
+  it('the numeric channel still prints a sourced strength, signed by the stated direction', () => {
+    vi.mocked(useEdgeLabelMode).mockImplementation((selector: any) => selector({ mode: 'numeric' }))
+    const { container } = renderEdge(SET_DATA)
+    expect(labelText(container)).toContain('w −0.35')
+  })
+
+  // ── THE TRIPLE: differ where they must ────────────────────────────────────
+
+  describe('set / strength-unset / neither render differently where they should', () => {
+    const TRIPLE = [
+      { name: 'strength set, direction stated', data: SET_DATA },
+      { name: 'strength unset, direction stated', data: NO_STRENGTH_DATA },
+      { name: 'neither set', data: NEITHER_DATA },
+    ] as const
+
+    it('the three labels are pairwise DISTINCT', () => {
+      const texts = TRIPLE.map(({ data }) => labelText(renderEdge(data).container))
+      expect(new Set(texts).size, `labels were ${JSON.stringify(texts)}`).toBe(3)
+    })
+
+    it('a band word appears exactly when the resolver licenses one', () => {
+      // The biconditional, derived per row from the ONE owner the stroke width
+      // already reads — so a row added to TRIPLE extends coverage with no list
+      // to maintain.
+      for (const { name, data } of TRIPLE) {
+        const { container } = renderEdge(data)
+        const licensed = resolveEdgeSignedStrengthDisplay(data).show
+        const bandAsserted = hasAny(labelText(container), BAND_WORDS)
+        expect(bandAsserted, `${name}: band word`).toBe(licensed)
+      }
+    })
+
+    it('the table is NOT vacuous — it produces both a licensed and an unlicensed row', () => {
+      const shown = TRIPLE.map(({ data }) => resolveEdgeSignedStrengthDisplay(data).show)
+      expect(shown).toContain(true)
+      expect(shown).toContain(false)
+    })
+  })
+
+  // ── IDENTITY BINDING (trap 19) ────────────────────────────────────────────
+  //
+  // The DISCRIMINATING MUTANT PAIR this block supports:
+  //   · loosen the strength gate for ALL edges (make `describeEdge` fabricate a
+  //     value when `show: false`) → the band/tooltip/copy assertions above RED.
+  //   · loosen it for a DIFFERENT edge only (fabricate only when the id is not
+  //     'e-under-test') → this file stays GREEN.
+  // Neither alone proves binding; the RED/GREEN pair does.
+
+  it('reads the label off THE EDGE UNDER TEST, not whichever label rendered first', () => {
+    const { container } = renderEdge(NO_STRENGTH_DATA)
+    expect(baseProps.id).toBe('e-under-test')
+    expect(container.querySelectorAll('[data-testid="edge-influence-label"]').length).toBe(1)
+    expect(labelText(container).toLowerCase()).toContain('strength not set')
+  })
+
+  // ── THE EDIT POPOVER SEAM: a user edit must become visible to the gate ────
+  //
+  // `EdgeEditPopover` live-previews on a 120 ms debounce, INCLUDING an initial
+  // fire with the SEED values the moment it opens. So the stamp has to be
+  // conditional on the value actually moving:
+  //   · stamp on every fire  → opening the popover launders the 0.5 default
+  //     into a user claim (the exact failure edgeValueProvenance.ts exists to
+  //     prevent) — the first test below REDs.
+  //   · never stamp          → the label says "not set" about a strength the
+  //     user just chose — the second test REDs.
+
+  describe('edge edit popover → weightSource stamp', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    function openPopover(container: HTMLElement) {
+      fireEvent.doubleClick(labelEl(container))
+    }
+
+    it('does NOT stamp on the popover\'s untouched initial fire (no laundering on open)', () => {
+      const { container } = renderEdge(NO_STRENGTH_DATA)
+      openPopover(container)
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+      // POSITIVE CONTROL for the absence: the initial fire itself happened.
+      expect(updateEdgeDataSpy).toHaveBeenCalled()
+      for (const [, data] of updateEdgeDataSpy.mock.calls) {
+        expect(data).not.toHaveProperty('weightSource')
+      }
+    })
+
+    it('stamps weightSource: "user" (and clears strength_mean) when the user moves the weight', () => {
+      const { container, getByLabelText } = renderEdge(NO_STRENGTH_DATA)
+      openPopover(container)
+      fireEvent.change(getByLabelText('Weight slider'), { target: { value: '0.9' } })
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+      const stamped = updateEdgeDataSpy.mock.calls.filter(([, data]) => data?.weightSource === 'user')
+      expect(stamped.length, 'no stamped write reached the store').toBeGreaterThan(0)
+      const [edgeId, data] = stamped[stamped.length - 1]
+      // Bound by identity: the stamp lands on the edge under test.
+      expect(edgeId).toBe('e-under-test')
+      expect(data.weight).toBeCloseTo(0.9)
+      // A stale producer mean would keep speaking over the user's number —
+      // the resolver prefers it — so the write clears it (PreAnalysisPanel
+      // precedent, :1216).
+      expect(data).toHaveProperty('strength_mean', undefined)
+    })
+  })
+})

--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -140,11 +140,17 @@ export function getStrengthLabel(absValue: number): string {
   return 'Slight'
 }
 
-export function getStrengthDescription(signedValue: number): string {
-  const label = getStrengthLabel(Math.abs(signedValue))
-  const dir = signedValue >= 0 ? 'positive' : 'negative'
-  return `${label} ${dir}`
-}
+// `getStrengthDescription(signedValue)` — DELETED (ROADMAP 2.950). It built the
+// literal string "Strong positive" from `signedValue >= 0`, i.e. read a
+// DIRECTION CLAIM off the sign of a number `resolveEdgeSignedStrengthDisplay`
+// may have signed from a defaulted `direction` — the 2.263/2.935 defect class,
+// as a utility waiting for a caller. Verified at the bytes before removal: its
+// ONLY import was `edges/StyledEdge.tsx`, which never called it (the KNOWN
+// SURVIVORS list in `domain/edgeValueProvenance.ts` recorded it as rendered;
+// that entry was stale and is corrected in the same change). If you need a
+// directional strength sentence, use `getDirectionalStrengthLabel`
+// (`components/model-tab/strengthBands.ts`), which takes a resolved
+// `EdgeDirectionDisplay` and cannot fabricate the direction.
 
 // ─── Empty states (DS v4 §16) ──────────────────────────────────────
 export const EMPTY_STATES = {

--- a/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
+++ b/src/canvas/utils/__tests__/edgeValidationMapperMirror.spec.ts
@@ -29,6 +29,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 import { mapDraftEdgeToCanvas } from '../applyDraftResult'
 import { DEFAULT_EDGE_DATA } from '../../domain/edges'
+import { resolveEdgeDirectionDisplay } from '../../domain/edgeValueProvenance'
 
 // ── The wire shape CEE's validation pipeline emits (abridged to the fields the
 //    UI's render surface and card actually read). Not a re-declaration of the
@@ -303,6 +304,77 @@ describe('edge data — the two hand-mirrored mappers build the SAME bag', () =>
     // both divergences this assertion originally recorded were adjudicated as
     // defects and fixed in the same change — see the two describes below.
     expect(KNOWN_HOP_DIVERGENCES.map(([k]) => k)).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// `effect_direction: 'unknown'` — THE SHARED-DROP SEMANTICS, PINNED (ROADMAP
+// 2.950 ride-along; the corpus above carried only `'negative'`).
+//
+// `'unknown'` is a DECLARED @talchain/schemas 0.30.0 contract member — the
+// producer explicitly declining to state a direction. Both mappers treat it
+// identically to an OMITTED direction, by construction: their extraction
+// accepts only `'positive' | 'negative'`, neither blind-spreads the wire, so
+// the raw `effect_direction` key does not survive into `data` at all, the
+// stored `direction` is the sign-of-mean fallback, and NO `directionSource` is
+// stamped — which is what routes `resolveEdgeDirectionDisplay` to `not_set`.
+// (`reason: 'unknown'` is reachable only where the raw spelling survives:
+// `v5/applyV5State.ts:660`'s verbatim merge and persisted graphs — see the
+// scope note in domain/edgeValueProvenance.ts.)
+//
+// Pinning this here matters because the two hops could drift APART on it in
+// either direction — one starting to stamp `'unknown'` as a stated direction
+// (a fabrication), or one starting to preserve the raw key while the other
+// drops it (a divergence invisible to every single-hop test).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("edge data — the two mappers agree on effect_direction: 'unknown' (shared drop)", () => {
+  const WIRE_EDGE_UNKNOWN_DIR = { ...WIRE_EDGE_FULL, effect_direction: 'unknown' }
+
+  beforeEach(() => {
+    seedPatchStore()
+  })
+
+  it('both hops build the SAME bag for an unknown-direction edge', () => {
+    const drafted = mapDraftEdgeToCanvas({ ...WIRE_EDGE_UNKNOWN_DIR }, 0)
+    applyAutoApplyPatch(addEdgePatch({ ...WIRE_EDGE_UNKNOWN_DIR }) as any)
+    const patched = storeEdges[0]
+
+    const keys = new Set([...Object.keys(drafted.data), ...Object.keys(patched.data)])
+    expect(keys.size).toBeGreaterThan(10)
+
+    const differing = [...keys]
+      .filter((k) => JSON.stringify(drafted.data[k]) !== JSON.stringify(patched.data[k]))
+      .sort()
+    expect(differing).toEqual([])
+  })
+
+  it("neither hop stores the raw 'unknown', stamps a source, or fabricates a STATED direction", () => {
+    // POSITIVE CONTROL (trap 13) for every absence below: the SAME wire edge
+    // with a stated direction produces the key's stamped counterpart, so these
+    // assertions measure a real drop rather than measuring nothing.
+    const statedControl = mapDraftEdgeToCanvas({ ...WIRE_EDGE_FULL }, 0)
+    expect(statedControl.data.directionSource).toBe('cee')
+    expect(WIRE_EDGE_UNKNOWN_DIR.effect_direction).toBe('unknown')
+
+    const drafted = mapDraftEdgeToCanvas({ ...WIRE_EDGE_UNKNOWN_DIR }, 0)
+    applyAutoApplyPatch(addEdgePatch({ ...WIRE_EDGE_UNKNOWN_DIR }) as any)
+    const patched = storeEdges[0]
+
+    for (const [hop, data] of [['draft', drafted.data], ['patch', patched.data]] as const) {
+      // The raw spelling is dropped — the explicit-refusal arm of the resolver
+      // is unreachable on these paths, by construction.
+      expect(data, `${hop}: effect_direction`).not.toHaveProperty('effect_direction')
+      // The stored direction is the sign-of-mean FALLBACK (mean 0.42 → positive),
+      // unstamped…
+      expect(data.direction, `${hop}: direction`).toBe('positive')
+      expect(data, `${hop}: directionSource`).not.toHaveProperty('directionSource')
+      // …so the one owner refuses to state it, with the shared-drop verdict.
+      expect(
+        resolveEdgeDirectionDisplay(data as Record<string, unknown>),
+        `${hop}: resolver verdict`,
+      ).toEqual({ show: false, reason: 'not_set' })
+    }
   })
 })
 


### PR DESCRIPTION
# ROADMAP 2.950 — gate the edge label's strength adjective on provenance (#627 lineage)

## The defect

#627 (ROADMAP 2.935) made the canvas edge label's **direction** word come from `resolveEdgeDirectionDisplay`. The **strength** clause of the same string still read its band adjective off `edgeData?.weight ?? 0.5` — a UI constant (`DEFAULT_EDGE_DATA.weight = 0.5`, `USER_EDGE_DEFAULTS.weight = 0.3`) defined on every edge whether anyone set it or not. An unset-strength edge therefore rendered **"Moderate effect, direction not stated"**: the direction half refusing to claim while the strength half asserted a band derived from a UI default. Same fabrication class #627 closed, other clause of the same sentence.

## The shape (ratified in the row's brief)

`describeEdge` / `formatNumericLabel` / `getEdgeLabel` now take a **required `EdgeValueDisplay`** resolved by `resolveEdgeSignedStrengthDisplay` — the same resolver that already gates this component's **stroke width** — so "0.5, source unknown" is not expressible at the type level, exactly parallel to #627's required `EdgeDirectionDisplay`. When `show: false`, the display's value is used for nothing: not the band, not the tooltip number, not the numeric label. When `show: true`, only its **magnitude** is read — the sign remains the direction argument's business (that resolver's header forbids reading its sign as a direction claim, and this change respects it).

## Copy, as implemented

| strength | direction | human label | tooltip weight | numeric |
|---|---|---|---|---|
| set | stated | `Moderate drag` (+ `(uncertain)` per belief — unchanged) | `Weight: −0.35` | `w −0.35 …` |
| set | not stated | `Moderate effect, direction not stated` (unchanged #627 copy — now only for genuinely set strengths) | `Weight: 0.35` | `w 0.35 …` |
| **not set** | stated | **`Drag, strength not set`** (+ `(uncertain)` per belief) | `Weight: not set` | `w not set …` |
| **not set** | not stated | **`Strength and likelihood not set`** — byte-identical to the popover's `edge-hover-popover-unset` sentence, per the ratified copy decision; no `(uncertain)` suffix (there is no claim to qualify) | `Weight: not set` | `w not set` |

Copy notes, disclosed rather than implied:
- The mixed-case clause `…, strength not set` composes existing vocabulary (the popover's "not set", the label's existing clause shape) — the brief ratified only the neither-set sentence, so this one composition is this lane's decision.
- The label fires the ratified sentence on (strength unset AND **direction** unset); the popover fires it on (strength unset AND **beliefExists-chain** unset), because the popover has no direction line and the label's only likelihood channel is the un-provenanced legacy `belief`. On an edge whose `beliefExists` **is** producer-sourced but whose strength and direction are both unset (no such edge exists in any committed capture — all 5 captures carry `strength` + a stated `effect_direction` on every edge; the state is reachable only synthetically or via a future producer change), the label would say "likelihood not set" while the popover shows "N% confident". Flagged for the copy owner; not resolved here because resolving it would mint new copy against the brief.

## The EdgeEditPopover seam (in-file consequence, disclosed)

`EdgeEditPopover` live-previews through `handleEdgeUpdate` on a 120 ms debounce, **including an initial fire with the seed values the moment it opens**. With the label now provenance-gated, that seam had to be closed in both directions:

- **never stamp** → the label says "not set" about a strength the user just chose (regression + under-disclosure);
- **stamp every fire** → merely opening the popover launders the 0.5/0.3 default into a user claim (the exact failure `edgeValueProvenance.ts` exists to prevent).

`handleEdgeUpdate` therefore stamps `weightSource: 'user'` (and clears `strength_mean`, `PreAnalysisPanel:1216` precedent — the resolver prefers a producer's pre-signed mean, so a stale one would keep speaking over the user's number) **only when the written weight differs from the one on screen**. Both directions are pinned by tests and both have biting mutants (M7/M8). `belief` is deliberately not stamped: it is the legacy confidence field, not the provenanced `beliefExists` channel.

## Bundle ride-alongs (from the row)

1. **`getStrengthDescription` DELETED** (`inspectorStrings.ts`), not just un-imported: verified at the bytes — its only import (`StyledEdge.tsx:46`) never called it, no other production caller exists (mocks in 11 specs are factory replacements, unaffected). It built `"Strong positive"` from `signedValue >= 0` — the 2.263/2.935 defect class as a utility waiting for a caller. Tombstone comment left in place; the stale KNOWN SURVIVORS entry in `edgeValueProvenance.ts` (which claimed it was "rendered by `StyledEdge.tsx:45`") corrected in the same change.
2. **`effect_direction: 'unknown'` parity corpus** added to `edgeValidationMapperMirror.spec.ts` (`WIRE_EDGE_FULL` carried only `'negative'`): pins that both hand-mirrored hops drop the raw key, stamp no source, and fabricate only the unstamped sign-of-mean fallback — with a stated-direction positive control so the absences measure something. Mutant M9 (hop 2 starts accepting `'unknown'` as stated) bites it.
3. **Scope sentence** at `edgeValueProvenance.ts:165`: a wire `'unknown'` reaches the resolver only via `applyV5State.ts:660`'s verbatim merge or persisted graphs — the three draft ingestion hops strip the key (each verified at the bytes; the 2935 spec header's contrary claim about `DraftChat` predates the correction recorded in `edgeValueProvenance.ts`).

## Out of scope (row 2.954, sequenced behind this)

The causal-lens `computeSignedMean` channel (`StyledEdge.tsx` causal-lens stroke/label, `domain/edges.ts:computeSignedMean`) — untouched, per the brief.

## Evidence

**RED-first at pristine `d33e20df`** — `StyledEdge.edgeLabelStrengthWords.2950.spec.tsx`, 10 named failing assertions / 10 green preconditions+invariants:

RED at pristine: `does NOT assert a strength band for a strength nobody set` · `says the strength was not set, in the popover's vocabulary` · `the TOOLTIP does not print the fabricated number, and says not set` · `the ACCESSIBLE NAME agrees with the visible text` · `NEITHER set → the ratified popover copy, exactly` · `the NUMERIC channel does not print the fabricated number either` · `the three labels are pairwise DISTINCT` · `a band word appears exactly when the resolver licenses one` · `reads the label off THE EDGE UNDER TEST` · `stamps weightSource: "user" … when the user moves the weight`.

GREEN at pristine (deliberately): the 5 fixture preconditions (pin the producer, trap 13b) · `still names the stated direction when only the strength is unset` (invariant preservation) · both SET-fixture regression pins · the popover no-laundering control (pristine doesn't stamp either; its bite is mutant M7).

**Fixtures**: real `pricing-model.draft.json` bytes through the exported `mapDraftEdgeToCanvas`; the unset variants delete wire keys only (`strength`, then also `effect_direction`), with an in-test pin that the wire edge spells its strength only as `strength` — so the fixture-construction technique itself fails loud if the capture changes. The mapper's 0.5 fallback lands in the Moderate band, which is what makes the fixture discriminate (also pinned).

**Mutant table** (throwaway worktree outside the repo root at `fc5dcac5`; isolation proven by sentinel WRITE + inode compare before any run; applied-check per mutation scoped to `src/`, control = exactly 0):

Pristine control in the worktree: applied-check 0 · 103/103 green across the 4 target files (collected counts matched pristine on every mutant run).

| # | Mutation | Expectation | Result |
|---|---|---|---|
| M1 | `describeEdge` fabricates `0.5` when `show: false` (loosen-for-ALL) | RED | **RED — 13 failed / 57 passed** |
| M2 | fabricate only when `id !== 'e-under-test'` (loosen-for-DIFFERENT-edge) | stays GREEN (trap-19 pair with M1) | **GREEN — 84/84** (incl. the 2935 spec) |
| M3 | ratified copy drifts one word (`not set` → `unset`) | RED | **RED — 3 failed** |
| M4 | tooltip re-fabricates `0.50` | RED | **RED — 2 failed** |
| M5 | mixed-case clause drops the direction word | RED | **RED — 4 failed** |
| M6 | numeric channel re-fabricates `0.50` | RED | **RED — 3 failed** |
| M7 | popover stamp unconditional (launders seed on open) | RED | **RED — 1 failed: `does NOT stamp on the popover's untouched initial fire`** |
| M8 | popover stamp removed | RED | **RED — 1 failed: `stamps weightSource: "user" … when the user moves the weight`** |
| M9 | hop 2 accepts `'unknown'` as a stated direction | RED (mirror corpus) | **RED — 2 failed in the new corpus block** |

M7 and M8 fail on **different** assertions — the pair proves the conditional stamp in both directions, not just its presence. M2's behavioural non-equivalence is by construction (it changes every edge except the one under test); its purpose per trap 19 is precisely that the suite must not see it while M1 REDs.

Mutants ran at content-identical commit `87d47085` (pre-rebase); the rebase onto `857548f8` (#628, disjoint files — overlap verified empty) changed no line of the mutated files, and the touched battery was re-run green at the rebased head.

**Suites**: touched battery 128/128 at both heads · `src/canvas/edges` + `src/canvas/ui/inspector-v2` 57 files / 626 tests green · `vitest run --changed` **738 files / 9,625 tests passed, 0 failures** · `pnpm typecheck` **PASSED** — and the change **shrinks the ratchet drift by 5 diagnostics** (2491 → 2486; baseline deliberately not regenerated — this lane's brief forbids baseline edits, banking it is a reviewer call). `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
