### PR TITLE
fix(honesty): stability chip + constraints tone + owner password sign-in (link-R1 items 1, 7)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -92,10 +92,16 @@
 
   # Front door (real sign-in) — keep the REAL Supabase SDK in the staging
   # bundle. Without this, vite.config.ts aliases @supabase/supabase-js to
-  # src/stubs/supabase-stub.mjs on every guest build, and that stub does not
-  # implement signInWithOtp/signInWithOAuth at all — so sign-in cannot work
-  # no matter what the requireLogin flag says (the runbook in src/flags.ts
-  # `requireLogin` documents exactly this trap).
+  # src/stubs/supabase-stub.mjs on every guest build, and that stub implements
+  # NO sign-in method at all — signInWithOtp, signInWithOAuth and
+  # signInWithPassword are all absent — so sign-in cannot work no matter what
+  # the requireLogin flag says (the runbook in src/flags.ts `requireLogin`
+  # documents exactly this trap).
+  #
+  # ⚠ This sentence was FALSE for the password route until #667 round 2: the
+  # stub did carry `signInWithPassword` and answered `{ error: null }`, i.e.
+  # production would have reported a successful sign-in it never performed.
+  # Fixed in the stub, and pinned by AuthContext.optionalAuth.spec.tsx.
   #
   # This does NOT turn guest mode off: VITE_AUTH_MODE stays "guest", so
   # unauthenticated visitors still land on the guest canvas exactly as today

--- a/src/canvas/hooks/useAnalysisMetadata.ts
+++ b/src/canvas/hooks/useAnalysisMetadata.ts
@@ -11,6 +11,25 @@ import { useCanvasStore } from '../store'
 export type RunStatus = 'draft' | 'running' | 'complete' | 'error'
 export type StabilityStatus = 'stable' | 'fragile' | null
 
+/**
+ * The producer's display-safe robustness verdict (PLoT #202,
+ * `robustness.display_verdict`). This is the ONLY field licensed to make a
+ * robustness claim on screen — see the single-source rule quoted in
+ * `buildAnalysisHeroViewModel.ts` and `useResultsSectionData.ts`.
+ *
+ * FAIL-CLOSED, exactly as every other consumer does it: only these four tokens
+ * count. An absent field (older PLoT build) or an unrecognised token yields no
+ * verdict, and no verdict means no claim.
+ */
+const DISPLAY_SAFE_VERDICTS = ['robust', 'moderate', 'fragile', 'not_assessed'] as const
+type RobustnessDisplayVerdict = (typeof DISPLAY_SAFE_VERDICTS)[number]
+
+function readDisplayVerdict(raw: unknown): RobustnessDisplayVerdict | null {
+  return (DISPLAY_SAFE_VERDICTS as readonly string[]).includes(raw as string)
+    ? (raw as RobustnessDisplayVerdict)
+    : null
+}
+
 interface AnalysisMetadata {
   /** Run status for display */
   runStatus: RunStatus
@@ -49,13 +68,39 @@ export function useAnalysisMetadata(): AnalysisMetadata {
       return typeof nSamples === 'number' ? nSamples : null
     })()
 
-    // Derive stability from robustness.is_robust
+    // ── THE HEADER'S STABILITY CLAIM ────────────────────────────────────────
+    //
+    // ⚠ THIS USED TO READ `robustness.is_robust`, AND THAT WAS THE DEFECT
+    // (link-track R1 item 1 / C6). On deployed staging `5597d867`, 2026-08-11,
+    // one screen state carried a green `Stable` chip above an analysis panel
+    // saying "fragile" four times, "Ranking sensitive to assumptions", and
+    // "Stability: (not available for this run)" (L3-BROWSER-TRUTH §9 C6 — "the
+    // most investor-damaging contradiction in the product", reproduced on a
+    // second brief and a newer build, so it is systemic).
+    //
+    // `is_robust` is a RAW producer field, and this chip was its ONLY display
+    // consumer repo-wide. Everything else in the product consumes the
+    // display-safe `display_verdict` under an explicit single-source rule, and
+    // fails CLOSED so an unassessed run keeps the certified "Robustness
+    // unknown" state.
+    //
+    // Two authorities, two different questions (CLAUDE.md trap 21):
+    //   `is_robust`       — did the perturbation set leave the winner standing?
+    //   `display_verdict` — what may this run CLAIM about robustness on screen?
+    // A chrome chip is a display surface, so it takes the display authority.
+    // The point is not to align the two defaults; it is to point the surface
+    // at the question it is actually asking.
+    //
+    // `not_assessed` and an absent/unrecognised token both yield null, and a
+    // null stability renders NO CHIP AT ALL (TopBar gates on `!== null`) —
+    // silence, never a cheerful default.
     const stability: StabilityStatus = (() => {
-      if (!report?.robustness) return null
-      const isRobust = report.robustness.is_robust ?? report.robustness.isRobust
-      if (typeof isRobust === 'boolean') {
-        return isRobust ? 'stable' : 'fragile'
-      }
+      const verdict = readDisplayVerdict(
+        (report?.robustness as { display_verdict?: unknown } | undefined)?.display_verdict,
+      )
+      if (verdict === 'robust') return 'stable'
+      if (verdict === 'moderate' || verdict === 'fragile') return 'fragile'
+      // 'not_assessed', absent, or unrecognised — the run may claim nothing.
       return null
     })()
 

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -389,9 +389,23 @@ export default function LoginPage() {
                   </p>
                 )}
                 {pageState === 'oauth-failed' && (
-                  <p className={`${typography.bodySmall} text-danger mt-1`} role="alert">
+                  /* ⚠ THE DIRECTION WORD IS LOAD-BEARING AND HAS NOW BEEN WRONG
+                     TWICE. This message renders INSIDE the email-field div,
+                     which closes above the password form — so BOTH controls it
+                     points at are below it. Round 1 said "the email link above"
+                     after that button moved below; round 2's correction then
+                     said "the password form above", which was wrong the same
+                     way. The container is `flex flex-col`, so DOM order IS
+                     visual order, and the spec measures it with
+                     `compareDocumentPosition` rather than reading this comment:
+                     move either form and the pin REDs. */
+                  <p
+                    className={`${typography.bodySmall} text-danger mt-1`}
+                    role="alert"
+                    data-testid="oauth-failed-message"
+                  >
                     We couldn&rsquo;t start Google sign-in. Please use the password
-                    form above or the email link below, or ask your Olumi contact.
+                    form or the email link below, or ask your Olumi contact.
                   </p>
                 )}
               </div>

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,5 +1,27 @@
 /**
- * Login page — magic link + Google OAuth.
+ * Login page — owner password + magic link + Google OAuth.
+ *
+ * ── LINK-TRACK R1 item 7 (11 Aug 2026) ─────────────────────────────────────
+ * Password sign-in is the PILOT'S auth route (ratified). Magic link is the
+ * route that does not currently work: staging's Supabase project has no SMTP,
+ * which is why the `send-failed` state exists on this page at all. A pilot
+ * owner sent a link today lands on a form whose only controls are ones they
+ * have no way to complete.
+ *
+ * The password form is deliberately minimal and deliberately INCOMPLETE:
+ *   · NO sign-up. Owners are pre-provisioned; the absence of a self-serve
+ *     path is a decision, not an oversight.
+ *   · NO password reset. There is no SMTP to deliver one, and a reset control
+ *     that cannot send an email is the guarantee-theatre this track exists to
+ *     remove.
+ *   · NO new error vocabulary. Supabase answers a wrong password and an
+ *     unknown address with the same 400, which is already enumeration-safe;
+ *     nothing here re-classifies it, and the copy says only what is true of
+ *     both.
+ *
+ * The email field is SHARED by both routes and therefore sits outside both
+ * forms — a second email input would be a second source of truth for the one
+ * value both submissions send.
  *
  * States: default → submitting → link-sent → rate-limited → invalid-email → expired-link
  * Shows identical message for invited and non-invited emails (prevents enumeration).
@@ -20,6 +42,8 @@ type PageState =
   | 'expired-link'
   | 'send-failed'
   | 'oauth-failed'
+  | 'password-submitting'
+  | 'password-failed'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -51,10 +75,11 @@ function isRateLimited(error: unknown): boolean {
 }
 
 export default function LoginPage() {
-  const { signInWithMagicLink, signInWithGoogle } = useAuth()
+  const { signInWithMagicLink, signInWithGoogle, signInWithPassword } = useAuth()
   const [searchParams] = useSearchParams()
 
   const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [pageState, setPageState] = useState<PageState>(() =>
     searchParams.get('error') === 'expired' ? 'expired-link' : 'default',
   )
@@ -120,6 +145,32 @@ export default function LoginPage() {
     setResendCooldown(60)
   }, [email, signInWithMagicLink])
 
+  const handlePasswordSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = email.trim()
+    if (!EMAIL_RE.test(trimmed)) {
+      setPageState('invalid-email')
+      return
+    }
+    if (password.length === 0) return
+
+    setPageState('password-submitting')
+    const { error } = await signInWithPassword(trimmed, password)
+    if (error) {
+      // ONE failure state. A wrong password, an unknown address and a
+      // capability-absent build all land here and read identically, so this
+      // page cannot be used to discover which addresses exist. `isServerFault`
+      // is deliberately NOT branched on here: splitting the message by cause
+      // would reintroduce exactly that signal.
+      setPageState('password-failed')
+      setPassword('')
+      return
+    }
+    // On success the AuthProvider's onAuthStateChange drives navigation. This
+    // component does not route, and must not claim a redirect it never
+    // performs.
+  }, [email, password, signInWithPassword])
+
   const handleGoogleClick = useCallback(async () => {
     // The result used to be discarded, so a disabled provider produced a button
     // that visibly did nothing whatsoever.
@@ -167,10 +218,13 @@ export default function LoginPage() {
           /* ---- Default / submitting / invalid-email / rate-limited ---- */
           <>
             <p className={`${typography.body} text-text-light mb-6`}>
-              Enter your email to receive a sign-in link
+              Sign in with the password your Olumi contact gave you
             </p>
 
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            {/* The email field is shared by BOTH routes, so it lives outside
+                both forms. Enter is still handled: it submits whichever form
+                the focused control belongs to. */}
+            <div className="flex flex-col gap-4">
               <div>
                 <label htmlFor="login-email" className="sr-only">Email address</label>
                 <input
@@ -187,7 +241,7 @@ export default function LoginPage() {
                     }
                   }}
                   onBlur={handleEmailBlur}
-                  disabled={pageState === 'submitting'}
+                  disabled={pageState === 'submitting' || pageState === 'password-submitting'}
                   className={`w-full min-h-[44px] rounded-md border bg-panel px-4 py-3 ${typography.body} text-text-body placeholder:text-text-light transition-colors duration-fast focus:outline-none focus:ring-2 focus:ring-info/50 ${
                     pageState === 'invalid-email'
                       ? 'border-danger'
@@ -222,10 +276,81 @@ export default function LoginPage() {
                 )}
               </div>
 
+              {/* ---- Owner password sign-in: the pilot's working route ---- */}
+              <form
+                onSubmit={handlePasswordSubmit}
+                className="flex flex-col gap-4"
+                data-testid="owner-password-form"
+              >
+                <div>
+                  <label htmlFor="owner-password" className="sr-only">Password</label>
+                  <input
+                    id="owner-password"
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="Password"
+                    value={password}
+                    onChange={e => {
+                      setPassword(e.target.value)
+                      if (pageState === 'password-failed') setPageState('default')
+                    }}
+                    disabled={pageState === 'submitting' || pageState === 'password-submitting'}
+                    data-testid="owner-password-input"
+                    className={`w-full min-h-[44px] rounded-md border bg-panel px-4 py-3 ${typography.body} text-text-body placeholder:text-text-light transition-colors duration-fast focus:outline-none focus:ring-2 focus:ring-info/50 ${
+                      pageState === 'password-failed'
+                        ? 'border-danger'
+                        : 'border-[rgba(38,38,38,0.16)]'
+                    }`}
+                  />
+                  {pageState === 'password-failed' && (
+                    /* Identical for a wrong password and an unregistered
+                       address — Supabase answers both with the same 400, and
+                       splitting them here would leak which addresses exist. */
+                    <p
+                      className={`${typography.bodySmall} text-danger mt-1`}
+                      role="alert"
+                      data-testid="owner-password-error"
+                    >
+                      That email and password didn&rsquo;t match. Check them, or ask
+                      your Olumi contact.
+                    </p>
+                  )}
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={pageState === 'submitting' || pageState === 'password-submitting' || password.length === 0}
+                  data-testid="owner-password-submit"
+                  className={`${typography.button} flex items-center justify-center gap-2 rounded-pill bg-primary px-6 py-3 text-text-on-color shadow-1 transition-all duration-fast hover:bg-primary-hover hover:-translate-y-px active:bg-primary-active active:translate-y-0 disabled:bg-primary-disabled disabled:cursor-not-allowed disabled:translate-y-0`}
+                >
+                  {pageState === 'password-submitting' ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Signing in…
+                    </>
+                  ) : (
+                    'Sign in'
+                  )}
+                </button>
+              </form>
+            </div>
+
+            {/* Divider */}
+            <div className="my-6 flex items-center gap-3">
+              <div className="h-px flex-1 bg-[rgba(38,38,38,0.16)]" />
+              <span className={`${typography.bodySmall} text-text-light`}>or</span>
+              <div className="h-px flex-1 bg-[rgba(38,38,38,0.16)]" />
+            </div>
+
+            <form
+              onSubmit={handleSubmit}
+              className="flex flex-col gap-4"
+              data-testid="magic-link-form"
+            >
               <button
                 type="submit"
-                disabled={pageState === 'submitting'}
-                className={`${typography.button} flex items-center justify-center gap-2 rounded-pill bg-primary px-6 py-3 text-text-on-color shadow-1 transition-all duration-fast hover:bg-primary-hover hover:-translate-y-px active:bg-primary-active active:translate-y-0 disabled:bg-primary-disabled disabled:cursor-not-allowed disabled:translate-y-0`}
+                disabled={pageState === 'submitting' || pageState === 'password-submitting'}
+                className={`${typography.button} flex items-center justify-center gap-2 rounded-pill border border-[rgba(38,38,38,0.16)] bg-transparent px-6 py-3 text-text-body transition-all duration-fast hover:bg-panel-hover hover:-translate-y-px active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0`}
               >
                 {pageState === 'submitting' ? (
                   <>
@@ -238,18 +363,13 @@ export default function LoginPage() {
               </button>
             </form>
 
-            {/* Divider */}
-            <div className="my-6 flex items-center gap-3">
-              <div className="h-px flex-1 bg-[rgba(38,38,38,0.16)]" />
-              <span className={`${typography.bodySmall} text-text-light`}>or</span>
-              <div className="h-px flex-1 bg-[rgba(38,38,38,0.16)]" />
-            </div>
+            <div className="h-4" />
 
             {/* Google OAuth */}
             <button
               type="button"
               onClick={handleGoogleClick}
-              disabled={pageState === 'submitting'}
+              disabled={pageState === 'submitting' || pageState === 'password-submitting'}
               className={`${typography.button} flex w-full items-center justify-center gap-2 rounded-pill border border-[rgba(38,38,38,0.16)] bg-transparent px-6 py-3 text-text-body transition-all duration-fast hover:bg-panel-hover hover:-translate-y-px active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0`}
             >
               <GoogleIcon />

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -14,21 +14,50 @@
  *   · NO password reset. There is no SMTP to deliver one, and a reset control
  *     that cannot send an email is the guarantee-theatre this track exists to
  *     remove.
- *   · NO new error vocabulary. Supabase answers a wrong password and an
- *     unknown address with the same 400, which is already enumeration-safe;
- *     nothing here re-classifies it, and the copy says only what is true of
- *     both.
  *
- * The email field is SHARED by both routes and therefore sits outside both
- * forms — a second email input would be a second source of truth for the one
- * value both submissions send.
+ * The email field is SHARED by both routes. It sits outside both forms — a
+ * second email input would be a second source of truth for the one value both
+ * submissions send — and is associated with the PASSWORD form by `form=`, so
+ * it has an owner and implicit submission has somewhere to go (see below).
  *
- * States: default → submitting → link-sent → rate-limited → invalid-email → expired-link
+ * ── ROUND 2 (11 Aug 2026): THREE THINGS THIS PAGE GOT WRONG ────────────────
+ * All three were measured by the #667 adversarial review, by execution.
+ *
+ * 1. THE SUCCESS PATH DEAD-ENDED. This file used to carry the comment "on
+ *    success the AuthProvider's onAuthStateChange drives navigation". Nothing
+ *    did: neither `handleAuthStateChange` nor `OptionalAuthProvider.adopt`
+ *    navigates on sign-IN (the only `navigate()` calls in AuthContext are
+ *    sign-OUT), and `/login` sits OUTSIDE `AuthGuard`, so no guard bounces an
+ *    authenticated user away either. An owner who typed the CORRECT password
+ *    got every control disabled, a "Signing in…" spinner, and no way out but a
+ *    reload. Success now moves to `password-signed-in` and this page routes —
+ *    automatically once the provider reports the session, and via an explicit
+ *    Continue control that is always present, so there is no state in which the
+ *    owner is stuck behind a promise nobody keeps.
+ *
+ * 2. SERVER FAULTS AND RATE LIMITS WERE REPORTED AS "your password didn't
+ *    match". 400 (wrong password) and 400 (unknown address) are the
+ *    enumeration surface and stay byte-identical. A 5xx, a 501 capability-absent
+ *    build and a 429 are NOT address-correlated — they are returned the same for
+ *    an address that exists and one that does not — so naming them leaks
+ *    nothing, and the magic-link half of this same page has said so with its own
+ *    `send-failed` state since #666. The 429 case was actively harmful: it
+ *    blamed the credentials AND cleared the password, so a rate-limited owner
+ *    retyped a correct password into more rate-limiting.
+ *
+ * 3. `Enter` IN THE EMAIL FIELD WAS A DEAD KEY. The field belonged to no form,
+ *    so implicit submission had nothing to submit. It is now owned by the
+ *    password form — the pilot's working route — via `form="owner-password-form"`.
+ *
+ * States: default → submitting → link-sent → rate-limited → invalid-email
+ *         → expired-link → send-failed → oauth-failed
+ *         → password-submitting → password-failed → password-server-fault
+ *         → password-signed-in
  * Shows identical message for invited and non-invited emails (prevents enumeration).
  */
 
 import { useState, useEffect, useCallback } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom'
 import { Mail, Loader2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { typography } from '../../styles/typography'
@@ -44,6 +73,8 @@ type PageState =
   | 'oauth-failed'
   | 'password-submitting'
   | 'password-failed'
+  | 'password-server-fault'
+  | 'password-signed-in'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -75,8 +106,10 @@ function isRateLimited(error: unknown): boolean {
 }
 
 export default function LoginPage() {
-  const { signInWithMagicLink, signInWithGoogle, signInWithPassword } = useAuth()
+  const { signInWithMagicLink, signInWithGoogle, signInWithPassword, authenticated } = useAuth()
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const location = useLocation()
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -84,6 +117,41 @@ export default function LoginPage() {
     searchParams.get('error') === 'expired' ? 'expired-link' : 'default',
   )
   const [resendCooldown, setResendCooldown] = useState(0)
+  /**
+   * A password sign-in on THIS page has just succeeded.
+   *
+   * The routing below is gated on this rather than on `authenticated` alone,
+   * and that is load-bearing: in the guest posture `authenticated` is ALWAYS
+   * true (OptionalAuthProvider hands every visitor the guest identity so the
+   * PoC stays reachable), so redirecting on `authenticated` would make /login
+   * unreachable for a guest who came here deliberately.
+   */
+  const [signedInHere, setSignedInHere] = useState(false)
+
+  /**
+   * Where an owner belongs after signing in. `AuthGuard` redirects with
+   * `state: { from: location }`, so an owner deep-linked to a protected route
+   * returns to it rather than to the root.
+   */
+  const destination =
+    (location.state as { from?: { pathname?: string } } | null)?.from?.pathname ?? '/'
+
+  const goToApp = useCallback(() => {
+    navigate(destination, { replace: true })
+  }, [navigate, destination])
+
+  /**
+   * Route the owner into the app once the provider has actually adopted the
+   * session. Waiting for `authenticated` rather than navigating straight off
+   * the resolved promise avoids the race where AuthGuard has not yet seen the
+   * session and bounces the owner back here — which would relocate the
+   * dead-end rather than remove it. The Continue control below is the escape
+   * if the session never lands, so no path ends in a spinner.
+   */
+  useEffect(() => {
+    if (!signedInHere || !authenticated) return
+    goToApp()
+  }, [signedInHere, authenticated, goToApp])
 
   // Resend cooldown timer
   useEffect(() => {
@@ -157,18 +225,43 @@ export default function LoginPage() {
     setPageState('password-submitting')
     const { error } = await signInWithPassword(trimmed, password)
     if (error) {
-      // ONE failure state. A wrong password, an unknown address and a
-      // capability-absent build all land here and read identically, so this
-      // page cannot be used to discover which addresses exist. `isServerFault`
-      // is deliberately NOT branched on here: splitting the message by cause
-      // would reintroduce exactly that signal.
+      // TWO QUESTIONS, TWO PREDICATES (CLAUDE.md trap 21). "Is this an
+      // enumeration signal?" and "is this a server fault?" are different
+      // questions, and the first version of this handler answered both with
+      // one branch — so a 500, a 501 and a 429 were all reported to the owner
+      // as "your password didn't match", which is false for all three.
+      //
+      // What stays byte-identical is the ENUMERATION SURFACE: a wrong password
+      // and an unknown address are both Supabase 400 `Invalid login
+      // credentials` and both land in `password-failed` with one sentence.
+      // That is the only pair whose difference would reveal which addresses
+      // exist. A 5xx, a 501 capability-absent build and a 429 are returned the
+      // same way for an address that exists and one that does not, so naming
+      // them tells an attacker nothing — which is precisely the reasoning the
+      // magic-link half of this page has run on since #666 (`send-failed`).
+      if (isRateLimited(error)) {
+        // Deliberately does NOT clear the password: blaming the credentials
+        // and wiping the field made a rate-limited owner retype a CORRECT
+        // password into more rate-limiting.
+        setPageState('rate-limited')
+        return
+      }
+      if (isServerFault(error)) {
+        // >= 500, which includes the 501 a build with no `signInWithPassword`
+        // reports. Ours, not theirs, and never dressed up as a bad password.
+        setPageState('password-server-fault')
+        return
+      }
       setPageState('password-failed')
       setPassword('')
       return
     }
-    // On success the AuthProvider's onAuthStateChange drives navigation. This
-    // component does not route, and must not claim a redirect it never
-    // performs.
+    // Success. Hold the password in memory no longer than the request needs,
+    // then hand the owner to the app (see the effect above: this page routes,
+    // because nothing else does).
+    setPassword('')
+    setSignedInHere(true)
+    setPageState('password-signed-in')
   }, [email, password, signInWithPassword])
 
   const handleGoogleClick = useCallback(async () => {
@@ -192,7 +285,30 @@ export default function LoginPage() {
 
         <h3 className={`${typography.h3} text-text-header mb-1`}>Sign in to Olumi</h3>
 
-        {pageState === 'link-sent' ? (
+        {pageState === 'password-signed-in' ? (
+          /* ---- Signed in ----
+             The owner IS signed in: Supabase returned no error. The effect
+             above routes as soon as the provider adopts the session; this
+             state is what they see in the meantime, and the Continue control
+             is the escape hatch if adoption never happens — so the success
+             path cannot dead-end again. */
+          <div
+            className="mt-6 flex flex-col items-center gap-4 text-center"
+            data-testid="owner-password-signed-in"
+          >
+            <p className={`${typography.body} text-text-body`}>
+              Signed in. Taking you to your workspace&hellip;
+            </p>
+            <button
+              type="button"
+              onClick={goToApp}
+              data-testid="owner-password-continue"
+              className={`${typography.button} rounded-pill bg-primary px-6 py-3 text-text-on-color shadow-1 transition-all duration-fast hover:bg-primary-hover`}
+            >
+              Continue
+            </button>
+          </div>
+        ) : pageState === 'link-sent' ? (
           /* ---- Link-sent state ---- */
           <div className="mt-6 flex flex-col items-center gap-4 text-center">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-panel">
@@ -222,13 +338,17 @@ export default function LoginPage() {
             </p>
 
             {/* The email field is shared by BOTH routes, so it lives outside
-                both forms. Enter is still handled: it submits whichever form
-                the focused control belongs to. */}
+                both forms — but it is OWNED by the password form via `form=`.
+                Without an owner it belonged to no form, and implicit
+                submission (Enter) had nothing to submit: a dead key, measured
+                by the #667 review. The password form is the pilot's working
+                route, so that is where Enter goes. */}
             <div className="flex flex-col gap-4">
               <div>
                 <label htmlFor="login-email" className="sr-only">Email address</label>
                 <input
                   id="login-email"
+                  form="owner-password-form"
                   type="email"
                   inputMode="email"
                   autoComplete="email"
@@ -270,14 +390,15 @@ export default function LoginPage() {
                 )}
                 {pageState === 'oauth-failed' && (
                   <p className={`${typography.bodySmall} text-danger mt-1`} role="alert">
-                    We couldn&rsquo;t start Google sign-in. Please use the email link
-                    above, or ask your Olumi contact.
+                    We couldn&rsquo;t start Google sign-in. Please use the password
+                    form above or the email link below, or ask your Olumi contact.
                   </p>
                 )}
               </div>
 
               {/* ---- Owner password sign-in: the pilot's working route ---- */}
               <form
+                id="owner-password-form"
                 onSubmit={handlePasswordSubmit}
                 className="flex flex-col gap-4"
                 data-testid="owner-password-form"
@@ -292,7 +413,9 @@ export default function LoginPage() {
                     value={password}
                     onChange={e => {
                       setPassword(e.target.value)
-                      if (pageState === 'password-failed') setPageState('default')
+                      if (pageState === 'password-failed' || pageState === 'password-server-fault') {
+                        setPageState('default')
+                      }
                     }}
                     disabled={pageState === 'submitting' || pageState === 'password-submitting'}
                     data-testid="owner-password-input"
@@ -312,6 +435,22 @@ export default function LoginPage() {
                       data-testid="owner-password-error"
                     >
                       That email and password didn&rsquo;t match. Check them, or ask
+                      your Olumi contact.
+                    </p>
+                  )}
+                  {pageState === 'password-server-fault' && (
+                    /* NOT address-correlated: a 5xx and a 501 capability-absent
+                       build are returned identically for an address that exists
+                       and one that does not, so this sentence leaks nothing —
+                       and unlike the copy above, it is TRUE. Says nothing about
+                       the password, because the password is not the problem. */
+                    <p
+                      className={`${typography.bodySmall} text-danger mt-1`}
+                      role="alert"
+                      data-testid="owner-password-server-error"
+                    >
+                      We couldn&rsquo;t complete sign-in. This is a problem on our
+                      side, not with your details. Please try again shortly, or ask
                       your Olumi contact.
                     </p>
                   )}

--- a/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
+++ b/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
@@ -23,11 +23,25 @@
  * (CLAUDE.md trap 19). jsdom proves WIRING, never pixels (trap 3) — the visual
  * claim is not made here.
  *
- * ⚠ ENUMERATION IS THE RISK THIS PAGE WAS BUILT AROUND, so it is asserted
- * directly: every failure cause must reach ONE state with ONE sentence. A
- * failure message that differs by cause tells an attacker which addresses
- * exist, and the magic-link half of this page goes to real lengths to avoid
- * exactly that.
+ * ⚠ ENUMERATION IS THE RISK THIS PAGE WAS BUILT AROUND — but the sentence that
+ * used to sit here was the PREMISE B3 DISPROVED, and it survived at the top of
+ * the very file that disproves it. It read: *"every failure cause must reach
+ * ONE state with ONE sentence."* That is false at this head and, more to the
+ * point, it was harmful: collapsing every cause into one message is how a 500,
+ * a 501 and a 429 came to be reported to a pilot owner as "your password didn't
+ * match", which is untrue of all three.
+ *
+ * THE REAL PROPERTY, which is what the cases below assert:
+ *   · ADDRESS-CORRELATED causes must be INDISTINGUISHABLE from one another.
+ *     Supabase answers a wrong password, an unknown address, an existing but
+ *     unconfirmed address and a banned account all with a 400 — and the last
+ *     two reveal that the address EXISTS. All four must render byte-identical
+ *     copy from the same element, or this page becomes an account oracle.
+ *   · Causes that are NOT address-correlated — 5xx, 501, 429 — are returned
+ *     identically whether or not the address exists, so reporting them
+ *     DISTINCTLY leaks nothing and is the only way for the copy to be true.
+ * Two questions, two predicates (CLAUDE.md trap 21). A header that contradicts
+ * the file beneath it is how the next lane re-collapses the states (trap 14).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
@@ -214,10 +228,37 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
    * The pair is now asserted directly, and the three non-enumeration causes get
    * their own cases below.
    */
-  it('a wrong password and an unknown address are BYTE-IDENTICAL — enumeration stays closed', async () => {
+  it('FOUR different address-correlated 400 causes are BYTE-IDENTICAL — enumeration stays closed', async () => {
+    /**
+     * ⚠ ROUND 3. The first version of this case built its list from TWO
+     * BYTE-IDENTICAL 400s, so it asserted DETERMINISM, not indistinguishability
+     * across causes — it could not see the property it was named for. The
+     * closing review demonstrated it with mutant E1 (the failure copy
+     * interpolating the raw Supabase `error.message`, a genuine leak vector):
+     * 49/49 GREEN. The product was fine; the guard was the weak thing.
+     *
+     * These four are the causes Supabase actually distinguishes behind one 400
+     * — and the last two are the dangerous ones, because they only occur for an
+     * address that EXISTS. If any of them reached different copy, this page
+     * would answer "does this account exist?" for anyone who asked.
+     */
     const enumerationSurface = [
-      Object.assign(new Error('Invalid login credentials'), { status: 400 }), // wrong password
-      Object.assign(new Error('Invalid login credentials'), { status: 400 }), // unknown address
+      Object.assign(new Error('Invalid login credentials'), {
+        status: 400,
+        code: 'invalid_credentials',
+      }), // wrong password
+      Object.assign(new Error('Invalid login credentials'), {
+        status: 400,
+        code: 'invalid_credentials',
+      }), // unknown address — the same wire response, deliberately
+      Object.assign(new Error('Email not confirmed'), {
+        status: 400,
+        code: 'email_not_confirmed',
+      }), // the address EXISTS but is unconfirmed
+      Object.assign(new Error('User is banned'), {
+        status: 400,
+        code: 'user_banned',
+      }), // the address EXISTS and is suspended
     ]
 
     const messages = new Set<string>()
@@ -232,8 +273,23 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
 
     expect(
       messages.size,
-      `the failure message differs between a wrong password and an unknown address, which leaks which addresses exist: ${[...messages].join(' | ')}`,
+      `the failure copy differs across address-correlated causes, which turns this page into an account oracle: ${[...messages].join(' | ')}`,
     ).toBe(1)
+
+    // POSITIVE CONTROL on the probe itself: the causes above must be
+    // distinguishable IN PRINCIPLE, or byte-identity is vacuous. A 500 renders
+    // a DIFFERENT element with DIFFERENT text, so the loop above is reading a
+    // surface that genuinely can vary.
+    mockSignInWithPassword.mockResolvedValue({
+      error: Object.assign(new Error('boom'), { status: 500 }),
+    })
+    renderLogin()
+    fillCredentials('owner@example.com', 'pw')
+    await submitPassword()
+    expect(screen.queryByTestId('owner-password-error')).toBeNull()
+    expect(screen.getByTestId('owner-password-server-error').textContent ?? '').not.toBe(
+      [...messages][0],
+    )
   })
 
   it('a 500 is reported as OUR fault — never as "your password didn’t match"', async () => {
@@ -363,6 +419,58 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
    * form-owner rules, Enter in a text control submits the form it is
    * associated with, and association is exactly what was missing.
    */
+  /**
+   * ── THE DIRECTION WORD IN THE oauth-failed COPY (round-1 N2, round-2 blocker)
+   * This sentence has now been wrong TWICE, in both directions, and each time it
+   * was a claim about LAYOUT asserted from someone's memory of the JSX. Round 1:
+   * *"use the email link above"* after that button moved below. Round 2's
+   * correction: *"the password form above"* — wrong the same way, and worse,
+   * because it sent an owner whose Google sign-in had just failed to look
+   * upward for the pilot's ONLY working control.
+   *
+   * So the direction is now MEASURED, not read: `compareDocumentPosition` on
+   * the rendered DOM, with a positive control proving the probe can tell the two
+   * directions apart. The container is `flex flex-col`, so DOM order is visual
+   * order. Move either form and this REDs, which is the point — the copy cannot
+   * silently drift away from the layout a third time.
+   */
+  it('the oauth-failed copy names a direction the DOM actually agrees with', async () => {
+    mockSignInWithGoogle.mockResolvedValue({
+      error: Object.assign(new Error('Unsupported provider'), { status: 400 }),
+    })
+    renderLogin()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /continue with google/i }))
+    })
+
+    const message = screen.getByTestId('oauth-failed-message')
+    const heading = screen.getByRole('heading', { name: /sign in to olumi/i })
+
+    /** Measured relationship of `el` to the message, in reading order. */
+    const relativeToMessage = (el: Element): 'above' | 'below' =>
+      // eslint-disable-next-line no-bitwise
+      message.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING ? 'below' : 'above'
+
+    // POSITIVE CONTROL FIRST: the probe must be able to return 'above'.
+    // Without this, a probe that answered 'below' for everything would satisfy
+    // the assertions beneath it while measuring nothing (trap 13).
+    expect(
+      relativeToMessage(heading),
+      'the position probe cannot distinguish the two directions — it never returns "above"',
+    ).toBe('above')
+
+    expect(relativeToMessage(screen.getByTestId('owner-password-form'))).toBe('below')
+    expect(relativeToMessage(screen.getByTestId('magic-link-form'))).toBe('below')
+
+    // Both controls the sentence points at are BELOW it, so the copy may say
+    // "below" and must not say "above".
+    const copy = (message.textContent ?? '').toLowerCase()
+    expect(copy, 'the copy claims a control is above this message; both are below').not.toMatch(
+      /\babove\b/,
+    )
+    expect(copy).toMatch(/\bbelow\b/)
+  })
+
   it('the shared email field is OWNED by the password form, so Enter has somewhere to go', () => {
     renderLogin()
     const emailField = screen.getByPlaceholderText('you@example.com') as HTMLInputElement

--- a/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
+++ b/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
@@ -1,0 +1,208 @@
+/**
+ * LINK-TRACK R1 item 7 — THE PILOT'S AUTH ROUTE HAD NO FRONT DOOR.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ * Password sign-in works on staging's Supabase project and is the pilot's
+ * ratified auth route (BRIEF-LINK-TRACK-R1 item 7). The login page offered
+ * only magic link and Google — and magic link is the route that does NOT
+ * work: staging has no SMTP, which is why this page carries a `send-failed`
+ * state at all. So an owner sent a link today reached a page with no control
+ * they could complete.
+ *
+ * Meanwhile `AuthContext` declared `signIn(email, password)` as a "legacy
+ * compat" no-op returning `new Error('Password auth removed')`. This lane did
+ * NOT make that no-op real: quietly turning a no-op into a working call is how
+ * a surface starts reporting success for something it never did (the same
+ * module's header records a silent-success twin that told users a link was on
+ * its way while making no network call). A new capability got a new name —
+ * `signInWithPassword` — and `signIn`/`signUp` are untouched.
+ *
+ * ── WHAT THESE CASES PIN ───────────────────────────────────────────────────
+ * Cases bind by identity to `data-testid`s the form owns, never to a role +
+ * label that a future copy edit could satisfy from elsewhere on the page
+ * (CLAUDE.md trap 19). jsdom proves WIRING, never pixels (trap 3) — the visual
+ * claim is not made here.
+ *
+ * ⚠ ENUMERATION IS THE RISK THIS PAGE WAS BUILT AROUND, so it is asserted
+ * directly: every failure cause must reach ONE state with ONE sentence. A
+ * failure message that differs by cause tells an attacker which addresses
+ * exist, and the magic-link half of this page goes to real lengths to avoid
+ * exactly that.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockSignInWithMagicLink = vi.fn()
+const mockSignInWithGoogle = vi.fn()
+const mockSignInWithPassword = vi.fn()
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    authenticated: false,
+    signInWithMagicLink: mockSignInWithMagicLink,
+    signInWithGoogle: mockSignInWithGoogle,
+    signInWithPassword: mockSignInWithPassword,
+  }),
+}))
+
+import LoginPage from '../LoginPage'
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+function fillCredentials(email: string, password: string) {
+  fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: email } })
+  fireEvent.change(screen.getByTestId('owner-password-input'), { target: { value: password } })
+}
+
+async function submitPassword() {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('owner-password-form'))
+  })
+}
+
+describe('LINK-R1 item 7 — owner password sign-in', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSignInWithMagicLink.mockResolvedValue({ error: null })
+    mockSignInWithGoogle.mockResolvedValue({ error: null })
+    mockSignInWithPassword.mockResolvedValue({ error: null })
+  })
+
+  it('renders a password field and a sign-in submit', () => {
+    renderLogin()
+    expect(screen.getByTestId('owner-password-input')).toHaveAttribute('type', 'password')
+    expect(screen.getByTestId('owner-password-submit')).toBeInTheDocument()
+  })
+
+  it('calls signInWithPassword with the shared email and the typed password', async () => {
+    renderLogin()
+    fillCredentials('owner@example.com', 'hunter2-but-longer')
+    await submitPassword()
+
+    expect(mockSignInWithPassword).toHaveBeenCalledTimes(1)
+    expect(mockSignInWithPassword).toHaveBeenCalledWith('owner@example.com', 'hunter2-but-longer')
+  })
+
+  /**
+   * ⚠ A TRIM ASSERTION HERE WOULD BE THEATRE, AND IT WAS — REMOVED AFTER A
+   * MUTANT SURVIVED IT.
+   *
+   * The first version of this file asserted the handler trims the email, using
+   * `'  owner@example.com  '`. A mutant that sent the RAW value survived: the
+   * shared field is `type="email"`, and the HTML value-sanitisation algorithm
+   * strips leading/trailing whitespace before React ever sees it (jsdom
+   * implements this). So no input reachable through this form can distinguish
+   * a trimming handler from a non-trimming one — the test could not fail, and
+   * a test that cannot fail is not a test (CLAUDE.md trap 13).
+   *
+   * What IS observable, and what is asserted instead: both routes are handed
+   * the SAME value for the same typed input. That is the property that
+   * actually matters — two auth routes must not disagree about who is signing
+   * in — and it is one a future edit can genuinely break.
+   */
+  it('hands BOTH routes the same email for the same typed input', async () => {
+    renderLogin()
+    fillCredentials('Owner@Example.com', 'pw')
+    await submitPassword()
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('magic-link-form'))
+    })
+
+    const passwordEmail = mockSignInWithPassword.mock.calls[0][0]
+    const magicLinkEmail = mockSignInWithMagicLink.mock.calls[0][0]
+    expect(passwordEmail).toBe(magicLinkEmail)
+  })
+
+  it('sends NOTHING and shows the email error when the address is malformed', async () => {
+    renderLogin()
+    fillCredentials('not-an-email', 'pw')
+    await submitPassword()
+
+    expect(mockSignInWithPassword).not.toHaveBeenCalled()
+    expect(screen.getByText(/enter a valid email/i)).toBeInTheDocument()
+  })
+
+  it('sends NOTHING on an empty password (the submit is disabled, and the handler agrees)', async () => {
+    renderLogin()
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'owner@example.com' },
+    })
+    expect(screen.getByTestId('owner-password-submit')).toBeDisabled()
+
+    await submitPassword()
+    expect(mockSignInWithPassword).not.toHaveBeenCalled()
+  })
+
+  it('reports failure, and CLEARS the password so a retry cannot resend a stale value', async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      error: Object.assign(new Error('Invalid login credentials'), { status: 400 }),
+    })
+    renderLogin()
+    fillCredentials('owner@example.com', 'wrong')
+    await submitPassword()
+
+    expect(screen.getByTestId('owner-password-error')).toBeInTheDocument()
+    expect((screen.getByTestId('owner-password-input') as HTMLInputElement).value).toBe('')
+  })
+
+  it('gives BYTE-IDENTICAL failure copy for every cause — enumeration stays closed', async () => {
+    // The discriminating property, and the one a well-meaning later edit is
+    // most likely to break by "improving" the message for a server fault.
+    const causes = [
+      Object.assign(new Error('Invalid login credentials'), { status: 400 }), // wrong password
+      Object.assign(new Error('Invalid login credentials'), { status: 400 }), // unknown address
+      Object.assign(new Error('boom'), { status: 500 }), // our fault
+      Object.assign(new Error('no signInWithPassword'), { status: 501 }), // capability absent
+      Object.assign(new Error('slow down'), { status: 429 }), // rate limited
+    ]
+
+    const messages = new Set<string>()
+    for (const error of causes) {
+      mockSignInWithPassword.mockResolvedValue({ error })
+      const view = renderLogin()
+      fillCredentials('owner@example.com', 'pw')
+      await submitPassword()
+      messages.add(screen.getByTestId('owner-password-error').textContent ?? '')
+      view.unmount()
+    }
+
+    expect(
+      messages.size,
+      `the password failure message varies by cause, which leaks which addresses exist: ${[...messages].join(' | ')}`,
+    ).toBe(1)
+  })
+
+  it('does not claim a redirect it never performs on success', async () => {
+    renderLogin()
+    fillCredentials('owner@example.com', 'pw')
+    await submitPassword()
+
+    // Navigation is the AuthProvider's job (onAuthStateChange). This surface
+    // must not print a "redirecting…" promise it does not keep.
+    expect(screen.queryByTestId('owner-password-error')).toBeNull()
+    expect(document.body.textContent ?? '').not.toMatch(/redirect/i)
+  })
+
+  it('leaves the magic-link route intact and reachable', async () => {
+    // The password form is the pilot route; it must not be added by deleting
+    // the other one (trap 13b — the fix must not pass by removing a control).
+    renderLogin()
+    expect(screen.getByTestId('magic-link-form')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /send magic link/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue with google/i })).toBeInTheDocument()
+  })
+
+  it('offers NO sign-up and NO password reset — both would be controls with nothing behind them', () => {
+    // Owners are pre-provisioned and there is no SMTP. A "create account" or
+    // "forgot password" control here would be guarantee theatre.
+    renderLogin()
+    const text = document.body.textContent ?? ''
+    expect(text).not.toMatch(/create an account|sign up|forgot (your )?password|reset password/i)
+  })
+})

--- a/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
+++ b/src/components/auth/__tests__/LoginPage.ownerPassword.spec.tsx
@@ -31,14 +31,20 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 
 const mockSignInWithMagicLink = vi.fn()
 const mockSignInWithGoogle = vi.fn()
 const mockSignInWithPassword = vi.fn()
+/**
+ * Whether the provider has adopted a real session yet. Mutable because the
+ * whole point of the success path is that it depends on this flipping: the
+ * page waits for the provider rather than navigating off the resolved promise.
+ */
+let mockAuthenticated = false
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
-    authenticated: false,
+    authenticated: mockAuthenticated,
     signInWithMagicLink: mockSignInWithMagicLink,
     signInWithGoogle: mockSignInWithGoogle,
     signInWithPassword: mockSignInWithPassword,
@@ -51,6 +57,24 @@ function renderLogin() {
   return render(
     <MemoryRouter initialEntries={['/login']}>
       <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+/**
+ * The same page inside a REAL router with real destinations, so "the owner
+ * ends up in the app" is proven by the router actually rendering the
+ * destination — not by spying on `useNavigate`, which would prove only that a
+ * function was called.
+ */
+function renderLoginRouted(initialEntries: unknown[] = ['/login']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries as never}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/" element={<div data-testid="app-root">workspace</div>} />
+        <Route path="/scenarios/abc" element={<div data-testid="app-deep-link">deep</div>} />
+      </Routes>
     </MemoryRouter>,
   )
 }
@@ -69,6 +93,7 @@ async function submitPassword() {
 describe('LINK-R1 item 7 — owner password sign-in', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAuthenticated = false
     mockSignInWithMagicLink.mockResolvedValue({ error: null })
     mockSignInWithGoogle.mockResolvedValue({ error: null })
     mockSignInWithPassword.mockResolvedValue({ error: null })
@@ -105,17 +130,37 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
    * the SAME value for the same typed input. That is the property that
    * actually matters — two auth routes must not disagree about who is signing
    * in — and it is one a future edit can genuinely break.
+   *
+   * ⚠ ROUND 2 (review N3): this case's DISCRIMINATING POWER is narrower than
+   * the paragraph above implies, and the reviewer measured it. Its fixture
+   * `'Owner@Example.com'` carries no whitespace, so `email === trimmed` and a
+   * mutant that passed the RAW value to one route survives. It pins AGREEMENT
+   * between the two routes, which is real; it does NOT pin trimming, and no
+   * test reachable through a `type="email"` field can.
    */
   it('hands BOTH routes the same email for the same typed input', async () => {
-    renderLogin()
-    fillCredentials('Owner@Example.com', 'pw')
+    // ⚠ TWO RENDERS, deliberately. Either successful submit now LEAVES the
+    // form — password sign-in goes to the signed-in state, magic link to
+    // `link-sent` — so no single render can exercise both routes. Feeding the
+    // same typed input to two fresh renders pins exactly the property that
+    // matters: the two routes must not disagree about who is signing in.
+    const TYPED = 'Owner@Example.com'
+
+    const first = renderLogin()
+    fillCredentials(TYPED, 'pw')
     await submitPassword()
+    first.unmount()
+
+    renderLogin()
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: TYPED } })
     await act(async () => {
       fireEvent.submit(screen.getByTestId('magic-link-form'))
     })
 
     const passwordEmail = mockSignInWithPassword.mock.calls[0][0]
     const magicLinkEmail = mockSignInWithMagicLink.mock.calls[0][0]
+    expect(mockSignInWithPassword).toHaveBeenCalledTimes(1)
+    expect(mockSignInWithMagicLink).toHaveBeenCalledTimes(1)
     expect(passwordEmail).toBe(magicLinkEmail)
   })
 
@@ -151,19 +196,32 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
     expect((screen.getByTestId('owner-password-input') as HTMLInputElement).value).toBe('')
   })
 
-  it('gives BYTE-IDENTICAL failure copy for every cause — enumeration stays closed', async () => {
-    // The discriminating property, and the one a well-meaning later edit is
-    // most likely to break by "improving" the message for a server fault.
-    const causes = [
+  /**
+   * ⚠ ROUND 2 — THIS CASE USED TO ENFORCE A LIE, AND IT IS THE CLEAREST
+   * example in this file of trap 21 (two questions under one predicate).
+   *
+   * It collapsed 400 / 429 / 500 / 501 into one message and asserted
+   * `messages.size === 1` — so the suite actively DEFENDED reporting a server
+   * outage and a rate limit as "your password didn't match". Three of the four
+   * were false. The enumeration property it was written to protect is real, but
+   * it is a property of ONE PAIR: a wrong password and an unknown address, both
+   * Supabase 400 `Invalid login credentials`. Those are what an attacker would
+   * diff. A 5xx, a 501 and a 429 are returned identically whether or not the
+   * address exists, so distinguishing them reveals nothing — which is exactly
+   * why the magic-link half of this same page has had a `send-failed` state
+   * since #666.
+   *
+   * The pair is now asserted directly, and the three non-enumeration causes get
+   * their own cases below.
+   */
+  it('a wrong password and an unknown address are BYTE-IDENTICAL — enumeration stays closed', async () => {
+    const enumerationSurface = [
       Object.assign(new Error('Invalid login credentials'), { status: 400 }), // wrong password
       Object.assign(new Error('Invalid login credentials'), { status: 400 }), // unknown address
-      Object.assign(new Error('boom'), { status: 500 }), // our fault
-      Object.assign(new Error('no signInWithPassword'), { status: 501 }), // capability absent
-      Object.assign(new Error('slow down'), { status: 429 }), // rate limited
     ]
 
     const messages = new Set<string>()
-    for (const error of causes) {
+    for (const error of enumerationSurface) {
       mockSignInWithPassword.mockResolvedValue({ error })
       const view = renderLogin()
       fillCredentials('owner@example.com', 'pw')
@@ -174,19 +232,144 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
 
     expect(
       messages.size,
-      `the password failure message varies by cause, which leaks which addresses exist: ${[...messages].join(' | ')}`,
+      `the failure message differs between a wrong password and an unknown address, which leaks which addresses exist: ${[...messages].join(' | ')}`,
     ).toBe(1)
   })
 
-  it('does not claim a redirect it never performs on success', async () => {
+  it('a 500 is reported as OUR fault — never as "your password didn’t match"', async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      error: Object.assign(new Error('boom'), { status: 500 }),
+    })
     renderLogin()
-    fillCredentials('owner@example.com', 'pw')
+    fillCredentials('owner@example.com', 'correct-horse')
     await submitPassword()
 
-    // Navigation is the AuthProvider's job (onAuthStateChange). This surface
-    // must not print a "redirecting…" promise it does not keep.
+    expect(screen.getByTestId('owner-password-server-error')).toBeInTheDocument()
     expect(screen.queryByTestId('owner-password-error')).toBeNull()
-    expect(document.body.textContent ?? '').not.toMatch(/redirect/i)
+    expect(screen.getByTestId('owner-password-server-error').textContent ?? '').toMatch(
+      /problem on our side/i,
+    )
+  })
+
+  it('a 501 capability-absent build is reported as OUR fault, not as bad credentials', async () => {
+    // This is the status `AuthContext.signInUnavailable` stamps when the
+    // bundled Supabase client has no `signInWithPassword` at all. Telling the
+    // owner their password was wrong would send them hunting for a password
+    // problem that does not exist.
+    mockSignInWithPassword.mockResolvedValue({
+      error: Object.assign(new Error('Sign-in is unavailable in this build'), { status: 501 }),
+    })
+    renderLogin()
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.getByTestId('owner-password-server-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('owner-password-error')).toBeNull()
+  })
+
+  it('a 429 is reported as a rate limit AND does not wipe a correct password', async () => {
+    // The actively harmful case: the old copy blamed the credentials and
+    // cleared the field, so a rate-limited owner retyped a CORRECT password
+    // into more rate-limiting — on the pilot's only working route, with no
+    // reset path.
+    mockSignInWithPassword.mockResolvedValue({
+      error: Object.assign(new Error('slow down'), { status: 429 }),
+    })
+    renderLogin()
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.getByText(/wait a moment before trying again/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('owner-password-error')).toBeNull()
+    expect((screen.getByTestId('owner-password-input') as HTMLInputElement).value).toBe(
+      'correct-horse',
+    )
+  })
+
+  /**
+   * ── THE SUCCESS PATH (review blocker 1) ───────────────────────────────────
+   * Measured at `e5d54d6a` by the reviewer, by execution: after a SUCCESSFUL
+   * submit, `[email, password, submit, magic-link, google].disabled` read
+   * `[true, true, true, true, true]` and stayed that way — every control dead,
+   * a "Signing in…" spinner, no route change, forever. The in-file comment
+   * blamed the AuthProvider's `onAuthStateChange`; nothing in `AuthContext`
+   * navigates on sign-IN, and `/login` sits outside `AuthGuard`, so nothing
+   * else was going to move either.
+   *
+   * These bind to the DESTINATION rendering, not to a `useNavigate` spy.
+   */
+  it('a correct password lands the owner IN THE APP once the provider adopts the session', async () => {
+    mockAuthenticated = true // the session the successful call just created
+    renderLoginRouted()
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.getByTestId('app-root')).toBeInTheDocument()
+    expect(screen.queryByTestId('owner-password-form')).toBeNull()
+  })
+
+  it('returns the owner to the route AuthGuard bounced them from, not to the root', async () => {
+    // AuthGuard redirects with `state: { from: location }`. Ignoring it would
+    // silently discard a deep link on every protected route.
+    mockAuthenticated = true
+    renderLoginRouted([{ pathname: '/login', state: { from: { pathname: '/scenarios/abc' } } }])
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.getByTestId('app-deep-link')).toBeInTheDocument()
+  })
+
+  it('does not dead-end while the session is still landing — Continue is live and routes', async () => {
+    // The provider has NOT adopted the session yet. The old page left the owner
+    // on a disabled form here indefinitely; there must always be a live control.
+    mockAuthenticated = false
+    renderLoginRouted()
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.getByTestId('owner-password-signed-in')).toBeInTheDocument()
+    const cont = screen.getByTestId('owner-password-continue') as HTMLButtonElement
+    expect(cont.disabled).toBe(false)
+    await act(async () => {
+      fireEvent.click(cont)
+    })
+    expect(screen.getByTestId('app-root')).toBeInTheDocument()
+  })
+
+  it('leaves no disabled-control dead end on success — the measured defect, inverted', async () => {
+    // The reviewer's measurement as an assertion: after success, the disabled
+    // form is not what the owner is looking at.
+    mockAuthenticated = false
+    renderLogin()
+    fillCredentials('owner@example.com', 'correct-horse')
+    await submitPassword()
+
+    expect(screen.queryByTestId('owner-password-input')).toBeNull()
+    expect(screen.queryByTestId('owner-password-submit')).toBeNull()
+    expect(document.body.textContent ?? '').not.toMatch(/signing in…/i)
+  })
+
+  /**
+   * ── `Enter` IN THE SHARED EMAIL FIELD (review N1) ─────────────────────────
+   * The field sits outside both forms so there is one source of truth for the
+   * address. At `e5d54d6a` it also had no `form=` attribute, so `input.form`
+   * was `null`: it belonged to no form and implicit submission had nothing to
+   * submit — a dead key.
+   *
+   * ⚠ jsdom does NOT implement implicit submission (measured: a synthetic
+   * `Enter` keydown on an associated input fires zero `submit` events), so the
+   * keypress itself cannot be proven here — trap 3. What IS the mechanism, and
+   * what is asserted, is OWNERSHIP, bound by element identity: per the HTML
+   * form-owner rules, Enter in a text control submits the form it is
+   * associated with, and association is exactly what was missing.
+   */
+  it('the shared email field is OWNED by the password form, so Enter has somewhere to go', () => {
+    renderLogin()
+    const emailField = screen.getByPlaceholderText('you@example.com') as HTMLInputElement
+    const passwordForm = screen.getByTestId('owner-password-form')
+
+    expect(emailField.form, 'the email field belongs to no form — Enter is a dead key').not.toBeNull()
+    expect(emailField.form).toBe(passwordForm)
   })
 
   it('leaves the magic-link route intact and reachable', async () => {
@@ -202,6 +385,19 @@ describe('LINK-R1 item 7 — owner password sign-in', () => {
     // Owners are pre-provisioned and there is no SMTP. A "create account" or
     // "forgot password" control here would be guarantee theatre.
     renderLogin()
+
+    // ⚠ POSITIVE CONTROL (review N4). This is a bare-absence probe over
+    // `document.body.textContent`, and an absence probe with nothing proving it
+    // can see a PRESENCE is vacuous (trap 13): at pristine, where no password
+    // form existed at all, it passed. Asserting the form IS rendered in the
+    // SAME test means a render that produced nothing can no longer be read as
+    // "no sign-up offered".
+    expect(
+      screen.getByTestId('owner-password-form'),
+      'the password form did not render — the absence assertion below would pass vacuously',
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('owner-password-input')).toBeInTheDocument()
+
     const text = document.body.textContent ?? ''
     expect(text).not.toMatch(/create an account|sign up|forgot (your )?password|reset password/i)
   })

--- a/src/components/auth/__tests__/LoginPage.test.tsx
+++ b/src/components/auth/__tests__/LoginPage.test.tsx
@@ -5,11 +5,13 @@ import React from 'react'
 
 const mockSignInWithMagicLink = vi.fn()
 const mockSignInWithGoogle = vi.fn()
+const mockSignInWithPassword = vi.fn()
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
     authenticated: false,
     signInWithMagicLink: mockSignInWithMagicLink,
     signInWithGoogle: mockSignInWithGoogle,
+    signInWithPassword: mockSignInWithPassword,
   }),
 }))
 
@@ -28,6 +30,7 @@ describe('LoginPage', () => {
     vi.clearAllMocks()
     mockSignInWithMagicLink.mockResolvedValue({ error: null })
     mockSignInWithGoogle.mockResolvedValue({ error: null })
+    mockSignInWithPassword.mockResolvedValue({ error: null })
   })
 
   it('renders sign-in heading and email input', () => {
@@ -52,7 +55,7 @@ describe('LoginPage', () => {
     fireEvent.change(input, { target: { value: 'user@example.com' } })
 
     await act(async () => {
-      fireEvent.submit(input.closest('form')!)
+      fireEvent.submit(screen.getByTestId('magic-link-form'))
     })
 
     expect(mockSignInWithMagicLink).toHaveBeenCalledWith('user@example.com')
@@ -64,7 +67,7 @@ describe('LoginPage', () => {
     fireEvent.change(input, { target: { value: 'user@example.com' } })
 
     await act(async () => {
-      fireEvent.submit(input.closest('form')!)
+      fireEvent.submit(screen.getByTestId('magic-link-form'))
     })
 
     expect(screen.getByText(/if this email is registered/i)).toBeInTheDocument()
@@ -115,7 +118,7 @@ describe('LoginPage × server faults are reported, enumeration stays closed', ()
     const input = screen.getByPlaceholderText('you@example.com')
     fireEvent.change(input, { target: { value: email } })
     await act(async () => {
-      fireEvent.submit(input.closest('form')!)
+      fireEvent.submit(screen.getByTestId('magic-link-form'))
     })
   }
 

--- a/src/components/layout/__tests__/TopBar.stabilityChipSingleSource.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.stabilityChipSingleSource.spec.tsx
@@ -1,0 +1,184 @@
+/**
+ * LINK-TRACK R1 item 1 (contradiction cluster, C6) — THE GREEN "Stable" CHIP
+ * IS THE ONLY ROBUSTNESS CLAIM IN THE PRODUCT THAT IGNORES THE DISPLAY-SAFE
+ * VERDICT.
+ *
+ * ── THE MEASURED CONTRADICTION ─────────────────────────────────────────────
+ * L3 browser lane, deployed staging `5597d867`, 2026-08-11
+ * (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/arch-decision-2026-08-11/L3-BROWSER-TRUTH.md`
+ * §9 C6 — "the most investor-damaging contradiction in the product"), one
+ * screen state:
+ *
+ *   Header chip     → `Stable` (green)
+ *   Analysis panel  → "…treat this as provisional: the link between … is fragile."
+ *   Analysis panel  → "The ordering holds in about 72% of variations, but the result is fragile…"
+ *   Analysis panel  → ⚠ "Ranking sensitive to assumptions"
+ *   Analysis panel  → Stability: (not available for this run)
+ *   Analysis panel  → "Fragile factors (3)" · "3 factors could flip the result"
+ *
+ * Reproduced on B1 on 10 Aug and on B2 on a newer build, so it is systemic.
+ *
+ * ── ROOT CAUSE, DERIVED AT THE BYTES AT `5597d867` ─────────────────────────
+ * The estate has an explicit SINGLE-SOURCE RULE for robustness claims, written
+ * into `buildAnalysisHeroViewModel.ts:162`:
+ *
+ *   "Sensitivity caveat is gated on the display-safe robustness verdict ONLY —
+ *    never raw recommendation_stability (single-source rule, see
+ *    ROBUSTNESS-VERDICT-CONTRACT). The verdict is the producer's own
+ *    robustness.display_verdict (PLoT #202)."
+ *
+ * `useAnalysisMetadata` — the sole feeder of this chip — does not follow it.
+ * It reads `report.robustness.is_robust`, a raw boolean, and `is_robust` has
+ * exactly ONE display consumer repo-wide: this chip. Everything else consumes
+ * `display_verdict` and fails CLOSED on an absent or unrecognised token,
+ * keeping the certified "Robustness unknown" state.
+ *
+ * So this is CLAUDE.md trap 21 exactly: two authorities answering DIFFERENT
+ * questions under similar names. `is_robust` answers "did the perturbation set
+ * leave the winner standing?"; `display_verdict` answers "what may this run
+ * CLAIM about robustness on screen?". The chip is a display surface, so it
+ * must consume the display authority. The fix is not to align the defaults —
+ * it is to point the surface at the question it is actually asking.
+ *
+ * ── WHAT THESE CASES PIN ───────────────────────────────────────────────────
+ * Case 1 is the RED: the exact deployed shape (`is_robust: true` beside a
+ * `fragile` verdict) must not render "Stable".
+ * Case 2 is the other measured half: no verdict on the wire, panel says
+ * stability is not available — the chrome must make no claim at all.
+ * Case 3 is the discriminating positive (trap 13b): a genuinely `robust`
+ * verdict must still render "Stable", so the fix cannot pass by deleting the
+ * chip.
+ * Case 4 binds by identity rather than by a value predicate (trap 19): the
+ * assertion is on the chip's own `data-stability` attribute, not on the word
+ * "Stable" appearing anywhere on screen.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { TopBar } from '../TopBar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+import { useCanvasStore } from '../../../canvas/store'
+
+/**
+ * ⚠ THE PROBE IS BOUND TO AN ATTRIBUTE THAT ALREADY EXISTS AT PRISTINE.
+ *
+ * The first draft of this spec queried a `data-testid` the fix was going to
+ * add. Four of its six cases then PASSED at pristine — not because the
+ * product was right, but because `queryByTestId` returned null for an element
+ * that had no testid yet. An absence probe with no positive control passes by
+ * testing nothing (CLAUDE.md trap 13). `data-stability` is on the shipped
+ * chip today, so every case below can genuinely see the pre-fix state.
+ */
+const STABILITY_SELECTOR = '[data-stability]'
+
+function stabilityChip(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(STABILITY_SELECTOR)
+}
+
+/**
+ * The shape measured on the wire: a raw `is_robust: true` alongside the
+ * producer's display-safe verdict. Both live under `report.robustness`.
+ */
+function seedResults(robustness: Record<string, unknown>) {
+  act(() => {
+    useCanvasStore.setState({
+      results: {
+        ...useCanvasStore.getState().results,
+        status: 'complete',
+        report: {
+          meta: { n_samples: 5000, computed_at: new Date().toISOString() },
+          robustness,
+        },
+      },
+    } as never)
+  })
+}
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar
+          scenarioTitle="Take £4m out of opex"
+          onTitleChange={vi.fn()}
+          onSave={vi.fn()}
+          onShare={vi.fn()}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('LINK-R1 C6 — the header stability chip consumes the display-safe verdict', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('does NOT say "Stable" when the producer\'s display verdict is fragile, even with is_robust true', () => {
+    // The deployed shape. `is_robust` said the winner survived the
+    // perturbation set; `display_verdict` said the run may not claim
+    // robustness. The chrome sided with the raw field.
+    renderTopBar()
+    seedResults({ is_robust: true, display_verdict: 'fragile' })
+
+    const chip = stabilityChip()
+    expect(
+      chip?.getAttribute('data-stability') ?? null,
+      'the header chip claimed stability the analysis panel had already refused',
+    ).not.toBe('stable')
+  })
+
+  it('makes NO stability claim at all when the producer sent no display verdict', () => {
+    // L3 §9: the panel read "Stability: (not available for this run)" on the
+    // same screen as the green chip. Absence of a verdict is the certified
+    // "Robustness unknown" state — the chrome must be silent, not cheerful.
+    renderTopBar()
+    seedResults({ is_robust: true })
+
+    expect(
+      stabilityChip(),
+      'the header chip claimed stability on a run whose robustness was never assessed',
+    ).toBeNull()
+  })
+
+  it('makes NO stability claim when the producer explicitly says not_assessed', () => {
+    renderTopBar()
+    seedResults({ is_robust: true, display_verdict: 'not_assessed' })
+
+    expect(stabilityChip()).toBeNull()
+  })
+
+  it('STILL says "Stable" on a genuinely robust verdict — the discriminating positive', () => {
+    // Without this the fix could pass by suppressing the chip unconditionally,
+    // which deletes a truthful signal rather than correcting a false one.
+    renderTopBar()
+    seedResults({ is_robust: true, display_verdict: 'robust' })
+
+    const chip = stabilityChip()
+    expect(chip).not.toBeNull()
+    expect(chip!.getAttribute('data-stability')).toBe('stable')
+    expect(chip!.textContent).toContain('Stable')
+  })
+
+  it('says "Sensitive" on a moderate verdict, and binds the claim to the chip itself', () => {
+    renderTopBar()
+    seedResults({ is_robust: true, display_verdict: 'moderate' })
+
+    const chip = stabilityChip()
+    expect(chip).not.toBeNull()
+    // Bound by identity to the chip's own attribute, never to the word
+    // appearing somewhere on the screen (trap 19). `fragile` is the shipped
+    // attribute vocabulary for the non-robust rendering; it is kept so this
+    // change moves the SOURCE of the claim, not the DOM contract.
+    expect(chip!.getAttribute('data-stability')).toBe('fragile')
+    expect(chip!.textContent).toContain('Sensitive')
+  })
+
+  it('ignores an unrecognised verdict token rather than guessing (fail-closed)', () => {
+    renderTopBar()
+    seedResults({ is_robust: true, display_verdict: 'extremely_robust_probably' })
+
+    expect(stabilityChip()).toBeNull()
+  })
+})

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -71,7 +71,18 @@ export const OVERVIEW_COPY = {
   // the Constraints chip and was wrong on each, in opposite ways. See the
   // chip-note derivation below. Its absence is pinned by
   // DecisionOverviewCard.spec.tsx, which asserts the literal sentence.
-  constraintsNoteEmpty: 'No limits on record',
+  // ⚠ THIS SENTENCE HAS NOW BEEN WRONG TWICE, IN TWO DIFFERENT WAYS, AND THE
+  // SECOND CORRECTION IS THE ONE TO KEEP IN MIND.
+  //
+  // v1 "Not captured yet" was a FALSE DENIAL of the user's own input, and was
+  // retired for that. v2 "No limits on record" fixed the denial and left an
+  // ambiguity: "on record" reads as easily as "on YOUR record" as "in my
+  // model". L3 measured a reader taking it the first way, on a brief stating
+  // three constraints — two of them prefixed with the literal word
+  // "constraint" — that the product demonstrably read and re-typed as soft
+  // risks (L3-BROWSER-TRUTH §9 C7). The sentence must be unambiguously about
+  // what the MODEL has set, which is the only thing `constraintCount` knows.
+  constraintsNoteEmpty: 'Nothing set as a hard limit',
   optionsNoteEmpty: 'No options mapped yet',
   // V6-RESPEC §4: empty classification fields fold into ONE muted aggregate
   // chip ("+N to set") — collapsed shows what IS, never a per-field inventory
@@ -403,7 +414,16 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
     // outlined otherwise.
     { dim: 'Goal', note: goalNote, dotTone: state === 'thin' ? 'border-warning' : 'border-success' },
     { dim: 'Context', note: contextNote, dotTone: 'border-success' },
-    { dim: 'Constraints', note: constraintsNote, dotTone: 'border-success' },
+    {
+      dim: 'Constraints',
+      note: constraintsNote,
+      // The NOTE was corrected before and the DOT was not, so the card went on
+      // rendering a zero-constraint record in the tone that means "all good"
+      // — the same claim the sentence had just stopped making, in the other
+      // channel (link-track R1 / C7). A zero is either a real gap or a
+      // silent loss; the chip may report it, it may not approve of it.
+      dotTone: constraintCount > 0 ? 'border-success' : 'border-text-light',
+    },
     {
       dim: 'Options',
       note: optionsNote,
@@ -490,6 +510,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
               >
                 <span
                   aria-hidden="true"
+                  data-dim-dot={dim.toLowerCase()}
                   className={`h-[7px] w-[7px] flex-none rounded-full border bg-transparent ${dotTone}`}
                 />
                 <span className="min-w-0">

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.constraintsHonesty.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.constraintsHonesty.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * LINK-TRACK R1 item 1 (contradiction cluster, C7) — THE CONSTRAINTS CHIP
+ * CANNOT REPORT A ZERO AS A HEALTHY STATE.
+ *
+ * ── THE MEASURED CONTRADICTION ─────────────────────────────────────────────
+ * L3 browser lane, deployed staging `5597d867`, 2026-08-11
+ * (`L3-BROWSER-TRUTH.md` §9 C7 — "the sharpest H3 evidence in the lane"):
+ * the framing panel reported **"Constraints — No limits on record"** for a
+ * brief that states three, two of them prefixed with the literal word
+ * *constraint*:
+ *
+ *   "constraint: no more than one compulsory redundancy round in the next
+ *    12 months … the CEO is adamant"
+ *   "constraint: engineering (58 heads) is ring-fenced, board agreed"
+ *   "the ops director says max two big changes in parallel"
+ *
+ * And the product demonstrably READ all three: the drafted graph carries
+ * `risk_redundancy_breach` (40% assumed strength) and `risk_change_saturation`
+ * (35%). They were extracted, silently re-typed as soft probabilistic risks,
+ * and the framing panel then truthfully reported that no constraints exist —
+ * because by then none did.
+ *
+ * ── WHAT IS AND IS NOT IN SCOPE HERE ───────────────────────────────────────
+ * The semantic half — a hard boundary becoming a 40% likelihood of "breach" —
+ * is WS-A's, and this lane must not touch it (BRIEF-LINK-TRACK-R1 "Explicitly
+ * OUT of scope"). What IS display-side, and what this pins, is the second
+ * defect on the same chip and the one L3 photographed:
+ *
+ *   the zero was rendered under a **`border-success`** dot.
+ *
+ * A previous lane already corrected this chip's SENTENCE (retiring the false
+ * denial "Not captured yet") and left the dot alone. So the card said "no
+ * limits" in a tone that means "all good" — the note stopped denying the
+ * user's input while the DOT went on approving of the gap. Two channels, one
+ * chip, and only one of them was fixed.
+ *
+ * A zero-constraint record is not a healthy state on any reading. It is either
+ * a real gap or a loss. The chip may report it; it may not congratulate it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard, OVERVIEW_COPY } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+
+/** The card is flag-gated; the chips only exist once it renders. */
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+const GOAL_NODE_WITH_MEASURE = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'G', threshold_source: 'user', success_threshold: 20 },
+}
+
+/** The literal a reader would see, pinned so deleting the constant cannot make this vacuous. */
+const DENIAL_SHAPE = /on record/i
+
+function openBrief() {
+  fireEvent.click(screen.getByTestId('brief-bar'))
+}
+
+describe('LINK-R1 C7 — the Constraints chip reports the zero without approving of it', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('feature.decisionOverview', '1')
+    useGuidanceStore.setState({ guidanceItems: [], _sendMessage: null } as never)
+    useAskOlumiStore.setState({
+      isOpen: false,
+      context: '',
+      draft: '',
+      label: '',
+      targetId: null,
+      parameters: undefined,
+      source: 'chip',
+    })
+    useCanvasStore.setState({
+      ceeAnalysisReady: READY,
+      goalThreshold: 20,
+      nodes: [GOAL_NODE_WITH_MEASURE],
+      goalConstraints: null,
+      currentBriefText: null,
+      graphHealth: null,
+    } as never)
+  })
+
+  it('does NOT carry a success dot when nothing is on record', () => {
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    const chip = screen.getByTestId('brief-dim-constraints')
+    const dot = chip.querySelector('[data-dim-dot]')
+    expect(dot, 'the constraints chip has no identifiable dot to assert on').not.toBeNull()
+    expect(
+      dot!.className,
+      'a zero-constraint record was rendered in the tone that means "all good"',
+    ).not.toContain('border-success')
+  })
+
+  it('DOES carry a success dot once limits are genuinely on record — the discriminating positive', () => {
+    // Without this the fix could pass by making the dot neutral always, which
+    // deletes a truthful signal instead of correcting a false one
+    // (CLAUDE.md trap 13b).
+    useCanvasStore.setState({
+      goalConstraints: [{ id: 'c1', label: 'Max one redundancy round', operator: '<=', value: 1 }],
+    } as never)
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    const chip = screen.getByTestId('brief-dim-constraints')
+    const dot = chip.querySelector('[data-dim-dot]')
+    expect(dot!.className).toContain('border-success')
+    expect(chip).toHaveTextContent('1 limit captured')
+  })
+
+  it('the empty note describes the MODEL, not the user\'s record', () => {
+    // "No limits on record" is ambiguous between "my model holds none" and
+    // "you supplied none", and L3 read it as the second — on a brief that
+    // states three. The sentence must be unambiguously about what is set.
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    const chip = screen.getByTestId('brief-dim-constraints')
+    expect(chip.textContent ?? '').not.toMatch(DENIAL_SHAPE)
+    expect(chip).toHaveTextContent(OVERVIEW_COPY.constraintsNoteEmpty)
+  })
+})

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,6 +21,16 @@ interface AuthContextType {
   authenticated: boolean;
   signInWithMagicLink: (email: string) => Promise<{ error: unknown }>;
   signInWithGoogle: () => Promise<{ error: unknown }>;
+  /**
+   * Owner password sign-in — the pilot's auth route (link-track R1 item 7,
+   * ratified 11 Aug 2026). Owners are PRE-PROVISIONED; there is deliberately
+   * no sign-up path, here or on the surface.
+   *
+   * Deliberately NOT named `signIn`: that name is taken by a legacy no-op
+   * below, and quietly making a no-op real is how a surface starts reporting
+   * success for something it never did. A new capability gets a new name.
+   */
+  signInWithPassword: (email: string, password: string) => Promise<{ error: unknown }>;
   signOut: () => Promise<{ error: unknown }>;
 
   // Legacy compat — kept so existing components that destructure these don't break.
@@ -36,6 +46,7 @@ const AuthContext = createContext<AuthContextType>({
   authenticated: false,
   signInWithMagicLink: async () => ({ error: new Error('AuthContext not initialized') }),
   signInWithGoogle: async () => ({ error: new Error('AuthContext not initialized') }),
+  signInWithPassword: async () => ({ error: new Error('AuthContext not initialized') }),
   signIn: async () => ({ error: new Error('Password auth removed'), data: null }),
   signUp: async () => ({ error: new Error('Password auth removed'), data: null }),
   signOut: async () => ({ error: new Error('AuthContext not initialized') }),
@@ -127,6 +138,39 @@ async function callSignInWithMagicLink(email: string): Promise<{ error: unknown 
   }
 }
 
+/**
+ * Owner password sign-in. ONE implementation, shared by every posture — the
+ * rule this module's header states, and the rule whose breach shipped a
+ * silent-success twin that told users a link was on its way while making no
+ * network call at all.
+ *
+ * No sign-up, no `shouldCreateUser`, no account creation of any kind: owners
+ * are pre-provisioned. A wrong password and an unknown address both return
+ * Supabase's own 400 `Invalid login credentials`, which is already
+ * enumeration-safe, so nothing here re-classifies it.
+ */
+async function callSignInWithPassword(
+  email: string,
+  password: string,
+): Promise<{ error: unknown }> {
+  // NEVER log the password, and never log it by accident via a spread.
+  authLogger.debug('SIGN_IN', 'Password sign-in request', { email });
+  try {
+    if (typeof supabase.auth.signInWithPassword !== 'function') {
+      return { error: signInUnavailable('signInWithPassword') };
+    }
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      authLogger.error('ERROR', 'Password sign-in failed', error);
+      return { error };
+    }
+    return { error: null };
+  } catch (error) {
+    authLogger.error('ERROR', 'Password sign-in error', error);
+    return { error: asFault(error) };
+  }
+}
+
 async function callSignInWithGoogle(): Promise<{ error: unknown }> {
   authLogger.debug('SIGN_IN', 'Google OAuth request');
   try {
@@ -180,6 +224,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       authenticated: true,
       signInWithMagicLink: async () => ({ error: null }),
       signInWithGoogle: async () => ({ error: null }),
+      signInWithPassword: async () => ({ error: null }),
       signIn: async () => ({ error: null, data: null }),
       signUp: async () => ({ error: null, data: null }),
       signOut: async () => ({ error: null }),
@@ -277,6 +322,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     signInWithMagicLink: callSignInWithMagicLink,
     signInWithGoogle: callSignInWithGoogle,
+    signInWithPassword: callSignInWithPassword,
 
     // Legacy no-ops
     signIn: legacyNoOp,
@@ -432,6 +478,7 @@ function OptionalAuthProvider({ children }: { children: React.ReactNode }) {
 
     signInWithMagicLink: callSignInWithMagicLink,
     signInWithGoogle: callSignInWithGoogle,
+    signInWithPassword: callSignInWithPassword,
 
     // Password auth is removed product-wide. The guest branch used to answer
     // `{ error: null, data: { id: 'guest' } }` here — a success report for a

--- a/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
+++ b/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
@@ -42,6 +42,7 @@ import React from 'react'
 
 const signInWithOtp = vi.fn()
 const signInWithOAuth = vi.fn()
+const signInWithPassword = vi.fn()
 const getSession = vi.fn()
 const onAuthStateChange = vi.fn()
 const supabaseSignOut = vi.fn()
@@ -54,6 +55,7 @@ const supabaseSignOut = vi.fn()
 // presence through a getter is the only way to model the real stub.
 let otpMethodPresent = true
 let oauthMethodPresent = true
+let passwordMethodPresent = true
 
 vi.mock('../../lib/supabase', () => ({
   supabase: {
@@ -63,6 +65,9 @@ vi.mock('../../lib/supabase', () => ({
       },
       get signInWithOAuth() {
         return oauthMethodPresent ? signInWithOAuth : undefined
+      },
+      get signInWithPassword() {
+        return passwordMethodPresent ? signInWithPassword : undefined
       },
       getSession,
       onAuthStateChange,
@@ -94,6 +99,7 @@ async function renderGuestProvider() {
   const seen: {
     signInWithMagicLink?: (email: string) => Promise<{ error: unknown }>
     signInWithGoogle?: () => Promise<{ error: unknown }>
+    signInWithPassword?: (email: string, password: string) => Promise<{ error: unknown }>
     signOut?: () => Promise<{ error: unknown }>
   } = {}
 
@@ -101,6 +107,7 @@ async function renderGuestProvider() {
     const ctx = useAuth()
     seen.signInWithMagicLink = ctx.signInWithMagicLink
     seen.signInWithGoogle = ctx.signInWithGoogle
+    seen.signInWithPassword = ctx.signInWithPassword
     seen.signOut = ctx.signOut
     return (
       <div>
@@ -135,12 +142,14 @@ describe('AuthContext × guest posture — the front door is REAL', () => {
     // into the next one, or a later assertion passes for the wrong reason.
     otpMethodPresent = true
     oauthMethodPresent = true
+    passwordMethodPresent = true
     getSession.mockResolvedValue({ data: { session: null } })
     onAuthStateChange.mockReturnValue({
       data: { subscription: { unsubscribe: vi.fn() } },
     })
     signInWithOtp.mockResolvedValue({ data: {}, error: null })
     signInWithOAuth.mockResolvedValue({ data: {}, error: null })
+    signInWithPassword.mockResolvedValue({ data: {}, error: null })
     supabaseSignOut.mockResolvedValue({ error: null })
   })
 
@@ -210,6 +219,107 @@ describe('AuthContext × guest posture — the front door is REAL', () => {
       result = await ctx.signInWithGoogle!()
     })
     expect(result!.error).toBe(providerDisabled)
+  })
+
+  /**
+   * ── OWNER PASSWORD SIGN-IN (#667 review blocker 2) ────────────────────────
+   * `callSignInWithPassword` shipped with ZERO coverage. The reviewer's mutant
+   * R1 replaced its body's Supabase call with `const error = null; void
+   * password;` — a silent-success no-op — and the whole suite stayed GREEN,
+   * including all 15 cases of THIS file, whose own title is "the front door is
+   * REAL". Complete manifest at the time (`rg -a signInWithPassword src`, 17
+   * hits): every spec-side occurrence was a `vi.fn()` in the two LoginPage
+   * specs, which mock this module wholesale. Nothing bound the context
+   * implementation to Supabase.
+   *
+   * These are the password twins of the four magic-link/Google cases above,
+   * written to the same rule: bind to the client method BY NAME and to the
+   * returned error BY IDENTITY.
+   */
+  it('password sign-in calls supabase.auth.signInWithPassword — not a no-op', async () => {
+    const ctx = await renderGuestProvider()
+    await act(async () => {
+      await ctx.signInWithPassword!('owner@example.com', 'correct-horse')
+    })
+    expect(signInWithPassword).toHaveBeenCalledTimes(1)
+    expect(signInWithPassword).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'owner@example.com', password: 'correct-horse' }),
+    )
+  })
+
+  it('password sign-in propagates the Supabase error BY IDENTITY — never reports success', async () => {
+    // The exact shape Supabase returns for a wrong password AND for an unknown
+    // address — one 400 for both, which is what makes the surface's single
+    // failure state enumeration-safe.
+    const badCredentials = Object.assign(new Error('Invalid login credentials'), {
+      status: 400,
+      code: 'invalid_credentials',
+    })
+    signInWithPassword.mockResolvedValue({ data: {}, error: badCredentials })
+
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithPassword!('owner@example.com', 'wrong')
+    })
+    expect(result!.error).toBe(badCredentials)
+  })
+
+  it('a build whose Supabase client LACKS signInWithPassword reports UNAVAILABLE, never success', async () => {
+    // ⚠ NOT hypothetical. `scripts/supabase-stub-decision.mjs` aliases the SDK
+    // to `src/stubs/supabase-stub.mjs` on every guest build unless
+    // `VITE_STUB_SUPABASE=0`, and `netlify.toml` sets that opt-out ONLY under
+    // `[context.staging.environment]` — production inherits `[build.environment]`
+    // alone. That stub USED TO implement `signInWithPassword` and answer
+    // `{ error: null }`, converting the honest capability failure the other two
+    // routes give into a silent success. The stub no longer implements it (that
+    // absence is the mechanism); this pins the guard that makes the absence
+    // honest rather than fatal.
+    passwordMethodPresent = false
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithPassword!('owner@example.com', 'correct-horse')
+    })
+    expect(signInWithPassword).not.toHaveBeenCalled()
+    expect(result!.error).toBeInstanceOf(Error)
+    expect((result!.error as Error).message).toMatch(/unavailable in this build/i)
+    // Same cross-module seam as the magic-link case: LoginPage consumes
+    // `>= 500` to decide "our fault, say so" — and since round 2 it routes a
+    // 501 to the server-fault copy rather than blaming the owner's password.
+    expect((result!.error as { status?: number }).status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('a password client that THROWS is classified as a fault, not as bad credentials', async () => {
+    // A network failure or CSP block carries no `status`. Left bare it would
+    // fall into the surface's enumeration-safe branch and be reported to the
+    // owner as a wrong password — a fault dressed up as their mistake.
+    signInWithPassword.mockImplementation(() => {
+      throw new TypeError('Failed to fetch')
+    })
+    const ctx = await renderGuestProvider()
+    let result: { error: unknown } | undefined
+    await act(async () => {
+      result = await ctx.signInWithPassword!('owner@example.com', 'correct-horse')
+    })
+    expect((result!.error as { status?: number }).status).toBeGreaterThanOrEqual(500)
+  })
+
+  it('the bundled stub implements NO sign-in method — absence is what keeps it honest', async () => {
+    // A DERIVED guard on the artefact itself, not a mirror of it. The stub is
+    // the module a production build actually gets; if a later edit adds any
+    // sign-in method back, the capability guards above stop firing and a build
+    // with no Supabase client starts reporting success again.
+    const stub = await import('../../stubs/supabase-stub.mjs')
+    const auth = (stub as { createClient: () => { auth: Record<string, unknown> } })
+      .createClient().auth
+    const signInMethods = Object.keys(auth).filter(k => /^signIn/i.test(k))
+    expect(
+      signInMethods,
+      `the Supabase stub implements sign-in method(s) ${signInMethods.join(', ')} — on a stubbed build they cannot reach Supabase, so anything they return is a lie`,
+    ).toEqual([])
+    // Positive control: the probe can see methods when they exist.
+    expect(Object.keys(auth)).toContain('getSession')
   })
 
   it('password signIn/signUp report the removal as an ERROR, not as guest success', async () => {

--- a/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
+++ b/src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx
@@ -310,9 +310,8 @@ describe('AuthContext × guest posture — the front door is REAL', () => {
     // the module a production build actually gets; if a later edit adds any
     // sign-in method back, the capability guards above stop firing and a build
     // with no Supabase client starts reporting success again.
-    const stub = await import('../../stubs/supabase-stub.mjs')
-    const auth = (stub as { createClient: () => { auth: Record<string, unknown> } })
-      .createClient().auth
+    const { createClient } = await import('../../stubs/supabase-stub.mjs')
+    const auth = createClient().auth
     const signInMethods = Object.keys(auth).filter(k => /^signIn/i.test(k))
     expect(
       signInMethods,

--- a/src/stubs/supabase-stub.d.mts
+++ b/src/stubs/supabase-stub.d.mts
@@ -1,0 +1,22 @@
+/**
+ * Types for `src/stubs/supabase-stub.mjs`.
+ *
+ * The stub is plain `.mjs` (it is a Vite ALIAS TARGET for
+ * `@supabase/supabase-js`, resolved by the bundler, not by TypeScript), so a
+ * direct `import` of it from a spec produced a fresh `TS7016` and the typecheck
+ * ratchet correctly refused it. This declaration types the module rather than
+ * baselining a new error.
+ *
+ * ⚠ `auth` is deliberately a `Record<string, unknown>` rather than a listed
+ * shape. A listed shape here would read as if TypeScript enforced which methods
+ * the stub may implement — it does not, and the property that matters (the stub
+ * implements NO sign-in method, so a stubbed build fails HONESTLY instead of
+ * reporting a success it never earned) is enforced at RUNTIME by
+ * `src/contexts/__tests__/AuthContext.optionalAuth.spec.tsx`. A type that
+ * implied a guarantee it cannot give would be the false label this estate keeps
+ * paying for.
+ */
+export declare function createClient(): {
+  auth: Record<string, unknown>
+  from: (...args: unknown[]) => unknown
+}

--- a/src/stubs/supabase-stub.mjs
+++ b/src/stubs/supabase-stub.mjs
@@ -1,8 +1,25 @@
 // POC: supabase stub module – prevents real SDK from being bundled
+//
+// ⚠ THIS STUB MUST NOT IMPLEMENT ANY SIGN-IN METHOD.
+//
+// It implemented `signInWithPassword` and answered `{ data: null, error: null }`
+// — a SILENT SUCCESS for a build with no Supabase client at all. That is the
+// exact shape `src/contexts/AuthContext.tsx`'s header exists to forbid, and it
+// was reachable: `scripts/supabase-stub-decision.mjs` aliases the SDK here on
+// every guest build unless `VITE_STUB_SUPABASE=0`, which `netlify.toml` sets
+// ONLY under `[context.staging.environment]` — production inherits
+// `[build.environment]` alone and therefore keeps the stub. Magic link and
+// Google fail HONESTLY on such a build precisely because the methods are
+// ABSENT, so `AuthContext`'s `typeof … !== 'function'` guard fires and yields a
+// 501 the surface can render. The password route's possession of the method
+// converted that honest failure into a silent success — and once LoginPage
+// routes the owner into the app on success (#667 round 2), that success would
+// have carried them in as a guest while claiming they had signed in.
+//
+// Absence IS the mechanism here. Do not add a sign-in method back.
 export function createClient() {
   return {
     auth: {
-      async signInWithPassword() { return { data: null, error: null }; },
       async signOut() { return { error: null }; },
       async getSession() { return { data: { session: null } }; },
       onAuthStateChange() { return { data: { subscription: { unsubscribe: () => {} } } }; },


### PR DESCRIPTION
**Link-readiness track, round 1 — brief `olumi-docs/parallel-briefs/BRIEF-LINK-TRACK-R1.md`. DO NOT MERGE — adversarial review is a separate seat.**

Three items, each **re-derived at the deployed build** (`/version.json` → `5597d8675b08…`, byte-identical to this branch's base) before anything was changed. Items 2, 3, 4, 5, 6 are **NOT** in this PR — see "What is not here", which carries the derivations rather than deferring silently.

---

## Item 1 / C6 — the green "Stable" chip

L3 §9, deployed staging, one screen state — *"the most investor-damaging contradiction in the product"*:

| Surface | Says |
|---|---|
| Header chip | **`Stable`** (green) |
| Analysis panel | *"…treat this as provisional: the link between … is **fragile**."* |
| Analysis panel | *"The ordering holds in about 72% of variations, but **the result is fragile**…"* |
| Analysis panel | ⚠ **"Ranking sensitive to assumptions"** |
| Analysis panel | **Stability: (not available for this run)** |

Reproduced on B1 (10 Aug) and B2 on a newer build — systemic, not brief-specific.

**Root cause, derived at the bytes.** The estate already has a single-source rule, written into `buildAnalysisHeroViewModel.ts:162`:

> *"Sensitivity caveat is gated on the display-safe robustness verdict ONLY — never raw recommendation_stability (single-source rule, see ROBUSTNESS-VERDICT-CONTRACT)."*

Every robustness claim in the product consumes `robustness.display_verdict` (`robust | moderate | fragile | not_assessed`, PLoT #202) and **fails closed**, so an unassessed run keeps the certified "Robustness unknown" state. `useAnalysisMetadata` — the chip's sole feeder — read raw `robustness.is_robust`. Swept repo-wide: **that chip was `is_robust`'s only display consumer.**

This is CLAUDE.md **trap 21**: two authorities answering *different questions* under similar names.

- `is_robust` → *did the perturbation set leave the winner standing?*
- `display_verdict` → *what may this run **claim** about robustness on screen?*

A chrome chip is a display surface, so it takes the display authority. The fix is not to align two defaults; it is to point the surface at the question it is actually asking.

**Behaviour change to be explicit about:** where `display_verdict` is absent or `not_assessed`, the chip now **does not render**. That is the intended outcome — it is the same state the panel was already reporting on the screen L3 photographed.

## Item 1 / C7 — the constraints chip's tone

L3 §9 C7 (*"the sharpest H3 evidence in the lane"*): **"Constraints — No limits on record"** for a brief stating three, two prefixed with the literal word *constraint* — and the product demonstrably read all three (the graph carries `risk_redundancy_breach` 40%, `risk_change_saturation` 35%).

The semantic half — a hard boundary silently re-typed as a soft probabilistic risk — is **WS-A's, and is untouched here** per the brief's out-of-scope list.

What is display-side is the half nobody fixed. A previous lane corrected this chip's **sentence** (retiring the false denial *"Not captured yet"*) and left the **dot** at `border-success`. So the card stopped denying the user's input in one channel while going on approving of the gap in the other. **Two channels, one chip, one of them fixed.**

- dot → `border-success` only when limits are genuinely on record; neutral otherwise
- empty note → **"Nothing set as a hard limit"**: unambiguously about the model, where *"on record"* read as easily as *"on YOUR record"*

## Item 7 — owner password sign-in

Password auth is the pilot's ratified route. The login page offered magic link and Google only — and **magic link is the route that cannot work on staging**: no SMTP, which is precisely why this page already carries a `send-failed` state. An owner sent a link today reached a page with no control they could complete.

- `AuthContext.signInWithPassword` — **one implementation, shared by every posture**, the rule this module's own header states after a silent-success twin once told users a link was on its way while making no network call.
- **Deliberately NOT by making the existing `signIn` no-op real.** Quietly turning a no-op into a working call is exactly that defect. New capability, new name; `signIn`/`signUp` untouched.
- **No sign-up** (owners are pre-provisioned) and **no password reset** (no SMTP to deliver one — a reset control here would be the guarantee theatre this track exists to remove). Both absences are decisions, stated in the file.
- **One failure state for every cause.** Wrong password, unknown address, 5xx, 501, 429 all produce byte-identical copy, so the page cannot be used to enumerate accounts — the property the magic-link half already goes to lengths to protect.
- The email field is **shared** by both routes and therefore sits outside both forms; a second input would be a second source of truth for one value.

---

## Evidence

**RED-first — and the first attempt at it was vacuous, which is worth reporting.** The chip spec initially queried a `data-testid` the fix was going to add; **4 of its 6 cases passed at pristine** because `queryByTestId` returned null for an element with no testid (trap 13 — an absence probe with no positive control). Rebound to `[data-stability]`, which is on the shipped chip today: **5 of 6 RED**, and the one that passed is the discriminating positive.

```
AssertionError: the header chip claimed stability the analysis panel had already refused:
  expected 'stable' not to be 'stable'
AssertionError: the header chip claimed stability on a run whose robustness was never assessed:
  expected <div …> to be null
```

**Mutants** — throwaway worktree **outside** the repo root, isolation proven by **sentinel write** with the source asserted unchanged (trap 9g), distinct inodes (`589987100` vs `590004158`), restores `git checkout HEAD --` (trap 9h), applied-check scoped to `src/`, control **exactly 0** before and after:

| # | Mutation | Result |
|---|---|---|
| U1 | chip reverts to raw `is_robust` | 5 failed — bites |
| U2 | `not_assessed`/absent treated as stable (fail-OPEN) | 3 failed — bites |
| U3 | constraints dot back to unconditional success | 1 failed — bites |
| U4 | chip suppressed **unconditionally** | 1 failed — **bites (discriminating)** |
| U5 | constraints dot neutral **always** | 1 failed — **bites (discriminating)** |
| U6b | the two auth routes disagree on the email | 2 failed — bites |
| U7b | password failure branches on `isServerFault` (enumeration leak) | 1 failed — bites |
| U8 | `signInWithPassword` never called (button inert) | 4 failed — bites |
| — | control, pristine, before **and** after | 19 passed, `applied=0` |

**Two survivors on the first pass, and they were not the same kind of thing:**

- **One was my test's fault.** A trim assertion (`'  owner@example.com  '` → trimmed) survived a mutant that sent the raw value — because the shared field is `type="email"` and HTML value-sanitisation strips whitespace before React ever sees it. **The test could not fail.** The claim was removed, not weakened, and replaced with one that is observable (both routes receive the same email). The reasoning is recorded in the spec rather than quietly dropped.
- **One was my mutant's fault.** The first enumeration mutant appended `pageState`, which is identical for every cause — so it leaked nothing and the test was right to pass. Re-run as U7b (`setPageState(isServerFault(error) ? 'send-failed' : 'password-failed')`), which is a genuine leak, and it bites. *An unapplied or non-discriminating mutation is indistinguishable from an equivalent one without checking what it actually changed.*

**Gates**

| Gate | Result |
|---|---|
| `pnpm lint` | **0 errors** (1265 pre-existing warnings); hooks ratchet exactly at baseline — 232 known violations / 15 files |
| `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) | **PASSED** — coverage 3353/3393 tracked files, ratchet within baseline |
| full `npx vitest run` | **1599 files passed / 23,186 passed / 0 failed** / 3 skipped |
| collect counts, **by name** | chip **6**, constraints **3**, owner-password **10** — asserted, never inferred from the suite total (trap 2b) |

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run.

⚠ **The typecheck gate offered a baseline update and I declined it.** It reports drift *shrank* (2487 → 2485) and suggests `--update-baseline`. I have not verified that both diagnostics are attributable to this PR, and banking an unattributed shrink is how a ratchet stops meaning anything (trap 2b's shrink-prompt lesson). Left for the reviewer to decide.

⚠ **Two existing `LoginPage` tests were rebound at the source, not baselined.** They used `input.closest('form')`, which no longer resolves now the shared email field sits outside both forms. They are bound by testid instead; no assertion was weakened.

---

## What is NOT here, and why — with the derivations, so nothing is silently deferred

The brief carries seven items. This PR closes item 1's UI half and item 7; item 1's C1 (*"your brief was light on detail"*) is in the sibling CEE PR **Talchain/olumi-assistants-service#918**. The rest are **not started**, and each is named with what re-derivation established, so the next lane starts from evidence rather than from the original finding:

**Item 2 — false precision (£735,619).** Not attempted. Display-side and tractable, but it needs a provenance-aware qualification rule, and writing one from this head without the outside corpus the estate now requires for that class is how #888/#853 went four rounds.

**Item 3 — the "Add this" CTA.** Root-caused, not fixed. The composed message is `Please add "£31m" from my brief to the model.` (`src/components/results/v7/V7WhatIWasGivenSection.tsx:298`). Derived at CEE `75516366`: it does **not** trip the vague-edit guard (it carries a numeric token and an add construct, both explicit MUST-NOT-MATCH cases). It reaches `edit_graph`, the LLM returns **zero operations**, and `edit-graph.ts:2449`'s no-op branch falls back to `composeEditClarifyResponse` — which is the exact refusal L3 quoted. **The brief requires the accepted phrasing be derived from the LIVE router, and I could not do that**: probing CEE needs the staging API key, and I will not authenticate with a found credential. Note also that `NotModelledItem` carries `charOffset` into the verbatim brief, so a future lane **can** recover the figure's surrounding sentence to give the edit engine semantics — that is the material the fix needs.

**Items 4 and 5 — first-100-seconds, and streamed honest progress.** Not attempted. The brief requires **real-browser witness evidence (screenshots + computed values)** for both, and explicitly that the fit-to-view fix prove *label legibility at the chosen zoom*, not DOM presence. I did not produce that evidence, and jsdom cannot (trap 3). Shipping these behind unit tests alone would be the exact thing the brief forbids. One derivation worth carrying forward: `useSmartScroll` fires on `messageCount`, but during the first turn `ChatThread` renders `null` for every message while `showEmptyState` holds — so the scroll fires against a container of near-zero height, and the content appears on a *later* commit. That is a hypothesis, not a finding; it needs the browser.

**Item 6 — guidance lost on reload.** Confirmed at the bytes, not fixed. `canvas/stores/guidanceStore.ts` is a plain `zustand.create` with **no `persist` middleware and no rehydration**; `guidanceItems` is written only from a live turn (`src/canvas/conversation/useConversation.ts:4816`). The graph and transcript rehydrate from `localStorage` (`olumi-canvas-autosave`, `olumi-canvas-transcript`) and guidance does not — so the strip, the node coaching markers and the inspector coaching all vanish on refresh. Note for whoever takes it: items carry `valid_while: { analysis_hash, graph_hash }`, so a rehydration must not resurrect guidance that is stale for the restored graph.

**Honest statement of capacity:** this is one lane's output against a seven-item brief. I would rather hand over three items at full standard plus five re-derivations than seven items nobody can trust.


---

# ROUND 2 — response to the adversarial review (`e5d54d6a` → `58d2a060`)

New head **`58d2a0605d5ffeaac4e141612af59c0afdd75af3`**. Fresh blobless clone at a unique `/private/tmp` path, `HEAD` asserted before any read. **Items 1/C6 (stability chip) and 1/C7 (constraints dot) are untouched** — the review passed them clean and re-executed every proof, so nothing here goes near them. Not merged.

All three blockers were real. Nothing in the review was refuted at the bytes; one reviewer recommendation was **deliberately implemented differently**, and that divergence is argued below rather than buried.

## 🔴 B1 — the success path dead-ended

The comment at `LoginPage.tsx:168-170` was false and I re-derived it rather than inheriting the finding: the only `navigate()` calls in `AuthContext.tsx` are sign-**out** (`:350`, `:356`, `:501`); neither `handleAuthStateChange` nor `OptionalAuthProvider.adopt` navigates on sign-**in**; and `/login` (`AppPoC.tsx:907`) sits **outside** the `AuthGuard` element (`:919`), so no guard bounces an authenticated owner away either.

**Fixed by making this page own the routing**, because nothing else does:

- success moves to a new `password-signed-in` state instead of leaving `password-submitting` set forever;
- an effect navigates **once the provider reports `authenticated`** — not off the resolved promise. Navigating immediately would have raced `AuthGuard`, which would have bounced the owner straight back to `/login` and merely *relocated* the dead end;
- the gate is `signedInHere && authenticated`, **not `authenticated` alone**. In the guest posture `OptionalAuthProvider` hands every visitor `authenticated: true`, so redirecting on `authenticated` would make `/login` unreachable for a guest who came here deliberately;
- `AuthGuard`'s `state.from` is honoured, so a deep link survives sign-in;
- an always-live **Continue** control is rendered, so even if the session never lands there is no state in which the owner is stuck behind a promise nobody keeps.

The false comment is **replaced, not deleted** — the file header now records what was wrong and why (trap 14).

### ⚠ And B1 could not ship safely without one more change, disclosed in full

`src/stubs/supabase-stub.mjs:5` implemented `async signInWithPassword() { return { data: null, error: null } }` — a **silent success on a build with no Supabase client at all**. Magic link and Google fail *honestly* on a stubbed build only because their methods are ABSENT, so `AuthContext`'s `typeof … !== 'function'` guard fires and yields a 501. `netlify.toml` sets `VITE_STUB_SUPABASE=0` only under `[context.staging.environment]`, so **production inherits `[build.environment]` and keeps the stub**.

Before this PR that produced a fake "signed in" that went nowhere. **With B1 landing it would have carried the owner INTO the app as a guest while telling them they had signed in** — a strictly worse lie than the one being fixed. So the stub's `signInWithPassword` is removed (absence is the mechanism), `netlify.toml`'s now-false comment — *"that stub does not implement signInWithOtp/signInWithOAuth"* — is corrected to name all three methods and to record that it was false for the password route, and a runtime guard asserts the stub exposes **no** `signIn*` method at all.

Per the scope-expansion rule: this is not "while we're here". The lane could not deliver B1 without it, it is the smallest enabling change (one method deleted), and it collides with nothing else in flight.

## 🔴 B2 — `callSignInWithPassword` had zero coverage

The reviewer's manifest was correct: every spec-side `signInWithPassword` was a `vi.fn()` in the two LoginPage specs, which mock the context module wholesale. `AuthContext.optionalAuth.spec.tsx` — the suite titled *"the front door is REAL"* — now carries the password twins of its four magic-link/Google cases, written to the same rule (**client method by NAME, error by IDENTITY**):

- calls `supabase.auth.signInWithPassword` with the email **and** the password — not a no-op;
- propagates the Supabase 400 `Invalid login credentials` **by identity**;
- a client that **LACKS** the method reports UNAVAILABLE with `status >= 500`, never success (the case the stub made non-hypothetical);
- a client that **THROWS** is classified as a fault, not as bad credentials;
- the bundled stub implements **no** `signIn*` method — a runtime guard on the artefact a production build actually gets, with a positive control (`getSession` must still be visible to the probe).

**The reviewer's R1 mutant now bites** — see the kit.

## 🔴 B3 — server faults and rate limits blamed the owner's password

Trap 21 exactly: *"is this an enumeration signal?"* and *"is this a server fault?"* were two questions under one predicate.

- **The enumeration surface is ONE PAIR** — a wrong password and an unknown address, both Supabase `400 Invalid login credentials` — and it stays **byte-identical**. That pair is now asserted directly, which the old test did not do: it asserted `messages.size === 1` across *all five* causes, i.e. the suite actively **defended** reporting an outage as a bad password.
- **`>= 500` (including 501)** routes to honest server-fault copy.
- **429** routes to the existing rate-limit copy **and no longer clears the password** — the actively harmful half, which had a rate-limited owner retyping a *correct* password into more rate-limiting on the pilot's only working route.

### The one place I did NOT follow the review, and why

The review says *"route ≥500/501 to the existing honest server-fault copy"* — i.e. reuse `send-failed`. **I didn't.** That copy reads *"We couldn't send the sign-in email … nothing was sent"*, which is false on the password route: nothing was being sent. Reusing it would have swapped one false sentence for another, in a PR whose whole subject is copy that isn't true. The password route gets its own state with the **same property** the review asked for — not address-correlated, honest about whose fault it is, silent about the password — and the 429 case *does* reuse the existing rate-limit copy, which is route-agnostic and true as written.

## RED-first replay — the reviewer-measured defects reproduce, then die

Both round-2 specs copied onto a pristine worktree at the **reviewed head `e5d54d6a`** (worktree outside the repo root, `HEAD` asserted, distinct inodes):

```
LoginPage.ownerPassword.spec.tsx        17 collected · 8 FAILED
AuthContext.optionalAuth.spec.tsx       20 collected · 1 FAILED
                                        9 failed | 28 passed (37)
```

RED at pristine, **by name**:

| Spec | RED at `e5d54d6a` |
|---|---|
| ownerPassword | a 500 is reported as OUR fault · a 501 capability-absent build is reported as OUR fault · a 429 is a rate limit AND does not wipe a correct password · a correct password lands the owner IN THE APP · returns the owner to the route AuthGuard bounced them from · does not dead-end while the session is still landing · leaves no disabled-control dead end on success · the shared email field is OWNED by the password form |
| optionalAuth | the bundled stub implements NO sign-in method |

⚠ **The four new password twins PASS at pristine, and that is the honest result, not a gap.** `callSignInWithPassword` was already correct; the defect B2 names is that **nothing tested it**. A RED-first replay cannot show that — only a mutant can, which is why R1 below is the load-bearing evidence for B2 and is reported as such.

## Mutants — my own kit, my own isolation

Throwaway worktrees **outside** the repo root, distinct inodes (`590612736` vs `590957657`), isolation proven by **writing a sentinel** into the worktree and asserting the source SHA-256 unchanged (`9c85a26c…` before and after), restores from a **pristine archive** outside the tree with a clean-tree assertion after each, applied-check scoped to `src/`, control asserting exactly **0** before **and** after, diff printed per mutant, and **collected count asserted on every run** (a run that collects the wrong number is a hard error, exit 9).

| # | Mutation | Result |
|---|---|---|
| CONTROL | none | applied=0 · **37/37 GREEN** |
| **R1** | *the reviewer's mutant* — `callSignInWithPassword` → `const error = null; void password;` | **3 failed — BITES.** Was 46/46 GREEN at `e5d54d6a`. |
| U2 | the navigation effect stops navigating | 2 failed — bites |
| **U3** | destination ignores `state.from` (**discriminating twin of U2**) | **1 failed** — only the deep-link case REDs; the land-in-app case stays GREEN, so the deep-link test binds to the DESTINATION, not merely to "navigation happened" |
| U4 | the server-fault branch removed (B3 collapse restored) | 2 failed — bites; the enumeration-pair test stays GREEN |
| **U5** | the **password** handler's rate-limit branch removed | **1 failed — bites** |
| **U5b** | branch kept but it CLEARS the password (the harmful half alone) | **1 failed — bites**, so the 429 test pins both halves, not just the copy |
| U5c | the **magic-link** handler's rate-limit branch removed | 2 failed in `LoginPage.test.tsx` — that branch was already guarded |
| U6 | the email field loses its `form=` owner | 1 failed — bites |
| U7 | the stub re-implements `signInWithPassword` | 1 failed — bites |
| TRAILING CONTROL | none | applied=0 · **37/37 GREEN** |

⚠ **U5's first run was a FALSE SURVIVOR and I am reporting it rather than the clean re-run alone.** `perl -0pi -e 's/…/…/'` without `/g` replaced the **first** `isRateLimited(error)` in the file — which is the **magic-link** handler's, not the password one. `applied_files` read `1`, the diff was real, and the specs were 37/37 green: **an applied-check proves a file changed, never that the intended SITE changed.** The re-run anchors the substitution on the following comment line and adds an explicit site assertion (`grep -c 'if (isRateLimited(error)) {'` → 2 when both branches are intact, 1 when one is mutated). U5c is the same mutation aimed where the first one actually landed, kept because it is a genuine measurement: it shows the magic-link branch is covered by `LoginPage.test.tsx`, a file my first kit had not included.

## Non-blocking findings

- **N1 — `Enter` in the email field was a dead key.** The field had no `form=` attribute, so `input.form` was `null` and implicit submission had nothing to submit. It is now owned by the **password** form — the pilot's working route; sending Enter to the route that cannot deliver on staging would have been the worse choice. ⚠ **jsdom does NOT implement implicit submission** — I measured it with a throwaway probe (a synthetic `Enter` keydown on an associated input fired **zero** submit events) — so the keypress itself is not provable here (trap 3). The test asserts **ownership by element identity** (`emailField.form === passwordForm`) and says exactly that in the spec.
- **N2 — fixed.** The `oauth-failed` copy said *"use the email link above"* after this PR moved that button below it. It now names the password form above and the email link below.
- **N3 — accepted and written into the spec.** The trim-agreement case's comment claimed more discriminating power than the test has; the fixture carries no whitespace, so a raw-vs-trimmed mutant cannot be distinguished through a `type="email"` field. The comment now says so. (That case also needed restructuring for an unrelated reason: **either** successful submit now leaves the form, so no single render can exercise both routes — it uses two renders with the same typed input.)
- **N4 — fixed.** The no-sign-up/no-reset absence probe now asserts the password form **is** rendered in the same test. Without it the probe passed at pristine, where no form existed at all (trap 13).
- **N5 — the typecheck shrink is real (2487 → 2485 at this head) and I have NOT banked it.** The gate PASSES with the headroom, and `--update-baseline` regenerates the whole identity baseline; adopting that wholesale on a lane that did not touch the constraints/stability half would mean signing for a regeneration I cannot independently verify. Flagged for whoever does the next deliberate baseline pass.
- **N6 — fixed in this body**: `src/components/results/v7/V7WhatIWasGivenSection.tsx` and `src/canvas/conversation/useConversation.ts`, both re-verified to exist at this tip.

## Gates at `58d2a060` — the `Staging Gate`'s constituent jobs, run in order

| Step (job) | Result |
|---|---|
| `pnpm run lint` (TypeScript + Lint) | **0 errors**; hooks ratchet **exactly 232 violations / 15 files**, matching baseline |
| `pnpm run typecheck` | ✅ **PASSED** — 618 files / **2485** errors vs baseline 2487, coverage gate clean |
| `pnpm run ci:guard:zustand` | PASS |
| `pnpm run ci:guard:starters` | OK — fixtures + manifest match source captures |
| `pnpm run check:vendor` | OK |
| `pnpm run ci:guard:schemas-version` | ✅ derived constant matches `0.39.0` |
| `pnpm run typecheck:selftest` (Typecheck Gate Self-Test) | **18 passed / 0 failed** — the gate demonstrably discriminates |
| `pnpm run build` (Production Build) | ✓ built |
| full `vitest run` (Full Test Suite) | **1599 files passed / 3 skipped (1602) · 23,198 passed / 0 failed / 66 skipped** |

⚠ A new `TS7016` appeared mid-work and the ratchet **correctly refused it**: importing the untyped `.mjs` stub from a spec. Fixed properly rather than baselined — `src/stubs/supabase-stub.d.mts` (`.d.mts`, because a `./x.mjs` specifier resolves to `.d.mts`, not `.d.ts`). Its `auth` is deliberately `Record<string, unknown>`: a listed shape would read as if TypeScript enforced which methods the stub may implement, and it does not — the property is enforced at runtime by the spec.

**Collect counts asserted BY NAME** (trap 2b), never inferred from a suite total: `LoginPage.ownerPassword.spec.tsx` **17**, `AuthContext.optionalAuth.spec.tsx` **20**, `LoginPage.test.tsx` **12**. Every UI run in this round exported `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`.

**CI at the exact head `58d2a060`** (`check-runs` at the SHA, `status == "completed"` filtered before `conclusion`, per trap 24b): 

```
total_count = 13   completed = 13   running = 0   failed = 0
```

`mergeable: MERGEABLE`, `mergeStateStatus: CLEAN` — no `DIRTY` branch, so the 13 green checks belong to the commit that would merge (trap 24). **`Security Audit (pnpm)` is GREEN**, as at the reviewed head.

## Two commits, and where each proof was measured

| Commit | Contents |
|---|---|
| `d6d2c13f` | B1 / B2 / B3 / N1–N4 — the product and spec changes. The mutation kit above ran at this tip (37 collected across the two round-2 specs). |
| `58d2a060` | the `.d.mts` declaration for the stub guard (types only) plus the spec's import tidy. |

**The load-bearing R1 proof was re-executed at the FINAL head `58d2a060`**, not carried over from the earlier tip — 49 collected across all three auth specs, control 49/49 GREEN, R1 **3 failed** on the three named cases, trailing control 49/49 GREEN, source tree clean throughout. Every other mutant is reported at `d6d2c13f`, where the only difference is a type declaration and an import form.

---

# ROUND 3 — response to the closing review (`58d2a060` → `3715a4c7`)

New head **`3715a4c74ee299cc884b84f8d47e7cead30a9dbb`**. Minimal scope: the one blocker and the two yellows the closing review named, nothing else. Not merged.

## 🔴 The word — and why "care" was never going to be the fix

The review is right, and the shape of the mistake matters more than the word: **this sentence has now been wrong twice, in both directions, and each time it was a claim about LAYOUT asserted from someone's memory of the JSX.** Round 1 raised it because it said *"the email link **above**"* after that button moved below. My round-2 correction then got the other half wrong the same way — *"the password form **above**"* — which is the worse of the two, because it sends an owner whose Google sign-in has just failed to look **upward** for the pilot's only working control.

Re-derived at the bytes rather than inherited: the `oauth-failed` `<p>` renders **inside the email-field `<div>`**, which closes at `:397`; the password form opens at `:400`. **Both** controls the sentence points at are below it. The container is `flex flex-col`, so DOM order is visual order.

**Copy:** *"Please use the password form or the email link below, or ask your Olumi contact."*

**And it is now PINNED BY MEASUREMENT.** A new case drives the real `oauth-failed` state and reads `compareDocumentPosition` for both forms — the reviewer's method — with a **positive control first**: the page heading must measure `'above'`, so a probe that answered `'below'` for everything cannot satisfy the assertions beneath it (trap 13). Then it asserts the copy contains no `above` and does contain `below`. **A future layout move REDs it** — proven, not asserted: see RED 2.

## 🟡 N-a — the enumeration guard could not see the property it was named for

Correct, and the demonstration was the convincing part: two byte-identical `400`s assert **determinism**, not indistinguishability across causes, which is why the reviewer's **E1** mutant (failure copy interpolating the raw Supabase `error.message` — a genuine leak vector) left **49/49 GREEN**.

The case now spans **four** causes Supabase distinguishes behind one 400:

| Fixture | `code` | Why it matters |
|---|---|---|
| wrong password | `invalid_credentials` | the baseline |
| unknown address | `invalid_credentials` | the same wire response, deliberately — the pair the property is really about |
| **existing, unconfirmed** | `email_not_confirmed` | **only occurs for an address that EXISTS** |
| **existing, banned** | `user_banned` | **only occurs for an address that EXISTS** |

Plus a **positive control** in the same test: a 500 must render a *different element* with *different text*, or byte-identity across the four is vacuous — the four could be identical simply because this surface never varies.

## 🟡 N-b — the stale premise at the top of the file that disproves it

The header still read *"every failure cause must reach ONE state with ONE sentence"*. That is the premise **B3 was raised to disprove**, and leaving it is exactly how the next lane re-collapses the states (trap 14). Replaced with the property that is actually true and actually asserted below it: **address-correlated causes (400: wrong password / unknown address / unconfirmed / banned) must be indistinguishable from one another; causes that are not address-correlated (5xx, 501, 429) are returned identically whether or not the address exists, so reporting them distinctly leaks nothing and is the only way the copy can be true.** Two questions, two predicates.

## N-c — deliberately NOT fixed

`isRateLimited` is a substring predicate checked before `isServerFault`, so a 5xx whose message contains `rate` renders the wait-a-moment copy. Reproduced from the review's own table (`500 Failed to generate token` → `true`, because *"gene**rate**"* contains `rate`). It is **pre-existing on both routes** and out of round-3's scope; left untouched and rowed separately, as instructed. It never blames the password, so the honest failure mode is a mild misclassification between two true-ish messages, not a lie about the owner.

## The three REDs

Throwaway worktree **outside** the repo root, distinct inodes (`591735813` vs `591739126`), isolation proven by **writing a sentinel** and asserting the source SHA-256 unchanged (`c8873ec7…`), restores from a pristine archive outside the tree with a clean-tree assertion after each, applied-check scoped to `src/`, **collected count hard-asserted at 50 on every run**, diff printed per mutant.

| # | Mutation | Result |
|---|---|---|
| CONTROL | none | applied=0 · **50/50 GREEN** |
| **RED 1** | the copy goes back to *"the password form **above**"* | **1 failed** — `the oauth-failed copy names a direction the DOM actually agrees with` |
| **RED 2** | **LAYOUT MOVE** — the `oauth-failed` block is relocated out of the email div to *after* `</form>`, so the password form is genuinely ABOVE it. Copy untouched. | **1 failed** — same case. *This is the one that matters: the pin catches the layout moving under correct copy, which is how the sentence went wrong both previous times.* |
| **RED 3** | **E1** — the failure copy interpolates the raw Supabase `error.message` | **1 failed** — `FOUR different address-correlated 400 causes are BYTE-IDENTICAL`. **The same mutant left the old two-fixture version 49/49 GREEN.** |
| TRAILING CONTROL | none | applied=0 · **50/50 GREEN** |

## Gates at `3715a4c7`

| Step | Result |
|---|---|
| `pnpm run lint` | **0 errors**; hooks ratchet **exactly 232 violations / 15 files** == baseline |
| `pnpm run typecheck` | ✅ **PASSED** — 2485 vs baseline 2487 (N-d: still not banked, for the reason the review accepts) |
| `pnpm run typecheck:selftest` | **18 passed / 0 failed** |
| `ci:guard:zustand` · `ci:guard:starters` · `check:vendor` · `ci:guard:schemas-version` | all PASS |
| `pnpm run build` | ✓ built in 50.03s (exit 0) |
| full `vitest run` | **1599 files passed / 3 skipped (1602) · 23,199 passed / 0 failed / 66 skipped** (exit 0) |

**Collect counts asserted BY NAME**: `LoginPage.ownerPassword.spec.tsx` **18** (+1, the position case) · `AuthContext.optionalAuth.spec.tsx` **20** · `LoginPage.test.tsx` **12** = **50**. `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run.

**CI at the exact head `3715a4c7`** (`check-runs` at the SHA, `status == "completed"` filtered before `conclusion`, trap 24b): 

```
total_count = 13   completed = 13   running = 0   failed = 0
```

The build regenerates `src/generated/validators.js` (a timestamp header only); it was reverted before the push, so the pushed tree carries exactly the two source files this round changed.
