### PR TITLE
feat(ui-agency): lift overlay open-state into uiStore so an AI directive can raise a menu

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -8,6 +8,7 @@ import { UserAvatarMenu } from './UserAvatarMenu'
 import { KebabMenu } from './KebabMenu'
 import { ScenarioSwitcher } from '../../canvas/components/ScenarioSwitcher'
 import { MENU_EXCLUSIVE_EVENT } from './LeftSidebar'
+import { useUIStore } from '../../stores/uiStore'
 
 // Custom events for help actions (communicated to ReactFlowGraph)
 // Lane 4 (P5): SHOW_ONBOARDING removed — its only dispatcher was the kebab
@@ -45,8 +46,26 @@ export const TopBar = ({
 }: TopBarProps) => {
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState(scenarioTitle)
-  const [showMenu, setShowMenu] = useState(false)
   const [showSavedPill, setShowSavedPill] = useState(false)
+
+  // The kebab menu's open-state lives in uiStore, NOT in component-local
+  // `useState`. That is the whole point: `applyV5State` dispatches the AI's
+  // ui_directive verbs from a once-per-envelope, non-render side-effect site
+  // whose only reach into the UI is `useUIStore.getState()`. A `useState`
+  // here made menus, pop-ups and coach-marks structurally unreachable to any
+  // assistant gesture. Both selectors return primitives, so no useShallow is
+  // needed and no fresh object is created per render.
+  const showMenu = useUIStore(s => s.activeOverlaySurface === 'top_bar_menu')
+  const overlayOrigin = useUIStore(s => s.overlaySurfaceOrigin)
+  const setOverlaySurface = useUIStore(s => s.setOverlaySurface)
+  const closeMenu = useCallback(() => {
+    // Close only OUR surface. Without this check a stray close would lower
+    // whichever surface happened to be raised — including one this component
+    // does not own.
+    if (useUIStore.getState().activeOverlaySurface === 'top_bar_menu') {
+      setOverlaySurface(null)
+    }
+  }, [setOverlaySurface])
 
   const menuRef = useRef<HTMLDivElement | null>(null)
 
@@ -98,19 +117,22 @@ export const TopBar = ({
     }
   }
 
+  // USER AGENCY over an assistant-raised surface. These dismissals are
+  // deliberately unconditional on WHO raised the menu: the assistant may put
+  // it on screen, and Escape / click-outside must always take it back.
   useEffect(() => {
     if (!showMenu) return
 
     const handleClickOutside = (event: MouseEvent) => {
       if (!menuRef.current) return
       if (!menuRef.current.contains(event.target as Node)) {
-        setShowMenu(false)
+        closeMenu()
       }
     }
 
     const handleEscapeKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setShowMenu(false)
+        closeMenu()
       }
     }
 
@@ -120,36 +142,76 @@ export const TopBar = ({
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleEscapeKey)
     }
-  }, [showMenu])
+  }, [showMenu, closeMenu])
 
   // Close kebab menu when another menu claims exclusivity
   useEffect(() => {
     const handler = (e: Event) => {
       const source = (e as CustomEvent).detail?.source
-      if (source !== 'kebab') setShowMenu(false)
+      if (source !== 'kebab') closeMenu()
     }
     window.addEventListener(MENU_EXCLUSIVE_EVENT, handler)
     return () => window.removeEventListener(MENU_EXCLUSIVE_EVENT, handler)
-  }, [])
+  }, [closeMenu])
+
+  // KEEP THE STORE TRUTHFUL ABOUT WHAT IS ON SCREEN. An overlay surface is
+  // anchored to a control; if that control is not mounted, a raised surface is
+  // a claim the screen does not support. Component-local `useState` gave this
+  // for free — it died with the component. A store does not, so the owner of a
+  // surface must lower it on unmount, or a route change would leave the store
+  // asserting a menu that no longer exists (and the next mount would paint it
+  // open). Unmount-only: nothing is cleared while the bar is alive, so an
+  // assistant gesture is never swallowed mid-session.
+  // Empty deps on purpose: this must be strictly unmount-only, so it reads the
+  // store directly rather than closing over an action whose identity could
+  // drift and turn the cleanup into a mid-life dismissal.
+  useEffect(
+    () => () => {
+      if (useUIStore.getState().activeOverlaySurface === 'top_bar_menu') {
+        useUIStore.getState().setOverlaySurface(null)
+      }
+    },
+    [],
+  )
+
+  // Claim exclusivity whenever OUR menu becomes raised — by a user click OR by
+  // an assistant gesture that never passes through a click handler. Announcing
+  // from the state transition rather than from `onToggle` is what makes the two
+  // paths equivalent; sibling menus (LeftSidebar's lens, UserAvatarMenu) still
+  // own their state and only learn about us through this event.
+  useEffect(() => {
+    if (!showMenu) return
+    window.dispatchEvent(
+      new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'kebab' } }),
+    )
+  }, [showMenu])
 
   // Help action handlers - emit custom events for ReactFlowGraph to handle
   const handleShowKeyboardLegend = useCallback(() => {
     window.dispatchEvent(new CustomEvent(HELP_EVENTS.SHOW_KEYBOARD_LEGEND))
-    setShowMenu(false)
-  }, [])
+    closeMenu()
+  }, [closeMenu])
 
   const handleShowInfluenceExplainer = useCallback(() => {
     window.dispatchEvent(new CustomEvent(HELP_EVENTS.SHOW_INFLUENCE_EXPLAINER))
-    setShowMenu(false)
-  }, [])
+    closeMenu()
+  }, [closeMenu])
 
   // Decision Graph Display v2 Task 13: Analysis metadata
   const analysisMetadata = useAnalysisMetadata()
   // A.15: Stage lifecycle pill
   const stagePill = useStagePill()
 
+  // `data-overlay-origin` is present only while an overlay this bar owns is
+  // raised, and names WHO raised it. A surface the assistant put on screen must
+  // be attributable rather than appearing to move on its own; this is the hook
+  // a visible attribution (and any browser-level check) binds to.
   return (
-    <div className={styles.topBar} role="banner">
+    <div
+      className={styles.topBar}
+      role="banner"
+      {...(showMenu && overlayOrigin ? { 'data-overlay-origin': overlayOrigin } : {})}
+    >
       {/* Left section - logo and title */}
       <div className={styles.topBarLeft}>
         <a href="/" className={styles.logoLink} aria-label="Olumi home">
@@ -357,14 +419,12 @@ export const TopBar = ({
         <KebabMenu
           isOpen={showMenu}
           onToggle={() => {
-            const next = !showMenu
-            setShowMenu(next)
-            if (next) {
-              window.dispatchEvent(new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'kebab' } }))
-            }
+            // The exclusivity announcement rides the state transition (effect
+            // above), so the user path and the assistant path behave alike.
+            setOverlaySurface(showMenu ? null : 'top_bar_menu')
           }}
-          onClose={() => setShowMenu(false)}
-          onStartRename={() => { setIsEditing(true); setShowMenu(false) }}
+          onClose={closeMenu}
+          onStartRename={() => { setIsEditing(true); closeMenu() }}
           onShowKeyboardLegend={handleShowKeyboardLegend}
           onShowInfluenceExplainer={handleShowInfluenceExplainer}
           menuRef={menuRef}

--- a/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
@@ -138,14 +138,33 @@ describe('TopBar kebab menu — lifted into uiStore', () => {
         overlaySurfaceOrigin: 'user',
       })
     })
-    // Escape and click-outside are this bar's dismissals. They must act on its
-    // OWN surface only — a component that lowers whatever happens to be raised
-    // would take a sibling's menu away the moment two surfaces are lifted.
-    fireEvent.keyDown(document, { key: 'Escape' })
-    fireEvent.mouseDown(document.body)
+
+    // ⚠ THE PATH MATTERS. Escape and click-outside are registered only while
+    // THIS bar's menu is open, so firing them here would prove nothing — the
+    // listeners are not even attached (a guard agreeing with itself). The
+    // exclusivity listener IS attached unconditionally, so it is the one path
+    // that can reach this bar's close while a sibling's surface is raised.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'lens' } }),
+      )
+    })
 
     expect(useUIStore.getState().activeOverlaySurface).toBe(FOREIGN_SURFACE)
     expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+
+    // PRECONDITION PINNED IN-TEST: the very same event, in this very render,
+    // DOES lower this bar's own surface. Without this the assertion above
+    // would also pass if the listener had silently stopped firing.
+    act(() => {
+      useUIStore.getState().setOverlaySurface('top_bar_menu')
+    })
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'lens' } }),
+      )
+    })
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
   })
 
   it('marks the banner with the origin so a surface the assistant raised is attributable', () => {

--- a/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
@@ -31,7 +31,26 @@ import { MemoryRouter } from 'react-router-dom'
 import { TopBar } from '../TopBar'
 import { MENU_EXCLUSIVE_EVENT } from '../LeftSidebar'
 import { ToastProvider } from '../../../canvas/ToastContext'
-import { useUIStore } from '../../../stores/uiStore'
+import { useUIStore, type OverlaySurfaceId } from '../../../stores/uiStore'
+
+/**
+ * A surface id this bar does NOT own.
+ *
+ * `OVERLAY_SURFACE_IDS` has one member today, so every "is my menu open?"
+ * predicate — `=== 'top_bar_menu'` and the far looser `!== null` — agrees on
+ * every value the enum can produce. A mutation kit confirmed it: replacing
+ * TopBar's identity check with `!== null` left the whole suite GREEN. That is
+ * trap 19 exactly (an assertion satisfied by an object other than the one it
+ * names), latent until the second surface is lifted, at which point the kebab
+ * would silently open whenever a sibling menu was raised.
+ *
+ * So the discrimination is pinned NOW, with a foreign id the store will one
+ * day carry for real. The cast is the point: it stands in for a future sibling
+ * surface, and it makes the pair complete — loosen the guard for ALL surfaces
+ * and this test REDs; loosen it for a DIFFERENT surface only and the
+ * assistant-open test stays green.
+ */
+const FOREIGN_SURFACE = 'a_surface_this_bar_does_not_own' as unknown as OverlaySurfaceId
 
 const props = {
   scenarioTitle: 'Pricing Decision 2025',
@@ -96,6 +115,37 @@ describe('TopBar kebab menu — lifted into uiStore', () => {
       'true',
     )
     expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+  })
+
+  // ── The binding is to THIS bar's surface, by identity ────────────────────
+  it('stays closed when a surface it does not own is raised', () => {
+    renderTopBar()
+    act(() => {
+      useUIStore.setState({
+        activeOverlaySurface: FOREIGN_SURFACE,
+        overlaySurfaceOrigin: 'assistant',
+      })
+    })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.getByRole('banner')).not.toHaveAttribute('data-overlay-origin')
+  })
+
+  it('does not lower a surface it does not own', () => {
+    renderTopBar()
+    act(() => {
+      useUIStore.setState({
+        activeOverlaySurface: FOREIGN_SURFACE,
+        overlaySurfaceOrigin: 'user',
+      })
+    })
+    // Escape and click-outside are this bar's dismissals. They must act on its
+    // OWN surface only — a component that lowers whatever happens to be raised
+    // would take a sibling's menu away the moment two surfaces are lifted.
+    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.mouseDown(document.body)
+
+    expect(useUIStore.getState().activeOverlaySurface).toBe(FOREIGN_SURFACE)
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
   })
 
   it('marks the banner with the origin so a surface the assistant raised is attributable', () => {

--- a/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.overlaySurface.spec.tsx
@@ -1,0 +1,243 @@
+/**
+ * TopBar — the kebab menu is driven by uiStore, not by component-local state.
+ *
+ * THE BLOCKER THIS CLOSES. `applyV5State` executes ui_directive verbs at a
+ * once-per-envelope, NON-RENDER side-effect site. It reaches the UI only
+ * through `useUIStore.getState()`. Until this change the TopBar menu's
+ * open-state was `const [showMenu, setShowMenu] = useState(false)` inside the
+ * component, so no assistant gesture could ever raise it — menus, pop-ups and
+ * coach-marks were structurally unreachable, not merely unimplemented.
+ *
+ * ⚠ TRAP 3b — BIND TO THE SURFACE THE DEPLOYED BUILD MOUNTS. This estate has
+ * twice shipped a green suite bound to a component the deployed flags do not
+ * render. The first test below is a MOUNT-PATH assertion: it pins that the
+ * module under test is the one in the deployed bundle, via a marker string
+ * that is unique to src/components/layout/TopBar.tsx in the source tree AND
+ * present in the deployed staging chunk CanvasMVP-y0VodO-Y.js (crawled to a
+ * fixpoint over 87 chunks at commit aa81aa1a, 2026-08-10; positive controls
+ * fired, negative controls read zero). If TopBar is ever replaced by a
+ * lookalike, that assertion fails rather than the suite passing on the wrong
+ * object (trap 19: bind by identity, never by a predicate another object
+ * could satisfy).
+ *
+ * ⚠ WHAT jsdom CANNOT PROVE. These tests prove the menu is MOUNTED and that
+ * `aria-expanded` is true. They prove NOTHING about visibility, stacking,
+ * layout or whether a human can see the menu. Only a real browser can, and
+ * the PR body carries that check separately.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TopBar } from '../TopBar'
+import { MENU_EXCLUSIVE_EVENT } from '../LeftSidebar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+import { useUIStore } from '../../../stores/uiStore'
+
+const props = {
+  scenarioTitle: 'Pricing Decision 2025',
+  onTitleChange: vi.fn(),
+  onSave: vi.fn(),
+  onShare: vi.fn(),
+}
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar {...props} />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+/** The assistant's only reach into the UI: the non-render store seam that
+ *  applyV5State uses. Deliberately NOT a component handler — calling a prop
+ *  would prove nothing about directive reachability. */
+function assistantRaises(surface: 'top_bar_menu') {
+  act(() => {
+    useUIStore.getState().requestOverlaySurface(surface)
+  })
+}
+
+describe('TopBar kebab menu — lifted into uiStore', () => {
+  beforeEach(() => {
+    useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
+  })
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
+  })
+
+  // ── Mount-path assertion (trap 3b) ───────────────────────────────────────
+  it('is the TopBar the deployed bundle mounts', () => {
+    renderTopBar()
+    // Marker unique to src/components/layout/TopBar.tsx and present in the
+    // deployed chunk. Its handler is the only producer of this string.
+    const versionHistory = screen.getByRole('button', { name: /version history/i })
+    expect(versionHistory).toBeInTheDocument()
+    // And this TopBar is the one that owns the kebab trigger.
+    expect(screen.getByRole('button', { name: /more options/i })).toBeInTheDocument()
+  })
+
+  // ── THE CAPABILITY: an assistant gesture opens a menu, no user input ─────
+  it('opens the kebab menu from the non-render store seam, with no user interaction', () => {
+    renderTopBar()
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /more options/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+
+    assistantRaises('top_bar_menu')
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /more options/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+  })
+
+  it('marks the banner with the origin so a surface the assistant raised is attributable', () => {
+    renderTopBar()
+    const banner = screen.getByRole('banner')
+    expect(banner).not.toHaveAttribute('data-overlay-origin')
+
+    assistantRaises('top_bar_menu')
+    expect(banner).toHaveAttribute('data-overlay-origin', 'assistant')
+
+    act(() => {
+      useUIStore.getState().setOverlaySurface(null)
+    })
+    expect(banner).not.toHaveAttribute('data-overlay-origin')
+  })
+
+  // ── The user path is unchanged ───────────────────────────────────────────
+  it('the user can still open the menu by clicking, and the store records it', () => {
+    renderTopBar()
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+  })
+
+  it('the user can still close the menu by clicking the trigger again', () => {
+    renderTopBar()
+    const trigger = screen.getByRole('button', { name: /more options/i })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+  })
+
+  // ── USER AGENCY over an assistant-raised surface ─────────────────────────
+  it('Escape dismisses a menu the ASSISTANT raised', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  it('a click outside dismisses a menu the ASSISTANT raised', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+  })
+
+  // ── The cross-menu exclusivity bridge still works ────────────────────────
+  // LeftSidebar's lens menu and UserAvatarMenu still hold their own local
+  // state (not this lane's files) and coordinate over this window event. The
+  // lifted kebab must keep honouring it in BOTH directions, or lifting one
+  // surface would silently create two competing exclusivity mechanisms.
+  it('closes when ANOTHER menu claims exclusivity', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'lens' } }),
+      )
+    })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+  })
+
+  it('stays open when the exclusivity claim is its OWN', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MENU_EXCLUSIVE_EVENT, { detail: { source: 'kebab' } }),
+      )
+    })
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+  })
+
+  it('announces its own exclusivity claim when the ASSISTANT raises it, so sibling menus close', () => {
+    renderTopBar()
+    const seen: string[] = []
+    const listener = (e: Event) => {
+      seen.push(String((e as CustomEvent).detail?.source))
+    }
+    window.addEventListener(MENU_EXCLUSIVE_EVENT, listener)
+    try {
+      assistantRaises('top_bar_menu')
+    } finally {
+      window.removeEventListener(MENU_EXCLUSIVE_EVENT, listener)
+    }
+    expect(seen).toContain('kebab')
+  })
+
+  it('reflects the store on first paint rather than defaulting closed', () => {
+    useUIStore.setState({
+      activeOverlaySurface: 'top_bar_menu',
+      overlaySurfaceOrigin: 'assistant',
+    })
+    renderTopBar()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  // ── The store must stay TRUTHFUL about what is on screen ─────────────────
+  // An overlay is anchored to a control. Component-local `useState` died with
+  // the component; a store does not. Without an unmount lower, a route change
+  // would leave the store asserting a menu that no longer exists — and the
+  // next TopBar to mount would paint it open, which is how a lifted surface
+  // turns into a ghost.
+  it('lowers its surface when the bar unmounts', () => {
+    const { unmount } = renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+
+    unmount()
+
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  it('a remount after an unmount starts closed', () => {
+    const first = renderTopBar()
+    assistantRaises('top_bar_menu')
+    first.unmount()
+
+    renderTopBar()
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/src/stores/__tests__/uiStore.overlaySurface.test.ts
+++ b/src/stores/__tests__/uiStore.overlaySurface.test.ts
@@ -17,12 +17,27 @@
  * inverts the channel's charter. Lifting overlay state out of component-local
  * `useState` into a globally-reachable store is exactly the change that could
  * make AI-driven closing possible BY ACCIDENT. So the assistant-facing action
- * is open-only by construction, and this file proves it two independent ways:
+ * is open-only by construction, and this file proves it THREE independent ways:
  *   (1) a DERIVED guard iterating the canonical id list — proves every consumer
  *       agrees with the list;
- *   (2) a HAND-WRITTEN adversarial corpus — proves the list is not the only
- *       thing standing between a hostile argument and a closed menu.
- * Trap 12d: derivation moves the risk, it does not remove it. Ship both.
+ *   (2) a HAND-WRITTEN adversarial corpus of INVALID arguments — proves the
+ *       list is not the only thing standing between a hostile argument and a
+ *       closed menu;
+ *   (3) ⚠ a VALID-BUT-FOREIGN surface id — the class (1) and (2) CANNOT SEE.
+ * Trap 12d: derivation moves the risk, it does not remove it. Ship all three.
+ *
+ * ⚠ WHY (3) HAD TO BE ADDED, and it is the sharpest lesson in this lane.
+ * Every member of the corpus in (2) is an INVALID value, so the corpus is
+ * structurally blind to the attack that uses a VALID one: with a second member
+ * in `OVERLAY_SURFACE_IDS`, a user-opened 'top_bar_menu' followed by
+ * `requestOverlaySurface('<other real surface>')` returned TRUE and the user's
+ * menu was GONE — because with ONE SLOT a raise into an occupied slot IS a
+ * lower. Measured with a second id present: the whole suite stayed GREEN. It is
+ * the identical latent defect that `FOREIGN_SURFACE` catches one layer up in
+ * TopBar.overlaySurface.spec.tsx — found at the component, missed at the store,
+ * which is where the user-agency claim actually lives. Unreachable today only
+ * because the enum has one member; the next step for this concept is lifting
+ * the second surface, so it would have landed with no red anywhere.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
@@ -36,6 +51,23 @@ import {
 function resetOverlaySlice() {
   useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
 }
+
+/**
+ * A second, VALID surface id — the one the enum does not carry yet.
+ *
+ * The cast is the entire point. `OVERLAY_SURFACE_IDS` has one member today, so
+ * "the assistant cannot displace the user's surface" is unfalsifiable from
+ * inside the enum: there is no other surface to displace it WITH. Standing in a
+ * foreign id makes the invariant testable NOW rather than the day the second
+ * menu is lifted, which is exactly when it would otherwise ship broken. Mirrors
+ * `FOREIGN_SURFACE` in TopBar.overlaySurface.spec.tsx.
+ *
+ * NOTE it is deliberately NOT added to `OVERLAY_SURFACE_IDS`: it must be
+ * rejected by `isOverlaySurfaceId` when it arrives as an ARGUMENT, so it is
+ * injected as STATE (what a second lifted surface would leave behind) and the
+ * argument under test is always the real id.
+ */
+const FOREIGN_SURFACE = 'left_sidebar_lens_menu' as unknown as OverlaySurfaceId
 
 describe('uiStore — overlay surface (assistant-drivable, open-only)', () => {
   beforeEach(resetOverlaySlice)
@@ -158,6 +190,82 @@ describe('uiStore — overlay surface (assistant-drivable, open-only)', () => {
     expect(opened).toBe(false)
     expect(useUIStore.getState().activeOverlaySurface).toBeNull()
     expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  // ── (3) VALID-BUT-FOREIGN: the class the corpus above cannot contain ─────
+  // Under one-slot exclusion a raise into an occupied slot IS a lower, so these
+  // four pin the only shape of "the assistant closed my menu" that a wholly
+  // well-formed request can reach.
+
+  it('the assistant cannot displace a surface the USER opened', () => {
+    // PRECONDITION pinned in-test: the slot is genuinely held, by the user.
+    useUIStore.setState({
+      activeOverlaySurface: FOREIGN_SURFACE,
+      overlaySurfaceOrigin: 'user',
+    })
+
+    const raised = useUIStore.getState().requestOverlaySurface('top_bar_menu')
+
+    expect(raised).toBe(false)
+    // The user's surface is UNTOUCHED — the assertion is on the positive value,
+    // not merely "not top_bar_menu".
+    expect(useUIStore.getState().activeOverlaySurface).toBe(FOREIGN_SURFACE)
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+  })
+
+  it('the assistant CAN replace a surface it raised itself', () => {
+    // The discriminating twin of the test above: same call, same occupied slot,
+    // only the ORIGIN differs. Without this pair the refusal could be a blanket
+    // "never raise into an occupied slot", which is a different rule.
+    useUIStore.setState({
+      activeOverlaySurface: FOREIGN_SURFACE,
+      overlaySurfaceOrigin: 'assistant',
+    })
+
+    const raised = useUIStore.getState().requestOverlaySurface('top_bar_menu')
+
+    expect(raised).toBe(true)
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+  })
+
+  it('re-raising the surface already up does not re-attribute it to the assistant', () => {
+    useUIStore.getState().setOverlaySurface('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+
+    const raised = useUIStore.getState().requestOverlaySurface('top_bar_menu')
+
+    // Idempotent: the surface IS up, so the honest answer is true...
+    expect(raised).toBe(true)
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    // ...but the provenance badge must not tell the user the assistant opened
+    // a menu the user opened themselves.
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+  })
+
+  it('still raises into an EMPTY slot — the refusal is not a blanket block', () => {
+    // Guards against "fixing" the two tests above by making the action never
+    // raise at all. The capability must survive its own safety rule.
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+
+    const raised = useUIStore.getState().requestOverlaySurface('top_bar_menu')
+
+    expect(raised).toBe(true)
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+  })
+
+  it('treats an unrecognised origin on a held slot as the USER’s (fail-closed)', () => {
+    // A slot held with no origin is a broken invariant, not an invitation. It
+    // must not become the loophole that a corrupted or externally-injected
+    // state can be leveraged through.
+    useUIStore.setState({
+      activeOverlaySurface: FOREIGN_SURFACE,
+      overlaySurfaceOrigin: null,
+    })
+
+    expect(useUIStore.getState().requestOverlaySurface('top_bar_menu')).toBe(false)
+    expect(useUIStore.getState().activeOverlaySurface).toBe(FOREIGN_SURFACE)
   })
 
   // ── The canonical list must contain the surface the deployed TopBar uses ──

--- a/src/stores/__tests__/uiStore.overlaySurface.test.ts
+++ b/src/stores/__tests__/uiStore.overlaySurface.test.ts
@@ -1,0 +1,170 @@
+/**
+ * uiStore — OVERLAY SURFACE concept (PR3, UI agency).
+ *
+ * WHY THIS CONCEPT IS SEPARATE (trap 21: write down the question each
+ * authority answers before reconciling them). The store now answers three
+ * DIFFERENT questions, and they must not be collapsed into one predicate:
+ *   - `activeOutputTab`        — which tab is fronted INSIDE the dock?
+ *   - `activeRightPanel`       — which PERSISTENT right-side region owns the slot?
+ *   - `activeOverlaySurface`   — which TRANSIENT overlay is currently raised?
+ * An overlay surface is anchored to a control, self-dismissing, and closed by
+ * default (a menu, a pop-up, a coach-mark). It is not a docked region, so it
+ * does not belong on `activeRightPanel`.
+ *
+ * THE USER-AGENCY INVARIANT THIS FILE EXISTS TO PIN.
+ * `close_panel` / `close_inspector` were deliberately REJECTED from the
+ * ui_directive design — the assistant taking surfaces AWAY from the user
+ * inverts the channel's charter. Lifting overlay state out of component-local
+ * `useState` into a globally-reachable store is exactly the change that could
+ * make AI-driven closing possible BY ACCIDENT. So the assistant-facing action
+ * is open-only by construction, and this file proves it two independent ways:
+ *   (1) a DERIVED guard iterating the canonical id list — proves every consumer
+ *       agrees with the list;
+ *   (2) a HAND-WRITTEN adversarial corpus — proves the list is not the only
+ *       thing standing between a hostile argument and a closed menu.
+ * Trap 12d: derivation moves the risk, it does not remove it. Ship both.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  useUIStore,
+  OVERLAY_SURFACE_IDS,
+  type OverlaySurfaceId,
+} from '../uiStore'
+
+/** Pristine overlay slice. Deliberately does NOT touch the tab/panel slices —
+ *  this concept is independent of them and a shared reset would hide a leak. */
+function resetOverlaySlice() {
+  useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
+}
+
+describe('uiStore — overlay surface (assistant-drivable, open-only)', () => {
+  beforeEach(resetOverlaySlice)
+
+  // ⚠ Reads getInitialState(), NOT getState(). `resetOverlaySlice` uses
+  // `setState`, which in Zustand MERGES arbitrary keys — so a `getState()`
+  // assertion here would pass because the RESET wrote the value, not because
+  // the store declares the default. That is a guard agreeing with itself
+  // (trap 13b): it was green at pristine, before the fields existed at all.
+  // `getInitialState()` returns the creator's own initial object and no
+  // `setState` can reach it, so this binds to the declaration.
+  it('declares the overlay slice closed and unstamped in its initial state', () => {
+    const initial = useUIStore.getInitialState()
+    expect(initial.activeOverlaySurface).toBeNull()
+    expect(initial.overlaySurfaceOrigin).toBeNull()
+    // Precondition pinned in-test: the reset really can write these keys, so
+    // the assertion above is about the declaration and not about an absence.
+    useUIStore.setState({ activeOverlaySurface: 'top_bar_menu' })
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getInitialState().activeOverlaySurface).toBeNull()
+  })
+
+  // ── The USER path: may open AND close ────────────────────────────────────
+  it('setOverlaySurface opens a surface and stamps origin "user"', () => {
+    useUIStore.getState().setOverlaySurface('top_bar_menu')
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+  })
+
+  it('setOverlaySurface(null) closes and clears the origin', () => {
+    useUIStore.getState().setOverlaySurface('top_bar_menu')
+    useUIStore.getState().setOverlaySurface(null)
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  // ── The ASSISTANT path: may open, and ONLY open ──────────────────────────
+  it('requestOverlaySurface opens a surface, stamps origin "assistant", returns true', () => {
+    const opened = useUIStore.getState().requestOverlaySurface('top_bar_menu')
+    // Assert the POSITIVE outcome — `not.toBe(false)` would pass for undefined.
+    expect(opened).toBe(true)
+    expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+  })
+
+  it('a user can always take back a surface the assistant raised', () => {
+    useUIStore.getState().requestOverlaySurface('top_bar_menu')
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+    useUIStore.getState().setOverlaySurface(null)
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  // ── (1) DERIVED guard: every canonical id works on BOTH paths ────────────
+  // Structurally blind to a MISSING id (that is what the corpus below is for),
+  // but it does prove no consumer has drifted from the canonical list.
+  it('every canonical overlay id opens on both the user and the assistant path', () => {
+    expect(OVERLAY_SURFACE_IDS.length).toBeGreaterThan(0)
+    for (const id of OVERLAY_SURFACE_IDS) {
+      resetOverlaySlice()
+      useUIStore.getState().setOverlaySurface(id)
+      expect(useUIStore.getState().activeOverlaySurface).toBe(id)
+
+      resetOverlaySlice()
+      expect(useUIStore.getState().requestOverlaySurface(id)).toBe(true)
+      expect(useUIStore.getState().activeOverlaySurface).toBe(id)
+      expect(useUIStore.getState().overlaySurfaceOrigin).toBe('assistant')
+    }
+  })
+
+  // ── (2) HAND-WRITTEN adversarial corpus: the open-only invariant ─────────
+  // Written from OUTSIDE the enum (trap 22: a corpus drawn only from the
+  // author's canonical list cannot see the class the list does not contain).
+  // The precondition is PINNED IN-TEST: a user-opened menu must be present
+  // BEFORE each hostile call, otherwise "still null" would pass vacuously and
+  // the test would agree with itself (trap 13b).
+  const HOSTILE_ARGUMENTS: ReadonlyArray<[label: string, value: unknown]> = [
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+    ['whitespace-padded id', ' top_bar_menu '],
+    ['wrong case', 'TOP_BAR_MENU'],
+    ['id without separators', 'topbarmenu'],
+    ['a close-sounding verb', 'close'],
+    ['a panel mode from the OTHER concept', 'provenance'],
+    ['an output tab from the OTHER concept', 'results'],
+    ['prototype key', '__proto__'],
+    ['number zero', 0],
+    ['boolean false', false],
+    ['NaN', Number.NaN],
+    ['empty object', {}],
+    ['empty array', []],
+    ['array containing a valid id', ['top_bar_menu']],
+    ['object shaped like a ui_target', { kind: 'overlay', id: 'top_bar_menu' }],
+  ]
+
+  it.each(HOSTILE_ARGUMENTS)(
+    'requestOverlaySurface(%s) cannot close a surface the user opened',
+    (_label, value) => {
+      // PRECONDITION, pinned in-test: the user has a menu open right now.
+      useUIStore.getState().setOverlaySurface('top_bar_menu')
+      expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+      expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+
+      const opened = (
+        useUIStore.getState().requestOverlaySurface as unknown as (v: unknown) => boolean
+      )(value)
+
+      expect(opened).toBe(false)
+      // The user's surface is UNTOUCHED — not merely "not closed".
+      expect(useUIStore.getState().activeOverlaySurface).toBe('top_bar_menu')
+      expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+    },
+  )
+
+  it('a rejected request on a CLOSED store leaves it closed and unstamped', () => {
+    const opened = (
+      useUIStore.getState().requestOverlaySurface as unknown as (v: unknown) => boolean
+    )('not_a_surface')
+    expect(opened).toBe(false)
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  // ── The canonical list must contain the surface the deployed TopBar uses ──
+  // Union assertion (trap 12d): the id TopBar binds to is not free to drift out
+  // of the canonical list without this failing.
+  it('the canonical list contains the TopBar kebab surface', () => {
+    const topBarSurface: OverlaySurfaceId = 'top_bar_menu'
+    expect(OVERLAY_SURFACE_IDS).toContain(topBarSurface)
+  })
+})

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -42,6 +42,16 @@ export type RightPanelMode = 'results' | 'provenance' | 'clarifier' | null
  * UserAvatarMenu — coordinate over the `menu:exclusive` window event; the
  * lifted surfaces keep honouring it, so lifting one at a time does not create
  * two competing exclusivity mechanisms.)
+ *
+ * ⚠ AND THAT IS EXACTLY WHY A RAISE CAN BE A LOWER IN DISGUISE. With one slot,
+ * `requestOverlaySurface('b')` while the user holds 'a' does not "open b" — it
+ * CLOSES A. The assistant would be taking the user's surface away through the
+ * one action that was supposed to be incapable of it, and no argument would
+ * have been invalid: 'b' is a perfectly good id. The hostile-argument corpus
+ * cannot see this class by construction, because every member of it is an
+ * INVALID value and this attack uses a VALID one. See `requestOverlaySurface`
+ * for the gate. Reachable the moment a second surface is lifted, which is the
+ * next step for this concept.
  */
 export const OVERLAY_SURFACE_IDS = ['top_bar_menu'] as const
 
@@ -110,15 +120,30 @@ export interface UIStoreActions {
    * ui_directive design: the assistant taking surfaces AWAY from the user
    * inverts the channel's charter. Lifting overlay state into a globally
    * reachable store is exactly the change that could make AI-driven closing
-   * possible BY ACCIDENT, so this action cannot express one:
+   * possible BY ACCIDENT, so this action cannot express one — in THREE ways,
+   * because the first two only stop an INVALID argument and the real attack
+   * uses a valid one:
    *   - the parameter type admits no null/undefined, so a close does not
    *     typecheck;
    *   - at runtime any value outside `OVERLAY_SURFACE_IDS` is REJECTED with
    *     the state left UNTOUCHED — never cleared. A malformed or
-   *     newer-producer id therefore cannot dismiss a menu the user opened.
+   *     newer-producer id therefore cannot dismiss a menu the user opened;
+   *   - ⚠ and a VALID id for a DIFFERENT surface is refused while the slot is
+   *     held by the user. Under one-slot exclusion a raise into an occupied
+   *     slot IS a lower, so without this the assistant could close the user's
+   *     menu using a wholly well-formed request. The refusal is fail-closed on
+   *     the origin: anything not provably `assistant`-raised is treated as the
+   *     user's.
    *
-   * Returns whether the surface was raised, so the ui_directive dispatcher can
-   * record `applied` vs `deferred` truthfully instead of assuming success.
+   * The assistant MAY replace a surface it raised itself, and a re-raise of
+   * the surface already up is IDEMPOTENT — it does not re-stamp the origin,
+   * because re-attributing a menu the USER opened would make the provenance
+   * badge tell the user the assistant opened something they opened themselves.
+   * A lie on the one channel whose whole purpose is truthfulness.
+   *
+   * Returns whether the surface is up as a result of this call, so the
+   * ui_directive dispatcher can record `applied` vs `deferred` truthfully
+   * instead of assuming success.
    */
   requestOverlaySurface: (surface: OverlaySurfaceId) => boolean
 }
@@ -139,7 +164,7 @@ export interface AssistantUiSurfaceActions {
   requestOverlaySurface: (surface: OverlaySurfaceId) => boolean
 }
 
-export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
+export const useUIStore = create<UIStoreState & UIStoreActions>((set, get) => ({
   activeOutputTab: 'results',
   activeOutputTabVersion: 0,
   activeRightPanel: null,
@@ -162,10 +187,28 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
     ),
 
   requestOverlaySurface: (surface) => {
-    // Fail-closed on ANYTHING that is not a known surface. Deliberately a
+    // (1) Fail-closed on ANYTHING that is not a known surface. Deliberately a
     // no-op rather than a clear: rejecting a bad id must never be a way to
     // close what the user has open.
     if (!isOverlaySurfaceId(surface)) return false
+
+    const current = get().activeOverlaySurface
+    const origin = get().overlaySurfaceOrigin
+
+    // (2) Already up: IDEMPOTENT, and specifically NOT a re-stamp. If the user
+    // opened this menu, it stays attributed to the user — re-attributing it
+    // would make the provenance badge claim the assistant opened something the
+    // user opened themselves.
+    if (current === surface) return true
+
+    // (3) The slot is held by a DIFFERENT surface. Under one-slot exclusion,
+    // raising over it would CLOSE it — a lower wearing a raise's clothes, and
+    // the only form of it that a valid argument can reach. Refuse unless the
+    // assistant is replacing a surface it raised itself. Fail-closed on the
+    // origin: an absent or unrecognised origin counts as the user's, so a
+    // corrupted or externally-injected state cannot be leveraged into a close.
+    if (current !== null && origin !== 'assistant') return false
+
     set({ activeOverlaySurface: surface, overlaySurfaceOrigin: 'assistant' })
     return true
   },

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -21,6 +21,47 @@ export type OutputTab = 'results' | 'compare' | 'diagnostics' | 'journey' | 'olu
  */
 export type RightPanelMode = 'results' | 'provenance' | 'clarifier' | null
 
+/**
+ * OVERLAY SURFACES — transient, anchored, self-dismissing UI (menus, pop-ups,
+ * coach-marks). A THIRD concept, deliberately not folded into either existing
+ * one, because the three answer different questions (trap 21 — name the
+ * concepts apart rather than bolting a conjunct onto a predicate with readers):
+ *   - `activeOutputTab`      — which tab is fronted INSIDE the dock?
+ *   - `activeRightPanel`     — which PERSISTENT right-side region owns the slot?
+ *   - `activeOverlaySurface` — which TRANSIENT overlay is currently raised?
+ *
+ * WHY THEY LIVE HERE AT ALL. `applyV5State` executes the AI's `ui_directive`
+ * verbs at a once-per-envelope, NON-RENDER side-effect site whose only reach
+ * into the UI is `useUIStore.getState()`. While a menu's open-state was
+ * `useState` inside its component, no assistant gesture could ever raise it —
+ * menus, pop-ups and coach-marks were structurally unreachable, not merely
+ * unimplemented. Lifting the state is the whole unblock.
+ *
+ * ONE SLOT, SO EXCLUSION IS STRUCTURAL: raising a surface lowers any other.
+ * (Surfaces still owned by their components — LeftSidebar's lens menu,
+ * UserAvatarMenu — coordinate over the `menu:exclusive` window event; the
+ * lifted surfaces keep honouring it, so lifting one at a time does not create
+ * two competing exclusivity mechanisms.)
+ */
+export const OVERLAY_SURFACE_IDS = ['top_bar_menu'] as const
+
+export type OverlaySurfaceId = (typeof OVERLAY_SURFACE_IDS)[number]
+
+/**
+ * WHO raised the current surface. P4 provenance: a surface the assistant put
+ * on screen is distinguishable from one the user opened, so the UI can
+ * attribute it rather than appearing to move on its own.
+ */
+export type OverlaySurfaceOrigin = 'user' | 'assistant'
+
+/** Derived membership test. The canonical list above is the only source. */
+function isOverlaySurfaceId(value: unknown): value is OverlaySurfaceId {
+  return (
+    typeof value === 'string' &&
+    (OVERLAY_SURFACE_IDS as ReadonlyArray<string>).includes(value)
+  )
+}
+
 export interface UIStoreState {
   /** Current active tab in the OutputsDock (synced bidirectionally) */
   activeOutputTab: OutputTab
@@ -37,6 +78,10 @@ export interface UIStoreState {
    * has acted. Null when no navigation is pending.
    */
   pendingModelTabSection: string | null
+  /** Which transient overlay surface is raised right now. Null when none. */
+  activeOverlaySurface: OverlaySurfaceId | null
+  /** Who raised it. Null exactly when no surface is raised. */
+  overlaySurfaceOrigin: OverlaySurfaceOrigin | null
 }
 
 export interface UIStoreActions {
@@ -52,6 +97,46 @@ export interface UIStoreActions {
   closeRightPanel: () => void
   /** Request the Model tab to focus + auto-expand a section on next render. */
   requestModelTabSection: (sectionId: string | null) => void
+  /**
+   * USER-driven overlay control: open a surface, or pass null to close.
+   * The user may always both raise and lower. This is the action a click,
+   * Escape, or a click-outside runs.
+   */
+  setOverlaySurface: (surface: OverlaySurfaceId | null) => void
+  /**
+   * ASSISTANT-driven overlay control — RAISE ONLY, by construction.
+   *
+   * `close_panel` / `close_inspector` were deliberately REJECTED from the
+   * ui_directive design: the assistant taking surfaces AWAY from the user
+   * inverts the channel's charter. Lifting overlay state into a globally
+   * reachable store is exactly the change that could make AI-driven closing
+   * possible BY ACCIDENT, so this action cannot express one:
+   *   - the parameter type admits no null/undefined, so a close does not
+   *     typecheck;
+   *   - at runtime any value outside `OVERLAY_SURFACE_IDS` is REJECTED with
+   *     the state left UNTOUCHED — never cleared. A malformed or
+   *     newer-producer id therefore cannot dismiss a menu the user opened.
+   *
+   * Returns whether the surface was raised, so the ui_directive dispatcher can
+   * record `applied` vs `deferred` truthfully instead of assuming success.
+   */
+  requestOverlaySurface: (surface: OverlaySurfaceId) => boolean
+}
+
+/**
+ * The narrowed handle `applyV5State`'s ui_directive site holds.
+ *
+ * Every member RAISES a surface. The closing actions (`closeRightPanel`,
+ * `openRightPanel(null)`, `setOverlaySurface(null)`) are absent, so the
+ * assistant seam cannot express a close even by mistake — the rule is carried
+ * by the type rather than by discipline. `requestModelTabSection` is narrowed
+ * to a non-null section here: clearing a pending section is the CONSUMER's job
+ * (ModelTabBody clears it once it has acted), never a gesture.
+ */
+export interface AssistantUiSurfaceActions {
+  forceActivateOutputTab: (tab: OutputTab) => void
+  requestModelTabSection: (sectionId: string) => void
+  requestOverlaySurface: (surface: OverlaySurfaceId) => boolean
 }
 
 export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
@@ -59,6 +144,8 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
   activeOutputTabVersion: 0,
   activeRightPanel: null,
   pendingModelTabSection: null,
+  activeOverlaySurface: null,
+  overlaySurfaceOrigin: null,
 
   setActiveOutputTab: (tab) => set({ activeOutputTab: tab }),
   forceActivateOutputTab: (tab) =>
@@ -66,8 +153,26 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set) => ({
   openRightPanel: (mode) => set({ activeRightPanel: mode }),
   closeRightPanel: () => set({ activeRightPanel: null }),
   requestModelTabSection: (sectionId) => set({ pendingModelTabSection: sectionId }),
+
+  setOverlaySurface: (surface) =>
+    set(
+      surface === null
+        ? { activeOverlaySurface: null, overlaySurfaceOrigin: null }
+        : { activeOverlaySurface: surface, overlaySurfaceOrigin: 'user' },
+    ),
+
+  requestOverlaySurface: (surface) => {
+    // Fail-closed on ANYTHING that is not a known surface. Deliberately a
+    // no-op rather than a clear: rejecting a bad id must never be a way to
+    // close what the user has open.
+    if (!isOverlaySurfaceId(surface)) return false
+    set({ activeOverlaySurface: surface, overlaySurfaceOrigin: 'assistant' })
+    return true
+  },
 }))
 
 // Selectors
 export const selectActiveOutputTab = (s: UIStoreState) => s.activeOutputTab
 export const selectActiveRightPanel = (s: UIStoreState) => s.activeRightPanel
+export const selectActiveOverlaySurface = (s: UIStoreState) => s.activeOverlaySurface
+export const selectOverlaySurfaceOrigin = (s: UIStoreState) => s.overlaySurfaceOrigin

--- a/src/v5/__tests__/applyV5State.assistantSurfaces.test.ts
+++ b/src/v5/__tests__/applyV5State.assistantSurfaces.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The assistant's UI-surface seam is OPEN-ONLY, enforced in TYPES.
+ *
+ * WHY A TYPE AND NOT A COMMENT. `close_panel` / `close_inspector` were
+ * deliberately REJECTED from the ui_directive design: the assistant taking
+ * surfaces AWAY from the user inverts the channel's charter. Before this
+ * change that rule was protected only by the fact that overlay state was
+ * unreachable — component-local `useState`. Lifting it into `uiStore` puts a
+ * global, non-render-reachable handle on the user's screen, and `uiStore`'s
+ * full action set contains `closeRightPanel`, `openRightPanel(null)` and
+ * `setOverlaySurface(null)`. Nothing but discipline would have stopped a
+ * later lane wiring one of those to a verb.
+ *
+ * So `applyV5State`'s ui_directive site no longer holds the whole store. It
+ * holds `AssistantUiSurfaceActions` — a narrowed handle carrying ONLY actions
+ * that RAISE a surface. A close does not typecheck at that seam.
+ *
+ * HOW THIS GUARD BITES, in both directions:
+ *   - widen the seam (add a closing action to `AssistantUiSurfaceActions`) and
+ *     the `@ts-expect-error` suppressions below become UNUSED, which `tsc`
+ *     reports as an error — the gate goes RED on the widening itself;
+ *   - remove a raising action the dispatcher needs and the calls stop
+ *     compiling.
+ * The repo's typecheck gate derives its file set from `git ls-files` (see
+ * scripts/ci/typecheck-gate.sh), so this spec is compiled by the required
+ * "Staging Gate" check. The guard is not decorative.
+ */
+import { describe, it, expect } from 'vitest'
+import { useUIStore, type AssistantUiSurfaceActions } from '../../stores/uiStore'
+
+// ── Compile-time half. Exported so they are unambiguously used. ────────────
+// Each line asserts an action is ABSENT from the assistant-facing seam.
+
+// @ts-expect-error — the assistant seam must not carry a right-panel close.
+export type _NoCloseRightPanel = AssistantUiSurfaceActions['closeRightPanel']
+
+// @ts-expect-error — `openRightPanel(null)` is a close in disguise.
+export type _NoOpenRightPanel = AssistantUiSurfaceActions['openRightPanel']
+
+// @ts-expect-error — `setOverlaySurface(null)` is the USER's close action.
+export type _NoSetOverlaySurface = AssistantUiSurfaceActions['setOverlaySurface']
+
+// @ts-expect-error — a bare tab set does not front the dock; it is not a raise.
+export type _NoSetActiveOutputTab = AssistantUiSurfaceActions['setActiveOutputTab']
+
+describe('assistant UI-surface seam is open-only', () => {
+  it('exposes exactly the RAISING actions the directive dispatcher needs', () => {
+    const surfaces: AssistantUiSurfaceActions = useUIStore.getState()
+
+    // Every gesture the dispatcher performs today, plus the overlay seam the
+    // menu / pop-up / coach-mark verbs will use. All three RAISE something.
+    expect(typeof surfaces.forceActivateOutputTab).toBe('function')
+    expect(typeof surfaces.requestModelTabSection).toBe('function')
+    expect(typeof surfaces.requestOverlaySurface).toBe('function')
+  })
+
+  it('the raising actions reject a close-shaped argument', () => {
+    const surfaces: AssistantUiSurfaceActions = useUIStore.getState()
+
+    // @ts-expect-error — there is no null overlay id; a raise cannot be a lower.
+    const rejected = surfaces.requestOverlaySurface(null)
+    expect(rejected).toBe(false)
+    expect(useUIStore.getState().activeOverlaySurface).toBeNull()
+  })
+
+  it('narrows the SEAM without removing the user-facing closes from the store', () => {
+    // The guard is about what the assistant can reach, not about deleting the
+    // user's own actions — those must still exist for TopBar / OutputsDock.
+    expect(typeof useUIStore.getState().closeRightPanel).toBe('function')
+    expect(typeof useUIStore.getState().setOverlaySurface).toBe('function')
+    expect(typeof useUIStore.getState().openRightPanel).toBe('function')
+  })
+})

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -53,7 +53,11 @@ import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
 import { pulseAppliedTargets } from '../canvas/utils/appliedEditPulse'
 import { focusNodeById, focusEdgeById } from '../canvas/utils/focusHelpers'
-import { useUIStore, type OutputTab } from '../stores/uiStore'
+import {
+  useUIStore,
+  type OutputTab,
+  type AssistantUiSurfaceActions,
+} from '../stores/uiStore'
 import {
   readDecisionReviewWireState,
   type DecisionReview030,
@@ -779,6 +783,20 @@ export function applyV5State(
         // cross-field rule guarantees a verb-matching ui_target on anything
         // that parsed, but the handler stays independently fail-closed (the
         // same defensive posture as the graph verbs' in-graph filter).
+        //
+        // ⚠ THE HANDLE IS NARROWED ON PURPOSE. `close_panel`/`close_inspector`
+        // were deliberately REJECTED from this design — the assistant taking
+        // surfaces AWAY from the user inverts the channel's charter. Overlay
+        // open-state now lives in uiStore (so a gesture CAN raise a menu at
+        // all), and uiStore's full action set contains `closeRightPanel`,
+        // `openRightPanel(null)` and `setOverlaySurface(null)`. Holding the
+        // whole store here would leave nothing but discipline between this
+        // seam and an accidental close. `AssistantUiSurfaceActions` carries
+        // ONLY raising actions, so a close does not typecheck at this site —
+        // and widening it turns the required typecheck RED, because the
+        // `@ts-expect-error` guards in applyV5State.assistantSurfaces.test.ts
+        // become unused directives.
+        const assistantSurfaces: AssistantUiSurfaceActions = useUIStore.getState()
         const uiTarget = (block as { ui_target?: { kind?: unknown; id?: unknown } }).ui_target
         if (uiTarget === undefined || uiTarget === null || typeof uiTarget !== 'object') {
           deferred.push({ reason: 'ui_directive_missing_ui_target', block })
@@ -790,12 +808,12 @@ export function applyV5State(
           })
         } else if (verb === 'open_panel' && uiTarget.kind === 'tab') {
           uiDirectiveExecuted = true
-          useUIStore.getState().forceActivateOutputTab(uiTarget.id as OutputTab)
+          assistantSurfaces.forceActivateOutputTab(uiTarget.id as OutputTab)
           applied.push(`ui_directive:open_panel:${String(uiTarget.id)}`)
         } else if (verb === 'open_section' && uiTarget.kind === 'model_section') {
           uiDirectiveExecuted = true
-          useUIStore.getState().requestModelTabSection(String(uiTarget.id))
-          useUIStore.getState().forceActivateOutputTab('diagnostics')
+          assistantSurfaces.requestModelTabSection(String(uiTarget.id))
+          assistantSurfaces.forceActivateOutputTab('diagnostics')
           applied.push(`ui_directive:open_section:${String(uiTarget.id)}`)
         } else {
           deferred.push({


### PR DESCRIPTION
**Proof: PR3 — living reasoning workspace · Component 3: UI agency.**

## Acceptance measure (one falsifiable sentence)

**An assistant gesture arriving at `applyV5State`'s non-render seam can now open the TopBar kebab menu with no user interaction — observable in a real browser as the menu appearing and the banner gaining `data-overlay-origin="assistant"` while nothing was clicked — where before that gesture could not reach the menu at all, because its open-state was React component-local `useState`.**

Falsify it by opening the deployed app, confirming the kebab menu is closed, and driving `useUIStore.getState().requestOverlaySurface('top_bar_menu')` from the store module with no click: if the menu does not appear, this PR did not deliver.

**Already observed, in a real browser, against the PRODUCTION build** (`pnpm run build` + `vite preview`; the store was located in the minified bundle *by capability* — an export whose `getState()` carries `requestOverlaySurface` — not by name):

| step | menu | `data-overlay-origin` | store origin |
|---|---|---|---|
| A — assistant seam raises it, no user input | **visible** | `assistant` | `assistant` |
| B — 13 hostile **invalid** args | **still open** (all returned `false`) | `assistant` | `assistant` |
| C — valid-but-**foreign** id vs a USER-held slot | user's surface **untouched** (returned `false`) | — | `user` |
| D — same call, slot held by the **assistant** | replaced (returned `true`) | `assistant` | `assistant` |
| E — assistant re-raises a **user**-opened menu | stays open (returned `true`) | **`user`** — no re-attribution | `user` |
| F — user presses Escape | closed | absent | `null` |

Exclusivity verified both ways in the same build: an assistant raise emits the `menu:exclusive` claim (so sibling menus close), a sibling's claim lowers the assistant-raised menu, and — the discriminating control — its **own** claim does not.

C/D are a discriminating pair: same call, same occupied slot, only the origin differs. Without D the refusal could be a blanket occupied-slot block, which is a different and wrong rule.

---

## The blocker this removes

Olumi's AI agency is live: five `ui_directive` verbs are emitted by CEE and genuinely executed by the UI at `src/v5/applyV5State.ts`, at a once-per-envelope side-effect site. But that site is **non-render** — its only reach into the UI is `useUIStore.getState()`. Menus, pop-ups and coach-marks kept their open-state in component-local `useState` (`TopBar.tsx:48` was `const [showMenu, setShowMenu] = useState(false)`), so **no assistant gesture could ever raise one**. That is a structural gap, not a missing feature: no amount of verb or prompt work would have reached it.

One change fixes it permanently for the whole class.

## What changed

**`src/stores/uiStore.ts`** gains a third concept, deliberately *not* folded into either existing one — they answer different questions, and aligning them would have been the wrong fix:

| field | question it answers |
|---|---|
| `activeOutputTab` | which tab is fronted *inside* the dock? |
| `activeRightPanel` | which *persistent* right-side region owns the slot? |
| `activeOverlaySurface` | which *transient* overlay is raised? |

plus `overlaySurfaceOrigin: 'user' | 'assistant'` (P4 provenance — a surface the assistant put on screen is attributable rather than appearing to move on its own).

**`src/components/layout/TopBar.tsx`** becomes a *consumer* of that state rather than its owner. Sibling menus that this lane does not own (LeftSidebar's lens, `UserAvatarMenu`) still hold their own state and coordinate over the existing `menu:exclusive` window event; the lifted kebab keeps honouring it in both directions, and now announces from the **state transition** rather than from the click handler — which is what makes the user path and the assistant path behave identically.

**`src/v5/applyV5State.ts`** holds a narrowed handle at the directive site.

## User agency is enforced in types, not by discipline

`close_panel` / `close_inspector` were deliberately rejected from this design — *the assistant taking surfaces away from the user inverts the channel's charter*. Until now that rule was protected only by the fact that overlay state was **unreachable**. Lifting it puts a global, non-render handle on the user's screen, and `uiStore` contains `closeRightPanel`, `openRightPanel(null)` and `setOverlaySurface(null)`. Nothing but discipline would have stopped a later lane wiring one of those to a verb.

So there are **four** independent locks — and note that the first two only stop an *invalid* argument, while the real attack uses a valid one:

1. **`requestOverlaySurface(surface)`** takes a non-nullable id — a close does not typecheck.
2. At runtime it **rejects** anything outside `OVERLAY_SURFACE_IDS` **leaving state untouched** — deliberately a no-op, never a clear, so a malformed or newer-producer id cannot dismiss a menu the user opened.
3. A **valid** id for a *different* surface is **refused while the slot is held by the user**. Under one-slot exclusion a raise into an occupied slot *is* a lower, so this is the only form of "the assistant closed my menu" a well-formed request can reach. Fail-closed on the origin: anything not provably `assistant`-raised counts as the user's. The assistant may replace a surface it raised itself, and a re-raise of the surface already up is **idempotent without re-stamping the origin** — re-attributing a user-opened menu would make the provenance badge lie.
4. `applyV5State`'s directive site holds **`AssistantUiSurfaceActions`**, an interface carrying only *raising* actions. Widening it turns the **required typecheck RED** — proven, not asserted: adding `closeRightPanel` to the interface produced `TS2578: Unused '@ts-expect-error' directive` and `Typecheck RATCHET FAILED — 2488 vs baseline 2487`, against a green control at the same commit.

## Why no new verb

New verbs (`annotate`, `start_tour`) need their own payload shapes and are deferred in-schema; `activate_tab` is ruled *do not add*. This PR changes **no contract**. `UiDirectiveUiTargetSchema` is a `.strict()` discriminated union over `tab | model_section`, so an overlay `ui_target` cannot appear on the wire yet — and an overlay arm in the dispatcher today would be worse than dead code: `ui_directive` sits in `LEGACY_SCHEMA_KNOWN_BLOCK_TYPES`, so it is **strict-validated rather than tolerated** — an overlay target would fail the **whole turn** into `INTERNAL_ERROR`, not degrade. The arm is unreachable by construction. What this PR buys is that the later addition is *one enum arm plus one dispatcher branch*, against a client that is already capable, already provenance-stamped, and already provably unable to close anything.

## Verification

- **RED-first**: re-measured at the tip — **48 collected / 45 red / 3 pass**, with literal failures recorded (`TypeError: useUIStore.getState(...).requestOverlaySurface is not a function`, `Unable to find an accessible element with the role "menu"`, …). The 3 pristine passes were the deployed-mount-path control and two existing-behaviour regression guards.
- **48 tests now**, all green (30 store / 15 TopBar / 3 seam); collected count asserted **by name**, not from a suite total.
- **12 behavioural mutants + 1 type mutant, all bite** (throwaway worktree at an absolute path outside the repo root; isolation proven by *writing* a sentinel and asserting the source byte-identical, plus an inode comparison — not by locating the tree; applied-check scoped to `src/` with the control reading exactly 0; restore from the git object, never from the other copy).
- **Deployed-mount binding** (trap 3b): tests bind to `src/components/layout/TopBar.tsx` via a marker string unique to it in the tree *and* present in the deployed staging chunk `CanvasMVP-y0VodO-Y.js` — BFS over the chunk graph to a fixpoint (87 chunks, 8 rounds) at `aa81aa1a`, with positive controls firing and negative controls reading zero. Deployed staging commit equals this branch's base, so there is no deploy skew.
- Typecheck gate ✅, lint 0 errors, rules-of-hooks ratchet exactly at baseline, React-185 Zustand guard ✅.

### Two mutants survived first, and both found real defects

- **M5** — replacing TopBar's `=== 'top_bar_menu'` with `!== null` left the **whole suite green**, because the enum has one member so both predicates agree on every value it can produce. Trap 19, latent until a second surface is lifted. Fixed by pinning the discrimination now, with a foreign id.
- **M9** — the ownership-check test fired Escape and click-outside while a foreign surface was raised, but those listeners are only registered while *this* bar's menu is open, so nothing was exercised. Re-routed through the exclusivity listener (the one path that is live in that state) and its precondition is now pinned in-test.

### A third latent defect, found by review at the layer below

The 17-member hostile corpus contains only **invalid** values, so it is structurally blind to the attack that uses a **valid** one. With a second member in `OVERLAY_SURFACE_IDS`, a user-opened `top_bar_menu` followed by `requestOverlaySurface('<other real surface>')` returned `true` and the user's menu was **gone** — with the whole suite **green**. This is the identical defect `FOREIGN_SURFACE` catches one layer up in TopBar: found at the component, missed at the store, which is where the user-agency claim actually lives. Unreachable today only because the enum has one member — and lifting the second surface is this concept's stated next step, so it would have shipped with no red anywhere.

## What these tests cannot support

jsdom proves the menu is **mounted** and `aria-expanded` is true. It proves **nothing** about visibility, stacking or layout. The real-browser table at the top is the only evidence that the menu actually *appears*; it was taken against a dev build of this branch, not against staging, because this PR is not merged.

## Follow-ups (not done here, deliberately)

- A **visible** attribution for an assistant-raised surface. `data-overlay-origin` on the banner is the hook; rendering a badge belongs with `KebabMenu.tsx`, which this lane does not own. Until then the gesture is honest but silent.
- Lifting `LeftSidebar`'s lens menu and `UserAvatarMenu` into the same store, retiring the `menu:exclusive` event once all three are lifted.

## Premise corrections (both from the lane brief, measured at this tip)

- **`setHoveredElementId` is not a `uiStore` setter and does not have zero consumers.** It is `useState` inside `src/canvas/highlighting/HighlightContext.tsx:92`, and the seam is live in both directions: writers at `ReactFlowGraph.tsx:2020` and `:2023` (canvas hover) and `WorthInvestigating.tsx:195,227,228` (panel hover); the reader is `WorthInvestigating.tsx:171`, flowing to a real className at `:225`. Nothing to fix.
- **The `constraint` target arm** does dead-end, but only for the **ReactFlow canvas-node renderer** — my earlier phrasing was broader than the code supports. `constraint` has live rendering consumers at `NodeShapeIndicator.tsx:94-101`, `coaching-panel/constants.ts:47` → `EntityTarget.tsx:33-34`, and `TargetRefPill.tsx:42-44`. `applyV5State` resolves non-edge targets against `store.nodes` while constraints live in `store.goalConstraints`, so a *canvas* target dead-ends. The fix is not a renderer: `src/canvas/domain/nodes.ts:25` records that one was deliberately removed in an honesty sweep and that re-adding it **requires a design review**. Left alone and rowed.
- **There is no symbol named `TargetRefKind`** — 0 hits across the clone including `node_modules`, with a positive control. The real construct is an anonymous inline enum in `@talchain/schemas` 0.39.0 `dist/boundary/blocks.d.ts:992`. The name came from the lane brief.
