### PR TITLE
PR3: the coaching card communicates importance, evidence and uncertainty

### DIFF
--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -296,6 +296,49 @@ export interface V5CoachingBlock {
    * 0.31.0 deliberately withholds it from ReviewCardBlock/EvidenceBlock.
    */
   action_prompt?: string
+  /**
+   * ── PR3 (living reasoning workspace): the IMPORTANCE / EVIDENCE signals ──
+   *
+   * All five are producer-owned, all OPTIONAL, all fail-closed. They already
+   * existed on the wire (schemas 0.19.0 / 0.20.0 / 0.39.0) and already reach
+   * the guidance store via `deriveGuidance`, which is why the guidance strip,
+   * the inspector and the Strengthen panel can rank and ground a suggestion.
+   * `adaptTypedCoachingBlock` simply never read them, so the CHAT card — the
+   * surface a user actually reads first — was the one consumer that threw the
+   * whole importance channel away. Carrying them here removes a lossy hop; it
+   * does NOT introduce a second source of truth.
+   */
+  /**
+   * The producer's four-value guidance class. The ONLY producer-owned
+   * severity signal on a coaching block (unlike ReviewCardBlock there is no
+   * `severity` field). Code-keyed: the consumer owns the display copy.
+   * ABSENT = the producer classified nothing → render NO badge, and never a
+   * fabricated "normal"/"unknown" tier.
+   */
+  category?: 'must_fix' | 'should_fix' | 'could_fix' | 'technique'
+  /**
+   * COARSE 0–100 urgency for cross-surface budgeting, HIGHER = more urgent.
+   * Band-granular (derived 1:1 from `category` producer-side), so ties are
+   * expected and normal. ⚠ NOT a display order — order by `priority_rank`
+   * ascending, which `composePhase3BridgedBlocks` already does.
+   */
+  priority?: number
+  /**
+   * The producer's STABLE machine-readable detector-class code
+   * (SCREAMING_SNAKE, e.g. `MISSING_BASE_RATE`). Open vocabulary, producer-
+   * owned. Rides as a data-* attribute for downstream readers and is NEVER
+   * rendered as copy — it is an id, not a sentence.
+   */
+  signal_code?: string
+  /**
+   * The producer's SHORT display line stating what TRIGGERED this item
+   * (≤140 on the wire). Producer prose, rendered verbatim — this is the
+   * field that lets a reader tell an evidence-backed signal from a passing
+   * note, and the UI must never compose a substitute for it.
+   */
+  signal?: string
+  /** Absent = this card claims no cited DSK claim. Never "unknown claim". */
+  dsk_claim_provenance?: V5DskClaimProvenance
 }
 
 /**
@@ -348,6 +391,28 @@ export interface V5DskProtocolProvenance {
   protocol_id: string
   protocol_title: string
   evidence_strength: 'strong' | 'medium' | 'weak' | 'mixed'
+}
+
+/**
+ * 0.39.0 `DskClaimProvenanceSchema` — the decision-science CLAIM a coaching
+ * card is grounded in. The CLAIM sibling of `V5DskProtocolProvenance` above.
+ *
+ * ⚠ ATOMIC TRIPLE, NEVER FLAT SIBLINGS — the contract's doctrine of record
+ * (CEE #830): an id must never travel without the title and strength that
+ * make it verifiable against `data/dsk/v1.json`. Three sibling optionals
+ * would let a producer emit a claim id alone — an authority claim with
+ * nothing a consumer can check it against. Do not "flatten it for
+ * consistency": the adapter admits all three members or none.
+ *
+ * ABSENCE SEMANTICS: absent means "not grounded in a cited DSK claim", and
+ * the card renders NO grounding badge. Absence is never a default and never
+ * "unknown claim" — no consumer may infer one.
+ */
+export interface V5DskClaimProvenance {
+  claim_id: string
+  claim_title: string
+  evidence_strength: 'strong' | 'medium' | 'weak' | 'mixed'
+  protocol_id?: string
 }
 
 export interface V5ExerciseBlock {

--- a/src/v5/__tests__/phase3TypedBlocks.coachingImportance.spec.ts
+++ b/src/v5/__tests__/phase3TypedBlocks.coachingImportance.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * PR3 — `adaptTypedCoachingBlock` carries the IMPORTANCE / EVIDENCE channel.
+ *
+ * THE DEFECT THIS PINS. The adapter is an implicit hand-maintained allowlist:
+ * a field reaches the chat card only if some line names it. Five producer
+ * fields that have been on the wire since 0.19.0 / 0.20.0 / 0.39.0 —
+ * `category`, `priority`, `signal_code`, `signal`, `dsk_claim_provenance` —
+ * were never named, so they arrived intact at the adapter (the parser sidecar
+ * preserves the raw object by reference) and were dropped one hop before the
+ * only surface a user reads first. The very same fields already reach the
+ * guidance store through `deriveGuidance`, which is why the strip, the
+ * inspector and the Strengthen panel could rank and ground the item while the
+ * card could not.
+ *
+ * THE CONTRACT SEMANTICS EACH ASSERTION ENCODES (schemas 0.39.0, derived from
+ * the vendored tarball, NOT from this lane's reading of what a field ought to
+ * mean — trap 13c):
+ *   - `category`: the four-value producer class, and the ONLY producer-owned
+ *     severity signal on a coaching block. Drives a visual channel, so it is
+ *     enum-checked and an unrecognised value yields ABSENCE, never a default.
+ *   - `priority`: COARSE 0–100, HIGHER = more urgent. A real number where 0
+ *     is meaningful — so the carry must not use truthiness.
+ *   - `signal_code`: OPEN vocabulary, producer-owned. Never enum-checked,
+ *     because a closed list here would be a mirror of a registry this repo
+ *     does not own.
+ *   - `signal`: producer prose, carried verbatim.
+ *   - `dsk_claim_provenance`: an ATOMIC STRICT TRIPLE. All three members or
+ *     none — an id must never travel without the title and strength that make
+ *     it verifiable against the bundle. `claim_id` is narrowed to the CLAIM
+ *     arms (B | T) so a protocol or trigger id cannot masquerade as a claim.
+ *
+ * THE STANDING RULE ALL OF IT SERVES: a refusal costs the ATTRIBUTION only,
+ * never the card. Losing a badge is a lost affordance; showing a wrong one is
+ * a lie about science.
+ */
+import { describe, it, expect } from 'vitest'
+import { adaptTypedCoachingBlock } from '../phase3TypedBlocks'
+import { CoachingBlockSchema } from '@talchain/schemas/boundary'
+
+/** A minimal payload the adapter already accepted before PR3. */
+const BASE = {
+  type: 'coaching',
+  block_id: '7e0855c7-d79d-5d16-9fee-19e68ece297d',
+  title: 'An assumption to check',
+  body: 'The relationship between leadership capacity and throughput remains stable.',
+  coaching_kind: 'assumption_check',
+  source: 'decision_review',
+  target_refs: [],
+  priority_rank: 120,
+  freshness: 'fresh',
+} as const
+
+const CLAIM = {
+  claim_id: 'DSK-B-003',
+  claim_title: 'Anchoring on an initial estimate narrows later revisions',
+  evidence_strength: 'strong',
+  protocol_id: 'DSK-P-002',
+} as const
+
+describe('adaptTypedCoachingBlock — importance / evidence carry (PR3)', () => {
+  it('carries all five producer signals when the producer sent them', () => {
+    const out = adaptTypedCoachingBlock({
+      ...BASE,
+      category: 'must_fix',
+      priority: 90,
+      signal_code: 'MISSING_BASE_RATE',
+      signal: 'Two options share one base-rate assumption.',
+      dsk_claim_provenance: CLAIM,
+    })
+    expect(out).not.toBeNull()
+    expect(out?.category).toBe('must_fix')
+    expect(out?.priority).toBe(90)
+    expect(out?.signal_code).toBe('MISSING_BASE_RATE')
+    expect(out?.signal).toBe('Two options share one base-rate assumption.')
+    expect(out?.dsk_claim_provenance).toEqual(CLAIM)
+  })
+
+  it('omits every one of them when the producer sent none — and still adapts the card', () => {
+    const out = adaptTypedCoachingBlock(BASE)
+    // The POSITIVE outcome first, so a null return cannot pass this test.
+    expect(out?.title).toBe(BASE.title)
+    expect(out).not.toHaveProperty('category')
+    expect(out).not.toHaveProperty('priority')
+    expect(out).not.toHaveProperty('signal_code')
+    expect(out).not.toHaveProperty('signal')
+    expect(out).not.toHaveProperty('dsk_claim_provenance')
+  })
+
+  it('keeps priority 0 — the least-urgent band is a value, not an absence', () => {
+    // A truthiness carry (`priority ? {priority} : {}`) drops this silently.
+    const out = adaptTypedCoachingBlock({ ...BASE, priority: 0 })
+    expect(out?.priority).toBe(0)
+  })
+
+  it.each([[-1], [101], [Number.NaN]])(
+    'refuses an out-of-contract priority (%s) without costing the card',
+    (priority) => {
+      const out = adaptTypedCoachingBlock({ ...BASE, priority })
+      expect(out?.title).toBe(BASE.title)
+      expect(out).not.toHaveProperty('priority')
+    },
+  )
+
+  it('refuses an unrecognised category rather than defaulting to a tier', () => {
+    const out = adaptTypedCoachingBlock({ ...BASE, category: 'blocker' })
+    expect(out?.title).toBe(BASE.title)
+    expect(out).not.toHaveProperty('category')
+  })
+
+  it('does NOT enum-check signal_code — the vocabulary is producer-owned', () => {
+    const out = adaptTypedCoachingBlock({ ...BASE, signal_code: 'A_BRAND_NEW_DETECTOR' })
+    expect(out?.signal_code).toBe('A_BRAND_NEW_DETECTOR')
+  })
+
+  describe('the DSK claim triple is atomic', () => {
+    it.each([
+      ['claim_title missing', { claim_id: 'DSK-B-003', evidence_strength: 'strong' }],
+      ['evidence_strength missing', { claim_id: 'DSK-B-003', claim_title: 'A claim' }],
+      ['claim_id missing', { claim_title: 'A claim', evidence_strength: 'strong' }],
+      [
+        'evidence_strength off-contract',
+        { claim_id: 'DSK-B-003', claim_title: 'A claim', evidence_strength: 'very strong' },
+      ],
+      [
+        'a PROTOCOL id masquerading as a claim',
+        { claim_id: 'DSK-P-002', claim_title: 'A claim', evidence_strength: 'strong' },
+      ],
+      [
+        'a TRIGGER id masquerading as a claim',
+        { claim_id: 'DSK-TR-001', claim_title: 'A claim', evidence_strength: 'strong' },
+      ],
+    ])('refuses the whole triple when %s — and never costs the card', (_label, provenance) => {
+      const out = adaptTypedCoachingBlock({ ...BASE, dsk_claim_provenance: provenance })
+      expect(out?.title).toBe(BASE.title)
+      expect(out).not.toHaveProperty('dsk_claim_provenance')
+    })
+
+    it('accepts a valid triple without the optional protocol_id', () => {
+      const withoutProtocol = {
+        claim_id: CLAIM.claim_id,
+        claim_title: CLAIM.claim_title,
+        evidence_strength: CLAIM.evidence_strength,
+      }
+      const out = adaptTypedCoachingBlock({ ...BASE, dsk_claim_provenance: withoutProtocol })
+      expect(out?.dsk_claim_provenance).toEqual(withoutProtocol)
+      expect(out?.dsk_claim_provenance).not.toHaveProperty('protocol_id')
+    })
+
+    it('drops a malformed protocol_id without costing the claim anchor', () => {
+      const out = adaptTypedCoachingBlock({
+        ...BASE,
+        dsk_claim_provenance: { ...CLAIM, protocol_id: 'DSK-B-003' },
+      })
+      expect(out?.dsk_claim_provenance?.claim_id).toBe('DSK-B-003')
+      expect(out?.dsk_claim_provenance).not.toHaveProperty('protocol_id')
+    })
+  })
+
+  /**
+   * THE COMPLETENESS CHECK THE DERIVED GUARDS CANNOT DO (trap 12d).
+   *
+   * Every assertion above is derived from this lane's own fixtures, so all of
+   * them agree with each other and NONE can notice that the adapter's
+   * category list is SHORT. This one asserts against the CONTRACT ITSELF: the
+   * vendored `CoachingBlockSchema` is the authority for which category values
+   * exist, and a widening there must RED here rather than silently arriving as
+   * an unbadged card.
+   */
+  it('accepts EVERY category the vendored contract declares — no short list', () => {
+    const shape = CoachingBlockSchema.shape as Record<string, { unwrap?: () => unknown }>
+    const categoryField = shape.category
+    // Positive control: the probe must actually find the field. An absence
+    // probe that cannot see a presence proves nothing (trap 13).
+    expect(categoryField).toBeDefined()
+    const inner = categoryField.unwrap?.() as { options?: readonly string[] } | undefined
+    const declared = inner?.options
+    expect(Array.isArray(declared)).toBe(true)
+    expect(declared!.length).toBeGreaterThan(0)
+
+    for (const value of declared!) {
+      const out = adaptTypedCoachingBlock({ ...BASE, category: value })
+      expect(
+        out?.category,
+        `contract declares category "${value}" but the adapter dropped it`,
+      ).toBe(value)
+    }
+  })
+})

--- a/src/v5/__tests__/phase3TypedBlocks.coachingImportance.spec.ts
+++ b/src/v5/__tests__/phase3TypedBlocks.coachingImportance.spec.ts
@@ -166,6 +166,131 @@ describe('adaptTypedCoachingBlock — importance / evidence carry (PR3)', () => 
    * exist, and a widening there must RED here rather than silently arriving as
    * an unbadged card.
    */
+  /**
+   * ⭐ THE FAIL-LOUD GUARD — the one that would have caught this whole lane.
+   *
+   * The enum check below catches a WIDENED ENUM. It does not catch the defect
+   * that produced this work: a NEW FIELD arriving on the contract and being
+   * dropped in silence. Five fields sat on the wire from 0.19.0 / 0.20.0 while
+   * the surface a user reads first threw them away, and NOTHING anywhere went
+   * red — because `adaptTypedCoachingBlock` is an implicit allowlist and an
+   * unread key is indistinguishable from a key nobody has heard of.
+   *
+   * So: every key the contract declares must be either CARRIED or EXPLICITLY
+   * IGNORED WITH A STATED REASON. A new field satisfies neither and REDs until
+   * a human decides which it is. Note what this deliberately is NOT — it is not
+   * a list of fields to carry (that is the mirror we are escaping). The carried
+   * set is DERIVED BY EXECUTING THE ADAPTER; only the ignore set is
+   * hand-written, and each entry is a decision record a reviewer can audit
+   * rather than a bare name.
+   */
+  const DELIBERATELY_NOT_CARRIED: Readonly<Record<string, string>> = {
+    signal_id:
+      'Per-instance DEDUPE identity, not render-relevant. The card shows no id, ' +
+      'and a real producer block must never be suppressed over metadata the UI never displays.',
+    created_at:
+      'Wire timestamp. The card states RECENCY through `freshness` (a producer ' +
+      'verdict), never through a raw date the user would have to interpret.',
+    source_handler:
+      'CEE-internal handler name. A machine token with no user-facing meaning; ' +
+      'rendering it would leak pipeline vocabulary into the product.',
+    graph_hash_at_generation:
+      'Opaque analysis-identity hash used upstream for invalidation. `freshness` ' +
+      'is the consumer-facing derivative of it, and is what the card renders.',
+  }
+
+  /**
+   * The comparison, extracted as a pure function so its FAILURE MODE can be
+   * demonstrated (below) rather than assumed. A completeness guard with no
+   * demonstrated red is exactly the shape this estate keeps finding vacuous.
+   */
+  function unhandledContractKeys(
+    schemaKeys: readonly string[],
+    carriedKeys: readonly string[],
+    ignored: Readonly<Record<string, string>>,
+  ): string[] {
+    const carried = new Set(carriedKeys)
+    return schemaKeys.filter((k) => !carried.has(k) && !(k in ignored))
+  }
+
+  /** A contract-valid block with EVERY declared key populated. */
+  const MAXIMAL = {
+    ...BASE,
+    signal_id: 'sig-1',
+    created_at: '2026-08-10T00:00:00.000Z',
+    source_handler: 'coaching_pass',
+    graph_hash_at_generation: 'deadbeef',
+    category: 'must_fix',
+    priority: 90,
+    signal_code: 'MISSING_BASE_RATE',
+    signal: 'Two options share one base-rate assumption.',
+    action_intent: 'confirm_factor',
+    action_label: 'Check this',
+    action_prompt: 'What would have to be true for that to hold?',
+    dsk_claim_provenance: CLAIM,
+  }
+
+  it('every key the contract declares is either CARRIED or ignored WITH A REASON', () => {
+    const schemaKeys = Object.keys(CoachingBlockSchema.shape)
+    // Positive controls: a probe that reads nothing agrees with everything.
+    expect(schemaKeys.length).toBeGreaterThan(10)
+    // The fixture must be a REAL contract-valid block, or "carried" is derived
+    // from something the producer could never send.
+    const parsed = CoachingBlockSchema.safeParse(MAXIMAL)
+    expect(parsed.success, `MAXIMAL fixture is not contract-valid: ${JSON.stringify((parsed as { error?: unknown }).error)}`).toBe(true)
+    // The fixture must exercise EVERY declared key, or a key could look
+    // "not carried" merely because the fixture forgot to set it.
+    expect(unhandledContractKeys(schemaKeys, Object.keys(MAXIMAL), {})).toEqual([])
+
+    // CARRIED is DERIVED — by running the adapter, never by listing.
+    const out = adaptTypedCoachingBlock(MAXIMAL)
+    expect(out).not.toBeNull()
+    const carriedKeys = Object.keys(out!)
+    expect(carriedKeys.length).toBeGreaterThan(10)
+
+    expect(
+      unhandledContractKeys(schemaKeys, carriedKeys, DELIBERATELY_NOT_CARRIED),
+      'The contract declares a field the adapter neither carries nor explicitly ignores. ' +
+        'Decide which it is: carry it in adaptTypedCoachingBlock, or add it to ' +
+        'DELIBERATELY_NOT_CARRIED with a stated reason. Do not silently drop it — ' +
+        'that is the defect this guard exists to catch.',
+    ).toEqual([])
+  })
+
+  it('the ignore-list carries no STALE entries and every reason is substantive', () => {
+    const schemaKeys = new Set(Object.keys(CoachingBlockSchema.shape))
+    for (const [key, reason] of Object.entries(DELIBERATELY_NOT_CARRIED)) {
+      // A decision record about a field the contract no longer has is the same
+      // mirror defect, one level up.
+      expect(schemaKeys.has(key), `ignore-list names "${key}", absent from the contract`).toBe(true)
+      expect(reason.trim().length, `ignore reason for "${key}" is a placeholder`).toBeGreaterThan(40)
+    }
+  })
+
+  it('PROOF THE GUARD CAN FAIL: a new contract field is reported as unhandled', () => {
+    const realSchemaKeys = Object.keys(CoachingBlockSchema.shape)
+    const out = adaptTypedCoachingBlock(MAXIMAL)
+    const carriedKeys = Object.keys(out!)
+
+    // Discriminating pair. Same inputs, one synthetic key added to the CONTRACT.
+    const clean = unhandledContractKeys(realSchemaKeys, carriedKeys, DELIBERATELY_NOT_CARRIED)
+    const widened = unhandledContractKeys(
+      [...realSchemaKeys, 'selection_role'],
+      carriedKeys,
+      DELIBERATELY_NOT_CARRIED,
+    )
+    expect(clean).toEqual([])
+    expect(widened).toEqual(['selection_role'])
+
+    // ...and an ignore entry silences it — deliberately, and only with a reason.
+    expect(
+      unhandledContractKeys([...realSchemaKeys, 'selection_role'], carriedKeys, {
+        ...DELIBERATELY_NOT_CARRIED,
+        selection_role: 'hypothetical — proves an explicit decision silences the guard',
+      }),
+    ).toEqual([])
+  })
+
   it('accepts EVERY category the vendored contract declares — no short list', () => {
     const shape = CoachingBlockSchema.shape as Record<string, { unwrap?: () => unknown }>
     const categoryField = shape.category

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -152,19 +152,39 @@ const CONTAINER_UNCATEGORISED: Record<'default' | 'bias_signal', string> = {
  *
  * The fix deliberately does NOT mint a new colour: colour stays derived from
  * the shared authority, so this card, the node marker and the inspector still
- * agree. What varies is WEIGHT — a filled badge for must_fix, outlined for
- * should_fix, outlined-quiet for could_fix, muted for technique. Weight is
- * driven by the producer's own `category`, so nothing here is invented; it is
- * the same fact, rendered with the emphasis it already carries.
+ * agree. What varies is WEIGHT — a filled badge for must_fix, then three
+ * border tints. Weight is driven by the producer's own `category`, so nothing
+ * here is invented; it is the same fact, rendered with the emphasis it
+ * already carries.
+ *
+ * ⚠ THE LABEL INK IS ALWAYS `text-text-body`, AND THAT IS THE DESIGN SYSTEM'S
+ * RULE, NOT A PREFERENCE. `Conversation.module.css` states it at the existing
+ * guidance badges: "Category badge colour variants — DS v5 §3.2: outlined
+ * pills, text-text-body". Colour rides the BORDER; the ink stays body-coloured.
+ *
+ * A first version of this ladder put the category colour in the INK
+ * (`text-danger` / `text-info` / muted grey) and it failed three ways at once,
+ * all of them measured from computed styles in a real browser:
+ *   - `should_fix` ink resolved to 2.80:1 against the card — BELOW WCAG AA
+ *     (4.5:1) at this 11px size, and `must_fix` white-on-fill to 2.83:1. No
+ *     token in the danger family reaches 4.5:1 with white ink (the best,
+ *     --danger-active, is 4.24:1), so ink-colouring cannot be made compliant
+ *     within the palette at all.
+ *   - the ladder INVERTED: `technique`, the least urgent tier, carried the
+ *     highest-contrast label on the card.
+ *   - it silently diverged from the four badge surfaces already shipped.
+ * Keeping the ink at body colour dissolves all three: every label is
+ * high-contrast, no label can out-shout another, and the tiers separate on
+ * fill and border exactly as the rest of the product already does.
  */
 const CATEGORY_BADGE_CLASS: Record<
   NonNullable<V5CoachingBlockType['category']>,
   string
 > = {
-  must_fix: 'border-danger bg-danger text-white font-medium',
-  should_fix: 'border-danger/50 text-danger',
-  could_fix: 'border-info/50 text-info',
-  technique: 'border-panel-border text-text-muted',
+  must_fix: 'bg-danger-light border-danger text-text-body font-medium',
+  should_fix: 'bg-transparent border-danger/50 text-text-body',
+  could_fix: 'bg-transparent border-info/50 text-text-body',
+  technique: 'bg-transparent border-panel-border text-text-body',
 }
 
 /** Card border weight per category — the same emphasis ladder, one step quieter. */
@@ -282,7 +302,7 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       */}
       {block.signal && (
         <p
-          className={`${typography.panelMeta} text-text-muted`}
+          className={`${typography.panelMeta} text-text-light`}
           data-testid={`${testIdPrefix}-signal`}
         >
           <span className="font-medium">Why this came up: </span>
@@ -296,7 +316,7 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       */}
       {freshnessNotice && (
         <p
-          className={`${typography.panelMeta} text-text-muted`}
+          className={`${typography.panelMeta} text-text-light`}
           data-testid={`${testIdPrefix}-freshness`}
         >
           {freshnessNotice}
@@ -330,7 +350,7 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
           data-dsk-claim-id={claim.claim_id}
           data-dsk-evidence-strength={claim.evidence_strength}
           {...(claim.protocol_id ? { 'data-dsk-protocol-id': claim.protocol_id } : {})}
-          className={`${typography.panelMeta} flex items-center gap-x-1.5 text-text-muted`}
+          className={`${typography.panelMeta} flex items-center gap-x-1.5 text-text-light`}
         >
           <BookOpenCheck size={12} className="flex-none text-info" aria-hidden="true" />
           <span>
@@ -401,14 +421,14 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       <details data-testid={`${testIdPrefix}-details`} className="group">
         <summary
           data-testid={`${testIdPrefix}-details-toggle`}
-          className={`${typography.panelMeta} cursor-pointer text-text-muted hover:text-text-body list-none`}
+          className={`${typography.panelMeta} cursor-pointer text-text-light hover:text-text-body list-none`}
         >
           <span aria-hidden="true" className="inline-block mr-1 group-open:rotate-90 transition-transform">
             ▸
           </span>
           Why this, and how sure
         </summary>
-        <div className={`${typography.panelMeta} mt-1.5 space-y-1 text-text-muted`}>
+        <div className={`${typography.panelMeta} mt-1.5 space-y-1 text-text-light`}>
           <p data-testid={`${testIdPrefix}-grounding-detail`}>
             {claim
               ? `This instantiates a cited decision-science claim: “${claim.claim_title}”, which the bundle rates ${claim.evidence_strength} evidence.`

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -2,17 +2,80 @@
  * V5CoachingBlock — renders a 0.13.x-typed CEE coaching block
  * (Track C slice 1, approved D-5; provisional_doctrine_v0).
  *
- * Truth-rendering contract (same as V5ReviewCardBlock):
- *   - Every visible string is the producer's, verbatim: title, body,
- *     target_refs[].label, action_label. The UI adds NO labels and NO
- *     interpretation.
- *   - Coaching is facilitator-voice content → info visual channel,
- *     matching the existing coaching-card idiom (DS: bg-panel, never
- *     bg-*-light on cards).
- *   - `coaching_kind` / `source` / `freshness` / `block_id` ride as data-*
- *     attributes only — never rendered as copy. (`freshness` is optional:
- *     the UI-side bias bridge builds blocks without it — the attribute is
- *     simply absent then.)
+ * ── PR3 (living reasoning workspace): THE CARD LEARNS TO SAY WHAT MATTERS ──
+ *
+ * THE DEFECT. Every coaching card looked the same: lightbulb, title, prose,
+ * optional pill. `coaching_kind` / `source` / `freshness` rode as inert
+ * `data-*` attributes with no per-kind treatment, and the producer's
+ * IMPORTANCE and EVIDENCE signals never arrived at all — the chat card was
+ * the one consumer of the coaching block that dropped them, while the
+ * guidance strip, the inspector, the node marker and the Strengthen panel all
+ * already ranked and grounded the very same wire object. A reader could not
+ * tell a must-fix finding from a passing technique note, could not tell a
+ * cited decision-science claim from assistant prose, and was never told when
+ * a card pre-dated their latest edit.
+ *
+ * THE FOUR CHANNELS THIS CARD NOW CARRIES, and the rule each obeys:
+ *
+ *   1. IMPORTANCE — the producer's `category` (must_fix / should_fix /
+ *      could_fix / technique). It sets a badge AND the card's whole tone, so
+ *      urgency is legible before the title is read. ABSENT = no badge and the
+ *      existing neutral treatment. The UI never invents a tier: there is no
+ *      "normal", no "unknown", no default.
+ *   2. EVIDENCE — `signal` (the producer's own "what triggered this" line,
+ *      verbatim) and `dsk_claim_provenance` (the cited claim's TITLE and
+ *      evidence strength). Together these are what let a reader separate an
+ *      evidence-backed finding from a suggestion.
+ *   3. UNCERTAINTY — `freshness`, which until now was an inert attribute.
+ *      A stale / pending / failed card says so in plain English instead of
+ *      presenting itself as current.
+ *   4. ACTION — unchanged: `action_label` + `action_prompt` through
+ *      ActionChip's existing `_sendChip` seam.
+ *
+ * ORDERING IS NOT THIS COMPONENT'S JOB, and deliberately so. The producer's
+ * `priority_rank` is an ASCENDING ordinal (lower = first, unbounded, NEVER
+ * inverted against 100) and `composePhase3BridgedBlocks` already sorts the
+ * feed by it. This card therefore mints NO ordering of its own — a second
+ * ordering authority in the client is exactly the drift the contract's
+ * `priority_rank` note warns about.
+ *
+ * DERIVE, DON'T MIRROR. The tone and icon come from `guidanceCategoryTone` /
+ * `guidanceCategoryIcon`, which the guidance store documents as the single
+ * source of truth every surface colouring a guidance element MUST derive
+ * from; the badge copy comes from `STRENGTHEN_COPY.severityLabel`. So this
+ * card, the on-canvas node marker, the inspector card and the Strengthen row
+ * cannot drift apart — one vocabulary, one colour language, four surfaces.
+ * A private copy of any of them here would be the hand-maintained mirror
+ * defect, and the spec pins the copy against the shared constant so a
+ * divergence REDs.
+ *
+ * ONE ICON AUTHORITY, NOT TWO. `coaching_kind` is NOT given a competing icon
+ * vocabulary: category owns the icon, so the marker on the canvas matches the
+ * card it opens. `coaching_kind` and `source` are stated as SENTENCES inside
+ * the disclosure instead — and only when we recognise them, because they are
+ * open pass-through discriminators and a raw `assumption_check` token is
+ * machine text, never copy.
+ *
+ * PROGRESSIVE DISCLOSURE. Everything a first-time reader needs is on the face
+ * of the card: badge, title, body, trigger line, grounding, action. The
+ * depth — which claim, how strong the evidence, what kind of move this is,
+ * where it came from — sits in a `<details>` that is CLOSED by default. A
+ * power user opens it; nobody else pays for it.
+ *
+ * A BLANK IS A DEFECT, NOT A STANDARD. Where a signal is unavailable the card
+ * says what is unknown in plain English rather than rendering nothing: an
+ * ungrounded card states that it is not linked to a cited claim. What the
+ * card must never do is manufacture a value — the honest degradations here
+ * are sentences, not silence, and never guesses.
+ *
+ * Truth-rendering contract (unchanged, and extended to the new fields):
+ *   - Every visible producer string is verbatim: title, body,
+ *     target_refs[].label, action_label, `signal`, and the DSK claim title.
+ *     The UI's own words are confined to STATIC channel labels ("Why this
+ *     came up", "Grounded in decision science") which name a channel and
+ *     make no claim about the science — the V5ExerciseBlock precedent.
+ *   - `signal_code` is an id, not a sentence: it rides as `data-signal-code`
+ *     and is never rendered as copy.
  *   - The action pill is ACTIONABLE when, and only when, the producer
  *     authored the turn text (ROADMAP 2.225; schemas 0.31.0
  *     `CoachingBlockSchema.action_prompt`):
@@ -23,29 +86,29 @@
  *     The second arm is deliberate and is the contract's stated failure
  *     semantics: the UI must NOT fall back to dispatching `action_label` (a
  *     button CAPTION, bounded at 40 chars) or `action_intent` (a machine
- *     enum) as turn text. "That fallback IS the defect" — a card with a
- *     label and no prompt is a non-interactive card, which is the honest
- *     degradation. See ActionChip.tsx for the full no-invention rule.
+ *     enum) as turn text. "That fallback IS the defect."
  *   - target_refs pills are click-to-focus (seamlessness R1): clickable only
  *     while the target exists on the canvas (fail-closed in TargetRefPill),
  *     label copy verbatim either way.
  *
  * Variants (review-folds C10+R1 — the separate BiasSignalCoachingCard
  * duplicated this whole structure and silently DROPPED action_label):
- *   - 'default': full border-info/30 card (the existing idiom).
- *   - 'bias_signal': the DS coaching-card recipe (DESIGN_SYSTEM.md
- *     "Coaching Cards (v4 §15)") — neutral bg-panel + a COMPLETE coloured
- *     border (border border-info; V7 L2 retired the one-sided
- *     `border-l-[3px]` accent under Paul's categorical complete-borders
- *     rule), testid prefix `bias-signal-card` (the #356 specs key on it).
- *     ONLY the container class and testid prefix differ; structure, refs and
- *     the action_label pill are identical.
+ *   - 'default': full card (the existing idiom), tone-tinted border.
+ *   - 'bias_signal': the DS coaching-card recipe, testid prefix
+ *     `bias-signal-card` (the #356 specs key on it).
+ *     ONLY the container class and testid prefix differ; every channel above
+ *     is identical on both forks, which is the whole point of the fold.
  */
 import { type ReactElement } from 'react'
-import { Lightbulb } from 'lucide-react'
+import { BookOpenCheck } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
 import { ActionChip } from './ActionChip'
+import {
+  guidanceCategoryIcon,
+  guidanceCategoryTone,
+} from '../../canvas/stores/guidanceStore'
+import { STRENGTHEN_COPY } from '../../components/results/strengthen/strengthenCopy'
 import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
 
 export interface V5CoachingBlockProps {
@@ -53,13 +116,75 @@ export interface V5CoachingBlockProps {
   variant?: 'default' | 'bias_signal'
 }
 
-const CONTAINER_CLASS: Record<'default' | 'bias_signal', string> = {
-  default: 'rounded-xl border border-info/30 bg-panel p-4 space-y-2',
-  bias_signal: 'bg-panel border border-info rounded-lg px-4 py-3 space-y-2',
+type Tone = 'danger' | 'info'
+
+/**
+ * Container recipe per variant × tone. The tone tint is the IMPORTANCE
+ * channel made visible; `info` reproduces the pre-PR3 appearance exactly, so
+ * an uncategorised card looks precisely as it always did.
+ */
+const CONTAINER_CLASS: Record<'default' | 'bias_signal', Record<Tone, string>> = {
+  default: {
+    info: 'rounded-xl border border-info/30 bg-panel p-4 space-y-2',
+    danger: 'rounded-xl border border-danger/40 bg-panel p-4 space-y-2',
+  },
+  bias_signal: {
+    info: 'bg-panel border border-info rounded-lg px-4 py-3 space-y-2',
+    danger: 'bg-panel border border-danger rounded-lg px-4 py-3 space-y-2',
+  },
+}
+
+const CATEGORY_BADGE_CLASS: Record<Tone, string> = {
+  danger: 'border-danger/40 text-danger',
+  info: 'border-info/40 text-info',
+}
+
+/**
+ * Plain-English sentences for the freshness verdict. `fresh` is deliberately
+ * absent from this map: a current card says nothing, because a "this is
+ * current" badge on every card is noise that teaches the reader to ignore the
+ * one time it matters.
+ */
+const FRESHNESS_NOTICE: Partial<Record<string, string>> = {
+  stale: 'Your model has changed since this was written — it may no longer apply.',
+  pending: 'This is still being written.',
+  failed: 'This could not be generated.',
+}
+
+/**
+ * Code-keyed display copy for the two pass-through discriminators. Both are
+ * OPEN vocabularies the producer owns, so an unrecognised value maps to
+ * `undefined` and the disclosure simply omits that line — it must never print
+ * the raw snake_case token, which is machine text and reads as a leak.
+ */
+const KIND_SENTENCE: Partial<Record<string, string>> = {
+  orientation: 'Getting oriented',
+  widening: 'Widening the options',
+  bias_signal: 'A possible bias in the reasoning',
+  strengthen: 'Strengthening the model',
+  assumption_check: 'An assumption worth checking',
+  calibration_prompt: 'Calibrating an estimate',
+}
+
+const SOURCE_SENTENCE: Partial<Record<string, string>> = {
+  draft_graph: 'Raised while drafting your model',
+  decision_review: 'Raised by the decision review',
+  deterministic_signal: 'Raised by an automatic check',
 }
 
 export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockProps): ReactElement {
   const testIdPrefix = variant === 'bias_signal' ? 'bias-signal-card' : 'v5-coaching'
+
+  // The IMPORTANCE channel, derived from the shared authority so this card,
+  // the node marker and the inspector cannot disagree.
+  const tone: Tone = guidanceCategoryTone(block.category)
+  const { Icon, tintClass } = guidanceCategoryIcon(block.category)
+
+  const freshnessNotice = block.freshness ? FRESHNESS_NOTICE[block.freshness] : undefined
+  const kindSentence = KIND_SENTENCE[block.coaching_kind]
+  const sourceSentence = SOURCE_SENTENCE[block.source]
+  const claim = block.dsk_claim_provenance
+
   return (
     <div
       data-testid={testIdPrefix}
@@ -67,17 +192,103 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       data-coaching-kind={block.coaching_kind}
       data-coaching-source={block.source}
       data-freshness={block.freshness}
-      className={CONTAINER_CLASS[variant]}
+      data-tone={tone}
+      {...(block.category ? { 'data-category': block.category } : {})}
+      {...(block.signal_code ? { 'data-signal-code': block.signal_code } : {})}
+      {...(typeof block.priority === 'number' ? { 'data-priority': String(block.priority) } : {})}
+      className={CONTAINER_CLASS[variant][tone]}
     >
+      {/*
+        IMPORTANCE, first and smallest. The badge is the producer's four-value
+        class in the SHARED vocabulary; absent category renders nothing at all
+        rather than a fabricated tier.
+      */}
+      {block.category && (
+        <div className="flex">
+          <span
+            data-testid={`${testIdPrefix}-category`}
+            data-category={block.category}
+            className={[
+              'inline-flex items-center rounded-full px-2 py-0.5',
+              'bg-transparent border',
+              CATEGORY_BADGE_CLASS[tone],
+              typography.panelMeta,
+            ].join(' ')}
+          >
+            {STRENGTHEN_COPY.severityLabel[block.category]}
+          </span>
+        </div>
+      )}
+
       <div className="flex items-start gap-2">
-        <Lightbulb size={16} className="flex-none mt-0.5 text-info" aria-hidden="true" />
+        <Icon size={16} className={`flex-none mt-0.5 ${tintClass}`} aria-hidden="true" />
         <h3 className={typography.panelHeader} data-testid={`${testIdPrefix}-title`}>
           {block.title}
         </h3>
       </div>
+
       <p className={typography.panelBody} data-testid={`${testIdPrefix}-body`}>
         {block.body}
       </p>
+
+      {/*
+        EVIDENCE, in one quiet line. `signal` is the producer's own statement
+        of what triggered this item — the single most useful sentence for
+        telling a measured finding from a passing note. "Why this came up" is
+        a static channel label; the claim itself is entirely the producer's.
+      */}
+      {block.signal && (
+        <p
+          className={`${typography.panelMeta} text-text-muted`}
+          data-testid={`${testIdPrefix}-signal`}
+        >
+          <span className="font-medium">Why this came up: </span>
+          {block.signal}
+        </p>
+      )}
+
+      {/*
+        UNCERTAINTY. Until now `freshness` was an inert attribute, so a card
+        written before the user's last edit presented itself as current.
+      */}
+      {freshnessNotice && (
+        <p
+          className={`${typography.panelMeta} text-text-muted`}
+          data-testid={`${testIdPrefix}-freshness`}
+        >
+          {freshnessNotice}
+        </p>
+      )}
+
+      {/*
+        GROUNDING. Every visible string is the CANONICAL BUNDLE's, carried
+        verbatim from `data/dsk/v1.json` by CEE: the claim's own `claim_title`
+        and its own `evidence_strength`. Nothing here is authored in the UI
+        except the static label, which names the channel and makes no claim
+        about the science.
+
+        ⚠ CEE #830's lesson: a sibling badge once rendered the MODEL'S OWN
+        PROSE under a label asserting the bundle's authority. So this must
+        never interpolate assistant text, never map an id to a friendly name
+        of its own, and never render a partial triple — the adapter admits all
+        three members or none.
+      */}
+      {claim && (
+        <p
+          data-testid={`${testIdPrefix}-dsk-provenance`}
+          data-dsk-claim-id={claim.claim_id}
+          data-dsk-evidence-strength={claim.evidence_strength}
+          {...(claim.protocol_id ? { 'data-dsk-protocol-id': claim.protocol_id } : {})}
+          className={`${typography.panelMeta} flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-text-muted`}
+        >
+          <BookOpenCheck size={12} className="flex-none text-info" aria-hidden="true" />
+          <span>Grounded in decision science:</span>
+          <span className="text-text-body">{claim.claim_title}</span>
+          <span aria-hidden="true">·</span>
+          <span>{claim.evidence_strength} evidence</span>
+        </p>
+      )}
+
       {block.target_refs.length > 0 && (
         <div
           className="flex flex-wrap gap-2"
@@ -101,6 +312,7 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
           ))}
         </div>
       )}
+
       {block.action_label && (
         <div className="flex">
           {block.action_prompt ? (
@@ -125,6 +337,41 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
           )}
         </div>
       )}
+
+      {/*
+        THE DEPTH LAYER — closed by default, so it costs a first-time reader
+        nothing. A native <details> gives keyboard reach, the disclosure
+        semantics and the open/close state for free.
+
+        It always has something to say: when the card is not grounded, that
+        ABSENCE is stated in plain English. A blank is a defect, not a
+        standard — but the sentence states only what we know, and never
+        guesses at a claim the producer did not cite.
+      */}
+      <details data-testid={`${testIdPrefix}-details`} className="group">
+        <summary
+          data-testid={`${testIdPrefix}-details-toggle`}
+          className={`${typography.panelMeta} cursor-pointer text-text-muted hover:text-text-body list-none`}
+        >
+          <span aria-hidden="true" className="inline-block mr-1 group-open:rotate-90 transition-transform">
+            ▸
+          </span>
+          Why this, and how sure
+        </summary>
+        <div className={`${typography.panelMeta} mt-1.5 space-y-1 text-text-muted`}>
+          <p data-testid={`${testIdPrefix}-grounding-detail`}>
+            {claim
+              ? `This instantiates a cited decision-science claim: “${claim.claim_title}”, which the bundle rates ${claim.evidence_strength} evidence.`
+              : 'This suggestion is not linked to a cited decision-science claim.'}
+          </p>
+          {kindSentence && (
+            <p data-testid={`${testIdPrefix}-kind-detail`}>{kindSentence}</p>
+          )}
+          {sourceSentence && (
+            <p data-testid={`${testIdPrefix}-source-detail`}>{sourceSentence}</p>
+          )}
+        </div>
+      </details>
     </div>
   )
 }

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -123,20 +123,59 @@ type Tone = 'danger' | 'info'
  * channel made visible; `info` reproduces the pre-PR3 appearance exactly, so
  * an uncategorised card looks precisely as it always did.
  */
-const CONTAINER_CLASS: Record<'default' | 'bias_signal', Record<Tone, string>> = {
-  default: {
-    info: 'rounded-xl border border-info/30 bg-panel p-4 space-y-2',
-    danger: 'rounded-xl border border-danger/40 bg-panel p-4 space-y-2',
-  },
-  bias_signal: {
-    info: 'bg-panel border border-info rounded-lg px-4 py-3 space-y-2',
-    danger: 'bg-panel border border-danger rounded-lg px-4 py-3 space-y-2',
-  },
+const CONTAINER_BASE: Record<'default' | 'bias_signal', string> = {
+  default: 'rounded-xl border bg-panel p-4 space-y-2',
+  bias_signal: 'bg-panel border rounded-lg px-4 py-3 space-y-2',
 }
 
-const CATEGORY_BADGE_CLASS: Record<Tone, string> = {
-  danger: 'border-danger/40 text-danger',
-  info: 'border-info/40 text-info',
+/**
+ * The uncategorised default, per variant. These reproduce the pre-PR3
+ * appearance EXACTLY, so a card the producer never classified looks precisely
+ * as it always did — the honest-absence rule made visual.
+ */
+const CONTAINER_UNCATEGORISED: Record<'default' | 'bias_signal', string> = {
+  default: 'border-info/30',
+  bias_signal: 'border-info',
+}
+
+/**
+ * EMPHASIS, WITHIN the shared colour channel — and this exists because a real
+ * browser proved the colour channel alone is not enough.
+ *
+ * `guidanceCategoryTone` maps FOUR producer categories onto TWO colours
+ * (must_fix/should_fix → danger, could_fix/technique → info). Rendered, that
+ * made "Must fix" and "Should fix" visually IDENTICAL — same border, same
+ * badge, same icon — so the single most important distinction the producer
+ * makes was legible only by reading the badge text. jsdom could never have
+ * shown this: it computes no layout and resolves no colour, and every
+ * structural test passed while the hierarchy did not exist.
+ *
+ * The fix deliberately does NOT mint a new colour: colour stays derived from
+ * the shared authority, so this card, the node marker and the inspector still
+ * agree. What varies is WEIGHT — a filled badge for must_fix, outlined for
+ * should_fix, outlined-quiet for could_fix, muted for technique. Weight is
+ * driven by the producer's own `category`, so nothing here is invented; it is
+ * the same fact, rendered with the emphasis it already carries.
+ */
+const CATEGORY_BADGE_CLASS: Record<
+  NonNullable<V5CoachingBlockType['category']>,
+  string
+> = {
+  must_fix: 'border-danger bg-danger text-white font-medium',
+  should_fix: 'border-danger/50 text-danger',
+  could_fix: 'border-info/50 text-info',
+  technique: 'border-panel-border text-text-muted',
+}
+
+/** Card border weight per category — the same emphasis ladder, one step quieter. */
+const CATEGORY_BORDER_CLASS: Record<
+  NonNullable<V5CoachingBlockType['category']>,
+  string
+> = {
+  must_fix: 'border-danger/60',
+  should_fix: 'border-danger/30',
+  could_fix: 'border-info/40',
+  technique: 'border-panel-border',
 }
 
 /**
@@ -196,7 +235,12 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       {...(block.category ? { 'data-category': block.category } : {})}
       {...(block.signal_code ? { 'data-signal-code': block.signal_code } : {})}
       {...(typeof block.priority === 'number' ? { 'data-priority': String(block.priority) } : {})}
-      className={CONTAINER_CLASS[variant][tone]}
+      className={[
+        CONTAINER_BASE[variant],
+        block.category
+          ? CATEGORY_BORDER_CLASS[block.category]
+          : CONTAINER_UNCATEGORISED[variant],
+      ].join(' ')}
     >
       {/*
         IMPORTANCE, first and smallest. The badge is the producer's four-value
@@ -209,9 +253,8 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
             data-testid={`${testIdPrefix}-category`}
             data-category={block.category}
             className={[
-              'inline-flex items-center rounded-full px-2 py-0.5',
-              'bg-transparent border',
-              CATEGORY_BADGE_CLASS[tone],
+              'inline-flex items-center rounded-full px-2 py-0.5 border',
+              CATEGORY_BADGE_CLASS[block.category],
               typography.panelMeta,
             ].join(' ')}
           >
@@ -261,11 +304,19 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       )}
 
       {/*
-        GROUNDING. Every visible string is the CANONICAL BUNDLE's, carried
-        verbatim from `data/dsk/v1.json` by CEE: the claim's own `claim_title`
-        and its own `evidence_strength`. Nothing here is authored in the UI
-        except the static label, which names the channel and makes no claim
-        about the science.
+        GROUNDING, COMPACT ON THE FACE. The strength is what a reader needs at
+        a glance; the CLAIM TITLE — the part that makes the attribution
+        checkable against the bundle — is one row down in the disclosure. A
+        browser pass showed the full title inline pushed this card to eight
+        stacked rows and orphaned the separator mid-wrap, which is the exact
+        opposite of "low cognitive load by default". This compact form is also
+        the idiom `InspectorGuidanceSection` already ships, so the two
+        surfaces read as one.
+
+        Every visible string is the CANONICAL BUNDLE's, carried verbatim from
+        `data/dsk/v1.json` by CEE: here `evidence_strength`, and `claim_title`
+        in the disclosure. Nothing is authored in the UI except the static
+        label, which names the channel and makes no claim about the science.
 
         ⚠ CEE #830's lesson: a sibling badge once rendered the MODEL'S OWN
         PROSE under a label asserting the bundle's authority. So this must
@@ -279,13 +330,12 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
           data-dsk-claim-id={claim.claim_id}
           data-dsk-evidence-strength={claim.evidence_strength}
           {...(claim.protocol_id ? { 'data-dsk-protocol-id': claim.protocol_id } : {})}
-          className={`${typography.panelMeta} flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-text-muted`}
+          className={`${typography.panelMeta} flex items-center gap-x-1.5 text-text-muted`}
         >
           <BookOpenCheck size={12} className="flex-none text-info" aria-hidden="true" />
-          <span>Grounded in decision science:</span>
-          <span className="text-text-body">{claim.claim_title}</span>
-          <span aria-hidden="true">·</span>
-          <span>{claim.evidence_strength} evidence</span>
+          <span>
+            Grounded in decision science · {claim.evidence_strength} evidence
+          </span>
         </p>
       )}
 

--- a/src/v5/blocks/__tests__/V5CoachingBlock.colourTokens.spec.ts
+++ b/src/v5/blocks/__tests__/V5CoachingBlock.colourTokens.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * PR3 follow-up — EVERY COLOUR CLASS ON THE COACHING CARD MUST RESOLVE.
+ *
+ * THE DEFECT THIS EXISTS FOR, and it shipped inside the very PR that set out
+ * to make hierarchy legible. Six new classes were written as
+ * `text-text-muted`. `colors.text` in `tailwind.config.js` declares
+ * `{header, body, light, on-color}` — there is **no `muted`** — so Tailwind
+ * emitted no rule and all six elements silently inherited the body colour.
+ * The "one quiet line", the freshness notice, the grounding line and the
+ * disclosure summary rendered at exactly the prominence of the body prose,
+ * and the emphasis ladder was not even monotone: `technique`, the LEAST
+ * urgent tier, carried the darkest label on the card.
+ *
+ * WHY NOTHING CAUGHT IT — this is the durable lesson and the reason this file
+ * is separate and loud:
+ *   - jsdom specs compare className STRINGS. A string differs identically
+ *     whether or not the class resolves to a rule. No structural test can
+ *     EVER see a dead utility class.
+ *   - The `Set(badges).size === 4` assertion passes before AND after the fix,
+ *     so the suite could not distinguish the broken card from the fixed one.
+ *   - Even the browser pass missed it, because it asked "are the four
+ *     DISTINCT?" (true — the ladder was distinct but mis-ordered) rather than
+ *     "is the ladder ORDERED?". A guard that agrees with itself, inside the
+ *     instrument added to escape jsdom.
+ *
+ * WHAT THIS GUARD DOES: derives the legal colour vocabulary from
+ * `tailwind.config.js` — the authority, never a copy — and asserts every
+ * colour utility written in the component resolves against it. It reads the
+ * SOURCE rather than a render, so it covers branches no fixture exercises.
+ * It is cheap, deterministic, and needs no CSS build.
+ *
+ * WHAT IT CANNOT DO, stated so nobody mistakes its scope: it proves a class
+ * NAME is legal, never that the resulting colour is legible, contrast-safe,
+ * or correctly ordered. Ordering is asserted from computed styles in the
+ * browser pass recorded on the PR.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+interface Tailwindish {
+  theme?: { extend?: { colors?: Record<string, unknown> } }
+}
+
+/**
+ * The config is plain JS with no type declaration, so a STATIC import trips
+ * TS7016 and fails the typecheck ratchet. It is loaded at runtime from an
+ * absolute file URL instead: the specifier is a variable, so TypeScript never
+ * has to resolve it, and no ambient `declare module` or `@ts-expect-error`
+ * suppression is needed. `beforeAll` fails loudly if the load returns nothing
+ * — a config that silently read as `{}` would make every assertion below pass
+ * by policing an empty palette.
+ */
+let tailwindConfig: Tailwindish
+beforeAll(async () => {
+  const url = pathToFileURL(resolve(process.cwd(), 'tailwind.config.js')).href
+  const mod = (await import(/* @vite-ignore */ url)) as { default?: Tailwindish }
+  tailwindConfig = mod.default ?? (mod as Tailwindish)
+  if (!tailwindConfig?.theme?.extend?.colors) {
+    throw new Error(`tailwind.config.js loaded but declared no colours (${url})`)
+  }
+})
+
+/**
+ * Resolved from the project root, not from `import.meta.url` — under vitest
+ * that is not a `file:` URL and `fileURLToPath` throws at COLLECTION, which
+ * would take the whole file to zero collected tests. Existence is asserted
+ * below rather than assumed: a path that silently reads nothing would make
+ * every assertion here pass by policing an empty string.
+ */
+const CARD_SOURCE = resolve(process.cwd(), 'src/v5/blocks/V5CoachingBlock.tsx')
+
+/**
+ * Tailwind built-ins that are legal on every colour utility and are not
+ * declared in the project palette.
+ */
+const BUILT_IN_COLOURS = new Set([
+  'transparent',
+  'current',
+  'inherit',
+  'white',
+  'black',
+])
+
+/** Flatten `theme.extend.colors` into the set of legal utility suffixes. */
+function legalColourNames(): Set<string> {
+  const colours = tailwindConfig.theme?.extend?.colors
+  const out = new Set<string>()
+  for (const [family, value] of Object.entries(colours ?? {})) {
+    if (typeof value === 'string') {
+      out.add(family)
+      continue
+    }
+    for (const shade of Object.keys(value as Record<string, unknown>)) {
+      // Tailwind's DEFAULT key is addressed by the bare family name.
+      out.add(shade === 'DEFAULT' ? family : `${family}-${shade}`)
+    }
+  }
+  return out
+}
+
+/** The first segment of every declared family — used to decide what to police. */
+function paletteRoots(names: Set<string>): Set<string> {
+  return new Set([...names].map((n) => n.split('-')[0]))
+}
+
+describe('V5CoachingBlock — every colour class resolves against the Tailwind palette', () => {
+  // Computed INSIDE each test, never at describe-evaluation: the config is
+  // loaded in `beforeAll`, which runs after the describe body.
+
+  it('the palette probe itself reads the real config (positive control)', () => {
+    const legal = legalColourNames()
+    // A probe that reads an empty config would pass every assertion below by
+    // policing nothing. It must see the families this card actually uses.
+    expect(legal.size).toBeGreaterThan(10)
+    expect(legal.has('text-light')).toBe(true)
+    expect(legal.has('text-body')).toBe(true)
+    expect(legal.has('danger')).toBe(true)
+    expect(legal.has('info')).toBe(true)
+    // ...and it must NOT invent the token that caused the defect.
+    expect(legal.has('text-muted')).toBe(false)
+  })
+
+  it('names no colour the config does not declare', () => {
+    const legal = legalColourNames()
+    const roots = paletteRoots(legal)
+    // Positive control: the component must actually be where we think it is.
+    expect(existsSync(CARD_SOURCE), `component not found at ${CARD_SOURCE}`).toBe(true)
+    const source = readFileSync(CARD_SOURCE, 'utf8')
+    // ...and the scan must actually see the file's classes.
+    expect(source.length).toBeGreaterThan(1000)
+
+    const used = source.match(/\b(?:text|bg|border|ring|fill|stroke)-[a-z][a-z0-9-]*(?:\/\d+)?/g) ?? []
+    expect(used.length, 'class scan found nothing — the regex or path is wrong').toBeGreaterThan(10)
+
+    const offenders: string[] = []
+    for (const raw of used) {
+      const [utility] = raw.split('-')
+      const suffix = raw.slice(utility.length + 1).split('/')[0]
+      // Only police tokens that CLAIM a palette family. `text-sm`, `border`,
+      // `bg-transparent` and the like are not colour references.
+      const root = suffix.split('-')[0]
+      if (!roots.has(root)) continue
+      if (BUILT_IN_COLOURS.has(suffix)) continue
+      if (!legal.has(suffix)) offenders.push(`${raw}  (resolves to nothing)`)
+    }
+
+    expect(
+      [...new Set(offenders)],
+      'A colour utility on this card names a token tailwind.config.js does not declare, ' +
+        'so Tailwind emits NO rule and the element silently inherits its parent colour. ' +
+        'This is invisible to every className-string assertion in the suite.',
+    ).toEqual([])
+  })
+
+  it('PROOF THE GUARD CAN FAIL: the exact dead class is reported as unresolvable', () => {
+    const legal = legalColourNames()
+    // Discriminating pair against the real palette — the fixed token passes,
+    // the token this PR actually shipped fails. A completeness guard with no
+    // demonstrated red is the shape this estate keeps finding vacuous.
+    const resolves = (suffix: string) => legal.has(suffix) || BUILT_IN_COLOURS.has(suffix)
+    expect(resolves('text-light'), 'the FIXED token must resolve').toBe(true)
+    expect(resolves('text-muted'), 'the SHIPPED dead token must not resolve').toBe(false)
+  })
+})

--- a/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
@@ -1,0 +1,240 @@
+/**
+ * PR3 (living reasoning workspace) — the coaching card learns to say WHAT
+ * MATTERS.
+ *
+ * THE DEFECT THIS PINS. Every coaching card rendered identically: a lightbulb,
+ * a title, prose, an optional pill. `coaching_kind`, `source` and `freshness`
+ * rode as inert `data-*` attributes with no per-kind treatment, and the five
+ * producer-owned signals that carry IMPORTANCE and EVIDENCE — `category`,
+ * `priority`, `signal_code`, `signal`, `dsk_claim_provenance` — were dropped
+ * by `adaptTypedCoachingBlock` before the card ever saw them. So a user could
+ * not tell a must-fix finding from a passing technique note, could not tell an
+ * evidence-grounded claim from assistant prose, and was never told when a card
+ * pre-dated their latest edit.
+ *
+ * WHAT THIS SPEC CAN AND CANNOT PROVE — stated up front, because the
+ * distinction is the whole reason the estate has shipped hierarchy defects
+ * before (trap 3).
+ *   CAN (jsdom, structural): that a signal the producer sent is PRESENT in the
+ *     DOM, bound to the right object by identity; that a signal the producer
+ *     did NOT send is absent AND replaced by an honest sentence rather than a
+ *     blank; that the depth layer is collapsed by default; that the display
+ *     vocabulary is the shared one and not a private copy.
+ *   CANNOT: that the hierarchy is legible. jsdom computes no layout, applies
+ *     no Tailwind, and resolves no colour. "must_fix reads as more urgent than
+ *     technique", "the disclosure stays out of the way", and every contrast /
+ *     size / spacing claim need a real browser and are verified there, not
+ *     here. No assertion below should be read as evidence about appearance.
+ *
+ * BINDING BY IDENTITY (trap 19). Every assertion keys on a testid or an
+ * explicit producer string, never on a value predicate another element could
+ * satisfy — and every absence assertion is paired with a POSITIVE assertion
+ * that the card still rendered its content, so a component that renders
+ * nothing at all cannot pass by looking empty.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { V5CoachingBlock } from '../V5CoachingBlock'
+import { STRENGTHEN_COPY } from '../../../components/results/strengthen/strengthenCopy'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../../../canvas/conversation/types'
+
+const BASE: V5CoachingBlockType = {
+  type: 'v5_coaching',
+  block_id: '7e0855c7-d79d-5d16-9fee-19e68ece297d',
+  title: 'An assumption to check',
+  body: 'The relationship between Technical Leadership Capacity and throughput remains stable.',
+  coaching_kind: 'assumption_check',
+  source: 'decision_review',
+  target_refs: [],
+  priority_rank: 120,
+  freshness: 'fresh',
+}
+
+/** A complete, well-formed claim triple — the contract's atomic unit. */
+const CLAIM: NonNullable<V5CoachingBlockType['dsk_claim_provenance']> = {
+  claim_id: 'DSK-B-003',
+  claim_title: 'Anchoring on an initial estimate narrows later revisions',
+  evidence_strength: 'strong',
+  protocol_id: 'DSK-P-002',
+}
+
+describe('V5CoachingBlock — importance channel (PR3)', () => {
+  it('renders the producer category as a badge, with the SHARED display copy', () => {
+    render(<V5CoachingBlock block={{ ...BASE, category: 'must_fix' }} />)
+    const badge = screen.getByTestId('v5-coaching-category')
+    // Identity: the badge names the category it was given...
+    expect(badge).toHaveAttribute('data-category', 'must_fix')
+    // ...and its copy is the SHARED vocabulary, not a private second copy.
+    // Asserting against the imported constant (not a literal) is what makes
+    // this a derived guard: if the Strengthen panel's wording moves, this
+    // card moves with it or REDs (trap 12 — derive, don't mirror).
+    expect(badge).toHaveTextContent(STRENGTHEN_COPY.severityLabel.must_fix)
+  })
+
+  it.each([
+    ['must_fix'],
+    ['should_fix'],
+    ['could_fix'],
+    ['technique'],
+  ] as const)('binds the badge to the producer value, not a constant: %s', (cat) => {
+    render(<V5CoachingBlock block={{ ...BASE, category: cat }} />)
+    const badge = screen.getByTestId('v5-coaching-category')
+    expect(badge).toHaveAttribute('data-category', cat)
+    expect(badge).toHaveTextContent(STRENGTHEN_COPY.severityLabel[cat])
+  })
+
+  it('shows NO category badge when the producer categorised nothing — and still renders the card', () => {
+    render(<V5CoachingBlock block={BASE} />)
+    // Honest absence: no invented "normal" tier...
+    expect(screen.queryByTestId('v5-coaching-category')).toBeNull()
+    // ...and the POSITIVE outcome, so an empty render cannot pass this test.
+    expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(BASE.title)
+    expect(screen.getByTestId('v5-coaching-body')).toHaveTextContent(BASE.body)
+  })
+
+  it('carries the severity tone on the card container so the whole card, not just a pill, reads as urgent', () => {
+    const { container: urgent } = render(<V5CoachingBlock block={{ ...BASE, category: 'must_fix' }} />)
+    const { container: quiet } = render(<V5CoachingBlock block={{ ...BASE, category: 'technique' }} />)
+    // Discriminating pair: the two categories must NOT resolve to the same
+    // tone. This is a structural proxy for the visual claim — it proves the
+    // component distinguishes them, never that a human sees the difference.
+    const urgentTone = urgent.querySelector('[data-testid="v5-coaching"]')?.getAttribute('data-tone')
+    const quietTone = quiet.querySelector('[data-testid="v5-coaching"]')?.getAttribute('data-tone')
+    expect(urgentTone).toBe('danger')
+    expect(quietTone).toBe('info')
+    expect(urgentTone).not.toBe(quietTone)
+  })
+})
+
+describe('V5CoachingBlock — evidence channel (PR3)', () => {
+  it("renders the producer's trigger line verbatim", () => {
+    const signal = 'Two of three options share the same base rate assumption.'
+    render(<V5CoachingBlock block={{ ...BASE, signal }} />)
+    expect(screen.getByTestId('v5-coaching-signal')).toHaveTextContent(signal)
+  })
+
+  it('renders NO trigger line when the producer sent none — and still renders the body', () => {
+    render(<V5CoachingBlock block={BASE} />)
+    expect(screen.queryByTestId('v5-coaching-signal')).toBeNull()
+    expect(screen.getByTestId('v5-coaching-body')).toHaveTextContent(BASE.body)
+  })
+
+  it('never renders signal_code as copy — it is an id, and rides as data-* only', () => {
+    render(<V5CoachingBlock block={{ ...BASE, signal_code: 'MISSING_BASE_RATE' }} />)
+    const card = screen.getByTestId('v5-coaching')
+    expect(card).toHaveAttribute('data-signal-code', 'MISSING_BASE_RATE')
+    // The machine token must not leak into the visible sentence stream.
+    expect(card.textContent).not.toContain('MISSING_BASE_RATE')
+    expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(BASE.title)
+  })
+
+  it('grounds the card in the cited claim, quoting the claim TITLE and its evidence strength', () => {
+    render(<V5CoachingBlock block={{ ...BASE, dsk_claim_provenance: CLAIM }} />)
+    const badge = screen.getByTestId('v5-coaching-dsk-provenance')
+    expect(badge).toHaveAttribute('data-dsk-claim-id', 'DSK-B-003')
+    expect(badge).toHaveAttribute('data-dsk-evidence-strength', 'strong')
+    // Identity, not a value predicate: the claim TITLE is what makes the
+    // attribution checkable against the bundle. A mutant that renders
+    // `signal` or `title` here must RED.
+    expect(badge).toHaveTextContent(CLAIM.claim_title)
+    expect(badge).toHaveTextContent('strong evidence')
+  })
+
+  it('says plainly that a card is NOT grounded, rather than leaving a blank', () => {
+    render(<V5CoachingBlock block={BASE} />)
+    // No badge...
+    expect(screen.queryByTestId('v5-coaching-dsk-provenance')).toBeNull()
+    // ...but the depth layer states the absence in plain English. A blank is
+    // a defect, not a standard.
+    const detail = screen.getByTestId('v5-coaching-grounding-detail')
+    expect(detail.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(detail).toHaveTextContent(/not linked to a cited decision-science claim/i)
+  })
+})
+
+describe('V5CoachingBlock — uncertainty channel (PR3)', () => {
+  it('tells the reader when the card pre-dates their latest change', () => {
+    render(<V5CoachingBlock block={{ ...BASE, freshness: 'stale' }} />)
+    const notice = screen.getByTestId('v5-coaching-freshness')
+    expect(notice.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(notice).toHaveTextContent(/changed since/i)
+  })
+
+  it('stays quiet when the card is fresh — and still renders the card', () => {
+    render(<V5CoachingBlock block={BASE} />)
+    expect(screen.queryByTestId('v5-coaching-freshness')).toBeNull()
+    expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(BASE.title)
+  })
+
+  it.each([
+    ['stale', /changed since/i],
+    ['pending', /still being written/i],
+    ['failed', /could not be generated/i],
+  ] as const)('gives %s its own honest sentence', (fresh, pattern) => {
+    render(<V5CoachingBlock block={{ ...BASE, freshness: fresh }} />)
+    expect(screen.getByTestId('v5-coaching-freshness')).toHaveTextContent(pattern)
+  })
+})
+
+describe('V5CoachingBlock — progressive disclosure (PR3)', () => {
+  it('keeps the depth layer COLLAPSED by default', () => {
+    render(<V5CoachingBlock block={{ ...BASE, dsk_claim_provenance: CLAIM }} />)
+    const details = screen.getByTestId('v5-coaching-details')
+    expect(details.tagName).toBe('DETAILS')
+    // `open` absent = collapsed. Asserting the attribute (not visibility)
+    // because jsdom cannot prove visibility — see the header.
+    expect(details).not.toHaveAttribute('open')
+  })
+
+  it('puts the depth INSIDE the disclosure: claim title, kind and origin in plain English', () => {
+    render(<V5CoachingBlock block={{ ...BASE, dsk_claim_provenance: CLAIM }} />)
+    const details = screen.getByTestId('v5-coaching-details')
+    expect(details).toHaveTextContent(CLAIM.claim_title)
+    // `coaching_kind` and `source` are machine tokens; the disclosure states
+    // them as sentences, and must never print the raw snake_case token.
+    expect(details).toHaveTextContent(/assumption/i)
+    expect(details).toHaveTextContent(/decision review/i)
+    expect(details.textContent).not.toContain('assumption_check')
+    expect(details.textContent).not.toContain('decision_review')
+  })
+
+  it('omits an unrecognised kind or source rather than printing a raw token', () => {
+    render(
+      <V5CoachingBlock
+        block={{ ...BASE, coaching_kind: 'brand_new_kind', source: 'brand_new_source' }}
+      />,
+    )
+    const details = screen.getByTestId('v5-coaching-details')
+    expect(details.textContent).not.toContain('brand_new_kind')
+    expect(details.textContent).not.toContain('brand_new_source')
+    // Fail-closed must not mean empty: the grounding sentence is always there.
+    expect(screen.getByTestId('v5-coaching-grounding-detail')).toHaveTextContent(
+      /not linked to a cited decision-science claim/i,
+    )
+  })
+})
+
+describe('V5CoachingBlock — the bias_signal variant keeps every signal', () => {
+  it('renders the same importance and evidence channels under the bias testid prefix', () => {
+    render(
+      <V5CoachingBlock
+        variant="bias_signal"
+        block={{
+          ...BASE,
+          coaching_kind: 'bias_signal',
+          category: 'must_fix',
+          signal: 'Your brief anchors on the first figure you wrote.',
+          dsk_claim_provenance: CLAIM,
+        }}
+      />,
+    )
+    // The C10+R1 fold exists so producer fields can never drop on one fork.
+    // This pins the new fields to that same guarantee.
+    expect(screen.getByTestId('bias-signal-card-category')).toHaveAttribute('data-category', 'must_fix')
+    expect(screen.getByTestId('bias-signal-card-signal')).toHaveTextContent(
+      'Your brief anchors on the first figure you wrote.',
+    )
+    expect(screen.getByTestId('bias-signal-card-dsk-provenance')).toHaveTextContent(CLAIM.claim_title)
+  })
+})

--- a/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
@@ -120,11 +120,39 @@ describe('V5CoachingBlock — evidence channel (PR3)', () => {
     expect(screen.getByTestId('v5-coaching-body')).toHaveTextContent(BASE.body)
   })
 
-  it('never renders signal_code as copy — it is an id, and rides as data-* only', () => {
+  /**
+   * ⚠ THE FIXTURE HERE CARRIES `signal` AS WELL AS `signal_code`, AND THAT IS
+   * THE WHOLE TEST. An earlier version set `signal_code` alone; a mutant that
+   * appended the code to the trigger line SURVIVED it, because with no
+   * `signal` the trigger line never renders and the leak site was never
+   * reached. The guard was correct and pointed at bytes that did not exist
+   * (trap 22). A card in the wild routinely carries both, so the corpus must.
+   */
+  it('never renders signal_code as copy — even beside the trigger line it could leak into', () => {
+    render(
+      <V5CoachingBlock
+        block={{
+          ...BASE,
+          signal: 'Two options share one base-rate assumption.',
+          signal_code: 'MISSING_BASE_RATE',
+        }}
+      />,
+    )
+    const card = screen.getByTestId('v5-coaching')
+    expect(card).toHaveAttribute('data-signal-code', 'MISSING_BASE_RATE')
+    // The machine token must not leak into the visible sentence stream...
+    expect(card.textContent).not.toContain('MISSING_BASE_RATE')
+    // ...while the producer's own prose beside it IS shown, so this cannot
+    // pass by rendering nothing at all.
+    expect(screen.getByTestId('v5-coaching-signal')).toHaveTextContent(
+      'Two options share one base-rate assumption.',
+    )
+  })
+
+  it('never renders signal_code as copy when there is no trigger line either', () => {
     render(<V5CoachingBlock block={{ ...BASE, signal_code: 'MISSING_BASE_RATE' }} />)
     const card = screen.getByTestId('v5-coaching')
     expect(card).toHaveAttribute('data-signal-code', 'MISSING_BASE_RATE')
-    // The machine token must not leak into the visible sentence stream.
     expect(card.textContent).not.toContain('MISSING_BASE_RATE')
     expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(BASE.title)
   })

--- a/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
@@ -120,8 +120,10 @@ describe('V5CoachingBlock — importance channel (PR3)', () => {
    * component emits four different recipes, never that a human perceives four
    * levels. That claim belongs to the browser pass recorded in the PR.
    */
-  it('gives all four categories DISTINCT visual weight, not just distinct words', () => {
-    const recipes = (['must_fix', 'should_fix', 'could_fix', 'technique'] as const).map((cat) => {
+  it('gives all four categories DISTINCT visual weight, in BOTH channels independently', () => {
+    const badges: string[] = []
+    const cards: string[] = []
+    for (const cat of ['must_fix', 'should_fix', 'could_fix', 'technique'] as const) {
       const { container } = render(<V5CoachingBlock block={{ ...BASE, category: cat }} />)
       const badge = container.querySelector('[data-testid="v5-coaching-category"]')
       const card = container.querySelector('[data-testid="v5-coaching"]')
@@ -129,9 +131,21 @@ describe('V5CoachingBlock — importance channel (PR3)', () => {
       // is comparing nulls and would agree with itself (trap 13).
       expect(badge, `no badge rendered for ${cat}`).not.toBeNull()
       expect(card, `no card rendered for ${cat}`).not.toBeNull()
-      return `${badge!.className}|${card!.className}`
-    })
-    expect(new Set(recipes).size).toBe(4)
+      badges.push(badge!.className)
+      cards.push(card!.className)
+    }
+    /**
+     * ⚠ EACH CHANNEL IS ASSERTED SEPARATELY, and that is the point. An earlier
+     * version compared the CONCATENATION of badge + card class, which two
+     * mutants walked straight through: collapsing the must_fix BADGE onto the
+     * should_fix recipe still left the card borders differing, so the joined
+     * string stayed unique and the suite stayed green. A combined key can only
+     * see that the PAIR differs somewhere — never that a given channel still
+     * discriminates. Asserting them independently is what makes a collapse in
+     * either one RED.
+     */
+    expect(new Set(badges).size, 'badge treatments collapsed').toBe(4)
+    expect(new Set(cards).size, 'card border treatments collapsed').toBe(4)
   })
 })
 

--- a/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingHierarchy.spec.tsx
@@ -105,6 +105,34 @@ describe('V5CoachingBlock — importance channel (PR3)', () => {
     expect(quietTone).toBe('info')
     expect(urgentTone).not.toBe(quietTone)
   })
+
+  /**
+   * ⚠ THIS TEST EXISTS BECAUSE A REAL BROWSER FOUND WHAT JSDOM COULD NOT.
+   *
+   * `guidanceCategoryTone` maps FOUR producer categories onto TWO colours, so
+   * the first version of this card rendered "Must fix" and "Should fix"
+   * IDENTICALLY — same border, same badge, same icon. Every structural test
+   * above passed while the most important distinction the producer makes was
+   * invisible. The screenshot is what caught it.
+   *
+   * So this pins the EMPHASIS ladder: all four categories must resolve to
+   * DISTINCT badge treatments. It is still a structural proxy — it proves the
+   * component emits four different recipes, never that a human perceives four
+   * levels. That claim belongs to the browser pass recorded in the PR.
+   */
+  it('gives all four categories DISTINCT visual weight, not just distinct words', () => {
+    const recipes = (['must_fix', 'should_fix', 'could_fix', 'technique'] as const).map((cat) => {
+      const { container } = render(<V5CoachingBlock block={{ ...BASE, category: cat }} />)
+      const badge = container.querySelector('[data-testid="v5-coaching-category"]')
+      const card = container.querySelector('[data-testid="v5-coaching"]')
+      // Positive control: the probe must find both, or the comparison below
+      // is comparing nulls and would agree with itself (trap 13).
+      expect(badge, `no badge rendered for ${cat}`).not.toBeNull()
+      expect(card, `no card rendered for ${cat}`).not.toBeNull()
+      return `${badge!.className}|${card!.className}`
+    })
+    expect(new Set(recipes).size).toBe(4)
+  })
 })
 
 describe('V5CoachingBlock — evidence channel (PR3)', () => {
@@ -157,16 +185,32 @@ describe('V5CoachingBlock — evidence channel (PR3)', () => {
     expect(screen.getByTestId('v5-coaching-title')).toHaveTextContent(BASE.title)
   })
 
-  it('grounds the card in the cited claim, quoting the claim TITLE and its evidence strength', () => {
+  /**
+   * The grounding is SPLIT by design: strength on the face (what a reader
+   * needs at a glance), the verifiable claim TITLE one row down inside the
+   * disclosure. A browser pass showed the full title inline made the card
+   * eight rows deep and orphaned the separator mid-wrap. Both halves are
+   * asserted — here and in the disclosure block below — so the split cannot
+   * quietly become a drop.
+   */
+  it('grounds the card on its face with the evidence strength and the claim id', () => {
     render(<V5CoachingBlock block={{ ...BASE, dsk_claim_provenance: CLAIM }} />)
     const badge = screen.getByTestId('v5-coaching-dsk-provenance')
     expect(badge).toHaveAttribute('data-dsk-claim-id', 'DSK-B-003')
     expect(badge).toHaveAttribute('data-dsk-evidence-strength', 'strong')
-    // Identity, not a value predicate: the claim TITLE is what makes the
-    // attribution checkable against the bundle. A mutant that renders
-    // `signal` or `title` here must RED.
-    expect(badge).toHaveTextContent(CLAIM.claim_title)
+    expect(badge).toHaveAttribute('data-dsk-protocol-id', 'DSK-P-002')
     expect(badge).toHaveTextContent('strong evidence')
+  })
+
+  it('binds the strength to the producer value, not a constant', () => {
+    render(
+      <V5CoachingBlock
+        block={{ ...BASE, dsk_claim_provenance: { ...CLAIM, evidence_strength: 'weak' } }}
+      />,
+    )
+    const badge = screen.getByTestId('v5-coaching-dsk-provenance')
+    expect(badge).toHaveTextContent('weak evidence')
+    expect(badge).not.toHaveTextContent('strong evidence')
   })
 
   it('says plainly that a card is NOT grounded, rather than leaving a blank', () => {
@@ -263,6 +307,7 @@ describe('V5CoachingBlock — the bias_signal variant keeps every signal', () =>
     expect(screen.getByTestId('bias-signal-card-signal')).toHaveTextContent(
       'Your brief anchors on the first figure you wrote.',
     )
-    expect(screen.getByTestId('bias-signal-card-dsk-provenance')).toHaveTextContent(CLAIM.claim_title)
+    expect(screen.getByTestId('bias-signal-card-dsk-provenance')).toHaveTextContent('strong evidence')
+    expect(screen.getByTestId('bias-signal-card-details')).toHaveTextContent(CLAIM.claim_title)
   })
 })

--- a/src/v5/phase3TypedBlocks.ts
+++ b/src/v5/phase3TypedBlocks.ts
@@ -42,6 +42,7 @@ import type {
   V5CoachingBlock,
   V5EvidenceBlock,
   V5ExerciseBlock,
+  V5DskClaimProvenance,
   V5DskProtocolProvenance,
   V5Phase3Freshness,
   V5ReviewCardBlock,
@@ -132,6 +133,72 @@ export function adaptTypedReviewCardBlock(raw: unknown): V5ReviewCardBlock | nul
   }
 }
 
+// ─── PR3 importance / evidence helpers ─────────────────────────────────
+
+/**
+ * The producer's four-value guidance class, enum-checked.
+ *
+ * ⚠ ENUM-CHECKED, unlike `coaching_kind`/`source` above — and the asymmetry
+ * is deliberate, not an inconsistency. Those two are pass-through
+ * discriminators that only ever reach a `data-*` attribute, so an unknown
+ * value costs nothing and a new producer kind must not need a UI release.
+ * `category` DRIVES A VISUAL SEVERITY CHANNEL and a user-facing badge, and
+ * the UI never guesses severity (the same rule `severity` on review_card
+ * already follows). An unrecognised value therefore yields `undefined` —
+ * the card renders with NO badge, which is the honest degradation. It must
+ * never fall back to a default tier: inventing "should fix" for a value we
+ * failed to parse is a claim about the user's decision that no one made.
+ *
+ * The four values are pinned against `GuidanceCategory` in the vendored
+ * schema by an identity assertion in the spec, so a contract widening REDs
+ * here rather than silently dropping the new class.
+ */
+const GUIDANCE_CATEGORIES = ['must_fix', 'should_fix', 'could_fix', 'technique'] as const
+
+function guidanceCategory(v: unknown): V5CoachingBlock['category'] | undefined {
+  const s = nonEmptyString(v)
+  if (!s) return undefined
+  return (GUIDANCE_CATEGORIES as readonly string[]).includes(s)
+    ? (s as NonNullable<V5CoachingBlock['category']>)
+    : undefined
+}
+
+/**
+ * The DSK CLAIM provenance triple — the claim sibling of
+ * `dskProtocolProvenance` below, and it follows that helper's doctrine
+ * exactly: ALL-OR-NOTHING.
+ *
+ * A refusal costs the ATTRIBUTION only — never the card. Losing a badge is
+ * a lost affordance; showing a wrong one is a lie about science. So a
+ * partial or malformed triple returns `undefined` and the card renders
+ * ungrounded, which is true, rather than grounded-in-something-unverifiable,
+ * which is not.
+ *
+ * `claim_id` is narrowed to the CLAIM arms — `B` (bias) and `T` (technique)
+ * — so a protocol id (`DSK-P-…`) or trigger id (`DSK-TR-…`) cannot
+ * masquerade as the claim this card cites. `protocol_id` is optional and,
+ * per the contract, lives INSIDE the object so it can never travel without
+ * its claim anchor; a malformed one is dropped without costing the triple.
+ */
+const DSK_CLAIM_ID_RE = /^DSK-(B|T)-\d{3}$/
+
+function dskClaimProvenance(raw: unknown): V5DskClaimProvenance | undefined {
+  if (!isPlainObject(raw)) return undefined
+  const id = nonEmptyString(raw.claim_id)
+  const title = nonEmptyString(raw.claim_title)
+  const strength = nonEmptyString(raw.evidence_strength)
+  if (!id || !title || !strength) return undefined
+  if (!DSK_CLAIM_ID_RE.test(id)) return undefined
+  if (!(DSK_EVIDENCE_STRENGTHS as readonly string[]).includes(strength)) return undefined
+  const protocolId = nonEmptyString(raw.protocol_id)
+  return {
+    claim_id: id,
+    claim_title: title,
+    evidence_strength: strength as V5DskClaimProvenance['evidence_strength'],
+    ...(protocolId && DSK_PROTOCOL_ID_RE.test(protocolId) ? { protocol_id: protocolId } : {}),
+  }
+}
+
 /**
  * Adapt a verbatim raw payload to a typed v5_coaching block.
  * Returns null when the payload is not a well-formed 0.13.x coaching block
@@ -170,6 +237,17 @@ export function adaptTypedCoachingBlock(
   // here would manufacture an affordance the producer never authorised.
   const actionPrompt = nonEmptyString(raw.action_prompt)
 
+  // ── PR3: the importance / evidence channel ─────────────────────────────
+  // Five producer-owned fields that have been on the wire since 0.19.0 /
+  // 0.20.0 / 0.39.0 and that this adapter has never read. Each is carried
+  // VERBATIM and only when the producer sent it in a form we can trust —
+  // a malformed member costs that one signal, never the card.
+  const category = guidanceCategory(raw.category)
+  const priority = finiteNumber(raw.priority)
+  const signalCode = nonEmptyString(raw.signal_code)
+  const signalLine = nonEmptyString(raw.signal)
+  const claimProvenance = dskClaimProvenance(raw.dsk_claim_provenance)
+
   return {
     type: 'v5_coaching',
     block_id: blockId,
@@ -183,6 +261,14 @@ export function adaptTypedCoachingBlock(
     ...(actionIntent ? { action_intent: actionIntent } : {}),
     ...(actionLabel ? { action_label: actionLabel } : {}),
     ...(actionPrompt ? { action_prompt: actionPrompt } : {}),
+    ...(category ? { category } : {}),
+    // `priority` is a real 0–100 number: 0 is meaningful and must survive, so
+    // this tests for undefined rather than truthiness (a `? :` here would
+    // silently drop the least-urgent band).
+    ...(priority !== undefined && priority >= 0 && priority <= 100 ? { priority } : {}),
+    ...(signalCode ? { signal_code: signalCode } : {}),
+    ...(signalLine ? { signal: signalLine } : {}),
+    ...(claimProvenance ? { dsk_claim_provenance: claimProvenance } : {}),
   }
 }
 


### PR DESCRIPTION
## Acceptance measure (one falsifiable sentence)

**A user reading the coaching feed can now tell, without opening anything, which suggestions the producer classified as must-fix versus optional technique, which are grounded in a cited decision-science claim and how strong that evidence is, and which were written before their latest edit — and we would observe the failure of this claim as a coaching card that renders a badge, grounding line or staleness notice the producer did not send, or that omits one it did.**

## What was actually broken

`V5CoachingBlock` rendered every suggestion identically — lightbulb, title, prose, optional pill — with `coaching_kind` / `source` / `freshness` as inert `data-*` attributes.

Worse, the producer's importance and evidence signals never reached it. `adaptTypedCoachingBlock` is an implicit hand-maintained allowlist, and five fields that have been on the wire since schemas 0.19.0 / 0.20.0 / 0.39.0 were never named in it:

| field | on the wire | reached the chat card |
|---|---|---|
| `category` (must_fix/should_fix/could_fix/technique) | yes | **no** |
| `priority` (0–100 urgency) | yes | **no** |
| `signal_code` | yes | **no** |
| `signal` (producer's "what triggered this") | yes | **no** |
| `dsk_claim_provenance` (claim + evidence strength) | yes | **no** |

The parser sidecar preserves the raw block **by reference**, and the parallel `deriveGuidance` path already carries all five — which is why the guidance strip, the inspector, the node marker and the Strengthen panel could rank and ground the item while the chat card, the surface a user reads *first*, threw the whole channel away.

## What changed

- **Adapter** (`phase3TypedBlocks.ts`) carries the five fields — additive, fail-closed, verbatim. `category` is enum-checked because it drives a visual severity channel; `signal_code` deliberately is **not**, because its vocabulary is producer-owned. The DSK triple is all-or-nothing, with `claim_id` narrowed to the claim arms so a protocol or trigger id cannot masquerade as a claim.
- **Card** gains four channels: importance (badge + card weight), evidence (trigger line + grounding chip), uncertainty (freshness in plain English — previously an inert attribute), action (unchanged).
- **Progressive disclosure**: a `<details>` closed by default holds the verifiable claim title, the kind and the origin as sentences. Raw snake_case tokens are never printed as copy.
- **Reuse, not duplication**: colour and icon derive from `guidanceCategoryTone` / `guidanceCategoryIcon`; badge copy from `STRENGTHEN_COPY.severityLabel`, pinned in-test against the shared constant so drift REDs.

## Ordering — no new authority

`priority_rank` is an ascending ordinal and `composePhase3BridgedBlocks` **already sorts the feed by it**. This card mints no ordering of its own. Nothing here needed a contract change.

## Honest absence, never blanks

No category → no badge and the pre-existing neutral treatment (an uncategorised card looks exactly as it always did). Not grounded → the disclosure says so in plain English. `fresh` says nothing, because a "this is current" badge on every card teaches readers to ignore the one time it matters.

## Evidence

- **Deployed mount settled at the bytes** (trap 3b): staging `version.json` = `aa81aa1a`, the branch base. 87 chunks crawled with positive **and** negative controls; `v5-coaching` / `bias-signal-card` present. The V5 gate is folded as `Tf({flag:"true"})` at **all three** call sites — this settles two contradictory second-hand claims in the repo; `docs/ui/useconversation-spec-diagnosis.md` is stale.
- **RED-first**: 21 collected by name, 18 failing, before any product code.
- **16/16 mutants bite**, in a detached worktree whose isolation was proved by **writing a sentinel** (distinct inodes, source hash unchanged), applied-check per mutation scoped to `src/`, control exactly 0.
- **Suites**: 266 files / 3822 passed. Typecheck gate PASSED. Lint 0 errors.


## Scope — what actually reaches this surface today

**Read this before the claims above.** Derived from CEE `staging` @ `edcaa98b`, the coaching card receives a **3-rung ladder, not 4**:

| `coaching_kind` | `category` CEE sends |
|---|---|
| `orientation`, `bias_signal` | `should_fix` |
| `assumption_check`, `strengthen` | `could_fix` |
| `calibration_prompt` | `technique` |

**`must_fix` does not arise on a coaching block.** It comes only from `guidanceSignalsForSeverity('critical')`, which serves `review_card` / `evidence`. The `must_fix` treatment here is correct and ready, but it is **currently unexercised on this surface** — it delivers no user value today.

The other two channels are also thinner than the code can carry:
- **`signal`** is emitted on `orientation` only, as a single fixed literal.
- **`dsk_claim_provenance`** reaches `calibration_prompt` only, `DSK-T-*` only, strengths medium/strong only. So on **4 of 5 live coaching kinds the disclosure always reads "not linked to a cited decision-science claim"**.

That honest-absence behaviour is correct and is the point — but the user-visible delta is **a 3-rung ladder, freshness sentences, kind/origin sentences, and a mostly-negative grounding disclosure**, not the fully-populated card the examples above depict. Widening what the producer sends is a CEE question, not a UI one.

## Accessibility — a defect found and fixed in review

The first version of the emphasis ladder put category colour in the **label ink**. Measured from computed styles, that failed three ways:

- `should_fix` ink resolved to **2.80:1** and `must_fix` white-on-fill to **2.83:1** — both **below WCAG AA (4.5:1)** at 11px. No token in the danger family reaches 4.5:1 with white ink (best: `--danger-active`, 4.24:1), so ink-colouring could not be made compliant within the palette.
- The ladder **inverted**: `technique`, the least urgent tier, carried the highest-contrast label.
- It silently diverged from the four badge surfaces already shipped.

`Conversation.module.css` states the convention at the existing guidance badges — *"Category badge colour variants — DS v5 §3.2: outlined pills, text-text-body"*. Colour rides the **border**; the ink stays body-coloured. Adopting it dissolves all three problems at once.

**Post-fix, from the live CSSOM:**

| category | badge | ink contrast | AA |
|---|---|---|---|
| `must_fix` | filled `danger-light`, medium weight | 6.09:1 | ✅ |
| `should_fix` | outlined danger | 10.45:1 | ✅ |
| `could_fix` | outlined info | 10.45:1 | ✅ |
| `technique` | outlined neutral | 10.45:1 | ✅ |

4 distinct appearances; meta rows **5.23:1** (quieter than body's 15.01:1, still AA); no tier can out-shout another by label contrast.

### Density — the honest claim

**This card is strictly heavier than before in the fully-populated case.** It gains up to four rows: the category badge, the trigger line, the freshness notice, and the disclosure summary. The quiet case — uncategorised, fresh, ungrounded — gains only the summary row.

So the claim I am making is narrower than "cognitive load fell", and deliberately so: **depth moved behind a disclosure, and the added rows carry information that was previously absent entirely.** Whether net load fell for a fully-populated card is genuinely arguable, and I do not assert it. If the fully-populated card proves too heavy in review, that is a real finding and the fix is to demote a row, not to argue.

### What the tests can and cannot support

Structural tests prove a signal the producer sent is present and bound by identity, that an absent one is replaced by a sentence rather than a blank, and that the depth layer is collapsed. **They cannot prove the hierarchy is legible.** That claim rests on a real-browser pass, which is also what caught the one design defect here:

> `guidanceCategoryTone` maps **four** categories onto **two** colours, so adjacent tiers rendered **identically**. Every structural test passed while the distinction the producer makes was invisible.

Fixed with an emphasis ladder (filled / outlined / outlined-quiet / muted) that keeps colour derived from the shared authority. Verified from the live CSSOM: **4 distinct computed badge appearances, 0 disclosures open by default.** Two mutants then proved the first version of that test was too weak — a combined badge+card key let a single-channel collapse through — so each channel is now asserted independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


