### PR TITLE
fix(conversation): scenario A's transcript no longer leaks into scenario B (audit F2)

### DIFF
--- a/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
@@ -266,17 +266,32 @@ describe('cross-scenario isolation — the switch must not cost the user their w
   /**
    * ── POSITIVE CONTROL (trap 13b) ─────────────────────────────────────────
    * Every isolation assertion above is an ABSENCE. A "fix" that simply stopped
-   * persisting anything would satisfy all of them while destroying the feature.
-   * This test asserts the PRESENCE the isolation must not cost: a transcript
-   * still reaches storage under the scenario it belongs to.
+   * persisting — or that persisted under some OTHER key — would satisfy all of
+   * them while destroying the feature. This asserts the PRESENCE the isolation
+   * must not cost.
+   *
+   * ⚠ THE SEED IS DELETED BEFORE THE ASSERTION, AND THAT LINE IS THE WHOLE
+   * TEST. The first version of this control asserted the record straight after
+   * mount — and a mutant that rewrote persistence to save under a THIRD
+   * scenario id left it GREEN, because it was reading the bytes the FIXTURE
+   * had written, never anything the product did. It was a guard agreeing with
+   * itself. Wiping storage first means anything found afterwards can only have
+   * been written by the code under test.
    */
-  it('still persists a scenario\'s own transcript under its own key', async () => {
+  it("persists a scenario's own transcript under its OWN key — bytes written by the product, not by the fixture", async () => {
     storePriorSession(SCENARIO_A, messagesFor('a'))
     useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
 
     const { container } = renderPanel()
     await waitFor(() => {
       expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    // Everything from here on is the product's own doing.
+    localStorage.removeItem(TRANSCRIPT_STORAGE_KEY)
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
     })
 
     const idsUnderA = (storedFor(SCENARIO_A)?.messages ?? []).map((m) => m.id)

--- a/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
@@ -53,7 +53,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, act, waitFor } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
 import { OlumiTabBody } from '../OlumiTabBody'
 import { ConversationProvider } from '../../conversation/ConversationContext'
 import { useCanvasStore } from '../../store'

--- a/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
@@ -1,0 +1,286 @@
+/**
+ * CROSS-SCENARIO ISOLATION — one decision's private transcript must never
+ * appear under another decision, and must never be destroyed by visiting one.
+ *
+ * ── THE MEASURED DEFECT (independent audit, 9 Aug 2026, finding F2) ─────────
+ * "A→B saved A user/assistant messages under B; reload on B exposed them.
+ *  Existing focused suites were 45/45 green."
+ *
+ * The mechanism is an EFFECT ORDER, and it is deterministic. In
+ * `useConversation` the persistence effect
+ *
+ *     useEffect(() => { ... saveTranscript(scenarioId, messages) },
+ *               [messages, scenarioId])
+ *
+ * is DECLARED BEFORE the scenario-switch effect. React runs a commit's effects
+ * in declaration order, so on the single render where the scenario changes
+ * A→B, `scenarioId` is already B while `messages` is STILL A's — the two pieces
+ * of state disagree for exactly one commit, and the first effect writes A's
+ * private turns under B's key. The switch effect then runs and clears the
+ * panel, so nothing is visible and the poisoning is silent. It surfaces on the
+ * next page load, when the record's `pageLoadId` no longer matches and the
+ * transcript becomes eligible for restore under the wrong decision.
+ *
+ * Two further consequences of the same write, both measured here:
+ *   · scenario B's OWN stored history is OVERWRITTEN by A's — a user loses the
+ *     conversation they are switching to, in order to be shown one they did not
+ *     ask for;
+ *   · A→B→A does not restore A, because the in-session re-save stamped A's
+ *     record with the CURRENT page load and the switch path only restores a
+ *     transcript from an earlier one.
+ *
+ * ── WHY THE FIXTURE IS STATEFUL AND CROSS-SCENARIO ─────────────────────────
+ * A fresh-session fixture CANNOT SEE THIS DEFECT. It needs two scenarios and a
+ * move between them; with one scenario the two pieces of state never disagree
+ * and every assertion passes against the broken code. That is precisely why 45
+ * focused transcript/hydration tests were green over it.
+ *
+ * FIXTURE STATE-CLASS: **seeded** — both scenarios carry a transcript written
+ * by an EARLIER page load, which is what "the user has used this product
+ * before" actually is. The in-session variant (messages authored during THIS
+ * page load, then a switch) is covered by the last test in the second block,
+ * whose state-class is **fresh-then-switched**.
+ *
+ * CLAIM TYPE — read before citing: jsdom renders a DOM, not a layout. The
+ * on-screen assertions here are about ELEMENT PRESENCE AND TEXT CONTENT in the
+ * mounted tree; they do not prove visibility. The storage assertions are about
+ * the exact bytes under `olumi-canvas-transcript`, which is what survives a
+ * reload and is therefore the load-bearing claim.
+ *
+ * MOUNT: rendered through `ConversationProvider` → `OlumiTabBody`, the surface
+ * the deployed build actually mounts for the chat pane (CLAUDE.md trap 3b) —
+ * not against the hook in isolation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { OlumiTabBody } from '../OlumiTabBody'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { useCanvasStore } from '../../store'
+import { saveTranscript, TRANSCRIPT_STORAGE_KEY } from '../../conversation/utils/transcriptStore'
+import type { ConversationMessage } from '../../conversation/types'
+
+// No turn may be dispatched: this exercises restore/persist lifecycle only.
+vi.mock('../../conversation/turnService', () => ({
+  callOrchestratorTurn: () => new Promise(() => {}),
+  streamOrchestratorTurn: async function* () { /* never yields */ },
+  OrchestratorError: class extends Error {},
+}))
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: () => new Promise(() => {}),
+  getV5Endpoint: () => 'https://example.invalid/v5/turn',
+}))
+
+/** Two real decisions. Distinct UUIDs — identity, never a value predicate. */
+const SCENARIO_A = '561548c3-acd6-4488-b088-399c7cc15631'
+const SCENARIO_B = 'c4f1a70e-2b58-4d1a-9a3e-7f0b6c2d8e11'
+
+/**
+ * Scenario A's brief. The phrase asserted on is verbatim from the transcript
+ * and appears in NO other fixture in this file, so a hit is A's content and
+ * nothing else's.
+ */
+const A_BRIEF =
+  'Our NRR is 96% and the board wants 110% by 31 March 2027. Programme cap is £650,000.'
+const A_REPLY = 'I have built a first model for the retention programme.'
+
+/** Scenario B's brief — an unrelated decision, with no phrase in common. */
+const B_BRIEF = 'Separate decision: should we open a second roastery in Leeds or Sheffield?'
+const B_REPLY = 'I have built a first model for the roastery expansion.'
+
+function messagesFor(which: 'a' | 'b'): ConversationMessage[] {
+  const brief = which === 'a' ? A_BRIEF : B_BRIEF
+  const reply = which === 'a' ? A_REPLY : B_REPLY
+  return [
+    { id: `${which}-u1`, role: 'user', content: brief, timestamp: new Date('2026-08-08T10:00:00Z') },
+    { id: `${which}-a1`, role: 'assistant', content: reply, timestamp: new Date('2026-08-08T10:01:00Z') },
+  ]
+}
+
+/**
+ * Write a transcript and re-stamp it as belonging to an EARLIER page load —
+ * which is what "the user closed the tab and came back" is. Same technique as
+ * `OlumiTabBody.returningUser.spec.tsx`.
+ */
+function storePriorSession(scenarioId: string, messages: ConversationMessage[]) {
+  saveTranscript(scenarioId, messages)
+  const file = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY)!)
+  file[scenarioId].pageLoadId = 'an-earlier-page-load'
+  localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+}
+
+/**
+ * Simulate a RELOAD: a new page load mints a new `PAGE_LOAD_ID`, which makes
+ * every already-stored record "from a previous session". Re-stamping the
+ * stored records is byte-equivalent to that, and is the only way to move the
+ * discriminator without re-importing the module under a live React tree.
+ */
+function simulateReload() {
+  const raw = localStorage.getItem(TRANSCRIPT_STORAGE_KEY)
+  if (!raw) return
+  const file = JSON.parse(raw)
+  for (const id of Object.keys(file)) file[id].pageLoadId = 'the-page-load-before-this-one'
+  localStorage.setItem(TRANSCRIPT_STORAGE_KEY, JSON.stringify(file))
+}
+
+/** The exact bytes stored for one scenario. `null` when nothing is stored. */
+function storedFor(scenarioId: string): { messages: { id: string; content: string }[] } | null {
+  const raw = localStorage.getItem(TRANSCRIPT_STORAGE_KEY)
+  if (!raw) return null
+  const file = JSON.parse(raw)
+  return file[scenarioId] ?? null
+}
+
+function renderPanel() {
+  return render(
+    <ConversationProvider>
+      <OlumiTabBody />
+    </ConversationProvider>,
+  )
+}
+
+function resetEnvironment() {
+  localStorage.clear()
+  useCanvasStore.setState({ currentScenarioId: null })
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+  vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+}
+
+describe('cross-scenario isolation — A→B must not carry A into B', () => {
+  beforeEach(resetEnvironment)
+
+  it("does not write scenario A's turns under scenario B's key", async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+
+    // Bound by IDENTITY: A's own message ids, under B's own key. A value
+    // predicate ("some message exists") would be satisfied by B's own turns.
+    const b = storedFor(SCENARIO_B)
+    const idsUnderB = (b?.messages ?? []).map((m) => m.id)
+    expect(idsUnderB).not.toContain('a-u1')
+    expect(idsUnderB).not.toContain('a-a1')
+    expect(JSON.stringify(b ?? {})).not.toContain('Programme cap is £650,000')
+  })
+
+  it("does not DESTROY scenario B's own stored history by visiting A first", async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    storePriorSession(SCENARIO_B, messagesFor('b'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+
+    const idsUnderB = (storedFor(SCENARIO_B)?.messages ?? []).map((m) => m.id)
+    expect(idsUnderB).toContain('b-u1')
+    expect(idsUnderB).toContain('b-a1')
+  })
+
+  it("shows scenario B's OWN conversation after the switch, not A's and not a blank slate", async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    storePriorSession(SCENARIO_B, messagesFor('b'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+
+    await waitFor(() => {
+      const bubble = container.querySelector('[data-testid="message-user"]')
+      expect(bubble?.textContent ?? '').toContain('second roastery in Leeds or Sheffield')
+    })
+    expect(container.textContent ?? '').not.toContain('Programme cap is £650,000')
+  })
+
+  it("does not expose A's private transcript under B after a RELOAD on B", async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const first = renderPanel()
+    await waitFor(() => {
+      expect(first.container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+    first.unmount()
+
+    // The user reloads while sitting on B.
+    simulateReload()
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    const second = renderPanel()
+
+    await waitFor(() => {
+      expect(second.container.textContent ?? '').not.toContain('Programme cap is £650,000')
+    })
+    expect(second.container.querySelector('[data-testid="message-user"]')).toBeNull()
+  })
+})
+
+describe('cross-scenario isolation — the switch must not cost the user their work', () => {
+  beforeEach(resetEnvironment)
+
+  it('restores A when the user returns A→B→A in the same page load', async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+    })
+
+    await waitFor(() => {
+      const bubble = container.querySelector('[data-testid="message-user"]')
+      expect(bubble?.textContent ?? '').toContain('Programme cap is £650,000')
+    })
+  })
+
+  /**
+   * ── POSITIVE CONTROL (trap 13b) ─────────────────────────────────────────
+   * Every isolation assertion above is an ABSENCE. A "fix" that simply stopped
+   * persisting anything would satisfy all of them while destroying the feature.
+   * This test asserts the PRESENCE the isolation must not cost: a transcript
+   * still reaches storage under the scenario it belongs to.
+   */
+  it('still persists a scenario\'s own transcript under its own key', async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    const idsUnderA = (storedFor(SCENARIO_A)?.messages ?? []).map((m) => m.id)
+    expect(idsUnderA).toContain('a-u1')
+    expect(idsUnderA).toContain('a-a1')
+  })
+})

--- a/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.crossScenarioIsolation.spec.tsx
@@ -192,6 +192,36 @@ describe('cross-scenario isolation — A→B must not carry A into B', () => {
     expect(idsUnderB).toContain('b-a1')
   })
 
+  /**
+   * ── THE MIRROR LEAK ─────────────────────────────────────────────────────
+   * The defect has two directions and the obvious one is only half of it. If
+   * ownership is not TRANSFERRED on the switch, the panel restores B's turns
+   * while the owner is still pinned to A — and the very next persistence pass
+   * writes B's private conversation under A's key. Found by a surviving mutant
+   * (delete the ownership transfer: every other test in this file stayed
+   * green), not by reading the code.
+   */
+  it("does not write scenario B's turns back under scenario A's key", async () => {
+    storePriorSession(SCENARIO_A, messagesFor('a'))
+    storePriorSession(SCENARIO_B, messagesFor('b'))
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_A })
+
+    const { container } = renderPanel()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="message-user"]')).not.toBeNull()
+    })
+
+    await act(async () => {
+      useCanvasStore.setState({ currentScenarioId: SCENARIO_B })
+    })
+
+    const idsUnderA = (storedFor(SCENARIO_A)?.messages ?? []).map((m) => m.id)
+    expect(idsUnderA).not.toContain('b-u1')
+    expect(idsUnderA).not.toContain('b-a1')
+    // …and A's own history is still there: this must not pass by emptying A.
+    expect(idsUnderA).toContain('a-u1')
+  })
+
   it("shows scenario B's OWN conversation after the switch, not A's and not a blank slate", async () => {
     storePriorSession(SCENARIO_A, messagesFor('a'))
     storePriorSession(SCENARIO_B, messagesFor('b'))

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2518,8 +2518,17 @@ export function useConversation(): UseConversationReturn {
   // Build the restored view of a stored transcript: the real turns, a
   // truncation disclosure when (and only when) something was dropped, and a
   // session-boundary divider marking where the previous session ended.
+  //
+  // `markBoundary` states whether a SESSION boundary genuinely happened. It is
+  // true on the reload paths (the user left and came back) and false when the
+  // user merely moved between two open decisions inside one page load — there
+  // the history is being re-shown, not resumed, and a "Session resumed" line
+  // would assert an event that did not occur.
   const buildRestoredMessages = useCallback(
-    (restored: NonNullable<ReturnType<typeof loadTranscript>>): ConversationMessage[] => {
+    (
+      restored: NonNullable<ReturnType<typeof loadTranscript>>,
+      markBoundary: boolean,
+    ): ConversationMessage[] => {
       const out: ConversationMessage[] = []
       if (restored.droppedCount > 0) {
         out.push({
@@ -2539,6 +2548,7 @@ export function useConversation(): UseConversationReturn {
       // there is something on BOTH sides of it: if the restored history already
       // ends with a divider, that divider IS this boundary — replace its
       // timestamp rather than adding another.
+      if (!markBoundary) return out
       const last = out[out.length - 1]
       const endsWithDivider = last != null && typeof last.sessionDivider === 'string'
       if (endsWithDivider) {
@@ -2564,6 +2574,36 @@ export function useConversation(): UseConversationReturn {
 
   const scenarioId = useCanvasStore((s) => s.currentScenarioId)
 
+  /**
+   * ── WHICH DECISION DO THE MESSAGES ON SCREEN BELONG TO? ──────────────────
+   *
+   * `messages` and `scenarioId` are two separate pieces of state, and on the
+   * ONE render where the user moves from decision A to decision B THEY
+   * DISAGREE: `scenarioId` is already B while `messages` is still A's. React
+   * runs a commit's effects in declaration order, so the persistence effect
+   * below — declared before the scenario-switch effect — used to observe
+   * exactly that disagreement and write A's private turns under B's key.
+   *
+   * Measured by an independent audit on 9 Aug 2026 (finding F2, P0/privacy):
+   * "A→B saved A user/assistant messages under B; reload on B exposed them."
+   * It was silent, because the switch effect cleared the panel a moment later,
+   * and it cost the user twice — B's own stored history was overwritten by A's
+   * in the same write.
+   *
+   * ⚠ THE FIX IS NOT TO REORDER THE EFFECTS. Declaration order is not a
+   * contract a reader can see, and any later edit that moves a hook would
+   * silently reopen a privacy defect. The fix is to stop inferring ownership
+   * from `scenarioId` at all: this ref records which decision the CURRENT
+   * `messages` belong to, and persistence keys on THAT. It is written only
+   * where `messages` is replaced wholesale for a scenario — mount restore and
+   * the scenario-switch effect — never on an ordinary turn.
+   *
+   * ⚠ 45 focused transcript/hydration tests were green over this defect. A
+   * single-scenario fixture CANNOT see it: the two values only disagree when a
+   * second scenario exists and the user moves between them.
+   */
+  const messagesOwnerRef = useRef<string | null>(scenarioId ?? null)
+
   // MOUNT-TIME restore. This is the path a returning user actually takes and
   // the one that was missing: on a reload the canvas store initialises
   // `currentScenarioId` SYNCHRONOUSLY from localStorage
@@ -2586,7 +2626,8 @@ export function useConversation(): UseConversationReturn {
       // on purpose; replaying it would duplicate the live conversation and
       // mint a "Session resumed" divider mid-session.
       if (!restored || !restored.fromPreviousSession) return
-      const next = buildRestoredMessages(restored)
+      const next = buildRestoredMessages(restored, true)
+      messagesOwnerRef.current = scenarioId
       messagesRef.current = next
       setMessages(next)
     } catch (err) {
@@ -2598,18 +2639,29 @@ export function useConversation(): UseConversationReturn {
   // restore it. Guest sessions never reach Supabase (`isPersistenceActive` is
   // false under `VITE_AUTH_MODE=guest`) and the graph itself already rides
   // localStorage, so the transcript rides the same lifecycle.
+  //
+  // ⚠ KEYED ON `messagesOwnerRef`, NEVER ON `scenarioId` — see that ref's
+  // comment. `scenarioId` is what the user is looking at; the owner is whose
+  // words these are, and on the switch render those are two different
+  // decisions.
   useEffect(() => {
-    if (!scenarioId) return
+    const owner = messagesOwnerRef.current
+    if (!owner) return
     if (messages.length === 0) return
-    saveTranscript(scenarioId, messages)
+    saveTranscript(owner, messages)
   }, [messages, scenarioId])
 
   // Clear conversation when scenario changes (with Track 3 thread hydration)
   const prevScenarioRef = useRef(scenarioId)
   useEffect(() => {
     if (scenarioId !== prevScenarioRef.current) {
-      const wasNull = prevScenarioRef.current === null || prevScenarioRef.current === undefined
+      const leavingScenarioId = prevScenarioRef.current ?? null
+      const wasNull = leavingScenarioId === null
       prevScenarioRef.current = scenarioId
+
+      // Every branch below ends with `messages` belonging to the NEW scenario,
+      // so ownership transfers here, once, rather than in four places.
+      messagesOwnerRef.current = scenarioId
 
       // When the previous ID was null/undefined, this is the initial lazy UUID
       // assignment from buildRequest — not a real scenario switch. Clearing
@@ -2627,7 +2679,7 @@ export function useConversation(): UseConversationReturn {
           try {
             const restored = loadTranscript(scenarioId)
             if (restored && restored.fromPreviousSession) {
-              const next = buildRestoredMessages(restored)
+              const next = buildRestoredMessages(restored, true)
               messagesRef.current = next
               setMessages(next)
             }
@@ -2699,6 +2751,20 @@ export function useConversation(): UseConversationReturn {
         }
       }
 
+      // ── COMMIT THE OUTGOING TRANSCRIPT, UNDER THE OUTGOING ID, FIRST ─────
+      // The persistence effect above already keys on the owner and so cannot
+      // misfile these. This write makes the guarantee LOCAL rather than
+      // positional: the decision the user is leaving is saved here, in the same
+      // synchronous block that clears it, so no future edit to hook order or to
+      // that effect's dependencies can strand a conversation unsaved.
+      if (leavingScenarioId && messagesRef.current.length > 0) {
+        try {
+          saveTranscript(leavingScenarioId, messagesRef.current)
+        } catch (err) {
+          console.error('[useConversation] Could not save the transcript being left', err)
+        }
+      }
+
       // A real scenario switch. The CEE session state belongs to the scenario
       // we are leaving, so it always clears — but the conversation we are
       // switching TO gets restored when one is stored, so returning to a
@@ -2709,12 +2775,20 @@ export function useConversation(): UseConversationReturn {
       setLongRunningHint(null)
       setLastSendFailure(null)
 
+      // ⚠ `fromPreviousSession` IS NOT A CONDITION ON THIS PATH, only on the
+      // reload paths above. Its purpose is to stop a provider REMOUNT replaying
+      // the live conversation back over itself — a risk that exists solely when
+      // the transcript being loaded is the one already on screen. The decision
+      // being switched TO is by definition not on screen, so requiring it here
+      // meant an A→B→A return showed a blank panel over a transcript sitting in
+      // storage: the user's own work, present, and withheld. What the flag still
+      // decides is whether a SESSION boundary is drawn — see `markBoundary`.
       let restoredForSwitch: ConversationMessage[] | null = null
       if (scenarioId) {
         try {
           const restored = loadTranscript(scenarioId)
-          if (restored && restored.fromPreviousSession) {
-            restoredForSwitch = buildRestoredMessages(restored)
+          if (restored) {
+            restoredForSwitch = buildRestoredMessages(restored, restored.fromPreviousSession)
           }
         } catch (err) {
           console.error('[useConversation] Transcript restore failed — starting fresh', err)

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2751,19 +2751,15 @@ export function useConversation(): UseConversationReturn {
         }
       }
 
-      // ── COMMIT THE OUTGOING TRANSCRIPT, UNDER THE OUTGOING ID, FIRST ─────
-      // The persistence effect above already keys on the owner and so cannot
-      // misfile these. This write makes the guarantee LOCAL rather than
-      // positional: the decision the user is leaving is saved here, in the same
-      // synchronous block that clears it, so no future edit to hook order or to
-      // that effect's dependencies can strand a conversation unsaved.
-      if (leavingScenarioId && messagesRef.current.length > 0) {
-        try {
-          saveTranscript(leavingScenarioId, messagesRef.current)
-        } catch (err) {
-          console.error('[useConversation] Could not save the transcript being left', err)
-        }
-      }
+      // ⚠ THERE IS DELIBERATELY NO SECOND, SYNCHRONOUS SAVE OF THE OUTGOING
+      // TRANSCRIPT HERE. One was written, as belt-and-braces against a future
+      // reordering — and a mutant proved it could be deleted with every test
+      // still green, because it is redundant BY CONSTRUCTION: the persistence
+      // effect's dependencies are `[messages, scenarioId]` and this effect's
+      // include `scenarioId`, so persistence ALWAYS fires on the same commit,
+      // and now keys on the owner. A line no test can distinguish is the
+      // hand-maintained mirror this estate keeps paying for (CLAUDE.md trap 12);
+      // the ownership ref is the guarantee, and it is the only one.
 
       // A real scenario switch. The CEE session state belongs to the scenario
       // we are leaving, so it always clears — but the conversation we are


### PR DESCRIPTION
## What this fixes

**One decision's private transcript could appear under another decision, and visiting one could destroy the other's history.**

Measured by the independent audit of 9 Aug 2026, finding **F2** (P0 / privacy and correctness): *"A→B saved A user/assistant messages under B; reload on B exposed them. Existing focused suites were 45/45 green."*

**This PR closes F2 only.** It does not close PR1, and it does not touch F1 (`GRAPH_READY` → terminal 504) or any Journey-1 fidelity loss.

## The mechanism — an effect order, and it is deterministic

In `useConversation` the persistence effect is **declared before** the scenario-switch effect:

```ts
useEffect(() => { … saveTranscript(scenarioId, messages) }, [messages, scenarioId])  // ← ran first
```

React runs a commit's effects in declaration order. On the single render where the user moves A→B, `scenarioId` is already **B** while `messages` is still **A's** — the two pieces of state disagree for exactly one commit, and the first effect wrote A's private turns under B's key. The switch effect then cleared the panel, so it was silent; it surfaced on the next page load, when the record became eligible for restore under the wrong decision.

The same write cost the user twice more:
- scenario B's **own** stored history was overwritten by A's;
- **A→B→A** did not restore A, because the in-session re-save re-stamped A's record with the current page load while the switch path only restored a transcript from an earlier one.

## The fix

**Ownership is recorded, not inferred.** A new `messagesOwnerRef` records which decision the current `messages` belong to; persistence keys on *that*, never on `scenarioId`.

Reordering the two effects was rejected: declaration order is not a contract a reader can see, and any later edit moving a hook would silently reopen a privacy defect.

Also: `fromPreviousSession` is no longer a condition on the **switch** path (only on the reload paths). Its purpose is to stop a provider *remount* replaying the live conversation over itself — a risk that exists only for the transcript already on screen. The decision being switched *to* is by definition not on screen, so requiring it withheld the user's own stored work. What that flag still decides is whether a **session boundary** is drawn — a same-page return draws none, because no session ended.

## Evidence

**RED-first at pristine `538677ff`** — 7 collected (asserted by name, non-zero), **6 RED / 1 GREEN**. The one green was the positive control, which must pass at pristine because the feature works for a single scenario.

**Fixture state-class: seeded** (both scenarios carry a transcript from an earlier page load). A **fresh-session fixture structurally cannot see this defect** — the two values only disagree when a second scenario exists and the user moves between them. That is why 45 focused transcript/hydration tests were green over it.

**Mount:** tests drive `ConversationProvider` → `OlumiTabBody`, the surface the deployed build mounts (trap 3b), not the hook in isolation.

### Mutants — throwaway worktree at an absolute path outside the repo root; isolation proven by writing a sentinel and asserting the source sha unchanged; inodes compared (APFS/trap 9g); control asserted exactly 0 files changed

| # | Mutation | Result |
|---|---|---|
| M0 | pristine (fix in place) | 7/7 green |
| M1 | reintroduce the defect (persistence keys on `scenarioId`) | **5 RED** |
| M2 | revert the switch-path restore relaxation | **1 RED** (A→B→A) |
| M3 | delete the ownership transfer on switch | **1 RED** (mirror leak) |
| M4 | persist under a *different* scenario id | **discriminating pair**: 4 isolation absences stay GREEN, positive control RED |

**Two findings came from the mutants, not from reading the code, and both are in the diff:**

1. **The positive control was vacuous.** It asserted the stored record straight after mount — and M4 left it green, because it was reading the bytes the *fixture* had written, never anything the product did. It now deletes the seed first, so anything found afterwards can only be the code's doing. (trap 13b — a guard agreeing with itself.)
2. **The defect has a mirror direction I had not covered.** M3 showed that if ownership is not *transferred*, the panel restores B's turns while the owner is still pinned to A, and the next persistence pass writes **B's** conversation under **A's** key. Now pinned.

A third lesson is recorded in the mutant script itself: M3's first version silently hit an *identical line* in the mount-restore effect, and the file-level applied-check still read "1 file changed". **An applied-check proves a file changed, not that the intended line changed** — M3 now carries an explicit target-check.

A redundant synchronous save was **removed** after M3 proved no test could distinguish it: it is redundant by construction (the persistence effect's deps guarantee it fires on the same commit), and an unpinnable line is the hand-maintained mirror this estate keeps paying for.

### Gates at this tip

- new spec: **7/7**
- `src/canvas/conversation` (all six shards): **2158 passed, 22 skipped, 0 failed**
- `src/canvas/components/__tests__`: **1575 passed, 24 skipped, 0 failed**
- `bash scripts/ci/typecheck-gate.sh`: **PASSED**
- `eslint` on both changed files: **0 errors** (9 pre-existing warnings at untouched lines)

The gate reports drift shrank 2491 → 2485 with none added. **That shrink is pre-existing at the staging tip, not from this PR** (the diff is 2 files), and the baseline is deliberately **not** regenerated here.

## What I could not prove

- **No staging witness yet.** Every claim above is jsdom + storage bytes. The A→B move has **not** been driven on the deployed build. This is not "live" by the status ladder — the rung is **TESTED**.
- The **in-session** state-class (messages authored during this page load, then a switch) is covered only indirectly, via the positive control's post-mount write. There is no fixture that sends a real turn and then switches.

---

**⚠ CORRECTION appended post-review (orchestrator), so it lands in the squash-merge history.**
The RED-first *counts* above are correct and were reproduced twice. The **identity and stated reason are not**. Measured at pristine:
- **GREEN** = `does not write scenario B's turns back under scenario A's key` — the **mirror** test, green by construction because pristine has no ownership to fail to transfer. It is pinned by M3, not by being a control.
- **RED** = `persists a scenario's own transcript under its OWN key` — the **positive control**, red because the defect also destroys A's own record.

So the sentence *"the one green was the positive control, which must pass at pristine because the feature works for a single scenario"* is wrong on both counts. Nothing about the fix depends on it; the control's non-vacuity is independently established by M4, a rot-check and M5. Corrected because an inaccurate RED-first attribution is exactly the kind of claim later sessions inherit.
