### PR TITLE
F1 draft-state truth: keep a rendered model through unproven terminal failure; honest staged progress

### DIFF
--- a/src/canvas/components/AIInputBar.tsx
+++ b/src/canvas/components/AIInputBar.tsx
@@ -23,7 +23,11 @@ import {
   type AddOptionCanvasTargets,
   type AddOptionChange,
 } from '../conversation/addOptionRequest'
-import { messageForElapsed, messageForSettling } from './DraftLoadingAnimation'
+import {
+  messageForElapsed,
+  messageForSettling,
+  messageForSettlingAfterCoaching,
+} from './DraftLoadingAnimation'
 import { useDraftStore, draftStreamPhaseFor, draftStreamInFlight } from '../stores/draftStore'
 
 export type AIInputBarVariant = 'strip' | 'docked-tab' | 'floating' | 'first-use' | 'welcome'
@@ -176,6 +180,12 @@ export const AIInputBar = memo(
     const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
     const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, currentScenarioId))
     const isSettling = draftStreamPhase === 'settling'
+    // F1 (honest staged progress): once the owning turn's COACHING_READY frame
+    // has landed, the settling copy must stop claiming coaching is
+    // outstanding. Scoped by the SAME ownership derivation as the phase — the
+    // flag is only meaningful while this scenario's own draft is settling, so
+    // it is read as a conjunct of `isSettling`, never bare.
+    const coachingLanded = useDraftStore((s) => s.draftStreamCoachingLanded)
     const isGenerating = isThinking && (nodeCount === 0 || isSettling)
 
     // ── ROADMAP 2.134: THE STOP CONTROL ─────────────────────────────────────
@@ -207,7 +217,13 @@ export const AIInputBar = memo(
       // lands: the settling table's thresholds are measured from the render, not
       // from the start of the turn. Sharing the turn's clock would put the
       // escalated settling line up immediately on every single draft.
-      const resolve = isSettling ? messageForSettling : messageForElapsed
+      // `coachingLanded` likewise restarts it when COACHING_READY lands — its
+      // table is licensed by that frame, and its own clock starts with it.
+      const resolve = isSettling
+        ? coachingLanded
+          ? messageForSettlingAfterCoaching
+          : messageForSettling
+        : messageForElapsed
       if (!isGenerating) {
         setGeneratingMessage(resolve(0))
         return
@@ -218,7 +234,7 @@ export const AIInputBar = memo(
         setGeneratingMessage(resolve(Math.floor((Date.now() - start) / 1000)))
       }, 1000)
       return () => window.clearInterval(id)
-    }, [isGenerating, isSettling])
+    }, [isGenerating, isSettling, coachingLanded])
 
     useImperativeHandle(
       ref,

--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -121,6 +121,29 @@ export const SETTLING_STAGES = [
 ] as const
 
 /**
+ * The post-COACHING_READY table (F1 — honest staged progress). Shown only when
+ * the client HOLDS a COACHING_READY frame on top of the GRAPH_READY one, i.e.
+ * the coaching pass has landed and the turn is still running (live median:
+ * a ~1.7 s window, 59.2 s → 60.9 s — but the 8 Aug measured journey sat in it
+ * for ~28 s, reading "waiting on the values and coaching" about a coaching
+ * pass that had already run).
+ *
+ * ── WHAT THE FRAME LICENSES, AND WHAT IT DELIBERATELY DOES NOT ────────────
+ * COACHING_READY carries only a `coaching_status` ENUM — derived at the CEE
+ * producer: 'complete' | 'partial' | 'failed_degraded' — never the coaching
+ * itself, which arrives only in the terminal payload. So this line may STOP
+ * claiming coaching is outstanding (the pass has landed, whatever its status),
+ * but it may NOT claim coaching "has arrived" or "is ready" — for the
+ * 'failed_degraded' status that would be false, and the client does not
+ * word-switch on the enum because a status-keyed claim about content it has
+ * not seen would still be a guess. Dropping the claim is the only wording
+ * true for every enum value.
+ */
+export const SETTLING_AFTER_COACHING_STAGES = [
+  { afterSeconds: 0, message: 'Your model is on the canvas. Waiting for the settled values…' },
+] as const
+
+/**
  * The terminal honest lines for a draft whose values will NOT settle in this
  * session (`draftStreamPhase === 'unsettled'`). Two, because there are two
  * genuinely different causes and one sentence cannot state both truthfully.
@@ -187,6 +210,33 @@ export const STOPPED_DRAFT_NOTICE =
   'Drafting ended before your model\u2019s values arrived, so they are not final \u2014 and we can\u2019t confirm from here whether this draft saved. The structure is still on the canvas \u2014 start a new draft to get a model with settled values.'
 
 /**
+ * The same terminal state, reached because the DRAFT TURN ITSELF ENDED IN A
+ * SERVER-REPORTED ERROR after GRAPH_READY (F1 \u2014 draft-state truth). Measured
+ * 8 Aug 2026 on deployed staging: GRAPH_READY at 96.981 s, terminal COMPLETE
+ * 504 UPSTREAM_TIMEOUT at 125.202 s \u2014 and the then-current UI REMOVED the
+ * rendered graph and told the user nothing was drafted, while the server
+ * commit remained authoritative (the next turn reloaded it). This notice is
+ * what that state says instead.
+ *
+ * Why a THIRD string rather than reusing the two above: the causes differ and
+ * one sentence cannot state all three truthfully (the same reasoning as the
+ * three early-stop notices). "The connection dropped" is false here \u2014 the
+ * connection delivered the error; "drafting ended" hides that the server
+ * reported a failure. What IS known, and all that is said: the turn failed
+ * after the model reached the canvas; the structure is a validated GRAPH_READY
+ * frame (real); the coaching and settled values only ever arrive in the
+ * terminal payload, which was an error, so they never arrived; and the save
+ * cannot be confirmed from this side of the socket (no status route, guest
+ * RLS \u2014 deliveryUnknown.ts's derivation; the 2.737 rule forbids promising a
+ * receipt the server may not deliver).
+ *
+ * Deliberately free of em dashes and bullet glyphs so `safeRichText`'s
+ * house-style substitutions leave it byte-stable in the DOM.
+ */
+export const DRAFT_FAILED_MODEL_KEPT_NOTICE =
+  'Drafting failed after your model reached the canvas, so its coaching and settled values never arrived. The structure you can see is real, but we can\u2019t confirm from here whether this draft saved. Start a new draft to get a model with settled values.'
+
+/**
  * ── THE THREE EARLY-STOP NOTICES ────────────────────────────────────────────
  *
  * Emitted on EVERY explicit user Stop, including one pressed before any
@@ -232,6 +282,7 @@ export const EARLY_STOP_UNCONFIRMED_NOTICE =
 export const NARRATION_TABLES = {
   'DraftLoadingAnimation.PROGRESSIVE_STAGES': PROGRESSIVE_STAGES,
   'DraftLoadingAnimation.SETTLING_STAGES': SETTLING_STAGES,
+  'DraftLoadingAnimation.SETTLING_AFTER_COACHING_STAGES': SETTLING_AFTER_COACHING_STAGES,
 } as const
 
 function resolveStage(
@@ -258,6 +309,16 @@ export function messageForElapsed(elapsedSeconds: number): string {
  */
 export function messageForSettling(elapsedSeconds: number): string {
   return resolveStage(SETTLING_STAGES, elapsedSeconds)
+}
+
+/**
+ * Resolve the post-COACHING_READY message. Same clock semantics as
+ * `messageForSettling` — the table is currently a single line, but taking the
+ * elapsed argument keeps the three resolvers interchangeable at the call site
+ * (AIInputBar picks one by held-frame state, not by shape).
+ */
+export function messageForSettlingAfterCoaching(elapsedSeconds: number): string {
+  return resolveStage(SETTLING_AFTER_COACHING_STAGES, elapsedSeconds)
 }
 
 export function DraftLoadingAnimation() {

--- a/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
+++ b/src/canvas/components/__tests__/AIInputBar.settlingNarration.spec.tsx
@@ -19,7 +19,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
-import { PROGRESSIVE_STAGES, SETTLING_STAGES } from '../DraftLoadingAnimation'
+import {
+  PROGRESSIVE_STAGES,
+  SETTLING_STAGES,
+  SETTLING_AFTER_COACHING_STAGES,
+} from '../DraftLoadingAnimation'
 
 vi.mock('../../../lib/supabase', () => ({
   supabase: {
@@ -50,9 +54,14 @@ vi.mock('../../store', () => ({
   useCanvasStore: (selector: (s: unknown) => unknown) => selector(canvasMockState),
 }))
 
-const draftMockState: { draftStreamPhase: string; draftStreamScenarioId: string | null } = {
+const draftMockState: {
+  draftStreamPhase: string
+  draftStreamScenarioId: string | null
+  draftStreamCoachingLanded: boolean
+} = {
   draftStreamPhase: 'idle',
   draftStreamScenarioId: SCENARIO,
+  draftStreamCoachingLanded: false,
 }
 /**
  * Only the HOOK is stubbed — `importOriginal` keeps every other export real.
@@ -114,12 +123,14 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 const DRAFTING_LINE = PROGRESSIVE_STAGES[0].message
 const SETTLING_LINE = SETTLING_STAGES[0].message
+const COACHED_LINE = SETTLING_AFTER_COACHING_STAGES[0].message
 
 beforeEach(() => {
   canvasMockState.nodes = []
   canvasMockState.currentScenarioId = SCENARIO
   draftMockState.draftStreamPhase = 'idle'
   draftMockState.draftStreamScenarioId = SCENARIO
+  draftMockState.draftStreamCoachingLanded = false
   conversationMockState.isThinking = false
   conversationMockState.messages = []
 })
@@ -161,6 +172,49 @@ describe('phase 2 — after GRAPH_READY, graph on canvas, turn still running', (
     draftMockState.draftStreamPhase = 'settling'
     renderBar()
     expect(screen.getByTestId('gen').querySelector('textarea')).toBeDisabled()
+  })
+})
+
+describe('phase 3 — after COACHING_READY, coaching pass landed, values still to come (F1)', () => {
+  it('stops claiming coaching is outstanding once the frame has landed', () => {
+    // The 8 Aug measured journey sat post-COACHING_READY for ~28 s while the
+    // copy still read "waiting on the values and coaching" about a pass that
+    // had already run. Once the frame is held, the line drops the coaching
+    // claim — and ONLY the coaching claim: no wording asserts the coaching
+    // content arrived, because the enum ('failed_degraded' included) does not
+    // license that.
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = [{ id: 'g1' }, { id: 'opt_a' }]
+    draftMockState.draftStreamPhase = 'settling'
+    draftMockState.draftStreamCoachingLanded = true
+    renderBar()
+    expect(screen.getByText(COACHED_LINE)).toBeInTheDocument()
+    expect(screen.queryByText(SETTLING_LINE)).toBeNull()
+    expect(screen.queryByText(DRAFTING_LINE)).toBeNull()
+  })
+
+  it('does NOT use the coached line while the coaching frame has not landed', () => {
+    // Discriminating twin (trap 19's pair rule at the fixture level): same
+    // state, only the flag differs, and the line must differ with it.
+    conversationMockState.isThinking = true
+    canvasMockState.nodes = [{ id: 'g1' }, { id: 'opt_a' }]
+    draftMockState.draftStreamPhase = 'settling'
+    draftMockState.draftStreamCoachingLanded = false
+    renderBar()
+    expect(screen.getByText(SETTLING_LINE)).toBeInTheDocument()
+    expect(screen.queryByText(COACHED_LINE)).toBeNull()
+  })
+
+  it('a landed coaching flag WITHOUT the settling phase narrates nothing new', () => {
+    // The flag is read as a conjunct of `isSettling`, never bare — a stale
+    // flag on an idle store must not put any wait line up.
+    canvasMockState.nodes = [{ id: 'g1' }]
+    draftMockState.draftStreamPhase = 'idle'
+    draftMockState.draftStreamCoachingLanded = true
+    conversationMockState.isThinking = true
+    renderBar()
+    expect(screen.queryByText(COACHED_LINE)).toBeNull()
+    expect(screen.queryByText(SETTLING_LINE)).toBeNull()
   })
 })
 

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -55,8 +55,10 @@ import {
   NARRATION_TABLES,
   PROGRESSIVE_STAGES,
   SETTLING_STAGES,
+  SETTLING_AFTER_COACHING_STAGES,
   UNSETTLED_DRAFT_NOTICE,
   STOPPED_DRAFT_NOTICE,
+  DRAFT_FAILED_MODEL_KEPT_NOTICE,
   EARLY_STOP_NOT_SAVED_NOTICE,
   EARLY_STOP_ALREADY_SAVED_NOTICE,
   EARLY_STOP_UNCONFIRMED_NOTICE,
@@ -283,8 +285,15 @@ function frameLicenceViolations(message: string): string[] {
  */
 const FRAME_LICENSED_STRINGS: ReadonlyArray<readonly [string, string]> = [
   ...SETTLING_STAGES.map((s) => [`SETTLING_STAGES@${s.afterSeconds}s`, s.message] as const),
+  // The post-COACHING_READY table is licensed by TWO held frames (GRAPH_READY
+  // + COACHING_READY) and held to the same bar: it may stop claiming coaching
+  // is outstanding, it may not claim coaching content it has never seen.
+  ...SETTLING_AFTER_COACHING_STAGES.map(
+    (s) => [`SETTLING_AFTER_COACHING_STAGES@${s.afterSeconds}s`, s.message] as const,
+  ),
   ['UNSETTLED_DRAFT_NOTICE', UNSETTLED_DRAFT_NOTICE],
   ['STOPPED_DRAFT_NOTICE', STOPPED_DRAFT_NOTICE],
+  ['DRAFT_FAILED_MODEL_KEPT_NOTICE', DRAFT_FAILED_MODEL_KEPT_NOTICE],
   // The three explicit-Stop notices (Codex P0 stop-fence). They are shown when
   // drafting has ENDED rather than while it runs, but they are held to the same
   // bar: the frame licence lets them say the canvas is or is not changed, never
@@ -346,14 +355,18 @@ describe('the derived table registry cannot silently miss a surface (trap 12)', 
     for (const label of Object.keys(NARRATION_TABLES)) {
       expect(governed).toContain(label)
     }
-    // And the registry really does carry both draft tables — a registry that
+    // And the registry really does carry every draft table — a registry that
     // had quietly lost one would make the loop above vacuous.
     expect(Object.keys(NARRATION_TABLES)).toEqual([
       'DraftLoadingAnimation.PROGRESSIVE_STAGES',
       'DraftLoadingAnimation.SETTLING_STAGES',
+      'DraftLoadingAnimation.SETTLING_AFTER_COACHING_STAGES',
     ])
     expect(NARRATION_TABLES['DraftLoadingAnimation.PROGRESSIVE_STAGES']).toBe(PROGRESSIVE_STAGES)
     expect(NARRATION_TABLES['DraftLoadingAnimation.SETTLING_STAGES']).toBe(SETTLING_STAGES)
+    expect(NARRATION_TABLES['DraftLoadingAnimation.SETTLING_AFTER_COACHING_STAGES']).toBe(
+      SETTLING_AFTER_COACHING_STAGES,
+    )
   })
 })
 
@@ -381,6 +394,7 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
     }
     // And the manifest is named, so a reviewer sees what was actually covered.
     expect(exportedNotices.sort()).toEqual([
+      'DRAFT_FAILED_MODEL_KEPT_NOTICE',
       'EARLY_STOP_ALREADY_SAVED_NOTICE',
       'EARLY_STOP_NOT_SAVED_NOTICE',
       'EARLY_STOP_UNCONFIRMED_NOTICE',
@@ -395,19 +409,32 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
     expect(governed).toContain('DRAFT_VALUES_UNSETTLED_REFUSAL')
   })
 
-  it('the two notices differ — one cause cannot describe both truthfully', () => {
-    // A dead connection and a user pressing Stop are different facts. One
-    // sentence asserting "the connection dropped" would be false for the Stop and
-    // timeout paths (review F1).
+  it('the three notices differ — one cause cannot describe them all truthfully', () => {
+    // A dead connection, a user pressing Stop, and a server-reported terminal
+    // error behind a kept model are three different facts. One sentence
+    // asserting "the connection dropped" would be false for the other two
+    // (review F1; F1-terminal extends the same rule).
     expect(UNSETTLED_DRAFT_NOTICE).not.toBe(STOPPED_DRAFT_NOTICE)
+    expect(DRAFT_FAILED_MODEL_KEPT_NOTICE).not.toBe(UNSETTLED_DRAFT_NOTICE)
+    expect(DRAFT_FAILED_MODEL_KEPT_NOTICE).not.toBe(STOPPED_DRAFT_NOTICE)
     expect(UNSETTLED_DRAFT_NOTICE).toMatch(/connection dropped/i)
     expect(STOPPED_DRAFT_NOTICE).not.toMatch(/connection dropped/i)
+    expect(DRAFT_FAILED_MODEL_KEPT_NOTICE).not.toMatch(/connection dropped/i)
+    // The kept-model notice names its own cause (the turn failed) and its own
+    // epistemic limit (the save is unconfirmed) — the two claims the 8 Aug
+    // measurement showed the product inverting.
+    expect(DRAFT_FAILED_MODEL_KEPT_NOTICE).toMatch(/drafting failed/i)
+    expect(DRAFT_FAILED_MODEL_KEPT_NOTICE).toMatch(/can[’']t confirm/i)
   })
 
-  it('neither notice promises an action the handler cannot perform (F3)', () => {
-    // Both used to say "Draft again", wired to `retryLast`, which CEE declines on
+  it('no notice promises an action the handler cannot perform (F3)', () => {
+    // They used to say "Draft again", wired to `retryLast`, which CEE declines on
     // a committed scenario. The copy now names the action that works.
-    for (const notice of [UNSETTLED_DRAFT_NOTICE, STOPPED_DRAFT_NOTICE]) {
+    for (const notice of [
+      UNSETTLED_DRAFT_NOTICE,
+      STOPPED_DRAFT_NOTICE,
+      DRAFT_FAILED_MODEL_KEPT_NOTICE,
+    ]) {
       expect(notice).toMatch(/start a new draft/i)
       expect(notice).not.toMatch(/draft again/i)
     }

--- a/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
+++ b/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
@@ -332,6 +332,33 @@ describe('the happy path — graph at GRAPH_READY, full ingest at COMPLETE', () 
     expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
   })
 
+  it('COACHING_READY flips the coaching flag for the owning turn, and idle resets it (F1)', async () => {
+    // The seam the narration tests cannot see: they mock the store, and the
+    // store tests call the action directly. This drives the REAL frame through
+    // the REAL stream into the REAL store, so a dropped `onCoachingReady`
+    // handler cannot hide behind green unit suites.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(false)
+
+    await stream.push(F_COACHING)
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(true)
+
+    await stream.push(fComplete())
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+    // Terminal ingest released ownership — the flag must not leak forward.
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(false)
+  })
+
   it('runs the FRESH-DRAFT ingest at COMPLETE, not the applied-edit reconcile', async () => {
     // The silent-failure pin. `ceeAnalysisReady` is written ONLY by
     // applyDraftResult's `hasAnalysisReady` branch; `reconcileAppliedGraph`

--- a/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
+++ b/src/canvas/conversation/__tests__/streamedDraftTurn.spec.ts
@@ -559,7 +559,45 @@ describe('FAILURE HONESTY — never a dead end, never a double-commit', () => {
     expect(result.current.messages.map((m) => m.content)).not.toContain(UNSETTLED_DRAFT_NOTICE)
   })
 
-  it('removes the preview when the terminal frame is an error', async () => {
+  it('removes the preview when the terminal frame PROVES the commit failed', async () => {
+    // ⚠ F1 REWROTE THIS PIN. It used to assert removal on ANY ≥400 terminal —
+    // and on the measured 8 Aug journey that destroyed a server-committed
+    // model (GRAPH_READY 96.981 s → terminal 504 at 125.202 s; the next turn
+    // reloaded the committed graph). Removal is honest for exactly one wire
+    // class: the commit-failure envelope, where the server said "Nothing was
+    // written". Every other ≥400 keeps the model and marks it — pinned in
+    // useConversation.streamedDraftTerminalError.spec.tsx.
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(F_DRAFTING + F_GRAPH_READY)
+    expect(useCanvasStore.getState().nodes).toHaveLength(TERMINAL_NODE_IDS.length)
+
+    await stream.push(
+      fComplete(500, {
+        error: 'INTERNAL_ERROR',
+        boundary: 'B1',
+        direction: 'egress',
+        validator: 'turn_commit',
+        details: { retryable: true, reason: 'draft_graph_commit_failed' },
+      }),
+    )
+    await stream.close()
+    await act(async () => {
+      await sent
+    })
+
+    // The server proved nothing was written — a standing preview would be the
+    // phantom model.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+
+  it('KEEPS the preview when the terminal error does not prove the commit failed, and marks it unsettled', async () => {
     const stream = controllableStream()
     mockOpenStream.mockResolvedValue(stream.response)
     const { result } = renderHook(() => useConversation())
@@ -576,9 +614,10 @@ describe('FAILURE HONESTY — never a dead end, never a double-commit', () => {
       await sent
     })
 
-    // A graph rendered on the promise of a turn that then failed must not stay.
-    expect(useCanvasStore.getState().nodes).toHaveLength(0)
-    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    // The commit is unknowable from this side; removal would assert a
+    // falsehood the 8 Aug measurement refuted. Keep, gate shut, marked.
+    expect(useCanvasStore.getState().nodes.map((n) => n.id).sort()).toEqual(TERMINAL_NODE_IDS)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
   })
 })
 

--- a/src/canvas/conversation/__tests__/useConversation.streamedDraftTerminalError.spec.tsx
+++ b/src/canvas/conversation/__tests__/useConversation.streamedDraftTerminalError.spec.tsx
@@ -1,0 +1,410 @@
+/**
+ * F1 — DRAFT-STATE TRUTH: terminal failure AFTER GRAPH_READY must not destroy
+ * the rendered model or claim nothing was drafted (PR1 / acceptance sentence 1).
+ *
+ * ── THE MEASURED DEFECT (deployed staging, 8 Aug 2026) ─────────────────────
+ * `PHASE0-EVIDENCE-2026-07-28/olumi-poc-independent-review-2026-08-09.md`:
+ * GRAPH_READY arrived at 96.981 s (21 nodes / 43 edges, committed server-side),
+ * the terminal COMPLETE carried 504 UPSTREAM_TIMEOUT at 125.202 s — and the UI
+ * REMOVED the rendered graph and told the user nothing was drafted, while a
+ * grounded follow-up found the canonical model under the same scenario and
+ * analysis then ran against it. The server commit was authoritative; the
+ * client's discard asserted a falsehood.
+ *
+ * ── THE RECONCILIATION RULE THESE TESTS PIN ────────────────────────────────
+ * The client cannot poll server state (no status route; guest RLS blocks
+ * `scenarios` reads — see deliveryUnknown.ts's derivation), so the cheapest
+ * authoritative check it holds is the terminal payload's own commit marker:
+ *
+ *   · the ONE class that PROVES no commit is `reason:
+ *     "draft_graph_commit_failed"` (CEE route-v2.ts's `!dg.commitPerformed`
+ *     envelope — fresh-journey-p0-diagnosis-2026-08-08.md §1.4, captured at
+ *     the wire). For that class the preview is removed: the server said
+ *     "Nothing was written", so removal states the truth.
+ *   · every other ≥400 terminal after GRAPH_READY (the measured 504 class,
+ *     proxy timeout bodies, unknown INTERNAL_ERRORs) leaves the commit
+ *     UNKNOWABLE from this side — and measured-COMMON to have succeeded
+ *     (CEE 2.709 first-write exemption; the 8 Aug case). The graph stays,
+ *     the phase goes `unsettled` (run gate shut, never persisted by the UI),
+ *     and ONE honest notice says exactly what is known.
+ *
+ * Harness = streamedDraftTurn.spec.ts's: a real ReadableStream through the
+ * real streamStageFrames → consumeStreamedDraftTurn → parseV5Response →
+ * routeV5Response, with only the network seams mocked.
+ *
+ * Mount-path note (trap 3b): these tests bind at useConversation, upstream of
+ * both flag postures (the same `messages` array feeds ConversationPanel/
+ * ChatThread under AI Panel v2 — deployed staging posture per netlify.toml
+ * `VITE_FEATURE_AI_PANEL_V2 = "true"` — and DraftChat when it is off). The
+ * DOM half renders ChatThread, the surface the deployed flags mount.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, render, screen, act, cleanup } from '@testing-library/react'
+
+import { useConversation, START_NEW_DRAFT_CHIP_ID } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useDraftStore, draftStreamPhaseFor, shouldPersistGraphForScenario } from '../../stores/draftStore'
+import { canRunAnalysis } from '../../utils/canRunAnalysis'
+import { assertsNonDelivery } from '../deliveryUnknown'
+// Namespace import, deliberately: at the RED-first (pristine) run the new
+// notice export does not exist yet, and a named import of a missing binding
+// fails the whole file at COLLECT — which trap 2b says is invisible to every
+// aggregate. The presence assertion below turns "export missing" into a
+// named, countable RED instead.
+import * as narration from '../../components/DraftLoadingAnimation'
+import { ChatThread } from '../zones/ChatThread'
+import type { ConversationMessage } from '../types'
+import wireFixture from './fixtures/cee-draft-goal-constraints-wire.json'
+
+// ---------------------------------------------------------------------------
+// Network seams — the only things mocked (streamedDraftTurn.spec.ts's set)
+// ---------------------------------------------------------------------------
+
+const mockOpenStream = vi.fn()
+const mockCallV5Turn = vi.fn()
+const mockStopV5Turn = vi.fn((..._args: unknown[]) =>
+  Promise.resolve({ kind: 'not_saved' as const }),
+)
+
+vi.mock('../../../v5/stopTurn', () => ({
+  stopV5Turn: (...args: unknown[]) => mockStopV5Turn(...args),
+  getV5StopEndpoint: () => 'https://cee.test/proxy/v5/turn/stop',
+  STOP_ACK_BUDGET_MS: 5000,
+}))
+
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: (...args: unknown[]) => mockOpenStream(...args),
+  }
+})
+
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/v5Adapter')>()
+  return {
+    ...actual,
+    callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+    getV5Endpoint: () => 'https://cee.test/proxy/v5/turn',
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return { ...actual, isV5Eligible: () => ({ eligible: true }) }
+})
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({ loadScenario: async () => null }))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TERMINAL_BODY = wireFixture as unknown as Record<string, unknown>
+const TERMINAL_GRAPH = TERMINAL_BODY.draft_graph as {
+  nodes: Array<Record<string, unknown>>
+  edges: Array<Record<string, unknown>>
+}
+
+/** Same identity derivation as streamedDraftTurn.spec.ts — the two shapes
+ * cannot drift apart and make the identity pin vacuous. */
+const READY_GRAPH = {
+  nodes: TERMINAL_GRAPH.nodes.map((n) => ({ id: n.id, kind: n.kind, label: n.label })),
+  edges: TERMINAL_GRAPH.edges.map((e) => ({ from: e.from, to: e.to, strength: { mean: 0 } })),
+}
+const TERMINAL_NODE_IDS = TERMINAL_GRAPH.nodes.map((n) => String(n.id)).sort()
+
+/**
+ * The 8 Aug measured class: a CEE boundary envelope carrying UPSTREAM_TIMEOUT
+ * on the terminal COMPLETE frame. Shape per the live BoundaryError wire
+ * (useConversation.transcriptHonesty504.spec.ts's BOUNDARY_ERROR_BODY family);
+ * the reason is CEE's typed timeout reason (`mapDraftGraphPipelineReason`).
+ * NOT a commit-failure proof — the commit ordinarily stands for this class.
+ */
+const CEE_504_UPSTREAM_TIMEOUT = {
+  error: 'UPSTREAM_TIMEOUT',
+  boundary: 'B1',
+  direction: 'egress',
+  validator: 'draft_graph_pipeline',
+  details: {
+    retryable: true,
+    reason: 'draft_graph_cee_timeout',
+  },
+}
+
+/** The Netlify/Render proxy's own timeout body (dress rehearsal 2026-07-20,
+ * wire/001-504) — the transport-class sibling. Also not a commit proof. */
+const PROXY_504_BODY = {
+  code: 'PROXY_UPSTREAM_TIMEOUT',
+  message:
+    'The model generation service did not respond within 125s. This can happen under heavy load. Please try again.',
+  request_id: '6f30b61f-b596-45c2-ac3e-9f40db7513a9',
+}
+
+/**
+ * The ONE class that proves the commit failed: CEE route-v2's
+ * `!dg.commitPerformed` envelope (fresh-journey-p0-diagnosis §1.4, wire
+ * capture: `{error: INTERNAL_ERROR, validator: turn_commit, reason:
+ * draft_graph_commit_failed, retryable: true}`).
+ */
+const CEE_500_COMMIT_FAILED = {
+  error: 'INTERNAL_ERROR',
+  boundary: 'B1',
+  direction: 'egress',
+  validator: 'turn_commit',
+  details: {
+    retryable: true,
+    reason: 'draft_graph_commit_failed',
+  },
+}
+
+function frame(obj: Record<string, unknown>): string {
+  return `event: stage\ndata: ${JSON.stringify(obj)}\n\n`
+}
+
+const F_DRAFTING = frame({ stage: 'DRAFTING', seq: 0, status: 'in_progress' })
+const F_GRAPH_READY = frame({
+  stage: 'GRAPH_READY',
+  seq: 2,
+  status: 'in_progress',
+  schema_version: 'v3',
+  elapsed_ms: 96_981,
+  graph: READY_GRAPH,
+})
+const fCompleteError = (statusCode: number, payload: unknown) =>
+  frame({ stage: 'COMPLETE', seq: 4, status: 'complete', status_code: statusCode, payload })
+
+function controllableStream() {
+  const encoder = new TextEncoder()
+  let ctrl!: ReadableStreamDefaultController<Uint8Array>
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      ctrl = c
+    },
+  })
+  const res = new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+  const settle = () =>
+    act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+  let closed = false
+  return {
+    response: res,
+    async push(text: string) {
+      if (!closed) ctrl.enqueue(encoder.encode(text))
+      await settle()
+    },
+    async close() {
+      if (!closed) {
+        closed = true
+        try {
+          ctrl.close()
+        } catch {
+          /* already closed by the consumer's own cancel */
+        }
+      }
+      await settle()
+    },
+  }
+}
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const BRIEF =
+  'How should we lift net revenue retention from 96% to 110% by March 2027 without breaking the £650k programme cap?'
+
+interface HookHarness {
+  messages: ConversationMessage[]
+  lastSendFailure: unknown
+}
+
+/** Drive one streamed draft: DRAFTING → GRAPH_READY → COMPLETE(error). */
+async function runDraftToTerminalError(
+  statusCode: number,
+  payload: unknown,
+): Promise<HookHarness> {
+  const stream = controllableStream()
+  mockOpenStream.mockResolvedValue(stream.response)
+  const { result } = renderHook(() => useConversation())
+  let sent!: Promise<void>
+  await act(async () => {
+    sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+  })
+  await stream.push(F_DRAFTING + F_GRAPH_READY)
+  // Precondition pin (trap 13b): the preview must actually be standing before
+  // the terminal error arrives, or every retention assertion below is vacuous.
+  expect(useCanvasStore.getState().nodes.map((n) => n.id).sort()).toEqual(TERMINAL_NODE_IDS)
+  await stream.push(fCompleteError(statusCode, payload))
+  await stream.close()
+  await act(async () => {
+    await sent
+  })
+  return {
+    messages: result.current.messages,
+    lastSendFailure: (result.current as unknown as { lastSendFailure: unknown }).lastSendFailure,
+  }
+}
+
+/** The kept-model notice, asserted to EXIST before it is used (see the
+ * namespace-import note above). */
+function keptModelNotice(): string {
+  const notice = (narration as Record<string, unknown>).DRAFT_FAILED_MODEL_KEPT_NOTICE
+  expect(typeof notice, 'DRAFT_FAILED_MODEL_KEPT_NOTICE must be exported by DraftLoadingAnimation').toBe('string')
+  return notice as string
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  mockOpenStream.mockReset()
+  mockCallV5Turn.mockReset()
+  useDraftStore.getState().resetDraft()
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [],
+    edges: [],
+    history: { past: [], future: [] },
+    _internal: {
+      ...(useCanvasStore.getState() as unknown as { _internal: object })._internal,
+      lastHistoryHash: null,
+    },
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    results: { status: 'idle' } as never,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// The measured 504 class — model KEPT, honest disclosure
+// ---------------------------------------------------------------------------
+
+describe.each([
+  ['CEE UPSTREAM_TIMEOUT envelope (the 8 Aug measured class)', 504, CEE_504_UPSTREAM_TIMEOUT],
+  ['proxy PROXY_UPSTREAM_TIMEOUT body (transport-class sibling)', 504, PROXY_504_BODY],
+])('terminal %s after GRAPH_READY', (_label, statusCode, payload) => {
+  it('keeps the rendered model on the canvas — the server commit is not the client’s to destroy', async () => {
+    await runDraftToTerminalError(statusCode, payload)
+    // Identity-bound retention: the exact preview node set, not "some nodes".
+    expect(useCanvasStore.getState().nodes.map((n) => n.id).sort()).toEqual(TERMINAL_NODE_IDS)
+  })
+
+  it('marks the draft unsettled: run gate shut, graph never persisted by the UI', async () => {
+    await runDraftToTerminalError(statusCode, payload)
+    expect(draftStreamPhaseFor(useDraftStore.getState(), SCENARIO)).toBe('unsettled')
+    // The gate consumes the phase (same call shape as OutputsDock).
+    const gate = canRunAnalysis({
+      graphHealth: null,
+      readiness: null,
+      hasBlockers: false,
+      nodeCount: useCanvasStore.getState().nodes.length,
+      draftStreamPhase: draftStreamPhaseFor(useDraftStore.getState(), SCENARIO),
+    })
+    expect(gate.allowed).toBe(false)
+    // And the unsettled preview must never reach `scenarios.graph` from here.
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(false)
+  })
+
+  it('renders EXACTLY ONE synthetic notice — the honest one, with the affordance that works', async () => {
+    const { messages } = await runDraftToTerminalError(statusCode, payload)
+    const synthetic = messages.filter((m) => m.role === 'assistant' && m.synthetic === true)
+    // One message owns this state. A second bubble (the generic failure copy)
+    // would either contradict the notice or duplicate it.
+    expect(synthetic).toHaveLength(1)
+    expect(synthetic[0].content).toBe(keptModelNotice())
+    // The affordance that genuinely works (F3: retryLast provably cannot).
+    expect(synthetic[0].actionChips?.map((c) => c.id)).toEqual([START_NEW_DRAFT_CHIP_ID])
+  })
+
+  it('claims non-delivery NOWHERE — no message may assert the draft did not happen', async () => {
+    const { messages } = await runDraftToTerminalError(statusCode, payload)
+    for (const m of messages) {
+      expect(assertsNonDelivery(m.content ?? ''), `message asserts non-delivery: "${m.content}"`).toBe(false)
+    }
+  })
+
+  it('the user bubble reads as DELIVERED — GRAPH_READY is proof the server processed it', async () => {
+    const { messages } = await runDraftToTerminalError(statusCode, payload)
+    const userBubbles = messages.filter((m) => m.role === 'user')
+    expect(userBubbles).toHaveLength(1)
+    expect(userBubbles[0].deliveryState ?? 'sent').toBe('sent')
+  })
+
+  it('raises no send-failure banner — the send demonstrably succeeded', async () => {
+    const { lastSendFailure } = await runDraftToTerminalError(statusCode, payload)
+    expect(lastSendFailure).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The PROVEN commit failure — removal states the truth
+// ---------------------------------------------------------------------------
+
+describe('terminal 500 whose payload PROVES the commit failed (draft_graph_commit_failed)', () => {
+  it('removes the preview — the server said "Nothing was written", and keeping it would be the phantom model', async () => {
+    await runDraftToTerminalError(500, CEE_500_COMMIT_FAILED)
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+  })
+
+  it('reports the failure plainly with a retry affordance, and does NOT show the kept-model notice', async () => {
+    const { messages } = await runDraftToTerminalError(500, CEE_500_COMMIT_FAILED)
+    const synthetic = messages.filter((m) => m.role === 'assistant' && m.synthetic === true)
+    expect(synthetic).toHaveLength(1)
+    // Discriminating pair with the kept-model cases: the SAME harness, only the
+    // payload's reason differs, and the behaviour must differ in BOTH directions
+    // (trap 19's mutant-pair rule, applied at the fixture level).
+    expect(synthetic[0].content).not.toBe(keptModelNotice())
+    // Wire retryable: true → the retry affordance is honest here (a re-send on a
+    // scenario with NO committed graph is a fresh draft, not a duplicate).
+    expect(synthetic[0].actionChips?.some((c) => c.id === 'retry')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DOM half — the honest state as the deployed panel renders it (ChatThread)
+// ---------------------------------------------------------------------------
+
+describe('the kept-model notice reaches the DOM of the mounted thread', () => {
+  it('renders the notice text and the start-new-draft chip in ChatThread', async () => {
+    const { messages } = await runDraftToTerminalError(504, CEE_504_UPSTREAM_TIMEOUT)
+    render(
+      <ChatThread
+        messages={messages}
+        isThinking={false}
+        longRunningHint={null}
+        nodeCount={TERMINAL_NODE_IDS.length}
+        patchBlockStates={new Map()}
+        patchRejections={new Map()}
+        onChipClick={async () => {}}
+        onPatchAccept={() => {}}
+        onPatchDismiss={() => {}}
+        onFeedback={() => {}}
+        onRetry={() => {}}
+      />,
+    )
+    // jsdom proves presence, not layout (trap 3) — asserted as presence only.
+    // The notice copy is deliberately free of em dashes and bullets, so
+    // safeRichText's house-style substitutions leave it byte-stable and the
+    // bubble's textContent carries it whole.
+    const assistantBubbles = screen.getAllByTestId('message-assistant')
+    const withNotice = assistantBubbles.filter((el) =>
+      (el.textContent ?? '').includes(keptModelNotice()),
+    )
+    expect(withNotice).toHaveLength(1)
+    // The affordance, on the surface the deployed flags mount.
+    expect(screen.getByTestId(`suggested-chip-${START_NEW_DRAFT_CHIP_ID}`)).toBeTruthy()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -24,7 +24,7 @@ import { callV5Turn, getV5Endpoint, type V5CallResult } from '../../v5/v5Adapter
 import { parseV5Response } from '../../v5/responseParser'
 import { openV5TurnStream, __streamInternals as streamTransport } from '../../v5/streamedTurnTransport'
 import { streamStageFrames } from '../../v5/streamedDraftFrames'
-import { consumeStreamedDraftTurn } from '../../v5/consumeStreamedDraftTurn'
+import { consumeStreamedDraftTurn, terminalProvesCommitFailed } from '../../v5/consumeStreamedDraftTurn'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
 import { isV5Eligible } from '../../v5/eligibility'
@@ -114,6 +114,7 @@ import { applyDraftResult, backfillGoalThresholdOntoGoalNode } from '../utils/ap
 import {
   UNSETTLED_DRAFT_NOTICE,
   STOPPED_DRAFT_NOTICE,
+  DRAFT_FAILED_MODEL_KEPT_NOTICE,
   EARLY_STOP_NOT_SAVED_NOTICE,
   EARLY_STOP_ALREADY_SAVED_NOTICE,
   EARLY_STOP_UNCONFIRMED_NOTICE,
@@ -494,12 +495,26 @@ export interface StreamedDraftTurnResult {
    */
   previewOwnsCanvas: boolean
   /**
-   * True in the one honest-failure case: the stream died after GRAPH_READY, the
-   * buffered fallback found the turn already committed, and CEE declined to
-   * re-draft — so the structure on screen is real and its numbers will never
-   * settle in this session.
+   * True in the honest-failure cases: the structure on screen is real and its
+   * numbers will never settle in this session. See `unsettledCause` for which
+   * failure produced the state — the notice copy must state the actual cause
+   * (the three-strings-not-one rule).
    */
   unsettled: boolean
+  /**
+   * Which failure produced `unsettled` (undefined when `unsettled` is false):
+   *   `stream_loss`   — the stream died after GRAPH_READY and the buffered
+   *                     fallback found the turn already committed (CEE
+   *                     declined to re-draft), OR a 200 terminal carried no
+   *                     extractable graph (review F4). The connection/payload
+   *                     failed the values, not the turn.
+   *   `terminal_error_model_kept` — the turn ended in a server-reported ≥400
+   *                     AFTER GRAPH_READY, without commit-failure proof (the
+   *                     measured 8 Aug 504 class). The model stays rendered;
+   *                     the save is unconfirmed; the generic failure bubble is
+   *                     suppressed in favour of the one honest notice.
+   */
+  unsettledCause?: 'stream_loss' | 'terminal_error_model_kept'
 }
 
 /**
@@ -637,7 +652,7 @@ async function runStreamedDraftTurn(args: {
       useDraftStore
         .getState()
         .setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
-      return { result, previewOwnsCanvas: false, unsettled: true }
+      return { result, previewOwnsCanvas: false, unsettled: true, unsettledCause: 'stream_loss' }
     }
     // Outcome 3.
     useDraftStore.getState().setDraftStreamPhase('idle', null, null)
@@ -658,6 +673,15 @@ async function runStreamedDraftTurn(args: {
   }
 
   const outcome = await consumeStreamedDraftTurn(streamStageFrames(res), {
+    // F1 (honest staged progress): record the COACHING_READY frame so the
+    // settling narration can stop claiming coaching is outstanding once the
+    // pass has landed. Identity-guarded in the store — a stale stream's frame
+    // cannot move a newer turn's narration. Only the ENUM is held; the
+    // coaching content itself arrives exclusively in the terminal payload, so
+    // no copy anywhere claims the coaching "has arrived".
+    onCoachingReady: () => {
+      useDraftStore.getState().markDraftStreamCoachingLanded(turnClientId)
+    },
     onGraphReady: (graph) => {
       // Scenario guard, same rule the buffered ingest applies: a response whose
       // scenario is no longer the open one must not write to the canvas.
@@ -745,8 +769,29 @@ async function runStreamedDraftTurn(args: {
   // `renderedGraph` is non-null only when the render callback ACCEPTED the frame
   // — a rejected preview (scenario switched away) must not have its element ids
   // stripped out of whatever scenario the user moved to.
+  //
+  // ═══ F1 — TERMINAL-FAILURE RECONCILIATION (draft-state truth) ═════════════
+  // A terminal ≥400 after GRAPH_READY used to remove the preview
+  // unconditionally, and on the measured 8 Aug journey that DESTROYED a
+  // server-committed model and told the user nothing was drafted (GRAPH_READY
+  // 96.981 s; terminal COMPLETE 504 UPSTREAM_TIMEOUT 125.202 s; the next turn
+  // reloaded the committed graph — olumi-poc-independent-review-2026-08-09.md).
+  // The commit runs server-side around the GRAPH_READY emission and survives
+  // late failures in the common case (CEE 2.709 first-write exemption), and
+  // this client cannot poll server state (no status route; guest RLS). So the
+  // reconciliation is the terminal payload's own commit marker:
+  //   · proof the commit failed (`draft_graph_commit_failed` — the server said
+  //     "Nothing was written") → remove the preview; removal states the truth.
+  //   · anything else → KEEP the graph. The `previewOwnsCanvas &&
+  //     !resultCarriesDraftGraph` branch below then marks it `unsettled`
+  //     (gate shut, never persisted) with the honest cause, and sendTurn
+  //     renders ONE notice instead of the generic failure copy.
   let previewOwnsCanvas = outcome.renderedGraph !== null
-  if (outcome.discardPreview && outcome.renderedGraph) {
+  const terminalErrorKeepsModel =
+    outcome.terminalError &&
+    outcome.renderedGraph !== null &&
+    !terminalProvesCommitFailed(outcome.terminalPayload)
+  if (outcome.terminalError && outcome.renderedGraph && !terminalErrorKeepsModel) {
     discardStreamedPreview(outcome.renderedGraph)
     previewOwnsCanvas = false
   }
@@ -766,9 +811,11 @@ async function runStreamedDraftTurn(args: {
 
   // ═══ ADVERSARIAL REVIEW F4 ══════════════════════════════════════════════
   // A 200 terminal frame that carries NO extractable `draft_graph` while a
-  // preview is standing is the FAILURE path, not a success. `discardPreview`
-  // only fires on `status_code >= 400`, so this used to leave a phantom preview
-  // on the canvas with the gate OPEN, the phase `idle` and no notice.
+  // preview is standing is the FAILURE path, not a success. The removal path
+  // only fires on a proven commit failure, so this used to leave a phantom
+  // preview on the canvas with the gate OPEN, the phase `idle` and no notice.
+  // (F1 widened this branch: it now also carries the kept-model terminal-error
+  // state, with the cause telling the two apart for the notice.)
   //
   // It is not a malice-only shape: it is the client shadow of the ROWED server
   // salvage gap — a truncation-salvaged turn is precisely a 200 whose graph may
@@ -780,7 +827,15 @@ async function runStreamedDraftTurn(args: {
   // deleting it asserts something false while marking it states the truth.
   if (previewOwnsCanvas && !resultCarriesDraftGraph(result)) {
     useDraftStore.getState().setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
-    return { result, previewOwnsCanvas: false, unsettled: true }
+    return {
+      result,
+      previewOwnsCanvas: false,
+      unsettled: true,
+      // The cause decides the notice: a kept model behind a terminal error is
+      // a different fact from a 200 that lost its graph, and one sentence
+      // cannot state both truthfully.
+      unsettledCause: terminalErrorKeepsModel ? 'terminal_error_model_kept' : 'stream_loss',
+    }
   }
 
   useDraftStore.getState().setDraftStreamPhase('idle', null, null)
@@ -4450,6 +4505,7 @@ export function useConversation(): UseConversationReturn {
         // receipt. `…Unsettled` says the values will not settle in this session.
         let streamedPreviewOwnsCanvas = false
         let streamedUnsettled = false
+        let streamedUnsettledCause: 'stream_loss' | 'terminal_error_model_kept' | undefined
 
         try {
           // Resolve session identity once — X-User-Id + Authorization Bearer
@@ -4497,6 +4553,7 @@ export function useConversation(): UseConversationReturn {
             v5Result = streamed.result
             streamedPreviewOwnsCanvas = streamed.previewOwnsCanvas
             streamedUnsettled = streamed.unsettled
+            streamedUnsettledCause = streamed.unsettledCause
           } else {
             v5Result = await callV5Turn(build.payload, { signal: controller.signal, headers: v5Headers })
           }
@@ -4622,9 +4679,18 @@ export function useConversation(): UseConversationReturn {
                 recovery: extractCeeRecovery(target.boundaryError ?? target.rawBody),
                 rawBody: target.rawBody,
               })
+            // F1: a typed_error whose stream already delivered GRAPH_READY is
+            // PROOF the server received and processed this message — a
+            // "failed"/"unconfirmed" marker would assert something the held
+            // frame refutes.
+            const deliveryProvenByFrame = streamedUnsettledCause === 'terminal_error_model_kept'
             updateMessage(userBubbleIdForTurn, {
               deliveryState:
-                target.kind !== 'typed_error' ? 'sent' : unverified ? 'unconfirmed' : 'failed',
+                target.kind !== 'typed_error' || deliveryProvenByFrame
+                  ? 'sent'
+                  : unverified
+                    ? 'unconfirmed'
+                    : 'failed',
             })
           }
 
@@ -5025,6 +5091,21 @@ export function useConversation(): UseConversationReturn {
               // feedback rather than fail silently (server class).
               setLastSendFailure({ kind: 'server', retryable: true, inputText: inputForRestore })
             }
+          } else if (streamedUnsettledCause === 'terminal_error_model_kept') {
+            // ═══ F1 — the kept-model terminal error says ONE thing ═══════════
+            // The turn ended ≥400 after GRAPH_READY without commit-failure
+            // proof, so the model is still on the canvas and the save is
+            // unconfirmed. The generic failure copy for this shape asserts
+            // states the held frame refutes ("the server did not reply" — it
+            // replied with a validated graph) or prescribes a retry that would
+            // re-send onto a scenario whose graph is likely committed (CEE's
+            // continuation guard declines — the F3 lesson). The
+            // DRAFT_FAILED_MODEL_KEPT_NOTICE emitted below (the
+            // streamedUnsettled block) is the single honest statement of this
+            // state, so this branch deliberately renders nothing and raises no
+            // send-failure banner: the send demonstrably succeeded.
+            // Streamed drafts are never system turns (streamedDraftEligible
+            // refuses system events), so no dispatcher is owed a failure here.
           } else {
             // Typed error — the LIVE V5 error surface (Codex F6 fix; #383's
             // recovery rendering was wired only to the dead V4 handleEnvelope
@@ -5169,7 +5250,15 @@ export function useConversation(): UseConversationReturn {
               id: crypto.randomUUID(),
               role: 'assistant',
               synthetic: true,
-              content: UNSETTLED_DRAFT_NOTICE,
+              // Cause-keyed copy (the three-strings-not-one rule): a kept
+              // model behind a terminal error is a different fact from a
+              // connection that dropped the values, and each notice states
+              // only its own cause. Both live in DraftLoadingAnimation and are
+              // governed by narrationHonesty.invariant.spec.ts.
+              content:
+                streamedUnsettledCause === 'terminal_error_model_kept'
+                  ? DRAFT_FAILED_MODEL_KEPT_NOTICE
+                  : UNSETTLED_DRAFT_NOTICE,
               // F3: NOT `retry`. `retryLast` re-sends onto the SAME scenario,
               // whose canvas is now non-empty, so it is a buffered turn CEE's
               // continuation guard DECLINES — the old chip could not deliver the

--- a/src/canvas/stores/__tests__/draftStreamOwnership.spec.ts
+++ b/src/canvas/stores/__tests__/draftStreamOwnership.spec.ts
@@ -154,3 +154,38 @@ describe('streamedPreviewStandingFor — F1 adjacent, the 130 s timeout copy', (
     expect(streamedPreviewStandingFor(useDraftStore.getState(), 't1', A)).toBe(false)
   })
 })
+
+describe('markDraftStreamCoachingLanded — F1, the coaching frame is identity-guarded', () => {
+  it('records the landing for the OWNING turn only', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    useDraftStore.getState().markDraftStreamCoachingLanded('t1')
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(true)
+  })
+
+  it('IGNORES a frame from a turn that does not own the phase — a stale stream cannot move a newer turn’s narration', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't2', A)
+    useDraftStore.getState().markDraftStreamCoachingLanded('t1')
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(false)
+  })
+
+  it('resets when a NEW turn starts drafting — the flag never leaks onto the next draft', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    useDraftStore.getState().markDraftStreamCoachingLanded('t1')
+    useDraftStore.getState().setDraftStreamPhase('drafting', 't2', A)
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(false)
+  })
+
+  it('resets on release to idle', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    useDraftStore.getState().markDraftStreamCoachingLanded('t1')
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(false)
+  })
+
+  it('SURVIVES the settling→unsettled transition of the turn that set it', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', 't1', A)
+    useDraftStore.getState().markDraftStreamCoachingLanded('t1')
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', A)
+    expect(useDraftStore.getState().draftStreamCoachingLanded).toBe(true)
+  })
+})

--- a/src/canvas/stores/draftStore.ts
+++ b/src/canvas/stores/draftStore.ts
@@ -96,6 +96,15 @@ export interface DraftState {
    * decides whether a phase is any of the current scenario's business.
    */
   draftStreamScenarioId: string | null
+  /**
+   * True once the owning turn's COACHING_READY frame has landed (F1 — honest
+   * staged progress). Licenses the settling narration to stop claiming
+   * coaching is outstanding. Meaningful only while `draftStreamPhase` is
+   * `settling` and only for the owning scenario — consumers read it beside
+   * `draftStreamPhaseFor`, and it resets whenever ownership does (phase
+   * `idle`) or a new turn starts (phase `drafting`).
+   */
+  draftStreamCoachingLanded: boolean
 }
 
 export interface DraftActions {
@@ -120,6 +129,12 @@ export interface DraftActions {
     turnId: string | null,
     scenarioId: string | null,
   ) => void
+  /**
+   * Record that the owning turn's COACHING_READY frame landed. Guarded by
+   * identity: a frame from a turn that no longer owns the phase (stale stream,
+   * preempted turn) must not move a newer turn's narration.
+   */
+  markDraftStreamCoachingLanded: (turnId: string) => void
   /**
    * Reset every field to initial values.
    *
@@ -146,6 +161,7 @@ const initialDraftState: DraftState = {
   draftStreamPhase: 'idle',
   draftStreamTurnId: null,
   draftStreamScenarioId: null,
+  draftStreamCoachingLanded: false,
 }
 
 export const useDraftStore = create<DraftState & DraftActions>((set) => ({
@@ -205,11 +221,24 @@ export const useDraftStore = create<DraftState & DraftActions>((set) => ({
   },
 
   setDraftStreamPhase: (phase, turnId, scenarioId) => {
-    set({
+    set((state) => ({
       draftStreamPhase: phase,
       draftStreamTurnId: phase === 'idle' ? null : turnId,
       draftStreamScenarioId: phase === 'idle' ? null : scenarioId,
-    })
+      // The coaching flag belongs to one turn's stream. It resets when
+      // ownership is released (`idle`) or a new turn starts (`drafting`), and
+      // survives the drafting→settling→unsettled transitions of the turn that
+      // set it. Derived here rather than at call sites so no caller can strand
+      // a stale flag onto the next draft's narration (trap 12).
+      draftStreamCoachingLanded:
+        phase === 'idle' || phase === 'drafting' ? false : state.draftStreamCoachingLanded,
+    }))
+  },
+
+  markDraftStreamCoachingLanded: (turnId) => {
+    set((state) =>
+      state.draftStreamTurnId === turnId ? { draftStreamCoachingLanded: true } : {},
+    )
   },
 
   resetDraft: () => {

--- a/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
+++ b/src/v5/__tests__/consumeStreamedDraftTurn.spec.ts
@@ -24,6 +24,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 import {
   consumeStreamedDraftTurn,
+  terminalProvesCommitFailed,
   nodeIdentities,
   edgeIdentities,
   expectComparableGraph,
@@ -242,8 +243,13 @@ describe('identity helpers — the two vacuity traps, pinned', () => {
   })
 })
 
-describe('the discard rule — a failed turn must not leave a rendered graph standing', () => {
-  it('orders the preview DISCARDED when COMPLETE carries status_code >= 400', async () => {
+describe('the terminal-error report — the consumer REPORTS, the caller decides (F1)', () => {
+  // ⚠ F1 RENAMED `discardPreview` → `terminalError`. The old name was an
+  // instruction the caller obeyed unconditionally, and on the measured 8 Aug
+  // journey that destroyed a server-committed model. The consumer now reports
+  // the fact (terminal ≥400); whether the preview goes is the caller's
+  // reconciliation, keyed on `terminalProvesCommitFailed`.
+  it('reports terminalError when COMPLETE carries status_code >= 400', async () => {
     const outcome = await consumeStreamedDraftTurn(
       iterate(
         frames(
@@ -258,12 +264,69 @@ describe('the discard rule — a failed turn must not leave a rendered graph sta
       ),
       { onGraphReady: () => {} },
     )
-    expect(outcome).toMatchObject({ kind: 'complete', statusCode: 422, discardPreview: true })
+    expect(outcome).toMatchObject({ kind: 'complete', statusCode: 422, terminalError: true })
   })
 
-  it('does NOT discard on a 200', async () => {
+  it('does NOT report terminalError on a 200', async () => {
     const outcome = await consumeStreamedDraftTurn(iterate(HAPPY()), { onGraphReady: () => {} })
-    expect((outcome as { discardPreview: boolean }).discardPreview).toBe(false)
+    expect((outcome as { terminalError: boolean }).terminalError).toBe(false)
+  })
+})
+
+describe('terminalProvesCommitFailed — the one wire class where removal states the truth', () => {
+  it('recognises the captured commit-failure envelope (reason under details)', () => {
+    // The §1.4 wire shape: route-v2's `!dg.commitPerformed` envelope.
+    expect(
+      terminalProvesCommitFailed({
+        error: 'INTERNAL_ERROR',
+        boundary: 'B1',
+        direction: 'egress',
+        validator: 'turn_commit',
+        details: { retryable: true, reason: 'draft_graph_commit_failed' },
+      }),
+    ).toBe(true)
+  })
+
+  it('recognises the reason at top level and under a nested error container', () => {
+    expect(terminalProvesCommitFailed({ reason: 'draft_graph_commit_failed' })).toBe(true)
+    expect(
+      terminalProvesCommitFailed({ error: { reason: 'draft_graph_commit_failed' } }),
+    ).toBe(true)
+    expect(
+      terminalProvesCommitFailed({
+        error: { details: { reason: 'draft_graph_commit_failed' } },
+      }),
+    ).toBe(true)
+  })
+
+  it('proves NOTHING for every other failure shape — fail-closed towards keeping the model', () => {
+    // The measured 8 Aug class: CEE UPSTREAM_TIMEOUT after GRAPH_READY.
+    expect(
+      terminalProvesCommitFailed({
+        error: 'UPSTREAM_TIMEOUT',
+        details: { retryable: true, reason: 'draft_graph_cee_timeout' },
+      }),
+    ).toBe(false)
+    // The proxy's own timeout body.
+    expect(
+      terminalProvesCommitFailed({
+        code: 'PROXY_UPSTREAM_TIMEOUT',
+        message: 'The model generation service did not respond within 125s.',
+      }),
+    ).toBe(false)
+    // The validation-failure class (never reaches GRAPH_READY, but must still
+    // not read as commit proof if it ever did).
+    expect(
+      terminalProvesCommitFailed({
+        error: 'INTERNAL_ERROR',
+        details: { retryable: true, reason: 'draft_graph_cee_graph_invalid' },
+      }),
+    ).toBe(false)
+    // Unreadable payloads prove nothing.
+    expect(terminalProvesCommitFailed(undefined)).toBe(false)
+    expect(terminalProvesCommitFailed(null)).toBe(false)
+    expect(terminalProvesCommitFailed('draft_graph_commit_failed')).toBe(false)
+    expect(terminalProvesCommitFailed([{ reason: 'draft_graph_commit_failed' }])).toBe(false)
   })
 })
 

--- a/src/v5/consumeStreamedDraftTurn.ts
+++ b/src/v5/consumeStreamedDraftTurn.ts
@@ -75,8 +75,22 @@ export type StreamedDraftOutcome =
       statusCode: number
       /** The graph handed to `onGraphReady`, or null if none was rendered. */
       renderedGraph: StageGraph | null
-      /** True when the terminal frame is an error and the preview must go. */
-      discardPreview: boolean
+      /**
+       * True when the terminal frame is an error (`status_code >= 400`).
+       *
+       * ⚠ This field used to be called `discardPreview`, and the name was an
+       * instruction the caller obeyed unconditionally — which destroyed a
+       * server-committed model on the measured 8 Aug 2026 journey (GRAPH_READY
+       * at 96.981 s, terminal COMPLETE 504 UPSTREAM_TIMEOUT at 125.202 s, UI
+       * removed the graph and said nothing was drafted while the next turn
+       * could reload the committed model). The commit runs server-side around
+       * the GRAPH_READY emission and ordinarily survives a late failure (CEE
+       * 2.709 first-write exemption), so "terminal error" does NOT imply "no
+       * model". The CALLER decides what to do with the preview, using
+       * `terminalProvesCommitFailed` on the payload — removal is honest only
+       * when the wire proves the commit failed.
+       */
+      terminalError: boolean
       /** Non-null when the preview and the terminal graph disagree on identity. */
       identityDrift: IdentityDrift | null
     }
@@ -169,6 +183,43 @@ function computeDrift(preview: unknown, terminal: unknown): IdentityDrift | null
 }
 
 // ---------------------------------------------------------------------------
+// Terminal-payload commit reconciliation (F1 — draft-state truth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Does this terminal error payload PROVE the draft's graph commit failed?
+ *
+ * The one wire shape that does is CEE route-v2's `!dg.commitPerformed`
+ * envelope — captured at the wire in the fresh-journey P0 diagnosis §1.4:
+ * `{error: INTERNAL_ERROR, validator: turn_commit, details: {reason:
+ * "draft_graph_commit_failed", retryable: true}}`. For that class the server
+ * has said "Nothing was written", so removing the rendered preview states the
+ * truth.
+ *
+ * Everything else — the measured 504 UPSTREAM_TIMEOUT class, proxy timeout
+ * bodies, any other ≥400 — leaves the commit UNKNOWABLE from this side of the
+ * socket, and measured-COMMON to have succeeded (the commit runs around the
+ * GRAPH_READY emission; CEE 2.709's first-write exemption protects it from
+ * mid-draft claims). Returning `false` routes the caller to keep-and-mark,
+ * which is never a fabrication: it claims only that the structure was rendered
+ * and the save is unconfirmed.
+ *
+ * The read is a narrow duck-walk over the containers CEE errors actually use
+ * (top level, `details`, nested `error`), matching `ceeRecovery.ts`'s
+ * fail-closed style. Fail-closed here means: an unreadable payload proves
+ * nothing, so the preview is KEPT and marked — the direction that cannot
+ * destroy a committed model.
+ */
+export function terminalProvesCommitFailed(payload: unknown): boolean {
+  const record = (v: unknown): Record<string, unknown> | null =>
+    typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : null
+  const root = record(payload)
+  if (!root) return false
+  const containers = [root, record(root.details), record(root.error), record(record(root.error)?.details)]
+  return containers.some((c) => c !== null && c.reason === 'draft_graph_commit_failed')
+}
+
+// ---------------------------------------------------------------------------
 
 export async function consumeStreamedDraftTurn(
   frames: AsyncIterable<StageFrame>,
@@ -209,9 +260,9 @@ export async function consumeStreamedDraftTurn(
           const statusCode = frame.status_code ?? 200
           // See the module header: `salvaged_from_truncation` is NOT a rung
           // here, because #751 established the streamed frames never carry it.
-          const discardPreview = statusCode >= 400
+          const terminalError = statusCode >= 400
           const identityDrift =
-            renderedGraph && !discardPreview
+            renderedGraph && !terminalError
               ? computeDrift(renderedGraph, (frame.payload as { draft_graph?: unknown })?.draft_graph)
               : null
           return {
@@ -219,7 +270,7 @@ export async function consumeStreamedDraftTurn(
             terminalPayload: frame.payload,
             statusCode,
             renderedGraph,
-            discardPreview,
+            terminalError,
             identityDrift,
           }
         }


### PR DESCRIPTION
## Pillar

PR1 / acceptance sentence 1 — Olumi makes clear what it used, inferred and left out, including about its own state. This is the first thing anyone opening a link experiences.

## The two measured defects

**DEFECT 1 — the 504 lie after a real save** (deployed staging, 8 Aug; `olumi-poc-independent-review-2026-08-09.md`): GRAPH_READY at 96.981 s (21n/43e, committed server-side), terminal COMPLETE 504 UPSTREAM_TIMEOUT at 125.202 s — the UI removed the rendered graph and said no model was drafted, while a grounded follow-up found the canonical model under the same scenario.

**DEFECT 2 — the silent wait.** Derived at `60c4b082` first (per brief): drafting narration (PROGRESSIVE_STAGES), render-at-GRAPH_READY, settling narration (SETTLING_STAGES) and the no-GRAPH_READY 500 failure report (CEE recovery + retry, tested against the live 8 Aug capture) **already exist**. The genuine residual gap: COACHING_READY was never consumed — the copy kept claiming "waiting on the values and coaching" after the coaching pass had landed (~28 s on the measured journey).

## What changed

**Terminal-failure reconciliation** (`consumeStreamedDraftTurn.ts`, `useConversation.ts`):
- `discardPreview` renamed `terminalError` — the old name was an instruction the caller obeyed unconditionally.
- Removal now happens ONLY when the terminal payload **proves** the commit failed (`draft_graph_commit_failed` — CEE route-v2's "Nothing was written" envelope, fresh-journey P0 diagnosis §1.4). The client cannot poll server state (no status route; guest RLS), so the payload's own commit marker is the cheapest authoritative check it holds.
- Every other ≥400 after GRAPH_READY **keeps the model**, marks the draft `unsettled` (run gate shut; `shouldPersistGraphForScenario` keeps the UI from ever persisting it), renders ONE honest notice — `DRAFT_FAILED_MODEL_KEPT_NOTICE`: *"Drafting failed after your model reached the canvas, so its coaching and settled values never arrived. The structure you can see is real, but we can't confirm from here whether this draft saved. Start a new draft to get a model with settled values."* — with the Start-a-new-draft chip (the affordance that genuinely works; F3), and suppresses the generic failure bubble + send-failure banner whose claims the held frame refutes. The user bubble reads delivered: GRAPH_READY is proof the server processed the message.
- The no-GRAPH_READY 500 class is untouched: plain failure + CEE recovery + retry chip (already live and pinned by `useConversation.streamedDraft500Recovery.spec.tsx`).

**Honest staged progress** (`draftStore.ts`, `AIInputBar.tsx`, `DraftLoadingAnimation.tsx`):
- COACHING_READY now sets an identity-guarded store flag through the real stream; the composer switches to `SETTLING_AFTER_COACHING_STAGES` ("Your model is on the canvas. Waiting for the settled values…") — it stops claiming coaching is outstanding without claiming its content arrived (the enum includes `failed_degraded`). No fabricated percentages, no time estimates.
- All new copy governed by `narrationHonesty.invariant.spec.ts` via the derived `*_NOTICE` / `NARRATION_TABLES` manifests.

## Evidence

- **RED-first**: `useConversation.streamedDraftTerminalError.spec.tsx` failed 12/15 at pristine `60c4b082` (kept-model, unsettled-phase, single-notice, delivery and no-banner assertions all red; the commit-failed removal guard green then and now). Real SSE frames through the real stream parser; only network seams mocked.
- **Mutants** (throwaway worktree outside the repo root, isolation proven by sentinel write + differing inodes, HEAD-relative restores, applied-check scoped to src/ with control asserting exactly zero, trailing control green; 108 tests collected every run): 10/10 BITTEN — including the discriminating pair `predicate-always-true` (kept-model tests red) vs `predicate-always-false` (commit-failed removal red), proving the reconciliation binds to the commit-failure marker in both directions, and `fix-revert-always-discard` (12 red) proving the suite sees the original defect.
- **Gates at tip**: `pnpm run typecheck` PASSED (ratchet 2487 = baseline) · `pnpm run lint` PASSED · conversation+v5+stores+components dirs: 373 files / 4922 tests passed, exit 0.

Do NOT merge — adversarial review to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)