### PR TITLE
fix(collab): a 403 is not a credential refusal — honest owner copy for collab_owner_only (REVIEW-674 finding 1)

### DIFF
--- a/src/collab/__tests__/panelSetupOwnerOnly403.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerOnly403.spec.tsx
@@ -143,8 +143,16 @@ describe('a 403 is not a credential refusal (REVIEW-674 finding 1)', () => {
     expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
       /no round you own with that id/i,
     )
+    // Scoped to THIS ACCOUNT (REVIEW-675 blocker): the unscoped "signing in
+    // again will not change that" was false in a reachable sub-case — the
+    // reminder record is keyed by scenario only (no account component), so it
+    // survives a same-browser account switch, and signing back in AS THE
+    // ACCOUNT THAT OPENED THE ROUND is exactly the remedy the copy denied.
     expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
-      /signing in again will not change that/i,
+      /signing in again as this account will not change that/i,
+    )
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /sign in with it instead/i,
     )
   })
 
@@ -211,6 +219,10 @@ describe('a 403 is not a credential refusal (REVIEW-674 finding 1)', () => {
     )
     expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
       /belongs to a different account/i,
+    )
+    // The same REVIEW-675 scoping, pinned on the open string too.
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /signing in again as this account will not change that/i,
     )
     expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/collab_owner_only/)
   })

--- a/src/collab/__tests__/panelSetupOwnerOnly403.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerOnly403.spec.tsx
@@ -1,0 +1,240 @@
+/**
+ * COLLAB — a 403 is NOT a credential refusal (REVIEW-674 finding 1).
+ *
+ * ── THE LIE THIS PINS ──────────────────────────────────────────────────────
+ * `describeOwnerFailure` routed `err.status === 403` to the credential branch
+ * ("Your session has ended. Sign in again…") on its own comment's premise that
+ * 401/403 = "the server declining the bearer". At CEE's bytes that premise is
+ * false for 403: `replyForRefusal` (route-support.ts) maps exactly ONE code to
+ * 403 — `collab_owner_only` — and the service mints it AFTER the bearer was
+ * accepted (`closeRound` fires it when the round does not exist OR the caller
+ * is not its owner, deliberately indistinguishable; a bad bearer 401s earlier
+ * in `requireOwnerUser`). Failure scenario: a stale recovery record (round
+ * purged server-side, e.g. a staging DB reset) → close → 403 → told to sign
+ * in → signing in changes nothing → loop.
+ *
+ * ── WHAT IS PINNED, per branch of the fixed predicate ─────────────────────
+ * • 403 `collab_owner_only` (close AND open) → honest ownership copy, no
+ *   sign-in affordance, detail naming the server's code + words verbatim.
+ * • 401 (wire) → STILL the credential copy with the sign-in affordance — the
+ *   DIFFERENT-OBJECT twin proving the fix did not swallow the true branch.
+ * • 403 with any OTHER code (CEE caller-key plugin answers `FORBIDDEN`) →
+ *   the honest-unknown fallback, NOT ownership copy, NOT sign-in — the copy
+ *   binds to the CODE, never the transport status.
+ *
+ * Assertions bind to the rendered surface by identity (`panel-sign-in`,
+ * `panel-error-guidance`, `panel-error-detail`) — the exact affordance the
+ * defect rendered futilely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-list its exports (trap 12).
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+import { rememberOpenRound } from '../openRoundRecord'
+
+const SCENARIO_ID = 'scn-ownersonly-1111'
+const ROUND_ID = 'rnd-ownersonly-2222'
+const OWNER_TOKEN = 'owner-access-token-ownersonly'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+const HEALTHY_REVEAL = {
+  round_id: ROUND_ID,
+  status: 'closed',
+  graph_version_ref: 'gv-1',
+  per_target: [],
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function seedRecord(): void {
+  rememberOpenRound({
+    roundId: ROUND_ID,
+    scenarioId: SCENARIO_ID,
+    participants: [{ participant_id: 'p-a', display_name: 'Ada' }],
+  })
+}
+
+/** Stub mint + close + reveal by route; everything else 404s loudly. */
+function stubWire(args: {
+  mint?: StubResponse
+  close?: StubResponse
+  reveal?: StubResponse
+}): void {
+  fetchMock.mockImplementation(async (input, init) => {
+    const url = String(input)
+    if (url === '/bff/collab/rounds' && init?.method === 'POST' && args.mint !== undefined) {
+      return args.mint
+    }
+    if (
+      url === `/bff/collab/rounds/${ROUND_ID}/close` &&
+      init?.method === 'POST' &&
+      args.close !== undefined
+    ) {
+      return args.close
+    }
+    if (url === `/bff/collab/rounds/${ROUND_ID}/reveal` && args.reveal !== undefined) {
+      return args.reveal
+    }
+    return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({ userId: 'user-abc', accessToken: OWNER_TOKEN })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('a 403 is not a credential refusal (REVIEW-674 finding 1)', () => {
+  it('close → 403 collab_owner_only does NOT say "sign in again" and renders NO sign-in affordance', async () => {
+    seedRecord()
+    // The witnessed failure scenario: a stale recovery record whose round was
+    // purged server-side. The reveal is stubbed HEALTHY so the only way this
+    // test passes is the copy itself being honest — not the flow accidentally
+    // never rendering it.
+    stubWire({
+      close: jsonResponse({ code: 'collab_owner_only', message: 'No round you own with that id.' }, 403),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.queryByTestId('collab-reveal')).toBeNull()
+    // The futile affordance the defect rendered: a sign-in link for a refusal
+    // the bearer had already PASSED.
+    expect(screen.queryByTestId('panel-sign-in')).toBeNull()
+    expect(screen.getByTestId('panel-error-guidance')).not.toHaveTextContent(
+      /your session has ended/i,
+    )
+    // The honest copy: whose the round is, and that signing in cannot fix it.
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /no round you own with that id/i,
+    )
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /signing in again will not change that/i,
+    )
+  })
+
+  it('close → 403 collab_owner_only names the server code and words verbatim in the detail', async () => {
+    seedRecord()
+    stubWire({
+      close: jsonResponse({ code: 'collab_owner_only', message: 'No round you own with that id.' }, 403),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    // The credential branch renders NO detail at all, so at the defective tip
+    // this element does not exist — the pin fails loud, not by text-diff.
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/collab_owner_only/)
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(
+      /No round you own with that id\./,
+    )
+  })
+
+  it('DIFFERENT-OBJECT TWIN: a wire 401 STILL renders the credential copy with the sign-in affordance', async () => {
+    seedRecord()
+    // A genuine bearer decline (requireOwnerUser at CEE). This test passes
+    // BEFORE and AFTER the fix — it exists to prove the 403 fix did not
+    // swallow the true credential branch.
+    stubWire({
+      close: jsonResponse(
+        { code: 'expired_token', message: 'Your session has expired. Sign in again and retry.' },
+        401,
+      ),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-sign-in')).toBeInTheDocument()
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /your session has ended\. sign in again/i,
+    )
+  })
+
+  it('open → 403 collab_owner_only (someone else’s scenario) is not a credential refusal either', async () => {
+    stubWire({
+      mint: jsonResponse(
+        { code: 'collab_owner_only', message: 'Only the scenario owner can open a round on it.' },
+        403,
+      ),
+    })
+
+    renderOwnerPanel()
+    fireEvent.change(screen.getByTestId('panel-target-id'), {
+      target: { value: 'factor-churn-risk' },
+    })
+    fireEvent.click(screen.getByTestId('panel-mint'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.queryByTestId('panel-sign-in')).toBeNull()
+    expect(screen.getByTestId('panel-error-guidance')).not.toHaveTextContent(
+      /your session has ended/i,
+    )
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /belongs to a different account/i,
+    )
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/collab_owner_only/)
+  })
+
+  it('a 403 that is NOT collab_owner_only (caller-key FORBIDDEN) gets the honest unknown fallback, not ownership copy, not sign-in', async () => {
+    seedRecord()
+    // CEE's caller-key plugin answers 403 {code: "FORBIDDEN"} when the
+    // proxy-injected key is wrong — a deploy misconfiguration, not a session
+    // problem and not an ownership answer. The copy must bind to the CODE:
+    // this 403 may claim neither "sign in again" nor "no round you own".
+    stubWire({
+      close: jsonResponse({ code: 'FORBIDDEN', message: 'Invalid API key.' }, 403),
+      reveal: jsonResponse(HEALTHY_REVEAL),
+    })
+
+    renderOwnerPanel()
+    fireEvent.click(screen.getByTestId('panel-resume-close'))
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.queryByTestId('panel-sign-in')).toBeNull()
+    expect(screen.getByTestId('panel-error-guidance')).not.toHaveTextContent(
+      /no round you own with that id/i,
+    )
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(/could not confirm/i)
+    expect(screen.getByTestId('panel-error-detail')).toHaveTextContent(/FORBIDDEN/)
+  })
+})

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -140,15 +140,18 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
   // `collab_owner_only`: the bearer was ACCEPTED, and the server is saying
   // there is no round (or scenario) THIS account owns with that id — "does
   // not exist" and "not yours" are deliberately the same code at CEE. Signing
-  // in again cannot change whose it is; the honest next step is the documented
-  // recovery — a fresh round — never the login page.
+  // in again AS THIS ACCOUNT cannot change whose it is — but the claim stops
+  // there (REVIEW-675): the "different account" may be another sign-in the
+  // same person owns, the reminder record is keyed by scenario alone so it
+  // survives a same-browser account switch, and in that sub-case switching
+  // accounts is exactly the remedy. The copy names it rather than denying it.
   if (err.code === 'collab_owner_only') {
     return {
       title: fallbackTitle,
       guidance:
         action === 'open'
-          ? 'This scenario belongs to a different account, so a round cannot be opened on it from this sign-in. Signing in again will not change that — ask the owner of the scenario to run the panel, or open a round on a scenario you own.'
-          : 'There is no round you own with that id — it may have been removed, or it was opened under a different account. Signing in again will not change that. If an old reminder brought you here, forget it and open a fresh round.',
+          ? 'This scenario belongs to a different account, so a round cannot be opened on it from this sign-in. Signing in again as this account will not change that; if that other account is yours, sign in with it instead. Otherwise ask the owner of the scenario to run the panel, or open a round on a scenario you own.'
+          : 'There is no round you own with that id — it may have been removed, or it was opened under a different account. Signing in again as this account will not change that; if that other account is yours, sign in with it instead. If the round is gone for good, forget the reminder and open a fresh round.',
       credential: false,
       detail: `${err.code} — ${err.message}`,
     }

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -94,10 +94,21 @@ interface OwnerFailure {
  *
  * ⚠ THE PREDICATE'S DOMAIN, NOT JUST THE CASE IN HAND. A credential refusal is
  * `sign_in_required` (minted locally, before any request leaves) OR an HTTP
- * 401/403 (the server declining the bearer) — two different paths that call for
- * the SAME next step. Everything else is a different question and must not be
- * routed to "sign in again", which would be a confident lie about a round whose
- * target simply does not exist.
+ * 401 (the server declining the bearer). 403 IS NOT ONE OF THEM: at CEE's
+ * bytes (`route-support.ts` `replyForRefusal`) the only refusal code that
+ * answers 403 is `collab_owner_only`, and the service mints it AFTER the
+ * bearer has been accepted — a bad bearer 401s in `requireOwnerUser` before
+ * the round is even looked up. `closeRound` fires it both when the round does
+ * not exist and when the caller is not its owner (deliberately
+ * indistinguishable), so a stale recovery record — the round purged
+ * server-side — used to 403 into "Sign in again", a loop no sign-in could
+ * exit (REVIEW-674 finding 1: an earlier version of this comment asserted the
+ * false premise this fix removes).
+ *
+ * The ownership copy binds to the CODE, never the status: other producers of
+ * 403 exist on this path (CEE's caller-key plugin answers `FORBIDDEN`, the
+ * edge proxy answers a code-less origin refusal), and for those the honest
+ * answer is the unknown-state fallback carrying the server's own words.
  */
 function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
   const fallbackTitle =
@@ -113,7 +124,7 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
     }
   }
 
-  if (err.code === 'sign_in_required' || err.status === 401 || err.status === 403) {
+  if (err.code === 'sign_in_required' || err.status === 401) {
     return {
       title: SIGN_IN_SENTENCE,
       guidance:
@@ -123,6 +134,23 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
       // verified.") tells the owner nothing they can act on, and repeating it
       // beside the guidance would only muddy it.
       detail: null,
+    }
+  }
+
+  // `collab_owner_only`: the bearer was ACCEPTED, and the server is saying
+  // there is no round (or scenario) THIS account owns with that id — "does
+  // not exist" and "not yours" are deliberately the same code at CEE. Signing
+  // in again cannot change whose it is; the honest next step is the documented
+  // recovery — a fresh round — never the login page.
+  if (err.code === 'collab_owner_only') {
+    return {
+      title: fallbackTitle,
+      guidance:
+        action === 'open'
+          ? 'This scenario belongs to a different account, so a round cannot be opened on it from this sign-in. Signing in again will not change that — ask the owner of the scenario to run the panel, or open a round on a scenario you own.'
+          : 'There is no round you own with that id — it may have been removed, or it was opened under a different account. Signing in again will not change that. If an old reminder brought you here, forget it and open a fresh round.',
+      credential: false,
+      detail: `${err.code} — ${err.message}`,
     }
   }
 


### PR DESCRIPTION
## The defect (REVIEW-674 finding 1, pre-existing — rowed for follow-up by #674's reviewer)

`describeOwnerFailure` (`src/pages/PanelSetupPage.tsx`) routed `err.status === 403` to the credential branch ("Your session has ended. Sign in again…", `credential: true`, sign-in affordance) on its own comment's premise that 401/403 = "the server declining the bearer".

**False at the producer's bytes** (CEE staging `a9022e77`, fresh clone): `replyForRefusal` (`src/collab/route-support.ts:131-133`) maps exactly ONE code to 403 — `collab_owner_only` — and the service mints it AFTER the bearer was accepted (`closeRound`, `rounds-service.ts:145/148`, fires it when the round does not exist OR the caller is not its owner, deliberately indistinguishable; a bad bearer 401s earlier in `requireOwnerUser`). Failure scenario: stale recovery record (round purged server-side, e.g. a staging DB reset) → close → 403 → told to sign in → signing in changes nothing → loop.

## The fix (surgical, one function)

- Credential predicate: `sign_in_required` OR **status 401 only** (403 removed). 401→sign-in verified true at the bytes: every `requireOwnerUser` refusal (`sign_in_required`/`expired_token`/`invalid_token`/`verification_unavailable`) is 401, before any service call.
- New `collab_owner_only` branch: honest ownership copy per action (close: "There is no round you own with that id… Signing in again will not change that. If an old reminder brought you here, forget it and open a fresh round." — the documented recovery; open: "This scenario belongs to a different account…"), `credential: false`, detail = the server's code and words **verbatim**.
- **Copy binds to the CODE, never the status**: other 403 producers exist on this path (CEE caller-key plugin → `FORBIDDEN`, edge proxy → code-less origin refusal) and those now get the honest unknown-state fallback + verbatim detail, which is true of them.

## Whole-domain audit (trap 22)

Every `replyForRefusal` code enumerated at the bytes: 401 TOKEN_FAMILY · 403 `collab_owner_only` only · 409 `collab_round_closed/round_open/owner_unsubmitted/guest_scenario` · 422 `collab_payload_invalid` · 400 default · **nothing maps to 404**. All other branches of `describeOwnerFailure` adjudicated TRUE and left untouched. Residuals reported (not fixed — unreachable from this UI's own mints or infra-shaped): 409 `collab_owner_unsubmitted` fallback prescribes a futile retry (F-6 gate needs a `supabase_user_id` this UI never sends; server sentence renders verbatim in detail); 401 `verification_unavailable`/`UNAUTHENTICATED` are infra failures wearing the sign-in copy. Detail in F403-FIX.md (evidence dir `two-person-witness-20260812T180221Z`).

## Evidence

- **RED-first at pristine `d21101b0`**: 4 failed / 1 passed — the four new pins RED, the DIFFERENT-OBJECT 401 twin the sole pass (throwaway worktree outside repo root, write-proven isolation, spec extracted from the commit and asserted non-empty).
- **GREEN at head**: 5/5, names enumerated.
- **Mutants** (committed state only, applied-check = 1 per mutation, HEAD-relative restores, controls 5/5 before and after): M1 403→credential REDs all four pins, twin green · M2 401-swallowed REDs exactly the twin · M3 detail-dropped REDs exactly the two detail pins · M4 code→status loosening REDs exactly the FORBIDDEN-fallback pin. Four mutants, four distinct failure sets.
- **Gates**: `pnpm typecheck` PASSED (drift shrank 2487→2485; `--update-baseline` declined, unattributed); eslint clean; whole `src/collab/__tests__/` 9 files / 80 tests green.
- **Overlap**: all 19 open PRs name-only diffed — zero overlap with the two owned files.

**Review-ready — do not merge without independent review** (programme rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)