### PR TITLE
UI: retire the win-frequency gap across the results panel + two persistence truth fixes

### DIFF
--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -432,7 +432,16 @@ export const OptionNode = memo((props: NodeProps) => {
   const viewMode = useCanvasStore(state => state.viewMode)
   const isDetailed = viewMode === 'expert'
 
-  // Graph v2 Task 4: close-call gap in percentage points. Non-zero only when
+  // Graph v2 Task 4: close-call gap in percentage points.
+  //
+  // ⭐ PREDICATE ONLY SINCE 2026-08-10 — the number is NEVER RENDERED. It
+  // decides two things: whether the qualitative "Close call" marker shows, and
+  // whether the extra "What would change this?" chip is offered. The 5pp
+  // window and the 1pp floor are kept exactly as they were, so the set of runs
+  // that qualify is provably unchanged by this retirement; only the sentence
+  // moved. Do not reintroduce it into copy.
+  //
+  // Non-zero only when
   // this option is a non-leader within 5pp of the leader's win probability.
   // Prefers report.robustness.recommended_option_id; falls back to max scan if
   // missing. Returns null when not in close-call territory or pre-analysis.
@@ -1248,10 +1257,26 @@ export const OptionNode = memo((props: NodeProps) => {
 
         {/* Graph v2 Task 4: close-call line — only when within 5pp of leader.
             Renders ABOVE the existing "Behind:" reason so users see both the
-            closeness signal and the causal explanation. */}
+            closeness signal and the causal explanation.
+
+            ⭐⭐ THE QUANTITY IS RETIRED (2026-08-10); THE SIGNAL IS NOT.
+            This read "Close call: within N percentage points" — the
+            percentage-point difference between two Monte-Carlo win
+            frequencies, which is the banned statistic: less reliable than
+            either estimate it is built from, yet printed as a bare integer
+            with no interval. The tie-ness signal it carried is genuinely
+            useful and stays, as a QUALITATIVE marker with no number.
+
+            Naming the leading option is entitled here and nowhere borrowed:
+            `closeCallGapPp` returns null unless `verdict.hasLeadingOption`,
+            so this line cannot render on a turn where the producer withheld
+            the designation. And the reader is not left without a number — the
+            node states this option's OWN win probability directly above
+            (`COMPARATIVE_COPY.phrase`), which is the statistic the ratified
+            rule licenses. */}
         {closeCallGapPp != null && (
           <p className={`${typography.nodeLabel} text-warning mt-0.5 m-0`}>
-            Close call: within {closeCallGapPp} percentage point{closeCallGapPp !== 1 ? 's' : ''}
+            Close call with the leading option
           </p>
         )}
 

--- a/src/canvas/nodes/__tests__/render-matrix.spec.tsx
+++ b/src/canvas/nodes/__tests__/render-matrix.spec.tsx
@@ -439,7 +439,7 @@ describe('Render matrix — OptionNode × view × phase', () => {
     },
   })
 
-  it('Standard post non-leader, gap 3pp: shows "Close call: within 3 percentage points" and keeps "Behind:" line', () => {
+  it('Standard post non-leader, gap 3pp: shows the qualitative close-call marker and keeps "Behind:" line', () => {
     applyStore(closeCallTopology(3))
     vi.mocked(useNodeDisplayMetadata).mockReturnValue({
       sensitivityRank: null,
@@ -452,11 +452,16 @@ describe('Render matrix — OptionNode × view × phase', () => {
       isResultsMode: true,
     } as any)
     renderOption({})
-    expect(screen.getByText('Close call: within 3 percentage points')).toBeDefined()
+    // ⭐ SUPERSEDED 2026-08-10: was 'Close call: within 3 percentage points'.
+    // The tie-ness SIGNAL is valuable and stays; the percentage-point gap is
+    // the banned statistic and is gone. The node already states this option's
+    // own win probability directly above.
+    expect(screen.getByText('Close call with the leading option')).toBeDefined()
+    expect(screen.queryByText(/percentage point/i)).toBeNull()
     expect(screen.getByText(/Behind:/)).toBeDefined()
   })
 
-  it('Standard post non-leader, gap 1pp: pluralisation drops the trailing "s"', () => {
+  it('Standard post non-leader, gap 1pp: the marker still fires at the narrow end of the window', () => {
     applyStore(closeCallTopology(1))
     vi.mocked(useNodeDisplayMetadata).mockReturnValue({
       sensitivityRank: null,
@@ -469,12 +474,17 @@ describe('Render matrix — OptionNode × view × phase', () => {
       isResultsMode: true,
     } as any)
     renderOption({})
-    expect(screen.getByText('Close call: within 1 percentage point')).toBeDefined()
+    // ⭐ SUPERSEDED 2026-08-10: this asserted the singular 'point' form. With
+    // no number rendered there is no pluralisation left to pin — what remains
+    // worth pinning is that a 1pp gap is still INSIDE the close-call window.
+    expect(screen.getByText('Close call with the leading option')).toBeDefined()
+    expect(screen.queryByText(/percentage point/i)).toBeNull()
   })
 
-  it('Standard post non-leader, sub-percent gap (0.4pp): floor at 1pp, never reads "0 percentage points"', () => {
-    // Gap of 0.004 → Math.round → 0; floor clamps to 1pp so the line never
-    // reads the awkward "within 0 percentage points" phrasing.
+  it('Standard post non-leader, sub-percent gap (0.4pp): still inside the window, and states no quantity', () => {
+    // Gap of 0.004 → Math.round → 0; the 1pp floor keeps the predicate
+    // non-null so the marker still fires. The floor no longer has a phrasing
+    // job — the rendered marker carries no number at all.
     applyStore({
       viewMode: 'standard',
       phase: 'post',
@@ -507,8 +517,8 @@ describe('Render matrix — OptionNode × view × phase', () => {
       isResultsMode: true,
     } as any)
     renderOption({})
-    expect(screen.getByText('Close call: within 1 percentage point')).toBeDefined()
-    expect(screen.queryByText(/within 0 percentage point/)).toBeNull()
+    expect(screen.getByText('Close call with the leading option')).toBeDefined()
+    expect(screen.queryByText(/percentage point/i)).toBeNull()
   })
 
   it('Standard post close-call: "What would change this?" chip is added alongside "What would make this lead?"', () => {
@@ -541,7 +551,10 @@ describe('Render matrix — OptionNode × view × phase', () => {
       isResultsMode: true,
     } as any)
     renderOption({})
-    expect(screen.queryByText(/Close call:/)).toBeNull()
+    // Bound to the marker that actually renders — the old /Close call:/ pattern
+    // stops matching once the colon-and-number form is gone, which would make
+    // this absence assertion pass by testing nothing.
+    expect(screen.queryByText(/Close call/i)).toBeNull()
     expect(screen.queryByText('What would change this?')).toBeNull()
     // The standard "What would make this lead?" chip is still present.
     expect(screen.getByText('What would make this lead?')).toBeDefined()

--- a/src/canvas/nodes/__tests__/residualComparative.optionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/residualComparative.optionNode.spec.tsx
@@ -209,7 +209,7 @@ const CLOSE_CALL_PERMITTED = {
 
 const CLOSE_CALL_NODES = OPTION_NODES.slice(0, 2)
 
-describe('OptionNode — "Close call: within N percentage points" (found, not dispatched)', () => {
+describe('OptionNode — the close-call marker (was "Close call: within N percentage points"; the quantity retired 2026-08-10, the signal kept)', () => {
   beforeEach(() => {
     vi.mocked(useNodeDisplayMetadata).mockReturnValue(resultsMetadata(0.47))
   })
@@ -217,12 +217,20 @@ describe('OptionNode — "Close call: within N percentage points" (found, not di
   it('WITHHELD: no distance-to-the-leader line', () => {
     withStore(CLOSE_CALL_WITHHELD, CLOSE_CALL_NODES)
     renderNode(RUNNER_UP_ID, 'Standardise on Dell XPS')
-    expect(screen.queryByText(/Close call: within/)).toBeNull()
+    // Bound to the marker that actually renders: /Close call: within/ stops
+    // matching once the colon-and-number form is retired, so it would pass by
+    // testing nothing.
+    expect(screen.queryByText(/Close call/i)).toBeNull()
   })
 
   it('PERMITTED: the line renders (over-suppression control)', () => {
     withStore(CLOSE_CALL_PERMITTED, CLOSE_CALL_NODES)
     renderNode(RUNNER_UP_ID, 'Standardise on Dell XPS')
-    expect(screen.getByText('Close call: within 3 percentage points')).toBeDefined()
+    // ⭐ SUPERSEDED 2026-08-10: was 'Close call: within 3 percentage points'.
+    // The withheld-turn ENTITLEMENT this describe block exists to pin is
+    // unchanged; only the quantity has gone. The percentage-point gap between
+    // two win frequencies is retired from every user-facing surface.
+    expect(screen.getByText('Close call with the leading option')).toBeDefined()
+    expect(screen.queryByText(/percentage point/i)).toBeNull()
   })
 })

--- a/src/canvas/store/__tests__/analysisFreshness.spec.ts
+++ b/src/canvas/store/__tests__/analysisFreshness.spec.ts
@@ -50,11 +50,58 @@ describe('deriveAnalysisFreshnessUpdate', () => {
       computed_at: '2026-06-23T09:00:00.000Z',
     })
     expect(older).toBe(p) // older ignored
-    const equal = deriveAnalysisFreshnessUpdate(p, {
+  })
+
+  /**
+   * ⭐ CORRECTED 2026-08-10. This block used to assert that an EQUAL-timestamp
+   * payload is ignored, which positively enshrined a live defect: `computed_at`
+   * stamps the ANALYSIS, not the verdict, so CEE re-evaluates freshness against
+   * the CURRENT graph and re-sends the SAME analysis with a NEW verdict and a
+   * NEW `current_graph_hash`. Witnessed on staging: after a graph edit CEE
+   * returned `freshness: 'stale'` with a new `current_graph_hash` at an
+   * unchanged `computed_at`, and the store discarded it — keeping `fresh` and
+   * the stale hashes, so the panel told the user the analysis reflected a model
+   * it did not.
+   *
+   * The ordering rule is now STRICTLY older. Equal timestamps are decided by
+   * the echo guard below (`sameVerdict`), which is the check that actually
+   * answers "is this the same verdict?" — the timestamp only ever answered
+   * "is this the same analysis?", a different question.
+   */
+  it('equal computed_at + IDENTICAL verdict: still a no-op (same reference — the echo guard, not the clock, decides)', () => {
+    const p = prev({
+      freshness: 'fresh',
+      computedAt: '2026-06-23T12:00:00.000Z',
+      graphHashAtRun: 'h-run',
+      currentGraphHash: 'h-run',
+    })
+    const echoed = deriveAnalysisFreshnessUpdate(p, {
+      freshness: 'fresh',
+      computed_at: '2026-06-23T12:00:00.000Z',
+      graph_hash_at_run: 'h-run',
+      current_graph_hash: 'h-run',
+    })
+    expect(echoed).toBe(p)
+  })
+
+  it('equal computed_at + CHANGED verdict: CEE’s re-evaluation is APPLIED, hashes and all', () => {
+    const p = prev({
+      freshness: 'fresh',
+      computedAt: '2026-06-23T12:00:00.000Z',
+      graphHashAtRun: 'h-run',
+      currentGraphHash: 'h-run',
+    })
+    const reEvaluated = deriveAnalysisFreshnessUpdate(p, {
       freshness: 'stale',
       computed_at: '2026-06-23T12:00:00.000Z',
+      graph_hash_at_run: 'h-run',
+      current_graph_hash: 'h-edited',
     })
-    expect(equal).toBe(p) // equal ignored (no change)
+    expect(reEvaluated).not.toBe(p)
+    expect(reEvaluated?.freshness).toBe('stale')
+    expect(reEvaluated?.graphHashAtRun).toBe('h-run')
+    expect(reEvaluated?.currentGraphHash).toBe('h-edited')
+    expect(reEvaluated?.computedAt).toBe('2026-06-23T12:00:00.000Z')
   })
 
   it('applies a newer payload', () => {

--- a/src/canvas/store/analysisFreshness.ts
+++ b/src/canvas/store/analysisFreshness.ts
@@ -154,10 +154,25 @@ export function deriveAnalysisFreshnessUpdate(
 
   const computedAt = nonEmptyString(o.computed_at)
 
-  // Order by computed_at: ignore a strictly-older (or equal) payload when both
-  // timestamps are present. When the new payload has no computed_at we cannot
-  // order it, so we fall through to the content check below.
-  if (prev?.computedAt && computedAt && computedAt <= prev.computedAt) {
+  // Order by computed_at: ignore a STRICTLY-older payload when both timestamps
+  // are present. When the new payload has no computed_at we cannot order it, so
+  // we fall through to the content check below.
+  //
+  // ⭐ CORRECTED 2026-08-10. This read `computed_at <= prev.computedAt`, and the
+  // equal arm silently discarded CEE's authoritative verdict. `computed_at`
+  // stamps the ANALYSIS, not the verdict: CEE re-evaluates freshness against the
+  // CURRENT graph and re-sends the SAME analysis with a NEW verdict and a NEW
+  // `current_graph_hash`. Witnessed on staging — after a graph edit CEE returned
+  // `freshness: 'stale'` with a new `current_graph_hash` at an unchanged
+  // `computed_at`, and this branch threw it away, leaving the store on `fresh`
+  // with the pre-edit hashes. The panel then told the user the analysis
+  // reflected a model it did not.
+  //
+  // The timestamp only ever answered "is this the SAME ANALYSIS?". Whether it is
+  // the SAME VERDICT is a different question, and the echo guard below
+  // (`sameVerdict`) is the check that answers it — so a genuine equal-time echo
+  // is still a reference-stable no-op, without this branch having to guess.
+  if (prev?.computedAt && computedAt && computedAt < prev.computedAt) {
     return prev
   }
 

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -212,8 +212,14 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
   // advantage" which rendered verbatim because coachingHeadline won the
   // precedence chain. When the tier is weak (certainty.caveat is present),
   // we now swap in certainty.headline instead so the headline softens with
-  // the caveat. winProbabilityGap preserves the numeric lead as "by N
-  // points" without the over-confident framing.
+  // the caveat.
+  //
+  // ⚠ `winProbabilityGap` IS NOW RENDER-DEAD (2026-08-10). It used to reach
+  // the user as " by N points" on the softened lede; that suffix is retired
+  // (no surface may state the percentage-point gap between win frequencies),
+  // and `buildCertaintyCopy` no longer reads this field. It is still computed
+  // and passed only so the retirement stayed a copy change; deleting it here
+  // and on the input type is a clean follow-up.
   const winProbabilityGap = useMemo(() => {
     const options = data.recommendation.allOptions
     if (!options || options.length < 2) return undefined

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -204,7 +204,8 @@ function hingeAwareDescription(
 ): string {
   // ROADMAP 1.223: every string in this function is comparative — it either
   // names an option as the leader ("Highest leading-option likelihood"),
-  // measures against one ("Behind by N percentage points"), or DENIES one
+  // measures against one ("Behind by N percentage points" — RETIRED
+  // 2026-08-10, see the two arms below), or DENIES one
   // ("Statistically tied with the leading option"). On a turn where the
   // producer withheld the leader claim the UI is entitled to none of the
   // three: the denial is not a safe default, it is a second unearned claim,
@@ -318,11 +319,31 @@ function hingeAwareDescription(
     if (hinge?.alternativeWinnerLabel && hinge.alternativeWinnerLabel === option.label) {
       return `If ${hinge.label} shifts, this option overtakes`
     }
-    // Task 9: Gap-based fallback instead of generic "Second highest"
+      // ⭐⭐ THE "Behind by N percentage points" LINE IS RETIRED (2026-08-10).
+      //
+      // It stated the percentage-point DIFFERENCE between two Monte-Carlo win
+      // frequencies. A difference of two estimates carries more uncertainty
+      // than either estimate does, and printed as a bare integer with no
+      // interval it read as the most precise number on the card while being
+      // the least reliable one. The ratified rule: no user-facing surface
+      // states that gap — own-probability statements only.
+      //
+      // DELETED rather than reworded, and the licence for deleting is
+      // derivable at this seam: both arms of this branch require
+      // `option.winProbability != null`, which is the SAME condition that
+      // renders the card's own `win-pct-{id}` readout. So wherever this line
+      // could ever have fired, the option's OWN probability is already on the
+      // card — the number survives, only the difference goes. `''` is this
+      // function's established withhold idiom (see the ROADMAP 1.223 header):
+      // the caller renders nothing and the card falls back to label + win % +
+      // bar, which are DATA and stay.
+      //
+      // The gap is still COMPUTED, purely as the near-tie predicate below. It
+      // is never rendered.
     if (winnerWinProbability != null && option.winProbability != null) {
       const gapPct = Math.round((winnerWinProbability - option.winProbability) * 100)
       if (gapPct > 0) {
-        return `Behind by ${gapPct} percentage point${gapPct === 1 ? '' : 's'}`
+        return ''
       }
       return 'Statistically tied with the leading option'
     }
@@ -336,11 +357,15 @@ function hingeAwareDescription(
   if (option.isBaseline) {
     return 'Lowest risk but lowest expected outcome'
   }
-  // Task 9: Other non-winner — gap-based
+  // Other non-winner. ⭐ Same retirement as the runner-up arm above, and for
+  // the same reason — see that block. Both arms are changed together: leaving
+  // either one would keep the banned quantity on screen for a different slice
+  // of the option list, which is how a "fixed" surface keeps shipping the
+  // defect to the users who happen to have three options.
   if (winnerWinProbability != null && option.winProbability != null) {
     const gapPct = Math.round((winnerWinProbability - option.winProbability) * 100)
     if (gapPct > 0) {
-      return `Behind by ${gapPct} percentage point${gapPct === 1 ? '' : 's'}`
+      return ''
     }
     return 'Statistically tied with the leading option'
   }

--- a/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
+++ b/src/components/results/__tests__/DecisionConfidencePanel.caveatGuarantee.spec.tsx
@@ -39,7 +39,7 @@ interface FixtureOpts {
 function makeData(opts: FixtureOpts): ResultsSectionDataReturn {
   // Brief 5.2 Task 1: winner and runner-up have distinct winProbability so
   // the gap computation (97.4 − 2.4 ≈ 95 points) exercises the new
-  // "by N points" suffix. Earlier fixtures used identical winProb on both
+  // (now retired) "by N points" suffix. Earlier fixtures used identical winProb on both
   // which hid the gap suffix behaviour.
   const winner: OptionResult = {
     id: 'opt-a',
@@ -140,7 +140,7 @@ function makeData(opts: FixtureOpts): ResultsSectionDataReturn {
 }
 
 describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + caveat', () => {
-  it('needs_work tier: suppresses over-confident coachingHeadline and renders softened lede with "by N points"', () => {
+  it('needs_work tier: suppresses over-confident coachingHeadline and renders the softened lede, which now states NO gap', () => {
     const data = makeData({
       coachingHeadline: 'Option A is the clear leader with a 95-point advantage',
       confidenceTier: 'needs_work',
@@ -157,7 +157,12 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
     // Softened lede renders instead — preserves numeric lead without the
     // over-confident framing. Gap = 97.4 − 2.4 = 95 points.
     expect(
-      screen.getByText(/Option A currently leads by 95 points/),
+      // ⭐ SUPERSEDED 2026-08-10: the " by 95 points" suffix is retired — it
+      // stated the percentage-point gap between two win frequencies. What this
+      // spec exists to guarantee — PLoT's over-confident coachingHeadline is
+      // SUPPRESSED and the softened certaintyCopy lede wins — is unchanged and
+      // still asserted here and by the forbid-list below.
+      screen.getByText(/Option A currently leads$/),
     ).toBeInTheDocument()
 
     // Caveat renders — tier is needs_work.
@@ -183,9 +188,10 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
     expect(
       screen.queryByText('Proceed with Option A with confidence.'),
     ).not.toBeInTheDocument()
-    // Confident fallback — "leads by N points", no "currently".
+    // Confident fallback — the magnitude-free comparative sentence (was
+    // "leads by N points"; the suffix is retired), no "currently".
     expect(
-      screen.getByText(/Option A leads by 95 points/),
+      screen.getByText(/Option A came out ahead most often across simulated scenarios/),
     ).toBeInTheDocument()
     // No caveat — caveat is scoped to needs_work only, and readiness never
     // softens a strong tier.
@@ -220,7 +226,7 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
     })
     render(<DecisionConfidencePanel data={data} />)
     expect(screen.queryByText('Option A has a slight edge')).not.toBeInTheDocument()
-    expect(screen.getByText(/Option A currently leads by 95 points/)).toBeInTheDocument()
+    expect(screen.getByText(/Option A currently leads$/)).toBeInTheDocument()
     // No caveat — fair softens but is not evidence-weak.
     expect(screen.queryByText(/limited evidence/)).not.toBeInTheDocument()
   })
@@ -248,14 +254,15 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
       })
       render(<DecisionConfidencePanel data={data} />)
       expect(screen.queryByText(/clear leader/)).not.toBeInTheDocument()
-      expect(screen.getByText(/Option A currently leads by 95 points/)).toBeInTheDocument()
+      expect(screen.getByText(/Option A currently leads$/)).toBeInTheDocument()
       // No caveat — caveat is scoped to needs_work.
       expect(screen.queryByText(/limited evidence/)).not.toBeInTheDocument()
     })
 
     it('fallback (unknown tier + absent readiness): confident fallback suppresses coachingHeadline', () => {
       // Unknown tier does not enter the soft gate. Falls through to confident
-      // fallback "leads by N points". conservative: true → coaching override
+      // fallback (magnitude-free since the gap suffix was retired).
+      // conservative: true → coaching override
       // suppressed.
       const data = makeData({
         coachingHeadline: 'Option A is clearly the best choice',
@@ -263,7 +270,7 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
       })
       render(<DecisionConfidencePanel data={data} />)
       expect(screen.queryByText(/clearly the best choice/)).not.toBeInTheDocument()
-      expect(screen.getByText(/Option A leads by 95 points/)).toBeInTheDocument()
+      expect(screen.getByText(/Option A came out ahead most often across simulated scenarios/)).toBeInTheDocument()
     })
 
     it('§2.7 — strong + missing readiness: confident fallback, coachingHeadline suppressed', () => {
@@ -278,7 +285,7 @@ describe('DecisionConfidencePanel — Brief 5.2 Task 1 tier-aware headline + cav
       })
       render(<DecisionConfidencePanel data={data} />)
       expect(screen.queryByText(/clear leader/)).not.toBeInTheDocument()
-      expect(screen.getByText(/Option A leads by 95 points/)).toBeInTheDocument()
+      expect(screen.getByText(/Option A came out ahead most often across simulated scenarios/)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
+++ b/src/components/results/__tests__/HeroFooterAlignment.matrix.spec.tsx
@@ -174,7 +174,12 @@ const matrix: MatrixCase[] = [
     tier: 'needs_work',
     readiness: 'ready',
     stability: 0.97,
-    expectHeroContains: 'Option A leads',
+    // ⭐ SUPERSEDED 2026-08-10: was `'Option A leads'`, the confident
+    // fallback's `"{winner} leads by N points"` form. That suffix stated the
+    // percentage-point gap between two win frequencies and is retired, so the
+    // branch now emits its own no-gap sentence — which was ALWAYS this rule's
+    // fallback. The ROW is unchanged; only the sentence it expects moved.
+    expectHeroContains: 'Option A came out ahead',
     forbidHero: ['currently leads', 'clear leader', 'advantage', 'is the leading option'],
     expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
@@ -185,7 +190,12 @@ const matrix: MatrixCase[] = [
     tier: 'strong',
     readiness: 'needs_evidence',
     stability: 0.95,
-    expectHeroContains: 'Option A leads',
+    // ⭐ SUPERSEDED 2026-08-10: was `'Option A leads'`, the confident
+    // fallback's `"{winner} leads by N points"` form. That suffix stated the
+    // percentage-point gap between two win frequencies and is retired, so the
+    // branch now emits its own no-gap sentence — which was ALWAYS this rule's
+    // fallback. The ROW is unchanged; only the sentence it expects moved.
+    expectHeroContains: 'Option A came out ahead',
     forbidHero: ['currently leads', 'clear leader', 'is the leading option'],
     expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],
@@ -196,7 +206,12 @@ const matrix: MatrixCase[] = [
     tier: 'fair',
     readiness: 'ready',
     stability: 0.90,
-    expectHeroContains: 'Option A leads',
+    // ⭐ SUPERSEDED 2026-08-10: was `'Option A leads'`, the confident
+    // fallback's `"{winner} leads by N points"` form. That suffix stated the
+    // percentage-point gap between two win frequencies and is retired, so the
+    // branch now emits its own no-gap sentence — which was ALWAYS this rule's
+    // fallback. The ROW is unchanged; only the sentence it expects moved.
+    expectHeroContains: 'Option A came out ahead',
     forbidHero: ['Option A currently leads', 'is the leading option'],
     expectFooterContains: 'Stable ranking',
     forbidFooter: ['Stability sensitive'],

--- a/src/components/results/__tests__/OptionCards.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.spec.tsx
@@ -110,9 +110,17 @@ describe('OptionCards', () => {
     it('falls back to hinge-aware description when no story headline and win data present', () => {
       render(<OptionCards options={mockOptions} winnerId="option-1" />)
 
-      // With win probabilities available, hingeAwareDescription provides gap-based text
+      // With win probabilities available, hingeAwareDescription provides the
+      // winner's own-probability sentence.
       expect(screen.getAllByText(/Came out ahead in .+ of simulated scenarios/)[0]).toBeInTheDocument()
-      expect(screen.getByText('Behind by 30 percentage points')).toBeInTheDocument()
+      // ⭐ SUPERSEDED 2026-08-10: asserted 'Behind by 30 percentage points'.
+      // The percentage-point gap between two win frequencies is retired from
+      // every user-facing surface. The non-leader's line is DELETED rather than
+      // reworded, because the card already carries that option's OWN
+      // probability in its header readout — pinned here by identity so the
+      // deletion cannot quietly become "the card lost its number".
+      expect(screen.queryByText(/percentage point/i)).toBeNull()
+      expect(screen.getByTestId('win-pct-option-2')).toHaveTextContent('35%')
     })
 
     it('shows baseline description for baseline option', () => {
@@ -564,10 +572,13 @@ describe('OptionCards', () => {
         />
       )
 
-      expect(screen.getByText('Behind by 30 percentage points')).toBeInTheDocument()
+      // ⭐ SUPERSEDED 2026-08-10 — see the note above: the gap line is retired,
+      // the card's own-probability readout is what carries the number.
+      expect(screen.queryByText(/percentage point/i)).toBeNull()
+      expect(screen.getByTestId('win-pct-option-2')).toHaveTextContent('35%')
     })
 
-    it('other options show gap-based description', () => {
+    it('other options state their OWN probability, never a gap', () => {
       const threeOptions: OptionResult[] = [
         ...mockOptions,
         {
@@ -596,7 +607,10 @@ describe('OptionCards', () => {
 
       // With 3 options only 2 show by default; expand to see the third
       fireEvent.click(screen.getByTestId('option-cards-toggle'))
-      expect(screen.getByText('Behind by 55 percentage points')).toBeInTheDocument()
+      // ⭐ SUPERSEDED 2026-08-10: asserted 'Behind by 55 percentage points'.
+      // Option C's own win probability (0.10) is on its card; the gap is not.
+      expect(screen.queryByText(/percentage point/i)).toBeNull()
+      expect(screen.getByTestId('win-pct-option-3')).toHaveTextContent('10%')
     })
 
     it('V11.2: VM hinge-aware description takes priority over story_headline when decisionState available', () => {

--- a/src/components/results/__tests__/ResultsBody.v7HeroGapSubline.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7HeroGapSubline.spec.tsx
@@ -1,0 +1,216 @@
+/**
+ * ResultsBody → V7 hero subline — THE GAP NUMBER IS RETIRED (2026-08-10).
+ *
+ * The deployed hero rendered a correct statement of the leader's OWN win
+ * probability ("… came out ahead in 71% of simulated scenarios") and then, on
+ * the line immediately beneath it, "Leads by 40 points" — the percentage-point
+ * DIFFERENCE between two Monte-Carlo win frequencies. The ratified rule: no
+ * user-facing surface states that gap; the leader's own probability is the
+ * statistic. The subline now names the runner-up and states ITS OWN
+ * probability instead, so the reader gets both numbers and the product asserts
+ * no difference it has not earned.
+ *
+ * ⭐ WHY THIS SPEC RENDERS `ResultsBody` AND NOT `buildV7Headline`.
+ * CLAUDE.md trap 3b: this estate has twice shipped a fix onto a component the
+ * deployed flags do not mount, with a fully green suite pointed at the dark
+ * one. `buildV7Headline.spec.ts` pins the builder; this spec pins the MOUNT
+ * PATH — that the V7 hero is on screen at all, and that the retired string is
+ * absent from the DOM a user loads.
+ *
+ * The mount-path derivation at 944799c1: `V7TopMatter` (and therefore
+ * `V7Hero`) is mounted UNCONDITIONALLY inside `ResultsBody`'s `v7-top-group`
+ * slot — "additive, passthrough, no flag" — while `analysisHeroPanel` gates a
+ * different pair of arms lower in the same component. So the hero renders on
+ * BOTH postures of that flag, and this spec asserts exactly that: if a future
+ * change hosts the hero on one arm, the posture that stops mounting it fails
+ * here rather than shipping the fix dark. The deployed posture is
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` (netlify.toml), which is the arm
+ * asserted first.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isStrengthenPanelEnabled: vi.fn(() => false),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => true),
+  }
+})
+
+import { isAnalysisHeroPanelEnabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+const WINNER_LABEL = 'Bring In 6-Month Contractor'
+const RUNNER_UP_LABEL = 'Hire Permanent Senior Tech Lead'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: WINNER_LABEL,
+    isRecommended: true,
+    winProbability: 0.71,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: RUNNER_UP_LABEL,
+    isRecommended: false,
+    winProbability: 0.31,
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+  } as unknown as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody() {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onFocusNode={() => {}}
+    />,
+  )
+}
+
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-08-10T00:00:00Z' }
+
+/** The retired form, in every pluralisation and casing it could return in. */
+const GAP_CLAIM = /leads?\s+by\s+\d+\s+points?/i
+
+describe('ResultsBody → V7 hero — the pp-gap subline is retired on the live mount path', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useGuidanceStore.setState({ guidanceItems: [] })
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+  })
+
+  it('DEPLOYED POSTURE (analysisHeroPanel ON): the hero mounts, states the leader’s OWN probability, and states NO gap', () => {
+    renderBody()
+
+    // MOUNT PATH — assert the hero is on screen before asserting anything
+    // about its copy. A green copy assertion against an unmounted component is
+    // the defect this spec exists to prevent.
+    expect(screen.getByTestId('v7-hero')).toBeInTheDocument()
+
+    const headline = screen.getByTestId('v7-hero-headline')
+    expect(headline).toHaveTextContent(
+      new RegExp(`${WINNER_LABEL} came out ahead in 71% of simulated scenarios`),
+    )
+
+    const subline = screen.getByTestId('v7-hero-subline')
+    expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
+    // The honest replacement: the runner-up's OWN probability, named.
+    expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
+  })
+
+  /**
+   * ⚠ SCOPE, STATED EXACTLY. This asserts the HERO's retired form
+   * ("Leads by N points") appears NOWHERE in the panel — not that the panel
+   * is free of pp-gap claims. It is not: `OptionCards` renders "Behind by N
+   * percentage points" for the same win-frequency difference, and the canvas
+   * `OptionNode` renders "Close call: within N percentage points". Both are
+   * separate surfaces, out of this lane's scope, and reported rather than
+   * silently folded in. Widening `GAP_CLAIM` to cover them would make this
+   * spec assert a claim about surfaces this change does not touch.
+   */
+  it('the hero’s retired gap form appears NOWHERE in the rendered panel (it was rendered once, by the hero)', () => {
+    const { container } = renderBody()
+    expect(container.textContent ?? '').not.toMatch(GAP_CLAIM)
+  })
+
+  it('FLAG-MOVE GUARD (analysisHeroPanel OFF): the hero still mounts and still states no gap', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
+    renderBody()
+
+    expect(
+      screen.getByTestId('v7-hero'),
+      'the V7 hero is mounted unconditionally; if it has been moved onto a flag arm, this fix can ship dark',
+    ).toBeInTheDocument()
+    const subline = screen.getByTestId('v7-hero-subline')
+    expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
+    expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
+  })
+
+  it('BOTH postures mount the hero — the flag decides nothing about this surface', () => {
+    for (const posture of [true, false]) {
+      vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(posture)
+      renderBody()
+      expect(screen.getByTestId('v7-hero'), `analysisHeroPanel=${posture}`).toBeInTheDocument()
+      cleanup()
+    }
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
@@ -1,14 +1,20 @@
 /**
- * ResultsBody → V7 hero subline — THE GAP NUMBER IS RETIRED (2026-08-10).
+ * ResultsBody — NO SURFACE ON THIS PANEL STATES A WIN-FREQUENCY GAP
+ * (2026-08-10). The durable guard for the whole class, not for one component.
  *
- * The deployed hero rendered a correct statement of the leader's OWN win
- * probability ("… came out ahead in 71% of simulated scenarios") and then, on
- * the line immediately beneath it, "Leads by 40 points" — the percentage-point
+ * The deployed panel stated the same banned quantity on TWO surfaces at once:
+ * the V7 hero rendered a correct statement of the leader's OWN win probability
+ * ("… came out ahead in 71% of simulated scenarios") and then "Leads by 40
+ * points" directly beneath it; and the option card for every non-leader
+ * rendered "Behind by 40 percentage points". Both are the percentage-point
  * DIFFERENCE between two Monte-Carlo win frequencies. The ratified rule: no
- * user-facing surface states that gap; the leader's own probability is the
- * statistic. The subline now names the runner-up and states ITS OWN
- * probability instead, so the reader gets both numbers and the product asserts
- * no difference it has not earned.
+ * user-facing surface states that gap — own-probability statements only.
+ *
+ * The hero's subline now names the runner-up and states ITS OWN probability.
+ * The option card's line is DELETED outright, because the card already carries
+ * the option's own probability in its header readout (`win-pct-{id}`) — pinned
+ * below, by identity, so "deleted the line" cannot quietly become "the card
+ * lost its number".
  *
  * ⭐ WHY THIS SPEC RENDERS `ResultsBody` AND NOT `buildV7Headline`.
  * CLAUDE.md trap 3b: this estate has twice shipped a fix onto a component the
@@ -68,7 +74,7 @@ import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
 const WINNER_LABEL = 'Bring In 6-Month Contractor'
 const RUNNER_UP_LABEL = 'Hire Permanent Senior Tech Lead'
 
-function makeData(): ResultsSectionDataReturn {
+function makeData(runnerUpLabel: string = RUNNER_UP_LABEL): ResultsSectionDataReturn {
   const winner = {
     id: 'opt_a',
     label: WINNER_LABEL,
@@ -77,7 +83,7 @@ function makeData(): ResultsSectionDataReturn {
   } as unknown as OptionResult
   const runnerUp = {
     id: 'opt_b',
-    label: RUNNER_UP_LABEL,
+    label: runnerUpLabel,
     isRecommended: false,
     winProbability: 0.31,
   } as unknown as OptionResult
@@ -134,10 +140,10 @@ function makeData(): ResultsSectionDataReturn {
   } as unknown as ResultsSectionDataReturn
 }
 
-function renderBody() {
+function renderBody(runnerUpLabel?: string) {
   return render(
     <ResultsBody
-      resultsSectionData={makeData()}
+      resultsSectionData={makeData(runnerUpLabel)}
       tornadoData={{ rows: [], expectedOutcome: null }}
       onSendMessage={() => {}}
       onFocusNode={() => {}}
@@ -147,10 +153,17 @@ function renderBody() {
 
 const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-08-10T00:00:00Z' }
 
-/** The retired form, in every pluralisation and casing it could return in. */
+/** The hero's retired form, in every pluralisation and casing it could return in. */
 const GAP_CLAIM = /leads?\s+by\s+\d+\s+points?/i
+/**
+ * The option-card / canvas-node retired form. Deliberately the BARE PHRASE
+ * rather than "Behind by N percentage points": the banned thing is the
+ * quantity, not one sentence that carried it, so any new copy that reaches for
+ * "percentage points" on this panel REDs here whatever its wording.
+ */
+const PP_CLAIM = /percentage\s+points?/i
 
-describe('ResultsBody → V7 hero — the pp-gap subline is retired on the live mount path', () => {
+describe('ResultsBody — no surface on the results panel states a win-frequency gap', () => {
   beforeEach(() => {
     useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
@@ -178,18 +191,69 @@ describe('ResultsBody → V7 hero — the pp-gap subline is retired on the live 
   })
 
   /**
-   * ⚠ SCOPE, STATED EXACTLY. This asserts the HERO's retired form
-   * ("Leads by N points") appears NOWHERE in the panel — not that the panel
-   * is free of pp-gap claims. It is not: `OptionCards` renders "Behind by N
-   * percentage points" for the same win-frequency difference, and the canvas
-   * `OptionNode` renders "Close call: within N percentage points". Both are
-   * separate surfaces, out of this lane's scope, and reported rather than
-   * silently folded in. Widening `GAP_CLAIM` to cover them would make this
-   * spec assert a claim about surfaces this change does not touch.
+   * ⭐ THE DURABLE GUARD FOR THE WHOLE CLASS.
+   *
+   * Both retired forms, asserted absent across the ENTIRE rendered panel
+   * rather than element by element — so a gap claim reintroduced on any
+   * surface `ResultsBody` composes REDs here, including a surface that does
+   * not exist yet.
+   *
+   * ⚠ SCOPE, STATED EXACTLY, because an absence claim is only as wide as what
+   * it searched (trap 20):
+   *   · WHAT IS SEARCHED — the DOM `ResultsBody` renders under this fixture.
+   *     The canvas `OptionNode` is NOT composed by `ResultsBody`; its own
+   *     retirement is pinned in `render-matrix.spec.tsx` and
+   *     `residualComparative.optionNode.spec.tsx`.
+   *   · WHAT IS NOT COVERED — `certaintyCopy`'s `" by N point(s)"` suffix,
+   *     which `DecisionConfidencePanel` still feeds from a live
+   *     `winProbabilityGap`. It is the same banned quantity in a DIFFERENT
+   *     phrasing, it is out of this lane's scope, and it is reported rather
+   *     than folded in. It does not fire under this fixture (the suffix rides
+   *     the softened lede, which needs a weak confidence tier). Do not read a
+   *     green here as "the panel states no gap anywhere" — read it as "no
+   *     surface states one in these two forms".
    */
-  it('the hero’s retired gap form appears NOWHERE in the rendered panel (it was rendered once, by the hero)', () => {
+  it('NEITHER retired form appears anywhere in the rendered panel', () => {
     const { container } = renderBody()
-    expect(container.textContent ?? '').not.toMatch(GAP_CLAIM)
+    const text = container.textContent ?? ''
+    // Positive control FIRST: an absence assertion over an empty or
+    // half-rendered panel passes by testing nothing (trap 13).
+    expect(text).toMatch(/came out ahead in 71% of simulated scenarios/i)
+    expect(text).toMatch(new RegExp(RUNNER_UP_LABEL))
+
+    expect(text).not.toMatch(GAP_CLAIM)
+    expect(text).not.toMatch(PP_CLAIM)
+  })
+
+  /**
+   * POSITIVE CONTROL FOR THE PROBE ITSELF (trap 13: a probe that proves an
+   * ABSENCE must first be shown capable of seeing a PRESENCE).
+   *
+   * The phrase is injected through a REAL render input — an option label,
+   * which `formatOptionLabelForCard` passes through verbatim for a
+   * non-baseline option — so this exercises the same component tree, the same
+   * `container.textContent` read and the same regex as the assertion above.
+   * If `PP_CLAIM` were mistyped, or the probe were reading a detached or
+   * empty node, this case would fail and the guard beside it would be
+   * exposed as vacuous.
+   */
+  it('POSITIVE CONTROL: the panel-wide probe DOES see the banned phrase when it is present', () => {
+    const { container } = renderBody('Behind by 40 percentage points')
+    expect(container.textContent ?? '').toMatch(PP_CLAIM)
+  })
+
+  /**
+   * The option card's own-probability readout, bound BY IDENTITY (the card's
+   * testid), not by a value another element could satisfy — the panel prints
+   * "31%" in several places. Pinned because the fix DELETED the non-leader's
+   * line rather than rewording it: the justification for deleting is that the
+   * card already carries this number, so if the number ever leaves, the
+   * deletion stops being justified and this REDs.
+   */
+  it('the non-leader card still carries its OWN probability, which is what licensed deleting the gap line', () => {
+    renderBody()
+    expect(screen.getByTestId('win-pct-opt_b')).toHaveTextContent('31%')
+    expect(screen.getByTestId('win-pct-opt_a')).toHaveTextContent('71%')
   })
 
   it('FLAG-MOVE GUARD (analysisHeroPanel OFF): the hero still mounts and still states no gap', () => {

--- a/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
@@ -77,24 +77,28 @@ const RUNNER_UP_LABEL = 'Hire Permanent Senior Tech Lead'
 function makeData(
   runnerUpLabel: string = RUNNER_UP_LABEL,
   soft = false,
+  withGoalData = false,
 ): ResultsSectionDataReturn {
   const winner = {
     id: 'opt_a',
     label: WINNER_LABEL,
     isRecommended: true,
     winProbability: 0.71,
+    ...(withGoalData ? { goalProbability: 0.9 } : {}),
   } as unknown as OptionResult
   const runnerUp = {
     id: 'opt_b',
     label: runnerUpLabel,
     isRecommended: false,
     winProbability: 0.31,
+    ...(withGoalData ? { goalProbability: 0.4 } : {}),
   } as unknown as OptionResult
 
   const recommendation = {
     recommendedOption: winner,
     allOptions: [winner, runnerUp],
     goalLabel: 'Maximise success',
+    ...(withGoalData ? { goalThreshold: 0.6 } : {}),
     isSingleOption: false,
     analysisStatus: 'computed',
     // `soft` reaches DecisionConfidencePanel's SOFTENED lede — the branch that
@@ -165,10 +169,10 @@ function makeData(
   } as unknown as ResultsSectionDataReturn
 }
 
-function renderBody(runnerUpLabel?: string, soft = false) {
+function renderBody(runnerUpLabel?: string, soft = false, withGoalData = false) {
   return render(
     <ResultsBody
-      resultsSectionData={makeData(runnerUpLabel, soft)}
+      resultsSectionData={makeData(runnerUpLabel, soft, withGoalData)}
       tornadoData={{ rows: [], expectedOutcome: null }}
       onSendMessage={() => {}}
       onFocusNode={() => {}}
@@ -194,6 +198,33 @@ const PP_CLAIM = /percentage\s+points?/i
  * QUANTITY SHAPE rather than any one sentence.
  */
 const POINTS_CLAIM = /\bby\s+-?\d+(\.\d+)?\s+points?\b/i
+
+/**
+ * ⚠ SCOPING, ADDED 2026-08-10 (review F3). `GAP_CLAIM` and `POINTS_CLAIM` match
+ * on the SHAPE "by N points", and one surface is entitled to that shape: the
+ * hero's GOAL arm, whose "Leads by N points" differences GOAL PROBABILITIES —
+ * a different quantity, with its own pairing rationale in `goalLeadPoints`, and
+ * deliberately out of this change's scope.
+ *
+ * Asserting those two patterns across the whole panel therefore only passed
+ * because the default fixture carries no goal data: the moment anyone added
+ * some, a SANCTIONED sentence would have turned this guard RED. A guard that
+ * fails on correct behaviour gets disabled, and then the class it protects is
+ * unguarded — so the patterns are scoped instead.
+ *
+ * The split is: the hero subline is judged ON ITS OWN (it may carry the
+ * sanctioned goal form and nothing else), and the REST of the panel may carry
+ * none of the three forms. `PP_CLAIM` stays panel-wide and unscoped — no
+ * sanctioned surface says "percentage points".
+ */
+function splitPanelText(container: HTMLElement): { heroSubline: string; rest: string } {
+  const heroSubline = screen.queryByTestId('v7-hero-subline')?.textContent ?? ''
+  const all = container.textContent ?? ''
+  return {
+    heroSubline,
+    rest: heroSubline ? all.replace(heroSubline, '') : all,
+  }
+}
 
 describe('ResultsBody — no surface on the results panel states a win-frequency gap', () => {
   beforeEach(() => {
@@ -251,9 +282,49 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
     expect(text).toMatch(/came out ahead in 71% of simulated scenarios/i)
     expect(text).toMatch(new RegExp(RUNNER_UP_LABEL))
 
-    expect(text).not.toMatch(GAP_CLAIM)
+    // `percentage points` is unambiguous — no sanctioned surface says it.
     expect(text).not.toMatch(PP_CLAIM)
-    expect(text).not.toMatch(POINTS_CLAIM)
+
+    // The "by N points" SHAPE is judged per-region (see `splitPanelText`).
+    const { heroSubline, rest } = splitPanelText(container)
+    // This fixture carries no goal data, so the hero is on the COMPARATIVE arm
+    // and is entitled to no gap form at all.
+    expect(heroSubline).not.toMatch(GAP_CLAIM)
+    expect(heroSubline).not.toMatch(PP_CLAIM)
+    expect(rest).not.toMatch(GAP_CLAIM)
+    expect(rest).not.toMatch(POINTS_CLAIM)
+    expect(rest).not.toMatch(PP_CLAIM)
+  })
+
+  /**
+   * ⭐ F3 — THE SANCTIONED FORM MUST SURVIVE, and this proves it does.
+   *
+   * With goal data present the hero takes its GOAL arm, whose subline is
+   * "Leads by N points" over GOAL PROBABILITIES (0.9 − 0.4 = 50). That form is
+   * out of this change's scope and is correct; a guard that REDs on it would
+   * be a false alarm, and a false alarm on correct behaviour is how a guard
+   * gets switched off. So: the sanctioned sentence is asserted PRESENT, and
+   * the banned class is asserted absent everywhere else in the same render.
+   */
+  it('F3: the SANCTIONED goal-arm subline survives, and nothing else in the panel states a gap', () => {
+    const { container } = renderBody(undefined, false, true)
+
+    // Precondition — we are actually on the goal arm, not silently comparative.
+    const subline = screen.getByTestId('v7-hero-subline')
+    expect(subline).toHaveTextContent('Leads by 50 points')
+
+    // ⭐ THE OVERLAP, MADE EXPLICIT: the sanctioned sentence DOES match the
+    // banned-shape pattern. That is precisely why the pattern is scoped by
+    // region rather than weakened — and it is executable proof that the
+    // previous panel-wide assertion would have RED on this correct render.
+    expect(subline.textContent ?? '').toMatch(GAP_CLAIM)
+
+    const { rest } = splitPanelText(container)
+    expect(rest).not.toMatch(GAP_CLAIM)
+    expect(rest).not.toMatch(POINTS_CLAIM)
+    expect(rest).not.toMatch(PP_CLAIM)
+    // And the unambiguous phrase is absent from the WHOLE panel, hero included.
+    expect(container.textContent ?? '').not.toMatch(PP_CLAIM)
   })
 
   /**
@@ -292,9 +363,11 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
     // Precondition 2 — we are on the SOFTENED branch, not a withheld one.
     expect(text).toMatch(new RegExp(`${WINNER_LABEL} currently leads`))
 
-    expect(text).not.toMatch(POINTS_CLAIM)
-    expect(text).not.toMatch(PP_CLAIM)
-    expect(text).not.toMatch(GAP_CLAIM)
+    const { heroSubline, rest } = splitPanelText(container)
+    expect(heroSubline).not.toMatch(GAP_CLAIM)
+    expect(rest).not.toMatch(POINTS_CLAIM)
+    expect(rest).not.toMatch(PP_CLAIM)
+    expect(rest).not.toMatch(GAP_CLAIM)
   })
 
   /**

--- a/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
@@ -74,7 +74,10 @@ import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
 const WINNER_LABEL = 'Bring In 6-Month Contractor'
 const RUNNER_UP_LABEL = 'Hire Permanent Senior Tech Lead'
 
-function makeData(runnerUpLabel: string = RUNNER_UP_LABEL): ResultsSectionDataReturn {
+function makeData(
+  runnerUpLabel: string = RUNNER_UP_LABEL,
+  soft = false,
+): ResultsSectionDataReturn {
   const winner = {
     id: 'opt_a',
     label: WINNER_LABEL,
@@ -94,7 +97,29 @@ function makeData(runnerUpLabel: string = RUNNER_UP_LABEL): ResultsSectionDataRe
     goalLabel: 'Maximise success',
     isSingleOption: false,
     analysisStatus: 'computed',
-    recommendationStability: 0.92,
+    // `soft` reaches DecisionConfidencePanel's SOFTENED lede — the branch that
+    // carried the retired " by N points" suffix. `shouldSoftenPhrasing` needs
+    // tier ∈ {needs_work, fair} AND stability < 0.85, so both move together.
+    recommendationStability: soft ? 0.5 : 0.92,
+    // ⚠ AND A PERMITTED VERDICT IS REQUIRED TO GET THERE AT ALL. Without one,
+    // `DecisionConfidencePanel` falls back to `NO_CLAIM_VERDICT`, whose
+    // `separation: 'unknown'` returns "the analysis did not put an option
+    // forward" long before any leader rule runs — so an absence assertion
+    // would have passed against a headline that never mentions a leader.
+    // The in-test precondition is what caught this; it is not decoration.
+    // Supplied ONLY on the soft variant, so the default fixture (and the six
+    // cases built on it) keeps the legacy no-verdict path it was written for.
+    ...(soft
+      ? {
+          verdict: {
+            leaderId: 'opt_a',
+            separation: 'clear',
+            hasLeadingOption: true,
+            gapPp: 40,
+            source: 'producer_near_tie',
+          },
+        }
+      : {}),
     robustnessLevel: 'high',
     isNormalised: false,
   } as unknown as DecisionResultData
@@ -108,7 +133,7 @@ function makeData(runnerUpLabel: string = RUNNER_UP_LABEL): ResultsSectionDataRe
   }
 
   const confidence = {
-    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    tier: { tier: soft ? 'fair' : 'strong', icon: 'Check', label: 'Tier', description: 'd' },
     qualityScore: 80,
     uncertainties: [],
     topUncertainties: [],
@@ -140,10 +165,10 @@ function makeData(runnerUpLabel: string = RUNNER_UP_LABEL): ResultsSectionDataRe
   } as unknown as ResultsSectionDataReturn
 }
 
-function renderBody(runnerUpLabel?: string) {
+function renderBody(runnerUpLabel?: string, soft = false) {
   return render(
     <ResultsBody
-      resultsSectionData={makeData(runnerUpLabel)}
+      resultsSectionData={makeData(runnerUpLabel, soft)}
       tornadoData={{ rows: [], expectedOutcome: null }}
       onSendMessage={() => {}}
       onFocusNode={() => {}}
@@ -162,6 +187,13 @@ const GAP_CLAIM = /leads?\s+by\s+\d+\s+points?/i
  * "percentage points" on this panel REDs here whatever its wording.
  */
 const PP_CLAIM = /percentage\s+points?/i
+/**
+ * `certaintyCopy`'s retired suffix, as rendered by `DecisionConfidencePanel`'s
+ * softened lede ("{winner} currently leads by 40 points"). A THIRD spelling of
+ * the same banned quantity — which is exactly why this guard matches the
+ * QUANTITY SHAPE rather than any one sentence.
+ */
+const POINTS_CLAIM = /\bby\s+-?\d+(\.\d+)?\s+points?\b/i
 
 describe('ResultsBody — no surface on the results panel states a win-frequency gap', () => {
   beforeEach(() => {
@@ -204,14 +236,12 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
    *     The canvas `OptionNode` is NOT composed by `ResultsBody`; its own
    *     retirement is pinned in `render-matrix.spec.tsx` and
    *     `residualComparative.optionNode.spec.tsx`.
-   *   · WHAT IS NOT COVERED — `certaintyCopy`'s `" by N point(s)"` suffix,
-   *     which `DecisionConfidencePanel` still feeds from a live
-   *     `winProbabilityGap`. It is the same banned quantity in a DIFFERENT
-   *     phrasing, it is out of this lane's scope, and it is reported rather
-   *     than folded in. It does not fire under this fixture (the suffix rides
-   *     the softened lede, which needs a weak confidence tier). Do not read a
-   *     green here as "the panel states no gap anywhere" — read it as "no
-   *     surface states one in these two forms".
+   *   · `certaintyCopy`'s `" by N point(s)"` suffix IS now covered, but on a
+   *     SEPARATE case below, because `DecisionConfidencePanel` mounts only on
+   *     the `analysisHeroPanel`-OFF arm — which is NOT the deployed posture.
+   *     This case runs on the deployed (ON) posture, where that panel is
+   *     absent, so its silence about the suffix here means "not rendered",
+   *     never "rendered and clean".
    */
   it('NEITHER retired form appears anywhere in the rendered panel', () => {
     const { container } = renderBody()
@@ -223,6 +253,48 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
 
     expect(text).not.toMatch(GAP_CLAIM)
     expect(text).not.toMatch(PP_CLAIM)
+    expect(text).not.toMatch(POINTS_CLAIM)
+  })
+
+  /**
+   * ⭐⭐ THE SOFTENED `DecisionConfidencePanel` LEDE — AND AN EXPLICIT NOTE ON
+   * WHICH ARM MOUNTS IT, BECAUSE THE DEPLOYED POSTURE DOES NOT.
+   *
+   * Derived at the bytes: `decisionConfidenceElement` is referenced at exactly
+   * one site (`ResultsBody.tsx:508`), INSIDE `{!isAnalysisHeroPanelEnabled()
+   * && …}` — and `netlify.toml` bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`.
+   * So `DecisionConfidencePanel` mounts on the flag-OFF arm ONLY, and the
+   * retired " by N points" suffix was NOT on the surface staging serves.
+   * `buildCertaintyCopy` has exactly one consumer, so that is the whole story
+   * for this copy.
+   *
+   * This case is therefore DEFENCE IN DEPTH, and it is labelled as such rather
+   * than dressed up as a live-surface guard: the arm is real code, one flag
+   * move from being what every user reads, and `certaintyCopy` is the single
+   * source for the sentence. The flag is forced OFF here deliberately — a
+   * test left on the deployed posture would render no panel at all and its
+   * absence assertions would pass by testing nothing.
+   *
+   * TWO preconditions are pinned in-test, and both earned their place by
+   * failing first: the panel must be MOUNTED, and the run must be ON the
+   * softened branch. The fixture originally carried no `verdict`, so
+   * `NO_CLAIM_VERDICT` returned "the analysis did not put an option forward"
+   * long before any leader rule ran — an absence assertion against a headline
+   * that never mentions a leader.
+   */
+  it('DEFENCE IN DEPTH (flag-OFF arm): the softened DecisionConfidencePanel lede states no gap, and keeps its hedge', () => {
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
+    const { container } = renderBody(undefined, true)
+    const text = container.textContent ?? ''
+
+    // Precondition 1 — the panel is actually mounted on this arm.
+    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+    // Precondition 2 — we are on the SOFTENED branch, not a withheld one.
+    expect(text).toMatch(new RegExp(`${WINNER_LABEL} currently leads`))
+
+    expect(text).not.toMatch(POINTS_CLAIM)
+    expect(text).not.toMatch(PP_CLAIM)
+    expect(text).not.toMatch(GAP_CLAIM)
   })
 
   /**

--- a/src/components/results/__tests__/ownedLeaderClaim.optionCards.spec.tsx
+++ b/src/components/results/__tests__/ownedLeaderClaim.optionCards.spec.tsx
@@ -76,6 +76,12 @@ function renderCards(hasLeadingOption: boolean | undefined) {
 const LEADER_LANGUAGE: ReadonlyArray<[string, RegExp]> = [
   ['Top-performing option', /top-performing option/i],
   ['Highest leading-option likelihood', /came out ahead in .+ of simulated scenarios/i],
+  // ⚠ RETIRED EVERYWHERE 2026-08-10, so this row is now UNCONDITIONALLY true
+  // and can no longer tell a withheld turn from a permitted one. It is kept
+  // deliberately — it still guards against the string coming back — but its
+  // loss of discriminating power is stated here rather than left to look like
+  // coverage, and the permitted-turn describe below now asserts the same
+  // absence explicitly so the new truth is pinned on BOTH turns.
   ['Behind by N percentage points', /behind by \d+ percentage point/i],
   ['Statistically tied with the leading option', /statistically tied with the leading option/i],
   ['Compare against the leading option', /compare against the leading option/i],
@@ -116,11 +122,21 @@ describe('OptionCards — withheld leader claim', () => {
 })
 
 describe('OptionCards — permitted leader claim (over-suppression controls)', () => {
-  it('keeps the winner and runner-up sentences', () => {
+  it('keeps the winner sentence, and the non-leader card keeps its OWN number', () => {
     const { container } = renderCards(true)
     const text = container.textContent ?? ''
     expect(text).toMatch(/came out ahead in .+ of simulated scenarios/i)
-    expect(text).toMatch(/behind by \d+ percentage point/i)
+
+    // ⭐ SUPERSEDED 2026-08-10. This asserted the non-leader's sentence was
+    // `/behind by \d+ percentage point/i` — the percentage-point gap between
+    // two win frequencies, now retired from every user-facing surface. The
+    // control's JOB is unchanged and still needed: prove a permitted turn does
+    // not OVER-suppress the non-leader card. It is simply rebound to what now
+    // carries that card's non-suppressed content — its own probability
+    // readout, by testid rather than by a value another element could satisfy.
+    expect(screen.getByTestId(`win-pct-${RUNNER_UP_ID}`).textContent).toMatch(/\d/)
+    expect(text).not.toMatch(/behind by \d+ percentage point/i)
+    expect(text).not.toMatch(/percentage\s+points?/i)
   })
 
   it('keeps the downside pill', () => {

--- a/src/components/results/__tests__/ownedLeaderClaim.surfaces.spec.ts
+++ b/src/components/results/__tests__/ownedLeaderClaim.surfaces.spec.ts
@@ -93,7 +93,12 @@ describe('V7 hero — the re-anchored leader headline / "Leads by N points" (SUP
   it('PERMITTED: both the headline and the numeric subline survive', () => {
     const m = v7(PERMITTED_VERDICT)
     expect(m.headline).toBe(`${LEADER_LABEL} ${COMPARATIVE_COPY.clause('66%')}`)
-    expect(m.subline).toBe('Leads by 35 points')
+    // ⭐ SUPERSEDED 2026-08-10: was `'Leads by 35 points'`, the percentage-point
+    // gap between two win frequencies. Retired — the subline now states the
+    // runner-up's OWN probability. The ENTITLEMENT this spec exists to pin (a
+    // permitted verdict still gets a numeric subline) is unchanged.
+    expect(m.subline).toBe(`Next: ${RUNNER_UP_LABEL}, 31%`)
+    expect(m.subline).not.toMatch(/leads?\s+by\s+\d+\s+points?/i)
   })
 })
 

--- a/src/components/results/utils/__tests__/certaintyCopy.spec.ts
+++ b/src/components/results/utils/__tests__/certaintyCopy.spec.ts
@@ -486,31 +486,65 @@ describe('buildCertaintyCopy — decision table', () => {
     }
   })
 
-  describe('Brief 5.2 Task 1 — winProbabilityGap suffix', () => {
-    it('soft path (needs_work + low stability): appends " by N points"', () => {
+  /**
+   * ⭐⭐ THE " by N point(s)" SUFFIX IS RETIRED (2026-08-10).
+   *
+   * This block used to pin the suffix's presence, pluralisation and rounding.
+   * The suffix stated the percentage-point gap between two Monte-Carlo win
+   * frequencies — `DecisionConfidencePanel` computes it as
+   * `(winner.winProbability − runnerUp.winProbability) * 100` — and the
+   * ratified rule is that no user-facing surface states that quantity.
+   *
+   * DELETED rather than replaced with the winner's own probability, on two
+   * independent grounds derived at the seam:
+   *   1. the panel ALREADY displays the winner's own probability where this
+   *      lede renders (the confidence ring's `overrideScore`, captioned
+   *      `COMPARATIVE_COPY.label`);
+   *   2. this module's own F4 adjudication (see `aheadHeadline`) states that a
+   *      magnitude-free comparative sentence on this surface is the CORRECT
+   *      behaviour and that threading the probability in "would have added a
+   *      live claim the ruling does not want". Replacing the gap with a
+   *      magnitude here would contradict an adjudicated ruling in this file.
+   *
+   * WHAT MUST SURVIVE, and is pinned below: the SOFTENING. The hedge
+   * ("currently"), the evidence caveat and the `conservative` flag are the
+   * lede's actual job and are untouched — only the banned quantity goes.
+   */
+  describe('the retired winProbabilityGap suffix (Brief 5.2 Task 1)', () => {
+    it('soft path (needs_work + low stability): states no gap, and KEEPS the hedge and the caveat', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
         winProbabilityGap: 95,
       })
-      expect(result.headline).toBe(`${WINNER} currently leads by 95 points`)
+      expect(result.headline).toBe(`${WINNER} currently leads`)
       expect(result.caveat).toContain('limited evidence')
+      expect(result.conservative).toBe(true)
     })
 
-    it('soft path (fair + low stability): appends suffix, NO caveat', () => {
+    it('soft path (fair + low stability): states no gap, NO caveat, still conservative', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
         winProbabilityGap: 7,
       })
-      expect(result.headline).toBe(`${WINNER} currently leads by 7 points`)
+      expect(result.headline).toBe(`${WINNER} currently leads`)
       expect(result.caveat).toBeNull()
       expect(result.conservative).toBe(true)
     })
 
-    it('close_call: does NOT append suffix — reserved definitive phrasing', () => {
+    it('confident fallback: the definitive magnitude-free leader headline, never "leads by N points"', () => {
+      const result = buildCertaintyCopy({
+        verdict: clearVerdict(),
+        winnerLabel: WINNER,
+        winProbabilityGap: 3,
+      })
+      expect(result.headline).toBe(AHEAD)
+    })
+
+    it('close_call: unchanged — reserved definitive phrasing', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
@@ -521,7 +555,7 @@ describe('buildCertaintyCopy — decision table', () => {
       expect(result.headline).toBe(AHEAD)
     })
 
-    it('row 6 (strong + ready): does NOT append suffix — reserved definitive phrasing', () => {
+    it('row 6 (strong + ready): unchanged — reserved definitive phrasing', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
@@ -530,46 +564,6 @@ describe('buildCertaintyCopy — decision table', () => {
         winProbabilityGap: 50,
       })
       expect(result.headline).toBe(AHEAD)
-    })
-
-    it('confident fallback: appends suffix as "{winner} leads by N points"', () => {
-      const result = buildCertaintyCopy({
-        verdict: clearVerdict(),
-        winnerLabel: WINNER,
-        winProbabilityGap: 3,
-      })
-      expect(result.headline).toBe(`${WINNER} leads by 3 points`)
-    })
-
-    it('singular point uses "point" not "points" (soft path)', () => {
-      const result = buildCertaintyCopy({
-        verdict: clearVerdict(),
-        winnerLabel: WINNER,
-        confidenceTier: 'needs_work',
-        winProbabilityGap: 1,
-      })
-      expect(result.headline).toBe(`${WINNER} currently leads by 1 point`)
-    })
-
-    it('rounds fractional gaps to the nearest whole point (confident fallback)', () => {
-      const result = buildCertaintyCopy({
-        verdict: clearVerdict(),
-        winnerLabel: WINNER,
-        winProbabilityGap: 4.6,
-      })
-      expect(result.headline).toBe(`${WINNER} leads by 5 points`)
-    })
-
-    it('omits suffix when gap is 0, negative, or non-finite — confident fallback emits the definitive leader headline (re-anchored)', () => {
-      for (const gap of [0, -1, NaN, Infinity, -Infinity]) {
-        // Use confident fallback path. No gap → no suffix → the definitive leader headline (re-anchored).
-        const result = buildCertaintyCopy({
-          verdict: clearVerdict(),
-          winnerLabel: WINNER,
-          winProbabilityGap: gap,
-        })
-        expect(result.headline).toBe(AHEAD)
-      }
     })
 
     it('row 2 (tied) ignores gap — canonical unstable copy is preserved', () => {
@@ -582,6 +576,42 @@ describe('buildCertaintyCopy — decision table', () => {
       expect(result.headline).toBe(
         'no clear leading option, the result is sensitive to your estimates',
       )
+    })
+
+    /**
+     * THE DERIVED GUARD, and the one that matters most: no gap VALUE — of any
+     * magnitude, sign, pluralisation-triggering size, or finiteness — produces
+     * a point-gap clause on ANY branch this module can return. A per-case pin
+     * cannot say that; this sweeps the input space the retired suffix used to
+     * read, across every tier/readiness combination that reaches a leader
+     * headline.
+     */
+    it('NO gap value on ANY branch emits a point-gap clause', () => {
+      const gaps = [0.4, 1, 3, 4.6, 7, 50, 95, 0, -1, NaN, Infinity, -Infinity]
+      const tiers = ['needs_work', 'fair', 'strong', 'unknown'] as const
+      const readiness = ['ready', 'close_call', undefined] as const
+      let asserted = 0
+      for (const winProbabilityGap of gaps) {
+        for (const confidenceTier of tiers) {
+          for (const coachingReadiness of readiness) {
+            const r = buildCertaintyCopy({
+              verdict: clearVerdict(),
+              winnerLabel: WINNER,
+              confidenceTier,
+              coachingReadiness: coachingReadiness as never,
+              winProbabilityGap,
+            })
+            const text = [r.headline, r.sub, r.caveat].filter(Boolean).join(' • ')
+            expect(text, `gap=${winProbabilityGap} tier=${confidenceTier} readiness=${coachingReadiness}`)
+              .not.toMatch(/\bby\s+-?\d+(\.\d+)?\s+points?\b/i)
+            expect(text).not.toMatch(/percentage\s+points?/i)
+            asserted += 1
+          }
+        }
+      }
+      // The sweep must actually have swept (trap 13: an assertion loop that
+      // ran zero times passes by testing nothing).
+      expect(asserted).toBe(gaps.length * tiers.length * readiness.length)
     })
   })
 

--- a/src/components/results/utils/__tests__/certaintyCopy.spec.ts
+++ b/src/components/results/utils/__tests__/certaintyCopy.spec.ts
@@ -495,16 +495,22 @@ describe('buildCertaintyCopy — decision table', () => {
    * `(winner.winProbability − runnerUp.winProbability) * 100` — and the
    * ratified rule is that no user-facing surface states that quantity.
    *
-   * DELETED rather than replaced with the winner's own probability, on two
-   * independent grounds derived at the seam:
-   *   1. the panel ALREADY displays the winner's own probability where this
-   *      lede renders (the confidence ring's `overrideScore`, captioned
-   *      `COMPARATIVE_COPY.label`);
-   *   2. this module's own F4 adjudication (see `aheadHeadline`) states that a
-   *      magnitude-free comparative sentence on this surface is the CORRECT
-   *      behaviour and that threading the probability in "would have added a
-   *      live claim the ruling does not want". Replacing the gap with a
-   *      magnitude here would contradict an adjudicated ruling in this file.
+   * DELETED rather than replaced with the winner's own probability.
+   *
+   * ⚠ CORRECTED 2026-08-10 (review F2). This docblock originally gave two
+   * grounds and the FIRST WAS FALSE — "the panel already displays the winner's
+   * own probability where this lede renders". It does not:
+   * `DecisionConfidencePanel`'s `ringClaim` PREFERS `goalProbability` and
+   * captions the arc with the GOAL register, so on any run carrying a target
+   * the winner's own WIN probability is absent from that panel.
+   *
+   * The deletion stands on the remaining ground, which is sufficient on its
+   * own: this module's F4 adjudication (see `aheadHeadline`) states that a
+   * magnitude-free comparative sentence on this surface is the CORRECT
+   * behaviour, because Paul's ruling demotes the comparative number here, and
+   * that threading the probability in "would have added a live claim the
+   * ruling does not want". Replacing the gap with a magnitude would contradict
+   * an adjudicated ruling recorded in the file being changed.
    *
    * WHAT MUST SURVIVE, and is pinned below: the SOFTENING. The hedge
    * ("currently"), the evidence caveat and the `conservative` flag are the

--- a/src/components/results/utils/certaintyCopy.ts
+++ b/src/components/results/utils/certaintyCopy.ts
@@ -172,16 +172,25 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
   // banned statistic: less reliable than either estimate it is built from, yet
   // rendered as a bare integer with no interval.
   //
-  // DELETED rather than replaced with the winner's own probability, on two
-  // independent grounds:
-  //   1. the panel ALREADY shows the winner's own probability where this lede
-  //      renders — the confidence ring's `overrideScore`, captioned
-  //      `COMPARATIVE_COPY.label`;
-  //   2. `aheadHeadline`'s F4 note below already adjudicated this exact
-  //      question and concluded that a magnitude-free comparative sentence is
-  //      the CORRECT behaviour here, because Paul's ruling DEMOTES the
-  //      comparative number on this surface. Threading a magnitude in would
-  //      contradict that ruling in the file that records it.
+  // DELETED rather than replaced with the winner's own probability.
+  //
+  // ⚠ CORRECTED 2026-08-10 (review F2). The first version of this note gave
+  // TWO grounds, and the first one was FALSE: it claimed "the panel already
+  // shows the winner's own probability where this lede renders". It does not.
+  // `DecisionConfidencePanel`'s `ringClaim` PREFERS `goalProbability` and
+  // captions the arc with the GOAL register, falling back to `winProbability`
+  // only when no goal figure exists — so on any run where a target was set,
+  // the winner's own WIN probability is nowhere on that panel. A false
+  // rationale left in a comment is how the next lane inherits a wrong premise,
+  // so it is corrected here rather than quietly dropped.
+  //
+  // THE DELETION STANDS ON THE REMAINING GROUND, WHICH IS SUFFICIENT:
+  // `aheadHeadline`'s F4 note below already adjudicated this exact question
+  // and concluded that a magnitude-free comparative sentence is the CORRECT
+  // behaviour on this surface, because Paul's ruling DEMOTES the comparative
+  // number here. Threading a magnitude in "would have added a live claim the
+  // ruling does not want" — its words. Replacing the gap with the winner's own
+  // probability would contradict a ruling recorded in this very file.
   //
   // The SOFTENING survives untouched — the "currently" hedge, the evidence
   // caveat and the `conservative` flag are the lede's actual job. Only the

--- a/src/components/results/utils/certaintyCopy.ts
+++ b/src/components/results/utils/certaintyCopy.ts
@@ -48,13 +48,16 @@
  *
  *   7. fallback (strong without ready, fair + high stab, needs_work +
  *      high stab, unknown tier, absent readiness)
- *      → "{winner} leads[ by N points]"    (confident)
+ *      → "{winner} came out ahead most often across simulated scenarios"
  *
- *   The "[ by N points]" suffix is appended when the caller supplies a
- *   positive finite winProbabilityGap (percentage-point lead vs. the next
- *   option). Brief 5.2 Task 1: preserves the numeric lead without the
- *   over-confident "clear leader / X-point advantage" framing that PLoT can
- *   produce for needs_work bundles with high numeric stability.
+ *   ⭐ THE "[ by N points]" SUFFIX IS RETIRED (2026-08-10). Brief 5.2 Task 1
+ *   appended it whenever the caller supplied a positive finite
+ *   `winProbabilityGap`, to preserve the numeric lead without PLoT's
+ *   over-confident "clear leader / X-point advantage" framing. The number it
+ *   preserved was the percentage-point gap between two win frequencies, which
+ *   no user-facing surface may state. The DEFENCE against that PLoT framing is
+ *   unchanged and lives where it always did — the `conservative` flag, which
+ *   keeps `coachingHeadline` from winning the precedence chain.
  *
  * British English. No em dashes in UI strings (use a period to separate
  * clauses instead). See DESIGN_SYSTEM.md and Brief 5.1 §Operating
@@ -75,9 +78,13 @@ export interface CertaintyCopyInput {
   optionCount?: number
   /**
    * Brief 5.2 Task 1: win-probability gap (percentage points) between the
-   * winner and the next option. When provided and > 0, Rules 4 and 5 append
-   * " by N points" to the softened lede so the numeric lead is preserved
-   * without over-confident language.
+   * winner and the next option.
+   *
+   * ⚠ UNREAD SINCE 2026-08-10 — this function no longer consumes it (the
+   * " by N points" suffix it fed is retired). Kept on the type so the sole
+   * caller still compiles; removing it, together with `DecisionVerdict.gapPp`
+   * which also has zero production readers, is a clean follow-up rather than
+   * scope on the change that retired the copy.
    */
   winProbabilityGap?: number
   /**
@@ -154,19 +161,36 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
     recommendationStability,
     analysisStatus,
     optionCount,
-    winProbabilityGap,
     verdict,
   } = input
 
-  // Brief 5.2 Task 1: "by N points" suffix preserves the numeric lead in the
-  // softened lede. Rounded to the nearest whole point; only appended when the
-  // gap is a positive finite number so callers can pass null/NaN safely.
-  const gapSuffix =
-    typeof winProbabilityGap === 'number'
-    && Number.isFinite(winProbabilityGap)
-    && winProbabilityGap > 0
-      ? ` by ${Math.round(winProbabilityGap)} point${Math.round(winProbabilityGap) === 1 ? '' : 's'}`
-      : ''
+  // ⭐⭐ THE " by N point(s)" SUFFIX IS RETIRED (2026-08-10). Brief 5.2 Task 1
+  // introduced it to "preserve the numeric lead" in the softened lede; the
+  // number it preserved was the percentage-point gap between two Monte-Carlo
+  // win frequencies (`DecisionConfidencePanel` computes it as
+  // `(winner.winProbability - runnerUp.winProbability) * 100`). That is the
+  // banned statistic: less reliable than either estimate it is built from, yet
+  // rendered as a bare integer with no interval.
+  //
+  // DELETED rather than replaced with the winner's own probability, on two
+  // independent grounds:
+  //   1. the panel ALREADY shows the winner's own probability where this lede
+  //      renders — the confidence ring's `overrideScore`, captioned
+  //      `COMPARATIVE_COPY.label`;
+  //   2. `aheadHeadline`'s F4 note below already adjudicated this exact
+  //      question and concluded that a magnitude-free comparative sentence is
+  //      the CORRECT behaviour here, because Paul's ruling DEMOTES the
+  //      comparative number on this surface. Threading a magnitude in would
+  //      contradict that ruling in the file that records it.
+  //
+  // The SOFTENING survives untouched — the "currently" hedge, the evidence
+  // caveat and the `conservative` flag are the lede's actual job. Only the
+  // quantity goes.
+  //
+  // `winProbabilityGap` is left on the input type and still passed by
+  // `DecisionConfidencePanel`; it is now UNREAD here. Removing the field (and
+  // `DecisionVerdict.gapPp`, which already has zero production readers) is a
+  // clean follow-up, deliberately not folded into this change.
 
   /**
    * The re-anchored leader sentence — the comparative quantity, named, with
@@ -291,7 +315,7 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
   // signal.
   if (shouldSoftenPhrasing(confidenceTier, recommendationStability)) {
     return {
-      headline: `${winnerLabel} currently leads${gapSuffix}`,
+      headline: `${winnerLabel} currently leads`,
       sub: null,
       caveat:
         confidenceTier === 'needs_work'
@@ -324,10 +348,14 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
     }
   }
 
-  // When a gap is available, "leads by N points" gives the numeric lead.
-  // When no gap, fall back to the definitive form to avoid the bare "leads".
+  // ⭐ Was `gapSuffix ? \`${winnerLabel} leads${gapSuffix}\` : aheadHeadline`.
+  // BOTH gap-bearing sites are changed together — leaving this one would keep
+  // the banned quantity on the confident branch while the softened branch was
+  // clean, i.e. the same partial fix the OptionCards two-arm case avoided.
+  // `aheadHeadline` was always this rule's no-gap form, so the retirement
+  // returns it to the module's own documented-correct sentence.
   return {
-    headline: gapSuffix ? `${winnerLabel} leads${gapSuffix}` : aheadHeadline,
+    headline: aheadHeadline,
     sub: null,
     caveat: null,
     conservative: true,

--- a/src/components/results/v7/__tests__/buildV7Headline.goalLeader.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.goalLeader.spec.ts
@@ -131,8 +131,11 @@ describe('buildV7Headline — when no honest goal crown exists, it does not crow
     expect(model.headline).not.toContain('highest chance')
     expect(model.headline).toBe(COMPARATIVE_A('70%'))
     // Subject and metric agree again: the comparative headline gets the
-    // comparative gap.
-    expect(model.subline).toBe('Leads by 40 points')
+    // comparative subline. ⭐ SUPERSEDED 2026-08-10 — that subline was the
+    // win-frequency GAP ('Leads by 40 points') and is retired; it now names the
+    // runner-up and states its OWN probability. The GOAL arm's gap subline,
+    // pinned above, is a different quantity and is unchanged.
+    expect(model.subline).toBe('Next: Option B, 30%')
   })
 
   it('TIE AT THE MAX: two options share the highest goal probability → no crown', () => {

--- a/src/components/results/v7/__tests__/buildV7Headline.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.spec.ts
@@ -96,6 +96,64 @@ describe('buildV7Headline — passthrough hero copy (V7 L4)', () => {
     expect(model.subline).toBeNull()
   })
 
+  /**
+   * ⭐⭐ THE GUARD THAT USED TO RIDE ON THE GAP (review F1, 2026-08-10).
+   *
+   * Retiring the gap subline was a REPLACEMENT, not a deletion, and the old
+   * `leadSubline(points)` had been silently carrying a second job: it returned
+   * null whenever `points <= 0`, which covered the state where the DESIGNATED
+   * WINNER IS NOT THE WIN-PROBABILITY MAXIMUM. The replacement only checked
+   * ties among RIVALS, so it began asserting "Next: {rival}" above a rival
+   * whose probability EXCEEDS the winner's — an ordering the two numbers on
+   * screen contradict.
+   *
+   * NOT hypothetical, and bounded at the PRODUCER rather than from a fixture:
+   * `determineWinnerSelection` returns the backend `recommended_option_id`
+   * verbatim with no argmax comparison, and `src/lib/decisionVerdict.ts:305`
+   * says it outright — "PLoT may recommend an option that is not the
+   * win-probability argmax, and a leader-minus-rival subtraction would then go
+   * NEGATIVE". `separation` is measured on the ACTUAL top two, so
+   * `hasLeadingOption` is TRUE in that state and the early return never fires.
+   *
+   * The suite missed it because all four corpus cases placed the rival BELOW
+   * the winner — the corpus shared the code's assumption (traps 22 / 13d).
+   */
+  it('F1: a rival ABOVE the designated winner gets NO subline — never an ordering the numbers contradict', () => {
+    const winner = opt('a', 'Option A', 0.4, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.55)] }),
+      'robust',
+    )
+    expect(model.subline).toBeNull()
+  })
+
+  it('F1 TWIN: with the winner genuinely ahead, the subline DOES render (the guard suppresses only the inverted state)', () => {
+    const winner = opt('a', 'Option A', 0.55, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.4)] }),
+      'robust',
+    )
+    expect(model.subline).toBe('Next: Option B, 40%')
+  })
+
+  it('F1: a rival EQUAL to the winner gets no subline either', () => {
+    const winner = opt('a', 'Option A', 0.5, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.5)] }),
+      'robust',
+    )
+    expect(model.subline).toBeNull()
+  })
+
+  it('F1: a lead too small to survive rounding gets no subline — MONOTONE with the pre-PR build, which was also silent here', () => {
+    const winner = opt('a', 'Option A', 0.404, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.4)] }),
+      'robust',
+    )
+    expect(model.subline).toBeNull()
+  })
+
   it('a rival below the display floor keeps the floored readout, never a bare "0%"', () => {
     const winner = opt('a', 'Option A', 0.99, true)
     const model = buildV7Headline(

--- a/src/components/results/v7/__tests__/buildV7Headline.spec.ts
+++ b/src/components/results/v7/__tests__/buildV7Headline.spec.ts
@@ -49,14 +49,60 @@ describe('buildV7Headline — passthrough hero copy (V7 L4)', () => {
     expect(model.winnerLabel).toBe('Option A')
   })
 
-  it('clear winner subline names the lead in points from the real runner-up gap', () => {
+  /**
+   * ⭐ SUPERSEDED EXPECTATION — the gap subline is RETIRED (2026-08-10).
+   *
+   * This asserted `'Leads by 40 points'`: the percentage-point DIFFERENCE
+   * between two win frequencies, printed beneath a correct statement of the
+   * leader's own probability. The ratified rule is that no user-facing surface
+   * states that gap — a difference of two Monte-Carlo estimates is less
+   * reliable than either of them and was being rendered as the most precise
+   * number on the screen. The subline now names the runner-up and states ITS
+   * OWN probability, same formatter as the headline.
+   */
+  it('clear winner subline names the RUNNER-UP and its OWN probability — never the gap', () => {
     const winner = opt('a', 'Option A', 0.7, true)
     const model = buildV7Headline(
       rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.3)] }),
       'robust',
     )
-    // 0.70 − 0.30 = 40 points — derived, never fabricated.
-    expect(model.subline).toBe('Leads by 40 points')
+    expect(model.subline).toBe('Next: Option B, 30%')
+    expect(model.subline).not.toMatch(/leads?\s+by\s+\d+\s+points?/i)
+  })
+
+  it('names the STRONGEST rival, by identity, when there are several', () => {
+    const winner = opt('a', 'Option A', 0.6, true)
+    const model = buildV7Headline(
+      rec({
+        recommendedOption: winner,
+        allOptions: [winner, opt('b', 'Option B', 0.11), opt('c', 'Option C', 0.29)],
+      }),
+      'robust',
+    )
+    // Option C (0.29) outranks Option B (0.11); the label, not the value,
+    // is what pins the subject.
+    expect(model.subline).toBe('Next: Option C, 29%')
+  })
+
+  it('rivals TIED at the top of the field → silence (naming one would be an arbitrary ordering claim)', () => {
+    const winner = opt('a', 'Option A', 0.6, true)
+    const model = buildV7Headline(
+      rec({
+        recommendedOption: winner,
+        allOptions: [winner, opt('b', 'Option B', 0.2), opt('c', 'Option C', 0.2)],
+      }),
+      'robust',
+    )
+    expect(model.subline).toBeNull()
+  })
+
+  it('a rival below the display floor keeps the floored readout, never a bare "0%"', () => {
+    const winner = opt('a', 'Option A', 0.99, true)
+    const model = buildV7Headline(
+      rec({ recommendedOption: winner, allOptions: [winner, opt('b', 'Option B', 0.001)] }),
+      'robust',
+    )
+    expect(model.subline).toBe(`Next: Option B, ${SUB_ONE_PERCENT_READOUT}`)
   })
 
   it('near-tie → "Too close to call" (from recommendation.nearTie)', () => {

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -2,10 +2,17 @@
  * buildV7Headline — pure passthrough for the V7 hero headline (V7 Lane L4).
  *
  * Composes the hero headline + subline from EXISTING results-store data only —
- * never invents a number or a claim (V6-RESPEC-2026-07-23 §L4: "UI IS A
- * PASSTHROUGH"). Every string form below is sourced VERBATIM from a live
- * production headline surface, so "Headline copy matches production strings"
- * (spec row 3 done-when) holds:
+ * never invents a NUMBER (V6-RESPEC-2026-07-23 §L4: "UI IS A PASSTHROUGH").
+ *
+ * ⚠ CORRECTED 2026-08-10 (review F4). This used to claim that "every string
+ * form below is sourced VERBATIM from a live production headline surface", and
+ * that is NO LONGER TRUE: the comparative arm's subline `"Next: {label},
+ * {pct}"` is NEW copy, written here when the percentage-point gap subline was
+ * retired, and it has no production antecedent. The PASSTHROUGH guarantee that
+ * does still hold is the one that matters and is now stated exactly: every
+ * NUMBER rendered is read from the results store and never derived into a new
+ * quantity. The provenance list below therefore describes the forms that were
+ * inherited, not an invariant over all of them:
  *
  *   · "{winner} performs best"        — M1 winner headline
  *     (src/components/debug/utils/exportBundle.ts `deriveHeroHeadline`;
@@ -279,5 +286,41 @@ function runnerUpSubline(
   const [first, second] = rivals
   if (!first || !first.label) return null
   if (second && second.winProbability === first.winProbability) return null
+
+  /**
+   * ⭐⭐ THE GUARD THAT USED TO RIDE ON THE GAP (restored 2026-08-10, review F1).
+   *
+   * Retiring the gap subline was a REPLACEMENT, not a deletion, and the
+   * retired `leadSubline(points)` had been silently carrying a SECOND job: it
+   * returned null whenever `points <= 0`, which covered the state where the
+   * DESIGNATED WINNER IS NOT THE WIN-PROBABILITY MAXIMUM. Dropping the gap
+   * dropped that cover, and "Next: {rival}" began appearing above a rival
+   * whose probability EXCEEDS the winner's — an ordering claim the two numbers
+   * on screen contradict, i.e. the exact defect class this change exists to
+   * close, reintroduced by the fix for it.
+   *
+   * THE STATE IS PRODUCER-REACHABLE, not a fixture artefact.
+   * `determineWinnerSelection` returns the backend `recommended_option_id`
+   * VERBATIM with no argmax comparison, and `decisionVerdict.ts:305` states it
+   * outright: "PLoT may recommend an option that is not the win-probability
+   * argmax, and a leader-minus-rival subtraction would then go NEGATIVE".
+   * Because `separation` is measured on the ACTUAL top two, `hasLeadingOption`
+   * is TRUE there, so the withheld-verdict early return does not gate it.
+   *
+   * The comparison is expressed as the ROUNDED lead so this function is
+   * MONOTONE against the pre-change build: a lead too small to survive
+   * rounding was silent before and stays silent, and the ordering is anyway
+   * not resolvable at the precision the panel displays. The value is a
+   * PREDICATE and is never rendered — the same shape as `OptionCards`' near-tie
+   * `gapPct` and `OptionNode`'s `closeCallGapPp`.
+   *
+   * ⚠ RECORDED, NOT BUILT: a backend recommendation that is not the
+   * probability leader currently has NO honest surface anywhere in the
+   * product. Suppression is right here; a surface that EXPLAINS that state is
+   * a real product question and a separate piece of work.
+   */
+  const leadPoints = Math.round((winProbability - first.winProbability) * 100)
+  if (leadPoints <= 0) return null
+
   return `Next: ${first.label}, ${formatProbabilityWithResolution(first.winProbability, null)}`
 }

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -18,7 +18,10 @@
  *   · "No clear leading option"       — indeterminate / GAP form
  *     (certaintyCopy.ts rule 1: "no clear leading option, …")
  *   · "Too close to call"             — near-tie form (recommendation.nearTie)
- *   · "Leads by N points" subline (certaintyCopy.ts rule 4)
+ *   · "Leads by N points" subline (certaintyCopy.ts rule 4) — ⚠ NOW THE GOAL
+ *     ARM ONLY. The COMPARATIVE arm's version of this line stated the
+ *     percentage-point gap between two WIN FREQUENCIES and is retired
+ *     (2026-08-10); that arm's subline is now the runner-up's own probability.
  *     (the companion "{winner} leads slightly more often" was REMOVED from
  *      both this file and certaintyCopy.ts — ROADMAP 1.223: a denial of a
  *      leading option must not carry a leader claim as its subline)
@@ -29,7 +32,7 @@
  */
 
 import type { DecisionResultData, DecisionState } from '../types'
-import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY } from '../utils/goalAnchorCopy'
+import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY, isFiniteProbability } from '../utils/goalAnchorCopy'
 import { formatGoalProbability } from '../utils/displayFloors'
 import { goalLeadPoints, selectGoalLeader } from '../utils/selectGoalLeader'
 import { formatProbabilityWithResolution } from '../../../utils/formatPercent'
@@ -190,18 +193,31 @@ export function buildV7Headline(
    * superlative with no stated basis, no number and no timeframe, which a
    * reader cannot argue with because it drops the figure that would let them.
    *
-   * Subline names the lead in points when the runner-up carries a win
-   * probability we can difference against (store-derived, never fabricated).
-   * Same metric as the headline above it, same subject.
+   * ⭐⭐ THE GAP SUBLINE IS RETIRED (2026-08-10 — F3's UI half; the CEE half
+   * ships separately). This arm used to compute the percentage-point
+   * DIFFERENCE between the leader's and the runner-up's win frequencies and
+   * print it as "Leads by 33 points" on the line immediately beneath a
+   * CORRECT statement of the leader's own probability. Both sentences were
+   * store-derived and neither was fabricated — which is precisely why it
+   * survived so long.
+   *
+   * The ratified rule: no user-facing surface states the percentage-point gap
+   * between win frequencies. A difference of two Monte-Carlo estimates carries
+   * more uncertainty than either estimate does, and rendered as a bare integer
+   * with no interval it reads as the most precise number on the screen while
+   * being the least reliable one. THE LEADER'S OWN PROBABILITY IS THE
+   * STATISTIC, and the headline directly above already states it.
+   *
+   * The subline now names the runner-up and states ITS OWN probability, in the
+   * same floored formatter as the headline — so the reader still gets both
+   * numbers and can compare them, and the product asserts neither a difference
+   * nor an ordering it has not earned. See `runnerUpSubline` for the three
+   * states in which it stays silent.
    */
-  const runnerUp = allOptions
+  const rivals = allOptions
     .filter(o => o.id !== winner?.id)
-    .filter((o): o is typeof o & { winProbability: number } => typeof o.winProbability === 'number')
-    .sort((a, b) => b.winProbability - a.winProbability)[0]
-  const gapPoints =
-    winProbability != null && runnerUp
-      ? Math.round((winProbability - runnerUp.winProbability) * 100)
-      : null
+    .filter((o): o is typeof o & { winProbability: number } => isFiniteProbability(o.winProbability))
+    .sort((a, b) => b.winProbability - a.winProbability)
 
   const headline =
     winProbability != null
@@ -214,19 +230,54 @@ export function buildV7Headline(
 
   return {
     headline,
-    subline: leadSubline(gapPoints),
+    subline: runnerUpSubline(winProbability, rivals),
     winProbability,
     winnerLabel,
   }
 }
 
 /**
- * The shipped lead-in-points subline (certaintyCopy.ts rule 4), built in ONE
- * place so the goal arm and the comparative arm cannot render the same claim
- * with different pluralisation. A non-positive or absent gap yields no
- * subline — silence rather than "Leads by 0 points".
+ * The shipped lead-in-points subline (certaintyCopy.ts rule 4). A non-positive
+ * or absent gap yields no subline — silence rather than "Leads by 0 points".
+ *
+ * ⚠ SOLE CALLER SINCE 2026-08-10: the GOAL arm. The comparative arm's use of
+ * this function was the retired win-frequency gap (see the block above). The
+ * goal arm differences GOAL PROBABILITIES — a different quantity, with its own
+ * pairing rationale in `goalLeadPoints` — and is deliberately left as it is
+ * rather than swept in on the same change.
  */
 function leadSubline(points: number | null): string | null {
   if (points == null || points <= 0) return null
   return `Leads by ${points} point${points === 1 ? '' : 's'}`
+}
+
+/**
+ * The COMPARATIVE arm's subline: the runner-up named, with ITS OWN win
+ * probability — never a difference.
+ *
+ * Silent (null) in three states, each of which would otherwise be a claim this
+ * run has not earned:
+ *
+ *   1. The headline carries no magnitude (`winProbability == null`). The
+ *      headline is then the honest-absence form, and a lone rival percentage
+ *      beneath it would name a metric the sentence above declined to state.
+ *   2. No rival carries a finite win probability — nothing to name.
+ *   3. TWO OR MORE rivals are TIED at the top of the field. "Next: X" is an
+ *      ORDERING claim, and between tied rivals which one gets named is
+ *      arbitrary. Same rule, and the same reason, as `selectGoalLeader`'s
+ *      `tiedAtMax` refusal one arm up.
+ *
+ * `formatProbabilityWithResolution` and not a bare percent: the same floored
+ * formatter the headline uses, so a sub-1% rival cannot read "0%" here while
+ * the option card beside it reads "< 1%".
+ */
+function runnerUpSubline(
+  winProbability: number | null,
+  rivals: ReadonlyArray<{ label?: string | null; winProbability: number }>,
+): string | null {
+  if (winProbability == null) return null
+  const [first, second] = rivals
+  if (!first || !first.label) return null
+  if (second && second.winProbability === first.winProbability) return null
+  return `Next: ${first.label}, ${formatProbabilityWithResolution(first.winProbability, null)}`
 }

--- a/src/hooks/__tests__/useScenario.unmountFlushPersistenceGate.spec.ts
+++ b/src/hooks/__tests__/useScenario.unmountFlushPersistenceGate.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * useScenario — the UNMOUNT best-effort graph flush must obey the SAME
+ * persistence gate as every other write path.
+ *
+ * THE DEFECT (found by the PR #662 adversarial review, pre-existing):
+ * `persistGraphNow` declares itself "the ONE write code path", and it is the
+ * function that consults `shouldPersistGraphForScenario` — the guard that
+ * refuses to write a graph whose streamed values the UI KNOWS are unsettled.
+ * The unmount flush called `scenarioService.saveGraphViaGatedPath` DIRECTLY,
+ * so the guard was never consulted: for a signed-in user, navigating away
+ * while a kept-unsettled preview stood on the canvas wrote that preview over
+ * CEE's committed graph. Exactly the loss `persistGraphNow`'s header says the
+ * suppression exists to prevent, reached through the one door that skipped it.
+ *
+ * SECOND LIMB — `graphSaveTimerRef` was never nulled once the debounce FIRED,
+ * so the unmount cleanup's `if (graphSaveTimerRef.current)` was truthy for a
+ * timer that had already run to completion. The "best-effort flush of a
+ * PENDING save" therefore fired for saves that were not pending at all.
+ *
+ * Both limbs are pinned by IDENTITY (the mock write's scenario id and node
+ * payload), and the (d)/(e) controls pin the flush's legitimate behaviour so
+ * the suite cannot be satisfied by deleting the flush.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }))
+
+let mockAuthValue = {
+  user: null as { id: string; email?: string } | null,
+  authenticated: false,
+}
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => mockAuthValue }))
+
+const mockSaveGraphViaGatedPath = vi.fn()
+const mockSaveFraming = vi.fn()
+const mockSaveTitle = vi.fn()
+
+vi.mock('../../services/scenarioService', () => ({
+  createScenario: vi.fn(),
+  loadScenario: vi.fn(),
+  deleteScenario: vi.fn(),
+  saveGraphViaGatedPath: (...args: unknown[]) => mockSaveGraphViaGatedPath(...args),
+  saveFraming: (...args: unknown[]) => mockSaveFraming(...args),
+  storeAnalysis: vi.fn(),
+  storeAnalysisFailure: vi.fn(),
+  storeBrief: vi.fn(),
+  setStage: vi.fn(),
+  createSharedBrief: vi.fn(),
+  resetAnalysisStatus: vi.fn(),
+  setAnalysisRunning: vi.fn(),
+  saveTitle: (...args: unknown[]) => mockSaveTitle(...args),
+}))
+
+const mockMarkClean = vi.fn()
+let storeState: Record<string, unknown> = {}
+
+const mockGetState = vi.fn(() => ({
+  markClean: mockMarkClean,
+  hydrateGraphSlice: vi.fn(),
+  ...storeState,
+}))
+const mockSetState = vi.fn((partial: Record<string, unknown>) => {
+  storeState = { ...storeState, ...partial }
+})
+
+type StoreSubscriber = (state: Record<string, unknown>, prev: Record<string, unknown>) => void
+const mockSubscribeCallbacks: StoreSubscriber[] = []
+
+vi.mock('../../canvas/store', () => ({
+  useCanvasStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+    {
+      getState: () => mockGetState(),
+      setState: (partial: Record<string, unknown>) => mockSetState(partial),
+      subscribe: (cb: StoreSubscriber) => {
+        mockSubscribeCallbacks.push(cb)
+        return () => {}
+      },
+    },
+  ),
+}))
+
+vi.mock('../../canvas/domain/edges', () => ({
+  DEFAULT_EDGE_DATA: { weight: 0.5, style: 'solid', curvature: 0.15 },
+}))
+
+import { useScenario } from '../useScenario'
+// REAL draft store — the guard under test reads it. A mocked guard would only
+// prove the test can mock, never that the live predicate is consulted.
+import { useDraftStore, shouldPersistGraphForScenario } from '../../canvas/stores/draftStore'
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+const SCENARIO = 'sc-unsettled-1'
+
+/**
+ * ⚠ EVERY CASE GETS ITS OWN GRAPH, and this is load-bearing, not tidiness.
+ * `useScenario` keeps `sharedLastSavedGraphKey` at MODULE scope — deliberately,
+ * so two mounts cannot re-write each other's save — and it survives
+ * `vi.clearAllMocks()`. Two cases sharing a node set therefore let the first
+ * case's successful write make the second case's debounce a no-op, and the
+ * second case would then "pass" while never exercising the path it names.
+ */
+function graphFor(caseId: string) {
+  return [{ id: `kept_goal_${caseId}` }, { id: `kept_opt_${caseId}` }]
+}
+
+/** Fire the canvas-store subscription so the debounced graph save is scheduled. */
+function scheduleGraphSave(nodes: Array<{ id: string }>) {
+  const prev = { ...storeState }
+  storeState = { ...storeState, nodes }
+  act(() => {
+    for (const cb of mockSubscribeCallbacks) cb(storeState, prev)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSubscribeCallbacks.length = 0
+  storeState = {
+    currentScenarioId: SCENARIO,
+    nodes: [],
+    edges: [],
+    goalConstraints: null,
+    currentScenarioFraming: null,
+    isDirty: false,
+    results: { status: 'idle' },
+  }
+  mockAuthValue = { user: { id: REAL_USER_ID, email: 'u@test.com' }, authenticated: true }
+  mockSaveGraphViaGatedPath.mockResolvedValue(undefined)
+  useDraftStore.getState().resetDraft()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  useDraftStore.getState().resetDraft()
+})
+
+describe('useScenario — unmount flush obeys the unsettled-persistence gate', () => {
+  it('(a) CONTROL: the debounced autosave IS suppressed while unsettled (the guard works on the guarded path)', async () => {
+    vi.useFakeTimers()
+    renderHook(() => useScenario())
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', SCENARIO)
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(false)
+
+    scheduleGraphSave(graphFor('a'))
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
+  })
+
+  it('(b) unmount after a FIRED-and-suppressed debounce must not write the unsettled graph', async () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() => useScenario())
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', SCENARIO)
+
+    scheduleGraphSave(graphFor('b'))
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
+    // Still unsettled at the moment of unmount — the guard's answer has not moved.
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(false)
+
+    unmount()
+
+    expect(
+      mockSaveGraphViaGatedPath,
+      'the unmount flush wrote the kept-unsettled graph over CEE’s commit',
+    ).not.toHaveBeenCalled()
+  })
+
+  it('(c) unmount with a PENDING (never-fired) debounce must not write the unsettled graph', () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() => useScenario())
+    useDraftStore.getState().setDraftStreamPhase('unsettled', 't1', SCENARIO)
+
+    scheduleGraphSave(graphFor('c'))
+    unmount()
+
+    expect(mockSaveGraphViaGatedPath).not.toHaveBeenCalled()
+  })
+
+  it('(d) CONTROL: with the gate OPEN, a pending debounce IS flushed at unmount — exactly once, for this scenario, with this graph', () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() => useScenario())
+    // No unsettled phase: the guard permits the write.
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(true)
+
+    const graph = graphFor('d')
+    scheduleGraphSave(graph)
+    unmount()
+
+    expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+    const [sid, written] = mockSaveGraphViaGatedPath.mock.calls[0] as [
+      string,
+      { nodes: unknown[]; edges: unknown[] },
+    ]
+    expect(sid).toBe(SCENARIO)
+    expect(written.nodes).toEqual(graph)
+  })
+
+  it('(e) a debounce that already FIRED AND WROTE is not re-flushed at unmount (the timer ref is nulled once it runs)', async () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() => useScenario())
+    expect(shouldPersistGraphForScenario(SCENARIO)).toBe(true)
+
+    scheduleGraphSave(graphFor('e'))
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockSaveGraphViaGatedPath).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    expect(
+      mockSaveGraphViaGatedPath,
+      'the settled graph was written a SECOND time by a flush for a save that was not pending',
+    ).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -338,6 +338,11 @@ export function useScenario(): UseScenarioReturn {
       if (graphSaveTimerRef.current) clearTimeout(graphSaveTimerRef.current)
 
       graphSaveTimerRef.current = setTimeout(async () => {
+        // This timer has RUN: it is no longer pending, and the unmount
+        // best-effort flush must not treat it as though it were. Nulled first,
+        // before any early return, so every exit from this callback leaves the
+        // ref honest.
+        graphSaveTimerRef.current = null
         const saveSid = scenarioIdRef.current
         if (!saveSid || !mountedRef.current) return
         // Re-check ownership + cleanliness at fire time: a flush barrier or the
@@ -445,17 +450,31 @@ export function useScenario(): UseScenarioReturn {
 
   useEffect(() => {
     return () => {
-      // Best-effort flush: if a debounced graph save is pending, fire it now
+      // Best-effort flush: if a debounced graph save is pending, fire it now.
+      //
+      // ⭐ CORRECTED 2026-08-10 (found by the PR #662 adversarial review;
+      // pre-existing). This called `scenarioService.saveGraphViaGatedPath`
+      // DIRECTLY. `persistGraphNow`'s own header declares it "the ONE write code
+      // path ... one derived choke point, no list of call sites to keep in
+      // step" — and this was the call site not in step: it never consulted
+      // `shouldPersistGraphForScenario`, so for a signed-in user, navigating
+      // away while a kept-unsettled streamed preview stood on the canvas wrote
+      // that preview over CEE's committed graph. Exactly the loss the
+      // suppression exists to prevent, reached through the one door that
+      // skipped it. It now goes through the choke point, so the gate cannot be
+      // bypassed here again without deleting the call.
       if (graphSaveTimerRef.current) {
         clearTimeout(graphSaveTimerRef.current)
+        // ⭐ And NULL it. The ref was only ever cleared, never nulled, so an
+        // already-FIRED debounce still read as "pending" here and this flush
+        // fired for a save that had already completed (or had already been
+        // suppressed) — a second write of a graph nobody had changed.
+        graphSaveTimerRef.current = null
         const sid = scenarioIdRef.current
         if (sid) {
-          const { nodes: n, edges: e, goalConstraints: gc } = useCanvasStore.getState()
-          scenarioService
-            .saveGraphViaGatedPath(sid, { nodes: n, edges: e }, crypto.randomUUID(), undefined, gc)
-            .catch((err) => {
-              console.error('[useScenario] Unmount graph flush failed:', err)
-            })
+          persistGraphNow(sid).catch((err) => {
+            console.error('[useScenario] Unmount graph flush failed:', err)
+          })
         }
       }
       if (framingSaveTimerRef.current) {


### PR DESCRIPTION
Truth fixes established by executed evidence (Codex audit, 10 Aug; the PR #662 review). **Do not merge without adversarial review.**

## THE CLASS — no user-facing surface states the percentage-point gap between win frequencies

A difference of two Monte-Carlo estimates carries more uncertainty than either estimate does; printed as a bare integer with no interval it reads as the most precise number on screen while being the least reliable. **The option's OWN probability is the statistic.** Four surfaces stated it; all four are closed.

| Surface | Was | Now |
|---|---|---|
| `buildV7Headline` / `V7Hero` | "Leads by 40 points" under a correct own-probability headline | names the runner-up and states **its own** probability; silent when the headline has no magnitude, no rival is measured, or two rivals **tie** at the top |
| `OptionCards` (2 arms) | "Behind by N percentage points" | **deleted** |
| `OptionNode` (canvas) | "Close call: within N percentage points" | "Close call with the leading option" — signal kept, quantity gone |
| `certaintyCopy` (2 sites) | "{winner} currently leads **by N points**" / "{winner} leads **by N points**" | **deleted**; the softening survives |

**Licence to delete, derived at each seam — never assumed.** `OptionCards`: both arms require `option.winProbability != null`, the *same* condition that renders the card's `win-pct-{id}` readout, so the own probability is already there. `certaintyCopy`: the panel already shows the winner's own probability (the ring's `overrideScore`, captioned `COMPARATIVE_COPY.label`) **and** `aheadHeadline`'s own F4 note had already adjudicated this question — a magnitude-free comparative sentence is the correct behaviour here, so replacing the gap with a magnitude would contradict a ruling recorded in the file being changed.

**Every multi-site surface changed all its sites together.** `OptionCards` runner-up + other-non-winner; `certaintyCopy` softened + confident. A half-fix leaves the quantity on screen for whichever users hit the other branch.

**`OptionNode`:** naming the leader is entitled — `closeCallGapPp` returns null unless `verdict.hasLeadingOption`. The 5pp window and 1pp floor are untouched, so the qualifying-run set is provably unchanged; only the sentence moved.

### ⚠ Correction to an earlier claim in this PR
Round 2 reported `certaintyCopy`'s suffix as *"still on screen"*. **That was an overclaim** — a live rendering consumer in *code* generalised to a live *rendered* surface without deriving the deployed flag posture. `decisionConfidenceElement` is referenced at exactly one site (`ResultsBody.tsx:508`), inside `{!isAnalysisHeroPanelEnabled() && …}`, and `netlify.toml` bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`. **The panel mounts on the flag-OFF arm only, so that suffix was never on the surface staging serves.** The fix is defence in depth on live code one flag move from every user, and its test is labelled as such rather than dressed up as a live-surface guard.

### The durable guard
`ResultsBody.winFrequencyGapAbsence.spec.tsx` asserts **all three** retired forms absent across everything `ResultsBody` renders, with a **positive control** injecting the phrase through a real render input (an option label) proving the probe can *see* it. Plus a derived sweep in `certaintyCopy.spec.ts`: no gap value — 12 magnitudes x 4 tiers x 3 readiness states, with a count assertion so the loop cannot pass by running zero times — emits a point-gap clause on **any** branch.

Two preconditions in the flag-OFF case earned their place **by failing first**: the panel must be MOUNTED, and the run must be ON the softened branch. The fixture carried no `verdict`, so `NO_CLAIM_VERDICT` returned "the analysis did not put an option forward" — the absence assertion would have passed against a headline that never mentions a leader.

### Producers
- **`decisionVerdict.gapPp` — render-dead** (zero production readers; only two test files).
- **`certaintyCopy.winProbabilityGap` — now render-dead too**: still computed and passed, no longer read. Deleting both is a clean follow-up, deliberately not folded in.

---

## FIX 2 — freshness discarded CEE's verdict at an equal timestamp
`computed_at <= prev.computedAt` returned the previous object, but `computed_at` stamps the **analysis**, not the verdict: CEE re-evaluates against the current graph and re-sends the same analysis with a new verdict and hash. Witnessed on staging — CEE returned `stale` with a new hash, the store kept `fresh` with pre-edit hashes. Now rejects only **strictly** older; `sameVerdict` no-ops genuine echoes.

## FIX 3 — the unmount graph flush bypassed the persistence gate
`persistGraphNow` declares itself *"the ONE write code path"*; the unmount cleanup called `saveGraphViaGatedPath` directly, so a signed-in user navigating away wrote a kept-unsettled preview **over CEE's committed graph**. Now routed through the choke point. **Second limb:** `graphSaveTimerRef` was cleared but never nulled, so an already-**fired** debounce read as "pending" — nulled at fire time and after the flush.

---

## Evidence

**RED-first per surface**, measured before each source edit, by name.

**Mutants** — throwaway worktree outside the repo root; isolation proven by **inode comparison + sentinel write test**; restores from a pristine archive outside both trees; clean-tree assertion before *and* after each; applied-check scoped to `src/`; **collected-count asserted every run**; trailing control.

| Round | Mutant | Result |
|---|---|---|
| 1 | `M1` hero gap restored | 9 RED incl. both mount postures |
| 1 | `M5` weakest rival named | **1 RED — the identity test only** (pair with `M1`) |
| 1 | `M6` tie guard deleted | 1 RED |
| 1 | `M2` `<` → `<=` | **RED equal+changed / GREEN equal+identical** |
| 1 | `M3`/`M4`/`M7` | RED (c) / RED (e) / RED (b)(c)(e) — reproducing the pristine signature |
| 2 | `A1` behind-by, **runner-up arm only** | RED that arm; **other arm GREEN** |
| 2 | `A2` behind-by, **other arm only** | RED that arm; **runner-up GREEN** |
| 2 | `A3` own-% readout deleted | RED the identity pin; **absence guard GREEN** |
| 2 | `B1`/`B2` node quantity / window | RED node tests only / RED window test only |
| 2 | `C1` hero regression | RED hero + guard; no card/node test trips |
| 3 | `D1b` soft site restored | 14 RED — certaintyCopy, caveatGuarantee, the flag-OFF guard |
| 3 | `D2b` confident site restored | 18 RED — certaintyCopy, caveatGuarantee, HeroFooterAlignment |

`A1`/`A2` and `D1b`/`D2b` prove each multi-site surface is pinned **per site**. `A3` proves the absence guard and the identity pin measure different things. **No surface's mutant trips another surface's tests.** `D1b`/`D2b` were re-cut after the first attempt failed by *throwing* rather than emitting the clause — `referenceErrors=0` is asserted, because a mutant that fails for the wrong reason proves nothing.

**Gates at `cef39dba`**, in the required check's step order (`lint → typecheck → tests`): lint **0 errors**, hooks ratchet 232/15 exactly at baseline · typecheck **PASSED**, coverage 3347/3387, ratchet **2487 = baseline 2487** · selftest **18/18** · build OK · `src/components/results` **252 files / 4,471 tests** green; earlier rounds swept `src/canvas` + `src/hooks` (**1,115 files / 16,412 tests**).

**CI on the exact head: 13/13 green**, including the required Staging Gate and all four shards.

## Scope
20 files — **6 source, 14 spec**. Nothing else. The Research CTA was checked and is **already retired** (ROADMAP 2.816, `researchCtaRetired.spec.tsx` pins both deployed arms) — the brief's premise was stale; no change needed or made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)