### PR TITLE
collab: reachable panel entry + owner round recovery (PR4)

### DIFF
--- a/src/collab/__tests__/openRoundRecord.spec.ts
+++ b/src/collab/__tests__/openRoundRecord.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * COLLAB — the open-round record: NON-SECRET round metadata an owner can come
+ * back to.
+ *
+ * ── WHAT THIS MODULE IS ALLOWED TO STORE, AND WHAT IT NEVER MAY ───────────
+ * The round id, the scenario id, when it was opened, and each participant's
+ * id + display name. NEVER a participant token: the token is a bearer
+ * capability, shown once by design, and `PanelSetupPage`'s own header explains
+ * why it must not sit in browser storage. The record is what lets an owner
+ * CLOSE a round or open a replacement after navigating away — the round id is
+ * not a credential (every owner route also demands the Supabase JWT).
+ *
+ * The token-exclusion test below is the load-bearing one: it feeds the module
+ * the EXACT shape the mint response carries (token and all) and proves the
+ * token never reaches storage — with a positive control proving the probe
+ * could see it if it did.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { forgetOpenRound, recallOpenRound, rememberOpenRound } from '../openRoundRecord'
+
+const SCENARIO_ID = 'scn-record-1234'
+const OTHER_SCENARIO_ID = 'scn-other-5678'
+const ROUND_ID = 'rnd-record-9012'
+
+/** The distinctive secret used by the exclusion probe. */
+const SECRET_TOKEN = 'tok-SECRET-must-never-be-stored-f00d'
+
+/** The shape the mint response actually hands the caller — token included. */
+const MINTED_PARTICIPANTS = [
+  { participant_id: 'p-a', display_name: 'Ada', token: SECRET_TOKEN },
+  { participant_id: 'p-b', display_name: 'Grace', token: 'tok-SECRET-second-cafe' },
+]
+
+function rememberFixture(): void {
+  rememberOpenRound({
+    roundId: ROUND_ID,
+    scenarioId: SCENARIO_ID,
+    participants: MINTED_PARTICIPANTS,
+  })
+}
+
+/** Every value in the whole store, so the probe cannot miss a stray key. */
+function wholeStore(): string {
+  const parts: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key !== null) parts.push(key, localStorage.getItem(key) ?? '')
+  }
+  return parts.join('\n')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('openRoundRecord', () => {
+  it('round-trips the non-secret fields for the scenario it was saved under', () => {
+    rememberFixture()
+    const record = recallOpenRound(SCENARIO_ID)
+    expect(record).not.toBeNull()
+    expect(record?.round_id).toBe(ROUND_ID)
+    expect(record?.scenario_id).toBe(SCENARIO_ID)
+    expect(record?.participants).toEqual([
+      { participant_id: 'p-a', display_name: 'Ada' },
+      { participant_id: 'p-b', display_name: 'Grace' },
+    ])
+    // opened_at is stamped by the module — an ISO string a Date can parse.
+    expect(Number.isNaN(Date.parse(record?.opened_at ?? ''))).toBe(false)
+  })
+
+  it('DIFFERENT OBJECT: recall for another scenario id returns null, not this record', () => {
+    rememberFixture()
+    expect(recallOpenRound(OTHER_SCENARIO_ID)).toBeNull()
+  })
+
+  it('NEVER stores a participant token — proven against the whole store, with a positive control', () => {
+    // POSITIVE CONTROL: the input really does carry the secret, so a probe
+    // that cannot see it in the input could not prove its absence in storage.
+    expect(JSON.stringify(MINTED_PARTICIPANTS)).toContain(SECRET_TOKEN)
+
+    rememberFixture()
+
+    const stored = wholeStore()
+    expect(stored).not.toBe('') // something WAS written — absence is not vacuous
+    expect(stored).not.toContain(SECRET_TOKEN)
+    expect(stored).not.toContain('tok-SECRET-second-cafe')
+
+    // And the recalled shape carries no token key at all.
+    const record = recallOpenRound(SCENARIO_ID)
+    for (const p of record?.participants ?? []) {
+      expect(Object.keys(p).sort()).toEqual(['display_name', 'participant_id'])
+    }
+  })
+
+  it('forget removes the record for that scenario only', () => {
+    rememberFixture()
+    rememberOpenRound({
+      roundId: 'rnd-other-3456',
+      scenarioId: OTHER_SCENARIO_ID,
+      participants: [{ participant_id: 'p-c', display_name: 'Lin' }],
+    })
+    forgetOpenRound(SCENARIO_ID)
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+    // DIFFERENT OBJECT: the other scenario's record survives.
+    expect(recallOpenRound(OTHER_SCENARIO_ID)?.round_id).toBe('rnd-other-3456')
+  })
+
+  it('a malformed stored value reads as null rather than throwing', () => {
+    rememberFixture()
+    // Corrupt the exact key the module wrote — derived from the write, so this
+    // test cannot drift onto a key nothing reads.
+    const keys: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key !== null) keys.push(key)
+    }
+    expect(keys.length).toBe(1)
+    localStorage.setItem(keys[0], '{not json')
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+  })
+
+  it('an empty scenario id is a no-op in both directions', () => {
+    rememberOpenRound({ roundId: ROUND_ID, scenarioId: '', participants: [] })
+    expect(localStorage.length).toBe(0)
+    expect(recallOpenRound('')).toBeNull()
+  })
+})

--- a/src/collab/__tests__/panelRoute.spec.ts
+++ b/src/collab/__tests__/panelRoute.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * COLLAB — the owner-panel href builder, bound to the REAL route table.
+ *
+ * The entry point this repo is adding (TopBar → blind panel) must send the
+ * owner to the route AppPoC actually declares. A helper tested only against a
+ * literal of itself would be a guard agreeing with itself, so the third test
+ * DERIVES the expectation from `src/poc/AppPoC.tsx` at this tip: it takes the
+ * declared path pattern, substitutes the id, and demands the helper agree.
+ * Moving or renaming the route REDs this file rather than silently stranding
+ * the entry point on a dead href.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { ownerPanelHash } from '../panelRoute'
+
+describe('ownerPanelHash', () => {
+  it('builds the hash-router href for the owner panel page', () => {
+    expect(ownerPanelHash('scn-1')).toBe('#/scenario/scn-1/panel')
+  })
+
+  it('percent-encodes the scenario id so a hostile id cannot change the route', () => {
+    expect(ownerPanelHash('a b/c')).toBe('#/scenario/a%20b%2Fc/panel')
+  })
+
+  it('agrees with the route AppPoC actually declares (derived, not retyped)', () => {
+    const src = readFileSync(resolve(process.cwd(), 'src/poc/AppPoC.tsx'), 'utf8')
+
+    // POSITIVE CONTROL: the pattern this test derives from must exist at all.
+    const declared = 'path="/scenario/:id/panel"'
+    expect(src).toContain(declared)
+
+    const pattern = declared.slice('path="'.length, -1) // "/scenario/:id/panel"
+    const substituted = `#${pattern.replace(':id', encodeURIComponent('scn-derived-7'))}`
+    expect(ownerPanelHash('scn-derived-7')).toBe(substituted)
+  })
+
+  it("DIFFERENT OBJECT: does not build the PARTICIPANT route — '/panel/:round_id' is a different page for a different person", () => {
+    // The participant route is public and token-gated; the owner route is
+    // auth-guarded. An href that lands an owner on the participant page would
+    // fail soft (an error card), which is exactly why it must fail loud here.
+    expect(ownerPanelHash('scn-1').startsWith('#/panel/')).toBe(false)
+  })
+})

--- a/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
+++ b/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
@@ -1,0 +1,298 @@
+/**
+ * COLLAB — owner ROUND RECOVERY on the panel setup page.
+ *
+ * ── THE RESIDUE THIS CLOSES (measured on the tip this branch left) ─────────
+ * The mint response is the only place participant tokens ever exist, and the
+ * page deliberately holds them in component state alone. But it also held the
+ * ROUND ID nowhere else — so an owner who navigated away lost not only the
+ * links (by design) but the round itself: no way to close it, no way to reach
+ * the answers already given, and a blank form on return that never said a
+ * round was open. "A lost link is re-minted" was the page's own recovery
+ * story, with no affordance to act it out.
+ *
+ * ── WHAT RECOVERY IS, PRECISELY ────────────────────────────────────────────
+ * A NON-SECRET record (round id, names — never tokens) written at mint,
+ * surfaced on return as a banner ABOVE the form: close the recorded round and
+ * read the answers, forget the reminder, or open a fresh round below (the
+ * re-mint). Re-DISPLAY of a lost token stays impossible on purpose; re-mint
+ * into the SAME round needs a CEE route that does not exist yet — this page
+ * says so honestly by never promising either.
+ *
+ * ⚠ jsdom proves behaviour and presence, never visibility.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-list its exports (trap 12).
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+import { recallOpenRound, rememberOpenRound } from '../openRoundRecord'
+
+const SCENARIO_ID = 'scn-recovery-1111'
+const MINTED_ROUND_ID = 'rnd-minted-2222'
+const RECORDED_ROUND_ID = 'rnd-RECORDED-99'
+const OWNER_TOKEN = 'owner-access-token-recovery-IDENTITY'
+const SECRET_TOKEN_A = 'tok-SECRET-ada-1a2b'
+const SECRET_TOKEN_B = 'tok-SECRET-grace-3c4d'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+const MINT_RESPONSE = {
+  round_id: MINTED_ROUND_ID,
+  graph_version_ref: 'gv-1',
+  participants: [
+    { participant_id: 'p-a', display_name: 'Ada', token: SECRET_TOKEN_A },
+    { participant_id: 'p-b', display_name: 'Grace', token: SECRET_TOKEN_B },
+  ],
+}
+
+const EMPTY_REVEAL = {
+  round_id: RECORDED_ROUND_ID,
+  status: 'closed',
+  graph_version_ref: 'gv-1',
+  per_target: [],
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function seedRecord(): void {
+  rememberOpenRound({
+    roundId: RECORDED_ROUND_ID,
+    scenarioId: SCENARIO_ID,
+    participants: [
+      { participant_id: 'p-a', display_name: 'Ada' },
+      { participant_id: 'p-b', display_name: 'Grace' },
+    ],
+  })
+}
+
+async function mintARound(): Promise<void> {
+  fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: 'factor-churn' } })
+  fireEvent.change(screen.getByTestId('panel-name-a'), { target: { value: 'Ada' } })
+  fireEvent.change(screen.getByTestId('panel-name-b'), { target: { value: 'Grace' } })
+  fireEvent.click(screen.getByTestId('panel-mint'))
+  await waitFor(() => expect(screen.getByTestId('panel-close')).toBeInTheDocument())
+}
+
+/** Calls whose URL touches the collab seam — the wire the forget test pins shut. */
+function collabCalls(): string[] {
+  return fetchMock.mock.calls.map(([input]) => String(input)).filter((u) => u.includes('/bff/collab'))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({ userId: 'user-abc', accessToken: OWNER_TOKEN })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+/* ══ Minting leaves a record the owner can come back to ═══════════════════ */
+
+describe('minting writes a non-secret open-round record', () => {
+  it('records round id and names for THIS scenario — and never a token', async () => {
+    fetchMock.mockImplementation(async (input) => {
+      if (String(input) === '/bff/collab/rounds') return jsonResponse(MINT_RESPONSE, 201)
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderOwnerPanel()
+    await mintARound()
+
+    const record = recallOpenRound(SCENARIO_ID)
+    expect(record?.round_id).toBe(MINTED_ROUND_ID)
+    expect(record?.participants).toEqual([
+      { participant_id: 'p-a', display_name: 'Ada' },
+      { participant_id: 'p-b', display_name: 'Grace' },
+    ])
+
+    // POSITIVE CONTROL first: the mint response really carried the secrets…
+    expect(JSON.stringify(MINT_RESPONSE)).toContain(SECRET_TOKEN_A)
+    // …and none of them reached ANY storage key.
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i) as string
+      const value = localStorage.getItem(key) ?? ''
+      expect(`${key}${value}`).not.toContain(SECRET_TOKEN_A)
+      expect(`${key}${value}`).not.toContain(SECRET_TOKEN_B)
+    }
+  })
+})
+
+/* ══ Returning to the page with an open round on record ═══════════════════ */
+
+describe('the recovery banner', () => {
+  it('shows the recorded round — names on the banner, and the form still below it (the re-mint path)', () => {
+    seedRecord()
+    renderOwnerPanel()
+
+    const banner = screen.getByTestId('panel-resume')
+    expect(within(banner).getByText(/Ada/)).toBeInTheDocument()
+    expect(within(banner).getByText(/Grace/)).toBeInTheDocument()
+    // The form is NOT replaced: opening a fresh round is the documented
+    // recovery for a lost link, so it must stay reachable.
+    expect(screen.getByTestId('panel-target-id')).toBeInTheDocument()
+    expect(screen.getByTestId('panel-mint')).toBeInTheDocument()
+  })
+
+  it('is honest that the old links cannot be shown again', () => {
+    seedRecord()
+    renderOwnerPanel()
+    expect(screen.getByTestId('panel-resume')).toHaveTextContent(/cannot be shown again/i)
+  })
+
+  it('does not render without a record — the form is the positive control', () => {
+    renderOwnerPanel()
+    expect(screen.queryByTestId('panel-resume')).toBeNull()
+    expect(screen.getByTestId('panel-target-id')).toBeInTheDocument()
+  })
+
+  it('DIFFERENT OBJECT: a record for ANOTHER scenario does not raise this page’s banner', () => {
+    rememberOpenRound({
+      roundId: 'rnd-elsewhere-42',
+      scenarioId: 'scn-some-other-scenario',
+      participants: [{ participant_id: 'p-z', display_name: 'Zed' }],
+    })
+    renderOwnerPanel()
+    expect(screen.queryByTestId('panel-resume')).toBeNull()
+  })
+})
+
+/* ══ Closing the RECORDED round from the banner ════════════════════════════ */
+
+describe('closing the recorded round', () => {
+  it('closes THE RECORDED round id with the owner bearer, shows the reveal, clears the record', async () => {
+    seedRecord()
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ round_id: RECORDED_ROUND_ID, status: 'closed' })
+      }
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/reveal`) {
+        return jsonResponse(EMPTY_REVEAL)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+
+    // IDENTITY: the close went to the RECORDED round, carrying the owner token.
+    const closeCall = fetchMock.mock.calls.find(
+      ([input]) => String(input) === `/bff/collab/rounds/${RECORDED_ROUND_ID}/close`,
+    )
+    expect(closeCall).toBeDefined()
+    expect(
+      new Headers(closeCall?.[1]?.headers as HeadersInit).get('authorization'),
+    ).toBe(`Bearer ${OWNER_TOKEN}`)
+
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+  })
+
+  it('a round already closed elsewhere is NOT a dead end — the reveal is fetched anyway', async () => {
+    seedRecord()
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ code: 'collab_round_closed', message: 'That round is already closed.' }, 409)
+      }
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/reveal`) {
+        return jsonResponse(EMPTY_REVEAL)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+  })
+
+  it('DIFFERENT OBJECT: any other close failure keeps the banner and the record, and shows the failure', async () => {
+    seedRecord()
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ code: 'collab_store_unavailable', message: 'Store fell over.' }, 503)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-resume')).toBeInTheDocument()
+    expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(RECORDED_ROUND_ID)
+  })
+})
+
+/* ══ Forgetting the reminder ═══════════════════════════════════════════════ */
+
+describe('forgetting the recorded round', () => {
+  it('clears the reminder locally and sends NOTHING on the collab wire', async () => {
+    seedRecord()
+    renderOwnerPanel()
+
+    fireEvent.click(screen.getByTestId('panel-resume-forget'))
+
+    await waitFor(() => expect(screen.queryByTestId('panel-resume')).toBeNull())
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+    expect(collabCalls()).toEqual([])
+    // The form remains — forgetting is not an exit from the page.
+    expect(screen.getByTestId('panel-target-id')).toBeInTheDocument()
+  })
+})
+
+/* ══ The fresh-mint path keeps the record honest too ═══════════════════════ */
+
+describe('closing from the fresh-mint state', () => {
+  it('clears the record once the reveal is on screen', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === '/bff/collab/rounds') return jsonResponse(MINT_RESPONSE, 201)
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ round_id: MINTED_ROUND_ID, status: 'closed' })
+      }
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/reveal`) {
+        return jsonResponse({ ...EMPTY_REVEAL, round_id: MINTED_ROUND_ID })
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    await mintARound()
+    expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(MINTED_ROUND_ID)
+
+    fireEvent.click(screen.getByTestId('panel-close'))
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+  })
+})

--- a/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
+++ b/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
@@ -264,6 +264,69 @@ describe('closing the recorded round', () => {
   })
 })
 
+/* ══ Multi-tab supersession: forget ONLY the round actually closed ═════════ */
+
+describe('closing a round whose record has been superseded (two tabs)', () => {
+  // The stored record is LATEST-WINS: a second tab minting R2 overwrites R1's
+  // record. Closing R1 from the first tab (still on its fresh-mint screen)
+  // must NOT delete R2's live reminder — the record no longer points at the
+  // round being closed.
+  const R2_ROUND_ID = 'rnd-SUPERSEDES-R2'
+
+  it("DIFFERENT OBJECT: closing R1 leaves R2's record intact when R2 superseded it", async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === '/bff/collab/rounds') return jsonResponse(MINT_RESPONSE, 201)
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ round_id: MINTED_ROUND_ID, status: 'closed' })
+      }
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/reveal`) {
+        return jsonResponse({ ...EMPTY_REVEAL, round_id: MINTED_ROUND_ID })
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    await mintARound() // this tab's round: MINTED_ROUND_ID (R1), record = R1
+
+    // Tab B mints R2 for the same scenario — latest-wins overwrite.
+    rememberOpenRound({
+      roundId: R2_ROUND_ID,
+      scenarioId: SCENARIO_ID,
+      participants: [{ participant_id: 'p-c', display_name: 'Lin' }],
+    })
+
+    fireEvent.click(screen.getByTestId('panel-close')) // closes R1
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+
+    // IDENTITY: R2's reminder survives R1's close.
+    expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(R2_ROUND_ID)
+  })
+
+  it('MATCHING TWIN: closing the round the record points at forgets it', async () => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === '/bff/collab/rounds') return jsonResponse(MINT_RESPONSE, 201)
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/close` && init?.method === 'POST') {
+        return jsonResponse({ round_id: MINTED_ROUND_ID, status: 'closed' })
+      }
+      if (url === `/bff/collab/rounds/${MINTED_ROUND_ID}/reveal`) {
+        return jsonResponse({ ...EMPTY_REVEAL, round_id: MINTED_ROUND_ID })
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderOwnerPanel()
+    await mintARound() // record = R1, closing R1
+    expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(MINTED_ROUND_ID)
+
+    fireEvent.click(screen.getByTestId('panel-close'))
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+
+    expect(recallOpenRound(SCENARIO_ID)).toBeNull()
+  })
+})
+
 /* ══ Forgetting the reminder ═══════════════════════════════════════════════ */
 
 describe('forgetting the recorded round', () => {

--- a/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
+++ b/src/collab/__tests__/panelSetupRoundRecovery.spec.tsx
@@ -237,10 +237,19 @@ describe('closing the recorded round', () => {
 
   it('DIFFERENT OBJECT: any other close failure keeps the banner and the record, and shows the failure', async () => {
     seedRecord()
+    // ⚠ The reveal is stubbed to SUCCEED here on purpose. Only
+    // `collab_round_closed` may fall through to it — a predicate widened to
+    // swallow every close failure would sail on to this healthy reveal and
+    // paint success over a round that is still open. With the reveal healthy,
+    // the ONLY way this test passes is the close failure actually stopping
+    // the flow.
     fetchMock.mockImplementation(async (input, init) => {
       const url = String(input)
       if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/close` && init?.method === 'POST') {
         return jsonResponse({ code: 'collab_store_unavailable', message: 'Store fell over.' }, 503)
+      }
+      if (url === `/bff/collab/rounds/${RECORDED_ROUND_ID}/reveal`) {
+        return jsonResponse(EMPTY_REVEAL)
       }
       return jsonResponse({ code: 'not_stubbed', message: url }, 404)
     })
@@ -249,6 +258,7 @@ describe('closing the recorded round', () => {
     fireEvent.click(screen.getByTestId('panel-resume-close'))
 
     await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.queryByTestId('collab-reveal')).toBeNull()
     expect(screen.getByTestId('panel-resume')).toBeInTheDocument()
     expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(RECORDED_ROUND_ID)
   })

--- a/src/collab/openRoundRecord.ts
+++ b/src/collab/openRoundRecord.ts
@@ -1,0 +1,117 @@
+/**
+ * COLLAB — the open-round record: the NON-SECRET half of what a mint returns,
+ * kept so the owner can come back.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ * Participant tokens are shown once and never stored — that is a design
+ * property this module must not erode. But the tip this branch left forgot
+ * MORE than the tokens: it forgot the ROUND, so an owner who navigated away
+ * could never close it and the answers already given were stranded forever.
+ * The round id is not a credential — every owner route also demands the
+ * owner's Supabase JWT — so remembering it trades no security for recovery.
+ *
+ * ── THE RULE, ENFORCED BY CONSTRUCTION AND BY TEST ─────────────────────────
+ * `rememberOpenRound` PICKS the two non-secret participant fields explicitly.
+ * It never spreads its input: the caller's natural argument is the mint
+ * response's participant array, which carries `token`, and a spread would
+ * smuggle every token into localStorage in one keystroke.
+ * `__tests__/openRoundRecord.spec.ts` feeds this module token-bearing input
+ * and proves, against the whole store, that no token lands.
+ *
+ * One record per scenario, latest wins — matching the page, which shows one
+ * round at a time. Storage failures (private mode, quota) are swallowed: the
+ * record is a convenience, never a correctness dependency.
+ */
+
+const KEY_PREFIX = 'olumi.collab.open-round.'
+
+export interface OpenRoundParticipant {
+  participant_id: string
+  display_name: string
+}
+
+export interface OpenRoundRecord {
+  round_id: string
+  scenario_id: string
+  /** ISO timestamp, stamped at remember time. */
+  opened_at: string
+  participants: OpenRoundParticipant[]
+}
+
+function keyFor(scenarioId: string): string {
+  return `${KEY_PREFIX}${scenarioId}`
+}
+
+export function rememberOpenRound(args: {
+  roundId: string
+  scenarioId: string
+  /**
+   * Deliberately WIDER than what is stored: callers hand this the mint
+   * response's participants (token and all); only the two named fields survive.
+   */
+  participants: ReadonlyArray<{ participant_id: string; display_name: string }>
+}): void {
+  if (args.scenarioId === '' || args.roundId === '') return
+  const record: OpenRoundRecord = {
+    round_id: args.roundId,
+    scenario_id: args.scenarioId,
+    opened_at: new Date().toISOString(),
+    // PICKED, never spread — see the module header.
+    participants: args.participants.map((p) => ({
+      participant_id: p.participant_id,
+      display_name: p.display_name,
+    })),
+  }
+  try {
+    localStorage.setItem(keyFor(args.scenarioId), JSON.stringify(record))
+  } catch {
+    /* storage unavailable — the page still works, only the reminder is lost */
+  }
+}
+
+export function recallOpenRound(scenarioId: string): OpenRoundRecord | null {
+  if (scenarioId === '') return null
+  try {
+    const raw = localStorage.getItem(keyFor(scenarioId))
+    if (raw === null) return null
+    const parsed = JSON.parse(raw) as Partial<OpenRoundRecord> | null
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      typeof parsed.round_id !== 'string' ||
+      parsed.round_id === '' ||
+      typeof parsed.scenario_id !== 'string' ||
+      typeof parsed.opened_at !== 'string' ||
+      !Array.isArray(parsed.participants)
+    ) {
+      return null
+    }
+    return {
+      round_id: parsed.round_id,
+      scenario_id: parsed.scenario_id,
+      opened_at: parsed.opened_at,
+      // Re-picked on the way OUT too, so a hand-edited or legacy value cannot
+      // hand the page fields this type never promised.
+      participants: parsed.participants
+        .filter(
+          (p): p is OpenRoundParticipant =>
+            p !== null &&
+            typeof p === 'object' &&
+            typeof (p as OpenRoundParticipant).participant_id === 'string' &&
+            typeof (p as OpenRoundParticipant).display_name === 'string',
+        )
+        .map((p) => ({ participant_id: p.participant_id, display_name: p.display_name })),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function forgetOpenRound(scenarioId: string): void {
+  if (scenarioId === '') return
+  try {
+    localStorage.removeItem(keyFor(scenarioId))
+  } catch {
+    /* nothing to do — an unremovable reminder is still only a reminder */
+  }
+}

--- a/src/collab/panelRoute.ts
+++ b/src/collab/panelRoute.ts
@@ -1,0 +1,13 @@
+/**
+ * COLLAB — the one place the owner-panel href is built.
+ *
+ * The app is a HashRouter, so an in-app link to the blind-panel owner page is
+ * a hash href. Spelling `#/scenario/<id>/panel` at each call site would be a
+ * hand-maintained mirror of the route table; this helper is the single
+ * spelling, and `__tests__/panelRoute.spec.ts` binds it to the route AppPoC
+ * actually declares (derived from the source, not retyped), so a route move
+ * REDs the suite instead of stranding the entry point on a dead href.
+ */
+export function ownerPanelHash(scenarioId: string): string {
+  return `#/scenario/${encodeURIComponent(scenarioId)}/panel`
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -7,6 +7,7 @@ import { useStagePill } from '../../canvas/hooks/useStagePill'
 import { UserAvatarMenu } from './UserAvatarMenu'
 import { KebabMenu } from './KebabMenu'
 import { ScenarioSwitcher } from '../../canvas/components/ScenarioSwitcher'
+import { ownerPanelHash } from '../../collab/panelRoute'
 import { MENU_EXCLUSIVE_EVENT } from './LeftSidebar'
 import { useUIStore } from '../../stores/uiStore'
 
@@ -32,6 +33,13 @@ interface TopBarProps {
   saveStatus?: 'saved' | 'saving' | 'error'
   saveError?: string | null
   isPersisted?: boolean
+  /**
+   * COLLAB: when a PERSISTED scenario is on the canvas, its id — and the bar
+   * shows the "Ask your team" entry to the blind-panel owner page. Null/absent
+   * hides it: a guest scenario cannot mint a round (CEE refuses — no immutable
+   * model version to pin), so showing the entry would be a control that lies.
+   */
+  panelScenarioId?: string | null
 }
 
 export const TopBar = ({
@@ -43,6 +51,7 @@ export const TopBar = ({
   saveStatus,
   saveError,
   isPersisted = false,
+  panelScenarioId = null,
 }: TopBarProps) => {
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState(scenarioTitle)
@@ -386,6 +395,23 @@ export const TopBar = ({
           }
           return null
         })()}
+
+        {/* COLLAB: entry to the blind-panel owner page — previously URL-only.
+            An anchor, not a navigate(): the app is a HashRouter and this is
+            the same pattern as the logo link, so middle-click/new-tab work.
+            Rendered only for a persisted scenario (see the prop's doc). */}
+        {panelScenarioId != null && panelScenarioId !== '' && (
+          <Tooltip content="Ask your team — everyone answers privately, then compare">
+            <a
+              href={ownerPanelHash(panelScenarioId)}
+              className={styles.iconButton}
+              aria-label="Ask your team"
+              data-testid="topbar-panel-link"
+            >
+              <Users size={14} aria-hidden="true" />
+            </a>
+          </Tooltip>
+        )}
 
         {/* Share button */}
         <Tooltip content="Generate shareable link">

--- a/src/components/layout/__tests__/TopBar.panelEntry.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.panelEntry.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * COLLAB — the navigation entry point to the blind-panel owner page.
+ *
+ * Before this existed, `/scenario/:id/panel` was URL-only: a pilot host had to
+ * be handed the address out of band. This pins the TopBar entry: present with
+ * the exact owner-panel href when the canvas is showing a persisted scenario,
+ * absent otherwise (a guest scenario cannot mint a round — CEE refuses it —
+ * so an entry point would be a control that lies).
+ *
+ * ⚠ jsdom CANNOT prove the control is VISIBLE — presence and href only. The
+ * visibility rung belongs to the browser witness after deploy.
+ *
+ * The href expectation is a LITERAL, written from the user's side on purpose:
+ * asserting `ownerPanelHash(...)` here would only prove the component agrees
+ * with the helper, not that either is right. `panelRoute.spec.ts` binds the
+ * helper to the deployed route table; this file binds the component to the
+ * same literal shape.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { TopBar } from '../TopBar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+
+function renderTopBar(panelScenarioId: string | null | undefined): void {
+  render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar
+          scenarioTitle="Pricing decision"
+          onTitleChange={vi.fn()}
+          onShare={vi.fn()}
+          panelScenarioId={panelScenarioId}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('TopBar blind-panel entry point', () => {
+  it('links to the owner panel page for THIS scenario', () => {
+    renderTopBar('scn-entry-1')
+    const link = screen.getByTestId('topbar-panel-link')
+    expect(link).toHaveAttribute('href', '#/scenario/scn-entry-1/panel')
+  })
+
+  it('is a real link with an accessible name a person can find', () => {
+    renderTopBar('scn-entry-1')
+    const byName = screen.getByRole('link', { name: /ask your team/i })
+    // IDENTITY: the named link IS the entry point, not some neighbour.
+    expect(byName).toBe(screen.getByTestId('topbar-panel-link'))
+  })
+
+  it('percent-encodes the scenario id in the href', () => {
+    renderTopBar('a b')
+    expect(screen.getByTestId('topbar-panel-link')).toHaveAttribute(
+      'href',
+      '#/scenario/a%20b/panel',
+    )
+  })
+
+  it('is absent without a persisted scenario — with the Share control as the positive control', () => {
+    renderTopBar(null)
+    expect(screen.queryByTestId('topbar-panel-link')).toBeNull()
+    // POSITIVE CONTROL: the bar itself rendered; absence is not an empty page.
+    expect(screen.getByRole('button', { name: /share decision/i })).toBeInTheDocument()
+  })
+
+  it('is absent when the prop is not passed at all (every existing call site)', () => {
+    renderTopBar(undefined)
+    expect(screen.queryByTestId('topbar-panel-link')).toBeNull()
+  })
+})

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -53,6 +53,12 @@ import {
   type RevealView,
 } from '../collab/collabService'
 import { requireOwnerAccessToken } from '../collab/ownerAccessToken'
+import {
+  forgetOpenRound,
+  recallOpenRound,
+  rememberOpenRound,
+  type OpenRoundRecord,
+} from '../collab/openRoundRecord'
 import { typography } from '../styles/typography'
 import { RevealBody } from './ParticipantPacketPage'
 
@@ -131,6 +137,21 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
   }
 }
 
+/** "Ada", "Ada and Grace", "Ada, Grace and Lin" — or '' when no names exist. */
+function participantNames(record: OpenRoundRecord): string {
+  const names = record.participants.map((p) => p.display_name).filter((n) => n.trim() !== '')
+  if (names.length === 0) return ''
+  if (names.length === 1) return names[0]
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+}
+
+/** A human date for the banner, or null when the stamp cannot be parsed. */
+function openedOn(record: OpenRoundRecord): string | null {
+  const stamp = Date.parse(record.opened_at)
+  if (Number.isNaN(stamp)) return null
+  return new Date(stamp).toLocaleDateString(undefined, { day: 'numeric', month: 'long' })
+}
+
 /** Best-effort clipboard write. Returns false when the browser refuses. */
 async function writeToClipboard(text: string): Promise<boolean> {
   try {
@@ -166,6 +187,14 @@ export default function PanelSetupPage(): JSX.Element {
   const [copiedIds, setCopiedIds] = useState<ReadonlySet<string>>(() => new Set())
   const [copyRefused, setCopyRefused] = useState<ReadonlySet<string>>(() => new Set())
 
+  // COLLAB ROUND RECOVERY: the NON-SECRET record of a round this owner opened
+  // for THIS scenario and may have navigated away from. Read once at mount —
+  // the only other writers are this page's own handlers, which keep the state
+  // and the store in step. Never tokens (see openRoundRecord's header).
+  const [openRecord, setOpenRecord] = useState<OpenRoundRecord | null>(() =>
+    recallOpenRound(scenarioId ?? ''),
+  )
+
   const handleMint = useCallback(async () => {
     setBusyAction('open')
     setFailure(null)
@@ -187,6 +216,15 @@ export default function PanelSetupPage(): JSX.Element {
         ),
       })
       setMinted(result)
+      // Remember the non-secret half so navigating away no longer strands the
+      // round. `rememberOpenRound` PICKS id + name; the tokens in `result`
+      // never reach storage (pinned by panelSetupRoundRecovery.spec.tsx).
+      rememberOpenRound({
+        roundId: result.round_id,
+        scenarioId: scenarioId ?? '',
+        participants: result.participants,
+      })
+      setOpenRecord(recallOpenRound(scenarioId ?? ''))
     } catch (err) {
       setFailure(describeOwnerFailure(err, 'open'))
     } finally {
@@ -194,23 +232,44 @@ export default function PanelSetupPage(): JSX.Element {
     }
   }, [scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
 
-  const handleClose = useCallback(async () => {
-    if (minted === null) return
-    setBusyAction('close')
-    setFailure(null)
-    try {
-      // ONE getSession() round-trip for the whole action, reused across both
-      // requests — the identity seam's stated contract ("one call per turn;
-      // callers must never make a second getSession() round-trip for the token").
-      const accessToken = await requireOwnerAccessToken()
-      await closeRound(accessToken, minted.round_id)
-      setReveal(await fetchOwnerReveal(accessToken, minted.round_id))
-    } catch (err) {
-      setFailure(describeOwnerFailure(err, 'close'))
-    } finally {
-      setBusyAction(null)
-    }
-  }, [minted])
+  // Parameterised by round id because there are now TWO callers: the fresh
+  // mint on screen, and the recovery banner's RECORDED round.
+  const handleClose = useCallback(
+    async (roundId: string) => {
+      setBusyAction('close')
+      setFailure(null)
+      try {
+        // ONE getSession() round-trip for the whole action, reused across both
+        // requests — the identity seam's stated contract ("one call per turn;
+        // callers must never make a second getSession() round-trip for the token").
+        const accessToken = await requireOwnerAccessToken()
+        try {
+          await closeRound(accessToken, roundId)
+        } catch (err) {
+          // A recorded round may have been closed in another tab or session.
+          // `collab_round_closed` is not a dead end — the reveal is exactly
+          // what the owner came for, so fall through to it. Every OTHER
+          // refusal still surfaces as a failure below.
+          if (!(err instanceof CollabRequestError) || err.code !== 'collab_round_closed') {
+            throw err
+          }
+        }
+        setReveal(await fetchOwnerReveal(accessToken, roundId))
+        forgetOpenRound(scenarioId ?? '')
+        setOpenRecord(null)
+      } catch (err) {
+        setFailure(describeOwnerFailure(err, 'close'))
+      } finally {
+        setBusyAction(null)
+      }
+    },
+    [scenarioId],
+  )
+
+  const handleForget = useCallback(() => {
+    forgetOpenRound(scenarioId ?? '')
+    setOpenRecord(null)
+  }, [scenarioId])
 
   const handleCopy = useCallback(async (participantId: string, link: string) => {
     const ok = await writeToClipboard(link)
@@ -247,6 +306,48 @@ export default function PanelSetupPage(): JSX.Element {
             you close the round. Then you see them all, side by side, in each person&rsquo;s own
             words.
           </p>
+
+          {/* ROUND RECOVERY: a round opened earlier and navigated away from.
+              A banner ABOVE the form, never a replacement for it — opening a
+              fresh round below IS the documented recovery for a lost link
+              (the tokens themselves are unrecoverable by design). Hidden the
+              moment fresh links are on screen: `minted` supersedes it. */}
+          {minted === null && openRecord !== null && (
+            <section
+              data-testid="panel-resume"
+              className="mt-8 rounded-md border border-info/30 bg-panel p-4"
+            >
+              <p className={`${typography.label} text-text-header`}>A round is already open</p>
+              <p className={`${typography.body} mt-2 text-text-body`}>
+                {participantNames(openRecord) === ''
+                  ? 'You opened a round'
+                  : `You opened a round for ${participantNames(openRecord)}`}
+                {openedOn(openRecord) !== null ? ` on ${openedOn(openRecord)}` : ''}. Its links
+                were shown once and cannot be shown again &mdash; if someone has lost theirs,
+                close this round and open a fresh one below.
+              </p>
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <Button
+                  data-testid="panel-resume-close"
+                  onClick={() => void handleClose(openRecord.round_id)}
+                  disabled={busyAction !== null}
+                >
+                  Close the round and show everyone&rsquo;s answers
+                </Button>
+                <Button
+                  variant="secondary"
+                  data-testid="panel-resume-forget"
+                  onClick={handleForget}
+                  disabled={busyAction !== null}
+                >
+                  Forget this round
+                </Button>
+              </div>
+              <p className={`${typography.bodySmall} mt-3 text-text-light`}>
+                Forgetting only clears this reminder &mdash; the round itself stays open.
+              </p>
+            </section>
+          )}
 
           {minted === null ? (
             <div className="mt-8 space-y-6">
@@ -470,7 +571,11 @@ export default function PanelSetupPage(): JSX.Element {
               </p>
 
               <div className="mt-6">
-                <Button data-testid="panel-close" onClick={handleClose} disabled={busyAction !== null}>
+                <Button
+                  data-testid="panel-close"
+                  onClick={() => void handleClose(minted.round_id)}
+                  disabled={busyAction !== null}
+                >
                   Close the round and show everyone&rsquo;s answers
                 </Button>
               </div>

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -255,8 +255,18 @@ export default function PanelSetupPage(): JSX.Element {
           }
         }
         setReveal(await fetchOwnerReveal(accessToken, roundId))
-        forgetOpenRound(scenarioId ?? '')
-        setOpenRecord(null)
+        // Forget ONLY the round we actually closed. The stored record is
+        // latest-wins: a second tab minting R2 overwrites R1's record, so an
+        // UNCONDITIONAL forget here — reached from tab A still closing R1 —
+        // would delete the LIVE round's reminder. On a mismatch the record
+        // stays, and local state re-reads it so page and store agree.
+        const stored = recallOpenRound(scenarioId ?? '')
+        if (stored === null || stored.round_id === roundId) {
+          forgetOpenRound(scenarioId ?? '')
+          setOpenRecord(null)
+        } else {
+          setOpenRecord(stored)
+        }
       } catch (err) {
         setFailure(describeOwnerFailure(err, 'close'))
       } finally {

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -270,6 +270,10 @@ export default function CanvasMVP() {
         saveStatus={isPersistenceActive ? supabaseSaveStatus : undefined}
         saveError={isPersistenceActive ? supabaseSaveError : undefined}
         isPersisted={isPersistenceActive}
+        // COLLAB: the blind-panel entry needs a PERSISTED scenario — CEE's
+        // mint refuses guest scenarios (no immutable model version to pin),
+        // and the owner route sits behind AuthGuard.
+        panelScenarioId={isPersistenceActive && currentScenarioId ? currentScenarioId : null}
       />
 
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>


### PR DESCRIPTION
## What a user can now do (PR4 — collaborative reasoning)

1. **Reach the blind-panel owner page by navigation.** The canvas TopBar carries an "Ask your team" entry (Users icon beside Share) linking to `#/scenario/:id/panel`. Until now both collaboration pages were URL-only (measured residue of #669) — a pilot host had to be handed the address out of band.
2. **Recover a round after navigating away.** Minting now writes a NON-SECRET record (round id, participant ids + names — never tokens) to localStorage. Returning to the setup page shows a "round in progress" banner: close the recorded round and read everyone's answers, forget the reminder, or open a fresh round below — which is the documented re-mint recovery for a lost participant link. A round already closed in another tab falls through to the reveal instead of dead-ending (`collab_round_closed` only; every other refusal still surfaces).

## Entry-point placement, and why

- **Host: TopBar right section, beside Share** — the canvas/scenario chrome is where an owner is when they want another head on an estimate, and Share is the sibling affordance. Icon button matches the existing visual language exactly (`styles.iconButton`, Lucide `Users`, Tooltip); an anchor (not `navigate()`) so middle-click/new-tab work, same pattern as the logo link.
- Shown **only for a persisted scenario** (`isPersistenceActive && currentScenarioId`): CEE's mint refuses guest scenarios (no immutable model version to pin) and the owner route sits behind AuthGuard — an always-on entry would be a control that lies.
- **Alternative host considered:** a KebabMenu "Decision" item (and/or a ScenarioListPage row action). Least-invasive single host chosen; happy to add the kebab item in a follow-up if discoverability wants both.

## Link recovery — the derivation and the boundary

- **Re-DISPLAY of a lost token is impossible by design at every layer** (UI holds tokens in component state only; CEE stores a SHA-256 hash, no read-back route). Deliberate security property — not asked for and not eroded here.
- **Re-mint into the SAME round needs a CEE route that does not exist.** Stopped at that boundary. **Exact minimal CEE ask** (derived at CEE staging tip `a9022e77`, `src/routes/collab.v1.rounds.ts`):
  `POST /collab/v1/rounds/:round_id/participants/:participant_id/reissue` — owner-JWT via `requireOwnerUser`; open rounds only (refuse `collab_round_closed`); rotates the stored `token_hash` (old link dies); returns `{ participant_id, display_name, token }` with the raw token exactly once (same one-time-disclosure contract as mint). Prior submissions and `authored_by` unchanged — participant_id is the identity, the token only the capability. The recovery banner is the natural consumer once it exists.
- **Re-mint via a NEW round is wire-legal today** (CEE mint has no already-open refusal) and is what the banner + form now make actionable; previously the forgotten round_id stranded the old round's answers forever.

## N1 / N3 from #669's review — left named, not fixed

Both sit in `ParticipantPacketPage`, outside this lane's path (untouched here):
- **N1**: `CODE_IN_LINK` (`ParticipantPacketPage.tsx:102`) hand-copies `TOKEN_PARAM_NAMES` (`participantToken.ts:38`) — derive it instead.
- **N3**: "Try again" (`ParticipantPacketPage.tsx:493`) renders on the credential branch where retrying the same rejected token cannot work.

## Evidence (full log: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/pr4-two-person-witness-2026-08-12/collab-reachability/DERIVATION.md`)

- **RED-first at pristine** (staging `4c8cd740`): 3 named TopBar failures (`topbar-panel-link` absent) + 3 files failing on unresolvable imports of the not-yet-existing modules.
- **GREEN**: 4 new spec files, 25 tests, each collecting its expected count by name (4/6/5/10). Adjacent suites green (8 files, 78 tests: friction, ownerAuth ratchets, route-position pin, 4 TopBar suites, CanvasMVP hydration). `vitest --changed origin/staging`: 12 files / 115 tests green. Typecheck gate PASSED (drift shrank 2487→2485 — not this lane's shrink, `--update-baseline` declined). Lint: 0 errors; all 8 warnings on touched files reproduce byte-identical at pristine.
- **Mutants**: 8/8 bit, in an absolute-path worktree outside the repo root with write-proven isolation (sentinel + inode compare), per-mutant applied-check scoped to `src/` with zero-control, HEAD-relative restores, pristine 25/25 control before and after. Includes a discriminating pair on the TopBar guard (M1a/M1b fail different assertions), a wrong-object mutant (banner closing the scenario id — bit by the close-URL identity assertion), a route-swap mutant (owner href → participant route — 6 failures), and a predicate-widening mutant (swallow all close failures — bit only because the other-failure test stubs a HEALTHY reveal).
- **Token safety**: `rememberOpenRound` picks fields, never spreads; proven by feeding it the mint response shape (tokens included) and scanning the whole store, with a positive control that the probe sees the token in the input.

## Honesty about rungs

jsdom proves presence/behaviour only — "the entry point is visible" is TESTED-level. The browser/journey rung (real click-through from canvas → mint → link → participant page) belongs to the orchestrator's witness after deploy. `panel-resume` banner date/name rendering also unverified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
