### PR TITLE
PR3: a menu the assistant raised says so, and says how to take it back

### DIFF
--- a/src/components/layout/KebabMenu.tsx
+++ b/src/components/layout/KebabMenu.tsx
@@ -20,6 +20,7 @@
 import { useState, useCallback } from 'react'
 import {
   MoreVertical,
+  Sparkles,
   Pencil,
   Download,
   Upload,
@@ -37,8 +38,32 @@ import { useSettingsStore } from '../../canvas/settingsStore'
 import { useCanvasStore } from '../../canvas/store'
 import styles from './TopBar.module.css'
 
+/**
+ * The complete sentence this menu is allowed to make about its own origin.
+ *
+ * WHO, and HOW TO TAKE IT BACK — never WHY. There is no reachable reason at
+ * this tip: `ui_directive.note` is the only free-text carrier on the 0.39.0
+ * wire and nothing in src/ reads it, so any rationale rendered here would be
+ * invented. A fabricated "why" on the provenance channel is worse than no
+ * badge at all, because this is the one channel whose entire purpose is
+ * truthfulness. If a reason ever becomes available, it arrives as a new
+ * field and this constant grows a parameter — it does not get guessed.
+ *
+ * The dismissal hint is a VERIFIED fact, not reassurance: TopBar's Escape
+ * handler runs `closeMenu()` unconditionally on origin, so Escape genuinely
+ * takes the surface back from the assistant.
+ */
+export const OVERLAY_ATTRIBUTION_TEXT = 'Opened by Olumi'
+export const OVERLAY_DISMISS_HINT = 'Esc to dismiss'
+
 interface KebabMenuProps {
   isOpen: boolean
+  /**
+   * Who raised THIS menu — `'assistant'` only when the AI put it on screen.
+   * Null whenever the menu is the user's own (or not raised at all), so the
+   * attribution cannot outlive the fact it describes.
+   */
+  raisedBy?: 'user' | 'assistant' | null
   onToggle: () => void
   onClose: () => void
   onStartRename: () => void
@@ -49,6 +74,7 @@ interface KebabMenuProps {
 
 export function KebabMenu({
   isOpen,
+  raisedBy = null,
   onToggle,
   onClose,
   onStartRename,
@@ -129,7 +155,44 @@ export function KebabMenu({
         </Tooltip>
 
         {isOpen && (
-          <div className={styles.dropdownMenu} role="menu">
+          <div
+            className={styles.dropdownMenu}
+            role="menu"
+            // The visible badge below is a plain <div>: inside `role="menu"`
+            // only menuitems are reliably announced, so a screen-reader user —
+            // the person MOST disoriented by a menu that appears unprompted —
+            // would get nothing. The menu's accessible NAME carries it instead,
+            // and is left undefined (falling back to the trigger) when the user
+            // opened the menu themselves, so nothing is announced that is not
+            // true.
+            aria-label={
+              raisedBy === 'assistant'
+                ? `More options — ${OVERLAY_ATTRIBUTION_TEXT}`
+                : undefined
+            }
+          >
+            {/* PROVENANCE, not decoration. A surface the assistant raised must
+                say so, inside the surface itself — the answer sits where the
+                question ("why did this open?") is asked, rather than somewhere
+                the user has to hunt for it. Deliberately non-interactive, no
+                animation, no focus steal, no colour alarm: a user who did not
+                notice the menu open should not be startled by the explanation
+                of it. */}
+            {raisedBy === 'assistant' && (
+              <div className={styles.overlayOriginRow} data-testid="overlay-origin-badge">
+                <span className={styles.overlayOriginBadge} data-testid="overlay-origin-label">
+                  <Sparkles size={11} aria-hidden="true" />
+                  {OVERLAY_ATTRIBUTION_TEXT}
+                </span>
+                <span
+                  className={styles.overlayOriginHint}
+                  data-testid="overlay-origin-dismiss-hint"
+                >
+                  {OVERLAY_DISMISS_HINT}
+                </span>
+              </div>
+            )}
+
             {/* Decision group */}
             <div className={styles.dropdownMenuLabel}>Decision</div>
             <button

--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -291,6 +291,50 @@
   color: var(--text-light, #6E6B6B);
 }
 
+/* ── Attribution for an assistant-raised menu ──────────────────────────────
+   Shown ONLY while this menu is on screen because the assistant put it there.
+   Calm by construction: no animation, no fill, no focus, nothing interactive —
+   a user who did not notice the menu open must not be startled by the
+   explanation of it, while a user who wonders "why did that open?" finds the
+   answer at the top of the thing that opened.
+
+   DS v5 §3.2 / DESIGN_SYSTEM.md: pills are OUTLINED only —
+   `bg-transparent border-{colour}/30 text-text-body`. The colour is carried on
+   the BORDER; the ink stays --text-body. Colouring the text is what produced a
+   sibling lane's 2.80:1 and 2.83:1 failures against WCAG AA. Measured here:
+   --text-body #3F3F3E on the menu's white surface = 10.5:1, and the hint's
+   --text-light #6E6B6B = 5.1:1 at 12px (both AA; --text-light is already the
+   audited choice for .dropdownMenuLabel in this same menu). */
+.overlayOriginRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px 8px;
+  margin-bottom: 2px;
+  border-bottom: 1px solid var(--border-default, #EEE6D8);
+}
+
+.overlayOriginBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  border-radius: var(--radius-pill, 999px);
+  background: transparent;
+  color: var(--text-body, #3F3F3E);
+  border: 1px solid color-mix(in srgb, var(--info, #277A9D) 30%, transparent);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.overlayOriginHint {
+  font-size: 12px;
+  color: var(--text-light, #6E6B6B);
+  white-space: nowrap;
+}
+
 /* Canvas settings (flattened in kebab menu) */
 .settingsRow {
   display: flex;

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -418,6 +418,17 @@ export const TopBar = ({
         {/* Kebab menu */}
         <KebabMenu
           isOpen={showMenu}
+          // WHO raised this menu, so the menu can attribute itself. Passed
+          // rather than re-subscribed inside KebabMenu so there is exactly one
+          // reader of the store slice on this path, and so the value the badge
+          // renders from is provably the same one `data-overlay-origin`
+          // renders from. `showMenu &&` is the identity conjunct: an
+          // assistant-raised surface that is NOT this bar's must never
+          // attribute this bar (today OVERLAY_SURFACE_IDS has one member, so
+          // the two predicates agree on every value the enum can produce —
+          // pinning it now is what stops the badge lying when a second
+          // surface is lifted).
+          raisedBy={showMenu ? overlayOrigin : null}
           onToggle={() => {
             // The exclusivity announcement rides the state transition (effect
             // above), so the user path and the assistant path behave alike.

--- a/src/components/layout/__tests__/TopBar.overlayAttribution.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.overlayAttribution.spec.tsx
@@ -1,0 +1,301 @@
+/**
+ * TopBar kebab menu — ATTRIBUTION for an assistant-raised surface.
+ *
+ * #645 lifted the menu's open-state into uiStore and recorded WHO raised it
+ * (`overlaySurfaceOrigin`). It rendered nothing from that fact: a menu could
+ * appear and the user was given no way to know Olumi did it. An interface that
+ * acts on its own without saying so is startling, and this is the one channel
+ * whose entire purpose is truthfulness. This spec pins the visible half.
+ *
+ * ⚠ WHAT THIS BADGE MAY AND MAY NOT SAY. It says WHO ("Opened by Olumi") and
+ * HOW TO TAKE IT BACK ("Esc to dismiss" — verified: TopBar's Escape handler is
+ * unconditional on origin). It does NOT say WHY, because no reason is
+ * reachable at this tip: `ui_directive.note` is the only candidate carrier on
+ * the 0.39.0 wire and NOTHING in src/ reads it. A plausible-sounding rationale
+ * here would be a fabrication on the provenance channel, which is worse than
+ * no badge at all.
+ *
+ * ⚠ TRAP 3b — BIND TO THE SURFACE THE DEPLOYED BUILD MOUNTS. The first test is
+ * a mount-path assertion, reusing the identity markers TopBar.overlaySurface
+ * .spec.tsx pinned against the deployed staging chunk.
+ *
+ * ⚠ TRAP 19 — BIND BY IDENTITY. The badge's truth condition is a CONJUNCTION:
+ * "the surface THIS bar owns is raised" AND "the assistant raised it". Either
+ * conjunct alone is satisfiable by a state where the badge would be a lie, so
+ * both are pinned with a discriminating pair below.
+ *
+ * ⚠ WHAT jsdom CANNOT PROVE. `css: false` in vitest.config.ts means CSS-module
+ * lookups return the key regardless of whether any rule exists — a className
+ * assertion here would pass against a class that generates NO CSS, which is
+ * exactly the defect a sibling PR shipped tonight (`text-text-muted`). The
+ * style guard below therefore reads TopBar.module.css FROM DISK. Visibility,
+ * layout and contrast are proven only in a real browser; the PR body carries
+ * those readings separately.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, cleanup, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TopBar } from '../TopBar'
+import {
+  OVERLAY_ATTRIBUTION_TEXT,
+  OVERLAY_DISMISS_HINT,
+} from '../KebabMenu'
+import { ToastProvider } from '../../../canvas/ToastContext'
+import { useUIStore, type OverlaySurfaceId } from '../../../stores/uiStore'
+
+/** The exact sentences the product is allowed to make.
+ *
+ * ⚠ These are asserted as LITERALS as well as imported. Importing alone would
+ * be a guard agreeing with itself (trap 13b): rename the constant's VALUE to
+ * anything — including an invented rationale — and an import-only test stays
+ * green. The literal is what makes a copy change come through this test. */
+const ATTRIBUTION_TEXT = 'Opened by Olumi'
+const DISMISS_HINT = 'Esc to dismiss'
+
+/** A surface id this bar does NOT own — stands in for a future sibling surface
+ *  so the identity binding is pinned now rather than when it starts to matter. */
+const FOREIGN_SURFACE = 'a_surface_this_bar_does_not_own' as unknown as OverlaySurfaceId
+
+const props = {
+  scenarioTitle: 'Pricing Decision 2025',
+  onTitleChange: vi.fn(),
+  onSave: vi.fn(),
+  onShare: vi.fn(),
+}
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar {...props} />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+/** The assistant's ONLY reach into the UI: the non-render store seam
+ *  applyV5State holds. Deliberately not a component handler — calling a prop
+ *  would prove nothing about the gesture path. */
+function assistantRaises(surface: OverlaySurfaceId) {
+  act(() => {
+    useUIStore.getState().requestOverlaySurface(surface)
+  })
+}
+
+/** The user's seam: a click, Escape, or click-outside all run this. */
+function userRaises(surface: OverlaySurfaceId) {
+  act(() => {
+    useUIStore.getState().setOverlaySurface(surface)
+  })
+}
+
+function queryBadge() {
+  return screen.queryByTestId('overlay-origin-badge')
+}
+
+describe('TopBar kebab menu — attribution for an assistant-raised surface', () => {
+  beforeEach(() => {
+    useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
+  })
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ activeOverlaySurface: null, overlaySurfaceOrigin: null })
+  })
+
+  // ── Mount-path assertion (trap 3b) ───────────────────────────────────────
+  it('is the TopBar the deployed bundle mounts', () => {
+    renderTopBar()
+    expect(screen.getByRole('button', { name: /version history/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /more options/i })).toBeInTheDocument()
+  })
+
+  // ── THE CAPABILITY ───────────────────────────────────────────────────────
+  it('says the assistant opened the menu, in the menu, when the assistant opened it', () => {
+    renderTopBar()
+    expect(queryBadge()).not.toBeInTheDocument()
+
+    assistantRaises('top_bar_menu')
+
+    const badge = queryBadge()
+    expect(badge).toBeInTheDocument()
+    // Positive outcome, not a non-emptiness check: the exact sentence.
+    expect(badge).toHaveTextContent(ATTRIBUTION_TEXT)
+    expect(badge).toHaveTextContent(DISMISS_HINT)
+    // It lives INSIDE the surface it explains — the answer is where the
+    // question is asked, not somewhere the user has to hunt for it.
+    expect(within(screen.getByRole('menu')).getByTestId('overlay-origin-badge')).toBe(badge)
+  })
+
+  it('names the origin to assistive technology as well as on screen', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    // A menu that appears unprompted is exactly the case where a screen-reader
+    // user is most disoriented, and a bare <div> inside role="menu" is not
+    // reliably announced. The accessible NAME of the menu carries it.
+    expect(screen.getByRole('menu')).toHaveAccessibleName(
+      new RegExp(ATTRIBUTION_TEXT),
+    )
+  })
+
+  // ── HONESTY: the badge must not appear over a menu the USER opened ───────
+  it('says nothing when the USER opened the menu', () => {
+    renderTopBar()
+
+    userRaises('top_bar_menu')
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(queryBadge()).not.toBeInTheDocument()
+    expect(screen.getByRole('menu')).not.toHaveAccessibleName(
+      new RegExp(ATTRIBUTION_TEXT),
+    )
+  })
+
+  it('says nothing when the user opens the menu with the kebab button', () => {
+    renderTopBar()
+
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+    expect(queryBadge()).not.toBeInTheDocument()
+  })
+
+  // ── TRAP 19 — the DISCRIMINATING PAIR on the conjunction ─────────────────
+  // Conjunct A ("assistant raised it") alone: a foreign surface raised by the
+  // assistant must NOT badge this bar. Conjunct B ("this bar's surface is up")
+  // alone: a user-raised top_bar_menu must NOT badge. Loosen the guard to
+  // EITHER conjunct and one of these REDs; both together are the only state
+  // in which the sentence is true.
+  it('does not badge when an assistant-raised surface is one this bar does not own', () => {
+    renderTopBar()
+
+    act(() => {
+      useUIStore.setState({
+        activeOverlaySurface: FOREIGN_SURFACE,
+        overlaySurfaceOrigin: 'assistant',
+      })
+    })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(queryBadge()).not.toBeInTheDocument()
+  })
+
+  // ── THE BADGE CANNOT OUTLIVE THE FACT IT DESCRIBES ───────────────────────
+  it('disappears when the user dismisses the assistant-raised menu with Escape', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(queryBadge()).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' })
+    })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(queryBadge()).not.toBeInTheDocument()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBeNull()
+  })
+
+  it('disappears when the user clicks outside the assistant-raised menu', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(queryBadge()).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.mouseDown(document.body)
+    })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(queryBadge()).not.toBeInTheDocument()
+  })
+
+  it('disappears when the user takes the surface over by re-opening it themselves', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(queryBadge()).toBeInTheDocument()
+
+    // Close via the kebab button, then re-open it — the second raise is the
+    // user's, and the store re-stamps the origin.
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(useUIStore.getState().overlaySurfaceOrigin).toBe('user')
+    expect(queryBadge()).not.toBeInTheDocument()
+  })
+
+  it('does not survive the bar unmounting and remounting', () => {
+    const first = renderTopBar()
+    assistantRaises('top_bar_menu')
+    expect(queryBadge()).toBeInTheDocument()
+
+    first.unmount()
+    renderTopBar()
+
+    expect(queryBadge()).not.toBeInTheDocument()
+  })
+
+  // ── IT MUST NOT INVENT A REASON ──────────────────────────────────────────
+  it('claims only who and how to dismiss — never a rationale it cannot know', () => {
+    renderTopBar()
+    assistantRaises('top_bar_menu')
+
+    // The two claims, each pinned exactly — a positive outcome, not a
+    // non-emptiness check (`not.toBe('')` passes when nothing renders).
+    expect(screen.getByTestId('overlay-origin-label')).toHaveTextContent(
+      new RegExp(`^${ATTRIBUTION_TEXT}$`),
+    )
+    expect(screen.getByTestId('overlay-origin-dismiss-hint')).toHaveTextContent(
+      new RegExp(`^${DISMISS_HINT}$`),
+    )
+    // ...and the badge contains NOTHING ELSE. This is the conjunct that stops a
+    // rationale being appended somewhere the two assertions above cannot see.
+    const text = (queryBadge()?.textContent ?? '').replace(/\s+/g, ' ').trim()
+    expect(text).toBe(`${ATTRIBUTION_TEXT}${DISMISS_HINT}`)
+
+    // The constants the component actually renders from are the same ones.
+    expect(OVERLAY_ATTRIBUTION_TEXT).toBe(ATTRIBUTION_TEXT)
+    expect(OVERLAY_DISMISS_HINT).toBe(DISMISS_HINT)
+
+    // And no causal claim smuggled in. `note` is the only reason-carrier on the
+    // 0.39.0 wire and nothing in src/ reads it, so any of these would be made up.
+    for (const forbidden of [/because/i, /so that/i, /to help you/i, /I thought/i]) {
+      expect(text).not.toMatch(forbidden)
+    }
+  })
+
+  // ── THE DEAD-CLASS GUARD (read from disk, not from a className string) ────
+  // vitest runs with `css: false`, so `styles.overlayOriginBadge` resolves to a
+  // truthy string whether or not any rule exists. A sibling PR shipped exactly
+  // that defect tonight. This reads the stylesheet itself.
+  it('the badge class actually exists in TopBar.module.css and follows DS v5 §3.2', () => {
+    // ⚠ `?raw` is NOT usable here: with `css: false`, vitest's CSS-module stub
+    // intercepts `*.module.css` and returns a key-echoing Proxy, so
+    // `topBarCss.length` came back as the STRING "length" — an instrument that
+    // reads nothing and agrees with everything. Read the file directly.
+    const cssPath = resolve(process.cwd(), 'src/components/layout/TopBar.module.css')
+    const css = readFileSync(cssPath, 'utf8')
+
+    // Positive control for the instrument itself, BEFORE any absence claim: a
+    // wrong cwd or a moved file must RED here rather than make every assertion
+    // below vacuously true (trap 13 — an absence probe needs to prove it can
+    // see a presence).
+    expect(typeof css).toBe('string')
+    expect(css.length).toBeGreaterThan(1000)
+    expect(css).toContain('.dropdownMenu')
+
+    const block = css.match(/\.overlayOriginBadge\s*\{([^}]*)\}/)
+    expect(block, '.overlayOriginBadge has no rule in TopBar.module.css').not.toBeNull()
+    const body = block![1]
+
+    // DS v5 §3.2 / DESIGN_SYSTEM.md: outlined pills only — transparent
+    // background, body-coloured INK, the colour carried on the BORDER. The
+    // sibling lane's 2.80:1 failure came from colouring the text instead.
+    expect(body).toMatch(/background:\s*transparent/)
+    expect(body).toMatch(/color:\s*var\(--text-body/)
+    expect(body).toMatch(/border:\s*1px solid/)
+    // Never a filled pill.
+    expect(body).not.toMatch(/background:\s*var\(--info/)
+  })
+})


### PR DESCRIPTION
## Acceptance measure (one falsifiable sentence)

**A user whose menu opened without them touching it can now read, inside that menu, that Olumi opened it and that Escape takes it back — and we would observe it by raising `top_bar_menu` through `requestOverlaySurface` and finding the exact strings "Opened by Olumi" and "Esc to dismiss" rendered inside `role="menu"`, while the same menu opened by the user renders neither.**

Both halves are witnessed in a real browser below, not only in jsdom.

---

## ⚠ CORRECTED PREMISE — READ THIS FIRST

The brief for this lane said *"the assistant can now raise a menu"*. **That is true of the store and false of the wire, and the difference decides how this PR should be valued.**

Derived at the bytes at `60c4b082`:

- **`requestOverlaySurface` has ZERO production call sites.** Complete manifest of every reference under `src/` (`rg` over all `.ts`/`.tsx`): `src/stores/uiStore.ts` (declaration ×2, impl, 3 comment lines) and three **test** files. `applyV5State.ts` never calls it.
- **Schema `0.39.0`** (`vendor/talchain-schemas-0.39.0.tgz` → `dist/boundary/blocks.d.ts`): `UiDirectiveVerb = ["highlight","focus","open_inspector","open_panel","open_section"]`, and `UiDirectiveUiTargetSchema` is a discriminated union over `kind ∈ {"tab","model_section"}`. **No overlay verb and no overlay target kind exist.** The schema's own comment records the ratified wave-2 verdict: *"NO new verbs"*.
- `applyV5State`'s panel branch dispatches `open_panel → forceActivateOutputTab` and `open_section → requestModelTabSection + forceActivateOutputTab('diagnostics')`. Neither touches `activeOverlaySurface`.

**Therefore `overlaySurfaceOrigin` can only ever be `'user'` on a real turn today, and `data-overlay-origin="assistant"` is unreachable from the wire.** This is trap 16-inverse: the code path is live, the producer cannot feed it.

**What that means for this PR.** It completes the display half of a capability whose state half (#645) is dark for the same reason — it does not itself make anything reachable. Rung on the status ladder: **TESTED + browser-witnessed against the store seam; NOT wire-witnessed, NOT journey-witnessed.** I did **not** widen scope to fix reachability: the smallest enabling change is a `{kind:'overlay_surface'}` target in `olumi-schemas` plus a CEE emit and an `applyV5State` dispatch — three repos, and a Paul-ratifiable contract decision that reverses a recorded verdict.

**More valuable adjacent finding, deliberately not actioned.** `open_panel` / `open_section` **are** reachable today and **do** move the user's UI on a real turn — switching their tab, opening a model section — with **no attribution of any kind**. That is the *reachable* instance of exactly the harm this lane was scoped to fix. It lives in `OutputsDock`/`uiStore`, owned by other lanes.

---

## What the badge says, and what it refuses to say

An outlined pill at the top of the dropdown, above the existing divider:

> ✨ **Opened by Olumi**    ·    Esc to dismiss

- **Where it sits:** inside the surface it explains. The answer is where the question ("why did that open?") is asked, not somewhere the user has to hunt.
- **Calm:** non-interactive, no animation, no focus steal, no colour alarm. A user who did not notice the menu open is not startled by the explanation of it.
- **It does not say WHY, because no reason is reachable.** `ui_directive.note` is the only free-text carrier on the 0.39.0 wire and **nothing in `src/` reads it** (`rg '\.note\b|note:' src/v5/applyV5State.ts src/v5/blocks/mapV5Blocks.ts` → 0 hits). A plausible-sounding rationale on the provenance channel is worse than no badge, so the copy is pinned as a literal in both the component and the spec, and a test asserts the badge contains **nothing else**.
- **The dismissal hint is a verified fact, not reassurance:** TopBar's Escape handler runs `closeMenu()` unconditionally on origin.
- **Accessibility:** inside `role="menu"` only menuitems are reliably announced, so a bare `<div>` would give a screen-reader user — the person most disoriented by a menu that appears unprompted — nothing. The menu's accessible **name** carries it (`"More options — Opened by Olumi"`), and is left undefined when the user opened it themselves.

## Real-browser readings (dev build, Chrome — the thing jsdom cannot prove)

Driven through the assistant's actual seam: `(await import('/src/stores/uiStore.ts')).useUIStore.getState().requestOverlaySurface('top_bar_menu')`.

| | reading |
|---|---|
| menu background | `rgb(255,255,255)` |
| pill ink | `rgb(63,63,62)` (`--text-body`) — **10.54:1** ✅ AA/AAA |
| pill background | `rgba(0,0,0,0)` — transparent |
| pill border | `color(srgb 0.152941 0.478431 0.615686 / 0.3)` — the info blue at 30%, **colour on the border** |
| hint ink | `rgb(110,107,107)` (`--text-light`) at 12px — **5.28:1** ✅ AA |
| box | 132×22, `visibility: visible`, `elementFromPoint` at its centre resolves **inside the badge** (not occluded) |
| menu `aria-label` | `"More options — Opened by Olumi"` |

This follows the shipped convention (DS v5 §3.2 / `DESIGN_SYSTEM.md`: outlined pills, `bg-transparent border-{colour}/30 text-text-body`) rather than inventing one. The sibling lane's 2.80:1 / 2.83:1 came from colouring the **text**; mutant **M6b** reproduces that exact failure and is caught.

Real-browser negative and takeover cases, same session:

| action | menu | badge | `data-overlay-origin` | menu aria-label |
|---|---|---|---|---|
| assistant raises | ✅ | ✅ | `assistant` | `More options — Opened by Olumi` |
| Escape | ✅ closed | ✅ gone | — | — |
| **user** opens via kebab | ✅ | **✅ absent** | `user` | **`null`** |
| click outside | ✅ closed | ✅ gone | — | — |

## Test strategy

New spec `TopBar.overlayAttribution.spec.tsx` — **12 tests, asserted collected BY NAME** (`Tests 12 passed (12)`), run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported. RED-first at pristine: **8 failed / 4 passed of 12**.

The truth condition is a **conjunction** — *this bar's surface is raised* **AND** *the assistant raised it*. Either conjunct alone admits a state where the sentence would be a lie, so both are pinned.

**The style guard reads the stylesheet from disk.** vitest runs `css: false`, so a CSS-module lookup returns a key-echoing Proxy and a `className` assertion passes against a class that generates **no CSS** — the defect a sibling PR shipped tonight (`text-text-muted`). `?raw` does not escape it either: the stub intercepts `*.module.css` and `topBarCss.length` came back as the **string** `"length"`. The guard reads the file and proves it can see a presence (length > 1000, contains `.dropdownMenu`) before claiming an absence.

## Mutation kit — 8/8 bit, each on the expected test

Throwaway worktree at an **absolute** path outside the repo root. **Isolation proven by WRITING**, not by locating: distinct inodes (`578916560` vs `578928433`), a sentinel appended to the worktree copy left the source SHA-256 **identical**, and restores came from a **pristine `git archive` tar**, never from the other copy. Applied-check scoped to `src/`; **control read exactly 0**. Every run asserted collected == 27 (12 mine + 15 sibling) or hard-errored.

| mutant | expected | result |
|---|---|---|
| **M1** delete the badge render | capability RED | 🔴 6 RED incl. the capability test |
| **M2** loosen the ORIGIN conjunct (`=== 'assistant'` → `!== null`) | user-negatives RED, **capability GREEN** | 🔴 3 RED — all three "user" tests; capability stayed green |
| **M3** loosen the IDENTITY conjunct (`=== 'top_bar_menu'` → `!== null`) | foreign-surface RED | 🔴 2 RED (mine + the sibling's own foreign test) |
| **M4** fabricate a rationale in the copy | copy test RED | 🔴 1 RED, only that test |
| **M5** drop the `aria-label` | AT test RED | 🔴 1 RED, only that test |
| **M6a** delete the `.overlayOriginBadge` CSS rule | style guard RED | 🔴 1 RED |
| **M6b** colour the TEXT instead of the border | style guard RED | 🔴 1 RED |
| **M7** latch the origin so the badge OUTLIVES the fact | takeover test RED | 🔴 1 RED |
| **M8** drop `showMenu &&` in TopBar | — | 🟢 **DEMONSTRATED EQUIVALENT** |

**M2 + M3 are the discriminating pair (trap 19).** M2 loosens the guard for *all* origins and REDs the user tests while the assistant test stays **green** — sensitivity to the *named* origin, not merely to *something*. M3 loosens it for a *different surface* and REDs the foreign-surface test. Neither alone shows binding; the pair does.

**M8 is demonstrated equivalent, not asserted equivalent** (trap 13c: a survivor is a claim either way). Reason: the badge sits structurally inside `{isOpen && …}`, so `showMenu &&` in TopBar is defence-in-depth that makes the conjunction explicit at the reading site, not the load-bearing gate. Kept deliberately — `OVERLAY_SURFACE_IDS` has one member today, so `=== 'top_bar_menu'` and `!== null` agree on every value the enum can produce; the moment a second surface is lifted they stop agreeing.

## Gates

- `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) — ✅ **PASSED**, coverage 3345/3385, ratchet 618 files / 2487 errors **== baseline 2487**. No `--update-baseline`.
- `npx eslint` on the three changed files — **0 errors**. The single warning (`TopBar.tsx:115`, unused `no-console` disable) is **pre-existing**: verified present at `60c4b082`.
- Neighbouring suites (`src/components/layout`, `src/stores`, `applyV5State.assistantSurfaces`, `OutputsDock.overlayOcclusion`) — ✅ **100/100**, no collateral.

## The other two menus — checked, and deliberately NOT lifted

`LeftSidebar`'s lens menu and `UserAvatarMenu` still hold their open-state in component-local `useState` and cannot be assistant-raised. **Lifting one is not small at this tip and I have not done it.** Both coordinate with the kebab over the `menu:exclusive` window event; lifting one means it must simultaneously honour the event *and* the one-slot store, and `uiStore`'s own header records that a second lifted surface immediately activates the raise-into-an-occupied-slot hazard `requestOverlaySurface` guards. `src/stores/uiStore.ts` is also explicitly **not this lane's file**. Converting that discovery into scope is this programme's most repeated failure, so it stays a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
