### PR TITLE
fix(results): the sharpen line stops attributing our derived goal label to the user (ROADMAP 2.993)

### DIFF
--- a/src/components/results/__tests__/ResultsBody.v7SharpenQuoteProvenance.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7SharpenQuoteProvenance.spec.tsx
@@ -1,0 +1,283 @@
+/**
+ * ResultsBody — the V7 sharpen line's "You wrote: …" quote must be the USER's
+ * words, never ours (ROADMAP 2.993).
+ *
+ * THE DEFECT (measured at `e15c6b81`, the commit staging deploys):
+ * `V7TopMatter` computed `briefWording = recommendation.goalText ?? goalLabel`
+ * and `V7SharpenLine` rendered it under `You wrote: "…"`. `goalText` is the
+ * user's own framing goal; `goalLabel` is OUR derivation
+ * (`useResultsSectionData`: sanitised, sourced from the drafted goal NODE's
+ * label, sometimes re-phrased as `the best outcome for X`, and defaulting to
+ * the literal `your goal`). The fallback therefore put the product's own
+ * generated text inside quotation marks and attributed it to the user — a lie
+ * about authorship, on the one surface designed to reflect their words back.
+ *
+ * WHY THE ASSERTIONS BIND TO PROVENANCE, NOT TO A VALUE (trap 19):
+ * a test that merely asserted "the quote equals X" would pass whenever the
+ * derived label and the brief happen to coincide. So every case here is built
+ * from a fixture where the two DIFFER, and the honest-path oracle is the
+ * PRODUCER of the submitted brief — `composeBriefText`, the function
+ * `useAsk` uses to build the `brief` this app sends to CEE. The displayed
+ * characters must occur inside those bytes; the derived label must not.
+ * Each test pins that precondition in-test, so if `composeBriefText` ever
+ * stops carrying the framing goal, these tests go RED instead of quietly
+ * becoming tautologies.
+ *
+ * MOUNT PATH (trap 3b): `v7-top-group` carries NO flag in `ResultsBody`, and
+ * the deployed staging bundle confirms it (chunk `ReactFlowGraph-9aiLXlpO.js`
+ * at commit `e15c6b81` renders the group unguarded, unlike its flag-gated
+ * hero sibling). Each test asserts the surface actually mounted, so an absence
+ * assertion can never pass because the whole component vanished.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  DriverItem,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+import { composeBriefText } from '@/hooks/useAsk'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isStrengthenPanelEnabled: vi.fn(() => false),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => false),
+  }
+})
+
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+/**
+ * The user's own words. Deliberately unlike anything a label deriver would
+ * produce, and carrying a token (`kestrel`) that appears nowhere else.
+ */
+const USER_BRIEF_GOAL =
+  'Keep the kestrel migration under budget without slipping the December date'
+
+/**
+ * OUR text. Shaped like a real `goalLabel` output — this is exactly the form
+ * `useResultsSectionData` emits for a short/colliding label — and sharing NO
+ * distinctive token with the brief above.
+ */
+const DERIVED_GOAL_LABEL = 'the best outcome for Cat'
+
+/** The framing this app would submit, with the user's goal in it. */
+const FRAMING_WITH_USER_GOAL = {
+  title: 'Platform migration',
+  goal: USER_BRIEF_GOAL,
+  timeline: 'By December',
+}
+
+/**
+ * The framing a fresh session actually has. The only in-app writer that ever
+ * set `framing.goal` (`InputsDock`) now lives in `archive/`, so `goalText` is
+ * absent and the old code fell through to the derived label EVERY time.
+ */
+const FRAMING_WITHOUT_USER_GOAL = {
+  title: 'Platform migration',
+  timeline: 'By December',
+}
+
+function driver(): DriverItem {
+  return {
+    factorKey: 'n_lead',
+    factorLabel: 'Tech lead hired',
+    rawElasticity: 1,
+    normalisedInfluence: 1,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: true,
+    matchedNodeId: 'n_lead',
+  } as DriverItem
+}
+
+/**
+ * @param goalText the user's framing goal as `useResultsSectionData` exposes
+ *   it (`currentScenarioFraming?.goal || undefined`) — `undefined` reproduces
+ *   a session with no user-written goal.
+ */
+function makeData(goalText: string | undefined): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Bring In 6-Month Contractor',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.71,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Hire Permanent Senior Tech Lead',
+    isRecommended: false,
+    winProbability: 0.31,
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: DERIVED_GOAL_LABEL,
+    ...(goalText === undefined ? {} : { goalText }),
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+  } as unknown as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [driver()],
+    topDrivers: [driver()],
+    driversStatus: 'computed',
+    totalCount: 1,
+    hasMagnitudeData: true,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    // The sharpen line only renders when there ARE inputs to sharpen.
+    topEvidenceGaps: [
+      {
+        factorId: 'n_pipeline',
+        factorLabel: 'Hiring Pipeline Duration',
+        confidence: 40,
+        voi: 0.6,
+        suggestion: 'Confirm the pipeline estimate',
+        targetNodeId: 'n_pipeline',
+      },
+    ],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: DERIVED_GOAL_LABEL,
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody(goalText: string | undefined) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(goalText)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onFocusNode={() => {}}
+    />,
+  )
+}
+
+/** The surface must actually be on screen — otherwise an absence proves nothing. */
+function assertSharpenSurfaceMounted(): HTMLElement {
+  expect(
+    screen.getByTestId('v7-top-matter'),
+    'V7 top matter must mount — the deployed bundle mounts it with no flag',
+  ).toBeInTheDocument()
+  return screen.getByTestId('v7-sharpen-line')
+}
+
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-07-23T00:00:00Z' }
+
+describe('ResultsBody — V7 sharpen line quote provenance (ROADMAP 2.993)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useGuidanceStore.setState({ guidanceItems: [] })
+  })
+
+  it('never attributes OUR derived goal label to the user when the brief carries no goal', () => {
+    // Precondition, pinned in-test: the derived label is NOT in the bytes this
+    // app submits as the brief, so quoting it under "You wrote" cannot be true.
+    const submittedBrief = composeBriefText(FRAMING_WITHOUT_USER_GOAL)
+    expect(submittedBrief).not.toContain(DERIVED_GOAL_LABEL)
+
+    renderBody(undefined)
+    const line = assertSharpenSurfaceMounted()
+
+    expect(
+      screen.queryByTestId('v7-sharpen-quote'),
+      'no authorship claim is made when nothing the user wrote is available',
+    ).not.toBeInTheDocument()
+    expect(line).not.toHaveTextContent('You wrote')
+    expect(line).not.toHaveTextContent(DERIVED_GOAL_LABEL)
+  })
+
+  it('quotes text traceable to the SUBMITTED BRIEF bytes, not to the derived label', () => {
+    // Preconditions, pinned in-test (trap 13b — a discriminator must pin its
+    // own precondition or it decays into a tautology):
+    //   1. the two candidate strings genuinely differ;
+    //   2. the user's goal IS in the submitted brief bytes;
+    //   3. the derived label is NOT.
+    const submittedBrief = composeBriefText(FRAMING_WITH_USER_GOAL)
+    expect(USER_BRIEF_GOAL).not.toBe(DERIVED_GOAL_LABEL)
+    expect(submittedBrief).toContain(USER_BRIEF_GOAL)
+    expect(submittedBrief).not.toContain(DERIVED_GOAL_LABEL)
+
+    renderBody(USER_BRIEF_GOAL)
+    assertSharpenSurfaceMounted()
+
+    const quoted = screen.getByTestId('v7-sharpen-quote').textContent ?? ''
+    const match = quoted.match(/^You wrote:\s*[“"](.+)[”"]$/)
+    expect(match, `quote did not render in the expected frame: ${JSON.stringify(quoted)}`).not.toBeNull()
+
+    // PROVENANCE: the displayed characters must occur inside the brief this
+    // app submits — not merely equal some string that happens to match.
+    expect(submittedBrief).toContain(match![1])
+    // …and the derived label must not have leaked into the attributed quote.
+    expect(match![1]).not.toContain(DERIVED_GOAL_LABEL)
+  })
+
+  it('shows the inputs to sharpen either way — only the authorship claim is withheld', () => {
+    // Positive control against a vacuous absence: the first test asserts the
+    // quote is gone; this proves the rest of the line still renders, so the
+    // absence is of the CLAIM, not of the component.
+    renderBody(undefined)
+    const line = assertSharpenSurfaceMounted()
+    expect(line).toHaveTextContent('A few inputs would sharpen these results')
+    expect(within(line).getByText('Hiring Pipeline Duration')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/v7/V7SharpenLine.tsx
+++ b/src/components/results/v7/V7SharpenLine.tsx
@@ -3,9 +3,17 @@
  * (V7 Lane L4, spec row 2).
  *
  * Passthrough only. Two honest, store-backed parts:
- *   · The brief quote ← the user's own framing goal
- *     (`recommendation.goalText`, else `goalLabel`) — Paul's own wording,
- *     rendered verbatim in quotes.
+ *   · The brief quote ← the user's own framing goal (`recommendation.goalText`)
+ *     — their wording, rendered verbatim in quotes, and ONLY theirs.
+ *     ⚠ ROADMAP 2.993: this used to fall back to `goalLabel` when the user had
+ *     written no goal, which put OUR generated text inside quotation marks
+ *     under "You wrote". `goalLabel` is a derivation, not a quotation
+ *     (`useResultsSectionData`: sanitised, sourced from the drafted goal NODE's
+ *     label, re-phrased as "the best outcome for X" for short/colliding
+ *     labels, and defaulting to the literal "your goal"). Attributing it to
+ *     the user is a lie about authorship on the one surface designed to show
+ *     them their own words — so the quote now carries its PROVENANCE and the
+ *     line refuses to render anything it cannot honestly attribute.
  *   · The inputs to review (≤3 + "and N more") ← `confidence.topEvidenceGaps`
  *     (each carries `factorLabel` + a canvas focus target), the factors whose
  *     evidence is thin enough to be worth confirming.
@@ -32,9 +40,35 @@ export interface V7SharpenInput {
   nodeId?: string
 }
 
+/**
+ * Where a candidate quote came from. Only `user_brief` may ever be attributed
+ * to the user.
+ *
+ * · `user_brief`    — the framing goal the USER typed. `composeBriefText`
+ *                     (`src/hooks/useAsk.ts`) interpolates these exact bytes
+ *                     into the brief this app submits, so quoting them back is
+ *                     a true statement about what they wrote.
+ * · `derived_label` — OUR text (`useResultsSectionData`'s `goalLabel`). Passed
+ *                     in with its true provenance so the refusal happens HERE,
+ *                     on the live path, where re-attributing it would have to
+ *                     be a visible diff in this file.
+ */
+export type V7BriefQuoteSource = 'user_brief' | 'derived_label'
+
+export interface V7BriefQuote {
+  /** The candidate text, verbatim. */
+  text: string
+  /** Its provenance — the whole point (ROADMAP 2.993). */
+  source: V7BriefQuoteSource
+}
+
 export interface V7SharpenLineProps {
-  /** The user's own framing goal — `recommendation.goalText ?? goalLabel`. */
-  briefWording?: string | null
+  /**
+   * A candidate quote WITH its provenance. Rendered under "You wrote" only
+   * when `source === 'user_brief'`; anything else is our own text and is
+   * silently withheld rather than put in the user's mouth.
+   */
+  briefQuote?: V7BriefQuote | null
   /** Inputs worth confirming — derived from `confidence.topEvidenceGaps`. */
   inputs: V7SharpenInput[]
   /** Focus the matching canvas element for an input. */
@@ -44,13 +78,17 @@ export interface V7SharpenLineProps {
 /** How many inputs show before collapsing into "and N more". */
 const VISIBLE_INPUTS = 3
 
-export function V7SharpenLine({ briefWording, inputs, onFocusNode }: V7SharpenLineProps) {
+export function V7SharpenLine({ briefQuote, inputs, onFocusNode }: V7SharpenLineProps) {
   // Honest absence — nothing to sharpen, so make no claim.
   if (inputs.length === 0) return null
 
   const shown = inputs.slice(0, VISIBLE_INPUTS)
   const moreCount = inputs.length - shown.length
-  const quote = briefWording?.trim()
+  // PROVENANCE GATE (ROADMAP 2.993) — "You wrote" is a claim about AUTHORSHIP,
+  // so only text whose provenance is the user's own brief may appear under it.
+  // A derived label is withheld entirely: saying nothing is honest, saying
+  // "you wrote" about our own sentence is not.
+  const quote = briefQuote?.source === 'user_brief' ? briefQuote.text.trim() : ''
 
   return (
     <section

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -18,7 +18,7 @@ import { useMemo } from 'react'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type { DecisionState } from '../types'
 import { V7FreshnessStrip } from './V7FreshnessStrip'
-import { V7SharpenLine, type V7SharpenInput } from './V7SharpenLine'
+import { V7SharpenLine, type V7SharpenInput, type V7BriefQuote } from './V7SharpenLine'
 import { V7Hero } from './V7Hero'
 import { V7LensGroup } from './V7LensGroup'
 import { V7EvidenceDisclosure } from './V7EvidenceDisclosure'
@@ -52,7 +52,22 @@ export function V7TopMatter({
     label: gap.factorLabel,
     nodeId: gap.targetNodeId,
   }))
-  const briefWording = recommendation.goalText ?? resultsSectionData.goalLabel ?? null
+  // The brief quote carries its PROVENANCE, not just a string (ROADMAP 2.993).
+  // `goalText` is the user's own framing goal — `useResultsSectionData` reads it
+  // straight from `currentScenarioFraming.goal`, the same bytes `composeBriefText`
+  // puts into the brief this app submits. `goalLabel` is OUR derivation of the
+  // same idea (sanitised, node-label-sourced, re-phrased, or the literal "your
+  // goal"), and the old `goalText ?? goalLabel` fallback made the line say
+  // "You wrote:" about text the user never wrote. It is still handed over —
+  // labelled honestly — so the refusal lives in the component on the live path
+  // and a future re-attribution has to be a visible diff there.
+  const userGoalText = recommendation.goalText?.trim()
+  const derivedGoalLabel = resultsSectionData.goalLabel?.trim()
+  const briefQuote: V7BriefQuote | null = userGoalText
+    ? { text: userGoalText, source: 'user_brief' }
+    : derivedGoalLabel
+      ? { text: derivedGoalLabel, source: 'derived_label' }
+      : null
 
   // L5 lens group + evidence disclosure — passthrough over the SAME
   // resultsSectionData the live panel consumes. The lens model is built ONCE
@@ -64,7 +79,7 @@ export function V7TopMatter({
   return (
     <div className="flex flex-col gap-4" data-testid="v7-top-matter">
       <V7FreshnessStrip />
-      <V7SharpenLine briefWording={briefWording} inputs={sharpenInputs} onFocusNode={onFocusNode} />
+      <V7SharpenLine briefQuote={briefQuote} inputs={sharpenInputs} onFocusNode={onFocusNode} />
       <V7Hero
         recommendation={recommendation}
         decisionState={decisionState}


### PR DESCRIPTION
## ROADMAP 2.993 — the sharpen line stops putting our words in the user's mouth

`V7SharpenLine` rendered **`You wrote: "…"`** around `recommendation.goalText ?? goalLabel`.

* `goalText` is the user's own framing goal — `useResultsSectionData` reads it straight from
  `currentScenarioFraming.goal`, the exact bytes `composeBriefText` (`src/hooks/useAsk.ts`)
  interpolates into the `brief` this app submits.
* `goalLabel` is **our derivation**: sanitised through `sanitizeCoachingText`, sourced from the
  *drafted* goal NODE's label, re-phrased as `the best outcome for X` for short or colliding
  labels, and defaulting to the literal `your goal`.

So the fallback put the product's own generated sentence inside quotation marks and attributed it
to the user, on the one surface designed to reflect their words back at them.

### The premise held, and the defect is wider than the row said

Not an edge case. `git grep -a` over the whole tracked tree at `e15c6b81` gives the complete
manifest of writers of `currentScenarioFraming`: the only live setter is `updateScenarioFraming`,
whose only live caller (`src/routes/CanvasMVP.tsx:194`) passes `{ title }`. The only caller that
ever set `goal` is `archive/dead-canvas-components-2026-07/InputsDock.tsx` — **dead**. So for any
session that does not load a legacy record, `goalText` is absent and the deployed line quotes the
derived label **every time**.

RED-first reproduced it verbatim, and the fixture's derived label is the one shape that makes the
lie unmistakable:

```
× ResultsBody — V7 sharpen line quote provenance (ROADMAP 2.993)
  > never attributes OUR derived goal label to the user when the brief carries no goal
Error: expect(element).not.toBeInTheDocument()
expected document not to contain element, found
  <p data-testid="v7-sharpen-quote">You wrote: “ the best outcome for Cat ”</p>
```

### The surface is live, not dark (trap 3b)

Derived from the **deployed artefact**, not from `src/`. `staging--olumi.netlify.app/version.json`
pins the deployed commit at `e15c6b81…` — the same commit as `staging`'s tip. A transitive crawl of
`index.html` + **154** reachable `.js` chunks finds `v7-sharpen-line`, `You wrote: `,
`A few inputs would sharpen these results` and `v7-top-group` in
`/assets/ReactFlowGraph-9aiLXlpO.js`; a nonsense control needle reads 0 chunks, so the instrument
discriminates. In that chunk the group renders **unguarded** —
`n.jsx("div",{…"data-testid":"v7-top-group",children:…jae…})` — beside a flag-gated hero sibling
(`Wa()&&…`), and `jae` computes `p=s.goalText??e.goalLabel??null`. The defect was on screen.

### Which fix, and why

The row sanctioned either *quote the user's real submitted text* or *stop claiming they wrote it*.
**The first is not available at this render point**: the only user-typed goal field was archived, and
the alternative — reaching into the conversation store and nominating some message as "the brief" —
is a new derivation whose breadth I would have to defend, and getting it wrong reproduces the same
authorship lie in a new place. So: **stop claiming it**, and make the claim structurally impossible
to re-open by accident.

The quote now carries its **provenance**:

```ts
export type V7BriefQuoteSource = 'user_brief' | 'derived_label'
export interface V7BriefQuote { text: string; source: V7BriefQuoteSource }
```

`V7SharpenLine` renders the `You wrote` line only when `source === 'user_brief'`. `V7TopMatter`
still hands the derived label over — **labelled honestly** — so the refusal happens in the component
on the live path, and any future re-attribution has to be a visible diff there rather than a silent
prop change.

### Verification

**RED-first** at pristine `e15c6b81`: signature above (1 failed / 2 passed).

**Discriminating mutant pair** (isolated worktree at an absolute path outside the repo root;
isolation proven by *writing* a sentinel and asserting the source sha unchanged, plus an inode
compare — trap 9g; applied-check scoped to `src/`, control exactly 0; restore from a pristine
archive, never from the other copy):

| # | mutation | expected | measured |
|---|---|---|---|
| 1 | loosen the provenance check for **all** strings (`briefQuote?.text.trim()`) | RED | **RED** — kills the fallback test only |
| 2 | change an **unrelated adjacent** string (the model-limit caveat sentence) | GREEN | **GREEN** — 2 files passed |
| 3 | attribute the **other** source (`'derived_label'`) — trap-19 identity twin | RED | **RED** |
| 4 | delete the quote's producer entirely | RED | **RED** |

M1 RED / M2 GREEN is the pair: the guard binds to provenance, not to nearby copy. M3 and M4 close
the identity obligation — the test cannot pass on a different object, and cannot survive its
producer's deletion.

**The assertions bind to provenance, not to a value another object could satisfy.** Every case uses a
fixture where the brief text and the derived label **differ**, and the oracle is the *producer* of the
submitted brief: the displayed characters must occur inside `composeBriefText(framing)`, and the
derived label must not. Each test pins that precondition in-test (the two strings differ · the goal
IS in the brief bytes · the label is NOT), so if `composeBriefText` ever stops carrying the framing
goal these tests go RED instead of quietly becoming tautologies. A positive control asserts the rest
of the line still renders, so the absence is of the **claim**, not of the component.

**Gates** at this tip: `pnpm typecheck` → PASSED (3319/3359 files loaded; ratchet 2485 vs baseline
2491 — the gate offers `--update-baseline`, **declined**: this PR touches 3 files and the shrink is
not attributable to it). `pnpm lint` → 0 errors; rules-of-hooks ratchet exact. Full `vitest run`
result in the thread. UI suites run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported.

### Consequence worth flagging (not fixed here)

Because no live surface writes `framing.goal`, the `You wrote` line will now render only for
scenarios carrying a legacy framing goal — i.e. in practice, almost never. That is the honest state:
what was there before was a lie rendered every time. Whether the slot should carry a **non-attributing**
frame instead (e.g. naming the goal the analysis was run against, without claiming authorship) is a
copy/product call, deliberately left to a follow-up rather than invented inside a defect fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
