### PR TITLE
fix(collab): make the two PR4 panel surfaces usable on first contact

### DIFF
--- a/src/collab/__tests__/collabFirstRunFriction.spec.tsx
+++ b/src/collab/__tests__/collabFirstRunFriction.spec.tsx
@@ -1,0 +1,493 @@
+/**
+ * COLLAB — FIRST-RUN FRICTION on the two PR4 panel surfaces.
+ *
+ * ── WHAT THIS FILE PINS AND WHY IT EXISTS ─────────────────────────────────
+ * A live browser witness on deployed UI `3a4e3df2` drove both collaboration
+ * pages as a first-time user and found the surfaces unusable before any
+ * collaboration science got a chance to matter:
+ *
+ *   F1  both pages rendered with ZERO design-system classes (`main [class]`
+ *       measured 0 in the live DOM). Tailwind preflight strips native styling
+ *       and nothing restored it, so the h1 computed to 16px/400 — identical to
+ *       body text — and inputs had `border: 0; padding: 0`.
+ *   F2  a participant who mistyped their code was TRAPPED: the entry form
+ *       rendered only when no token was held, and nothing could clear a bad
+ *       one. Only a full reload escaped, and the page never said so.
+ *   F3  "Continue" was dead on empty input, with no feedback at all.
+ *   F4  the owner saw CEE's raw wire sentence after ~8 seconds with no busy
+ *       indicator and no statement of what to do next.
+ *   F5  a "Sign in again…" message with no sign-in affordance on the page.
+ *   F7  participant links are one-shot and unrecoverable — and had no copy
+ *       button.
+ *
+ * ── WHAT JSDOM CAN AND CANNOT SETTLE HERE, STATED PLAINLY ─────────────────
+ * F2/F3/F4/F5/F7 are BEHAVIOUR and are settled here: each was written RED
+ * against the pristine pages and named the missing affordance by test id.
+ *
+ * F1 IS NOT SETTLED HERE. jsdom computes no layout, so nothing below is
+ * evidence about visual hierarchy, spacing, contrast or focus rings. What the
+ * F1 block asserts is narrower and honest: the design-system tokens are
+ * APPLIED to the surfaces the deployed app actually MOUNTS. Layout truth needs
+ * the browser witness that follows the deploy — this suite cannot supply it
+ * and does not claim to.
+ *
+ * ── BINDING ───────────────────────────────────────────────────────────────
+ * Every assertion selects its object by IDENTITY (test id, or role + name),
+ * never by a value predicate a neighbouring element could satisfy — the two
+ * participant links in particular are deliberately distinct objects, and the
+ * copy tests assert the OTHER one did not move.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-list its exports (trap 12: a
+  // hand-listed factory REPLACES the module and every later export vanishes).
+  // It also means this spec collects only when the Supabase env vars are set —
+  // a deliberate tripwire, since without them whole spec files disappear from
+  // the run while the total still prints green.
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+import ParticipantPacketPage from '../../pages/ParticipantPacketPage'
+import { participantLink, type OpenPacket } from '../collabService'
+import {
+  __resetParticipantTokenForTests,
+  getParticipantToken,
+  setParticipantToken,
+} from '../participantToken'
+import { typography } from '../../styles/typography'
+
+const ROUND_ID = 'rnd-friction-1111-2222-3333'
+const SCENARIO_ID = 'scn-friction-4444-5555-6666'
+const PACKET_URL = `/bff/collab/packet/${ROUND_ID}`
+const MINT_URL = '/bff/collab/rounds'
+
+/** Distinctive on purpose: an assertion naming these cannot be met by chance. */
+const GOOD_CODE = 'CODE-THAT-WORKS-a1b2c3'
+const BAD_CODE = 'CODE-THAT-DOES-NOT-WORK-zzzz'
+const OWNER_TOKEN = 'owner-access-token-friction-IDENTITY'
+
+/** The exact sentence the collab seam mints for a credential refusal. Written
+ *  here from the user's side, deliberately NOT imported from the product — a
+ *  guard that imports its own expectation only proves the code agrees with
+ *  itself. */
+const SIGN_IN_COPY = 'Sign in again to open or close a round.'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+const OPEN_PACKET: OpenPacket = {
+  round_id: ROUND_ID,
+  status: 'open',
+  context_note: 'We are deciding whether to raise the price.',
+  graph_version_ref: 'gv-1',
+  targets: [
+    {
+      target: { kind: 'factor', id: 'factor-churn-risk' },
+      label: 'Churn risk after a price rise',
+      description: 'How likely is it that churn goes up?',
+      unit: null,
+    },
+  ],
+  self: { participant_id: 'p-a', display_name: 'Ada', completed_target_ids: [] },
+}
+
+function renderParticipant(): void {
+  render(
+    <MemoryRouter initialEntries={[`/panel/${ROUND_ID}`]}>
+      <Routes>
+        <Route path="/panel/:round_id" element={<ParticipantPacketPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+async function mintARound(): Promise<void> {
+  fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+  fireEvent.change(screen.getByTestId('panel-name-a'), { target: { value: 'Ada' } })
+  fireEvent.change(screen.getByTestId('panel-name-b'), { target: { value: 'Grace' } })
+  fireEvent.click(screen.getByTestId('panel-mint'))
+  await waitFor(() => expect(screen.getByTestId('panel-close')).toBeInTheDocument())
+}
+
+/** True only when EVERY class in a design-system token is applied. */
+function carriesToken(el: Element, token: string): boolean {
+  return token.split(/\s+/).filter(Boolean).every((c) => el.classList.contains(c))
+}
+
+beforeEach(() => {
+  __resetParticipantTokenForTests()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({ userId: 'user-abc', accessToken: OWNER_TOKEN })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  __resetParticipantTokenForTests()
+})
+
+/* ══ F2 — a rejected code must be recoverable IN PLACE ═════════════════════ */
+
+describe('F2: a participant who mistypes their code is not trapped', () => {
+  beforeEach(() => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL) {
+        return jsonResponse(
+          { code: 'collab_token_invalid', message: 'That token could not be verified.' },
+          401,
+        )
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+  })
+
+  it('offers a way back to the code entry form, and clearing actually drops the token', async () => {
+    setParticipantToken(BAD_CODE)
+    renderParticipant()
+
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+
+    // THE AFFORDANCE ITSELF. Before this lane there was none: the entry form
+    // rendered only while no token was held, so a held-but-rejected token was
+    // a dead end that only a full page reload escaped.
+    fireEvent.click(screen.getByTestId('packet-reenter-code'))
+
+    expect(screen.getByTestId('packet-manual-token')).toBeInTheDocument()
+    // Not merely a re-rendered form: the rejected credential is GONE, so the
+    // next request cannot re-send it.
+    expect(getParticipantToken()).toBeNull()
+  })
+
+  it('the second, correct code is the one that goes on the wire', async () => {
+    setParticipantToken(BAD_CODE)
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('packet-reenter-code'))
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL) return jsonResponse(OPEN_PACKET)
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    fireEvent.change(screen.getByTestId('packet-manual-token'), { target: { value: GOOD_CODE } })
+    fireEvent.click(screen.getByTestId('packet-manual-continue'))
+
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    const packetCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === PACKET_URL)
+    const last = packetCalls[packetCalls.length - 1]
+    const header = new Headers((last[1] ?? {}).headers).get('x-collab-participant-token')
+    // IDENTITY, both ways: the good code went, and the rejected one did not
+    // survive as a stale header on the retry.
+    expect(header).toBe(GOOD_CODE)
+    expect(header).not.toBe(BAD_CODE)
+  })
+
+  it('the failure says what to do next rather than repeating the wire sentence alone', async () => {
+    setParticipantToken(BAD_CODE)
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+
+    expect(screen.getByTestId('packet-error-guidance')).toBeInTheDocument()
+    expect(screen.getByTestId('packet-error')).toHaveTextContent(/access code/i)
+  })
+})
+
+/* ══ F3 — "Continue" must not be a dead control ════════════════════════════ */
+
+describe('F3: the code entry form gives feedback instead of doing nothing', () => {
+  it('Continue is disabled until there is something to submit', () => {
+    renderParticipant()
+    const button = screen.getByTestId('packet-manual-continue')
+    const field = screen.getByTestId('packet-manual-token')
+
+    expect(button).toBeDisabled()
+    fireEvent.change(field, { target: { value: '    ' } })
+    expect(button).toBeDisabled()
+    fireEvent.change(field, { target: { value: GOOD_CODE } })
+    expect(button).toBeEnabled()
+  })
+
+  it('a pasted link that lost its code is refused HERE, with the reason, and nothing is sent', () => {
+    renderParticipant()
+    fireEvent.change(screen.getByTestId('packet-manual-token'), {
+      target: { value: 'https://app.example.com/#/panel/rnd-abc' },
+    })
+    fireEvent.click(screen.getByTestId('packet-manual-continue'))
+
+    expect(screen.getByTestId('packet-manual-token-error')).toHaveTextContent(/access code/i)
+    // The whole URL must not be adopted AS the code — that is what turned a
+    // trimmed link into an unexplained server refusal eight seconds later.
+    expect(getParticipantToken()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('DIFFERENT OBJECT: a pasted link that DOES carry a code is accepted, code extracted', async () => {
+    // The opposite-direction twin. Without it the refusal above could be a
+    // predicate that rejects every link, which would be a worse defect than
+    // the one it replaces.
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL) return jsonResponse(OPEN_PACKET)
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderParticipant()
+    fireEvent.change(screen.getByTestId('packet-manual-token'), {
+      target: { value: `https://app.example.com/?ct=${GOOD_CODE}#/panel/${ROUND_ID}` },
+    })
+    fireEvent.click(screen.getByTestId('packet-manual-continue'))
+
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+    expect(getParticipantToken()).toBe(GOOD_CODE)
+    expect(screen.queryByTestId('packet-manual-token-error')).toBeNull()
+  })
+})
+
+/* ══ F4 / F5 — the owner is told what is happening, and what to do ═════════ */
+
+describe('F4: the owner sees that the round is being opened', () => {
+  it('a busy state is shown while the request is in flight, and cleared after', async () => {
+    let release: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === MINT_URL) {
+        await gate
+        return jsonResponse({
+          round_id: ROUND_ID,
+          graph_version_ref: 'gv-1',
+          participants: [
+            { participant_id: 'p-a', display_name: 'Ada', token: 'tok-a' },
+            { participant_id: 'p-b', display_name: 'Grace', token: 'tok-b' },
+          ],
+        })
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+
+    renderOwnerPanel()
+    fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+    fireEvent.change(screen.getByTestId('panel-name-a'), { target: { value: 'Ada' } })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    // THE MISSING SIGNAL. Eight seconds of a page that looks broken is the
+    // finding; this is the affordance that answers it.
+    await waitFor(() => expect(screen.getByTestId('panel-busy')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-busy')).toHaveTextContent(/opening the round/i)
+    expect(screen.getByTestId('panel-mint')).toBeDisabled()
+
+    ;(release as unknown as () => void)()
+    await waitFor(() => expect(screen.getByTestId('panel-close')).toBeInTheDocument())
+    expect(screen.queryByTestId('panel-busy')).toBeNull()
+  })
+})
+
+describe('F4/F5: a failure is translated into human copy with a next step', () => {
+  it('a credential refusal keeps the sentence AND offers the way to act on it', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+    renderOwnerPanel()
+    fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(SIGN_IN_COPY)
+    expect(screen.getByTestId('panel-error-guidance')).toBeInTheDocument()
+
+    // F5: the affordance the message presupposed but never provided.
+    // ⚠ Matched by SUFFIX, not equality: the deployed app is a HashRouter, so
+    // the real anchor reads `#/login` while MemoryRouter renders `/login`. An
+    // equality assertion here would be a claim about the TEST's router.
+    expect(screen.getByTestId('panel-sign-in').getAttribute('href')).toMatch(/\/login$/)
+  })
+
+  it("a 401 from the server is treated as a credential failure, not as CEE's raw sentence", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === MINT_URL) {
+        return jsonResponse(
+          { code: 'collab_token_invalid', message: 'That token could not be verified.' },
+          401,
+        )
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderOwnerPanel()
+    fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(SIGN_IN_COPY)
+    expect(screen.getByTestId('panel-sign-in')).toBeInTheDocument()
+  })
+
+  it('DIFFERENT OBJECT: an ordinary failure gets its own copy and NO sign-in link', async () => {
+    // The opposite-direction twin: a predicate that routed every failure to
+    // "sign in again" would pass the two tests above and be a lie on this one.
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === MINT_URL) {
+        return jsonResponse(
+          { code: 'collab_round_invalid', message: 'targets[0].id is not a known factor' },
+          422,
+        )
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderOwnerPanel()
+    fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(/could not open the round/i)
+    expect(screen.getByTestId('panel-error-guidance')).toBeInTheDocument()
+    expect(screen.queryByTestId('panel-sign-in')).toBeNull()
+  })
+})
+
+/* ══ F7 — one-shot links need a copy button ════════════════════════════════ */
+
+describe('F7: each one-shot link can be copied, and says it was', () => {
+  let writeText: Mock<[text: string], Promise<void>>
+
+  beforeEach(() => {
+    writeText = vi.fn(async (text: string) => {
+      // The write itself is not under test — WHICH link reaches it is.
+      void text
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === MINT_URL) {
+        return jsonResponse({
+          round_id: ROUND_ID,
+          graph_version_ref: 'gv-1',
+          participants: [
+            { participant_id: 'p-a', display_name: 'Ada', token: 'tok-a' },
+            { participant_id: 'p-b', display_name: 'Grace', token: 'tok-b' },
+          ],
+        })
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+  })
+
+  it("copies THAT participant's link — and leaves the other one alone", async () => {
+    renderOwnerPanel()
+    await mintARound()
+
+    fireEvent.click(screen.getByTestId('panel-copy-p-b'))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    // Bound by identity to Grace's token, not to "a link was copied": the two
+    // rows are deliberately different objects and either could satisfy a
+    // looser predicate.
+    expect(writeText).toHaveBeenCalledWith(participantLink(ROUND_ID, 'tok-b'))
+    expect(writeText).not.toHaveBeenCalledWith(participantLink(ROUND_ID, 'tok-a'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-copied-p-b')).toBeInTheDocument())
+    // DISCRIMINATION: the confirmation belongs to the row that was clicked.
+    expect(screen.queryByTestId('panel-copied-p-a')).toBeNull()
+  })
+})
+
+/* ══ F1 — the design system is applied, on the mounted surfaces ════════════ */
+
+describe('F1: both surfaces carry the design system (NOT a claim about layout)', () => {
+  /**
+   * ⚠ SCOPE. jsdom computes no layout, so none of this is evidence about
+   * hierarchy, spacing, contrast or focus rings — the very things the witness
+   * measured. It asserts only that DS tokens are APPLIED, and that the surface
+   * carrying them is the one the deployed app mounts. The layout claim belongs
+   * to the browser witness that follows the deploy.
+   */
+  it('POSITIVE CONTROL: the token detector can tell applied from unapplied', () => {
+    const el = document.createElement('div')
+    el.className = 'bg-canvas min-h-screen'
+    expect(carriesToken(el, 'bg-canvas')).toBe(true)
+    expect(carriesToken(el, 'text-3xl font-semibold')).toBe(false)
+  })
+
+  it('the participant page root is a styled surface, not a bare <main>', async () => {
+    setParticipantToken(GOOD_CODE)
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL) return jsonResponse(OPEN_PACKET)
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderParticipant()
+
+    const root = await screen.findByTestId('participant-packet-page')
+    expect(root.className.trim()).not.toBe('')
+    expect(carriesToken(root, 'bg-canvas')).toBe(true)
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(carriesToken(heading, typography.h2)).toBe(true)
+  })
+
+  it('the code entry form is styled too — it is the first thing a participant sees', () => {
+    renderParticipant()
+    const root = screen.getByTestId('packet-token-entry')
+    expect(carriesToken(root, 'bg-canvas')).toBe(true)
+    const field = screen.getByTestId('packet-manual-token')
+    expect(carriesToken(field, 'border')).toBe(true)
+    // The witness measured `border: 0; padding: 0` on this exact input.
+    expect(field.className).toMatch(/\bpx-/)
+  })
+
+  it('the owner page root is a styled surface, not a bare <main>', () => {
+    renderOwnerPanel()
+    const root = screen.getByTestId('panel-setup-page')
+    expect(root.className.trim()).not.toBe('')
+    expect(carriesToken(root, 'bg-canvas')).toBe(true)
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(carriesToken(heading, typography.h2)).toBe(true)
+  })
+
+  it("the owner's five fields are labelled controls, not a run-on wall", () => {
+    renderOwnerPanel()
+    // Each field is reachable BY ITS OWN accessible name. A label that merely
+    // wraps an input satisfies nothing here if the association is lost.
+    for (const name of [
+      /which factor should they estimate/i,
+      /how should it be described to them/i,
+      /anything they should know first/i,
+      /first person/i,
+      /second person/i,
+    ]) {
+      expect(screen.getByLabelText(name)).toBeInTheDocument()
+    }
+  })
+
+  it('MOUNT PATH: the deployed app mounts exactly these two components at these two paths', () => {
+    // Trap 3b: a green suite says nothing about a component the deployment
+    // does not render. This binds the styling claim above to the real routes.
+    const appSrc = readFileSync(resolve(process.cwd(), 'src/poc/AppPoC.tsx'), 'utf8')
+    expect(appSrc).toContain('path="/panel/:round_id" element={<ParticipantPacketPage />}')
+    expect(appSrc).toContain('path="/scenario/:id/panel" element={<PanelSetupPage />}')
+  })
+})

--- a/src/collab/participantToken.ts
+++ b/src/collab/participantToken.ts
@@ -119,3 +119,21 @@ export function __resetParticipantTokenForTests(): void {
 export function setParticipantToken(token: string): void {
   participantToken = token.trim() === '' ? null : token.trim()
 }
+
+/**
+ * Forget the held token so the participant can enter a different one.
+ *
+ * ⚠ THIS IS UI RECOVERY, NOT A CHANGE TO VERIFICATION. Nothing here decides
+ * whether a code is valid — the server does, and it is unchanged. What this
+ * closes is a DEAD END measured on deployed build `3a4e3df2`: the packet page
+ * showed its code-entry form only while no token was held, so a participant who
+ * mistyped their code held a rejected credential with nothing able to drop it.
+ * Every retry re-sent the same bad token, and only a full page reload escaped —
+ * which the page never suggested. A first-time panellist met a wall.
+ *
+ * It is also the correct hygiene move on a refusal: a bearer capability the
+ * server has just declined has no reason to stay in memory.
+ */
+export function clearParticipantToken(): void {
+  participantToken = null
+}

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -10,7 +10,20 @@
  *
  * ⚠ The page does not store them. Navigating away loses them, deliberately: the
  * alternative is a bearer capability sitting in browser storage after the round
- * has closed.
+ * has closed. That is exactly why each link now has a COPY BUTTON: a one-shot,
+ * unrecoverable secret that a person must select by hand is a design that
+ * guarantees a re-mint.
+ *
+ * ── WHAT A LIVE WITNESS FOUND ON DEPLOYED BUILD `3a4e3df2` ────────────────
+ *   • the page rendered with ZERO design-system classes — Tailwind preflight
+ *     strips native styling, so the five labels collapsed into a run-on wall of
+ *     text with unstyled inline inputs and the h1 read as body copy. Every
+ *     surface here now carries the app's own tokens; nothing is styled by an
+ *     inline `style` attribute.
+ *   • opening a round took ~8 seconds with NO busy indicator, then showed the
+ *     raw wire sentence. There is now a busy region, and every failure is
+ *     translated into copy that says what to do next.
+ *   • the "Sign in again…" message had no way to sign in ON THE PAGE.
  *
  * ── WHAT THE OWNER CANNOT SEE BEFORE CLOSE ────────────────────────────────
  * Nothing anyone has written — not even whether they have written. The owner is
@@ -25,19 +38,109 @@
  */
 
 import { useCallback, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
+import { AlertTriangle, Check, Copy, Loader2, LogIn, Users } from 'lucide-react'
 
+import { Button } from '../components/ui/Button'
 import {
   CollabRequestError,
   closeRound,
   fetchOwnerReveal,
   mintRound,
+  ownerSignInRequired,
   participantLink,
   type MintedRound,
   type RevealView,
 } from '../collab/collabService'
 import { requireOwnerAccessToken } from '../collab/ownerAccessToken'
+import { typography } from '../styles/typography'
 import { RevealBody } from './ParticipantPacketPage'
+
+const PAGE_SHELL = 'min-h-screen bg-canvas px-4 py-10 sm:px-6 sm:py-14'
+const COLUMN = 'mx-auto w-full max-w-[680px]'
+const CARD = 'rounded-[20px] border border-panel-border bg-panel p-6 shadow-1 sm:p-8'
+const FIELD =
+  'w-full min-h-[44px] rounded-md border border-panel-border bg-panel px-4 py-3 text-text-body placeholder:text-text-light transition-colors duration-fast focus:border-info focus:outline-none focus:ring-2 focus:ring-info/50'
+
+/**
+ * ⚠ DERIVED FROM THE SEAM, NOT RETYPED. `ownerSignInRequired()` is the one
+ * place a credential refusal is minted; spelling its sentence again here would
+ * be the hand-maintained mirror this estate keeps paying for — two copies of
+ * one sentence, and the copy that drifts is always the one a user reads.
+ */
+const SIGN_IN_SENTENCE = ownerSignInRequired().message
+
+type OwnerAction = 'open' | 'close'
+
+interface OwnerFailure {
+  /** The headline. Human, and for a credential refusal the seam's own sentence. */
+  title: string
+  /** What to do next — the part the witness found missing entirely. */
+  guidance: string
+  /** Whether a sign-in affordance is the right next step. */
+  credential: boolean
+  /** The server's own words, shown as secondary detail — never as the message. */
+  detail: string | null
+}
+
+/**
+ * Translate a failure into something an owner can act on.
+ *
+ * ⚠ THE PREDICATE'S DOMAIN, NOT JUST THE CASE IN HAND. A credential refusal is
+ * `sign_in_required` (minted locally, before any request leaves) OR an HTTP
+ * 401/403 (the server declining the bearer) — two different paths that call for
+ * the SAME next step. Everything else is a different question and must not be
+ * routed to "sign in again", which would be a confident lie about a round whose
+ * target simply does not exist.
+ */
+function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
+  const fallbackTitle =
+    action === 'open' ? 'We could not open the round.' : 'We could not close the round.'
+
+  if (!(err instanceof CollabRequestError)) {
+    return {
+      title: fallbackTitle,
+      guidance:
+        'Something went wrong before we heard back. Check your connection and try again — nothing has been sent to anyone.',
+      credential: false,
+      detail: null,
+    }
+  }
+
+  if (err.code === 'sign_in_required' || err.status === 401 || err.status === 403) {
+    return {
+      title: SIGN_IN_SENTENCE,
+      guidance:
+        'Your session has ended. Sign in again in the new tab, then come back here and try again — what you have typed on this page is kept.',
+      credential: true,
+      // The wire sentence for a credential refusal ("That token could not be
+      // verified.") tells the owner nothing they can act on, and repeating it
+      // beside the guidance would only muddy it.
+      detail: null,
+    }
+  }
+
+  return {
+    title: fallbackTitle,
+    guidance:
+      action === 'open'
+        ? 'Check that the factor id matches your model, then try again. Nothing has been sent to anyone yet.'
+        : 'The round is still open. Try again in a moment — nobody has seen anything they should not.',
+    credential: false,
+    detail: err.message,
+  }
+}
+
+/** Best-effort clipboard write. Returns false when the browser refuses. */
+async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator === 'undefined' || navigator.clipboard === undefined) return false
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}
 
 export default function PanelSetupPage(): JSX.Element {
   const { id: scenarioId } = useParams<{ id: string }>()
@@ -58,12 +161,14 @@ export default function PanelSetupPage(): JSX.Element {
   const [nameB, setNameB] = useState('')
   const [minted, setMinted] = useState<MintedRound | null>(null)
   const [reveal, setReveal] = useState<RevealView | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
+  const [failure, setFailure] = useState<OwnerFailure | null>(null)
+  const [busyAction, setBusyAction] = useState<OwnerAction | null>(null)
+  const [copiedIds, setCopiedIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [copyRefused, setCopyRefused] = useState<ReadonlySet<string>>(() => new Set())
 
   const handleMint = useCallback(async () => {
-    setBusy(true)
-    setError(null)
+    setBusyAction('open')
+    setFailure(null)
     try {
       const accessToken = await requireOwnerAccessToken()
       const result = await mintRound(accessToken, {
@@ -83,18 +188,16 @@ export default function PanelSetupPage(): JSX.Element {
       })
       setMinted(result)
     } catch (err) {
-      setError(
-        err instanceof CollabRequestError ? err.message : 'Could not open the round.',
-      )
+      setFailure(describeOwnerFailure(err, 'open'))
     } finally {
-      setBusy(false)
+      setBusyAction(null)
     }
   }, [scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
 
   const handleClose = useCallback(async () => {
     if (minted === null) return
-    setBusy(true)
-    setError(null)
+    setBusyAction('close')
+    setFailure(null)
     try {
       // ONE getSession() round-trip for the whole action, reused across both
       // requests — the identity seam's stated contract ("one call per turn;
@@ -103,112 +206,337 @@ export default function PanelSetupPage(): JSX.Element {
       await closeRound(accessToken, minted.round_id)
       setReveal(await fetchOwnerReveal(accessToken, minted.round_id))
     } catch (err) {
-      setError(err instanceof CollabRequestError ? err.message : 'Could not close the round.')
+      setFailure(describeOwnerFailure(err, 'close'))
     } finally {
-      setBusy(false)
+      setBusyAction(null)
     }
   }, [minted])
 
+  const handleCopy = useCallback(async (participantId: string, link: string) => {
+    const ok = await writeToClipboard(link)
+    if (ok) {
+      setCopiedIds((prev) => new Set(prev).add(participantId))
+      setCopyRefused((prev) => {
+        if (!prev.has(participantId)) return prev
+        const next = new Set(prev)
+        next.delete(participantId)
+        return next
+      })
+      return
+    }
+    setCopyRefused((prev) => new Set(prev).add(participantId))
+  }, [])
+
   if (reveal !== null) return <RevealBody reveal={reveal} />
 
+  const targetIdHasSpaces = targetId.trim() !== '' && /\s/.test(targetId.trim())
+
   return (
-    <main
-      data-testid="panel-setup-page"
-      style={{ maxWidth: 720, margin: '2rem auto', padding: '0 1rem' }}
-    >
-      <h1>Ask your team, without anchoring them</h1>
-      <p>
-        Everyone answers privately. Nobody &mdash; including you &mdash; sees any answer until you
-        close the round. Then you see them all, side by side, in each person&rsquo;s own words.
-      </p>
+    <main data-testid="panel-setup-page" className={PAGE_SHELL}>
+      <div className={COLUMN}>
+        <div className={CARD}>
+          <p className={`${typography.label} flex items-center gap-2 text-info`}>
+            <Users className="h-4 w-4" aria-hidden="true" />
+            Blind panel
+          </p>
+          <h1 className={`${typography.h2} mt-3 text-text-header`}>
+            Ask your team, without anchoring them
+          </h1>
+          <p className={`${typography.body} mt-3 text-text-body`}>
+            Everyone answers privately. Nobody &mdash; including you &mdash; sees any answer until
+            you close the round. Then you see them all, side by side, in each person&rsquo;s own
+            words.
+          </p>
 
-      {minted === null ? (
-        <>
-          <label>
-            Which factor should they estimate?
-            <input
-              data-testid="panel-target-id"
-              value={targetId}
-              onChange={(e) => setTargetId(e.target.value)}
-              placeholder="factor id from your model"
-            />
-          </label>
-          <label>
-            How should it be described to them?
-            <input
-              data-testid="panel-target-label"
-              value={targetLabel}
-              onChange={(e) => setTargetLabel(e.target.value)}
-            />
-          </label>
-          <label>
-            Anything they should know first? (optional)
-            <textarea
-              data-testid="panel-context-note"
-              value={contextNote}
-              onChange={(e) => setContextNote(e.target.value)}
-            />
-          </label>
-          <label>
-            First person&rsquo;s name
-            <input
-              data-testid="panel-name-a"
-              value={nameA}
-              onChange={(e) => setNameA(e.target.value)}
-            />
-          </label>
-          <label>
-            Second person&rsquo;s name
-            <input
-              data-testid="panel-name-b"
-              value={nameB}
-              onChange={(e) => setNameB(e.target.value)}
-            />
-          </label>
-          <button
-            type="button"
-            data-testid="panel-mint"
-            onClick={handleMint}
-            disabled={busy || targetId.trim() === ''}
-          >
-            Open the round
-          </button>
-        </>
-      ) : (
-        <>
-          <h2>Send each person their own link</h2>
-          {/* Said once, plainly, at the only moment it can be acted on. */}
-          <p data-testid="panel-token-warning">
-            These links are shown once and cannot be recovered — they are not stored anywhere. Copy
-            them now. Anyone holding a link can answer as that person, so send each one directly.
-          </p>
-          <ul>
-            {minted.participants.map((p) => (
-              <li key={p.participant_id} data-testid={`panel-link-${p.participant_id}`}>
-                <strong>{p.display_name}</strong>
-                <input readOnly value={participantLink(minted.round_id, p.token)} />
-              </li>
-            ))}
-          </ul>
-          <p style={{ opacity: 0.75 }}>
-            This round is pinned to the version of your model as it is right now, so the answers
-            stay meaningful even if you keep editing.
-          </p>
-          <button type="button" data-testid="panel-close" onClick={handleClose} disabled={busy}>
-            Close the round and show everyone&rsquo;s answers
-          </button>
-          <p style={{ opacity: 0.75 }}>
-            You will not see whether they have answered yet &mdash; that would tell you something
-            about their replies before you have given yours. Check with them first.
-          </p>
-        </>
-      )}
+          {minted === null ? (
+            <div className="mt-8 space-y-6">
+              <div>
+                <label
+                  htmlFor="panel-target-id-input"
+                  className={`${typography.label} block text-text-header`}
+                >
+                  Which factor should they estimate?
+                </label>
+                <input
+                  id="panel-target-id-input"
+                  data-testid="panel-target-id"
+                  className={`${FIELD} ${typography.body} mt-2`}
+                  value={targetId}
+                  autoComplete="off"
+                  spellCheck={false}
+                  aria-describedby="panel-target-id-hint"
+                  onChange={(e) => setTargetId(e.target.value)}
+                  placeholder="factor-churn-risk"
+                />
+                <p
+                  id="panel-target-id-hint"
+                  data-testid="panel-target-id-hint"
+                  className={`${typography.bodySmall} mt-2 text-text-light`}
+                >
+                  The factor&rsquo;s id in your model, for example{' '}
+                  <span className="text-text-body">factor-churn-risk</span>.
+                </p>
+                {targetIdHasSpaces && (
+                  <p
+                    data-testid="panel-target-id-warning"
+                    className={`${typography.bodySmall} mt-2 text-warning`}
+                  >
+                    Factor ids do not usually contain spaces. If you meant to describe the factor
+                    to your panel, use the next field instead.
+                  </p>
+                )}
+              </div>
 
-      {error !== null && (
-        <p role="alert" data-testid="panel-error" style={{ color: 'crimson' }}>
-          {error}
-        </p>
-      )}
+              <div>
+                <label
+                  htmlFor="panel-target-label-input"
+                  className={`${typography.label} block text-text-header`}
+                >
+                  How should it be described to them?
+                </label>
+                <input
+                  id="panel-target-label-input"
+                  data-testid="panel-target-label"
+                  className={`${FIELD} ${typography.body} mt-2`}
+                  value={targetLabel}
+                  onChange={(e) => setTargetLabel(e.target.value)}
+                  aria-describedby="panel-target-label-hint"
+                  placeholder="Churn risk after a price rise"
+                />
+                <p
+                  id="panel-target-label-hint"
+                  className={`${typography.bodySmall} mt-2 text-text-light`}
+                >
+                  This is the wording your panel sees. Leave it blank and they see the id above.
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="panel-context-note-input"
+                  className={`${typography.label} block text-text-header`}
+                >
+                  Anything they should know first? (optional)
+                </label>
+                <textarea
+                  id="panel-context-note-input"
+                  data-testid="panel-context-note"
+                  rows={3}
+                  className={`${FIELD} ${typography.body} mt-2`}
+                  value={contextNote}
+                  onChange={(e) => setContextNote(e.target.value)}
+                  placeholder="One or two lines of context — the same for everyone."
+                />
+              </div>
+
+              <fieldset className="rounded-md border border-panel-border p-4">
+                <legend className={`${typography.label} px-1 text-text-header`}>
+                  Who is answering?
+                </legend>
+                <div className="mt-2 grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor="panel-name-a-input"
+                      className={`${typography.label} block text-text-header`}
+                    >
+                      First person&rsquo;s name
+                    </label>
+                    <input
+                      id="panel-name-a-input"
+                      data-testid="panel-name-a"
+                      className={`${FIELD} ${typography.body} mt-2`}
+                      value={nameA}
+                      onChange={(e) => setNameA(e.target.value)}
+                      placeholder="Ada"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="panel-name-b-input"
+                      className={`${typography.label} block text-text-header`}
+                    >
+                      Second person&rsquo;s name
+                    </label>
+                    <input
+                      id="panel-name-b-input"
+                      data-testid="panel-name-b"
+                      className={`${FIELD} ${typography.body} mt-2`}
+                      value={nameB}
+                      onChange={(e) => setNameB(e.target.value)}
+                      placeholder="Grace"
+                    />
+                  </div>
+                </div>
+                <p className={`${typography.bodySmall} mt-3 text-text-light`}>
+                  Names are what everyone sees beside each answer when the round closes.
+                </p>
+              </fieldset>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  data-testid="panel-mint"
+                  onClick={handleMint}
+                  disabled={busyAction !== null || targetId.trim() === ''}
+                >
+                  Open the round
+                </Button>
+                {targetId.trim() === '' && (
+                  <span
+                    data-testid="panel-mint-hint"
+                    className={`${typography.bodySmall} text-text-light`}
+                  >
+                    Name the factor above to open the round.
+                  </span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-8">
+              <h2 className={`${typography.h4} text-text-header`}>
+                Send each person their own link
+              </h2>
+              {/* Said once, plainly, at the only moment it can be acted on. */}
+              <p
+                data-testid="panel-token-warning"
+                className={`${typography.body} mt-3 rounded-md border border-warning/30 bg-panel p-4 text-text-body`}
+              >
+                These links are shown once and cannot be recovered — they are not stored anywhere.
+                Copy them now. Anyone holding a link can answer as that person, so send each one
+                directly.
+              </p>
+
+              <ul className="mt-5 space-y-4">
+                {minted.participants.map((p) => {
+                  const link = participantLink(minted.round_id, p.token)
+                  const copied = copiedIds.has(p.participant_id)
+                  return (
+                    <li
+                      key={p.participant_id}
+                      data-testid={`panel-link-${p.participant_id}`}
+                      className="rounded-md border border-panel-border bg-panel p-4"
+                    >
+                      <p className={`${typography.label} text-text-header`}>{p.display_name}</p>
+                      <div className="mt-2 flex flex-wrap items-center gap-3">
+                        <input
+                          readOnly
+                          aria-label={`Panel link for ${p.display_name}`}
+                          value={link}
+                          onFocus={(e) => e.currentTarget.select()}
+                          className={`${FIELD} ${typography.bodySmall} min-w-0 flex-1`}
+                        />
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          data-testid={`panel-copy-${p.participant_id}`}
+                          onClick={() => void handleCopy(p.participant_id, link)}
+                        >
+                          <span className="flex items-center gap-2">
+                            {copied ? (
+                              <Check className="h-4 w-4" aria-hidden="true" />
+                            ) : (
+                              <Copy className="h-4 w-4" aria-hidden="true" />
+                            )}
+                            {copied ? 'Copied' : 'Copy link'}
+                          </span>
+                        </Button>
+                      </div>
+                      {copied && (
+                        <p
+                          data-testid={`panel-copied-${p.participant_id}`}
+                          role="status"
+                          className={`${typography.bodySmall} mt-2 text-success`}
+                        >
+                          Link copied. Send it to {p.display_name} now — it cannot be shown again.
+                        </p>
+                      )}
+                      {copyRefused.has(p.participant_id) && (
+                        <p
+                          data-testid={`panel-copy-failed-${p.participant_id}`}
+                          role="status"
+                          className={`${typography.bodySmall} mt-2 text-warning`}
+                        >
+                          This browser would not let us copy it. Select the link above and copy it
+                          by hand.
+                        </p>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+
+              <p className={`${typography.bodySmall} mt-5 text-text-light`}>
+                This round is pinned to the version of your model as it is right now, so the
+                answers stay meaningful even if you keep editing.
+              </p>
+
+              <div className="mt-6">
+                <Button data-testid="panel-close" onClick={handleClose} disabled={busyAction !== null}>
+                  Close the round and show everyone&rsquo;s answers
+                </Button>
+              </div>
+              <p className={`${typography.bodySmall} mt-3 text-text-light`}>
+                You will not see whether they have answered yet &mdash; that would tell you
+                something about their replies before you have given yours. Check with them first.
+              </p>
+            </div>
+          )}
+
+          {busyAction !== null && (
+            <p
+              data-testid="panel-busy"
+              role="status"
+              aria-live="polite"
+              className={`${typography.body} mt-6 flex items-center gap-3 text-text-light`}
+            >
+              <Loader2 className="h-5 w-5 animate-spin text-info" aria-hidden="true" />
+              {busyAction === 'open'
+                ? 'Opening the round… this can take a few seconds.'
+                : 'Closing the round and gathering everyone’s answers…'}
+            </p>
+          )}
+
+          {failure !== null && (
+            <div
+              data-testid="panel-error"
+              className="mt-6 rounded-md border border-danger/30 bg-panel p-4"
+            >
+              <p
+                role="alert"
+                className={`${typography.body} flex items-start gap-3 text-text-header`}
+              >
+                <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-danger" aria-hidden="true" />
+                <span>{failure.title}</span>
+              </p>
+              <p
+                data-testid="panel-error-guidance"
+                className={`${typography.bodySmall} mt-2 text-text-body`}
+              >
+                {failure.guidance}
+              </p>
+              {failure.detail !== null && (
+                <p
+                  data-testid="panel-error-detail"
+                  className={`${typography.bodySmall} mt-2 text-text-light`}
+                >
+                  Details: {failure.detail}
+                </p>
+              )}
+              {failure.credential && (
+                <Link
+                  to="/login"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid="panel-sign-in"
+                  className={`${typography.button} mt-4 inline-flex items-center gap-2 rounded-full border border-panel-border px-4 py-2 text-text-body transition-colors hover:bg-panel-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/40`}
+                >
+                  <LogIn className="h-4 w-4" aria-hidden="true" />
+                  Sign in (opens a new tab)
+                </Link>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
     </main>
   )
 }

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -12,6 +12,22 @@
  * (`authenticated && !!user && user.id !== 'guest'`), which is false for every
  * participant BY CONSTRUCTION.
  *
+ * ── THIS IS THE FIRST SCREEN AN EXTERNAL PILOT PARTICIPANT EVER SEES ──────
+ * A live browser witness on deployed build `3a4e3df2` drove it cold and found
+ * three things that stop a panellist before any collaboration science matters:
+ *
+ *   • the page rendered with ZERO design-system classes. Tailwind preflight
+ *     strips native styling and nothing restored it, so the h1 computed to
+ *     16px/400 — indistinguishable from body text — and the code field had
+ *     `border: 0; padding: 0`. Every surface here now carries the app's own
+ *     tokens (`bg-canvas`, `bg-panel`, `typography.*`, the DS `Button`), and
+ *     nothing is styled by an inline `style` attribute.
+ *   • a mistyped code was a DEAD END: the entry form rendered only while no
+ *     token was held, so a rejected credential could not be dropped and every
+ *     retry re-sent it. Only a reload escaped, and the page never said so.
+ *     `hasToken` is now STATE, and a refusal offers "Enter a different code".
+ *   • "Continue" was dead on empty input with no feedback at all.
+ *
  * ── WHAT THIS PAGE DELIBERATELY DOES NOT SHOW ─────────────────────────────
  * Before the round closes: no sibling answer, no model value for the target, no
  * response count, no roster. Not because the page hides them — because the
@@ -31,9 +47,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { AlertTriangle, KeyRound, Loader2, Lock } from 'lucide-react'
 
 import { BeliefElicitationField } from '../canvas/components/BeliefElicitationField'
 import { useBeliefElicitation } from '../canvas/hooks/useBeliefElicitation'
+import { Button } from '../components/ui/Button'
 import {
   CollabRequestError,
   declineTarget,
@@ -44,13 +62,83 @@ import {
   type PacketTarget,
   type RevealView,
 } from '../collab/collabService'
-import { getParticipantToken, setParticipantToken } from '../collab/participantToken'
+import {
+  clearParticipantToken,
+  getParticipantToken,
+  setParticipantToken,
+} from '../collab/participantToken'
+import { typography } from '../styles/typography'
+
+/* ── shared surface recipes ───────────────────────────────────────────────
+ * Named once rather than spelled per element: five hand-assembled copies of a
+ * card is how a design system drifts back into inline styles.
+ */
+const PAGE_SHELL = 'min-h-screen bg-canvas px-4 py-10 sm:px-6 sm:py-14'
+const COLUMN = 'mx-auto w-full max-w-[640px]'
+const CARD = 'rounded-[20px] border border-panel-border bg-panel p-6 shadow-1 sm:p-8'
+const FIELD =
+  'w-full min-h-[44px] rounded-md border border-panel-border bg-panel px-4 py-3 text-text-body placeholder:text-text-light transition-colors duration-fast focus:border-info focus:outline-none focus:ring-2 focus:ring-info/50'
 
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'packet'; packet: OpenPacket }
   | { kind: 'reveal'; reveal: RevealView }
-  | { kind: 'error'; message: string; code: string }
+  | { kind: 'error'; message: string; code: string; status: number }
+
+/**
+ * A refusal the participant can ACT on by supplying a different code.
+ *
+ * ⚠ Written against the SPEC of the seam, not against the one symptom in hand.
+ * `participantHeaders()` mints `collab_token_invalid` locally when no token is
+ * held; the SERVER's own code for a rejected bearer is not derivable from this
+ * repo, so the predicate leans on the HTTP status — which is, and stays, the
+ * transport-level truth about a credential the server would not accept.
+ */
+function isCredentialFailure(code: string, status: number): boolean {
+  return status === 401 || status === 403 || code === 'collab_token_invalid'
+}
+
+/** Both spellings the link builder and the boot-path strip accept. */
+const CODE_IN_LINK = /[?&](?:ct|collab_token)=([^&#\s]+)/
+
+type CodeReading = { code: string } | { problem: string }
+
+/**
+ * Read an access code out of whatever a participant pasted.
+ *
+ * The pristine page took `raw` as the code whenever no query parameter matched
+ * — so a link whose code had been trimmed in transit was adopted WHOLE as the
+ * credential, and the person learned about it as an unexplained server refusal
+ * several seconds later. A paste that is plainly a link and plainly carries no
+ * code is refused HERE, where the reason can still be given.
+ */
+export function readAccessCode(raw: string): CodeReading {
+  const trimmed = raw.trim()
+  if (trimmed === '') {
+    return { problem: 'Enter the code from your invitation, or paste the whole link you were sent.' }
+  }
+
+  const match = CODE_IN_LINK.exec(trimmed)
+  if (match !== null) {
+    let value = match[1]
+    try {
+      value = decodeURIComponent(value)
+    } catch {
+      /* a stray percent sign is not a reason to refuse a code that is present */
+    }
+    if (value.trim() !== '') return { code: value.trim() }
+  }
+
+  const looksLikeALink = /^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.includes('#/panel/')
+  if (looksLikeALink) {
+    return {
+      problem:
+        'That link does not include an access code — it was probably trimmed on the way to you. Ask whoever invited you to send it again, or paste just the code.',
+    }
+  }
+
+  return { code: trimmed }
+}
 
 /** One target, with its own phrase state (the field is caller-owned). */
 function TargetCard({
@@ -130,27 +218,32 @@ function TargetCard({
   }, [roundId, target, onAnswered])
 
   return (
-    <section data-testid={`packet-target-${target.target.id}`} style={{ marginBottom: '2rem' }}>
-      <h2 style={{ fontSize: '1.05rem', margin: '0 0 0.25rem' }}>{target.label}</h2>
+    <section data-testid={`packet-target-${target.target.id}`} className={`${CARD} mt-4`}>
+      <h2 className={`${typography.h4} text-text-header`}>{target.label}</h2>
       {target.description !== null && (
-        <p style={{ margin: '0 0 0.75rem', opacity: 0.8 }}>{target.description}</p>
+        <p className={`${typography.body} mt-1 text-text-light`}>{target.description}</p>
       )}
 
-      <BeliefElicitationField
-        label={target.label}
-        phrase={phrase}
-        onPhraseChange={handlePhraseChange}
-        elicitation={elicitation}
-        onAccept={commit}
-        testId={`packet-belief-${target.target.id}`}
-      />
+      <div className="mt-4">
+        <BeliefElicitationField
+          label={target.label}
+          phrase={phrase}
+          onPhraseChange={handlePhraseChange}
+          elicitation={elicitation}
+          onAccept={commit}
+          testId={`packet-belief-${target.target.id}`}
+        />
+      </div>
 
-      <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
-        <button type="button" onClick={handleDecline} disabled={busy}>
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <Button variant="secondary" size="sm" onClick={handleDecline} disabled={busy}>
           I would rather not answer this
-        </button>
+        </Button>
         {saved && (
-          <span data-testid={`packet-saved-${target.target.id}`}>
+          <span
+            data-testid={`packet-saved-${target.target.id}`}
+            className={`${typography.bodySmall} text-success`}
+          >
             {alreadyAnswered ? 'Answer updated.' : 'Answer recorded.'} You can change it until the
             round closes.
           </span>
@@ -158,7 +251,7 @@ function TargetCard({
       </div>
 
       {error !== null && (
-        <p role="alert" style={{ color: 'crimson' }}>
+        <p role="alert" className={`${typography.bodySmall} mt-3 text-danger`}>
           {error}
         </p>
       )}
@@ -170,13 +263,27 @@ export default function ParticipantPacketPage(): JSX.Element {
   const { round_id: roundId } = useParams<{ round_id: string }>()
   const [state, setState] = useState<LoadState>({ kind: 'loading' })
   const [manualToken, setManualToken] = useState('')
+  const [entryProblem, setEntryProblem] = useState<string | null>(null)
   const [answeredTick, setAnsweredTick] = useState(0)
 
-  const hasToken = getParticipantToken() !== null
+  /**
+   * ⚠ STATE, NOT A BARE MODULE READ — this is the whole of the dead-end fix.
+   * The token lives in module scope (deliberately: never on disk), so React has
+   * no way to learn that it changed. The pristine page recomputed
+   * `getParticipantToken() !== null` on every render, which meant the entry
+   * form could be reached only by never having had a token: once one was held,
+   * nothing in the page could go back.
+   */
+  const [hasToken, setHasToken] = useState<boolean>(() => getParticipantToken() !== null)
 
   const load = useCallback(async () => {
     if (roundId === undefined) {
-      setState({ kind: 'error', code: 'no_round', message: 'That link is incomplete.' })
+      setState({
+        kind: 'error',
+        code: 'no_round',
+        status: 0,
+        message: 'That link is incomplete.',
+      })
       return
     }
     setState({ kind: 'loading' })
@@ -185,6 +292,7 @@ export default function ParticipantPacketPage(): JSX.Element {
       setState({ kind: 'packet', packet })
     } catch (err) {
       const code = err instanceof CollabRequestError ? err.code : 'collab_request_failed'
+      const status = err instanceof CollabRequestError ? err.status : 0
       // A CLOSED round is not an error for a participant — it is the reveal.
       if (code === 'collab_round_closed') {
         try {
@@ -195,6 +303,7 @@ export default function ParticipantPacketPage(): JSX.Element {
           setState({
             kind: 'error',
             code,
+            status: revealErr instanceof CollabRequestError ? revealErr.status : 0,
             message:
               revealErr instanceof CollabRequestError
                 ? revealErr.message
@@ -206,6 +315,7 @@ export default function ParticipantPacketPage(): JSX.Element {
       setState({
         kind: 'error',
         code,
+        status,
         message: err instanceof CollabRequestError ? err.message : 'Could not load your panel.',
       })
     }
@@ -215,46 +325,176 @@ export default function ParticipantPacketPage(): JSX.Element {
     if (hasToken) void load()
   }, [hasToken, load, answeredTick])
 
+  /** Drop the held code and go back to the entry form, in place. */
+  const forgetCode = useCallback(() => {
+    clearParticipantToken()
+    setManualToken('')
+    setEntryProblem(null)
+    setState({ kind: 'loading' })
+    setHasToken(false)
+  }, [])
+
+  const submitCode = useCallback(() => {
+    const reading = readAccessCode(manualToken)
+    if ('problem' in reading) {
+      setEntryProblem(reading.problem)
+      return
+    }
+    setEntryProblem(null)
+    setParticipantToken(reading.code)
+    setHasToken(true)
+  }, [manualToken])
+
   // Fallback for a link that lost its query string in transit (chat clients do
-  // this). Typed into memory only — never stored.
+  // this), and the way back for anyone whose code was refused. Typed into
+  // memory only — never stored.
   if (!hasToken) {
+    const nothingToSubmit = manualToken.trim() === ''
     return (
-      <main style={{ maxWidth: 640, margin: '3rem auto', padding: '0 1rem' }}>
-        <h1>Your panel link needs its access code</h1>
-        <p>
-          The link you opened is missing its access code — some chat apps trim it. Paste the full
-          link you were sent, or the code itself.
-        </p>
-        <input
-          aria-label="Panel access code"
-          data-testid="packet-manual-token"
-          value={manualToken}
-          onChange={(e) => setManualToken(e.target.value)}
-        />
-        <button
-          type="button"
-          onClick={() => {
-            const raw = manualToken.trim()
-            const match = /[?&](?:ct|collab_token)=([^&#]+)/.exec(raw)
-            setParticipantToken(match !== null ? decodeURIComponent(match[1]) : raw)
-            setAnsweredTick((t) => t + 1)
-          }}
-        >
-          Continue
-        </button>
+      <main data-testid="packet-token-entry" className={PAGE_SHELL}>
+        <div className={COLUMN}>
+          <div className={CARD}>
+            <p className={`${typography.label} flex items-center gap-2 text-info`}>
+              <KeyRound className="h-4 w-4" aria-hidden="true" />
+              Panel access
+            </p>
+            <h1 className={`${typography.h2} mt-3 text-text-header`}>
+              Your panel link needs its access code
+            </h1>
+            <p className={`${typography.body} mt-3 text-text-body`}>
+              The link you opened is missing its access code — some chat apps trim it. Paste the
+              full link you were sent, or the code itself.
+            </p>
+
+            <div className="mt-6">
+              <label
+                htmlFor="packet-access-code"
+                className={`${typography.label} block text-text-header`}
+              >
+                Panel access code
+              </label>
+              <input
+                id="packet-access-code"
+                data-testid="packet-manual-token"
+                className={`${FIELD} ${typography.body} mt-2`}
+                value={manualToken}
+                autoComplete="off"
+                spellCheck={false}
+                aria-describedby="packet-access-code-hint"
+                aria-invalid={entryProblem !== null}
+                placeholder="Paste your link, or just the code"
+                onChange={(e) => {
+                  setManualToken(e.target.value)
+                  if (entryProblem !== null) setEntryProblem(null)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !nothingToSubmit) submitCode()
+                }}
+              />
+              <p
+                id="packet-access-code-hint"
+                data-testid="packet-manual-hint"
+                className={`${typography.bodySmall} mt-2 text-text-light`}
+              >
+                Your code stays in this tab only — it is never saved to this device.
+              </p>
+              {entryProblem !== null && (
+                <p
+                  data-testid="packet-manual-token-error"
+                  role="alert"
+                  className={`${typography.bodySmall} mt-2 text-danger`}
+                >
+                  {entryProblem}
+                </p>
+              )}
+            </div>
+
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <Button
+                data-testid="packet-manual-continue"
+                onClick={submitCode}
+                disabled={nothingToSubmit}
+              >
+                Continue
+              </Button>
+              {nothingToSubmit && (
+                <span
+                  data-testid="packet-manual-continue-hint"
+                  className={`${typography.bodySmall} text-text-light`}
+                >
+                  Paste your link or code to continue.
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
       </main>
     )
   }
 
   if (state.kind === 'loading') {
-    return <main data-testid="packet-loading">Loading your panel…</main>
+    return (
+      <main
+        data-testid="packet-loading"
+        className={`${PAGE_SHELL} flex items-center justify-center`}
+      >
+        <p
+          role="status"
+          className={`${typography.body} flex items-center gap-3 text-text-light`}
+        >
+          <Loader2 className="h-5 w-5 animate-spin text-info" aria-hidden="true" />
+          Loading your panel…
+        </p>
+      </main>
+    )
   }
 
   if (state.kind === 'error') {
+    const credential = isCredentialFailure(state.code, state.status)
     return (
-      <main data-testid="packet-error" style={{ maxWidth: 640, margin: '3rem auto' }}>
-        <h1>We could not open this panel</h1>
-        <p role="alert">{state.message}</p>
+      <main data-testid="packet-error" className={PAGE_SHELL}>
+        <div className={COLUMN}>
+          <div className={CARD}>
+            <AlertTriangle className="h-8 w-8 text-warning" aria-hidden="true" />
+            <h1 className={`${typography.h2} mt-4 text-text-header`}>
+              {credential
+                ? 'That access code was not recognised'
+                : 'We could not open this panel'}
+            </h1>
+            {/* THE PART THE WITNESS FOUND MISSING: what to do next. The wire
+                sentence alone ("That token could not be verified.") tells a
+                first-time panellist nothing they can act on. */}
+            <p
+              data-testid="packet-error-guidance"
+              role="alert"
+              className={`${typography.body} mt-3 text-text-body`}
+            >
+              {credential
+                ? 'Check the access code on your invitation and enter it again — a code only works for the round it was created for. If it still will not open, ask whoever invited you for a fresh link.'
+                : 'This is usually temporary. Try again in a moment. If it keeps happening, ask whoever invited you for a fresh link.'}
+            </p>
+            {!credential && (
+              <p
+                data-testid="packet-error-detail"
+                className={`${typography.bodySmall} mt-3 text-text-light`}
+              >
+                Details: {state.message}
+              </p>
+            )}
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Button data-testid="packet-reenter-code" onClick={forgetCode}>
+                Enter a different code
+              </Button>
+              <Button
+                variant="secondary"
+                data-testid="packet-retry"
+                onClick={() => setAnsweredTick((n) => n + 1)}
+              >
+                Try again
+              </Button>
+            </div>
+          </div>
+        </div>
       </main>
     )
   }
@@ -265,43 +505,56 @@ export default function ParticipantPacketPage(): JSX.Element {
 
   const { packet } = state
   return (
-    <main
-      data-testid="participant-packet-page"
-      style={{ maxWidth: 720, margin: '2rem auto', padding: '0 1rem' }}
-    >
-      <h1>You have been asked for your view</h1>
-      <p data-testid="packet-self-name">
-        Answering as <strong>{packet.self.display_name}</strong>
-      </p>
+    <main data-testid="participant-packet-page" className={PAGE_SHELL}>
+      <div className={COLUMN}>
+        <header className={CARD}>
+          <h1 className={`${typography.h2} text-text-header`}>You have been asked for your view</h1>
+          <p data-testid="packet-self-name" className={`${typography.body} mt-2 text-text-body`}>
+            Answering as <strong className="font-semibold text-text-header">{packet.self.display_name}</strong>
+          </p>
 
-      {/* ⭐ The blindness promise, stated. A person who does not KNOW their
-          answer is private behaves as though it is not — the guarantee only
-          does its work if it is said out loud. Every clause here is true of the
-          response this page received: it contains no sibling data at all. */}
-      <p data-testid="packet-blindness-notice">
-        Your answers are private until the round closes. You cannot see anyone else&rsquo;s answer,
-        how many people have replied, or the model&rsquo;s own number — and they cannot see yours.
-        That is deliberate: seeing them first would change what you write.
-      </p>
+          {/* ⭐ The blindness promise, stated. A person who does not KNOW their
+              answer is private behaves as though it is not — the guarantee only
+              does its work if it is said out loud. Every clause here is true of the
+              response this page received: it contains no sibling data at all. */}
+          <p
+            data-testid="packet-blindness-notice"
+            className={`${typography.body} mt-4 flex gap-3 rounded-md border border-info/30 bg-panel p-4 text-text-body`}
+          >
+            <Lock className="mt-0.5 h-4 w-4 flex-none text-info" aria-hidden="true" />
+            <span>
+              Your answers are private until the round closes. You cannot see anyone
+              else&rsquo;s answer, how many people have replied, or the model&rsquo;s own number —
+              and they cannot see yours. That is deliberate: seeing them first would change what
+              you write.
+            </span>
+          </p>
 
-      {packet.context_note !== null && (
-        <blockquote data-testid="packet-context-note">{packet.context_note}</blockquote>
-      )}
+          {packet.context_note !== null && (
+            <blockquote
+              data-testid="packet-context-note"
+              className={`${typography.body} mt-4 border-l-2 border-panel-border pl-4 text-text-body`}
+            >
+              {packet.context_note}
+            </blockquote>
+          )}
+        </header>
 
-      {packet.targets.map((t) => (
-        <TargetCard
-          key={t.target.id}
-          target={t}
-          roundId={packet.round_id}
-          alreadyAnswered={packet.self.completed_target_ids.includes(t.target.id)}
-          onAnswered={() => setAnsweredTick((n) => n + 1)}
-        />
-      ))}
+        {packet.targets.map((t) => (
+          <TargetCard
+            key={t.target.id}
+            target={t}
+            roundId={packet.round_id}
+            alreadyAnswered={packet.self.completed_target_ids.includes(t.target.id)}
+            onAnswered={() => setAnsweredTick((n) => n + 1)}
+          />
+        ))}
 
-      <p style={{ opacity: 0.75 }}>
-        When everyone has answered, whoever invited you will close the round and you will both see
-        every answer side by side.
-      </p>
+        <p className={`${typography.bodySmall} mt-6 text-text-light`}>
+          When everyone has answered, whoever invited you will close the round and you will both
+          see every answer side by side.
+        </p>
+      </div>
     </main>
   )
 }
@@ -317,59 +570,74 @@ export default function ParticipantPacketPage(): JSX.Element {
 export function RevealBody({ reveal }: { reveal: RevealView }): JSX.Element {
   const rows = useMemo(() => reveal.per_target, [reveal])
   return (
-    <main
-      data-testid="collab-reveal"
-      style={{ maxWidth: 820, margin: '2rem auto', padding: '0 1rem' }}
-    >
-      <h1>Everyone&rsquo;s answers</h1>
-      <p>
-        These are the answers as they were given, each in the words the person used. They are shown
-        side by side and are not combined into a single number.
-      </p>
+    <main data-testid="collab-reveal" className={PAGE_SHELL}>
+      <div className="mx-auto w-full max-w-[820px]">
+        <h1 className={`${typography.h2} text-text-header`}>Everyone&rsquo;s answers</h1>
+        <p className={`${typography.body} mt-3 text-text-body`}>
+          These are the answers as they were given, each in the words the person used. They are
+          shown side by side and are not combined into a single number.
+        </p>
 
-      {rows.map((row) => (
-        <section key={row.target.id} data-testid={`reveal-target-${row.target.id}`}>
-          {/* The owner's own words for this target. A heading that read
-              `factor-churn-risk` would obscure exactly what this view exists to
-              make obvious: WHERE these two people disagree. Falls back to the
-              id only if a round somehow carries no label. */}
-          <h2>{row.label !== '' ? row.label : row.target.id}</h2>
-          {row.model_value_at_version !== null && (
-            <p style={{ opacity: 0.75 }}>
-              The model held {row.model_value_at_version} for this when the round opened.
-            </p>
-          )}
-          <ul>
-            {row.responses.map((r) => (
-              <li key={r.participant_id} data-testid={`reveal-response-${r.participant_id}`}>
-                {/* ⭐ ATTRIBUTION: the person, then their number, then THEIR
-                    OWN WORDS. This line is the whole proof — a position that
-                    belongs to a named human. */}
-                <strong data-testid={`reveal-author-${r.participant_id}`}>{r.display_label}</strong>
-                {r.kind === 'declined' ? (
-                  <span> chose not to answer this one.</span>
-                ) : (
-                  <>
-                    <span data-testid={`reveal-value-${r.participant_id}`}> {r.value}</span>
-                    {r.expression_raw !== null && r.expression_raw !== '' && (
-                      <em data-testid={`reveal-words-${r.participant_id}`}>
-                        {' '}
-                        &mdash; &ldquo;{r.expression_raw}&rdquo;
-                      </em>
-                    )}
-                    {r.kind === 'belief_revised' && <span> (revised)</span>}
-                  </>
-                )}
-              </li>
-            ))}
-          </ul>
-          {row.responses.length === 1 && (
-            <p data-testid={`reveal-single-${row.target.id}`} style={{ opacity: 0.75 }}>
-              Only one person answered this. That is still their view, shown as given.
-            </p>
-          )}
-        </section>
-      ))}
+        {rows.map((row) => (
+          <section key={row.target.id} data-testid={`reveal-target-${row.target.id}`} className={`${CARD} mt-6`}>
+            {/* The owner's own words for this target. A heading that read
+                `factor-churn-risk` would obscure exactly what this view exists to
+                make obvious: WHERE these two people disagree. Falls back to the
+                id only if a round somehow carries no label. */}
+            <h2 className={`${typography.h4} text-text-header`}>
+              {row.label !== '' ? row.label : row.target.id}
+            </h2>
+            {row.model_value_at_version !== null && (
+              <p className={`${typography.bodySmall} mt-1 text-text-light`}>
+                The model held {row.model_value_at_version} for this when the round opened.
+              </p>
+            )}
+            <ul className="mt-4 space-y-3">
+              {row.responses.map((r) => (
+                <li
+                  key={r.participant_id}
+                  data-testid={`reveal-response-${r.participant_id}`}
+                  className={`${typography.body} rounded-md border border-panel-border bg-panel p-4 text-text-body`}
+                >
+                  {/* ⭐ ATTRIBUTION: the person, then their number, then THEIR
+                      OWN WORDS. This line is the whole proof — a position that
+                      belongs to a named human. */}
+                  <strong
+                    data-testid={`reveal-author-${r.participant_id}`}
+                    className="font-semibold text-text-header"
+                  >
+                    {r.display_label}
+                  </strong>
+                  {r.kind === 'declined' ? (
+                    <span className="text-text-light"> chose not to answer this one.</span>
+                  ) : (
+                    <>
+                      <span data-testid={`reveal-value-${r.participant_id}`}> {r.value}</span>
+                      {r.expression_raw !== null && r.expression_raw !== '' && (
+                        <em data-testid={`reveal-words-${r.participant_id}`}>
+                          {' '}
+                          &mdash; &ldquo;{r.expression_raw}&rdquo;
+                        </em>
+                      )}
+                      {r.kind === 'belief_revised' && (
+                        <span className="text-text-light"> (revised)</span>
+                      )}
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+            {row.responses.length === 1 && (
+              <p
+                data-testid={`reveal-single-${row.target.id}`}
+                className={`${typography.bodySmall} mt-3 text-text-light`}
+              >
+                Only one person answered this. That is still their view, shown as given.
+              </p>
+            )}
+          </section>
+        ))}
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Why

A live browser witness on deployed UI `3a4e3df2` drove both collaboration panel pages cold. **These are the first screens an external pilot participant ever sees**, and they were unusable before any collaboration science got a chance to matter. This PR fixes the friction on those two surfaces only.

## Per-finding disposition

| # | Finding | Disposition |
|---|---------|-------------|
| F1 | SEVERE — both pages rendered with **zero** design-system classes (`main [class]` → 0 in the live DOM); h1 computed to 16px/400, inputs `border:0 padding:0`, the owner's five labels a run-on wall | **Fixed** — both pages and the shared reveal use the app's own tokens (`bg-canvas` / `bg-panel` / `typography.*` / the DS `Button`). No inline `style` attribute survives on either page. Every owner field is a real `<label for>` + `<input id>` pair, with hints and focus rings. |
| F2 | SEVERE — a participant who mistyped their code was **trapped**; only a reload escaped and the page never said so | **Fixed** — `hasToken` is now **state** (the token lives in module scope, so React could never learn it changed). A refusal offers *"Enter a different code"*, and clearing genuinely drops the bearer rather than re-rendering the form. |
| F3 | HIGH — "Continue" dead on empty input, zero feedback | **Fixed** — disabled until there is something to submit, with the reason stated; and a pasted link whose code was trimmed in transit is refused **here**, with the reason, instead of being adopted whole as the credential and failing as an unexplained server refusal seconds later. |
| F4 | HIGH — owner saw CEE's raw wire sentence after ~8s with no busy indicator | **Fixed** — a `role="status"` busy region for both open and close, and every failure translated into a title + a next step. The credential branch **derives** its sentence from `ownerSignInRequired()` rather than retyping it. Non-credential failures keep the server's words as a clearly-labelled secondary detail line. |
| F5 | HIGH — "Sign in again…" with no sign-in affordance | **Fixed** — a link to `/login`, opened in a new tab so the owner does not lose what they typed. |
| F6 | HIGH — owner hand-types a literal factor id | **PARTIAL — picker reported out of scope.** The graph is **not** in this page's data flow: the canvas store is not persisted (no `persist(`) and this route is a separate lazy chunk, so a deep-link or refresh would render an empty picker. A picker needs new data plumbing. Shipped instead: a worked example placeholder, a hint that the *label* is what the panel actually sees, and a **non-blocking** warning when the id contains spaces (non-blocking deliberately — "ids have no spaces" is an invariant this lane could not derive). |
| F7 | MEDIUM — one-shot links, no copy button | **Fixed** — per-row copy button with per-row confirmation, plus a fallback message when the browser refuses the clipboard. |
| F8/F9 | — | **Out of scope per brief** (F8 needs a spec decision; F9 is harness-side). |

Nothing in auth logic, token verification semantics or CEE was touched. `clearParticipantToken()` is new — it forgets an in-memory bearer so the participant can retry; it decides nothing about validity.

## Evidence

**RED-first at pristine `3a4e3df2`:** the new spec collected **17 tests by name**, **14 failed / 3 passed** (the 3 were the positive control, the pre-existing label association, and the mount-path check). After the fix: **17/17 green**.

**Mutation kit — 10 mutants, all bite, in a detached worktree outside the repo root:**

- isolation **proven by writing** a sentinel (source SHA unchanged, inodes differ) — not by locating a path
- restores are `git checkout HEAD --`, with a clean-tree assertion before and after each mutant
- applied-check scoped to `src/`; **leading and trailing controls both read exactly 0 applied / 17 green**

| Mutant | REDs |
|---|---|
| M1 `clearParticipantToken` no-op | 1 (the clearing claim only) |
| M2 `forgetCode` never returns to the entry form | 2 |
| M3 Continue never disabled | 1 |
| M4 a codeless link adopted whole as the credential | 1 |
| M5 no failure treated as a credential failure (participant) | 1 |
| M6 every owner failure routed to sign-in | 1 (the DIFFERENT-OBJECT test) |
| M7 owner busy region never renders | 1 |
| M8 every copy button copies the first link | 1 |
| M9 participant page loses its shell tokens | 2 |
| M10 owner h1 loses its typography token | 1 |

Three of these are **discrimination pairs**, not just biting mutants: M1 REDs the clearing claim while leaving "the second code is the one on the wire" green; M4 REDs the codeless-link refusal while its opposite-direction twin (a link that *does* carry a code) stays green; M6 REDs only the ordinary-failure test while both credential tests stay green.

**Gates run locally at this tip:** `pnpm run typecheck` PASS (coverage + ratchet; drift shrank 2487→2485 in files this PR never touched, so the baseline was deliberately **not** regenerated). `pnpm run lint` 0 errors, and **zero warnings on the four touched files**. `ci:guard:ds` net-new list contains none of these files. `ci:guard:zustand`, `ci:guard:duplicates` PASS. 207 CI-guard tests, 391 tests across `src/pages`, `src/collab`, `src/poc`, `src/components/ui`, `src/components/auth` — all green.

## ⚠ What this evidence does NOT settle

**F1 is not settled by any test here.** jsdom computes no layout, so the F1 block asserts only that the design-system tokens are **applied**, and that the surfaces carrying them are the ones `AppPoC` actually mounts. Hierarchy, spacing, contrast and focus rings — the very things the witness measured — need the **browser witness that follows the deploy**. This PR does not claim them.

## Friction noticed beyond the list (reported, not fixed)

- A participant who reloads still loses their code — F8, out of scope by brief, but note the entry form is now a real recovery path rather than a dead end, so the reload is survivable in a way it was not before.
- The owner cannot re-mint a lost link from this page; the copy affordance reduces the need but does not remove it.
- Both pages are reachable only by URL — there is no route into the owner's panel page from the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)