### PR TITLE
Participant surface: lasting round-bound submit confirmation (W-F3), derived link reader (N1), honest credential-failure affordance (N3)

### DIFF
--- a/src/collab/__tests__/participantPacketConfirmation.spec.tsx
+++ b/src/collab/__tests__/participantPacketConfirmation.spec.tsx
@@ -22,6 +22,11 @@
  * drift mutant, not by history) and the N3 different-object twin (it pins the
  * direction the fix must NOT change; without it, deleting the retry button
  * everywhere would pass).
+ * Added after the first fix landed: the cross-person test (a different code on
+ * the same device must not inherit the previous person's confirmation) was
+ * measured RED against this lane's OWN pre-clear implementation at `8e19a10c`
+ * — the sharper signature, since at pristine it merely times out with the
+ * others — and green once `forgetCode` clears held confirmations.
  *
  * ── BINDING ───────────────────────────────────────────────────────────────
  * Every assertion selects by IDENTITY (testid carrying the target id, exact
@@ -372,6 +377,78 @@ describe('W-F3: the participant can tell their contribution landed', () => {
     expect(screen.queryByTestId(`packet-confirmation-${TARGET_X}`)).toBeNull()
     // WRONG-OBJECT TWIN: the unanswered sibling carries no such notice.
     expect(screen.queryByTestId(`packet-already-answered-${TARGET_Y}`)).toBeNull()
+  })
+
+  it("a different code entered on the same device does not inherit the previous person's confirmation", async () => {
+    // Two-person trials share laptops. Grace submits; her token is later
+    // refused (e.g. revoked); Priya enters HER code on the same page instance
+    // and lands on the SAME round — round_id alone cannot tell them apart, so
+    // held confirmations must die with the credential that produced them.
+    const priyaPacket = makePacket({ roundId: ROUND_A, note: NOTE_A, completed: [] })
+    priyaPacket.self = { ...priyaPacket.self, participant_id: 'p-priya-5555', display_name: 'Priya' }
+
+    let phase: 'grace' | 'revoked' | 'priya' = 'grace'
+    const completed: string[] = []
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === EVENTS_URL_A && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body)) as { kind: string; target: { id: string } }
+        completed.push(body.target.id)
+        return jsonResponse(
+          {
+            event_id: 'evt-0004',
+            round_id: ROUND_A,
+            target: body.target,
+            kind: body.kind,
+            event_version: 1,
+            authored_by: SELF_ID,
+            created_at: RECEIPT_CREATED_AT,
+          },
+          201,
+        )
+      }
+      if (url === PACKET_URL_A) {
+        if (phase === 'grace') {
+          return jsonResponse(makePacket({ roundId: ROUND_A, note: NOTE_A, completed: [...completed] }))
+        }
+        if (phase === 'revoked') {
+          return jsonResponse(
+            { code: 'collab_token_revoked', message: 'That participant link has been revoked.' },
+            401,
+          )
+        }
+        return jsonResponse(priyaPacket)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+    await submitOn(TARGET_X, LABEL_X, WORDS)
+
+    // Grace's token is refused on the next load; she hands over the laptop.
+    phase = 'revoked'
+    fireEvent.click(
+      within(screen.getByTestId(`packet-target-${TARGET_X}`)).getByRole('button', {
+        name: 'I would rather not answer this',
+      }),
+    )
+    // (that decline 201s, but the reload it triggers is now refused)
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+
+    phase = 'priya'
+    fireEvent.click(screen.getByTestId('packet-reenter-code'))
+    fireEvent.change(screen.getByTestId('packet-manual-token'), {
+      target: { value: 'CODE-THAT-BELONGS-TO-PRIYA' },
+    })
+    fireEvent.click(screen.getByTestId('packet-manual-continue'))
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    // Priya's page, Priya's truth: the server says SHE has not responded, and
+    // Grace's receipt is not evidence about her.
+    expect(screen.getByTestId('packet-self-name')).toHaveTextContent('Priya')
+    expect(screen.queryByTestId(`packet-confirmation-${TARGET_X}`)).toBeNull()
+    expect(screen.queryByTestId(`packet-already-answered-${TARGET_X}`)).toBeNull()
   })
 
   it('declining leaves an honest record of the choice — not "Answer recorded"', async () => {

--- a/src/collab/__tests__/participantPacketConfirmation.spec.tsx
+++ b/src/collab/__tests__/participantPacketConfirmation.spec.tsx
@@ -10,14 +10,18 @@
  * it from the server's 201 RECEIPT, and binds it to the round it was accepted
  * for. This file pins each of those clauses separately.
  *
- * ── RED-FIRST LEDGER (named signatures at pristine `d4c9326d`) ────────────
- * RED at pristine: the five W-F3 tests (no `packet-confirmation-*` /
- * `packet-already-answered-*` testid exists there) and the N3 credential test
- * (`packet-retry` renders unconditionally there).
- * GREEN at pristine, deliberately: the N1 loop (both spellings were in the
- * hand copy — the guard's bite is proven by the drift MUTANT, not by history)
- * and the N3 different-object twin (it pins the direction the fix must NOT
- * change; without it, deleting the retry button everywhere would pass).
+ * ── RED-FIRST LEDGER (measured at pristine `d4c9326d`: 8 RED / 2 GREEN) ───
+ * RED at pristine: the six W-F3 tests (no `packet-confirmation-*` /
+ * `packet-already-answered-*` testid exists there), the N3 credential test
+ * (`packet-retry` renders unconditionally there), and the N1 loop — pristine
+ * exports no `TOKEN_PARAM_NAMES`, so the import is undefined and the loop's
+ * non-vacuity control throws. (This file first PREDICTED that loop green at
+ * pristine; the measurement said otherwise, and the measurement wins.)
+ * GREEN at pristine, deliberately: the collab_token end-to-end test (both
+ * spellings were in the hand copy — the DRIFT guard's bite is proven by the
+ * drift mutant, not by history) and the N3 different-object twin (it pins the
+ * direction the fix must NOT change; without it, deleting the retry button
+ * everywhere would pass).
  *
  * ── BINDING ───────────────────────────────────────────────────────────────
  * Every assertion selects by IDENTITY (testid carrying the target id, exact

--- a/src/collab/__tests__/participantPacketConfirmation.spec.tsx
+++ b/src/collab/__tests__/participantPacketConfirmation.spec.tsx
@@ -1,0 +1,490 @@
+/**
+ * COLLAB — the PARTICIPANT's post-submit truth (W-F3), the derived link reader
+ * (N1) and the honest credential-failure affordance (N3).
+ *
+ * ── WHAT THE WITNESS FOUND (two-person run, 12 Aug, leg 2) ────────────────
+ * After a participant submitted their private estimate, the card silently
+ * reset: the post-submit reload remounts every `TargetCard`, the card-local
+ * "saved" flash died with it, and a real participant could not tell their
+ * contribution had landed. The fix holds a confirmation at PAGE level, builds
+ * it from the server's 201 RECEIPT, and binds it to the round it was accepted
+ * for. This file pins each of those clauses separately.
+ *
+ * ── RED-FIRST LEDGER (named signatures at pristine `d4c9326d`) ────────────
+ * RED at pristine: the five W-F3 tests (no `packet-confirmation-*` /
+ * `packet-already-answered-*` testid exists there) and the N3 credential test
+ * (`packet-retry` renders unconditionally there).
+ * GREEN at pristine, deliberately: the N1 loop (both spellings were in the
+ * hand copy — the guard's bite is proven by the drift MUTANT, not by history)
+ * and the N3 different-object twin (it pins the direction the fix must NOT
+ * change; without it, deleting the retry button everywhere would pass).
+ *
+ * ── BINDING ───────────────────────────────────────────────────────────────
+ * Every assertion selects by IDENTITY (testid carrying the target id, exact
+ * round context notes, exact wire codes) — never a value predicate another
+ * object could satisfy. Wrong-object twins are asserted alongside each
+ * positive (trap 19).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
+
+/**
+ * The elicitation hook is mocked (importOriginal spread — trap 12: a
+ * hand-listed factory replaces the module and every other export vanishes).
+ * The REAL hook debounces into a CEE call; this suite is about what happens
+ * AFTER a value is accepted, so the mock always offers 0.25 and the test
+ * drives the field's own "Use this" button — the page's real commit path.
+ */
+vi.mock('../../canvas/hooks/useBeliefElicitation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../canvas/hooks/useBeliefElicitation')>()
+  return {
+    ...actual,
+    useBeliefElicitation: vi.fn(() => ({
+      suggestion: {
+        suggested_value: 0.25,
+        reasoning: 'reads as unlikely',
+        confidence: 'medium',
+        needs_clarification: false,
+      },
+      loading: false,
+      error: null,
+      request: vi.fn(),
+      reset: vi.fn(),
+    })),
+  }
+})
+
+import ParticipantPacketPage, { readAccessCode } from '../../pages/ParticipantPacketPage'
+import type { OpenPacket } from '../collabService'
+import {
+  __resetParticipantTokenForTests,
+  setParticipantToken,
+  TOKEN_PARAM_NAMES,
+} from '../participantToken'
+
+const ROUND_A = 'rnd-participant-ux-aaaa-1111'
+const ROUND_B = 'rnd-participant-ux-bbbb-2222'
+const PACKET_URL_A = `/bff/collab/packet/${ROUND_A}`
+const PACKET_URL_B = `/bff/collab/packet/${ROUND_B}`
+const EVENTS_URL_A = `/bff/collab/packet/${ROUND_A}/events`
+
+const TARGET_X = 'factor-churn-risk'
+const TARGET_Y = 'factor-margin-hit'
+const LABEL_X = 'Churn risk after a price rise'
+const LABEL_Y = 'Margin hit if we discount'
+
+/** Distinctive on purpose — an assertion naming these cannot be met by chance. */
+const GOOD_CODE = 'CODE-THAT-WORKS-participant-ux'
+const SELF_ID = 'p-grace-4444'
+const SELF_NAME = 'Grace'
+const WORDS = 'quite unlikely — most customers are locked in'
+/** The producer's receipt timestamp (CEE sends `created_at` on every 201). */
+const RECEIPT_CREATED_AT = '2026-08-12T18:02:21.000Z'
+
+/** Context notes double as ROUND IDENTITY on screen — the page renders them
+ *  verbatim, and no other fixture text could satisfy the assertion. */
+const NOTE_A = 'Round A: we are deciding whether to raise the price.'
+const NOTE_B = 'Round B: same question, fresh panel.'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+function makePacket(args: {
+  roundId: string
+  note: string
+  completed: string[]
+  targets?: Array<{ id: string; label: string }>
+}): OpenPacket {
+  const targets = args.targets ?? [
+    { id: TARGET_X, label: LABEL_X },
+    { id: TARGET_Y, label: LABEL_Y },
+  ]
+  return {
+    round_id: args.roundId,
+    status: 'open',
+    context_note: args.note,
+    graph_version_ref: 'gv-1',
+    targets: targets.map((t) => ({
+      target: { kind: 'factor' as const, id: t.id },
+      label: t.label,
+      description: null,
+      unit: null,
+    })),
+    self: {
+      participant_id: SELF_ID,
+      display_name: SELF_NAME,
+      completed_target_ids: args.completed,
+    },
+  }
+}
+
+/**
+ * A truthful little wire: GETs serve the packet with `completed_target_ids`
+ * re-derived from what has been POSTed (exactly what CEE's fold does), and a
+ * POST answers 201 with the producer's receipt shape
+ * (`collab.v1.packet.ts`: event_id / round_id / target / kind / event_version
+ * / authored_by / created_at).
+ */
+function stubWire(opts?: {
+  receiptOverride?: Record<string, unknown>
+  packetB?: boolean
+}): { completed: string[] } {
+  const completed: string[] = []
+  fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url === EVENTS_URL_A && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as {
+        kind: string
+        target: { id: string }
+      }
+      completed.push(body.target.id)
+      const receipt = opts?.receiptOverride ?? {
+        event_id: 'evt-0001',
+        round_id: ROUND_A,
+        target: body.target,
+        kind: body.kind,
+        event_version: 1,
+        authored_by: SELF_ID,
+        created_at: RECEIPT_CREATED_AT,
+      }
+      return jsonResponse(receipt, 201)
+    }
+    if (url === PACKET_URL_A) {
+      return jsonResponse(makePacket({ roundId: ROUND_A, note: NOTE_A, completed: [...completed] }))
+    }
+    if (opts?.packetB === true && url === PACKET_URL_B) {
+      return jsonResponse(makePacket({ roundId: ROUND_B, note: NOTE_B, completed: [] }))
+    }
+    return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+  })
+  return { completed }
+}
+
+function renderAtRoundA(): void {
+  render(
+    <MemoryRouter initialEntries={[`/panel/${ROUND_A}`]}>
+      <Routes>
+        <Route path="/panel/:round_id" element={<ParticipantPacketPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/**
+ * Keeps the page MOUNTED across a round change — the SPA hazard under test.
+ * React Router re-renders the same element on a param change; component state
+ * (including held confirmations) survives, which is exactly why the round_id
+ * binding must be checked rather than assumed.
+ */
+function NavHarness(): JSX.Element {
+  const navigate = useNavigate()
+  return (
+    <>
+      <ParticipantPacketPage />
+      <button data-testid="test-nav-round-b" onClick={() => void navigate(`/panel/${ROUND_B}`)} />
+      <button data-testid="test-nav-round-a" onClick={() => void navigate(`/panel/${ROUND_A}`)} />
+    </>
+  )
+}
+
+function renderWithNav(): void {
+  render(
+    <MemoryRouter initialEntries={[`/panel/${ROUND_A}`]}>
+      <Routes>
+        <Route path="/panel/:round_id" element={<NavHarness />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** Type the participant's own words, then accept the elicited value (0.25). */
+async function submitOn(targetId: string, label: string, words: string): Promise<void> {
+  const card = screen.getByTestId(`packet-target-${targetId}`)
+  fireEvent.change(within(card).getByLabelText(`Describe ${label} in words`), {
+    target: { value: words },
+  })
+  fireEvent.click(within(card).getByRole('button', { name: `Use about 25% for ${label}` }))
+  await waitFor(() =>
+    expect(screen.getByTestId(`packet-confirmation-${targetId}`)).toBeInTheDocument(),
+  )
+}
+
+beforeEach(() => {
+  __resetParticipantTokenForTests()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  setParticipantToken(GOOD_CODE)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  __resetParticipantTokenForTests()
+})
+
+/* ══ W-F3 — a submission leaves a LASTING, truthful confirmation ═══════════ */
+
+describe('W-F3: the participant can tell their contribution landed', () => {
+  it('after a submit, a lasting confirmation names what was recorded — and it survives the post-submit reload', async () => {
+    stubWire()
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    await submitOn(TARGET_X, LABEL_X, WORDS)
+
+    // THE DEFECT: the confirmation used to die in the post-submit remount.
+    // Prove the reload actually happened (the packet was re-fetched and now
+    // carries the completion) and that the confirmation is STILL on screen.
+    const packetGets = fetchMock.mock.calls.filter((c) => String(c[0]) === PACKET_URL_A)
+    expect(packetGets.length).toBeGreaterThanOrEqual(2)
+
+    const confirmation = screen.getByTestId(`packet-confirmation-${TARGET_X}`)
+    expect(confirmation).toHaveTextContent('Your answer is in.')
+    // WHAT: the value and the participant's own words, verbatim.
+    expect(screen.getByTestId(`packet-confirmation-value-${TARGET_X}`)).toHaveTextContent('0.25')
+    expect(screen.getByTestId(`packet-confirmation-value-${TARGET_X}`)).toHaveTextContent(WORDS)
+    // PRIVACY: the clause the witness said was missing.
+    expect(confirmation).toHaveTextContent(/private until the round closes/i)
+    // WHEN and WHOSE: from the receipt (created_at + authored_by === self).
+    const recorded = screen.getByTestId(`packet-confirmation-recorded-${TARGET_X}`)
+    expect(recorded).toHaveTextContent(/Recorded at \d/)
+    expect(recorded).toHaveTextContent(`as ${SELF_NAME}`)
+
+    // WRONG-OBJECT TWIN (trap 19): the sibling card gets NO confirmation.
+    expect(screen.queryByTestId(`packet-confirmation-${TARGET_Y}`)).toBeNull()
+
+    // And the wire got the words verbatim on a first-submission kind.
+    const post = fetchMock.mock.calls.find(
+      (c) => String(c[0]) === EVENTS_URL_A && c[1]?.method === 'POST',
+    )
+    expect(post).toBeDefined()
+    const body = JSON.parse(String(post![1]!.body)) as {
+      kind: string
+      belief: { expression_raw: string | null }
+    }
+    expect(body.kind).toBe('belief_submitted')
+    expect(body.belief.expression_raw).toBe(WORDS)
+  })
+
+  it('makes no "when"/"whose" claim the receipt did not carry — nothing is fabricated', async () => {
+    // The producer sends created_at/authored_by today; this pins the page's
+    // honesty if a receipt ever arrives without them (and it is the RED line
+    // for the fabricated-timestamp mutant: a client clock would render a
+    // Recorded claim here).
+    stubWire({
+      receiptOverride: {
+        event_id: 'evt-0002',
+        round_id: ROUND_A,
+        target: { kind: 'factor', id: TARGET_X },
+        kind: 'belief_submitted',
+        event_version: 1,
+      },
+    })
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    await submitOn(TARGET_X, LABEL_X, WORDS)
+
+    expect(screen.getByTestId(`packet-confirmation-${TARGET_X}`)).toHaveTextContent(
+      'Your answer is in.',
+    )
+    expect(screen.queryByTestId(`packet-confirmation-recorded-${TARGET_X}`)).toBeNull()
+  })
+
+  it('does not claim a foreign authored_by as this participant', async () => {
+    // A receipt attributed to someone else must not be rendered "as Grace".
+    // (The server stamps authored_by from the token, so this should be
+    // unreachable — but the claim is the page's, and the page must not make
+    // it on evidence it does not hold.)
+    stubWire({
+      receiptOverride: {
+        event_id: 'evt-0003',
+        round_id: ROUND_A,
+        target: { kind: 'factor', id: TARGET_X },
+        kind: 'belief_submitted',
+        event_version: 1,
+        authored_by: 'p-somebody-else',
+        created_at: RECEIPT_CREATED_AT,
+      },
+    })
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    await submitOn(TARGET_X, LABEL_X, WORDS)
+
+    const recorded = screen.getByTestId(`packet-confirmation-recorded-${TARGET_X}`)
+    expect(recorded).toHaveTextContent(/Recorded at \d/)
+    expect(recorded).not.toHaveTextContent(`as ${SELF_NAME}`)
+  })
+
+  it("a fresh round re-asking the same factor gets a fresh form, never last round's confirmation — and going back restores it", async () => {
+    stubWire({ packetB: true })
+    renderWithNav()
+    await waitFor(() => expect(screen.getByTestId('packet-context-note')).toHaveTextContent(NOTE_A))
+
+    await submitOn(TARGET_X, LABEL_X, WORDS)
+
+    // NEW ROUND, same target id, page kept mounted (the SPA hazard).
+    fireEvent.click(screen.getByTestId('test-nav-round-b'))
+    await waitFor(() => expect(screen.getByTestId('packet-context-note')).toHaveTextContent(NOTE_B))
+
+    // BOUND BY round_id: round B must not inherit round A's confirmation,
+    // and the server says B is unanswered, so no fallback either.
+    expect(screen.queryByTestId(`packet-confirmation-${TARGET_X}`)).toBeNull()
+    expect(screen.queryByTestId(`packet-already-answered-${TARGET_X}`)).toBeNull()
+
+    // OPPOSITE LIMB: back on round A the confirmation is still the truth.
+    fireEvent.click(screen.getByTestId('test-nav-round-a'))
+    await waitFor(() => expect(screen.getByTestId('packet-context-note')).toHaveTextContent(NOTE_A))
+    expect(screen.getByTestId(`packet-confirmation-${TARGET_X}`)).toHaveTextContent(
+      'Your answer is in.',
+    )
+  })
+
+  it('a participant who re-opens their link mid-round is told the server holds their response', async () => {
+    // No confirmation is held (fresh mount) — the packet's own
+    // completed_target_ids is the surviving evidence, and it covers declines
+    // too, so the copy says "responded", not "answered".
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL_A) {
+        return jsonResponse(makePacket({ roundId: ROUND_A, note: NOTE_A, completed: [TARGET_X] }))
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    const fallback = screen.getByTestId(`packet-already-answered-${TARGET_X}`)
+    expect(fallback).toHaveTextContent(/already responded/i)
+    expect(fallback).toHaveTextContent(/private until the round closes/i)
+    // It does NOT invent what/when — that evidence died with the token.
+    expect(screen.queryByTestId(`packet-confirmation-${TARGET_X}`)).toBeNull()
+    // WRONG-OBJECT TWIN: the unanswered sibling carries no such notice.
+    expect(screen.queryByTestId(`packet-already-answered-${TARGET_Y}`)).toBeNull()
+  })
+
+  it('declining leaves an honest record of the choice — not "Answer recorded"', async () => {
+    stubWire()
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+
+    const card = screen.getByTestId(`packet-target-${TARGET_X}`)
+    fireEvent.click(within(card).getByRole('button', { name: 'I would rather not answer this' }))
+    await waitFor(() =>
+      expect(screen.getByTestId(`packet-confirmation-${TARGET_X}`)).toBeInTheDocument(),
+    )
+
+    const confirmation = screen.getByTestId(`packet-confirmation-${TARGET_X}`)
+    expect(confirmation).toHaveTextContent(/choice not to answer/i)
+    expect(confirmation).not.toHaveTextContent('Your answer is in.')
+    // The wire saw a decline, by exact kind.
+    const post = fetchMock.mock.calls.find(
+      (c) => String(c[0]) === EVENTS_URL_A && c[1]?.method === 'POST',
+    )
+    const body = JSON.parse(String(post![1]!.body)) as { kind: string }
+    expect(body.kind).toBe('declined')
+  })
+})
+
+/* ══ N1 — the link reader is DERIVED from the single authority ═════════════ */
+
+describe('N1: every token spelling the boot path accepts, the link reader accepts', () => {
+  it('accepts a pasted link for EVERY name in TOKEN_PARAM_NAMES, in both link shapes', () => {
+    // Non-vacuity control (trap 13): a loop over an empty authority would
+    // pass while testing nothing.
+    expect(TOKEN_PARAM_NAMES.length).toBeGreaterThanOrEqual(2)
+
+    for (const name of TOKEN_PARAM_NAMES) {
+      // Real query string (the shape participantLink writes).
+      expect(readAccessCode(`https://app.example.com/?${name}=${GOOD_CODE}#/panel/rnd-1`)).toEqual({
+        code: GOOD_CODE,
+      })
+      // Hash query (what a HashRouter user actually sees and re-pastes).
+      expect(readAccessCode(`https://app.example.com/#/panel/rnd-1?${name}=${GOOD_CODE}`)).toEqual({
+        code: GOOD_CODE,
+      })
+    }
+    // ⚠ This proves AGREEMENT with the authority, never that the authority is
+    // complete (trap 12d) — completeness lives with TOKEN_PARAM_NAMES itself.
+    // CONTRAST CONTROL: a name outside the authority is still refused, so the
+    // derived pattern discriminates rather than matching anything.
+    const foreign = readAccessCode(`https://app.example.com/?token=${GOOD_CODE}#/panel/rnd-1`)
+    expect('problem' in foreign).toBe(true)
+  })
+
+  it('the collab_token spelling works end-to-end through the entry form', async () => {
+    // The sibling suite drives `ct`; this drives the OTHER spelling through
+    // the same DOM path, so a regression that keeps the loop above green by
+    // exporting a narrowed list still fails a user-shaped test.
+    __resetParticipantTokenForTests()
+    stubWire()
+    renderAtRoundA()
+
+    fireEvent.change(screen.getByTestId('packet-manual-token'), {
+      target: { value: `https://app.example.com/?collab_token=${GOOD_CODE}#/panel/${ROUND_A}` },
+    })
+    fireEvent.click(screen.getByTestId('packet-manual-continue'))
+
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+    const packetCall = fetchMock.mock.calls.find((c) => String(c[0]) === PACKET_URL_A)
+    const header = new Headers((packetCall![1] ?? {}).headers).get('x-collab-participant-token')
+    expect(header).toBe(GOOD_CODE)
+  })
+})
+
+/* ══ N3 — no futile retry on a credential refusal ══════════════════════════ */
+
+describe('N3: the failure card offers only affordances that can work', () => {
+  it('a credential refusal has NO "Try again" — re-entry and a fresh link are the honest moves', async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL_A) {
+        return jsonResponse(
+          { code: 'collab_token_invalid', message: 'That token could not be verified.' },
+          401,
+        )
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+
+    // Retrying re-sends the very token the server just refused; the button
+    // was a promise the page could not keep.
+    expect(screen.queryByTestId('packet-retry')).toBeNull()
+    expect(screen.getByTestId('packet-reenter-code')).toBeInTheDocument()
+    // What the user should actually do, including the #672 recovery path:
+    // ask the owner for a fresh link.
+    const guidance = screen.getByTestId('packet-error-guidance')
+    expect(guidance).toHaveTextContent(/whoever invited you/i)
+    expect(guidance).toHaveTextContent(/fresh link/i)
+  })
+
+  it('DIFFERENT OBJECT: an ordinary failure keeps "Try again" — and it genuinely retries', async () => {
+    // The opposite-direction twin: without it, deleting the retry button on
+    // EVERY branch would satisfy the test above while removing a working
+    // affordance from recoverable failures.
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === PACKET_URL_A) {
+        return jsonResponse({ code: 'collab_upstream_unavailable', message: 'Upstream error.' }, 503)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+    })
+    renderAtRoundA()
+    await waitFor(() => expect(screen.getByTestId('packet-error')).toBeInTheDocument())
+
+    expect(screen.getByTestId('packet-retry')).toBeInTheDocument()
+    expect(screen.getByTestId('packet-reenter-code')).toBeInTheDocument()
+
+    // The retry is real: once the wire recovers, clicking it loads the panel.
+    stubWire()
+    fireEvent.click(screen.getByTestId('packet-retry'))
+    await waitFor(() => expect(screen.getByTestId('participant-packet-page')).toBeInTheDocument())
+  })
+})

--- a/src/collab/participantToken.ts
+++ b/src/collab/participantToken.ts
@@ -34,8 +34,17 @@
  * persisting it would put a bearer capability on disk to save one click.
  */
 
-/** Accepted spellings, in both the real query string and the hash query. */
-const TOKEN_PARAM_NAMES = ['ct', 'collab_token'] as const
+/**
+ * Accepted spellings, in both the real query string and the hash query.
+ *
+ * ⭐ THE SINGLE AUTHORITY. Exported because the packet page's link reader
+ * (`CODE_IN_LINK` in `ParticipantPacketPage.tsx`) DERIVES its pattern from
+ * this list rather than hand-copying it — a hand-copied twin drifted once
+ * already (#669 review, N1): a name added here but not there would have
+ * REFUSED valid participant links while every suite stayed green. Add a
+ * spelling here and every consumer accepts it without another edit.
+ */
+export const TOKEN_PARAM_NAMES = ['ct', 'collab_token'] as const
 
 /**
  * In-memory only. Module scope, not `window` — nothing enumerating globals

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -28,6 +28,13 @@
  *     `hasToken` is now STATE, and a refusal offers "Enter a different code".
  *   • "Continue" was dead on empty input with no feedback at all.
  *
+ * A second witness (the 12 Aug two-person run, leg 2) found the SUBMIT side
+ * equally silent: the post-submit reload remounts every card, so the card-local
+ * "saved" flash died instantly and neither person could tell the contribution
+ * had landed (W-F3). The confirmation is now PAGE-held, built from the 201
+ * receipt, and bound to the round it was accepted for — see
+ * `SubmissionConfirmation` below.
+ *
  * ── WHAT THIS PAGE DELIBERATELY DOES NOT SHOW ─────────────────────────────
  * Before the round closes: no sibling answer, no model value for the target, no
  * response count, no roster. Not because the page hides them — because the
@@ -47,7 +54,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { AlertTriangle, KeyRound, Loader2, Lock } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, KeyRound, Loader2, Lock } from 'lucide-react'
 
 import { BeliefElicitationField } from '../canvas/components/BeliefElicitationField'
 import { useBeliefElicitation } from '../canvas/hooks/useBeliefElicitation'
@@ -66,6 +73,7 @@ import {
   clearParticipantToken,
   getParticipantToken,
   setParticipantToken,
+  TOKEN_PARAM_NAMES,
 } from '../collab/participantToken'
 import { typography } from '../styles/typography'
 
@@ -98,8 +106,25 @@ function isCredentialFailure(code: string, status: number): boolean {
   return status === 401 || status === 403 || code === 'collab_token_invalid'
 }
 
-/** Both spellings the link builder and the boot-path strip accept. */
-const CODE_IN_LINK = /[?&](?:ct|collab_token)=([^&#\s]+)/
+/** Regex-escape a literal so a future param name cannot become an operator. */
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * The spellings the boot-path strip accepts — DERIVED from the single
+ * authority, never spelled here.
+ *
+ * ⚠ This was a hand-copied twin of `TOKEN_PARAM_NAMES` until #669's review
+ * demonstrated the drift (N1): a spelling added to the authority but not here
+ * would make this page REFUSE a link the boot path accepts — the participant's
+ * own paste-recovery path rejecting a valid invitation. Deriving it makes the
+ * two agree structurally; what derivation cannot prove is that the authority
+ * itself is complete (trap 12d), which is the authority's own concern.
+ */
+const CODE_IN_LINK = new RegExp(
+  `[?&](?:${[...TOKEN_PARAM_NAMES].map(escapeForRegExp).join('|')})=([^&#\\s]+)`,
+)
 
 type CodeReading = { code: string } | { problem: string }
 
@@ -140,22 +165,98 @@ export function readAccessCode(raw: string): CodeReading {
   return { code: trimmed }
 }
 
+/* ── W-F3: a submission must leave a LASTING, truthful confirmation ────────
+ * The two-person witness (leg 2, 12 Aug) found that after a participant
+ * submits, the card silently resets: the post-submit reload remounts every
+ * `TargetCard`, so card-local "saved" state died with it and neither person
+ * could tell the contribution had landed. The confirmation therefore lives at
+ * PAGE level, is built from the server's 201 RECEIPT (not from hope), and is
+ * shown only for the round it belongs to.
+ */
+
+/**
+ * What this participant has had RECORDED, per target — every claim in the
+ * rendered confirmation traces to a wire fact:
+ *   • that it was recorded at all — the 201 receipt;
+ *   • what — the value/words this page sent in the accepted request;
+ *   • when — the receipt's own `created_at` (server clock), never this
+ *     device's; absent from the receipt ⇒ no time is shown;
+ *   • whose — the receipt's `authored_by`, matched against the packet's
+ *     `self.participant_id` before any "as <name>" claim is made.
+ */
+type SubmissionConfirmation = {
+  /** The round the submission was ACCEPTED for — the binding identity. */
+  roundId: string
+  targetId: string
+  kind: 'answered' | 'revised' | 'declined'
+  value: number | null
+  words: string | null
+  /** ISO timestamp from the receipt, or null — never a client-side clock. */
+  createdAt: string | null
+  /** The participant the SERVER attributed the event to, from the receipt. */
+  authoredBy: string | null
+}
+
+/**
+ * ⚠ BOUND BY IDENTITY to the round on screen. A fresh round re-asking the same
+ * factor (same target id, new round_id) must render a fresh form, not last
+ * round's confirmation — a confirmation shown for the wrong round is a lie
+ * about THIS round. Keyed lookup by target id, then the round_id gate.
+ */
+function confirmationForRound(
+  held: Record<string, SubmissionConfirmation>,
+  roundId: string,
+  targetId: string,
+): SubmissionConfirmation | null {
+  const candidate = held[targetId]
+  if (candidate === undefined) return null
+  return candidate.roundId === roundId ? candidate : null
+}
+
+/**
+ * The receipt's server timestamp, if the wire carried one.
+ *
+ * The producer (CEE `collab.v1.packet.ts`) sends `created_at` on every 201;
+ * the UI's declared receipt type predates that field, so it is read here with
+ * a runtime check rather than widened in `collabService.ts` (that file is
+ * owned by open PR #674 — zero-overlap rule). An absent or unparseable value
+ * returns null and the confirmation simply makes no "when" claim.
+ */
+function receiptCreatedAt(receipt: unknown): string | null {
+  if (typeof receipt !== 'object' || receipt === null) return null
+  const value = (receipt as Record<string, unknown>).created_at
+  if (typeof value !== 'string') return null
+  return Number.isNaN(new Date(value).getTime()) ? null : value
+}
+
+/** "18:02" in the participant's own locale, or null if the wire gave no time. */
+function formatRecordedTime(createdAt: string | null): string | null {
+  if (createdAt === null) return null
+  const parsed = new Date(createdAt)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
 /** One target, with its own phrase state (the field is caller-owned). */
 function TargetCard({
   target,
   roundId,
+  self,
   alreadyAnswered,
-  onAnswered,
+  confirmation,
+  onConfirmed,
 }: {
   target: PacketTarget
   roundId: string
+  self: OpenPacket['self']
   alreadyAnswered: boolean
-  onAnswered: () => void
+  /** Round-bound already — the page filters through `confirmationForRound`. */
+  confirmation: SubmissionConfirmation | null
+  onConfirmed: (confirmation: SubmissionConfirmation) => void
 }): JSX.Element {
   const [phrase, setPhrase] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [saved, setSaved] = useState(false)
 
   // The hook's target shape is {nodeId, nodeLabel}: CEE refuses an empty id and
   // quotes the label back in its clarifying question. The packet's target id is
@@ -178,18 +279,28 @@ function TargetCard({
       setBusy(true)
       setError(null)
       try {
-        await submitBelief(roundId, {
+        const words = phrase.trim() === '' ? null : phrase
+        const receipt = await submitBelief(roundId, {
           targetId: target.target.id,
           targetKind: target.target.kind,
           value,
           // ⭐ VERBATIM. Not the parsed number, not a normalisation — the words
           // this person typed, which is what the reveal shows beside the number.
-          expressionRaw: phrase.trim() === '' ? null : phrase,
+          expressionRaw: words,
           confidence: null,
           revision: alreadyAnswered,
         })
-        setSaved(true)
-        onAnswered()
+        // Recorded at PAGE level, from the receipt: the post-submit reload
+        // remounts this card, and anything held here dies with it (W-F3).
+        onConfirmed({
+          roundId,
+          targetId: target.target.id,
+          kind: alreadyAnswered ? 'revised' : 'answered',
+          value,
+          words,
+          createdAt: receiptCreatedAt(receipt),
+          authoredBy: receipt.authored_by,
+        })
       } catch (err) {
         setError(
           err instanceof CollabRequestError
@@ -200,7 +311,7 @@ function TargetCard({
         setBusy(false)
       }
     },
-    [roundId, target, phrase, alreadyAnswered, onAnswered],
+    [roundId, target, phrase, alreadyAnswered, onConfirmed],
   )
 
   const handleDecline = useCallback(async () => {
@@ -208,20 +319,100 @@ function TargetCard({
     setError(null)
     try {
       await declineTarget(roundId, { targetId: target.target.id, targetKind: target.target.kind })
-      setSaved(true)
-      onAnswered()
+      // `declineTarget` surfaces no receipt body, so this confirmation makes
+      // no "when"/"whose" claim — kind and round are what the accepted request
+      // established, and nothing more is asserted.
+      onConfirmed({
+        roundId,
+        targetId: target.target.id,
+        kind: 'declined',
+        value: null,
+        words: null,
+        createdAt: null,
+        authoredBy: null,
+      })
     } catch (err) {
       setError(err instanceof CollabRequestError ? err.message : 'That did not save.')
     } finally {
       setBusy(false)
     }
-  }, [roundId, target, onAnswered])
+  }, [roundId, target, onConfirmed])
+
+  /* Every clause below is a wire fact or it is not rendered: the time comes
+   * from the receipt's `created_at` (none ⇒ no time claim), and "as <name>"
+   * is made only when the receipt's `authored_by` IS this packet's self. */
+  const recordedTime = confirmation === null ? null : formatRecordedTime(confirmation.createdAt)
+  const recordedAsSelf =
+    confirmation !== null &&
+    confirmation.authoredBy !== null &&
+    confirmation.authoredBy === self.participant_id
 
   return (
     <section data-testid={`packet-target-${target.target.id}`} className={`${CARD} mt-4`}>
       <h2 className={`${typography.h4} text-text-header`}>{target.label}</h2>
       {target.description !== null && (
         <p className={`${typography.body} mt-1 text-text-light`}>{target.description}</p>
+      )}
+
+      {/* W-F3: the LASTING confirmation. Page-held, receipt-built, round-bound
+          — it survives the post-submit reload that used to silently reset this
+          card, and a fresh round renders a fresh form instead of it. */}
+      {confirmation !== null && (
+        <p
+          data-testid={`packet-confirmation-${target.target.id}`}
+          className={`${typography.body} mt-4 flex gap-3 rounded-md border border-success/30 bg-panel p-4 text-text-body`}
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-success" aria-hidden="true" />
+          {confirmation.kind === 'declined' ? (
+            <span>
+              <strong className="font-semibold text-text-header">
+                Your choice not to answer this has been recorded.
+              </strong>{' '}
+              You can still answer below until the round closes.
+            </span>
+          ) : (
+            <span>
+              <strong className="font-semibold text-text-header">
+                {confirmation.kind === 'revised'
+                  ? 'Your answer has been updated.'
+                  : 'Your answer is in.'}
+              </strong>{' '}
+              <span data-testid={`packet-confirmation-value-${target.target.id}`}>
+                You answered {confirmation.value}
+                {confirmation.words !== null && (
+                  <em> &mdash; &ldquo;{confirmation.words}&rdquo;</em>
+                )}
+                .
+              </span>{' '}
+              {(recordedTime !== null || recordedAsSelf) && (
+                <span data-testid={`packet-confirmation-recorded-${target.target.id}`}>
+                  Recorded
+                  {recordedTime !== null ? ` at ${recordedTime}` : ''}
+                  {recordedAsSelf ? ` as ${self.display_name}` : ''}.{' '}
+                </span>
+              )}
+              It stays private until the round closes — you can change it below until then.
+            </span>
+          )}
+        </p>
+      )}
+
+      {/* The weaker truth that survives even a full reload (the token does not,
+          but a re-opened link lands here with the same packet): the SERVER says
+          this participant has responded — `self.completed_target_ids`, which
+          counts declines too, hence "responded", not "answered". What and when
+          are not in the packet, so they are not claimed. */}
+      {confirmation === null && alreadyAnswered && (
+        <p
+          data-testid={`packet-already-answered-${target.target.id}`}
+          className={`${typography.body} mt-4 flex gap-3 rounded-md border border-success/30 bg-panel p-4 text-text-body`}
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-success" aria-hidden="true" />
+          <span>
+            You have already responded to this one in this round. Your response is saved and
+            stays private until the round closes — answering below will update it.
+          </span>
+        </p>
       )}
 
       <div className="mt-4">
@@ -239,15 +430,6 @@ function TargetCard({
         <Button variant="secondary" size="sm" onClick={handleDecline} disabled={busy}>
           I would rather not answer this
         </Button>
-        {saved && (
-          <span
-            data-testid={`packet-saved-${target.target.id}`}
-            className={`${typography.bodySmall} text-success`}
-          >
-            {alreadyAnswered ? 'Answer updated.' : 'Answer recorded.'} You can change it until the
-            round closes.
-          </span>
-        )}
       </div>
 
       {error !== null && (
@@ -265,6 +447,22 @@ export default function ParticipantPacketPage(): JSX.Element {
   const [manualToken, setManualToken] = useState('')
   const [entryProblem, setEntryProblem] = useState<string | null>(null)
   const [answeredTick, setAnsweredTick] = useState(0)
+
+  /**
+   * W-F3: what this participant has had recorded, keyed by target id, held at
+   * PAGE level because the post-submit reload remounts every card. Entries
+   * carry the round they were accepted for and are surfaced only through
+   * `confirmationForRound` — a fresh round (new round_id, even for the same
+   * factor) gets a fresh form, never last round's confirmation.
+   */
+  const [confirmations, setConfirmations] = useState<Record<string, SubmissionConfirmation>>({})
+
+  const handleConfirmed = useCallback((confirmation: SubmissionConfirmation) => {
+    setConfirmations((prev) => ({ ...prev, [confirmation.targetId]: confirmation }))
+    // Same reload as before the fix: `completed_target_ids` is re-derived from
+    // the wire, so revision state stays the server's word, not this page's.
+    setAnsweredTick((n) => n + 1)
+  }, [])
 
   /**
    * ⚠ STATE, NOT A BARE MODULE READ — this is the whole of the dead-end fix.
@@ -485,13 +683,22 @@ export default function ParticipantPacketPage(): JSX.Element {
               <Button data-testid="packet-reenter-code" onClick={forgetCode}>
                 Enter a different code
               </Button>
-              <Button
-                variant="secondary"
-                data-testid="packet-retry"
-                onClick={() => setAnsweredTick((n) => n + 1)}
-              >
-                Try again
-              </Button>
+              {/* N3 (#669 review): "Try again" re-sends the SAME held token, so
+                  on a credential refusal it cannot succeed — the server has
+                  just declined exactly what it would re-send. The honest
+                  affordances there are the two the guidance names: enter the
+                  code again, or ask the owner for a fresh link (#672's
+                  recovery). Retry stays for every other failure, where a
+                  moment later genuinely can differ. */}
+              {!credential && (
+                <Button
+                  variant="secondary"
+                  data-testid="packet-retry"
+                  onClick={() => setAnsweredTick((n) => n + 1)}
+                >
+                  Try again
+                </Button>
+              )}
             </div>
           </div>
         </div>
@@ -545,8 +752,10 @@ export default function ParticipantPacketPage(): JSX.Element {
             key={t.target.id}
             target={t}
             roundId={packet.round_id}
+            self={packet.self}
             alreadyAnswered={packet.self.completed_target_ids.includes(t.target.id)}
-            onAnswered={() => setAnsweredTick((n) => n + 1)}
+            confirmation={confirmationForRound(confirmations, packet.round_id, t.target.id)}
+            onConfirmed={handleConfirmed}
           />
         ))}
 

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -526,6 +526,12 @@ export default function ParticipantPacketPage(): JSX.Element {
   /** Drop the held code and go back to the entry form, in place. */
   const forgetCode = useCallback(() => {
     clearParticipantToken()
+    // Held confirmations die with the credential that produced them: two-person
+    // trials share devices, and the next code entered may be ANOTHER
+    // participant on the SAME round — round_id binding alone cannot tell them
+    // apart, and Grace's receipt is not evidence about Priya (found RED-first
+    // by this lane's own cross-person test, not by the witness).
+    setConfirmations({})
     setManualToken('')
     setEntryProblem(null)
     setState({ kind: 'loading' })


### PR DESCRIPTION
## Verdict

The participant surface now tells the truth after a submit, reads links from the single token authority, and offers no futile retry on a credential refusal. Three measured defects closed (W-F3 / N1 / N3), plus a fourth this lane found RED-first in its own fix (cross-person confirmation leak on a shared device). **Review-ready; not merged.** Track 3 (collaboration), ahead of the first real two-person trial.

## What a participant now experiences

- **Submit** (W-F3, two-person witness 12 Aug, leg 2): the card no longer silently resets. A lasting confirmation renders — *"Your answer is in. You answered 0.25 — 'quite unlikely — most customers are locked in'. Recorded at 18:02 as Grace. It stays private until the round closes — you can change it below until then."* It survives the post-submit reload (held at page level, not card level) and is **bound by identity to the round**: a fresh round re-asking the same factor renders a fresh form.
- **Every clause is a wire fact or it is not rendered**: THAT it was recorded = the 201 receipt; WHAT = the value/words the accepted request carried (words verbatim); WHEN = the receipt's own `created_at` (server clock — absent ⇒ no time claim, pinned by a mutant); WHOSE = receipt `authored_by` matched against `packet.self.participant_id` before any "as \<name\>"; PRIVATE = the packet's construction.
- **Reload mid-round**: the token is memory-only, so page state dies — the packet's own `completed_target_ids` (which counts declines; verified at the CEE fold's bytes) yields the weaker truth: *"You have already responded to this one in this round… answering below will update it."*
- **Decline**: an honest *"Your choice not to answer this has been recorded."* — the pristine page flashed "Answer recorded." for declines.
- **Shared device** (self-found, RED-first): dropping the code clears held confirmations — Priya entering her code after Grace's is refused no longer inherits Grace's "Your answer is in" on the same round.
- **Bad code** (N3): the credential-failure card no longer offers "Try again" (it re-sends the very token the server just refused). It keeps "Enter a different code" and the guidance names the #672 recovery: ask whoever invited you for a fresh link. Ordinary failures keep a genuinely working retry (pinned by the different-object twin).
- **Pasted links** (N1): `CODE_IN_LINK` is now DERIVED from the exported `TOKEN_PARAM_NAMES` (regex-escaped) instead of hand-copying it — the #669-demonstrated drift class (a spelling added to the authority refusing valid links here) is closed structurally. Derivation proves agreement, not completeness (trap 12d, noted at the site).

## Evidence

- **RED-first at pristine `d4c9326d`** (throwaway worktree outside the repo root, write-isolation proven by sentinel write + inode compare): **8 RED / 2 GREEN, all named** — six W-F3 tests, the N3 credential test, and the N1 loop (pristine exports no `TOKEN_PARAM_NAMES`). Deliberate GREENs: the collab_token end-to-end guard and the N3 different-object twin. The spec's ledger comment first PREDICTED the N1 loop green at pristine; the measurement said otherwise and the comment was corrected to the measured truth.
- **Cross-person test** measured RED against this lane's own pre-clear implementation at `8e19a10c` (named signature), green after the fix.
- **Mutants — all 8 bite their NAMED tests** at the rebased tip (control + trailing control 11/11; applied-check per mutation = exactly `src/pages/ParticipantPacketPage.tsx`; control 0; HEAD-relative restores; clean tree asserted before/after each): M1 round-binding-broken → round-binding pin RED (the brief's confirmation-shown-for-wrong-round mutant) · M2 N1-drift-reintroduced → derived-guard loop + collab_token E2E RED · M3 futile-retry-reintroduced → N3 pin RED · M4 fabricated-timestamp → no-fabrication pin RED · M5 decline-kind-lie → honest-decline pin RED · M6 fallback-deleted → reload pin RED · M7 target-identity-broken → wrong-object twin RED (trap-19 pair) · M8 credential-clear-removed → cross-person pin RED. (M3's first anchor matched two sites; the kit hard-stopped on applied-count ≠ 1 and was re-run whole with a widened anchor.)
- **Gates at the rebased tip `69e0bee5`** (Staging Gate's own sequence, derived from `staging-full-tests.yml`: lint → typecheck(+guards) → full vitest + summary → build): `pnpm run lint` PASS (hooks ratchet: 232 known, no new) · `pnpm run typecheck` PASS (drift 2487→2485; shrink NOT banked — out of scope) · spec 11/11 collected by name · full suite: see checks on this PR.
- **Rebase**: #674 merged mid-lane (staging `d4c9326d → d21101b0`); clean rebase, zero file overlap held throughout (#674 owns `collabService.ts`/`PanelSetupPage.tsx`; this lane never touched them). Full ladder re-run at the rebased tip.
- Evidence stream: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/pr4-two-person-witness-2026-08-12/PARTICIPANT-UX.md`.

## Scope and binding notes for review

- Files: `src/pages/ParticipantPacketPage.tsx`, `src/collab/participantToken.ts` (export + doc only), new spec `src/collab/__tests__/participantPacketConfirmation.spec.tsx`. Nothing else.
- The receipt's `created_at`/`round_id`/`kind` are read at the page with a runtime check (`receiptCreatedAt`) rather than widening the declared type in `collabService.ts` — that file was #674's while this lane ran. Follow-up candidate now #674 is merged: declare the full producer receipt shape (CEE `collab.v1.packet.ts` sends `event_id/round_id/target/kind/event_version/authored_by/created_at` on every 201) and surface the decline receipt (currently `void`), which would let the decline confirmation carry a server timestamp too.
- Assertions bind by identity throughout: testids carry the target id; round identity on screen is asserted via exact context notes; wire assertions match exact codes/kinds; wrong-object twins accompany each positive.

## Residual risk (honest)

- **jsdom proves behaviour, not layout** (trap 3): the confirmation's visual presence on the deployed build needs the post-deploy browser witness, as with the F-series.
- `participantLink()` in `collabService.ts` still writes `?ct=` literally — one remaining hand-written member of the authority, harmless today (`ct` ∈ authority) and out of this lane's scope; worth folding into the follow-up above.
- A server that misclassifies a transient outage as 401 would cost the participant the one-click retry; "Enter a different code" (re-entering the same code) remains a manual retry path and the guidance says what to do.
- The confirmation deliberately does NOT survive a full page reload — the bearer token does not either; the packet-derived fallback covers that case truthfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
