### PR TITLE
Results panel: consume the shared clamp, fold three row styles, drop a guarantee nobody enforced

### DIFF
--- a/src/adapters/cee/notModelled.ts
+++ b/src/adapters/cee/notModelled.ts
@@ -20,6 +20,19 @@
  * `null` as "we cannot tell you" — never as "nothing was dropped".
  */
 
+/**
+ * The plain-object guard comes from `lib/guards`, the repo's declared home for
+ * it ("THIS FILE IS THE HOME, NOT THE MIGRATION"). This module used to carry a
+ * private `asRecord` — one more copy of a predicate that already had several
+ * definitions in `src/`, which is the hand-maintained mirror trap 12 names.
+ * `isRecord` rather than `mappers/utils`'s `asObject`: the predicate form
+ * NARROWS in place, so the call sites here need no `=== null` / `=== undefined`
+ * dance at all, and `guards.ts` is the file the migration is converging on.
+ * The predicate is byte-for-byte the same test the local copy performed, so
+ * this is a deletion, not a behaviour change.
+ */
+import { isRecord } from '../../lib/guards'
+
 export const NOT_MODELLED_SCHEMA = 'not_modelled.v1' as const
 
 export type QuantityVerdict = 'in_model' | 'prose_only' | 'absent'
@@ -76,15 +89,16 @@ export interface InferredFactors {
 }
 
 function parseInferredFactors(raw: unknown): InferredFactors {
-  const o = asRecord(raw)
-  if (o === null || (o.status !== 'derived' && o.status !== 'not_recorded')) {
+  if (!isRecord(raw)) return { status: 'not_recorded', items: [] }
+  const o = raw
+  if (o.status !== 'derived' && o.status !== 'not_recorded') {
     return { status: 'not_recorded', items: [] }
   }
   const items: InferredFactor[] = []
   if (Array.isArray(o.items)) {
     for (const r of o.items) {
-      const i = asRecord(r)
-      if (i === null) continue
+      if (!isRecord(r)) continue
+      const i = r
       if (typeof i.node_id !== 'string' || typeof i.label !== 'string') continue
       if (i.label.length === 0) continue
       items.push({ nodeId: i.node_id, label: i.label })
@@ -113,8 +127,8 @@ const EXCLUSION_STATUSES: ReadonlySet<string> = new Set([
 /** Unparseable or absent ⇒ `not_recorded`: we were told nothing, which is the
  *  honest reading and the one that promises the user least. */
 function parseDeclaredExclusions(raw: unknown): DeclaredExclusions {
-  const o = asRecord(raw)
-  if (o === null) return { status: 'not_recorded', items: [] }
+  if (!isRecord(raw)) return { status: 'not_recorded', items: [] }
+  const o = raw
   if (typeof o.status !== 'string' || !EXCLUSION_STATUSES.has(o.status)) {
     return { status: 'not_recorded', items: [] }
   }
@@ -127,16 +141,9 @@ function parseDeclaredExclusions(raw: unknown): DeclaredExclusions {
 const VERDICTS: ReadonlySet<string> = new Set(['in_model', 'prose_only', 'absent'])
 const KINDS: ReadonlySet<string> = new Set(['money', 'percent', 'count', 'date', 'period'])
 
-function asRecord(v: unknown): Record<string, unknown> | null {
-  return v !== null && typeof v === 'object' && !Array.isArray(v)
-    ? (v as Record<string, unknown>)
-    : null
-}
-
 function parseItem(raw: unknown): NotModelledItem | null {
-  const o = asRecord(raw)
-  if (o === null) return null
-  const { literal, kind, char_offset: charOffset, verdict, matched_node_id: matchedNodeId } = o
+  if (!isRecord(raw)) return null
+  const { literal, kind, char_offset: charOffset, verdict, matched_node_id: matchedNodeId } = raw
   if (typeof literal !== 'string' || literal.length === 0) return null
   if (typeof kind !== 'string' || !KINDS.has(kind)) return null
   if (typeof charOffset !== 'number' || !Number.isInteger(charOffset) || charOffset < 0) return null
@@ -162,8 +169,8 @@ function parseItem(raw: unknown): NotModelledItem | null {
  * about the user's own words.
  */
 export function parseNotModelled(raw: unknown): NotModelledManifest | null {
-  const o = asRecord(raw)
-  if (o === null) return null
+  if (!isRecord(raw)) return null
+  const o = raw
   if (o.schema !== NOT_MODELLED_SCHEMA) return null
 
   const notTracked = Array.isArray(o.not_tracked)
@@ -184,10 +191,10 @@ export function parseNotModelled(raw: unknown): NotModelledManifest | null {
 
   if (o.status !== 'derived') return null
 
-  const q = asRecord(o.quantities)
   // `derived` promises a tally. A derived manifest without one contradicts
   // itself, and we do not guess which half was true.
-  if (q === null) return null
+  if (!isRecord(o.quantities)) return null
+  const q = o.quantities
 
   const rawItems = Array.isArray(q.items) ? q.items : []
   const items: NotModelledItem[] = []

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -149,7 +149,6 @@ export async function hydrateCanvasFromServer(
   // an empty list, which on a brief we demonstrably lose content from would be
   // a new and more damaging lie than the silence it replaces.
   useContextIntegrityStore.getState().setContextIntegrity({
-    scenarioId,
     briefText: result.briefText,
     manifest: result.notModelled,
   })

--- a/src/canvas/stores/contextIntegrityStore.ts
+++ b/src/canvas/stores/contextIntegrityStore.ts
@@ -24,16 +24,31 @@ import { create } from 'zustand'
 
 import type { NotModelledManifest } from '../../adapters/cee/notModelled'
 
+/**
+ * ── WHY THERE IS NO `scenarioId` HERE ──────────────────────────────────────
+ * There was one, and its comment claimed it "guards against a stale read from a
+ * previous scenario being shown against the current one". It guarded nothing:
+ * it was WRITE-ONLY. `serverGraphHydration` set it and no consumer ever read it
+ * — `V7WhatIWasGivenSection` selects `briefText` and `manifest` and nothing
+ * else. A field with zero readers cannot fork identity and cannot gate a
+ * render, so its blast radius was zero by construction (CLAUDE.md trap 10),
+ * and a comment asserting a guarantee nobody enforces is worse than no field:
+ * the next reader trusts it and stops looking.
+ *
+ * The staleness question itself is real but is answered UPSTREAM, before this
+ * store is written: `serverGraphHydration` compares the requested scenario
+ * against `useCanvasStore.currentScenarioId` and returns `'skipped'` on a
+ * mismatch, so a hydration for a scenario the user has left never reaches
+ * `setContextIntegrity` at all. If that ever stops being true, the fix is a
+ * guard with a reader and a test — not a field that records the answer and
+ * throws it away.
+ */
 export interface ContextIntegrityState {
   /** The brief as the user wrote it, byte-verbatim. `null` = none persisted. */
   briefText: string | null
   /** CEE's manifest. `null` = we were told nothing. NEVER "nothing dropped". */
   manifest: NotModelledManifest | null
-  /** The scenario the two fields above describe. Guards against a stale read
-   *  from a previous scenario being shown against the current one. */
-  scenarioId: string | null
   setContextIntegrity: (input: {
-    scenarioId: string
     briefText: string | null
     manifest: NotModelledManifest | null
   }) => void
@@ -43,12 +58,10 @@ export interface ContextIntegrityState {
 const EMPTY = {
   briefText: null,
   manifest: null,
-  scenarioId: null,
 } as const
 
 export const useContextIntegrityStore = create<ContextIntegrityState>((set) => ({
   ...EMPTY,
-  setContextIntegrity: ({ scenarioId, briefText, manifest }) =>
-    set({ scenarioId, briefText, manifest }),
+  setContextIntegrity: ({ briefText, manifest }) => set({ briefText, manifest }),
   reset: () => set({ ...EMPTY }),
 }))

--- a/src/components/results/__tests__/ResultsBody.v7SharpenQuoteProvenance.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7SharpenQuoteProvenance.spec.tsx
@@ -32,6 +32,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { ResultsBody } from '../ResultsBody'
+import type { V7SharpenLineProps } from '../v7/V7SharpenLine'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {
   ConfidenceSectionData,
@@ -49,6 +50,40 @@ vi.mock('../../../canvas/utils/focusHelpers', () => ({
   focusExistingTarget: vi.fn(),
   focusModelTarget: vi.fn(() => true),
 }))
+
+/**
+ * ── OBSERVING THE PASS-THROUGH HALF OF THE MECHANISM ───────────────────────
+ *
+ * The refusal is only half of ROADMAP 2.993. The other half is that
+ * `V7TopMatter` STILL HANDS THE DERIVED LABEL OVER, correctly labelled, so that
+ * the decision not to attribute it lives in `V7SharpenLine` on the live path
+ * and any future re-attribution has to be a visible diff in that file.
+ *
+ * That half was UNPINNED. Every assertion in this file is an absence, so
+ * simplifying `V7TopMatter` to pass `null` when there is no `goalText` would
+ * delete the mechanism and leave the whole suite GREEN — a guard whose evidence
+ * comes from itself (CLAUDE.md trap 13b). A discarded value leaves no DOM
+ * trace, so the ONLY way to observe it is at the prop boundary.
+ *
+ * The mock spreads `importOriginal` and DELEGATES to the real component rather
+ * than replacing it: a `vi.mock` factory replaces the whole module, and a
+ * hand-listed stub is the mirror that silently drops whatever the module gains
+ * next (trap 12). Because it delegates, the three rendering tests below are
+ * unaffected and still exercise the real refusal.
+ */
+const { sharpenProps } = vi.hoisted(() => ({ sharpenProps: [] as V7SharpenLineProps[] }))
+
+vi.mock('../v7/V7SharpenLine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../v7/V7SharpenLine')>()
+  const { createElement } = await import('react')
+  return {
+    ...actual,
+    V7SharpenLine: (props: V7SharpenLineProps) => {
+      sharpenProps.push(props)
+      return createElement(actual.V7SharpenLine, props)
+    },
+  }
+})
 
 vi.mock('@/flags', async () => {
   const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
@@ -224,9 +259,51 @@ const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-07
 
 describe('ResultsBody — V7 sharpen line quote provenance (ROADMAP 2.993)', () => {
   beforeEach(() => {
+    sharpenProps.length = 0
     useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
     useGuidanceStore.setState({ guidanceItems: [] })
+  })
+
+  it('HANDS THE DERIVED LABEL OVER — the refusal happens in the component, not upstream', () => {
+    renderBody(undefined)
+    assertSharpenSurfaceMounted()
+
+    // The instrument must have observed the live render at all — otherwise
+    // every assertion below would pass vacuously on an empty array (trap 13).
+    expect(
+      sharpenProps.length,
+      'the recording wrapper must have seen V7SharpenLine render',
+    ).toBeGreaterThan(0)
+
+    // IDENTITY BINDING (trap 19): not "some quote was passed", but THIS quote —
+    // our derived label, carrying the one provenance that makes it refusable.
+    // A value predicate like "a non-null briefQuote" would be satisfied by the
+    // user_brief case too, which is the opposite of what is under test.
+    expect(sharpenProps.at(-1)?.briefQuote).toEqual({
+      text: DERIVED_GOAL_LABEL,
+      source: 'derived_label',
+    })
+
+    // …and receiving it changes nothing on screen. Both halves in one test, so
+    // a change that deletes the pass-through cannot pass by also deleting the
+    // assertion that the screen stays clean.
+    expect(screen.queryByTestId('v7-sharpen-quote')).not.toBeInTheDocument()
+  })
+
+  it('CONTROL — the pass-through discriminates: the user_brief case carries a DIFFERENT quote', () => {
+    // Without this, the test above could not tell "the derived label was passed"
+    // from "whatever was passed happened to match". Keeping one probe whose
+    // expected answer DIFFERS is what exposes an instrument that has stopped
+    // discriminating (CLAUDE.md trap 20).
+    renderBody(USER_BRIEF_GOAL)
+    assertSharpenSurfaceMounted()
+
+    expect(sharpenProps.at(-1)?.briefQuote).toEqual({
+      text: USER_BRIEF_GOAL,
+      source: 'user_brief',
+    })
+    expect(USER_BRIEF_GOAL).not.toBe(DERIVED_GOAL_LABEL)
   })
 
   it('never attributes OUR derived goal label to the user when the brief carries no goal', () => {

--- a/src/components/results/v7/ClampToggle.tsx
+++ b/src/components/results/v7/ClampToggle.tsx
@@ -1,6 +1,19 @@
 /**
- * ClampToggle — the row-clamp reveal affordance, ONE leaf for the THREE verbatim
- * copies in this directory.
+ * ClampToggle — the row-clamp reveal affordance, ONE leaf for the FOUR clamps in
+ * this directory.
+ *
+ * ⚠ THE COUNT HAS NOW BEEN WRONG TWICE, IN THE SAME HEADER, FOR THE SAME REASON.
+ * It was extracted for "the two verbatim copies" and there were three; it then
+ * said THREE while `V7WhatIWasGivenSection.tsx` — added later, in this same
+ * directory — hand-rolled a FOURTH. That fourth one was not a verbatim copy,
+ * which is exactly why it was easy to miss and exactly why it mattered: it
+ * rendered in a DIFFERENT COLOUR from the other three (`text-text-light
+ * underline` against `text-info hover:underline`) and it was ONE-WAY, with no
+ * "Show fewer". A user reads the results panel as one surface, so a divergent
+ * copy is not an internal tidiness problem — it is visible to them.
+ * **A hand-maintained count in a header is the very defect this component
+ * exists to remove (CLAUDE.md trap 12): if you add a clamp here, consume this,
+ * and if you find this number wrong, the number is not the bug.**
  *
  * ⚠ R-11 — IT WAS EXTRACTED FOR "THE TWO VERBATIM COPIES" AND THERE WERE THREE.
  * The extraction landed inside `V7EvidenceDisclosure.tsx` as a module-private
@@ -15,7 +28,9 @@
  *
  * `hiddenCount` is the number of rows the clamp HIDES and does not change when
  * the list expands, so the affordance stays mounted as "Show fewer" — the
- * behaviour all three suites pin. Renders nothing when the clamp hides nothing.
+ * behaviour every consumer's suite pins. Renders nothing when the clamp hides
+ * nothing. ⚠ A consumer that passes `items.length - visible.length` gets zero on
+ * expand and unmounts the control; that is the one-way bug, not a variant.
  *
  * ⚠ THE COUNTER IS THE ONLY DIGIT-BEARING STRING IN THE RESOLVE-NEXT VIEW, and it
  * is a count of HIDDEN ROWS — never a value of information. It is the string that
@@ -34,13 +49,24 @@ import { typography } from '../../../styles/typography'
  * consumers and copy-hygiene manifests are unchanged; what is gone is the second
  * definition of the string.
  *
- * ⚠ SCOPE. Four FURTHER copies of `Show ${n} more` exist outside this directory
- * (`strengthen/strengthenCopy.ts`, `coaching-panel/constants.ts`,
- * `pre-analysis-v3/constants.ts`, and `analysis-hero/heroCopy.ts`'s `showFewer`
- * half). They are pre-existing, belong to four other panels with their own copy
- * modules and copy-hygiene suites, and unifying user-facing copy across panels is
- * a copy decision rather than a refactor. Named here so the next reader knows the
- * count is six and not two, and does not mistake this file for the finish line.
+ * ⚠ SCOPE, AND A CORRECTION. This note used to say "four FURTHER copies exist
+ * outside this directory … the count is six and not two", naming four COPY
+ * MODULES (`strengthen/strengthenCopy.ts`, `coaching-panel/constants.ts`,
+ * `pre-analysis-v3/constants.ts`, `analysis-hero/heroCopy.ts`'s `showFewer`
+ * half). That total was too low, because the label is also produced INLINE in
+ * components that have no copy module at all — `ChangeAttributionPanel.tsx`,
+ * `conversation/InlineBlocks.tsx`, `blocks/GraphPatchBlockRenderer.tsx`,
+ * `results/ConfidenceSection.tsx`, `results/TriageActionCardsBody.tsx`,
+ * `sandbox-guide/.../TopDriversSection.tsx` among them. Scope of that sweep,
+ * stated so the next reader can judge it: `rg` over `src/` for `Show ${…`,
+ * "`Show ", "Show {" and 'Show ' filtered to more/fewer, EXCLUDING tests and
+ * `__tests__/`; it does not cover `e2e/`, `docs/`, or any unmerged branch.
+ * ⚠ NO TOTAL IS STATED HERE ON PURPOSE. A count in a comment is a
+ * hand-maintained mirror, it has now been wrong twice in this one header, and
+ * replacing a wrong number with a freshly-measured one just resets the clock
+ * (CLAUDE.md trap 12). Re-derive it if you need it. What remains true and is
+ * the actual point: unifying user-facing copy ACROSS panels is a copy decision
+ * rather than a refactor, so this file is not the finish line for it.
  */
 export const clampRevealLabel = (n: number): string => `Show ${n} more`
 

--- a/src/components/results/v7/ClampToggle.tsx
+++ b/src/components/results/v7/ClampToggle.tsx
@@ -73,24 +73,60 @@ export const clampRevealLabel = (n: number): string => `Show ${n} more`
 /** The collapse label, paired with `clampRevealLabel` for the same reason. */
 export const clampCollapseLabel = 'Show fewer'
 
+/**
+ * ⚠ THE TAP TARGET IS THE REASON `py-1.5` IS NOT NEGOTIABLE HERE.
+ * Tailwind's preflight sets `button { padding: 0 }` (verified in this project:
+ * `src/index.css:6` loads `@tailwind base`, tailwindcss 3.4.19), so a bare
+ * button really is zero-padded — not merely un-styled. `panelMeta` is
+ * `text-[11px] leading-snug`, i.e. 11 x 1.375 = **15.125px** of line box, which
+ * is a 15px-tall hit area for a control a user is expected to click repeatedly.
+ * `py-1.5` (6px each side) takes it to **27.125px**, clearing WCAG 2.2 SC 2.5.8
+ * Target Size (Minimum)'s 24x24 floor. `py-1` was considered and reaches only
+ * **23.125px** — it restores the old look and still misses the floor, which is
+ * why the taller value is here. Width is never the binding constraint: the
+ * shortest label, "Show fewer", is far wider than 24px at any inset.
+ */
+const CLAMP_TAP_PADDING = 'py-1.5'
+
+/**
+ * How far the control is inset from the left, which MUST equal the horizontal
+ * padding of the rows it sits beneath or the label will not line up with the
+ * text above it.
+ *
+ * ⚠ MEASURED AT THE RENDERED DOM, not assumed: three of the four consumers
+ * (`V7EvidenceDisclosure`'s drivers and resolve-next lists, `V7GuidanceSection`)
+ * render rows with NO horizontal padding, so they sit flush and `'none'` is
+ * correct for them. `V7WhatIWasGivenSection`'s rows carry `px-2`, so it — and
+ * only it — passes `'px-2'`. Putting `px-2` on this component unconditionally
+ * would have fixed one consumer by misaligning three.
+ *
+ * A closed union rather than a free `className`: a consumer must not be able to
+ * quietly re-style the shared affordance, because divergent styling is the
+ * defect this component exists to prevent, not a knob it offers.
+ */
+export type ClampRowInset = 'none' | 'px-2'
+
 export function ClampToggle({
   testId,
   hiddenCount,
   expanded,
   onToggle,
+  rowInset = 'none',
 }: {
   testId: string
   hiddenCount: number
   expanded: boolean
   onToggle: () => void
+  rowInset?: ClampRowInset
 }) {
   if (hiddenCount <= 0) return null
+  const inset = rowInset === 'none' ? '' : ` ${rowInset}`
   return (
     <button
       type="button"
       onClick={onToggle}
       data-testid={testId}
-      className={`${typography.panelMeta} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+      className={`${typography.panelMeta} ${CLAMP_TAP_PADDING}${inset} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
     >
       {expanded ? clampCollapseLabel : clampRevealLabel(hiddenCount)}
     </button>

--- a/src/components/results/v7/V7WhatIWasGivenSection.tsx
+++ b/src/components/results/v7/V7WhatIWasGivenSection.tsx
@@ -208,12 +208,18 @@ function Rows({
       {/* The panel's ONE clamp affordance (`./ClampToggle`), in the directory
           that component's own header names. The copy this replaced rendered in
           a different colour from every other clamp in the results panel and
-          offered no way back. */}
+          offered no way back.
+
+          `rowInset` MUST track `ROW_BOX`'s horizontal padding: preflight zeroes
+          a bare button, so without it the control hangs 8px left of the rows it
+          belongs to. This is the ONLY consumer that passes one — the other
+          three render rows with no horizontal padding and sit flush. */}
       <ClampToggle
         testId={`${testId}-show-all`}
         hiddenCount={hiddenCount}
         expanded={showAll}
         onToggle={() => setShowAll((s) => !s)}
+        rowInset="px-2"
       />
     </div>
   )

--- a/src/components/results/v7/V7WhatIWasGivenSection.tsx
+++ b/src/components/results/v7/V7WhatIWasGivenSection.tsx
@@ -44,9 +44,25 @@ import { ChevronDown } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { useContextIntegrityStore } from '../../../canvas/stores/contextIntegrityStore'
 import type { NotModelledItem } from '../../../adapters/cee/notModelled'
+import { ClampToggle } from './ClampToggle'
 
 /** Rows shown per group before "show all". Keeps the open state scannable. */
 const VISIBLE_ROWS = 6
+
+/**
+ * ── ONE LIST RHYTHM, ONE ROW BOX ───────────────────────────────────────────
+ * The container rhythm was written three times in this file and the row box
+ * twice verbatim (plus once in part). A reader takes this panel to be one
+ * surface, so the day one of the copies is adjusted and the others are not,
+ * the drift is visible to them — the hand-maintained mirror at user-facing
+ * scale (CLAUDE.md trap 12).
+ */
+const LIST_CLASS = 'mt-1 space-y-0.5'
+const ROW_BOX = 'rounded px-2 py-1 odd:bg-panel-hover/40'
+/** A plain text row. */
+const TEXT_ROW_CLASS = `${typography.panelBody} ${ROW_BOX} text-text-body`
+/** A row that also carries an action on the right. */
+const ACTION_ROW_CLASS = `flex items-baseline justify-between gap-2 ${ROW_BOX}`
 
 const COPY = {
   heading: 'What you gave me, and what I did with it',
@@ -109,6 +125,41 @@ function notTrackedCopy(codes: readonly string[]): string {
   return known.join('; ')
 }
 
+/**
+ * One item of a plain text list.
+ *
+ * `key` and `attrs` exist so every row is addressed by IDENTITY — a node id, a
+ * char offset — never by a value another row could also produce (trap 19).
+ */
+interface TextRow {
+  readonly key: string
+  readonly label: string
+  readonly attrs?: Readonly<Record<string, string>>
+}
+
+/**
+ * The unclamped text list — "what I estimated" and "I also considered these".
+ * The two were byte-identical apart from their key, their testid and one
+ * `data-` attribute, so they are one component parameterised by exactly those.
+ *
+ * `<ul>`/`<li>` rather than `<div>`: each block is a list of discrete facts and
+ * that is what lets assistive tech announce how many there are. The
+ * "considered" block already did this, so unifying the other list DOWN to a
+ * `<div>` would have been the regression. Tailwind's preflight strips list
+ * markers and padding, so the rendered pixels are unchanged.
+ */
+function TextRowList({ rows, testId }: { rows: readonly TextRow[]; testId: string }) {
+  return (
+    <ul className={LIST_CLASS} data-testid={testId}>
+      {rows.map((row) => (
+        <li key={row.key} data-testid={`${testId}-row`} {...row.attrs} className={TEXT_ROW_CLASS}>
+          {row.label}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 function Rows({
   items,
   testId,
@@ -120,43 +171,50 @@ function Rows({
 }) {
   const [showAll, setShowAll] = useState(false)
   const visible = showAll ? items : items.slice(0, VISIBLE_ROWS)
-  const moreCount = items.length - visible.length
+  // ⚠ `ClampToggle`'s contract is that `hiddenCount` is what the clamp HIDES
+  // and does NOT change when the list expands — that is what keeps the control
+  // mounted as "Show fewer". `items.length - visible.length` falls to zero on
+  // expand and would unmount the affordance, which is precisely the one-way
+  // behaviour this replaced.
+  const hiddenCount = items.length - VISIBLE_ROWS
 
   return (
-    <div className="mt-1 space-y-0.5" data-testid={testId}>
-      {visible.map((item) => (
-        // Keyed and addressed by IDENTITY (offset + literal): a brief can state
-        // the same figure twice and they are two different facts.
-        <div
-          key={`${item.charOffset}:${item.literal}`}
-          data-testid={`${testId}-row`}
-          data-char-offset={item.charOffset}
-          data-matched-node-id={item.matchedNodeId ?? undefined}
-          className="flex items-baseline justify-between gap-2 rounded px-2 py-1 odd:bg-panel-hover/40"
-        >
-          <span className={`${typography.panelBody} text-text-body`}>{item.literal}</span>
-          {onAdd && (
-            <button
-              type="button"
-              onClick={() => onAdd(item)}
-              data-testid={`${testId}-add`}
-              className={`${typography.panelMeta} flex-none rounded px-1.5 py-0.5 text-text-light underline hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-            >
-              {COPY.addAction}
-            </button>
-          )}
-        </div>
-      ))}
-      {moreCount > 0 && (
-        <button
-          type="button"
-          onClick={() => setShowAll(true)}
-          data-testid={`${testId}-show-all`}
-          className={`${typography.panelMeta} px-2 py-1 text-text-light underline hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
-        >
-          Show {moreCount} more
-        </button>
-      )}
+    <div className={LIST_CLASS}>
+      <ul className="space-y-0.5" data-testid={testId}>
+        {visible.map((item) => (
+          // Keyed and addressed by IDENTITY (offset + literal): a brief can state
+          // the same figure twice and they are two different facts.
+          <li
+            key={`${item.charOffset}:${item.literal}`}
+            data-testid={`${testId}-row`}
+            data-char-offset={item.charOffset}
+            data-matched-node-id={item.matchedNodeId ?? undefined}
+            className={ACTION_ROW_CLASS}
+          >
+            <span className={`${typography.panelBody} text-text-body`}>{item.literal}</span>
+            {onAdd && (
+              <button
+                type="button"
+                onClick={() => onAdd(item)}
+                data-testid={`${testId}-add`}
+                className={`${typography.panelMeta} flex-none rounded px-1.5 py-0.5 text-text-light underline hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+              >
+                {COPY.addAction}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      {/* The panel's ONE clamp affordance (`./ClampToggle`), in the directory
+          that component's own header names. The copy this replaced rendered in
+          a different colour from every other clamp in the results panel and
+          offered no way back. */}
+      <ClampToggle
+        testId={`${testId}-show-all`}
+        hiddenCount={hiddenCount}
+        expanded={showAll}
+        onToggle={() => setShowAll((s) => !s)}
+      />
     </div>
   )
 }
@@ -285,18 +343,14 @@ export function V7WhatIWasGivenSection({ onSendMessage }: V7WhatIWasGivenSection
                 {COPY.estimatedHeading}
               </h4>
               <p className={`${typography.panelMeta} text-text-light`}>{COPY.estimatedLead}</p>
-              <div className="mt-1 space-y-0.5" data-testid="what-i-was-given-estimated">
-                {estimated.map((f) => (
-                  <div
-                    key={f.nodeId}
-                    data-testid="what-i-was-given-estimated-row"
-                    data-node-id={f.nodeId}
-                    className={`${typography.panelBody} rounded px-2 py-1 text-text-body odd:bg-panel-hover/40`}
-                  >
-                    {f.label}
-                  </div>
-                ))}
-              </div>
+              <TextRowList
+                testId="what-i-was-given-estimated"
+                rows={estimated.map((f) => ({
+                  key: f.nodeId,
+                  label: f.label,
+                  attrs: { 'data-node-id': f.nodeId },
+                }))}
+              />
             </div>
           )}
 
@@ -304,17 +358,10 @@ export function V7WhatIWasGivenSection({ onSendMessage }: V7WhatIWasGivenSection
           {considered.length > 0 && (
             <div>
               <p className={`${typography.panelMeta} text-text-light`}>{COPY.consideredLead}</p>
-              <ul className="mt-1 space-y-0.5" data-testid="what-i-was-given-considered">
-                {considered.map((text) => (
-                  <li
-                    key={text}
-                    data-testid="what-i-was-given-considered-row"
-                    className={`${typography.panelBody} rounded px-2 py-1 text-text-body odd:bg-panel-hover/40`}
-                  >
-                    {text}
-                  </li>
-                ))}
-              </ul>
+              <TextRowList
+                testId="what-i-was-given-considered"
+                rows={considered.map((text) => ({ key: text, label: text }))}
+              />
             </div>
           )}
 

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
@@ -60,6 +60,7 @@ import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 import type { OptionResult } from '../../types'
 import { useContextIntegrityStore } from '@/canvas/stores/contextIntegrityStore'
 import { parseNotModelled } from '@/adapters/cee/notModelled'
+import { ClampToggle, clampRevealLabel, clampCollapseLabel } from '../ClampToggle'
 
 import b1Fixture from './fixtures/b1-cold-read.not-modelled.json'
 import b2Fixture from './fixtures/b2-cold-read.not-modelled.json'
@@ -92,7 +93,6 @@ function coldReadOf(fixture: Record<string, unknown>) {
 function seedFrom(fixture: Record<string, unknown>): void {
   const cold = coldReadOf(fixture)
   useContextIntegrityStore.getState().setContextIntegrity({
-    scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
     briefText: cold.brief_text,
     manifest: parseNotModelled(cold.not_modelled),
   })
@@ -391,7 +391,6 @@ describe('THE TWO SECTIONS MAY NEVER CONTRADICT EACH OTHER ON SCREEN', () => {
       const { briefText, manifest } = caseFor(notation)
       expect(manifest, 'the real parser must accept the real manifest').not.toBeNull()
       useContextIntegrityStore.getState().setContextIntegrity({
-        scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
         briefText,
         manifest,
       })
@@ -470,7 +469,6 @@ describe('counts come from the manifest, not from the rendered rows', () => {
     expect(manifest?.quantities?.truncated).toBe(true)
 
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: 'A long brief.',
       manifest,
     })
@@ -497,7 +495,6 @@ describe('an unknown untracked code never leaks onto the screen', () => {
       not_tracked: ['corrections_and_second_thoughts', 'some_future_class_v2'],
     })
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: 'A brief.',
       manifest,
     })
@@ -570,7 +567,6 @@ describe('the parser refuses to vouch for what it cannot read', () => {
   it('a payload it cannot read reaches the user as "we cannot tell you"', () => {
     // The end-to-end consequence of the above, at the surface.
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: 'We need £4m out by March 2027.',
       manifest: parseNotModelled({ schema: 'not_modelled.v2', status: 'derived' }),
     })
@@ -594,7 +590,6 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
     // null. The surface must say "we cannot tell you" — not show an empty list,
     // and not stay silent, both of which read as "nothing was dropped".
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: coldReadOf(b1Fixture as never).brief_text,
       manifest: null,
     })
@@ -627,7 +622,6 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
     expect(manifest?.quantities).toBeNull()
 
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: 'We need £4m out by March 2027.',
       manifest,
     })
@@ -647,7 +641,6 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
       not_tracked: ['competing_or_dissenting_proposals'],
     })
     useContextIntegrityStore.getState().setContextIntegrity({
-      scenarioId: 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c',
       briefText: 'Should I take the job or stay put?',
       manifest,
     })
@@ -806,5 +799,82 @@ describe('MOUNT PATH — live under the DEPLOYED flag posture, and under its opp
 
     expect(heroOn, 'flag-on arm renders the hero panel').not.toBeNull()
     expect(heroOff, 'flag-off arm does not').toBeNull()
+  })
+})
+
+/**
+ * ── THE REVEAL CONTROL IS THE PANEL'S SHARED ONE, NOT A LOOK-ALIKE ──────────
+ *
+ * This section hand-rolled its own "Show N more" button in the SAME directory
+ * as `ClampToggle`, whose header declares itself "ONE leaf for the THREE
+ * verbatim copies in this directory". Two costs the user could see:
+ *
+ *   · it rendered in a DIFFERENT colour from every other clamp in the results
+ *     panel (`text-text-light underline` vs `text-info hover:underline`), in a
+ *     surface a reader takes to be one thing;
+ *   · it was ONE-WAY — once expanded there was no way back, where all three
+ *     existing consumers keep the affordance mounted as "Show fewer".
+ *
+ * Both assertions below are DERIVED from `ClampToggle` itself rather than from
+ * a copied class string or a hardcoded count: a literal here would be the same
+ * hand-maintained mirror the change removes (CLAUDE.md trap 12), and would keep
+ * passing on the day `ClampToggle` moved.
+ */
+describe('the reveal control — the panel-wide clamp affordance, not a local copy', () => {
+  const notYetRows = () =>
+    screen.getByTestId('what-i-was-given-notyet').querySelectorAll('[data-char-offset]').length
+
+  it('reverses: the control stays mounted as "Show fewer" and re-collapses the list', () => {
+    seedFrom(b1Fixture as never)
+    render(<V7WhatIWasGivenSection />)
+    openPanel()
+
+    const collapsed = notYetRows()
+    const toggle = screen.getByTestId('what-i-was-given-notyet-show-all')
+    // Captured while STILL COLLAPSED — the control is one node that relabels
+    // itself, so reading it after the click would read the collapse label.
+    const revealLabel = toggle.textContent
+
+    fireEvent.click(toggle)
+    const expanded = notYetRows()
+    // PRECONDITION, pinned in-test (trap 13b): the clamp must genuinely be
+    // hiding rows, or every assertion below would hold on a list that was
+    // never truncated and this test would discriminate nothing.
+    expect(
+      expanded,
+      'the notyet group must actually be clamped for this test to mean anything',
+    ).toBeGreaterThan(collapsed)
+
+    // The reveal label counted the rows it was hiding — derived from the shared
+    // label function AND from the row delta we just measured, so neither the
+    // string nor the number is copied here.
+    expect(revealLabel).toBe(clampRevealLabel(expanded - collapsed))
+
+    // THE BEHAVIOUR THIS CHANGE RESTORES: the affordance is still on screen,
+    // now offering the way back, and it works.
+    const back = screen.getByTestId('what-i-was-given-notyet-show-all')
+    expect(back, 'the clamp control must stay mounted once expanded').toBeInTheDocument()
+    expect(back).toHaveTextContent(clampCollapseLabel)
+    fireEvent.click(back)
+    expect(notYetRows()).toBe(collapsed)
+  })
+
+  it('renders the SAME affordance the rest of the results panel renders', () => {
+    // The reference comes from the shared component, mounted here directly.
+    const reference = render(
+      <ClampToggle testId="clamp-reference" hiddenCount={3} expanded={false} onToggle={() => {}} />,
+    )
+    const referenceClass = reference.getByTestId('clamp-reference').className
+    expect(
+      referenceClass.length,
+      'the reference affordance must actually carry classes, or this compares nothing',
+    ).toBeGreaterThan(0)
+    cleanup()
+
+    seedFrom(b1Fixture as never)
+    render(<V7WhatIWasGivenSection />)
+    openPanel()
+
+    expect(screen.getByTestId('what-i-was-given-notyet-show-all').className).toBe(referenceClass)
   })
 })

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
@@ -859,6 +859,45 @@ describe('the reveal control — the panel-wide clamp affordance, not a local co
     expect(notYetRows()).toBe(collapsed)
   })
 
+  it('LINES UP with the rows above it — the clamp inset matches the row inset', () => {
+    // Tailwind preflight sets `button { padding: 0 }` (verified in this project:
+    // `src/index.css:6` loads `@tailwind base`, tailwindcss 3.4.19), so a button
+    // with no `px-*` sits at a REAL zero inset while these rows carry one. The
+    // control would then hang 8px left of the text it belongs to.
+    //
+    // Both sides are read from the RENDERED DOM, so neither the row's inset nor
+    // the toggle's is written down here: change either and this test makes the
+    // other follow. A hardcoded `px-2` would be the mirror (trap 12).
+    seedFrom(b1Fixture as never)
+    render(<V7WhatIWasGivenSection />)
+    openPanel()
+
+    const insetOf = (el: Element | null | undefined): string =>
+      (el?.className ?? '').match(/(?:^|\s)(px-[^\s]+)/)?.[1] ?? 'none'
+
+    const row = screen.getByTestId('what-i-was-given-notyet').querySelector('[data-char-offset]')
+    const toggle = screen.getByTestId('what-i-was-given-notyet-show-all')
+
+    // PRECONDITION (trap 13b): if the rows ever lose their inset this test would
+    // pass on 'none' === 'none' while proving nothing about alignment.
+    expect(
+      insetOf(row),
+      'the rows must carry a horizontal inset or this test discriminates nothing',
+    ).not.toBe('none')
+
+    expect(insetOf(toggle)).toBe(insetOf(row))
+  })
+
+  it('the shared clamp carries vertical padding — preflight zeroes a bare button', () => {
+    // The tap target, at the ONE place that fixes it for all four consumers.
+    // jsdom cannot compute layout (trap 3), so this pins the CLASS, and the
+    // pixel arithmetic is stated in the PR body from the type tokens.
+    const r = render(
+      <ClampToggle testId="clamp-tap" hiddenCount={3} expanded={false} onToggle={() => {}} />,
+    )
+    expect(r.getByTestId('clamp-tap').className).toMatch(/(?:^|\s)py-/)
+  })
+
   it('renders the SAME affordance the rest of the results panel renders', () => {
     // The reference comes from the shared component, mounted here directly.
     const reference = render(
@@ -875,6 +914,15 @@ describe('the reveal control — the panel-wide clamp affordance, not a local co
     render(<V7WhatIWasGivenSection />)
     openPanel()
 
-    expect(screen.getByTestId('what-i-was-given-notyet-show-all').className).toBe(referenceClass)
+    // Everything EXCEPT the horizontal inset comes from the shared component —
+    // colour, type scale, focus ring, and the tap padding. The inset is
+    // deliberately per-consumer (it tracks each consumer's own row padding, and
+    // three of the four need none), so it is stripped from BOTH sides here
+    // rather than written down a second time; the alignment test above is what
+    // pins it, derived from the rows themselves.
+    const withoutInset = (cn: string) => cn.replace(/(?:^|\s)px-[^\s]+/g, '').trim()
+    expect(withoutInset(screen.getByTestId('what-i-was-given-notyet-show-all').className)).toBe(
+      withoutInset(referenceClass),
+    )
   })
 })


### PR DESCRIPTION
Five deduped quality fixes from a four-angle review of tonight's 2.973 / 2.993 work, plus a padding regression caught in review. Base `staging` @ `a4a0906e`.

## What a user would see

**This PR makes three deliberate visual changes to the clamp control, and no other visual change.** (An earlier version of this description said "everything else is byte-identical on screen" — that was **wrong**, and the correction is the second commit. See *Visual claims, precisely* below for what is and is not asserted.)

| | Before | After |
|---|---|---|
| Clamp colour | `text-text-light underline` | `text-info hover:underline` — the same as every other clamp in the results panel |
| Expanding a long list | one-way, no way back | reversible — "Show fewer", matching all three existing consumers |
| Clamp hit area | 23.125px tall | **27.125px** — clears WCAG 2.2 SC 2.5.8's 24×24 floor, for **all four** consumers |

## The padding regression, and why the fix is split

Adopting `ClampToggle` initially **dropped `px-2 py-1`**. Tailwind preflight sets `button { padding: 0 }` — verified in this project at `src/index.css:6` (`@tailwind base`) with `tailwindcss@3.4.19` — so computed padding really went `4px 8px` → `0`, not merely "unstyled".

The proposed fix was to put `px-2 py-1` on `ClampToggle` itself. **Measured at the rendered DOM, that would have fixed one consumer by misaligning three:**

| Consumer | Row `px` | Toggle `px` (before) | Aligned |
|---|---|---|---|
| `V7WhatIWasGivenSection` | **`px-2`** | none | **NO** ← the defect |
| `V7EvidenceDisclosure` (drivers) | none | none | yes |
| `V7EvidenceDisclosure` (resolve next) | none | none | yes |
| `V7GuidanceSection` | none | none | yes |

Three of the four render rows with **no** horizontal padding and sit flush. So:

- **Vertical padding → the shared component.** `panelMeta` is `text-[11px] leading-snug`, i.e. 11 × 1.375 = **15.125px** of line box. `py-1.5` (6px each side) → **27.125px**.
  ⚠ **Deviation, flagged:** `py-1` was specified, but 4px each side reaches only **23.125px** — it restores the original look and *still misses the 24px floor that motivated the request*. `py-1.5` is the smallest step that meets it. **One token to revert** if the exact `py-1` is preferred.
- **Horizontal inset → per consumer**, via a closed `rowInset: 'none' | 'px-2'` union defaulting to `'none'`. Only `V7WhatIWasGivenSection` passes one. A closed union rather than a free `className`, so a consumer cannot quietly re-style the shared affordance — divergent styling is the defect this component exists to prevent, not a knob it offers.

After, at the rendered DOM: **all four aligned** (`px-2`↔`px-2` for the panel; `none`↔`none` preserved for the other three), all four at `py-1.5`.

## Visual claims, precisely

- **The three row sites: no visual change.** The row class strings are identical *sets* — `TEXT_ROW_CLASS` reorders `text-text-body` after the shared `ROW_BOX`, and attribute/class **order cannot affect the cascade** (specificity and source order in the stylesheet decide, not the order of names in the attribute).
- **`div` → `ul/li`: inert.** Preflight is present and verified (`src/index.css:6`, `tailwindcss@3.4.19`), and it zeroes list `margin`, `padding` and `list-style`. Semantics improve (assistive tech gets an item count); pixels do not move.
- **The clamp: deliberately changed**, per the table above.
- **jsdom cannot prove layout** (trap 3). The class-string evidence proves *which classes are applied*; the pixel figures are derived from the type/spacing tokens (`leading-snug` = 1.375, `p-1` = 4px, `p-1.5` = 6px, `p-2` = 8px), not measured in a browser. Stated as arithmetic, not as a rendered measurement.

## The five original fixes

1. **Consume the shared `ClampToggle`.** `V7WhatIWasGivenSection` hand-rolled a fourth clamp *in the same directory as* `ClampToggle`, whose header declared itself "ONE leaf for the THREE verbatim copies in this directory". That count was false and is corrected. Its SCOPE note was also understated — it named four copy modules and missed the inline producers (`ChangeAttributionPanel`, `InlineBlocks`, `GraphPatchBlockRenderer`, `ConfidenceSection`, `TriageActionCardsBody`, `TopDriversSection`). **That note now states no total at all**: a count in a comment has been wrong twice in this one header, and replacing a wrong number with a fresh one only resets the clock (trap 12). The sweep's scope is recorded so the next reader can judge it.

2. **One list rhythm, one row box.** `mt-1 space-y-0.5` was written three times and the row box twice verbatim (plus once in part — the brief said three; the third differs). "Estimated" and "considered" differed only in key, testid and one `data-` attribute, so they are now one `TextRowList` parameterised by exactly those. **Chose `<ul>/<li>` for all three**: each block is a list of discrete facts, "considered" already did it, so folding the others *down* to `<div>` would have been the regression.

3. **Deleted `contextIntegrityStore.scenarioId`.** Write-only: set by `serverGraphHydration`, read by nothing, while its comment claimed it "guards against a stale read from a previous scenario". A zero-reader field cannot guard anything (trap 10). **The guard is deliberately NOT implemented** — that would be a behaviour change, and it isn't needed here: hydration compares against `currentScenarioId` at `serverGraphHydration.ts:130` and returns `'skipped'` at `:131-136`, *before* the write at `:151`. `reset()` is kept — a live test-isolation helper.

4. **Pinned the pass-through half of the 2.993 attribution fix.** `V7TopMatter` still hands `V7SharpenLine` the derived label, honestly labelled, so the refusal lives on the live path. Every existing assertion was an *absence*, so simplifying that to `null` would have deleted the mechanism with the suite green (trap 13b).

5. **Replaced `notModelled.ts`'s private `asRecord`** with `isRecord` from `lib/guards`, the repo's declared home for that predicate. Identical predicate — a deletion, not a behaviour change.

## Verification

**RED-first at pristine**, four signatures named:
- `reverses: …` → `Unable to find an element by: [data-testid="what-i-was-given-notyet-show-all"]` — the one-way defect.
- `renders the SAME affordance …` → `expected '… px-2 py-1 text-text-light underline …' to be '… text-info hover:underline …'`.
- `LINES UP with the rows above it …` → `AssertionError: expected 'none' to be 'px-2'`.
- `the shared clamp carries vertical padding …` → `expected '…leading-snug te…' to match /(?:^|\s)py-/`.

The alignment test reads **both** the row inset and the toggle inset from the rendered DOM, so neither is written down — change either and it makes the other follow. Its precondition is pinned in-test, so it cannot pass on `'none' === 'none'`.

**Mutants** — throwaway worktree at an absolute path outside the repo root; isolation proven by **writing** a sentinel and asserting the source sha unchanged, plus an inode compare (APFS hard-link check); applied-check scoped to `src/`, control asserted **exactly zero** before every mutant; restored from git, never from the other copy.

| Mutant | Expected | Result |
|---|---|---|
| M1 — remove the `derived_label` branch | new test RED | **RED**, and **all three pre-existing tests GREEN** — the coverage gap measured, not claimed |
| M2 — same provenance, different text | RED (binds to the exact quote) | **RED** |
| M3 — neuter a *different* prop | GREEN (binds to `briefQuote`, not "something changed") | **GREEN** |
| M4 — revert `hiddenCount` | reversibility test RED | **RED**; styling test stayed GREEN |

M1+M2 vs M3 is the discriminating pair (trap 19).

**Collected counts, asserted BY NAME** (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run — without them a new spec collects zero while the total still reads healthy). The counting instrument is cross-checked against the runner's own total and exits non-zero on disagreement; its first version read **0** because a BSD-`grep` bracket expression over the multibyte `✓`/`×` marks matches nothing — caught by that assertion, not by inspection.

| Spec | Baseline | After |
|---|---|---|
| `V7WhatIWasGivenSection.spec.tsx` | 43 | **47** (+4) |
| `ResultsBody.v7SharpenQuoteProvenance.spec.tsx` | 3 | **5** (+2) |
| 9 other affected specs (incl. both `V7EvidenceDisclosure` suites and `V7GuidanceSection`) | 103 | 103 (unchanged) |
| **total** | — | **155 / 155 pass** |

`pnpm run typecheck` — **PASSED** (3323/3363 tracked files at this tip; **0 diagnostics added**). It offers `--update-baseline` for a 6-diagnostic shrink; **declined** — not this PR's business and the shrink is not attributed. `npx eslint` on every changed file — clean (rc=0, measured directly rather than through a pipe).

## Explicitly not touched

The hand-rolled parser (matches its neighbour's house pattern), the `NOT_TRACKED_CLASSES` mirror (fails safe, rowed separately), the two `.filter` passes (measured 1.8 µs), the zustand creator. No magnitude/currency/unit handling added — there is none in these files and that is correct.

## Refined premises

- **Fix 5's "seventh copy"** — measured: `asRecord` is one of **seven** in the `as*`-named family; the wider plain-object-predicate family is **14**. Chose `isRecord` over `asObject` because `guards.ts` is the file the migration is converging on.
- **Fix 2's "written three times"** — true of the *container* class; the *row* class is verbatim twice and the third differs.
- **"`px-2 py-1` on `ClampToggle`"** — the horizontal half would have misaligned three consumers (table above); the vertical half at `py-1` would not have cleared the 24px floor it was requested for.

## Known, not introduced here, rowed separately

The hydration guard does not fire when `currentScenarioId` is null/undefined, and `reset()` has no production caller — so moving to a scenario whose hydration returns a non-`'graph'` status can leave the previous brief in the store. Equally true before this PR; a zero-reader field could never have prevented it. The replacement comment in `contextIntegrityStore.ts` says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
