### PR TITLE
fix(collab): the owner's panel page can obtain an access token (PR4 blocker)

### DIFF
--- a/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
@@ -30,8 +30,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 
 vi.mock('../../lib/supabase', async (importOriginal) => {
   // Spread the real module rather than hand-listing its exports: a hand-listed
@@ -75,6 +75,61 @@ const REVEAL_URL = `/bff/collab/rounds/${ROUND_ID}/reveal`
 type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
 
 let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+/* ── source-level helpers ─────────────────────────────────────────────────
+ * These measure CODE, never the prose that explains the defect — this file's
+ * own headers spell `useAuth()` and the cast, and an earlier version of the
+ * detector below duly reported the explanation as a defect. Every test using
+ * them carries a positive control, because a stripper that ate the file and a
+ * walker that resolved nothing both look exactly like a clean result.
+ */
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+}
+
+/** Every TS/TSX file under src/, repo-relative. */
+function srcFiles(): string[] {
+  return readdirSync(resolve(process.cwd(), 'src'), { recursive: true, encoding: 'utf8' })
+    .filter((p) => /\.(ts|tsx)$/.test(p))
+    .map((p) => `src/${p}`)
+}
+
+/** `from '…'`, `import('…')` and `require('…')` alike — a guard that matched
+ *  only the static form was proven evadable by both of the other two. */
+const MODULE_SPEC =
+  /(?:from\s*['"]([^'"]+)['"])|(?:\bimport\(\s*['"]([^'"]+)['"]\s*\))|(?:\brequire\(\s*['"]([^'"]+)['"]\s*\))/g
+
+function resolveSpec(fromFile: string, spec: string): string | null {
+  let base: string
+  if (spec.startsWith('@/')) base = join('src', spec.slice(2))
+  else if (spec.startsWith('.')) base = join(dirname(fromFile), spec)
+  else return null // a bare package specifier — not part of this repo's graph
+  for (const c of [base, `${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]) {
+    if (existsSync(c) && statSync(c).isFile()) return c
+  }
+  return null
+}
+
+/** Transitive closure over relative imports. Catches the re-export barrel that
+ *  a single-file text match cannot see. NOT a statement about any bundle. */
+function reachableFrom(entry: string): Set<string> {
+  const seen = new Set<string>()
+  const queue: string[] = [entry]
+  while (queue.length > 0) {
+    const file = queue.shift() as string
+    if (seen.has(file)) continue
+    seen.add(file)
+    const code = stripComments(readFileSync(resolve(process.cwd(), file), 'utf8'))
+    for (const m of code.matchAll(MODULE_SPEC)) {
+      const spec = m[1] ?? m[2] ?? m[3]
+      if (spec === undefined) continue
+      const next = resolveSpec(file, spec)
+      if (next !== null && !seen.has(next)) queue.push(next)
+    }
+  }
+  return seen
+}
 
 function jsonResponse(body: unknown, status = 200): StubResponse {
   return { ok: status >= 200 && status < 300, status, json: async () => body }
@@ -265,7 +320,7 @@ describe('the surface these tests bind to is the one the deployed app mounts', (
     // of one. (This spec caught itself doing exactly that.) Strip comments
     // first — the page has no string literal containing `//`, which is the one
     // input this deliberately simple stripper would mangle.
-    const code = pageSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+    const code = stripComments(pageSrc)
 
     // POSITIVE CONTROL: the stripper left real code behind. Without this every
     // `toBe(false)` below could be passing on an empty string.
@@ -281,14 +336,59 @@ describe('the surface these tests bind to is the one the deployed app mounts', (
     expect(/\brequireOwnerAccessToken\s*\(/.test(code)).toBe(true)
   })
 
-  it('collabService stays free of the Supabase client — the participant page loads it', () => {
-    // The participant route is PUBLIC and holds no Supabase session. Putting
-    // the owner accessor inside collabService would drag the auth client into
-    // every participant's bundle through a shared import; it lives in its own
-    // module for exactly that reason, and this is what keeps it there.
-    const service = readFileSync(resolve(process.cwd(), 'src/collab/collabService.ts'), 'utf8')
-    expect(/from\s*'[^']*lib\/supabase'/.test(service)).toBe(false)
-    // POSITIVE CONTROL: the detector does fire on the import the file really has.
-    expect(/from\s*'\.\/participantToken'/.test(service)).toBe(true)
+  it('NO MODULE REACHABLE FROM collabService imports the Supabase client (relative-import graph, not a bundle claim)', () => {
+    // ⚠ WHAT THIS DOES AND DOES NOT CLAIM. It walks the RELATIVE-IMPORT GRAPH
+    // under src/ from collabService and asserts lib/supabase is not reachable.
+    // It says NOTHING about what any bundle contains — an earlier version of
+    // this test was NAMED as though it did, and an adversarial review proved
+    // the implied property false: the auth client is already in the eagerly
+    // loaded app-shell chunk via AppPoC -> AuthContext -> lib/supabase.
+    //
+    // That earlier version also only matched the literal single-quoted static
+    // form. Re-executed by the reviewer: a static import RED, `await
+    // import('../lib/supabase')` GREEN, a one-line re-export barrel GREEN. A
+    // guard that catches a SPELLING while its name asserts a PROPERTY reads
+    // green forever. This walks the graph instead, so all three forms bite.
+    const reachable = reachableFrom('src/collab/collabService.ts')
+
+    // POSITIVE CONTROL, and the important one: the same walker, from the page
+    // that legitimately DOES reach the client, must find it. Without this the
+    // assertion below could be passing because the walker resolves nothing.
+    const fromPage = reachableFrom('src/pages/PanelSetupPage.tsx')
+    expect(fromPage.has('src/lib/supabase.ts'), 'the walker must find a known-present edge').toBe(
+      true,
+    )
+    expect(reachable.size, 'the walker must have resolved a real graph').toBeGreaterThan(1)
+
+    expect(reachable.has('src/lib/supabase.ts')).toBe(false)
+  })
+})
+
+describe('the owner Bearer has exactly one builder — the ratchets behind that claim', () => {
+  const files = srcFiles()
+
+  it('POSITIVE CONTROL: the scanner sees a real source tree', () => {
+    // Without this, both assertions below could pass on an empty file list.
+    expect(files.length).toBeGreaterThan(1000)
+    expect(files).toContain('src/collab/collabService.ts')
+  })
+
+  it('the collab seam base is referenced from collabService and nowhere else in src/', () => {
+    // This is what makes "no other call site can build an owner header" TRUE
+    // rather than merely stated: a new caller cannot reach /bff/collab without
+    // coming through this file, and inside it the only way to build the header
+    // is ownerAuthorization().
+    const referencing = files.filter(
+      (f) => !/__tests__|\.spec\.|\.test\./.test(f) && readFileSync(f, 'utf8').includes('/bff/collab'),
+    )
+    expect(referencing).toEqual(['src/collab/collabService.ts'])
+  })
+
+  it('collabService constructs exactly one Bearer value', () => {
+    const code = stripComments(
+      readFileSync(resolve(process.cwd(), 'src/collab/collabService.ts'), 'utf8'),
+    )
+    const built = code.match(/`Bearer \$\{/g) ?? []
+    expect(built).toHaveLength(1)
   })
 })

--- a/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
@@ -27,7 +27,7 @@
  * Each request is selected BY ITS OWN URL, never by "some call had the header":
  * the mint assertion cannot be satisfied by the close request and vice versa.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { readFileSync } from 'node:fs'
@@ -69,20 +69,21 @@ const MINT_URL = '/bff/collab/rounds'
 const CLOSE_URL = `/bff/collab/rounds/${ROUND_ID}/close`
 const REVEAL_URL = `/bff/collab/rounds/${ROUND_ID}/reveal`
 
-let fetchMock: ReturnType<typeof vi.fn>
+/** Only the three members the collab seam touches; typed as such, so this stub
+ *  never quietly claims to be a whole `Response` behind a cast — which is the
+ *  very move that produced the defect this file pins. */
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  } as unknown as Response
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
 }
 
 function collabCalls(url: string): Array<[string, RequestInit]> {
   return fetchMock.mock.calls
     .filter((c) => String(c[0]) === url)
-    .map((c) => [String(c[0]), (c[1] ?? {}) as RequestInit])
+    .map((c): [string, RequestInit] => [String(c[0]), c[1] ?? {}])
 }
 
 function authorizationFor(url: string): string | null {
@@ -110,7 +111,7 @@ async function mintARound(): Promise<void> {
 }
 
 beforeEach(() => {
-  fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
     const url = String(input)
     if (url === MINT_URL) {
       return jsonResponse({

--- a/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
@@ -258,13 +258,26 @@ describe('the surface these tests bind to is the one the deployed app mounts', (
   })
 
   it('the page takes its token from the session seam, with no cast over useAuth', () => {
-    // The root cause was a CAST, so bind to the cast's absence and to the
-    // replacement's presence — a page that imported neither would otherwise
-    // satisfy a bare "no useAuth" check while being just as broken.
-    expect(/\buseAuth\s*\(/.test(pageSrc), 'useAuth must not be called here').toBe(false)
-    expect(/\bas\s*\{\s*session\?/.test(pageSrc), 'the session cast must be gone').toBe(false)
-    expect(/import\s*\{[^}]*\brequireOwnerAccessToken\b[^}]*\}/.test(pageSrc)).toBe(true)
-    expect(/\brequireOwnerAccessToken\s*\(/.test(pageSrc)).toBe(true)
+    // ⚠ MEASURE THE CODE, NOT THE PROSE. The file's header explains the defect
+    // and therefore SPELLS `useAuth()` and the cast; a bare substring check
+    // fires on the explanation and reports a defect that is only a description
+    // of one. (This spec caught itself doing exactly that.) Strip comments
+    // first — the page has no string literal containing `//`, which is the one
+    // input this deliberately simple stripper would mangle.
+    const code = pageSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+
+    // POSITIVE CONTROL: the stripper left real code behind. Without this every
+    // `toBe(false)` below could be passing on an empty string.
+    expect(code.length).toBeGreaterThan(500)
+    expect(code).toContain('export default function PanelSetupPage')
+
+    // The root cause was a CAST, so bind to the cast's absence AND to the
+    // replacement's presence — a page that used neither would otherwise satisfy
+    // a bare "no useAuth" check while being just as broken.
+    expect(/\buseAuth\s*\(/.test(code), 'useAuth must not be called here').toBe(false)
+    expect(/\bas\s*\{\s*session\?/.test(code), 'the session cast must be gone').toBe(false)
+    expect(/import\s*\{[^}]*\brequireOwnerAccessToken\b[^}]*\}/.test(code)).toBe(true)
+    expect(/\brequireOwnerAccessToken\s*\(/.test(code)).toBe(true)
   })
 
   it('collabService stays free of the Supabase client — the participant page loads it', () => {

--- a/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
@@ -1,0 +1,280 @@
+/**
+ * COLLAB — the OWNER'S BEARER, asserted ON THE WIRE.
+ *
+ * ── THE DEFECT THIS PINS ──────────────────────────────────────────────────
+ * `PanelSetupPage` read its token as
+ *
+ *     const { session } = useAuth() as { session?: { access_token?: string } | null }
+ *     const accessToken = session?.access_token ?? ''
+ *
+ * `AuthContext` has NO `session` member — `handleAuthStateChange` receives the
+ * session and keeps only `session.user`. So `accessToken` was ALWAYS `''`, and
+ * every owner call shipped `Authorization: "Bearer "`. CEE answers that with
+ * HTTP 401 `sign_in_required`, byte-identical to sending no header at all, so
+ * mint / close / reveal were unreachable for a signed-in owner: the whole
+ * two-person panel journey could not start.
+ *
+ * The `as` cast is WHY TYPESCRIPT NEVER SAW IT. A cast asserts a shape onto a
+ * value that does not have it, and `?? ''` then turned "absent" into a value
+ * the type system is perfectly happy with.
+ *
+ * ── WHY THESE ASSERTIONS LOOK THE WAY THEY DO ─────────────────────────────
+ * Every header assertion names the EXACT token the session seam returned.
+ * `expect(auth).not.toBe('Bearer ')` would pass on a header carrying the WRONG
+ * token, which is the same defect one step along — so the mutant that swaps in
+ * a different non-empty token must RED, and it does.
+ *
+ * Each request is selected BY ITS OWN URL, never by "some call had the header":
+ * the mint assertion cannot be satisfied by the close request and vice versa.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-listing its exports: a hand-listed
+  // mock factory REPLACES the module, so every export added later goes silently
+  // missing. (It also means this spec collects only when the Supabase env vars
+  // are set — a deliberate tripwire, since without them 24 spec files vanish
+  // from the run while the total still prints green.)
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+import { CollabRequestError, closeRound, fetchOwnerReveal, mintRound } from '../collabService'
+
+/**
+ * The path the DEPLOYED app declares for the owner's page. Bound to
+ * `AppPoC.tsx` by the mount-path test below, so a route rename fails loud here
+ * rather than leaving these tests green about a surface nobody can reach.
+ */
+const OWNER_ROUTE_PATH = '/scenario/:id/panel'
+
+/** Distinctive on purpose: an assertion that names it cannot be met by chance. */
+const OWNER_TOKEN = 'owner-access-token-9d4f1c-IDENTITY'
+const OTHER_TOKEN = 'participant-token-DIFFERENT-OBJECT'
+const SCENARIO_ID = 'scn-11111111-2222-3333-4444-555555555555'
+const ROUND_ID = 'rnd-66666666-7777-8888-9999-aaaaaaaaaaaa'
+
+/** The exact sentence a signed-out owner must see. Written here from the
+ *  user's side, deliberately NOT imported from the product — a guard that
+ *  imports its own expectation only proves the code agrees with itself. */
+const SIGN_IN_COPY = 'Sign in again to open or close a round.'
+
+const MINT_URL = '/bff/collab/rounds'
+const CLOSE_URL = `/bff/collab/rounds/${ROUND_ID}/close`
+const REVEAL_URL = `/bff/collab/rounds/${ROUND_ID}/reveal`
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+function collabCalls(url: string): Array<[string, RequestInit]> {
+  return fetchMock.mock.calls
+    .filter((c) => String(c[0]) === url)
+    .map((c) => [String(c[0]), (c[1] ?? {}) as RequestInit])
+}
+
+function authorizationFor(url: string): string | null {
+  const calls = collabCalls(url)
+  expect(calls.length, `exactly one request to ${url} must have been issued`).toBe(1)
+  return new Headers(calls[0][1].headers).get('authorization')
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path={OWNER_ROUTE_PATH} element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+async function mintARound(): Promise<void> {
+  fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+  fireEvent.change(screen.getByTestId('panel-name-a'), { target: { value: 'Ada' } })
+  fireEvent.change(screen.getByTestId('panel-name-b'), { target: { value: 'Grace' } })
+  fireEvent.click(screen.getByTestId('panel-mint'))
+  await waitFor(() => expect(screen.getByTestId('panel-close')).toBeInTheDocument())
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url === MINT_URL) {
+      return jsonResponse({
+        round_id: ROUND_ID,
+        graph_version_ref: 'gv-1',
+        participants: [
+          { participant_id: 'p-a', display_name: 'Ada', token: 'tok-a' },
+          { participant_id: 'p-b', display_name: 'Grace', token: 'tok-b' },
+        ],
+      })
+    }
+    if (url === CLOSE_URL) return jsonResponse({})
+    if (url === REVEAL_URL) {
+      return jsonResponse({
+        round_id: ROUND_ID,
+        status: 'closed',
+        graph_version_ref: 'gv-1',
+        per_target: [],
+      })
+    }
+    return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({
+    userId: 'user-abc',
+    accessToken: OWNER_TOKEN,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("the owner's panel page authenticates — the request carries a real bearer", () => {
+  it('mint sends the access token the session seam returned, not an empty bearer', async () => {
+    renderOwnerPanel()
+    await mintARound()
+
+    // The positive outcome, named: the header carries THIS token. Not
+    // "non-empty", not "defined" — the value a signed-in owner actually has.
+    expect(authorizationFor(MINT_URL)).toBe(`Bearer ${OWNER_TOKEN}`)
+  })
+
+  it('close and reveal both send the same real access token', async () => {
+    renderOwnerPanel()
+    await mintARound()
+
+    fireEvent.click(screen.getByTestId('panel-close'))
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+
+    expect(authorizationFor(CLOSE_URL)).toBe(`Bearer ${OWNER_TOKEN}`)
+    expect(authorizationFor(REVEAL_URL)).toBe(`Bearer ${OWNER_TOKEN}`)
+  })
+
+  it('one getSession round-trip per user action, even though closing issues two requests', async () => {
+    renderOwnerPanel()
+    await mintARound()
+    vi.mocked(getSessionIdentity).mockClear()
+
+    fireEvent.click(screen.getByTestId('panel-close'))
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+
+    // The seam's own contract: "One call per turn; callers must never make a
+    // second getSession() round-trip for the token."
+    expect(collabCalls(CLOSE_URL).length + collabCalls(REVEAL_URL).length).toBe(2)
+    expect(vi.mocked(getSessionIdentity)).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('a signed-out owner is told so, and NO request is issued', () => {
+  it('issues no collab request at all and shows the sign-in sentence', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+    renderOwnerPanel()
+
+    fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(SIGN_IN_COPY)
+
+    // An empty bearer is not merely useless — it is INDISTINGUISHABLE at CEE
+    // from an unauthenticated call, so it must never leave the browser.
+    const collabRequests = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).startsWith('/bff/collab'),
+    )
+    expect(collabRequests).toHaveLength(0)
+  })
+})
+
+describe('the collab seam refuses to build an empty bearer — the choke point', () => {
+  it('mintRound throws sign_in_required and issues no request', async () => {
+    await expect(
+      mintRound('', { scenarioId: SCENARIO_ID, contextNote: null, targets: [], participants: [] }),
+    ).rejects.toMatchObject({ name: 'CollabRequestError', code: 'sign_in_required', status: 401 })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('closeRound throws sign_in_required and issues no request', async () => {
+    await expect(closeRound('', ROUND_ID)).rejects.toBeInstanceOf(CollabRequestError)
+    await expect(closeRound('', ROUND_ID)).rejects.toMatchObject({ code: 'sign_in_required' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetchOwnerReveal throws sign_in_required and issues no request', async () => {
+    await expect(fetchOwnerReveal('', ROUND_ID)).rejects.toMatchObject({
+      code: 'sign_in_required',
+      status: 401,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('DISCRIMINATION: a real token is not refused — the guard rejects emptiness, not owner calls', async () => {
+    await expect(closeRound(OWNER_TOKEN, ROUND_ID)).resolves.toBeUndefined()
+    expect(authorizationFor(CLOSE_URL)).toBe(`Bearer ${OWNER_TOKEN}`)
+  })
+
+  it('DIFFERENT OBJECT: the participant credential is untouched by the owner guard', async () => {
+    // The owner assertions above must be bound to OWNER requests. A participant
+    // token is a different credential on a different route; breaking it must
+    // leave every owner assertion green, and this test is what makes that
+    // pairing meaningful rather than asserted.
+    const { setParticipantToken } = await import('../participantToken')
+    setParticipantToken(OTHER_TOKEN)
+    const { fetchOpenPacket } = await import('../collabService')
+    await fetchOpenPacket(ROUND_ID).catch(() => undefined)
+    const packetCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).startsWith('/bff/collab/packet/'),
+    )
+    expect(packetCalls).toHaveLength(1)
+    expect(new Headers((packetCalls[0][1] ?? {}).headers).get('x-collab-participant-token')).toBe(
+      OTHER_TOKEN,
+    )
+  })
+})
+
+describe('the surface these tests bind to is the one the deployed app mounts', () => {
+  const appSrc = readFileSync(resolve(process.cwd(), 'src/poc/AppPoC.tsx'), 'utf8')
+  const pageSrc = readFileSync(resolve(process.cwd(), 'src/pages/PanelSetupPage.tsx'), 'utf8')
+
+  it('AppPoC declares exactly this path → this element (the constant these tests render)', () => {
+    expect(appSrc).toContain(`path="${OWNER_ROUTE_PATH}" element={<PanelSetupPage />}`)
+    // POSITIVE CONTROL: the detector fires on a route that really is declared,
+    // so the assertion above is a finding rather than a lucky substring.
+    expect(appSrc).toContain('path="/panel/:round_id" element={<ParticipantPacketPage />}')
+  })
+
+  it('the page takes its token from the session seam, with no cast over useAuth', () => {
+    // The root cause was a CAST, so bind to the cast's absence and to the
+    // replacement's presence — a page that imported neither would otherwise
+    // satisfy a bare "no useAuth" check while being just as broken.
+    expect(/\buseAuth\s*\(/.test(pageSrc), 'useAuth must not be called here').toBe(false)
+    expect(/\bas\s*\{\s*session\?/.test(pageSrc), 'the session cast must be gone').toBe(false)
+    expect(/import\s*\{[^}]*\brequireOwnerAccessToken\b[^}]*\}/.test(pageSrc)).toBe(true)
+    expect(/\brequireOwnerAccessToken\s*\(/.test(pageSrc)).toBe(true)
+  })
+
+  it('collabService stays free of the Supabase client — the participant page loads it', () => {
+    // The participant route is PUBLIC and holds no Supabase session. Putting
+    // the owner accessor inside collabService would drag the auth client into
+    // every participant's bundle through a shared import; it lives in its own
+    // module for exactly that reason, and this is what keeps it there.
+    const service = readFileSync(resolve(process.cwd(), 'src/collab/collabService.ts'), 'utf8')
+    expect(/from\s*'[^']*lib\/supabase'/.test(service)).toBe(false)
+    // POSITIVE CONTROL: the detector does fire on the import the file really has.
+    expect(/from\s*'\.\/participantToken'/.test(service)).toBe(true)
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -207,8 +207,16 @@ export function ownerSignInRequired(): CollabRequestError {
  * `?? ''` turned an absent field into a value the type system was happy with,
  * and the failure surfaced three hops away as an ordinary 401.
  *
- * A guard here cannot be routed around by a future call site, because there is
- * no other way to build an owner header.
+ * ⚠ SCOPE OF THAT PROTECTION, STATED HONESTLY. This function is the only
+ * builder of an owner `Bearer` TODAY, and two ratchets in
+ * `__tests__/panelSetupOwnerAuth.spec.tsx` keep it that way at rest: the collab
+ * base `/bff/collab` is referenced from this file and nowhere else in `src/`,
+ * so a new caller cannot reach the seam without coming through here; and this
+ * file constructs exactly one `Bearer` value. Nothing in the LANGUAGE enforces
+ * it — the guarantee is the pair of ratchets, and it is only as good as they
+ * are. An earlier version of this comment claimed the property was structural
+ * ("no other way to build an owner header"); it was not, and nothing enforced
+ * it at all until those ratchets existed.
  */
 function ownerAuthorization(accessToken: string): string {
   if (accessToken.trim() === '') throw ownerSignInRequired()

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -183,8 +183,40 @@ export async function fetchParticipantReveal(roundId: string): Promise<RevealVie
 
 /* ── owner ───────────────────────────────────────────────────────────────── */
 
+/**
+ * The one place an owner-credential refusal is minted, so every path a user can
+ * hit says the same sentence. `PanelSetupPage` renders `.message` verbatim.
+ */
+export function ownerSignInRequired(): CollabRequestError {
+  return new CollabRequestError({
+    code: 'sign_in_required',
+    message: 'Sign in again to open or close a round.',
+    status: 401,
+  })
+}
+
+/**
+ * ⚠ THE CHOKE POINT. Every owner request's Authorization value is built here,
+ * and an empty token STOPS THE REQUEST rather than sending `Bearer `.
+ *
+ * This is not belt-and-braces. `Bearer ` is not a weak credential — at CEE it
+ * is INDISTINGUISHABLE from sending no header at all (both answer 401
+ * `sign_in_required`), so a caller that produces one gets a server error that
+ * reads exactly like "you are signed out" and tells nobody that the browser
+ * never had a token to send. That is precisely how this shipped: the page's
+ * `?? ''` turned an absent field into a value the type system was happy with,
+ * and the failure surfaced three hops away as an ordinary 401.
+ *
+ * A guard here cannot be routed around by a future call site, because there is
+ * no other way to build an owner header.
+ */
+function ownerAuthorization(accessToken: string): string {
+  if (accessToken.trim() === '') throw ownerSignInRequired()
+  return `Bearer ${accessToken}`
+}
+
 function ownerHeaders(accessToken: string): HeadersInit {
-  return { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' }
+  return { Authorization: ownerAuthorization(accessToken), 'Content-Type': 'application/json' }
 }
 
 export interface MintedRound {
@@ -233,7 +265,7 @@ export async function fetchOwnerReveal(
 ): Promise<RevealView> {
   const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/reveal`, {
     method: 'GET',
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: { Authorization: ownerAuthorization(accessToken) },
   })
   if (!res.ok) throw await parseError(res)
   return (await res.json()) as RevealView

--- a/src/collab/ownerAccessToken.ts
+++ b/src/collab/ownerAccessToken.ts
@@ -18,11 +18,23 @@
  * error rather than a silent empty header.
  *
  * ── WHY IT IS NOT IN collabService.ts ─────────────────────────────────────
- * `collabService` is imported by the PUBLIC participant page, which holds no
- * Supabase session by construction. Putting this accessor there would drag the
- * auth client into every participant's bundle through a shared import — a
- * transitive route past the guard that `collabParticipantRouteIsPublic.spec.tsx`
- * checks at the page. It lives here so that import edge never exists.
+ * SEPARATION OF CONCERNS, not bundle weight. `collabService` describes the wire
+ * — URLs, headers, error shapes — and knows nothing about where a credential
+ * comes from; this module knows about the session and nothing about the wire.
+ * Keeping them apart is what lets the participant half of that file be read,
+ * and tested, without a session anywhere in view.
+ *
+ * ⚠ AN EARLIER VERSION OF THIS COMMENT CLAIMED A BUNDLE HARM, AND IT WAS FALSE.
+ * It said putting the accessor in `collabService` would "drag the auth client
+ * into every participant's bundle". The auth client is ALREADY in the eagerly
+ * loaded app-shell chunk: `AppPoC.tsx` statically imports `AuthProvider`, and
+ * `contexts/AuthContext.tsx` statically imports `{ supabase, getProfile }` from
+ * `../lib/supabase`. An adversarial review proved it in a real production
+ * build — the `AppPoC-*.js` chunk contains `GoTrueClient` AND declares
+ * `path="/panel/:round_id"`, with a positive control showing zero occurrences
+ * of that marker in the `ParticipantPacketPage` chunk. The split is good
+ * hygiene; it was never load-bearing for bundle content, and a comment that
+ * invents a harm is the same defect class as a test name that overreaches.
  *
  * ── NO THIRD OUTCOME ──────────────────────────────────────────────────────
  * A non-empty string, or a throw. Deliberately no `''` fallback: at CEE an

--- a/src/collab/ownerAccessToken.ts
+++ b/src/collab/ownerAccessToken.ts
@@ -1,0 +1,41 @@
+/**
+ * COLLAB — the OWNER's bearer, from the one canonical session seam.
+ *
+ * ── WHY THIS MODULE EXISTS RATHER THAN A CONTEXT READ ─────────────────────
+ * `PanelSetupPage` used to take its token from `useAuth()`:
+ *
+ *     const { session } = useAuth() as { session?: { access_token?: string } | null }
+ *     const accessToken = session?.access_token ?? ''
+ *
+ * `AuthContext` has no `session` member — it receives the session and keeps
+ * only `session.user` — so this was ALWAYS `''`. The `as` is why the compiler
+ * said nothing: a cast asserts a shape onto a value that does not have it, and
+ * `?? ''` then turned "absent" into a perfectly well-typed empty string.
+ *
+ * `getSessionIdentity()` is the repo's declared single-`getSession()`-per-turn
+ * identity read, and it is FULLY TYPED — `{ userId: string | null; accessToken:
+ * string | null }`. Reading it needs no cast, and a rename would be a compile
+ * error rather than a silent empty header.
+ *
+ * ── WHY IT IS NOT IN collabService.ts ─────────────────────────────────────
+ * `collabService` is imported by the PUBLIC participant page, which holds no
+ * Supabase session by construction. Putting this accessor there would drag the
+ * auth client into every participant's bundle through a shared import — a
+ * transitive route past the guard that `collabParticipantRouteIsPublic.spec.tsx`
+ * checks at the page. It lives here so that import edge never exists.
+ *
+ * ── NO THIRD OUTCOME ──────────────────────────────────────────────────────
+ * A non-empty string, or a throw. Deliberately no `''` fallback: at CEE an
+ * empty bearer is indistinguishable from an absent one, so a "harmless" default
+ * would restore exactly the defect this replaces, three hops from where a
+ * reader could see it.
+ */
+
+import { getSessionIdentity } from '../lib/supabase'
+import { ownerSignInRequired } from './collabService'
+
+export async function requireOwnerAccessToken(): Promise<string> {
+  const { accessToken } = await getSessionIdentity()
+  if (accessToken === null || accessToken.trim() === '') throw ownerSignInRequired()
+  return accessToken
+}

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -27,7 +27,6 @@
 import { useCallback, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useAuth } from '../contexts/AuthContext'
 import {
   CollabRequestError,
   closeRound,
@@ -37,12 +36,20 @@ import {
   type MintedRound,
   type RevealView,
 } from '../collab/collabService'
+import { requireOwnerAccessToken } from '../collab/ownerAccessToken'
 import { RevealBody } from './ParticipantPacketPage'
 
 export default function PanelSetupPage(): JSX.Element {
   const { id: scenarioId } = useParams<{ id: string }>()
-  const { session } = useAuth() as { session?: { access_token?: string } | null }
-  const accessToken = session?.access_token ?? ''
+
+  // ⚠ The token is read PER ACTION, from `requireOwnerAccessToken()`, and never
+  // held in component state. Two reasons, and the second is the one that bit:
+  //   • a token read at mount is stale by the time a round is closed;
+  //   • this page previously destructured `session` off `useAuth()` behind an
+  //     `as` cast. AuthContext has no such member, so the token was always ''
+  //     and every owner call shipped `Authorization: "Bearer "` — a 401 at CEE,
+  //     indistinguishable from sending no header. There is now no cast here and
+  //     no `?? ''`: an absent session throws, and the owner is told to sign in.
 
   const [targetId, setTargetId] = useState('')
   const [targetLabel, setTargetLabel] = useState('')
@@ -58,6 +65,7 @@ export default function PanelSetupPage(): JSX.Element {
     setBusy(true)
     setError(null)
     try {
+      const accessToken = await requireOwnerAccessToken()
       const result = await mintRound(accessToken, {
         scenarioId: scenarioId ?? '',
         contextNote: contextNote.trim() === '' ? null : contextNote,
@@ -81,13 +89,17 @@ export default function PanelSetupPage(): JSX.Element {
     } finally {
       setBusy(false)
     }
-  }, [accessToken, scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
+  }, [scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
 
   const handleClose = useCallback(async () => {
     if (minted === null) return
     setBusy(true)
     setError(null)
     try {
+      // ONE getSession() round-trip for the whole action, reused across both
+      // requests — the identity seam's stated contract ("one call per turn;
+      // callers must never make a second getSession() round-trip for the token").
+      const accessToken = await requireOwnerAccessToken()
       await closeRound(accessToken, minted.round_id)
       setReveal(await fetchOwnerReveal(accessToken, minted.round_id))
     } catch (err) {
@@ -95,7 +107,7 @@ export default function PanelSetupPage(): JSX.Element {
     } finally {
       setBusy(false)
     }
-  }, [accessToken, minted])
+  }, [minted])
 
   if (reveal !== null) return <RevealBody reveal={reveal} />
 


### PR DESCRIPTION
## The defect

`PanelSetupPage` — the owner's side of the collaboration panel, route `#/scenario/:id/panel` — **could never obtain an access token, so every owner call shipped an empty bearer and 401'd.** Signing in changed nothing. Mint / close / reveal were unreachable, which means the two-person panel journey (PR4) could not start at all.

```ts
// src/pages/PanelSetupPage.tsx:44-45, before
const { session } = useAuth() as { session?: { access_token?: string } | null }
const accessToken = session?.access_token ?? ''
```

`AuthContext` has **no `session` member** — `handleAuthStateChange` receives the session and keeps only `session.user`. So `accessToken` was always `''`.

**Why TypeScript never caught it:** the `as` cast asserts a shape onto a value that does not have it, and `?? ''` then turned "absent" into a perfectly well-typed empty string. That cast is the actual root cause, not the missing field.

Runtime evidence, prior to this branch:

- **Deployed bundle** `staging--olumi.netlify.app/assets/PanelSetupPage-DVPyDrd4.js`: `const{id:u}=a(),{session:p}=n(),h=p?.access_token??""` — `n` is `useAuth`, so `h` is always `""`.
- **Live seam**, from the staging origin: `GET /bff/collab/rounds/<uuid>/reveal` with `Authorization: "Bearer "` returns **HTTP 401 `sign_in_required`** — byte-identical to sending no header at all. That equivalence is what made this invisible: the browser's failure to hold a token surfaced three hops away as an ordinary "you are signed out".

## The fix

Three parts, so this class of error cannot recur at this seam:

1. **`src/collab/ownerAccessToken.ts` (new)** — `requireOwnerAccessToken()` reads the bearer from `getSessionIdentity()`, the repo's declared single-`getSession()`-per-turn identity seam. It is **fully typed** (`{ userId: string | null; accessToken: string | null }`), so the read needs **no cast** and a rename would be a compile error rather than a silent empty header. It returns a non-empty string **or throws** — deliberately no `''` fallback.

   It is a **separate module, not part of `collabService`**, for **separation of concerns**: `collabService` describes the wire and knows nothing about where a credential comes from; this module knows the session and nothing about the wire. *(An earlier revision of this PR justified the split as keeping the auth client out of the participant bundle. **That was false and is retracted — see "Review round 1" below.**)*

2. **`collabService.ownerAuthorization()`** — the single choke point where every owner `Authorization` value is built. An empty token **stops the request** instead of sending `Bearer `. It is the only builder of an owner `Bearer`, and **two ratchets keep it that way at rest** (added in review round 1): `/bff/collab` is referenced from `collabService` and nowhere else in `src/`, and `collabService` constructs exactly one `Bearer` value. Nothing in the language enforces it — the guarantee is those ratchets, and it is only as good as they are. `ownerSignInRequired()` mints the refusal in one place, so every path a user can hit says the same sentence.

3. **`PanelSetupPage`** — no cast, no `?? ''`, no token held in component state. The token is read **per action**; `handleClose` reads once and reuses it across close + reveal, honouring the seam's stated contract ("one call per turn; callers must never make a second `getSession()` round-trip for the token"). A signed-out owner now sees *"Sign in again to open or close a round."* instead of a silent 401.

## RED-first evidence

New spec `src/collab/__tests__/panelSetupOwnerAuth.spec.tsx` — **12 tests collected** (15 after review round 1) (asserted by name, never inferred from the suite total; `passWithNoTests: true` in this repo means a vanished spec reads green). Run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported — the spec mocks `../../lib/supabase` by spreading `importOriginal`, so it fails at collect without them rather than silently shrinking.

At pristine `aa81aa1a`: **8 failed | 4 passed (12)**. Literal messages:

| # | Test | Literal failure |
|---|------|-----------------|
| 1 | mint sends the real access token | `expected 'Bearer' to be 'Bearer owner-access-token-9d4f1c-IDENTITY'` |
| 2 | close and reveal send the real access token | `expected 'Bearer' to be 'Bearer owner-access-token-9d4f1c-IDENTITY'` |
| 3 | one getSession round-trip per action | `expected "spy" to be called 1 times, but got 0 times` |
| 4 | signed-out owner: no request, sign-in sentence | `Unable to find an element by: [data-testid="panel-error"]` |
| 5 | `mintRound('')` refuses | `promise resolved "{ …(3) }" instead of rejecting` |
| 6 | `closeRound('')` refuses | `promise resolved "undefined" instead of rejecting` |
| 7 | `fetchOwnerReveal('')` refuses | `promise resolved "{ …(4) }" instead of rejecting` |
| 8 | no cast over `useAuth` | `useAuth must not be called here: expected true to be false` |

After the fix: **12 passed (12)**.

**The assertions name the exact token**, never `not.toBe('')` — a header carrying the *wrong* token is the same defect one step along, and mutant M2 proves the difference is detected. Each request is selected **by its own URL**, so the mint assertion cannot be satisfied by the close request.

## Mutants

Throwaway worktree at an **absolute path outside the repo root**. Isolation proven **by writing**, not by locating: distinct inodes (`577024157` vs `577028267`) and a sentinel appended to the worktree copy left the source file's SHA-256 unchanged. Applied-check scoped to `src/`; control asserts **exactly zero**; collected-count asserted every run (a count ≠ 12 is a hard error, never a bite).

| Mutant | Expected | Result | Which tests bit |
|---|---|---|---|
| M0 control (no mutation) | GREEN, applied-check 0 | **GREEN** | — |
| M1 revert `PanelSetupPage` to the pristine defect | RED | **RED** | 4 (the defect itself) |
| M2 accessor returns a *different non-empty* token | RED | **RED** | 2 (mint, close/reveal) — kills `not.toBe('')` vacuity |
| M3 accessor returns `''` instead of throwing | RED | **GREEN — survivor, see below** | — |
| M4 `ownerAuthorization` empty-guard removed | RED | **RED** | 3 (the three seam tests) |
| M5 `handleClose` takes a second `getSession` | RED | **RED** | 1 (round-trip contract) |
| M6 **different object** — break the *participant* header only | every owner test GREEN | **all 10 owner tests GREEN**; only the participant test RED | discrimination proven |
| M7 change the sign-in sentence | RED | **RED** | 1 (signed-out journey) |
| M8 `collabService` imports the Supabase client (static) | RED | **RED** | 1 (the import guard) |
| M9 AppPoC renames the owner route | RED | **RED** | 1 (mount-path binding) |
| M10 control again | GREEN, applied-check 0 | **GREEN** | tree came back clean |

**M1 + M6 are the discriminating pair** required for identity binding: break it for all owner calls → RED; break a *different* credential → every owner assertion stays GREEN.

**M3 survived, and the reason is demonstrated rather than asserted.** With only the accessor's throw removed, the choke point in `collabService` still refuses the empty token, so the user-visible property holds — this is the layering working as designed. Removing **both** layers (combined mutant, applied-check read exactly 2 files) turns the run **RED on 4 tests including the signed-out journey test**. So the property is held by the pair, and the pair is pinned.

### Instrument defect found and disclosed

**The first run of this kit was void and is not reported above.** `git checkout <sha> -- <path>` **stages**, and `git checkout -- src/` restores **from the index** — so M1's restore wrote the pristine defective page back and every later mutant measured a tree that still carried the original defect. The applied-check compared worktree-vs-index and was therefore **structurally blind to the pollution it had itself created**, reading a clean `1` each time. The tell was uniformity: mutants that touch neither the page nor the wire (M6, M8, M9) were REDing the owner wire tests. The kit now uses `git diff HEAD` for the applied-check, restores with `git checkout HEAD -- src/` + `git reset`, asserts a clean tree **before and after every mutant**, and re-runs the control at the end. All figures above are from the re-derived run at the final tip `bf65f07e`.

## Gates

- `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`, the named gate at this tip): **PASSED** — coverage 3338/3378 tracked files, ratchet 618 files / 2487 errors, within baseline. It initially caught a `Mock` signature error in the spec; fixed by declaring the real type and narrowing the stub to the three `Response` members the seam touches — **not** by `as unknown as Response`, which is the very move this PR removes.
- `eslint` on all four changed files: clean.
- `src/collab src/poc src/pages`: **28 files / 309 tests passed**.
- `scripts/validate-prepush.sh` (named gate): checks 1–7 **pass**; **check 8 (DS v5 drift) fails and is a standing red**, proven with a control at this tip — a pristine worktree at `aa81aa1a` produces **byte-identical output** (2774 bytes, same four ratchet counts, same two net-new classes). **Not baselined**; nothing here touches design-system tokens.

## Review round 1 — CHANGES REQUIRED, addressed at `bd848d57`

An independent adversarial review passed the auth fix (attacks A, C, D, E could not be refuted; RED-first, the discriminating pair, and M3's non-equivalence all reproduced independently) but **refuted design claim 4** and found the import guard weaker than its name. Both findings were **reproduced here before being fixed**.

**1. The bundle justification was false — retracted.** I claimed the module split kept the Supabase auth client out of the participant bundle. It is already there, by an edge that predates this PR: `AppPoC.tsx:16` statically imports `AuthProvider`; `contexts/AuthContext.tsx:4` statically imports `{ supabase, getProfile }` from `../lib/supabase`. The review proved it in a real production build — the `AppPoC-*.js` chunk (487,215 bytes) contains `GoTrueClient` **and** declares `path="/panel/:round_id"`, with a positive control showing zero occurrences of that marker in the `ParticipantPacketPage` chunk. I verified the two import lines at this tip. **The split stays — it is good hygiene — but the comment now says the true reason (separation of concerns) and records the retraction, because a comment that invents a harm is the same defect class as a test name that overreaches.**

**2. The guard caught a spelling, not a property.** Reproduced in an isolated worktree at the previous head: static import → **RED**; `await import('../lib/supabase')` → **GREEN**; one-line re-export barrel → **GREEN**. Its name asserted a bundle property that was false, so it would have read green forever. Replaced with a transitive walk of the relative-import graph (`from`, `import()`, `require()`, plus the `@/` alias), and renamed to state exactly what it measures — a module-graph property, **explicitly not a bundle claim**.

**3. The "cannot be routed around" claim was unenforced — so it is enforced now.** Rather than soften it, the two ratchets that make it true at rest were added. `Bearer` is constructed in several files repo-wide, so a "sole Bearer builder" ratchet would be false; but `/bff/collab` is referenced in exactly one non-test file, which is the property that actually matters — no new caller can reach the collab seam without coming through `collabService`, and inside it there is exactly one `Bearer` construction.

### Mutants for the review fixes

| Mutant | Before | Expected | Result |
|---|---|---|---|
| MG1 static import of `lib/supabase` | RED | RED | **RED** |
| MG2 `await import('../lib/supabase')` | **GREEN (evasion)** | RED | **RED** |
| MG3 one-line re-export barrel | **GREEN (evasion)** | RED | **RED** |
| MR1 a second file references `/bff/collab` | n/a | RED | **RED** |
| MR2 a second `Bearer` construction | n/a | RED | **RED** (exactly its own ratchet) |
| MI1 **instrument** — blind the walker's resolver | n/a | RED | **RED** (positive control catches it) |
| MI2 **instrument** — empty the file scanner | n/a | RED | **RED** (positive control catches it) |
| Controls before and after | — | GREEN, applied-check 0 | **GREEN** |

MI1 and MI2 exist because a walker that resolves nothing and a scanner that reads no files both look exactly like a clean result. **MR2 needed a second run and the first is disclosed:** my `perl` replacement interpolated `${accessToken}` as an undefined perl variable, so the mutant silently blanked the token too and REDed four tests instead of one. Re-run with the escaping fixed, it REDs exactly its own ratchet — a behaviour-preserving mutant, which is what that ratchet is supposed to catch.

The full original kit was **re-derived at `bd848d57`** and reproduces unchanged (M3 still the demonstrated survivor; M6 discrimination intact). Isolation re-proven by write sentinel on the new worktree. Gates re-run: typecheck gate **PASSED** (618 files / 2487 errors, within baseline), eslint clean, `src/collab src/poc src/pages` **28 files / 312 tests passed**. In CI at `bd848d57`: **13/13 checks green** including the required Staging Gate, and this spec's **15 tests confirmed passing in shard 4/4 by name**.

## What this does NOT fix — deliberately out of scope

**PR4 capability gap, not fixed here:** the mint form sends only `display_name` and never `supabase_user_id`, so the F-6 anti-anchoring rule ("an owner on their own panel must submit or decline before closing") **can never fire through the UI**. It is a real gap in the same capability and it needs its own lane; converting it into this branch's scope is the failure mode this brief explicitly banned.

Also untouched: the participant route's mount path (unchanged — still outside `AuthGuard`), `src/utils/telemetry.ts` (frozen this wave), and the DS v5 ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
