### PR TITLE
chore(ui): behaviour-preserving quality pass over the 10-11 Aug wave

### DIFF
--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -24,7 +24,7 @@ import { callV5Turn, getV5Endpoint, type V5CallResult } from '../../v5/v5Adapter
 import { parseV5Response } from '../../v5/responseParser'
 import { openV5TurnStream, __streamInternals as streamTransport } from '../../v5/streamedTurnTransport'
 import { streamStageFrames } from '../../v5/streamedDraftFrames'
-import { consumeStreamedDraftTurn, terminalProvesCommitFailed } from '../../v5/consumeStreamedDraftTurn'
+import { consumeStreamedDraftTurn, reconcileTerminalPreview } from '../../v5/consumeStreamedDraftTurn'
 import { routeV5Response } from '../../v5/responseRouter'
 import { getTimeoutMs } from '../../v5/getTimeoutMs'
 import { isV5Eligible } from '../../v5/eligibility'
@@ -495,14 +495,20 @@ export interface StreamedDraftTurnResult {
    */
   previewOwnsCanvas: boolean
   /**
-   * True in the honest-failure cases: the structure on screen is real and its
-   * numbers will never settle in this session. See `unsettledCause` for which
-   * failure produced the state — the notice copy must state the actual cause
-   * (the three-strings-not-one rule).
-   */
-  unsettled: boolean
-  /**
-   * Which failure produced `unsettled` (undefined when `unsettled` is false):
+   * PRESENT in the honest-failure cases: the structure on screen is real and
+   * its numbers will never settle in this session. Its VALUE is which failure
+   * produced that state — the notice copy must state the actual cause (the
+   * three-strings-not-one rule).
+   *
+   * ⭐ THERE IS DELIBERATELY NO SEPARATE `unsettled` BOOLEAN. There was one,
+   * set in lockstep with this field at every return site — two variables
+   * carrying one fact, which is trap 12 at interface scope, and the shape that
+   * lets a later return site set `unsettled: true` with no cause (an unsettled
+   * state with no honest sentence to say about it) or a cause with
+   * `unsettled: false` (a diagnosed failure the notice never renders). The
+   * presence of a cause IS the unsettled answer, and the type makes the two
+   * impossible to disagree.
+   *
    *   `stream_loss`   — the stream died after GRAPH_READY and the buffered
    *                     fallback found the turn already committed (CEE
    *                     declined to re-draft), OR a 200 terminal carried no
@@ -643,7 +649,7 @@ async function runStreamedDraftTurn(args: {
       // Outcome 1. The buffered body carries the whole graph, so the terminal
       // ingest replaces whatever the preview put up.
       useDraftStore.getState().setDraftStreamPhase('idle', null, null)
-      return { result, previewOwnsCanvas: previewOnCanvas, unsettled: false }
+      return { result, previewOwnsCanvas: previewOnCanvas }
     }
     if (previewOnCanvas) {
       // Outcome 2 — the honest failure. Phase stays non-idle so the run gate
@@ -652,11 +658,11 @@ async function runStreamedDraftTurn(args: {
       useDraftStore
         .getState()
         .setDraftStreamPhase('unsettled', turnClientId, scenarioIdAtDispatch)
-      return { result, previewOwnsCanvas: false, unsettled: true, unsettledCause: 'stream_loss' }
+      return { result, previewOwnsCanvas: false, unsettledCause: 'stream_loss' }
     }
     // Outcome 3.
     useDraftStore.getState().setDraftStreamPhase('idle', null, null)
-    return { result, previewOwnsCanvas: false, unsettled: false }
+    return { result, previewOwnsCanvas: false }
   }
 
   let res: Response
@@ -787,11 +793,16 @@ async function runStreamedDraftTurn(args: {
   //     (gate shut, never persisted) with the honest cause, and sendTurn
   //     renders ONE notice instead of the generic failure copy.
   let previewOwnsCanvas = outcome.renderedGraph !== null
-  const terminalErrorKeepsModel =
-    outcome.terminalError &&
-    outcome.renderedGraph !== null &&
-    !terminalProvesCommitFailed(outcome.terminalPayload)
-  if (outcome.terminalError && outcome.renderedGraph && !terminalErrorKeepsModel) {
+  // The decision is `reconcileTerminalPreview`'s (pure, truth-table-proved
+  // identical to the expression that used to sit here); the EFFECT stays here.
+  const { discardPreview, terminalErrorKeepsModel } = reconcileTerminalPreview(
+    outcome.terminalError,
+    outcome.renderedGraph,
+    outcome.terminalPayload,
+  )
+  // The `!== null` re-check is TypeScript narrowing only: `discardPreview` is
+  // true exclusively on the branch that already required a non-null graph.
+  if (discardPreview && outcome.renderedGraph !== null) {
     discardStreamedPreview(outcome.renderedGraph)
     previewOwnsCanvas = false
   }
@@ -830,7 +841,6 @@ async function runStreamedDraftTurn(args: {
     return {
       result,
       previewOwnsCanvas: false,
-      unsettled: true,
       // The cause decides the notice: a kept model behind a terminal error is
       // a different fact from a 200 that lost its graph, and one sentence
       // cannot state both truthfully.
@@ -839,7 +849,7 @@ async function runStreamedDraftTurn(args: {
   }
 
   useDraftStore.getState().setDraftStreamPhase('idle', null, null)
-  return { result, previewOwnsCanvas, unsettled: false }
+  return { result, previewOwnsCanvas }
 }
 
 /**
@@ -4502,9 +4512,10 @@ export function useConversation(): UseConversationReturn {
         // says "the nodes on the canvas are this turn's own GRAPH_READY
         // preview", which is what lets the terminal ingest take the fresh-draft
         // branch instead of mistaking its own preview for an applied-edit
-        // receipt. `…Unsettled` says the values will not settle in this session.
+        // receipt. `…UnsettledCause` says the values will not settle in this
+        // session, and which failure produced that — its PRESENCE is the
+        // unsettled answer (there is no separate boolean that can disagree).
         let streamedPreviewOwnsCanvas = false
-        let streamedUnsettled = false
         let streamedUnsettledCause: 'stream_loss' | 'terminal_error_model_kept' | undefined
 
         try {
@@ -4552,7 +4563,6 @@ export function useConversation(): UseConversationReturn {
             })
             v5Result = streamed.result
             streamedPreviewOwnsCanvas = streamed.previewOwnsCanvas
-            streamedUnsettled = streamed.unsettled
             streamedUnsettledCause = streamed.unsettledCause
           } else {
             v5Result = await callV5Turn(build.payload, { signal: controller.signal, headers: v5Headers })
@@ -5101,7 +5111,7 @@ export function useConversation(): UseConversationReturn {
             // re-send onto a scenario whose graph is likely committed (CEE's
             // continuation guard declines — the F3 lesson). The
             // DRAFT_FAILED_MODEL_KEPT_NOTICE emitted below (the
-            // streamedUnsettled block) is the single honest statement of this
+            // streamedUnsettledCause block) is the single honest statement of this
             // state, so this branch deliberately renders nothing and raises no
             // send-failure banner: the send demonstrably succeeded.
             // Streamed drafts are never system turns (streamedDraftEligible
@@ -5245,7 +5255,7 @@ export function useConversation(): UseConversationReturn {
           // before its values arrived, a new draft gets the finished model. No
           // duration forecast, no verdict — held to the same bar as the wait
           // narration and pinned by `narrationHonesty.invariant.spec.ts`.
-          if (streamedUnsettled && mode === 'user' && !hidden) {
+          if (streamedUnsettledCause != null && mode === 'user' && !hidden) {
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',

--- a/src/components/results/DecisionConfidencePanel.tsx
+++ b/src/components/results/DecisionConfidencePanel.tsx
@@ -214,28 +214,14 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
   // we now swap in certainty.headline instead so the headline softens with
   // the caveat.
   //
-  // ⚠ `winProbabilityGap` IS NOW RENDER-DEAD (2026-08-10). It used to reach
-  // the user as " by N points" on the softened lede; that suffix is retired
-  // (no surface may state the percentage-point gap between win frequencies),
-  // and `buildCertaintyCopy` no longer reads this field. It is still computed
-  // and passed only so the retirement stayed a copy change; deleting it here
-  // and on the input type is a clean follow-up.
-  const winProbabilityGap = useMemo(() => {
-    const options = data.recommendation.allOptions
-    if (!options || options.length < 2) return undefined
-    const winner = data.recommendation.recommendedOption
-    if (!winner || typeof winner.winProbability !== 'number') return undefined
-    const runnerUp = options
-      .filter(o => o.id !== winner.id && typeof o.winProbability === 'number')
-      .reduce<typeof winner | null>((best, cur) => {
-        if (!best) return cur
-        return (cur.winProbability ?? 0) > (best.winProbability ?? 0) ? cur : best
-      }, null)
-    if (!runnerUp || typeof runnerUp.winProbability !== 'number') return undefined
-    const gapPct = (winner.winProbability - runnerUp.winProbability) * 100
-    return gapPct > 0 ? gapPct : undefined
-  }, [data.recommendation.allOptions, data.recommendation.recommendedOption])
-
+  // ⚠ THE `winProbabilityGap` CHAIN IS GONE (deleted 2026-08-11, the follow-up
+  // the 10 Aug retirement named). It used to reach the user as " by N points"
+  // on the softened lede; that suffix is retired (no surface may state the
+  // percentage-point gap between win frequencies), and `buildCertaintyCopy`
+  // stopped reading the field on 10 Aug — so a 15-line `useMemo` computed the
+  // banned statistic on every render and handed it to a function that ignored
+  // it. Deleting the computation is what makes the retirement structural: the
+  // number no longer exists to be re-rendered by a later branch.
   const certainty = useMemo(() => {
     const winner = data.recommendation.recommendedOption
     if (!winner) return null
@@ -246,7 +232,6 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
       recommendationStability: data.recommendation.recommendationStability,
       analysisStatus: data.recommendation.analysisStatus,
       optionCount: data.recommendation.allOptions.length,
-      winProbabilityGap,
       // SINGLE VERDICT: the shared "is there a leading option?" answer,
       // derived from the same PLoT report the canvas badge reads.
       //
@@ -270,7 +255,6 @@ export const DecisionConfidencePanel = memo(function DecisionConfidencePanel({
     data.recommendation.analysisStatus,
     data.recommendation.allOptions.length,
     data.confidence.tier.tier,
-    winProbabilityGap,
     data.recommendation.verdict,
   ])
 

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -187,6 +187,59 @@ function fallbackDescription(
 }
 
 /**
+ * The non-winner comparative line, for the ONE state both non-winner arms share.
+ *
+ * ⭐⭐ THE "Behind by N percentage points" LINE IS RETIRED (2026-08-10).
+ *
+ * It stated the percentage-point DIFFERENCE between two Monte-Carlo win
+ * frequencies. A difference of two estimates carries more uncertainty than
+ * either estimate does, and printed as a bare integer with no interval it read
+ * as the most precise number on the card while being the least reliable one.
+ * The ratified rule: no user-facing surface states that gap — own-probability
+ * statements only.
+ *
+ * DELETED rather than reworded, and the licence for deleting is derivable at
+ * this seam: the branch requires `option.winProbability != null`, which is the
+ * SAME condition that renders the card's own `win-pct-{id}` readout. So
+ * wherever this line could ever have fired, the option's OWN probability is
+ * already on the card — the number survives, only the difference goes. `''` is
+ * the caller's established withhold idiom (see the ROADMAP 1.223 header): the
+ * caller renders nothing and the card falls back to label + win % + bar, which
+ * are DATA and stay.
+ *
+ * The gap is still COMPUTED, purely as the near-tie predicate here. It is never
+ * rendered.
+ *
+ * ⭐ ONE COPY, TWO CALLERS (2026-08-11). The runner-up arm and the
+ * other-non-winner arm carried byte-identical five-line blocks. They were
+ * changed together at the retirement precisely because leaving either one would
+ * keep the banned quantity on screen for a different slice of the option list —
+ * and two copies is how the next such change reaches only one of them. Returns
+ * `null` when the comparison cannot be made, so each caller keeps its OWN
+ * fallback sentence ("Close competitor" / "Compare against the leading
+ * option"), which is the only thing that ever differed between them.
+ *
+ * ⚠ THE BOUNDARY IS `Math.round(diff * 100) > 0`, NOT `diff > 0`. They are not
+ * the same predicate: a raw difference of +0.004 is a positive `diff` and a
+ * ROUNDED gap of 0, i.e. a tie at the precision this card displays. Rounding
+ * first is what makes the near-tie sentence agree with the two percentages
+ * printed beside it.
+ */
+function tiedOrWithheld(
+  winnerWinProbability: number | null | undefined,
+  optionWinProbability: number | null | undefined,
+): string | null {
+  if (winnerWinProbability != null && optionWinProbability != null) {
+    const gapPct = Math.round((winnerWinProbability - optionWinProbability) * 100)
+    if (gapPct > 0) {
+      return ''
+    }
+    return 'Statistically tied with the leading option'
+  }
+  return null
+}
+
+/**
  * V11: Hinge-aware description for option cards.
  * Used when decisionState is available OR when win probability data exists.
  * Task 9: Specific text using flip data and win probability gap.
@@ -319,34 +372,10 @@ function hingeAwareDescription(
     if (hinge?.alternativeWinnerLabel && hinge.alternativeWinnerLabel === option.label) {
       return `If ${hinge.label} shifts, this option overtakes`
     }
-      // ⭐⭐ THE "Behind by N percentage points" LINE IS RETIRED (2026-08-10).
-      //
-      // It stated the percentage-point DIFFERENCE between two Monte-Carlo win
-      // frequencies. A difference of two estimates carries more uncertainty
-      // than either estimate does, and printed as a bare integer with no
-      // interval it read as the most precise number on the card while being
-      // the least reliable one. The ratified rule: no user-facing surface
-      // states that gap — own-probability statements only.
-      //
-      // DELETED rather than reworded, and the licence for deleting is
-      // derivable at this seam: both arms of this branch require
-      // `option.winProbability != null`, which is the SAME condition that
-      // renders the card's own `win-pct-{id}` readout. So wherever this line
-      // could ever have fired, the option's OWN probability is already on the
-      // card — the number survives, only the difference goes. `''` is this
-      // function's established withhold idiom (see the ROADMAP 1.223 header):
-      // the caller renders nothing and the card falls back to label + win % +
-      // bar, which are DATA and stay.
-      //
-      // The gap is still COMPUTED, purely as the near-tie predicate below. It
-      // is never rendered.
-    if (winnerWinProbability != null && option.winProbability != null) {
-      const gapPct = Math.round((winnerWinProbability - option.winProbability) * 100)
-      if (gapPct > 0) {
-        return ''
-      }
-      return 'Statistically tied with the leading option'
-    }
+    // The retired point-gap line and its surviving near-tie predicate — see
+    // `tiedOrWithheld`, which is the single copy both non-winner arms call.
+    const runnerUpTied = tiedOrWithheld(winnerWinProbability, option.winProbability)
+    if (runnerUpTied !== null) return runnerUpTied
     return 'Close competitor'
   }
   // Task 9: Status quo / baseline — specific copy. ROADMAP 1.239 corrects the
@@ -357,18 +386,12 @@ function hingeAwareDescription(
   if (option.isBaseline) {
     return 'Lowest risk but lowest expected outcome'
   }
-  // Other non-winner. ⭐ Same retirement as the runner-up arm above, and for
-  // the same reason — see that block. Both arms are changed together: leaving
-  // either one would keep the banned quantity on screen for a different slice
-  // of the option list, which is how a "fixed" surface keeps shipping the
-  // defect to the users who happen to have three options.
-  if (winnerWinProbability != null && option.winProbability != null) {
-    const gapPct = Math.round((winnerWinProbability - option.winProbability) * 100)
-    if (gapPct > 0) {
-      return ''
-    }
-    return 'Statistically tied with the leading option'
-  }
+  // Other non-winner. Same retirement and the same near-tie predicate as the
+  // runner-up arm above — now literally the same code, so a future change
+  // cannot reach one arm and miss the other (which would keep the banned
+  // quantity on screen for whoever happens to have three options).
+  const tied = tiedOrWithheld(winnerWinProbability, option.winProbability)
+  if (tied !== null) return tied
   return 'Compare against the leading option'
 }
 

--- a/src/components/results/__tests__/OptionCards.tieBoundary.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.tieBoundary.spec.tsx
@@ -1,0 +1,181 @@
+/**
+ * OptionCards — the near-tie predicate, at its BOUNDARY and on BOTH arms.
+ *
+ * ── WHY THIS FILE EXISTS ──────────────────────────────────────────────────
+ * The runner-up arm and the other-non-winner arm of `hingeAwareDescription`
+ * carried byte-identical five-line blocks. They are now one helper
+ * (`tiedOrWithheld`) called from both. That dedup is only safe if two things
+ * are pinned, and NEITHER was pinned anywhere in the repo before this file:
+ *
+ *   1. THE BOUNDARY IS `Math.round(diff * 100) > 0`, NOT `diff > 0`. They are
+ *      different predicates: a raw difference of +0.002 is a positive `diff`
+ *      and a ROUNDED gap of ZERO — a tie at the precision the card displays.
+ *      Rounding first is what makes this sentence agree with the two
+ *      percentages printed beside it. The pre-existing corpus could not tell
+ *      the two apart: its only fixture is 0.66 vs 0.314, where the raw and
+ *      rounded answers agree, so `diff > 0` passed every existing spec.
+ *
+ *   2. BOTH ARMS still produce it. A single shared helper is a REGRESSION if
+ *      one caller stops reaching it — and "both arms move together" is the
+ *      whole reason the 10 Aug retirement changed them in one commit ("leaving
+ *      either one would keep the banned quantity on screen for a different
+ *      slice of the option list"). Each arm therefore gets its own case, so a
+ *      mutation that breaks ONE caller reds ONE test (trap 19: bind to the
+ *      object, and prove the binding with a discriminating pair).
+ *
+ * ── WHAT THIS FILE IS NOT ─────────────────────────────────────────────────
+ * It is not a claim that the tie copy is the RIGHT copy — that is adjudicated
+ * in ROADMAP 1.223/1.239 and pinned by `ownedLeaderClaim.optionCards.spec.tsx`,
+ * which asserts these sentences are ABSENT on a withheld turn. That absence
+ * suite is why the arms' positive content was never covered: a forbidden-string
+ * list gets safer, never redder, when the string changes.
+ *
+ * CLAUDE.md trap 3: this asserts presence/absence of TEXT and DOM structure.
+ * jsdom cannot prove visibility and nothing here claims it does.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import type { OptionResult } from '../types'
+
+vi.mock('../coaching/askOlumiStore', () => ({ openAskOlumi: vi.fn() }))
+
+const WINNER_ID = 'opt_mac'
+const OTHER_ID = 'opt_dell'
+
+/** The exact sentence, spelled out — a regex would survive a truncation. */
+const TIE_SENTENCE = 'Statistically tied with the leading option'
+
+/**
+ * THE BOUNDARY PAIR. Both have a strictly POSITIVE raw difference; they differ
+ * only in whether it survives rounding to whole percentage points.
+ */
+const TIE = { winner: 0.662, other: 0.66 } // raw +0.002 → rounds to 0pp
+const AHEAD = { winner: 0.67, other: 0.66 } // raw +0.010 → rounds to 1pp
+
+function opts(winnerWin: number, otherWin: number): OptionResult[] {
+  return [
+    {
+      id: WINNER_ID,
+      label: 'Standardise on MacBook Pro',
+      winProbability: winnerWin,
+      isRecommended: true,
+      expected: 68,
+      outcome: { mean: 68, p10: 54, p50: 67, p90: 82 },
+    },
+    {
+      id: OTHER_ID,
+      label: 'Standardise on Dell XPS',
+      winProbability: otherWin,
+      isRecommended: false,
+      expected: 41,
+      outcome: { mean: 41, p10: 30, p50: 40, p90: 52 },
+    },
+  ] as unknown as OptionResult[]
+}
+
+/**
+ * `runnerId` is what selects the ARM: passing it routes the non-winner through
+ * the runner-up branch, omitting it routes the same card through the
+ * other-non-winner branch. Everything else is held identical, so a difference
+ * between the two cases can only come from the arm.
+ */
+function renderCards(pair: { winner: number; other: number }, runnerId?: string) {
+  return render(
+    <OptionCards
+      options={opts(pair.winner, pair.other)}
+      winnerId={WINNER_ID}
+      runnerId={runnerId}
+      hasLeadingOption
+      confidenceTier={'fair' as never}
+      recommendationStability={0.5}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+const cardOf = (container: HTMLElement, id: string): HTMLElement => {
+  const el = container.querySelector<HTMLElement>(`[data-testid="option-card-${id}"]`)
+  if (!el) throw new Error(`option-card-${id} did not render`)
+  return el
+}
+
+const paragraphsOf = (container: HTMLElement, id: string): string[] =>
+  Array.from(cardOf(container, id).querySelectorAll('p')).map((p) => p.textContent ?? '')
+
+describe('the fixtures pin their own precondition', () => {
+  /**
+   * Trap 13b: a boundary test whose fixture silently stops straddling the
+   * boundary keeps passing while testing nothing. Both facts are asserted here
+   * rather than trusted, because they are the ONLY reason the cases below
+   * discriminate `Math.round(diff * 100) > 0` from `diff > 0`.
+   */
+  it('the TIE pair has a strictly positive RAW difference that rounds to zero', () => {
+    expect(TIE.winner - TIE.other).toBeGreaterThan(0)
+    expect(Math.round((TIE.winner - TIE.other) * 100)).toBe(0)
+  })
+
+  it('the AHEAD pair rounds to a positive gap — so the two cases differ', () => {
+    expect(Math.round((AHEAD.winner - AHEAD.other) * 100)).toBeGreaterThan(0)
+  })
+
+  it('POSITIVE CONTROL: both cards render on both pairs', () => {
+    for (const pair of [TIE, AHEAD]) {
+      const { container, unmount } = renderCards(pair, OTHER_ID)
+      expect(cardOf(container, WINNER_ID)).toBeDefined()
+      expect(cardOf(container, OTHER_ID)).toBeDefined()
+      unmount()
+    }
+  })
+})
+
+describe('the near-tie sentence fires at the ROUNDED boundary, on both arms', () => {
+  it('RUNNER-UP arm: a lead that rounds to 0pp reads as a tie', () => {
+    const { container } = renderCards(TIE, OTHER_ID)
+    expect(paragraphsOf(container, OTHER_ID)).toContain(TIE_SENTENCE)
+  })
+
+  it('OTHER-NON-WINNER arm: the same lead reads as the same tie', () => {
+    const { container } = renderCards(TIE, undefined)
+    expect(paragraphsOf(container, OTHER_ID)).toContain(TIE_SENTENCE)
+  })
+
+  it('RUNNER-UP arm: a lead that rounds to 1pp is WITHHELD, not called a tie', () => {
+    const { container } = renderCards(AHEAD, OTHER_ID)
+    expect(paragraphsOf(container, OTHER_ID)).not.toContain(TIE_SENTENCE)
+  })
+
+  it('OTHER-NON-WINNER arm: a lead that rounds to 1pp is WITHHELD too', () => {
+    const { container } = renderCards(AHEAD, undefined)
+    expect(paragraphsOf(container, OTHER_ID)).not.toContain(TIE_SENTENCE)
+  })
+})
+
+describe("the withhold idiom is SILENCE, not a substitute sentence", () => {
+  /**
+   * `''` means the caller renders no paragraph at all (`{description ? … :
+   * null}`), which is the difference between withholding a claim and making a
+   * different one. Asserting the sentence's absence cannot see that: ANY
+   * replacement string would also fail to match `TIE_SENTENCE`. Comparing the
+   * paragraph COUNT can, and does.
+   */
+  for (const [arm, runnerId] of [
+    ['runner-up', OTHER_ID],
+    ['other-non-winner', undefined],
+  ] as const) {
+    it(`${arm} arm: the withheld card renders exactly one paragraph FEWER`, () => {
+      const tie = renderCards(TIE, runnerId)
+      const tieParagraphs = paragraphsOf(tie.container, OTHER_ID)
+      tie.unmount()
+
+      const ahead = renderCards(AHEAD, runnerId)
+      const aheadParagraphs = paragraphsOf(ahead.container, OTHER_ID)
+      ahead.unmount()
+
+      // The tie render must actually have produced the extra paragraph, or the
+      // count comparison below is comparing two nothings (trap 13).
+      expect(tieParagraphs).toContain(TIE_SENTENCE)
+      expect(aheadParagraphs).toHaveLength(tieParagraphs.length - 1)
+    })
+  }
+})

--- a/src/components/results/__tests__/ownedLeaderClaim.surfaces.spec.ts
+++ b/src/components/results/__tests__/ownedLeaderClaim.surfaces.spec.ts
@@ -112,7 +112,6 @@ function certainty(verdict: ReturnType<typeof deriveDecisionVerdict>) {
     recommendationStability: 0.9,
     analysisStatus: 'computed',
     optionCount: 3,
-    winProbabilityGap: 35,
     verdict,
   })
 }

--- a/src/components/results/__tests__/withheldProse.spec.tsx
+++ b/src/components/results/__tests__/withheldProse.spec.tsx
@@ -664,7 +664,6 @@ describe('buildCertaintyCopy — no caller can reach the leader rules without a 
     recommendationStability: 0.9,
     analysisStatus: 'computed' as const,
     optionCount: 3,
-    winProbabilityGap: 30,
   }
 
   it('ANTI-VACUITY: a PERMITTED verdict still reaches the leader-asserting rule', () => {

--- a/src/components/results/utils/__tests__/certaintyCopy.spec.ts
+++ b/src/components/results/utils/__tests__/certaintyCopy.spec.ts
@@ -41,7 +41,9 @@ const WINNER = 'Option A'
  * ⚠ THIS COMMENT PREVIOUSLY SAID "the magnitude-bearing arm is covered
  * separately below". THAT WAS FALSE — there was no such coverage, and (F4)
  * there is now no such arm: it was dead on the live path, since the sole
- * caller passes only `winProbabilityGap` and never the absolute probability.
+ * caller passed only the win-probability GAP and never the absolute
+ * probability (and as of 2026-08-11 the gap input is deleted too, so this
+ * module takes no comparative magnitude at all).
  * It has been deleted rather than wired, because Paul's ruling demotes the
  * comparative number and a magnitude-free sentence here is the CORRECT
  * behaviour. A spec comment advertising coverage that does not exist is the
@@ -129,7 +131,6 @@ describe('buildCertaintyCopy — decision table', () => {
       recommendationStability: 0.55,
       confidenceTier: 'strong',
       coachingReadiness: 'ready',
-      winProbabilityGap: 52,
       verdict: clearVerdict(),
     })
     expect(result.headline).not.toContain('no clear leading option')
@@ -515,14 +516,22 @@ describe('buildCertaintyCopy — decision table', () => {
    * WHAT MUST SURVIVE, and is pinned below: the SOFTENING. The hedge
    * ("currently"), the evidence caveat and the `conservative` flag are the
    * lede's actual job and are untouched — only the banned quantity goes.
+   *
+   * ⭐ UPDATED 2026-08-11: the `winProbabilityGap` INPUT is now gone from
+   * `CertaintyCopyInput` (it had been unread since the retirement, and
+   * `DecisionConfidencePanel` no longer computes it). These cases therefore no
+   * longer pass a gap — there is none to pass. The per-branch copy assertions
+   * are unchanged and still pin the softening; the sweep below dropped its gap
+   * dimension for the same reason and keeps sweeping the branch space, because
+   * "no branch states a point gap" is still a claim worth pinning even though
+   * the input that fed one cannot be supplied any more.
    */
-  describe('the retired winProbabilityGap suffix (Brief 5.2 Task 1)', () => {
+  describe('the retired win-probability point-gap suffix (Brief 5.2 Task 1)', () => {
     it('soft path (needs_work + low stability): states no gap, and KEEPS the hedge and the caveat', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'needs_work',
-        winProbabilityGap: 95,
       })
       expect(result.headline).toBe(`${WINNER} currently leads`)
       expect(result.caveat).toContain('limited evidence')
@@ -534,7 +543,6 @@ describe('buildCertaintyCopy — decision table', () => {
         verdict: clearVerdict(),
         winnerLabel: WINNER,
         confidenceTier: 'fair',
-        winProbabilityGap: 7,
       })
       expect(result.headline).toBe(`${WINNER} currently leads`)
       expect(result.caveat).toBeNull()
@@ -545,7 +553,6 @@ describe('buildCertaintyCopy — decision table', () => {
       const result = buildCertaintyCopy({
         verdict: clearVerdict(),
         winnerLabel: WINNER,
-        winProbabilityGap: 3,
       })
       expect(result.headline).toBe(AHEAD)
     })
@@ -556,7 +563,6 @@ describe('buildCertaintyCopy — decision table', () => {
         winnerLabel: WINNER,
         confidenceTier: 'unknown',
         coachingReadiness: 'close_call',
-        winProbabilityGap: 5,
       })
       expect(result.headline).toBe(AHEAD)
     })
@@ -567,7 +573,6 @@ describe('buildCertaintyCopy — decision table', () => {
         winnerLabel: WINNER,
         confidenceTier: 'strong',
         coachingReadiness: 'ready',
-        winProbabilityGap: 50,
       })
       expect(result.headline).toBe(AHEAD)
     })
@@ -576,7 +581,6 @@ describe('buildCertaintyCopy — decision table', () => {
       const result = buildCertaintyCopy({
         winnerLabel: WINNER,
         recommendationStability: 0.55,
-        winProbabilityGap: 95,
         verdict: tiedVerdict(),
       })
       expect(result.headline).toBe(
@@ -585,31 +589,38 @@ describe('buildCertaintyCopy — decision table', () => {
     })
 
     /**
-     * THE DERIVED GUARD, and the one that matters most: no gap VALUE — of any
-     * magnitude, sign, pluralisation-triggering size, or finiteness — produces
-     * a point-gap clause on ANY branch this module can return. A per-case pin
-     * cannot say that; this sweeps the input space the retired suffix used to
-     * read, across every tier/readiness combination that reaches a leader
-     * headline.
+     * THE DERIVED GUARD, and the one that matters most: NO branch this module
+     * can return states a point gap. A per-case pin cannot say that; this
+     * sweeps every tier × readiness × stability combination that reaches a
+     * leader headline.
+     *
+     * ⭐ 2026-08-11: this used to sweep a third dimension — twelve gap VALUES
+     * fed to the (already unread) `winProbabilityGap` input. That dimension is
+     * gone because the input is gone, which is a STRONGER guarantee than the
+     * sweep was: a magnitude cannot be rendered from a number the type will not
+     * accept. What survives here is the part deletion does not cover — that no
+     * branch invents a point gap from the inputs it DOES take.
      */
-    it('NO gap value on ANY branch emits a point-gap clause', () => {
-      const gaps = [0.4, 1, 3, 4.6, 7, 50, 95, 0, -1, NaN, Infinity, -Infinity]
+    it('NO branch emits a point-gap clause', () => {
       const tiers = ['needs_work', 'fair', 'strong', 'unknown'] as const
       const readiness = ['ready', 'close_call', undefined] as const
+      const stabilities = [undefined, 0, 0.55, 0.7, 0.85, 1]
       let asserted = 0
-      for (const winProbabilityGap of gaps) {
-        for (const confidenceTier of tiers) {
-          for (const coachingReadiness of readiness) {
+      for (const confidenceTier of tiers) {
+        for (const coachingReadiness of readiness) {
+          for (const recommendationStability of stabilities) {
             const r = buildCertaintyCopy({
               verdict: clearVerdict(),
               winnerLabel: WINNER,
               confidenceTier,
               coachingReadiness: coachingReadiness as never,
-              winProbabilityGap,
+              recommendationStability,
             })
             const text = [r.headline, r.sub, r.caveat].filter(Boolean).join(' • ')
-            expect(text, `gap=${winProbabilityGap} tier=${confidenceTier} readiness=${coachingReadiness}`)
-              .not.toMatch(/\bby\s+-?\d+(\.\d+)?\s+points?\b/i)
+            expect(
+              text,
+              `tier=${confidenceTier} readiness=${coachingReadiness} stability=${recommendationStability}`,
+            ).not.toMatch(/\bby\s+-?\d+(\.\d+)?\s+points?\b/i)
             expect(text).not.toMatch(/percentage\s+points?/i)
             asserted += 1
           }
@@ -617,7 +628,7 @@ describe('buildCertaintyCopy — decision table', () => {
       }
       // The sweep must actually have swept (trap 13: an assertion loop that
       // ran zero times passes by testing nothing).
-      expect(asserted).toBe(gaps.length * tiers.length * readiness.length)
+      expect(asserted).toBe(tiers.length * readiness.length * stabilities.length)
     })
   })
 

--- a/src/components/results/utils/certaintyCopy.ts
+++ b/src/components/results/utils/certaintyCopy.ts
@@ -51,13 +51,15 @@
  *      → "{winner} came out ahead most often across simulated scenarios"
  *
  *   ⭐ THE "[ by N points]" SUFFIX IS RETIRED (2026-08-10). Brief 5.2 Task 1
- *   appended it whenever the caller supplied a positive finite
- *   `winProbabilityGap`, to preserve the numeric lead without PLoT's
- *   over-confident "clear leader / X-point advantage" framing. The number it
- *   preserved was the percentage-point gap between two win frequencies, which
- *   no user-facing surface may state. The DEFENCE against that PLoT framing is
- *   unchanged and lives where it always did — the `conservative` flag, which
- *   keeps `coachingHeadline` from winning the precedence chain.
+ *   appended it whenever the caller supplied a positive finite win-probability
+ *   gap, to preserve the numeric lead without PLoT's over-confident "clear
+ *   leader / X-point advantage" framing. The number it preserved was the
+ *   percentage-point gap between two win frequencies, which no user-facing
+ *   surface may state. The input that carried it is GONE from this module's
+ *   type as of 2026-08-11 — there is no longer a gap to render. The DEFENCE
+ *   against that PLoT framing is unchanged and lives where it always did — the
+ *   `conservative` flag, which keeps `coachingHeadline` from winning the
+ *   precedence chain.
  *
  * British English. No em dashes in UI strings (use a period to separate
  * clauses instead). See DESIGN_SYSTEM.md and Brief 5.1 §Operating
@@ -76,17 +78,6 @@ export interface CertaintyCopyInput {
   recommendationStability?: number
   analysisStatus?: 'computed' | 'partial' | 'failed' | 'blocked'
   optionCount?: number
-  /**
-   * Brief 5.2 Task 1: win-probability gap (percentage points) between the
-   * winner and the next option.
-   *
-   * ⚠ UNREAD SINCE 2026-08-10 — this function no longer consumes it (the
-   * " by N points" suffix it fed is retired). Kept on the type so the sole
-   * caller still compiles; removing it, together with `DecisionVerdict.gapPp`
-   * which also has zero production readers, is a clean follow-up rather than
-   * scope on the change that retired the copy.
-   */
-  winProbabilityGap?: number
   /**
    * SINGLE VERDICT: the shared answer to "is there a leading option?"
    * (`src/lib/decisionVerdict.ts`), derived from the same PLoT report the
@@ -196,10 +187,11 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
   // caveat and the `conservative` flag are the lede's actual job. Only the
   // quantity goes.
   //
-  // `winProbabilityGap` is left on the input type and still passed by
-  // `DecisionConfidencePanel`; it is now UNREAD here. Removing the field (and
-  // `DecisionVerdict.gapPp`, which already has zero production readers) is a
-  // clean follow-up, deliberately not folded into this change.
+  // ⭐ AND THE FOLLOW-UP LANDED (2026-08-11). `winProbabilityGap` is no longer
+  // on this input type, and `DecisionConfidencePanel` no longer computes it —
+  // so the retirement is now STRUCTURAL rather than a copy decision a later
+  // branch could quietly undo. `DecisionVerdict.gapPp` is deliberately still
+  // there: it is typed contract surface with its own rowed disposition.
 
   /**
    * The re-anchored leader sentence — the comparative quantity, named, with
@@ -208,11 +200,12 @@ export function buildCertaintyCopy(input: CertaintyCopyInput): CertaintyCopy {
    *
    * ⚠ F4 — WHY THERE IS NO MAGNITUDE-BEARING ARM HERE, adjudicated.
    * The first draft added `winProbability` to this input and branched on it.
-   * That arm was DEAD: the sole caller (`DecisionConfidencePanel`) passes
-   * only `winProbabilityGap`, never the absolute probability, so the branch
+   * That arm was DEAD: the sole caller (`DecisionConfidencePanel`) passed
+   * only the win-probability GAP, never the absolute probability, so the branch
    * could not execute on any live path — and it carried the mid-sentence
    * casing defect (§10.2) precisely because nothing exercised it. Its spec
-   * even advertised coverage that did not exist.
+   * even advertised coverage that did not exist. (The gap input itself was
+   * deleted on 2026-08-11; no comparative magnitude reaches this module now.)
    *
    * Deleted rather than wired: Paul's ruling DEMOTES the comparative number
    * below the goal number, so a magnitude-free comparative sentence on this

--- a/src/components/results/v7/buildV7Headline.ts
+++ b/src/components/results/v7/buildV7Headline.ts
@@ -319,6 +319,13 @@ function runnerUpSubline(
    * product. Suppression is right here; a surface that EXPLAINS that state is
    * a real product question and a separate piece of work.
    */
+  // ⚠ NOT `DecisionVerdict.gapPp`, and the difference is the whole point of the
+  // block above: `gapPp` is TOP1 − TOP2 (the two highest win probabilities,
+  // measuring whether the analysis discriminates at all), whereas this is
+  // DESIGNATED WINNER − best rival, which goes NEGATIVE exactly when the
+  // producer's recommendation is not the win-probability argmax — the state
+  // this guard exists to suppress. Same units, different numerator; do not
+  // substitute one for the other.
   const leadPoints = Math.round((winProbability - first.winProbability) * 100)
   if (leadPoints <= 0) return null
 

--- a/src/v5/__tests__/reconcileTerminalPreview.spec.ts
+++ b/src/v5/__tests__/reconcileTerminalPreview.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * `reconcileTerminalPreview` — the branch that decides whether a
+ * SERVER-COMMITTED MODEL IS DESTROYED. Proved row by row against the exact
+ * expression it replaced.
+ *
+ * ── WHY THIS FILE EXISTS ──────────────────────────────────────────────────
+ * The decision used to live inline in `useConversation.runStreamedDraftTurn`
+ * as:
+ *
+ *   const terminalErrorKeepsModel = A && G && !P
+ *   if (A && G && !terminalErrorKeepsModel) discardStreamedPreview(...)
+ *
+ * `A && G && !(A && G && !P)` reduces to `A && G && P`, but a reader had to
+ * perform that reduction to see it — on the one branch in this codebase whose
+ * wrong answer removed a committed graph from the canvas and told the user
+ * nothing was drafted (the measured 8 Aug 2026 journey: GRAPH_READY 96.981 s,
+ * terminal COMPLETE 504 UPSTREAM_TIMEOUT 125.202 s).
+ *
+ * A shape change on THAT branch is only safe if it is proved equivalent, and
+ * an inline branch inside an unexported network-driven function cannot carry
+ * such a proof. So the decision (pure) was lifted out; the effects stayed.
+ *
+ * ── WHAT THIS SPEC IS, AND IS NOT ─────────────────────────────────────────
+ * It is a TRUTH TABLE over the three booleans, complete at 8 of 8 rows, with
+ * the OLD expression transcribed literally as the oracle. That is what makes
+ * it an equivalence proof rather than a restatement of the new code's opinion
+ * of itself — the oracle is the code that shipped, not the code under test.
+ *
+ * It is NOT a claim that the decision is the RIGHT one (trap 13c: a mutant kit
+ * validates sensitivity, never correctness). The rightness of "discard only on
+ * proven commit failure" is adjudicated in `terminalProvesCommitFailed`'s
+ * docblock and pinned end-to-end by `streamedDraftTurn.spec.ts`'s two
+ * behavioural cases. This file pins that the REWRITE changed nothing.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  reconcileTerminalPreview,
+  terminalProvesCommitFailed,
+} from '../consumeStreamedDraftTurn'
+import type { StageGraph } from '../streamedDraftFrames'
+
+// ---------------------------------------------------------------------------
+// The three booleans, and the wire values that produce them
+// ---------------------------------------------------------------------------
+
+/** G = true. A real preview object, as `onGraphReady` recorded it. */
+const GRAPH: StageGraph = { nodes: [{ id: 'n1' }], edges: [] }
+
+/** P = true. The captured route-v2 `!dg.commitPerformed` envelope (§1.4). */
+const PROVES_COMMIT_FAILED = {
+  error: 'INTERNAL_ERROR',
+  validator: 'turn_commit',
+  details: { retryable: true, reason: 'draft_graph_commit_failed' },
+}
+
+/** P = false. The measured 504 UPSTREAM_TIMEOUT class — proves nothing. */
+const PROVES_NOTHING = { error: 'UPSTREAM_TIMEOUT', status: 504 }
+
+/**
+ * ANTI-VACUITY (trap 13: an absence assertion must first prove it can see a
+ * presence). If both payload fixtures produced the same `P`, every row below
+ * would still pass while testing only two of the three dimensions.
+ */
+describe('the fixtures actually discriminate P', () => {
+  it('the two payloads produce OPPOSITE commit-failure verdicts', () => {
+    expect(terminalProvesCommitFailed(PROVES_COMMIT_FAILED)).toBe(true)
+    expect(terminalProvesCommitFailed(PROVES_NOTHING)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The oracle: the pre-change expression, transcribed literally
+// ---------------------------------------------------------------------------
+
+/**
+ * VERBATIM from `useConversation.ts` at 084ff1f7, with the variable names kept:
+ *
+ *   const terminalErrorKeepsModel =
+ *     outcome.terminalError &&
+ *     outcome.renderedGraph !== null &&
+ *     !terminalProvesCommitFailed(outcome.terminalPayload)
+ *   if (outcome.terminalError && outcome.renderedGraph && !terminalErrorKeepsModel) {
+ *     discardStreamedPreview(outcome.renderedGraph)
+ *   }
+ *
+ * Transcribed, not re-derived: the point is to compare against what SHIPPED,
+ * so any simplification here would defeat the whole exercise. The `!!` on the
+ * discard line reproduces the original's TRUTHINESS test on `renderedGraph`
+ * (the old line tested the object, not `!== null`) — that distinction is
+ * itself part of what the table proves is immaterial.
+ */
+function oldDecision(
+  terminalError: boolean,
+  renderedGraph: StageGraph | null,
+  terminalPayload: unknown,
+): { discardPreview: boolean; terminalErrorKeepsModel: boolean } {
+  const terminalErrorKeepsModel =
+    terminalError && renderedGraph !== null && !terminalProvesCommitFailed(terminalPayload)
+  const discardPreview = !!(terminalError && renderedGraph && !terminalErrorKeepsModel)
+  return { discardPreview, terminalErrorKeepsModel }
+}
+
+// ---------------------------------------------------------------------------
+// The table
+// ---------------------------------------------------------------------------
+
+interface Row {
+  A: boolean
+  G: boolean
+  P: boolean
+  /** What the branch must do — stated independently of both implementations. */
+  discardPreview: boolean
+  terminalErrorKeepsModel: boolean
+}
+
+/**
+ * All 8 rows. `discardPreview` is true on EXACTLY ONE of them — the row where
+ * the wire said "nothing was written". Every other row keeps the graph,
+ * because keeping is the direction that cannot destroy a committed model.
+ */
+const TABLE: readonly Row[] = [
+  { A: false, G: false, P: false, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: false, G: false, P: true, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: false, G: true, P: false, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: false, G: true, P: true, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: true, G: false, P: false, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: true, G: false, P: true, discardPreview: false, terminalErrorKeepsModel: false },
+  { A: true, G: true, P: false, discardPreview: false, terminalErrorKeepsModel: true },
+  { A: true, G: true, P: true, discardPreview: true, terminalErrorKeepsModel: false },
+]
+
+const label = (r: Row) => `A=${r.A ? 1 : 0} G=${r.G ? 1 : 0} P=${r.P ? 1 : 0}`
+const argsFor = (r: Row) =>
+  [r.A, r.G ? GRAPH : null, r.P ? PROVES_COMMIT_FAILED : PROVES_NOTHING] as const
+
+describe('reconcileTerminalPreview — the 8-row truth table', () => {
+  it('covers the whole input space (2^3 rows, no duplicates)', () => {
+    expect(TABLE).toHaveLength(8)
+    expect(new Set(TABLE.map(label)).size).toBe(8)
+  })
+
+  for (const row of TABLE) {
+    it(`${label(row)} → discard=${row.discardPreview ? 1 : 0} keepsModel=${row.terminalErrorKeepsModel ? 1 : 0}`, () => {
+      expect(reconcileTerminalPreview(...argsFor(row))).toEqual({
+        discardPreview: row.discardPreview,
+        terminalErrorKeepsModel: row.terminalErrorKeepsModel,
+      })
+    })
+  }
+
+  it('AGREES WITH THE PRE-CHANGE EXPRESSION on every row (old === new, 8/8)', () => {
+    let compared = 0
+    for (const row of TABLE) {
+      const args = argsFor(row)
+      expect(reconcileTerminalPreview(...args), label(row)).toEqual(oldDecision(...args))
+      compared += 1
+    }
+    // The loop must actually have run (trap 13: a comparison loop that ran
+    // zero times passes by testing nothing).
+    expect(compared).toBe(8)
+  })
+
+  it('DISCARDS ON EXACTLY ONE ROW — the one where the wire proved the commit failed', () => {
+    const discarding = TABLE.filter((r) => reconcileTerminalPreview(...argsFor(r)).discardPreview)
+    expect(discarding.map(label)).toEqual(['A=1 G=1 P=1'])
+  })
+
+  it('the two outputs are never both true — a discarded preview is not a kept model', () => {
+    for (const row of TABLE) {
+      const out = reconcileTerminalPreview(...argsFor(row))
+      expect(out.discardPreview && out.terminalErrorKeepsModel, label(row)).toBe(false)
+    }
+  })
+})
+
+describe('the payload is only walked when it can matter', () => {
+  it('an unreadable payload is harmless on every row that does not read it', () => {
+    // Not a performance claim — a CORRECTNESS one. The old `&&` chain
+    // short-circuited before `terminalProvesCommitFailed`, and the nested form
+    // must too, or a hostile/garbage 200 payload gains a say it never had.
+    for (const payload of [undefined, null, 'nonsense', [], 0]) {
+      expect(reconcileTerminalPreview(false, GRAPH, payload)).toEqual({
+        discardPreview: false,
+        terminalErrorKeepsModel: false,
+      })
+      expect(reconcileTerminalPreview(true, null, payload)).toEqual({
+        discardPreview: false,
+        terminalErrorKeepsModel: false,
+      })
+    }
+  })
+})

--- a/src/v5/consumeStreamedDraftTurn.ts
+++ b/src/v5/consumeStreamedDraftTurn.ts
@@ -47,6 +47,7 @@ import {
   type StageGraph,
   type StreamAbandonReason,
 } from './streamedDraftFrames'
+import { isRecord } from '../lib/guards'
 
 export interface StreamedDraftHandlers {
   /** Fired once, on the opening frame (live: 271 ms). */
@@ -211,12 +212,60 @@ function computeDrift(preview: unknown, terminal: unknown): IdentityDrift | null
  * destroy a committed model.
  */
 export function terminalProvesCommitFailed(payload: unknown): boolean {
-  const record = (v: unknown): Record<string, unknown> | null =>
-    typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : null
-  const root = record(payload)
-  if (!root) return false
-  const containers = [root, record(root.details), record(root.error), record(record(root.error)?.details)]
-  return containers.some((c) => c !== null && c.reason === 'draft_graph_commit_failed')
+  // `isRecord` is the repo's canonical plain-object guard (`src/lib/guards.ts`)
+  // — same predicate, one definition. This module used to carry a private copy,
+  // which is the hand-maintained-mirror shape that file exists to end.
+  if (!isRecord(payload)) return false
+  const error = isRecord(payload.error) ? payload.error : null
+  const containers: unknown[] = [payload, payload.details, payload.error, error?.details]
+  return containers.some((c) => isRecord(c) && c.reason === 'draft_graph_commit_failed')
+}
+
+/**
+ * The terminal-frame reconciliation DECISION, as the two facts its caller needs.
+ *
+ * ⭐ THIS IS A SHAPE CHANGE ONLY — the truth table is IDENTICAL to the
+ * expression it replaces, and `reconcileTerminalPreview.spec.ts` proves that
+ * row by row against a literal transcription of the old form. It used to read:
+ *
+ *   const terminalErrorKeepsModel = A && G && !P
+ *   if (A && G && !terminalErrorKeepsModel) discard()
+ *
+ * i.e. `A && G && !(A && G && !P)`, which reduces to `A && G && P` — the reader
+ * had to perform that reduction to see that the discard fires ONLY on proven
+ * commit failure. The nested form below states it directly, which matters here
+ * more than anywhere: this is the branch that decides whether a
+ * server-committed model is DESTROYED (the 8 Aug journey P0).
+ *
+ * Extracted out of `runStreamedDraftTurn` rather than left inline because that
+ * function is unexported and network-driven, so an inline branch cannot carry
+ * a truth-table proof. The decision is pure; the effects stay with the caller.
+ *
+ *   A = `terminalError`      — the terminal frame was a ≥400
+ *   G = `renderedGraph !== null` — a preview of ours is on the canvas
+ *   P = `terminalProvesCommitFailed(payload)` — the wire says nothing was written
+ *
+ * `discardPreview` is true ONLY on A ∧ G ∧ P. Every other row keeps the graph,
+ * because keeping is the direction that cannot destroy a committed model.
+ * `terminalErrorKeepsModel` (A ∧ G ∧ ¬P) is what tells the caller's notice
+ * which of the two honest failures happened.
+ *
+ * `terminalProvesCommitFailed` is read INSIDE the A ∧ G branch, preserving the
+ * short-circuit the old `&&` chain had: on an ordinary 200 the payload is never
+ * walked.
+ */
+export function reconcileTerminalPreview(
+  terminalError: boolean,
+  renderedGraph: StageGraph | null,
+  terminalPayload: unknown,
+): { discardPreview: boolean; terminalErrorKeepsModel: boolean } {
+  if (terminalError && renderedGraph !== null) {
+    if (terminalProvesCommitFailed(terminalPayload)) {
+      return { discardPreview: true, terminalErrorKeepsModel: false }
+    }
+    return { discardPreview: false, terminalErrorKeepsModel: true }
+  }
+  return { discardPreview: false, terminalErrorKeepsModel: false }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Behaviour-preserving quality pass over the 10–11 Aug wave. **No user-visible copy change and no predicate-breadth change.** Every rendered string this touches is byte-identical; the specs that prove it are named per item.

Branched from staging `084ff1f7`.

---

## Applied

### 1. Delete the render-dead `winProbabilityGap` chain — DONE
The `" by N points"` suffix was retired on 10 Aug and `buildCertaintyCopy` stopped reading the field, but a 15-line `useMemo` in `DecisionConfidencePanel` kept computing the banned statistic on every render and handing it to a function that ignored it. Deleted: the `useMemo`, the prop pass, the dep-array entry, and `CertaintyCopyInput.winProbabilityGap`.

Re-verified at my tip before deleting, with a contrast control (trap 13e): `rg -ain winProbabilityGap src/ tests/ e2e/` → 22 hits, all comments/type/spec-inputs, **zero readers**; contrast `gapPp` → 42 hits (probe demonstrably not blind). After: only explanatory comments remain.

`DecisionVerdict.gapPp` is **untouched** (do-not-touch list — typed contract surface, rowed separately).

Specs: three files passed the field as an unread input and no longer do (`ownedLeaderClaim.surfaces`, `withheldProse`, `certaintyCopy`). The `certaintyCopy` sweep that fed 12 gap VALUES to the unread input dropped that dimension — **the deletion is a stronger guarantee than the sweep was** (a magnitude cannot be rendered from a number the type will not accept) — and was rebound to sweep tier × readiness × stability instead, so "no branch invents a point gap from the inputs it DOES take" is still pinned. Four stale present-tense comments asserting the field "is still passed" were corrected rather than left to become the next false premise.

### 2. Delete the derivable `unsettled` boolean — DONE
**Lockstep proved first**, as the brief required: all five return sites set `unsettled: true` exactly where `unsettledCause` is non-null (`:652 :661 :665 :844 :853` pre-change). No site sets them independently. Removed the boolean; the one consumer now tests `streamedUnsettledCause != null`.

Post-deletion sweep: `.unsettled` property reads → **0**; contrast control `.unsettledCause` → 1 (the consumer). The type now makes "unsettled with no cause" and "a cause the notice never renders" unrepresentable.

### 3. Simplify the preview-discard condition — DONE
`A && G && !(A && G && !P)` reduces to `A && G && P`. The reader had to perform that reduction on **the branch that decides whether a server-committed model is destroyed** (the 8 Aug journey P0). Rewritten as the nested if/else the adjacent comment already described.

**Deviation, stated:** the nested form was lifted into a pure `reconcileTerminalPreview` in `consumeStreamedDraftTurn.ts` (beside `terminalProvesCommitFailed`, whose docblock already adjudicates this decision) rather than left inline. Reason: `runStreamedDraftTurn` is unexported and network-driven, so an inline branch **cannot carry the truth-table proof the brief makes mandatory**. Effects stayed at the call site; the short-circuit is preserved (the payload is never walked on an ordinary 200).

`reconcileTerminalPreview.spec.ts` — 14 tests. All 8 rows, plus `old === new` against a **literal transcription of the pre-change expression** (the oracle is the code that shipped, not the new code's opinion of itself), plus an anti-vacuity control proving the two payload fixtures produce opposite `P`.

### 4. Canonical record guard — DONE
`terminalProvesCommitFailed` now imports `isRecord` from `src/lib/guards.ts` instead of a private copy. Container semantics unchanged (top level, `details`, `error`, `error.details`), proven by the existing 21-test suite. `ceeRecovery.ts`'s twin left alone (out of scope).

### 5. Deduplicate the OptionCards tie block — DONE
Two byte-identical five-line blocks → one `tiedOrWithheld` helper called from both arms. `Math.round(diff * 100) > 0` **survives verbatim**; `diff > 0` does not appear anywhere (only in a comment naming it as the forbidden form). Each caller keeps its own fallback sentence, which is the only thing that ever differed.

**⚠ This is where mutation testing found something, and it is a pre-existing gap, not one this PR introduced.** Mutating the production line to `diff > 0` left **every existing OptionCards spec GREEN** (9 spec files, incl. `OptionCards.spec.tsx` and `ownedLeaderClaim.optionCards.spec.tsx`). Cause: the only fixture is 0.66 vs 0.314, where raw and rounded agree; and the pre-existing coverage is a **forbidden-string list**, which gets safer — never redder — when the string changes. So the arms' positive content was uncovered and the boundary was unpinned.

Added `OptionCards.tieBoundary.spec.tsx` (9 tests) bound to **rendered output**: +0.002 (raw positive, rounds to 0pp) must read as a tie; +0.010 must be withheld. Each arm gets its own case, and the withhold idiom is pinned by paragraph **count**, because an absence assertion cannot distinguish `''` from any other replacement string.

## Skipped

### 6. `leadPoints` extraction — SKIPPED (deliberate, reason below)
Mechanically it *is* a clean pure hoist. It is skipped on judgement, because shipping it would create a canonical-looking export that is not canonical:

- `decisionVerdict.ts` exports `deriveDecisionVerdict` / `normalizeHeadlineBanded` — report-shaped derivations. **`gapPp` is a FIELD, not a function**, so the proposed "second named export" would have no sibling of its kind to sit beside.
- The same arithmetic lives at **three** sites: `buildV7Headline.leadPoints`, `OptionCards.tiedOrWithheld` (which item 5 explicitly requires to stay LOCAL), and `OptionNode.closeCallGapPp`. Publishing one of them into `src/lib` while two local copies remain mints a name that **reads** as the single source of truth and is not one — the guarantee-theatre shape, and the differently-named-twins hazard, for a one-line `Math.round`.

The actual value on offer — stopping the two quantities being conflated — is delivered without the hoist: `leadPoints` now carries a comment naming `gapPp` and the exact difference (top1−top2 vs designated-winner−best-rival, and why the latter goes negative). A genuine three-site consolidation is a separate, rowable change.

---

## Verification

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run; `set -o pipefail`; all runner args quoted.

Required check is **`Staging Gate`** (derived: `gh api .../branches/staging/protection`), which needs `tsc`, `typecheck-selftest`, `vitest`, `vitest-summary`, `build`. All run locally at this head:

| Step | Result |
|---|---|
| `pnpm run lint` (+ hooks ratchet) | ✅ 0 errors; ratchet 232/232 exact |
| `pnpm run typecheck` | ✅ coverage 3348/3388 files; ratchet 2487 = baseline 2487 |
| `pnpm run typecheck:selftest` | ✅ 18 passed / 0 failed |
| `pnpm run ci:guard:zustand` · `ci:guard:starters` · `check:vendor` · `ci:guard:schemas-version` | ✅ all pass |
| Full `vitest run` (unsharded) | ✅ **1595 files passed, 3 skipped · 23146 tests passed, 66 skipped, 0 failed** |
| `pnpm run build` | ✅ built in 41.88s |

**Own specs asserted to have collected, BY NAME** (a new spec collecting 0 is invisible to every aggregate): `reconcileTerminalPreview.spec.ts` (14) · `OptionCards.tieBoundary.spec.tsx` (9) · `certaintyCopy.spec.ts` (51) · `consumeStreamedDraftTurn.spec.ts` (21) · `ownedLeaderClaim.surfaces.spec.ts` (6) · `withheldProse.spec.tsx` (45) · `streamedDraftTurn.spec.ts` (44) · `ownedLeaderClaim.optionCards.spec.tsx` (9).

### Mutation battery
Throwaway worktrees **outside** the repo root, mutating only committed state. Isolation proven by **write test** (sentinel written into the worktree, source asserted unchanged) and distinct inodes — not by locating paths (trap 9g). Restores are `git checkout HEAD -- src/` (trap 9h), with a clean-tree assertion **before and after every mutant** and a leading *and* trailing control.

| # | Mutation | Result |
|---|---|---|
| CTL | none — applied count must be exactly 0 | GREEN |
| M1 | invert `terminalProvesCommitFailed` in the nested branch | **RED** (6) |
| M2 | drop the `renderedGraph !== null` conjunct | **RED** (5) |
| M3 | `terminalErrorKeepsModel: true` → `false` | **RED** (2) |
| M4 | drop the `error.details` container | **RED** (1) |
| M5 | withhold `''` → a substitute string | **RED** (2) |
| M6 | truncate the tie sentence | **RED** (4) |
| M7 | invert the `unsettledCause != null` consumer test | **RED** (4) |
| M8 | append a point gap to `aheadHeadline` | **RED** (17) |
| M9 | **`Math.round(diff*100) > 0` → `diff > 0`** | **RED** (4) — *survived every pre-existing spec; this is the mutant the new spec exists for* |
| M10 | break ONLY the runner-up caller | **RED** — reds the 2 runner-up tests |
| M11 | break ONLY the other-non-winner caller | **RED** — reds the 2 other-arm tests |
| CTL2 | trailing control, tree pristine | GREEN |

M10/M11 are a **discriminating pair** (trap 19): they red **disjoint** test sets, which is what proves the assertions bind to their named arm rather than to "something changed". A single biting mutant would not show that.

### Honest limits
- M1–M4, M7, M8 were measured at `02ac8c2e`; the only later commit adds a spec file (`git diff 02ac8c2e becb94ac --name-only` = one path), so those production sources are byte-identical and the results hold at this head. Verified, not assumed.
- A wider mutant sweep over the whole `src/components/results` tree was started and **terminated by PID before completion** (buffered output, CPU contention). The coverage-gap claim above is therefore scoped to the **9 named OptionCards spec files**, not to the whole tree. Stated rather than generalised.
- jsdom proves text and DOM structure, never visibility (trap 3). Nothing here claims otherwise.

**Do not merge without independent review.**
