### PR TITLE
P0: the provenance receipt rendered a DIFFERENT decision's brief

### DIFF
--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -148,7 +148,12 @@ export async function hydrateCanvasFromServer(
   // stored AS a null: the surface renders it as "we cannot tell you", never as
   // an empty list, which on a brief we demonstrably lose content from would be
   // a new and more damaging lie than the silence it replaces.
+  // `scenarioId` is the scenario this content DESCRIBES, and the surface refuses
+  // to render unless it matches the live one. It is the requested id, not
+  // `currentId`: the two are equal here (the guard above returned otherwise),
+  // and the requested id is the one the payload actually came back for.
   useContextIntegrityStore.getState().setContextIntegrity({
+    scenarioId,
     briefText: result.briefText,
     manifest: result.notModelled,
   })

--- a/src/canvas/stores/contextIntegrityStore.ts
+++ b/src/canvas/stores/contextIntegrityStore.ts
@@ -25,30 +25,62 @@ import { create } from 'zustand'
 import type { NotModelledManifest } from '../../adapters/cee/notModelled'
 
 /**
- * ── WHY THERE IS NO `scenarioId` HERE ──────────────────────────────────────
- * There was one, and its comment claimed it "guards against a stale read from a
- * previous scenario being shown against the current one". It guarded nothing:
- * it was WRITE-ONLY. `serverGraphHydration` set it and no consumer ever read it
- * — `V7WhatIWasGivenSection` selects `briefText` and `manifest` and nothing
- * else. A field with zero readers cannot fork identity and cannot gate a
- * render, so its blast radius was zero by construction (CLAUDE.md trap 10),
- * and a comment asserting a guarantee nobody enforces is worse than no field:
- * the next reader trusts it and stops looking.
+ * ── WHY `scenarioId` IS BACK, AND WHY IT MUST HAVE A READER ────────────────
+ * This field existed, was removed as write-only, and its removal shipped a
+ * P0: the receipt rendered A PREVIOUS DECISION'S BRIEF under "What you gave
+ * me", and survived reset-canvas → new brief → draft → analysis → edit. Only a
+ * page reload cleared it (this store is in-memory, so a reload re-inits it).
  *
- * The staleness question itself is real but is answered UPSTREAM, before this
- * store is written: `serverGraphHydration` compares the requested scenario
- * against `useCanvasStore.currentScenarioId` and returns `'skipped'` on a
- * mismatch, so a hydration for a scenario the user has left never reaches
- * `setContextIntegrity` at all. If that ever stops being true, the fix is a
- * guard with a reader and a test — not a field that records the answer and
- * throws it away.
+ * The removal note argued the staleness question was "answered UPSTREAM" by
+ * `serverGraphHydration` comparing the requested scenario against
+ * `useCanvasStore.currentScenarioId`. THAT WAS FALSE, and the reason is
+ * CLAUDE.md trap 21 — two questions under one name:
+ *
+ *   · The upstream guard answers *"is this in-flight RESPONSE for the scenario
+ *     the user is still on?"* It only runs on the `'graph'` path.
+ *   · The render needs *"does the content I am about to SHOW belong to the
+ *     scenario on screen?"*
+ *
+ * They differ precisely where the defect lives. `setContextIntegrity` is
+ * reached ONLY on `result.status === 'graph'`; every other cold-read outcome
+ * (`absent`, `notReadable`, `unavailable`, `refused`, `unusable`, and the
+ * non-UUID `skipped`) returns BEFORE the write. A freshly-minted scenario
+ * reliably answers `absent` — CEE has no graph for it yet at the moment
+ * `useServerGraphHydration` fires — so nothing is written, nothing is cleared,
+ * and the previous decision's brief simply stays. The hook attempts ONCE PER
+ * SCENARIO ID, so it never self-corrects.
+ *
+ * The removal reasoning about write-only fields (trap 10) was right in general
+ * and wrong here: the answer was not to delete the field but to GIVE IT A
+ * READER. `V7WhatIWasGivenSection` now refuses to render unless this id
+ * positively matches `useCanvasStore.currentScenarioId`, so a stale store
+ * cannot reach the screen even when nothing clears it. Keying the content is
+ * what makes clearing unnecessary: an unkeyed clear must be remembered at every
+ * transition (the hand-maintained mirror, trap 12), whereas content that
+ * carries its own identity fails safe at the point of use.
  */
 export interface ContextIntegrityState {
+  /**
+   * The scenario this content describes. `null` = nothing recorded.
+   *
+   * ⚠ HAS A READER, AND MUST KEEP ONE. `V7WhatIWasGivenSection` gates its
+   * entire render on this matching the live scenario. If a future change drops
+   * that comparison, the P0 above returns silently — the pinning spec is
+   * `V7WhatIWasGivenSection.spec.tsx` → "never renders another decision's
+   * brief".
+   */
+  scenarioId: string | null
   /** The brief as the user wrote it, byte-verbatim. `null` = none persisted. */
   briefText: string | null
   /** CEE's manifest. `null` = we were told nothing. NEVER "nothing dropped". */
   manifest: NotModelledManifest | null
+  /**
+   * `scenarioId` is REQUIRED, deliberately: content this store cannot attribute
+   * to a decision is content the surface must never show, and making the caller
+   * state it means a new writer cannot omit it by accident.
+   */
   setContextIntegrity: (input: {
+    scenarioId: string | null
     briefText: string | null
     manifest: NotModelledManifest | null
   }) => void
@@ -56,12 +88,14 @@ export interface ContextIntegrityState {
 }
 
 const EMPTY = {
+  scenarioId: null,
   briefText: null,
   manifest: null,
 } as const
 
 export const useContextIntegrityStore = create<ContextIntegrityState>((set) => ({
   ...EMPTY,
-  setContextIntegrity: ({ briefText, manifest }) => set({ briefText, manifest }),
+  setContextIntegrity: ({ scenarioId, briefText, manifest }) =>
+    set({ scenarioId, briefText, manifest }),
   reset: () => set({ ...EMPTY }),
 }))

--- a/src/components/results/v7/V7WhatIWasGivenSection.tsx
+++ b/src/components/results/v7/V7WhatIWasGivenSection.tsx
@@ -32,6 +32,15 @@
  * those read as "everything made it in", which on a brief we demonstrably lose
  * content from is a worse lie than the silence it replaces.
  *
+ * ── THE IDENTITY GATE ──────────────────────────────────────────────────────
+ * This surface renders ONLY when the context-integrity store's `scenarioId`
+ * positively matches the live `currentScenarioId`. It shipped without that
+ * check and rendered A PREVIOUS DECISION'S BRIEF, verbatim, under "What you
+ * gave me" — the trust anchor telling the user something false about their own
+ * input, with a cross-decision data-leak shape on any shared session. See the
+ * store's header for the mechanism. The gate lives at the point of RENDER, not
+ * only at the point of write, so that a store nobody cleared cannot defeat it.
+ *
  * ── MOUNT ──────────────────────────────────────────────────────────────────
  * Hosted in the UNCONDITIONAL `v7-top-group`. `ResultsBody` forks on
  * `analysisHeroPanel` and this estate has twice shipped a feature dark by
@@ -42,6 +51,7 @@ import { useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 
 import { typography } from '../../../styles/typography'
+import { useCanvasStore } from '../../../canvas/store'
 import { useContextIntegrityStore } from '../../../canvas/stores/contextIntegrityStore'
 import type { NotModelledItem } from '../../../adapters/cee/notModelled'
 import { ClampToggle } from './ClampToggle'
@@ -233,8 +243,34 @@ export interface V7WhatIWasGivenSectionProps {
 
 export function V7WhatIWasGivenSection({ onSendMessage }: V7WhatIWasGivenSectionProps = {}) {
   const [open, setOpen] = useState(false)
+  const recordedScenarioId = useContextIntegrityStore((s) => s.scenarioId)
   const briefText = useContextIntegrityStore((s) => s.briefText)
   const manifest = useContextIntegrityStore((s) => s.manifest)
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+
+  // ── THE IDENTITY GATE — read the store's header before touching this ───────
+  //
+  // This panel's whole claim is *"this is what YOU gave ME, on THIS decision"*.
+  // It is the one surface where showing the right shape of the wrong content is
+  // worse than showing nothing, so it renders ONLY on a POSITIVE identity match
+  // and treats every other case as "we have nothing for this decision".
+  //
+  // ⚠ IT MUST BE A POSITIVE MATCH, NOT `!==`. A `!==` test passes when either
+  // side is `null`, and `null` is exactly the state this store sits in for a
+  // decision it was never told about — which is the P0: a freshly-minted
+  // scenario's cold read answers `absent`, so `setContextIntegrity` is never
+  // called, nothing is cleared, and the PREVIOUS decision's brief stays live
+  // until a page reload. Requiring both ids to be present and equal makes a
+  // store that was never written for this decision indistinguishable from an
+  // empty one — which is the truthful reading of it.
+  //
+  // Suppressing rather than refetching is deliberate: there is no fetch this
+  // component owns (`serverGraphHydration` is the sole writer, once per
+  // scenario id), and inventing one here would race the boot path. Silence is
+  // the honest answer; the previous decision's brief never is.
+  const isForCurrentDecision =
+    typeof recordedScenarioId === 'string' && recordedScenarioId === currentScenarioId
+  if (!isForCurrentDecision) return null
 
   if (briefText === null && manifest === null) return null
 

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
@@ -81,6 +81,17 @@ const B1_DROPPED_NRR = '112%' // trace atom B1-A22, graded SEVERE
 const B1_KEPT_CAP = '£1.5m' // trace atom B1-A20, faithful (cap 1.5 £m)
 const B2_DANA = "Dana's across-the-board RIF option"
 
+/**
+ * ── THE TWO DECISION IDENTITIES ────────────────────────────────────────────
+ * Real scenario ids are UUIDs (`scenarios.id` is a uuid column, and
+ * `serverGraphHydration` refuses anything else), so these are UUID-shaped.
+ * `LIVE_SCENARIO_ID` is the decision on screen throughout this spec;
+ * `OTHER_SCENARIO_ID` is the one the user has LEFT — it exists only to prove
+ * its content can never reach the screen.
+ */
+const LIVE_SCENARIO_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_SCENARIO_ID = '22222222-2222-4222-8222-222222222222'
+
 const PROVENANCE_KEYS = ['_provenance']
 function coldReadOf(fixture: Record<string, unknown>) {
   return Object.fromEntries(
@@ -89,10 +100,16 @@ function coldReadOf(fixture: Record<string, unknown>) {
 }
 
 /** Seed the store exactly as `serverGraphHydration` does, through the REAL
- *  boundary parser — never a hand-built manifest object. */
-function seedFrom(fixture: Record<string, unknown>): void {
+ *  boundary parser — never a hand-built manifest object. `scenarioId` defaults
+ *  to the decision on screen; pass `OTHER_SCENARIO_ID` to stage the stale-store
+ *  state the P0 shipped. */
+function seedFrom(
+  fixture: Record<string, unknown>,
+  scenarioId: string | null = LIVE_SCENARIO_ID,
+): void {
   const cold = coldReadOf(fixture)
   useContextIntegrityStore.getState().setContextIntegrity({
+    scenarioId,
     briefText: cold.brief_text,
     manifest: parseNotModelled(cold.not_modelled),
   })
@@ -105,10 +122,15 @@ function openPanel(): void {
 beforeEach(() => {
   localStorage.removeItem('feature.analysisHeroPanel')
   useContextIntegrityStore.getState().reset()
+  // The decision on screen. The surface renders only on a POSITIVE identity
+  // match, so without this every assertion below would exercise the suppressed
+  // branch and agree with itself.
+  useCanvasStore.setState({ currentScenarioId: LIVE_SCENARIO_ID } as never)
 })
 afterEach(() => {
   localStorage.removeItem('feature.analysisHeroPanel')
   useContextIntegrityStore.getState().reset()
+  useCanvasStore.setState({ currentScenarioId: null } as never)
   cleanup()
 })
 
@@ -121,6 +143,92 @@ describe('the fixtures carry the case they are used to prove (anti-vacuity)', ()
     // And the manifest survives the REAL parser — if it did not, every
     // rendering assertion below would be exercising the null branch instead.
     expect(parseNotModelled(cold.not_modelled)?.status).toBe('derived')
+  })
+})
+
+/**
+ * ── THE P0: A DIFFERENT DECISION'S BRIEF, RENDERED AS THE USER'S OWN ────────
+ *
+ * Witnessed on deployed staging (UI 944799c1, 2026-08-10): under "What you gave
+ * me" the panel showed, verbatim, a PREVIOUS session's brief, with a subtitle
+ * counting that brief's figures — through reset-canvas, a new brief, a draft, an
+ * analysis and an edit turn. Only a page reload corrected it.
+ *
+ * Mechanism: `serverGraphHydration` writes this store ONLY on `status: 'graph'`.
+ * A freshly-minted scenario's cold read answers `absent`, so nothing is written;
+ * nothing clears the store either; and the hook attempts once per scenario id,
+ * so it never self-corrects. The store simply kept the previous decision's
+ * content and the surface had no identity assertion to stop it.
+ *
+ * These tests bind to DECISION IDENTITY — "this text belongs to scenario A
+ * while scenario B is current" — never to a value predicate another decision's
+ * brief could also satisfy (CLAUDE.md trap 19).
+ */
+describe("identity gate — the receipt never speaks for a decision it isn't about", () => {
+  it('THE P0: content recorded for another scenario is NOT rendered on this one', () => {
+    // Scenario A's brief is in the store; scenario B (LIVE) is on screen.
+    seedFrom(b1Fixture as never, OTHER_SCENARIO_ID)
+    const { container } = render(<V7WhatIWasGivenSection />)
+
+    expect(screen.queryByTestId('what-i-was-given-section')).toBeNull()
+    expect(screen.queryByTestId('what-i-was-given-brief')).toBeNull()
+    // The subtitle is what exposed the defect in the wild ("27 of 28" on two
+    // unrelated decisions), so it is pinned by name too.
+    expect(screen.queryByTestId('what-i-was-given-summary')).toBeNull()
+    // Bound to the OTHER decision's own words: these literals identify B1's
+    // brief specifically, and none of them may reach the screen.
+    for (const literal of [B1_DROPPED_ARR, B1_DROPPED_NRR, B1_KEPT_CAP]) {
+      expect(container.textContent ?? '').not.toContain(literal)
+    }
+  })
+
+  it("POSITIVE CONTROL — the same seed on the CURRENT decision DOES render", () => {
+    // Without this the absence above could pass by rendering nothing for any
+    // reason at all (trap 13: an absence assertion needs to prove it can see a
+    // presence). Same fixture, same component, only the identity differs.
+    seedFrom(b1Fixture as never, LIVE_SCENARIO_ID)
+    render(<V7WhatIWasGivenSection />)
+
+    expect(screen.getByTestId('what-i-was-given-section')).toBeInTheDocument()
+    openPanel()
+    expect(screen.getByTestId('what-i-was-given-brief').textContent ?? '').toContain(
+      B1_DROPPED_NRR,
+    )
+  })
+
+  it('content recorded with NO scenario id is never rendered', () => {
+    // `null` is what this store holds for a decision it was never told about.
+    seedFrom(b1Fixture as never, null)
+    render(<V7WhatIWasGivenSection />)
+    expect(screen.queryByTestId('what-i-was-given-section')).toBeNull()
+  })
+
+  it('BOTH ids absent is NOT a match — the null===null hole stays shut', () => {
+    // ⚠ THIS TEST EXISTS BECAUSE A MUTANT SURVIVED WITHOUT IT. Dropping the
+    // `typeof recordedScenarioId === 'string'` conjunct — leaving a bare
+    // `recordedScenarioId === currentScenarioId` — passed the whole suite,
+    // because no other case puts BOTH ids at null while content is on file.
+    // In that state a bare equality is `null === null`, i.e. TRUE, and the
+    // panel renders unattributable content as the user's own. This is the
+    // shape the P0 took (`resetCanvas` sets `currentScenarioId: null`), so the
+    // conjunct is the guard and this is the case that pins it.
+    seedFrom(b1Fixture as never, null)
+    useCanvasStore.setState({ currentScenarioId: null } as never)
+    render(<V7WhatIWasGivenSection />)
+
+    expect(screen.queryByTestId('what-i-was-given-section')).toBeNull()
+    expect(screen.queryByTestId('what-i-was-given-brief')).toBeNull()
+  })
+
+  it('a POSITIVE match is required — an unknown current decision renders nothing', () => {
+    // The gate must not be a `!==` test: `!==` passes whenever either side is
+    // null, which is exactly the state a canvas sits in immediately after
+    // "Reset canvas" (`resetCanvas` sets `currentScenarioId: null`) while the
+    // store still holds the decision the user has just left.
+    seedFrom(b1Fixture as never, LIVE_SCENARIO_ID)
+    useCanvasStore.setState({ currentScenarioId: null } as never)
+    render(<V7WhatIWasGivenSection />)
+    expect(screen.queryByTestId('what-i-was-given-section')).toBeNull()
   })
 })
 
@@ -391,6 +499,7 @@ describe('THE TWO SECTIONS MAY NEVER CONTRADICT EACH OTHER ON SCREEN', () => {
       const { briefText, manifest } = caseFor(notation)
       expect(manifest, 'the real parser must accept the real manifest').not.toBeNull()
       useContextIntegrityStore.getState().setContextIntegrity({
+        scenarioId: LIVE_SCENARIO_ID,
         briefText,
         manifest,
       })
@@ -469,6 +578,7 @@ describe('counts come from the manifest, not from the rendered rows', () => {
     expect(manifest?.quantities?.truncated).toBe(true)
 
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: 'A long brief.',
       manifest,
     })
@@ -495,6 +605,7 @@ describe('an unknown untracked code never leaks onto the screen', () => {
       not_tracked: ['corrections_and_second_thoughts', 'some_future_class_v2'],
     })
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: 'A brief.',
       manifest,
     })
@@ -567,6 +678,7 @@ describe('the parser refuses to vouch for what it cannot read', () => {
   it('a payload it cannot read reaches the user as "we cannot tell you"', () => {
     // The end-to-end consequence of the above, at the surface.
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: 'We need £4m out by March 2027.',
       manifest: parseNotModelled({ schema: 'not_modelled.v2', status: 'derived' }),
     })
@@ -590,6 +702,7 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
     // null. The surface must say "we cannot tell you" — not show an empty list,
     // and not stay silent, both of which read as "nothing was dropped".
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: coldReadOf(b1Fixture as never).brief_text,
       manifest: null,
     })
@@ -622,6 +735,7 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
     expect(manifest?.quantities).toBeNull()
 
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: 'We need £4m out by March 2027.',
       manifest,
     })
@@ -641,6 +755,7 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
       not_tracked: ['competing_or_dissenting_proposals'],
     })
     useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
       briefText: 'Should I take the job or stay put?',
       manifest,
     })
@@ -651,6 +766,18 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
   })
 
   it('renders nothing only when there is genuinely nothing on file', () => {
+    // ⚠ THE IDENTITY MUST MATCH HERE, and it is load-bearing for what this test
+    // PROVES. With the store left empty its `scenarioId` is null, the identity
+    // gate suppresses the section first, and this assertion passes without the
+    // empty-state guard below it ever running — a test passing for a reason it
+    // was not written for (CLAUDE.md trap 13b). Recording THIS decision with no
+    // content on file is the state the guard actually exists for, and a mutant
+    // that removes the guard reddens this test only in this form.
+    useContextIntegrityStore.getState().setContextIntegrity({
+      scenarioId: LIVE_SCENARIO_ID,
+      briefText: null,
+      manifest: null,
+    })
     render(<V7WhatIWasGivenSection />)
     expect(screen.queryByTestId('what-i-was-given-section')).toBeNull()
   })


### PR DESCRIPTION
**Do not merge — adversarial review follows.**

## The defect

Witnessed on deployed staging (UI `944799c1`, CEE `1cbe757`, 10 Aug 21:05–21:33 UTC). The surface titled **"What you gave me, and what I did with it"** — whose entire job is to tell the user what Olumi did with *their* brief — rendered **a different decision's brief**, verbatim, under "What you gave me", with a subtitle counting *that* brief's figures ("27 of 28"). It persisted through reset canvas → new brief → draft → analysis → an edit turn. **Only a hard page reload corrected it.** Two unrelated decisions both reporting "27 of 28" is what exposed it.

It has a data-leak shape: on a shared session this renders one person's strategic brief inside another's decision. **Bound:** the store is plain in-memory Zustand (no `persist`), so it cannot cross page loads or profiles — the exposure is one page session, e.g. an unreloaded handover on a shared screen. That bound is a property of the current implementation, not a guarantee; persisting this store later would widen it to a genuine cross-user leak.

## Mechanism (at the bytes)

`serverGraphHydration` writes `contextIntegrityStore` **only** on `result.status === 'graph'`. Every other cold-read outcome — `absent`, `notReadable`, `unavailable`, `refused`, `unusable`, and the non-UUID `skipped` — returns **before** that write. Nothing clears the store either: `reset()` had **zero production callers**, and `DECISION_CONTEXT_CLEAR` — the canonical per-decision clear set, which does carry the sibling 2.312 `serverGraphIdentity` token for exactly this reason — is a partial of `useCanvasStore` and cannot reach a separate store. `useServerGraphHydration` attempts **once per scenario id**, so it never self-corrects. The previous decision's content simply stayed, and a reload fixed it because the store re-initialises empty.

The store had carried a `scenarioId`; it was removed as write-only. That reasoning (trap 10) was right in general and wrong here — the answer was to give the field a **reader**, not delete it. The removal note argued staleness was "answered UPSTREAM", but the upstream guard answers *"is this in-flight response for the scenario the user is still on?"* and runs only on the `'graph'` path, while the render needs *"does the content I am about to show belong to the scenario on screen?"* Two questions under one name (trap 21), differing exactly where the defect lives.

## Reachable set

| Transition | Verdict | How established |
|---|---|---|
| Reset canvas → new decision | **LEAKY** | witnessed live + traced |
| Any 2nd+ decision in one page session, cold read not `graph` | **LEAKY** | traced (same mechanism; reset not required) |
| Scenario switch A→B, B's read `absent`/404/503/401/429/transport-fail | **LEAKY** | traced |
| Local draft (non-UUID id → `skipped`) | **LEAKY** | traced |
| In-flight window during a slow A→B switch | **LEAKY** | traced (now also closed by this fix) |
| Scenario switch A→B where B's read returns `graph` | safe | traced — the write overwrites |
| Virgin profile, **first** decision of a page session | safe | traced — store starts empty |
| Virgin profile, **second** decision, no reload | **LEAKY** | traced — *not* reset-specific |
| Hard reload | safe | witnessed live |

**Not tested by execution:** every row marked *traced* is a state-lifecycle derivation, not a driven browser witness. I did not drive staging; the live evidence is the original witness's. The reset-canvas row is the only one with a live witness.

## The fix

Bind content to its decision and assert it **at the point of render**, so a store nobody cleared cannot defeat it:

- `contextIntegrityStore` carries `scenarioId`, **required** on every write — a new writer cannot omit it by accident.
- `serverGraphHydration` records the scenario the payload came back for.
- `V7WhatIWasGivenSection` renders only on a **positive** identity match, otherwise nothing — the truthful reading of "we have nothing for this decision". It must be positive, not `!==`: `!==` passes when either side is null, which is exactly what `resetCanvas` leaves behind (`currentScenarioId: null`).

Keying the content is what makes clearing unnecessary: an unkeyed clear must be remembered at every transition (trap 12), whereas content carrying its own identity fails safe at the point of use. Twelve effective lines of behaviour change.

## Evidence

**RED-first at pristine `944799c1`**, by name — 51 collected, 3 failed:
- `THE P0: content recorded for another scenario is NOT rendered on this one`
- `content recorded with NO scenario id is never rendered`
- `a POSITIVE match is required — an unknown current decision renders nothing`

**Mutants** — throwaway worktree outside the repo root, isolation proven by *writing* a sentinel and asserting the source was unchanged (inodes compared, trap 9g), HEAD-relative restores, applied-check scoped to `src/`, control at exactly 0, **aim asserted per mutation**:

| # | Mutation | Applied | Result |
|---|---|---|---|
| M0 | control, unmutated | **0** | GREEN 52/52 |
| M1 | identity gate removed | 1 | **RED** — 3 identity tests |
| M2 | gate unconditionally `true` | 1 | **RED** — 3 identity tests |
| M3 | `typeof` conjunct dropped | 1 | **RED** — the null===null test |
| M4 | writer drops `scenarioId` | 1 | **RED** — 36 tests |
| M5 | *unrelated* empty-state guard broken | 1 | **RED on its own test only; identity tests GREEN** |

M5 is the discriminating partner: it proves the identity tests bind to the identity gate specifically, not to any change in the component.

**Two findings the kit forced, both fixed here:**
1. **M3 initially SURVIVED.** No case put *both* ids at null with content on file, so a bare `recordedScenarioId === currentScenarioId` (`null === null` → true) passed the whole suite. Now pinned by `BOTH ids absent is NOT a match`.
2. **The new gate SHADOWED an existing test.** `renders nothing only when there is genuinely nothing on file` began passing via the identity gate rather than the guard it names (trap 13b) — it left the store empty, so `scenarioId` was null and the gate suppressed first. Repaired to record *this* decision with no content, so the empty-state mutant reddens it again.

**Gates, in the required check's step order** (`lint → typecheck → guards`):
- lint: **0 errors**; hooks ratchet **exactly at baseline** (232 violations / 15 files)
- typecheck ratchet: **2487 = baseline 2487**; coverage 3345/3385
- `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version`: all pass
- full suite, sharded 4×: **23,103 passed · 66 skipped · 0 failed**

UI suites run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported; the target spec's own collected count asserted by name (51 pristine → 52 fixed), never inferred from the suite total.

## Scope

This defect only. **The counts-on-reload finding does NOT share this store** — "N worth checking" comes from `StrengthenPanel` via `strengthenStore`, which never reads `contextIntegrityStore`. It is left untouched. It *is* the same defect class, though, and worth its own row: `strengthenStore` has no `scenarioId` and its `_reset` has **zero production callers** (complete manifest: all six non-declaration hits are in `__tests__`). I did not establish causation for the witnessed 5→1 by execution.

No file in this change overlaps the CEE brief-audit/state-query lane — the cause is entirely UI-side and CEE was not touched.

### Known limitation, stated plainly

Where the gate suppresses, the receipt is now **absent** for that session rather than wrong, and hydration will not retry (once per scenario id). A reload still produces the truthful receipt. Truthful absence beats confident wrongness, but closing that gap — re-hydrating when the server graph appears — is a separate change and is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)