### PR TITLE
feat(coaching): the coaching card can finally say its advice is out of date

### DIFF
--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -339,6 +339,24 @@ export interface V5CoachingBlock {
   signal?: string
   /** Absent = this card claims no cited DSK claim. Never "unknown claim". */
   dsk_claim_provenance?: V5DskClaimProvenance
+  /**
+   * CEE's `aag_v1` graph hash AT THE MOMENT THIS CARD WAS WRITTEN.
+   *
+   * This is what lets a card in the transcript notice that the model moved
+   * underneath it. `freshness` cannot: the producer stamps it at emission
+   * (wire-measured `'fresh'` on 13/13 blocks, 2026-08-12) and a rendered
+   * transcript block is immutable, so CEE can never re-stamp a card the user
+   * is already reading. Compared at RENDER time against
+   * `analysisFreshness.currentGraphHash` — see `coachingCurrency.ts`.
+   *
+   * ⚠ CEE-PRODUCED, AND ONLY EVER COMPARABLE WITH ANOTHER CEE HASH. The UI's
+   * `generateGraphHash` is a different algorithm over different inputs
+   * (`guidanceStore.ts` §2b); comparing the two is a category error.
+   *
+   * Optional because the producer omits it on some paths (4/13 wire-measured,
+   * all draft-path). Absent ⇒ cannot-confirm, never "current".
+   */
+  graph_hash_at_generation?: string
 }
 
 /**

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -109,6 +109,8 @@ import {
   guidanceCategoryTone,
 } from '../../canvas/stores/guidanceStore'
 import { STRENGTHEN_COPY } from '../../components/results/strengthen/strengthenCopy'
+import { useCanvasStore } from '../../canvas/store'
+import { deriveCoachingCurrency } from './coachingCurrency'
 import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
 
 export interface V5CoachingBlockProps {
@@ -211,6 +213,16 @@ const FRESHNESS_NOTICE: Partial<Record<string, string>> = {
 }
 
 /**
+ * The depth-layer sentence for CANNOT-CONFIRM. It is the card's existing
+ * honest-absence idiom — the same voice as "This suggestion is not linked to a
+ * cited decision-science claim" — applied to the one other thing the card can
+ * fail to know. It states what is unknown; it never guesses, and it never
+ * implies the advice is wrong.
+ */
+const CURRENCY_UNKNOWN_DETAIL =
+  'We can’t confirm whether your model has changed since this was written.'
+
+/**
  * Code-keyed display copy for the two pass-through discriminators. Both are
  * OPEN vocabularies the producer owns, so an unrecognised value maps to
  * `undefined` and the disclosure simply omits that line — it must never print
@@ -239,7 +251,41 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
   const tone: Tone = guidanceCategoryTone(block.category)
   const { Icon, tintClass } = guidanceCategoryIcon(block.category)
 
-  const freshnessNotice = block.freshness ? FRESHNESS_NOTICE[block.freshness] : undefined
+  /*
+    THE UNCERTAINTY CHANNEL, MADE REACHABLE.
+
+    `freshness` is the PRODUCER's verdict, stamped at emission — so on a card
+    the user is reading it is always `fresh` (wire-measured 13/13, 2026-08-12)
+    and the `stale` sentence below could never fire. Currency is a DIFFERENT
+    question — "is this still about the model you have?" — and only the client
+    can answer it, because only the client is still here after the user edits.
+
+    Read at RENDER time, on a store subscription, exactly as `TargetRefPill`
+    (already inside this card) resolves its targets: "Resolution is render-time,
+    not ingest-time … a pill never points at a guess." At ingest the two hashes
+    are always equal, which is precisely why an ingest-time verdict is worthless.
+
+    ⚠ BOTH SIDES ARE CEE-PRODUCED. `currentGraphHash` comes from
+    `analysis_ready.current_graph_hash`; the block's from
+    `graph_hash_at_generation`. The UI's own `generateGraphHash` is a different
+    algorithm and MUST NOT be substituted here — see `coachingCurrency.ts`.
+  */
+  const currentGraphHash = useCanvasStore((s) => s.analysisFreshness?.currentGraphHash)
+  const currency = deriveCoachingCurrency(block.graph_hash_at_generation, currentGraphHash)
+
+  /*
+    The producer's verdict WINS when it has said anything at all.
+
+    `freshness` answers "did this card generate correctly?" (pending / failed)
+    and currency answers "is it still about your model?" — two questions, and
+    trap 21 is what happens when two questions share one channel. So the
+    derived verdict FILLS THE PRODUCER'S SILENCE and never overwrites its
+    speech. When both point at staleness they resolve to the same sentence, so
+    the notice renders once and cannot contradict itself.
+  */
+  const freshnessNotice =
+    (block.freshness ? FRESHNESS_NOTICE[block.freshness] : undefined) ??
+    (currency === 'changed' ? FRESHNESS_NOTICE.stale : undefined)
   const kindSentence = KIND_SENTENCE[block.coaching_kind]
   const sourceSentence = SOURCE_SENTENCE[block.source]
   const claim = block.dsk_claim_provenance
@@ -251,6 +297,7 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
       data-coaching-kind={block.coaching_kind}
       data-coaching-source={block.source}
       data-freshness={block.freshness}
+      data-currency={currency}
       data-tone={tone}
       {...(block.category ? { 'data-category': block.category } : {})}
       {...(block.signal_code ? { 'data-signal-code': block.signal_code } : {})}
@@ -434,6 +481,19 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
               ? `This instantiates a cited decision-science claim: “${claim.claim_title}”, which the bundle rates ${claim.evidence_strength} evidence.`
               : 'This suggestion is not linked to a cited decision-science claim.'}
           </p>
+          {/*
+            CANNOT-CONFIRM lives HERE, not on the face, and the placement is the
+            argument: the card makes no currency claim on its face, so there is
+            nothing false to correct — but silence would let "we cannot tell"
+            read exactly like "still current". The depth layer is where this
+            card already states what it does not know ("not linked to a cited
+            decision-science claim"), and the summary above it literally asks
+            "how sure". A CHANGED model is different: that contradicts what the
+            reader would otherwise assume, so it goes on the face, unprompted.
+          */}
+          {currency === 'cannot_confirm' && (
+            <p data-testid={`${testIdPrefix}-currency-detail`}>{CURRENCY_UNKNOWN_DETAIL}</p>
+          )}
           {kindSentence && (
             <p data-testid={`${testIdPrefix}-kind-detail`}>{kindSentence}</p>
           )}

--- a/src/v5/blocks/__tests__/V5CoachingBlock.currency.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingBlock.currency.spec.tsx
@@ -1,0 +1,221 @@
+/**
+ * PR3 follow-on — THE COACHING CARD CAN FINALLY TELL YOU ITS ADVICE IS OUT OF DATE.
+ *
+ * ## The defect this pins (guarantee theatre, this programme's named dominant class)
+ *
+ * `V5CoachingBlock` has shipped the sentence *"Your model has changed since this was
+ * written — it may no longer apply."* since #644. **No execution path could ever
+ * reach it.** The sentence is keyed on the producer's `freshness`, and:
+ *
+ *   - CEE stamps `freshness` at EMISSION time. Wire-measured 2026-08-12 across 13
+ *     coaching blocks in 2 scenarios: `freshness` was `'fresh'` on **13/13**. It is
+ *     never anything else on a block the user is about to read.
+ *   - A rendered transcript block is IMMUTABLE. CEE cannot reach back and
+ *     re-stamp a card the user is already looking at.
+ *
+ * So a user edits the model and keeps acting on coaching written for a model that
+ * no longer exists, with nothing on screen saying so. A promise rendered in the
+ * product that no code path can satisfy is worse than an absent one.
+ *
+ * ## What makes the fix possible, and why the comparison is safe
+ *
+ * CEE already puts BOTH halves on the wire:
+ *   - the block's own `graph_hash_at_generation` (9/13 on the wire; preserved
+ *     verbatim by the parser sidecar, and `useConversation.ts:4771` says it is kept
+ *     "so consumers can read it directly" — until now none did);
+ *   - the response's `analysis_ready.current_graph_hash`, parsed into the canvas
+ *     store by `analysisFreshness.ts` as `currentGraphHash`.
+ *
+ * ⚠ THE CATEGORY ERROR THIS DELIBERATELY AVOIDS. `guidanceStore.ts` §2b states it
+ * outright: the UI's own `generateGraphHash` is a DIFFERENT algorithm over different
+ * inputs, and comparing a CEE hash against a UI hash is meaningless. This module
+ * therefore compares **CEE's hash to CEE's hash, and nothing else**. That the two
+ * are the same family is not assumed — it is MEASURED: in both captured scenarios
+ * the coaching block's `graph_hash_at_generation`, the response's top-level
+ * `graph_hash` and `analysis_ready.current_graph_hash` were byte-identical
+ * (`0b9ba6ac328d8b50`; `94eefbc9b712082d`). Evidence:
+ * `olumi-docs/PHASE0-EVIDENCE-2026-07-28/coaching-surface-2026-08-12/`.
+ *
+ * ## Render-time, not ingest-time
+ *
+ * At ingest the two hashes are always equal — that is exactly why the producer can
+ * only ever say `fresh`. The comparison must therefore happen at RENDER time, on a
+ * store subscription, so a card already on screen starts telling the truth the
+ * moment the model moves underneath it. This is the same contract `TargetRefPill`
+ * (already inside this very card) documents: "Resolution is render-time, not
+ * ingest-time … a pill never points at a guess."
+ *
+ * ## Three states, and absence is never fresh
+ *
+ * The verdict reuses the estate's EXISTING vocabulary, `FreshnessDisplaySemantic`
+ * ('current' | 'changed' | 'cannot_confirm'), whose own doc-comment states the rule
+ * this must obey: "'changed' must never be claimed for a CEE-sourced 'unknown'".
+ * A block with no hash, or a store with no CEE hash, is CANNOT-CONFIRM — never
+ * silently fresh, never fabricated stale.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
+import { useCanvasStore } from '../../../canvas/store'
+import { adaptTypedCoachingBlock } from '../../phase3TypedBlocks'
+import type { V5CoachingBlock as V5CoachingBlockType } from '../../../canvas/conversation/types'
+
+/** The exact sentence #644 shipped. Reused, never re-authored. */
+const CHANGED_SENTENCE =
+  'Your model has changed since this was written — it may no longer apply.'
+
+/** CEE-shaped hashes, taken from the 2026-08-12 staging captures. */
+const HASH_AT_GENERATION = '0b9ba6ac328d8b50'
+const HASH_AFTER_EDIT = '94eefbc9b712082d'
+
+const BLOCK_ID = '7e0855c7-d79d-5d16-9fee-19e68ece297d'
+
+/**
+ * A wire-shaped raw coaching block. Field-for-field the shape measured on
+ * staging (`wire-leg3-analyse-raw.json`), including `freshness: 'fresh'` —
+ * which is the whole point: this is what CEE actually sends.
+ */
+function rawCoaching(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'coaching',
+    block_id: BLOCK_ID,
+    title: 'An assumption to check',
+    body: 'The link from Estimated Delivery Confidence to Build Delivery Failure assumes the current timeline holds.',
+    coaching_kind: 'assumption_check',
+    source: 'decision_review',
+    target_refs: [],
+    priority_rank: 101,
+    freshness: 'fresh',
+    category: 'could_fix',
+    priority: 50,
+    signal_code: 'ASSUMPTION_CHECK',
+    graph_hash_at_generation: HASH_AT_GENERATION,
+    ...overrides,
+  }
+}
+
+/** Adapt through the REAL producer path, then mount through the REAL renderer. */
+function renderThroughMountPath(raw: Record<string, unknown>): void {
+  const adapted = adaptTypedCoachingBlock(raw)
+  expect(adapted, 'fixture must adapt — a null here would make every assertion vacuous').not.toBeNull()
+  render(<InlineBlocks blocks={[adapted as V5CoachingBlockType]} />)
+}
+
+/** Bind by IDENTITY: the card carrying THIS block_id, never "some card". */
+function theCard(): HTMLElement {
+  const card = document.querySelector(`[data-block-id="${BLOCK_ID}"]`)
+  expect(card, 'the coaching card must be mounted by InlineBlocks case v5_coaching').not.toBeNull()
+  return card as HTMLElement
+}
+
+/** Set the CEE-sourced current graph hash exactly as `analysisFreshness` stores it. */
+function setCeeCurrentGraphHash(currentGraphHash: string | undefined): void {
+  useCanvasStore.setState({
+    analysisFreshness: currentGraphHash === undefined
+      ? { freshness: 'fresh' }
+      : { freshness: 'fresh', currentGraphHash },
+    analysisFreshnessDirty: false,
+  })
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+})
+
+describe('coaching card currency — the model moved underneath the advice', () => {
+  it('RED-FIRST: says the model has changed when CEE’s current hash differs from the block’s', () => {
+    // The user was coached at HASH_AT_GENERATION, then edited; CEE now reports a
+    // different current hash. At pristine this sentence is UNFIREABLE.
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    renderThroughMountPath(rawCoaching())
+
+    const notice = within(theCard()).getByTestId('v5-coaching-freshness')
+    expect(notice).toHaveTextContent(CHANGED_SENTENCE)
+    expect(theCard()).toHaveAttribute('data-currency', 'changed')
+  })
+
+  it('stays SILENT while the hashes agree — no "still current" noise on every card', () => {
+    setCeeCurrentGraphHash(HASH_AT_GENERATION)
+    renderThroughMountPath(rawCoaching())
+
+    expect(within(theCard()).queryByTestId('v5-coaching-freshness')).toBeNull()
+    expect(theCard()).toHaveAttribute('data-currency', 'current')
+  })
+
+  it('THE THIRD STATE: a block with no hash is CANNOT-CONFIRM — never stale, never silently fresh', () => {
+    // 4 of 13 wire-measured coaching blocks carried no graph_hash_at_generation.
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    const raw = rawCoaching()
+    delete raw.graph_hash_at_generation
+    renderThroughMountPath(raw)
+
+    expect(theCard()).toHaveAttribute('data-currency', 'cannot_confirm')
+    // It must NOT fabricate the change it cannot observe...
+    expect(within(theCard()).queryByTestId('v5-coaching-freshness')).toBeNull()
+    // ...and must NOT pass silently as current either: it says so in the depth layer.
+    expect(within(theCard()).getByTestId('v5-coaching-currency-detail')).toBeInTheDocument()
+  })
+
+  it('CANNOT-CONFIRM when the store holds no CEE hash — absence is never a change', () => {
+    setCeeCurrentGraphHash(undefined)
+    renderThroughMountPath(rawCoaching())
+
+    expect(theCard()).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard()).queryByTestId('v5-coaching-freshness')).toBeNull()
+    expect(within(theCard()).getByTestId('v5-coaching-currency-detail')).toBeInTheDocument()
+  })
+
+  it('never states cannot-confirm once currency IS established', () => {
+    setCeeCurrentGraphHash(HASH_AT_GENERATION)
+    renderThroughMountPath(rawCoaching())
+    expect(within(theCard()).queryByTestId('v5-coaching-currency-detail')).toBeNull()
+  })
+
+  it('the PRODUCER’s own verdict wins — a pending card is not overwritten by a derived "changed"', () => {
+    // freshness is about GENERATION; currency is about the MODEL. When the
+    // producer has said something, it is not ours to overwrite (trap 21: two
+    // questions, one channel).
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    renderThroughMountPath(rawCoaching({ freshness: 'pending' }))
+
+    const notice = within(theCard()).getByTestId('v5-coaching-freshness')
+    expect(notice).toHaveTextContent('This is still being written.')
+    expect(notice).not.toHaveTextContent(CHANGED_SENTENCE)
+  })
+
+  it('renders the sentence ONCE when producer and derivation agree it is stale', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    renderThroughMountPath(rawCoaching({ freshness: 'stale' }))
+
+    expect(within(theCard()).getAllByTestId('v5-coaching-freshness')).toHaveLength(1)
+    expect(within(theCard()).getByTestId('v5-coaching-freshness')).toHaveTextContent(CHANGED_SENTENCE)
+  })
+})
+
+describe('adaptTypedCoachingBlock — graph_hash_at_generation carry', () => {
+  it('carries the producer hash VERBATIM', () => {
+    const adapted = adaptTypedCoachingBlock(rawCoaching())
+    expect(adapted?.graph_hash_at_generation).toBe(HASH_AT_GENERATION)
+  })
+
+  it('OMITS the field when the producer sent none — never invents, never defaults', () => {
+    const raw = rawCoaching()
+    delete raw.graph_hash_at_generation
+    const adapted = adaptTypedCoachingBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('OMITS a non-string hash rather than coercing it', () => {
+    const adapted = adaptTypedCoachingBlock(rawCoaching({ graph_hash_at_generation: 12345 }))
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('a missing hash never costs the CARD — the block still adapts', () => {
+    const raw = rawCoaching()
+    delete raw.graph_hash_at_generation
+    expect(adaptTypedCoachingBlock(raw)).not.toBeNull()
+  })
+})

--- a/src/v5/blocks/__tests__/V5CoachingBlock.currency.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingBlock.currency.spec.tsx
@@ -54,7 +54,7 @@
  * silently fresh, never fabricated stale.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, within } from '@testing-library/react'
 
 import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
 import { useCanvasStore } from '../../../canvas/store'

--- a/src/v5/blocks/coachingCurrency.ts
+++ b/src/v5/blocks/coachingCurrency.ts
@@ -1,0 +1,84 @@
+/**
+ * coachingCurrency — is this coaching card still about the model the user has?
+ *
+ * ## The defect this exists to close (guarantee theatre)
+ *
+ * `V5CoachingBlock` has rendered the sentence *"Your model has changed since this
+ * was written — it may no longer apply."* since #644, and NO EXECUTION PATH COULD
+ * REACH IT. The sentence is keyed on the producer's `freshness`, which CEE stamps
+ * at EMISSION time — wire-measured 2026-08-12, `freshness` was `'fresh'` on 13 of
+ * 13 coaching blocks across two scenarios — and a rendered transcript block is
+ * immutable, so CEE can never re-stamp a card the user is already reading. The
+ * user edits the model and keeps acting on advice about a model that no longer
+ * exists, with nothing on screen saying so.
+ *
+ * ## Why the comparison is meaningful — CEE's hash against CEE's hash, only
+ *
+ * `guidanceStore.ts` §2b states the category error to avoid, and it is this
+ * estate's own scar: *"The UI's own `generateGraphHash` is a DIFFERENT algorithm
+ * over different inputs … Comparing the two would be the category error."* This
+ * module therefore takes TWO CEE-PRODUCED VALUES and nothing else:
+ *
+ *   - `blockGraphHash`  — the block's `graph_hash_at_generation` (CEE `aag_v1`),
+ *     carried verbatim through the parser sidecar by `adaptTypedCoachingBlock`.
+ *   - `currentGraphHash` — `analysis_ready.current_graph_hash` (CEE), parsed into
+ *     the canvas store by `analysisFreshness.ts`.
+ *
+ * That the two are the same hash family is MEASURED, not assumed: in both captured
+ * staging scenarios the coaching block's `graph_hash_at_generation`, the response's
+ * top-level `graph_hash` and `analysis_ready.current_graph_hash` were byte-identical
+ * (`0b9ba6ac328d8b50`, then `94eefbc9b712082d`). Evidence:
+ * `olumi-docs/PHASE0-EVIDENCE-2026-07-28/coaching-surface-2026-08-12/`.
+ *
+ * ⚠ THE ONE WAY TO BREAK THIS is to pass a UI-side hash as either argument. The
+ * signature cannot prevent it (both are strings), so the mutant kit pins it: a
+ * mutant that sources the current hash from the UI's `generateGraphHash` must RED.
+ *
+ * ## Why the verdict vocabulary is borrowed, not minted
+ *
+ * `FreshnessDisplaySemantic` ('current' | 'changed' | 'cannot_confirm' | 'none')
+ * already exists in `canvas/store/analysisFreshness.ts` for exactly this
+ * distinction, and its doc-comment states the rule this obeys: *"'changed' must
+ * never be claimed for a CEE-sourced 'unknown'"*. A second, parallel vocabulary
+ * for the same question is the drift defect this estate keeps paying for.
+ *
+ * ## Absence is CANNOT-CONFIRM — never fresh, never stale
+ *
+ * 4 of the 13 wire-measured blocks carried no `graph_hash_at_generation`, and a
+ * turn can arrive before any `analysis_ready`. Either gap means the question is
+ * unanswerable, and the honest answer to an unanswerable question is to say so:
+ * inferring `current` from absence would restore the exact silent-but-wrong state
+ * this module exists to end, and inferring `changed` would cry wolf.
+ */
+import type { FreshnessDisplaySemantic } from '../../canvas/store/analysisFreshness'
+
+/**
+ * The three answers a coaching card can honestly give about its own currency.
+ * `'none'` — the fourth `FreshnessDisplaySemantic` member — is deliberately NOT
+ * reachable here: it means "no analysis has been run", which is a statement about
+ * the ANALYSIS, not about whether this card's model still exists.
+ */
+export type CoachingCurrency = Exclude<FreshnessDisplaySemantic, 'none'>
+
+/** A hash is usable only as a non-empty string; `''` is absence, not a value. */
+function usableHash(v: string | undefined | null): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined
+}
+
+/**
+ * Compare the model this card was written about with the model CEE currently
+ * reports. BOTH arguments must be CEE-produced hashes — see the module header.
+ *
+ * @param blockGraphHash   the block's `graph_hash_at_generation`
+ * @param currentGraphHash `analysis_ready.current_graph_hash` from the store
+ */
+export function deriveCoachingCurrency(
+  blockGraphHash: string | undefined | null,
+  currentGraphHash: string | undefined | null,
+): CoachingCurrency {
+  const authored = usableHash(blockGraphHash)
+  const current = usableHash(currentGraphHash)
+  // Either side missing ⇒ the question cannot be answered. Stated, never guessed.
+  if (!authored || !current) return 'cannot_confirm'
+  return authored === current ? 'current' : 'changed'
+}

--- a/src/v5/phase3TypedBlocks.ts
+++ b/src/v5/phase3TypedBlocks.ts
@@ -248,6 +248,17 @@ export function adaptTypedCoachingBlock(
   const signalLine = nonEmptyString(raw.signal)
   const claimProvenance = dskClaimProvenance(raw.dsk_claim_provenance)
 
+  // CEE's graph hash at authoring time. Preserved verbatim so the card can
+  // compare it — at RENDER time — against CEE's CURRENT graph hash and notice
+  // that the model moved underneath the advice. `useConversation.ts` has kept
+  // this field on the raw block "so consumers can read it directly" since
+  // slice 1; until now no consumer did, which is why the card's
+  // "your model has changed" sentence was unreachable.
+  //
+  // A non-string is DROPPED rather than coerced: a fabricated hash would
+  // compare unequal to everything and manufacture a permanent false "changed".
+  const graphHashAtGeneration = nonEmptyString(raw.graph_hash_at_generation)
+
   return {
     type: 'v5_coaching',
     block_id: blockId,
@@ -269,6 +280,7 @@ export function adaptTypedCoachingBlock(
     ...(signalCode ? { signal_code: signalCode } : {}),
     ...(signalLine ? { signal: signalLine } : {}),
     ...(claimProvenance ? { dsk_claim_provenance: claimProvenance } : {}),
+    ...(graphHashAtGeneration ? { graph_hash_at_generation: graphHashAtGeneration } : {}),
   }
 }
 


### PR DESCRIPTION
## The defect: a promise no code path could keep

`V5CoachingBlock` has rendered the sentence **"Your model has changed since this was written — it may no longer apply."** since #644. **No execution path could ever reach it.**

The sentence is keyed on the producer's `freshness`, and:

- CEE stamps `freshness` at **emission** time. Wire-measured 12 Aug across **13 coaching blocks in 2 scenarios**: `freshness` was `'fresh'` on **13/13**.
- A rendered transcript block is **immutable**. CEE cannot reach back and re-stamp a card the user is already reading.

So a user edits the model and keeps acting on coaching written for a model that no longer exists, with nothing on screen saying so. That is guarantee theatre — the class this programme has named as its dominant defect.

## Both halves were already on the wire

| half | where | status before this PR |
|---|---|---|
| `graph_hash_at_generation` (CEE `aag_v1`) | the coaching block, 9/13 on the wire | preserved verbatim, **zero consumers** — `useConversation.ts:4771` literally says it is kept "so consumers can read it directly" |
| `analysis_ready.current_graph_hash` (CEE) | already parsed into the canvas store by `analysisFreshness.ts` | used for analysis freshness only |

This PR joins them. Nothing new is requested from CEE.

## ⚠ CEE's hash against CEE's hash — never the UI's

`guidanceStore.ts` §2b states the category error outright: *"The UI's own `generateGraphHash` is a DIFFERENT algorithm over different inputs … Comparing the two would be the category error."* This estate also carries the two-`generateGraphHash`-twins scar.

That the two CEE values are the same family is **measured, not assumed**: in both captured scenarios the block's `graph_hash_at_generation`, the response's top-level `graph_hash` and `analysis_ready.current_graph_hash` were byte-identical (`0b9ba6ac328d8b50`; then `94eefbc9b712082d`).

**Mutant M5 pins it**: sourcing `graphHashAtRun` instead of `currentGraphHash` — the *wrong* CEE hash — REDs.

## Render-time, not ingest-time

At ingest the two hashes are always equal, which is exactly why an ingest-time verdict is worthless. The comparison runs at **render** time on a store subscription, so a card already on screen starts telling the truth the moment the model moves. This is the contract `TargetRefPill` — already inside this very card — documents: *"Resolution is render-time, not ingest-time … a pill never points at a guess."*

## Three states, and absence is never "fresh"

Verdict reuses the **existing** `FreshnessDisplaySemantic` vocabulary, whose own doc-comment states the rule obeyed here: *"'changed' must never be claimed for a CEE-sourced 'unknown'"*.

| verdict | where it surfaces | why there |
|---|---|---|
| `changed` | **card face** — the existing #644 sentence, unaltered | it contradicts what the reader would otherwise assume, so it must not need an interaction |
| `current` | silent | a "still current" badge on every card is noise that teaches people to ignore the one time it matters (existing card doctrine) |
| `cannot_confirm` | the existing `<details>` depth layer | the card makes no currency claim on its face, so nothing is false to correct — but silence would let "we can't tell" read as "still current". This is the card's existing honest-absence idiom, next to *"not linked to a cited decision-science claim"*, under a summary that already asks **"how sure"** |

4 of 13 wire-measured blocks carried no hash, so `cannot_confirm` is a real, reachable state — not a defensive branch.

**The producer's verdict always wins.** `freshness` answers *"did this generate correctly?"* (pending/failed); currency answers *"is it still about your model?"* — two questions, and trap 21 is what happens when they share a channel. The derived verdict fills the producer's **silence** and never overwrites its speech. Mutant M6 pins that.

## Which surfaces — and why only this one

The `guidanceStore`-fed surfaces (guidance strip, `NodeCoachingMarker`, `InspectorGuidanceSection`, Strengthen panel) **deliberately get nothing**, and the reason is derived rather than chosen: `evictStaleItems` **removes** items whose `valid_while` no longer holds, and `rehydrateGuidance` fails closed. Those surfaces present only currently-valid items *by construction*; a staleness notice there would describe a state they cannot be in.

The transcript is the **only** surface that must retain a superseded item — because it is a record of what was said. So it is the only one that needs a notice. Adding one elsewhere would be a second authority over the same question.

## Proof

- **RED-first, and it demonstrates unfireability**: at pristine `035b1a92`, **11 collected / 5 failed**, including the headline case. Recorded in `RED-first-pristine.txt`. The 6 that passed at pristine did so vacuously and are regression guards.
- **After**: 11/11 green, asserted **by name** with a non-zero expected count.
- **Mutants — 8, in a worktree OUTSIDE the repo root**, isolation proven **by writing** (distinct inodes + a sentinel write that did not reach the source clone), HEAD-relative restores, per-mutant applied-check scoped to `src/` asserting exactly 1 changed file, leading **and** trailing controls GREEN at `collected=11`:

| mutant | expected | got |
|---|---|---|
| M1 comparison always `current` | RED | RED |
| M2 comparison inverted | RED | RED |
| M3 absence → `current` (silent-fresh) | RED | RED |
| M4 absence → `changed` (cry wolf) | RED | RED |
| **M5 the WRONG hash (`graphHashAtRun`)** | RED | RED |
| M6 derived verdict overwrites producer's | RED | RED |
| M7 adapter drops the carry | RED | RED |
| **M8 discriminating GREEN arm** — unrelated copy in the *same* file | GREEN | GREEN |

M8 is the half that matters for trap 19: it proves the suite is bound to its object, not merely sensitive to any edit in the file.

- **Mount path asserted, not assumed**: every card test renders through `InlineBlocks` (the real `case 'v5_coaching'` dispatch) and binds by `data-block-id` identity — never a value predicate another element could satisfy.
- **The required check's own step sequence**, derived at this tip (`lint → typecheck → zustand → starters → vendor → schemas-version`): all pass. **Typecheck caught an unused import that vitest could not see** — fixed at source; the baseline was **not** regenerated (drift shrank 2487 → 2485).
- **Regression**: 242 files / 3442 passed / 0 failed across `src/v5` + `src/canvas/conversation`.

⚠ **jsdom cannot prove visual hierarchy.** These tests prove the sentence fires, on the right surface, bound by identity. That the notice is *legible in place* needs the browser witness that follows deploy.

## What still needs CEE (reported, not faked)

Nothing in this PR advertises an action that ends in refusal.

1. **No re-ask/refresh affordance exists on the wire.** Observed `action_intent` values are `confirm_factor` and `start_guided_chat` only. A stale card can tell you it is stale; it cannot yet offer "refresh this advice". CEE would need to emit a coaching action carrying producer-authored turn text for that. **Deliberately not faked.**
2. **`graph_hash_at_generation` is missing on 4/13 blocks**, all draft-path — exactly the bias coaching most likely to be outlived by an edit. Those cards can only ever say `cannot_confirm`. Emitting the hash on the draft path would upgrade them to a real verdict.

## Evidence

`olumi-docs/PHASE0-EVIDENCE-2026-07-28/coaching-surface-2026-08-12/` — raw wire captures, the field-presence census, `RED-first-pristine.txt`, `mutants.txt`, and both probe scripts.
