### PR TITLE
V7 move: Analysis tab renders the analysis once; V7TopMatter group moves unchanged to temporary 'Alt view' dock tab

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -24,7 +24,7 @@
  */
 
 import { useEffect, useState, useRef, useMemo, useCallback, lazy, Suspense } from 'react'
-import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, XCircle, MessageCircle, MessageSquare, CheckCircle } from 'lucide-react'
+import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, XCircle, MessageCircle, MessageSquare, CheckCircle, FlaskConical } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
@@ -111,6 +111,7 @@ import { useResultsSectionData } from '../../components/results/useResultsSectio
 import type { TornadoRow } from '../../components/results/TornadoChart'
 import { useCanvasResultsSync } from '../../components/results/useCanvasResultsSync'
 import { ResultsBody } from '../../components/results/ResultsBody'
+import { V7ComparisonTabBody } from '../../components/results/v7/V7ComparisonTabBody'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
 import { executeAutoFix, determineFixType, type AutoFixParams } from '../utils/autoFix'
@@ -161,7 +162,9 @@ function mapCritiqueToValidation(critique: CritiqueItemV1[] | undefined): Critiq
   }))
 }
 
-type OutputsDockTab = 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
+/** Derived from the store's union rather than hand-mirrored beside it —
+ *  the two were previously separate "must match exactly" copies (trap 12). */
+type OutputsDockTab = OutputTab
 
 interface OutputsDockState {
   isOpen: boolean
@@ -192,7 +195,7 @@ export function readPersistedActiveDockTab(): OutputsDockTab | null {
     if (!raw) return null
     const parsed = JSON.parse(raw) as Partial<OutputsDockState>
     const tab = parsed?.activeTab
-    if (tab === 'results' || tab === 'compare' || tab === 'diagnostics' || tab === 'journey' || tab === 'olumi') {
+    if (tab === 'results' || tab === 'altview' || tab === 'compare' || tab === 'diagnostics' || tab === 'journey' || tab === 'olumi') {
       return tab
     }
     return null
@@ -258,6 +261,13 @@ export function getOutputTabsForParity(): { id: OutputsDockTab; label: string }[
     // 'results' (Analysis) via the state initialiser, not array position.
     ...(isAiPanelV2Enabled() ? [{ id: 'olumi' as const, label: 'Olumi' }] : []),
     { id: 'results', label: 'Analysis' },
+    // TEMPORARY comparison tab (Paul, 12 Aug 2026): hosts the V7 assessment
+    // group MOVED off the Analysis tab (see v7/V7ComparisonTabBody.tsx), so
+    // the two renderings of the same analysis stay comparable side by side.
+    // Unflagged on purpose (no-dark-launch); retires with the V7-vs-Current
+    // adjudication (COMPONENT-INVENTORY 2026-08-12 §10A). Sits directly after
+    // 'results' so the two surfaces under comparison are adjacent.
+    { id: 'altview', label: 'Alt view' },
     ...(isCompareTabEnabled() ? [{ id: 'compare' as const, label: 'Compare' }] : []),
     // ⚠ IDENTITY TRAP — READ THIS BEFORE WRITING A TEST AGAINST "THE MODEL TAB".
     // The tab a user (and every brief, roadmap row and bug report) calls "Model"
@@ -2082,6 +2092,8 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             const Icon =
               tab.id === 'results'
                 ? BarChart3
+                : tab.id === 'altview'
+                ? FlaskConical
                 : tab.id === 'compare'
                 ? Shuffle
                 : tab.id === 'journey'
@@ -2635,6 +2647,20 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   />
                 )}
               </div>
+            )}
+            {effectiveActiveTab === 'altview' && (
+              // TEMPORARY comparison tab (12 Aug 2026): the V7 assessment
+              // group, moved off the Analysis tab. SINGLE DATA AUTHORITY:
+              // the SAME resultsSectionData instance + the SAME
+              // fragile/robust edge-count expressions ResultsBody receives
+              // above — never a re-derivation.
+              <V7ComparisonTabBody
+                resultsSectionData={resultsSectionData}
+                fragileEdgeCount={(report as any)?.robustness?.fragile_edges?.length}
+                robustEdgeCount={(report as any)?.robustness?.robust_edges?.length}
+                onFocusNode={handleFocusResultNode}
+                onSendMessage={sendMessage}
+              />
             )}
             {effectiveActiveTab === 'compare' && (
               // 2.581 — ONE expert mode for the product. The Compare pill used

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -188,9 +188,14 @@ describe('OutputsDock DOM', () => {
     const tabNav = screen.getByRole('navigation', { name: 'Outputs sections' })
     const tabs = within(tabNav).getAllByRole('button')
 
+    // 12 Aug 2026: 'Alt view' (id 'altview') is the TEMPORARY V7 comparison
+    // tab — the V7 assessment group moved off the Analysis tab (Paul: "move,
+    // NOT delete"). Unflagged, directly after Analysis. Retires with the
+    // V7-vs-Current adjudication.
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
+      'Alt view',
       'Compare',
       'Model',
     ])
@@ -1056,6 +1061,7 @@ describe('I.2a: Secondary action button interaction', () => {
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
+      'Alt view',
       'Compare',
       'Model',
       'Journey',

--- a/src/canvas/components/olumiSurface.ts
+++ b/src/canvas/components/olumiSurface.ts
@@ -22,7 +22,15 @@
  * `__tests__/olumiSurfaceInvariant.spec.ts`.
  */
 
-export type OlumiDockTab = 'olumi' | 'results' | 'compare' | 'diagnostics' | 'journey'
+import type { OutputTab } from '../../stores/uiStore'
+
+/**
+ * Derived from the store's union rather than hand-mirrored (12 Aug 2026 —
+ * this was the THIRD hand-maintained copy of the dock-tab union; adding the
+ * 'altview' tab surfaced it via a TS2322). Type-only import: the module stays
+ * runtime-dependency-free, `dockHostsOlumi` only ever compares to 'olumi'.
+ */
+export type OlumiDockTab = OutputTab
 
 export type OlumiSurface = 'hero' | 'docked' | 'floating' | 'none'
 

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -37,7 +37,6 @@ import { InferenceWarningStrip } from './InferenceWarningStrip'
 import { CritiqueWarningStrip } from './CritiqueWarningStrip'
 import { FocusNowContainer } from '@/canvas/components/coaching-panel/focus-now'
 import { AnalysisHeroContainer, KeyQuestionCard } from './analysis-hero'
-import { V7TopMatter } from './v7/V7TopMatter'
 import { openDefineSuccess, HowComputedTrigger } from './modals'
 import { isAnalysisHeroV17Enabled, isAnalysisHeroCompareEnabled, isFocusNowPanelEnabled, isAnalysisHeroPanelEnabled, isStrengthenPanelEnabled } from '@/flags'
 
@@ -334,48 +333,16 @@ export const ResultsBody = memo(function ResultsBody({
         hasResults={(resultsSectionData.recommendation.allOptions?.length ?? 0) > 0}
       />
 
-      {/* ══ V7 ASSESSMENT-MODE SCAFFOLD (V7 Lane L3) ═══════════════════════
-          Paul's ruling (V6-RESPEC-2026-07-23 §1, "Option A GO — additive,
-          never replace"): the panel renders in two stacked groups so Paul can
-          assess new V7 components against today's live panel in one scroll.
-          L3 is re-parenting + a divider ONLY — no component deleted, no logic
-          changed, no flag. The Current-view group retires once Paul signs off
-          (V6-RESPEC Paul-question P2). */}
-
-      {/* ▛ V7 (new) top group ▟ — the L4–L6 mount point. `empty:hidden` keeps
-          it out of layout until a lane fills it. L4 (V7 top matter — freshness
-          strip, sharpen line, V7 hero + signal row + max-2 chips) mounts here;
-          V7TopMatter returns null pre-analysis, so the group stays hidden until
-          analysis data exists. Reads the SAME resultsSectionData + vm the live
-          panel below consumes — additive, passthrough, no flag. */}
-      <div className="flex flex-col gap-4 empty:hidden" data-testid="v7-top-group">
-        <SectionErrorBoundary section="V7 top matter">
-          <V7TopMatter
-            resultsSectionData={resultsSectionData}
-            decisionState={vm.decisionState}
-            onFocusNode={onFocusNode}
-            onSendMessage={onSendMessage}
-          />
-        </SectionErrorBoundary>
-      </div>
-
-      {/* ── "Current view" divider ─────────────────────────────────────────
-          Plain SectionHeader-style separator (sentence case, muted, no accent
-          fill). COMPLETE border only — the four-sided neutral border obeys the
-          L1 rule (complete-borders guard); never a one-sided accent edge.
-          Everything beneath is the shipped panel, re-parented, zero logic
-          change. */}
-      <div
-        data-testid="assessment-current-view-divider"
-        className="flex items-center rounded-lg border border-panel-border bg-panel px-3 py-1.5"
-      >
-        <h3 className={`${typography.panelMeta} text-text-light`}>Current view</h3>
-      </div>
-
-      {/* ── Current view group — today's components, UNCHANGED, pushed down ──
-          Same order, same props, same stores as before L3. This wrapper only
-          re-parents them beneath the divider; the inner `gap-4` preserves the
-          exact inter-component spacing the outer container gave them. */}
+      {/* ══ V7 ASSESSMENT SCAFFOLD RETIRED FROM THIS TAB (12 Aug 2026) ══════
+          The V7 top group (`V7TopMatter`) + the "Current view" divider — the
+          V6-RESPEC-2026-07-23 §1 side-by-side assessment scaffold — MOVED,
+          unchanged, to the temporary "Alt view" dock tab
+          (`v7/V7ComparisonTabBody`), so the Analysis tab renders the analysis
+          ONCE. Paul's instruction: move, NOT delete — the fork stays
+          comparable across the two tabs until he adjudicates it. The wrapper
+          below is kept as-is so everything beneath the old divider renders
+          byte-identically. Re-mounting V7 here REDs
+          `ResultsBody.v7Retired.spec.tsx`. */}
       <div className="flex flex-col gap-4" data-testid="assessment-current-view-group">
 
       {/* Freshness/staleness — CEE analysis_ready.freshness verdict. Renders
@@ -885,7 +852,8 @@ export const ResultsBody = memo(function ResultsBody({
           extracted into `DevBuildMarker` so the production-vs-expert
           combination is unit-testable. */}
       <DevBuildMarker isDev={import.meta.env.DEV} expertMode={!!expertMode} sha={typeof __GIT_SHA__ !== 'undefined' ? __GIT_SHA__ : 'dev'} />
-      {/* ── end Current view group (V7 L3 assessment-mode scaffold) ── */}
+      {/* ── end current-view wrapper (scaffold retired 12 Aug 2026; wrapper
+          kept so everything inside renders byte-identically) ── */}
       </div>
     </div>
   )

--- a/src/components/results/__tests__/ResultsBody.assessmentScaffold.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.assessmentScaffold.spec.tsx
@@ -1,21 +1,22 @@
 /**
- * ResultsBody — V7 Lane L3: assessment-mode scaffold.
+ * ResultsBody — the live surfaces survive the V7 scaffold's retirement,
+ * exactly once and in their original order.
  *
- * Paul's ruling (V6-RESPEC-2026-07-23 §1): the Analysis panel renders in TWO
- * stacked groups for the assessment window — a V7 (new) top group above a
- * "Current view" divider, with today's shipped components re-parented UNCHANGED
- * beneath it. L3 is re-parenting + a divider only: no component deleted, no
- * logic changed, no flag.
+ * HISTORY: until 12 Aug 2026 this file pinned the V7 L3 assessment-mode
+ * scaffold (Paul's V6-RESPEC-2026-07-23 §1 ruling: a V7 top group ABOVE a
+ * "Current view" divider, with today's components re-parented beneath — so
+ * Paul could assess the two renderings in one scroll). Paul then ruled the
+ * duplication off the working tab: the V7 group MOVED, unchanged, to the
+ * temporary "Alt view" dock tab (`v7/V7ComparisonTabBody`). The scaffold's
+ * absence from THIS tab is pinned in `ResultsBody.v7Retired.spec.tsx`; the
+ * new home's presence in `v7/__tests__/V7ComparisonTabBody.spec.tsx`.
  *
- * These pins lock the additive shape:
- *   (a) render-parity — every pushed-down component still mounts exactly ONCE,
- *       and BELOW the "Current view" divider;
- *   (b) the divider renders;
- *   (c) count-pin — no current component is lost in the re-parent;
- *   (d) the empty V7 top group mounts ABOVE the divider (the L4–L6 slot).
- *
- * RED-first: with the scaffold absent the divider/group testids do not exist,
- * so every pin below fails until the scaffold lands.
+ * What SURVIVES here is this file's other half — the "nothing lost" pins:
+ *   (a) every live component still renders exactly ONCE (the retirement
+ *       removed the duplicate rendering, not a component);
+ *   (b) the live components keep their existing document order (everything
+ *       below the old divider renders byte-identically — the wrapper
+ *       `assessment-current-view-group` is deliberately retained for that).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -140,9 +141,9 @@ function renderBody() {
 const before = (a: HTMLElement, b: HTMLElement) =>
   Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
 
-// The current (pushed-down) components' stable anchors — each must survive the
-// re-parent, render exactly once, and sit BELOW the "Current view" divider.
-const PUSHED_DOWN_ANCHORS = [
+// The live components' stable anchors — each must survive the scaffold's
+// retirement, render exactly once, in the original order.
+const LIVE_ANCHORS = [
   'decision-confidence-panel', // #3 hero (DecisionConfidencePanel, flag-off)
   'focus-now-panel', // Strengthen / Focus panel
   'section-header-options', // #2 options section (WinGauge + RiskAppetiteFilter + OptionCards)
@@ -152,45 +153,20 @@ const PUSHED_DOWN_ANCHORS = [
   'accordion-advanced', // #12 AdvancedSection (KEEP, single instance)
 ] as const
 
-describe('ResultsBody — V7 L3 assessment-mode scaffold', () => {
+describe('ResultsBody — live surfaces after the V7 scaffold retirement', () => {
   beforeEach(() => {
     useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
 
-  it('(b) renders the "Current view" divider', () => {
+  it('(a) every live component renders exactly ONCE — the duplication is gone, the components are not', () => {
     renderBody()
-    const divider = screen.getByTestId('assessment-current-view-divider')
-    expect(divider).toBeInTheDocument()
-    expect(divider).toHaveTextContent('Current view')
-  })
-
-  it('(d) mounts the empty V7 top group ABOVE the divider', () => {
-    renderBody()
-    const topGroup = screen.getByTestId('v7-top-group')
-    const divider = screen.getByTestId('assessment-current-view-divider')
-    expect(topGroup).toBeInTheDocument()
-    expect(before(topGroup, divider), 'V7 top group precedes the divider').toBe(true)
-  })
-
-  it('(a) every pushed-down component renders exactly ONCE and BELOW the divider', () => {
-    renderBody()
-    const divider = screen.getByTestId('assessment-current-view-divider')
-    for (const anchor of PUSHED_DOWN_ANCHORS) {
-      const matches = screen.getAllByTestId(anchor)
-      expect(matches, `${anchor} renders exactly once`).toHaveLength(1)
-      expect(before(divider, matches[0]), `${anchor} sits below the divider`).toBe(true)
+    for (const anchor of LIVE_ANCHORS) {
+      expect(screen.getAllByTestId(anchor), `${anchor} renders exactly once`).toHaveLength(1)
     }
   })
 
-  it('(c) count-pin: the current components are all present (nothing lost in the re-parent)', () => {
-    renderBody()
-    for (const anchor of PUSHED_DOWN_ANCHORS) {
-      expect(screen.queryByTestId(anchor), `${anchor} present`).toBeInTheDocument()
-    }
-  })
-
-  it('re-parented components keep their existing document order (byte-identical composition)', () => {
+  it('(b) the live components keep their existing document order (byte-identical composition)', () => {
     renderBody()
     const hero = screen.getByTestId('decision-confidence-panel')
     const focus = screen.getByTestId('focus-now-panel')

--- a/src/components/results/__tests__/ResultsBody.v7Retired.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.v7Retired.spec.tsx
@@ -1,0 +1,205 @@
+/**
+ * ResultsBody — the V7 assessment scaffold is RETIRED FROM THE ANALYSIS TAB
+ * (Paul, 12 Aug 2026: move the duplicated analysis surfaces to a temporary
+ * comparison tab — move, NOT delete).
+ *
+ * The Analysis tab (`results`) rendered the whole analysis TWICE: `V7TopMatter`
+ * (the V6-RESPEC-2026-07-23 §1 "Option A — additive, never replace" assessment
+ * scaffold) ABOVE a divider literally labelled "Current view", then the live
+ * answer-first surfaces below. The scaffold never retired. It has now MOVED —
+ * unchanged — to the temporary "Alt view" dock tab (`V7ComparisonTabBody`),
+ * so the two renderings stay comparable without the duplication polluting the
+ * working tab.
+ *
+ * These pins are the ANALYSIS-TAB half of the move (the new home's half lives
+ * in `v7/__tests__/V7ComparisonTabBody.spec.tsx`):
+ *   (a) the V7 top matter (and its host group) is ABSENT from the Analysis
+ *       tab's render;
+ *   (b) the "Current view" divider is ABSENT (only meaningful while the two
+ *       views coexisted on one tab);
+ *   (c) the temporary comparison tab is REGISTERED in the dock tab set,
+ *       unconditionally (no flag — no-dark-launch doctrine).
+ *
+ * RED-first at pristine 611d91c0: (a) and (b) fail because the scaffold still
+ * mounts on the Analysis tab; (c) fails because no 'altview' tab exists.
+ *
+ * A regression that re-mounts V7 on the Analysis tab turns (a) RED — this is
+ * the named test the brief requires. Bound to testids (identity), not to copy.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import { getOutputTabsForParity } from '../../../canvas/components/OutputsDock'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroV17Enabled: vi.fn(() => false),
+    isAnalysisHeroCompareEnabled: vi.fn(() => false),
+    isFocusNowPanelEnabled: vi.fn(() => true),
+    isStrengthenPanelEnabled: vi.fn(() => false),
+    isAiPanelV2Enabled: vi.fn(() => true),
+    isAnalysisHeroPanelEnabled: vi.fn(() => true),
+  }
+})
+
+import { isAnalysisHeroPanelEnabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+
+/**
+ * Post-run fixture — analysis data PRESENT, so at pristine the V7 group's own
+ * analysis-presence gate is satisfied and the group genuinely renders. An
+ * absence asserted against a fixture the group would not render on anyway
+ * would pass vacuously (trap 13: prove the probe can see a presence — the
+ * pristine RED run is that proof, and the positive control below keeps it).
+ */
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody() {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+describe('ResultsBody — V7 scaffold retired from the Analysis tab (moved to the Alt view tab)', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: null, analysisFreshnessDirty: false })
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+  })
+
+  it('(a) V7-on-results is GONE: no v7-top-matter, no v7-top-group, on either hero-flag posture', () => {
+    // POSITIVE CONTROL first: this render genuinely paints the post-run panel
+    // (the live surfaces are on screen), so the absences below are absences
+    // from a real render, not from an empty one.
+    for (const posture of [true, false]) {
+      vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(posture)
+      const { container, unmount } = renderBody()
+      expect(
+        screen.getByTestId('outputs-results-redesign'),
+        `positive control (analysisHeroPanel=${posture}): the panel rendered`,
+      ).toBeInTheDocument()
+      expect(container.textContent ?? '', 'positive control: real content painted').toMatch(/Option A/)
+
+      expect(
+        screen.queryByTestId('v7-top-matter'),
+        `analysisHeroPanel=${posture}: V7 top matter re-mounted on the Analysis tab — it lives on the Alt view tab now`,
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('v7-top-group'),
+        `analysisHeroPanel=${posture}: the v7-top-group slot must not survive on the Analysis tab`,
+      ).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('(b) the "Current view" divider is GONE from the Analysis tab', () => {
+    const { container } = renderBody()
+    expect(screen.getByTestId('outputs-results-redesign')).toBeInTheDocument()
+    expect(screen.queryByTestId('assessment-current-view-divider')).not.toBeInTheDocument()
+    // The literal label too — a re-introduced divider under a new testid would
+    // still say "Current view" to a user.
+    expect(container.textContent ?? '').not.toMatch(/Current view/)
+  })
+
+  it('(c) the temporary comparison tab is registered, unflagged, beside Analysis', () => {
+    const tabs = getOutputTabsForParity()
+    const ids = tabs.map(t => t.id)
+    expect(ids).toContain('altview')
+    const alt = tabs.find(t => t.id === 'altview')
+    expect(alt?.label).toBe('Alt view')
+    // Adjacency: directly after 'results' so the two renderings under
+    // comparison sit side by side in the strip.
+    expect(ids[ids.indexOf('results') + 1]).toBe('altview')
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.winFrequencyGapAbsence.spec.tsx
@@ -10,28 +10,21 @@
  * DIFFERENCE between two Monte-Carlo win frequencies. The ratified rule: no
  * user-facing surface states that gap — own-probability statements only.
  *
- * The hero's subline now names the runner-up and states ITS OWN probability.
- * The option card's line is DELETED outright, because the card already carries
- * the option's own probability in its header readout (`win-pct-{id}`) — pinned
- * below, by identity, so "deleted the line" cannot quietly become "the card
- * lost its number".
+ * ⚠ RE-SCOPED 12 Aug 2026 (the V7 move): the V7 hero MOVED, unchanged, to the
+ * temporary "Alt view" dock tab (`v7/V7ComparisonTabBody`) — Paul: "move, NOT
+ * delete". Its arms of this guard moved WITH it, to
+ * `v7/__tests__/V7Hero.winFrequencyGapAbsence.spec.tsx`. What remains here is
+ * the ANALYSIS-TAB half, and it got STRONGER: the one surface entitled to the
+ * "by N points" SHAPE (the V7 hero's goal arm, a GOAL-probability difference
+ * with its own rationale in `goalLeadPoints`) left this tab, so the whole
+ * panel — goal data or not — may now carry NONE of the three banned forms.
+ * No region split, no sanctioned exception.
  *
- * ⭐ WHY THIS SPEC RENDERS `ResultsBody` AND NOT `buildV7Headline`.
- * CLAUDE.md trap 3b: this estate has twice shipped a fix onto a component the
- * deployed flags do not mount, with a fully green suite pointed at the dark
- * one. `buildV7Headline.spec.ts` pins the builder; this spec pins the MOUNT
- * PATH — that the V7 hero is on screen at all, and that the retired string is
- * absent from the DOM a user loads.
- *
- * The mount-path derivation at 944799c1: `V7TopMatter` (and therefore
- * `V7Hero`) is mounted UNCONDITIONALLY inside `ResultsBody`'s `v7-top-group`
- * slot — "additive, passthrough, no flag" — while `analysisHeroPanel` gates a
- * different pair of arms lower in the same component. So the hero renders on
- * BOTH postures of that flag, and this spec asserts exactly that: if a future
- * change hosts the hero on one arm, the posture that stops mounting it fails
- * here rather than shipping the fix dark. The deployed posture is
- * `VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"` (netlify.toml), which is the arm
- * asserted first.
+ * ⭐ WHY THIS SPEC RENDERS `ResultsBody` AND NOT A BUILDER (CLAUDE.md trap 3b):
+ * this estate has twice shipped a fix onto a component the deployed flags do
+ * not mount, with a fully green suite pointed at the dark one. This spec pins
+ * the MOUNT PATH — what the Analysis tab actually composes — on BOTH postures
+ * of `analysisHeroPanel` (deployed = ON via netlify.toml).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
@@ -111,7 +104,7 @@ function makeData(
     // forward" long before any leader rule runs — so an absence assertion
     // would have passed against a headline that never mentions a leader.
     // The in-test precondition is what caught this; it is not decoration.
-    // Supplied ONLY on the soft variant, so the default fixture (and the six
+    // Supplied ONLY on the soft variant, so the default fixture (and the
     // cases built on it) keeps the legacy no-verdict path it was written for.
     ...(soft
       ? {
@@ -199,33 +192,6 @@ const PP_CLAIM = /percentage\s+points?/i
  */
 const POINTS_CLAIM = /\bby\s+-?\d+(\.\d+)?\s+points?\b/i
 
-/**
- * ⚠ SCOPING, ADDED 2026-08-10 (review F3). `GAP_CLAIM` and `POINTS_CLAIM` match
- * on the SHAPE "by N points", and one surface is entitled to that shape: the
- * hero's GOAL arm, whose "Leads by N points" differences GOAL PROBABILITIES —
- * a different quantity, with its own pairing rationale in `goalLeadPoints`, and
- * deliberately out of this change's scope.
- *
- * Asserting those two patterns across the whole panel therefore only passed
- * because the default fixture carries no goal data: the moment anyone added
- * some, a SANCTIONED sentence would have turned this guard RED. A guard that
- * fails on correct behaviour gets disabled, and then the class it protects is
- * unguarded — so the patterns are scoped instead.
- *
- * The split is: the hero subline is judged ON ITS OWN (it may carry the
- * sanctioned goal form and nothing else), and the REST of the panel may carry
- * none of the three forms. `PP_CLAIM` stays panel-wide and unscoped — no
- * sanctioned surface says "percentage points".
- */
-function splitPanelText(container: HTMLElement): { heroSubline: string; rest: string } {
-  const heroSubline = screen.queryByTestId('v7-hero-subline')?.textContent ?? ''
-  const all = container.textContent ?? ''
-  return {
-    heroSubline,
-    rest: heroSubline ? all.replace(heroSubline, '') : all,
-  }
-}
-
 describe('ResultsBody — no surface on the results panel states a win-frequency gap', () => {
   beforeEach(() => {
     useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
@@ -234,97 +200,50 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
     vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
   })
 
-  it('DEPLOYED POSTURE (analysisHeroPanel ON): the hero mounts, states the leader’s OWN probability, and states NO gap', () => {
-    renderBody()
-
-    // MOUNT PATH — assert the hero is on screen before asserting anything
-    // about its copy. A green copy assertion against an unmounted component is
-    // the defect this spec exists to prevent.
-    expect(screen.getByTestId('v7-hero')).toBeInTheDocument()
-
-    const headline = screen.getByTestId('v7-hero-headline')
-    expect(headline).toHaveTextContent(
-      new RegExp(`${WINNER_LABEL} came out ahead in 71% of simulated scenarios`),
-    )
-
-    const subline = screen.getByTestId('v7-hero-subline')
-    expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
-    // The honest replacement: the runner-up's OWN probability, named.
-    expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
-  })
-
   /**
    * ⭐ THE DURABLE GUARD FOR THE WHOLE CLASS.
    *
-   * Both retired forms, asserted absent across the ENTIRE rendered panel
+   * All three retired forms, asserted absent across the ENTIRE rendered panel
    * rather than element by element — so a gap claim reintroduced on any
    * surface `ResultsBody` composes REDs here, including a surface that does
-   * not exist yet.
+   * not exist yet. Since the V7 move there is NO sanctioned exception on this
+   * tab (the goal-arm "Leads by N points" lives on the Alt view tab), so the
+   * scoped `splitPanelText` region logic this file used to need is retired —
+   * the assertion is whole-panel on every fixture, goal data included.
    *
    * ⚠ SCOPE, STATED EXACTLY, because an absence claim is only as wide as what
    * it searched (trap 20):
-   *   · WHAT IS SEARCHED — the DOM `ResultsBody` renders under this fixture.
-   *     The canvas `OptionNode` is NOT composed by `ResultsBody`; its own
-   *     retirement is pinned in `render-matrix.spec.tsx` and
-   *     `residualComparative.optionNode.spec.tsx`.
-   *   · `certaintyCopy`'s `" by N point(s)"` suffix IS now covered, but on a
-   *     SEPARATE case below, because `DecisionConfidencePanel` mounts only on
-   *     the `analysisHeroPanel`-OFF arm — which is NOT the deployed posture.
-   *     This case runs on the deployed (ON) posture, where that panel is
-   *     absent, so its silence about the suffix here means "not rendered",
-   *     never "rendered and clean".
+   *   · WHAT IS SEARCHED — the DOM `ResultsBody` renders under this fixture,
+   *     on BOTH `analysisHeroPanel` postures. The canvas `OptionNode` is NOT
+   *     composed by `ResultsBody`; its own retirement is pinned in
+   *     `render-matrix.spec.tsx` and `residualComparative.optionNode.spec.tsx`.
+   *     The V7 hero is NOT composed by `ResultsBody` any more; its guard is
+   *     `v7/__tests__/V7Hero.winFrequencyGapAbsence.spec.tsx`.
+   *   · `certaintyCopy`'s `" by N point(s)"` suffix IS covered, on the
+   *     flag-OFF arm case below, because `DecisionConfidencePanel` mounts
+   *     only there — which is NOT the deployed posture. Its silence on the
+   *     ON posture means "not rendered", never "rendered and clean".
    */
-  it('NEITHER retired form appears anywhere in the rendered panel', () => {
-    const { container } = renderBody()
-    const text = container.textContent ?? ''
-    // Positive control FIRST: an absence assertion over an empty or
-    // half-rendered panel passes by testing nothing (trap 13).
-    expect(text).toMatch(/came out ahead in 71% of simulated scenarios/i)
-    expect(text).toMatch(new RegExp(RUNNER_UP_LABEL))
+  it('NONE of the retired forms appears anywhere in the rendered panel — either hero posture, with or without goal data', () => {
+    for (const posture of [true, false]) {
+      for (const withGoalData of [false, true]) {
+        vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(posture)
+        const { container, unmount } = renderBody(undefined, false, withGoalData)
+        const text = container.textContent ?? ''
+        const label = `analysisHeroPanel=${posture}, goalData=${withGoalData}`
+        // Positive control FIRST: an absence assertion over an empty or
+        // half-rendered panel passes by testing nothing (trap 13). Both
+        // option labels are painted by the live options section.
+        expect(text, `${label}: positive control — winner painted`).toMatch(new RegExp(WINNER_LABEL))
+        expect(text, `${label}: positive control — runner-up painted`).toMatch(new RegExp(RUNNER_UP_LABEL))
 
-    // `percentage points` is unambiguous — no sanctioned surface says it.
-    expect(text).not.toMatch(PP_CLAIM)
-
-    // The "by N points" SHAPE is judged per-region (see `splitPanelText`).
-    const { heroSubline, rest } = splitPanelText(container)
-    // This fixture carries no goal data, so the hero is on the COMPARATIVE arm
-    // and is entitled to no gap form at all.
-    expect(heroSubline).not.toMatch(GAP_CLAIM)
-    expect(heroSubline).not.toMatch(PP_CLAIM)
-    expect(rest).not.toMatch(GAP_CLAIM)
-    expect(rest).not.toMatch(POINTS_CLAIM)
-    expect(rest).not.toMatch(PP_CLAIM)
-  })
-
-  /**
-   * ⭐ F3 — THE SANCTIONED FORM MUST SURVIVE, and this proves it does.
-   *
-   * With goal data present the hero takes its GOAL arm, whose subline is
-   * "Leads by N points" over GOAL PROBABILITIES (0.9 − 0.4 = 50). That form is
-   * out of this change's scope and is correct; a guard that REDs on it would
-   * be a false alarm, and a false alarm on correct behaviour is how a guard
-   * gets switched off. So: the sanctioned sentence is asserted PRESENT, and
-   * the banned class is asserted absent everywhere else in the same render.
-   */
-  it('F3: the SANCTIONED goal-arm subline survives, and nothing else in the panel states a gap', () => {
-    const { container } = renderBody(undefined, false, true)
-
-    // Precondition — we are actually on the goal arm, not silently comparative.
-    const subline = screen.getByTestId('v7-hero-subline')
-    expect(subline).toHaveTextContent('Leads by 50 points')
-
-    // ⭐ THE OVERLAP, MADE EXPLICIT: the sanctioned sentence DOES match the
-    // banned-shape pattern. That is precisely why the pattern is scoped by
-    // region rather than weakened — and it is executable proof that the
-    // previous panel-wide assertion would have RED on this correct render.
-    expect(subline.textContent ?? '').toMatch(GAP_CLAIM)
-
-    const { rest } = splitPanelText(container)
-    expect(rest).not.toMatch(GAP_CLAIM)
-    expect(rest).not.toMatch(POINTS_CLAIM)
-    expect(rest).not.toMatch(PP_CLAIM)
-    // And the unambiguous phrase is absent from the WHOLE panel, hero included.
-    expect(container.textContent ?? '').not.toMatch(PP_CLAIM)
+        expect(text, `${label}: no "leads by N points"`).not.toMatch(GAP_CLAIM)
+        expect(text, `${label}: no "by N points" shape`).not.toMatch(POINTS_CLAIM)
+        expect(text, `${label}: no "percentage points"`).not.toMatch(PP_CLAIM)
+        unmount()
+        cleanup()
+      }
+    }
   })
 
   /**
@@ -332,12 +251,11 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
    * WHICH ARM MOUNTS IT, BECAUSE THE DEPLOYED POSTURE DOES NOT.
    *
    * Derived at the bytes: `decisionConfidenceElement` is referenced at exactly
-   * one site (`ResultsBody.tsx:508`), INSIDE `{!isAnalysisHeroPanelEnabled()
-   * && …}` — and `netlify.toml` bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`.
-   * So `DecisionConfidencePanel` mounts on the flag-OFF arm ONLY, and the
-   * retired " by N points" suffix was NOT on the surface staging serves.
-   * `buildCertaintyCopy` has exactly one consumer, so that is the whole story
-   * for this copy.
+   * one site inside `{!isAnalysisHeroPanelEnabled() && …}` — and `netlify.toml`
+   * bakes `VITE_FEATURE_ANALYSIS_HERO_PANEL="1"`. So `DecisionConfidencePanel`
+   * mounts on the flag-OFF arm ONLY, and the retired " by N points" suffix was
+   * NOT on the surface staging serves. `buildCertaintyCopy` has exactly one
+   * consumer, so that is the whole story for this copy.
    *
    * This case is therefore DEFENCE IN DEPTH, and it is labelled as such rather
    * than dressed up as a live-surface guard: the arm is real code, one flag
@@ -363,11 +281,9 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
     // Precondition 2 — we are on the SOFTENED branch, not a withheld one.
     expect(text).toMatch(new RegExp(`${WINNER_LABEL} currently leads`))
 
-    const { heroSubline, rest } = splitPanelText(container)
-    expect(heroSubline).not.toMatch(GAP_CLAIM)
-    expect(rest).not.toMatch(POINTS_CLAIM)
-    expect(rest).not.toMatch(PP_CLAIM)
-    expect(rest).not.toMatch(GAP_CLAIM)
+    expect(text).not.toMatch(GAP_CLAIM)
+    expect(text).not.toMatch(POINTS_CLAIM)
+    expect(text).not.toMatch(PP_CLAIM)
   })
 
   /**
@@ -399,27 +315,5 @@ describe('ResultsBody — no surface on the results panel states a win-frequency
     renderBody()
     expect(screen.getByTestId('win-pct-opt_b')).toHaveTextContent('31%')
     expect(screen.getByTestId('win-pct-opt_a')).toHaveTextContent('71%')
-  })
-
-  it('FLAG-MOVE GUARD (analysisHeroPanel OFF): the hero still mounts and still states no gap', () => {
-    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(false)
-    renderBody()
-
-    expect(
-      screen.getByTestId('v7-hero'),
-      'the V7 hero is mounted unconditionally; if it has been moved onto a flag arm, this fix can ship dark',
-    ).toBeInTheDocument()
-    const subline = screen.getByTestId('v7-hero-subline')
-    expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
-    expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
-  })
-
-  it('BOTH postures mount the hero — the flag decides nothing about this surface', () => {
-    for (const posture of [true, false]) {
-      vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(posture)
-      renderBody()
-      expect(screen.getByTestId('v7-hero'), `analysisHeroPanel=${posture}`).toBeInTheDocument()
-      cleanup()
-    }
   })
 })

--- a/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
+++ b/src/components/results/__tests__/optionScaleSubstitutionHonesty.spec.tsx
@@ -27,26 +27,29 @@
  *    distributions."
  * A robustness Monte-Carlo distribution is exactly where they diverge.
  *
- * ⚠ WHY THESE PINS RENDER `<ResultsBody>` AND BIND TO `v7-range-bar`.
+ * ⚠ WHY THESE PINS RENDER THE MOUNT PATH AND BIND TO `v7-range-bar`.
  * Two components render the same shared `OptionRangeBar`, and only one of them
  * reaches an ordinary reader on the deployed build:
- *   · V7LensGroup's bar (`v7-range-bar`) mounts through V7TopMatter, which
- *     ResultsBody mounts with NO FLAG ("additive, passthrough, no flag").
- *   · OptionCards' bar (`option-range-bar`) sits inside `{expertMode && ...}`.
- * DOM census over the real captures in `PHASE0-EVIDENCE-2026-07-28/`:
- * `v7-range-bar` in 53 capture files, `v7-outcome-row` in 53, `v7-top-matter`
- * in 81; `option-range-bar` in 1, and that one file is a model inventory rather
- * than a rendered results DOM. `ResultsBody.downsideTailMountPath.spec.tsx`
- * reached the same conclusion independently, from a different capture: "the
- * 10th/median/90th the tester still saw comes from the V7 'Likely outcome'
- * lens, which is not expert-gated at all."
+ *   · V7LensGroup's bar (`v7-range-bar`) mounts through V7TopMatter — hosted,
+ *     since the 12 Aug 2026 move, on the temporary "Alt view" dock tab
+ *     (`V7ComparisonTabBody`, no flag; previously ResultsBody's unflagged
+ *     `v7-top-group`). The harness below renders that host — V7TopMatter's
+ *     ONLY production parent — so these pins stay pointed at the surface a
+ *     reader actually loads.
+ *   · OptionCards' bar (`option-range-bar`) sits inside `{expertMode && ...}`
+ *     on the Analysis tab, and is NOT what these pins cover.
+ * DOM census over the real captures in `PHASE0-EVIDENCE-2026-07-28/` (taken
+ * pre-move, when the group lived on the Analysis tab — the CONTENT is
+ * unchanged by the move): `v7-range-bar` in 53 capture files, `v7-outcome-row`
+ * in 53, `v7-top-matter` in 81; `option-range-bar` in 1, and that one file is
+ * a model inventory rather than a rendered results DOM.
  *
- * So every arm renders the MOUNT PATH (`<ResultsBody>`) rather than a component
- * in isolation, and the first arm asserts the mount itself — rows 2.466 and
- * 2.491 shipped the same feature dark TWICE past a full mutant kit, a RED-first
- * discipline and a positive control, because every instrument was pointed at a
- * component the deployed flags do not mount. A green suite is not evidence
- * about a surface the deployment does not render.
+ * So every arm renders the MOUNT PATH (`<V7ComparisonTabBody>`) rather than a
+ * component in isolation, and the first arm asserts the mount itself — rows
+ * 2.466 and 2.491 shipped the same feature dark TWICE past a full mutant kit,
+ * a RED-first discipline and a positive control, because every instrument was
+ * pointed at a component the deployed flags do not mount. A green suite is not
+ * evidence about a surface the deployment does not render.
  *
  * BINDING: every assertion addresses a row by `data-option-id="<exact id>"` and
  * re-asserts that row's own label, so no assertion can be satisfied by a
@@ -55,6 +58,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, within } from '@testing-library/react'
 
+import { V7ComparisonTabBody } from '../v7/V7ComparisonTabBody'
 import { ResultsBody } from '../ResultsBody'
 import { computeOptionScale } from '../shared/OptionRangeBar'
 import { V7_LENS_COPY } from '../v7/v7LensCopy'
@@ -160,8 +164,19 @@ function makeData(options: OptionResult[]): ResultsSectionDataReturn {
   } as unknown as ResultsSectionDataReturn
 }
 
-/** THE MOUNT PATH — V7TopMatter's only production parent. */
-function renderBody(options: OptionResult[], expertMode = false) {
+/** THE MOUNT PATH — V7TopMatter's only production parent (the Alt view tab). */
+function renderBody(options: OptionResult[]) {
+  return render(
+    <V7ComparisonTabBody
+      resultsSectionData={makeData(options)}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+/** The ANALYSIS-TAB host — used ONLY by the expert-twin arm at the bottom,
+ *  which pins `OptionCards`' bar (a ResultsBody surface, expert-gated). */
+function renderAnalysisTab(options: OptionResult[], expertMode = false) {
   return render(
     <ResultsBody
       resultsSectionData={makeData(options)}
@@ -222,7 +237,7 @@ afterEach(() => {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('2.800 — MOUNT PATH: the pinned surface is the one the deployed build renders', () => {
-  it('ResultsBody mounts the V7 lens and its range bar with NO flag and NO expert mode', () => {
+  it('the Alt view tab body mounts the V7 lens and its range bar with NO flag and NO expert mode', () => {
     renderBody([
       opt('scored', 'Scored option', { p10: 50, p50: 75, p90: 100, win: 0.6 }),
       opt('other', 'Other option', { p10: 60, p50: 70, p90: 80, win: 0.4 }),
@@ -235,10 +250,11 @@ describe('2.800 — MOUNT PATH: the pinned surface is the one the deployed build
     expect(screen.queryByTestId('v7-lens-group')).not.toBeNull()
     expect(rangeBar('scored', 'Scored option')).not.toBeNull()
 
-    // ...and the expert-gated twin is NOT what we are pinning: it is absent at
-    // this posture, which is exactly why binding there would have proved
-    // nothing about what a reader sees.
-    expect(screen.queryByTestId('option-range-bar')).toBeNull()
+    // NOTE (12 Aug 2026 move): the old assertion that the expert-gated twin
+    // (`option-range-bar`) is absent here became VACUOUS in this host —
+    // OptionCards never mounts on the Alt view tab, so its absence proves
+    // nothing. The twin's own rule is pinned in the ResultsBody-bound arm at
+    // the bottom of this file, which mounts the surface it asserts about.
   })
 })
 
@@ -392,7 +408,7 @@ describe('2.800a — median honesty: an absent p50 is NEVER the mean', () => {
 
 describe('2.800a — the expert OptionCards bar holds the same median rule', () => {
   it('shows no median label when the producer sent no p50, and one when it did', () => {
-    renderBody(
+    renderAnalysisTab(
       [
         opt('a', 'Skewed option', { mean: 90, p10: 10, p50: null, p90: 100, win: 0.6 }),
         opt('b', 'Other option', { mean: 50, p10: 20, p50: 50, p90: 80, win: 0.4 }),

--- a/src/components/results/v7/V7ComparisonTabBody.tsx
+++ b/src/components/results/v7/V7ComparisonTabBody.tsx
@@ -1,0 +1,99 @@
+/**
+ * V7ComparisonTabBody — TEMPORARY comparison surface (Paul, 12 Aug 2026).
+ *
+ * Hosts the ENTIRE V7 assessment group (`V7TopMatter`: freshness strip,
+ * sharpen line, what-I-was-given, hero, lens group, evidence disclosure,
+ * guidance, bias), MOVED here unchanged from the Analysis tab — where it
+ * rendered the whole analysis a second time above a "Current view" divider
+ * (the V6-RESPEC-2026-07-23 §1 "Option A — additive, never replace"
+ * assessment scaffold that never retired). This tab exists so Paul can
+ * compare the two renderings of the SAME analysis side by side; it retires
+ * when he adjudicates the V7-vs-Current fork (COMPONENT-INVENTORY §10A).
+ * Reversal = code revert. No flag (no-dark-launch doctrine).
+ *
+ * SINGLE DATA AUTHORITY (the estate's chronic defect is same-named twins):
+ *   · `resultsSectionData` is the SAME object OutputsDock hands `ResultsBody`
+ *     on the Analysis tab (one `useResultsSectionData()` call, one instance).
+ *   · `decisionState` is derived by the ONE shared `buildResultsVM`, from the
+ *     SAME `fragileEdgeCount`/`robustEdgeCount` inputs OutputsDock passes
+ *     `ResultsBody` — the exact derivation (and value) the live hero consumes.
+ *     No forked builder, no duplicated selector.
+ *   · The empty state gates on `v7HasAnalysis` — the SAME predicate
+ *     `V7TopMatter` itself returns-null on — so "empty invitation" and "V7
+ *     content" are mutually exclusive by construction.
+ */
+
+import { useMemo } from 'react'
+import { typography } from '../../../styles/typography'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { buildResultsVM } from '../buildResultsVM'
+import { SectionErrorBoundary } from '../../../canvas/components/SectionErrorBoundary'
+import { V7TopMatter, v7HasAnalysis } from './V7TopMatter'
+
+export interface V7ComparisonTabBodyProps {
+  /** The SAME instance OutputsDock feeds ResultsBody — never a re-derivation. */
+  resultsSectionData: ResultsSectionDataReturn
+  /** Same source expressions as ResultsBody's props (report.robustness.*). */
+  fragileEdgeCount?: number
+  robustEdgeCount?: number
+  onFocusNode?: (nodeId: string) => void
+  onSendMessage?: (text: string) => void
+}
+
+export function V7ComparisonTabBody({
+  resultsSectionData,
+  fragileEdgeCount,
+  robustEdgeCount,
+  onFocusNode,
+  onSendMessage,
+}: V7ComparisonTabBodyProps) {
+  // Byte-for-byte the derivation ResultsBody performs for its own `vm` —
+  // same shared builder, same inputs, therefore the same decisionState the
+  // Analysis tab's live hero consumes. Kept identical ON PURPOSE; if
+  // ResultsBody's derivation ever changes, change this with it (both feed
+  // from the one `buildResultsVM`, so a divergence is a visible diff here).
+  const robustnessEdgeTotal = (fragileEdgeCount ?? 0) + (robustEdgeCount ?? 0)
+  const vm = useMemo(
+    () => buildResultsVM(resultsSectionData, {
+      fragileEdgeCount,
+      totalEdgeCount: robustnessEdgeTotal,
+    }),
+    [resultsSectionData, fragileEdgeCount, robustnessEdgeTotal],
+  )
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="v7-comparison-tab-body">
+      {/* One-line orientation header — names this a TEMPORARY comparison so
+          nobody mistakes it for a second product surface. */}
+      <div
+        data-testid="v7-comparison-tab-header"
+        className="rounded-lg border border-panel-border bg-panel px-3 py-1.5"
+      >
+        <p className={`${typography.panelMeta} text-text-light`}>
+          Temporary comparison view — an alternate rendering of the same
+          analysis shown on the Analysis tab.
+        </p>
+      </div>
+
+      {v7HasAnalysis(resultsSectionData) ? (
+        <SectionErrorBoundary section="V7 top matter">
+          <V7TopMatter
+            resultsSectionData={resultsSectionData}
+            decisionState={vm.decisionState}
+            onFocusNode={onFocusNode}
+            onSendMessage={onSendMessage}
+          />
+        </SectionErrorBoundary>
+      ) : (
+        <p
+          data-testid="v7-comparison-tab-empty"
+          className={`${typography.panelMeta} text-text-light px-1`}
+        >
+          Run an analysis to see the alternate rendering here.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default V7ComparisonTabBody

--- a/src/components/results/v7/V7TopMatter.tsx
+++ b/src/components/results/v7/V7TopMatter.tsx
@@ -1,17 +1,21 @@
 /**
  * V7TopMatter — the V7 (new) top group's L4 content (V7 Lane L4).
  *
- * Mounts inside the `v7-top-group` slot in ResultsBody, ABOVE the
- * "Current view" divider (the L3 scaffold). Composes the L4 components:
+ * MOUNT SITE MOVED 12 Aug 2026 (Paul: "move, NOT delete"): now mounts inside
+ * `V7ComparisonTabBody` — the temporary "Alt view" dock tab — its ONLY
+ * production parent. Until then it mounted in ResultsBody's `v7-top-group`
+ * slot ABOVE a "Current view" divider (the V6-RESPEC-2026-07-23 §1 L3
+ * assessment scaffold, "Option A — additive, never replace"), which rendered
+ * the whole analysis twice on the Analysis tab. The group itself is UNCHANGED.
+ * Composes the L4 components:
  *   1. V7FreshnessStrip — current / changed / cannot-confirm, honest
  *   2. V7SharpenLine    — brief quote + inputs to confirm + model-limit caveat
  *   3. V7Hero           — gauge + live headline + subline + signal row + chips
  *
  * ADDITIVE and PASSTHROUGH: every part reads existing store data and renders
  * nothing when its backing data is absent. The whole group is gated on
- * analysis presence — pre-analysis it returns null, so `v7-top-group`'s
- * `empty:hidden` keeps it out of layout entirely (spec: renders NOTHING
- * pre-analysis; nothing below the divider changes).
+ * analysis presence (`v7HasAnalysis` below) — pre-analysis it returns null,
+ * and the host tab shows its empty state off the SAME predicate.
  */
 
 import { useMemo } from 'react'
@@ -35,18 +39,30 @@ export interface V7TopMatterProps {
   onSendMessage?: (text: string) => void
 }
 
+/**
+ * Analysis-presence gate — mirror the live hero: there is analysis to show
+ * once options with results exist and the panel is neither loading nor errored.
+ *
+ * Exported as THE single predicate (12 Aug 2026, the V7 move): the host tab
+ * body (`V7ComparisonTabBody`) shows its empty state exactly when this group
+ * renders nothing. One predicate consulted by both, so the two surfaces are
+ * mutually exclusive by construction — a re-derived copy in the host would be
+ * this estate's same-named-twin defect.
+ */
+export function v7HasAnalysis(resultsSectionData: ResultsSectionDataReturn): boolean {
+  const { recommendation, isLoading, isError } = resultsSectionData
+  return !isLoading && !isError && (recommendation.allOptions?.length ?? 0) > 0
+}
+
 export function V7TopMatter({
   resultsSectionData,
   decisionState,
   onFocusNode,
   onSendMessage,
 }: V7TopMatterProps) {
-  const { recommendation, drivers, confidence, isLoading, isError } = resultsSectionData
+  const { recommendation, drivers, confidence } = resultsSectionData
 
-  // Analysis-presence gate — mirror the live hero: there is analysis to show
-  // once options with results exist and the panel is neither loading nor errored.
-  const hasAnalysis = !isLoading && !isError && (recommendation.allOptions?.length ?? 0) > 0
-  if (!hasAnalysis) return null
+  if (!v7HasAnalysis(resultsSectionData)) return null
 
   // Sharpen inputs — the evidence gaps worth confirming (honest, store-backed).
   const sharpenInputs: V7SharpenInput[] = (confidence.topEvidenceGaps ?? []).map(gap => ({
@@ -82,12 +98,12 @@ export function V7TopMatter({
       <V7FreshnessStrip />
       <V7SharpenLine briefQuote={briefQuote} inputs={sharpenInputs} onFocusNode={onFocusNode} />
       {/* ROADMAP 2.973 — "what I was given / what I used".
-          MOUNTED HERE, in the UNCONDITIONAL `v7-top-group`, deliberately: the
-          two arms of `analysisHeroPanel` in ResultsBody are mutually exclusive,
-          and this estate has twice shipped a feature dark by hosting it on the
-          arm the deployed flags switch off. This slot mounts on BOTH postures,
-          so a flag move cannot make it disappear. It sits beside V7SharpenLine
-          because that is the "what you told us" region of the panel. */}
+          MOUNTED HERE, in the UNCONDITIONAL V7 group, deliberately: this
+          estate has twice shipped a feature dark by hosting it on the arm the
+          deployed flags switch off. The group's host (the Alt view tab since
+          12 Aug 2026; previously ResultsBody's `v7-top-group`) mounts on NO
+          flag, so a flag move cannot make it disappear. It sits beside
+          V7SharpenLine because that is the "what you told us" region. */}
       <V7WhatIWasGivenSection onSendMessage={onSendMessage} />
       <V7Hero
         recommendation={recommendation}

--- a/src/components/results/v7/__tests__/V7ComparisonTabBody.spec.tsx
+++ b/src/components/results/v7/__tests__/V7ComparisonTabBody.spec.tsx
@@ -1,0 +1,217 @@
+/**
+ * V7ComparisonTabBody — the V7 group's NEW (and only) production home
+ * (Paul, 12 Aug 2026: move the duplicated analysis surfaces to a temporary
+ * comparison tab — move, NOT delete).
+ *
+ * The entire V7 assessment group (`V7TopMatter`: freshness strip, sharpen
+ * line, what-I-was-given, hero, lens group, evidence disclosure, guidance,
+ * bias) MOVED here unchanged from the Analysis tab, so Paul can compare the
+ * two renderings of the SAME analysis without the duplication polluting the
+ * working tab.
+ *
+ * Pins (the NEW-HOME half of the move; the Analysis-tab half lives in
+ * `__tests__/ResultsBody.v7Retired.spec.tsx`):
+ *   (a) PRESENCE — with analysis data, the tab body mounts `V7TopMatter`
+ *       (a regression that removes V7 from this tab turns this RED — the
+ *       brief's named presence test);
+ *   (b) the in-tab header names it a TEMPORARY comparison of an alternate
+ *       rendering of the same analysis;
+ *   (c) EMPTY STATE — pre-analysis, no V7 content and an honest one-line
+ *       invitation instead (same `v7HasAnalysis` predicate V7TopMatter itself
+ *       gates on — one predicate, no twin);
+ *   (d) SINGLE DATA AUTHORITY — `V7TopMatter` receives the SAME
+ *       `resultsSectionData` object (identity, not a copy) handed to the tab
+ *       body, and a `decisionState` equal to what the ONE shared
+ *       `buildResultsVM` derives from those same inputs — the exact value the
+ *       Analysis tab's live hero consumes. No forked derivation.
+ *
+ * RED-first at pristine 611d91c0: the module under test does not exist, so
+ * this file fails at collect — the loudest possible RED.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { V7TopMatterProps } from '../V7TopMatter'
+import { V7ComparisonTabBody } from '../V7ComparisonTabBody'
+import { buildResultsVM } from '../../buildResultsVM'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../../types'
+
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+/**
+ * Observe the prop boundary WITHOUT replacing the component: the mock spreads
+ * `importOriginal` and DELEGATES to the real `V7TopMatter`, so every rendering
+ * assertion still exercises the real tree (the drift-proof pattern from
+ * `ResultsBody.v7SharpenQuoteProvenance.spec.tsx` — trap 12: a hand-listed
+ * stub silently drops whatever the module gains next).
+ */
+const { topMatterProps } = vi.hoisted(() => ({ topMatterProps: [] as V7TopMatterProps[] }))
+
+vi.mock('../V7TopMatter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../V7TopMatter')>()
+  const { createElement } = await import('react')
+  return {
+    ...actual,
+    V7TopMatter: (props: V7TopMatterProps) => {
+      topMatterProps.push(props)
+      return createElement(actual.V7TopMatter, props)
+    },
+  }
+})
+
+import { useCanvasStore } from '@/canvas/store'
+import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+const WINNER_LABEL = 'Bring In 6-Month Contractor'
+
+function makeData(overrides?: { empty?: boolean }): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: WINNER_LABEL,
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.71,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Hire Permanent Senior Tech Lead',
+    isRecommended: false,
+    winProbability: 0.31,
+  } as unknown as OptionResult
+
+  const recommendation = overrides?.empty
+    ? ({ recommendedOption: undefined, allOptions: [], isSingleOption: false } as unknown as DecisionResultData)
+    : ({
+        recommendedOption: winner,
+        allOptions: [winner, runnerUp],
+        goalLabel: 'Maximise success',
+        goalText: 'Ship the Q4 migration without blowing the budget',
+        goalThreshold: 0.6,
+        isSingleOption: false,
+        analysisStatus: 'computed',
+        recommendationStability: 0.92,
+        robustnessLevel: 'high',
+        isNormalised: false,
+      } as unknown as DecisionResultData)
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-08-12T00:00:00Z' }
+
+describe('V7ComparisonTabBody — the moved V7 group in its temporary comparison tab', () => {
+  beforeEach(() => {
+    topMatterProps.length = 0
+    useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
+    useGuidanceStore.setState({ guidanceItems: [] })
+  })
+
+  it('(a) PRESENCE: with analysis data, the tab body mounts the V7 top matter — removing it from this tab REDs here', () => {
+    render(
+      <V7ComparisonTabBody
+        resultsSectionData={makeData()}
+        onSendMessage={() => {}}
+        onFocusNode={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('v7-comparison-tab-body')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-top-matter')).toBeInTheDocument()
+    // The group's own composition is unchanged in its new home — spot-pin the
+    // hero by identity and its headline by the fixture winner (no invented
+    // content; deep behaviour pins live in the V7 component suites).
+    expect(screen.getByTestId('v7-hero')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-hero-headline')).toHaveTextContent(
+      new RegExp(`${WINNER_LABEL} came out ahead in 71% of simulated scenarios`),
+    )
+    expect(screen.getByTestId('v7-freshness-strip')).toBeInTheDocument()
+  })
+
+  it('(b) the in-tab header names it a temporary comparison of an alternate rendering, same analysis', () => {
+    render(<V7ComparisonTabBody resultsSectionData={makeData()} />)
+    const header = screen.getByTestId('v7-comparison-tab-header')
+    expect(header.textContent ?? '').toMatch(/[Tt]emporary comparison/)
+    expect(header.textContent ?? '').toMatch(/alternat(e|ive) rendering/)
+    expect(header.textContent ?? '').toMatch(/same analysis/)
+  })
+
+  it('(c) EMPTY STATE: pre-analysis, no V7 content — an honest invitation renders instead, never both', () => {
+    render(<V7ComparisonTabBody resultsSectionData={makeData({ empty: true })} />)
+    expect(screen.queryByTestId('v7-top-matter')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('v7-hero')).not.toBeInTheDocument()
+    expect(screen.getByTestId('v7-comparison-tab-empty')).toBeInTheDocument()
+    // The header still orients the user on what this tab is.
+    expect(screen.getByTestId('v7-comparison-tab-header')).toBeInTheDocument()
+  })
+
+  it('(d) SINGLE DATA AUTHORITY: V7TopMatter gets the SAME data object, and the SAME decisionState the shared builder derives', () => {
+    const data = makeData()
+    render(
+      <V7ComparisonTabBody
+        resultsSectionData={data}
+        fragileEdgeCount={2}
+        robustEdgeCount={3}
+      />,
+    )
+    expect(topMatterProps.length).toBeGreaterThan(0)
+    const received = topMatterProps[topMatterProps.length - 1]
+    // Identity, not equality: a cloned/re-derived payload would be a forked
+    // authority even if deep-equal today (trap 19 — bind by identity).
+    expect(received.resultsSectionData).toBe(data)
+    // decisionState comes from the ONE shared buildResultsVM over the SAME
+    // inputs ResultsBody hands it on the Analysis tab (fragile=2, total=5).
+    const expected = buildResultsVM(data, { fragileEdgeCount: 2, totalEdgeCount: 5 }).decisionState
+    expect(received.decisionState).toBe(expected)
+  })
+})

--- a/src/components/results/v7/__tests__/V7Hero.winFrequencyGapAbsence.spec.tsx
+++ b/src/components/results/v7/__tests__/V7Hero.winFrequencyGapAbsence.spec.tsx
@@ -1,0 +1,226 @@
+/**
+ * V7 hero — NO WIN-FREQUENCY GAP, in its new home (the Alt view tab).
+ *
+ * The V7-hero arms of the 2026-08-10 win-frequency-gap guard, moved here from
+ * `ResultsBody.winFrequencyGapAbsence.spec.tsx` when the V7 group moved to the
+ * temporary "Alt view" dock tab (12 Aug 2026, Paul: "move, NOT delete"). The
+ * BEHAVIOUR pinned is byte-for-byte what the hero did on the Analysis tab:
+ *   · the hero states the leader's OWN probability, and NO gap;
+ *   · the honest subline names the runner-up with ITS OWN probability;
+ *   · the SANCTIONED exception survives the move: the hero's GOAL arm may say
+ *     "Leads by N points" over GOAL probabilities (its own pairing rationale
+ *     in `goalLeadPoints`) — and ONLY the hero subline may carry that shape;
+ *   · the surface mounts on BOTH postures of `analysisHeroPanel` — the Alt
+ *     view tab consults no flag, and this guard proves a future change cannot
+ *     quietly re-gate it (trap 3b: the estate shipped the same feature dark
+ *     twice by hosting it on the arm the deployed flags switch off).
+ *
+ * The Analysis-tab half of the class guard (whole-panel absence, positive
+ * controls, the DecisionConfidencePanel defence-in-depth arm) stays in
+ * `ResultsBody.winFrequencyGapAbsence.spec.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { V7ComparisonTabBody } from '../V7ComparisonTabBody'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../../types'
+
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+vi.mock('@/flags', async () => {
+  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
+  return {
+    ...actual,
+    isAnalysisHeroPanelEnabled: vi.fn(() => true),
+  }
+})
+
+import { isAnalysisHeroPanelEnabled } from '@/flags'
+import { useCanvasStore } from '@/canvas/store'
+import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
+import type { AnalysisFreshnessState } from '@/canvas/store/analysisFreshness'
+
+const WINNER_LABEL = 'Bring In 6-Month Contractor'
+const RUNNER_UP_LABEL = 'Hire Permanent Senior Tech Lead'
+
+function makeData(withGoalData = false): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: WINNER_LABEL,
+    isRecommended: true,
+    winProbability: 0.71,
+    ...(withGoalData ? { goalProbability: 0.9 } : {}),
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: RUNNER_UP_LABEL,
+    isRecommended: false,
+    winProbability: 0.31,
+    ...(withGoalData ? { goalProbability: 0.4 } : {}),
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    ...(withGoalData ? { goalThreshold: 0.6 } : {}),
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+  } as unknown as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    challengeFragileEdges: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderTab(withGoalData = false) {
+  return render(
+    <V7ComparisonTabBody
+      resultsSectionData={makeData(withGoalData)}
+      onSendMessage={() => {}}
+      onFocusNode={() => {}}
+    />,
+  )
+}
+
+const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-08-12T00:00:00Z' }
+
+/** The retired form, in every pluralisation and casing it could return in. */
+const GAP_CLAIM = /leads?\s+by\s+\d+\s+points?/i
+const PP_CLAIM = /percentage\s+points?/i
+const POINTS_CLAIM = /\bby\s+-?\d+(\.\d+)?\s+points?\b/i
+
+/**
+ * The hero subline is the ONE surface entitled to the "by N points" shape
+ * (its GOAL arm — goal probabilities, not win frequencies), so it is judged
+ * on its own and the REST of the tab may carry none of the three forms.
+ */
+function splitTabText(container: HTMLElement): { heroSubline: string; rest: string } {
+  const heroSubline = screen.queryByTestId('v7-hero-subline')?.textContent ?? ''
+  const all = container.textContent ?? ''
+  return {
+    heroSubline,
+    rest: heroSubline ? all.replace(heroSubline, '') : all,
+  }
+}
+
+describe('V7 hero in the Alt view tab — own-probability statements only, never a win-frequency gap', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
+    useGuidanceStore.setState({ guidanceItems: [] })
+    vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(true)
+  })
+
+  it('the hero mounts, states the leader’s OWN probability, and states NO gap', () => {
+    renderTab()
+
+    // MOUNT PATH — assert the hero is on screen before asserting anything
+    // about its copy. A green copy assertion against an unmounted component is
+    // the defect this guard exists to prevent.
+    expect(screen.getByTestId('v7-hero')).toBeInTheDocument()
+
+    const headline = screen.getByTestId('v7-hero-headline')
+    expect(headline).toHaveTextContent(
+      new RegExp(`${WINNER_LABEL} came out ahead in 71% of simulated scenarios`),
+    )
+
+    const subline = screen.getByTestId('v7-hero-subline')
+    expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
+    // The honest replacement: the runner-up's OWN probability, named.
+    expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
+  })
+
+  /**
+   * ⭐ THE SANCTIONED FORM MUST SURVIVE THE MOVE, and this proves it does.
+   *
+   * With goal data present the hero takes its GOAL arm, whose subline is
+   * "Leads by N points" over GOAL PROBABILITIES (0.9 − 0.4 = 50). That form
+   * is correct and has its own pairing rationale; a guard that REDs on it
+   * would be a false alarm, and a false alarm on correct behaviour is how a
+   * guard gets switched off. So: the sanctioned sentence is asserted PRESENT,
+   * and the banned class is asserted absent everywhere else in the same
+   * render.
+   */
+  it('the SANCTIONED goal-arm subline survives, and nothing else in the tab states a gap', () => {
+    const { container } = renderTab(true)
+
+    // Precondition — we are actually on the goal arm, not silently comparative.
+    const subline = screen.getByTestId('v7-hero-subline')
+    expect(subline).toHaveTextContent('Leads by 50 points')
+
+    // ⭐ THE OVERLAP, MADE EXPLICIT: the sanctioned sentence DOES match the
+    // banned-shape pattern — which is precisely why the pattern is scoped by
+    // region rather than weakened.
+    expect(subline.textContent ?? '').toMatch(GAP_CLAIM)
+
+    const { rest } = splitTabText(container)
+    expect(rest).not.toMatch(GAP_CLAIM)
+    expect(rest).not.toMatch(POINTS_CLAIM)
+    expect(rest).not.toMatch(PP_CLAIM)
+    // And the unambiguous phrase is absent from the WHOLE tab, hero included.
+    expect(container.textContent ?? '').not.toMatch(PP_CLAIM)
+  })
+
+  it('BOTH postures of analysisHeroPanel mount the hero — the Alt view tab consults no flag', () => {
+    for (const posture of [true, false]) {
+      vi.mocked(isAnalysisHeroPanelEnabled).mockReturnValue(posture)
+      renderTab()
+      expect(
+        screen.getByTestId('v7-hero'),
+        `analysisHeroPanel=${posture}: if the Alt view tab has been re-gated, this comparison surface can ship dark`,
+      ).toBeInTheDocument()
+      const subline = screen.getByTestId('v7-hero-subline')
+      expect(subline.textContent ?? '').not.toMatch(GAP_CLAIM)
+      expect(subline).toHaveTextContent(`Next: ${RUNNER_UP_LABEL}, 31%`)
+      cleanup()
+    }
+  })
+})

--- a/src/components/results/v7/__tests__/V7TopMatter.inAltViewTab.spec.tsx
+++ b/src/components/results/v7/__tests__/V7TopMatter.inAltViewTab.spec.tsx
@@ -1,24 +1,27 @@
 /**
- * ResultsBody — V7 Lane L4: V7 top matter.
+ * V7 top matter, in its new home — the Alt view comparison tab.
  *
- * Pins the additive top-group content that mounts in the `v7-top-group` slot,
- * ABOVE the "Current view" divider:
- *   (a) present  — freshness strip + hero (+headline +signal row) render, and
- *       ALL sit ABOVE the divider;
- *   (b) absent   — with no analysis, the top matter renders NOTHING (the group
- *       stays empty → hidden), and the pushed-down panel is untouched;
+ * HISTORY: this file was `ResultsBody.v7TopMatter.spec.tsx` and pinned the V7
+ * L4 top matter inside ResultsBody's `v7-top-group` slot, above the "Current
+ * view" divider. On 12 Aug 2026 the whole V7 group MOVED, unchanged, to the
+ * temporary "Alt view" dock tab (`V7ComparisonTabBody`) — Paul: "move, NOT
+ * delete". The harness is re-bound to the new (and only) production parent;
+ * every BEHAVIOUR pin below is byte-for-byte the behaviour the group had on
+ * the Analysis tab:
+ *   (a) present  — freshness strip + hero (+headline +signal row) render
+ *       inside the tab body;
+ *   (b) absent   — with no analysis, the top matter renders NOTHING (the
+ *       tab's empty state shows instead, never both);
  *   (c) max-2    — with 3 guidance items only 2 chips render;
- *   (d) fresh    — the freshness strip reflects the store's fresh/stale verdict;
+ *   (d) fresh    — the freshness strip reflects the store's fresh/stale
+ *       verdict;
  *   (e) honest   — the hero headline is composed ONLY from the fixture winner
  *       label (no invented content).
- *
- * RED-first: against the L3 ResultsBody (no L4 mount) the `v7-top-matter`
- * / `v7-hero` testids do not exist, so (a),(c),(d),(e) fail until L4 lands.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { ResultsBody } from '../ResultsBody'
-import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { render, screen, within } from '@testing-library/react'
+import { V7ComparisonTabBody } from '../V7ComparisonTabBody'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 import type {
   ConfidenceSectionData,
   DecisionResultData,
@@ -26,27 +29,14 @@ import type {
   DriverItem,
   ImprovementsSectionData,
   OptionResult,
-} from '../types'
+} from '../../types'
 
-vi.mock('../../../canvas/utils/focusHelpers', () => ({
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
   focusByTarget: vi.fn(),
   focusExistingTarget: vi.fn(),
   focusModelTarget: vi.fn(() => true),
 }))
-
-vi.mock('@/flags', async () => {
-  const actual = await vi.importActual<typeof import('@/flags')>('@/flags')
-  return {
-    ...actual,
-    isAnalysisHeroV17Enabled: vi.fn(() => false),
-    isAnalysisHeroCompareEnabled: vi.fn(() => false),
-    isFocusNowPanelEnabled: vi.fn(() => true),
-    isStrengthenPanelEnabled: vi.fn(() => false),
-    isAiPanelV2Enabled: vi.fn(() => true),
-    isAnalysisHeroPanelEnabled: vi.fn(() => false),
-  }
-})
 
 import { useCanvasStore } from '@/canvas/store'
 import { useUIStore } from '@/stores/uiStore'
@@ -153,78 +143,62 @@ function guidanceItem(id: string, priority: number): GuidanceItem {
   } as GuidanceItem
 }
 
-function renderBody(overrides?: { empty?: boolean }) {
+function renderTab(overrides?: { empty?: boolean }) {
   return render(
-    <ResultsBody
+    <V7ComparisonTabBody
       resultsSectionData={makeData(overrides)}
-      tornadoData={{ rows: [], expectedOutcome: null }}
       onSendMessage={() => {}}
       onFocusNode={() => {}}
     />,
   )
 }
 
-const before = (a: HTMLElement, b: HTMLElement) =>
-  Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
-
 const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-07-23T00:00:00Z' }
 const STALE: AnalysisFreshnessState = { freshness: 'stale', computedAt: '2026-07-23T00:00:00Z' }
 
-describe('ResultsBody — V7 L4 top matter', () => {
+describe('V7 top matter — behaviour unchanged in the Alt view tab', () => {
   beforeEach(() => {
     useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
-    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useUIStore.setState({ activeOutputTab: 'altview', activeOutputTabVersion: 0 })
     useGuidanceStore.setState({ guidanceItems: [] })
   })
 
-  it('(a) renders the hero + signal row + freshness strip, ALL above the divider', () => {
-    renderBody()
-    const divider = screen.getByTestId('assessment-current-view-divider')
-    const topMatter = screen.getByTestId('v7-top-matter')
-    const hero = screen.getByTestId('v7-hero')
-    const signalRow = screen.getByTestId('v7-signal-row')
-    const strip = screen.getByTestId('v7-freshness-strip')
-    for (const el of [topMatter, hero, signalRow, strip]) {
-      expect(el).toBeInTheDocument()
-      expect(before(el, divider), 'top matter precedes the divider').toBe(true)
+  it('(a) renders the hero + signal row + freshness strip inside the tab body', () => {
+    renderTab()
+    const tabBody = screen.getByTestId('v7-comparison-tab-body')
+    for (const id of ['v7-top-matter', 'v7-hero', 'v7-signal-row', 'v7-freshness-strip']) {
+      expect(within(tabBody).getByTestId(id), `${id} mounts inside the tab body`).toBeInTheDocument()
     }
-    // Live hero below the divider is untouched (parity).
-    const liveHero = screen.getByTestId('decision-confidence-panel')
-    expect(before(divider, liveHero)).toBe(true)
   })
 
-  it('(b) renders NOTHING pre-analysis (top group stays empty), pushed-down panel intact', () => {
-    renderBody({ empty: true })
+  it('(b) renders NOTHING pre-analysis — the empty state shows instead, never both', () => {
+    renderTab({ empty: true })
     expect(screen.queryByTestId('v7-top-matter')).not.toBeInTheDocument()
     expect(screen.queryByTestId('v7-hero')).not.toBeInTheDocument()
-    const group = screen.getByTestId('v7-top-group')
-    expect(group).toBeEmptyDOMElement()
-    // The divider + live panel still render (nothing below the divider changed).
-    expect(screen.getByTestId('assessment-current-view-divider')).toBeInTheDocument()
-    expect(screen.getByTestId('decision-confidence-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('v7-comparison-tab-empty')).toBeInTheDocument()
   })
 
   it('(c) max-2 chips: 3 guidance items → exactly 2 chips', () => {
     useGuidanceStore.setState({
       guidanceItems: [guidanceItem('one', 90), guidanceItem('two', 80), guidanceItem('three', 70)],
     })
-    renderBody()
+    renderTab()
     expect(screen.getAllByTestId('v7-suggested-chip')).toHaveLength(2)
   })
 
   it('(d) freshness strip reflects the store verdict (fresh vs stale)', () => {
-    const { unmount } = renderBody()
+    const { unmount } = renderTab()
     expect(screen.getByTestId('v7-freshness-strip')).toHaveAttribute('data-freshness-semantic', 'current')
     expect(screen.getByTestId('v7-freshness-strip')).toHaveTextContent('Analysis reflects the current model.')
     unmount()
 
     useCanvasStore.setState({ analysisFreshness: STALE, analysisFreshnessDirty: false })
-    renderBody()
+    renderTab()
     expect(screen.getByTestId('v7-freshness-strip')).toHaveAttribute('data-freshness-semantic', 'changed')
   })
 
   it('(e) no invented content: hero headline is composed only from the fixture winner', () => {
-    renderBody()
+    renderTab()
     // Robust fixture (stability 0.92, clear gap) → the re-anchored leader
     // headline. SUPERSEDED 2026-07-31: was the "performs best" form, a bare
     // superlative retired under §6.2c. The BRANCH is unchanged.

--- a/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
+++ b/src/components/results/v7/__tests__/V7WhatIWasGivenSection.spec.tsx
@@ -28,7 +28,9 @@
  * forks on `analysisHeroPanel`, staging deploys `=1`, and the two arms are
  * mutually exclusive by construction — so a section hosted on the `=0` arm is
  * invisible in production while every render test passes. This section is
- * mounted in the UNCONDITIONAL `v7-top-group`, and the spec asserts it under
+ * mounted in the UNCONDITIONAL V7 group — hosted, since the 12 Aug 2026 move,
+ * on the "Alt view" tab (`V7ComparisonTabBody`, no flag; previously
+ * ResultsBody's unflagged `v7-top-group`) — and the spec asserts it under
  * BOTH postures so that a flag move cannot make it disappear silently.
  *
  * Flags are injected through the flag system's OWN seam (localStorage, which
@@ -52,6 +54,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 
 import { ResultsBody } from '../../ResultsBody'
+import { V7ComparisonTabBody } from '../V7ComparisonTabBody'
 import { V7WhatIWasGivenSection } from '../V7WhatIWasGivenSection'
 import { isAnalysisHeroPanelEnabled } from '@/flags'
 import { useCanvasStore } from '@/canvas/store'
@@ -786,11 +789,12 @@ describe('THE THREE ZEROS MUST NOT COLLAPSE', () => {
 // ── MOUNT PATH ──────────────────────────────────────────────────────────────
 
 /**
- * `ResultsBody` renders `v7-top-group` unconditionally, and `V7TopMatter`
- * inside it returns null until analysis exists (`allOptions.length > 0`). This
- * is the repo's own harness for that component (`ResultsBody.v7TopMatter.spec`),
- * reused verbatim in shape so the mount proof is about the FLAG, not about a
- * bespoke data shape.
+ * The Alt view tab body (`V7ComparisonTabBody`, the V7 group's only
+ * production parent since the 12 Aug 2026 move) mounts `V7TopMatter`
+ * unconditionally, and `V7TopMatter` returns null until analysis exists
+ * (`allOptions.length > 0`). This is the repo's own harness for that
+ * component (`V7TopMatter.inAltViewTab.spec`), reused verbatim in shape so
+ * the mount proof is about the FLAG, not about a bespoke data shape.
  */
 function makeAnalysedData(): ResultsSectionDataReturn {
   const winner = {
@@ -853,7 +857,19 @@ function makeAnalysedData(): ResultsSectionDataReturn {
   } as unknown as ResultsSectionDataReturn
 }
 
-function renderBody() {
+function renderAltViewTab() {
+  return render(
+    <V7ComparisonTabBody
+      resultsSectionData={makeAnalysedData()}
+      onSendMessage={() => {}}
+      onFocusNode={() => {}}
+    />,
+  )
+}
+
+/** The hero-fork CONTROL below still needs the ANALYSIS tab's host — the
+ *  fork the flag injection must demonstrably reach lives in ResultsBody. */
+function renderAnalysisTab() {
   return render(
     <ResultsBody
       resultsSectionData={makeAnalysedData()}
@@ -881,20 +897,20 @@ describe('MOUNT PATH — live under the DEPLOYED flag posture, and under its opp
     expect(isAnalysisHeroPanelEnabled()).toBe(true)
   })
 
-  it('DEPLOYED POSTURE (analysisHeroPanel=1): the section mounts inside the unconditional group', () => {
+  it('DEPLOYED POSTURE (analysisHeroPanel=1): the section mounts inside the Alt view tab body', () => {
     localStorage.setItem('feature.analysisHeroPanel', '1')
     seedFrom(b1Fixture as never)
-    renderBody()
+    renderAltViewTab()
 
     expect(isAnalysisHeroPanelEnabled()).toBe(true)
     const section = screen.getByTestId('what-i-was-given-section')
     expect(section).toBeInTheDocument()
     // Assert the MOUNT PATH itself, not merely presence: the section must be
-    // inside `v7-top-group`, which is the slot ResultsBody renders on BOTH
-    // arms of the flag. Presence alone would still pass if a later change
-    // re-hosted it onto the flag-on arm, which is how this estate shipped a
+    // inside the Alt view tab body — the host that mounts the V7 group on
+    // BOTH arms of the flag. Presence alone would still pass if a later
+    // change re-hosted it onto a flag arm, which is how this estate shipped a
     // feature dark twice.
-    expect(screen.getByTestId('v7-top-group').contains(section)).toBe(true)
+    expect(screen.getByTestId('v7-comparison-tab-body').contains(section)).toBe(true)
   })
 
   it('OPPOSITE POSTURE (analysisHeroPanel=0): the section STILL mounts, in the same slot', () => {
@@ -902,12 +918,12 @@ describe('MOUNT PATH — live under the DEPLOYED flag posture, and under its opp
     // flips the deployed arm, this surface must not vanish with it.
     localStorage.setItem('feature.analysisHeroPanel', '0')
     seedFrom(b1Fixture as never)
-    renderBody()
+    renderAltViewTab()
 
     expect(isAnalysisHeroPanelEnabled()).toBe(false)
     const section = screen.getByTestId('what-i-was-given-section')
     expect(section).toBeInTheDocument()
-    expect(screen.getByTestId('v7-top-group').contains(section)).toBe(true)
+    expect(screen.getByTestId('v7-comparison-tab-body').contains(section)).toBe(true)
   })
 
   it('CONTROL — the two postures really do render different heroes', () => {
@@ -915,13 +931,13 @@ describe('MOUNT PATH — live under the DEPLOYED flag posture, and under its opp
     // above are genuinely two postures and not the same render twice.
     localStorage.setItem('feature.analysisHeroPanel', '1')
     seedFrom(b1Fixture as never)
-    const on = renderBody()
+    const on = renderAnalysisTab()
     const heroOn = on.container.querySelector('[data-testid="analysis-hero-panel"]')
     cleanup()
 
     localStorage.setItem('feature.analysisHeroPanel', '0')
     seedFrom(b1Fixture as never)
-    const off = renderBody()
+    const off = renderAnalysisTab()
     const heroOff = off.container.querySelector('[data-testid="analysis-hero-panel"]')
 
     expect(heroOn, 'flag-on arm renders the hero panel').not.toBeNull()

--- a/src/components/results/v7/__tests__/v7SharpenQuoteProvenance.spec.tsx
+++ b/src/components/results/v7/__tests__/v7SharpenQuoteProvenance.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * ResultsBody — the V7 sharpen line's "You wrote: …" quote must be the USER's
+ * The V7 sharpen line's "You wrote: …" quote must be the USER's
  * words, never ours (ROADMAP 2.993).
  *
  * THE DEFECT (measured at `e15c6b81`, the commit staging deploys):
@@ -23,17 +23,19 @@
  * stops carrying the framing goal, these tests go RED instead of quietly
  * becoming tautologies.
  *
- * MOUNT PATH (trap 3b): `v7-top-group` carries NO flag in `ResultsBody`, and
- * the deployed staging bundle confirms it (chunk `ReactFlowGraph-9aiLXlpO.js`
- * at commit `e15c6b81` renders the group unguarded, unlike its flag-gated
- * hero sibling). Each test asserts the surface actually mounted, so an absence
- * assertion can never pass because the whole component vanished.
+ * MOUNT PATH (trap 3b), RE-BOUND 12 Aug 2026: the V7 group MOVED, unchanged,
+ * from ResultsBody's unflagged `v7-top-group` slot to the temporary "Alt view"
+ * dock tab (`V7ComparisonTabBody`, also unflagged) — Paul: "move, NOT delete".
+ * This file was `ResultsBody.v7SharpenQuoteProvenance.spec.tsx`; the harness
+ * now renders the new (and only) production parent. Each test still asserts
+ * the surface actually mounted, so an absence assertion can never pass
+ * because the whole component vanished.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
-import { ResultsBody } from '../ResultsBody'
-import type { V7SharpenLineProps } from '../v7/V7SharpenLine'
-import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { V7ComparisonTabBody } from '../V7ComparisonTabBody'
+import type { V7SharpenLineProps } from '../V7SharpenLine'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 import type {
   ConfidenceSectionData,
   DecisionResultData,
@@ -41,10 +43,10 @@ import type {
   DriverItem,
   ImprovementsSectionData,
   OptionResult,
-} from '../types'
+} from '../../types'
 import { composeBriefText } from '@/hooks/useAsk'
 
-vi.mock('../../../canvas/utils/focusHelpers', () => ({
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
   focusByTarget: vi.fn(),
   focusExistingTarget: vi.fn(),
@@ -73,8 +75,8 @@ vi.mock('../../../canvas/utils/focusHelpers', () => ({
  */
 const { sharpenProps } = vi.hoisted(() => ({ sharpenProps: [] as V7SharpenLineProps[] }))
 
-vi.mock('../v7/V7SharpenLine', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../v7/V7SharpenLine')>()
+vi.mock('../V7SharpenLine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../V7SharpenLine')>()
   const { createElement } = await import('react')
   return {
     ...actual,
@@ -237,9 +239,8 @@ function makeData(goalText: string | undefined): ResultsSectionDataReturn {
 
 function renderBody(goalText: string | undefined) {
   return render(
-    <ResultsBody
+    <V7ComparisonTabBody
       resultsSectionData={makeData(goalText)}
-      tornadoData={{ rows: [], expectedOutcome: null }}
       onSendMessage={() => {}}
       onFocusNode={() => {}}
     />,
@@ -250,18 +251,18 @@ function renderBody(goalText: string | undefined) {
 function assertSharpenSurfaceMounted(): HTMLElement {
   expect(
     screen.getByTestId('v7-top-matter'),
-    'V7 top matter must mount — the deployed bundle mounts it with no flag',
+    'V7 top matter must mount — the Alt view tab hosts it with no flag',
   ).toBeInTheDocument()
   return screen.getByTestId('v7-sharpen-line')
 }
 
 const FRESH: AnalysisFreshnessState = { freshness: 'fresh', computedAt: '2026-07-23T00:00:00Z' }
 
-describe('ResultsBody — V7 sharpen line quote provenance (ROADMAP 2.993)', () => {
+describe('V7 sharpen line quote provenance (ROADMAP 2.993) — in the Alt view tab', () => {
   beforeEach(() => {
     sharpenProps.length = 0
     useCanvasStore.setState({ analysisFreshness: FRESH, analysisFreshnessDirty: false })
-    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+    useUIStore.setState({ activeOutputTab: 'altview', activeOutputTabVersion: 0 })
     useGuidanceStore.setState({ guidanceItems: [] })
   })
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -9,8 +9,14 @@
  */
 import { create } from 'zustand'
 
-/** Must match OutputsDockTab in OutputsDock.tsx exactly */
-export type OutputTab = 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
+/**
+ * The dock tab ids. OutputsDock.tsx's `OutputsDockTab` is now an ALIAS of
+ * this type (12 Aug 2026) — previously the two unions were hand-mirrored
+ * ("must match exactly"), which is the derive-don't-mirror defect class:
+ * adding the 'altview' tab required editing both sides in lockstep.
+ * `'altview'` is the TEMPORARY V7 comparison tab (see v7/V7ComparisonTabBody).
+ */
+export type OutputTab = 'results' | 'altview' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
 
 /**
  * Right-panel modes. Only one right-side panel can be open at a time.


### PR DESCRIPTION
## What moved

The Analysis tab now renders the analysis once: the `V7TopMatter` group (V7FreshnessStrip, V7SharpenLine, V7WhatIWasGivenSection, V7Hero, V7LensGroup, V7EvidenceDisclosure, V7GuidanceSection, V7BiasSection) and the "Current view" divider are removed from `ResultsBody`. The whole group moves **unchanged** to a new, unflagged dock tab **'Alt view'** (`altview`, after Analysis), hosted by the new `src/components/results/v7/V7ComparisonTabBody.tsx`. The `assessment-current-view-group` content below the old divider is byte-identical.

Also: `OutputsDockTab` and `OlumiDockTab` are now aliases of the uiStore `OutputTab` union (three hand-mirrored unions → one; surfaced by TS2322 during the move).

## Why a tab, not a URL/route

The V7 group reads live canvas-session stores (analysisFreshness, guidance, ceeReview, run history) plus `useResultsSectionData()` — all inside the canvas workspace. A route would have to reconstruct that store context (fork risk, violates single data authority). A dock tab keeps it in the same session context.

## Single data authority

- `V7ComparisonTabBody` receives the **same** `resultsSectionData` instance OutputsDock feeds `ResultsBody`, plus the same fragile/robust edge-count expressions, deriving `decisionState` via the one shared `buildResultsVM` — no twin.
- V7TopMatter's analysis-presence predicate is extracted as exported `v7HasAnalysis()`, so the tab body's empty state uses the **same predicate** (no second definition to drift).

## Evidence

- RED-first at pristine `611d91c0`: 3 named assertion REDs + 1 collect RED, all flipped GREEN.
- Suites (VITE_SUPABASE vars exported, collected counts asserted per file): 8 results-side files 39/39 green; OutputsDock.dom 38 + V7WhatIWasGivenSection 52 = 90/90 green. Typecheck ratchet PASSED (drift 2487 → 2485). Lint exit 0.
- Spec re-bindings (trap 3b — bind to the mounted surface): 7 files re-bound/split; 2 git-mv'd into `v7/__tests__/`; OutputsDock.dom exact ordered tab lists gain 'Alt view'.
- Mutation kit (throwaway worktree outside the repo, write-proven isolation via inode + sentinel, HEAD-relative restores, zero-dirty controls, trailing pristine control): **7/7 mutants bite**, including the **discriminating pair proven by name in both directions** — (A) V7-on-results restored → REDs exactly "(a) V7-on-results is GONE…" while the new-home suite stays 4/4 GREEN; (B) V7-in-new-tab removed → REDs exactly "(a) PRESENCE…" + "(d) SINGLE DATA AUTHORITY…" while the retired suite stays 3/3 GREEN.
- Broad dependent sweep `npx vitest run --changed origin/staging`, re-run to conclusion at head `4a36a8e2` in a fresh blobless clone: **exit 0 — Test Files 735 passed | 2 skipped (737) · Tests 8884 passed | 59 skipped (8943)** (698s). Full trail in FINDINGS.md (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/ui-consolidation-2026-08-12/v7-move/`).

## Residual risk / scope notes

- jsdom cannot prove visibility (trap 3) — the browser/visibility rung belongs to the orchestrator, not this lane.
- **'Alt view' is TEMPORARY**: it exists for the V7-vs-Current comparison and retires with that adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
