### PR TITLE
fix(canvas): provenance-gate the causal lens params (ROADMAP 2.954)

### DIFF
--- a/src/canvas/components/LensInfoPanel.tsx
+++ b/src/canvas/components/LensInfoPanel.tsx
@@ -12,6 +12,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import { useCanvasStore } from '../store'
 import { isGraphLensEnabled } from '../../flags'
 import type { LensMode } from '../store'
+import type { CausalLensEdgeParams } from '../domain/edgeValueProvenance'
 
 /** Causal lens panel: shows variable/edge count, model summary, and edge table */
 function CausalPanel() {
@@ -28,7 +29,7 @@ function CausalPanel() {
   // Build edge table data with source/target labels
   const edgeTableRows = useMemo(() => {
     const nodeMap = new Map(nodes.map(n => [n.id, (n.data as Record<string, unknown>)?.label as string ?? n.id]))
-    const rows: Array<{ from: string; to: string; mean: number; std: number | null; existsProb: number | null }> = []
+    const rows: Array<{ from: string; to: string } & CausalLensEdgeParams> = []
     for (const [edgeId, params] of causalEdgeParams) {
       const edge = edges.find(e => e.id === edgeId)
       if (!edge) continue
@@ -81,7 +82,16 @@ function CausalPanel() {
                 <tr key={i} style={{ borderTop: '1px solid var(--border-default, #EEE6D8)' }}>
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.from}>{r.from}</td>
                   <td style={{ padding: '2px 4px', maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={r.to}>{r.to}</td>
-                  <td style={{ padding: '2px 4px' }}>{r.mean >= 0 ? '+' : ''}{r.mean.toFixed(2)}</td>
+                  {/* ROADMAP 2.954 — provenance-gated Mean: an unset strength
+                      renders this table's own absent-quantity mark (the em
+                      dash its Std / P(exists) cells use), never the `+0.50`
+                      default; the sign renders only from the STATED direction
+                      ('−' U+2212, `formatNumericLabel`'s sign). */}
+                  <td style={{ padding: '2px 4px', color: r.magnitude === null ? 'var(--text-light, #6E6B6B)' : undefined }}>
+                    {r.magnitude !== null
+                      ? `${r.direction === 'positive' ? '+' : r.direction === 'negative' ? '−' : ''}${r.magnitude.toFixed(2)}`
+                      : '—'}
+                  </td>
                   <td style={{ padding: '2px 4px', color: r.std === null ? 'var(--text-light, #6E6B6B)' : undefined }}>{r.std !== null ? r.std.toFixed(2) : '\u2014'}</td>
                   <td style={{ padding: '2px 4px', color: r.existsProb === null ? 'var(--text-light, #6E6B6B)' : undefined }}>{r.existsProb !== null ? `${Math.round(r.existsProb * 100)}%` : '\u2014'}</td>
                 </tr>

--- a/src/canvas/components/__tests__/LensInfoPanel.causalLens.2954.spec.tsx
+++ b/src/canvas/components/__tests__/LensInfoPanel.causalLens.2954.spec.tsx
@@ -1,0 +1,131 @@
+/**
+ * ROADMAP 2.954 — the causal table must not sign or speak a strength nobody
+ * set. Same defect family as the canvas label (see
+ * StyledEdge.causalLens.2954.spec.tsx): the Mean column rendered
+ * `computeSignedMean`'s output — `+0.50` for a fully-defaulted edge, a
+ * UI-signed `-0.35` for a producer-declined direction.
+ *
+ * Copy: an unset Mean renders this table's OWN absent-quantity mark — the em
+ * dash its Std / P(exists) cells have always used (no new copy, #629 rule).
+ * A stated direction signs with U+2212 / '+'; an unstated one prints the bare
+ * magnitude.
+ *
+ * Pattern: real store via setState (the file's sibling spec's technique), map
+ * populated through the REAL exported producer so the chain producer → store →
+ * table is the one under test. State-class: seeded, fresh per test.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { LensInfoPanel } from '../LensInfoPanel'
+import { useCanvasStore } from '../../store'
+import { mapDraftEdgeToCanvas } from '../../utils/applyDraftResult'
+import { resolveCausalLensEdgeParams } from '../../domain/edgeValueProvenance'
+import { USER_EDGE_DEFAULTS } from '../../domain/edges'
+
+const EM_DASH = '—'
+
+type WireEdge = Record<string, unknown>
+
+function findEdge(from: string, to: string): WireEdge {
+  const p = resolve(__dirname, '../../starters/data', 'pricing-model.draft.json')
+  const j = JSON.parse(readFileSync(p, 'utf8'))
+  const edges = (j.edges ?? j.graph?.edges ?? []) as WireEdge[]
+  const hit = edges.find(e => e.from === from && e.to === to)
+  expect(hit, `capture no longer carries ${from} → ${to}`).toBeDefined()
+  return hit as WireEdge
+}
+
+const SET_WIRE = findEdge('fac_adoption_friction', 'out_bottom_up_growth')
+const UNKNOWN_DIR_WIRE: WireEdge = { ...SET_WIRE, effect_direction: 'unknown' }
+
+const SET_DATA = mapDraftEdgeToCanvas(SET_WIRE, 0).data as Record<string, unknown>
+const UNKNOWN_DIR_DATA = mapDraftEdgeToCanvas(UNKNOWN_DIR_WIRE, 0).data as Record<string, unknown>
+const USER_DATA: Record<string, unknown> = { ...USER_EDGE_DEFAULTS }
+
+/** Seed the causal lens with ONE edge whose params come from the real producer. */
+function seedCausalLens(edgeId: string, data: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    nodes: [
+      { id: 'n-from', data: { label: 'From node' }, position: { x: 0, y: 0 } },
+      { id: 'n-to', data: { label: 'To node' }, position: { x: 0, y: 0 } },
+    ] as never,
+    edges: [
+      { id: edgeId, source: 'n-from', target: 'n-to', data },
+    ] as never,
+    lens: {
+      ...useCanvasStore.getState().lens,
+      active: 'causal',
+      _causalEdgeParams: new Map([[edgeId, resolveCausalLensEdgeParams(data)]]),
+    },
+  } as never)
+}
+
+/** The Mean cell of the single seeded row, located via its row's From label. */
+function meanCellText(): string {
+  fireEvent.click(screen.getByText(/Show edge table/))
+  const fromCell = screen.getByTitle('From node')
+  const row = fromCell.closest('tr') as HTMLTableRowElement
+  expect(row, 'the edge row did not render').not.toBeNull()
+  // Columns: From | To | Mean | Std | P(exists)
+  return row.cells[2].textContent ?? ''
+}
+
+function rowCells(): { mean: string; std: string; exists: string } {
+  fireEvent.click(screen.getByText(/Show edge table/))
+  const row = screen.getByTitle('From node').closest('tr') as HTMLTableRowElement
+  return {
+    mean: row.cells[2].textContent ?? '',
+    std: row.cells[3].textContent ?? '',
+    exists: row.cells[4].textContent ?? '',
+  }
+}
+
+describe('LensInfoPanel causal table — provenance-gated Mean (ROADMAP 2.954)', () => {
+  beforeEach(() => {
+    localStorage.setItem('feature.graphLens', '1')
+  })
+
+  afterEach(() => {
+    localStorage.removeItem('feature.graphLens')
+    useCanvasStore.setState({
+      nodes: [] as never,
+      edges: [] as never,
+      lens: {
+        ...useCanvasStore.getState().lens,
+        active: 'full',
+        _causalEdgeParams: new Map(),
+      },
+    } as never)
+  })
+
+  it('a stated edge prints the signed mean (U+2212), std and P(exists) — the producer numbers', () => {
+    seedCausalLens('e-0', SET_DATA)
+    render(<LensInfoPanel />)
+    expect(rowCells()).toEqual({ mean: '−0.35', std: '0.11', exists: '88%' })
+  })
+
+  it('a producer-declined direction prints the BARE magnitude — no sign [ROADMAP 2.954]', () => {
+    seedCausalLens('e-0', UNKNOWN_DIR_DATA)
+    render(<LensInfoPanel />)
+    const mean = meanCellText()
+    expect(mean).toBe('0.35')
+    expect(mean).not.toMatch(/[+\-−]/)
+  })
+
+  it('a user-drawn edge (all channels defaulted) prints em dashes across the row [ROADMAP 2.954]', () => {
+    seedCausalLens('e-0', USER_DATA)
+    render(<LensInfoPanel />)
+    expect(rowCells()).toEqual({ mean: EM_DASH, std: EM_DASH, exists: EM_DASH })
+  })
+
+  it('CONTROL: the em dash is absence, not a formatting accident — the stated edge shows none', () => {
+    seedCausalLens('e-0', SET_DATA)
+    render(<LensInfoPanel />)
+    const cells = rowCells()
+    expect(cells.mean).not.toContain(EM_DASH)
+    expect(cells.std).not.toContain(EM_DASH)
+    expect(cells.exists).not.toContain(EM_DASH)
+  })
+})

--- a/src/canvas/domain/edgeValueProvenance.ts
+++ b/src/canvas/domain/edgeValueProvenance.ts
@@ -533,6 +533,12 @@ export function resolveEdgeSignedStrengthDisplay(
     //   · inspector-v2/shared/ConnectionRow.tsx:99   bar tone `signedValue >= 0 ? 'bg-success' : 'bg-danger'`
     //   · inspector-v2/shared/ConnectionRow.tsx:106  `signedValue > 0 ? '+' : ''`
     //   · inspector-v2/shared/ConnectionRow.tsx:110  `signedValue >= 0 ? '+' : '−'`
+    //   · ~~the causal lens~~ — GATED (ROADMAP 2.954). It was never on this
+    //     list because it did not read THIS function's sign: it rendered
+    //     `computeSignedMean` directly (a third signing function) through
+    //     `useLensFilter` → `causalEdgeParams`. It now routes through
+    //     `resolveCausalLensEdgeParams` below, which refuses both the number
+    //     and the sign independently.
     // Each reads a direction off a number this function may have signed from a
     // defaulted `direction` — the same defect the Model tab just had, on the
     // canvas and inspector surfaces. They need the same `EdgeDirectionDisplay`
@@ -542,6 +548,69 @@ export function resolveEdgeSignedStrengthDisplay(
     return { show: true, value: sign * data.weight, source }
   }
   return { show: false, reason: 'absent' }
+}
+
+/**
+ * What the CAUSAL LENS may say about one edge — all four channels, resolved.
+ *
+ * ROADMAP 2.954, the LAST raw-signed channel in the #625 → #627 (2.935) →
+ * #629 (2.950) edge-label honesty family. The lens (`useLensFilter`'s causal
+ * arm → `StyledEdge`'s causal label/stroke, `LensInfoPanel`'s table) rendered
+ * `computeSignedMean(edgeData)` — a THIRD signing function beside the two the
+ * family had already gated. On an edge whose producer declined a direction
+ * (`effect_direction: 'unknown'` — ingestion strips the key, leaving an
+ * unstamped fallback `direction`) it printed a signed number and a danger-red
+ * stroke the producer refused to state; on a fully-defaulted edge it printed
+ * `+0.50` — `DEFAULT_EDGE_DATA.weight`, signed by the `'negative' ? -1 : 1`
+ * fallback — plus a fabricated std (0.15) and exists probability (0.8) from
+ * `USER_EDGE_DEFAULTS`.
+ *
+ * SHAPE RULES (each field refuses independently — refusing the number is not
+ * refusing the direction):
+ *   · `magnitude` — |strength| via `resolveEdgeSignedStrengthDisplay`; null
+ *     when nothing proves anyone set a strength. Always non-negative: the
+ *     resolver's sign is NOT a direction claim (its header forbids reading it
+ *     as one, in capitals) and must not leak through this seam.
+ *   · `direction` — the STATED direction via `resolveEdgeDirectionDisplay`;
+ *     null for unset / declined / unrecognised. The sign glyph and the
+ *     danger-red stroke are direction claims and render ONLY from this field.
+ *   · `std` / `existsProb` — via `resolveEdgeValueDisplay`; null when
+ *     defaulted or absent. The lens surfaces already have absent forms for
+ *     these (label span omitted; table em dash) — refusal reuses them.
+ *
+ * The legacy raw `mean` field is deliberately GONE from this shape: a stale
+ * consumer reading `.mean` breaks at the type level instead of silently
+ * reading a fabricated sign (the fail-loud rename, trap 12).
+ *
+ * NOT FOR WIRE PAYLOADS — same boundary as `EdgeValueDisplay` above: the
+ * adapters legitimately need a number for every edge and keep their own
+ * `computeSignedMean`s.
+ */
+export interface CausalLensEdgeParams {
+  /** |strength| when provenance-set; null = nobody set one (refuse the number). */
+  magnitude: number | null
+  /** The STATED direction only; null = unstated/declined (refuse sign and colour). */
+  direction: 'positive' | 'negative' | null
+  /** Parametric uncertainty when provenance-set; null otherwise. */
+  std: number | null
+  /** Exists probability when provenance-set; null otherwise. */
+  existsProb: number | null
+}
+
+/** Resolve every causal-lens channel for one edge — THE lens read-side gate. */
+export function resolveCausalLensEdgeParams(
+  data: Record<string, unknown> | undefined | null,
+): CausalLensEdgeParams {
+  const strength = resolveEdgeSignedStrengthDisplay(data)
+  const direction = resolveEdgeDirectionDisplay(data)
+  const std = resolveEdgeValueDisplay(data, 'strengthStd')
+  const exists = resolveEdgeValueDisplay(data, 'beliefExists')
+  return {
+    magnitude: strength.show ? Math.abs(strength.value) : null,
+    direction: direction.show ? direction.direction : null,
+    std: std.show ? std.value : null,
+    existsProb: exists.show ? exists.value : null,
+  }
 }
 
 /**

--- a/src/canvas/domain/edges.ts
+++ b/src/canvas/domain/edges.ts
@@ -561,7 +561,25 @@ export function formatConfidence(confidence: number | undefined): string {
  * D.1: Compute signed strength mean from edge data (domain-level).
  *
  * Priority: strength_mean (already signed) > weight + direction (legacy).
- * Used for visual encoding (stroke width) — not for adapter payloads.
+ *
+ * ⚠ THE FALLBACK FABRICATES (ROADMAP 2.954): `weight` defaults to 0.5 on
+ * every edge and the sign falls through `direction === 'negative' ? -1 : 1`,
+ * so on an edge nobody characterised this returns `+0.5` — a constant wearing
+ * a sign. NO DISPLAY SURFACE may render this value or read its sign as a
+ * direction; displays go through `resolveEdgeSignedStrengthDisplay` /
+ * `resolveEdgeDirectionDisplay` (or, for the causal lens,
+ * `resolveCausalLensEdgeParams`) in ./edgeValueProvenance.ts.
+ *
+ * Caller manifest, verified at the bytes 2026-08-08 (re-derive, don't trust):
+ *   · nodes/shared/EdgePills.tsx — the ONE remaining display caller, and it
+ *     gates on `isEdgeValueSet(data, 'weight')` BEFORE calling (its
+ *     sign→direction read is a listed KNOWN SURVIVOR, rowed).
+ *   · The causal lens (useLensFilter) called this raw — the 2.954 defect —
+ *     and now routes through `resolveCausalLensEdgeParams`.
+ *   · useScienceIcons imported it with zero call sites — import deleted.
+ * The same-named functions in adapters/islRequestAdapter.ts and
+ * adapters/plot/v2/adapter.ts are SEPARATE wire-path functions (adapters
+ * legitimately need a number for every edge), not callers of this one.
  */
 export function computeSignedMean(
   data: Record<string, unknown> | undefined,

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -33,6 +33,7 @@ import {
   resolveEdgeDirectionDisplay,
   compareEdgeValueDisplays,
   type EdgeValueDisplay,
+  type CausalLensEdgeParams,
 } from '../domain/edgeValueProvenance'
 import { useIsDark } from '../hooks/useTheme'
 import { getEdgeLabel } from '../domain/edgeLabels'
@@ -123,7 +124,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           lensSensWeight: null as number | null,
           lensQ25: null as number | null, lensQ75: null as number | null,
           isLensFragile: false, isLensHidden: false,
-          causalEdgeParams: null as { mean: number; std: number | null; existsProb: number | null } | null,
+          causalEdgeParams: null as CausalLensEdgeParams | null,
           evidenceEdgeClass: null as string | null,
           lensHiddenNodeIds: EMPTY_ID_SET,
           lensHiddenEdgeIds: EMPTY_ID_SET,
@@ -725,9 +726,14 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             const base = (() => {
             // Structural edges: fixed 1px regardless of lens / hover / highlight
             if (isStructuralEdge) return 1
-            // Causal lens: thickness encodes |strength.mean|
+            // Causal lens: thickness encodes the PROVENANCE-SET strength
+            // magnitude (ROADMAP 2.954). An unset strength draws at the floor
+            // width — the same refusal the non-lens stroke (:286) makes — so
+            // thickness never reports the `weight` default as a measurement.
             if (lensMode === 'causal' && causalEdgeParams) {
-              return weightMagnitudeToStrokeWidth(causalEdgeParams.mean)
+              return causalEdgeParams.magnitude !== null
+                ? weightMagnitudeToStrokeWidth(causalEdgeParams.magnitude)
+                : UNSET_EDGE_STROKE_WIDTH
             }
             // Evidence lens: uniform thickness (not importance-weighted)
             if (lensMode === 'evidence') return 1.5
@@ -768,9 +774,13 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
           stroke: (() => {
             // Structural edges: fixed grey regardless of lens / highlight
             if (isStructuralEdge) return STRUCTURAL_EDGE_COLOUR
-            // Causal lens: neutral colour, danger for negative edges
+            // Causal lens: neutral colour; danger ONLY for a STATED negative
+            // (ROADMAP 2.954). Danger-red is a direction claim, so it renders
+            // from the resolved direction — never from the sign of a mean the
+            // UI itself may have fabricated (`effect_direction: 'unknown'`
+            // edges used to draw red here off the fallback sign).
             if (lensMode === 'causal' && causalEdgeParams) {
-              return causalEdgeParams.mean < 0 ? 'var(--semantic-danger, #ef4444)' : 'var(--text-body, #3F3F3E)'
+              return causalEdgeParams.direction === 'negative' ? 'var(--semantic-danger, #ef4444)' : 'var(--text-body, #3F3F3E)'
             }
             // Evidence lens: colour by provenance classification
             if (lensMode === 'evidence' && evidenceEdgeClass) {
@@ -845,7 +855,15 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             className="bg-panel text-text-body border border-panel-border shadow-sm"
             data-testid="causal-edge-label"
           >
-            {causalEdgeParams.mean >= 0 ? '+' : ''}{causalEdgeParams.mean.toFixed(2)}
+            {/* ROADMAP 2.954 — the number is a strength claim, the sign a
+                direction claim, and each renders only from its own resolved
+                channel. Unset strength: the numeric channel's ratified "not
+                set" (#629), never the `+0.50` default this label used to
+                print. Unstated direction: bare magnitude, no sign character.
+                '−' is U+2212, matching `formatNumericLabel`'s sign. */}
+            {causalEdgeParams.magnitude !== null
+              ? `${causalEdgeParams.direction === 'positive' ? '+' : causalEdgeParams.direction === 'negative' ? '−' : ''}${causalEdgeParams.magnitude.toFixed(2)}`
+              : 'not set'}
             {causalEdgeParams.existsProb !== null && (
               <span style={{ color: 'var(--text-light, #6E6B6B)' }}>
                 {' '}({Math.round(causalEdgeParams.existsProb * 100)}%)

--- a/src/canvas/edges/__tests__/StyledEdge.causalLens.2954.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.causalLens.2954.spec.tsx
@@ -1,0 +1,515 @@
+/**
+ * ROADMAP 2.954 — THE CAUSAL LENS MUST NOT SIGN OR SPEAK A STRENGTH NOBODY SET.
+ *
+ * THE DEFECT (found by #627's review, the LAST raw-signed channel in the
+ * #625 → #627/2.935 → #629/2.950 family)
+ * ---------------------------------------------------------------------------
+ * The causal lens rendered `computeSignedMean(edgeData)` — a THIRD signing
+ * function, absent from `resolveEdgeSignedStrengthDisplay`'s KNOWN SURVIVORS
+ * list — through `useLensFilter`'s causal arm into three channels:
+ *   · `causal-edge-label` printed `+0.50` — the `DEFAULT_EDGE_DATA.weight`
+ *     constant, signed positive by the fallback `direction === 'negative' ?
+ *     -1 : 1` — for edges whose strength and direction nobody stated;
+ *   · the stroke colour claimed danger-red (a NEGATIVE-direction verdict) off
+ *     the same fallback sign, on edges whose producer sent
+ *     `effect_direction: 'unknown'` (ingestion strips the key, leaving an
+ *     unstamped fallback `direction` that resolves `not_set`);
+ *   · the stroke width reported a measured-looking thickness off the default.
+ *
+ * THE SHAPE OF THE FIX (parallel to #627/#629, deliberately)
+ * ----------------------------------------------------------
+ * `useLensFilter`'s causal arm now writes `resolveCausalLensEdgeParams(data)`
+ * — a composition of the SAME resolver pair the main edge label uses
+ * (`resolveEdgeSignedStrengthDisplay` / `resolveEdgeDirectionDisplay`), plus
+ * `resolveEdgeValueDisplay` for the std / exists-probability channels. The
+ * map's value shape carries `magnitude: number | null` and
+ * `direction: 'positive' | 'negative' | null` — the legacy raw `mean` field is
+ * GONE, so a stale consumer breaks loudly at the type level rather than
+ * silently reading a fabricated sign.
+ *
+ * COPY (ratified in #629, reused byte-for-byte — no new copy): an unset
+ * strength prints "not set" (the numeric channel's established form); an
+ * unstated direction prints NO sign character and claims NO danger colour;
+ * absent std / exists quantities keep this surface's existing absent forms
+ * (label span omitted; table em dash).
+ *
+ * DEPLOYED FLAG POSTURE (derived 2026-08-08 at deployed tip bcee7479):
+ * `netlify.toml` does NOT set `VITE_FEATURE_GRAPH_LENS`, but the SERVED
+ * staging flags chunk (assets/flags-DBpusaUf.js, deploy of bcee7479) bakes
+ * `VITE_FEATURE_GRAPH_LENS: "1"` (dashboard env — trap 18). Controls: known-ON
+ * COMPARE_TAB reads "1", known-absent JOURNEY_TAB reads `void 0`, so the probe
+ * discriminates. The lens surface is therefore MOUNTED on deployed staging;
+ * this spec mocks the flag ON to match, and the mount-path block below asserts
+ * the label mounts under exactly that posture (trap 3b).
+ *
+ * FIXTURES — real capture bytes through the real exported ingestion mapper
+ * -----------------------------------------------------------------------
+ * As in the #627/#629 templates: no hand-authored wire `data`. Every draft
+ * fixture starts from a REAL edge in the committed `pricing-model.draft.json`
+ * capture and goes through `mapDraftEdgeToCanvas`; unset variants delete wire
+ * KEYS (or set the declared contract value `effect_direction: 'unknown'`).
+ * The USER fixture is `{ ...USER_EDGE_DEFAULTS }` — byte-identical to the
+ * store's own user-edge construction (`store.ts` onConnect, `data:
+ * { ...USER_EDGE_DEFAULTS }`), which is the producer for user-drawn edges.
+ *
+ * CLAIM TYPES — nothing here claims more than one of these:
+ *   1. Pure-function return values (`mapDraftEdgeToCanvas`, the resolvers,
+ *      `resolveCausalLensEdgeParams`).
+ *   2. Rendered text content and attribute values read off the DOM (the
+ *      BaseEdge mock serialises the style props StyledEdge passes, so the
+ *      stroke assertions bind to the component's output, not jsdom's CSS
+ *      engine).
+ * jsdom cannot prove VISIBILITY or layout (platform trap 3).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { Position } from '@xyflow/react'
+import { StyledEdge } from '../StyledEdge'
+import { mapDraftEdgeToCanvas } from '../../utils/applyDraftResult'
+import {
+  resolveEdgeDirectionDisplay,
+  resolveEdgeSignedStrengthDisplay,
+  resolveEdgeValueDisplay,
+  resolveCausalLensEdgeParams,
+} from '../../domain/edgeValueProvenance'
+import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from '../../domain/edges'
+import { UNSET_EDGE_STROKE_WIDTH, weightMagnitudeToStrokeWidth } from '../../utils/graphDisplayCalculations'
+import { useEdgeLabelMode } from '../../store/edgeLabelMode'
+
+const nodeKinds: Record<string, string> = {}
+
+// Per-test lens state. The store mock reads THIS, so each test decides the
+// lens mode and the exact params map entry the store carries — set via
+// `renderCausal` below, which routes the data through the REAL producer.
+const holder = vi.hoisted(() => ({
+  lensActive: 'causal' as string,
+  params: null as unknown,
+  updateEdgeDataSpy: vi.fn(),
+}))
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: ({ style }: any) => (
+      <path
+        data-testid="base-edge"
+        data-stroke={String(style?.stroke)}
+        data-stroke-width={String(style?.strokeWidth)}
+      />
+    ),
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({
+      getNode: (id: string) =>
+        nodeKinds[id]
+          ? { id, type: nodeKinds[id], data: { label: id === 'src' ? 'Adoption friction' : 'Bottom-up growth' }, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 } }
+          : null,
+      getEdges: () => [],
+      getNodes: () =>
+        Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+    }),
+    useStore: (selector: any) =>
+      selector({
+        nodes: Object.entries(nodeKinds).map(([id, kind]) => ({
+          id, type: kind, data: {}, position: { x: 0, y: 0 }, measured: { width: 200, height: 80 },
+        })),
+      }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: holder.updateEdgeDataSpy,
+      runMeta: { ceeReview: null },
+      results: { status: 'complete', report: null },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      viewMode: 'detailed',
+      lens: {
+        active: holder.lensActive,
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+        _hiddenNodeIds: new Set<string>(),
+        _hiddenEdgeIds: new Set<string>(),
+        _causalEdgeParams: holder.params !== null
+          ? new Map([['e-under-test', holder.params]])
+          : new Map(),
+        _evidenceNodeClass: new Map(),
+        _evidenceEdgeClass: new Map(),
+      },
+    })
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+// DEPLOYED POSTURE: the served staging bundle bakes VITE_FEATURE_GRAPH_LENS "1"
+// (derivation in the header). The lens surface is mounted; tests bind to it.
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => true }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+  isTopFragileEdge: () => false,
+}))
+// ⛔ importOriginal-SPREAD, never a hand-listed replacement (CLAUDE.md trap 12).
+// `weightMagnitudeToStrokeWidth` and `UNSET_EDGE_STROKE_WIDTH` stay REAL — the
+// width assertions below bind to the genuine band mapping.
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  existenceCertaintyToLineStyle: () => undefined,
+  calculateEdgeImportance: () => 0.5,
+  importanceToStrokeWidth: () => 7,
+}))
+vi.mock('../../theme/edges', () => ({ applyEdgeVisualProps: (_: any, props: any) => props }))
+
+const baseProps = {
+  id: 'e-under-test', source: 'src', target: 'tgt',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left,
+  selected: false,
+}
+
+// ── Fixtures: real capture edges, through the real ingestion mapper ──────────
+
+type WireEdge = Record<string, unknown>
+
+function captureEdges(file: string): WireEdge[] {
+  const p = resolve(__dirname, '../../starters/data', file)
+  const j = JSON.parse(readFileSync(p, 'utf8'))
+  const edges = (j.edges ?? j.graph?.edges ?? []) as WireEdge[]
+  expect(edges.length, `${file} carried no edges`).toBeGreaterThan(0)
+  return edges
+}
+
+function findEdge(file: string, from: string, to: string): WireEdge {
+  const hit = captureEdges(file).find(e => e.from === from && e.to === to)
+  expect(hit, `${file} no longer carries ${from} → ${to}`).toBeDefined()
+  return hit as WireEdge
+}
+
+/** The PRODUCER. Whatever ingestion writes is what the lens sees. */
+function ingest(wire: WireEdge): Record<string, unknown> {
+  return mapDraftEdgeToCanvas(wire, 0).data as Record<string, unknown>
+}
+
+/** Same real negative edge the #627/#629 templates pinned: mean −0.3504, stated negative. */
+const SET_WIRE = findEdge('pricing-model.draft.json', 'fac_adoption_friction', 'out_bottom_up_growth')
+
+/** A stated edge whose |mean| (0.5) sits in the 2px band — width discrimination. */
+const STRONG_WIRE = findEdge('pricing-model.draft.json', 'fac_enterprise_revenue_risk', 'out_nrr')
+
+/**
+ * The producer EXPLICITLY declined a direction — `effect_direction: 'unknown'`
+ * is a declared 0.30.0 contract member (#627's own fixture technique).
+ * Ingestion strips the key and falls back to an UNSTAMPED `direction` derived
+ * from the mean's sign, so the resolver refuses (`not_set`) while the raw
+ * signed value (−0.3504) sits right there to be leaked. THE defect input.
+ */
+const UNKNOWN_DIR_WIRE: WireEdge = { ...SET_WIRE, effect_direction: 'unknown' }
+
+/** STRENGTH UNSET, direction still stated: the one strength-bearing key deleted. */
+const NO_STRENGTH_WIRE: WireEdge = (() => {
+  const { strength: _s, ...rest } = SET_WIRE as Record<string, unknown> & { strength?: unknown }
+  return rest
+})()
+
+/** NEITHER half stated: strength AND the stated direction both deleted. */
+const NEITHER_WIRE: WireEdge = (() => {
+  const { effect_direction: _d, ...rest } = NO_STRENGTH_WIRE as Record<string, unknown> & { effect_direction?: unknown }
+  return rest
+})()
+
+const SET_DATA = ingest(SET_WIRE)
+const STRONG_DATA = ingest(STRONG_WIRE)
+const UNKNOWN_DIR_DATA = ingest(UNKNOWN_DIR_WIRE)
+const NO_STRENGTH_DATA = ingest(NO_STRENGTH_WIRE)
+const NEITHER_DATA = ingest(NEITHER_WIRE)
+
+/**
+ * A user-drawn edge, byte-identical to the store's own construction site
+ * (`store.ts` onConnect: `data: { ...USER_EDGE_DEFAULTS }`). Every channel is
+ * an unstamped default: weight 0.3, direction 'positive', beliefExists 0.8,
+ * strengthStd 0.15 — the lens previously printed ALL FOUR as measurements.
+ */
+const USER_DATA: Record<string, unknown> = { ...USER_EDGE_DEFAULTS }
+
+// ── Render helpers, bound by identity (CLAUDE.md trap 19) ────────────────────
+
+/** Route data through the REAL producer, then render under the causal lens. */
+function renderCausal(data: Record<string, unknown>) {
+  holder.lensActive = 'causal'
+  holder.params = resolveCausalLensEdgeParams(data)
+  return render(<StyledEdge {...(baseProps as any)} data={data} />)
+}
+
+function causalLabel(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[data-testid="causal-edge-label"]')
+}
+
+function causalLabelText(container: HTMLElement): string {
+  const el = causalLabel(container)
+  expect(el, 'the causal lens label did not render').not.toBeNull()
+  return (el as HTMLElement).textContent ?? ''
+}
+
+function baseEdgeAttr(container: HTMLElement, attr: 'data-stroke' | 'data-stroke-width'): string {
+  const el = container.querySelector('[data-testid="base-edge"]')
+  expect(el, 'BaseEdge did not render').not.toBeNull()
+  return (el as HTMLElement).getAttribute(attr) ?? ''
+}
+
+const DANGER_STROKE = 'var(--semantic-danger, #ef4444)'
+const NEUTRAL_STROKE = 'var(--text-body, #3F3F3E)'
+/** Any character that claims a sign: ASCII plus/minus or U+2212 MINUS SIGN. */
+const SIGN_CHARS = /[+\-−]/
+
+describe('StyledEdge causal lens — provenance-gated params (ROADMAP 2.954, #629 lineage)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(nodeKinds)) delete nodeKinds[k]
+    nodeKinds.src = 'factor'
+    nodeKinds.tgt = 'outcome'
+    holder.lensActive = 'causal'
+    holder.params = null
+    holder.updateEdgeDataSpy.mockClear()
+    vi.mocked(useEdgeLabelMode).mockImplementation((selector: any) => selector({ mode: 'human' }))
+  })
+
+  // ── PRECONDITIONS. Pin the fixtures in-test so a discriminator can never
+  //    silently stop discriminating (trap 13b). If ingestion changes shape,
+  //    THIS block REDs — not a downstream assertion passing for the wrong
+  //    reason.
+  describe('fixture preconditions (derived from the producer, not assumed)', () => {
+    it('SET: producer-stamped strength (negative, Moderate band), direction, std and likelihood', () => {
+      expect((SET_WIRE as any).strength.mean).toBeCloseTo(-0.3504, 3)
+      expect((SET_WIRE as any).exists_probability).toBe(0.88)
+      expect(resolveEdgeSignedStrengthDisplay(SET_DATA)).toEqual(
+        expect.objectContaining({ show: true, source: 'cee' }),
+      )
+      expect(resolveEdgeDirectionDisplay(SET_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative', source: 'cee' }),
+      )
+      expect(resolveEdgeValueDisplay(SET_DATA, 'strengthStd')).toEqual(
+        expect.objectContaining({ show: true, source: 'cee' }),
+      )
+      expect(resolveEdgeValueDisplay(SET_DATA, 'beliefExists')).toEqual(
+        expect.objectContaining({ show: true, value: 0.88, source: 'cee' }),
+      )
+    })
+
+    it('STRONG: |mean| = 0.5 sits in the 2px width band — discriminating from the 1.5 unset floor', () => {
+      expect((STRONG_WIRE as any).strength.mean).toBe(-0.5)
+      expect((STRONG_WIRE as any).exists_probability).toBe(0.92)
+      expect(weightMagnitudeToStrokeWidth(0.5)).toBe(2)
+      expect(UNSET_EDGE_STROKE_WIDTH).toBe(1.5)
+      expect(resolveEdgeDirectionDisplay(STRONG_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative' }),
+      )
+    })
+
+    it('UNKNOWN-direction: strength stamped, direction UNSTAMPED — and the resolved signed value is negative', () => {
+      // The trap input, asserted rather than described: the resolver's value
+      // carries a MINUS the direction resolver refuses to endorse. An
+      // implementation leaking that sign renders "−"/danger here and the
+      // defect assertions below RED.
+      const strength = resolveEdgeSignedStrengthDisplay(UNKNOWN_DIR_DATA)
+      expect(strength).toEqual(expect.objectContaining({ show: true, source: 'cee' }))
+      expect((strength as { value: number }).value).toBeLessThan(0)
+      expect(resolveEdgeDirectionDisplay(UNKNOWN_DIR_DATA)).toEqual({ show: false, reason: 'not_set' })
+      // Ingestion strips the raw key but writes a plausible fallback — the trap.
+      expect(UNKNOWN_DIR_DATA.direction).toBe('negative')
+      expect(UNKNOWN_DIR_DATA.directionSource).toBeUndefined()
+    })
+
+    it('NO-STRENGTH: weight is the DEFAULT constant, unstamped — direction still stated', () => {
+      expect(NO_STRENGTH_DATA.weight).toBe(DEFAULT_EDGE_DATA.weight)
+      expect(NO_STRENGTH_DATA.weightSource).toBeUndefined()
+      expect(resolveEdgeSignedStrengthDisplay(NO_STRENGTH_DATA)).toEqual({ show: false, reason: 'not_set' })
+      expect(resolveEdgeDirectionDisplay(NO_STRENGTH_DATA)).toEqual(
+        expect.objectContaining({ show: true, direction: 'negative', source: 'cee' }),
+      )
+    })
+
+    it('NEITHER: both halves unset while the raw fields still look plausible', () => {
+      expect(NEITHER_DATA.weight).toBe(DEFAULT_EDGE_DATA.weight)
+      expect(NEITHER_DATA.direction).toBe('positive')
+      expect(NEITHER_DATA.directionSource).toBeUndefined()
+      expect(resolveEdgeSignedStrengthDisplay(NEITHER_DATA)).toEqual({ show: false, reason: 'not_set' })
+      expect(resolveEdgeDirectionDisplay(NEITHER_DATA)).toEqual({ show: false, reason: 'not_set' })
+      // The likelihood IS the producer's here (exists_probability survived).
+      expect(resolveEdgeValueDisplay(NEITHER_DATA, 'beliefExists')).toEqual(
+        expect.objectContaining({ show: true, value: 0.88 }),
+      )
+    })
+
+    it('USER edge: all four channels are unstamped defaults — nothing may speak', () => {
+      expect(USER_DATA.weight).toBe(0.3)
+      expect(USER_DATA.direction).toBe('positive')
+      expect(USER_DATA.beliefExists).toBe(0.8)
+      expect(USER_DATA.strengthStd).toBe(0.15)
+      expect(resolveEdgeSignedStrengthDisplay(USER_DATA)).toEqual({ show: false, reason: 'not_set' })
+      expect(resolveEdgeDirectionDisplay(USER_DATA)).toEqual({ show: false, reason: 'not_set' })
+      expect(resolveEdgeValueDisplay(USER_DATA, 'beliefExists')).toEqual({ show: false, reason: 'not_set' })
+      expect(resolveEdgeValueDisplay(USER_DATA, 'strengthStd')).toEqual({ show: false, reason: 'not_set' })
+    })
+
+    it('wire spelling guard: `strength` is the only strength key, so deleting it deletes the claim', () => {
+      expect(SET_WIRE).not.toHaveProperty('strength_mean')
+      expect(SET_WIRE).not.toHaveProperty('weight')
+      expect(NO_STRENGTH_WIRE).not.toHaveProperty('strength')
+      expect(NEITHER_WIRE).not.toHaveProperty('strength')
+      expect(NEITHER_WIRE).not.toHaveProperty('effect_direction')
+    })
+  })
+
+  // ── THE PRODUCER (resolveCausalLensEdgeParams) ────────────────────────────
+
+  describe('resolveCausalLensEdgeParams — the one owner of "may the lens speak?"', () => {
+    it('SET: all four channels speak the producer values', () => {
+      const p = resolveCausalLensEdgeParams(SET_DATA)
+      expect(p.magnitude).toBeCloseTo(0.3504, 3)
+      expect(p.direction).toBe('negative')
+      expect(p.std).toBeCloseTo(0.109, 3)
+      expect(p.existsProb).toBe(0.88)
+    })
+
+    it('UNKNOWN direction: the magnitude speaks UNSIGNED and the direction refuses', () => {
+      const p = resolveCausalLensEdgeParams(UNKNOWN_DIR_DATA)
+      expect(p.magnitude).toBeCloseTo(0.3504, 3)
+      expect(p.magnitude).toBeGreaterThan(0) // no raw-sign leak into the magnitude
+      expect(p.direction).toBeNull()
+    })
+
+    it('NO strength: the magnitude refuses while the stated direction still speaks', () => {
+      const p = resolveCausalLensEdgeParams(NO_STRENGTH_DATA)
+      expect(p.magnitude).toBeNull()
+      expect(p.direction).toBe('negative')
+      expect(p.std).toBeNull()
+      expect(p.existsProb).toBe(0.88)
+    })
+
+    it('NEITHER: magnitude and direction both refuse', () => {
+      const p = resolveCausalLensEdgeParams(NEITHER_DATA)
+      expect(p.magnitude).toBeNull()
+      expect(p.direction).toBeNull()
+    })
+
+    it('USER edge: every channel refuses — no default reaches the lens', () => {
+      const p = resolveCausalLensEdgeParams(USER_DATA)
+      expect(p).toEqual({ magnitude: null, direction: null, std: null, existsProb: null })
+    })
+  })
+
+  // ── MOUNT PATH (trap 3b: bind to the surface the deployed flags mount) ────
+
+  describe('mount path under the deployed posture (flag ON, causal lens active)', () => {
+    it('the causal label MOUNTS for a stated edge under the causal lens', () => {
+      const { container } = renderCausal(SET_DATA)
+      expect(causalLabel(container)).not.toBeNull()
+    })
+
+    it('the causal label does NOT mount outside the causal lens (the mount switch is real)', () => {
+      holder.lensActive = 'full'
+      holder.params = resolveCausalLensEdgeParams(SET_DATA)
+      const { container } = render(<StyledEdge {...(baseProps as any)} data={SET_DATA} />)
+      expect(causalLabel(container)).toBeNull()
+    })
+  })
+
+  // ── THE NAMED DEFECT, per channel ─────────────────────────────────────────
+
+  describe('the label channel', () => {
+    it('SET: prints the stated sign (U+2212), the magnitude and the producer likelihood', () => {
+      const { container } = renderCausal(SET_DATA)
+      expect(causalLabelText(container)).toBe('−0.35 (88%)')
+    })
+
+    it('UNKNOWN direction: prints the BARE magnitude — no sign character of any kind [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(UNKNOWN_DIR_DATA)
+      const text = causalLabelText(container)
+      expect(text).toBe('0.35 (88%)')
+      expect(text).not.toMatch(SIGN_CHARS)
+    })
+
+    it('NO strength: says "not set", never the 0.50 constant [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(NO_STRENGTH_DATA)
+      const text = causalLabelText(container)
+      expect(text).toContain('not set')
+      expect(text).not.toContain('0.50')
+      expect(text).not.toContain('+')
+      // The likelihood IS the producer's (exists_probability 0.88) — it may speak.
+      expect(text).toBe('not set (88%)')
+    })
+
+    it('NEITHER: says "not set" — the fabricated "+0.50" is gone [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(NEITHER_DATA)
+      const text = causalLabelText(container)
+      expect(text).toBe('not set (88%)')
+      expect(text).not.toContain('+0.50')
+    })
+
+    it('USER edge: "not set" alone — no fabricated likelihood "(80%)" either [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(USER_DATA)
+      const text = causalLabelText(container)
+      expect(text).toBe('not set')
+      expect(text).not.toContain('(80')
+      expect(text).not.toContain('0.30')
+    })
+  })
+
+  describe('the stroke colour channel (danger = a NEGATIVE-direction claim)', () => {
+    it('SET: a stated negative claims danger', () => {
+      const { container } = renderCausal(SET_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke')).toBe(DANGER_STROKE)
+    })
+
+    it('UNKNOWN direction: the stroke does NOT claim danger off the raw sign [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(UNKNOWN_DIR_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke')).toBe(NEUTRAL_STROKE)
+    })
+
+    it('NO strength: the stroke keeps the STATED negative — refusing the number is not refusing the direction', () => {
+      const { container } = renderCausal(NO_STRENGTH_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke')).toBe(DANGER_STROKE)
+    })
+
+    it('NEITHER: neutral — no claim from the fallback "positive" either', () => {
+      const { container } = renderCausal(NEITHER_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke')).toBe(NEUTRAL_STROKE)
+    })
+  })
+
+  describe('the stroke width channel (thickness = a strength measurement)', () => {
+    it('STRONG (|mean| 0.5): width reads the magnitude band (2px), sign irrelevant', () => {
+      const { container } = renderCausal(STRONG_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke-width')).toBe('2')
+    })
+
+    it('NO strength: width sits at the UNSET floor, never a band derived from the default [ROADMAP 2.954]', () => {
+      const { container } = renderCausal(NO_STRENGTH_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke-width')).toBe(String(UNSET_EDGE_STROKE_WIDTH))
+    })
+
+    it('USER edge: width sits at the UNSET floor too', () => {
+      const { container } = renderCausal(USER_DATA)
+      expect(baseEdgeAttr(container, 'data-stroke-width')).toBe(String(UNSET_EDGE_STROKE_WIDTH))
+    })
+  })
+})

--- a/src/canvas/hooks/__tests__/useLensFilter.causalLens.2954.spec.tsx
+++ b/src/canvas/hooks/__tests__/useLensFilter.causalLens.2954.spec.tsx
@@ -1,0 +1,172 @@
+/**
+ * ROADMAP 2.954 — the causal ARM of useLensFilter must write provenance-gated
+ * params into the store, not `computeSignedMean`'s fabrications.
+ *
+ * WHY THIS FILE EXISTS BESIDE THE StyledEdge SPEC: the DOM spec feeds the
+ * store map itself, so it proves store → render and producer purity — and
+ * NOTHING about the arm that populates the map on the live chain
+ * (useLensFilter → setLensVisuals → store). A fix that changed the producer
+ * but left the arm calling `computeSignedMean` would pass every DOM test
+ * while staging kept fabricating (trap 16: reachability within one seam is
+ * not reachability in the system). This spec drives the REAL hook against the
+ * REAL store with REAL ingested capture bytes and reads the map the
+ * components will read.
+ *
+ * Fixtures: the same pricing-model.draft.json edges as the DOM spec, through
+ * the exported `mapDraftEdgeToCanvas`, plus a `{ ...USER_EDGE_DEFAULTS }`
+ * user-drawn edge (byte-identical to the store's onConnect construction).
+ * State-class: seeded store, fresh per test.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { useLensFilter } from '../useLensFilter'
+import { useCanvasStore } from '../../store'
+import { mapDraftEdgeToCanvas } from '../../utils/applyDraftResult'
+import { resolveCausalLensEdgeParams } from '../../domain/edgeValueProvenance'
+import { USER_EDGE_DEFAULTS } from '../../domain/edges'
+
+type WireEdge = Record<string, unknown>
+
+function findEdge(from: string, to: string): WireEdge {
+  const p = resolve(__dirname, '../../starters/data', 'pricing-model.draft.json')
+  const j = JSON.parse(readFileSync(p, 'utf8'))
+  const edges = (j.edges ?? j.graph?.edges ?? []) as WireEdge[]
+  const hit = edges.find(e => e.from === from && e.to === to)
+  expect(hit, `capture no longer carries ${from} → ${to}`).toBeDefined()
+  return hit as WireEdge
+}
+
+const SET_WIRE = findEdge('fac_adoption_friction', 'out_bottom_up_growth')
+const NEITHER_WIRE: WireEdge = (() => {
+  const { strength: _s, effect_direction: _d, ...rest } =
+    SET_WIRE as Record<string, unknown> & { strength?: unknown; effect_direction?: unknown }
+  return rest
+})()
+
+// Real mapped edges — ids e-0 / e-1 from the mapper's fallback; the user edge
+// mirrors store.ts onConnect (`data: { ...USER_EDGE_DEFAULTS }`).
+const SET_EDGE = mapDraftEdgeToCanvas(SET_WIRE, 0)
+const NEITHER_EDGE = mapDraftEdgeToCanvas(NEITHER_WIRE, 1)
+NEITHER_EDGE.id = 'e-1' // distinct id (mapper falls back to e-<i>; pin it explicitly)
+const USER_EDGE = {
+  id: 'e-user',
+  source: 'fac_adoption_friction',
+  target: 'out_bottom_up_growth',
+  type: 'styled' as const,
+  data: { ...USER_EDGE_DEFAULTS },
+}
+
+const NODES = [
+  { id: 'fac_adoption_friction', type: 'factor', data: { label: 'Adoption friction' }, position: { x: 0, y: 0 } },
+  { id: 'out_bottom_up_growth', type: 'outcome', data: { label: 'Bottom-up growth' }, position: { x: 0, y: 0 } },
+  // An organisational pair, to pin the arm's hide branch stays intact.
+  { id: 'dec_pricing', type: 'decision', data: { label: 'Pricing' }, position: { x: 0, y: 0 } },
+  { id: 'opt_hybrid', type: 'option', data: { label: 'Hybrid' }, position: { x: 0, y: 0 } },
+]
+const STRUCTURAL_EDGE = {
+  id: 'e-structural',
+  source: 'dec_pricing',
+  target: 'opt_hybrid',
+  type: 'styled' as const,
+  data: { ...USER_EDGE_DEFAULTS },
+}
+
+function Probe() {
+  useLensFilter()
+  return null
+}
+
+/**
+ * Seed graph state with the lens OFF ('full'). The hook's push effect skips
+ * the FIRST computed visuals (its prevVisualsRef starts equal), so the live
+ * flow is always mount → user activates the lens → recompute → push. The
+ * tests reproduce exactly that: render the probe, THEN switch to 'causal'.
+ */
+function seedGraph(): void {
+  useCanvasStore.setState({
+    nodes: NODES as never,
+    edges: [SET_EDGE, NEITHER_EDGE, USER_EDGE, STRUCTURAL_EDGE] as never,
+    lens: { ...useCanvasStore.getState().lens, active: 'full' },
+  } as never)
+}
+
+/** Mount the hook, then activate the causal lens the way the product does. */
+function mountAndActivateCausal(): void {
+  render(<Probe />)
+  act(() => {
+    useCanvasStore.setState({
+      lens: { ...useCanvasStore.getState().lens, active: 'causal' },
+    } as never)
+  })
+}
+
+describe('useLensFilter causal arm — provenance-gated store map (ROADMAP 2.954)', () => {
+  beforeEach(() => {
+    seedGraph()
+  })
+
+  afterEach(() => {
+    useCanvasStore.setState({
+      nodes: [] as never,
+      edges: [] as never,
+      lens: {
+        ...useCanvasStore.getState().lens,
+        active: 'full',
+        _causalEdgeParams: new Map(),
+        _hiddenNodeIds: new Set(),
+        _hiddenEdgeIds: new Set(),
+      },
+    } as never)
+  })
+
+  it('writes the producer values for the stated edge (hook → store, live chain)', () => {
+    mountAndActivateCausal()
+    const map = useCanvasStore.getState().lens._causalEdgeParams
+    const p = map.get(SET_EDGE.id)
+    expect(p, 'the stated edge got no causal params').toBeDefined()
+    expect(p!.magnitude).toBeCloseTo(0.3504, 3)
+    expect(p!.direction).toBe('negative')
+    expect(p!.std).toBeCloseTo(0.109, 3)
+    expect(p!.existsProb).toBe(0.88)
+  })
+
+  it('DEFECT WITNESS: writes a REFUSAL, not the fabricated +0.5 constant, for the unset edge', () => {
+    mountAndActivateCausal()
+    const map = useCanvasStore.getState().lens._causalEdgeParams
+    const p = map.get('e-1') as Record<string, unknown> | undefined
+    expect(p, 'the unset edge got no causal params').toBeDefined()
+    expect(p!.magnitude).toBeNull()
+    expect(p!.direction).toBeNull()
+    // The legacy raw `mean` channel is GONE from the map — the rename is the
+    // fail-loud guard: a stale consumer reading `.mean` breaks at types, and
+    // at pristine this assertion prints the fabricated 0.5 in the diff.
+    expect(p!.mean).toBeUndefined()
+  })
+
+  it('the user-drawn edge (all channels defaulted) refuses on every channel', () => {
+    mountAndActivateCausal()
+    const map = useCanvasStore.getState().lens._causalEdgeParams
+    expect(map.get('e-user')).toEqual({ magnitude: null, direction: null, std: null, existsProb: null })
+  })
+
+  it('the arm agrees with the exported producer, edge for edge (one owner, no drift)', () => {
+    mountAndActivateCausal()
+    const map = useCanvasStore.getState().lens._causalEdgeParams
+    for (const edge of [SET_EDGE, NEITHER_EDGE, USER_EDGE]) {
+      expect(map.get(edge.id)).toEqual(
+        resolveCausalLensEdgeParams(edge.data as Record<string, unknown>),
+      )
+    }
+  })
+
+  it('INVARIANT: structural edges stay hidden and get no params (the hide branch is untouched)', () => {
+    mountAndActivateCausal()
+    const s = useCanvasStore.getState().lens
+    expect(s._hiddenEdgeIds.has('e-structural')).toBe(true)
+    expect(s._causalEdgeParams.has('e-structural')).toBe(false)
+    expect(s._hiddenNodeIds.has('dec_pricing')).toBe(true)
+    expect(s._hiddenNodeIds.has('opt_hybrid')).toBe(true)
+  })
+})

--- a/src/canvas/hooks/useLensFilter.ts
+++ b/src/canvas/hooks/useLensFilter.ts
@@ -10,7 +10,7 @@
 import { useMemo, useEffect, useRef } from 'react'
 import { useCanvasStore } from '../store'
 import { computeOptionPaths } from '../utils/computeOptionPaths'
-import { computeSignedMean } from '../domain/edges'
+import { resolveCausalLensEdgeParams, type CausalLensEdgeParams } from '../domain/edgeValueProvenance'
 import type { FragileEdgeCandidate } from '../utils/fragileEdgeMatch'
 
 // ─── Sensitivity helpers ─────────────────────────────────────────────────────
@@ -93,7 +93,7 @@ interface LensVisuals {
   // Expanded lenses (Brief 5)
   hiddenNodeIds?: Set<string>
   hiddenEdgeIds?: Set<string>
-  causalEdgeParams?: Map<string, { mean: number; std: number | null; existsProb: number | null }>
+  causalEdgeParams?: Map<string, CausalLensEdgeParams>
   evidenceNodeClass?: Map<string, 'grounded' | 'assumed' | 'none' | 'na'>
   evidenceEdgeClass?: Map<string, 'evidence' | 'assumed' | 'unknown'>
 }
@@ -212,7 +212,7 @@ export function useLensFilter(): void {
     if (lensActive === 'causal') {
       const hiddenNodeIds = new Set<string>()
       const hiddenEdgeIds = new Set<string>()
-      const causalEdgeParams = new Map<string, { mean: number; std: number | null; existsProb: number | null }>()
+      const causalEdgeParams = new Map<string, CausalLensEdgeParams>()
 
       // Hide organisational nodes (decision, option, constraint) — they don't participate in inference
       for (const node of nodes) {
@@ -229,12 +229,17 @@ export function useLensFilter(): void {
           continue
         }
 
-        // P0-5 fix: use canonical values from graph store only — null when absent (no synthetic defaults)
+        // ROADMAP 2.954 — every channel PROVENANCE-GATED through the same
+        // resolver family the main edge label uses. The previous line here
+        // called `computeSignedMean`, whose fallback signs the UI-defaulted
+        // `weight` off the raw `direction` field — so the lens printed `+0.50`
+        // (a constant) for edges nobody characterised and a danger-red
+        // negative claim for producers that explicitly declined one. (Its
+        // P0-5-era comment said "no synthetic defaults"; that was true of
+        // std/existsProb on THIS ingestion path and false of the mean on
+        // every path — the fabrication lived in the fallback itself.)
         const edgeData = edge.data as Record<string, unknown> | undefined
-        const mean = computeSignedMean(edgeData)
-        const std = typeof edgeData?.strengthStd === 'number' ? (edgeData.strengthStd as number) : null
-        const existsProb = typeof edgeData?.beliefExists === 'number' ? (edgeData.beliefExists as number) : null
-        causalEdgeParams.set(edge.id, { mean, std, existsProb })
+        causalEdgeParams.set(edge.id, resolveCausalLensEdgeParams(edgeData))
       }
 
       return {

--- a/src/canvas/hooks/useScienceIcons.ts
+++ b/src/canvas/hooks/useScienceIcons.ts
@@ -14,7 +14,9 @@ import {
 import { biasSignal } from '../shared/biasSignalTitles'
 import type { ComponentType } from 'react'
 import type { NodeType } from '../domain/nodes'
-import { computeSignedMean } from '../domain/edges'
+// `computeSignedMean` was imported here with ZERO call sites (verified at the
+// bytes, ROADMAP 2.954) — removed rather than left as an invitation to wire a
+// fourth raw-signed channel (#629's `getStrengthDescription` precedent).
 import { unwrapInterventionValue } from '../utils/labelUtils'
 import { isReviewedSource } from '../components/pre-analysis/utils/isReviewedByUser'
 

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -5,7 +5,7 @@ import { saveSnapshot as persistSnapshot, importCanvas as persistImport, exportC
 import { setsEqual, mapsEqual } from './store/utils'
 import { assignStableOptionNumbers } from './store/stableOptionNumbers'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS, type EdgeData } from './domain/edges'
-import { edgeValueSourcePatch } from './domain/edgeValueProvenance'
+import { edgeValueSourcePatch, type CausalLensEdgeParams } from './domain/edgeValueProvenance'
 import { NODE_REGISTRY, type NodeType, type NodeData } from './domain/nodes'
 import { hasAnalyticalNodeChange, hasAnalyticalEdgeChange } from './domain/analyticalChange'
 import { applyLayout, applyLayoutWithPolicy } from './layout'
@@ -124,7 +124,7 @@ function createDefaultLensState() {
     // Expanded lenses (Brief 5)
     _hiddenNodeIds: new Set<string>(),
     _hiddenEdgeIds: new Set<string>(),
-    _causalEdgeParams: new Map<string, { mean: number; std: number | null; existsProb: number | null }>(),
+    _causalEdgeParams: new Map<string, CausalLensEdgeParams>(),
     _evidenceNodeClass: new Map<string, 'grounded' | 'assumed' | 'none' | 'na'>(),
     _evidenceEdgeClass: new Map<string, 'evidence' | 'assumed' | 'unknown'>(),
   }
@@ -604,7 +604,7 @@ interface CanvasState {
     // Expanded lenses (Brief 5)
     _hiddenNodeIds: Set<string>
     _hiddenEdgeIds: Set<string>
-    _causalEdgeParams: Map<string, { mean: number; std: number | null; existsProb: number | null }>
+    _causalEdgeParams: Map<string, CausalLensEdgeParams>
     _evidenceNodeClass: Map<string, 'grounded' | 'assumed' | 'none' | 'na'>
     _evidenceEdgeClass: Map<string, 'evidence' | 'assumed' | 'unknown'>
   }
@@ -942,7 +942,7 @@ interface CanvasState {
     fragileEdgeIds: Set<string>
     hiddenNodeIds?: Set<string>
     hiddenEdgeIds?: Set<string>
-    causalEdgeParams?: Map<string, { mean: number; std: number | null; existsProb: number | null }>
+    causalEdgeParams?: Map<string, CausalLensEdgeParams>
     evidenceNodeClass?: Map<string, 'grounded' | 'assumed' | 'none' | 'na'>
     evidenceEdgeClass?: Map<string, 'evidence' | 'assumed' | 'unknown'>
   }) => void
@@ -4769,7 +4769,7 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   setLensVisuals: (visuals) => {
     const { lens } = get()
     const EMPTY = new Set<string>()
-    const EMPTY_CEP = new Map<string, { mean: number; std: number | null; existsProb: number | null }>()
+    const EMPTY_CEP = new Map<string, CausalLensEdgeParams>()
     const EMPTY_ENC = new Map<string, 'grounded' | 'assumed' | 'none' | 'na'>()
     const EMPTY_EEC = new Map<string, 'evidence' | 'assumed' | 'unknown'>()
     // Skip no-op updates to avoid re-renders (use setsEqual/mapsEqual for collection comparison)


### PR DESCRIPTION
ROADMAP **2.954** — the LAST raw-signed channel in the edge-label honesty family (**#625 → #627/2.935 → #629/2.950**; this PR completes the component).

## The defect (found by #627's review, verified pre-existing at bcee7479)

`useLensFilter`'s causal arm wrote `computeSignedMean(edgeData)` — a THIRD signing function, absent from `resolveEdgeSignedStrengthDisplay`'s KNOWN SURVIVORS list — into `causalEdgeParams`, and three channels rendered it:

- **`causal-edge-label`** printed `+0.50` — `DEFAULT_EDGE_DATA.weight`, signed by the `'negative' ? -1 : 1` fallback — for edges nobody characterised;
- the **stroke colour** claimed danger-red (a NEGATIVE-direction verdict) on edges whose producer sent `effect_direction: 'unknown'` (ingestion strips the key, leaving an unstamped fallback `direction` that resolves `not_set`);
- the **stroke width** reported a measured-looking band off the default.

A user-drawn edge (`{ ...USER_EDGE_DEFAULTS }`, store.ts onConnect) fabricated **all four channels**: `+0.30 (80%)` with std `0.15` in the lens table — every number an unstamped default. Witnessed at pristine on the LIVE hook→store chain: the store map carried `{ mean: 0.3, std: 0.15, existsProb: 0.8 }`.

## The fix (same resolver pair as #627/#629, one owner)

- **`resolveCausalLensEdgeParams`** (edgeValueProvenance.ts): magnitude via `resolveEdgeSignedStrengthDisplay` (|value| — its sign never leaks), direction via `resolveEdgeDirectionDisplay`, std/existsProb via `resolveEdgeValueDisplay`. Each channel refuses independently — refusing the number is not refusing the direction (a stated-negative edge with unset strength keeps its danger stroke and prints "not set").
- **Fail-loud rename**: the map shape drops `mean` for `magnitude` + `direction`; a stale `.mean` consumer breaks at types. All four store type sites + both consumers (StyledEdge, LensInfoPanel) updated.
- **Copy** (reused from #629, none minted): label prints `not set`; panel Mean prints the table's own em dash; sign is U+2212 and renders only from a STATED direction; unset width = `UNSET_EDGE_STROKE_WIDTH`, the non-lens stroke's existing refusal.

## `computeSignedMean` caller manifest (verified at the bytes)

| Caller | Verdict |
|---|---|
| `useLensFilter.ts` (the defect) | now routes through the resolver |
| `nodes/shared/EdgePills.tsx:64` | RETAINED — gates on `isEdgeValueSet` before calling (its sign→direction read is a listed KNOWN SURVIVOR, rowed) |
| `useScienceIcons.ts:17` | DEAD IMPORT, zero call sites — deleted (#629's `getStrengthDescription` precedent) |
| `islRequestAdapter.ts` / `plot/v2/adapter.ts` | SEPARATE same-named wire-path functions, untouched (adapters legitimately need a number per edge) |

`computeSignedMean` retains a legitimate caller → kept, docblock now carries the manifest + the NO-DISPLAY-SURFACE rule.

## Deployed flag posture (derived, not mirrored — trap 18)

`netlify.toml` does NOT set `VITE_FEATURE_GRAPH_LENS`; the SERVED staging flags chunk (`assets/flags-DBpusaUf.js`, deploy of `bcee7479`) bakes **`"1"`** (dashboard env). Probe controls discriminate: COMPARE_TAB (known ON) `"1"`, JOURNEY_TAB (known absent) `void 0`. **The lens surface IS mounted on deployed staging**; the specs mock the flag ON to match and assert the mount path (trap 3b).

## Evidence

- **RED-first at pristine `bcee7479`**: 27 named failing tests / 8 green fixture-pinning preconditions across three specs (producer / StyledEdge DOM / LensInfoPanel / useLensFilter arm). The arm spec closes the trap-16 gap: it drives the REAL hook against the REAL store, and its defect witness showed the fabricated bytes at pristine.
- **Fixtures**: real `pricing-model.draft.json` bytes through the exported `mapDraftEdgeToCanvas`; unset variants delete wire keys or use the declared contract value `effect_direction:'unknown'`; width fixture `fac_enterprise_revenue_risk → out_nrr` (|mean| 0.5 → 2px band vs 1.5 floor).
- **Mutant kit** (throwaway clone outside the repo root; write-sentinel + inode isolation proven; applied-check 1 src file per mutant, control 0):

| # | Seam | Mutation | Expected | Result |
|---|---|---|---|---|
| M1 | producer | fabricate-for-ALL (weight-default fallback) | RED | ✅ 10 REDs, all four surfaces |
| M2 | producer | direction re-derived from signed value | RED | ✅ 4 REDs, UNKNOWN-direction family |
| M3 | arm | bypass gate at the live seam | RED | ✅ 3 REDs — arm spec ONLY (DOM/producer stayed green: the arm spec carries independent weight) |
| M4 | arm | fabricate for a DIFFERENT edge id | GREEN | ✅ 35/35 — non-equivalence DEMONSTRATED (discriminating fixture REDs under M4 showing `magnitude: 0.5`, GREEN restored) |
| M5 | label | unset prints `+0.50` | RED | ✅ 3 REDs |
| M6 | stroke | danger for unstated direction | RED | ✅ 2 REDs (stated-danger controls green) |
| M7 | width | measures the default (`?? 0.5`) | RED | ✅ 2 REDs (STRONG band control green) |
| M8 | panel | Mean prints `+0.50` | RED | ✅ 1 RED |
| M9 | producer | existsProb from raw `beliefExists` | RED | ✅ 4 REDs (incl. the `(80%)` guard) |

- **Gates**: `pnpm typecheck` ratchet PASSED — 6 diagnostics fixed, none added (`--update-baseline` declined per trap 2b). Full `src/canvas` suite: **848 files / 11,753 tests passed, 0 failed** with the fix in tree.

Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)