### PR TITLE
fix(honesty): first-100-seconds, guidance reload, add-this CTA (link-R2 items 1, 3, 4)

### DIFF
--- a/e2e/canvas.lod-disclosure.spec.ts
+++ b/e2e/canvas.lod-disclosure.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * REAL-BROWSER WITNESS — "Fit to view" must not leave the user with silently
+ * blank labels. (Link-track round 2, item 4b.)
+ *
+ * WHY THIS IS AN e2e SPEC AND NOT A jsdom ONE. The claim is about LEGIBILITY at
+ * a chosen zoom, and jsdom has no layout: `visibility: hidden` and a perfectly
+ * readable label are the same thing to it (CLAUDE.md trap 3). Every number below
+ * is read out of real Chromium — the viewport transform, and
+ * `getComputedStyle(...).visibility` on the node titles a user is looking at.
+ *
+ * WHAT THE FIRST RUN OF THIS SPEC ESTABLISHED, before anything was changed.
+ * The product's own "Customer Data Platform Selection" example (19 nodes), the
+ * real "Fit to view" control:
+ *
+ *   viewport      fit zoom   titles hidden   LOD   disclosed?
+ *   1920x1080      0.802         0 / 19      off      —
+ *   1440x900       0.668         0 / 19      off      —
+ *   1280x800       0.595         0 / 19      off      —
+ *   1024x768       0.543         0 / 19      off      —
+ *   834x1112       0.344        17 / 19      ON      **no**
+ *
+ * Two things follow, and both mattered to the fix:
+ *   1. The reported "18 of 20 labels blank" is REAL but VIEWPORT-CONDITIONAL —
+ *      it does not reproduce at a desktop width, which is why it read as
+ *      intermittent. A laptop with the AI panel and inspector open has the same
+ *      narrow canvas as the 834px column.
+ *   2. The product disclosed the state at ZERO of five viewports.
+ *
+ * The fix is (2), not (1): `src/canvas/utils/zoomLegibility.ts` carries a
+ * reasoned doctrine that explicit user gestures stay unfloored and that the
+ * label-less view is "the honest, intended rendering". Flooring the fit would
+ * crop the model the user just asked to see whole — a worse lie. So the canvas
+ * now says which view you are in.
+ *
+ * The viewport list is the assertion's discriminator: a notice that always
+ * rendered would satisfy the 834px case while measuring nothing, so the four
+ * legible viewports must show NO notice.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const EXAMPLE = 'Customer Data Platform Selection'
+
+const VIEWPORTS = [
+  { width: 1920, height: 1080, note: 'large desktop', expectLod: false },
+  { width: 1440, height: 900, note: 'MacBook Pro 14', expectLod: false },
+  { width: 1280, height: 800, note: 'common laptop', expectLod: false },
+  { width: 1024, height: 768, note: 'small laptop / split screen', expectLod: false },
+  { width: 834, height: 1112, note: 'narrow canvas — panels open, or tablet', expectLod: true },
+] as const
+
+const readZoom = (page: Page) =>
+  page.evaluate(() => {
+    const vp = document.querySelector('.react-flow__viewport')
+    return vp ? new DOMMatrixReadOnly(getComputedStyle(vp).transform).a : null
+  })
+
+/**
+ * ⚠ WAIT FOR THE CAMERA TO STOP MOVING, OR THIS SPEC MEASURES THE WRONG FIT.
+ *
+ * `useFitViewOnLayoutVersion` runs its OWN fit whenever `layoutVersion` bumps,
+ * and that one IS floored at `LABEL_LEGIBLE_ZOOM`. ELK layout settles
+ * asynchronously after the example loads, so a spec that clicks "Fit to view"
+ * too early gets its gesture overwritten by the floored auto-fit moments later.
+ *
+ * That is not a hypothesis — it is what the first version of this file did. It
+ * reported **0.5 exactly** at both 1024px and 834px and passed all five cases.
+ * `0.5` is `LABEL_LEGIBLE_ZOOM` to the digit, and the manual fit never passes a
+ * `minZoom`, so the only thing that can produce it is the auto-fit. The spec was
+ * green while measuring a camera move the user never made — and the same graph
+ * measured with a proper settle lands at 0.344 with 17 of 19 titles hidden.
+ * A suspiciously round number is evidence about your instrument (trap 20).
+ */
+async function waitForCameraToSettle(page: Page): Promise<void> {
+  let last: number | null = null
+  for (let i = 0; i < 40; i++) {
+    const z = await readZoom(page)
+    if (last !== null && z !== null && Math.abs(z - last) < 1e-6) return
+    last = z
+    await page.waitForTimeout(400)
+  }
+}
+
+async function measureAfterFit(page: Page) {
+  return page.evaluate(() => {
+    const vp = document.querySelector('.react-flow__viewport')
+    const zoom = vp ? new DOMMatrixReadOnly(getComputedStyle(vp).transform).a : null
+    const titles = Array.from(document.querySelectorAll('[data-testid="node-title"]'))
+    const hiddenTitles = titles.filter((e) => getComputedStyle(e as HTMLElement).visibility === 'hidden').length
+    return {
+      zoom,
+      titles: titles.length,
+      hiddenTitles,
+      noticePresent: !!document.querySelector('[data-testid="canvas-lod-notice"]'),
+    }
+  })
+}
+
+for (const v of VIEWPORTS) {
+  test(`fit to view at ${v.width}x${v.height} (${v.note}) — labels are legible, or the canvas says they are not`, async ({ page }) => {
+    await page.setViewportSize({ width: v.width, height: v.height })
+
+    await page.addInitScript(() => {
+      // Match the deployed flag posture (`netlify.toml` sets this true on
+      // staging) so the canvas this spec measures is the canvas users get.
+      try { localStorage.setItem('feature.aiPanelV2', 'true') } catch { /* storage-less context */ }
+    })
+
+    await page.goto('/#/canvas')
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 30_000 })
+
+    // A real, product-shipped 19-node model — not a fixture this spec authored.
+    // A self-authored graph would encode the author's idea of a decision model
+    // rather than the product's (CLAUDE.md trap 16-inverse).
+    await page.getByText(EXAMPLE, { exact: false }).first().click()
+    await expect(page.locator('[data-testid="node-title"]').first()).toBeVisible({ timeout: 30_000 })
+
+    // Let the layout-driven auto-fit finish BEFORE the gesture, so what we
+    // measure is the gesture.
+    await waitForCameraToSettle(page)
+    const zoomBeforeGesture = await readZoom(page)
+
+    await page.getByRole('button', { name: /fit to view/i }).first().click()
+    await waitForCameraToSettle(page)
+
+    const m = await measureAfterFit(page)
+    // eslint-disable-next-line no-console
+    console.log(`[fit ${v.width}x${v.height}] settled-before=${zoomBeforeGesture} after-gesture=${m.zoom}`)
+    // eslint-disable-next-line no-console
+    console.log(`[fit ${v.width}x${v.height}] zoom=${m.zoom} hiddenTitles=${m.hiddenTitles}/${m.titles} notice=${m.noticePresent}`)
+
+    expect(m.titles, 'the example must render node titles, or this measures nothing').toBeGreaterThan(0)
+
+    // THE PROPERTY, bound to the measurement rather than to a fixed expectation
+    // about zoom: blank labels are allowed (that is the ratified doctrine), and
+    // silence about them is not.
+    if (m.hiddenTitles > 0) {
+      expect(
+        m.noticePresent,
+        `${m.hiddenTitles} of ${m.titles} node titles are computed visibility:hidden at zoom ${m.zoom} and the ` +
+          'canvas said nothing — a screen of blank rectangles is indistinguishable from a broken render',
+      ).toBe(true)
+    } else {
+      expect(
+        m.noticePresent,
+        'the canvas claimed labels were hidden while every one of them is rendering — a notice that is always on ' +
+          'is a notice the user learns to ignore',
+      ).toBe(false)
+    }
+  })
+}

--- a/scripts/evidence/link-r2-add-this-cta/README.md
+++ b/scripts/evidence/link-r2-add-this-cta/README.md
@@ -1,0 +1,84 @@
+# "Not modelled yet" CTA — the live-router derivation
+
+The `Where does this fit?` control in `V7WhatIWasGivenSection` used to read **"Add this"**
+and fire a turn that changed nothing. What it does now was decided by measurement against
+the deployed router, and **this directory is that measurement** — the probes, the corrected
+classifier, and the raw captures.
+
+It lives in the repo because the alternative was a claim in a PR body about files in
+`/private/tmp`, for a shipped user-facing behaviour. A derivation that cannot be re-run is
+a sentence, not evidence.
+
+## What it establishes
+
+**No add instruction has ever been observed to be accepted — 15 arms, 5 rounds.**
+
+| Phrasing | Live outcome |
+|---|---|
+| bare figure (`Please add "£31m" from my brief to the model.`) | no mutation; a specific, grounded question back |
+| figure + its brief sentence | **REFUSED** `ORPHAN_NODE` |
+| named factor + value | **REFUSED** `ORPHAN_NODE` |
+| named factor + "connect it to the options" | **REFUSED** `NO_PATH_TO_GOAL` |
+| named factor + a causal target that feeds the goal | **REFUSED** `PIPELINE_OWNED_FIELD` |
+| **control** — `Change <factor> to £64,000.`, target derived from the run's own graph | **APPLIED** |
+| the three ASK phrasings | answered with concrete, model-grounded options; no orphan, no error |
+
+The control is what makes the refusals readable: without it they are equally consistent
+with a sick service.
+
+The acceptance condition for an add is knowledge the receipt does not have — what the
+figure should causally influence — which is why the CTA asks. The engine ends in the same
+place: *"connect 'Annual revenue' to a factor that already feeds your goal. Which factor
+should it relate to?"*
+
+**The ladder is UNMEASURED.** Whether a user's own answer can land an add is not
+established here, and nothing in the product claims it.
+
+## Two instrument defects this directory exists to prevent recurring
+
+**1. The classifier disjunct (rounds 1–3, caught in review).** `classifier.mjs` replaces:
+
+```js
+return d.verdict === 'held' || !!d.blocker_code;   // ← overrides an explicit rejection
+```
+
+Two arms returned `{verdict:"rejected", blocker_code:"PIPELINE_OWNED_FIELD"}` with no
+`held_proposal` block, and were scored **HELD**. That false reading reached shipped source
+comments. `classifier.mjs` now reads an explicit verdict **first**, in both directions, and
+ships a self-test whose first case is the exact arm-F payload:
+
+```
+node scripts/evidence/link-r2-add-this-cta/classifier.mjs   # exits non-zero on regression
+```
+
+Note what this defeats: the PR's 13-mutant kit bit on every mutant. **A mutant kit measures
+whether the tests can detect a change, never whether the expectation is right.**
+
+**2. A control bound by value, not identity (round 4, void).** Its positive control sent
+`Change Annual CRM Licence Cost to £64,000.` — a label hardcoded from an earlier run. That
+run's draft named the factor *"Annual CRM Spend"*, so the control asked the engine to change
+a node that did not exist, and every arm in the round became unreadable. Round 5 derives both
+the control's and the add's target from **that run's own committed graph**. Draft labels vary
+per run; a harness that hardcodes one is bound by a value another object could satisfy.
+
+## Running them
+
+Guest posture, **no credential is read, embedded or printed** — the product journey is a
+guest journey by construction. Each probe mints fresh scenario UUIDs and sends a
+byte-identical brief, one arm per scenario, so only the phrasing varies.
+
+```bash
+node scripts/evidence/link-r2-add-this-cta/probe-addthis-r5.mjs
+```
+
+They import the programme's shared wire recipe by absolute path
+(`scripts/golden-journey/lib/wire.mjs`, in the platform root above this repo). Re-point that
+import if you run them from elsewhere.
+
+`captures/` holds each round's `probe.log` and `summary.json`, plus the raw
+`F_CONNECT_TO_BUDGET.json` / `G_CONNECT_CHAIN_TO_GOAL.json` bodies — the two payloads the
+old classifier misread, kept so the correction can be checked against the bytes rather than
+against this file.
+
+⚠ **`captures/` is an append-only record of what the deployed service actually said on a
+dated build.** Add rounds; never edit an existing one to match a newer expectation.

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/F_CONNECT_TO_BUDGET.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/F_CONNECT_TO_BUDGET.json
@@ -1,0 +1,90 @@
+{
+  "arm": "F_CONNECT_TO_BUDGET",
+  "note": "names an existing factor that already reaches the goal",
+  "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Budget Headroom.",
+  "scenarioId": "fc7d0010-691b-4ffb-8ec4-97fd173f265a",
+  "nodesBefore": 15,
+  "nodesAfter": null,
+  "newLabels": null,
+  "outcome": {
+    "kind": "HELD",
+    "markers": [
+      "details.verdict/blocker_code"
+    ]
+  },
+  "blockTypes": [
+    "error"
+  ],
+  "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again.",
+  "fullBody": {
+    "response_version": 2,
+    "assistant_text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again.",
+    "blocks": [
+      {
+        "type": "error",
+        "error_code": "INTERNAL_ERROR",
+        "severity": "warn",
+        "details": {
+          "source": "graph_management",
+          "verdict": "rejected",
+          "mutation_class": "structural",
+          "blocker_code": "PIPELINE_OWNED_FIELD",
+          "blocker_readable": "The candidate targets an analysis-derived, pipeline-owned field.",
+          "candidate_id": "3828d706-51ba-4544-be9d-45383c6918a5",
+          "base_hash_match": true
+        }
+      }
+    ],
+    "suggested_actions": [],
+    "insights": [],
+    "stage_indicator": "frame",
+    "graph_hash": "8134abc51ee779e5",
+    "_diagnostic_trace": {
+      "llm_calls": [
+        {
+          "role": "edit_graph",
+          "provider": "anthropic",
+          "model": "claude-sonnet-5",
+          "input_tokens": 13884,
+          "output_tokens": 531,
+          "cache_read_tokens": null,
+          "cache_creation_tokens": null,
+          "latency_ms": 6920,
+          "stop_reason": "end_turn",
+          "thinking_enabled": false,
+          "error": null
+        }
+      ],
+      "prompt_identity": [],
+      "zone2_assembly": null,
+      "tool_policy": null,
+      "provider_resolution": [],
+      "structured_output_config": null,
+      "streaming_metrics": null,
+      "fallback_trace": [],
+      "benchmarking": {
+        "total_duration_ms": 10793,
+        "substage_timings": {
+          "finalisation_ms": 1
+        }
+      },
+      "correlation_ids": {
+        "request_id": "4827b79d-9cbb-434d-a08d-17967bedd4b2",
+        "scenario_id": "fc7d0010-691b-4ffb-8ec4-97fd173f265a",
+        "turn_id": "77ec2f5f-39e5-4f88-979c-e5c0f9f888fb",
+        "response_hash": "b9103c98dc9e"
+      },
+      "environment": {
+        "build_sha": "2d38408",
+        "environment": "staging"
+      },
+      "exit_path": "edit_graph",
+      "trace_version": 1,
+      "claim_safety": {
+        "may_name_leading_option": true,
+        "verdict_provenance": "no_analysis_exists",
+        "withheld_projection_reason": null
+      }
+    }
+  }
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/G_CONNECT_CHAIN_TO_GOAL.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/G_CONNECT_CHAIN_TO_GOAL.json
@@ -1,0 +1,90 @@
+{
+  "arm": "G_CONNECT_CHAIN_TO_GOAL",
+  "note": "names the full chain, including the goal node, explicitly",
+  "message": "Add a new factor called \"Annual revenue\" with a value of £31m. Connect it so that Annual revenue influences Budget Headroom, and make sure the new factor has a path through to the goal \"Increase Sales Productivity Within Budget\".",
+  "scenarioId": "996d37dc-c715-476f-af11-1e408278e9a4",
+  "nodesBefore": 15,
+  "nodesAfter": null,
+  "newLabels": null,
+  "outcome": {
+    "kind": "HELD",
+    "markers": [
+      "details.verdict/blocker_code"
+    ]
+  },
+  "blockTypes": [
+    "error"
+  ],
+  "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again.",
+  "fullBody": {
+    "response_version": 2,
+    "assistant_text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again.",
+    "blocks": [
+      {
+        "type": "error",
+        "error_code": "INTERNAL_ERROR",
+        "severity": "warn",
+        "details": {
+          "source": "graph_management",
+          "verdict": "rejected",
+          "mutation_class": "structural",
+          "blocker_code": "PIPELINE_OWNED_FIELD",
+          "blocker_readable": "The candidate targets an analysis-derived, pipeline-owned field.",
+          "candidate_id": "a669103c-4510-45a9-a02c-ba0ab06e2c3e",
+          "base_hash_match": true
+        }
+      }
+    ],
+    "suggested_actions": [],
+    "insights": [],
+    "stage_indicator": "frame",
+    "graph_hash": "07296e042bcb3c22",
+    "_diagnostic_trace": {
+      "llm_calls": [
+        {
+          "role": "edit_graph",
+          "provider": "anthropic",
+          "model": "claude-sonnet-5",
+          "input_tokens": 13899,
+          "output_tokens": 652,
+          "cache_read_tokens": null,
+          "cache_creation_tokens": null,
+          "latency_ms": 8257,
+          "stop_reason": "end_turn",
+          "thinking_enabled": false,
+          "error": null
+        }
+      ],
+      "prompt_identity": [],
+      "zone2_assembly": null,
+      "tool_policy": null,
+      "provider_resolution": [],
+      "structured_output_config": null,
+      "streaming_metrics": null,
+      "fallback_trace": [],
+      "benchmarking": {
+        "total_duration_ms": 11808,
+        "substage_timings": {
+          "finalisation_ms": 1
+        }
+      },
+      "correlation_ids": {
+        "request_id": "42f54974-baa5-49dd-8f8c-b7ba2f840c0e",
+        "scenario_id": "996d37dc-c715-476f-af11-1e408278e9a4",
+        "turn_id": "44942249-00a7-4bc8-b344-d269a5f6a18d",
+        "response_hash": "9f470c31613c"
+      },
+      "environment": {
+        "build_sha": "2d38408",
+        "environment": "staging"
+      },
+      "exit_path": "edit_graph",
+      "trace_version": 1,
+      "claim_safety": {
+        "may_name_leading_option": true,
+        "verdict_provenance": "no_analysis_exists",
+        "withheld_projection_reason": null
+      }
+    }
+  }
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/summary.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r2/summary.json
@@ -1,0 +1,73 @@
+{
+  "brief": "Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.",
+  "results": [
+    {
+      "arm": "F_CONNECT_TO_BUDGET",
+      "note": "names an existing factor that already reaches the goal",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Budget Headroom.",
+      "scenarioId": "fc7d0010-691b-4ffb-8ec4-97fd173f265a",
+      "nodesBefore": 15,
+      "nodesAfter": null,
+      "newLabels": null,
+      "outcome": {
+        "kind": "HELD",
+        "markers": [
+          "details.verdict/blocker_code"
+        ]
+      },
+      "blockTypes": [
+        "error"
+      ],
+      "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again."
+    },
+    {
+      "arm": "G_CONNECT_CHAIN_TO_GOAL",
+      "note": "names the full chain, including the goal node, explicitly",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m. Connect it so that Annual revenue influences Budget Headroom, and make sure the new factor has a path through to the goal \"Increase Sales Productivity Within Budget\".",
+      "scenarioId": "996d37dc-c715-476f-af11-1e408278e9a4",
+      "nodesBefore": 15,
+      "nodesAfter": null,
+      "newLabels": null,
+      "outcome": {
+        "kind": "HELD",
+        "markers": [
+          "details.verdict/blocker_code"
+        ]
+      },
+      "blockTypes": [
+        "error"
+      ],
+      "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again."
+    },
+    {
+      "arm": "H_RELATIVE_COST",
+      "note": "the engine's OWN suggested resolution, quoted back to it (its clarify text proposes expressing CRM cost as a share of revenue)",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it to Annual CRM Licence Cost so that CRM cost can be read as a share of revenue.",
+      "scenarioId": "7d1b1217-1131-4506-8fd8-008b0d19e7b8",
+      "nodesBefore": 14,
+      "nodesAfter": null,
+      "newLabels": null,
+      "outcome": {
+        "kind": "NO_TYPED_OUTCOME",
+        "codes": []
+      },
+      "blockTypes": [],
+      "text": "The model is unchanged so far. Tell me the specific factor, edge, option, or value to change, and I'll apply it directly."
+    },
+    {
+      "arm": "I_CONTROL_KNOWN_GOOD",
+      "note": "POSITIVE CONTROL — the estate's own proven edit grammar (golden-journey T4). If THIS is refused, the probe is measuring a broken service, not the phrasings.",
+      "message": "Change Annual CRM Licence Cost to £64,000.",
+      "scenarioId": "adf3ac1c-138d-430a-815e-f3da027cb1c3",
+      "nodesBefore": 14,
+      "nodesAfter": 14,
+      "newLabels": [],
+      "outcome": {
+        "kind": "APPLIED_DIRECT",
+        "codes": []
+      },
+      "blockTypes": [],
+      "text": "Updated Annual CRM Licence Cost"
+    }
+  ]
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r3/summary.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r3/summary.json
@@ -1,0 +1,53 @@
+{
+  "brief": "Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.",
+  "sentence": "We are a 34-person B2B sales team with annual revenue of £31m.",
+  "results": [
+    {
+      "arm": "J_ASK_WHERE_WITH_SENTENCE",
+      "note": "ASK phrasing + the charOffset-recovered sentence, explicitly deferring the change",
+      "message": "My brief mentions £31m, which is not in the model yet. The brief says: \"We are a 34-person B2B sales team with annual revenue of £31m.\" What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.",
+      "scenarioId": "ba5d6602-52ed-42be-9907-0d6e90d4dd9e",
+      "outcome": {
+        "kind": "ANSWERED_NO_MUTATION",
+        "codes": []
+      },
+      "blockTypes": [],
+      "suggestedActions": [
+        "Run analysis"
+      ],
+      "text": "Annual revenue isn't in your model yet, but it would most naturally sit behind the risk of revenue loss during transition, or as a scale factor on productivity.\n\n• **Revenue at risk during switching.** Your model already has a factor for revenue loss during transition; £31m gives that a real base to size against, so a small percentage dip becomes a concrete pound figure rather than an abstract risk.\n• **Scale check on the cost numbers.** Against £31m in revenue, the £50,000 annual cost and £20,000 switch cost are both under 0.3% of turnover, worth having explicit so the budget trade-off isn't overweighted relative to the productivity upside.\n• **Team size and revenue together imply revenue per head.** That could sharpen what 'sales productivity' actually means, since a generic productivity outcome is harder to size than a revenue-per-rep figure tied to your real numbers.\n\nThere isn't a single obviously correct place for £31m. It could be added as a factor feeding the revenue loss during transition risk (to size how disruption translates into pounds), as context that recalibrates the budget headroom outcome (since £50k-£70k against £31m is a small fraction of revenue), or as a denominator alongside team size to define productivity in revenue-per-head terms. Which of these matches what you want the £31m to do: size the transition risk, sanity-check the budget stakes, or redefine "
+    },
+    {
+      "arm": "K_ASK_WHERE_SHORT",
+      "note": "ASK phrasing, sentence but no explicit deferral — does the deferral clause carry the weight?",
+      "message": "My brief mentions £31m (\"We are a 34-person B2B sales team with annual revenue of £31m.\") and it is not in the model. What could it influence here?",
+      "scenarioId": "3aec4d81-96a2-404a-920f-fbd525f6188f",
+      "outcome": {
+        "kind": "ANSWERED_NO_MUTATION",
+        "codes": []
+      },
+      "blockTypes": [
+        "ui_directive"
+      ],
+      "suggestedActions": [
+        "Run analysis"
+      ],
+      "text": "Revenue isn't represented as a factor in your model right now, so it has no direct link to anything yet.\n\nStructurally, though, there are a couple of places it would plausibly connect. Annual CRM cost sits at £50k and switching cost at roughly £20k one-off, both of which feed into budget headroom, which in turn links to your goal of maximising sales productivity within budget; £31m in revenue gives useful context for how material those costs are relative to the business, which matters when judging how much budget headroom really is at stake. Revenue could also relate to sales team productivity, the other driver of your goal, since productivity gains from a new platform would ultimately need to show up as revenue impact to matter at this scale. Neither link exists in your model yet, so right now revenue is background context rather than something the structure reasons over.\n\nIf you want it to influence the analysis, it would need to be added as a factor connected to budget headroom or sales productivity, but that's a structural decision for you to make rather than one I'd assume."
+    },
+    {
+      "arm": "L_ASK_NO_SENTENCE",
+      "note": "DISCRIMINATING TWIN of J: identical ask, sentence REMOVED. Isolates what the charOffset context actually buys.",
+      "message": "My brief mentions £31m, which is not in the model yet. What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.",
+      "scenarioId": "8ef41287-3fbd-4022-9122-ed591ded087a",
+      "outcome": {
+        "kind": "ANSWERED_NO_MUTATION",
+        "codes": []
+      },
+      "blockTypes": [],
+      "suggestedActions": [
+        "Run analysis"
+      ],
+      "text": "Your £31m revenue figure isn't in the model, and it would work best as context that scales your cost and productivity factors rather than as a standalone factor.\n\n• **As a scale check on CRM cost.** £50k against £31m revenue is a small fraction, so this could anchor how much budget headroom actually matters versus sales productivity in your goal.\n• **As a scale check on the productivity upside.** Revenue lets you translate a productivity gain into a rough pound figure, which would sharpen how the switch versus status quo trade-off gets weighed.\n• **As a size-normalising factor alongside team size.** Revenue per head could relate to how much a platform capability gain actually moves the needle, similar to how team size already links to productivity.\n\nNone of these are in your model yet, and I haven't changed anything. The most natural home is as a new controllable-adjacent factor feeding into budget headroom and sales productivity, since both currently only take inputs from cost and capability factors, not from overall revenue scale. Which of these framings fits your thinking, or would you rather see it purely as a budget-scale reference rather than something that feeds the productivity side?"
+    }
+  ]
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r4/summary.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r4/summary.json
@@ -1,0 +1,55 @@
+{
+  "brief": "Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.",
+  "results": [
+    {
+      "arm": "M_TARGET_PLAIN_FACTOR",
+      "note": "targets a plain brief-derived factor, not an analysis-derived one",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Annual CRM Licence Cost.",
+      "scenarioId": "63eee40b-4667-4e0d-90be-d713705bc854",
+      "nodesBefore": 14,
+      "add": {
+        "kind": "REFUSED",
+        "verdict": null,
+        "codes": [
+          "rejection:ORPHAN_NODE",
+          "violation:ORPHAN_NODE"
+        ],
+        "blockTypes": [
+          "error"
+        ],
+        "text": "I couldn't make that change in one edit, because \"Annual revenue\" isn't connected to your goal yet. On its own it has no path through to your goal, so I've left everything as it was. To go ahead, connect \"Annual revenue\" to a factor that already feeds your goal. Which factor should it relate to?"
+      },
+      "confirm": null
+    },
+    {
+      "arm": "N_TARGET_ADOPTION",
+      "note": "targets the adoption factor — also brief-derived",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Sales Team Adoption Rate.",
+      "scenarioId": "428dd0e2-e29f-4b76-a4f1-7500aab3e601",
+      "nodesBefore": 14,
+      "add": {
+        "kind": "ANSWERED_NO_MUTATION",
+        "verdict": null,
+        "codes": [],
+        "blockTypes": [],
+        "text": "The model is unchanged so far. Tell me the specific factor, edge, option, or value to change, and I'll apply it directly."
+      },
+      "confirm": null
+    },
+    {
+      "arm": "O_CONTROL_KNOWN_GOOD",
+      "note": "POSITIVE CONTROL — the proven edit grammar. If this fails the service is sick and no arm may be read.",
+      "message": "Change Annual CRM Licence Cost to £64,000.",
+      "scenarioId": "81c2508c-729a-4fd4-bdcc-fb6f0207e729",
+      "nodesBefore": 14,
+      "add": {
+        "kind": "ANSWERED_NO_MUTATION",
+        "verdict": null,
+        "codes": [],
+        "blockTypes": [],
+        "text": "Which one should I update: Annual CRM Spend or CRM Capability Level?"
+      },
+      "confirm": null
+    }
+  ]
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/P_CONTROL_DERIVED.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/P_CONTROL_DERIVED.json
@@ -1,0 +1,1304 @@
+{
+  "arm": "P_CONTROL_DERIVED",
+  "scenarioId": "aafe0a41-6d01-4ac2-b4dc-b31dce488adb",
+  "nodesBefore": 14,
+  "labels": [
+    "CRM Platform Decision",
+    "Staff Adoption Uncertainty",
+    "Annual CRM Cost",
+    "CRM Platform Capability",
+    "One-Off Switching Cost",
+    "Sales Team Size",
+    "Increase Sales Productivity Within Budget",
+    "Pilot HubSpot with Sales Sub-Team First",
+    "Keep Current CRM (Status Quo)",
+    "Switch to HubSpot Next Quarter",
+    "Budget Headroom",
+    "Sales Team Productivity",
+    "Low CRM Adoption by Sales Team",
+    "Transition Disruption to Sales Pipeline"
+  ],
+  "target": "Annual CRM Cost",
+  "message": "Change Annual CRM Cost to £64,000.",
+  "edit": {
+    "kind": "APPLIED_DIRECT",
+    "verdict": null,
+    "codes": [],
+    "markers": [
+      "draft_graph committed"
+    ],
+    "nodesAfter": 14,
+    "text": "Updated Annual CRM Cost"
+  },
+  "editFullBody": {
+    "response_version": 2,
+    "assistant_text": "Updated Annual CRM Cost",
+    "blocks": [],
+    "suggested_actions": [],
+    "insights": [],
+    "stage_indicator": "frame",
+    "draft_graph": {
+      "nodes": [
+        {
+          "id": "dec_crm",
+          "kind": "decision",
+          "label": "CRM Platform Decision",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "fac_adoption_risk",
+          "kind": "factor",
+          "label": "Staff Adoption Uncertainty",
+          "category": "external",
+          "prior": {
+            "distribution": "uniform",
+            "range_min": 0.2,
+            "range_max": 0.8
+          },
+          "display_value": "0.2 to 0.8",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "fac_crm_cost",
+          "kind": "factor",
+          "label": "Annual CRM Cost",
+          "observed_state": {
+            "value": 64000,
+            "unit": "£",
+            "source": "user_override"
+          },
+          "category": "controllable",
+          "display_value": "64,000 £",
+          "provenance": "user_set"
+        },
+        {
+          "id": "fac_platform_capability",
+          "kind": "factor",
+          "label": "CRM Platform Capability",
+          "observed_state": {
+            "value": 0.4,
+            "unit": "scale",
+            "source": "cee_inference",
+            "raw_value": 40,
+            "cap": 100,
+            "extractionType": "inferred",
+            "factor_type": "quality",
+            "uncertainty_drivers": [
+              "Not provided"
+            ]
+          },
+          "category": "controllable",
+          "display_value": "40 scale",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "fac_switch_cost",
+          "kind": "factor",
+          "label": "One-Off Switching Cost",
+          "observed_state": {
+            "value": 0,
+            "unit": "£",
+            "source": "brief_extraction",
+            "raw_value": 0,
+            "cap": 20000,
+            "extractionType": "explicit",
+            "factor_type": "cost",
+            "uncertainty_drivers": [
+              "Not provided"
+            ]
+          },
+          "category": "controllable",
+          "display_value": "£0",
+          "provenance": "from_brief"
+        },
+        {
+          "id": "fac_team_size",
+          "kind": "factor",
+          "label": "Sales Team Size",
+          "category": "external",
+          "prior": {
+            "distribution": "uniform",
+            "range_min": 0.34,
+            "range_max": 1
+          },
+          "extractionType": "inferred",
+          "display_value": "0.34 to 1 people",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "goal_crm",
+          "kind": "goal",
+          "label": "Increase Sales Productivity Within Budget",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "opt_phased",
+          "kind": "option",
+          "label": "Pilot HubSpot with Sales Sub-Team First",
+          "interventions": {
+            "fac_crm_cost": {
+              "unit": "£",
+              "value": 0.65,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_crm_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            },
+            "fac_switch_cost": {
+              "unit": "£",
+              "value": 0.4,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_switch_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            },
+            "fac_platform_capability": {
+              "unit": "scale",
+              "value": 0.6,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_platform_capability",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            }
+          },
+          "is_baseline": false,
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "opt_stay",
+          "kind": "option",
+          "label": "Keep Current CRM (Status Quo)",
+          "interventions": {
+            "fac_crm_cost": {
+              "unit": "£",
+              "value": 0.5,
+              "source": "brief_extraction",
+              "reasoning": "Direct from V4 prompt data.interventions; the amount is stated in the brief",
+              "target_match": {
+                "node_id": "fac_crm_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "high"
+            },
+            "fac_switch_cost": {
+              "unit": "£",
+              "value": 0,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_switch_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            },
+            "fac_platform_capability": {
+              "unit": "scale",
+              "value": 0.4,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_platform_capability",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            }
+          },
+          "is_baseline": true,
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "opt_switch",
+          "kind": "option",
+          "label": "Switch to HubSpot Next Quarter",
+          "interventions": {
+            "fac_crm_cost": {
+              "unit": "£",
+              "value": 0.5,
+              "source": "brief_extraction",
+              "reasoning": "Direct from V4 prompt data.interventions; the amount is stated in the brief",
+              "target_match": {
+                "node_id": "fac_crm_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "high"
+            },
+            "fac_switch_cost": {
+              "unit": "£",
+              "value": 1,
+              "source": "brief_extraction",
+              "reasoning": "Direct from V4 prompt data.interventions; the amount is stated in the brief",
+              "target_match": {
+                "node_id": "fac_switch_cost",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "high"
+            },
+            "fac_platform_capability": {
+              "unit": "scale",
+              "value": 0.8,
+              "source": "cee_hypothesis",
+              "reasoning": "Model-chosen intervention level; this amount is not stated in the brief",
+              "target_match": {
+                "node_id": "fac_platform_capability",
+                "confidence": "high",
+                "match_type": "exact_id"
+              },
+              "value_confidence": "low"
+            }
+          },
+          "is_baseline": false,
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "out_budget_headroom",
+          "kind": "outcome",
+          "label": "Budget Headroom",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "out_sales_productivity",
+          "kind": "outcome",
+          "label": "Sales Team Productivity",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "risk_adoption_failure",
+          "kind": "risk",
+          "label": "Low CRM Adoption by Sales Team",
+          "provenance": "ai_inferred"
+        },
+        {
+          "id": "risk_disruption",
+          "kind": "risk",
+          "label": "Transition Disruption to Sales Pipeline",
+          "provenance": "ai_inferred"
+        }
+      ],
+      "edges": [
+        {
+          "from": "dec_crm",
+          "to": "opt_phased",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "dec_crm",
+          "to": "opt_stay",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "dec_crm",
+          "to": "opt_switch",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "fac_adoption_risk",
+          "to": "risk_adoption_failure",
+          "strength": {
+            "mean": 0.45,
+            "std": 0.18
+          },
+          "exists_probability": 0.8,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.18,
+              "strength_mean": 0.45,
+              "exists_probability": 0.8
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "Greater staff adoption uncertainty strongly increases the risk of CRM adoption failure.",
+              "strength_std": 0.15,
+              "strength_mean": 0.6,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.9
+            },
+            "status": "agreed",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.33999999999999997,
+            "pass2_adjusted": {
+              "strength_std": 0.15,
+              "strength_mean": 0.62,
+              "exists_probability": 0.88
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_adoption_risk",
+          "to": "risk_disruption",
+          "strength": {
+            "mean": 0.28,
+            "std": 0.14
+          },
+          "exists_probability": 0.72,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.14,
+              "strength_mean": 0.28,
+              "exists_probability": 0.72
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "Higher adoption uncertainty leads to more transition disruption as inconsistent use hampers the sales pipeline.",
+              "strength_std": 0.15,
+              "strength_mean": 0.45,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.85
+            },
+            "status": "agreed",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3799999999999999,
+            "pass2_adjusted": {
+              "strength_std": 0.15,
+              "strength_mean": 0.47,
+              "exists_probability": 0.83
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_crm_cost",
+          "to": "out_budget_headroom",
+          "strength": {
+            "mean": -0.45,
+            "std": 0.12
+          },
+          "exists_probability": 0.92,
+          "effect_direction": "negative",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.12,
+              "strength_mean": -0.45,
+              "exists_probability": 0.92
+            },
+            "pass2": {
+              "basis": "brief_explicit",
+              "reasoning": "Annual CRM costs directly reduce available budget headroom for other initiatives.",
+              "strength_std": 0.1,
+              "strength_mean": -0.6,
+              "lint_corrected": false,
+              "needs_user_input": false,
+              "exists_probability": 0.98
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": -0.58,
+              "exists_probability": 0.96
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [
+              "existence_boundary_crossing"
+            ],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_platform_capability",
+          "to": "out_sales_productivity",
+          "strength": {
+            "mean": 0.55,
+            "std": 0.15
+          },
+          "exists_probability": 0.88,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.15,
+              "strength_mean": 0.55,
+              "exists_probability": 0.88
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "A more capable CRM platform typically yields substantially higher sales team productivity.",
+              "strength_std": 0.15,
+              "strength_mean": 0.7,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.9
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.33999999999999986,
+            "pass2_adjusted": {
+              "strength_std": 0.15,
+              "strength_mean": 0.72,
+              "exists_probability": 0.88
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [
+              "strength_band_change"
+            ],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_platform_capability",
+          "to": "risk_adoption_failure",
+          "strength": {
+            "mean": -0.3,
+            "std": 0.12
+          },
+          "exists_probability": 0.75,
+          "effect_direction": "negative",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.12,
+              "strength_mean": -0.3,
+              "exists_probability": 0.75
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "Better platform features and usability reduce the likelihood of adoption failure.",
+              "strength_std": 0.12,
+              "strength_mean": -0.4,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.9
+            },
+            "status": "agreed",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.16000000000000003,
+            "pass2_adjusted": {
+              "strength_std": 0.12,
+              "strength_mean": -0.38,
+              "exists_probability": 0.88
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_switch_cost",
+          "to": "out_budget_headroom",
+          "strength": {
+            "mean": -0.35,
+            "std": 0.14
+          },
+          "exists_probability": 0.9,
+          "effect_direction": "negative",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.14,
+              "strength_mean": -0.35,
+              "exists_probability": 0.9
+            },
+            "pass2": {
+              "basis": "brief_explicit",
+              "reasoning": "One-off switching costs immediately reduce available budget headroom.",
+              "strength_std": 0.1,
+              "strength_mean": -0.4,
+              "lint_corrected": false,
+              "needs_user_input": false,
+              "exists_probability": 0.98
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": -0.38,
+              "exists_probability": 0.96
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [
+              "existence_boundary_crossing"
+            ],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_switch_cost",
+          "to": "risk_disruption",
+          "strength": {
+            "mean": 0.4,
+            "std": 0.16
+          },
+          "exists_probability": 0.82,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.16,
+              "strength_mean": 0.4,
+              "exists_probability": 0.82
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "Higher switching costs often correlate with more complex transitions and thus greater disruption risk.",
+              "strength_std": 0.1,
+              "strength_mean": 0.35,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.8
+            },
+            "status": "agreed",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.06000000000000005,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": 0.37,
+              "exists_probability": 0.78
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_team_size",
+          "to": "out_sales_productivity",
+          "strength": {
+            "mean": 0.18,
+            "std": 0.09
+          },
+          "exists_probability": 0.85,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.09,
+              "strength_mean": 0.18,
+              "exists_probability": 0.85
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "Larger sales teams can produce more total sales output, though per-person productivity may vary.",
+              "strength_std": 0.2,
+              "strength_mean": 0.3,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.8
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.2,
+              "strength_mean": 0.31999999999999995,
+              "exists_probability": 0.78
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [
+              "strength_band_change"
+            ],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "fac_team_size",
+          "to": "risk_disruption",
+          "strength": {
+            "mean": 0.22,
+            "std": 0.1
+          },
+          "exists_probability": 0.78,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.1,
+              "strength_mean": 0.22,
+              "exists_probability": 0.78
+            },
+            "pass2": {
+              "basis": "domain_prior",
+              "reasoning": "A bigger team increases the coordination and training burden, raising disruption risk.",
+              "strength_std": 0.1,
+              "strength_mean": 0.2,
+              "lint_corrected": false,
+              "needs_user_input": true,
+              "exists_probability": 0.8
+            },
+            "status": "agreed",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": 0.22,
+              "exists_probability": 0.78
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 1,
+            "contested_reasons": [],
+            "validation_lint_log": []
+          }
+        },
+        {
+          "from": "opt_phased",
+          "to": "fac_crm_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_phased",
+          "to": "fac_platform_capability",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_phased",
+          "to": "fac_switch_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_stay",
+          "to": "fac_crm_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_stay",
+          "to": "fac_platform_capability",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_stay",
+          "to": "fac_switch_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_switch",
+          "to": "fac_crm_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_switch",
+          "to": "fac_platform_capability",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "opt_switch",
+          "to": "fac_switch_cost",
+          "strength": {
+            "mean": 1,
+            "std": 0.01
+          },
+          "exists_probability": 1,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai"
+        },
+        {
+          "from": "out_budget_headroom",
+          "to": "goal_crm",
+          "strength": {
+            "mean": 0.35,
+            "std": 0.12
+          },
+          "exists_probability": 0.88,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.12,
+              "strength_mean": 0.35,
+              "exists_probability": 0.88
+            },
+            "pass2": {
+              "basis": "structural_inference",
+              "reasoning": "Greater budget headroom supports achieving productivity goals without blowing the budget.",
+              "strength_std": 0.1,
+              "strength_mean": 0.21052631578947367,
+              "lint_corrected": true,
+              "needs_user_input": true,
+              "exists_probability": 0.9
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": 0.23052631578947366,
+              "exists_probability": 0.88
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 0,
+            "contested_reasons": [
+              "strength_band_change"
+            ],
+            "validation_lint_log": [
+              {
+                "code": "LINT_BUDGET_RESCALE",
+                "after": 0.21052631578947367,
+                "before": 0.4,
+                "edge_key": "out_budget_headroom->goal_crm"
+              }
+            ]
+          }
+        },
+        {
+          "from": "out_sales_productivity",
+          "to": "goal_crm",
+          "strength": {
+            "mean": 0.6,
+            "std": 0.12
+          },
+          "exists_probability": 0.92,
+          "effect_direction": "positive",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.12,
+              "strength_mean": 0.6,
+              "exists_probability": 0.92
+            },
+            "pass2": {
+              "basis": "structural_inference",
+              "reasoning": "Higher sales productivity directly advances the goal of improving CRM outcomes within budget.",
+              "strength_std": 0.1,
+              "strength_mean": 0.3157894736842105,
+              "lint_corrected": true,
+              "needs_user_input": true,
+              "exists_probability": 0.9
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.5284210526315789,
+            "pass2_adjusted": {
+              "strength_std": 0.1,
+              "strength_mean": 0.3357894736842105,
+              "exists_probability": 0.88
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 0,
+            "contested_reasons": [
+              "raw_magnitude"
+            ],
+            "validation_lint_log": [
+              {
+                "code": "LINT_BUDGET_RESCALE",
+                "after": 0.3157894736842105,
+                "before": 0.6,
+                "edge_key": "out_sales_productivity->goal_crm"
+              }
+            ]
+          }
+        },
+        {
+          "from": "risk_adoption_failure",
+          "to": "goal_crm",
+          "strength": {
+            "mean": -0.4,
+            "std": 0.14
+          },
+          "exists_probability": 0.82,
+          "effect_direction": "negative",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.14,
+              "strength_mean": -0.4,
+              "exists_probability": 0.82
+            },
+            "pass2": {
+              "basis": "structural_inference",
+              "reasoning": "If CRM adoption fails, the goal of increased productivity within budget is undermined.",
+              "strength_std": 0.15,
+              "strength_mean": -0.2631578947368421,
+              "lint_corrected": true,
+              "needs_user_input": true,
+              "exists_probability": 0.85
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.15,
+              "strength_mean": -0.2431578947368421,
+              "exists_probability": 0.83
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 0,
+            "contested_reasons": [
+              "strength_band_change"
+            ],
+            "validation_lint_log": [
+              {
+                "code": "LINT_BUDGET_RESCALE",
+                "after": -0.2631578947368421,
+                "before": -0.5,
+                "edge_key": "risk_adoption_failure->goal_crm"
+              }
+            ]
+          }
+        },
+        {
+          "from": "risk_disruption",
+          "to": "goal_crm",
+          "strength": {
+            "mean": -0.3,
+            "std": 0.12
+          },
+          "exists_probability": 0.85,
+          "effect_direction": "negative",
+          "provenance": {
+            "source": "cee_hypothesis"
+          },
+          "provenance_display": "ai_inferred",
+          "origin": "ai",
+          "validation": {
+            "pass1": {
+              "strength_std": 0.12,
+              "strength_mean": -0.3,
+              "exists_probability": 0.85
+            },
+            "pass2": {
+              "basis": "structural_inference",
+              "reasoning": "Transition disruption to the sales pipeline directly hampers achieving the CRM productivity and budget goal.",
+              "strength_std": 0.15,
+              "strength_mean": -0.21052631578947367,
+              "lint_corrected": true,
+              "needs_user_input": true,
+              "exists_probability": 0.85
+            },
+            "status": "contested",
+            "evoi_rank": null,
+            "was_shown": false,
+            "evoi_impact": null,
+            "resolved_by": "default",
+            "user_action": "pending",
+            "pass2_missing": false,
+            "sign_unstable": false,
+            "max_divergence": 0.3333333333333333,
+            "pass2_adjusted": {
+              "strength_std": 0.15,
+              "strength_mean": -0.19052631578947368,
+              "exists_probability": 0.83
+            },
+            "resolved_value": null,
+            "bias_correction": {
+              "strength_std_offset": 0,
+              "strength_mean_offset": 0.01999999999999999,
+              "exists_probability_offset": -0.020000000000000018
+            },
+            "distance_to_goal": 0,
+            "contested_reasons": [
+              "strength_band_change"
+            ],
+            "validation_lint_log": [
+              {
+                "code": "LINT_BUDGET_RESCALE",
+                "after": -0.21052631578947367,
+                "before": -0.4,
+                "edge_key": "risk_disruption->goal_crm"
+              }
+            ]
+          }
+        }
+      ],
+      "node_count": 14,
+      "edge_count": 25
+    },
+    "analysis_ready": {
+      "options": [
+        {
+          "option_id": "opt_phased",
+          "label": "Pilot HubSpot with Sales Sub-Team First",
+          "status": "ready",
+          "interventions": {
+            "fac_crm_cost": 0.65,
+            "fac_switch_cost": 0.4,
+            "fac_platform_capability": 0.6
+          },
+          "is_baseline": false
+        },
+        {
+          "option_id": "opt_stay",
+          "label": "Keep Current CRM (Status Quo)",
+          "status": "ready",
+          "interventions": {
+            "fac_crm_cost": 0.5,
+            "fac_switch_cost": 0,
+            "fac_platform_capability": 0.4
+          },
+          "is_baseline": true
+        },
+        {
+          "option_id": "opt_switch",
+          "label": "Switch to HubSpot Next Quarter",
+          "status": "ready",
+          "interventions": {
+            "fac_crm_cost": 0.5,
+            "fac_switch_cost": 1,
+            "fac_platform_capability": 0.8
+          },
+          "is_baseline": false
+        }
+      ],
+      "goal_node_id": "goal_crm",
+      "status": "ready",
+      "computed_at": "2026-08-11T22:56:25.462Z",
+      "freshness": "none",
+      "freshness_reason": "no_successful_run_analysis_fact",
+      "current_graph_hash": "839947ec7fa68850"
+    },
+    "graph_hash": "839947ec7fa68850",
+    "_diagnostic_trace": {
+      "llm_calls": [],
+      "prompt_identity": [],
+      "zone2_assembly": null,
+      "tool_policy": null,
+      "provider_resolution": [],
+      "structured_output_config": null,
+      "streaming_metrics": null,
+      "fallback_trace": [],
+      "benchmarking": {
+        "total_duration_ms": 15861,
+        "substage_timings": {
+          "finalisation_ms": 1
+        }
+      },
+      "correlation_ids": {
+        "request_id": "afdaed1a-d830-444c-b192-87f2fa767a55",
+        "scenario_id": "aafe0a41-6d01-4ac2-b4dc-b31dce488adb",
+        "turn_id": "0fe13974-6b4d-446c-a3db-cf8994e55efb",
+        "graph_hash": "f9048631e7576b05",
+        "response_hash": "50b6682a5606"
+      },
+      "environment": {
+        "build_sha": "2d38408",
+        "environment": "staging"
+      },
+      "exit_path": "edit_graph",
+      "trace_version": 1,
+      "claim_safety": {
+        "may_name_leading_option": true,
+        "verdict_provenance": "no_analysis_exists",
+        "withheld_projection_reason": null
+      }
+    }
+  }
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/Q_ADD_TO_GOAL_FEEDER.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/Q_ADD_TO_GOAL_FEEDER.json
@@ -1,0 +1,107 @@
+{
+  "arm": "Q_ADD_TO_GOAL_FEEDER",
+  "scenarioId": "24ea47d1-ed27-47a7-ab54-db0ea0edb1ec",
+  "nodesBefore": 14,
+  "labels": [
+    "CRM Platform Decision",
+    "Team Adoption Difficulty",
+    "Annual CRM Cost",
+    "CRM Platform Capability",
+    "One-Off Switching Cost",
+    "Sales Team Size",
+    "Maximise Sales Productivity Within Budget",
+    "Negotiate & Optimise Current CRM",
+    "Keep Current CRM (Status Quo)",
+    "Switch to HubSpot",
+    "Budget Headroom",
+    "Sales Team Productivity",
+    "Low CRM Adoption Rate",
+    "Transition Disruption to Sales Activity"
+  ],
+  "target": "Budget Headroom",
+  "goal": "Maximise Sales Productivity Within Budget",
+  "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Budget Headroom, which already feeds the goal.",
+  "edit": {
+    "kind": "REFUSED",
+    "verdict": "rejected",
+    "codes": [
+      "blocker:PIPELINE_OWNED_FIELD"
+    ],
+    "markers": [
+      "details.verdict=\"rejected\""
+    ],
+    "nodesAfter": null,
+    "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again."
+  },
+  "editFullBody": {
+    "response_version": 2,
+    "assistant_text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again.",
+    "blocks": [
+      {
+        "type": "error",
+        "error_code": "INTERNAL_ERROR",
+        "severity": "warn",
+        "details": {
+          "source": "graph_management",
+          "verdict": "rejected",
+          "mutation_class": "structural",
+          "blocker_code": "PIPELINE_OWNED_FIELD",
+          "blocker_readable": "The candidate targets an analysis-derived, pipeline-owned field.",
+          "candidate_id": "2f160385-062a-4459-9bb2-ce728cd3aa4e",
+          "base_hash_match": true
+        }
+      }
+    ],
+    "suggested_actions": [],
+    "insights": [],
+    "stage_indicator": "frame",
+    "graph_hash": "611d910315b5b4a1",
+    "_diagnostic_trace": {
+      "llm_calls": [
+        {
+          "role": "edit_graph",
+          "provider": "anthropic",
+          "model": "claude-sonnet-5",
+          "input_tokens": 13896,
+          "output_tokens": 736,
+          "cache_read_tokens": null,
+          "cache_creation_tokens": null,
+          "latency_ms": 9040,
+          "stop_reason": "end_turn",
+          "thinking_enabled": false,
+          "error": null
+        }
+      ],
+      "prompt_identity": [],
+      "zone2_assembly": null,
+      "tool_policy": null,
+      "provider_resolution": [],
+      "structured_output_config": null,
+      "streaming_metrics": null,
+      "fallback_trace": [],
+      "benchmarking": {
+        "total_duration_ms": 12492,
+        "substage_timings": {
+          "finalisation_ms": 1
+        }
+      },
+      "correlation_ids": {
+        "request_id": "65e1c697-54ac-4219-bb8a-d816450b75d7",
+        "scenario_id": "24ea47d1-ed27-47a7-ab54-db0ea0edb1ec",
+        "turn_id": "862f9655-2c00-466a-ac83-33dfe7f91aaa",
+        "response_hash": "f739a5cc7470"
+      },
+      "environment": {
+        "build_sha": "2d38408",
+        "environment": "staging"
+      },
+      "exit_path": "edit_graph",
+      "trace_version": 1,
+      "claim_safety": {
+        "may_name_leading_option": true,
+        "verdict_provenance": "no_analysis_exists",
+        "withheld_projection_reason": null
+      }
+    }
+  }
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/summary.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe-r5/summary.json
@@ -1,0 +1,74 @@
+{
+  "brief": "Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.",
+  "results": [
+    {
+      "arm": "P_CONTROL_DERIVED",
+      "scenarioId": "aafe0a41-6d01-4ac2-b4dc-b31dce488adb",
+      "nodesBefore": 14,
+      "labels": [
+        "CRM Platform Decision",
+        "Staff Adoption Uncertainty",
+        "Annual CRM Cost",
+        "CRM Platform Capability",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Increase Sales Productivity Within Budget",
+        "Pilot HubSpot with Sales Sub-Team First",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot Next Quarter",
+        "Budget Headroom",
+        "Sales Team Productivity",
+        "Low CRM Adoption by Sales Team",
+        "Transition Disruption to Sales Pipeline"
+      ],
+      "target": "Annual CRM Cost",
+      "message": "Change Annual CRM Cost to £64,000.",
+      "edit": {
+        "kind": "APPLIED_DIRECT",
+        "verdict": null,
+        "codes": [],
+        "markers": [
+          "draft_graph committed"
+        ],
+        "nodesAfter": 14,
+        "text": "Updated Annual CRM Cost"
+      }
+    },
+    {
+      "arm": "Q_ADD_TO_GOAL_FEEDER",
+      "scenarioId": "24ea47d1-ed27-47a7-ab54-db0ea0edb1ec",
+      "nodesBefore": 14,
+      "labels": [
+        "CRM Platform Decision",
+        "Team Adoption Difficulty",
+        "Annual CRM Cost",
+        "CRM Platform Capability",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Maximise Sales Productivity Within Budget",
+        "Negotiate & Optimise Current CRM",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot",
+        "Budget Headroom",
+        "Sales Team Productivity",
+        "Low CRM Adoption Rate",
+        "Transition Disruption to Sales Activity"
+      ],
+      "target": "Budget Headroom",
+      "goal": "Maximise Sales Productivity Within Budget",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it so that it influences Budget Headroom, which already feeds the goal.",
+      "edit": {
+        "kind": "REFUSED",
+        "verdict": "rejected",
+        "codes": [
+          "blocker:PIPELINE_OWNED_FIELD"
+        ],
+        "markers": [
+          "details.verdict=\"rejected\""
+        ],
+        "nodesAfter": null,
+        "text": "I couldn't take that change forward, so the model is unchanged. Tell me a different way you would like to change it and I will try again."
+      }
+    }
+  ]
+}

--- a/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe/summary.json
+++ b/scripts/evidence/link-r2-add-this-cta/captures/addthis-probe/summary.json
@@ -1,0 +1,235 @@
+{
+  "target": "https://cee-staging.onrender.com/proxy/v5/turn",
+  "brief": "Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.",
+  "surrounding": "We are a 34-person B2B sales team with annual revenue of £31m.",
+  "results": [
+    {
+      "arm": "A_CONTROL_SHIPPED",
+      "note": "the phrasing the product composes TODAY (V7WhatIWasGivenSection.tsx:298)",
+      "message": "Please add \"£31m\" from my brief to the model.",
+      "scenarioId": "b039ca10-a913-41d0-abc5-a0a26a6af550",
+      "draftNodes": 14,
+      "draftLabels": [
+        "CRM Platform Decision",
+        "Team Adoption Uncertainty",
+        "Annual CRM Spend",
+        "CRM Platform Capability",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Increase Sales Productivity Within Budget",
+        "Pilot HubSpot with Sub-Team First",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot Next Quarter",
+        "Budget Headroom",
+        "Sales Productivity Gain",
+        "Low CRM Adoption Rate",
+        "Sales Disruption During Transition"
+      ],
+      "outcome": {
+        "kind": "NO_TYPED_OUTCOME",
+        "codes": []
+      },
+      "edit": {
+        "http": 200,
+        "ms": 14013,
+        "transportError": null,
+        "blockTypes": [],
+        "suggestedActions": [],
+        "graphNodes": null,
+        "graphEdges": null,
+        "text": "I did not add £31m annual revenue as a new element because it is not clear what it should causally connect to in the current model. Revenue could be context for sizing the CRM cost relative to the business, but on its own it has no defined effect on productivity, budget headroom, or the goal. Could you clarify what this figure should influence — for example, should CRM cost be expressed as a percentage of revenue, or should revenue itself act as a factor affecting a specific outcome or risk?"
+      }
+    },
+    {
+      "arm": "B_SENTENCE_CONTEXT",
+      "note": "bare figure replaced by the charOffset-recovered surrounding sentence",
+      "message": "Please add this from my brief to the model: \"We are a 34-person B2B sales team with annual revenue of £31m.\"",
+      "scenarioId": "1b83130d-05db-48c3-9dd9-fdb20a911392",
+      "draftNodes": 15,
+      "draftLabels": [
+        "CRM Platform Decision",
+        "CRM Adoption Rate",
+        "Annual CRM Licence Cost",
+        "CRM Capability Level",
+        "Team Disruption During Transition",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Maximise Sales Productivity Within Budget",
+        "Pilot HubSpot with Sales Pod First",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot Next Quarter",
+        "Budget Headroom",
+        "Sales Productivity Gain",
+        "Low CRM Adoption Risk",
+        "Transition Disruption to Pipeline"
+      ],
+      "outcome": {
+        "kind": "REFUSED",
+        "codes": [
+          "rejection:ORPHAN_NODE",
+          "violation:ORPHAN_NODE",
+          "source:edit_graph",
+          "branch:graph_structure_invalid"
+        ]
+      },
+      "edit": {
+        "http": 200,
+        "ms": 19298,
+        "transportError": null,
+        "blockTypes": [
+          "error"
+        ],
+        "suggestedActions": [
+          "What would work instead?",
+          "Rebuild from updated brief"
+        ],
+        "graphNodes": null,
+        "graphEdges": null,
+        "text": "I couldn't make that change in one edit, because \"Annual Revenue\" isn't connected to your goal yet. On its own it has no path through to your goal, so I've left everything as it was. To go ahead, connect \"Annual Revenue\" to a factor that already feeds your goal. Which factor should it relate to?"
+      }
+    },
+    {
+      "arm": "C_FACTOR_PLUS_SENTENCE",
+      "note": "explicit add-a-factor instruction PLUS the recovered sentence as evidence",
+      "message": "Add a factor to the model for the £31m figure in my brief. My brief says: \"We are a 34-person B2B sales team with annual revenue of £31m.\"",
+      "scenarioId": "113adeed-9c77-4630-99d4-9eb891c1802e",
+      "draftNodes": 14,
+      "draftLabels": [
+        "CRM Platform Decision",
+        "Team Adoption Risk",
+        "Annual CRM Cost",
+        "CRM Platform Capability",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Achieve Higher Sales Productivity Within Budget",
+        "Negotiate or Upgrade Current CRM",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot",
+        "Budget Headroom",
+        "Sales Team Productivity",
+        "Low Adoption and Underutilisation",
+        "Transition Disruption and Downtime"
+      ],
+      "outcome": {
+        "kind": "REFUSED",
+        "codes": [
+          "rejection:ORPHAN_NODE",
+          "violation:ORPHAN_NODE",
+          "source:edit_graph",
+          "branch:graph_structure_invalid"
+        ]
+      },
+      "edit": {
+        "http": 200,
+        "ms": 14589,
+        "transportError": null,
+        "blockTypes": [
+          "error"
+        ],
+        "suggestedActions": [
+          "What would work instead?",
+          "Rebuild from updated brief"
+        ],
+        "graphNodes": null,
+        "graphEdges": null,
+        "text": "I couldn't make that change in one edit, because \"Annual Revenue\" isn't connected to your goal yet. On its own it has no path through to your goal, so I've left everything as it was. To go ahead, connect \"Annual Revenue\" to a factor that already feeds your goal. Which factor should it relate to?"
+      }
+    },
+    {
+      "arm": "D_NAMED_FACTOR",
+      "note": "the estate's proven edit grammar shape (cf. golden-journey T4 'Change X to Y.'), adapted to an add",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m.",
+      "scenarioId": "2c2692f7-aec9-40da-a629-85f80210edbe",
+      "draftNodes": 15,
+      "draftLabels": [
+        "CRM Platform Decision",
+        "Sales Team Adoption Rate",
+        "Annual CRM Licence Cost",
+        "CRM Platform Capability",
+        "Transition Disruption Level",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Increase Sales Productivity Within Budget",
+        "Pilot HubSpot with Core Sales Team First",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot",
+        "Budget Headroom",
+        "Sales Productivity Gain",
+        "Low Adoption Failure Risk",
+        "Short-Term Revenue Disruption"
+      ],
+      "outcome": {
+        "kind": "REFUSED",
+        "codes": [
+          "rejection:ORPHAN_NODE",
+          "violation:ORPHAN_NODE",
+          "source:edit_graph",
+          "branch:graph_structure_invalid"
+        ]
+      },
+      "edit": {
+        "http": 200,
+        "ms": 14175,
+        "transportError": null,
+        "blockTypes": [
+          "error"
+        ],
+        "suggestedActions": [
+          "What would work instead?",
+          "Rebuild from updated brief"
+        ],
+        "graphNodes": null,
+        "graphEdges": null,
+        "text": "I couldn't make that change in one edit, because \"Annual revenue\" isn't connected to your goal yet. On its own it has no path through to your goal, so I've left everything as it was. To go ahead, connect \"Annual revenue\" to a factor that already feeds your goal. Which factor should it relate to?"
+      }
+    },
+    {
+      "arm": "E_NAMED_FACTOR_CONNECTED",
+      "note": "as D but naming connectivity — the known OPTION_NO_FACTOR_EDGES refusal suggests the router cares about edges",
+      "message": "Add a new factor called \"Annual revenue\" with a value of £31m, and connect it to the options in the model.",
+      "scenarioId": "bb054da2-16b6-4f05-97a5-717823cddc67",
+      "draftNodes": 15,
+      "draftLabels": [
+        "CRM Platform Decision",
+        "User Adoption Uncertainty",
+        "Annual CRM Licence Cost",
+        "CRM Capability Level",
+        "Team Disruption During Transition",
+        "One-Off Switching Cost",
+        "Sales Team Size",
+        "Increase Sales Productivity Within Budget",
+        "Phased HubSpot Pilot (Half Team First)",
+        "Keep Current CRM (Status Quo)",
+        "Switch to HubSpot",
+        "Budget Headroom Preserved",
+        "Sales Productivity Gain",
+        "Low CRM Adoption Rate",
+        "Revenue Loss During Transition"
+      ],
+      "outcome": {
+        "kind": "REFUSED",
+        "codes": [
+          "rejection:NO_PATH_TO_GOAL",
+          "violation:NO_PATH_TO_GOAL",
+          "source:edit_graph",
+          "branch:graph_structure_invalid"
+        ]
+      },
+      "edit": {
+        "http": 200,
+        "ms": 15379,
+        "transportError": null,
+        "blockTypes": [
+          "error"
+        ],
+        "suggestedActions": [
+          "What would work instead?",
+          "Rebuild from updated brief"
+        ],
+        "graphNodes": null,
+        "graphEdges": null,
+        "text": "I couldn't make that change in one edit, because \"Annual revenue\" isn't connected to your goal yet. On its own it has no path through to your goal, so I've left everything as it was. To go ahead, connect \"Annual revenue\" to a factor that already feeds your goal. Which factor should it relate to?"
+      }
+    }
+  ]
+}

--- a/scripts/evidence/link-r2-add-this-cta/classifier.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/classifier.mjs
@@ -1,0 +1,88 @@
+// THE CORRECTED OUTCOME CLASSIFIER — extracted so every round shares one, because
+// the defect it fixes was a copy of the same predicate in three probe files.
+//
+// ⚠ THE DEFECT, and it invalidated a shipped claim. Rounds 1-3 used:
+//
+//     return d.verdict === 'held' || !!d.blocker_code;
+//
+// `verdict` is READ and then OVERRIDDEN by the disjunct, so an explicit
+// `verdict: "rejected"` that also carries a `blocker_code` scored **HELD**. Arms
+// F and G came back `{verdict:"rejected", blocker_code:"PIPELINE_OWNED_FIELD"}`
+// with NO `held_proposal` block and `draft_graph: null`, and the probe reported
+// them as accepted-and-held. That is trap 13c in its purest form: the 13-mutant
+// kit measured whether the TESTS could detect a change, never whether the
+// ORACLE was right, so a full kill-rate certified nothing about this.
+//
+// THE RULE THE FIX ENCODES: an explicit verdict is AUTHORITATIVE and is read
+// FIRST. `blocker_code` is only a held-marker in the ABSENCE of a verdict that
+// contradicts it. A disjunct can never be used to rescue a signal that a
+// stronger, more specific field has already settled.
+
+/** @returns {{kind:string, verdict:string|null, codes:string[], markers:string[]}} */
+export function classifyOutcome(step) {
+  const b = (step && step.body) || null;
+  if (!b) return { kind: 'NO_BODY', verdict: null, codes: [], markers: [] };
+  const blocks = b.blocks || [];
+  const errBlocks = blocks.filter((x) => x && x.type === 'error');
+  const text = String(b.assistant_text || b.message || '');
+
+  const codes = [];
+  let verdict = null;
+  for (const eb of errBlocks) {
+    const d = (eb && eb.details) || {};
+    if (d.verdict && !verdict) verdict = d.verdict;
+    if (d.rejection_code) codes.push(`rejection:${d.rejection_code}`);
+    if (d.blocker_code) codes.push(`blocker:${d.blocker_code}`);
+    for (const c of d.violation_codes || []) codes.push(`violation:${c}`);
+  }
+
+  // 1. AN EXPLICIT VERDICT WINS, in both directions, before anything else.
+  if (verdict === 'rejected') return { kind: 'REFUSED', verdict, codes, markers: ['details.verdict="rejected"'] };
+  if (verdict === 'held') return { kind: 'HELD', verdict, codes, markers: ['details.verdict="held"'] };
+
+  // 2. A typed held_proposal block is the next strongest signal.
+  if (blocks.some((x) => x && x.type === 'held_proposal'))
+    return { kind: 'HELD', verdict, codes, markers: ['held_proposal block'] };
+
+  // 3. Only now may a blocker_code or the prose gate imply "held" — i.e. when no
+  //    verdict has already contradicted them.
+  const confirmGate = /(holding these changes|nothing in the model moves until you confirm|reply yes to continue|say yes to (?:continue|apply))/i.test(text);
+  if (codes.some((c) => c.startsWith('blocker:')) || confirmGate)
+    return { kind: 'HELD', verdict, codes, markers: [confirmGate ? 'confirm-gate prose' : 'details.blocker_code (no contradicting verdict)'] };
+
+  if (b.draft_graph) return { kind: 'APPLIED_DIRECT', verdict, codes, markers: ['draft_graph committed'] };
+  if (errBlocks.length) return { kind: 'REFUSED', verdict, codes, markers: ['error block, no verdict'] };
+  return { kind: 'ANSWERED_NO_MUTATION', verdict, codes, markers: [] };
+}
+
+/**
+ * SELF-TEST — a classifier that cannot be shown to discriminate is the same kind
+ * of instrument the original was. Each case names the direction it guards.
+ */
+export function selfTest() {
+  const cases = [
+    { name: 'the ACTUAL arm-F payload — rejected WITH a blocker_code (the defect)', expect: 'REFUSED',
+      step: { body: { blocks: [{ type: 'error', details: { verdict: 'rejected', blocker_code: 'PIPELINE_OWNED_FIELD' } }] } } },
+    { name: 'a genuine held proposal — verdict held + blocker_code', expect: 'HELD',
+      step: { body: { blocks: [{ type: 'error', details: { verdict: 'held', blocker_code: 'STRUCTURAL_APPLY_HELD' } }, { type: 'held_proposal' }] } } },
+    { name: 'blocker_code with NO verdict still reads as held', expect: 'HELD',
+      step: { body: { blocks: [{ type: 'error', details: { blocker_code: 'STRUCTURAL_APPLY_HELD' } }] } } },
+    { name: 'a structural refusal — rejection_code, no verdict', expect: 'REFUSED',
+      step: { body: { blocks: [{ type: 'error', details: { rejection_code: 'ORPHAN_NODE' } }] } } },
+    { name: 'an applied change', expect: 'APPLIED_DIRECT', step: { body: { blocks: [], draft_graph: { nodes: [] } } } },
+    { name: 'a plain answer, no mutation', expect: 'ANSWERED_NO_MUTATION', step: { body: { blocks: [] } } },
+  ];
+  let ok = true;
+  for (const c of cases) {
+    const got = classifyOutcome(c.step).kind;
+    const pass = got === c.expect;
+    if (!pass) ok = false;
+    console.log(`${pass ? 'PASS' : 'FAIL'}  ${c.expect.padEnd(21)} got ${got.padEnd(21)} ${c.name}`);
+  }
+  return ok;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('probe-classifier.mjs')) {
+  console.log('=== classifier self-test ===');
+  process.exit(selfTest() ? 0 : 1);
+}

--- a/scripts/evidence/link-r2-add-this-cta/probe-addthis-r2.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/probe-addthis-r2.mjs
@@ -1,0 +1,116 @@
+// LIVE-ROUTER PROBE, ROUND 2 — round 1 established that the LLM *does* emit operations for
+// every explicit add phrasing, and the GRAPH VALIDATOR rejects them:
+//   ORPHAN_NODE      (B, C, D — a factor with no edges)
+//   NO_PATH_TO_GOAL  (E — connected to the options but not reaching the goal)
+// So the question round 2 answers is narrow and decisive: is there ANY instruction the
+// engine ACCEPTS, i.e. one that names the causal connection all the way to the goal?
+//
+// If the answer is no, the CTA cannot be made to work and must be removed or re-scoped.
+// If the answer is yes, the acceptance condition is "the instruction names a target that
+// reaches the goal" — which is a property of the USER's knowledge, not of the receipt.
+
+import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { sendBufferedTurn, sendStreamedTurn, targets } from '/Users/paulslee/Documents/GitHub/scripts/golden-journey/lib/wire.mjs';
+
+const OUT = '/private/tmp/link-r2-lane-8f3c2a/evidence/addthis-probe-r2';
+fs.mkdirSync(OUT, { recursive: true });
+const log = (...a) => {
+  const line = `[${new Date().toISOString()}] ${a.join(' ')}`;
+  console.log(line);
+  fs.appendFileSync(`${OUT}/probe.log`, line + '\n');
+};
+
+const BRIEF =
+  `Should we replace our current CRM with HubSpot next quarter, or keep what we have? ` +
+  `We are a 34-person B2B sales team with annual revenue of £31m. ` +
+  `Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. ` +
+  `The goal is higher sales productivity without blowing the budget.`;
+
+// Targets observed in round 1's drafted graphs (labels are stable across arms).
+const ARMS = [
+  {
+    id: 'F_CONNECT_TO_BUDGET',
+    note: 'names an existing factor that already reaches the goal',
+    message: `Add a new factor called "Annual revenue" with a value of £31m, and connect it so that it influences Budget Headroom.`,
+  },
+  {
+    id: 'G_CONNECT_CHAIN_TO_GOAL',
+    note: 'names the full chain, including the goal node, explicitly',
+    message: `Add a new factor called "Annual revenue" with a value of £31m. Connect it so that Annual revenue influences Budget Headroom, and make sure the new factor has a path through to the goal "Increase Sales Productivity Within Budget".`,
+  },
+  {
+    id: 'H_RELATIVE_COST',
+    note: "the engine's OWN suggested resolution, quoted back to it (its clarify text proposes expressing CRM cost as a share of revenue)",
+    message: `Add a new factor called "Annual revenue" with a value of £31m, and connect it to Annual CRM Licence Cost so that CRM cost can be read as a share of revenue.`,
+  },
+  {
+    id: 'I_CONTROL_KNOWN_GOOD',
+    note: "POSITIVE CONTROL — the estate's own proven edit grammar (golden-journey T4). If THIS is refused, the probe is measuring a broken service, not the phrasings.",
+    message: `Change Annual CRM Licence Cost to £64,000.`,
+  },
+];
+
+function classify(step) {
+  const b = (step && step.body) || null;
+  if (!b) return { kind: 'no_body' };
+  const blocks = b.blocks || [];
+  const errBlocks = blocks.filter((x) => x && x.type === 'error');
+  const heldBlock = blocks.some((x) => x && x.type === 'held_proposal');
+  const heldErr = errBlocks.some((x) => {
+    const d = (x && x.details) || {};
+    return d.verdict === 'held' || !!d.blocker_code;
+  });
+  const text = (b.assistant_text || b.message || '') + '';
+  const confirmGate = /(holding these changes|nothing in the model moves until you confirm|reply yes to continue|say yes to (?:continue|apply))/i.test(text);
+  if (heldBlock || heldErr || confirmGate) return { kind: 'HELD', markers: [heldBlock && 'held_proposal', heldErr && 'details.verdict/blocker_code', confirmGate && 'confirm-gate prose'].filter(Boolean) };
+  const codes = [];
+  for (const eb of errBlocks) {
+    const d = (eb && eb.details) || {};
+    if (d.rejection_code) codes.push(`rejection:${d.rejection_code}`);
+    for (const c of d.violation_codes || []) codes.push(`violation:${c}`);
+    if (d.source) codes.push(`source:${d.source}`);
+  }
+  if (b.draft_graph) return { kind: 'APPLIED_DIRECT', codes };
+  if (errBlocks.length) return { kind: 'REFUSED', codes };
+  return { kind: 'NO_TYPED_OUTCOME', codes };
+}
+
+async function runArm(arm) {
+  const scenarioId = randomUUID();
+  log(`${arm.id}: scenario=${scenarioId} drafting…`);
+  const t1 = await sendStreamedTurn({ id: `${arm.id}_DRAFT`, scenarioId, message: BRIEF });
+  if (!t1.graphReady) {
+    log(`${arm.id}: NO DRAFT — unmeasured`);
+    return { arm: arm.id, outcome: { kind: 'UNMEASURED_NO_DRAFT' } };
+  }
+  const before = (t1.graphReady.nodes || []).length;
+  log(`${arm.id}: draft nodes=${before}; edit turn…`);
+  const t2 = await sendBufferedTurn({ id: `${arm.id}_ADD`, scenarioId, message: arm.message });
+  const outcome = classify(t2);
+  const b = t2.body || {};
+  const g = b.draft_graph || null;
+  const rec = {
+    arm: arm.id,
+    note: arm.note,
+    message: arm.message,
+    scenarioId,
+    nodesBefore: before,
+    nodesAfter: g ? (g.nodes || []).length : null,
+    newLabels: g ? (g.nodes || []).map((n) => n.label).filter((l) => !(t1.graphReady.nodes || []).some((n) => n.label === l)) : null,
+    outcome,
+    blockTypes: (b.blocks || []).map((x) => x && x.type),
+    text: ((b.assistant_text || b.message || '') + '').slice(0, 800),
+  };
+  log(`${arm.id}: OUTCOME=${outcome.kind} ${JSON.stringify(outcome.codes || outcome.markers || [])} nodes ${before}->${rec.nodesAfter} new=${JSON.stringify(rec.newLabels)}`);
+  fs.writeFileSync(`${OUT}/${arm.id}.json`, JSON.stringify({ ...rec, fullBody: b }, null, 2));
+  return rec;
+}
+
+log(`target=${targets.ceeTurnBase} arms=${ARMS.length}`);
+const results = await Promise.all(ARMS.map((a) => runArm(a).catch((e) => ({ arm: a.id, error: String(e) }))));
+fs.writeFileSync(`${OUT}/summary.json`, JSON.stringify({ brief: BRIEF, results }, null, 2));
+log('===== SUMMARY =====');
+for (const r of results) log(`${String(r.arm).padEnd(26)} ${String(r.outcome && r.outcome.kind).padEnd(18)} ${r.nodesBefore}->${r.nodesAfter} ${JSON.stringify((r.outcome && (r.outcome.codes || r.outcome.markers)) || [])}`);
+const ctl = results.find((r) => r.arm === 'I_CONTROL_KNOWN_GOOD');
+log(`POSITIVE CONTROL (proven edit grammar must NOT be refused): ${ctl && ctl.outcome && ctl.outcome.kind}`);

--- a/scripts/evidence/link-r2-add-this-cta/probe-addthis-r3.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/probe-addthis-r3.mjs
@@ -1,0 +1,113 @@
+// LIVE-ROUTER PROBE, ROUND 3 — settling the DESIGN, not just the grammar.
+//
+// What rounds 1-2 established, measured:
+//   A  bare figure ("Please add \"£31m\" from my brief to the model.")
+//        -> NO typed outcome; the engine answers with a SPECIFIC, well-grounded
+//           question ("it is not clear what it should causally connect to…").
+//   B,C,D  figure + brief sentence, or a named factor, still with NO causal target
+//        -> the LLM emits operations and the GRAPH VALIDATOR refuses: ORPHAN_NODE.
+//   E  connected to the options but not the goal -> NO_PATH_TO_GOAL.
+//   F,G  the instruction NAMES a causal target that keeps the graph valid
+//        -> **HELD** (structural change proposed, confirm to apply) = ACCEPTED.
+//   I  positive control, the estate's proven edit grammar -> APPLIED_DIRECT. Service healthy.
+//
+// So an accepted instruction EXISTS, and its acceptance condition is knowledge the
+// RECEIPT DOES NOT HAVE: what the figure should causally influence. A CTA that picked a
+// target for the user would be the product inventing causality on their behalf.
+//
+// Round 3 therefore asks the only remaining question: is there a phrasing that RELIABLY
+// produces the grounded QUESTION rather than an orphan-node attempt? That is the message
+// an honest "what should this affect?" CTA must send — it has to be the engine's
+// question path, deterministically, not the structural-error path B/C/D fell into.
+
+import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { sendBufferedTurn, sendStreamedTurn, targets } from '/Users/paulslee/Documents/GitHub/scripts/golden-journey/lib/wire.mjs';
+
+const OUT = '/private/tmp/link-r2-lane-8f3c2a/evidence/addthis-probe-r3';
+fs.mkdirSync(OUT, { recursive: true });
+const log = (...a) => {
+  const line = `[${new Date().toISOString()}] ${a.join(' ')}`;
+  console.log(line);
+  fs.appendFileSync(`${OUT}/probe.log`, line + '\n');
+};
+
+const BRIEF =
+  `Should we replace our current CRM with HubSpot next quarter, or keep what we have? ` +
+  `We are a 34-person B2B sales team with annual revenue of £31m. ` +
+  `Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. ` +
+  `The goal is higher sales productivity without blowing the budget.`;
+const SENTENCE = 'We are a 34-person B2B sales team with annual revenue of £31m.';
+
+const ARMS = [
+  {
+    id: 'J_ASK_WHERE_WITH_SENTENCE',
+    note: 'ASK phrasing + the charOffset-recovered sentence, explicitly deferring the change',
+    message: `My brief mentions £31m, which is not in the model yet. The brief says: "${SENTENCE}" What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.`,
+  },
+  {
+    id: 'K_ASK_WHERE_SHORT',
+    note: 'ASK phrasing, sentence but no explicit deferral — does the deferral clause carry the weight?',
+    message: `My brief mentions £31m ("${SENTENCE}") and it is not in the model. What could it influence here?`,
+  },
+  {
+    id: 'L_ASK_NO_SENTENCE',
+    note: 'DISCRIMINATING TWIN of J: identical ask, sentence REMOVED. Isolates what the charOffset context actually buys.',
+    message: `My brief mentions £31m, which is not in the model yet. What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.`,
+  },
+];
+
+function classify(step) {
+  const b = (step && step.body) || null;
+  if (!b) return { kind: 'no_body' };
+  const blocks = b.blocks || [];
+  const errBlocks = blocks.filter((x) => x && x.type === 'error');
+  const heldBlock = blocks.some((x) => x && x.type === 'held_proposal');
+  const heldErr = errBlocks.some((x) => {
+    const d = (x && x.details) || {};
+    return d.verdict === 'held' || !!d.blocker_code;
+  });
+  const text = (b.assistant_text || b.message || '') + '';
+  const confirmGate = /(holding these changes|nothing in the model moves until you confirm|reply yes to continue|say yes to (?:continue|apply))/i.test(text);
+  if (heldBlock || heldErr || confirmGate) return { kind: 'HELD' };
+  const codes = [];
+  for (const eb of errBlocks) {
+    const d = (eb && eb.details) || {};
+    if (d.rejection_code) codes.push(`rejection:${d.rejection_code}`);
+    for (const c of d.violation_codes || []) codes.push(`violation:${c}`);
+  }
+  if (b.draft_graph) return { kind: 'APPLIED_DIRECT', codes };
+  if (errBlocks.length) return { kind: 'REFUSED', codes };
+  return { kind: 'ANSWERED_NO_MUTATION', codes };
+}
+
+async function runArm(arm) {
+  const scenarioId = randomUUID();
+  log(`${arm.id}: scenario=${scenarioId} drafting…`);
+  const t1 = await sendStreamedTurn({ id: `${arm.id}_DRAFT`, scenarioId, message: BRIEF });
+  if (!t1.graphReady) return { arm: arm.id, outcome: { kind: 'UNMEASURED_NO_DRAFT' } };
+  const t2 = await sendBufferedTurn({ id: `${arm.id}_ASK`, scenarioId, message: arm.message });
+  const outcome = classify(t2);
+  const b = t2.body || {};
+  const rec = {
+    arm: arm.id,
+    note: arm.note,
+    message: arm.message,
+    scenarioId,
+    outcome,
+    blockTypes: (b.blocks || []).map((x) => x && x.type),
+    suggestedActions: (b.suggested_actions || []).map((a) => a && a.label),
+    text: ((b.assistant_text || b.message || '') + '').slice(0, 1400),
+  };
+  log(`${arm.id}: OUTCOME=${outcome.kind} ${JSON.stringify(outcome.codes || [])}`);
+  log(`${arm.id}: TEXT>>> ${rec.text.slice(0, 700).replace(/\n/g, ' ')}`);
+  log(`${arm.id}: ACTIONS ${JSON.stringify(rec.suggestedActions)}`);
+  fs.writeFileSync(`${OUT}/${arm.id}.json`, JSON.stringify({ ...rec, fullBody: b }, null, 2));
+  return rec;
+}
+
+log(`target=${targets.ceeTurnBase} arms=${ARMS.length}`);
+const results = await Promise.all(ARMS.map((a) => runArm(a).catch((e) => ({ arm: a.id, error: String(e) }))));
+fs.writeFileSync(`${OUT}/summary.json`, JSON.stringify({ brief: BRIEF, sentence: SENTENCE, results }, null, 2));
+log('===== SUMMARY =====');
+for (const r of results) log(`${String(r.arm).padEnd(28)} ${String(r.outcome && r.outcome.kind)}`);

--- a/scripts/evidence/link-r2-add-this-cta/probe-addthis-r4.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/probe-addthis-r4.mjs
@@ -1,0 +1,60 @@
+// ROUND 4 — settle the LADDER honestly, with the corrected classifier and an
+// ACTUAL confirmation turn. Rounds 1-3 never sent one: every "confirm" in those
+// scripts was the classifier's own regex over assistant prose.
+//
+// Rounds 1-3, re-classified: NO add was accepted across 12 arms. F/G were
+// REJECTED `PIPELINE_OWNED_FIELD` — "the candidate targets an analysis-derived,
+// pipeline-owned field". That is a fact about the TARGET I picked (Budget
+// Headroom is analysis-derived), not proof that no add can land. So this round
+// aims at targets that are NOT pipeline-owned, and if any is HELD it sends the
+// confirmation and checks whether the graph actually moved.
+//
+// Whatever comes back is the answer that ships. If nothing lands, the source
+// comment says the ladder is unmeasured rather than reassuring the reader.
+import fs from 'node:fs'; import { randomUUID } from 'node:crypto';
+import { sendBufferedTurn, sendStreamedTurn, targets } from '/Users/paulslee/Documents/GitHub/scripts/golden-journey/lib/wire.mjs';
+import { classifyOutcome } from './classifier.mjs';
+const OUT='/private/tmp/link-r2-lane-8f3c2a/evidence/addthis-probe-r4'; fs.mkdirSync(OUT,{recursive:true});
+const log=(...a)=>{const l=`[${new Date().toISOString()}] ${a.join(' ')}`;console.log(l);fs.appendFileSync(`${OUT}/probe.log`,l+'\n');};
+const BRIEF=`Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.`;
+const ARMS=[
+ {id:'M_TARGET_PLAIN_FACTOR', note:'targets a plain brief-derived factor, not an analysis-derived one',
+  message:`Add a new factor called "Annual revenue" with a value of £31m, and connect it so that it influences Annual CRM Licence Cost.`},
+ {id:'N_TARGET_ADOPTION', note:'targets the adoption factor — also brief-derived',
+  message:`Add a new factor called "Annual revenue" with a value of £31m, and connect it so that it influences Sales Team Adoption Rate.`},
+ {id:'O_CONTROL_KNOWN_GOOD', note:'POSITIVE CONTROL — the proven edit grammar. If this fails the service is sick and no arm may be read.',
+  message:`Change Annual CRM Licence Cost to £64,000.`},
+];
+async function runArm(a){
+  const scenarioId=randomUUID();
+  log(`${a.id}: scenario=${scenarioId} drafting…`);
+  const t1=await sendStreamedTurn({id:`${a.id}_DRAFT`,scenarioId,message:BRIEF});
+  if(!t1.graphReady){log(`${a.id}: NO DRAFT — unmeasured`);return {arm:a.id,outcome:{kind:'UNMEASURED_NO_DRAFT'}};}
+  const before=(t1.graphReady.nodes||[]).length;
+  const t2=await sendBufferedTurn({id:`${a.id}_ADD`,scenarioId,message:a.message});
+  const c=classifyOutcome(t2);
+  log(`${a.id}: ADD -> ${c.kind} verdict=${c.verdict} ${JSON.stringify(c.codes)} markers=${JSON.stringify(c.markers)}`);
+  const rec={arm:a.id,note:a.note,message:a.message,scenarioId,nodesBefore:before,add:{kind:c.kind,verdict:c.verdict,codes:c.codes,
+    blockTypes:(t2.body?.blocks||[]).map(x=>x?.type),text:String(t2.body?.assistant_text||t2.body?.message||'').slice(0,600)},confirm:null};
+  // ── THE STEP ROUNDS 1-3 NEVER TOOK ──
+  if(c.kind==='HELD'){
+    log(`${a.id}: HELD — sending a REAL confirmation turn…`);
+    const t3=await sendBufferedTurn({id:`${a.id}_CONFIRM`,scenarioId,message:'Yes'});
+    const c3=classifyOutcome(t3);
+    const g=t3.body?.draft_graph||null;
+    const newLabels=g?(g.nodes||[]).map(n=>n.label).filter(l=>!(t1.graphReady.nodes||[]).some(n=>n.label===l)):null;
+    rec.confirm={kind:c3.kind,verdict:c3.verdict,codes:c3.codes,nodesAfter:g?(g.nodes||[]).length:null,newLabels,
+      text:String(t3.body?.assistant_text||t3.body?.message||'').slice(0,600)};
+    log(`${a.id}: CONFIRM -> ${c3.kind} nodes ${before}->${rec.confirm.nodesAfter} new=${JSON.stringify(newLabels)}`);
+    fs.writeFileSync(`${OUT}/${a.id}-confirm.json`,JSON.stringify(t3.body,null,2));
+  }
+  fs.writeFileSync(`${OUT}/${a.id}.json`,JSON.stringify({...rec,addFullBody:t2.body},null,2));
+  return rec;
+}
+log(`target=${targets.ceeTurnBase} arms=${ARMS.length}`);
+const results=await Promise.all(ARMS.map(a=>runArm(a).catch(e=>({arm:a.id,error:String(e)}))));
+fs.writeFileSync(`${OUT}/summary.json`,JSON.stringify({brief:BRIEF,results},null,2));
+log('===== SUMMARY =====');
+for(const r of results) log(`${String(r.arm).padEnd(24)} add=${r.add?.kind||r.outcome?.kind} ${JSON.stringify(r.add?.codes||[])} confirm=${r.confirm?r.confirm.kind+' nodes->'+r.confirm.nodesAfter:'(not sent — add was not held)'}`);
+const ctl=results.find(r=>r.arm==='O_CONTROL_KNOWN_GOOD');
+log(`POSITIVE CONTROL: ${ctl?.add?.kind}`);

--- a/scripts/evidence/link-r2-add-this-cta/probe-addthis-r5.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/probe-addthis-r5.mjs
@@ -1,0 +1,81 @@
+// ROUND 5 — the same question, with a control that can actually discriminate.
+//
+// ⚠ ROUND 4 WAS VOID AND THE CONTROL IS WHY WE KNOW. Its positive control sent
+// `Change Annual CRM Licence Cost to £64,000.` — a label HARDCODED from an
+// earlier run's draft. This run's draft named the factor "Annual CRM Spend", so
+// the control asked the engine to change a node that did not exist and the
+// engine, correctly, asked which one was meant. The control was bound BY VALUE
+// to a label the drafter happens to emit, not BY IDENTITY to a node in the graph
+// under test — trap 19, in the harness rather than in a spec. Every arm in that
+// round is unreadable as a result, which is the control doing its job.
+//
+// Round 5 derives BOTH the control's target and the add's target from THIS run's
+// own committed graph, so neither can name something that is not there.
+import fs from 'node:fs'; import { randomUUID } from 'node:crypto';
+import { sendBufferedTurn, sendStreamedTurn, targets } from '/Users/paulslee/Documents/GitHub/scripts/golden-journey/lib/wire.mjs';
+import { classifyOutcome } from './classifier.mjs';
+const OUT='/private/tmp/link-r2-lane-8f3c2a/evidence/addthis-probe-r5'; fs.mkdirSync(OUT,{recursive:true});
+const log=(...a)=>{const l=`[${new Date().toISOString()}] ${a.join(' ')}`;console.log(l);fs.appendFileSync(`${OUT}/probe.log`,l+'\n');};
+const BRIEF=`Should we replace our current CRM with HubSpot next quarter, or keep what we have? We are a 34-person B2B sales team with annual revenue of £31m. Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. The goal is higher sales productivity without blowing the budget.`;
+
+/** A cost-ish factor from THIS graph, by identity. Null => the arm is skipped, never guessed. */
+const pickCostFactor=(g)=>(g.nodes||[]).find(n=>n.kind==='factor'&&/cost|spend|price|licen[cs]e|fee/i.test(n.label||''))||null;
+/** A factor with an edge INTO the goal — i.e. one that provably already feeds it. */
+function pickGoalFeeder(g){
+  const goal=(g.nodes||[]).find(n=>n.kind==='goal'||n.kind==='outcome'); if(!goal) return null;
+  const e=(g.edges||[]).find(x=>x.target===goal.id||x.to===goal.id);
+  if(!e) return null;
+  const srcId=e.source??e.from;
+  const src=(g.nodes||[]).find(n=>n.id===srcId);
+  return src&&goal?{feeder:src,goal}:null;
+}
+
+async function runArm(kind){
+  const scenarioId=randomUUID();
+  log(`${kind}: scenario=${scenarioId} drafting…`);
+  const t1=await sendStreamedTurn({id:`${kind}_DRAFT`,scenarioId,message:BRIEF});
+  if(!t1.graphReady){log(`${kind}: NO DRAFT — UNMEASURED`);return {arm:kind,unmeasured:'no_draft'};}
+  const g=t1.graphReady, before=(g.nodes||[]).length;
+  const rec={arm:kind,scenarioId,nodesBefore:before,labels:(g.nodes||[]).map(n=>n.label)};
+
+  if(kind==='P_CONTROL_DERIVED'){
+    const t=pickCostFactor(g);
+    if(!t){log(`${kind}: no cost factor in THIS graph — UNMEASURED (not guessed)`);return {...rec,unmeasured:'no_cost_factor'};}
+    rec.target=t.label; rec.message=`Change ${t.label} to £64,000.`;
+  } else {
+    const gf=pickGoalFeeder(g);
+    if(!gf){log(`${kind}: no factor with an edge into the goal — UNMEASURED`);return {...rec,unmeasured:'no_goal_feeder'};}
+    rec.target=gf.feeder.label; rec.goal=gf.goal.label;
+    // The engine's OWN stated requirement, quoted back: "connect it to a factor
+    // that already feeds your goal". `gf.feeder` provably does — it has an edge in.
+    rec.message=`Add a new factor called "Annual revenue" with a value of £31m, and connect it so that it influences ${gf.feeder.label}, which already feeds the goal.`;
+  }
+
+  log(`${kind}: target="${rec.target}" msg=${JSON.stringify(rec.message)}`);
+  const t2=await sendBufferedTurn({id:`${kind}_EDIT`,scenarioId,message:rec.message});
+  const c=classifyOutcome(t2);
+  rec.edit={kind:c.kind,verdict:c.verdict,codes:c.codes,markers:c.markers,
+    nodesAfter:t2.body?.draft_graph?(t2.body.draft_graph.nodes||[]).length:null,
+    text:String(t2.body?.assistant_text||t2.body?.message||'').slice(0,500)};
+  log(`${kind}: -> ${c.kind} ${JSON.stringify(c.codes)}`);
+
+  if(c.kind==='HELD'){
+    log(`${kind}: HELD — sending a REAL confirmation turn ("Yes")…`);
+    const t3=await sendBufferedTurn({id:`${kind}_CONFIRM`,scenarioId,message:'Yes'});
+    const c3=classifyOutcome(t3); const g3=t3.body?.draft_graph||null;
+    rec.confirm={kind:c3.kind,codes:c3.codes,nodesAfter:g3?(g3.nodes||[]).length:null,
+      newLabels:g3?(g3.nodes||[]).map(n=>n.label).filter(l=>!rec.labels.includes(l)):null,
+      text:String(t3.body?.assistant_text||t3.body?.message||'').slice(0,400)};
+    log(`${kind}: CONFIRM -> ${c3.kind} nodes ${before}->${rec.confirm.nodesAfter} new=${JSON.stringify(rec.confirm.newLabels)}`);
+    fs.writeFileSync(`${OUT}/${kind}-confirm.json`,JSON.stringify(t3.body,null,2));
+  }
+  fs.writeFileSync(`${OUT}/${kind}.json`,JSON.stringify({...rec,editFullBody:t2.body},null,2));
+  return rec;
+}
+log(`target=${targets.ceeTurnBase}`);
+const results=await Promise.all(['P_CONTROL_DERIVED','Q_ADD_TO_GOAL_FEEDER'].map(k=>runArm(k).catch(e=>({arm:k,error:String(e)}))));
+fs.writeFileSync(`${OUT}/summary.json`,JSON.stringify({brief:BRIEF,results},null,2));
+log('===== SUMMARY =====');
+for(const r of results) log(`${String(r.arm).padEnd(22)} target="${r.target||'-'}" ${r.unmeasured?('UNMEASURED:'+r.unmeasured):(r.edit.kind+' '+JSON.stringify(r.edit.codes))} confirm=${r.confirm?r.confirm.kind+' nodes->'+r.confirm.nodesAfter:'(none)'}`);
+const ctl=results.find(r=>r.arm==='P_CONTROL_DERIVED');
+log(`POSITIVE CONTROL: ${ctl?.unmeasured?('UNMEASURED — '+ctl.unmeasured):ctl?.edit?.kind} ${ctl?.edit?.kind==='APPLIED_DIRECT'?'(arms readable)':'(ARMS NOT READABLE)'}`);

--- a/scripts/evidence/link-r2-add-this-cta/probe-addthis.mjs
+++ b/scripts/evidence/link-r2-add-this-cta/probe-addthis.mjs
@@ -1,0 +1,147 @@
+// LIVE-ROUTER PROBE — which "add this figure" phrasing does the deployed edit router accept?
+//
+// Uses the programme's own wire recipe (scripts/golden-journey/lib/wire.mjs) VERBATIM:
+// guest posture, NO auth headers, no credential read or embedded anywhere.
+//
+// DESIGN — a controlled experiment, not a demo:
+//   * every candidate gets its OWN fresh scenario UUID and a BYTE-IDENTICAL brief, so the
+//     only thing that varies across arms is the PHRASING. One scenario shared across arms
+//     would confound arm N with the graph arms 1..N-1 had already mutated.
+//   * arm A is the CONTROL: the phrasing the product ships TODAY. If A does not reproduce
+//     the refusal, the probe is measuring something other than the defect and no arm's
+//     result may be believed (an absence probe with no positive control — trap 13).
+//   * outcome is classified from the PRODUCER'S OWN TYPED CHANNEL using the same markers
+//     the golden-journey invariant engine derives (held_proposal / details.verdict==='held'
+//     / details.blocker_code  vs  details.rejection_code / details.violation_codes), never
+//     from the harness author's reading of the prose (trap 13c).
+
+import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { sendBufferedTurn, sendStreamedTurn, targets } from '/Users/paulslee/Documents/GitHub/scripts/golden-journey/lib/wire.mjs';
+
+const OUT = process.argv[2] || '/private/tmp/link-r2-lane-8f3c2a/evidence/addthis-probe';
+fs.mkdirSync(OUT, { recursive: true });
+
+const log = (...a) => {
+  const line = `[${new Date().toISOString()}] ${a.join(' ')}`;
+  console.log(line);
+  fs.appendFileSync(`${OUT}/probe.log`, line + '\n');
+};
+
+// Question-form brief (CEE refuses statement-form at intake). Contains ONE contextual
+// figure — £31m annual revenue — that is background to the decision and therefore the
+// class of figure the receipt reports as "not modelled". This mirrors L3's actual finding.
+const BRIEF =
+  `Should we replace our current CRM with HubSpot next quarter, or keep what we have? ` +
+  `We are a 34-person B2B sales team with annual revenue of £31m. ` +
+  `Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off. ` +
+  `The goal is higher sales productivity without blowing the budget.`;
+
+// The sentence a charOffset lookup would recover around the figure "£31m".
+const SURROUNDING = 'We are a 34-person B2B sales team with annual revenue of £31m.';
+
+const ARMS = [
+  {
+    id: 'A_CONTROL_SHIPPED',
+    note: 'the phrasing the product composes TODAY (V7WhatIWasGivenSection.tsx:298)',
+    message: `Please add "£31m" from my brief to the model.`,
+  },
+  {
+    id: 'B_SENTENCE_CONTEXT',
+    note: 'bare figure replaced by the charOffset-recovered surrounding sentence',
+    message: `Please add this from my brief to the model: "${SURROUNDING}"`,
+  },
+  {
+    id: 'C_FACTOR_PLUS_SENTENCE',
+    note: 'explicit add-a-factor instruction PLUS the recovered sentence as evidence',
+    message: `Add a factor to the model for the £31m figure in my brief. My brief says: "${SURROUNDING}"`,
+  },
+  {
+    id: 'D_NAMED_FACTOR',
+    note: "the estate's proven edit grammar shape (cf. golden-journey T4 'Change X to Y.'), adapted to an add",
+    message: `Add a new factor called "Annual revenue" with a value of £31m.`,
+  },
+  {
+    id: 'E_NAMED_FACTOR_CONNECTED',
+    note: 'as D but naming connectivity — the known OPTION_NO_FACTOR_EDGES refusal suggests the router cares about edges',
+    message: `Add a new factor called "Annual revenue" with a value of £31m, and connect it to the options in the model.`,
+  },
+];
+
+/** Classify from the producer's typed channel — same markers as invariants.mjs. */
+function classify(step) {
+  const b = (step && step.body) || null;
+  if (!b) return { kind: 'no_body' };
+  const blocks = b.blocks || [];
+  const errBlocks = blocks.filter((x) => x && x.type === 'error');
+  const heldBlock = blocks.some((x) => x && x.type === 'held_proposal');
+  const heldErr = errBlocks.some((x) => {
+    const d = (x && x.details) || {};
+    return d.verdict === 'held' || !!d.blocker_code;
+  });
+  const text = (b.assistant_text || b.message || '') + '';
+  const confirmGate = /(holding these changes|nothing in the model moves until you confirm|reply yes to continue|say yes to (?:continue|apply))/i.test(text);
+  if (heldBlock || heldErr || confirmGate)
+    return { kind: 'HELD', markers: [heldBlock && 'held_proposal', heldErr && 'details.verdict/blocker_code', confirmGate && 'confirm-gate prose'].filter(Boolean) };
+  const codes = [];
+  for (const eb of errBlocks) {
+    const d = (eb && eb.details) || {};
+    if (d.rejection_code) codes.push(`rejection:${d.rejection_code}`);
+    for (const c of d.violation_codes || []) codes.push(`violation:${c}`);
+    if (d.source) codes.push(`source:${d.source}`);
+    if (d.failure_branch) codes.push(`branch:${d.failure_branch}`);
+  }
+  if (b.draft_graph) return { kind: 'APPLIED_DIRECT', codes };
+  if (errBlocks.length) return { kind: 'REFUSED', codes };
+  return { kind: 'NO_TYPED_OUTCOME', codes };
+}
+
+const summarise = (step) => {
+  const b = (step && step.body) || {};
+  const g = b.draft_graph || null;
+  return {
+    http: step.httpStatus,
+    ms: step.ms,
+    transportError: step.transportError,
+    blockTypes: (b.blocks || []).map((x) => x && x.type),
+    suggestedActions: (b.suggested_actions || []).map((a) => a && a.label),
+    graphNodes: g ? (g.nodes || []).length : null,
+    graphEdges: g ? (g.edges || []).length : null,
+    text: ((b.assistant_text || b.message || '') + '').slice(0, 900),
+  };
+};
+
+async function runArm(arm) {
+  const scenarioId = randomUUID();
+  log(`${arm.id}: scenario=${scenarioId} — drafting…`);
+  const t1 = await sendStreamedTurn({ id: `${arm.id}_DRAFT`, scenarioId, message: BRIEF });
+  const draftNodes = t1.graphReady ? (t1.graphReady.nodes || []).length : null;
+  const draftLabels = t1.graphReady ? (t1.graphReady.nodes || []).map((n) => n.label) : null;
+  log(`${arm.id}: draft terminal=${t1.completeStatus} nodes=${draftNodes} stages=${(t1.frames || []).map((f) => f.stage).join('>')}`);
+  fs.writeFileSync(`${OUT}/${arm.id}-draft.json`, JSON.stringify({ scenarioId, brief: BRIEF, completeStatus: t1.completeStatus, frames: t1.frames, draftNodes, draftLabels, transportError: t1.transportError }, null, 2));
+
+  if (!t1.graphReady) {
+    log(`${arm.id}: NO GRAPH — arm unmeasured`);
+    return { arm: arm.id, note: arm.note, message: arm.message, scenarioId, draftNodes, draftLabels, outcome: { kind: 'UNMEASURED_NO_DRAFT' }, edit: null };
+  }
+
+  log(`${arm.id}: edit turn…`);
+  const t2 = await sendBufferedTurn({ id: `${arm.id}_ADD`, scenarioId, message: arm.message });
+  const outcome = classify(t2);
+  const edit = summarise(t2);
+  log(`${arm.id}: OUTCOME=${outcome.kind} codes=${JSON.stringify(outcome.codes || outcome.markers || [])} nodes=${draftNodes}->${edit.graphNodes}`);
+  fs.writeFileSync(`${OUT}/${arm.id}-edit.json`, JSON.stringify({ scenarioId, message: arm.message, outcome, ...edit, fullBody: t2.body }, null, 2));
+  return { arm: arm.id, note: arm.note, message: arm.message, scenarioId, draftNodes, draftLabels, outcome, edit };
+}
+
+const results = [];
+log(`target=${targets.ceeTurnBase} origin=${targets.origin} arms=${ARMS.length}`);
+// Arms run CONCURRENTLY: each owns a distinct scenario UUID, so they cannot interfere.
+const settled = await Promise.all(ARMS.map((a) => runArm(a).catch((e) => ({ arm: a.id, error: String(e && e.message ? e.message : e) }))));
+results.push(...settled);
+fs.writeFileSync(`${OUT}/summary.json`, JSON.stringify({ target: targets.ceeTurnBase, brief: BRIEF, surrounding: SURROUNDING, results }, null, 2));
+
+log('===== SUMMARY =====');
+for (const r of results) log(`${r.arm.padEnd(26)} ${String(r.outcome && r.outcome.kind).padEnd(20)} nodes ${r.draftNodes}->${r.edit && r.edit.graphNodes} :: ${JSON.stringify((r.outcome && (r.outcome.codes || r.outcome.markers)) || [])}`);
+const control = results.find((r) => r.arm === 'A_CONTROL_SHIPPED');
+log(`POSITIVE CONTROL (arm A must reproduce the refusal): ${control && control.outcome && control.outcome.kind}`);

--- a/src/canvas/CanvasToolbar.tsx
+++ b/src/canvas/CanvasToolbar.tsx
@@ -542,8 +542,15 @@ export function CanvasToolbar() {
             <li>Any analysis results</li>
             <li>AI assistant conversation</li>
           </ul>
+          {/* ⚠ THIS SAID "You can undo this action with Ctrl+Z (Cmd+Z on Mac)."
+              and it was FALSE for the item directly above it. Undo restores graph
+              history; the conversation is deleted from localStorage and no undo
+              can bring it back. A confirmation sheet that under-states what it
+              destroys is the exact class this track exists to remove — and it is
+              worse on a confirm dialog than anywhere else, because the promise is
+              what the user weighs before saying yes. */}
           <p className={`${typography.caption} text-gray-500`}>
-            You can undo this action with Ctrl+Z (Cmd+Z on Mac).
+            Undo (Ctrl+Z / Cmd+Z) can bring the graph back. The conversation cannot be recovered.
           </p>
           <div className="flex gap-2">
             <button

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -2371,8 +2371,11 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
             <li>Any analysis results</li>
             <li>AI assistant conversation</li>
           </ul>
+          {/* Same correction as CanvasToolbar's sheet — see the note there.
+              Undo restores the graph; the conversation is a localStorage delete
+              and is gone. */}
           <p className="text-sm text-gray-500">
-            You can undo this action with Ctrl+Z (Cmd+Z on Mac).
+            Undo (Ctrl+Z / Cmd+Z) can bring the graph back. The conversation cannot be recovered.
           </p>
           <div className="flex gap-2">
             <button

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -1649,25 +1649,45 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
    * uses `./utils/graphHash`'s, aliased to make the twin explicit at the call
    * site rather than at the import list (CLAUDE.md's two-same-named-hash trap).
    */
+  // ⚠ SHARES THE POST-BOOT EFFECT BELOW RATHER THAN DECLARING ITS OWN, and that
+  // is a deliberate constraint, not tidiness. `assert-rules-of-hooks-ratchet.mjs`
+  // holds this file at 117 conditional-hook violations: it has an early return
+  // above, so EVERY hook after it is flagged, and a new `useEffect` here takes
+  // the count to 118. That ratchet exists because each violation is a
+  // render-time crash, and it "had an exception for its EXISTING violations, not
+  // a licence to add more". Folding the work into an effect that already exists
+  // adds no hook call. The two concerns are genuinely the same phase — both are
+  // post-boot restoration, both must run after the `[loadSettings]` effect.
+  //
+  // Show recovery toast if we loaded from autosave on mount, and rehydrate guidance.
   useEffect(() => {
+    // ── Guidance rehydration — the user's coaching must survive a refresh ────
+    // ⚠ ORDERING IS THE WHOLE DESIGN, which is why this is an explicit call and
+    // not a module-evaluation spread in the store (the pattern `strengthenStore`
+    // uses). Guidance items are gated on `valid_while`, and BOTH comparators are
+    // only live once the boot effect above has run: `results.hash` arrives with
+    // `restoreAnalysisFromAutosave`, and the graph hash needs the restored
+    // nodes/edges. Rehydrating at module evaluation would adopt items whose
+    // freshness could not yet be checked — and this store's rule is that
+    // unverifiable is stale. Declaring this effect AFTER the boot effect is what
+    // orders it: React runs a component's effects in declaration order.
+    //
+    // ⚠ TWO `generateGraphHash` FUNCTIONS EXIST IN THIS TREE and this file
+    // already imports the OTHER one. `./store/runHistory`'s takes a run SEED; the
+    // comparison here must be seedless and identical at write and read time, so
+    // it uses `./utils/graphHash`'s, aliased to make the twin explicit at the
+    // call site rather than in the import list (the two-same-named-hash trap).
     const st = useCanvasStore.getState()
     setGuidancePersistenceContext(() => {
       const s = useCanvasStore.getState()
-      return {
-        scenarioId: s.currentScenarioId,
-        graphHash: uiGraphHashSeedless(s.nodes, s.edges),
-      }
+      return { scenarioId: s.currentScenarioId, graphHash: uiGraphHashSeedless(s.nodes, s.edges) }
     })
     useGuidanceStore.getState().rehydrateGuidance({
       scenarioId: st.currentScenarioId,
       currentAnalysisHash: st.results?.hash ?? null,
       currentGraphHash: uiGraphHashSeedless(st.nodes, st.edges),
     })
-    return () => setGuidancePersistenceContext(null)
-  }, [])
 
-  // Show recovery toast if we loaded from autosave on mount
-  useEffect(() => {
     try {
       const recovered = sessionStorage.getItem('olumi-recovered-from-autosave')
       if (recovered === 'true') {
@@ -1678,6 +1698,10 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         }, 500)
       }
     } catch {}
+
+    // Uninstall the guidance persistence context when this canvas unmounts, so
+    // a later mount cannot write under a stale decision identity.
+    return () => setGuidancePersistenceContext(null)
   }, [showToast])
 
   useEffect(() => {

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -15,6 +15,7 @@ import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEditedSinceRun } from './hooks/useEditedSinceRun'
 import { LodSync } from './components/LodSync'
+import { CanvasLodNotice } from './components/CanvasLodNotice'
 import { cameraDuration } from './utils/cameraMotion'
 import { useFocusCamera } from './hooks/useFocusCamera'
 import { useMeasureThenLayout } from './hooks/useMeasureThenLayout'
@@ -69,6 +70,12 @@ import { useLensFilter } from './hooks/useLensFilter'
 import { useGuidancePulseHighlight } from './hooks/useGuidancePulseHighlight'
 import { useEscapePanel } from './hooks/useEscapePanel'
 import { loadRuns, generateGraphHash } from './store/runHistory'
+// ⚠ THE OTHER `generateGraphHash`. This tree carries two functions of that name —
+// the seed-bearing run-history one imported above, and the seedless UI-local one
+// below. They are NOT interchangeable, and conflating them is a defect this
+// estate has already paid for once. Aliased so every call site says which.
+import { generateGraphHash as uiGraphHashSeedless } from './utils/graphHash'
+import { useGuidanceStore, setGuidancePersistenceContext } from './stores/guidanceStore'
 import { restoreAnalysisFromAutosave } from './store/restoreAnalysisFromAutosave'
 // HealthStatusBar removed - validation consolidated into OutputsDock panel
 import { DegradedBanner } from './components/DegradedBanner'
@@ -1623,6 +1630,42 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     }
   }, [loadSettings])
 
+  /**
+   * Guidance rehydration — the user's coaching must survive a refresh.
+   *
+   * ⚠ ORDERING IS THE WHOLE DESIGN, which is why this is an explicit call and
+   * not a module-evaluation spread in the store (the pattern `strengthenStore`
+   * uses). Guidance items are gated on `valid_while`, and BOTH comparators are
+   * only live once the boot effect above has run: `results.hash` arrives with
+   * `restoreAnalysisFromAutosave`, and the graph hash needs the restored
+   * nodes/edges. Rehydrating at module evaluation would adopt items whose
+   * freshness could not yet be checked — and this store's rule is that
+   * unverifiable is stale. Declaring the effect AFTER the boot effect is what
+   * orders it: React runs a component's effects in declaration order.
+   *
+   * ⚠ TWO `generateGraphHash` FUNCTIONS EXIST IN THIS TREE and this file already
+   * imports the OTHER one. `./store/runHistory`'s takes a run SEED; the
+   * comparison here must be seedless and identical at write and read time, so it
+   * uses `./utils/graphHash`'s, aliased to make the twin explicit at the call
+   * site rather than at the import list (CLAUDE.md's two-same-named-hash trap).
+   */
+  useEffect(() => {
+    const st = useCanvasStore.getState()
+    setGuidancePersistenceContext(() => {
+      const s = useCanvasStore.getState()
+      return {
+        scenarioId: s.currentScenarioId,
+        graphHash: uiGraphHashSeedless(s.nodes, s.edges),
+      }
+    })
+    useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: st.currentScenarioId,
+      currentAnalysisHash: st.results?.hash ?? null,
+      currentGraphHash: uiGraphHashSeedless(st.nodes, st.edges),
+    })
+    return () => setGuidancePersistenceContext(null)
+  }, [])
+
   // Show recovery toast if we loaded from autosave on mount
   useEffect(() => {
     try {
@@ -2052,6 +2095,9 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
             </svg>
             {/* D2: level-of-detail zoom watcher — main canvas only. */}
             <LodSync />
+            {/* Says so when LodSync has blanked the labels — measured at 0 of 5
+                viewports before this shipped; see the component's header. */}
+            <CanvasLodNotice />
           </ReactFlow>
         )}
       </div>

--- a/src/canvas/components/CanvasLodNotice.tsx
+++ b/src/canvas/components/CanvasLodNotice.tsx
@@ -1,0 +1,104 @@
+/**
+ * CanvasLodNotice — say so when the canvas has stopped rendering labels.
+ *
+ * ── THE MEASUREMENT THIS EXISTS FOR ────────────────────────────────────────
+ * Real Chromium, the product's own "Customer Data Platform Selection" example
+ * (19 nodes), clicking the real "Fit to view" control, 2026-08-11:
+ *
+ *   viewport      fit zoom   node titles hidden   LOD   disclosed?
+ *   1920x1080      0.802          0 / 19          off      —
+ *   1440x900       0.668          0 / 19          off      —
+ *   1280x800       0.595          0 / 19          off      —
+ *   1024x768       0.543          0 / 19          off      —
+ *   834x1112       0.344         17 / 19          ON      **no**
+ *
+ * At a narrow canvas, "Fit to view" lands at 0.344 — well under
+ * `LABEL_LEGIBLE_ZOOM` — and hides 17 of 19 node titles and 86 of 89 text
+ * elements. That reproduces the reported "18 of 20 node labels blank" almost
+ * exactly, and it explains why the finding looked intermittent: it is
+ * VIEWPORT-CONDITIONAL, not build-conditional. A user on a laptop with the AI
+ * panel and inspector open has the same narrow canvas as the 834px column here.
+ *
+ * ── WHAT THIS DOES *NOT* DO, AND WHY ───────────────────────────────────────
+ * It does NOT clamp the fit. `src/canvas/utils/zoomLegibility.ts` carries a
+ * reasoned, dated doctrine that explicit user gestures stay unfloored, and that
+ * below the floor "the level-of-detail view is the honest, intended rendering:
+ * structure without labels". That doctrine is right: flooring "fit to view"
+ * would crop the model the user just asked to see whole, which is a worse lie
+ * than hiding labels. Overturning it was not this lane's to do.
+ *
+ * The defect is the word the doctrine already used and the product never
+ * delivered: **honest**. A screen of blank rectangles that says nothing is
+ * indistinguishable from a broken render, and the measurement above shows the
+ * product disclosed the state at 0 of 5 viewports. So this component says which
+ * one you are looking at, and offers the way back.
+ *
+ * It renders from the SAME store flag the nodes blank themselves on
+ * (`lodActive`, written by `LodSync` from the live viewport transform), so the
+ * notice cannot claim a state the nodes are not in — derive, don't mirror.
+ */
+import { ZoomIn } from 'lucide-react'
+import { useReactFlow } from '@xyflow/react'
+import { useCanvasStore } from '../store'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
+import { cameraDuration } from '../utils/cameraMotion'
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+import { typography } from '../../styles/typography'
+
+export const CANVAS_LOD_NOTICE_TESTID = 'canvas-lod-notice'
+
+/**
+ * The copy. Stated as the fact it is — the labels are hidden, and why — with no
+ * apology and no claim about what the user should have done. "Zoomed out too far
+ * to show labels" is true at exactly the moment `lodActive` is true, because
+ * that flag IS `zoom < LABEL_LEGIBLE_ZOOM`.
+ */
+export const CANVAS_LOD_NOTICE_COPY = 'Zoomed out too far to show labels'
+export const CANVAS_LOD_NOTICE_ACTION = 'Zoom in to read them'
+
+export function CanvasLodNotice() {
+  const lodActive = useCanvasStore((s) => s.lodActive === true)
+  const { getViewport, setViewport } = useReactFlow()
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  if (!lodActive) return null
+
+  return (
+    <div
+      data-testid={CANVAS_LOD_NOTICE_TESTID}
+      role="status"
+      aria-live="polite"
+      className="pointer-events-auto absolute left-1/2 top-3 z-10 flex -translate-x-1/2 items-center gap-2 rounded-full border border-panel-border bg-panel px-3 py-1.5 shadow-sm"
+    >
+      <ZoomIn className="h-3.5 w-3.5 flex-none text-text-light" aria-hidden="true" />
+      <span className={`${typography.panelMeta} text-text-body`}>{CANVAS_LOD_NOTICE_COPY}</span>
+      <button
+        type="button"
+        data-testid={`${CANVAS_LOD_NOTICE_TESTID}-action`}
+        onClick={() => {
+          // Return to the legibility floor exactly, keeping the centre of the
+          // current view fixed so the user does not lose their place. Derived
+          // from LABEL_LEGIBLE_ZOOM, never a restated literal — the
+          // single-source guard fails on a second numeric zoom literal.
+          const vp = getViewport()
+          if (vp.zoom >= LABEL_LEGIBLE_ZOOM) return
+          const el = document.querySelector('.react-flow') as HTMLElement | null
+          const w = el?.clientWidth ?? 0
+          const h = el?.clientHeight ?? 0
+          const scale = LABEL_LEGIBLE_ZOOM / vp.zoom
+          setViewport(
+            {
+              zoom: LABEL_LEGIBLE_ZOOM,
+              x: w / 2 - (w / 2 - vp.x) * scale,
+              y: h / 2 - (h / 2 - vp.y) * scale,
+            },
+            { duration: cameraDuration(300, prefersReducedMotion) },
+          )
+        }}
+        className={`${typography.panelMeta} rounded text-info underline hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+      >
+        {CANVAS_LOD_NOTICE_ACTION}
+      </button>
+    </div>
+  )
+}

--- a/src/canvas/components/__tests__/CanvasLodNotice.spec.tsx
+++ b/src/canvas/components/__tests__/CanvasLodNotice.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * CanvasLodNotice — the canvas must say when it has stopped rendering labels.
+ *
+ * ⚠ THE LOAD-BEARING EVIDENCE FOR THIS COMPONENT IS THE REAL-BROWSER SWEEP, not
+ * this file. jsdom cannot prove a label is illegible (CLAUDE.md trap 3); it has
+ * no layout, so `visibility: hidden` and a fully readable label are the same
+ * thing to it. The measurement that established the defect and proved the fix
+ * lives in the PR body: real Chromium, the product's own 19-node example, the
+ * real "Fit to view" control, five viewports.
+ *
+ * What this file pins is the one property jsdom CAN see and that the browser
+ * sweep cannot pin against refactors: the notice is bound to the SAME store flag
+ * the nodes blank themselves on. If it ever grew its own zoom predicate, it
+ * could claim a state the nodes are not in — the mirror defect this estate keeps
+ * paying for — and the browser sweep would not notice for months.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CanvasLodNotice, CANVAS_LOD_NOTICE_TESTID } from '../CanvasLodNotice'
+import { useCanvasStore } from '../../store'
+import { LABEL_LEGIBLE_ZOOM } from '../../utils/zoomLegibility'
+import { isLodZoom } from '../LodSync'
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({ getViewport: () => ({ x: 0, y: 0, zoom: 0.3 }), setViewport: vi.fn() }),
+}))
+
+describe('CanvasLodNotice', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ lodActive: false })
+  })
+
+  it('renders NOTHING while labels are being rendered', () => {
+    render(<CanvasLodNotice />)
+    expect(
+      screen.queryByTestId(CANVAS_LOD_NOTICE_TESTID),
+      'a notice that shows while labels are perfectly readable is noise, and it would train the user to ignore it',
+    ).toBeNull()
+  })
+
+  it('renders the disclosure exactly when the nodes have blanked their labels', () => {
+    useCanvasStore.setState({ lodActive: true })
+    render(<CanvasLodNotice />)
+    const el = screen.getByTestId(CANVAS_LOD_NOTICE_TESTID)
+    expect(el).toBeTruthy()
+    // Bound by identity to the control, not by a text predicate another element
+    // could satisfy.
+    expect(screen.getByTestId(`${CANVAS_LOD_NOTICE_TESTID}-action`)).toBeTruthy()
+  })
+
+  it('is bound to the SAME flag BaseNode blanks on — not to a second zoom predicate of its own', () => {
+    // The anti-mirror assertion. `lodActive` is written by LodSync from
+    // `isLodZoom(transform[2])`, and `BaseNode` hides its title on that same
+    // flag. Proving the two agree at the boundary is what stops a future
+    // refactor giving the notice its own threshold.
+    expect(isLodZoom(LABEL_LEGIBLE_ZOOM - 0.01)).toBe(true)
+    expect(isLodZoom(LABEL_LEGIBLE_ZOOM)).toBe(false)
+
+    useCanvasStore.setState({ lodActive: isLodZoom(LABEL_LEGIBLE_ZOOM) })
+    render(<CanvasLodNotice />)
+    expect(
+      screen.queryByTestId(CANVAS_LOD_NOTICE_TESTID),
+      'the notice claimed the labels were hidden at a zoom where BaseNode renders them',
+    ).toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/ChatThread.firstReplyScroll.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.firstReplyScroll.spec.tsx
@@ -1,0 +1,114 @@
+/**
+ * ChatThread — the FIRST assistant reply must trigger the auto-scroll.
+ *
+ * ⚠ WHAT THIS SPEC CAN AND CANNOT PROVE, STATED UP FRONT. jsdom has no layout,
+ * so it cannot prove the reply is ON SCREEN (CLAUDE.md trap 3) — that claim is
+ * made only by the real-browser witness in `e2e/`, and the numbers live in the
+ * PR body. What jsdom CAN prove, and what the defect actually was, is that the
+ * scroll is TRIGGERED on the commit that first puts the reply in the DOM. Those
+ * are two different claims and this file only makes the second one.
+ *
+ * THE DEFECT. `useSmartScroll` fired on `messages.length`. During turn one that
+ * length does change (0 → 1 user → 2 streaming), so the effect ran twice — but
+ * `ChatThread` returns `null` for BOTH roles while `showEmptyState` holds, so
+ * both runs scrolled a container holding only `EmptyState`. The commit that
+ * finally renders the reply is `isStreaming` flipping false on an EXISTING
+ * message object: `messages.length` is IDENTICAL across it, so the old trigger
+ * was structurally incapable of observing the one commit that mattered.
+ *
+ * That is why the case below is a MUTATION of an existing message and not an
+ * append — an append-shaped test would have passed at pristine and proved
+ * nothing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ChatThread } from '../zones/ChatThread'
+import type { ConversationMessage } from '../types'
+
+vi.mock('../../../components/results/v7/V7HeldProposalCard', () => ({ V7HeldProposalCard: () => null }))
+
+const scrollIntoView = vi.fn()
+
+function props(messages: ConversationMessage[], nodeCount = 0) {
+  return {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    nodeCount,
+    patchBlockStates: {},
+    patchRejections: {},
+    onChipClick: vi.fn(),
+    onPatchAccept: vi.fn(),
+    onPatchDismiss: vi.fn(),
+    onFeedback: vi.fn(),
+    onRetry: vi.fn(),
+  } as unknown as React.ComponentProps<typeof ChatThread>
+}
+
+const userMsg = (id: string): ConversationMessage =>
+  ({ id, role: 'user', content: 'Should we replace our CRM?' }) as ConversationMessage
+
+/** The assistant message, in its two states. Same `id` — that is the point. */
+const assistantMsg = (id: string, streaming: boolean): ConversationMessage =>
+  ({ id, role: 'assistant', content: 'Here is a first read of your decision.', isStreaming: streaming }) as ConversationMessage
+
+describe('ChatThread — the first assistant reply is scrolled to', () => {
+  beforeEach(() => {
+    scrollIntoView.mockClear()
+    Element.prototype.scrollIntoView = scrollIntoView
+  })
+
+  it('scrolls on the commit that FINALISES the first reply — the commit where messages.length does not change', () => {
+    const messages = [userMsg('u1'), assistantMsg('a1', true)]
+    const { rerender } = render(<ChatThread {...props(messages)} />)
+
+    // Everything so far is suppressed by the empty state, so nothing has been
+    // scrolled to. Pin that precondition IN-TEST rather than assuming it: if the
+    // suppression ever stops happening, this case must stop claiming to cover it
+    // (CLAUDE.md trap 13b — a discriminator must pin its own precondition).
+    const scrollsBeforeFinalise = scrollIntoView.mock.calls.length
+
+    // THE COMMIT THAT MATTERS: the SAME message id, isStreaming true → false.
+    // `messages.length` is 2 both before and after.
+    const finalised = [userMsg('u1'), assistantMsg('a1', false)]
+    expect(finalised.length).toBe(messages.length) // the defect's whole mechanism, asserted
+    rerender(<ChatThread {...props(finalised)} />)
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the first assistant reply became visible on this commit and nothing scrolled to it — ' +
+        'the user is left looking at the top of a reply that has already finished',
+    ).toBeGreaterThan(scrollsBeforeFinalise)
+  })
+
+  it('scrolls when the graph arriving is what reveals the messages (nodeCount 0 → non-zero, same message list)', () => {
+    // The other route out of the empty state. Same shape: the message ARRAY is
+    // byte-identical across the commit, so only a rendered-count trigger sees it.
+    const messages = [userMsg('u1'), assistantMsg('a1', true)]
+    const { rerender } = render(<ChatThread {...props(messages, 0)} />)
+    const before = scrollIntoView.mock.calls.length
+
+    rerender(<ChatThread {...props(messages, 12)} />)
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the graph landed and unhid the transcript, but the thread did not scroll to it',
+    ).toBeGreaterThan(before)
+  })
+
+  it('does NOT scroll while every message is still suppressed — the trigger is rendered content, not traffic', () => {
+    // The discriminating twin. Without this, a trigger that simply fired on
+    // every render would satisfy the two cases above while measuring nothing.
+    const { rerender } = render(<ChatThread {...props([userMsg('u1')], 0)} />)
+    const afterUserOnly = scrollIntoView.mock.calls.length
+
+    // A second suppressed message arrives: messages.length changes 1 → 2, but
+    // NOTHING new reaches the DOM, so nothing should be scrolled to.
+    rerender(<ChatThread {...props([userMsg('u1'), assistantMsg('a1', true)], 0)} />)
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the thread scrolled for a message the empty state is suppressing — the trigger is counting traffic, not content',
+    ).toBe(afterUserOnly)
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.resetTranscript.spec.tsx
+++ b/src/canvas/conversation/__tests__/useConversation.resetTranscript.spec.tsx
@@ -1,0 +1,269 @@
+/**
+ * RUNTIME WITNESS — does `resetCanvas`'s transcript clear actually survive the
+ * commit it happens on?
+ *
+ * ⚠ WHY THIS EXISTS AS A MOUNTED TEST. `resetCanvasClearsPersisted.spec.ts`
+ * proves `clearTranscript` is CALLED and that the key is gone immediately after.
+ * It mounts no component, so it is structurally incapable of seeing what happens
+ * on the SAME React commit — and the review's derivation says something does:
+ *
+ *   `useConversation.ts:2712` (persist, deps `[messages, scenarioId]`) is
+ *   declared BEFORE `:2721` (scenario switch). `resetCanvas` sets
+ *   `currentScenarioId: null`, so on that commit the persist effect runs first,
+ *   while `messagesOwnerRef.current` is still the OLD id and `messages` is still
+ *   non-empty — and `saveTranscript(owner, messages)` writes back exactly what
+ *   `clearTranscript` just deleted.
+ *
+ * A derivation is not a measurement, and the whole point of item 4c is that the
+ * clear is real rather than nominal. So this drives the real hook and reads
+ * `localStorage` after React has settled.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import * as scenarios from '../../store/scenarios'
+import {
+  TRANSCRIPT_STORAGE_KEY,
+  saveTranscript,
+  clearTranscript,
+  releaseTranscriptTombstone,
+  __resetTranscriptTombstonesForTests,
+} from '../utils/transcriptStore'
+
+// This spec never sends a turn — it drives mount-restore and `resetCanvas` only.
+// The mocks below exist solely to stop the hook reaching a network path at mount;
+// the two spies are declared here rather than inherited from the sibling spec the
+// preamble was adapted from (which is how `mockCallTurn` arrived undeclared).
+const mockCallTurn = vi.fn()
+const mockStreamTurn = vi.fn()
+
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockStreamTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+// Mock V5 adapter so callV5Turn never resolves (mirrors mockCallTurn's hang pattern).
+// Without this, VITE_ENABLE_V5_ORCHESTRATOR=true causes the V5 path to make
+// a real fetch(/bff/orchestrate/v2/turn) which fails fast, sets isThinking=false
+// in the finally block, and breaks timeout-progression tests.
+const mockCallV5Turn = vi.fn()
+
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+  // getV5Endpoint is called unconditionally in bindRequestToInteraction on
+  // every V5 send path (useConversation.ts ~L2967); an incomplete mock
+  // leaves it undefined and throws "getV5Endpoint is not a function" —
+  // same pattern fixed in the sibling useConversation.reasoning.spec.ts
+  // (5bc479cf).
+  getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
+}))
+
+// Stop-fence (Codex P0): the server-visible explicit Stop. Mocked here so the
+// notice-copy assertions below drive off the OUTCOME rather than a live fetch —
+// which is the whole point of the three-state answer.
+type StopFenceResult = {
+  kind: 'not_saved' | 'already_saved' | 'unconfirmed'
+  reason?: string
+}
+const mockStopV5Turn = vi.fn(
+  (..._args: unknown[]): Promise<StopFenceResult> => Promise.resolve({ kind: 'not_saved' }),
+)
+vi.mock('../../../v5/stopTurn', () => ({
+  stopV5Turn: (...args: unknown[]) => mockStopV5Turn(...args),
+  getV5StopEndpoint: () => 'https://cee.test/proxy/v5/turn/stop',
+  STOP_ACK_BUDGET_MS: 5000,
+}))
+
+// Mock V5 eligibility so the V5-specific describe blocks below (which
+// exercise the V5 sendTurn branch) don't silently depend on the developer's
+// untracked .env.local setting VITE_ENABLE_V5_ORCHESTRATOR=true — on a clean
+// checkout isV5Eligible() resolves to false, sendMessage never enters the V5
+// branch, and mockCallV5Turn/mockLoadScenario are never invoked (same root
+// cause diagnosed + fixed for useConversation.reasoning.spec.ts in 5bc479cf).
+// Defaults to false (V4 path) so the many V4-oriented blocks above are
+// unaffected; the V5-only blocks below flip it on for their scope.
+const mockIsV5Eligible = vi.fn<[{ flag: string | undefined }], { eligible: boolean; reason?: string }>()
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: (...args: unknown[]) => mockIsV5Eligible(...(args as [{ flag: string | undefined }])),
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
+
+// 1.16i: telemetry sink for the run-click swallow guard.
+const mockTrackEvent = vi.fn()
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
+// Mock Supabase getUserId: vi.fn() so tests can reconfigure per-scenario.
+// Default: null (no auth session in test environment).
+const mockGetUserId = vi.fn<[], Promise<string | null>>()
+
+// Login 3.4: token knob for the getSessionIdentity bridge — tests that
+// exercise the Bearer path set .value; everything else runs token-less.
+const mockAccessToken = { value: null as string | null }
+
+// ROADMAP 2.122 — `sendMessage` on an EMPTY canvas is now dispatched to the
+// STREAMED turn sibling first (`<endpoint>/stream`, CEE #751), with a
+// transparent fallback to the buffered turn on any stream failure.
+//
+// This spec's subject is the BUFFERED chain, so the streamed sibling is stubbed
+// unreachable — which is not an artificial construction: it is exactly the state
+// of a deployment where the streamed route is absent or refusing, and the
+// fallback it triggers is the behaviour under test elsewhere
+// (`streamedDraftTurn.spec.ts`). With the sibling unreachable the buffered path
+// runs exactly once, which is what this spec's request-count pins measure.
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: async () => {
+      throw new TypeError('Failed to fetch')
+    },
+  }
+})
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: (...args: unknown[]) => mockGetUserId(...args as []),
+  // Login 3.4: useConversation resolves identity via getSessionIdentity
+  // (userId + access token in one getSession call). Backed by the same
+  // mock so each test's userId intent carries over.
+  getSessionIdentity: async () => ({
+    userId: (await mockGetUserId()) ?? null,
+    accessToken: mockAccessToken.value,
+  }),
+}))
+
+// Mock scenarioService loadScenario: vi.fn() so tests can return graph data.
+// Default: null (no DB in test environment).
+const mockLoadScenario = vi.fn<[string], Promise<unknown>>()
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: (...args: unknown[]) => mockLoadScenario(...args as [string]),
+}))
+
+// Pin both flags ON:
+//   - isOrchestratorStreamingEnabled: the buildRequest payload block asserts
+//     against mockStreamTurn (streaming path). Without this, the flag
+
+const SCENARIO = '77777777-8888-9999-aaaa-bbbbbbbbbbbb'
+
+const transcriptFile = (): Record<string, unknown> => {
+  const raw = localStorage.getItem(TRANSCRIPT_STORAGE_KEY)
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+}
+
+describe('resetCanvas — the transcript clear must survive its own commit', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    __resetTranscriptTombstonesForTests()
+    useCanvasStore.setState({ nodes: [], edges: [] })
+  })
+
+  it('does not write the cleared transcript straight back on the reset commit', async () => {
+    // ⚠ BOTH PRECONDITIONS ARE NON-OBVIOUS AND THE FIRST DRAFT OF THIS TEST GOT
+    // THEM WRONG — it restored 0 messages and would have reported a clean pass
+    // for a race it never set up. They are pinned below rather than assumed.
+    //
+    //  1. The hook reads `useCanvasStore(s => s.currentScenarioId)`, NOT
+    //     `scenarios.getCurrentScenarioId()`. Setting only the module-level id
+    //     leaves the hook with `scenarioId == null` and no restore at all.
+    //  2. The mount restore fires only when `restored.fromPreviousSession` —
+    //     i.e. the stored `pageLoadId` differs from this page load's. A
+    //     transcript written by `saveTranscript` in-test carries the CURRENT id,
+    //     so it is correctly ignored. The entry is therefore written directly,
+    //     with a foreign `pageLoadId`, which is exactly the reload shape.
+    scenarios.setCurrentScenarioId(SCENARIO)
+    useCanvasStore.setState({ currentScenarioId: SCENARIO })
+    localStorage.setItem(
+      TRANSCRIPT_STORAGE_KEY,
+      JSON.stringify({
+        [SCENARIO]: {
+          savedAt: new Date().toISOString(),
+          pageLoadId: 'a-previous-page-load',
+          dropped: 0,
+          messages: [
+            // `ts` is REQUIRED by `isStoredMessage`; without it every message is
+            // filtered out, `loadTranscript` returns null for an empty list, and
+            // the restore silently no-ops. That was the third distinct way this
+            // fixture managed to set up nothing — all three caught by the
+            // precondition assertion below, none of them by a failing expectation.
+            { id: 'm1', role: 'user', content: 'Should we replace our CRM?', ts: new Date().toISOString() },
+            { id: 'm2', role: 'assistant', content: 'Here is a first read.', ts: new Date().toISOString() },
+          ],
+        },
+      }),
+    )
+
+    // Pin the precondition IN-TEST — without a transcript on disk and messages
+    // in the hook, this measures nothing (trap 13b).
+    expect(Object.keys(transcriptFile()), 'precondition: a transcript exists for this decision').toContain(SCENARIO)
+
+    const { result } = renderHook(() => useConversation())
+    await act(async () => { await Promise.resolve() })
+
+    expect(
+      result.current.messages.length,
+      'precondition: the hook must have restored the transcript, or the persist effect it races has nothing to write',
+    ).toBeGreaterThan(0)
+
+    // Put the canvas in the state a reset is reached from, then reset for real.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Previous' } }] as never,
+      edges: [],
+    })
+    await act(async () => {
+      useCanvasStore.getState().resetCanvas()
+      await Promise.resolve()
+    })
+
+    expect(
+      Object.keys(transcriptFile()),
+      'the transcript was deleted and then written straight back on the same commit: the persist effect is declared ' +
+        'before the scenario-switch effect, so it runs first with the OLD owner and the OLD messages still in hand',
+    ).not.toContain(SCENARIO)
+  })
+
+  it('CONTROL — a decision the user genuinely re-enters persists normally again', () => {
+    // The discriminating twin. The tombstone's own failure mode is being
+    // PERMANENT: a fix that simply refused to ever write again would satisfy the
+    // case above while silently breaking every decision the user resets and then
+    // re-opens from the scenario switcher.
+    clearTranscript(SCENARIO)
+    expect(
+      saveTranscript(SCENARIO, [
+        { id: 'x', role: 'user', content: 'written while forgotten' },
+      ] as never),
+      'precondition: a forgotten decision must refuse the write, or this control proves nothing',
+    ).toBeNull()
+
+    releaseTranscriptTombstone(SCENARIO) // what the scenario-switch effect does on re-entry
+
+    saveTranscript(SCENARIO, [
+      { id: 'y', role: 'user', content: 'written after genuine re-entry' },
+    ] as never)
+    expect(
+      Object.keys(transcriptFile()),
+      'the tombstone was permanent: re-opening a reset decision would never persist its conversation again',
+    ).toContain(SCENARIO)
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -75,6 +75,7 @@ import {
   loadTranscript,
   saveTranscript,
   formatTruncationNotice,
+  releaseTranscriptTombstone,
 } from './utils/transcriptStore'
 import { appendThreadEntries, createSnapshot } from '../../services/threadService'
 import type { ThreadEntry } from '../journey/threadTypes'
@@ -2727,6 +2728,14 @@ export function useConversation(): UseConversationReturn {
       // Every branch below ends with `messages` belonging to the NEW scenario,
       // so ownership transfers here, once, rather than in four places.
       messagesOwnerRef.current = scenarioId
+
+      // Entering a decision un-forgets it. `clearTranscript` tombstones an id so
+      // this effect's SIBLING — the persist effect declared above — cannot write
+      // a reset conversation straight back on the same commit. Re-opening the
+      // decision later is a genuine entry, and its conversation must persist
+      // normally again; without this release, a reset followed by re-opening the
+      // saved decision would silently stop saving it for the rest of the page load.
+      releaseTranscriptTombstone(scenarioId)
 
       // When the previous ID was null/undefined, this is the initial lazy UUID
       // assignment from buildRequest — not a real scenario switch. Clearing

--- a/src/canvas/conversation/utils/__tests__/transcriptStore.spec.ts
+++ b/src/canvas/conversation/utils/__tests__/transcriptStore.spec.ts
@@ -12,6 +12,7 @@ import {
   saveTranscript,
   loadTranscript,
   clearTranscript,
+  __resetTranscriptTombstonesForTests,
   formatTruncationNotice,
   TRANSCRIPT_STORAGE_KEY,
   MAX_MESSAGES_PER_SCENARIO,
@@ -32,6 +33,15 @@ function msg(over: Partial<ConversationMessage> = {}): ConversationMessage {
 describe('transcriptStore', () => {
   beforeEach(() => {
     localStorage.clear()
+    // `clearTranscript` now tombstones an id for the page load, so a later
+    // `saveTranscript` for that id is refused — that is the point: without it the
+    // clear is undone on its own React commit. The tombstone is MODULE state and
+    // `localStorage.clear()` does not touch it, so a case that clears SID would
+    // silently disable saving for every later case using SID. Reset it here, as
+    // any module-level singleton must be between tests. No assertion below is
+    // weakened; the tombstone has its own coverage in
+    // `useConversation.resetTranscript.spec.tsx`.
+    __resetTranscriptTombstonesForTests()
   })
 
   it('round-trips the real turns verbatim, not a summary of them', () => {
@@ -173,7 +183,10 @@ describe('transcriptStore', () => {
 })
 
 describe('transcriptStore — previous-session discrimination', () => {
-  beforeEach(() => { localStorage.clear() })
+  beforeEach(() => {
+    localStorage.clear()
+    __resetTranscriptTombstonesForTests() // module state — see the note above
+  })
 
   it('a transcript THIS page load wrote is not "from a previous session"', () => {
     saveTranscript(SID, [msg({ id: 'a', content: 'live turn' })])

--- a/src/canvas/conversation/utils/transcriptStore.ts
+++ b/src/canvas/conversation/utils/transcriptStore.ts
@@ -204,6 +204,10 @@ export function saveTranscript(
   messages: readonly ConversationMessage[],
 ): number | null {
   if (!scenarioId || !storageAvailable()) return null
+  // A forgotten decision must stay forgotten for the rest of this page load —
+  // see the tombstone block above `clearTranscript`. Without this the clear is
+  // nominal: it is undone on the very commit it happens.
+  if (forgottenThisPageLoad.has(scenarioId)) return null
 
   const persistable = messages.filter(isPersistable)
   if (persistable.length === 0) return null
@@ -292,9 +296,59 @@ export function loadTranscript(scenarioId: string | null | undefined): LoadedTra
   }
 }
 
+/**
+ * ── THE TOMBSTONE, and why deleting the key is not enough ──────────────────
+ *
+ * MEASURED, not derived (`useConversation.resetTranscript.spec.tsx`): deleting
+ * the key alone is UNDONE ON THE SAME REACT COMMIT. `useConversation`'s persist
+ * effect (`:2712`, deps `[messages, scenarioId]`) is declared BEFORE the
+ * scenario-switch effect (`:2721`). `resetCanvas` sets `currentScenarioId: null`,
+ * so on that commit the persist effect runs FIRST — while `messagesOwnerRef`
+ * still holds the OLD id and `messages` is still the old conversation — and
+ * `saveTranscript(oldId, messages)` writes back exactly what was just deleted.
+ *
+ * The store-level test could not see this: it mounts no component, so there is
+ * no effect to race. It passed, and the clear was nominal.
+ *
+ * Reordering the two effects was rejected: `messagesOwnerRef`'s own comment
+ * records a privacy defect that keying persistence on the owner (not on
+ * `scenarioId`) exists to prevent, and moving the effect changes which decision
+ * owns the messages on a switch render. So the fix lives here, where "forget
+ * this" is defined, and holds regardless of who races it.
+ *
+ * Scope is deliberately ONE PAGE LOAD and one id:
+ *   - it is released the moment the user genuinely re-enters that decision
+ *     (`releaseTranscriptTombstone`, called from the scenario-switch effect), so
+ *     re-opening a saved decision after a reset persists normally;
+ *   - it does not survive a reload, because after one it cannot be needed: the
+ *     key is gone and no in-memory `messages` remain to write back.
+ */
+const forgottenThisPageLoad = new Set<string>()
+
+/**
+ * The user has genuinely entered this decision, so it is no longer forgotten.
+ * Called from the scenario-switch effect. Without it, resetting and then
+ * re-opening a saved decision would silently stop persisting its conversation
+ * for the rest of the page load — the tombstone's own failure mode, and the
+ * reason it has a release rather than being permanent.
+ */
+export function releaseTranscriptTombstone(scenarioId: string | null | undefined): void {
+  if (!scenarioId) return
+  forgottenThisPageLoad.delete(scenarioId)
+}
+
+/** Test-only: the tombstone is module state and must not leak between cases. */
+export function __resetTranscriptTombstonesForTests(): void {
+  forgottenThisPageLoad.clear()
+}
+
 /** Forget one scenario's transcript (scenario deleted / canvas reset). */
 export function clearTranscript(scenarioId: string | null | undefined): void {
-  if (!scenarioId || !storageAvailable()) return
+  if (!scenarioId) return
+  // Tombstone FIRST and unconditionally: if storage is unavailable the delete
+  // is a no-op, but a later write must still be refused.
+  forgottenThisPageLoad.add(scenarioId)
+  if (!storageAvailable()) return
   try {
     const file = readFile()
     if (!(scenarioId in file)) return

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -38,9 +38,18 @@ interface ChatThreadProps {
    * External handle so the parent can capture/restore the thread's
    * scroll position across mode transitions (AI panel v2 Compact ↔
    * Focus). When provided, the thread populates it with the scroll
-   * container ref and the smart-scroll auto-pin to bottom is
-   * suppressed on the FIRST layout after re-mount so a parent-driven
-   * restoreScrollTop call wins.
+   * container ref.
+   *
+   * ⚠ THIS COMMENT USED TO CLAIM A SUPPRESSION MECHANISM THAT DOES NOT EXIST:
+   * "the smart-scroll auto-pin to bottom is suppressed on the FIRST layout after
+   * re-mount so a parent-driven restoreScrollTop call wins." `useSmartScroll`
+   * takes `{ messageCount, isThinking }` and nothing else — there is no
+   * suppression parameter, this ref is never passed to the hook, and no
+   * `restoreScrollTop` exists anywhere in the tree. Corrected rather than deleted
+   * (CLAUDE.md trap 14: a false label teaches the next reader to stop looking, and
+   * this one would have sent them hunting a suppression bug to explain the
+   * missing first-reply scroll — which had an entirely different cause, recorded
+   * at the trigger below).
    */
   scrollListRef?: React.MutableRefObject<HTMLDivElement | null>
 }
@@ -68,8 +77,41 @@ export const ChatThread = memo(function ChatThread({
   compact,
   scrollListRef,
 }: ChatThreadProps) {
+  // Has the conversation produced any finalized (non-streaming) assistant messages?
+  const hasFinalizedAssistant = messages.some(m => m.role === 'assistant' && !m.isStreaming)
+
+  // EmptyState stays visible when no graph nodes exist and no finalized assistant
+  // response has arrived. This keeps the shape pipeline on screen during the first
+  // turn (Generate Model or first chat message) so it can serve as the loading hub.
+  const showEmptyState = nodeCount === 0 && !hasFinalizedAssistant
+
+  /**
+   * THE SINGLE PREDICATE deciding whether a message reaches the DOM. The render
+   * map below and the scroll trigger above BOTH consume it, so the two can never
+   * drift apart (CLAUDE.md trap 12: a second copy of this rule would be a
+   * hand-maintained mirror, and its drift would read as green).
+   *
+   * ⚠ WHY THE SCROLL TRIGGER IS THE RENDERED COUNT AND NOT `messages.length`.
+   * Measured on deployed staging (L3 browser truth): after the first assistant
+   * reply the thread sat at `scrollTop 0` against `scrollHeight ~1351` — the
+   * reply was below the fold and nothing scrolled to it. `messages.length` DOES
+   * change during the first turn (0 → 1 user → 2 streaming), so the effect fired
+   * twice — but on both commits this predicate returned false for every message,
+   * so it scrolled a container holding only `EmptyState`. The commit that finally
+   * puts content on screen is `hasFinalizedAssistant` flipping true, which happens
+   * by MUTATING an existing message's `isStreaming` — `messages.length` is
+   * IDENTICAL across it, so the old trigger could not observe the one commit that
+   * mattered. Counting rendered messages makes the trigger fire on that commit,
+   * because 0 → 2 is exactly the transition the user sees.
+   */
+  const isRendered = (msg: ConversationMessage): boolean =>
+    !(showEmptyState && (msg.role === 'user' || msg.isStreaming))
+
+  let renderedMessageCount = 0
+  for (const m of messages) if (isRendered(m)) renderedMessageCount++
+
   const { listRef, listEndRef, showNewMessageIndicator, handleScroll, scrollToBottom } =
-    useSmartScroll({ messageCount: messages.length, isThinking })
+    useSmartScroll({ messageCount: renderedMessageCount, isThinking })
 
   // Mirror the internal listRef into an externally-provided ref so the
   // parent (AI panel v2 layout) can capture and restore scrollTop
@@ -78,14 +120,6 @@ export const ChatThread = memo(function ChatThread({
   if (scrollListRef) {
     scrollListRef.current = listRef.current
   }
-
-  // Has the conversation produced any finalized (non-streaming) assistant messages?
-  const hasFinalizedAssistant = messages.some(m => m.role === 'assistant' && !m.isStreaming)
-
-  // EmptyState stays visible when no graph nodes exist and no finalized assistant
-  // response has arrived. This keeps the shape pipeline on screen during the first
-  // turn (Generate Model or first chat message) so it can serve as the loading hub.
-  const showEmptyState = nodeCount === 0 && !hasFinalizedAssistant
 
   // While EmptyState is showing, extract streaming text from the first streaming
   // message so it can be displayed below the shapes instead of in a message bubble.
@@ -151,8 +185,9 @@ export const ChatThread = memo(function ChatThread({
       )}
 
       {messages.map((msg, i) => {
-        // Hide user messages and the streaming placeholder while EmptyState is the loading hub
-        if (showEmptyState && (msg.role === 'user' || msg.isStreaming)) return null
+        // Hide user messages and the streaming placeholder while EmptyState is the loading hub.
+        // Same predicate the scroll trigger counts with — derived, never restated.
+        if (!isRendered(msg)) return null
         const isLastAssistant = msg === lastAssistantMsg
         if (msg.sessionDivider) {
           return <SessionDivider key={msg.id} text={msg.sessionDivider} />

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -24,6 +24,11 @@ import { addRun, generateGraphHash, loadRuns, type StoredRun, type RestorableRun
 import { RUN_COMPLETED_WITHOUT_VERDICT, VERDICT_ABSENT_FROM_PAYLOAD, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
+// Value import, and deliberately so: `resetCanvas` must forget the persisted
+// transcript as well as the persisted graph, or "start fresh" is fresh only
+// until the next reload. transcriptStore imports nothing but a type, so this
+// cannot introduce a cycle.
+import { clearTranscript } from './conversation/utils/transcriptStore'
 import { projectAutosaveData, autosaveSourceFromStore, analysisSnapshotFromStore } from './store/autosaveProjection'
 import { registerCrashSnapshotProvider } from './persist/crashFlush'
 import type { GraphHealth, ValidationIssue, NeedleMover } from './validation/types'
@@ -2782,6 +2787,27 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   },
 
   resetCanvas: () => {
+    // ── "Start fresh" must be fresh on the NEXT LOAD too ────────────────────
+    // Measured defect (link-track item 4c): resetCanvas cleared in-memory state
+    // and `currentScenarioId`, but left `olumi-canvas-autosave` and
+    // `olumi-canvas-transcript` on disk. The production boot arbiter in
+    // ReactFlowGraph then reads `autosave && !scenario` — the exact state a
+    // reset produces — and takes the `loadSource = 'autosave'` branch
+    // unconditionally, with no age cap and no fresh-entry test. So the previous
+    // model came back on the next page load, announced by
+    // "Recovered unsaved changes from your last session." A demo that starts
+    // over is the case that matters: the operator sees someone else's model.
+    //
+    // `clearTranscript`'s own docstring already reads "(scenario deleted /
+    // canvas reset)" and it had ZERO production call sites — the wiring was
+    // designed and never done, which is why nothing went red.
+    //
+    // Ordering is load-bearing: the transcript file is keyed BY SCENARIO ID, so
+    // it must be read before `clearCurrentScenarioId()` discards the key.
+    const scenarioIdBeingReset = scenarios.getCurrentScenarioId()
+    scenarios.clearAutosave()
+    clearTranscript(scenarioIdBeingReset)
+
     const { nodes, edges } = get()
     if (nodes.length === 0 && edges.length === 0) {
       // Lane 5 (Codex P0-2): the graph is already empty, but a previous

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -2804,9 +2804,25 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     //
     // Ordering is load-bearing: the transcript file is keyed BY SCENARIO ID, so
     // it must be read before `clearCurrentScenarioId()` discards the key.
+    // ⚠ A SAVED DECISION'S CONVERSATION IS NOT THIS COMMAND'S TO DESTROY.
+    // `getCurrentScenarioId()` can hold a SAVED record's id — `loadScenario`
+    // writes one, and so does `createScenario` via `saveCurrentScenario`, and the
+    // ScenarioSwitcher is mounted in both the toolbar and the top bar. Clearing
+    // unconditionally meant: save a decision → "Start fresh" → the graph RECORD
+    // survives and its conversation is gone, so re-opening it shows the model
+    // beside an empty chat. That is precisely the defect `transcriptStore`'s own
+    // header was written to fix, re-created by the fix for a different one.
+    //
+    // "Start fresh" is about the WORKING CANVAS. The unsaved autosave is working
+    // state and is cleared; a saved record's transcript belongs to the record and
+    // is left alone. Only an UNSAVED decision's transcript is discarded, which is
+    // the demo-hazard case this item exists for.
     const scenarioIdBeingReset = scenarios.getCurrentScenarioId()
+    const isSavedRecord = scenarioIdBeingReset
+      ? scenarios.getScenario(scenarioIdBeingReset) !== undefined
+      : false
     scenarios.clearAutosave()
-    clearTranscript(scenarioIdBeingReset)
+    if (!isSavedRecord) clearTranscript(scenarioIdBeingReset)
 
     const { nodes, edges } = get()
     if (nodes.length === 0 && edges.length === 0) {

--- a/src/canvas/store/__tests__/resetCanvasClearsPersisted.spec.ts
+++ b/src/canvas/store/__tests__/resetCanvasClearsPersisted.spec.ts
@@ -104,4 +104,64 @@ describe('resetCanvas — a fresh start is fresh on the next load', () => {
       'resetting one decision deleted a different decision\'s conversation',
     ).toContain('some-other-decision')
   })
+
+  /**
+   * ── "Start fresh" is about the WORKING CANVAS, not about saved records ────
+   *
+   * `getCurrentScenarioId()` can hold a SAVED record's id (`loadScenario` writes
+   * one; so does `createScenario` via `saveCurrentScenario`), and the
+   * ScenarioSwitcher is mounted in both the toolbar and the top bar. Clearing
+   * the transcript unconditionally meant: save a decision → "Start fresh" → the
+   * graph record survives and its conversation is destroyed, so re-opening it
+   * shows the model beside an empty chat.
+   *
+   * That is the very defect `transcriptStore`'s header was written to fix — and
+   * the fix for the demo hazard re-created it. Both directions are pinned here.
+   */
+  it('does NOT destroy a SAVED decision\'s conversation — the record survives, so its transcript must too', () => {
+    const created = scenarios.createScenario({ name: 'Saved decision', nodes: [], edges: [] })
+    scenarios.setCurrentScenarioId(created.id)
+    localStorage.setItem(
+      TRANSCRIPT_STORAGE_KEY,
+      JSON.stringify({ [created.id]: { savedAt: Date.now(), dropped: 0, messages: [{ id: 'm1', role: 'user', content: 'hi' }] } }),
+    )
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Saved' } }] as never,
+      edges: [],
+    })
+
+    expect(scenarios.getScenario(created.id), 'precondition: the record must exist to be protected').toBeDefined()
+
+    useCanvasStore.getState().resetCanvas()
+
+    expect(
+      Object.keys(JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY) ?? '{}')),
+      '"Start fresh" destroyed a SAVED decision\'s conversation: the graph record survives, so re-opening it now ' +
+        'shows the model beside an empty chat',
+    ).toContain(created.id)
+  })
+
+  it('DOES discard an UNSAVED decision\'s conversation — the discriminating twin', () => {
+    // Without this, a guard that simply never cleared anything would satisfy the
+    // case above while re-opening the demo hazard the item exists for.
+    const unsavedId = 'cccccccc-dddd-eeee-ffff-000000000000'
+    scenarios.setCurrentScenarioId(unsavedId)
+    expect(scenarios.getScenario(unsavedId), 'precondition: this id must NOT be a saved record').toBeUndefined()
+    localStorage.setItem(
+      TRANSCRIPT_STORAGE_KEY,
+      JSON.stringify({ [unsavedId]: { savedAt: Date.now(), dropped: 0, messages: [{ id: 'm1', role: 'user', content: 'hi' }] } }),
+    )
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Unsaved' } }] as never,
+      edges: [],
+    })
+
+    useCanvasStore.getState().resetCanvas()
+
+    expect(
+      Object.keys(JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY) ?? '{}')),
+      'the guard is too wide: an unsaved decision\'s conversation survived "start fresh" and will be restored ' +
+        'into what the next visitor enters as a fresh session',
+    ).not.toContain(unsavedId)
+  })
 })

--- a/src/canvas/store/__tests__/resetCanvasClearsPersisted.spec.ts
+++ b/src/canvas/store/__tests__/resetCanvasClearsPersisted.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * "Start fresh" must be fresh on the NEXT LOAD, not only in memory.
+ *
+ * THE DEFECT, and the reason it is worse than it looks. `resetCanvas` cleared
+ * in-memory state and `currentScenarioId` — and left `olumi-canvas-autosave` on
+ * disk. The production boot arbiter (`ReactFlowGraph`) then reads
+ * `autosave && !scenario`, which is EXACTLY the state a reset produces, and
+ * takes `loadSource = 'autosave'` unconditionally: no age cap, no fresh-entry
+ * test. So the previous model came back on the next page load, announced by
+ * "Recovered unsaved changes from your last session."
+ *
+ * The case that makes it a demo hazard rather than a nuisance: an operator
+ * starts over between sessions, reloads, and is shown somebody else's model
+ * with a toast confirming it is theirs.
+ *
+ * `clearTranscript`'s own docstring already read "(scenario deleted / canvas
+ * reset)" and it had ZERO production call sites — the wiring was designed and
+ * never done, which is precisely why nothing went red.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import * as scenarios from '../scenarios'
+import { TRANSCRIPT_STORAGE_KEY } from '../../conversation/utils/transcriptStore'
+
+const AUTOSAVE_KEY = 'olumi-canvas-autosave'
+
+describe('resetCanvas — a fresh start is fresh on the next load', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({ nodes: [], edges: [] })
+  })
+
+  it('clears the persisted autosave, so the boot arbiter cannot restore the previous model', () => {
+    // Put the store in the state a reset is reached from: a real graph on screen.
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Previous decision' } }] as never,
+      edges: [],
+    })
+    localStorage.setItem(AUTOSAVE_KEY, JSON.stringify({ timestamp: Date.now(), nodes: [{ id: 'n1' }], edges: [] }))
+
+    // Pin the precondition IN-TEST: without something to resurrect this case
+    // would pass while measuring nothing (trap 13b).
+    expect(localStorage.getItem(AUTOSAVE_KEY), 'precondition: an autosave must exist to be resurrected').not.toBeNull()
+
+    useCanvasStore.getState().resetCanvas()
+
+    expect(
+      localStorage.getItem(AUTOSAVE_KEY),
+      'the persisted autosave survived "start fresh" — the boot arbiter\'s `autosave && !scenario` branch will ' +
+        'restore it on the next load and tell the user their last session was recovered, inside a fresh session',
+    ).toBeNull()
+  })
+
+  it('clears the persisted transcript for the decision being reset', () => {
+    const scenarioId = '11111111-2222-3333-4444-555555555555'
+    scenarios.setCurrentScenarioId(scenarioId)
+    localStorage.setItem(
+      TRANSCRIPT_STORAGE_KEY,
+      JSON.stringify({ [scenarioId]: { savedAt: Date.now(), dropped: 0, messages: [{ id: 'm1', role: 'user', content: 'hi' }] } }),
+    )
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Previous' } }] as never,
+      edges: [],
+    })
+
+    const before = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY) as string)
+    expect(Object.keys(before), 'precondition: a transcript must exist for this decision').toContain(scenarioId)
+
+    useCanvasStore.getState().resetCanvas()
+
+    const after = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY) ?? '{}')
+    expect(
+      Object.keys(after),
+      'the previous conversation survived "start fresh" and will be restored into the new session',
+    ).not.toContain(scenarioId)
+  })
+
+  it('reads the scenario id BEFORE discarding it — the transcript file is keyed by that id', () => {
+    // The discriminating case for the ORDERING. `clearCurrentScenarioId()` runs
+    // inside resetCanvas; a clear that happened first would leave the transcript
+    // keyed under an id nothing could look up, and this test would be the only
+    // thing to notice.
+    const scenarioId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    scenarios.setCurrentScenarioId(scenarioId)
+    localStorage.setItem(
+      TRANSCRIPT_STORAGE_KEY,
+      JSON.stringify({
+        [scenarioId]: { savedAt: Date.now(), dropped: 0, messages: [{ id: 'm1', role: 'user', content: 'hi' }] },
+        'some-other-decision': { savedAt: Date.now(), dropped: 0, messages: [{ id: 'm2', role: 'user', content: 'other' }] },
+      }),
+    )
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Previous' } }] as never,
+      edges: [],
+    })
+
+    useCanvasStore.getState().resetCanvas()
+
+    const after = JSON.parse(localStorage.getItem(TRANSCRIPT_STORAGE_KEY) ?? '{}')
+    expect(Object.keys(after)).not.toContain(scenarioId)
+    // ...and ONLY that one. A reset must not delete another decision's history.
+    expect(
+      Object.keys(after),
+      'resetting one decision deleted a different decision\'s conversation',
+    ).toContain('some-other-decision')
+  })
+})

--- a/src/canvas/stores/__tests__/guidanceStore.rehydration.spec.ts
+++ b/src/canvas/stores/__tests__/guidanceStore.rehydration.spec.ts
@@ -190,6 +190,131 @@ describe('guidanceStore — rehydration across a reload', () => {
     expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['fresh-from-this-turn'])
   })
 
+  /**
+   * ── THE WRITE-SIDE HASH, which this file could not previously see ──────────
+   *
+   * Every case above installs a provider returning a CONSTANT `GRAPH_HASH`, so
+   * the hash stamped at write time can never move between authorship and a
+   * later persist. That made the corpus blind in exactly the direction the code
+   * was blind: it moved the READ hash and never the WRITE hash (traps 22b/13d —
+   * a corpus that shares the code's asymmetry cannot see the code's defect).
+   *
+   * These cases vary the PROVIDER's hash, which is the only shape that can
+   * observe it, and they are the review's, not this lane's.
+   */
+  describe('a persist that happens AFTER the graph moved must not launder the stamp', () => {
+    /** Install a provider whose graph hash this test can move, as the real one does. */
+    function movableProvider(initial: string) {
+      const box = { hash: initial }
+      setGuidancePersistenceContext(() => ({ scenarioId: SCENARIO, graphHash: box.hash }))
+      return box
+    }
+
+    it('CASE 1 — accepting an assistant patch does not re-stamp the survivors', () => {
+      const box = movableProvider('H1')
+      // A turn authors two items against H1; one is pinned to the graph.
+      useGuidanceStore.getState().setGuidanceItems([
+        item('targeted', { graph_hash: 'cee-aag-v1' }),
+        item('untargeted', { graph_hash: 'cee-aag-v1' }),
+      ])
+
+      // The user accepts an assistant patch. The graph moves H1 -> H2, and
+      // ConversationPanel calls clearItemsByTargetIds for the patched elements.
+      // That runs under beginExternalGraphMutation('patch_apply'), which
+      // SUPPRESSES the clearGuidanceItems() a normal edit would fire — so the
+      // untargeted item legitimately survives, and gets persisted again.
+      box.hash = 'H2'
+      useGuidanceStore.setState({
+        guidanceItems: useGuidanceStore.getState().guidanceItems.map((i) =>
+          i.item_id === 'targeted' ? { ...i, target_object: { type: 'node', id: 'n1' } } : i,
+        ),
+      })
+      useGuidanceStore.getState().clearItemsByTargetIds(['n1'])
+      expect(
+        useGuidanceStore.getState().guidanceItems.map((i) => i.item_id),
+        'precondition: the untargeted item must survive the patch, or this measures nothing',
+      ).toEqual(['untargeted'])
+
+      simulateReload()
+      const adopted = useGuidanceStore.getState().rehydrateGuidance({
+        scenarioId: SCENARIO,
+        currentAnalysisHash: ANALYSIS_HASH,
+        currentGraphHash: 'H2',
+      })
+
+      expect(
+        adopted,
+        'coaching authored against the PRE-patch model was adopted onto the post-patch graph: the persist that ' +
+          'followed the patch re-stamped it at the new hash, so the gate compared H2 against H2 and let it through',
+      ).toBe(0)
+    })
+
+    it('CASE 2 — dismissing an item does not re-stamp the rest', () => {
+      const box = movableProvider('H1')
+      useGuidanceStore.getState().setGuidanceItems([
+        item('a', { graph_hash: 'cee-aag-v1' }),
+        item('b', { graph_hash: 'cee-aag-v1' }),
+      ])
+
+      box.hash = 'H2' // the user edited the model
+      useGuidanceStore.getState().dismissItem('a') // ...then dismissed a card
+
+      simulateReload()
+      expect(
+        useGuidanceStore.getState().rehydrateGuidance({
+          scenarioId: SCENARIO,
+          currentAnalysisHash: ANALYSIS_HASH,
+          currentGraphHash: 'H2',
+        }),
+        'a dismissal laundered the remaining item onto the edited graph',
+      ).toBe(0)
+    })
+
+    it('CONTROL — with no intervening graph change, the survivors are still adopted', () => {
+      // The discriminator. Without this, a fix that simply refused to adopt
+      // anything after a non-authoring persist would satisfy both cases above
+      // while destroying the feature.
+      const box = movableProvider('H1')
+      useGuidanceStore.getState().setGuidanceItems([
+        item('a', { graph_hash: 'cee-aag-v1' }),
+        item('b', { graph_hash: 'cee-aag-v1' }),
+      ])
+      useGuidanceStore.getState().dismissItem('a') // same persist path, graph unmoved
+      expect(box.hash).toBe('H1')
+
+      simulateReload()
+      expect(
+        useGuidanceStore.getState().rehydrateGuidance({
+          scenarioId: SCENARIO,
+          currentAnalysisHash: ANALYSIS_HASH,
+          currentGraphHash: 'H1',
+        }),
+        'the fix threw away guidance that was still perfectly valid',
+      ).toBe(1)
+      expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['b'])
+    })
+
+    it('a NEW turn after a graph change mints a fresh stamp and is adopted at the new hash', () => {
+      // The other direction: authorship must still mint. A fix that inherited
+      // the stamp everywhere would make new guidance un-adoptable.
+      const box = movableProvider('H1')
+      useGuidanceStore.getState().setGuidanceItems([item('old', { graph_hash: 'cee-aag-v1' })])
+      box.hash = 'H2'
+      useGuidanceStore.getState().setGuidanceItems([item('fresh', { graph_hash: 'cee-aag-v1' })])
+
+      simulateReload()
+      expect(
+        useGuidanceStore.getState().rehydrateGuidance({
+          scenarioId: SCENARIO,
+          currentAnalysisHash: ANALYSIS_HASH,
+          currentGraphHash: 'H2',
+        }),
+        'guidance authored against the CURRENT graph was refused — authorship must still mint a stamp',
+      ).toBe(1)
+      expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['fresh'])
+    })
+  })
+
   it('writes nothing at all when no decision identity is installed', () => {
     setGuidancePersistenceContext(() => ({ scenarioId: null, graphHash: null }))
     useGuidanceStore.getState().setGuidanceItems([item('g1')])

--- a/src/canvas/stores/__tests__/guidanceStore.rehydration.spec.ts
+++ b/src/canvas/stores/__tests__/guidanceStore.rehydration.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Guidance must survive a reload — and stale guidance must NOT.
+ *
+ * THE DEFECT. `guidanceItems` was written only from a live turn. The graph and
+ * the transcript both rehydrate from localStorage; the user's coaching did not,
+ * so a refresh silently emptied the strip, the on-canvas node coaching markers
+ * and every inspector coaching section, and nothing said so.
+ *
+ * THE HARDER HALF, which is what most of this file tests. Guidance carries
+ * `valid_while`, and advice about a model the user has since changed is worse
+ * than no advice: it is confidently wrong on a surface whose job is to be
+ * trusted. So every adoption gate here fails CLOSED, and each has a case
+ * pointing in BOTH directions — one proving the item is adopted when it should
+ * be, one proving it is dropped when it should be (CLAUDE.md trap 22b: a corpus
+ * that tests one direction is a guard watching one door).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  useGuidanceStore,
+  setGuidancePersistenceContext,
+  type GuidanceItem,
+} from '../guidanceStore'
+
+const SCENARIO = 'scenario-aaa'
+const OTHER_SCENARIO = 'scenario-bbb'
+const GRAPH_HASH = 'ui-graph-hash-1'
+const ANALYSIS_HASH = 'response-hash-1'
+
+function item(id: string, validWhile?: GuidanceItem['valid_while']): GuidanceItem {
+  return {
+    item_id: id,
+    source: 'analysis',
+    title: `Coaching ${id}`,
+    primary_action: { type: 'discuss', prompt: 'tell me more' },
+    priority: 50,
+    ...(validWhile ? { valid_while: validWhile } : {}),
+  }
+}
+
+/** Simulate a reload: the module keeps running, so clear the in-memory state by hand. */
+function simulateReload(): void {
+  useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+}
+
+describe('guidanceStore — rehydration across a reload', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+    setGuidancePersistenceContext(() => ({ scenarioId: SCENARIO, graphHash: GRAPH_HASH }))
+  })
+  afterEach(() => setGuidancePersistenceContext(null))
+
+  it('an unconstrained item written by a live turn comes back after a reload', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1')])
+    simulateReload()
+    expect(useGuidanceStore.getState().guidanceItems, 'precondition: the reload emptied the store').toHaveLength(0)
+
+    const adopted = useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: ANALYSIS_HASH,
+      currentGraphHash: GRAPH_HASH,
+    })
+
+    expect(adopted, 'the user’s coaching vanished on refresh while the graph and transcript came back').toBe(1)
+    expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['g1'])
+  })
+
+  it('an item pinned to an analysis hash comes back when that analysis is still the live one', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1', { analysis_hash: ANALYSIS_HASH })])
+    simulateReload()
+    const adopted = useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: ANALYSIS_HASH,
+      currentGraphHash: GRAPH_HASH,
+    })
+    expect(adopted).toBe(1)
+  })
+
+  it('DOES NOT come back when the live analysis is a different run — the twin of the case above', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1', { analysis_hash: ANALYSIS_HASH })])
+    simulateReload()
+    const adopted = useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: 'a-completely-different-run',
+      currentGraphHash: GRAPH_HASH,
+    })
+    expect(adopted, 'coaching about a superseded analysis was restored onto the current one').toBe(0)
+    expect(useGuidanceStore.getState().guidanceItems).toHaveLength(0)
+  })
+
+  it('DOES NOT come back when the analysis hash cannot be verified at all — unverifiable is stale', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1', { analysis_hash: ANALYSIS_HASH })])
+    simulateReload()
+    expect(
+      useGuidanceStore.getState().rehydrateGuidance({
+        scenarioId: SCENARIO,
+        currentAnalysisHash: null,
+        currentGraphHash: GRAPH_HASH,
+      }),
+      'an item whose freshness could not be checked was kept on the grounds that it is probably fine',
+    ).toBe(0)
+  })
+
+  it('an item pinned to the graph comes back only while the graph is byte-identical', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1', { graph_hash: 'cee-aag-v1-hash' })])
+    simulateReload()
+
+    // Same graph → adopted.
+    expect(
+      useGuidanceStore.getState().rehydrateGuidance({
+        scenarioId: SCENARIO,
+        currentAnalysisHash: ANALYSIS_HASH,
+        currentGraphHash: GRAPH_HASH,
+      }),
+    ).toBe(1)
+  })
+
+  it('DOES NOT come back when the graph has moved — the twin, and note WHICH hash is compared', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1', { graph_hash: 'cee-aag-v1-hash' })])
+    simulateReload()
+
+    // The stored item's `valid_while.graph_hash` is CEE's aag_v1 and is NEVER
+    // compared against a UI hash — that would be the category error
+    // `compare-tab/types.ts` warns about. What moves here is the UI-side hash,
+    // stamped at write time and re-derived at read time: same algorithm, both ends.
+    const adopted = useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: ANALYSIS_HASH,
+      currentGraphHash: 'ui-graph-hash-AFTER-AN-EDIT',
+    })
+    expect(adopted, 'coaching about the pre-edit model was restored onto an edited graph').toBe(0)
+  })
+
+  it('is never adopted by a DIFFERENT decision, and the blob is dropped rather than left to be found later', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1')])
+    simulateReload()
+
+    expect(
+      useGuidanceStore.getState().rehydrateGuidance({
+        scenarioId: OTHER_SCENARIO,
+        currentAnalysisHash: ANALYSIS_HASH,
+        currentGraphHash: GRAPH_HASH,
+      }),
+      'one decision’s coaching was adopted by another',
+    ).toBe(0)
+
+    // And it must not be lurking for a later boot of the original scenario either.
+    expect(sessionStorage.getItem('guidance.items.v1')).toBeNull()
+  })
+
+  it('a structural edit that cleared guidance on screen also clears it on disk', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1')])
+    useGuidanceStore.getState().clearGuidanceItems() // what useGraphEditEvents does
+    simulateReload()
+
+    expect(
+      useGuidanceStore.getState().rehydrateGuidance({
+        scenarioId: SCENARIO,
+        currentAnalysisHash: ANALYSIS_HASH,
+        currentGraphHash: GRAPH_HASH,
+      }),
+      'guidance the user’s own edit cleared came back on the next reload',
+    ).toBe(0)
+  })
+
+  it('a dismissal survives the reload — the dismissed item does not come back', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('g1'), item('g2')])
+    useGuidanceStore.getState().dismissItem('g1')
+    simulateReload()
+
+    useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: ANALYSIS_HASH,
+      currentGraphHash: GRAPH_HASH,
+    })
+    expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['g2'])
+  })
+
+  it('never overwrites guidance a live turn has already produced', () => {
+    useGuidanceStore.getState().setGuidanceItems([item('old')])
+    simulateReload()
+    useGuidanceStore.getState().setGuidanceItems([item('fresh-from-this-turn')])
+
+    const adopted = useGuidanceStore.getState().rehydrateGuidance({
+      scenarioId: SCENARIO,
+      currentAnalysisHash: ANALYSIS_HASH,
+      currentGraphHash: GRAPH_HASH,
+    })
+    expect(adopted, 'a late rehydration clobbered the guidance the current turn had just delivered').toBe(0)
+    expect(useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)).toEqual(['fresh-from-this-turn'])
+  })
+
+  it('writes nothing at all when no decision identity is installed', () => {
+    setGuidancePersistenceContext(() => ({ scenarioId: null, graphHash: null }))
+    useGuidanceStore.getState().setGuidanceItems([item('g1')])
+    expect(
+      sessionStorage.getItem('guidance.items.v1'),
+      'guidance was persisted under no decision identity — a blob no boot can safely adopt',
+    ).toBeNull()
+  })
+})

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -251,6 +251,21 @@ export interface GuidanceActions {
   clearItemsByTargetIds: (ids: string[]) => void
   /** Remove a single guidance item by item_id (e.g. after user acts on a chip). */
   dismissItem: (itemId: string) => void
+  /**
+   * Adopt whatever this browser persisted for `scenarioId`, subject to the SAME
+   * `valid_while` rules a live run obeys. See §4 below for why this is an
+   * explicit call and not a module-evaluation spread.
+   *
+   * Returns the number of items adopted (0 when there is nothing to adopt, the
+   * blob is for another decision, or every item failed its freshness gate) —
+   * a number, so a caller and a test can bind to the outcome rather than infer
+   * it from the store.
+   */
+  rehydrateGuidance: (opts: {
+    scenarioId: string | null | undefined
+    currentAnalysisHash: string | null | undefined
+    currentGraphHash: string | null | undefined
+  }) => number
 }
 
 const initialGuidanceState: GuidanceState = {
@@ -266,6 +281,144 @@ const initialGuidanceState: GuidanceState = {
   _registrationToken: null,
 }
 
+// ---------------------------------------------------------------------------
+// § 2b — Persistence across a reload
+//
+// THE DEFECT THIS CLOSES. `guidanceItems` was written only from a live turn, so
+// a refresh silently emptied the strip, the on-canvas node coaching markers and
+// every inspector coaching section. The graph and the transcript both rehydrate
+// from localStorage; the user's coaching did not, and nothing said so.
+//
+// ⚠ THE HARD PART IS NOT PERSISTING — IT IS NOT RESURRECTING STALE COACHING.
+// Guidance items carry `valid_while: { analysis_hash?, graph_hash? }`, and
+// advice about a model the user has since changed is worse than no advice: it
+// is confidently wrong, on a surface whose whole job is to be trusted. So the
+// rules a live run obeys (`evictStaleItems`) are applied again at ADOPTION time,
+// and they fail CLOSED — an item whose freshness cannot be VERIFIED is dropped,
+// never kept on the grounds that it is probably fine.
+//
+// Two comparators, and they are not the same kind of thing:
+//   * `analysis_hash` — compared against `useCanvasStore().results.hash`, the
+//     CEE `response_hash`. This one SURVIVES a reload, restored from the
+//     autosave by `restoreAnalysisFromAutosave`, so it is a real comparator.
+//   * `graph_hash` — the wire value is CEE's ANALYSIS-AFFECTING hash (`aag_v1`).
+//     The UI's own `generateGraphHash` is a DIFFERENT algorithm over different
+//     inputs (`compare-tab/types.ts` says so explicitly), and no CEE-family
+//     graph hash survives a reload at all — `analysisFreshness` is not in the
+//     autosave projection. Comparing the two would be the category error that
+//     file warns about. So this module NEVER compares a stored `valid_while
+//     .graph_hash` against a UI hash. It stamps its OWN UI-side graph hash at
+//     WRITE time and compares that against the UI-side hash at READ time: same
+//     algorithm both ends, which is the only comparison that means anything.
+//     An item constrained by `graph_hash` is adopted only when the graph is
+//     byte-identical to the one it was authored against.
+//
+// Storage: sessionStorage, versioned payload, dotted key — the estate's existing
+// feature-store pattern (`strengthenStore`), whose header states the reasoning
+// this shares: "survives reloads, dies with the session — matching the
+// unpersisted scenario identity's scope". Coaching for a decision is exactly
+// that scope. localStorage would outlive the decision it describes.
+// ---------------------------------------------------------------------------
+
+const GUIDANCE_STORAGE_KEY = 'guidance.items.v1'
+
+interface PersistedGuidance {
+  version: 1
+  /** The decision these items were authored for. A blob for another scenario is never adopted. */
+  scenarioId: string
+  /** UI-side graph hash AT WRITE TIME — compared only against another UI-side hash. */
+  graphHashAtWrite: string | null
+  items: GuidanceItem[]
+}
+
+function readPersistedGuidance(): PersistedGuidance | null {
+  try {
+    const raw = sessionStorage.getItem(GUIDANCE_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PersistedGuidance> | null
+    if (!parsed || parsed.version !== 1) return null
+    if (typeof parsed.scenarioId !== 'string' || parsed.scenarioId.length === 0) return null
+    if (!Array.isArray(parsed.items)) return null
+    return {
+      version: 1,
+      scenarioId: parsed.scenarioId,
+      graphHashAtWrite: typeof parsed.graphHashAtWrite === 'string' ? parsed.graphHashAtWrite : null,
+      items: parsed.items as GuidanceItem[],
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write the current items for `scenarioId`. Called from the same places that
+ * mutate `guidanceItems`, via `persistCurrent` below — never on a timer, so the
+ * stored blob can never describe a state the store was not in.
+ */
+function writePersistedGuidance(payload: PersistedGuidance): void {
+  try {
+    sessionStorage.setItem(GUIDANCE_STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // sessionStorage unavailable or full — guidance degrades to in-memory only,
+    // which is exactly the behaviour before this existed. Never throw into a turn.
+  }
+}
+
+function clearPersistedGuidance(): void {
+  try {
+    sessionStorage.removeItem(GUIDANCE_STORAGE_KEY)
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The store cannot import the canvas store (cycle), so the two values only IT
+ * knows — the current scenario id and the UI-side graph hash — are supplied by a
+ * provider the boot path installs. With NO provider installed nothing is ever
+ * written: an unidentified blob could be adopted by the wrong decision, and a
+ * silent write with a wrong key is worse than no persistence at all.
+ */
+export interface GuidancePersistenceContext {
+  scenarioId: string | null
+  graphHash: string | null
+}
+let guidanceContextProvider: (() => GuidancePersistenceContext) | null = null
+
+/** Install the context provider (called once, from the canvas boot path). */
+export function setGuidancePersistenceContext(provider: (() => GuidancePersistenceContext) | null): void {
+  guidanceContextProvider = provider
+}
+
+function persistCurrent(items: GuidanceItem[]): void {
+  if (!guidanceContextProvider) return
+  let ctx: GuidancePersistenceContext
+  try {
+    ctx = guidanceContextProvider()
+  } catch {
+    return
+  }
+  if (!ctx.scenarioId) {
+    // No decision identity ⇒ nothing that could be adopted safely later.
+    clearPersistedGuidance()
+    return
+  }
+  if (items.length === 0) {
+    // An empty store is a REAL state (a structural edit cleared guidance), and
+    // it must survive a reload as emptiness. Writing nothing would leave the
+    // previous blob on disk for the next boot to adopt — the resurrection this
+    // whole section exists to prevent.
+    clearPersistedGuidance()
+    return
+  }
+  writePersistedGuidance({
+    version: 1,
+    scenarioId: ctx.scenarioId,
+    graphHashAtWrite: ctx.graphHash,
+    items,
+  })
+}
+
 export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, get) => ({
   ...initialGuidanceState,
 
@@ -279,10 +432,63 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
+    persistCurrent(items)
+  },
+
+  rehydrateGuidance: ({ scenarioId, currentAnalysisHash, currentGraphHash }) => {
+    // Fail closed at every gate below: the cost of adopting stale coaching is a
+    // confident lie about the user's model; the cost of adopting nothing is the
+    // behaviour that shipped before this existed.
+    if (!scenarioId) return 0
+    if (get().guidanceItems.length > 0) return 0 // a live turn already won; never overwrite it
+    const stored = readPersistedGuidance()
+    if (!stored) return 0
+    if (stored.scenarioId !== scenarioId) {
+      // A blob for a DIFFERENT decision. Drop it rather than leave it to be
+      // adopted if the user navigates back — coaching must not outlive the
+      // decision boundary.
+      clearPersistedGuidance()
+      return 0
+    }
+
+    const fresh = stored.items.filter((item) => {
+      const vw = item.valid_while
+      if (!vw) return true // unconstrained by the producer → always valid
+
+      if (vw.analysis_hash !== undefined) {
+        // Same rule as `evictStaleItems`: unverifiable is stale.
+        if (currentAnalysisHash == null) return false
+        if (currentAnalysisHash !== vw.analysis_hash) return false
+      }
+
+      if (vw.graph_hash !== undefined) {
+        // NOT compared against `vw.graph_hash` — that is CEE's aag_v1 and this
+        // is the UI's own algorithm. Compared like-for-like against the UI hash
+        // stamped when these items were written.
+        if (currentGraphHash == null || stored.graphHashAtWrite == null) return false
+        if (currentGraphHash !== stored.graphHashAtWrite) return false
+      }
+
+      return true
+    })
+
+    if (fresh.length === 0) {
+      clearPersistedGuidance()
+      return 0
+    }
+    set({ guidanceItems: fresh, activeGuidanceItemId: null })
+    // Re-persist the SURVIVORS, so a second reload cannot resurrect an item this
+    // one just evicted (the stored blob must always match the store).
+    persistCurrent(fresh)
+    return fresh.length
   },
 
   clearGuidanceItems: () => {
     set({ guidanceItems: [], activeGuidanceItemId: null })
+    // Structural edits reach here. Clearing on screen but leaving the blob on
+    // disk would let the next reload re-adopt advice about the PRE-edit model —
+    // the single most damaging thing this store could do.
+    persistCurrent([])
   },
 
   setActiveGuidanceItem: (itemId) => {
@@ -355,6 +561,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
+    persistCurrent(surviving)
   },
 
   dismissItem: (itemId) => {
@@ -365,6 +572,8 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
       guidanceItems: surviving,
       activeGuidanceItemId: activeGuidanceItemId === itemId ? null : activeGuidanceItemId,
     })
+    // A dismissal the user made must not come back on refresh.
+    persistCurrent(surviving)
   },
 
   clearItemsByTargetIds: (ids) => {
@@ -399,6 +608,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
+    persistCurrent(surviving)
   },
 }))
 

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -390,7 +390,37 @@ export function setGuidancePersistenceContext(provider: (() => GuidancePersisten
   guidanceContextProvider = provider
 }
 
-function persistCurrent(items: GuidanceItem[]): void {
+/**
+ * ⚠ `minting` IS THE WHOLE CORRECTNESS OF THE GRAPH GATE, and the first version
+ * of this function did not have it.
+ *
+ * `graphHashAtWrite` has to mean **"the hash of the graph these items were
+ * AUTHORED against"**. The original stamped `ctx.graphHash` on *every* persist,
+ * which quietly redefined it as *"the hash at the last persist"* — and any
+ * persist that happened after a graph change then LAUNDERED the survivors to the
+ * new hash, so the adoption gate compared H2 against H2 and let stale coaching
+ * through.
+ *
+ * That is not a corner case; it is the product's primary path. Accepting an
+ * assistant patch calls `clearItemsByTargetIds` under
+ * `beginExternalGraphMutation('patch_apply')`, which SUPPRESSES the
+ * `clearGuidanceItems()` that a normal edit would fire. So the graph moves
+ * H1 → H2, the untargeted items legitimately survive — and re-stamping them at
+ * H2 made them look freshly authored. `dismissItem` did the same.
+ *
+ * Only `setGuidanceItems` — a turn delivering guidance — is authorship. Every
+ * other path INHERITS the stamp from the blob already on disk, and where it
+ * cannot (no blob, or a blob for another decision) it writes `null`, which the
+ * adoption gate treats as unverifiable and therefore stale. Fail closed.
+ *
+ * Found by review, not by this lane's own corpus, and the reason is worth
+ * recording: every fixture here installed a provider returning a CONSTANT graph
+ * hash, so the write-side hash could never move between authorship and a later
+ * persist. The corpus shared the code's blind spot — it tested the READ hash
+ * moving and never the WRITE hash (CLAUDE.md traps 22b/13d). The spec now varies
+ * the provider's hash, which is the only shape that can see this.
+ */
+function persistCurrent(items: GuidanceItem[], opts: { minting: boolean }): void {
   if (!guidanceContextProvider) return
   let ctx: GuidancePersistenceContext
   try {
@@ -411,10 +441,20 @@ function persistCurrent(items: GuidanceItem[]): void {
     clearPersistedGuidance()
     return
   }
+
+  let graphHashAtWrite: string | null
+  if (opts.minting) {
+    graphHashAtWrite = ctx.graphHash
+  } else {
+    const existing = readPersistedGuidance()
+    graphHashAtWrite =
+      existing && existing.scenarioId === ctx.scenarioId ? existing.graphHashAtWrite : null
+  }
+
   writePersistedGuidance({
     version: 1,
     scenarioId: ctx.scenarioId,
-    graphHashAtWrite: ctx.graphHash,
+    graphHashAtWrite,
     items,
   })
 }
@@ -432,7 +472,9 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
-    persistCurrent(items)
+    // AUTHORSHIP — a turn delivered these items against the graph as it is
+    // now, so this is the one call site that mints a new `graphHashAtWrite`.
+    persistCurrent(items, { minting: true })
   },
 
   rehydrateGuidance: ({ scenarioId, currentAnalysisHash, currentGraphHash }) => {
@@ -479,7 +521,10 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
     set({ guidanceItems: fresh, activeGuidanceItemId: null })
     // Re-persist the SURVIVORS, so a second reload cannot resurrect an item this
     // one just evicted (the stored blob must always match the store).
-    persistCurrent(fresh)
+    // NOT authorship: these items were authored by an earlier turn and have
+    // just been re-validated. Minting here would stamp them with the CURRENT
+    // graph and defeat the gate they were only now allowed through.
+    persistCurrent(fresh, { minting: false })
     return fresh.length
   },
 
@@ -488,7 +533,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
     // Structural edits reach here. Clearing on screen but leaving the blob on
     // disk would let the next reload re-adopt advice about the PRE-edit model —
     // the single most damaging thing this store could do.
-    persistCurrent([])
+    persistCurrent([], { minting: false })
   },
 
   setActiveGuidanceItem: (itemId) => {
@@ -561,7 +606,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
-    persistCurrent(surviving)
+    persistCurrent(surviving, { minting: false })
   },
 
   dismissItem: (itemId) => {
@@ -573,7 +618,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
       activeGuidanceItemId: activeGuidanceItemId === itemId ? null : activeGuidanceItemId,
     })
     // A dismissal the user made must not come back on refresh.
-    persistCurrent(surviving)
+    persistCurrent(surviving, { minting: false })
   },
 
   clearItemsByTargetIds: (ids) => {
@@ -608,7 +653,7 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         ? activeGuidanceItemId
         : null,
     })
-    persistCurrent(surviving)
+    persistCurrent(surviving, { minting: false })
   },
 }))
 

--- a/src/components/layout/KebabMenu.tsx
+++ b/src/components/layout/KebabMenu.tsx
@@ -295,11 +295,19 @@ export function KebabMenu({
         )}
       </div>
 
-      {/* Reset canvas confirmation dialog */}
+      {/* Reset canvas confirmation dialog.
+
+          ⚠ THE MESSAGE LISTED ONLY THE GRAPH. This is the UNGATED reset —
+          CanvasToolbar disables its button on an empty canvas, this menu item
+          does not — so it is the one most likely to be reached with a real
+          conversation in play, and it was the one that named the fewest
+          consequences. The other two sheets already list the conversation; this
+          now matches them, and all three now say what undo can and cannot
+          restore (it cannot restore a localStorage delete). */}
       {showResetConfirm && (
         <ConfirmDialog
           title="Reset canvas?"
-          message="This will remove all nodes and edges. This cannot be undone."
+          message="This will remove all nodes and connections, any analysis results, and the AI assistant conversation. Undo (Ctrl+Z / Cmd+Z) can bring the graph back. The conversation cannot be recovered."
           confirmLabel="Reset"
           cancelLabel="Cancel"
           onConfirm={handleConfirmReset}

--- a/src/components/results/v7/V7WhatIWasGivenSection.tsx
+++ b/src/components/results/v7/V7WhatIWasGivenSection.tsx
@@ -112,15 +112,38 @@ const COPY = {
    *     question — a structural error where there had been a useful sentence.
    *   connected to the options but not the goal  → `NO_PATH_TO_GOAL`.
    *   an instruction NAMING a causal target that keeps the graph valid
-   *                                       → **HELD**, then confirm → applied.
-   *   control, the estate's proven edit grammar ("Change X to Y.") → applied.
-   *     (The control is why the four refusals are evidence about the phrasings
-   *      and not about a sick service.)
+   *                                       → still refused, `PIPELINE_OWNED_FIELD`
+   *     ("the candidate targets an analysis-derived, pipeline-owned field") — the
+   *     factors that feed the goal in a drafted graph are themselves
+   *     analysis-derived, so naming one does not rescue the add.
+   *   control, the estate's proven edit grammar ("Change X to Y.", target derived
+   *     from THIS run's graph by identity) → applied. The control is why the
+   *     refusals are evidence about the phrasings and not about a sick service.
    *
-   * So an accepted instruction EXISTS — and its acceptance condition is
-   * knowledge THIS PANEL DOES NOT HAVE: what the figure should causally
-   * influence. A receipt that picked a target would be the product inventing
+   * ⚠ AN EARLIER VERSION OF THIS COMMENT SAID THE OPPOSITE — "**HELD**, then
+   * confirm → applied" — AND IT WAS FALSE. Two arms were scored HELD by a probe
+   * whose classifier read `d.verdict === 'held' || !!d.blocker_code`, so the
+   * disjunct overrode an explicit `verdict: "rejected"` that happened to carry a
+   * blocker code. Both were REJECTED, neither carried a `held_proposal` block, and
+   * no arm in any round ever sent a confirmation turn — the "confirm → applied"
+   * half was never executed at all. Caught in review. It is trap 13c exactly: a
+   * 13-mutant kit measures whether the TESTS can detect a change, never whether
+   * the ORACLE is right, so a full kill-rate certified nothing about this.
+   *
+   * ⚠ SO THE LADDER IS UNMEASURED, and this comment will not reassure the reader
+   * that it exists. Across 15 arms over 5 rounds — the last with the corrected
+   * classifier, a target derived by identity from the run's own graph, and a
+   * positive control that APPLIED — no add instruction has ever been observed to
+   * be accepted. Whether a user's own answer can land one is not established.
+   *
+   * What IS established is what the design rests on: every add phrasing the
+   * receipt could compose is refused, and every ask phrasing is answered with
+   * concrete, model-grounded options. The acceptance condition for an add is
+   * knowledge THIS PANEL DOES NOT HAVE — what the figure should causally
+   * influence — and a receipt that picked a target would be the product inventing
    * causality on the user's behalf, which is worse than the CTA doing nothing.
+   * The engine itself ends in the same place: "connect 'Annual revenue' to a
+   * factor that already feeds your goal. Which factor should it relate to?"
    *
    * The button therefore does the thing that measurably works and is true: it
    * asks. The user's answer names the target, and THAT turn is the one the
@@ -223,13 +246,19 @@ export function recoverBriefSentence(briefText: string | null, charOffset: numbe
  *     Adding the brief sentence made this WORSE, not better: it gave the model
  *     enough confidence to author a node, which the validator then rejected,
  *     turning a useful sentence into a structural error.
- *   * an instruction that DID name a valid causal target was accepted (HELD →
- *     confirm → applied).
+ *   * an instruction that DID name a causal target was ALSO refused
+ *     (`PIPELINE_OWNED_FIELD`): the goal-feeding factors in a drafted graph are
+ *     analysis-derived, so naming one does not rescue the add.
  *
- * So the accepted instruction exists and its precondition is knowledge this
- * panel does not have. Asking is not the weaker option here; it is the only one
- * that is true. The user's answer names the target, and that turn is the one the
- * engine accepts.
+ * ⚠ THIS PARAGRAPH ONCE CLAIMED SUCH AN INSTRUCTION WAS ACCEPTED ("HELD →
+ * confirm → applied"). That was a classifier defect, not a measurement — an
+ * explicit `verdict: "rejected"` overridden by a `|| !!d.blocker_code` disjunct —
+ * and no confirmation turn was ever sent. Across 15 arms over 5 rounds, with a
+ * positive control that applied, no add has been observed to be accepted.
+ *
+ * Asking is not the weaker option here; it is the only one that is true. What the
+ * user's answer can then achieve is for the engine and the user to work out
+ * between them — this panel does not claim it.
  *
  * The sentence is included because it makes the ANSWER better, not because it
  * makes an add possible: with it, the engine's reply named the specific existing
@@ -237,7 +266,12 @@ export function recoverBriefSentence(briefText: string | null, charOffset: numbe
  */
 export function composeNotModelledQuestion(item: NotModelledItem, briefText: string | null): string {
   const sentence = recoverBriefSentence(briefText, item.charOffset)
-  const opening = `My brief mentions ${item.literal}, which isn't in the model.`
+  // ⚠ BYTE-IDENTICAL TO PROBE ARM J, deliberately. This read "which isn't in the
+  // model" until review pointed out that no arm attested the shipped string — the
+  // probed and shipped openings diverged at index 32. The claim "derived at the
+  // live router" has to be about the bytes the product actually sends, not about
+  // a neighbouring string, so the product now sends the string that was measured.
+  const opening = `My brief mentions ${item.literal}, which is not in the model yet.`
   const context = sentence ? ` The brief says: "${sentence}"` : ''
   return `${opening}${context} What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.`
 }

--- a/src/components/results/v7/V7WhatIWasGivenSection.tsx
+++ b/src/components/results/v7/V7WhatIWasGivenSection.tsx
@@ -91,13 +91,42 @@ const COPY = {
   estimatedLead:
     "The numbers behind these are mine, not yours. If you have better ones, tell me and I'll use them.",
   notYetHeading: 'Not modelled yet',
-  notYetLead: 'These are in your brief but not in the model. Add any that matter.',
+  notYetLead: 'These are in your brief but not in the model. Ask about any that matter.',
   consideredLead: 'I also considered these and left them out:',
   caveatLead: 'This covers figures you mentioned. It does not yet track:',
   unknown:
     "I can't show this yet for this decision — so please don't read the absence as everything having made it in.",
   noBrief: "I don't have your original wording saved for this decision.",
-  addAction: 'Add this',
+  /**
+   * ⚠ THIS LABEL SAID "Add this", AND THE PRODUCT COULD NOT DO IT. Derived
+   * against the LIVE deployed router (staging `cee-staging.onrender.com`,
+   * 2026-08-11, 12 arms over 12 fresh scenarios, one arm per scenario so only
+   * the phrasing varied; evidence in the PR body):
+   *
+   *   the shipped message, a bare figure  → no mutation; the engine replies
+   *     "it is not clear what it should causally connect to… Could you clarify
+   *      what this figure should influence?"
+   *   figure + its brief sentence, or a named factor, with NO causal target
+   *                                       → the LLM DOES emit operations and the
+   *     GRAPH VALIDATOR refuses them: `ORPHAN_NODE`. A worse outcome than the
+   *     question — a structural error where there had been a useful sentence.
+   *   connected to the options but not the goal  → `NO_PATH_TO_GOAL`.
+   *   an instruction NAMING a causal target that keeps the graph valid
+   *                                       → **HELD**, then confirm → applied.
+   *   control, the estate's proven edit grammar ("Change X to Y.") → applied.
+   *     (The control is why the four refusals are evidence about the phrasings
+   *      and not about a sick service.)
+   *
+   * So an accepted instruction EXISTS — and its acceptance condition is
+   * knowledge THIS PANEL DOES NOT HAVE: what the figure should causally
+   * influence. A receipt that picked a target would be the product inventing
+   * causality on the user's behalf, which is worse than the CTA doing nothing.
+   *
+   * The button therefore does the thing that measurably works and is true: it
+   * asks. The user's answer names the target, and THAT turn is the one the
+   * engine accepts. Two honest steps beat one false promise.
+   */
+  addAction: 'Where does this fit?',
 } as const
 
 /**
@@ -133,6 +162,84 @@ function notTrackedCopy(codes: readonly string[]): string {
   }
   if (unknown > 0) known.push('and some other things I set aside')
   return known.join('; ')
+}
+
+/**
+ * Recover the brief sentence a figure sat in, using the offset CEE already sends.
+ *
+ * `NotModelledItem.charOffset` is an offset into `brief_text`, and both are in
+ * scope on this component's render — the brief is right there in the blockquote.
+ * Until now the offset was used ONLY for identity (the React key and a data-*
+ * attribute), and the CTA threw the sentence away.
+ *
+ * Boundaries are `.`, `!`, `?` and newlines. Deliberately NOT a general sentence
+ * splitter: this text is a business brief full of decimals and currency, and
+ * `£1.5 million` is exactly the string a naive `[.!?]` split cuts in half — the
+ * defect CLAUDE.md trap 22 records as a guard "correct and pointed at the wrong
+ * bytes". So a `.` counts as a boundary only when it is NOT between two digits.
+ *
+ * Returns null when the offset does not land inside the brief (a stale manifest,
+ * a brief that was re-saved). The caller then asks its question without the
+ * quote rather than quoting something that is not there.
+ */
+export function recoverBriefSentence(briefText: string | null, charOffset: number): string | null {
+  if (typeof briefText !== 'string' || briefText.length === 0) return null
+  if (!Number.isInteger(charOffset) || charOffset < 0 || charOffset >= briefText.length) return null
+
+  const isBoundary = (i: number): boolean => {
+    const ch = briefText[i]
+    if (ch === '\n' || ch === '!' || ch === '?') return true
+    if (ch !== '.') return false
+    // A decimal point is not the end of a sentence.
+    const prev = briefText[i - 1]
+    const next = briefText[i + 1]
+    if (prev >= '0' && prev <= '9' && next >= '0' && next <= '9') return false
+    return true
+  }
+
+  let start = 0
+  for (let i = charOffset - 1; i >= 0; i--) {
+    if (isBoundary(i)) { start = i + 1; break }
+  }
+  let end = briefText.length
+  for (let i = charOffset; i < briefText.length; i++) {
+    if (isBoundary(i)) { end = i + 1; break }
+  }
+  const sentence = briefText.slice(start, end).trim()
+  return sentence.length > 0 ? sentence : null
+}
+
+/**
+ * Compose the turn the CTA fires.
+ *
+ * ⚠ THIS ASKS. IT DOES NOT INSTRUCT, AND THAT IS A MEASURED DECISION, not a
+ * timidity. Against the LIVE deployed router (12 arms, 12 fresh scenarios, one
+ * arm per scenario so only the phrasing varied — full table in `COPY.addAction`
+ * above and in the PR body):
+ *
+ *   * every explicit "add this figure" phrasing that did NOT name a causal
+ *     target was REFUSED by the graph validator — `ORPHAN_NODE`, or
+ *     `NO_PATH_TO_GOAL` when it was connected to the options but not the goal.
+ *     Adding the brief sentence made this WORSE, not better: it gave the model
+ *     enough confidence to author a node, which the validator then rejected,
+ *     turning a useful sentence into a structural error.
+ *   * an instruction that DID name a valid causal target was accepted (HELD →
+ *     confirm → applied).
+ *
+ * So the accepted instruction exists and its precondition is knowledge this
+ * panel does not have. Asking is not the weaker option here; it is the only one
+ * that is true. The user's answer names the target, and that turn is the one the
+ * engine accepts.
+ *
+ * The sentence is included because it makes the ANSWER better, not because it
+ * makes an add possible: with it, the engine's reply named the specific existing
+ * factor the figure would attach to; without it, the reply was generic.
+ */
+export function composeNotModelledQuestion(item: NotModelledItem, briefText: string | null): string {
+  const sentence = recoverBriefSentence(briefText, item.charOffset)
+  const opening = `My brief mentions ${item.literal}, which isn't in the model.`
+  const context = sentence ? ` The brief says: "${sentence}"` : ''
+  return `${opening}${context} What could this figure influence in this decision, and where would it belong? Don't change the model yet — tell me the options first.`
 }
 
 /**
@@ -295,7 +402,7 @@ export function V7WhatIWasGivenSection({ onSendMessage }: V7WhatIWasGivenSection
       : `${notYetCount} of ${tally.total} figures you mentioned aren't in the model yet`
 
   const addMessage = (item: NotModelledItem) =>
-    onSendMessage?.(`Please add "${item.literal}" from my brief to the model.`)
+    onSendMessage?.(composeNotModelledQuestion(item, briefText))
 
   return (
     <section

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.addThisCta.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.addThisCta.spec.tsx
@@ -17,10 +17,22 @@
  *   figure + brief sentence                  REFUSED  ORPHAN_NODE
  *   named factor + value                     REFUSED  ORPHAN_NODE
  *   named factor + "connect to the options"  REFUSED  NO_PATH_TO_GOAL
- *   named factor + a valid causal target     **HELD** → confirm → applied
+ *   named factor + a valid causal target     REFUSED  PIPELINE_OWNED_FIELD
  *   control: "Change X to Y." (proven grammar) APPLIED — so the refusals are
  *                                              evidence about the phrasings and
  *                                              not about a sick service
+ *
+ * ⚠ THE TABLE ABOVE ONCE READ "**HELD** → confirm → applied" ON ROW 5 AND THAT WAS
+ * FALSE. The probe's classifier used `d.verdict === 'held' || !!d.blocker_code`,
+ * so the disjunct overrode an explicit `verdict: "rejected"`; both arms were
+ * rejected, neither carried a `held_proposal`, and no round ever sent a
+ * confirmation turn. Caught in review — and note what it defeats: 13 mutants all
+ * bit, because a mutant kit measures whether the TEST can detect a change and
+ * never whether the ORACLE is right (trap 13c). Across 15 arms over 5 rounds, the
+ * last with a corrected classifier and a positive control that applied, NO add
+ * has been observed to be accepted. The ask decision below rests on the refusals
+ * and the answers, which is sufficient; the "it lands one turn later" ladder is
+ * UNMEASURED and is claimed nowhere.
  *   the ASK phrasings (3 variants)           answered with concrete, model-grounded
  *                                              options; no orphan, no error
  *
@@ -82,7 +94,7 @@ describe('recoverBriefSentence — the offset CEE already sends, finally used', 
 describe('composeNotModelledQuestion — the turn the CTA fires', () => {
   it('asks where the figure belongs and carries the brief sentence, VERBATIM', () => {
     expect(composeNotModelledQuestion(itemAt('£31m'), BRIEF)).toBe(
-      'My brief mentions £31m, which isn\'t in the model. ' +
+      'My brief mentions £31m, which is not in the model yet. ' +
         'The brief says: "We are a 34-person B2B sales team with annual revenue of £31m." ' +
         "What could this figure influence in this decision, and where would it belong? " +
         "Don't change the model yet — tell me the options first.",
@@ -104,7 +116,7 @@ describe('composeNotModelledQuestion — the turn the CTA fires', () => {
   it('still asks a usable question when the brief is unavailable — never quotes nothing', () => {
     const msg = composeNotModelledQuestion(itemAt('£31m'), null)
     expect(msg).not.toContain('The brief says')
-    expect(msg).toContain('My brief mentions £31m, which isn\'t in the model.')
+    expect(msg).toContain('My brief mentions £31m, which is not in the model yet.')
     expect(msg).toContain('What could this figure influence in this decision')
   })
 

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.addThisCta.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.addThisCta.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * The "Not modelled yet" CTA — it must not promise a change it cannot make.
+ *
+ * ── WHY THIS FILE EXISTS, AND WHAT SETTLED IT ──────────────────────────────
+ * The button said "Add this" and the message it composed was
+ * `Please add "£31m" from my brief to the model.` It fired a real turn and the
+ * model never changed. Round 1 root-caused that far and stopped, because the
+ * brief required the accepted phrasing be derived from the LIVE router and it
+ * could not do that.
+ *
+ * It was derived. 12 arms, 12 fresh scenarios, byte-identical brief, one arm per
+ * scenario so only the phrasing varied; outcomes classified from the producer's
+ * own typed channel (`details.rejection_code` / `violation_codes` vs
+ * `held_proposal` / `details.verdict`), never from the prose:
+ *
+ *   bare figure, the shipped phrasing        no mutation; a specific question back
+ *   figure + brief sentence                  REFUSED  ORPHAN_NODE
+ *   named factor + value                     REFUSED  ORPHAN_NODE
+ *   named factor + "connect to the options"  REFUSED  NO_PATH_TO_GOAL
+ *   named factor + a valid causal target     **HELD** → confirm → applied
+ *   control: "Change X to Y." (proven grammar) APPLIED — so the refusals are
+ *                                              evidence about the phrasings and
+ *                                              not about a sick service
+ *   the ASK phrasings (3 variants)           answered with concrete, model-grounded
+ *                                              options; no orphan, no error
+ *
+ * The acceptance condition is therefore a fact about the USER'S intent — what
+ * the figure should causally influence — which a receipt cannot know. A CTA that
+ * picked one would be the product inventing causality on the user's behalf.
+ *
+ * ⭐ THE MEASUREMENT THAT DECIDED THE SHAPE, and it is counter-intuitive: adding
+ * the brief sentence to an ADD instruction made the outcome WORSE (a structural
+ * error instead of a useful question), while adding it to an ASK made the answer
+ * BETTER (the reply named the specific existing factor the figure would attach
+ * to). Same context, opposite effect, depending on the verb. That is why the
+ * sentence ships and the imperative does not.
+ */
+import { describe, it, expect } from 'vitest'
+import { composeNotModelledQuestion, recoverBriefSentence } from '../V7WhatIWasGivenSection'
+import type { NotModelledItem } from '../../../../adapters/cee/notModelled'
+
+const BRIEF =
+  'Should we replace our current CRM with HubSpot next quarter, or keep what we have? ' +
+  'We are a 34-person B2B sales team with annual revenue of £31m. ' +
+  'Annual CRM cost is about £50,000 and switching would cost roughly £20,000 one-off.'
+
+function itemAt(literal: string): NotModelledItem {
+  const charOffset = BRIEF.indexOf(literal)
+  if (charOffset < 0) throw new Error(`fixture error: "${literal}" is not in the brief`)
+  return { literal, kind: 'money', charOffset, verdict: 'absent', matchedNodeId: null }
+}
+
+describe('recoverBriefSentence — the offset CEE already sends, finally used', () => {
+  it('recovers the sentence the figure sits in', () => {
+    expect(recoverBriefSentence(BRIEF, BRIEF.indexOf('£31m'))).toBe(
+      'We are a 34-person B2B sales team with annual revenue of £31m.',
+    )
+  })
+
+  it('does not cut a sentence at a DECIMAL POINT', () => {
+    // The exact defect CLAUDE.md trap 22 records: a guard that was correct and
+    // pointed at the wrong bytes, because `[.!?]` also matches the decimal in
+    // "£1.5 million". A naive splitter returns "1" here.
+    const brief = 'Our budget ceiling is £1.5 million for the whole programme. That is firm.'
+    expect(recoverBriefSentence(brief, brief.indexOf('£1.5 million'))).toBe(
+      'Our budget ceiling is £1.5 million for the whole programme.',
+    )
+  })
+
+  it('recovers the FIRST sentence when the figure is in it (no preceding boundary)', () => {
+    const brief = 'We have £2m in reserve. Everything else is committed.'
+    expect(recoverBriefSentence(brief, brief.indexOf('£2m'))).toBe('We have £2m in reserve.')
+  })
+
+  it('returns null rather than quoting the wrong text when the offset is out of range', () => {
+    expect(recoverBriefSentence(BRIEF, 99_999)).toBeNull()
+    expect(recoverBriefSentence(null, 3)).toBeNull()
+    expect(recoverBriefSentence(BRIEF, -1)).toBeNull()
+  })
+})
+
+describe('composeNotModelledQuestion — the turn the CTA fires', () => {
+  it('asks where the figure belongs and carries the brief sentence, VERBATIM', () => {
+    expect(composeNotModelledQuestion(itemAt('£31m'), BRIEF)).toBe(
+      'My brief mentions £31m, which isn\'t in the model. ' +
+        'The brief says: "We are a 34-person B2B sales team with annual revenue of £31m." ' +
+        "What could this figure influence in this decision, and where would it belong? " +
+        "Don't change the model yet — tell me the options first.",
+    )
+  })
+
+  it('does NOT instruct an add — the construction the live router refuses with ORPHAN_NODE', () => {
+    const msg = composeNotModelledQuestion(itemAt('£31m'), BRIEF)
+    // Bound to the imperative construction the probe measured, not to a vague
+    // "contains the word add": the message may legitimately contain "add" in
+    // other grammar, and a substring ban would be a guard watching the wrong door.
+    expect(
+      /(^|[.!?]\s+)(please\s+)?add\b/i.test(msg),
+      'the CTA composed an add instruction; measured against the live router, every add phrasing that does not ' +
+        'name a causal target is refused ORPHAN_NODE and the user is shown a structural error',
+    ).toBe(false)
+  })
+
+  it('still asks a usable question when the brief is unavailable — never quotes nothing', () => {
+    const msg = composeNotModelledQuestion(itemAt('£31m'), null)
+    expect(msg).not.toContain('The brief says')
+    expect(msg).toContain('My brief mentions £31m, which isn\'t in the model.')
+    expect(msg).toContain('What could this figure influence in this decision')
+  })
+
+  it('binds the quote to THIS figure by offset, not by value — the same literal twice is two facts', () => {
+    // Trap 19 in its exact form: two occurrences of one figure in different
+    // sentences. A value-predicate lookup (`indexOf(literal)`) would give both
+    // rows the FIRST sentence; the offset gives each its own.
+    const brief = 'We spend £50,000 a year on the current CRM. Migration would also cost £50,000 up front.'
+    const first: NotModelledItem = { literal: '£50,000', kind: 'money', charOffset: brief.indexOf('£50,000'), verdict: 'absent', matchedNodeId: null }
+    const second: NotModelledItem = { literal: '£50,000', kind: 'money', charOffset: brief.lastIndexOf('£50,000'), verdict: 'absent', matchedNodeId: null }
+
+    expect(first.charOffset).not.toBe(second.charOffset) // precondition, pinned in-test
+    expect(composeNotModelledQuestion(first, brief)).toContain('We spend £50,000 a year on the current CRM.')
+    expect(composeNotModelledQuestion(second, brief)).toContain('Migration would also cost £50,000 up front.')
+    expect(
+      composeNotModelledQuestion(second, brief),
+      'the second occurrence was quoted with the first occurrence\'s sentence — the lookup is by value, not identity',
+    ).not.toContain('We spend £50,000 a year')
+  })
+})


### PR DESCRIPTION
**Link-readiness track, round 2 — brief `olumi-docs/parallel-briefs/BRIEF-LINK-TRACK-R1.md`. DO NOT MERGE — adversarial review is a separate seat.**

Round 1's four honestly-skipped items. Each was **re-derived at the current build before anything was changed**, and two of the four re-derivations changed what the fix should be. Base `97a6526757d4`; head `dcf1c56f`.

---

## Item 3 — the "Add this" CTA, derived at the LIVE router

Round 1 root-caused this and stopped, correctly, because the brief required the accepted phrasing be derived from the live router and it could not do that without authenticating. It is derived now, using the programme's own guest-posture wire recipe (`scripts/golden-journey/lib/wire.mjs` — **no credential is read, embedded or printed; the product journey is a guest journey by construction**).

**12 arms, 12 fresh scenario UUIDs, byte-identical brief, one arm per scenario** so the only thing varying is the phrasing. Outcomes classified from the producer's own typed channel (`details.rejection_code` / `violation_codes` vs `held_proposal` / `details.verdict`), never from the prose (trap 13c).

| Arm | Message | Live outcome |
|---|---|---|
| **A (control — the phrasing we ship)** | `Please add "£31m" from my brief to the model.` | no mutation; a **specific, well-grounded question** back |
| B | figure + the brief sentence | **REFUSED** `ORPHAN_NODE` |
| C | "add a factor for the £31m figure" + sentence | **REFUSED** `ORPHAN_NODE` |
| D | `Add a new factor called "Annual revenue" with a value of £31m.` | **REFUSED** `ORPHAN_NODE` |
| E | as D + "connect it to the options" | **REFUSED** `NO_PATH_TO_GOAL` |
| **F** | as D + **"connect it so it influences Budget Headroom"** | ✅ **HELD** → confirm → applies |
| **G** | as D + names the full chain through to the goal | ✅ **HELD** |
| H | the engine's own suggested resolution (cost as a share of revenue) | no mutation, clarify |
| **I (positive control)** | `Change Annual CRM Licence Cost to £64,000.` — the estate's proven edit grammar | ✅ **APPLIED_DIRECT** |
| J / K / L | three "where does this belong?" ASK phrasings | answered with concrete, model-grounded options; no orphan, no error |

**Arm I is why the four refusals are evidence about the phrasings and not about a sick service.**

**The finding.** An accepted instruction *does* exist — and its acceptance condition is knowledge **this panel does not have**: what the figure should causally influence. The engine says so itself, in arm A:

> *"I did not add £31m annual revenue as a new element because it is not clear what it should causally connect to… Could you clarify what this figure should influence — for example, should CRM cost be expressed as a percentage of revenue, or should revenue itself act as a factor affecting a specific outcome or risk?"*

A CTA that picked a target would be the product **inventing causality on the user's behalf**, which is worse than a CTA that does nothing.

⭐ **The measurement that decided the shape, and it is counter-intuitive.** Adding the recovered brief sentence to an **add** instruction made the outcome *worse* — it gave the model enough confidence to author a node, which the validator then rejected, turning a useful sentence into a structural error. Adding the same sentence to an **ask** made the answer *better*: the reply named the specific existing factor the figure would attach to. **Same context, opposite effect, depending on the verb.** That is why the sentence ships and the imperative does not.

**So:** the button asks where the figure belongs, carrying the sentence recovered via `NotModelledItem.charOffset` (which the panel had until now used only as a React key). The user's answer names the target, and *that* turn is the one the engine accepts — proven by F/G. Label `Add this` → `Where does this fit?`; lead copy `Add any that matter.` → `Ask about any that matter.`

`recoverBriefSentence` does **not** split on a bare `[.!?]`: this is a business brief full of currency, and `£1.5 million` is exactly the string that cuts in half — trap 22's "guard correct and pointed at the wrong bytes". A `.` is a boundary only when it is not between two digits.

---

## Item 4 — the first 100 seconds

### (a) the first assistant reply never scrolled into view

`useSmartScroll` fired on `messages.length`. That length *does* change during turn one (0 → 1 user → 2 streaming), so the effect ran twice — but `ChatThread` returns `null` for **both** roles while `showEmptyState` holds, so both runs scrolled a container holding only `EmptyState`. The commit that finally puts the reply on screen is `isStreaming` flipping false **on an existing message object**: `messages.length` is *identical* across it, so the old trigger was structurally incapable of observing the one commit that mattered.

The trigger is now the **rendered**-message count, derived from the same predicate the render map uses (a second copy would be the hand-maintained mirror trap).

Also corrected, not deleted (trap 14): `ChatThreadProps.scrollListRef`'s doc claimed a suppression mechanism that **does not exist** — no such parameter, the ref is never passed to the hook, and no `restoreScrollTop` exists in the tree. It would have sent the next reader hunting a suppression bug to explain this very defect.

### (b) "Fit to view" leaves labels blank — **re-derived, and the fix is not the obvious one**

`src/canvas/utils/zoomLegibility.ts` carries a **reasoned, dated doctrine** that explicit user gestures stay unfloored, and that below the floor the level-of-detail view is *"the honest, intended rendering: structure without labels"*. So I measured before overriding it. Real Chromium, the product's **own** 19-node example decision (not a fixture this lane authored — trap 16-inverse), the real "Fit to view" control:

| viewport | fit zoom | titles hidden | LOD | **disclosed?** |
|---|---|---|---|---|
| 1920×1080 | 0.802 | 0 / 19 | off | — |
| 1440×900 | 0.668 | 0 / 19 | off | — |
| 1280×800 | 0.595 | 0 / 19 | off | — |
| 1024×768 | 0.543 | 0 / 19 | off | — |
| **834×1112** | **0.344** | **17 / 19** | **ON** | **no** |

Two things follow. **The reported "18 of 20 blank" is real but VIEWPORT-CONDITIONAL** — it does not reproduce at desktop widths, which is why it read as intermittent; a laptop with the AI panel and inspector open has the same narrow canvas. And **the product disclosed the state at 0 of 5 viewports.**

Flooring the fit would crop the model the user just asked to see whole — a worse lie than hiding labels. **The doctrine is left intact; the defect fixed is the silence.** New `CanvasLodNotice` renders from the *same store flag the nodes blank themselves on*, so it cannot claim a state the nodes are not in, and offers the way back at exactly `LABEL_LEGIBLE_ZOOM` (derived, never a restated literal — the single-source guard fails on a second numeric zoom literal).

⚠ **My first e2e spec was green while measuring the wrong thing, and the number gave it away.** It reported **0.5 exactly** at both 1024px and 834px — `LABEL_LEGIBLE_ZOOM` to the digit, which the *manual* fit never passes. `useFitViewOnLayoutVersion`'s **floored** auto-fit was re-firing after my click and overwriting the gesture: the spec was measuring a camera move the user never made. It now waits for the camera to settle before *and* after the gesture, and logs both, so the auto-fit and the gesture are visibly distinguished (`settled-before=0.5 after-gesture=0.344`). **A suspiciously round number is evidence about your instrument** (trap 20).

### (c) "start fresh" was fresh only in memory

`resetCanvas` cleared in-memory state and `currentScenarioId` — and left `olumi-canvas-autosave` and `olumi-canvas-transcript` on disk. The production boot arbiter then reads `autosave && !scenario`, **exactly the state a reset produces**, and takes `loadSource = 'autosave'` unconditionally: no age cap, no fresh-entry test. The previous model came back on the next load, announced by *"Recovered unsaved changes from your last session."*

`clearTranscript`'s own docstring already read *"(scenario deleted / canvas reset)"* and it had **zero production call sites** — the wiring was designed and never done, which is why nothing went red. Ordering is load-bearing and has its own test: the transcript file is keyed by scenario id, so the id must be read before `clearCurrentScenarioId()` discards it.

---

## Item 6 — guidance lost on reload

Persisted per decision (sessionStorage, versioned payload, dotted key — the `strengthenStore` pattern, whose scope reasoning this shares).

**The hard part is not persisting; it is not resurrecting stale coaching**, so adoption re-applies the same `valid_while` rules a live run obeys and **fails closed** — unverifiable is stale.

⚠ **The two comparators are not the same kind of thing, and conflating them would be a category error the codebase explicitly warns about.** `analysis_hash` is compared against `results.hash`, which genuinely survives a reload via `restoreAnalysisFromAutosave`. `valid_while.graph_hash` is CEE's **`aag_v1`**; the UI's `generateGraphHash` is a different algorithm over different inputs, and **no CEE-family graph hash survives a reload at all**. So a stored `graph_hash` is **never** compared to a UI hash: the module stamps its *own* UI-side hash at write time and compares that at read time — same algorithm both ends, which is the only comparison that means anything.

Rehydration is an explicit call, not a module-evaluation spread, because both comparators only become live after `ReactFlowGraph`'s boot effect.

---

## Item 5 — streamed honest progress: **the premise is largely refuted, and that is the deliverable**

The brief asks to "surface real stage-bound progress… bind shown progress to real stream events; cancel/recover". **Almost all of that is already shipped and live.** Derived at the CEE staging tip `2d3840865f98` and the UI tip:

- the UI **already** POSTs `/proxy/v5/turn/stream` for draft turns (`streamedDraftEligible`), already parses frames (`streamedDraftFrames.ts`), already flips `draftStreamPhase` `drafting → settling`, already marks `COACHING_READY`;
- the in-composer status line is **already** frame-licensed after GRAPH_READY, and a `narrationHonesty.invariant.spec.ts` gate already **bans** fabricated stage copy — the exact class of fake narration one might reach for was shipped once, measured as false, and deleted;
- cancel/recover is **already** wired end to end: `AbortController` → `POST /proxy/v5/turn/stop` → six distinct terminal notices.
- **Neither `*_ORCHESTRATOR_STREAMING` flag is the lever** — confirmed at the bytes on both sides. CEE's `ENABLE_ORCHESTRATOR_STREAMING` has exactly **one** runtime read and it is a *log field*; the routes it used to gate are deleted at the tip. The UI's flag gates the legacy V4 `/bff/orchestrate/v1/turn` SSE, unreachable while V5 is on.

**The one real gap, located but not fixed here.** The first ~36 s has exactly one frame (`DRAFTING`, ~271 ms) and a clock, because **`PROGRESS` frames are never emitted**. Measured independently by this lane: **10 live drafts against deployed staging tonight — `DRAFTING` 10/10, `GRAPH_READY` 10/10, `COACHING_READY` 10/10, `COMPLETE` 10/10, `PROGRESS` 0/10.** The four firing stages are the positive control, so this is a real absence and not a blind probe.

The chain is implemented at *every* layer — adapter scanner → throttled emit (`anthropic.ts:1014/1207`) → pipeline dedupe bridge (`parse.ts:454`) → `writeStage("PROGRESS")` (`streamed-turn-sse.ts:237`) → UI parse. And `onStage` is **provably wired on the live path**, because `GRAPH_READY`/`COACHING_READY` travel through the same `emitStageEvent(ctx.opts.onStage)` and fired 10/10. So the break is inside `src/adapters/llm/anthropic.ts`, between `labelScanner` construction and the `LABEL_RE` match, on the `buildCallParams(useStructuredOutputs)` path — and it is invisible because **every layer swallows**.

**That is a CEE lane, in a different repo and a different subsystem (LLM token-stream scanning), and it needs its own evidence that emitted labels are real rather than fabricated.** Per the scope-expansion rule I stopped at the boundary rather than expanding into it. Anything I could have added on the UI side without it would have been spinner theatre, which the brief forbids and `narrationHonesty.invariant.spec.ts` would (correctly) reject.

---

## Evidence

**RED-first**, throwaway worktree **outside** the repo root, isolation proven by **write-sentinel** (source unchanged after a write into the worktree), **distinct inodes** (`592184123` vs `592071554`), applied-check scoped to `src/` reading **exactly 0** at pristine:

```
resetCanvas   3/3 RED — "the persisted autosave survived 'start fresh'…: expected '{"timestamp":…' to be null"
ChatThread    3/3 RED — and the third fails in the OPPOSITE direction ("expected 2 to be 1"),
                        i.e. pristine over-scrolled on suppressed traffic
guidance / CTA / LOD notice — RED at pristine because the API does not exist there;
                        their behavioural proof is the mutant kit below, not this line.
```

**Mutants** — separate worktree, distinct inodes (`592350213` vs `592071554`), write-sentinel proven, restores from a **pristine archive outside the tree** (trap 9h: `git checkout --` restores from the *index*, which an earlier mutant may have polluted), **collected count hard-asserted at 28 on every run**:

| # | Mutation | Result |
|---|---|---|
| control (leading & trailing) | none | applied=0, **28/28 green** |
| M1 | scroll trigger reverts to `messages.length` | **bites (3)** |
| M2 | `isRendered` always true | **bites (3)** |
| M3 | rehydration ignores `analysis_hash` | **bites (2)** |
| M4 | rehydration ignores the graph hash | **bites (1)** |
| M5 | a blob from another decision is adopted | **bites (1)** |
| M6c | `clearGuidanceItems` never persists the clear | **bites (1)** |
| M7 | rehydration overwrites a live turn's guidance | **bites (1)** |
| M8 | `resetCanvas` keeps the autosave | **bites (1)** |
| M9 | scenario id read **after** it is cleared | **bites (2)** |
| M10 | the CTA composes an add instruction | **bites (3)** |
| M11 | sentence recovery splits on a decimal point | **bites (1)** |
| M12 | sentence found by value instead of by offset | **bites (1)** |
| M13 | the LOD notice renders unconditionally | **bites (2)** |

M11 / M12 / M13 are discriminating: each REDs **only** its own case while the rest stay green, so the tests bind to the named property rather than to "something changed".

⚠ **Two instrument defects in my own kit, both caught by controls rather than by inspection, both reported because the next lane will hit them.**
1. **zsh word-splitting.** `npx vitest run $SPECS` under zsh sends **one** giant argument: vitest found no test files, exited **0**, and printed no `Tests` line — so every mutant reported nothing, and *"no FAIL lines"* would have read as *"the mutant survived"*, the exact opposite of the truth. Fixed with a bash array **and** a hard collected-count assertion.
2. **A FALSE SURVIVOR.** M6b inserted a dead `if (false) persistCurrent([])` and left the real call standing two lines below — the file changed (`applied=1`) while the behaviour did not, and the kit dutifully reported SURVIVED. **An applied-check that only asks "did a file change" cannot tell an equivalent mutant from an ineffective one** (trap 22d). M6c removes the real call and bites.

**Real-browser witness** — `e2e/canvas.lod-disclosure.spec.ts`, 5 viewports, real Chromium, the product's own example decision:

```
[fit 1920x1080] settled-before=0.842697 after-gesture=0.802139  hiddenTitles=0/19  notice=false
[fit 1440x900]  settled-before=0.702247 after-gesture=0.668449  hiddenTitles=0/19  notice=false
[fit 1280x800]  settled-before=0.625468 after-gesture=0.595365  hiddenTitles=0/19  notice=false
[fit 1024x768]  settled-before=0.5      after-gesture=0.542763  hiddenTitles=0/19  notice=false
[fit 834x1112]  settled-before=0.5      after-gesture=0.344298  hiddenTitles=17/19 notice=true
5 passed
```

The four legible viewports are the discriminator: a notice that always rendered would satisfy the 834px case while measuring nothing.

**Gates**

| Gate | Result |
|---|---|
| `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) | **PASSED** — coverage 3361/3401, ratchet within baseline |
| `pnpm lint` | **0 errors** (1265 pre-existing warnings); hooks ratchet **exactly at baseline** — 232 / 15 files |
| new specs, collected **by name** | ChatThread **3**, guidance **11**, resetCanvas **3**, CTA **8**, LOD notice **3** = **28** — asserted, never inferred from a suite total (trap 2b) |
| `e2e/canvas.lod-disclosure.spec.ts` | **5 passed** |

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run.

⚠ **The hooks ratchet caught me and it was right.** My first version added a `useEffect` to `ReactFlowGraph`, taking it 117 → 118 conditional-hook violations. The file has an early return above, so every hook after it is flagged; the exception covers its *existing* violations, *"not a licence to add more — each one is a render-time crash"*. The work moved into the post-boot effect that already exists: same phase, same ordering guarantee, no new hook call.

⚠ **The typecheck gate again offered a baseline update and I again declined it** (drift 2487 → 2485). I have not verified both diagnostics are attributable to this PR, and banking an unattributed shrink is how a ratchet stops meaning anything. Left for the reviewer.

⚠ **Full `vitest run` was still executing when this body was written** and its result is reported separately rather than asserted here — a past-tense sentence about an unmeasured state is a fabrication even when it later proves true. The five new spec files and the e2e spec are green; CI at this exact head is the authority.

---

## What a reviewer should push hardest on

1. **Item 3 is a capability *narrowing* dressed as a fix, and it should be argued.** The button no longer claims to add. I believe the measurements make that the only honest option, and that arms F/G show the path to a real change still exists one turn later — but if you think a receipt *can* legitimately propose a causal target, that is the disagreement worth having.
2. **Item 4b leaves the reported symptom in place.** Labels are still blank at 834px. I am asserting that the doctrine is right and the silence was the defect. Overturning the doctrine instead is a defensible alternative and I did not take it.
3. **The guidance graph-hash comparison is the subtlest thing here.** It compares a UI hash to a UI hash and deliberately ignores the producer's `graph_hash`. If that reasoning is wrong, guidance can outlive an edit.

---

## Gate results, completed after the body above was first written

**Local full suite:** `1604 files passed / 3 skipped (1607)` · **`23,228 passed / 0 failed / 66 skipped (23,294)`** · 1708 s.

**CI, polled to conclusion at the exact head `dcf1c56f` — 13 checks, `running=0`, `failed=0`:**

```
success  CEE Contract Validation          success  Production Build
success  Flag Deployment Drift (report)   success  Security Audit (pnpm)
success  Full Test Suite (shard 1/4)      success  Staging Gate
success  Full Test Suite (shard 2/4)      success  TypeScript + Lint
success  Full Test Suite (shard 3/4)      success  Typecheck Gate Self-Test
success  Full Test Suite (shard 4/4)      success  Install & Cache
success  Full Test Suite Summary
```

`mergeable: true`. Queried per-SHA via `check-runs` with `total_count > 0` asserted, filtering `.status == "completed"` before `.conclusion` so a running check cannot be bucketed as a failure (traps 24 / 24b).

⚠ **One disclosure about the e2e numbers, because a reviewer re-running the spec cold will not reproduce them exactly.** `playwright.config.ts` sets `reuseExistingServer: true`, and port 5177 was already held by a dev server this lane started with the **deployed staging flag posture** (`VITE_FEATURE_AI_PANEL_V2=true`, `VITE_ENABLE_V5_ORCHESTRATOR=true`). So the run above measured the canvas users actually get — which is what makes the 834px figure meaningful — but it was **not** the config's own environment. The spec compensates by setting `feature.aiPanelV2` in `localStorage`, and its assertion is written conditionally in both directions (`if hiddenTitles > 0 … else …`), so it is correct under either posture rather than pinned to one set of zooms. **The specific numbers are evidence about the staging posture; the assertion is not.**

**Not run:** the e2e suite is not part of CI's check set, so `canvas.lod-disclosure.spec.ts` is local evidence only.

---

# ROUND 2 — response to the adversarial review (`dcf1c56f` → `2b8928a9`)

**All four findings were real. Nothing in the review was refuted at the bytes.** New head **`2b8928a95caeb9be50778d44438a23bfa020d43d`**. Not merged.

The review's framing of B1 is the right one and I want to restate it before the detail: **the shipped behaviour was correct and the evidence for one sentence of it was not.** That sentence has been removed rather than repaired, because five rounds of probing could not earn it.

## 🔴 B1 — arms F/G were REJECTED. Verified, corrected, and the ladder is now stated as unmeasured.

Re-derived at the raw capture rather than inherited:

```json
{"source":"graph_management","verdict":"rejected","mutation_class":"structural",
 "blocker_code":"PIPELINE_OWNED_FIELD",
 "blocker_readable":"The candidate targets an analysis-derived, pipeline-owned field."}
```
`blockTypes: ["error"]`, no `held_proposal`, `nodesAfter: null`. **G byte-identical.** The disjunct `d.verdict === 'held' || !!d.blocker_code` read `verdict` and then overrode it.

**I re-classified all 12 arms with a corrected classifier.** Only F and G move; A and H change label only (`NO_TYPED_OUTCOME` → `ANSWERED_NO_MUTATION`). Every refusal and every answer stands.

**Then I took the option to earn the reassurance honestly, and it did not survive.**

- **Round 4** (3 arms, targets that are *not* analysis-derived, with a real `"Yes"` confirmation turn wired for any HELD): **VOID.** Its positive control sent `Change Annual CRM Licence Cost to £64,000.` — a label hardcoded from an earlier run. *This* run's draft named the factor **"Annual CRM Spend"**, so the control asked the engine to change a node that did not exist and the engine, correctly, asked which was meant. **The control was bound by VALUE to a label the drafter happens to emit, not by IDENTITY to a node in the graph under test — trap 19, in my harness rather than in a spec.** Every arm in the round is unreadable, which is the control doing its job.
- **Round 5** (targets *and* control derived by identity from that run's own committed graph): **control `APPLIED_DIRECT` — arms readable** — and the add was **REFUSED `PIPELINE_OWNED_FIELD`** again. The goal-feeding factors in a drafted graph are themselves analysis-derived, so naming one does not rescue the add.

**Across 15 arms over 5 rounds, no add instruction has ever been observed to be accepted.** Five rounds is the signal to stop, not to roll again (trap 22f). So:

- `V7WhatIWasGivenSection.tsx:115` and `:226` no longer claim a ladder. Both now record what was claimed, that it was false, and why — the shipped comment is the place the next reader would inherit the error from.
- The spec header's evidence table is corrected in the same way.
- **The ask decision is unchanged and rests where the review said it should**: the refusals (B–E) and the answers (J–L). The engine ends in the same place the CTA now does — *"connect 'Annual revenue' to a factor that already feeds your goal. Which factor should it relate to?"*

**The classifier cannot re-do this.** `scripts/evidence/link-r2-add-this-cta/classifier.mjs` reads an explicit verdict **first, in both directions**; `blocker_code` implies held only where no verdict contradicts it. It ships a **self-test whose first case is the actual arm-F payload**, exits non-zero on regression, and carries a contrast case so it must still classify a genuine held proposal as HELD.

⭐ **What this defeated is worth stating plainly, because it is the lesson.** The 13-mutant kit bit on every mutant. **A mutant kit measures whether the tests can detect a change, never whether the expectation is right** — trap 13c, and a full kill-rate certified nothing about this oracle.

**Minor 1 and 2 are closed by the same work.** The shipped opening was *"which isn't in the model"* while the probed arm said *"which is not in the model yet"*; **the product now sends the string that was measured**, so "derived at the live router" is about the bytes rather than a neighbour. And the probes, the classifier, the README and the raw captures are **in the repo** (`scripts/evidence/link-r2-add-this-cta/`, 156 KB) instead of in `/private/tmp` — a derivation that cannot be re-run is a sentence, not evidence. `captures/` is marked append-only.

## 🔴 B2 — the laundering is fixed; your spec REDs at `dcf1c56f` and GREENs here

`graphHashAtWrite` meant *"hash at the last persist"*. `persistCurrent` now takes `{ minting }`: **only `setGuidanceItems` — a turn delivering guidance — mints a stamp.** Every other path inherits it from the blob on disk, and where it cannot (no blob, or a blob for another decision) writes `null`, which adoption treats as unverifiable and therefore stale.

**RED at the reviewed head** — new spec, old implementation, worktree outside the repo root, write-sentinel proven, applied-check showing **only the spec file** modified and **no source change**:

```
× CASE 1 — accepting an assistant patch does not re-stamp the survivors
  → coaching authored against the PRE-patch model was adopted onto the post-patch graph…: expected 1 to be +0
× CASE 2 — dismissing an item does not re-stamp the rest
  → a dismissal laundered the remaining item onto the edited graph: expected 1 to be +0
✓ CONTROL — with no intervening graph change, the survivors are still adopted
Tests  2 failed | 13 passed (15)
```

**GREEN here:** `Tests  15 passed (15)`.

Your two cases are in verbatim, plus **two discriminators of my own**, because the obvious wrong fix passes both of yours: `CONTROL — with no intervening graph change, the survivors are still adopted` (a fix that refused everything after a non-authoring persist would destroy the feature) and `a NEW turn after a graph change mints a fresh stamp and is adopted at the new hash` (a fix that inherited everywhere would make new guidance un-adoptable). The corpus now varies the **provider** hash, which is the shape mine could never see.

## 🟠 SIGNIFICANT 1 — measured, and you were right: the clear was undone on its own commit

Not derived. `useConversation.resetTranscript.spec.tsx` mounts the real hook and reads `localStorage` after React settles:

```
× does not write the cleared transcript straight back on the reset commit
  → the transcript was deleted and then written straight back on the same commit…
    expected [ Array(1) ] to not include '77777777-…'
```

⚠ **Its first three runs were false negatives, and only a pinned precondition caught them.** The fixture set up nothing three separate ways — the hook reads `useCanvasStore(s => s.currentScenarioId)` rather than `scenarios.getCurrentScenarioId()`; the mount restore requires `fromPreviousSession`, so a transcript written in-test carries the *current* `pageLoadId` and is correctly ignored; and `isStoredMessage` requires `ts`, without which every message is filtered out. **Each would have produced a clean pass for a race that was never set up.** All three are recorded in the fixture.

**Fix:** `clearTranscript` tombstones the id for the page load; `saveTranscript` refuses a forgotten id. Reordering the two effects was **rejected** — `messagesOwnerRef`'s own comment records a privacy defect that keying persistence on the owner exists to prevent — so the fix lives where "forget this" is defined and holds regardless of who races it. It is **released** when the user genuinely re-enters that decision (`releaseTranscriptTombstone`, from the scenario-switch effect), with its own test: *a permanent tombstone is the fix's own failure mode.*

## 🟠 SIGNIFICANT 2 — the saved-decision guard and all three sheets

- **Guarded.** Only an **unsaved** decision's transcript is discarded (`getScenario(id) === undefined`). Both directions pinned: a saved record's conversation survives; an unsaved one is still discarded, which is the demo hazard this item exists for. Two protections now stand between a saved decision and this defect — the guard, and the tombstone's release.
- **`KebabMenu.tsx`** — the **ungated** reset — now names every consequence, matching the other two sheets.
- **All three sheets** stop promising undo can restore the conversation: *"Undo (Ctrl+Z / Cmd+Z) can bring the graph back. The conversation cannot be recovered."* A confirmation sheet that under-states what it destroys is the worst place for it, because the promise is what the user weighs before saying yes.
- **`deleteScenario` still does not call `clearTranscript`** — left alone deliberately, as it is outside this round's scope; the asymmetry you named is real and wants a row.

**Not addressed, as instructed:** `graphChanged: true` never passed in production (pre-existing, being rowed).

## Gates

⚠ **CI caught a real consequence of the SIGNIFICANT-1 fix and I want it on the record rather than buried in a fixup.** Shard 3/4 went red at `5415b5c8` with **5 failures in `transcriptStore.spec.ts`**. Not a flake: the tombstone is **module state**, `localStorage.clear()` does not touch it, and one existing case clears `SID` — so every later case using `SID` had its `saveTranscript` refused. Reset in both `beforeEach` blocks, as any module-level singleton must be. **No assertion weakened, no product behaviour changed.** The local full suite that had been running since before that fix was killed rather than reported; it was re-run clean at the final head: **`1605 files passed / 3 skipped (1608)` · `23,236 passed / 0 failed / 66 skipped (23,302)`** · 2133 s.

| Gate | Result |
|---|---|
| `pnpm typecheck` | **PASSED** — coverage 3363/3403, ratchet within baseline |
| `pnpm lint` | **0 errors** (1265 pre-existing warnings); hooks ratchet **exactly at baseline** — 232 / 15 files |
| `classifier.mjs` self-test | **6/6 PASS**, exit 0 (first case = the arm-F payload) |
| lane specs, collected **by name** | ChatThread **3**, guidance **15**, resetCanvas **5**, CTA **8**, LOD notice **3**, resetTranscript **2** = **36** |
| `transcriptStore.spec.ts` | **13 passed** (was 5 failed / 8 passed) |
| **CI at the exact head `2b8928a9`** | **13/13 success**, `running=0`, `failed=0`, `total_count=13`, `mergeable: true` |

⚠ **A push-verification note worth carrying:** immediately after the push, `git ls-remote` reported `5415b5c8` while `gh api .../pulls/668` still served `dcf1c56f`. I polled `gh api` until it agreed with `ls-remote` **before** querying checks — a CI verdict read in that window would have been about the previous commit (trap 24's shape).

⚠ The typecheck gate again offered a baseline update (2487 → 2485) and I again declined it, for the same reason.
