### PR TITLE
COLLAB U-S0 (UI): participant packet page, owner panel setup, and the transport that makes them reachable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -255,3 +255,12 @@
 [[edge_functions]]
   function = "cee-proxy"
   path = "/bff/cee/*"
+
+# COLLAB (blind elicitation panels) proxy — /bff/collab/* → CEE /collab/v1/*.
+# A FOURTH seam, not a reuse of /bff/cee/*: that one rewrites to /assist/v1/*,
+# so the collab routes had no browser-reachable path at all. This function is
+# also the only one whose forward allowlist carries x-collab-participant-token —
+# without it a participant request reaches CEE token-less and 401s every time.
+[[edge_functions]]
+  function = "collab-proxy"
+  path = "/bff/collab/*"

--- a/netlify/edge-functions/collab-proxy.ts
+++ b/netlify/edge-functions/collab-proxy.ts
@@ -1,0 +1,182 @@
+/**
+ * COLLAB proxy edge function — serves `/bff/collab/*` → CEE `/collab/v1/*`.
+ *
+ * Fourth sibling of `cee-proxy.ts` / `orchestrator-proxy.ts` / `isl-proxy.ts`.
+ *
+ * ── WHY A FOURTH SEAM RATHER THAN REUSING `/bff/cee/*` ────────────────────
+ * `/bff/cee/*` rewrites to `/assist/v1/*`, `/bff/orchestrate/*` rewrites to
+ * `/orchestrate/*`, and the direct `VITE_V5_ENDPOINT` seam is pinned to the
+ * `/proxy/v5/turn` family. NONE of them maps to `/collab/v1/*`, so the collab
+ * routes were registered and unreachable — the "green in every test, dark for
+ * every user" shape.
+ *
+ * The alternative was aliasing every collab route under `/assist/v1/collab/*`
+ * to ride the existing seam. This is strictly better: it adds NO second CEE
+ * surface to reason about, NO CEE CORS entry, NO CSP change and NO Render
+ * dashboard dependency — and it keeps one entrance to what is a privacy
+ * boundary.
+ *
+ * ── THE ONE THING THIS FUNCTION DOES THAT ITS SIBLINGS DO NOT ─────────────
+ * It forwards `x-collab-participant-token`. The siblings' forward allowlists do
+ * not carry it, so a participant request through any of them arrives at CEE
+ * token-less and 401s — every time, invisibly, with both repos' suites green.
+ *
+ * ── AUTH, AND WHAT ORIGIN IS NOT ──────────────────────────────────────────
+ * This function injects `X-Olumi-Assist-Key` (CALLER auth) exactly as its
+ * siblings do. It does NOT authenticate the person: CEE's collab routes do that
+ * themselves, from the participant token or the owner's verified Supabase JWT.
+ * `Origin` is a CORS control and is not treated as identity anywhere in this
+ * chain — a forged Origin reaches CEE's own checks and still has to hold a real
+ * token.
+ *
+ * A MISSING `Origin` is allowed, matching `cee-proxy.ts`: browsers omit it on
+ * same-origin GET/HEAD, and `/bff/collab/*` is same-origin by construction.
+ * Rejecting it would 403 the packet page's own first fetch.
+ */
+
+import type { Config, Context } from '@netlify/edge-functions'
+
+const CEE_TARGET = 'https://cee-staging.onrender.com'
+
+// SECURITY: CORS allow-list (never a wildcard). Identical to cee-proxy.ts.
+const ALLOWED_ORIGINS = [
+  'https://decisionguide.ai',
+  'https://decision-guide-ai.netlify.app',
+  'https://staging--olumi.netlify.app',
+  'http://localhost:5173',
+  'http://localhost:4173',
+]
+
+const NETLIFY_PREVIEW_PATTERN = /^https:\/\/[a-z0-9-]+--olumi\.netlify\.app$/
+
+function isOriginAllowed(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin) || NETLIFY_PREVIEW_PATTERN.test(origin)
+}
+
+/**
+ * GET for the packet and the reveal; POST for mint, close and contributions.
+ * ENFORCED below and ADVERTISED verbatim — an allow-list that advertises more
+ * than it enforces (or less) is a false guarantee.
+ */
+const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'OPTIONS'] as const
+
+/**
+ * ⭐ THE PARTICIPANT CAPABILITY HEADER. Without this entry the whole feature is
+ * dark: the token is stripped at the edge and CEE refuses every request.
+ * `tests/ci-guards/collab-proxy-token-forwarding.spec.ts` binds this list to the
+ * advertised CORS header so the two cannot drift apart.
+ */
+const COLLAB_TOKEN_HEADER = 'x-collab-participant-token'
+
+const ALLOWED_FORWARD_HEADERS = [
+  'content-type',
+  'accept',
+  // The OWNER's Supabase access token (mint / close / preview / reveal).
+  'authorization',
+  'x-correlation-id',
+  'x-request-id',
+  'x-user-id',
+  COLLAB_TOKEN_HEADER,
+]
+
+function getCorsHeaders(requestOrigin: string): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': requestOrigin,
+    'Access-Control-Allow-Methods': ALLOWED_METHODS.join(', '),
+    // Kept in step with ALLOWED_FORWARD_HEADERS by the CI guard. Not strictly
+    // load-bearing today (same-origin fetches with a custom header do not
+    // preflight), which is exactly why it would rot unnoticed without the guard.
+    'Access-Control-Allow-Headers':
+      'Content-Type, Authorization, x-correlation-id, x-request-id, x-user-id, x-collab-participant-token',
+    Vary: 'Origin, Access-Control-Request-Headers',
+  }
+}
+
+export default async function handler(request: Request, _context: Context) {
+  const origin = request.headers.get('origin')
+
+  if (origin !== null && !isOriginAllowed(origin)) {
+    // NOTE: no token, no path and no round id in this log line.
+    console.warn('[Collab Proxy] Rejected request from unknown origin:', origin)
+    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const corsHeaders = origin === null ? null : getCorsHeaders(origin)
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders ?? {} })
+  }
+
+  if (!(ALLOWED_METHODS as readonly string[]).includes(request.method)) {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: {
+        ...(corsHeaders ?? {}),
+        'Content-Type': 'application/json',
+        Allow: ALLOWED_METHODS.join(', '),
+      },
+    })
+  }
+
+  // /bff/collab/packet/<id> → /collab/v1/packet/<id>
+  const url = new URL(request.url)
+  const targetPath = url.pathname.replace(/^\/bff\/collab/, '/collab/v1')
+  const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
+
+  const headers = new Headers()
+  for (const headerName of ALLOWED_FORWARD_HEADERS) {
+    const value = request.headers.get(headerName)
+    if (value) headers.set(headerName, value)
+  }
+
+  const assistKey = Deno.env.get('ASSIST_API_KEY')
+  if (assistKey) {
+    headers.set('X-Olumi-Assist-Key', assistKey)
+  } else {
+    console.warn('[Collab Proxy] ASSIST_API_KEY not set - requests will fail with 401')
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+      // @ts-ignore - duplex is required for streaming bodies
+      duplex: 'half',
+    })
+
+    const responseHeaders = new Headers(response.headers)
+    if (corsHeaders) {
+      Object.entries(corsHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
+  } catch (error) {
+    // SECURITY: never leak internal detail — and never the token.
+    console.error('[Collab Proxy] Upstream error:', (error as Error).name)
+    const isTimeout =
+      (error as Error).name === 'AbortError' || (error as Error).message?.includes('timed out')
+    return new Response(
+      JSON.stringify({
+        error: isTimeout
+          ? 'That took too long. Please try again.'
+          : 'The panel service is unavailable. Please try again.',
+      }),
+      {
+        status: isTimeout ? 504 : 502,
+        headers: { ...(corsHeaders ?? {}), 'Content-Type': 'application/json' },
+      },
+    )
+  }
+}
+
+export const config: Config = {
+  path: '/bff/collab/*',
+}

--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2491
+# count=2487
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -90,6 +90,8 @@
 1	integration/integration-check.ts	TS2769	No overload matches this call.
 1	netlify/edge-functions/cee-proxy.ts	TS2304	Cannot find name 'Deno'.
 1	netlify/edge-functions/cee-proxy.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
+1	netlify/edge-functions/collab-proxy.ts	TS2304	Cannot find name 'Deno'.
+1	netlify/edge-functions/collab-proxy.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
 1	netlify/edge-functions/csp-nonce.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
 1	netlify/edge-functions/isl-proxy.ts	TS2304	Cannot find name 'Deno'.
 1	netlify/edge-functions/isl-proxy.ts	TS2307	Cannot find module '@netlify/edge-functions' or its corresponding type declarations.
@@ -349,7 +351,6 @@
 1	src/canvas/components/ModelQualityScore.tsx	TS6133	'Info' is declared but its value is never read.
 1	src/canvas/components/ModelTabBody.tsx	TS6133	'SectionErrorBoundary' is declared but its value is never read.
 1	src/canvas/components/OutputsDock.stories.tsx	TS2307	Cannot find module '@storybook/react' or its corresponding type declarations.
-1	src/canvas/components/ParetoInsights.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'RiskProfilePreset'.
 1	src/canvas/components/PreAnalysisGuidance.tsx	TS2322	Type '{}' is not assignable to type 'string'.
 1	src/canvas/components/PreAnalysisGuidance.tsx	TS2322	Type '{}[] | undefined' is not assignable to type 'string[] | undefined'.
 1	src/canvas/components/PreAnalysisGuidance.tsx	TS2339	Property 'bias_findings' does not exist on type 'CeeDecisionReviewPayload'.
@@ -562,7 +563,6 @@
 1	src/canvas/edges/StyledEdge.tsx	TS6133	'formatConfidence' is declared but its value is never read.
 1	src/canvas/edges/StyledEdge.tsx	TS6133	'labelVisibility' is declared but its value is never read.
 1	src/canvas/edges/StyledEdge.tsx	TS6133	'useGuidanceStore' is declared but its value is never read.
-1	src/canvas/edges/StyledEdge.tsx	TS6192	All imports in import declaration are unused.
 4	src/canvas/edges/__tests__/EdgeEditPopover.dom.spec.tsx	TS6133	'container' is declared but its value is never read.
 1	src/canvas/edges/__tests__/EdgeEditPopover.dom.spec.tsx	TS6133	'waitFor' is declared but its value is never read.
 2	src/canvas/edges/__tests__/EdgeEditPopover.perf.spec.tsx	TS6133	'container' is declared but its value is never read.
@@ -624,7 +624,6 @@
 1	src/canvas/hooks/useRiskToleranceSuggestion.ts	TS2339	Property 'getRiskProfileFromPreset' does not exist on type '{ run(input: RunRequest): Promise<ReportV1>; templates(): Promise<TemplateListV1>; template(id: string): Promise<TemplateDetail>; ... 4 more ...; stream: { ...; }; }'.
 8	src/canvas/hooks/useScienceIcons.ts	TS2322	Type 'LucideIcon' is not assignable to type 'ComponentType<{ size?: number | undefined; className?: string | undefined; }>'.
 1	src/canvas/hooks/useScienceIcons.ts	TS6133	'category' is declared but its value is never read.
-1	src/canvas/hooks/useScienceIcons.ts	TS6133	'computeSignedMean' is declared but its value is never read.
 1	src/canvas/hooks/useSequentialAnalysis.ts	TS6133	'stage' is declared but its value is never read.
 1	src/canvas/hooks/useUnifiedActions.ts	TS2339	Property 'bias_findings' does not exist on type 'CeeDecisionReviewPayload'.
 4	src/canvas/hooks/useUnifiedActions.ts	TS2339	Property 'code' does not exist on type 'ValidationIssue'.
@@ -1073,7 +1072,6 @@
 1	src/components/decisions/DecisionEdit.tsx	TS6133	'user' is declared but its value is never read.
 1	src/components/layout/KebabMenu.tsx	TS2322	Type 'RefObject<HTMLDivElement | null>' is not assignable to type 'LegacyRef<HTMLDivElement> | undefined'.
 1	src/components/results/AdvancedSection.tsx	TS6133	'expertMode' is declared but its value is never read.
-1	src/components/results/BaselineTargetRow.tsx	TS6133	'hasBaseline' is declared but its value is never read.
 1	src/components/results/ConfidenceSection.tsx	TS6133	'ActionItem' is declared but its value is never read.
 1	src/components/results/ConfidenceSection.tsx	TS6133	'FocusTargetType' is declared but its value is never read.
 1	src/components/results/ConfidenceSection.tsx	TS6133	'GitBranch' is declared but its value is never read.
@@ -1098,7 +1096,6 @@
 1	src/components/results/SuccessTargetRow.tsx	TS6133	'showHitsTarget' is declared but its value is never read.
 1	src/components/results/TriageActionCardsBody.tsx	TS2345	Argument of type 'Map<string, StrengthenOverlay> | null' is not assignable to parameter of type 'Map<string, StrengthenOverlay>'.
 1	src/components/results/__tests__/Accordion.spec.tsx	TS6133	'vi' is declared but its value is never read.
-2	src/components/results/__tests__/BaselineTargetRow.spec.tsx	TS2339	Property 'toBeTruthy' does not exist on type 'void'.
 2	src/components/results/__tests__/ConfidenceSection.spec.tsx	TS2739	Type '{ factorId: string; factorLabel: string; voi: number; }' is missing the following properties from type 'EvidenceGapItem': confidence, suggestion
 2	src/components/results/__tests__/ConfidenceSection.spec.tsx	TS2741	Property 'confidence' is missing in type '{ factorId: string; factorLabel: string; suggestion: string; voi: number; }' but required in type 'EvidenceGapItem'.
 2	src/components/results/__tests__/ConfidenceSection.spec.tsx	TS2741	Property 'suggestion' is missing in type '{ factorId: string; factorLabel: string; voi: number; confidence: number; }' but required in type 'EvidenceGapItem'.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2491
+# count=2487
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -55,6 +55,7 @@
 3	e2e/webvitals.spec.ts
 1	integration/integration-check.ts
 2	netlify/edge-functions/cee-proxy.ts
+2	netlify/edge-functions/collab-proxy.ts
 1	netlify/edge-functions/csp-nonce.ts
 3	netlify/edge-functions/isl-proxy.ts
 2	netlify/edge-functions/orchestrator-proxy.ts
@@ -146,7 +147,6 @@
 5	src/canvas/components/ModelQualityScore.tsx
 1	src/canvas/components/ModelTabBody.tsx
 1	src/canvas/components/OutputsDock.stories.tsx
-1	src/canvas/components/ParetoInsights.tsx
 27	src/canvas/components/PreAnalysisGuidance.tsx
 2	src/canvas/components/RangeDisplay.tsx
 3	src/canvas/components/RecoveryBanner.tsx
@@ -245,7 +245,7 @@
 1	src/canvas/domain/__tests__/edgeLabels.spec.ts
 1	src/canvas/domain/__tests__/migrations.spec.ts
 1	src/canvas/domain/__tests__/nodes.spec.ts
-32	src/canvas/edges/StyledEdge.tsx
+31	src/canvas/edges/StyledEdge.tsx
 5	src/canvas/edges/__tests__/EdgeEditPopover.dom.spec.tsx
 2	src/canvas/edges/__tests__/EdgeEditPopover.perf.spec.tsx
 1	src/canvas/health/issueExplainers.ts
@@ -273,7 +273,7 @@
 3	src/canvas/hooks/useResultsRun.ts
 8	src/canvas/hooks/useRiskProfile.ts
 3	src/canvas/hooks/useRiskToleranceSuggestion.ts
-10	src/canvas/hooks/useScienceIcons.ts
+9	src/canvas/hooks/useScienceIcons.ts
 1	src/canvas/hooks/useSequentialAnalysis.ts
 20	src/canvas/hooks/useUnifiedActions.ts
 6	src/canvas/hooks/useUtilityWeights.ts
@@ -424,7 +424,6 @@
 9	src/components/decisions/DecisionEdit.tsx
 1	src/components/layout/KebabMenu.tsx
 1	src/components/results/AdvancedSection.tsx
-1	src/components/results/BaselineTargetRow.tsx
 15	src/components/results/ConfidenceSection.tsx
 1	src/components/results/DriversSection.tsx
 2	src/components/results/ParetoChart.tsx
@@ -433,7 +432,6 @@
 1	src/components/results/SuccessTargetRow.tsx
 1	src/components/results/TriageActionCardsBody.tsx
 1	src/components/results/__tests__/Accordion.spec.tsx
-2	src/components/results/__tests__/BaselineTargetRow.spec.tsx
 7	src/components/results/__tests__/ConfidenceSection.spec.tsx
 1	src/components/results/__tests__/DecisionConfidencePanel.autoNoise.spec.tsx
 3	src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx

--- a/src/collab/__tests__/participantTokenHygiene.spec.ts
+++ b/src/collab/__tests__/participantTokenHygiene.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * COLLAB — TOKEN HYGIENE. These are capability tests, not robustness overhead:
+ * attribution is the proof PR4 exists to make, and a leaked bearer token means
+ * a forged answer under someone else's name.
+ *
+ * ── EVERY ABSENCE ASSERTION HERE HAS A POSITIVE CONTROL ───────────────────
+ * The detector is proven to SEE a token before it is trusted to report one
+ * absent. Without that, "no token in the debug log" is equally consistent with
+ * "the detector is blind" — and a vacuous absence assertion about a credential
+ * is worse than none, because it is believed.
+ *
+ * ── THE LEAK THIS CLOSES IS OUTSIDE THIS MODULE ───────────────────────────
+ * `src/main.tsx` captures `location.href` into `window.__SAFE_DEBUG__.logs` at
+ * `boot:start`, and persists it to localStorage under ENABLE_DEBUG_PERSISTENCE.
+ * That fires BEFORE React mounts, so no page-level cleanup can beat it. The
+ * strip therefore happens in the boot path, and these tests bind to that
+ * ordering rather than to the strip function in isolation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import {
+  captureParticipantTokenFromUrl,
+  getParticipantToken,
+  __resetParticipantTokenForTests,
+} from '../participantToken'
+
+const TOKEN = 'COLLAB-TEST-TOKEN-e3b0c44298fc1c149afbf4c8996fb924'
+
+/** Drive the URL the way a real participant link does. */
+function setUrl(url: string): void {
+  window.history.replaceState({}, '', url)
+}
+
+describe('participant token capture and strip', () => {
+  beforeEach(() => {
+    __resetParticipantTokenForTests()
+    setUrl('/')
+    localStorage.clear()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('captures from the real query string and REMOVES it from location.href', () => {
+    setUrl(`/?ct=${TOKEN}#/panel/round-abc`)
+    // POSITIVE CONTROL: the token IS in the URL before the strip, so the
+    // assertion below is about the strip and not about an empty fixture.
+    expect(window.location.href).toContain(TOKEN)
+
+    const captured = captureParticipantTokenFromUrl()
+
+    expect(captured).toBe(TOKEN)
+    expect(getParticipantToken()).toBe(TOKEN)
+    expect(window.location.href).not.toContain(TOKEN)
+    // The route survives — the strip must not break navigation.
+    expect(window.location.hash).toBe('#/panel/round-abc')
+  })
+
+  it('captures from a hash query too (HashRouter link shape) and preserves the route', () => {
+    setUrl(`/#/panel/round-abc?ct=${TOKEN}`)
+    expect(window.location.href).toContain(TOKEN)
+
+    expect(captureParticipantTokenFromUrl()).toBe(TOKEN)
+    expect(window.location.href).not.toContain(TOKEN)
+    expect(window.location.hash).toBe('#/panel/round-abc')
+  })
+
+  it('preserves OTHER query parameters while removing only the token', () => {
+    setUrl(`/?diag=1&ct=${TOKEN}&analysisHeroCompare=1#/panel/round-abc`)
+    captureParticipantTokenFromUrl()
+    expect(window.location.href).not.toContain(TOKEN)
+    expect(window.location.search).toContain('diag=1')
+    expect(window.location.search).toContain('analysisHeroCompare=1')
+  })
+
+  it('leaves no history entry that could restore the token via Back', () => {
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    setUrl(`/?ct=${TOKEN}#/panel/round-abc`)
+    replaceSpy.mockClear()
+    pushSpy.mockClear()
+
+    captureParticipantTokenFromUrl()
+
+    expect(replaceSpy).toHaveBeenCalled()
+    expect(pushSpy).not.toHaveBeenCalled()
+  })
+
+  it('NEVER writes the token to localStorage or sessionStorage', () => {
+    const localSpy = vi.spyOn(Storage.prototype, 'setItem');
+    setUrl(`/?ct=${TOKEN}#/panel/round-abc`)
+
+    captureParticipantTokenFromUrl()
+
+    // POSITIVE CONTROL: the spy DOES observe a write when one happens, so an
+    // empty call list means "nothing was written", not "the spy is inert".
+    localStorage.setItem('collab-hygiene-control', TOKEN)
+    expect(localSpy).toHaveBeenCalledWith('collab-hygiene-control', TOKEN)
+
+    const tokenWrites = localSpy.mock.calls.filter(
+      ([key, value]) =>
+        key !== 'collab-hygiene-control' && String(value).includes(TOKEN),
+    )
+    expect(tokenWrites).toEqual([])
+  })
+
+  it('is not reachable from any enumerable global — a diagnostic bundle cannot find it', () => {
+    setUrl(`/?ct=${TOKEN}#/panel/round-abc`)
+    captureParticipantTokenFromUrl()
+    expect(getParticipantToken()).toBe(TOKEN)
+
+    // POSITIVE CONTROL for the scan: a value deliberately placed on window IS
+    // found by exactly this walk.
+    ;(window as unknown as Record<string, unknown>).__collabHygieneControl = TOKEN
+    const scan = (): string[] =>
+      Object.keys(window).filter((k) => {
+        try {
+          return JSON.stringify((window as unknown as Record<string, unknown>)[k])?.includes(TOKEN)
+        } catch {
+          return false
+        }
+      })
+    expect(scan()).toContain('__collabHygieneControl')
+
+    delete (window as unknown as Record<string, unknown>).__collabHygieneControl
+    expect(scan()).toEqual([])
+  })
+})
+
+describe('the boot path strips BEFORE the first location.href capture', () => {
+  it('main.tsx calls captureParticipantTokenFromUrl ahead of the boot:start log that records location.href', async () => {
+    // Bound to the SOURCE ORDER, because the ordering IS the guarantee: a strip
+    // that runs one line later is a strip that runs after the capture.
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const src = readFileSync(resolve(process.cwd(), 'src/main.tsx'), 'utf8')
+
+    const stripAt = src.indexOf('captureParticipantTokenFromUrl()')
+    const captureAt = src.indexOf("log('boot:start'")
+
+    // POSITIVE CONTROL: both anchors must EXIST. If either is renamed away this
+    // test would otherwise pass on two -1s and prove nothing.
+    expect(stripAt).toBeGreaterThan(-1)
+    expect(captureAt).toBeGreaterThan(-1)
+    expect(src).toContain('href: location.href')
+
+    expect(stripAt).toBeLessThan(captureAt)
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -64,6 +64,8 @@ export interface RevealView {
   graph_version_ref: string
   per_target: Array<{
     target: { kind: 'factor' | 'edge'; id: string }
+    /** The words the panel was actually asked about — see the CEE type. */
+    label: string
     model_value_at_version: number | null
     responses: RevealResponse[]
   }>

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -1,0 +1,250 @@
+/**
+ * COLLAB — the browser's only path to the panel routes.
+ *
+ * Everything goes to the same-origin `/bff/collab/*` seam, which
+ * `netlify/edge-functions/collab-proxy.ts` rewrites to CEE `/collab/v1/*` and
+ * where the caller-auth key is injected server-side. The key never enters this
+ * bundle.
+ *
+ * ── TWO CREDENTIALS, TWO AUDIENCES, NEVER MIXED ───────────────────────────
+ * • PARTICIPANT calls carry `x-collab-participant-token` — a per-round bearer
+ *   capability held in memory only (`participantToken.ts`).
+ * • OWNER calls carry `Authorization: Bearer <supabase access token>`.
+ * A participant token is worthless on an owner route and vice versa; CEE checks
+ * each independently, and neither is ever put in a URL.
+ *
+ * ⚠ THE TOKEN TRAVELS AS A HEADER, NEVER AS A QUERY PARAMETER. A query
+ * parameter would land in `location.href` captures, proxy access logs and any
+ * error report carrying a URL — the exact class of leak the boot-path strip
+ * exists to close.
+ */
+
+import { getParticipantToken } from './participantToken'
+
+/** Same-origin seam. A literal, so nothing can rewrite it to another host. */
+const COLLAB_BASE = '/bff/collab'
+
+export interface PacketTarget {
+  target: { kind: 'factor' | 'edge'; id: string }
+  label: string
+  description: string | null
+  unit: string | null
+}
+
+/**
+ * The blind packet. NOTE WHAT IS NOT HERE: no sibling answers, no model value,
+ * no response count, no roster. That absence is the feature, and it is enforced
+ * server-side — this type simply refuses to describe anything else.
+ */
+export interface OpenPacket {
+  round_id: string
+  status: 'open'
+  context_note: string | null
+  graph_version_ref: string
+  targets: PacketTarget[]
+  self: {
+    participant_id: string
+    display_name: string
+    completed_target_ids: string[]
+  }
+}
+
+export interface RevealResponse {
+  participant_id: string
+  display_label: string
+  value: number | null
+  expression_raw: string | null
+  confidence: number | null
+  kind: string
+}
+
+export interface RevealView {
+  round_id: string
+  status: string
+  graph_version_ref: string
+  per_target: Array<{
+    target: { kind: 'factor' | 'edge'; id: string }
+    model_value_at_version: number | null
+    responses: RevealResponse[]
+  }>
+}
+
+export interface CollabError {
+  code: string
+  message: string
+  status: number
+}
+
+export class CollabRequestError extends Error {
+  readonly code: string
+  readonly status: number
+  constructor(err: CollabError) {
+    super(err.message)
+    this.name = 'CollabRequestError'
+    this.code = err.code
+    this.status = err.status
+  }
+}
+
+async function parseError(res: Response): Promise<CollabRequestError> {
+  let code = 'collab_request_failed'
+  let message = 'Something went wrong. Please try again.'
+  try {
+    const body = (await res.json()) as { code?: string; message?: string }
+    if (typeof body.code === 'string') code = body.code
+    if (typeof body.message === 'string') message = body.message
+  } catch {
+    /* a non-JSON body stays on the defaults */
+  }
+  return new CollabRequestError({ code, message, status: res.status })
+}
+
+function participantHeaders(): HeadersInit {
+  const token = getParticipantToken()
+  if (token === null) {
+    throw new CollabRequestError({
+      code: 'collab_token_invalid',
+      message: 'This link is missing its access code. Open the original link again.',
+      status: 401,
+    })
+  }
+  return { 'x-collab-participant-token': token }
+}
+
+/* ── participant ─────────────────────────────────────────────────────────── */
+
+export async function fetchOpenPacket(roundId: string): Promise<OpenPacket> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}`, {
+    method: 'GET',
+    headers: participantHeaders(),
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as OpenPacket
+}
+
+export async function submitBelief(
+  roundId: string,
+  args: {
+    targetId: string
+    targetKind: 'factor' | 'edge'
+    value: number
+    expressionRaw: string | null
+    confidence: number | null
+    revision: boolean
+  },
+): Promise<{ authored_by: string; event_id: string }> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}/events`, {
+    method: 'POST',
+    headers: { ...participantHeaders(), 'Content-Type': 'application/json' },
+    // ⚠ NO provenance member. The server stamps `authored_by` from the token;
+    // a payload that offered one would be REFUSED, not ignored.
+    body: JSON.stringify({
+      kind: args.revision ? 'belief_revised' : 'belief_submitted',
+      target: { kind: args.targetKind, id: args.targetId },
+      belief: {
+        value: args.value,
+        // The participant's own words, verbatim — this is what makes the reveal
+        // a record of reasoning rather than a row of numbers.
+        expression_raw: args.expressionRaw,
+        confidence: args.confidence,
+      },
+    }),
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as { authored_by: string; event_id: string }
+}
+
+export async function declineTarget(
+  roundId: string,
+  args: { targetId: string; targetKind: 'factor' | 'edge' },
+): Promise<void> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}/events`, {
+    method: 'POST',
+    headers: { ...participantHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      kind: 'declined',
+      target: { kind: args.targetKind, id: args.targetId },
+      belief: null,
+    }),
+  })
+  if (!res.ok) throw await parseError(res)
+}
+
+export async function fetchParticipantReveal(roundId: string): Promise<RevealView> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}/reveal`, {
+    method: 'GET',
+    headers: participantHeaders(),
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as RevealView
+}
+
+/* ── owner ───────────────────────────────────────────────────────────────── */
+
+function ownerHeaders(accessToken: string): HeadersInit {
+  return { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' }
+}
+
+export interface MintedRound {
+  round_id: string
+  graph_version_ref: string
+  participants: Array<{ participant_id: string; display_name: string; token: string }>
+}
+
+export async function mintRound(
+  accessToken: string,
+  args: {
+    scenarioId: string
+    contextNote: string | null
+    targets: PacketTarget[]
+    participants: Array<{ display_name: string }>
+  },
+): Promise<MintedRound> {
+  const res = await fetch(`${COLLAB_BASE}/rounds`, {
+    method: 'POST',
+    headers: ownerHeaders(accessToken),
+    body: JSON.stringify({
+      scenario_id: args.scenarioId,
+      context_note: args.contextNote,
+      targets: args.targets,
+      participants: args.participants,
+    }),
+  })
+  if (!res.ok) throw await parseError(res)
+  // ⚠ The raw participant tokens are in THIS response and nowhere else, ever.
+  // The caller shows them once so the owner can send the links, and must not
+  // persist them.
+  return (await res.json()) as MintedRound
+}
+
+export async function closeRound(accessToken: string, roundId: string): Promise<void> {
+  const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/close`, {
+    method: 'POST',
+    headers: ownerHeaders(accessToken),
+  })
+  if (!res.ok) throw await parseError(res)
+}
+
+export async function fetchOwnerReveal(
+  accessToken: string,
+  roundId: string,
+): Promise<RevealView> {
+  const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/reveal`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as RevealView
+}
+
+/**
+ * Build the link an owner sends a participant.
+ *
+ * The token rides a REAL query string (before the hash), because the app is a
+ * HashRouter and the boot-path strip removes `location.search` cleanly before
+ * anything captures `location.href`.
+ */
+export function participantLink(roundId: string, token: string, origin?: string): string {
+  const base = origin ?? (typeof location !== 'undefined' ? location.origin : '')
+  return `${base}/?ct=${encodeURIComponent(token)}#/panel/${encodeURIComponent(roundId)}`
+}

--- a/src/collab/participantToken.ts
+++ b/src/collab/participantToken.ts
@@ -1,0 +1,121 @@
+/**
+ * COLLAB — participant token capture and hygiene (browser side).
+ *
+ * ── ⚠ WHY THE URL FRAGMENT IS NOT A HIDING PLACE IN THIS APP ──────────────
+ * The usual advice — "put the bearer token in the fragment, it is never sent to
+ * a server" — is WRONG HERE, and would have shipped a leak that this module's
+ * own tests could not have caught, because the leak is outside this module.
+ *
+ * 1. This app uses a **HashRouter**, so the fragment IS the route. Anything in
+ *    it is route state, read and re-read by the router.
+ * 2. `src/main.tsx` captures `location.href` into `window.__SAFE_DEBUG__.logs`
+ *    at `boot:start`, and persists that array to **localStorage** when
+ *    `ENABLE_DEBUG_PERSISTENCE` is on. Other sinks read the same string
+ *    (`lib/Build.ts`, `canvas/ErrorBoundary.tsx`, `lib/diagnostic-bundle.ts`,
+ *    `pages/sandbox-guide/DiagnosticBanner.tsx`).
+ * 3. That capture happens **at boot, before React mounts** — so any
+ *    read-once-then-`replaceState` inside a page component runs far too late.
+ *
+ * ── THE RULE THIS MODULE IMPLEMENTS ───────────────────────────────────────
+ * The token is stripped **in the boot path itself, before the first capture**.
+ * `captureParticipantTokenFromUrl()` is the FIRST statement of `boot()`, ahead
+ * of `log('boot:start', { href: location.href })`. By the time anything reads
+ * `location.href`, the token is gone from it.
+ *
+ * Thereafter the token lives in a module-level variable and NOWHERE else:
+ * • never `localStorage` or `sessionStorage` — this is a bearer capability, and
+ *   a device that keeps it keeps it after the round closes;
+ * • never a cookie — nothing here needs ambient authority;
+ * • never a log line, never an error message, never a telemetry payload;
+ * • never a query parameter on an outbound request — it travels as a header.
+ *
+ * The cost is deliberate and worth naming: a hard refresh loses the token and
+ * the participant re-opens their link. That is the correct trade for a PoC —
+ * persisting it would put a bearer capability on disk to save one click.
+ */
+
+/** Accepted spellings, in both the real query string and the hash query. */
+const TOKEN_PARAM_NAMES = ['ct', 'collab_token'] as const
+
+/**
+ * In-memory only. Module scope, not `window` — nothing enumerating globals
+ * (a diagnostic bundle, an error reporter) can find it.
+ */
+let participantToken: string | null = null
+
+function takeFromSearchString(search: string): { token: string | null; rest: string } {
+  if (search === '' || search === '?') return { token: null, rest: '' }
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+  let found: string | null = null
+  for (const name of TOKEN_PARAM_NAMES) {
+    const value = params.get(name)
+    if (value !== null && value !== '') {
+      found = value
+      params.delete(name)
+    }
+  }
+  const remaining = params.toString()
+  return { token: found, rest: remaining === '' ? '' : `?${remaining}` }
+}
+
+/**
+ * Read the participant token out of the URL and REMOVE it from the address bar,
+ * synchronously, before anything can capture `location.href`.
+ *
+ * Handles both shapes, because a link is written by a person:
+ *   https://host/?ct=TOKEN#/panel/<round_id>      (real query string)
+ *   https://host/#/panel/<round_id>?ct=TOKEN      (hash query — HashRouter)
+ *
+ * Returns the token so the caller can act on it; callers should NOT log it.
+ */
+export function captureParticipantTokenFromUrl(): string | null {
+  if (typeof window === 'undefined' || typeof location === 'undefined') return null
+
+  try {
+    const fromSearch = takeFromSearchString(location.search)
+
+    // The hash may itself carry a query: "#/panel/abc?ct=TOKEN".
+    const rawHash = location.hash.startsWith('#') ? location.hash.slice(1) : location.hash
+    const qIndex = rawHash.indexOf('?')
+    const hashPath = qIndex === -1 ? rawHash : rawHash.slice(0, qIndex)
+    const fromHash =
+      qIndex === -1 ? { token: null, rest: '' } : takeFromSearchString(rawHash.slice(qIndex))
+
+    const token = fromSearch.token ?? fromHash.token
+    if (token === null) return null
+
+    participantToken = token
+
+    // Rewrite the address bar with the token removed. `replaceState` leaves no
+    // history entry, so Back cannot restore a URL containing it.
+    const cleanedHash = hashPath === '' ? '' : `#${hashPath}${fromHash.rest}`
+    const cleanedUrl = `${location.pathname}${fromSearch.rest}${cleanedHash}`
+    history.replaceState(history.state, '', cleanedUrl)
+
+    return token
+  } catch {
+    // Never break boot over this. A failure here means the token stays in the
+    // URL, so callers must treat capture as best-effort — but the page still
+    // works, and the participant is not locked out.
+    return null
+  }
+}
+
+/** The captured token, or null. Read at request time; never persisted. */
+export function getParticipantToken(): string | null {
+  return participantToken
+}
+
+/** Test-only: reset module state between cases. */
+export function __resetParticipantTokenForTests(): void {
+  participantToken = null
+}
+
+/**
+ * Set the token directly. For the packet page's manual-entry fallback (a
+ * participant who copied a link that lost its query string) — NOT for restoring
+ * from any store.
+ */
+export function setParticipantToken(token: string): void {
+  participantToken = token.trim() === '' ? null : token.trim()
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 // src/main.tsx
 import './index.css';
+import { captureParticipantTokenFromUrl } from './collab/participantToken';
 import { Suspense, lazy, Component, ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { initVersionCache } from './lib/version-cache';
@@ -153,6 +154,16 @@ class BootErrorBoundary extends Component<{ children: ReactNode }, { error: Erro
 
 (function boot() {
   try {
+    // ⭐ FIRST STATEMENT OF BOOT, DELIBERATELY. A participant's bearer token
+    // arrives in the URL, and the very next line captures `location.href` into
+    // window.__SAFE_DEBUG__.logs — which is persisted to localStorage under
+    // ENABLE_DEBUG_PERSISTENCE, and re-read by the error boundary, the
+    // diagnostic bundle and the sandbox banner. Stripping the token anywhere
+    // later (a React effect, a route component) is far too late: React has not
+    // mounted yet. See src/collab/participantToken.ts for why the URL fragment
+    // is not a hiding place in a HashRouter app.
+    captureParticipantTokenFromUrl();
+
     log('boot:start', { href: location.href, token: ENTRY_PROOF_TOKEN });
 
     // Analysis hero v17 — read ?analysisHeroCompare=1|0 from URL once and

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -1,0 +1,202 @@
+/**
+ * COLLAB — the owner's side: open a blind round, hand out the links, close it,
+ * read the reveal.
+ *
+ * ── THE ONE-TIME TOKEN DISCLOSURE ─────────────────────────────────────────
+ * Participant tokens are returned by the mint response and exist NOWHERE else —
+ * not in the database (only a SHA-256 hash), not in a log, and behind no
+ * read-back route. This page shows them once so the owner can send the links,
+ * and says plainly that they cannot be recovered. A lost link is re-minted.
+ *
+ * ⚠ The page does not store them. Navigating away loses them, deliberately: the
+ * alternative is a bearer capability sitting in browser storage after the round
+ * has closed.
+ *
+ * ── WHAT THE OWNER CANNOT SEE BEFORE CLOSE ────────────────────────────────
+ * Nothing anyone has written — not even whether they have written. The owner is
+ * a panellist too and is not exempt from anchoring; that is a property of the
+ * method, not a permission decision, so it holds for the person who owns the
+ * account.
+ *
+ * A consequence, ruled and accepted for this slice: the owner closes without
+ * knowing whether the others have finished, and coordinates out of band. Two
+ * people running a panel are talking to each other. The fix is NOT to add a
+ * submitted-count to the packet — that is precisely how the anchor gets back in.
+ */
+
+import { useCallback, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useAuth } from '../contexts/AuthContext'
+import {
+  CollabRequestError,
+  closeRound,
+  fetchOwnerReveal,
+  mintRound,
+  participantLink,
+  type MintedRound,
+  type RevealView,
+} from '../collab/collabService'
+import { RevealBody } from './ParticipantPacketPage'
+
+export default function PanelSetupPage(): JSX.Element {
+  const { id: scenarioId } = useParams<{ id: string }>()
+  const { session } = useAuth() as { session?: { access_token?: string } | null }
+  const accessToken = session?.access_token ?? ''
+
+  const [targetId, setTargetId] = useState('')
+  const [targetLabel, setTargetLabel] = useState('')
+  const [contextNote, setContextNote] = useState('')
+  const [nameA, setNameA] = useState('')
+  const [nameB, setNameB] = useState('')
+  const [minted, setMinted] = useState<MintedRound | null>(null)
+  const [reveal, setReveal] = useState<RevealView | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const handleMint = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await mintRound(accessToken, {
+        scenarioId: scenarioId ?? '',
+        contextNote: contextNote.trim() === '' ? null : contextNote,
+        targets: [
+          {
+            target: { kind: 'factor', id: targetId.trim() },
+            label: targetLabel.trim() === '' ? targetId.trim() : targetLabel.trim(),
+            description: null,
+            unit: null,
+          },
+        ],
+        participants: [{ display_name: nameA.trim() }, { display_name: nameB.trim() }].filter(
+          (p) => p.display_name !== '',
+        ),
+      })
+      setMinted(result)
+    } catch (err) {
+      setError(
+        err instanceof CollabRequestError ? err.message : 'Could not open the round.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }, [accessToken, scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
+
+  const handleClose = useCallback(async () => {
+    if (minted === null) return
+    setBusy(true)
+    setError(null)
+    try {
+      await closeRound(accessToken, minted.round_id)
+      setReveal(await fetchOwnerReveal(accessToken, minted.round_id))
+    } catch (err) {
+      setError(err instanceof CollabRequestError ? err.message : 'Could not close the round.')
+    } finally {
+      setBusy(false)
+    }
+  }, [accessToken, minted])
+
+  if (reveal !== null) return <RevealBody reveal={reveal} />
+
+  return (
+    <main
+      data-testid="panel-setup-page"
+      style={{ maxWidth: 720, margin: '2rem auto', padding: '0 1rem' }}
+    >
+      <h1>Ask your team, without anchoring them</h1>
+      <p>
+        Everyone answers privately. Nobody &mdash; including you &mdash; sees any answer until you
+        close the round. Then you see them all, side by side, in each person&rsquo;s own words.
+      </p>
+
+      {minted === null ? (
+        <>
+          <label>
+            Which factor should they estimate?
+            <input
+              data-testid="panel-target-id"
+              value={targetId}
+              onChange={(e) => setTargetId(e.target.value)}
+              placeholder="factor id from your model"
+            />
+          </label>
+          <label>
+            How should it be described to them?
+            <input
+              data-testid="panel-target-label"
+              value={targetLabel}
+              onChange={(e) => setTargetLabel(e.target.value)}
+            />
+          </label>
+          <label>
+            Anything they should know first? (optional)
+            <textarea
+              data-testid="panel-context-note"
+              value={contextNote}
+              onChange={(e) => setContextNote(e.target.value)}
+            />
+          </label>
+          <label>
+            First person&rsquo;s name
+            <input
+              data-testid="panel-name-a"
+              value={nameA}
+              onChange={(e) => setNameA(e.target.value)}
+            />
+          </label>
+          <label>
+            Second person&rsquo;s name
+            <input
+              data-testid="panel-name-b"
+              value={nameB}
+              onChange={(e) => setNameB(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            data-testid="panel-mint"
+            onClick={handleMint}
+            disabled={busy || targetId.trim() === ''}
+          >
+            Open the round
+          </button>
+        </>
+      ) : (
+        <>
+          <h2>Send each person their own link</h2>
+          {/* Said once, plainly, at the only moment it can be acted on. */}
+          <p data-testid="panel-token-warning">
+            These links are shown once and cannot be recovered — they are not stored anywhere. Copy
+            them now. Anyone holding a link can answer as that person, so send each one directly.
+          </p>
+          <ul>
+            {minted.participants.map((p) => (
+              <li key={p.participant_id} data-testid={`panel-link-${p.participant_id}`}>
+                <strong>{p.display_name}</strong>
+                <input readOnly value={participantLink(minted.round_id, p.token)} />
+              </li>
+            ))}
+          </ul>
+          <p style={{ opacity: 0.75 }}>
+            This round is pinned to the version of your model as it is right now, so the answers
+            stay meaningful even if you keep editing.
+          </p>
+          <button type="button" data-testid="panel-close" onClick={handleClose} disabled={busy}>
+            Close the round and show everyone&rsquo;s answers
+          </button>
+          <p style={{ opacity: 0.75 }}>
+            You will not see whether they have answered yet &mdash; that would tell you something
+            about their replies before you have given yours. Check with them first.
+          </p>
+        </>
+      )}
+
+      {error !== null && (
+        <p role="alert" data-testid="panel-error" style={{ color: 'crimson' }}>
+          {error}
+        </p>
+      )}
+    </main>
+  )
+}

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -1,0 +1,371 @@
+/**
+ * COLLAB — the participant's page. The whole of a panellist's experience.
+ *
+ * ── WHY THIS ROUTE IS OUTSIDE `AuthGuard` ─────────────────────────────────
+ * A participant holds NO Supabase session. Placing this inside the guard would
+ * bounce every one of them to `/login`, and the feature would be dark while
+ * every test stayed green — the single most likely way to ship this page dark.
+ * It copies the `/brief/:slug` precedent, which sits outside the guard for the
+ * same reason.
+ *
+ * ⚠ For the same reason this page must NOT be gated on `isPersistenceActive`
+ * (`authenticated && !!user && user.id !== 'guest'`), which is false for every
+ * participant BY CONSTRUCTION.
+ *
+ * ── WHAT THIS PAGE DELIBERATELY DOES NOT SHOW ─────────────────────────────
+ * Before the round closes: no sibling answer, no model value for the target, no
+ * response count, no roster. Not because the page hides them — because the
+ * server never sends them, and `OpenPacket` has no member that could carry one.
+ * The blindness is not a rendering decision that a future refactor could undo.
+ *
+ * That absence is the scientific mechanism, so the page SAYS so rather than
+ * leaving it to be inferred: a person who does not know their answer is private
+ * behaves as if it is not.
+ *
+ * ── THE REUSE SEAM ────────────────────────────────────────────────────────
+ * `BeliefElicitationField` + `useBeliefElicitation`: the CALLER owns the phrase,
+ * so the participant's own words survive to `expression_raw` verbatim. (The
+ * older `BeliefInput` owns and clears its phrase and emits only a number — it
+ * cannot return the words, which is exactly what the reveal needs.)
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { BeliefElicitationField } from '../canvas/components/BeliefElicitationField'
+import { useBeliefElicitation } from '../canvas/hooks/useBeliefElicitation'
+import {
+  CollabRequestError,
+  declineTarget,
+  fetchOpenPacket,
+  fetchParticipantReveal,
+  submitBelief,
+  type OpenPacket,
+  type PacketTarget,
+  type RevealView,
+} from '../collab/collabService'
+import { getParticipantToken, setParticipantToken } from '../collab/participantToken'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'packet'; packet: OpenPacket }
+  | { kind: 'reveal'; reveal: RevealView }
+  | { kind: 'error'; message: string; code: string }
+
+/** One target, with its own phrase state (the field is caller-owned). */
+function TargetCard({
+  target,
+  roundId,
+  alreadyAnswered,
+  onAnswered,
+}: {
+  target: PacketTarget
+  roundId: string
+  alreadyAnswered: boolean
+  onAnswered: () => void
+}): JSX.Element {
+  const [phrase, setPhrase] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  // The hook's target shape is {nodeId, nodeLabel}: CEE refuses an empty id and
+  // quotes the label back in its clarifying question. The packet's target id is
+  // the factor id, which is exactly what it wants.
+  const elicitation = useBeliefElicitation({
+    nodeId: target.target.id,
+    nodeLabel: target.label,
+  })
+
+  const handlePhraseChange = useCallback(
+    (next: string) => {
+      setPhrase(next)
+      elicitation.request(next)
+    },
+    [elicitation],
+  )
+
+  const commit = useCallback(
+    async (value: number) => {
+      setBusy(true)
+      setError(null)
+      try {
+        await submitBelief(roundId, {
+          targetId: target.target.id,
+          targetKind: target.target.kind,
+          value,
+          // ⭐ VERBATIM. Not the parsed number, not a normalisation — the words
+          // this person typed, which is what the reveal shows beside the number.
+          expressionRaw: phrase.trim() === '' ? null : phrase,
+          confidence: null,
+          revision: alreadyAnswered,
+        })
+        setSaved(true)
+        onAnswered()
+      } catch (err) {
+        setError(
+          err instanceof CollabRequestError
+            ? err.message
+            : 'That did not save. Please try again.',
+        )
+      } finally {
+        setBusy(false)
+      }
+    },
+    [roundId, target, phrase, alreadyAnswered, onAnswered],
+  )
+
+  const handleDecline = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await declineTarget(roundId, { targetId: target.target.id, targetKind: target.target.kind })
+      setSaved(true)
+      onAnswered()
+    } catch (err) {
+      setError(err instanceof CollabRequestError ? err.message : 'That did not save.')
+    } finally {
+      setBusy(false)
+    }
+  }, [roundId, target, onAnswered])
+
+  return (
+    <section data-testid={`packet-target-${target.target.id}`} style={{ marginBottom: '2rem' }}>
+      <h2 style={{ fontSize: '1.05rem', margin: '0 0 0.25rem' }}>{target.label}</h2>
+      {target.description !== null && (
+        <p style={{ margin: '0 0 0.75rem', opacity: 0.8 }}>{target.description}</p>
+      )}
+
+      <BeliefElicitationField
+        label={target.label}
+        phrase={phrase}
+        onPhraseChange={handlePhraseChange}
+        elicitation={elicitation}
+        onAccept={commit}
+        testId={`packet-belief-${target.target.id}`}
+      />
+
+      <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+        <button type="button" onClick={handleDecline} disabled={busy}>
+          I would rather not answer this
+        </button>
+        {saved && (
+          <span data-testid={`packet-saved-${target.target.id}`}>
+            {alreadyAnswered ? 'Answer updated.' : 'Answer recorded.'} You can change it until the
+            round closes.
+          </span>
+        )}
+      </div>
+
+      {error !== null && (
+        <p role="alert" style={{ color: 'crimson' }}>
+          {error}
+        </p>
+      )}
+    </section>
+  )
+}
+
+export default function ParticipantPacketPage(): JSX.Element {
+  const { round_id: roundId } = useParams<{ round_id: string }>()
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+  const [manualToken, setManualToken] = useState('')
+  const [answeredTick, setAnsweredTick] = useState(0)
+
+  const hasToken = getParticipantToken() !== null
+
+  const load = useCallback(async () => {
+    if (roundId === undefined) {
+      setState({ kind: 'error', code: 'no_round', message: 'That link is incomplete.' })
+      return
+    }
+    setState({ kind: 'loading' })
+    try {
+      const packet = await fetchOpenPacket(roundId)
+      setState({ kind: 'packet', packet })
+    } catch (err) {
+      const code = err instanceof CollabRequestError ? err.code : 'collab_request_failed'
+      // A CLOSED round is not an error for a participant — it is the reveal.
+      if (code === 'collab_round_closed') {
+        try {
+          const reveal = await fetchParticipantReveal(roundId)
+          setState({ kind: 'reveal', reveal })
+          return
+        } catch (revealErr) {
+          setState({
+            kind: 'error',
+            code,
+            message:
+              revealErr instanceof CollabRequestError
+                ? revealErr.message
+                : 'Could not load the results.',
+          })
+          return
+        }
+      }
+      setState({
+        kind: 'error',
+        code,
+        message: err instanceof CollabRequestError ? err.message : 'Could not load your panel.',
+      })
+    }
+  }, [roundId])
+
+  useEffect(() => {
+    if (hasToken) void load()
+  }, [hasToken, load, answeredTick])
+
+  // Fallback for a link that lost its query string in transit (chat clients do
+  // this). Typed into memory only — never stored.
+  if (!hasToken) {
+    return (
+      <main style={{ maxWidth: 640, margin: '3rem auto', padding: '0 1rem' }}>
+        <h1>Your panel link needs its access code</h1>
+        <p>
+          The link you opened is missing its access code — some chat apps trim it. Paste the full
+          link you were sent, or the code itself.
+        </p>
+        <input
+          aria-label="Panel access code"
+          data-testid="packet-manual-token"
+          value={manualToken}
+          onChange={(e) => setManualToken(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            const raw = manualToken.trim()
+            const match = /[?&](?:ct|collab_token)=([^&#]+)/.exec(raw)
+            setParticipantToken(match !== null ? decodeURIComponent(match[1]) : raw)
+            setAnsweredTick((t) => t + 1)
+          }}
+        >
+          Continue
+        </button>
+      </main>
+    )
+  }
+
+  if (state.kind === 'loading') {
+    return <main data-testid="packet-loading">Loading your panel…</main>
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <main data-testid="packet-error" style={{ maxWidth: 640, margin: '3rem auto' }}>
+        <h1>We could not open this panel</h1>
+        <p role="alert">{state.message}</p>
+      </main>
+    )
+  }
+
+  if (state.kind === 'reveal') {
+    return <RevealBody reveal={state.reveal} />
+  }
+
+  const { packet } = state
+  return (
+    <main
+      data-testid="participant-packet-page"
+      style={{ maxWidth: 720, margin: '2rem auto', padding: '0 1rem' }}
+    >
+      <h1>You have been asked for your view</h1>
+      <p data-testid="packet-self-name">
+        Answering as <strong>{packet.self.display_name}</strong>
+      </p>
+
+      {/* ⭐ The blindness promise, stated. A person who does not KNOW their
+          answer is private behaves as though it is not — the guarantee only
+          does its work if it is said out loud. Every clause here is true of the
+          response this page received: it contains no sibling data at all. */}
+      <p data-testid="packet-blindness-notice">
+        Your answers are private until the round closes. You cannot see anyone else&rsquo;s answer,
+        how many people have replied, or the model&rsquo;s own number — and they cannot see yours.
+        That is deliberate: seeing them first would change what you write.
+      </p>
+
+      {packet.context_note !== null && (
+        <blockquote data-testid="packet-context-note">{packet.context_note}</blockquote>
+      )}
+
+      {packet.targets.map((t) => (
+        <TargetCard
+          key={t.target.id}
+          target={t}
+          roundId={packet.round_id}
+          alreadyAnswered={packet.self.completed_target_ids.includes(t.target.id)}
+          onAnswered={() => setAnsweredTick((n) => n + 1)}
+        />
+      ))}
+
+      <p style={{ opacity: 0.75 }}>
+        When everyone has answered, whoever invited you will close the round and you will both see
+        every answer side by side.
+      </p>
+    </main>
+  )
+}
+
+/**
+ * The reveal: every position, attributed, side by side.
+ *
+ * ⚠ NOTHING HERE AVERAGES, RANKS OR HIDES. There is no mean, no "recommended",
+ * no winner and no consensus line — and a lone dissenter renders exactly like
+ * anyone else. Disagreement is the signal this method exists to surface;
+ * averaging it away would destroy the only thing it produces.
+ */
+export function RevealBody({ reveal }: { reveal: RevealView }): JSX.Element {
+  const rows = useMemo(() => reveal.per_target, [reveal])
+  return (
+    <main
+      data-testid="collab-reveal"
+      style={{ maxWidth: 820, margin: '2rem auto', padding: '0 1rem' }}
+    >
+      <h1>Everyone&rsquo;s answers</h1>
+      <p>
+        These are the answers as they were given, each in the words the person used. They are shown
+        side by side and are not combined into a single number.
+      </p>
+
+      {rows.map((row) => (
+        <section key={row.target.id} data-testid={`reveal-target-${row.target.id}`}>
+          <h2>{row.target.id}</h2>
+          {row.model_value_at_version !== null && (
+            <p style={{ opacity: 0.75 }}>
+              The model held {row.model_value_at_version} for this when the round opened.
+            </p>
+          )}
+          <ul>
+            {row.responses.map((r) => (
+              <li key={r.participant_id} data-testid={`reveal-response-${r.participant_id}`}>
+                {/* ⭐ ATTRIBUTION: the person, then their number, then THEIR
+                    OWN WORDS. This line is the whole proof — a position that
+                    belongs to a named human. */}
+                <strong data-testid={`reveal-author-${r.participant_id}`}>{r.display_label}</strong>
+                {r.kind === 'declined' ? (
+                  <span> chose not to answer this one.</span>
+                ) : (
+                  <>
+                    <span data-testid={`reveal-value-${r.participant_id}`}> {r.value}</span>
+                    {r.expression_raw !== null && r.expression_raw !== '' && (
+                      <em data-testid={`reveal-words-${r.participant_id}`}>
+                        {' '}
+                        &mdash; &ldquo;{r.expression_raw}&rdquo;
+                      </em>
+                    )}
+                    {r.kind === 'belief_revised' && <span> (revised)</span>}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+          {row.responses.length === 1 && (
+            <p data-testid={`reveal-single-${row.target.id}`} style={{ opacity: 0.75 }}>
+              Only one person answered this. That is still their view, shown as given.
+            </p>
+          )}
+        </section>
+      ))}
+    </main>
+  )
+}

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -329,7 +329,11 @@ export function RevealBody({ reveal }: { reveal: RevealView }): JSX.Element {
 
       {rows.map((row) => (
         <section key={row.target.id} data-testid={`reveal-target-${row.target.id}`}>
-          <h2>{row.target.id}</h2>
+          {/* The owner's own words for this target. A heading that read
+              `factor-churn-risk` would obscure exactly what this view exists to
+              make obvious: WHERE these two people disagree. Falls back to the
+              id only if a round somehow carries no label. */}
+          <h2>{row.label !== '' ? row.label : row.target.id}</h2>
           {row.model_value_at_version !== null && (
             <p style={{ opacity: 0.75 }}>
               The model held {row.model_value_at_version} for this when the round opened.

--- a/src/poc/AppPoC.tsx
+++ b/src/poc/AppPoC.tsx
@@ -49,6 +49,8 @@ const ScenarioListPage = lazy(() => import('../pages/ScenarioListPage'))
 // Internal hero fixture gallery — flag-gated (staging-on/prod-off), unlinked.
 const HeroGallery = lazy(() => import('../routes/HeroGallery'))
 const SharedBriefPage = lazy(() => import('../pages/SharedBriefPage'))
+const ParticipantPacketPage = lazy(() => import('../pages/ParticipantPacketPage'))
+const PanelSetupPage = lazy(() => import('../pages/PanelSetupPage'))
 const LoginPage = lazy(() => import('../components/auth/LoginPage'))
 const AuthCallback = lazy(() => import('../components/auth/AuthCallback'))
 const AuthGuard = lazy(() => import('../components/auth/AuthGuard'))
@@ -905,12 +907,23 @@ export default function AppPoC() {
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/auth/callback" element={<AuthCallback />} />
                 <Route path="/brief/:slug" element={<SharedBriefPage />} />
+                {/* COLLAB — the participant's panel page. OUTSIDE AuthGuard,
+                    DELIBERATELY: a participant holds no Supabase session, and
+                    the guard would bounce every one of them to /login while
+                    every test stayed green. Same reason /brief/:slug sits here.
+                    `collabParticipantRouteIsPublic.spec.tsx` asserts the mount
+                    PATH itself, so moving it inside the guard fails loud. */}
+                <Route path="/panel/:round_id" element={<ParticipantPacketPage />} />
 
                 {/* Auth-guarded routes */}
                 <Route element={<AuthGuard />}>
                   <Route path="/" element={<ScenarioListPage />} />
                   <Route path="/scenarios" element={<ScenarioListPage />} />
                   <Route path="/scenario/:id" element={<CanvasMVP />} />
+                  {/* COLLAB — the owner's side. INSIDE AuthGuard: minting a
+                      round pins a version of the owner's model and names real
+                      people, so it requires a verified session. */}
+                  <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
                   <Route path="/canvas" element={<CanvasMVP />} />
                   <Route path="/profile" element={<ProfileSettingsPage />} />
                   <Route path="/templates" element={<DecisionTemplates />} />

--- a/src/poc/__tests__/collabParticipantRouteIsPublic.spec.tsx
+++ b/src/poc/__tests__/collabParticipantRouteIsPublic.spec.tsx
@@ -1,0 +1,80 @@
+/**
+ * COLLAB — the MOUNT PATH itself, asserted.
+ *
+ * ── WHY THIS TEST EXISTS AND WHY IT READS SOURCE ──────────────────────────
+ * This repo has shipped the same defect twice: a component whose tests were all
+ * green while the deployed app never mounted it. Rendering the participant page
+ * directly would prove the component works and say NOTHING about whether a
+ * participant can reach it — and "a participant cannot reach it" is the entire
+ * failure mode.
+ *
+ * The thing that must hold is a RELATIVE ORDERING in the route tree:
+ * `/panel/:round_id` sits with the public routes, ABOVE the `<Route
+ * element={<AuthGuard />}>` block. A participant holds no Supabase session, so
+ * inside the guard they are redirected to /login — silently, on the deployed
+ * build, with every other test still passing.
+ *
+ * So this binds to the route declaration's POSITION, which is the property, and
+ * carries a positive control proving the anchors it measures actually exist.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const src = readFileSync(resolve(process.cwd(), 'src/poc/AppPoC.tsx'), 'utf8')
+
+describe('participant panel route is mounted OUTSIDE AuthGuard', () => {
+  it('the route exists at all', () => {
+    expect(src).toContain('path="/panel/:round_id"')
+    expect(src).toContain('ParticipantPacketPage')
+  })
+
+  it('POSITIVE CONTROL: the anchors this test measures are present and ordered as expected', () => {
+    // Without this, every index below could be -1 and the ordering assertions
+    // would pass on nonsense.
+    const guardAt = src.indexOf('<Route element={<AuthGuard />}>')
+    const publicBriefAt = src.indexOf('path="/brief/:slug"')
+    const guardedScenarioAt = src.indexOf('path="/scenario/:id"')
+    expect(guardAt).toBeGreaterThan(-1)
+    expect(publicBriefAt).toBeGreaterThan(-1)
+    expect(guardedScenarioAt).toBeGreaterThan(-1)
+    // The known-public route precedes the guard; the known-guarded one follows.
+    expect(publicBriefAt).toBeLessThan(guardAt)
+    expect(guardedScenarioAt).toBeGreaterThan(guardAt)
+  })
+
+  it('/panel/:round_id is declared BEFORE the AuthGuard block — a participant has no session to guard', () => {
+    const panelAt = src.indexOf('path="/panel/:round_id"')
+    const guardAt = src.indexOf('<Route element={<AuthGuard />}>')
+    expect(panelAt).toBeGreaterThan(-1)
+    expect(panelAt).toBeLessThan(guardAt)
+  })
+
+  it("the OWNER's setup route is INSIDE the guard — minting names real people and pins the owner's model", () => {
+    const ownerAt = src.indexOf('path="/scenario/:id/panel"')
+    const guardAt = src.indexOf('<Route element={<AuthGuard />}>')
+    expect(ownerAt).toBeGreaterThan(-1)
+    expect(ownerAt).toBeGreaterThan(guardAt)
+  })
+
+  it('the participant page neither IMPORTS nor CALLS the session-bound gates, which are false for every participant by construction', () => {
+    const page = readFileSync(resolve(process.cwd(), 'src/pages/ParticipantPacketPage.tsx'), 'utf8')
+
+    // ⚠ Bind to IMPORT and CALL shapes, not to the bare substring: the file's
+    // own header explains WHY these gates must not be used, and a substring
+    // check would fire on the explanation. (A loose predicate that another
+    // object satisfies is the trap this whole suite exists to avoid — here the
+    // other object was a comment.)
+    for (const symbol of ['isPersistenceActive', 'getSessionIdentity', 'useAuth']) {
+      const imported = new RegExp(`import\\s*\\{[^}]*\\b${symbol}\\b[^}]*\\}`).test(page)
+      const called = new RegExp(`\\b${symbol}\\s*\\(`).test(page)
+      expect(imported, `${symbol} must not be imported by the participant page`).toBe(false)
+      expect(called, `${symbol} must not be called by the participant page`).toBe(false)
+    }
+
+    // POSITIVE CONTROL: this detector DOES fire on a symbol the page really
+    // imports and calls — so the falses above are findings, not a blind regex.
+    expect(/import\s*\{[^}]*\bfetchOpenPacket\b[^}]*\}/.test(page)).toBe(true)
+    expect(/\bfetchOpenPacket\s*\(/.test(page)).toBe(true)
+  })
+})

--- a/tests/ci-guards/collab-proxy-token-forwarding.spec.ts
+++ b/tests/ci-guards/collab-proxy-token-forwarding.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * CI GUARD — the collab transport, which is the difference between this feature
+ * working and this feature being registered-and-dark.
+ *
+ * Three independent declarations have to agree, and NOTHING derives them from
+ * one another:
+ *   1. `netlify/edge-functions/collab-proxy.ts` — forwards the participant
+ *      token header and rewrites `/bff/collab/*` → `/collab/v1/*`;
+ *   2. `netlify.toml` — binds the function to that path;
+ *   3. `vite.config.ts` — the SAME rewrite, in BOTH dev-proxy blocks.
+ *
+ * That is a hand-maintained mirror by construction, so it gets a guard that
+ * fails loud rather than a comment asking people to remember.
+ *
+ * ⚠ The `vite.config.ts` dev-proxy block is DUPLICATED in that file. Declaring
+ * the route in only one silently diverges dev from preview — a class of defect
+ * that looks like "works on my machine" and costs a day.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+const read = (p: string): string => readFileSync(resolve(root, p), 'utf8')
+
+const TOKEN_HEADER = 'x-collab-participant-token'
+
+describe('collab proxy transport', () => {
+  const proxy = read('netlify/edge-functions/collab-proxy.ts')
+
+  it('forwards the participant token header — without this the whole feature 401s, invisibly', () => {
+    const forwardBlock = /const ALLOWED_FORWARD_HEADERS = \[([\s\S]*?)\]/.exec(proxy)
+    expect(forwardBlock, 'ALLOWED_FORWARD_HEADERS not found').not.toBeNull()
+    // The constant is referenced by name in the array, so assert the binding
+    // resolves rather than that a literal appears somewhere in the file.
+    expect(forwardBlock?.[1]).toContain('COLLAB_TOKEN_HEADER')
+    expect(proxy).toContain(`const COLLAB_TOKEN_HEADER = '${TOKEN_HEADER}'`)
+  })
+
+  it('advertises the same header in Access-Control-Allow-Headers (kept in step so it cannot rot)', () => {
+    const acah = /'Access-Control-Allow-Headers':\s*\n?\s*'([^']+)'/.exec(proxy)
+    expect(acah, 'Access-Control-Allow-Headers not found').not.toBeNull()
+    expect(acah?.[1]).toContain(TOKEN_HEADER)
+  })
+
+  it('rewrites /bff/collab/* to the contract-pinned /collab/v1/* prefix', () => {
+    expect(proxy).toContain("replace(/^\\/bff\\/collab/, '/collab/v1')")
+    expect(proxy).toContain("path: '/bff/collab/*'")
+  })
+
+  it('injects the caller key server-side and never returns it to the client', () => {
+    expect(proxy).toContain("Deno.env.get('ASSIST_API_KEY')")
+    expect(proxy).toContain("headers.set('X-Olumi-Assist-Key', assistKey)")
+  })
+
+  it('never logs the token — the proxy is a place a credential could be echoed and is not', () => {
+    const consoleLines = proxy.split('\n').filter((l) => l.includes('console.'))
+    // POSITIVE CONTROL: there ARE console lines to inspect, so an empty result
+    // below means "none of them carries the token", not "there is nothing here".
+    expect(consoleLines.length).toBeGreaterThan(0)
+    for (const line of consoleLines) {
+      expect(line).not.toContain(TOKEN_HEADER)
+      expect(line.toLowerCase()).not.toContain('token')
+      expect(line).not.toContain('targetUrl')
+    }
+  })
+
+  it('is bound in netlify.toml at the path its own config declares', () => {
+    const toml = read('netlify.toml')
+    expect(toml).toContain('function = "collab-proxy"')
+    expect(toml).toContain('path = "/bff/collab/*"')
+  })
+
+  it('is declared in BOTH vite dev-proxy blocks — one alone diverges dev from preview', () => {
+    const vite = read('vite.config.ts')
+    const declarations = vite.split("'/bff/collab'").length - 1
+    // POSITIVE CONTROL: the sibling seam is duplicated exactly twice, which is
+    // what establishes 2 as the correct expectation rather than a guess.
+    const ceeDeclarations = vite.split("'/bff/cee'").length - 1
+    expect(ceeDeclarations).toBe(2)
+    expect(declarations).toBe(2)
+
+    const rewrites = vite.split("replace(/^\\/bff\\/collab/, '/collab/v1')").length - 1
+    expect(rewrites).toBe(2)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -269,6 +269,22 @@ optimizeDeps: {
           })
         }
       },
+      // COLLAB panels — /bff/collab/* → CEE /collab/v1/*. Mirrors
+      // netlify/edge-functions/collab-proxy.ts so dev, preview and production
+      // agree. Declared in BOTH dev-proxy blocks in this file on purpose: the
+      // block is duplicated, and editing only one diverges dev from preview.
+      '/bff/collab': {
+        target: requireProxyEnv('CEE_SERVICE_URL'),
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/bff\/collab/, '/collab/v1'),
+        configure: (proxy) => {
+          const ceeApiKey = env.ASSIST_API_KEY
+          proxy.on('proxyReq', (proxyReq) => {
+            if (ceeApiKey) proxyReq.setHeader('X-Olumi-Assist-Key', ceeApiKey)
+          })
+        },
+      },
       '/bff/cee': {
         target: requireProxyEnv('CEE_SERVICE_URL'),
         changeOrigin: true,
@@ -410,6 +426,22 @@ optimizeDeps: {
             console.error('[PROXY ERROR] /bff/assist', err.message)
           })
         }
+      },
+      // COLLAB panels — /bff/collab/* → CEE /collab/v1/*. Mirrors
+      // netlify/edge-functions/collab-proxy.ts so dev, preview and production
+      // agree. Declared in BOTH dev-proxy blocks in this file on purpose: the
+      // block is duplicated, and editing only one diverges dev from preview.
+      '/bff/collab': {
+        target: requireProxyEnv('CEE_SERVICE_URL'),
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/bff\/collab/, '/collab/v1'),
+        configure: (proxy) => {
+          const ceeApiKey = env.ASSIST_API_KEY
+          proxy.on('proxyReq', (proxyReq) => {
+            if (ceeApiKey) proxyReq.setHeader('X-Olumi-Assist-Key', ceeApiKey)
+          })
+        },
       },
       '/bff/cee': {
         target: requireProxyEnv('CEE_SERVICE_URL'),


### PR DESCRIPTION
The user-visible half of PR4-a. Two people answer privately, then see every
answer side by side with each person's own words attached.

WHAT LANDS
- netlify/edge-functions/collab-proxy.ts — /bff/collab/* → CEE /collab/v1/*,
  declared in netlify.toml and in BOTH vite.config.ts dev-proxy blocks.
- src/pages/ParticipantPacketPage.tsx — mounted at /panel/:round_id, OUTSIDE
  AuthGuard, and the reveal view.
- src/pages/PanelSetupPage.tsx — /scenario/:id/panel, INSIDE AuthGuard.
- src/collab/{participantToken,collabService}.ts.

THE TWO DEFECTS THIS FIXES, BOTH "REGISTERED AND DARK"
1. No existing browser→CEE seam maps to /collab/v1/*. Manifest swept:
   netlify.toml edge-function/redirect declarations and ui/src/** absolute CEE
   hosts at 538677ff — /bff/cee/* → /assist/v1/*, /bff/orchestrate/* →
   /orchestrate/*, and a direct VITE_V5_ENDPOINT seam pinned to /proxy/v5/turn.
   A fourth seam is strictly better than aliasing collab into /assist/v1/*: no
   second CEE surface, no CEE CORS entry, no CSP change, no Render dependency.
2. x-collab-participant-token appears in no existing proxy's forward allowlist,
   so it was stripped at the edge and every participant request would 401 —
   invisibly, with both repos' suites green. A CI guard binds the forward
   allowlist to the advertised CORS header and asserts BOTH vite blocks, since
   editing one diverges dev from preview.

TOKEN HYGIENE — THE URL FRAGMENT DOES NOT WORK IN THIS APP
This is a HashRouter, so the fragment IS the route, and src/main.tsx captures
location.href into window.__SAFE_DEBUG__.logs at boot:start — persisted to
localStorage under ENABLE_DEBUG_PERSISTENCE — before React mounts. Any
read-once-then-replaceState inside a page component runs far too late.

So the token is stripped in the BOOT PATH ITSELF, as the first statement of
boot(), ahead of that capture. Thereafter it lives in a module-level variable
and nowhere else: never localStorage/sessionStorage, never a cookie, never a
log line, never a query parameter on an outbound request — it travels as a
header. A hard refresh loses it and the participant reopens their link; that is
the correct trade rather than putting a bearer capability on disk.

Every absence assertion in the hygiene spec carries a POSITIVE CONTROL proving
the detector sees a token when one IS present, including a window-walk that
finds a deliberately planted value and then finds nothing.

BLINDNESS, STATED TO THE USER
The packet page says plainly that answers are private, that nobody can see
sibling answers or counts, and why. A guarantee only does its work if the
person knows it holds. The page cannot leak what it is not sent: OpenPacket has
no member for a sibling answer, a model value or a count.

The reveal shows each person, their number, and THEIR OWN WORDS verbatim.
Nothing averages, ranks or hides; a lone dissenter is shown as given.

NOTE FOR REVIEWER SIGN-OFF — TYPECHECK BASELINE
scripts/ci/typecheck-gate.sh --update-baseline was required (the two baseline
files are generated together and refuse hand edits). It banks +2 for
collab-proxy.ts — the same Deno/@netlify/edge-functions pair its four siblings
already carry — AND SIX PRE-EXISTING FIXES IN FILES THIS PR NEVER TOUCHED
(ParetoInsights, StyledEdge, useScienceIcons, BaselineTargetRow x2). Verified
on a pristine 538677ff clone: it passes and already reports "Drift shrank
(2491 → 2485) — tighten it with --update-baseline in this PR", so the shrink is
pre-existing and gate-invited, not this lane's doing. Flagged rather than
absorbed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)