### PR TITLE
fix(canvas): screen = commit — invalidate contradicting display text, restore freshness on reload (2.1003)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState, useMemo, useRef, lazy, Suspense, memo } from 'react'
+import { resolveRestoredFreshnessUpdate } from './store/analysisFreshness'
 import { X } from 'lucide-react'
 import { useLocation } from 'react-router-dom'
 import { ReactFlow, ReactFlowProvider, MiniMap, Background, BackgroundVariant, SelectionMode, useReactFlow, type Connection, type NodeChange, type EdgeChange } from '@xyflow/react'
@@ -190,7 +191,18 @@ interface ReactFlowGraphProps {
  * - If graph loaded from scenario → prefer scenario readiness
  * - Only use sessionStorage when no persistent source exists (draft mode)
  */
-function restoreCeeAnalysisReady(
+/**
+ * ROADMAP 2.1003 / F4 — EXPORTED FOR TEST SO THE CALL SITE IS PINNED.
+ *
+ * ⚠ Measured: deleting the freshness re-ingestion inside this function fully
+ * re-introduces F4 and yet survived the F4 spec 10/10 AND a sweep of 101 spec
+ * files / 1,122 tests with zero reds — because every test called
+ * `resolveRestoredFreshnessUpdate` directly and nothing exercised the one
+ * production reference. A pure function with a perfect unit kit is not
+ * evidence that the product calls it. The export exists so
+ * `reactFlowGraph.restoreFreshnessOnBoot.spec.ts` can drive this seam.
+ */
+export function restoreCeeAnalysisReady(
   loadSource: 'autosave' | 'scenario' | 'none',
   autosave: scenarios.AutosaveData | null,
   scenario: Scenario | null,
@@ -252,6 +264,24 @@ function restoreCeeAnalysisReady(
 
     if (validation.isValid) {
       useCanvasStore.getState().setCeeAnalysisReady(ceeAnalysisReady)
+      // ROADMAP 2.1003 / F4 — re-ingest the persisted freshness attestation.
+      // Ordering is load-bearing: `resultsLoadHistorical` ran earlier in the
+      // boot effect and stamped the cannot-confirm hydration marker, so this
+      // must come AFTER it to have anything to upgrade. Fail-closed and
+      // one-directional — it can only move `unknown` → `fresh`.
+      // `validation.isValid` above is the node-identity half of the proof; the
+      // attestation's matching graph hashes are the other half.
+      const restoredFreshness = resolveRestoredFreshnessUpdate(
+        useCanvasStore.getState().analysisFreshness,
+        useCanvasStore.getState().analysisFreshnessDirty,
+        ceeAnalysisReady,
+      )
+      if (restoredFreshness) {
+        useCanvasStore.setState({
+          analysisFreshness: restoredFreshness,
+          analysisFreshnessDirty: false,
+        })
+      }
       if (import.meta.env.DEV) {
         console.warn('[canvas:init] Restored ceeAnalysisReady:', {
           source,

--- a/src/canvas/__tests__/reactFlowGraph.restoreFreshnessOnBoot.spec.ts
+++ b/src/canvas/__tests__/reactFlowGraph.restoreFreshnessOnBoot.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * ROADMAP 2.1003 / F4 — THE BOOT CALL SITE AND ITS ORDERING.
+ *
+ * ⚠ WHY THIS FILE EXISTS, and it is the second time this lane learned it:
+ * `resolveRestoredFreshnessUpdate` had a complete unit kit — 10/10, with five
+ * mutants biting — and **deleting the sole production call site in
+ * `ReactFlowGraph.restoreCeeAnalysisReady` fully re-introduced F4 while
+ * surviving that spec 10/10 and a sweep of 101 spec files / 1,122 tests, exit
+ * 0, zero reds.** Every test called the pure function directly; nothing
+ * exercised the one line that makes it reach a user. A perfect unit kit is not
+ * evidence that the product calls the unit.
+ *
+ * These tests drive the REAL boot function against the REAL store, so:
+ *   · deleting the re-ingestion block goes RED (call site pinned);
+ *   · changing what `resultsLoadHistorical` stamps goes RED (ordering pinned),
+ *     because the precondition is produced by CALLING that action rather than
+ *     by hand-writing the marker it happens to use today. That coupling is the
+ *     thing the code comment calls "load-bearing", and it was pinned by nothing.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+
+import { restoreCeeAnalysisReady } from '../ReactFlowGraph'
+import { useCanvasStore } from '../store'
+import { RESTORED_ATTESTATION_HASHES_ALIGNED } from '../store/analysisFreshness'
+
+const GOAL_ID = 'goal_nrr'
+const OPTION_ID = 'opt_onboarding'
+
+const CURRENT_NODES = [
+  { id: GOAL_ID, position: { x: 0, y: 0 }, data: {} },
+  { id: OPTION_ID, position: { x: 0, y: 0 }, data: {} },
+  { id: 'fac_cs_coverage_depth', position: { x: 0, y: 0 }, data: {} },
+] as unknown as Node[]
+
+/** An analysis_ready whose attestation says: the graph had not moved. */
+function analysisReady(overrides: Record<string, unknown> = {}) {
+  return {
+    options: [{ id: OPTION_ID, label: 'Onboarding' }],
+    goal_node_id: GOAL_ID,
+    status: 'ready',
+    freshness: 'fresh',
+    freshness_reason: 'graph_hash_match',
+    graph_hash_at_run: 'b8a38343926af945',
+    current_graph_hash: 'b8a38343926af945',
+    computed_at: '2026-08-09T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function autosaveWith(ready: unknown) {
+  return {
+    nodes: CURRENT_NODES,
+    edges: [],
+    ceeAnalysisReady: ready,
+  } as never
+}
+
+/**
+ * Reproduce the boot state the way BOOT reproduces it: by running the real
+ * historical-load action. If that action ever stops stamping the marker the
+ * re-ingestion keys on, these tests go red — which is the whole point.
+ */
+function loadHistoricalLikeBootDoes() {
+  const { resultsLoadHistorical, reset } = useCanvasStore.getState()
+  reset()
+  // `reset()` does not clear this slice; blank it explicitly so "readiness was
+  // restored" is a fact about THIS call and not a leftover from a sibling test.
+  useCanvasStore.setState({ ceeAnalysisReady: null })
+  resultsLoadHistorical({
+    id: 'run-f4',
+    ts: Date.now(),
+    seed: 1,
+    hash: 'h-f4',
+    report: {
+      schema: 'report.v1',
+      meta: { seed: 1, response_id: 'r-f4', elapsed_ms: 10 },
+      model_card: { response_hash: 'h-f4', response_hash_algo: 'sha256', normalized: true },
+      results: {},
+    },
+    drivers: [],
+    ceeReview: null,
+    ceeTrace: null,
+    ceeError: null,
+  } as never)
+}
+
+describe('F4 — the boot call site re-ingests the attestation', () => {
+  beforeEach(() => {
+    loadHistoricalLikeBootDoes()
+  })
+
+  it('PRECONDITION, derived not asserted: the historical load leaves cannot-confirm', () => {
+    // Pinning the ORDERING contract. `restoreCeeAnalysisReady` must run AFTER
+    // this, and it only has something to upgrade because this stamped it.
+    const s = useCanvasStore.getState().analysisFreshness
+    expect(s?.freshness).toBe('unknown')
+    expect(s?.freshnessReason).toBe('hydrated_without_capture')
+  })
+
+  it('⭐ THE MEASURED CASE: boot restores fresh from a matching attestation', () => {
+    restoreCeeAnalysisReady('autosave', autosaveWith(analysisReady()), null, CURRENT_NODES)
+
+    const s = useCanvasStore.getState().analysisFreshness
+    expect(s?.freshness).toBe('fresh')
+    expect(s?.freshnessReason).toBe(RESTORED_ATTESTATION_HASHES_ALIGNED)
+    // The readiness restore itself must still have happened — this test must
+    // fail for the freshness reason, not because the whole function no-opped.
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+  })
+
+  it('MISMATCHED hashes: boot leaves cannot-confirm, and still restores readiness', () => {
+    restoreCeeAnalysisReady(
+      'autosave',
+      autosaveWith(analysisReady({ current_graph_hash: '3346784355b3fc7b' })),
+      null,
+      CURRENT_NODES,
+    )
+
+    const s = useCanvasStore.getState().analysisFreshness
+    expect(s?.freshness).toBe('unknown')
+    expect(s?.freshnessReason).toBe('hydrated_without_capture')
+    // The discriminating half: readiness DID restore, so the unknown verdict
+    // above is the attestation check refusing — not the function bailing out.
+    expect(useCanvasStore.getState().ceeAnalysisReady).not.toBeNull()
+  })
+
+  it('a payload that fails node-identity validation upgrades nothing', () => {
+    // Goal node absent from the current graph ⇒ validateCeeAnalysisReady
+    // rejects ⇒ neither readiness nor freshness may move.
+    restoreCeeAnalysisReady(
+      'autosave',
+      autosaveWith(analysisReady({ goal_node_id: 'goal_that_no_longer_exists' })),
+      null,
+      CURRENT_NODES,
+    )
+
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('unknown')
+    expect(useCanvasStore.getState().ceeAnalysisReady).toBeNull()
+  })
+
+  it('no persisted analysis_ready at all: boot changes nothing', () => {
+    restoreCeeAnalysisReady('none', null, null, CURRENT_NODES)
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('unknown')
+  })
+
+  it('a stored NON-fresh verdict is never upgraded by boot', () => {
+    restoreCeeAnalysisReady(
+      'autosave',
+      autosaveWith(analysisReady({ freshness: 'stale' })),
+      null,
+      CURRENT_NODES,
+    )
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('unknown')
+  })
+})

--- a/src/canvas/store/__tests__/restoredFreshnessAttestation.spec.ts
+++ b/src/canvas/store/__tests__/restoredFreshnessAttestation.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * ROADMAP 2.1003 / audit finding F4 — "fresh analysis becomes unknown on
+ * reload".
+ *
+ * RED-first. At pristine `538677ff`, `deriveRestoredFreshnessAttestation` and
+ * `resolveRestoredFreshnessUpdate` do not exist.
+ *
+ * MEASURED ON DEPLOYED STAGING, 2026-08-09: before reload the rerun was
+ * `fresh` / `graph_hash_match` on graph hash `b8a38343926af945`. After reload
+ * the SAME graph and the SAME result read "Cannot confirm whether this
+ * analysis is current." The stored `ceeAnalysisReady` already contained
+ * MATCHING graph hashes; boot restored readiness and never re-ingested the
+ * attestation.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  deriveRestoredFreshnessAttestation,
+  resolveRestoredFreshnessUpdate,
+  RESTORED_ATTESTATION_HASHES_ALIGNED,
+} from '../analysisFreshness'
+
+const HYDRATED = { freshness: 'unknown' as const, freshnessReason: 'hydrated_without_capture' }
+
+const ALIGNED = {
+  freshness: 'fresh',
+  freshness_reason: 'graph_hash_match',
+  graph_hash_at_run: 'b8a38343926af945',
+  current_graph_hash: 'b8a38343926af945',
+  computed_at: '2026-08-09T12:00:00.000Z',
+}
+
+describe('deriveRestoredFreshnessAttestation — fail-closed by construction', () => {
+  it('⭐ THE MEASURED CASE: aligned hashes + stated fresh => a fresh verdict', () => {
+    const out = deriveRestoredFreshnessAttestation(ALIGNED)
+    expect(out?.freshness).toBe('fresh')
+    expect(out?.graphHashAtRun).toBe('b8a38343926af945')
+    expect(out?.currentGraphHash).toBe('b8a38343926af945')
+  })
+
+  it('stamps its own provenance — a client re-derivation is NOT CEE stating it', () => {
+    // A later reader must be able to tell "CEE said graph_hash_match on this
+    // turn" from "we reconstructed this from stored bytes at boot".
+    expect(deriveRestoredFreshnessAttestation(ALIGNED)?.freshnessReason)
+      .toBe(RESTORED_ATTESTATION_HASHES_ALIGNED)
+    expect(deriveRestoredFreshnessAttestation(ALIGNED)?.freshnessReason)
+      .not.toBe('graph_hash_match')
+  })
+
+  it('MISMATCHED hashes stay unknown — the audit\'s explicit requirement', () => {
+    expect(deriveRestoredFreshnessAttestation({ ...ALIGNED, current_graph_hash: '3346784355b3fc7b' }))
+      .toBeNull()
+  })
+
+  it('never upgrades a stored stale or unknown verdict', () => {
+    expect(deriveRestoredFreshnessAttestation({ ...ALIGNED, freshness: 'stale' })).toBeNull()
+    expect(deriveRestoredFreshnessAttestation({ ...ALIGNED, freshness: 'unknown' })).toBeNull()
+    expect(deriveRestoredFreshnessAttestation({ ...ALIGNED, freshness: 'none' })).toBeNull()
+  })
+
+  it('NEVER absence -> fresh: a missing or empty hash stays unknown', () => {
+    const { graph_hash_at_run: _a, ...noAtRun } = ALIGNED
+    const { current_graph_hash: _b, ...noCurrent } = ALIGNED
+    expect(deriveRestoredFreshnessAttestation(noAtRun)).toBeNull()
+    expect(deriveRestoredFreshnessAttestation(noCurrent)).toBeNull()
+    expect(deriveRestoredFreshnessAttestation({ ...ALIGNED, graph_hash_at_run: '', current_graph_hash: '' }))
+      .toBeNull()
+    expect(deriveRestoredFreshnessAttestation({ options: [], goal_node_id: 'g' })).toBeNull()
+    expect(deriveRestoredFreshnessAttestation(null)).toBeNull()
+    expect(deriveRestoredFreshnessAttestation(undefined)).toBeNull()
+  })
+})
+
+describe('resolveRestoredFreshnessUpdate — only ever unknown -> fresh', () => {
+  it('⭐ upgrades the hydration marker when the attestation validates', () => {
+    expect(resolveRestoredFreshnessUpdate(HYDRATED, false, ALIGNED)?.freshness).toBe('fresh')
+  })
+
+  it('leaves the hydration marker alone when the hashes disagree', () => {
+    expect(
+      resolveRestoredFreshnessUpdate(HYDRATED, false, { ...ALIGNED, current_graph_hash: '3346784355b3fc7b' }),
+    ).toBeNull()
+  })
+
+  it('NEVER overwrites a LIVE CEE verdict — only the hydration marker', () => {
+    // The discriminating half: same valid attestation, different starting
+    // state. If the guard keyed on anything looser than the marker, this
+    // would clobber a verdict CEE stated on this session's turn.
+    expect(
+      resolveRestoredFreshnessUpdate(
+        { freshness: 'stale', freshnessReason: 'graph_hash_diverged' },
+        false,
+        ALIGNED,
+      ),
+    ).toBeNull()
+    expect(
+      resolveRestoredFreshnessUpdate(
+        { freshness: 'fresh', freshnessReason: 'graph_hash_match' },
+        false,
+        ALIGNED,
+      ),
+    ).toBeNull()
+    expect(resolveRestoredFreshnessUpdate(null, false, ALIGNED)).toBeNull()
+  })
+
+  it('NEVER upgrades when the user has edited since (dirty overlay set)', () => {
+    expect(resolveRestoredFreshnessUpdate(HYDRATED, true, ALIGNED)).toBeNull()
+  })
+
+  it('is a no-op on a null/garbage payload', () => {
+    expect(resolveRestoredFreshnessUpdate(HYDRATED, false, null)).toBeNull()
+    expect(resolveRestoredFreshnessUpdate(HYDRATED, false, 'nonsense')).toBeNull()
+  })
+})

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -59,6 +59,23 @@ export const RUN_COMPLETED_WITHOUT_VERDICT = 'run_completed_without_verdict'
  */
 export const VERDICT_ABSENT_FROM_PAYLOAD = 'payload_carried_no_freshness_verdict'
 
+/**
+ * Reason code written by the BOOT/restore path when a persisted freshness
+ * attestation was re-ingested after exact graph-identity validation.
+ *
+ * ROADMAP 2.1003 / audit finding F4. Measured on deployed staging 2026-08-09:
+ * before reload the rerun was `fresh` / `graph_hash_match`; after reload the
+ * SAME graph and the SAME result read *"Cannot confirm whether this analysis
+ * is current."* The stored `ceeAnalysisReady` already contained MATCHING graph
+ * hashes — boot restored readiness and never looked at the attestation.
+ *
+ * Deliberately DISTINCT from CEE's own `graph_hash_match`: this verdict was
+ * re-derived by the client from stored bytes, not stated by CEE on this turn,
+ * and a later reader must be able to tell those apart. Never user copy.
+ */
+export const RESTORED_ATTESTATION_HASHES_ALIGNED = 'restored_attestation_hashes_aligned'
+
+
 export interface AnalysisFreshnessState {
   freshness: AnalysisFreshnessValue
   /** Technical reason code from CEE (e.g. 'graph_hash_match') — debug only, never user copy. */
@@ -368,4 +385,88 @@ export function classifyFreshnessForDisplay(
     return 'changed'
   }
   return 'cannot_confirm'
+}
+
+
+/**
+ * ROADMAP 2.1003 / F4 — re-ingest a PERSISTED freshness attestation at boot,
+ * and only when it can be positively validated.
+ *
+ * `resultsLoadHistorical` stamps `{ freshness: 'unknown', freshnessReason:
+ * 'hydrated_without_capture' }` because a hydrated snapshot has no live
+ * capture proving it matches the current graph. That reasoning is right in
+ * general and WRONG in the one case where the snapshot carries its own proof:
+ * an `analysis_ready` whose `graph_hash_at_run` EQUALS its `current_graph_hash`
+ * is an attestation that the graph had not moved when the verdict was formed.
+ *
+ * FAIL-CLOSED BY CONSTRUCTION. It returns a verdict only when EVERY one of
+ * these holds, and `null` (leave it as cannot-confirm) otherwise:
+ *   · the stored payload states `freshness === 'fresh'` — a stored 'stale' or
+ *     'unknown' is never upgraded;
+ *   · BOTH hashes are present, non-empty strings;
+ *   · they are EQUAL. Any mismatch stays unknown, exactly as the audit
+ *     prescribes.
+ * It never invents `fresh` from silence, and it never downgrades anything: the
+ * caller applies it only over the hydration marker.
+ *
+ * Note what it does NOT do: it does not compare the stored hash against a
+ * freshly computed hash of the restored graph. It validates the attestation's
+ * INTERNAL consistency plus the caller's node-identity check
+ * (`validateCeeAnalysisReady`). A client-side recomputation would need CEE's
+ * hash function, which the UI does not have — claiming otherwise would be the
+ * two-hash-functions trap.
+ */
+export function deriveRestoredFreshnessAttestation(
+  storedAnalysisReady: unknown,
+): AnalysisFreshnessState | null {
+  if (storedAnalysisReady === null || typeof storedAnalysisReady !== 'object') return null
+  const o = storedAnalysisReady as Record<string, unknown>
+
+  if (o.freshness !== 'fresh') return null
+
+  const atRun = nonEmptyString(o.graph_hash_at_run)
+  const current = nonEmptyString(o.current_graph_hash)
+  if (atRun === undefined || current === undefined) return null
+  if (atRun !== current) return null
+
+  return {
+    freshness: 'fresh',
+    freshnessReason: RESTORED_ATTESTATION_HASHES_ALIGNED,
+    graphHashAtRun: atRun,
+    currentGraphHash: current,
+    computedAt: nonEmptyString(o.computed_at),
+  }
+}
+
+/**
+ * The whole boot-restore decision as ONE pure function: given the current
+ * freshness slice, the dirty overlay, and the stored payload, should the
+ * verdict be replaced — and with what?
+ *
+ * Deliberately NOT a store action. Adding a member to the canvas store's
+ * interface changes the rendered text of a pre-existing `V5ApplicatorStore`
+ * assignability diagnostic (its elided "… N more …" property count moves),
+ * which the typecheck gate's identity baseline reads as a NEW diagnostic and
+ * its self-test then fails on. Absorbing that by regenerating the baseline
+ * would also absorb ~7 unrelated pre-existing drops in files this lane never
+ * touched. Keeping the logic pure avoids the perturbation entirely and makes
+ * every guard directly testable.
+ *
+ * Returns `null` for "change nothing". It can only ever move the hydration
+ * cannot-confirm marker to `fresh`; it can never downgrade, never overwrite a
+ * live CEE verdict, and never invent a verdict from silence.
+ */
+export function resolveRestoredFreshnessUpdate(
+  current: AnalysisFreshnessState | null,
+  dirty: boolean,
+  storedAnalysisReady: unknown,
+): AnalysisFreshnessState | null {
+  // 1. Only the hydration marker is eligible. A live CEE verdict — including a
+  //    'stale' one — is never touched.
+  if (current?.freshnessReason !== 'hydrated_without_capture') return null
+  // 2. If the user has edited since, the attestation is about a graph that no
+  //    longer exists.
+  if (dirty) return null
+  // 3. The attestation must validate on its own terms.
+  return deriveRestoredFreshnessAttestation(storedAnalysisReady)
 }

--- a/src/utils/__tests__/displayValueContradiction.spec.ts
+++ b/src/utils/__tests__/displayValueContradiction.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * ROADMAP 2.1003 / audit finding F3 — "the screen lies".
+ *
+ * RED-first. At pristine `538677ff`, `isDisplayValueContradicted` does not
+ * exist and `formatFactorDisplayValue` returns a contradicting `display_value`
+ * verbatim.
+ *
+ * MEASURED ON DEPLOYED STAGING, 2026-08-09: a CEE receipt carried
+ * `observed_state.value = 40` beside a stale top-level
+ * `display_value = "20%"`. The canvas preferred the string and kept showing
+ * 20% — before AND after reload — while the rerun computed on 40 and flipped
+ * the leading option from Pricing 32% to Onboarding 53%.
+ *
+ * ⚠ THE CORPUS BELOW IS NOT DRAWN FROM MY HEAD (trap 22). Every "must not be
+ * judged" string is either taken from the deployed capture, from the golden
+ * staging fixture in this repo (`golden-path-staging-2026-04-05.json`), or
+ * from the PRODUCER's own declared output vocabulary — CEE's
+ * `synthesiseDisplayValue` doc-comment enumerates exactly what it can emit:
+ * "£500k", "$2.1m", "3%", "42 days", "18 months", "500,000", "Low (0.15)",
+ * "0.15" — plus `synthesiseRangeDisplayValue`'s "0.48 to 1".
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  isDisplayValueContradicted,
+  formatFactorDisplayValue,
+} from '../formatFactorDisplayValue'
+
+describe('isDisplayValueContradicted — the measured case', () => {
+  it('⭐ "20%" beside observed value 40 IS contradicted', () => {
+    expect(isDisplayValueContradicted('20%', { value: 40 })).toBe(true)
+  })
+
+  it('"40%" beside observed value 40 is NOT contradicted', () => {
+    expect(isDisplayValueContradicted('40%', { value: 40 })).toBe(false)
+  })
+
+  it('honours the 0-1 percent scaling in both directions', () => {
+    expect(isDisplayValueContradicted('40%', { value: 0.4 })).toBe(false)
+    expect(isDisplayValueContradicted('20%', { value: 0.4 })).toBe(true)
+    expect(isDisplayValueContradicted('0.4', { value: 40 })).toBe(false)
+  })
+
+  it('accepts a display string that is a ROUNDING of the value', () => {
+    expect(isDisplayValueContradicted('0.42', { value: 0.4234 })).toBe(false)
+    expect(isDisplayValueContradicted('35%', { value: 35.2 })).toBe(false)
+    // …but not a different number at the precision the string committed to.
+    expect(isDisplayValueContradicted('0.42', { value: 0.51 })).toBe(true)
+  })
+
+  it('accepts agreement with raw_value as well as value', () => {
+    expect(isDisplayValueContradicted('£30,000', { value: 0.3, raw_value: 30000 })).toBe(false)
+  })
+})
+
+describe('isDisplayValueContradicted — the breadth guard (must judge NOTHING else)', () => {
+  // Each row is a string the PRODUCER can legitimately emit. Judging any of
+  // them would need a vocabulary, and a vocabulary over natural language is
+  // exactly the predicate class this estate keeps getting wrong. Expectations
+  // were written from `synthesiseDisplayValue`'s declared output list BEFORE
+  // running, not from what the code does.
+  const NEVER_JUDGED: Array<[string, string]> = [
+    ['Moderate', 'qualitative band'],
+    ['Low (0.15)', 'qualitative band with a parenthesised number'],
+    ['0.48 to 1', 'a prior RANGE — two numbers, not the observed point'],
+    ['3 to 5', 'range, bare'],
+    ['£500k', 'currency magnitude shorthand — the digits are not the value'],
+    ['$2.1m', 'currency magnitude shorthand'],
+    ['42 days', 'time unit'],
+    ['18 months', 'time unit'],
+    ['6 developers', 'count with a unit word'],
+    ['CHF 500', 'ISO currency prefix'],
+    ['No acquisition pursued', 'contextual text from the golden fixture'],
+    ['No dedicated tech lead', 'contextual text'],
+    ['No cost allocated', 'contextual text'],
+  ]
+
+  it.each(NEVER_JUDGED)('never judges %s (%s)', (text) => {
+    // Deliberately paired with a wildly different numeric state: if the guard
+    // were willing to judge these at all, it would call them contradicted.
+    expect(isDisplayValueContradicted(text, { value: 999, raw_value: 999 })).toBe(false)
+  })
+
+  it('THE SHAPE GATE IS THE AUTHORITY, not Number() — exotic numeric literals are not judged', () => {
+    // MEASURED GAP: a mutant that DELETED the single-numeric shape gate left
+    // this whole suite green, because every string above also fails
+    // `Number.isFinite` after stripping. These two DO parse via `Number()`
+    // while failing the shape gate, so they are the only cases that can tell
+    // the gate apart from the finiteness check — without them the gate is
+    // untested and a tidy-up would remove it.
+    expect(isDisplayValueContradicted('1e5', { value: 999 })).toBe(false)
+    expect(isDisplayValueContradicted('0x10', { value: 999 })).toBe(false)
+    // Positive control for the pair: a plain number at the same magnitude IS
+    // judged, so the two assertions above are about SHAPE, not magnitude.
+    expect(isDisplayValueContradicted('100000', { value: 999 })).toBe(true)
+  })
+
+  it('never judges when there is no numeric state to contradict it with', () => {
+    expect(isDisplayValueContradicted('20%', {})).toBe(false)
+    expect(isDisplayValueContradicted('20%', { value: null, raw_value: null })).toBe(false)
+  })
+
+  it('never judges an empty or absent display value', () => {
+    expect(isDisplayValueContradicted('', { value: 40 })).toBe(false)
+    expect(isDisplayValueContradicted(null, { value: 40 })).toBe(false)
+    expect(isDisplayValueContradicted(undefined, { value: 40 })).toBe(false)
+  })
+})
+
+describe('formatFactorDisplayValue — the seam (not just the unit)', () => {
+  it('⭐ THE MEASURED CASE: a contradicting display_value no longer wins', () => {
+    // PRECONDITION PINNED IN-TEST: this is the exact shape the audit captured
+    // — a numeric observed value, NO raw_value, and a stale percent string.
+    const input = {
+      label: 'Customer Success Coverage Depth',
+      value: 40,
+      raw_value: null,
+      unit: '%',
+      display_value: '20%',
+    }
+    expect(input.display_value).toBe('20%')
+    expect(input.value).toBe(40)
+
+    // ⭐ ASSERT THE POSITIVE OUTCOME, NOT THE ABSENCE OF THE SYMPTOM.
+    // The first version of this test asserted only `not.toBe('20%')` — a
+    // negative that CANNOT distinguish "renders 40%" from "renders nothing".
+    // It passed while the node rendered BLANK: the invalidated string fell
+    // through to Pattern 2's non-binary branch, which returns null. Killing the
+    // symptom metric while never measuring the outcome metric is exactly the
+    // failure this lane exists to stop, and it shipped inside the lane's own
+    // suite until an independent review measured the rendered value.
+    const out = formatFactorDisplayValue(input)
+    expect(out).toBe('40%')
+  })
+
+  it('⭐ the recovery renders the COMMITTED value on the 0-1 scale too', () => {
+    expect(
+      formatFactorDisplayValue({
+        label: 'Customer Success Coverage Depth',
+        value: 0.4,
+        raw_value: null,
+        unit: '%',
+        display_value: '20%',
+      }),
+    ).toBe('40%')
+  })
+
+  it('⭐ unitless: the invalidated string is replaced by the bare committed number', () => {
+    expect(
+      formatFactorDisplayValue({
+        label: 'Headcount delta',
+        value: 40,
+        raw_value: null,
+        unit: null,
+        display_value: '20',
+      }),
+    ).toBe('40')
+  })
+
+  it('DISCLOSED LIMIT: a real-world unit with no raw_value renders NOTHING, not a wrong number', () => {
+    // `value` is normalised against `cap` for currency/time/count units, so it
+    // is not a real-world magnitude. Rendering "£0.3" for a £30,000 factor
+    // would replace one lie with a worse one; reconstructing `value × cap`
+    // would be inventing a number. Blank is the honest outcome and this test
+    // PINS it so the boundary is visible rather than discovered later.
+    expect(
+      formatFactorDisplayValue({
+        label: 'Annual CRM Licence Cost',
+        value: 0.3,
+        raw_value: null,
+        unit: '£',
+        display_value: '£20,000',
+      }),
+    ).toBeNull()
+  })
+
+  it('the recovery fires ONLY where something was suppressed', () => {
+    // A node that simply never had a display_value keeps today's behaviour
+    // byte-for-byte — this is the breadth guard on the recovery itself.
+    expect(
+      formatFactorDisplayValue({
+        label: 'CS Coverage Depth',
+        value: 40,
+        raw_value: null,
+        unit: '%',
+      }),
+    ).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: an AGREEING display_value is still returned verbatim', () => {
+    // Without this the fix could be "never trust display_value", which would
+    // destroy every contextual string CEE authors.
+    expect(
+      formatFactorDisplayValue({
+        label: 'Customer Success Coverage Depth',
+        value: 40,
+        raw_value: null,
+        unit: '%',
+        display_value: '40%',
+      }),
+    ).toBe('40%')
+  })
+
+  it('POSITIVE CONTROL: contextual text with no number survives a mismatched value', () => {
+    expect(
+      formatFactorDisplayValue({
+        label: 'Acquisition',
+        value: 0.9,
+        raw_value: null,
+        unit: null,
+        display_value: 'No acquisition pursued',
+      }),
+    ).toBe('No acquisition pursued')
+  })
+
+  it('Pattern 1 (fresh raw_value + meaningful unit) still outranks display_value', () => {
+    // The pre-existing stale-value protection must be untouched.
+    expect(
+      formatFactorDisplayValue({
+        label: 'Cost',
+        value: 0.26,
+        raw_value: 26000,
+        unit: '£',
+        display_value: '£20,000',
+      }),
+    ).toBe('£26,000')
+  })
+})

--- a/src/utils/formatFactorDisplayValue.ts
+++ b/src/utils/formatFactorDisplayValue.ts
@@ -30,6 +30,101 @@ function formatNumber(value: number): string {
     : String(value)
 }
 
+/**
+ * A display string this guard is willing to JUDGE: a single bare, percent, or
+ * currency-prefixed number. Nothing else.
+ *
+ * Deliberately, provably narrow — everything it does not match keeps today's
+ * behaviour byte-for-byte:
+ *   · qualitative text ("Moderate", "No acquisition pursued") — no number, so
+ *     no contradiction can be established;
+ *   · ranges ("0.48 to 1", "3–5 months") — two numbers, describes a prior, not
+ *     the observed point;
+ *   · magnitude shorthand ("£40k", "$2.1m") — the digits are not the value;
+ *   · anything with unit words ("42 days", "6 developers").
+ * Judging any of those would need a vocabulary, and a vocabulary over natural
+ * language drawn from one author's head is exactly the class of predicate this
+ * estate keeps getting wrong.
+ */
+const SINGLE_NUMERIC_DISPLAY = /^\s*[-+]?[£$€¥₹]?\s*[-+]?\d[\d,]*(?:\.\d+)?\s*%?\s*$/
+
+/** How many decimal places a display string committed to. */
+function decimalPlaces(text: string): number {
+  const m = /\.(\d+)/.exec(text)
+  return m ? m[1].length : 0
+}
+
+/**
+ * Could `candidate` have been rounded to produce `shown`, at the precision
+ * `shown` committed to? "0.42" may legitimately render 0.4234; "20" may not
+ * render 40.
+ */
+function couldRoundTo(candidate: number, shown: number, places: number): boolean {
+  if (!Number.isFinite(candidate)) return false
+  const tolerance = 0.5 * Math.pow(10, -places)
+  return Math.abs(candidate - shown) <= tolerance + Number.EPSILON * 8
+}
+
+/**
+ * Is this `display_value` CONTRADICTED by the node's own numeric state?
+ *
+ * ROADMAP 2.1003 / audit finding F3 — "the screen lies". Measured on deployed
+ * staging 2026-08-09: a CEE receipt carried `observed_state.value = 40` beside
+ * a stale top-level `display_value = "20%"`. This formatter returned "20%"
+ * verbatim, so the canvas showed 20% — before AND after reload — while the
+ * rerun computed on 40 and flipped the leading option. The brief's words:
+ * **contradictory display must be invalidated, not preferred.**
+ *
+ * FAILS SAFE IN THE DIRECTION THAT MATTERS. It answers "can I POSITIVELY
+ * establish a contradiction?" — never "does this look right?". Anything it
+ * cannot judge is not contradicted, and renders exactly as it does today.
+ *
+ * Accepted renderings of the state are `value`, `raw_value`, and the two
+ * percent scalings (`value × 100`, `value ÷ 100`), because the estate stores
+ * percentages on both 0–1 and 0–100 scales and a display string cannot tell us
+ * which one it used.
+ *
+ * ⚠ KNOWN LIMIT, stated rather than hidden: when `raw_value` is present but
+ * itself stale, the display agrees with `raw_value` and this returns false.
+ * That is a real, measured CEE-side applier defect (the value applier updates
+ * `observed_state.value` and leaves `raw_value` behind) and it is not
+ * repairable here — a consumer cannot tell a stale producer field from a
+ * deliberate one.
+ *
+ * Exported so the rule is a concept with its own tests and its own mutants,
+ * not an expression buried in a branch.
+ */
+export function isDisplayValueContradicted(
+  displayValue: string | null | undefined,
+  state: { value?: number | null; raw_value?: number | string | null },
+): boolean {
+  if (displayValue == null || displayValue === '') return false
+  if (!SINGLE_NUMERIC_DISPLAY.test(displayValue)) return false
+
+  const shown = Number(displayValue.replace(/[£$€¥₹,%\s]/g, ''))
+  if (!Number.isFinite(shown)) return false
+
+  const rawNumeric =
+    typeof state.raw_value === 'number'
+      ? state.raw_value
+      : typeof state.raw_value === 'string' && state.raw_value.trim() !== ''
+        ? Number(state.raw_value)
+        : null
+
+  const candidates: number[] = []
+  if (typeof state.value === 'number' && Number.isFinite(state.value)) {
+    candidates.push(state.value, state.value * 100, state.value / 100)
+  }
+  if (rawNumeric != null && Number.isFinite(rawNumeric)) {
+    candidates.push(rawNumeric, rawNumeric * 100, rawNumeric / 100)
+  }
+  // No numeric state at all ⇒ nothing to contradict it with.
+  if (candidates.length === 0) return false
+
+  const places = decimalPlaces(displayValue)
+  return !candidates.some((c) => couldRoundTo(c, shown, places))
+}
+
 export interface FactorDisplayInput {
   label: string
   value?: number | null
@@ -202,8 +297,60 @@ export function formatFactorDisplayValue(input: FactorDisplayInput): string | nu
   // moved here so a stale display_value cannot mask a fresh raw_value +
   // meaningful unit (Pattern 1), but still beats the unitless-raw numeric
   // fallback below and the value-only heuristic that follows.
-  if (display_value != null && display_value !== '') {
+  //
+  // ROADMAP 2.1003 — …UNLESS THE NODE'S OWN NUMBERS SAY IT IS WRONG.
+  // A denormalised string that contradicts the value the analysis is actually
+  // computing on is not a "contextual override", it is a lie about the user's
+  // model. Measured live: `display_value = "20%"` beside
+  // `observed_state.value = 40`, rendered as 20% on the canvas immediately and
+  // after reload while the rerun used 40 and flipped the leading option.
+  const displayValueContradicted =
+    display_value != null
+    && display_value !== ''
+    && isDisplayValueContradicted(display_value, { value, raw_value })
+
+  if (display_value != null && display_value !== '' && !displayValueContradicted) {
     return display_value
+  }
+
+  // ROADMAP 2.1003 — RECOVERY AFTER INVALIDATION. **Do not delete this without
+  // reading the next paragraph: without it, suppressing the lie renders BLANK.**
+  //
+  // MEASURED: with the exact audit fixture (`value: 40, raw_value: null,
+  // unit: '%', display_value: '20%'`) the invalidated string fell through to
+  // Pattern 2, whose non-binary branch returns `null` — so the factor node got
+  // NO BODY TEXT AT ALL. The user went from a wrong "20%" to nothing. Killing
+  // the symptom (the wrong number) while never measuring the outcome (what the
+  // user actually sees) is the defect class this lane exists to stop.
+  //
+  // WHY `raw_value` IS ABSENT IN THAT FIXTURE, and why this is one defect and
+  // not two: CEE's value applier updates `observed_state.value` and leaves
+  // `raw_value` behind (ROADMAP 2.1033). The numeric branches below need
+  // `raw_value`; it isn't there; so there is nothing left to render.
+  //
+  // ⚠ SCOPED TO WHAT CAN BE RENDERED HONESTLY — and the exclusions are the
+  // point, not an oversight:
+  //   · percent units — `value` maps deterministically to the shown
+  //     percentage, using Pattern 1's own 0–1-vs-0–100 rule (reused, not
+  //     re-implemented), so "40" and "0.4" both render "40%";
+  //   · no unit at all — the bare committed number is exactly the truth;
+  //   · EVERYTHING ELSE (currency, time, counts, ISO codes) returns nothing
+  //     here and falls through. For those, `value` is a 0–1 figure normalised
+  //     against `cap` and is NOT a real-world magnitude: rendering "£0.3" for
+  //     a £30,000 factor would replace one lie with a worse one, and
+  //     reconstructing `value × cap` would be inventing a number. Blank is the
+  //     honest outcome there, and it is disclosed rather than papered over.
+  // Gated on `displayValueContradicted` so it fires ONLY where we just
+  // suppressed something — a node that simply never had a `display_value`
+  // keeps today's behaviour byte-for-byte.
+  if (displayValueContradicted && raw_value == null && value != null) {
+    if (unitKind === 'percent') {
+      const scaled = value > 0 && value < 1 ? value * 100 : value
+      return `${Math.round(scaled)}%`
+    }
+    if (!unit) {
+      return formatNumber(value)
+    }
   }
 
   // raw_value without unit — numeric fallback formatter. Runs AFTER


### PR DESCRIPTION
**ROADMAP 2.1003** (was 3.16) · audit findings **F3** + **F4** · Lane B, UI half.
Pairs with CEE **#884**, merged to `staging` as `1ff2469d` after an independent adversarial review (PASS, mutants independently re-executed from a fresh clone).

## ⭐ Round 2 — both review blockers cleared at `e2bdaf08`

**B1 — the measured case rendered BLANK, not 40%. Reproduced by my own execution before fixing:** `formatFactorDisplayValue({ value: 40, raw_value: null, unit: '%', display_value: '20%' })` returned **`null`**. Invalidating the lie dropped through to Pattern 2's non-binary branch and the node got no body text — the user went from a wrong "20%" to nothing. My code comment asserted the opposite and the seam test asserted only `not.toBe('20%')`, **a negative that cannot distinguish "renders 40%" from "renders nothing"**. Trap 23 inside the lane's own suite.

Fixed by **(a)**: a recovery branch renders the committed value where that can be done honestly, and the test now asserts the **positive** outcome — `expect(out).toBe('40%')`.

**The reviewer's synthesis is right and it is one defect, not two.** The fixture has `raw_value: null` *because* CEE's value applier updates `observed_state.value` and leaves `raw_value` stale (ROADMAP **2.1033**, found and rowed by this lane). The numeric branches need `raw_value`; it isn't there; so invalidating the lie left nothing to render.

**Scope of the recovery, and the exclusions are deliberate:**
| Case | Renders | Why |
|---|---|---|
| percent unit | **`40%`** | `value` maps deterministically to the shown percentage, reusing Pattern 1's own 0–1-vs-0–100 rule (so `40` and `0.4` both give `40%`) |
| no unit | **`40`** | the bare committed number is exactly the truth |
| currency / time / count / ISO | **nothing** | `value` is normalised against `cap`, not a real-world magnitude — `"£0.3"` for a £30,000 factor would replace one lie with a worse one, and `value × cap` would be inventing a number |
| no `display_value` was suppressed | unchanged | the recovery is gated on invalidation having occurred, so untouched nodes are byte-identical to today |

The blank-for-currency boundary is **pinned by its own test**, not left to be discovered.

**B2 — the F4 producer-deletion mutant now bites.** `restoreCeeAnalysisReady` is exported and `reactFlowGraph.restoreFreshnessOnBoot.spec.ts` drives the real boot function against the real store. **And the ordering is pinned**: the spec produces its precondition by *calling* `resultsLoadHistorical` rather than hand-writing the marker, so renaming that stamp goes red.

| Round-2 mutant | Result |
|---|---|
| ⭐ **U-M10** delete the sole boot call site (fully re-introduces F4 — previously survived 101 files / 1,122 tests) | **RED** |
| ⭐ **U-M11** rename the marker `resultsLoadHistorical` stamps (the "load-bearing" ordering) | **RED** ×3 |
| ⭐ **U-M12** remove the B1 recovery (measured case renders blank again) | **RED** ×3 |
| U-M13 recovery fires where nothing was suppressed (breadth) | **RED** ×9 |
| U-M14 render the normalised value against ANY unit (would print `£0.3`) | **RED** |
| U-M15 drop the 0–1 scaling in the recovery | **RED** |

**Gates at `e2bdaf08`:** typecheck gate **PASSED** with **no** added-diagnostics notice (byte-identical to the pristine control — the `export` did not perturb it) · self-test **18 passed / 0 failed** · full suite **1579 files passed, 3 skipped; 22,924 tests passed, 0 failed, exit 0** · my three specs collected **29 + 10 + 6 = 45 by name** · CI **13 checks, 0 failures, required `Staging Gate` success, `mergeable_state: clean`**.

**Still not merged by this lane. Re-review requested.**

---



> The brief originally excluded the UI. That exclusion is **refuted** by the audit and withdrawn (brief §0.0): *a server-only seam cannot prove screen = commit.* CEE emitted `observed_state.value = 40` and the canvas showed 20% anyway.

## What was measured on deployed staging (wire + DOM)
- A receipt carried `observed_state.value = 40` beside a stale top-level `display_value = "20%"`. The canvas preferred the string and kept showing **20% before AND after reload**, while the rerun computed on 40 and flipped the leader (Pricing 32% → Onboarding 53%).
- After reload the same graph and result went from `fresh` / `graph_hash_match` to **"Cannot confirm whether this analysis is current"**, while the stored `ceeAnalysisReady` already held **matching** graph hashes.

## RED-first signatures at pristine `538677ff`
Detached worktree **outside** the repo root; isolation proven by **writing** a sentinel and asserting the source unchanged.

| Spec | At pristine |
|---|---|
| `displayValueContradiction.spec.ts` | 24 collected, **21 failed** |
| `restoredFreshnessAttestation.spec.ts` | 10 collected, **10 failed** |
| **Total** | **34 collected, 31 failed / 3 passed** |

The **3 that passed at pristine are the positive controls** — an agreeing `display_value`, contextual text, and Pattern 1 precedence. That is the point: they prove the fix is not "stop trusting `display_value`".

At HEAD each spec collects a non-zero, expected count **asserted by name**: `displayValueContradiction` **25**, `restoredFreshnessAttestation` **10**. Both run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported.

## Mutant kit — applied-check == 1 per mutant, control == 0, summary asserted present, collected count asserted == baseline 154
| Mutant | Result |
|---|---|
| U-M1 **producer-deletion**: formatter stops consulting the guard | **RED** |
| U-M2 **breadth**: drop the single-numeric shape gate | **RED** *(see below)* |
| U-M3 drop the percent-scaling candidates | **RED** |
| U-M4 drop `raw_value` as an accepted rendering | **RED** |
| U-M5 **F4** remove the hash-equality requirement | **RED** ×2 |
| U-M6 **F4** upgrade any verdict, not just the hydration marker | **RED** |
| U-M7 **F4** ignore the dirty overlay | **RED** |
| U-M8 **F4** allow a stored non-fresh verdict to upgrade | **RED** |
| U-M9 **F4** impersonate CEE's own `graph_hash_match` reason code | **RED** |

**U-M2 SURVIVED on the first pass.** Every string in the breadth corpus also fails `Number.isFinite` after stripping, so the corpus could not tell the shape gate apart from the finiteness check — **the gate was untested and a tidy-up would have removed it.** Closed with the only inputs that discriminate (`'1e5'`, `'0x10'` — they parse via `Number()` but fail the shape gate), plus a positive control at the same magnitude so the pair is about SHAPE, not size.

## The breadth corpus is not from my head (trap 22)
Every "must never be judged" row comes from the deployed capture, this repo's `golden-path-staging-2026-04-05.json`, or the **producer's own declared output vocabulary** — CEE's `synthesiseDisplayValue` doc-comment enumerates what it can emit (`"£500k"`, `"$2.1m"`, `"3%"`, `"42 days"`, `"18 months"`, `"500,000"`, `"Low (0.15)"`, `"0.15"`), plus `synthesiseRangeDisplayValue`'s `"0.48 to 1"`. Expectations were written from that list **before** running.

## ⚠ Why F4 is two pure functions and not a store action — this failed CI once
The first push added `restoreAnalysisFreshnessFromAttestation` to the canvas store. **`Staging Gate` (the required check) FAILED**, via `Typecheck Gate Self-Test`: *"no added-diagnostics notice on a clean tree — did NOT expect text 'NOT in the identity baseline appeared', but the gate printed it."*

Diagnosed by control rather than assumed: the gate was **run at pristine `538677ff`**, which prints **no** added-diagnostics notice (and the same `Drift shrank (2491 → 2485)`). So the added diagnostic was **mine**: widening the store interface by one member moves the elided `… N more …` property count inside a **pre-existing** `useConversation.ts(4583) TS2345` `V5ApplicatorStore` assignability error, and the identity baseline keys on the rendered text.

`--update-baseline` was **deliberately declined** — it would also absorb ~7 unrelated pre-existing drops in files this lane never touched (the exact churn CLAUDE.md's 9-Aug note says to refuse). The logic was moved into pure functions instead, which removes the perturbation entirely and makes every guard directly testable. **Verified locally: the self-test now reports `18 passed, 0 failed`, including that exact check.**

## Existing tests changed
**None.** In particular `mergeAppliedGraph.spec.ts`'s local-`0.7`-beats-server-`0.5` pins are untouched — that defect is **not addressed here**.

## Gates (at `0096dc46`)
- `bash scripts/ci/typecheck-gate.sh` (named gate) — **PASSED**, byte-identical output to the pristine control.
- `bash scripts/ci/typecheck-gate-selftest.sh` — **18 passed, 0 failed, exit 0.**
- Full `vitest run` — **1578 files passed, 3 skipped; 22,914 tests passed, 0 failed, exit 0** (run on the pre-refactor tree; the targeted re-run after the refactor is 187/187 across the six affected specs).
- **CI at the exact head SHA: 13 checks, 0 failures, required `Staging Gate` = success, `mergeable_state: clean`.**

## What this PR does NOT prove or fix — read before approving
- **NO STAGING WITNESS.** Nothing here is WIRE- or JOURNEY-witnessed. Rung: **TESTED**. The immediate-canvas and reloaded-canvas claims need the real deployed arm — jsdom proves structure, never layout (trap 3).
- **The second-F4-driver caution in the first version of this PR body was MORE conservative than reality** — corrected by independent measurement, and recorded rather than quietly deleted. Staging bakes `VITE_V5_CANONICAL_ANALYSIS="true"` and `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`; `resolveTrustEffectiveState` synthesises the orphan only when `state === null || freshness === 'none'`, so a restored `fresh` neutralises it, and the sole non-test reader of `.orphaned` is a debug export. **No user-visible freshness complaint survives — provided the upgrade fires**, which is exactly what B2 left unpinned and what the boot spec now guards.
- **Defect 2 (synthetic-shape edge applicator) NOT fixed.** Confirmed at the bytes: `applyPatch.ts` `update_edge` matches strictly on `e.id` (canvas ids are synthetic `e-0` / `factor-1::goal-1::0`, never the wire's `A->B` arrow target), and it splats the raw bag so `strength.mean` / `effect_direction` land as literal keys while `data.weight` / `data.direction` go untouched. `buildEdge` (the `add_edge` path) **already** has the correct nested-shape priority — the fix is to share it and resolve endpoints through the existing `wireEdgePairKey`. **Lane A2 needs this.**
- **Defect 3 (explicit-default reconciliation) NOT fixed.** `mergeAppliedGraph.ts:341-346` treats a wire value equal to the mapper default as absent; `DEFAULT_EDGE_DATA.weight = 0.5`, so an explicitly committed server `0.5` is indistinguishable from omission. The fix is to compute "supplied" from **key presence on the raw wire edge** before mapping, and it will require changing four existing tests that positively pin today's behaviour.
- **ROADMAP 2.1033 (CEE) is NOT fixed here and is the other half of B1.** When a node carries `raw_value`, the value applier updates `observed_state.value` and leaves `raw_value` stale. The display then agrees with `raw_value`, so the contradiction guard correctly returns `false` and the screen still shows the old number. **A consumer cannot repair that** — it cannot distinguish a stale producer field from a deliberate one. Deliberately out of scope for this PR.
