### PR TITLE
PR4: optional real authentication — the guest front door stops reporting success it never earned

### DIFF
--- a/evidence/pr4-optional-auth/README.md
+++ b/evidence/pr4-optional-auth/README.md
@@ -1,0 +1,133 @@
+# PR4 — optional real authentication + two-person collaboration witness
+
+Evidence for the lane. Everything here was **measured**, on the dates shown; nothing is
+inherited from a document. Where a claim is derived rather than observed, the derivation is
+written out so it can be refuted.
+
+Measured **11 Aug 2026**, against UI staging tip `b62f7e5282cd96798f5062f9045f835afdc9e1b5`
+(`https://staging--olumi.netlify.app/version.json` reported that exact commit, so the deployed
+build and the branch point are the same tree) and CEE staging `assistants 1.12.0`.
+
+---
+
+## 1. Auth capability on staging Supabase — DERIVED, not assumed
+
+Source: `GET /auth/v1/settings` (public, anon-key, read-only) plus one exercised call per method
+with clearly-labelled throwaway accounts at the reserved `example.test` TLD.
+
+| Method | Result today | Evidence |
+|---|---|---|
+| **email + password sign-up** | **WORKS** — HTTP 200, session returned immediately | `disable_signup: false`, `mailer_autoconfirm: true`; `email_confirmed_at` stamped at creation |
+| **email + password sign-in** | **WORKS** — HTTP 200, `access_token` (HS256) | `POST /auth/v1/token?grant_type=password` |
+| **magic link, existing user** | **FAILS** — HTTP 500 `unexpected_failure`, *"Error sending magic link email"* | SMTP not configured on the project |
+| **magic link, unknown user** | HTTP 422 `otp_disabled` | expected: the app passes `shouldCreateUser: false` |
+| **Google OAuth** | **FAILS** — HTTP 400 *"Unsupported provider: provider is not enabled"* | `external.google: false` |
+| **anonymous sign-in** | disabled — HTTP 422 `anonymous_provider_disabled` | `external.anonymous_users: false` |
+
+The anon key used is the one **in the deployed bundle** (public by construction). It is never
+printed here; SHA-256 prefix `22443e6c08d8c378`, which is byte-identical to the value in
+`netlify.toml` — so repo config and deployed reality agree on this one, unusually.
+
+**The load-bearing consequence:** the only method that completes today is the one the product
+does not offer, and both methods the product does offer are blocked on configuration only Paul
+can change. That is why this lane ships an *honest* front door rather than a working one.
+
+## 2. Deployed-bundle posture — crawled, with a contrast control
+
+88 chunks / 5.87 MB crawled from `/assets/index-COspGXQe.js`:
+
+- `GoTrueClient` present in 1 chunk → the **real** Supabase SDK is in the staging bundle
+  (`VITE_STUB_SUPABASE=0` is genuinely in effect).
+- `signInWithOtp` present in 1 chunk.
+- the stub's marker comment present in **0** chunks.
+
+The zero is supported rather than assumed: `GoTrueClient` is the **contrast control** in the same
+sweep, and it read non-zero. An absence claim from a sweep that found nothing at all would be a
+claim about the instrument.
+
+## 3. The two-person witness — BLOCKED, with the cause derived at the bytes
+
+`scripts/witness/pr4-two-person-collab-witness.mjs`
+
+- `--dry-run` → **PASS 7/7**, and those seven are discriminating pairs: three well-formed payloads
+  pass, four corrupted twins fail on a named problem (leaked siblings' answers, leaked model value,
+  missing attribution, rewritten words, missing target). State-class **replayed**: it proves the
+  assertions bite, and nothing about the product.
+- live against staging → **BLOCKED at leg 4**, verdict in `witness-live-verdict.json`.
+  State-class **fresh, two-identity**.
+
+Legs 1–3 passed on the real wire: capability derived, a real Supabase identity obtained, and the
+control refusal observed **before** the acceptance path. Leg 4 (owner mints the round) is blocked.
+
+### Why leg 4 is blocked — and why it is *this* cause and not another
+
+CEE answers every owner call `401 verification_unavailable`. `verification_unavailable` is
+reachable in `src/utils/supabase-user-jwt.ts` from exactly two guards, both of which fire
+**before any signature check**: no `SUPABASE_JWT_SECRET` for an HS256 token, or no JWKS URL for an
+asymmetric one. The token Supabase issues here is **HS256** (`alg` read from the token header;
+the project's JWKS publishes only an ES256 key, which is a *standby* key, not the signing key).
+
+Three probes against the same endpoint, one of which was expected to differ:
+
+| Bearer sent | Response code |
+|---|---|
+| garbage, not JWT-shaped | `invalid_token` |
+| well-formed JWT, **one character flipped in the signature** | `verification_unavailable` |
+| valid, signature-intact HS256 token | `verification_unavailable` |
+
+The first row is the positive control: the route **can** emit a different reason, so
+`verification_unavailable` is discriminating and not a constant. The second row is the decisive
+one: a configured-but-wrong secret would fail signature verification and answer `invalid_token`.
+It answers `verification_unavailable` instead, which is only reachable at the
+`!secret || secret.length === 0` guard.
+
+**Therefore `SUPABASE_JWT_SECRET` is unset or empty on the CEE staging service.** This is a
+derivation from deployed behaviour, not a reading of any config file — CEE's `/v1/status` exposes
+no auth configuration, so it cannot be confirmed from the service's own report.
+
+## 4. RED-first and mutants
+
+**RED-first, at pristine `b62f7e52`,** before any source change:
+`AuthContext.optionalAuth.spec.tsx` collected **12 by name** and **8 failed**; the three new
+`LoginPage` cases failed against the unchanged page. The four that already passed are the
+byte-identical-guest pins, and they are supposed to pass — they exist to fail if the *optional*
+half ever breaks.
+
+**Eight mutants**, in a tree whose isolation was proven **by writing a sentinel and checking the
+source did not change** (not by reading paths — an APFS hard link has defeated that here before),
+against **committed** state, each with an applied-check asserting exactly one file changed in
+`src/`, restored `HEAD`-relative, with a leading and a trailing control that agree.
+
+| Mutant | Result |
+|---|---|
+| `isServerFault` threshold `500` → `600` | 2 RED |
+| `signInUnavailable` drops its `status: 501` (the cross-module seam) | 1 RED |
+| `asFault` stops stamping thrown errors | 1 RED |
+| `asFault` **overwrites** an existing status | 1 RED *(see below)* |
+| guest `signOut` branch removed | 1 RED |
+| `OptionalAuthProvider` never adopts a real session | 1 RED |
+| guest `loading` flipped to `true` | 1 RED |
+| rate-limit status `429` → `431` | 1 RED *(see below)* |
+
+⚠ **Two of those eight SURVIVED on the first pass, and both were real holes, not equivalents.**
+They are recorded because the fix is the interesting part:
+
+- **`asFault` overwrite.** The suite had a 422-keeps-its-status case, but it *resolved* an error,
+  and `asFault` only runs in the `catch`. So the guard against promoting a 422 to a server fault
+  was tested by a case that never reached it — a test passing on the wrong object. Closed by a
+  **thrown** 422 twin. Had it shipped, a refactor could have deleted the guard and reintroduced an
+  enumeration leak through the very code written to remove a lie.
+- **rate-limit `429`.** Every rate-limit fixture also matched the message fallback, so the status
+  branch carried no test weight at all. Closed by a 429 whose wording mentions no rate.
+
+Both were found only because a mutant survived; neither was visible in a green suite.
+
+## 5. What is NOT claimed
+
+- **No UI journey witness.** Everything here is wire-level and jsdom. Neither collaboration page
+  has been rendered in a real browser by this lane, and jsdom cannot prove visibility or layout.
+- **The fixtures are not captures.** No round has ever been minted on staging, so there is no real
+  traffic to record. They are built from the wire contract in `src/collab/collabService.ts` and
+  say so in their own header. When leg 4 unblocks, replace them with real captures.
+- **The ES256 path is untested.** No ES256 token can be minted while the project signs HS256, so
+  whether CEE has `SUPABASE_URL`/`SUPABASE_JWKS_URL` set is **unknown**, not "absent".

--- a/evidence/pr4-optional-auth/bundle-crawl-probe.mjs
+++ b/evidence/pr4-optional-auth/bundle-crawl-probe.mjs
@@ -1,0 +1,32 @@
+const BASE='https://staging--olumi.netlify.app';
+const seen=new Set(); const q=['/assets/index-COspGXQe.js'];
+const found=new Map();
+while(q.length){
+  const p=q.shift(); if(seen.has(p))continue; seen.add(p);
+  let t; try{ const r=await fetch(BASE+p); if(!r.ok){continue;} t=await r.text(); }catch(e){continue;}
+  found.set(p,t.length);
+  for(const m of t.matchAll(/["'`]([./][A-Za-z0-9._\-/]*?\.js)["'`]/g)){
+    let u=m[1];
+    if(u.startsWith('./')) u='/assets/'+u.slice(2);
+    else if(!u.startsWith('/assets/')&&u.startsWith('/')) {}
+    if(!seen.has(u)) q.push(u);
+  }
+  for(const m of t.matchAll(/(assets\/[A-Za-z0-9._-]+\.js)/g)){
+    const u='/'+m[1]; if(!seen.has(u)) q.push(u);
+  }
+}
+console.log('CHUNKS_CRAWLED='+found.size);
+let bytes=0; for(const v of found.values()) bytes+=v;
+console.log('TOTAL_BYTES='+bytes);
+// now search
+const hits={supabaseUrl:new Set(),authMode:new Set(),requireLogin:0,stub:0,signInWithOtp:0,gotrue:0};
+for(const p of found.keys()){
+  const t=await (await fetch(BASE+p)).text();
+  for(const m of t.matchAll(/https:\/\/[a-z0-9]{10,}\.supabase\.co/g)) hits.supabaseUrl.add(m[0]);
+  if(/signInWithOtp/.test(t)) hits.signInWithOtp++;
+  if(/GoTrueClient/.test(t)) hits.gotrue++;
+  if(/feature\.requireLogin/.test(t)) hits.requireLogin++;
+  if(/prevents real SDK|supabase stub/i.test(t)) hits.stub++;
+}
+console.log('SUPABASE_URLS='+JSON.stringify([...hits.supabaseUrl]));
+console.log('signInWithOtp_chunks='+hits.signInWithOtp, 'GoTrueClient_chunks='+hits.gotrue, 'feature.requireLogin_chunks='+hits.requireLogin, 'stubmarker_chunks='+hits.stub);

--- a/evidence/pr4-optional-auth/witness-live-verdict.json
+++ b/evidence/pr4-optional-auth/witness-live-verdict.json
@@ -1,0 +1,45 @@
+{
+  "witness": "PR4 two-person collaboration",
+  "mode": "live wire",
+  "state_class": "fresh, two-identity",
+  "origin": "https://staging--olumi.netlify.app",
+  "started": "2026-08-11T11:16:56.307Z",
+  "finished": "2026-08-11T11:16:59.135Z",
+  "legs": [
+    {
+      "leg": "1. auth capability derived",
+      "status": "PASS",
+      "capability": {
+        "email_provider": true,
+        "google_provider": false,
+        "anonymous_users": false,
+        "disable_signup": false,
+        "mailer_autoconfirm": true
+      }
+    },
+    {
+      "leg": "2. owner identity (real Supabase session)",
+      "status": "PASS",
+      "owner_email": "olumi-witness+owner-1786447016999-8d331f6f@example.test",
+      "owner_user_id": "98650cca-7e77-4cc6-9a5c-bbcac5c3e7fc",
+      "access_token_sha256_prefix": "18c349c40ff13f9e",
+      "method": "email+password (auto-confirmed)"
+    },
+    {
+      "leg": "3. CONTROL: round over an unowned scenario is refused",
+      "status": "PASS",
+      "http": 401,
+      "code": "verification_unavailable",
+      "because": "That token could not be verified."
+    },
+    {
+      "leg": "4. owner mints the round",
+      "status": "BLOCKED",
+      "http": 401,
+      "code": "verification_unavailable",
+      "because": "CEE cannot verify the Supabase access token, so no owner call can reach an ownership check. The token is HS256, and CEE returns verification_unavailable only when SUPABASE_JWT_SECRET is unset (src/utils/supabase-user-jwt.ts — an incorrect secret would answer invalid_token instead).",
+      "remedy": "Set SUPABASE_JWT_SECRET on the CEE staging service (Render) to the Supabase project JWT secret."
+    }
+  ],
+  "overall": "BLOCKED"
+}

--- a/scripts/witness/fixtures/pr4-two-person-collab.json
+++ b/scripts/witness/fixtures/pr4-two-person-collab.json
@@ -1,0 +1,269 @@
+{
+  "_readme": [
+    "Fixtures for `--dry-run` of pr4-two-person-collab-witness.mjs.",
+    "",
+    "These exist to prove the witness's ASSERTIONS BITE, never to stand in for a",
+    "live run. Each case comes in a discriminating pair: a well-formed payload",
+    "that must PASS and a corrupted twin that must FAIL on a named problem. A",
+    "single passing fixture would show only that the assertions can agree with",
+    "something — it could not show they discriminate.",
+    "",
+    "The shapes are taken from the wire contract in src/collab/collabService.ts",
+    "(OpenPacket, RevealView, RevealResponse), not invented here. They are NOT",
+    "captures of real traffic: no live round has ever been minted on staging,",
+    "because CEE cannot verify a Supabase access token (SUPABASE_JWT_SECRET is",
+    "unset). When that lands, replace these with real captures and say so."
+  ],
+  "cases": [
+    {
+      "name": "a blind packet passes",
+      "kind": "packet",
+      "expect": "pass",
+      "target_count": 2,
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "open",
+        "context_note": "Two questions for the panel",
+        "graph_version_ref": "gv_witness_0001",
+        "targets": [
+          { "target": { "kind": "factor", "id": "witness-target-a" }, "label": "Monthly churn rate", "description": null, "unit": "%" },
+          { "target": { "kind": "factor", "id": "witness-target-b" }, "label": "Time to first value", "description": null, "unit": "days" }
+        ],
+        "self": {
+          "participant_id": "22222222-2222-4222-8222-222222222222",
+          "display_name": "Witness Participant",
+          "completed_target_ids": []
+        }
+      }
+    },
+    {
+      "name": "a packet leaking siblings' answers FAILS",
+      "kind": "packet",
+      "expect": "fail",
+      "target_count": 2,
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "open",
+        "context_note": "Two questions for the panel",
+        "graph_version_ref": "gv_witness_0001",
+        "targets": [
+          { "target": { "kind": "factor", "id": "witness-target-a" }, "label": "Monthly churn rate", "description": null, "unit": "%" },
+          { "target": { "kind": "factor", "id": "witness-target-b" }, "label": "Time to first value", "description": null, "unit": "days" }
+        ],
+        "responses": [{ "participant_id": "someone-else", "value": 0.09 }],
+        "self": {
+          "participant_id": "22222222-2222-4222-8222-222222222222",
+          "display_name": "Witness Participant",
+          "completed_target_ids": []
+        }
+      }
+    },
+    {
+      "name": "a packet leaking the model's current value FAILS",
+      "kind": "packet",
+      "expect": "fail",
+      "target_count": 2,
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "open",
+        "context_note": null,
+        "graph_version_ref": "gv_witness_0001",
+        "targets": [
+          { "target": { "kind": "factor", "id": "witness-target-a" }, "label": "Monthly churn rate", "description": null, "unit": "%", "model_value": 0.04 },
+          { "target": { "kind": "factor", "id": "witness-target-b" }, "label": "Time to first value", "description": null, "unit": "days" }
+        ],
+        "self": {
+          "participant_id": "22222222-2222-4222-8222-222222222222",
+          "display_name": "Witness Participant",
+          "completed_target_ids": []
+        }
+      }
+    },
+    {
+      "name": "an attributed reveal passes",
+      "kind": "reveal",
+      "expect": "pass",
+      "expected": {
+        "targetCount": 2,
+        "minResponses": 2,
+        "participantId": "22222222-2222-4222-8222-222222222222",
+        "expressions": [
+          "about one in twenty a month, based on the last two quarters",
+          "a fortnight if onboarding is staffed, longer otherwise"
+        ]
+      },
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "closed",
+        "graph_version_ref": "gv_witness_0001",
+        "per_target": [
+          {
+            "target": { "kind": "factor", "id": "witness-target-a" },
+            "label": "Monthly churn rate",
+            "model_value_at_version": 0.04,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 0.05,
+                "expression_raw": "about one in twenty a month, based on the last two quarters",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          },
+          {
+            "target": { "kind": "factor", "id": "witness-target-b" },
+            "label": "Time to first value",
+            "model_value_at_version": 21,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 14,
+                "expression_raw": "a fortnight if onboarding is staffed, longer otherwise",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "an UNATTRIBUTED reveal FAILS (a number with no author)",
+      "kind": "reveal",
+      "expect": "fail",
+      "expected": {
+        "targetCount": 2,
+        "minResponses": 2,
+        "participantId": "22222222-2222-4222-8222-222222222222",
+        "expressions": [
+          "about one in twenty a month, based on the last two quarters",
+          "a fortnight if onboarding is staffed, longer otherwise"
+        ]
+      },
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "closed",
+        "graph_version_ref": "gv_witness_0001",
+        "per_target": [
+          {
+            "target": { "kind": "factor", "id": "witness-target-a" },
+            "label": "Monthly churn rate",
+            "model_value_at_version": 0.04,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "",
+                "value": 0.05,
+                "expression_raw": "about one in twenty a month, based on the last two quarters",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          },
+          {
+            "target": { "kind": "factor", "id": "witness-target-b" },
+            "label": "Time to first value",
+            "model_value_at_version": 21,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 14,
+                "expression_raw": "a fortnight if onboarding is staffed, longer otherwise",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "a reveal whose words were REWRITTEN FAILS (expertise must survive verbatim)",
+      "kind": "reveal",
+      "expect": "fail",
+      "expected": {
+        "targetCount": 2,
+        "minResponses": 2,
+        "participantId": "22222222-2222-4222-8222-222222222222",
+        "expressions": [
+          "about one in twenty a month, based on the last two quarters",
+          "a fortnight if onboarding is staffed, longer otherwise"
+        ]
+      },
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "closed",
+        "graph_version_ref": "gv_witness_0001",
+        "per_target": [
+          {
+            "target": { "kind": "factor", "id": "witness-target-a" },
+            "label": "Monthly churn rate",
+            "model_value_at_version": 0.04,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 0.05,
+                "expression_raw": "Estimated 5% monthly churn.",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          },
+          {
+            "target": { "kind": "factor", "id": "witness-target-b" },
+            "label": "Time to first value",
+            "model_value_at_version": 21,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 14,
+                "expression_raw": "a fortnight if onboarding is staffed, longer otherwise",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "a reveal MISSING a target FAILS (one axis is not a panel)",
+      "kind": "reveal",
+      "expect": "fail",
+      "expected": {
+        "targetCount": 2,
+        "minResponses": 2,
+        "participantId": "22222222-2222-4222-8222-222222222222",
+        "expressions": ["about one in twenty a month, based on the last two quarters"]
+      },
+      "payload": {
+        "round_id": "11111111-1111-4111-8111-111111111111",
+        "status": "closed",
+        "graph_version_ref": "gv_witness_0001",
+        "per_target": [
+          {
+            "target": { "kind": "factor", "id": "witness-target-a" },
+            "label": "Monthly churn rate",
+            "model_value_at_version": 0.04,
+            "responses": [
+              {
+                "participant_id": "22222222-2222-4222-8222-222222222222",
+                "display_label": "Witness Participant",
+                "value": 0.05,
+                "expression_raw": "about one in twenty a month, based on the last two quarters",
+                "confidence": 0.6,
+                "kind": "belief_submitted"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/witness/pr4-two-person-collab-witness.mjs
+++ b/scripts/witness/pr4-two-person-collab-witness.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+/**
+ * PR4 TWO-PERSON COLLABORATION WITNESS — wire-level, fresh-session.
+ *
+ * ── WHAT IT WITNESSES ─────────────────────────────────────────────────────
+ * The PR4 journey end to end, at the wire, against a DEPLOYED environment:
+ *
+ *   OWNER (a real Supabase identity)   mints a round over two targets
+ *   PARTICIPANT (a round-scoped token) fetches a BLIND packet
+ *   PARTICIPANT                        submits a belief plus their own words
+ *   OWNER                              closes the round
+ *   OWNER                              reads the reveal and sees ATTRIBUTION
+ *
+ * ── THE TWO IDENTITIES, NAMED PRECISELY ───────────────────────────────────
+ * ⚠ The journey needs ONE Supabase login, not two. The participant is
+ * deliberately NOT a Supabase session: `/panel/:round_id` is mounted OUTSIDE
+ * `AuthGuard` (see src/poc/AppPoC.tsx and collabParticipantRouteIsPublic.spec)
+ * because a participant holds a per-round bearer capability instead. Anyone
+ * scripting "two logins" is testing a product that does not exist.
+ *
+ * ── STATE-CLASS ───────────────────────────────────────────────────────────
+ * FRESH, two-identity. The owner account is created by this run and used once;
+ * the participant token is minted by this run. Nothing is replayed and nothing
+ * is seeded. `--dry-run` is a DIFFERENT state-class (replayed) and says so in
+ * its own verdict — it exercises the assertions, never the product.
+ *
+ * ── WHAT IT WILL NOT DO ───────────────────────────────────────────────────
+ * It never weakens a check to make a leg pass. A refusal is a RESULT: the
+ * verdict names the leg, the HTTP status and the service's own error code, so
+ * a BLOCKED run is evidence rather than a failure to produce evidence.
+ *
+ * ── SECRETS ───────────────────────────────────────────────────────────────
+ * Access tokens and participant tokens are never printed, never written to the
+ * evidence file, and never put in a URL. Only lengths and SHA-256 prefixes.
+ * The Supabase anon key is public by construction (it is in the shipped
+ * bundle) but is still taken from the environment, never committed here.
+ *
+ * ── USAGE ─────────────────────────────────────────────────────────────────
+ *   VITE_SUPABASE_URL=... VITE_SUPABASE_ANON_KEY=... \
+ *   node scripts/witness/pr4-two-person-collab-witness.mjs \
+ *     --origin https://staging--olumi.netlify.app \
+ *     --scenario <uuid owned by the owner>        # optional; see leg 2
+ *
+ *   node scripts/witness/pr4-two-person-collab-witness.mjs --dry-run
+ */
+
+import { createHash, randomUUID } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.join(HERE, 'fixtures', 'pr4-two-person-collab.json')
+
+const argv = process.argv.slice(2)
+const arg = name => {
+  const i = argv.indexOf(`--${name}`)
+  return i >= 0 ? argv[i + 1] : undefined
+}
+const DRY_RUN = argv.includes('--dry-run')
+const ORIGIN = arg('origin') ?? 'https://staging--olumi.netlify.app'
+const SCENARIO_ID = arg('scenario') ?? null
+const OUT = arg('out') ?? null
+
+const sha = s => createHash('sha256').update(String(s)).digest('hex').slice(0, 16)
+
+/* ── the assertion layer ──────────────────────────────────────────────────
+ * Pure functions over payloads, so `--dry-run` exercises EXACTLY the checks a
+ * live run does. A dry run that used different assertions would prove nothing
+ * about the live one.
+ */
+
+export function assertPacketIsBlind(packet, targetCount) {
+  const problems = []
+  if (packet?.status !== 'open') problems.push(`packet.status is ${packet?.status}, expected "open"`)
+  if (!Array.isArray(packet?.targets) || packet.targets.length !== targetCount) {
+    problems.push(`packet.targets has ${packet?.targets?.length}, expected ${targetCount}`)
+  }
+  // Blindness is the capability. It is a SERVER property; this asserts the
+  // wire actually shows it, rather than trusting the type that describes it.
+  for (const forbidden of ['responses', 'model_value_at_version', 'per_target', 'roster', 'response_count']) {
+    if (packet && Object.prototype.hasOwnProperty.call(packet, forbidden)) {
+      problems.push(`packet leaks "${forbidden}" — the blind packet must carry no sibling answers, no model value, no counts`)
+    }
+  }
+  for (const t of packet?.targets ?? []) {
+    for (const forbidden of ['value', 'model_value', 'responses']) {
+      if (Object.prototype.hasOwnProperty.call(t, forbidden)) {
+        problems.push(`packet.targets[].${forbidden} leaks a value into a blind packet`)
+      }
+    }
+  }
+  if (typeof packet?.self?.participant_id !== 'string') {
+    problems.push('packet.self.participant_id missing — the participant cannot be attributed')
+  }
+  return problems
+}
+
+export function assertRevealCarriesAttribution(reveal, expected) {
+  const problems = []
+  const perTarget = reveal?.per_target ?? []
+  if (perTarget.length !== expected.targetCount) {
+    problems.push(`reveal.per_target has ${perTarget.length}, expected ${expected.targetCount}`)
+  }
+  let attributedResponses = 0
+  for (const pt of perTarget) {
+    for (const r of pt.responses ?? []) {
+      attributedResponses += 1
+      // ATTRIBUTION, bound by identity: the response must name WHO, and carry
+      // their own words. A number with no author is the thing this capability
+      // exists to replace.
+      if (typeof r.participant_id !== 'string' || r.participant_id.length === 0) {
+        problems.push(`a response on target "${pt.target?.id}" has no participant_id`)
+      }
+      if (typeof r.display_label !== 'string' || r.display_label.length === 0) {
+        problems.push(`a response on target "${pt.target?.id}" has no display_label — unattributed`)
+      }
+      if (expected.participantId && r.participant_id !== expected.participantId) {
+        problems.push(
+          `response attributed to ${sha(r.participant_id)} but the submitting participant was ${sha(expected.participantId)}`,
+        )
+      }
+      if (expected.expressions && r.expression_raw !== null) {
+        if (!expected.expressions.includes(r.expression_raw)) {
+          problems.push(`expression_raw "${r.expression_raw}" is not one of the words the participant actually wrote`)
+        }
+      }
+    }
+  }
+  if (attributedResponses < expected.minResponses) {
+    problems.push(`only ${attributedResponses} attributed responses, expected at least ${expected.minResponses}`)
+  }
+  return problems
+}
+
+/* ── the wire ─────────────────────────────────────────────────────────── */
+
+const legs = []
+function leg(name, status, detail) {
+  legs.push({ leg: name, status, ...detail })
+  const mark = status === 'PASS' ? 'PASS' : status === 'BLOCKED' ? 'BLOCKED' : 'FAIL'
+  console.log(`[${mark}] ${name}${detail?.because ? ` — ${detail.because}` : ''}`)
+  return status === 'PASS'
+}
+
+async function json(res) {
+  try {
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+async function liveRun() {
+  const supabaseUrl = process.env.VITE_SUPABASE_URL
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !anonKey) {
+    leg('0. environment', 'BLOCKED', {
+      because: 'VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY not set (both are public; take them from the deployed bundle or netlify.toml)',
+    })
+    return
+  }
+
+  // ── leg 1: which sign-in methods does this project actually complete? ───
+  // Derived, never assumed: the public settings endpoint is the source of
+  // truth for what a real user can do today.
+  const settingsRes = await fetch(`${supabaseUrl}/auth/v1/settings`, { headers: { apikey: anonKey } })
+  const settings = await json(settingsRes)
+  const capability = {
+    email_provider: settings?.external?.email ?? null,
+    google_provider: settings?.external?.google ?? null,
+    anonymous_users: settings?.external?.anonymous_users ?? null,
+    disable_signup: settings?.disable_signup ?? null,
+    mailer_autoconfirm: settings?.mailer_autoconfirm ?? null,
+  }
+  leg('1. auth capability derived', settingsRes.ok ? 'PASS' : 'FAIL', { capability })
+
+  // ── leg 2: a REAL Supabase identity for the owner ──────────────────────
+  // Throwaway, clearly labelled, reserved-TLD address. Never a real account.
+  const nonce = `${Date.now()}-${randomUUID().slice(0, 8)}`
+  const ownerEmail = `olumi-witness+owner-${nonce}@example.test`
+  const ownerPassword = `Olumi-Witness-${nonce}-Aa1!`
+  const signupRes = await fetch(`${supabaseUrl}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: ownerEmail, password: ownerPassword }),
+  })
+  const signup = await json(signupRes)
+  const accessToken = signup?.access_token ?? null
+  if (!accessToken) {
+    leg('2. owner identity (real Supabase session)', 'BLOCKED', {
+      http: signupRes.status,
+      code: signup?.error_code ?? signup?.code ?? null,
+      because: signup?.msg ?? 'no session returned',
+      remedy: 'Supabase → Authentication → Providers → Email: allow sign-ups, or pre-provision the witness account.',
+    })
+    return
+  }
+  leg('2. owner identity (real Supabase session)', 'PASS', {
+    owner_email: ownerEmail,
+    owner_user_id: signup?.user?.id ?? null,
+    access_token_sha256_prefix: sha(accessToken),
+    method: 'email+password (auto-confirmed)',
+  })
+
+  // ── leg 3: the CONTROL, run before the acceptance path ─────────────────
+  // An acceptance run with no failing control proves less than it looks. A
+  // round over a scenario this owner does not own MUST be refused.
+  const controlRes = await fetch(`${ORIGIN}/bff/collab/rounds`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scenario_id: randomUUID(),
+      context_note: 'PR4 witness CONTROL — must be refused',
+      targets: [],
+      participants: [],
+    }),
+  })
+  const control = await json(controlRes)
+  leg('3. CONTROL: round over an unowned scenario is refused', controlRes.ok ? 'FAIL' : 'PASS', {
+    http: controlRes.status,
+    code: control?.code ?? null,
+    because: control?.message ?? null,
+  })
+
+  if (controlRes.status === 401 && control?.code === 'verification_unavailable') {
+    // The control refused for the WRONG reason: the credential never reached
+    // an ownership check at all. Saying "control passed" here would be a lie
+    // by omission, so the run stops and names the blocker.
+    leg('4. owner mints the round', 'BLOCKED', {
+      http: 401,
+      code: 'verification_unavailable',
+      because:
+        'CEE cannot verify the Supabase access token, so no owner call can reach an ownership check. ' +
+        'The token is HS256, and CEE returns verification_unavailable only when SUPABASE_JWT_SECRET is unset ' +
+        '(src/utils/supabase-user-jwt.ts — an incorrect secret would answer invalid_token instead).',
+      remedy: 'Set SUPABASE_JWT_SECRET on the CEE staging service (Render) to the Supabase project JWT secret.',
+    })
+    return
+  }
+
+  if (!SCENARIO_ID) {
+    leg('4. owner mints the round', 'BLOCKED', {
+      because: '--scenario <uuid> not supplied: a round pins a version of a scenario the OWNER owns.',
+      remedy: 'Create a scenario as the witness owner and pass its id.',
+    })
+    return
+  }
+
+  // ── leg 4: mint, over TWO targets ──────────────────────────────────────
+  // Two, not one: a single-target round shows one axis and invites the wrong
+  // conclusion whichever way it lands.
+  const targets = [
+    { target: { kind: 'factor', id: 'witness-target-a' }, label: 'Monthly churn rate', description: null, unit: '%' },
+    { target: { kind: 'factor', id: 'witness-target-b' }, label: 'Time to first value', description: null, unit: 'days' },
+  ]
+  const mintRes = await fetch(`${ORIGIN}/bff/collab/rounds`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scenario_id: SCENARIO_ID,
+      context_note: 'PR4 two-person witness',
+      targets,
+      participants: [{ display_name: 'Witness Participant' }],
+    }),
+  })
+  const minted = await json(mintRes)
+  const roundId = minted?.round_id ?? null
+  const participantToken = minted?.participants?.[0]?.token ?? null
+  if (!roundId || !participantToken) {
+    leg('4. owner mints the round', 'BLOCKED', {
+      http: mintRes.status,
+      code: minted?.code ?? null,
+      because: minted?.message ?? 'no round_id / participant token returned',
+    })
+    return
+  }
+  leg('4. owner mints the round', 'PASS', {
+    round_id: roundId,
+    graph_version_ref: minted?.graph_version_ref ?? null,
+    participant_token_sha256_prefix: sha(participantToken),
+  })
+
+  // ── leg 5: the participant's BLIND packet ──────────────────────────────
+  const packetRes = await fetch(`${ORIGIN}/bff/collab/packet/${encodeURIComponent(roundId)}`, {
+    headers: { 'x-collab-participant-token': participantToken },
+  })
+  const packet = await json(packetRes)
+  const blindProblems = assertPacketIsBlind(packet, targets.length)
+  leg('5. participant receives a BLIND packet', blindProblems.length === 0 ? 'PASS' : 'FAIL', {
+    http: packetRes.status,
+    problems: blindProblems,
+  })
+  if (blindProblems.length > 0) return
+
+  // ── leg 6: the participant contributes privately, in their own words ───
+  const expressions = [
+    'about one in twenty a month, based on the last two quarters',
+    'a fortnight if onboarding is staffed, longer otherwise',
+  ]
+  const submitted = []
+  for (let i = 0; i < targets.length; i += 1) {
+    const res = await fetch(`${ORIGIN}/bff/collab/packet/${encodeURIComponent(roundId)}/events`, {
+      method: 'POST',
+      headers: { 'x-collab-participant-token': participantToken, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'belief_submitted',
+        target: targets[i].target,
+        belief: { value: i === 0 ? 0.05 : 14, expression_raw: expressions[i], confidence: 0.6 },
+      }),
+    })
+    const body = await json(res)
+    submitted.push({ http: res.status, authored_by_sha256_prefix: body?.authored_by ? sha(body.authored_by) : null })
+    if (!res.ok) {
+      leg('6. participant submits beliefs privately', 'FAIL', { http: res.status, code: body?.code ?? null, because: body?.message })
+      return
+    }
+  }
+  leg('6. participant submits beliefs privately', 'PASS', { submitted })
+
+  // ── leg 7: owner closes ────────────────────────────────────────────────
+  const closeRes = await fetch(`${ORIGIN}/bff/collab/rounds/${encodeURIComponent(roundId)}/close`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!closeRes.ok) {
+    const body = await json(closeRes)
+    // F-6 is the anti-anchoring rule, not a bug: an owner who joined their own
+    // panel cannot close until they submit or decline.
+    leg('7. owner closes the round', 'FAIL', { http: closeRes.status, code: body?.code ?? null, because: body?.message })
+    return
+  }
+  leg('7. owner closes the round', 'PASS', { http: closeRes.status })
+
+  // ── leg 8: the reveal, WITH attribution ────────────────────────────────
+  const revealRes = await fetch(`${ORIGIN}/bff/collab/rounds/${encodeURIComponent(roundId)}/reveal`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  const reveal = await json(revealRes)
+  const revealProblems = assertRevealCarriesAttribution(reveal, {
+    targetCount: targets.length,
+    minResponses: targets.length,
+    participantId: packet?.self?.participant_id ?? null,
+    expressions,
+  })
+  leg('8. owner sees the reveal WITH attribution', revealProblems.length === 0 ? 'PASS' : 'FAIL', {
+    http: revealRes.status,
+    problems: revealProblems,
+  })
+}
+
+async function dryRun() {
+  const fixtures = JSON.parse(readFileSync(FIXTURES, 'utf8'))
+  // A dry run proves the ASSERTIONS bite; it proves nothing about the product.
+  // So each fixture pair is a discriminating pair: the good payload must pass
+  // and the corrupted twin must fail, on a NAMED problem.
+  for (const c of fixtures.cases) {
+    const problems =
+      c.kind === 'packet'
+        ? assertPacketIsBlind(c.payload, c.target_count)
+        : assertRevealCarriesAttribution(c.payload, c.expected)
+    const ok = c.expect === 'pass' ? problems.length === 0 : problems.length > 0
+    leg(`dry-run: ${c.name}`, ok ? 'PASS' : 'FAIL', {
+      expected: c.expect,
+      problems,
+    })
+  }
+}
+
+const started = new Date().toISOString()
+if (DRY_RUN) await dryRun()
+else await liveRun()
+
+const verdict = {
+  witness: 'PR4 two-person collaboration',
+  mode: DRY_RUN ? 'dry-run (replayed fixtures — proves the assertions, NOT the product)' : 'live wire',
+  state_class: DRY_RUN ? 'replayed' : 'fresh, two-identity',
+  origin: DRY_RUN ? null : ORIGIN,
+  started,
+  finished: new Date().toISOString(),
+  legs,
+  overall: legs.some(l => l.status === 'FAIL')
+    ? 'FAIL'
+    : legs.some(l => l.status === 'BLOCKED')
+      ? 'BLOCKED'
+      : 'PASS',
+}
+console.log(`\nOVERALL: ${verdict.overall}`)
+if (OUT) {
+  writeFileSync(OUT, JSON.stringify(verdict, null, 2))
+  console.log(`verdict written to ${OUT}`)
+}
+process.exit(verdict.overall === 'FAIL' ? 1 : 0)

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -11,9 +11,44 @@ import { Mail, Loader2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { typography } from '../../styles/typography'
 
-type PageState = 'default' | 'submitting' | 'link-sent' | 'rate-limited' | 'invalid-email' | 'expired-link'
+type PageState =
+  | 'default'
+  | 'submitting'
+  | 'link-sent'
+  | 'rate-limited'
+  | 'invalid-email'
+  | 'expired-link'
+  | 'send-failed'
+  | 'oauth-failed'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Is this failure OURS rather than a fact about the address?
+ *
+ * The link-sent state exists to make a registered and an unregistered address
+ * indistinguishable — that is worth protecting and is untouched here. But it
+ * was catching everything, including a 500 from a Supabase project with no
+ * SMTP configured, which is what staging returns today for an address that
+ * DOES exist. Reporting that as "your link is on its way" is a lie the user
+ * cannot detect and cannot act on.
+ *
+ * A 5xx is returned identically for every address, so naming it leaks nothing.
+ * The predicate is written against the SPEC (5xx = server fault) rather than
+ * against the single failure mode in hand, so a different server fault is
+ * classified correctly the first time it appears.
+ */
+function isServerFault(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status
+  return typeof status === 'number' && status >= 500
+}
+
+function isRateLimited(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status
+  if (status === 429) return true
+  const msg = error instanceof Error ? error.message : String(error ?? '')
+  return msg.toLowerCase().includes('rate') || msg.toLowerCase().includes('too many')
+}
 
 export default function LoginPage() {
   const { signInWithMagicLink, signInWithGoogle } = useAuth()
@@ -52,9 +87,11 @@ export default function LoginPage() {
     const { error } = await signInWithMagicLink(trimmed)
 
     if (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      if (msg.toLowerCase().includes('rate') || msg.toLowerCase().includes('too many')) {
+      if (isRateLimited(error)) {
         setPageState('rate-limited')
+      } else if (isServerFault(error)) {
+        // Ours, not theirs. Never dressed up as a sent link.
+        setPageState('send-failed')
       } else {
         // Show generic link-sent for all other errors (including "user not found")
         // to prevent email enumeration.
@@ -72,13 +109,22 @@ export default function LoginPage() {
     const trimmed = email.trim()
     if (!EMAIL_RE.test(trimmed)) return
     setPageState('submitting')
-    await signInWithMagicLink(trimmed)
+    // The resend path used to ignore its result entirely, so a resend into a
+    // broken mailer always claimed success — the same defect as the first send.
+    const { error } = await signInWithMagicLink(trimmed)
+    if (error && isServerFault(error)) {
+      setPageState('send-failed')
+      return
+    }
     setPageState('link-sent')
     setResendCooldown(60)
   }, [email, signInWithMagicLink])
 
   const handleGoogleClick = useCallback(async () => {
-    await signInWithGoogle()
+    // The result used to be discarded, so a disabled provider produced a button
+    // that visibly did nothing whatsoever.
+    const { error } = await signInWithGoogle()
+    if (error) setPageState('oauth-failed')
   }, [signInWithGoogle])
 
   return (
@@ -156,6 +202,22 @@ export default function LoginPage() {
                 {pageState === 'rate-limited' && (
                   <p className={`${typography.bodySmall} text-danger mt-1`}>
                     Please wait a moment before trying again.
+                  </p>
+                )}
+                {pageState === 'send-failed' && (
+                  /* Deliberately says nothing about whether the address is
+                     registered — this text is identical for every address, so
+                     it cannot be used to enumerate accounts. */
+                  <p className={`${typography.bodySmall} text-danger mt-1`} role="alert">
+                    We couldn&rsquo;t send the sign-in email. This is a problem on our
+                    side, not with your address &mdash; nothing was sent. Please try
+                    again later or ask your Olumi contact.
+                  </p>
+                )}
+                {pageState === 'oauth-failed' && (
+                  <p className={`${typography.bodySmall} text-danger mt-1`} role="alert">
+                    We couldn&rsquo;t start Google sign-in. Please use the email link
+                    above, or ask your Olumi contact.
                   </p>
                 )}
               </div>

--- a/src/components/auth/__tests__/LoginPage.test.tsx
+++ b/src/components/auth/__tests__/LoginPage.test.tsx
@@ -67,7 +67,7 @@ describe('LoginPage', () => {
       fireEvent.submit(input.closest('form')!)
     })
 
-    expect(screen.getByText(/receive a sign-in link/i)).toBeInTheDocument()
+    expect(screen.getByText(/if this email is registered/i)).toBeInTheDocument()
   })
 
   it('calls signInWithGoogle when Google button clicked', () => {
@@ -79,5 +79,120 @@ describe('LoginPage', () => {
   it('shows expired link message when URL has error=expired', () => {
     renderLogin(['/login?error=expired'])
     expect(screen.getByText(/link has expired/i)).toBeInTheDocument()
+  })
+})
+
+/**
+ * PR4 — A SERVER FAULT IS NOT A "LINK SENT".
+ *
+ * The anti-enumeration branch used to swallow EVERY non-rate-limit error into
+ * the link-sent state. That is right for anything that could distinguish a
+ * registered address from an unregistered one, and wrong for a fault on our
+ * side: staging's Supabase has no SMTP configured, so `signInWithOtp` answers
+ * HTTP 500 `unexpected_failure` ("Error sending magic link email") for an
+ * address that DOES exist — and the page told the user their link was on its
+ * way. The predicate guarded two opposite harms with one branch: a gap (we
+ * leak which addresses exist) and a lie (we claim to have sent nothing).
+ *
+ * Two parameters now, not one:
+ *   • status >= 500 → OUR fault. Say so. Reveals nothing about the address,
+ *     because it is returned identically for every address.
+ *   • anything else → link-sent, unchanged. Enumeration safety is untouched.
+ *
+ * The two cases below are opposite-direction twins deliberately: one proves
+ * the fault is reported, the other proves the enumeration guard did not get
+ * traded away to buy it.
+ */
+describe('LoginPage × server faults are reported, enumeration stays closed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSignInWithMagicLink.mockResolvedValue({ error: null })
+    mockSignInWithGoogle.mockResolvedValue({ error: null })
+  })
+
+  async function submit(email = 'user@example.com') {
+    renderLogin()
+    const input = screen.getByPlaceholderText('you@example.com')
+    fireEvent.change(input, { target: { value: email } })
+    await act(async () => {
+      fireEvent.submit(input.closest('form')!)
+    })
+  }
+
+  it('a 500 from Supabase (SMTP unconfigured) is NOT reported as a sent link', async () => {
+    mockSignInWithMagicLink.mockResolvedValue({
+      error: Object.assign(new Error('Error sending magic link email'), {
+        status: 500,
+        code: 'unexpected_failure',
+      }),
+    })
+    await submit()
+    expect(screen.queryByText(/if this email is registered/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/couldn.t send/i)).toBeInTheDocument()
+  })
+
+  it("a build with no sign-in capability (501) is NOT reported as a sent link", async () => {
+    mockSignInWithMagicLink.mockResolvedValue({
+      error: Object.assign(new Error('Sign-in is unavailable in this build'), {
+        status: 501,
+      }),
+    })
+    await submit()
+    expect(screen.queryByText(/if this email is registered/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/couldn.t send/i)).toBeInTheDocument()
+  })
+
+  it('an unknown-address error STILL shows link-sent — enumeration stays closed', async () => {
+    // The opposite-direction twin. Supabase answers 422 `otp_disabled` when the
+    // address has no account and shouldCreateUser is false; distinguishing that
+    // on screen would tell an attacker which addresses are registered.
+    mockSignInWithMagicLink.mockResolvedValue({
+      error: Object.assign(new Error('Signups not allowed for otp'), {
+        status: 422,
+        code: 'otp_disabled',
+      }),
+    })
+    await submit()
+    expect(screen.getByText(/if this email is registered/i)).toBeInTheDocument()
+    expect(screen.queryByText(/couldn.t send/i)).not.toBeInTheDocument()
+  })
+
+  it('a rate-limit error still shows the rate-limit message, not a server fault', async () => {
+    mockSignInWithMagicLink.mockResolvedValue({
+      error: Object.assign(new Error('For security purposes, too many requests'), {
+        status: 429,
+      }),
+    })
+    await submit()
+    expect(screen.getByText(/wait a moment/i)).toBeInTheDocument()
+  })
+
+  it('a 429 whose WORDING says nothing about rates is still a rate limit', async () => {
+    // ⚠ THIS CASE EXISTS BECAUSE A MUTANT SURVIVED. Changing the status check
+    // from 429 killed nothing: every other rate-limit fixture also matched the
+    // message fallback, so the status branch was carrying no test weight and a
+    // refactor could have deleted it silently. Supabase does not guarantee the
+    // wording; it does guarantee the status.
+    mockSignInWithMagicLink.mockResolvedValue({
+      error: Object.assign(new Error('Request throttled, retry shortly'), { status: 429 }),
+    })
+    await submit()
+    expect(screen.getByText(/wait a moment/i)).toBeInTheDocument()
+  })
+
+  it('a failed Google sign-in is surfaced, not discarded', async () => {
+    // `handleGoogleClick` used to `await signInWithGoogle()` and throw the
+    // result away, so a disabled provider produced a button that visibly did
+    // nothing at all.
+    mockSignInWithGoogle.mockResolvedValue({
+      error: Object.assign(new Error('Unsupported provider: provider is not enabled'), {
+        status: 400,
+      }),
+    })
+    renderLogin()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+    })
+    expect(screen.getByText(/couldn.t start google sign-in/i)).toBeInTheDocument()
   })
 })

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -45,6 +45,116 @@ const AuthContext = createContext<AuthContextType>({
 const legacyNoOp = async () => ({ error: new Error('Password auth removed — use magic link'), data: null });
 
 // ---------------------------------------------------------------------------
+// The sign-in calls — ONE implementation, shared by every posture
+// ---------------------------------------------------------------------------
+//
+// These used to exist twice: once for real, and once as
+// `async () => ({ error: null })` inside the guest branch below. Staging
+// deploys VITE_AUTH_MODE="guest", so the *deployed* implementation was the
+// second one — both login buttons made no network call and reported SUCCESS,
+// and LoginPage duly told the user a link was on its way. A silent-success
+// twin of a real function is the worst shape available: it cannot be seen in
+// a diff of either half, and every test of the real one stays green.
+//
+// There is now no second copy to drift. The posture decides WHO YOU ARE; it
+// does not decide whether the button does anything.
+
+/**
+ * The Supabase SDK is aliased to `src/stubs/supabase-stub.mjs` on any build
+ * that does not set `VITE_STUB_SUPABASE=0` (see scripts/supabase-stub-decision.mjs),
+ * and that stub implements NEITHER `signInWithOtp` NOR `signInWithOAuth`.
+ * Calling one there throws a TypeError. The honest answer is an error the
+ * surface can render — never `{ error: null }`, which is exactly the lie this
+ * whole module was changed to stop telling.
+ */
+function signInUnavailable(method: string): Error {
+  // `status: 501` is not decoration. Surfaces classify a failure by HTTP-style
+  // status (see LoginPage: >= 500 means OUR fault, say so; anything else stays
+  // in the enumeration-safe branch), and a build with no sign-in capability is
+  // exactly Not Implemented. Without a status this error would fall into the
+  // "might be an unknown address" bucket and be reported as a sent link — the
+  // very lie being removed.
+  return Object.assign(
+    new Error(
+      `Sign-in is unavailable in this build: the bundled Supabase client has no ${method}. ` +
+        'No sign-in request was sent.',
+    ),
+    { status: 501 },
+  );
+}
+
+/**
+ * A THROW from the Supabase client is a fault, never a fact about the address.
+ *
+ * `signInWithOtp` can reject or throw for a network failure, a CSP block, or a
+ * missing method on a stubbed client. None of those say anything about whether
+ * an account exists — but a bare `Error` carries no `status`, and LoginPage's
+ * enumeration-safe default would file it under "might be an unknown address"
+ * and report a sent link. Stamping 5xx puts it in the honest branch.
+ *
+ * An error that ALREADY carries a numeric status keeps it: a real
+ * `AuthApiError` has classified itself better than this wrapper can, and
+ * overwriting a 422 with a 500 would turn an enumeration-safe outcome into a
+ * false server-fault message.
+ */
+function asFault(error: unknown): unknown {
+  if (typeof (error as { status?: unknown } | null)?.status === 'number') return error;
+  if (error instanceof Error) return Object.assign(error, { status: 500 });
+  return Object.assign(new Error(String(error)), { status: 500 });
+}
+
+async function callSignInWithMagicLink(email: string): Promise<{ error: unknown }> {
+  authLogger.debug('SIGN_IN', 'Magic link request', { email });
+  try {
+    if (typeof supabase.auth.signInWithOtp !== 'function') {
+      return { error: signInUnavailable('signInWithOtp') };
+    }
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        shouldCreateUser: false,
+        emailRedirectTo: `${window.location.origin}/#/auth/callback`,
+      },
+    });
+    if (error) {
+      authLogger.error('ERROR', 'Magic link failed', error);
+      return { error };
+    }
+    return { error: null };
+  } catch (error) {
+    authLogger.error('ERROR', 'Magic link error', error);
+    return { error: asFault(error) };
+  }
+}
+
+async function callSignInWithGoogle(): Promise<{ error: unknown }> {
+  authLogger.debug('SIGN_IN', 'Google OAuth request');
+  try {
+    if (typeof supabase.auth.signInWithOAuth !== 'function') {
+      return { error: signInUnavailable('signInWithOAuth') };
+    }
+    // Invite-only enforcement for Google OAuth relies on a server-side
+    // "Before User Created" hook configured in the Supabase dashboard,
+    // not on client-side config. signInWithOAuth does not support
+    // shouldCreateUser — the hook checks an email allowlist.
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/#/auth/callback`,
+      },
+    });
+    if (error) {
+      authLogger.error('ERROR', 'Google OAuth failed', error);
+      return { error };
+    }
+    return { error: null };
+  } catch (error) {
+    authLogger.error('ERROR', 'Google OAuth error', error);
+    return { error: asFault(error) };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
 
@@ -56,24 +166,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     throw new Error('E2E test mode is forbidden in production bundles');
   }
 
-  // Guest/PoC mode: provide an immediately-ready auth context with no network calls
+  // Guest/PoC mode: an immediately-ready guest identity WITH a real front door.
   if (isGuestAuth) {
-    const value: AuthContextType = {
-      user: { id: 'guest', email: 'guest@poc' } as User,
-      profile: null,
-      loading: false,
-      authenticated: true,
-      signInWithMagicLink: async () => ({ error: null }),
-      signInWithGoogle: async () => ({ error: null }),
-      signIn: async () => ({ error: null, data: { id: 'guest', email: 'guest@poc' } }),
-      signUp: async () => ({ error: null, data: { id: 'guest', email: 'guest@poc' } }),
-      signOut: async () => ({ error: null }),
-    };
-    return (
-      <AuthContext.Provider value={value}>
-        {children}
-      </AuthContext.Provider>
-    );
+    return <OptionalAuthProvider>{children}</OptionalAuthProvider>;
   }
 
   // E2E test-mode (non-prod builds): provide an immediately-ready auth context
@@ -180,50 +275,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = React.useMemo((): AuthContextType => ({
     ...state,
 
-    signInWithMagicLink: async (email: string) => {
-      authLogger.debug('SIGN_IN', 'Magic link request', { email });
-      try {
-        const { error } = await supabase.auth.signInWithOtp({
-          email,
-          options: {
-            shouldCreateUser: false,
-            emailRedirectTo: `${window.location.origin}/#/auth/callback`,
-          },
-        });
-        if (error) {
-          authLogger.error('ERROR', 'Magic link failed', error);
-          return { error };
-        }
-        return { error: null };
-      } catch (error) {
-        authLogger.error('ERROR', 'Magic link error', error);
-        return { error };
-      }
-    },
-
-    // Invite-only enforcement for Google OAuth relies on a server-side
-    // "Before User Created" hook configured in the Supabase dashboard,
-    // not on client-side config. signInWithOAuth does not support
-    // shouldCreateUser — the hook checks an email allowlist.
-    signInWithGoogle: async () => {
-      authLogger.debug('SIGN_IN', 'Google OAuth request');
-      try {
-        const { error } = await supabase.auth.signInWithOAuth({
-          provider: 'google',
-          options: {
-            redirectTo: `${window.location.origin}/#/auth/callback`,
-          },
-        });
-        if (error) {
-          authLogger.error('ERROR', 'Google OAuth failed', error);
-          return { error };
-        }
-        return { error: null };
-      } catch (error) {
-        authLogger.error('ERROR', 'Google OAuth error', error);
-        return { error };
-      }
-    },
+    signInWithMagicLink: callSignInWithMagicLink,
+    signInWithGoogle: callSignInWithGoogle,
 
     // Legacy no-ops
     signIn: legacyNoOp,
@@ -269,6 +322,145 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
+}
+
+// ---------------------------------------------------------------------------
+// OPTIONAL AUTH — the guest posture, with a real front door
+// ---------------------------------------------------------------------------
+//
+// ── WHAT "OPTIONAL" BUYS, AND WHAT IT COSTS ───────────────────────────────
+// A visitor who never signs in is byte-for-byte where they were: guest
+// identity, `authenticated: true`, `loading: false` on the FIRST render, so
+// `AuthGuard` lets them straight through and no spinner is ever shown. That is
+// asserted per-render (not just at settle) in
+// `__tests__/AuthContext.optionalAuth.spec.tsx`, because a single frame of
+// `loading: true` is a visible flash the PoC does not have today.
+//
+// What changes is that signing in now DOES something: this provider adopts a
+// real Supabase session if one exists or arrives, and the sign-in calls are
+// the same shared implementations the real-auth path uses.
+//
+// ── WHY A SEPARATE COMPONENT RATHER THAN UNIFYING `AuthProvider` ──────────
+// `AuthProvider` returns early for three postures BEFORE its hooks run. Adding
+// hooks to the guest branch in place would have made that conditional-hook
+// shape worse and moved `src/contexts/AuthContext.tsx`'s entry in
+// `scripts/ci/rules-of-hooks-baseline.json` — which fails the ratchet in
+// EITHER direction, by design. A child component owns its own hooks
+// unconditionally, so it adds none, and the real-auth path below is untouched:
+// this change cannot regress a signed-in user, because it does not run for one.
+//
+// ── WHY `getSession()` IS SAFE TO CALL HERE ──────────────────────────────
+// With no stored session it is a synchronous-ish storage read and issues no
+// network request, so a guest pays nothing. `AuthContext` already imported the
+// Supabase client at module scope in guest builds, so no new code enters the
+// bundle either.
+function OptionalAuthProvider({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate();
+
+  // `null` = no real session; the guest identity stands in.
+  const [session, setSession] = React.useState<{
+    user: User;
+    profile: UserProfile | null;
+  } | null>(null);
+  const [pendingUser, setPendingUser] = React.useState<User | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let cleanup: (() => void) | undefined;
+
+    const adopt = (s: Session | null) => {
+      if (cancelled) return;
+      if (!s) {
+        setSession(null);
+        setPendingUser(null);
+        return;
+      }
+      const u = s.user;
+      setSentryUser(u.id, u.email ?? '');
+      identifyUser(u.id, u.email ?? '', u.user_metadata?.full_name);
+      setSession(prev => ({ user: u, profile: prev?.profile ?? null }));
+      setPendingUser(u);
+    };
+
+    (async () => {
+      try {
+        const { data } = await supabase.auth.getSession();
+        adopt(data?.session ?? null);
+        const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => adopt(s));
+        cleanup = () => sub?.subscription?.unsubscribe?.();
+      } catch (error) {
+        // A guest build must never fail to boot because auth is unavailable.
+        authLogger.debug('INIT', 'Optional auth unavailable; staying a guest', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, []);
+
+  // Deferred profile fetch, mirroring the real path: never chained inside the
+  // auth-state callback.
+  useEffect(() => {
+    if (!pendingUser) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data: profile, error } = await getProfile(pendingUser.id);
+        if (error) throw error;
+        if (!cancelled) {
+          setSession(prev => (prev ? { ...prev, profile: profile ?? null } : prev));
+        }
+      } catch (err) {
+        authLogger.error('ERROR', 'Failed to fetch profile', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingUser]);
+
+  const value = React.useMemo((): AuthContextType => ({
+    user: session?.user ?? ({ id: 'guest', email: 'guest@poc' } as User),
+    profile: session?.profile ?? null,
+    // Never true: a guest is ready immediately, and AuthGuard must not spin.
+    loading: false,
+    // A guest counts as authenticated so every route stays reachable — that is
+    // what makes signing in OPTIONAL rather than merely available.
+    authenticated: true,
+
+    signInWithMagicLink: callSignInWithMagicLink,
+    signInWithGoogle: callSignInWithGoogle,
+
+    // Password auth is removed product-wide. The guest branch used to answer
+    // `{ error: null, data: { id: 'guest' } }` here — a success report for a
+    // capability that does not exist.
+    signIn: legacyNoOp,
+    signUp: legacyNoOp,
+
+    signOut: async () => {
+      // No real session: there is genuinely nothing to sign out of, and
+      // pretending otherwise would send a request that cannot succeed.
+      if (!session) return { error: null };
+      authLogger.debug('SIGN_OUT', 'Sign out attempt (optional-auth posture)');
+      try {
+        clearAuthStates();
+        clearSentryUser();
+        resetPostHog();
+        setSession(null);
+        setPendingUser(null);
+        await supabase.auth.signOut({ scope: 'local' });
+        navigate('/', { replace: true });
+        return { error: null };
+      } catch (error) {
+        authLogger.error('ERROR', 'Sign out failed', error);
+        return { error };
+      }
+    },
+  }), [session, navigate]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {

--- a/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
+++ b/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
@@ -1,0 +1,409 @@
+/**
+ * PR4 — OPTIONAL REAL AUTH: the guest posture must offer a REAL front door.
+ *
+ * ── THE DEFECT THIS PINS ──────────────────────────────────────────────────
+ * `AuthProvider` short-circuited on `isGuestAuth` and handed the app a context
+ * whose sign-in members were:
+ *
+ *     signInWithMagicLink: async () => ({ error: null })
+ *     signInWithGoogle:    async () => ({ error: null })
+ *
+ * Staging deploys `VITE_AUTH_MODE = "guest"`, so those were the DEPLOYED
+ * implementations. Both login buttons made no network call at all and reported
+ * SUCCESS — `LoginPage` reads `{ error: null }` and renders "you'll receive a
+ * sign-in link shortly" for an email that was never sent. A button that does
+ * nothing may not report success.
+ *
+ * ── WHAT "OPTIONAL" MEANS, AND WHY EACH HALF NEEDS ITS OWN TEST ───────────
+ * Two claims, two harms, so they are asserted separately (one predicate
+ * guarding two opposite harms is the estate's recurring defect):
+ *   • REAL   — a sign-in call reaches Supabase and its failure is propagated.
+ *              Harm if wrong: the product lies about having sent an email.
+ *   • OPTIONAL — a visitor who never signs in still gets the guest identity,
+ *              `authenticated: true` and `loading: false` on the FIRST render.
+ *              Harm if wrong: every guest is bounced to /login by AuthGuard and
+ *              the whole PoC becomes unreachable.
+ *
+ * ── BINDING ───────────────────────────────────────────────────────────────
+ * The assertions bind to the Supabase client method BY NAME (`signInWithOtp`,
+ * `signInWithOAuth`) and to the returned error BY IDENTITY (the same object
+ * reference the client produced), never by a value predicate some other object
+ * could satisfy.
+ *
+ * ── STATE-CLASS ───────────────────────────────────────────────────────────
+ * Fresh: `getSession` resolves to no session in every case here. The
+ * session-adoption path is covered by its own case with an explicit session.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import React from 'react'
+
+const signInWithOtp = vi.fn()
+const signInWithOAuth = vi.fn()
+const getSession = vi.fn()
+const onAuthStateChange = vi.fn()
+const supabaseSignOut = vi.fn()
+
+// ⚠ THIS EXISTS BECAUSE THE FIRST VERSION OF THE STUB-BUILD CASE WAS VACUOUS.
+// It made `signInWithOtp` a spy that THREW, which is not what a stubbed build
+// looks like: there the method is genuinely ABSENT, so the capability guard is
+// what should fire. A throwing spy left the method present, exercised the catch
+// block instead, and the test passed on the wrong object entirely. Toggling
+// presence through a getter is the only way to model the real stub.
+let otpMethodPresent = true
+let oauthMethodPresent = true
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      get signInWithOtp() {
+        return otpMethodPresent ? signInWithOtp : undefined
+      },
+      get signInWithOAuth() {
+        return oauthMethodPresent ? signInWithOAuth : undefined
+      },
+      getSession,
+      onAuthStateChange,
+      signOut: supabaseSignOut,
+    },
+  },
+  getProfile: vi.fn(async () => ({ data: null, error: null })),
+  getSessionIdentity: vi.fn(async () => ({ userId: null, accessToken: null })),
+}))
+
+// Boot-time side-effect modules the provider imports. Spread the original so
+// this is not a hand-maintained allowlist that silently drops a new export.
+vi.mock('../../lib/monitoring', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/monitoring')>()),
+  setSentryUser: vi.fn(),
+  clearSentryUser: vi.fn(),
+}))
+vi.mock('../../lib/posthog', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/posthog')>()),
+  identifyUser: vi.fn(),
+  resetPostHog: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+/** Renders the real provider in the real guest posture and exposes the context. */
+async function renderGuestProvider() {
+  const { AuthProvider, useAuth } = await import('../AuthContext')
+
+  const seen: {
+    signInWithMagicLink?: (email: string) => Promise<{ error: unknown }>
+    signInWithGoogle?: () => Promise<{ error: unknown }>
+    signOut?: () => Promise<{ error: unknown }>
+  } = {}
+
+  function Probe() {
+    const ctx = useAuth()
+    seen.signInWithMagicLink = ctx.signInWithMagicLink
+    seen.signInWithGoogle = ctx.signInWithGoogle
+    seen.signOut = ctx.signOut
+    return (
+      <div>
+        <span data-testid="user-id">{ctx.user?.id ?? 'none'}</span>
+        <span data-testid="authenticated">{String(ctx.authenticated)}</span>
+        <span data-testid="loading">{String(ctx.loading)}</span>
+      </div>
+    )
+  }
+
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+  })
+
+  return seen
+}
+
+describe('AuthContext × guest posture — the front door is REAL', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    // The deployed staging posture, verbatim from netlify.toml.
+    vi.stubEnv('VITE_AUTH_MODE', 'guest')
+    // Reset the presence toggles: a case that hid a method must not leak that
+    // into the next one, or a later assertion passes for the wrong reason.
+    otpMethodPresent = true
+    oauthMethodPresent = true
+    getSession.mockResolvedValue({ data: { session: null } })
+    onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })
+    signInWithOtp.mockResolvedValue({ data: {}, error: null })
+    signInWithOAuth.mockResolvedValue({ data: {}, error: null })
+    supabaseSignOut.mockResolvedValue({ error: null })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    localStorage.clear()
+  })
+
+  it('PRECONDITION: this test runs in the guest posture (isGuestAuth true)', async () => {
+    // Pins the precondition IN-TEST. Without this the cases below could pass
+    // by accidentally exercising the real-auth provider, and the suite would
+    // be green about a branch it never entered.
+    const { isGuestAuth } = await import('../../lib/poc')
+    expect(isGuestAuth).toBe(true)
+  })
+
+  it('magic link calls supabase.auth.signInWithOtp — not a no-op', async () => {
+    const ctx = await renderGuestProvider()
+    await act(async () => {
+      await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    expect(signInWithOtp).toHaveBeenCalledTimes(1)
+    expect(signInWithOtp).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'someone@example.com' }),
+    )
+  })
+
+  it('magic link propagates the Supabase error BY IDENTITY — never reports success', async () => {
+    // The exact shape staging returns today: HTTP 500, SMTP unconfigured.
+    const smtpFailure = Object.assign(new Error('Error sending magic link email'), {
+      status: 500,
+      code: 'unexpected_failure',
+    })
+    signInWithOtp.mockResolvedValue({ data: {}, error: smtpFailure })
+
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    // Identity, not a value predicate: it must be the very object the client
+    // produced, so a synthesised look-alike error cannot satisfy this.
+    expect(result!.error).toBe(smtpFailure)
+  })
+
+  it('Google calls supabase.auth.signInWithOAuth with the google provider', async () => {
+    const ctx = await renderGuestProvider()
+    await act(async () => {
+      await ctx.signInWithGoogle!()
+    })
+    expect(signInWithOAuth).toHaveBeenCalledTimes(1)
+    expect(signInWithOAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'google' }),
+    )
+  })
+
+  it('Google propagates the Supabase error BY IDENTITY — never reports success', async () => {
+    const providerDisabled = Object.assign(
+      new Error('Unsupported provider: provider is not enabled'),
+      { status: 400 },
+    )
+    signInWithOAuth.mockResolvedValue({ data: {}, error: providerDisabled })
+
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithGoogle!()
+    })
+    expect(result!.error).toBe(providerDisabled)
+  })
+
+  it('password signIn/signUp report the removal as an ERROR, not as guest success', async () => {
+    const { AuthProvider, useAuth } = await import('../AuthContext')
+    let captured: { error: unknown } | undefined
+    function Probe() {
+      const { signIn } = useAuth()
+      React.useEffect(() => {
+        void signIn('a@b.com', 'pw').then(r => {
+          captured = r
+        })
+      }, [signIn])
+      return null
+    }
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <AuthProvider>
+            <Probe />
+          </AuthProvider>
+        </MemoryRouter>,
+      )
+    })
+    expect(captured!.error).toBeInstanceOf(Error)
+  })
+
+  it('a build whose Supabase client LACKS signInWithOtp reports UNAVAILABLE, never success', async () => {
+    // src/stubs/supabase-stub.mjs implements NEITHER signInWithOtp NOR
+    // signInWithOAuth — the method is ABSENT, not throwing. Modelling it as a
+    // throwing spy would exercise the catch block and prove nothing about the
+    // capability guard.
+    otpMethodPresent = false
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    expect(signInWithOtp).not.toHaveBeenCalled()
+    expect(result!.error).toBeInstanceOf(Error)
+    expect((result!.error as Error).message).toMatch(/unavailable in this build/i)
+    // ⚠ CROSS-MODULE SEAM, pinned here because nothing else binds the two ends.
+    // This module PRODUCES the status; `LoginPage.isServerFault` CONSUMES it as
+    // `>= 500` to decide between "our fault, say so" and the enumeration-safe
+    // link-sent branch. Two authorities answering two different questions with
+    // nothing holding them together is how a fix gets silently un-made: drop
+    // the status here and the surface would go back to reporting an
+    // unavailable build as a sent email, with every test still green.
+    expect((result!.error as { status?: number }).status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('a client that THROWS is classified as a fault, not as a possible unknown address', async () => {
+    // A network failure, a CSP block or a rejected promise carries no `status`.
+    // Left bare, LoginPage's enumeration-safe default would file it under
+    // "might be an unknown address" and report a sent link — the same lie, via
+    // a different door. The catch block stamps 5xx so the surface can be honest.
+    signInWithOtp.mockImplementation(() => {
+      throw new TypeError('Failed to fetch')
+    })
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    expect((result!.error as { status?: number }).status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('a RESOLVED 422 keeps its status — the enumeration-safe outcome is untouched', async () => {
+    const unknownAddress = Object.assign(new Error('Signups not allowed for otp'), {
+      status: 422,
+      code: 'otp_disabled',
+    })
+    signInWithOtp.mockResolvedValue({ data: {}, error: unknownAddress })
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    expect((result!.error as { status?: number }).status).toBe(422)
+  })
+
+  it('a THROWN 422 also keeps its status — asFault must not promote it to a server fault', async () => {
+    // ⚠ THIS CASE EXISTS BECAUSE A MUTANT SURVIVED. Deleting `asFault`'s
+    // already-has-a-status guard left the whole suite GREEN: the resolved-422
+    // case above never reaches `asFault` at all, because it returns through the
+    // `if (error)` branch. supabase-js can REJECT rather than resolve, and on
+    // that path an overwrite would make the page announce a server fault for
+    // every unregistered address — the enumeration leak, reintroduced by the
+    // very code written to stop the lie. The opposite-direction twin of the
+    // thrown-network-error case; neither alone pins the guard.
+    const thrown422 = Object.assign(new Error('Signups not allowed for otp'), {
+      status: 422,
+      code: 'otp_disabled',
+    })
+    signInWithOtp.mockImplementation(() => {
+      throw thrown422
+    })
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithMagicLink!('someone@example.com')
+    })
+    expect((result!.error as { status?: number }).status).toBe(422)
+  })
+})
+
+describe('AuthContext × guest posture — auth stays OPTIONAL', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    vi.stubEnv('VITE_AUTH_MODE', 'guest')
+    getSession.mockResolvedValue({ data: { session: null } })
+    onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    localStorage.clear()
+  })
+
+  it('a visitor who never signs in keeps the guest identity and passes AuthGuard', async () => {
+    await renderGuestProvider()
+    expect(screen.getByTestId('user-id').textContent).toBe('guest')
+    expect(screen.getByTestId('authenticated').textContent).toBe('true')
+  })
+
+  it('loading is false on the FIRST render — no auth spinner is ever shown to a guest', async () => {
+    // AuthGuard renders a full-screen spinner while `loading` is true. A guest
+    // build must never reach that state, not even for one frame, or the PoC
+    // gains a flash of loading UI it does not have today.
+    const { AuthProvider, useAuth } = await import('../AuthContext')
+    const loadingByRender: boolean[] = []
+    function Probe() {
+      const { loading } = useAuth()
+      loadingByRender.push(loading)
+      return null
+    }
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <AuthProvider>
+            <Probe />
+          </AuthProvider>
+        </MemoryRouter>,
+      )
+    })
+    expect(loadingByRender.length).toBeGreaterThan(0)
+    expect(loadingByRender[0]).toBe(false)
+    expect(loadingByRender).not.toContain(true)
+  })
+
+  it('a REAL session, when one exists, replaces the guest identity', async () => {
+    // This is what makes the posture optional-but-real rather than
+    // guest-forever: signing in has to actually change who you are.
+    getSession.mockResolvedValue({
+      data: {
+        session: {
+          user: { id: 'real-user-uuid', email: 'real@example.com', app_metadata: {}, user_metadata: {} },
+          access_token: 'irrelevant-here',
+        },
+      },
+    })
+    await renderGuestProvider()
+    expect(screen.getByTestId('user-id').textContent).toBe('real-user-uuid')
+    expect(screen.getByTestId('authenticated').textContent).toBe('true')
+  })
+
+  it('a guest with no session is not signed out through Supabase (nothing to sign out of)', async () => {
+    const ctx = await renderGuestProvider()
+    await act(async () => {
+      await ctx.signOut!()
+    })
+    expect(supabaseSignOut).not.toHaveBeenCalled()
+  })
+
+  it('a REAL session IS signed out through Supabase', async () => {
+    // The opposite-direction twin of the case above. Together they prove the
+    // branch discriminates; either alone is consistent with signOut being
+    // unconditionally dead or unconditionally live.
+    getSession.mockResolvedValue({
+      data: {
+        session: {
+          user: { id: 'real-user-uuid', email: 'real@example.com', app_metadata: {}, user_metadata: {} },
+          access_token: 'irrelevant-here',
+        },
+      },
+    })
+    supabaseSignOut.mockResolvedValue({ error: null })
+    const ctx = await renderGuestProvider()
+    await act(async () => {
+      await ctx.signOut!()
+    })
+    expect(supabaseSignOut).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## ⚠ PAUL-SIDE TOGGLES — nothing in this PR can substitute for these

Derived by exercising the deployed services on **11 Aug 2026**, never read from a config file.
Ordered by what each one unblocks. **(1) is the one that matters** — it is the only thing standing
between us and a real PR4 two-person witness.

| # | Where | Setting | Set it to | Why / what it unblocks |
|---|---|---|---|---|
| **1** | **CEE staging service, Render env** | **`SUPABASE_JWT_SECRET`** | the Supabase project's **legacy JWT secret** (Supabase → Project Settings → API / JWT Keys → "JWT Secret") | **THE BLOCKER.** Every owner call to `/bff/collab/*` answers `401 verification_unavailable`, so no round can be minted and the PR4 journey cannot run at all. Signing in changes nothing without this. A secret, therefore Paul's — I have not seen it and must not. |
| 2 | Supabase → Authentication → Emails / SMTP | custom SMTP provider | configured | Magic link is the product's primary sign-in and it returns **HTTP 500 "Error sending magic link email"** for an address that *does* exist. Also fixes the broken invite emails (row 2.1044). |
| 3 | Supabase → Authentication → Providers → Google | enable + client ID/secret | enabled | "Continue with Google" is on the login page and the provider answers **400 "Unsupported provider: provider is not enabled"**. |

Alternative to (1), for completeness: rotating the project's signing key to the ES256 key already
published in its JWKS would let CEE verify via JWKS instead — but that needs `SUPABASE_URL` or
`SUPABASE_JWKS_URL` set on CEE, and **I could not determine whether they are** (CEE's `/v1/status`
exposes no auth config). It also changes the token algorithm for every client. (1) is one variable
and no blast radius.

---

## What this PR does

Staging deploys `VITE_AUTH_MODE = "guest"`, so `AuthProvider` short-circuited and the **deployed**
implementations of both login buttons were:

```js
signInWithMagicLink: async () => ({ error: null })
signInWithGoogle:    async () => ({ error: null })
```

No network call, and a success report. `LoginPage` reads `{ error: null }` and tells the user a
sign-in link is on its way. That is the whole of ROADMAP **2.1043**.

The lie had two levels, so the fix has two halves.

**1. `AuthContext` — the guest branch becomes `OptionalAuthProvider`.**
A visitor who never signs in is byte-for-byte where they were: guest identity, `authenticated: true`,
and `loading: false` **on the first render**, so `AuthGuard` never spins (asserted per-render, not
just at settle — one frame of `loading: true` is a visible flash the PoC does not have today). What
changes is that the sign-in calls are now the **same shared implementations** the real-auth path
uses — there is no second copy left to drift — and a real session, if one exists or arrives,
replaces the guest identity.

A separate child component rather than a unified provider, deliberately: the real-auth path is
**untouched**, so this cannot regress a signed-in user, and `src/contexts/AuthContext.tsx` stays at
exactly its 6 entries in `rules-of-hooks-baseline.json` (that ratchet fails in either direction).
Verified: `232 violations across 15 files, exactly matching the baseline`.

**2. `LoginPage` — a server fault is not a sent link.**
The anti-enumeration branch swallowed *every* non-rate-limit error into `link-sent`, including the
500 staging returns when SMTP is unconfigured. One predicate was guarding two opposite harms: a
**gap** (leaking which addresses exist) and a **lie** (claiming to have sent nothing). It now has
two parameters — `>= 500` is ours and is named; everything else stays enumeration-safe and
unchanged, pinned by an opposite-direction twin. The resend path and the Google button stop
discarding their results.

**No new flag, no new build mode, no new roadmap row.** This extends **2.1043**; the SMTP and
witness rows **2.1044** / **2.1045** are the ones that resurface with the toggles above.

## Deliverables

| # | Deliverable | State |
|---|---|---|
| 1 | Optional real auth; silent-success no-op dead | **DONE** |
| 2 | Capability derivation | **DONE** — table below |
| 3 | Two-person witness | **script + dry-run DONE; live run BLOCKED** on toggle (1), cause derived at the bytes |

## Capability on staging Supabase, exercised

Public `/auth/v1/settings` plus one real call per method, with clearly-labelled throwaway accounts
at the reserved `example.test` TLD. No real account touched, no key printed (the anon key is public
by construction; SHA-256 prefix `22443e6c08d8c378`, byte-identical to `netlify.toml`).

| Method | Today |
|---|---|
| email + password sign-up / sign-in | **WORKS** — 200, session returned, auto-confirmed (`disable_signup: false`, `mailer_autoconfirm: true`) |
| magic link, existing user | **FAILS** — 500 `unexpected_failure`, "Error sending magic link email" |
| Google OAuth | **FAILS** — 400 "provider is not enabled" |
| anonymous sign-in | disabled |

**The sharp point: the only method that completes today is the one the product does not offer, and
both methods the product does offer are blocked on Paul-side config.** I deliberately did **not**
add a password form — it would not unblock the PR4 journey (toggle 1 gates that regardless), and
adding a new front door to an "invite-only pilot" is a product decision, not a lane decision.

## Witness

`scripts/witness/pr4-two-person-collab-witness.mjs`

- `--dry-run` → **PASS 7/7**, discriminating pairs: 3 well-formed payloads pass, 4 corrupted twins
  fail on a named problem (leaked siblings' answers, leaked model value, missing attribution,
  rewritten words, missing target). State-class **replayed** — it proves the assertions, not the product.
- live → **BLOCKED at leg 4**. State-class **fresh, two-identity**. Legs 1–3 passed on the real
  wire, including the control refusal run **before** the acceptance path.

Why the blocker is *this* cause, with a positive control:

| Bearer sent to `/bff/collab/rounds` | CEE answers |
|---|---|
| garbage, not JWT-shaped | `invalid_token` |
| valid JWT, **one character flipped in the signature** | `verification_unavailable` |
| valid, signature-intact HS256 token | `verification_unavailable` |

Row 1 proves the route *can* emit a different reason. Row 2 is decisive: a configured-but-wrong
secret would fail signature verification and answer `invalid_token`; `verification_unavailable` is
only reachable at the `!secret || secret.length === 0` guard, **before** any signature check
(`src/utils/supabase-user-jwt.ts`). The token is HS256 — the project's JWKS publishes only a
standby ES256 key.

## Brief premises refuted or corrected at the bytes

1. **`isGuestAuth` is not what the brief quotes.** At tip it is `!isRequireLoginEnabled() && (...)`
   — a `VITE_REQUIRE_LOGIN` flag already exists. It makes login **required** (no guest is ever
   minted), which is the opposite of the optional posture, so it was not the lever here.
2. **The no-op list was incomplete.** `signIn` and `signUp` also returned
   `{ error: null, data: { id: 'guest' } }` — success reports for a capability removed product-wide.
3. **"Whether password signup works is UNKNOWN" → it works**, and is the *only* method that does.
4. **"Two real authenticated identities" is not the shape of this product.** The journey needs
   **one** Supabase login (the owner) plus per-round **participant capability tokens**;
   `/panel/:round_id` is mounted **outside** `AuthGuard` precisely because a participant holds no
   session. Anyone scripting two logins would be testing a product that does not exist.
5. **The blocker is not a Supabase dashboard toggle at all** — it is a **CEE Render env var**. The
   brief anticipated a Supabase-side answer; the derivation says otherwise.

## Gates (run at this head, all steps of the required check's `tsc` job in order)

- `pnpm run lint` → **0 errors**; hooks ratchet **232/15 exactly matching baseline**
- `pnpm run typecheck` → **PASSED**, 3349/3389 files, 2487 diagnostics = baseline exactly
- new + touched specs → **27 passed (27)**, collected count asserted by name
- 8 mutants, isolation proven by **write test**, applied-check per mutation, leading and trailing
  controls agreeing → all 8 RED. **Two survived first time; both were real holes and are written up
  in the evidence dir rather than quietly patched.**

Evidence: `evidence/pr4-optional-auth/`.

## Not claimed

No UI journey witness. Everything here is wire-level and jsdom; neither collaboration page has been
rendered in a real browser by this lane, and jsdom cannot prove visibility. The witness fixtures are
built from the wire contract, **not** captures — no round has ever been minted on staging — and they
say so in their own header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
