### PR TITLE
fix(collab): owner close sends the JSON body Fastify requires (W-F1) + honest close-failure copy (W-F2)

### DIFF
--- a/src/collab/__tests__/collabServiceRequestBodies.spec.ts
+++ b/src/collab/__tests__/collabServiceRequestBodies.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * COLLAB — request-body discipline on the `/bff/collab` seam.
+ *
+ * ── THE DEFECT THIS PINS (W-F1, witnessed fresh 12 Aug 2026) ───────────────
+ * The deployed `closeRound` sent `Content-Type: application/json` with NO body.
+ * Fastify refuses such a request BEFORE the route handler runs
+ * (`FST_ERR_CTP_EMPTY_JSON_BODY`) and CEE flattens the refusal to 500 INTERNAL
+ * — so the owner could not close a round from the UI at all, 100% of the time,
+ * and the designed `collab_round_closed` → reveal fall-through was unreachable.
+ * Discriminating pair at the live wire: no body → 500; body `'{}'` → 200.
+ *
+ * ── WHAT THIS SPEC ASSERTS, AND HOW IT BINDS ───────────────────────────────
+ * The invariant is the CLASS, not the instance (a sibling call could grow the
+ * same defect): **any request this module sends that declares
+ * `Content-Type: application/json` must carry a body that parses as a JSON
+ * object.** Every wire function in the module is exercised — the module is the
+ * browser's ONLY path to the seam (pinned by panelSetupOwnerAuth's ratchets),
+ * so this enumeration IS the class.
+ *
+ * It binds to the ACTUAL fetch payload — the captured `RequestInit` of the real
+ * call — never to a mock's silence. A helper that could not fail would be
+ * theatre, so the helper itself has a positive control: a synthetic bodyless
+ * JSON request MUST be flagged.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+
+import {
+  closeRound,
+  declineTarget,
+  fetchOpenPacket,
+  fetchOwnerReveal,
+  fetchParticipantReveal,
+  mintRound,
+  submitBelief,
+} from '../collabService'
+import { setParticipantToken, __resetParticipantTokenForTests } from '../participantToken'
+
+const OWNER_TOKEN = 'owner-access-token-BODIES'
+const ROUND_ID = 'rnd-bodies-1234'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+/** The single captured init of the one call a test just made. */
+function capturedInit(): RequestInit | undefined {
+  expect(fetchMock.mock.calls).toHaveLength(1)
+  return fetchMock.mock.calls[0][1]
+}
+
+/**
+ * The class invariant, as a checker that RETURNS its finding rather than
+ * asserting inline — so the positive-control test below can prove the checker
+ * is capable of flagging a violation (an absence assertion that cannot see a
+ * presence is vacuous).
+ */
+function jsonBodyViolation(init: RequestInit | undefined): string | null {
+  const contentType = new Headers(init?.headers).get('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('application/json')) return null
+  if (typeof init?.body !== 'string' || init.body === '') {
+    return 'declares application/json but carries no body — Fastify refuses this pre-handler (FST_ERR_CTP_EMPTY_JSON_BODY)'
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(init.body)
+  } catch {
+    return 'declares application/json but the body is not valid JSON'
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return 'declares application/json but the body is not a JSON object'
+  }
+  return null
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+    jsonResponse({}, 200),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  setParticipantToken('participant-token-BODIES')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  __resetParticipantTokenForTests()
+})
+
+/* ══ Positive control: the checker can see a violation ═════════════════════ */
+
+describe('the json-body checker itself', () => {
+  it('POSITIVE CONTROL: flags a bodyless application/json request', () => {
+    expect(
+      jsonBodyViolation({ method: 'POST', headers: { 'Content-Type': 'application/json' } }),
+    ).not.toBeNull()
+  })
+
+  it('POSITIVE CONTROL: flags an unparseable body', () => {
+    expect(
+      jsonBodyViolation({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      }),
+    ).not.toBeNull()
+  })
+})
+
+/* ══ W-F1: the owner close ═════════════════════════════════════════════════ */
+
+describe('closeRound (W-F1)', () => {
+  it('declares JSON and carries a body that parses as a JSON object', async () => {
+    await closeRound(OWNER_TOKEN, ROUND_ID)
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+  })
+
+  it('still sends the owner bearer and POSTs the round it was given', async () => {
+    // The fix must not disturb what already worked: identity binding.
+    await closeRound(OWNER_TOKEN, ROUND_ID)
+    const [input, init] = fetchMock.mock.calls[0]
+    expect(String(input)).toBe(`/bff/collab/rounds/${ROUND_ID}/close`)
+    expect(init?.method).toBe('POST')
+    expect(new Headers(init?.headers).get('authorization')).toBe(`Bearer ${OWNER_TOKEN}`)
+  })
+})
+
+/* ══ The class: every sibling on the seam ══════════════════════════════════ */
+
+describe('json-body discipline across every wire function in the module', () => {
+  it('mintRound', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ round_id: ROUND_ID, graph_version_ref: 'gv-1', participants: [] }, 201),
+    )
+    await mintRound(OWNER_TOKEN, {
+      scenarioId: 'scn-1',
+      contextNote: null,
+      targets: [],
+      participants: [{ display_name: 'Ada' }],
+    })
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+  })
+
+  it('submitBelief', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ authored_by: 'p-a', event_id: 'e-1' }, 201))
+    await submitBelief(ROUND_ID, {
+      targetId: 'factor-1',
+      targetKind: 'factor',
+      value: 0.4,
+      expressionRaw: 'fairly likely',
+      confidence: null,
+      revision: false,
+    })
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+  })
+
+  it('declineTarget', async () => {
+    await declineTarget(ROUND_ID, { targetId: 'factor-1', targetKind: 'factor' })
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+  })
+
+  // The GETs must not declare a JSON content-type at all: a GET carrying the
+  // header with no body is the same refusal class waiting to fire.
+  it('fetchOpenPacket declares no JSON content-type', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        round_id: ROUND_ID,
+        status: 'open',
+        context_note: null,
+        graph_version_ref: 'gv-1',
+        targets: [],
+        self: { participant_id: 'p-a', display_name: 'Ada', completed_target_ids: [] },
+      }),
+    )
+    await fetchOpenPacket(ROUND_ID)
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+    expect(new Headers(capturedInit()?.headers).get('content-type')).toBeNull()
+  })
+
+  it('fetchParticipantReveal declares no JSON content-type', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ round_id: ROUND_ID, status: 'closed', graph_version_ref: 'gv-1', per_target: [] }),
+    )
+    await fetchParticipantReveal(ROUND_ID)
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+    expect(new Headers(capturedInit()?.headers).get('content-type')).toBeNull()
+  })
+
+  it('fetchOwnerReveal declares no JSON content-type', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ round_id: ROUND_ID, status: 'closed', graph_version_ref: 'gv-1', per_target: [] }),
+    )
+    await fetchOwnerReveal(OWNER_TOKEN, ROUND_ID)
+    expect(jsonBodyViolation(capturedInit())).toBeNull()
+    expect(new Headers(capturedInit()?.headers).get('content-type')).toBeNull()
+  })
+})

--- a/src/collab/__tests__/panelSetupCloseFailureCopy.spec.tsx
+++ b/src/collab/__tests__/panelSetupCloseFailureCopy.spec.tsx
@@ -1,0 +1,191 @@
+/**
+ * COLLAB — what the owner is TOLD when a close fails (W-F2).
+ *
+ * ── THE LIE THIS PINS (witnessed fresh 12 Aug 2026, leg 6) ─────────────────
+ * After an out-of-band close, the owner clicked "Close the round…" and the
+ * error card said "The round is still open." — while the round was CLOSED at
+ * the wire. The copy asserted a state it could not know: it was the fallback
+ * for EVERY non-credential failure (500 INTERNAL included), not a fact derived
+ * from the wire's answer.
+ *
+ * ── THE HONEST MAPPING, derived from the codes the wire actually returns ───
+ * • `collab_round_closed` (409, close): NOT a failure — the call site falls
+ *   through to the reveal (pinned by panelSetupRoundRecovery.spec.tsx, "a
+ *   round already closed elsewhere is NOT a dead end").
+ * • `collab_round_open` (409, reveal): the ONE code that PROVES the round is
+ *   still open — only this branch may say so.
+ * • Everything else (500 INTERNAL, unknown codes, non-JSON bodies): the state
+ *   is UNKNOWN. The copy must not assert it either way, and the detail names
+ *   the server's own code so the failure is diagnosable.
+ *
+ * Assertions bind to the rendered surface (`panel-error-guidance` /
+ * `panel-error-detail`) — the exact card the witness photographed lying.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-list its exports (trap 12).
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+import { recallOpenRound, rememberOpenRound } from '../openRoundRecord'
+
+const SCENARIO_ID = 'scn-closecopy-1111'
+const ROUND_ID = 'rnd-closecopy-2222'
+const OWNER_TOKEN = 'owner-access-token-closecopy'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+const HEALTHY_REVEAL = {
+  round_id: ROUND_ID,
+  status: 'closed',
+  graph_version_ref: 'gv-1',
+  per_target: [],
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function seedRecord(): void {
+  rememberOpenRound({
+    roundId: ROUND_ID,
+    scenarioId: SCENARIO_ID,
+    participants: [{ participant_id: 'p-a', display_name: 'Ada' }],
+  })
+}
+
+/** Stub close + reveal by status/code; everything else 404s loudly. */
+function stubWire(args: {
+  close: StubResponse
+  reveal: StubResponse
+}): void {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input)
+    if (url === `/bff/collab/rounds/${ROUND_ID}/close` && init?.method === 'POST') {
+      return args.close
+    }
+    if (url === `/bff/collab/rounds/${ROUND_ID}/reveal`) {
+      return args.reveal
+    }
+    return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({ userId: 'user-abc', accessToken: OWNER_TOKEN })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('close failure copy tells the truth about round state (W-F2)', () => {
+  it('an unexplained failure (500 INTERNAL) does NOT claim the round is still open, and names the code', async () => {
+    seedRecord()
+    // The witnessed shape: CEE flattened the refusal to 500 INTERNAL. The
+    // reveal is stubbed HEALTHY so the only way this test passes is the copy
+    // itself being honest — not the flow accidentally never rendering it.
+    stubWire({
+      close: jsonResponse({ code: 'INTERNAL', message: 'Internal server error' }, 500),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    // The card must not paint success…
+    expect(screen.queryByTestId('collab-reveal')).toBeNull()
+    // …and must not assert a state the wire did not establish. This is the
+    // sentence the witness photographed lying about a CLOSED round.
+    expect(screen.getByTestId('panel-error-guidance')).not.toHaveTextContent(
+      /the round is still open/i,
+    )
+    // Honest unknown instead — and still actionable.
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /could not confirm/i,
+    )
+    // The server's own code is named, so the failure is diagnosable.
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/INTERNAL/)
+    // The recovery record survives an unexplained failure.
+    expect(recallOpenRound(SCENARIO_ID)?.round_id).toBe(ROUND_ID)
+  })
+
+  it('collab_round_open — the one code that PROVES the round is open — may say so, and names the code', async () => {
+    seedRecord()
+    // A reachable race: the close lands (200) but the reveal is refused with
+    // `collab_round_open`. The wire has POSITIVELY said the round is open —
+    // here, and only here, "still open" is the truth.
+    stubWire({
+      close: jsonResponse({ round_id: ROUND_ID, status: 'closed' }),
+      reveal: jsonResponse(
+        { code: 'collab_round_open', message: 'The round has not been closed.' },
+        409,
+      ),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /the round is still open/i,
+    )
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/collab_round_open/)
+  })
+
+  it('DIFFERENT OBJECT: an unknown wire code is treated as unknown state, not as "still open"', async () => {
+    seedRecord()
+    stubWire({
+      close: jsonResponse({ code: 'collab_store_unavailable', message: 'Store fell over.' }, 503),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-error-guidance')).not.toHaveTextContent(
+      /the round is still open/i,
+    )
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/collab_store_unavailable/)
+  })
+
+  it('POSITIVE CONTROL: the happy path still routes to the reveal, no error card', async () => {
+    seedRecord()
+    stubWire({
+      close: jsonResponse({ round_id: ROUND_ID, status: 'closed' }),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+    expect(screen.queryByTestId('panel-error')).toBeNull()
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -263,6 +263,13 @@ export async function closeRound(accessToken: string, roundId: string): Promise<
   const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/close`, {
     method: 'POST',
     headers: ownerHeaders(accessToken),
+    // ⚠ THE BODY IS LOAD-BEARING (W-F1, witnessed live 12 Aug 2026). A POST
+    // declaring `Content-Type: application/json` with NO body is refused by
+    // Fastify BEFORE the route handler runs (FST_ERR_CTP_EMPTY_JSON_BODY) and
+    // CEE flattens that to 500 — so the owner could never close a round from
+    // the UI. The close takes no parameters; the body is the empty JSON
+    // object, never absent. Pinned by collabServiceRequestBodies.spec.ts.
+    body: JSON.stringify({}),
   })
   if (!res.ok) throw await parseError(res)
 }

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -126,14 +126,35 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
     }
   }
 
+  // ⚠ ONLY THE WIRE MAY SAY THE ROUND IS OPEN (W-F2, witnessed live 12 Aug
+  // 2026: this function's fallback said "The round is still open" about a
+  // round that was CLOSED — a confident lie on every unexplained failure).
+  // `collab_round_open` is the one code that PROVES it: the server refusing a
+  // reveal because contributions are still blind. Every other code leaves the
+  // round's state UNKNOWN here, and the copy must not assert it either way.
+  // (`collab_round_closed` never reaches this function from the close action —
+  // the call site falls through to the reveal, which is what the owner came
+  // for.)
+  if (action === 'close' && err.code === 'collab_round_open') {
+    return {
+      title: fallbackTitle,
+      guidance:
+        'The round is still open. Try again in a moment — nobody has seen anything they should not.',
+      credential: false,
+      detail: `${err.code} — ${err.message}`,
+    }
+  }
+
   return {
     title: fallbackTitle,
     guidance:
       action === 'open'
         ? 'Check that the factor id matches your model, then try again. Nothing has been sent to anyone yet.'
-        : 'The round is still open. Try again in a moment — nobody has seen anything they should not.',
+        : 'We could not confirm what happened to the round. Try again in a moment — nobody has seen anything they should not.',
     credential: false,
-    detail: err.message,
+    // The server's own code is part of the detail: "Internal server error"
+    // alone is undiagnosable, and the code is what the wire witness greps for.
+    detail: `${err.code} — ${err.message}`,
   }
 }
 


### PR DESCRIPTION
## What this closes

The LAST blocker on the proven two-person collaboration journey (fresh witness 12 Aug 2026, evidence dir `two-person-witness-20260812T180221Z/`, streamed lane findings in its `WF1-FIX.md`):

- **W-F1 (SEVERE, reproduced 3x on deployed `611d91c0`):** `collabService.closeRound` declared `Content-Type: application/json` with NO body → Fastify refuses pre-handler (`FST_ERR_CTP_EMPTY_JSON_BODY`) → CEE 500 → the owner cannot close a round from the UI, ever. Discriminating pair at the live wire: no body → 500; `'{}'` → 200. The witness's one-byte shim proved everything downstream (close → `collab_round_closed` fall-through → rendered owner reveal → record-forget) already works.
- **W-F2 (HIGH):** the close-failure fallback said "The round is still open" on EVERY non-credential failure — witnessed as a confident lie after an out-of-band close.

## The fix (surgical, 2 product files)

- `closeRound` sends `body: JSON.stringify({})` — the exact accepted shape. Comment pins why the body is load-bearing.
- `describeOwnerFailure`: only `collab_round_open` (the one wire code that PROVES the round is open) may say so; every other failure gets honest unknown-state copy; the detail now names the server's own code (`INTERNAL — Internal server error`). The `collab_round_closed` → reveal routing already existed at the call site and is untouched (pinned by `panelSetupRoundRecovery.spec.tsx`).

## The class, not the instance

New `collabServiceRequestBodies.spec.ts` makes the invariant executable for ALL seven wire functions in the module (the browser's only path to `/bff/collab`): any request declaring `application/json` must carry a parseable JSON object body, captured from the REAL fetch init, with positive controls proving the checker can flag a violation. Enumeration: mint/submit/decline carry bodies (OK); the three GETs declare no JSON content-type (OK); `closeRound` was the only violating instance.

## Evidence

- **RED-first at pristine `611d91c0`:** 4 named failures (bodyless close; the "still open" lie on 500 INTERNAL; the lie on an unknown code; detail missing the wire code) / 10 passed (siblings + controls). GREEN after.
- **Mutants (6, isolated worktree outside repo root, write-proven isolation, HEAD-relative restores, applied-check = 1 file each, controls = 0):** body-dropped-again and body-`''` RED the W-F1 pin alone; copy-revert REDs the two unknown-state pins; branch-never-fires REDs the round_open pin alone; detail-drops-code REDs the three detail pins; fall-through-removed REDs the recovery pin alone. Trailing control 26/26 GREEN. Re-run at the final head.
- **Gates at tip:** `pnpm run lint` PASS · `pnpm run typecheck` PASS (first run caught a TS arity error in my own new spec — fixed at source, not absorbed) · `ci:guard:zustand` PASS · scope run `src/collab/ src/pages/` 25 files / 324 tests GREEN.
- Reviewer note: the typecheck gate prints a drift-shrink notice (2487 → 2485); the shrink pre-exists this branch on staging (pristine = 2485 vs baseline 2487), so the baseline is deliberately left alone here.
- Zero file overlap with open PR #673 (`comm -12` of the two name-only diffs = empty).

## Out of scope (rowed separately)

CEE-side empty-body→4xx mapping · W-F3 submit confirmation · W-F4 responsive overflow.

**Re-witness after merge+deploy:** banner close on a fresh round, no shim — ~2 minutes per the witness VERDICT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)