### PR TITLE
feat(staleness): review, evidence and exercise cards can say their content is out of date

### DIFF
--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -260,6 +260,15 @@ export interface V5ReviewCardBlock {
   freshness: V5Phase3Freshness
   action_intent?: string
   action_label?: string
+  /**
+   * CEE's `aag_v1` graph hash AT THE MOMENT THIS CARD WAS WRITTEN — the same
+   * field, same semantics and same CEE-hash-only comparison rule as
+   * `V5CoachingBlock.graph_hash_at_generation` below (see that doc-comment
+   * and `coachingCurrency.ts`). REQUIRED at schemas 0.39.0
+   * (`ReviewCardBlockSchema`, blocks.d.ts:1074) but kept optional here:
+   * absence costs the VERDICT (cannot-confirm), never the card.
+   */
+  graph_hash_at_generation?: string
 }
 
 /**
@@ -387,6 +396,14 @@ export interface V5EvidenceBlock {
   freshness: V5Phase3Freshness
   action_intent?: string
   action_label?: string
+  /**
+   * CEE's `aag_v1` graph hash at authoring time — same semantics and
+   * CEE-hash-only comparison rule as on V5ReviewCardBlock / V5CoachingBlock
+   * (see `coachingCurrency.ts`). REQUIRED at schemas 0.39.0
+   * (`EvidenceBlockSchema`, blocks.d.ts:1452) but optional here: absence
+   * costs the verdict (cannot-confirm), never the card.
+   */
+  graph_hash_at_generation?: string
 }
 
 /**
@@ -448,6 +465,14 @@ export interface V5ExerciseBlock {
   target_element_ref?: V5BlockTargetRef
   target_refs: V5BlockTargetRef[]
   freshness: V5Phase3Freshness
+  /**
+   * CEE's `aag_v1` graph hash at authoring time — same semantics and
+   * CEE-hash-only comparison rule as on the other Phase 3 typed blocks
+   * (see `coachingCurrency.ts`). Optional at schemas 0.39.0
+   * (`ExerciseBlockSchema`, blocks.d.ts:1669); carried on the live wire
+   * (T3 / no-critiques captures). Absent ⇒ cannot-confirm, never "current".
+   */
+  graph_hash_at_generation?: string
 }
 
 /**

--- a/src/v5/blocks/V5CoachingBlock.tsx
+++ b/src/v5/blocks/V5CoachingBlock.tsx
@@ -109,9 +109,8 @@ import {
   guidanceCategoryTone,
 } from '../../canvas/stores/guidanceStore'
 import { STRENGTHEN_COPY } from '../../components/results/strengthen/strengthenCopy'
-import { useCanvasStore } from '../../canvas/store'
-import { classifyFreshnessForDisplay } from '../../canvas/store/analysisFreshness'
-import { deriveCoachingCurrency } from './coachingCurrency'
+import { resolveFreshnessNotice } from './coachingCurrency'
+import { useCoachingCurrency } from './useCoachingCurrency'
 import type { V5CoachingBlock as V5CoachingBlockType } from '../../canvas/conversation/types'
 
 export interface V5CoachingBlockProps {
@@ -201,17 +200,12 @@ const CATEGORY_BORDER_CLASS: Record<
   technique: 'border-panel-border',
 }
 
-/**
- * Plain-English sentences for the freshness verdict. `fresh` is deliberately
- * absent from this map: a current card says nothing, because a "this is
- * current" badge on every card is noise that teaches the reader to ignore the
- * one time it matters.
+/*
+ * The freshness-notice sentences and the producer-wins resolution now live in
+ * `coachingCurrency.ts` (`FRESHNESS_NOTICE` / `resolveFreshnessNotice`),
+ * shared with the other hash-carrying Phase 3 renderers — one copy of the
+ * sentences, one resolution rule, four cards that cannot drift apart.
  */
-const FRESHNESS_NOTICE: Partial<Record<string, string>> = {
-  stale: 'Your model has changed since this was written — it may no longer apply.',
-  pending: 'This is still being written.',
-  failed: 'This could not be generated.',
-}
 
 /**
  * The depth-layer sentence for CANNOT-CONFIRM. It is the card's existing
@@ -283,32 +277,16 @@ export function V5CoachingBlock({ block, variant = 'default' }: V5CoachingBlockP
     answering "is the analysis stale?" under one name is trap 21. The borrow is
     gated on the overlay inside `deriveCoachingCurrency`; the reasoning for the
     gate is in that module's header.
-  */
-  const freshnessState = useCanvasStore((s) => s.analysisFreshness)
-  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
-  const importHold = useCanvasStore((s) => s.importPendingServerRegistration)
-  const currency = deriveCoachingCurrency(
-    block.graph_hash_at_generation,
-    freshnessState?.currentGraphHash,
-    {
-      dirty: freshnessDirty,
-      displaySemantic: classifyFreshnessForDisplay(freshnessState, freshnessDirty, importHold),
-    },
-  )
 
-  /*
-    The producer's verdict WINS when it has said anything at all.
-
-    `freshness` answers "did this card generate correctly?" (pending / failed)
-    and currency answers "is it still about your model?" — two questions, and
-    trap 21 is what happens when two questions share one channel. So the
-    derived verdict FILLS THE PRODUCER'S SILENCE and never overwrites its
-    speech. When both point at staleness they resolve to the same sentence, so
-    the notice renders once and cannot contradict itself.
+    The store reads + the classify call live in `useCoachingCurrency` — the ONE
+    consumption seam every hash-carrying Phase 3 renderer shares, so no card can
+    drift on how it feeds the authority. The producer-wins resolution is
+    `resolveFreshnessNotice` from the same mechanism module: the producer's
+    verdict wins where it has said anything (stale/pending/failed); the derived
+    verdict fills its silence and never overwrites its speech.
   */
-  const freshnessNotice =
-    (block.freshness ? FRESHNESS_NOTICE[block.freshness] : undefined) ??
-    (currency === 'changed' ? FRESHNESS_NOTICE.stale : undefined)
+  const currency = useCoachingCurrency(block.graph_hash_at_generation)
+  const freshnessNotice = resolveFreshnessNotice(block.freshness, currency)
   const kindSentence = KIND_SENTENCE[block.coaching_kind]
   const sourceSentence = SOURCE_SENTENCE[block.source]
   const claim = block.dsk_claim_provenance

--- a/src/v5/blocks/V5EvidenceBlock.tsx
+++ b/src/v5/blocks/V5EvidenceBlock.tsx
@@ -15,7 +15,13 @@
  *   - `severity` drives the visual channel only (border/icon colour per
  *     the DS three-channel rule) — identical mapping to V5ReviewCardBlock.
  *   - `current_confidence` / `freshness` / `block_id` ride as data-*
- *     attributes only — never rendered as copy.
+ *     attributes only — never rendered as copy — EXCEPT that the freshness/
+ *     currency verdict now resolves to a plain-English notice (#670's
+ *     mechanism, extended to this card; the #670 witness recorded evidence
+ *     blocks carrying the superseded hash with no sentence, `WITNESS.md`
+ *     §F1). Producer's verdict wins; the render-time derivation fills its
+ *     silence. `cannot_confirm` rides as `data-currency` only (no depth
+ *     layer on this card; #670 keeps cannot-confirm off the face).
  *   - `action_label` renders as a display-only outlined pill this slice;
  *     wiring `action_intent` to turn dispatch remains the recorded
  *     follow-up from slice 1.
@@ -24,6 +30,8 @@ import { type ReactElement } from 'react'
 import { AlertTriangle, Search } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
+import { resolveFreshnessNotice } from './coachingCurrency'
+import { useCoachingCurrency } from './useCoachingCurrency'
 import type { V5EvidenceBlock as V5EvidenceBlockType } from '../../canvas/conversation/types'
 
 export interface V5EvidenceBlockProps {
@@ -48,6 +56,13 @@ export function V5EvidenceBlock({ block }: V5EvidenceBlockProps): ReactElement {
   // top-level factor_label is a backward-compatibility convenience.
   const primaryFactor = block.target_refs.find((ref) => ref.kind === 'factor')
   const title = primaryFactor?.label ?? block.factor_label
+  /*
+    THE UNCERTAINTY CHANNEL — #670's mechanism, consumed through the shared
+    seam (`useCoachingCurrency` → `deriveCoachingCurrency`). Render-time, so
+    the card starts telling the truth the moment the model moves.
+  */
+  const currency = useCoachingCurrency(block.graph_hash_at_generation)
+  const freshnessNotice = resolveFreshnessNotice(block.freshness, currency)
   return (
     <div
       data-testid="v5-evidence"
@@ -55,6 +70,7 @@ export function V5EvidenceBlock({ block }: V5EvidenceBlockProps): ReactElement {
       data-current-confidence={block.current_confidence}
       data-severity={block.severity}
       data-freshness={block.freshness}
+      data-currency={currency}
       className={`rounded-xl border ${SEVERITY_BORDER[block.severity]} bg-panel p-4 space-y-2`}
     >
       <div className="flex items-start gap-2">
@@ -76,6 +92,14 @@ export function V5EvidenceBlock({ block }: V5EvidenceBlockProps): ReactElement {
       <p className={typography.panelBody} data-testid="v5-evidence-impact">
         {block.impact_if_gathered}
       </p>
+      {freshnessNotice && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="v5-evidence-freshness"
+        >
+          {freshnessNotice}
+        </p>
+      )}
       {block.target_refs.length > 0 && (
         <div
           className="flex flex-wrap gap-2"

--- a/src/v5/blocks/V5ExerciseBlock.tsx
+++ b/src/v5/blocks/V5ExerciseBlock.tsx
@@ -16,7 +16,15 @@
  *     legacy exercise idiom's info badge. No severity exists on this
  *     block type, so no severity channel is fabricated.
  *   - `exercise_kind` / `freshness` / `block_id` ride as data-*
- *     attributes only — never rendered as copy.
+ *     attributes only — never rendered as copy — EXCEPT that the freshness/
+ *     currency verdict now resolves to a plain-English notice (#670's
+ *     mechanism, extended to this card: exercise blocks carry
+ *     `graph_hash_at_generation` on the live wire — T3 / no-critiques
+ *     captures — and a pre-mortem about a model that no longer exists is as
+ *     stale as any assumption card). Producer's verdict wins; the render-time
+ *     derivation fills its silence. `cannot_confirm` rides as `data-currency`
+ *     only (no depth layer on this card; #670 keeps cannot-confirm off the
+ *     face).
  *   - `target_element_ref` (the element the exercise targets) and
  *     `target_refs` render together as reference pills, labels verbatim.
  */
@@ -24,6 +32,8 @@ import { type ReactElement } from 'react'
 import { BookOpenCheck, ClipboardList } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
+import { resolveFreshnessNotice } from './coachingCurrency'
+import { useCoachingCurrency } from './useCoachingCurrency'
 import type {
   V5BlockTargetRef,
   V5ExerciseBlock as V5ExerciseBlockType,
@@ -47,12 +57,21 @@ export function V5ExerciseBlock({ block }: V5ExerciseBlockProps): ReactElement {
     refs.push(ref)
   }
 
+  /*
+    THE UNCERTAINTY CHANNEL — #670's mechanism, consumed through the shared
+    seam (`useCoachingCurrency` → `deriveCoachingCurrency`). Render-time, so
+    the card starts telling the truth the moment the model moves.
+  */
+  const currency = useCoachingCurrency(block.graph_hash_at_generation)
+  const freshnessNotice = resolveFreshnessNotice(block.freshness, currency)
+
   return (
     <div
       data-testid="v5-exercise"
       data-block-id={block.block_id}
       data-exercise-kind={block.exercise_kind}
       data-freshness={block.freshness}
+      data-currency={currency}
       className="rounded-xl border border-info/30 bg-panel p-4 space-y-2"
     >
       {/*
@@ -125,6 +144,14 @@ export function V5ExerciseBlock({ block }: V5ExerciseBlockProps): ReactElement {
           )}
         </div>
       </div>
+      {freshnessNotice && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="v5-exercise-freshness"
+        >
+          {freshnessNotice}
+        </p>
+      )}
       {refs.length > 0 && (
         <div
           className="flex flex-wrap gap-2"

--- a/src/v5/blocks/V5ReviewCardBlock.tsx
+++ b/src/v5/blocks/V5ReviewCardBlock.tsx
@@ -10,7 +10,18 @@
  *     the DS three-channel rule): info → info, warning → warning,
  *     critical → danger.
  *   - `card_kind` / `freshness` / `block_id` ride as data-* attributes for
- *     tests + diagnostics; they are never rendered as copy.
+ *     tests + diagnostics; they are never rendered as copy — EXCEPT that the
+ *     freshness/currency verdict now resolves to a plain-English notice
+ *     (#670's mechanism, extended to this card): the producer's verdict wins
+ *     where it has spoken (stale/pending/failed), and the render-time
+ *     CEE-hash-vs-CEE-hash derivation fills its silence. The #670 browser
+ *     witness caught THIS card silent — two "load-bearing assumption" review
+ *     cards directly above a coaching card that said it was out of date, all
+ *     three carrying the same superseded hash (`WITNESS.md` §F1).
+ *   - `cannot_confirm` rides as `data-currency` only: this card has no depth
+ *     layer, and #670 deliberately keeps cannot-confirm OFF the face (the
+ *     card makes no currency claim there, so there is nothing false to
+ *     correct). Minting a disclosure here would be new design, not extension.
  *   - `action_label` renders as a display-only outlined pill this slice;
  *     wiring `action_intent` to turn dispatch is a recorded follow-up
  *     (next round), not invented here.
@@ -19,6 +30,8 @@ import { type ReactElement } from 'react'
 import { AlertTriangle, Lightbulb } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { TargetRefPill } from '../../canvas/conversation/components/TargetRefPill'
+import { resolveFreshnessNotice } from './coachingCurrency'
+import { useCoachingCurrency } from './useCoachingCurrency'
 import type { V5ReviewCardBlock as V5ReviewCardBlockType } from '../../canvas/conversation/types'
 
 export interface V5ReviewCardBlockProps {
@@ -39,6 +52,14 @@ const SEVERITY_ICON_COLOUR: Record<V5ReviewCardBlockType['severity'], string> = 
 
 export function V5ReviewCardBlock({ block }: V5ReviewCardBlockProps): ReactElement {
   const Icon = block.severity === 'info' ? Lightbulb : AlertTriangle
+  /*
+    THE UNCERTAINTY CHANNEL — #670's mechanism, consumed through the shared
+    seam (`useCoachingCurrency` → `deriveCoachingCurrency`; see those modules
+    for the whole argument). Read at RENDER time so a card already on screen
+    starts telling the truth the moment the model moves underneath it.
+  */
+  const currency = useCoachingCurrency(block.graph_hash_at_generation)
+  const freshnessNotice = resolveFreshnessNotice(block.freshness, currency)
   return (
     <div
       data-testid="v5-review-card"
@@ -46,6 +67,7 @@ export function V5ReviewCardBlock({ block }: V5ReviewCardBlockProps): ReactEleme
       data-card-kind={block.card_kind}
       data-severity={block.severity}
       data-freshness={block.freshness}
+      data-currency={currency}
       className={`rounded-xl border ${SEVERITY_BORDER[block.severity]} bg-panel p-4 space-y-2`}
     >
       <div className="flex items-start gap-2">
@@ -61,6 +83,14 @@ export function V5ReviewCardBlock({ block }: V5ReviewCardBlockProps): ReactEleme
       <p className={typography.panelBody} data-testid="v5-review-card-body">
         {block.body}
       </p>
+      {freshnessNotice && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="v5-review-card-freshness"
+        >
+          {freshnessNotice}
+        </p>
+      )}
       {block.target_refs.length > 0 && (
         <div
           className="flex flex-wrap gap-2"

--- a/src/v5/blocks/__tests__/V5Phase3Blocks.currencyExtension.spec.tsx
+++ b/src/v5/blocks/__tests__/V5Phase3Blocks.currencyExtension.spec.tsx
@@ -1,0 +1,522 @@
+/**
+ * #670 EXTENSION — THE OTHER THREE HASH-CARRYING CARDS LEARN TO SAY THEIR
+ * CONTENT IS OUT OF DATE.
+ *
+ * ## The witnessed gap this closes
+ *
+ * #670's own browser witness (`browser-witness-670-2026-08-12/WITNESS.md` §F1)
+ * recorded, on a single superseded turn, `graph_hash_at_generation:
+ * 535e857ac14881b5` carried by **4 review_card and 2 evidence blocks as well as
+ * the 4 coaching blocks** — and in the DOM after the edit, 0 of 4 review cards
+ * carried `data-currency` or the staleness sentence. Two "A load-bearing
+ * assumption" review cards sat immediately above a coaching card that said it
+ * was out of date, with identical content lineage and no notice of their own.
+ * Same data, same surface, no sentence.
+ *
+ * ## The carrier domain (derived, not inherited — trap 22)
+ *
+ * All four Phase 3 typed block types carry the hash on the live wire:
+ * coaching (#670, done), review_card, evidence, AND exercise (live fixtures
+ * `live-analysis-turn-T3-20260808T155759Z.json` and
+ * `live-analysis-turn-no-critiques-2026-08-08.json`, one hash-bearing exercise
+ * each). At schemas 0.39.0 the field is REQUIRED on ReviewCardBlockSchema and
+ * EvidenceBlockSchema and optional on CoachingBlockSchema and
+ * ExerciseBlockSchema (`dist/boundary/blocks.d.ts:1074/1452/1184/1669`). The
+ * adapters still treat it as optional: absence costs the VERDICT
+ * (cannot-confirm), never the card — #670's witnessed discriminating control,
+ * unchanged here.
+ *
+ * ## One authority, three new consumers, zero new sentences
+ *
+ * Every verdict below is `deriveCoachingCurrency` — imported, never copied —
+ * fed through the single consumption seam (`useCoachingCurrency`) that also
+ * feeds the coaching card, so no surface can drift on HOW the authority is
+ * consulted (e.g. silently dropping the import-hold argument). The sentences
+ * are #670's exact strings, now exported from `coachingCurrency.ts` rather
+ * than duplicated per renderer: a copied sentence map is the same-named-twin
+ * defect this estate keeps paying for (trap 12).
+ *
+ * The producer's verdict always wins where the block speaks for itself
+ * (stale / pending / failed); the derivation fills SILENCE only (`fresh`,
+ * which is what CEE stamps at emission on every block a user ever reads —
+ * wire-measured 13/13 in #670).
+ *
+ * ## Binding discipline
+ *
+ * Every fixture is wire-shaped (field-for-field from the T3 capture), adapts
+ * through the REAL producer path (`adaptTyped*Block`), mounts through the REAL
+ * transcript renderer (`InlineBlocks`), and every assertion binds by IDENTITY
+ * (`data-block-id`), never by a value predicate another card could satisfy
+ * (trap 19).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, within } from '@testing-library/react'
+
+import { InlineBlocks } from '../../../canvas/conversation/InlineBlocks'
+import { useCanvasStore } from '../../../canvas/store'
+import {
+  classifyFreshnessForDisplay,
+  type AnalysisFreshnessState,
+} from '../../../canvas/store/analysisFreshness'
+import {
+  adaptTypedReviewCardBlock,
+  adaptTypedEvidenceBlock,
+  adaptTypedExerciseBlock,
+} from '../../phase3TypedBlocks'
+import type { ConversationBlock } from '../../../canvas/conversation/types'
+
+/** The exact sentences #644 shipped and #670 made reachable. Reused, never re-authored. */
+const CHANGED_SENTENCE =
+  'Your model has changed since this was written — it may no longer apply.'
+const PENDING_SENTENCE = 'This is still being written.'
+
+/**
+ * CEE-shaped hashes. HASH_AT_GENERATION is the exact hash the #670 browser
+ * witness recorded on the superseded turn's review_card and evidence blocks;
+ * HASH_AFTER_EDIT is the post-edit hash from the same session's captures.
+ */
+const HASH_AT_GENERATION = '535e857ac14881b5'
+const HASH_AFTER_EDIT = '94eefbc9b712082d'
+/** A third CEE-shaped value, for the "analysis ran on an older graph" twin. */
+const HASH_AT_RUN = 'a1b2c3d4e5f60718'
+
+const REVIEW_ID = '4440b6a7-f373-567c-8c4b-38f46328b785'
+const EVIDENCE_ID = '73e31daf-8a42-5260-9c13-e209b70f70ba'
+const EXERCISE_ID = 'c3683223-2330-5431-b911-fe01086f2ecf'
+const COACHING_ID = '7e0855c7-d79d-5d16-9fee-19e68ece297d'
+
+/** Wire-shaped raw blocks, field-for-field from live-analysis-turn-T3-20260808T155759Z.json. */
+function rawReviewCard(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'review_card',
+    block_id: REVIEW_ID,
+    signal_id: 'review:narrative:27e97e8e072b8bec',
+    created_at: '2026-08-08T15:59:37.262Z',
+    source_handler: 'decision_review_enricher',
+    card_kind: 'narrative',
+    title: 'How the analysis reads',
+    body: 'Pilot HubSpot with Sales Pod First leads by a substantial 56 percentage points, but the result depends on how user adoption unfolds in practice.',
+    severity: 'info',
+    target_refs: [],
+    priority_rank: 10,
+    freshness: 'fresh',
+    graph_hash_at_generation: HASH_AT_GENERATION,
+    ...overrides,
+  }
+}
+
+function rawEvidence(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'evidence',
+    block_id: EVIDENCE_ID,
+    factor_label: 'User Adoption Uncertainty',
+    current_confidence: 'medium',
+    evidence_gap: 'Adoption rates have strong potential to swing the outcome.',
+    suggested_technique: 'Survey or interview sales staff to estimate likely adoption.',
+    impact_if_gathered: 'Estimate likely adoption before looking at external benchmarks.',
+    priority_rank: 1,
+    severity: 'info',
+    freshness: 'fresh',
+    target_refs: [
+      { id: 'fac_adoption_risk', label: 'User Adoption Uncertainty', kind: 'factor' },
+    ],
+    graph_hash_at_generation: HASH_AT_GENERATION,
+    ...overrides,
+  }
+}
+
+function rawExercise(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'exercise',
+    block_id: EXERCISE_ID,
+    signal_id: 'exercise:consider_opposite:27e97e8e072b8bec',
+    exercise_kind: 'consider_opposite',
+    counter_case:
+      'Take the opposite view for a moment: assume the option in front turns out to be the wrong choice.',
+    freshness: 'fresh',
+    target_refs: [
+      { id: 'opt_phased', label: 'Pilot HubSpot with Sales Pod First', kind: 'option' },
+    ],
+    graph_hash_at_generation: HASH_AT_GENERATION,
+    ...overrides,
+  }
+}
+
+/** Mount through the REAL transcript renderer. */
+function mount(blocks: ConversationBlock[]): void {
+  render(<InlineBlocks blocks={blocks} />)
+}
+
+/** Bind by IDENTITY: the card carrying THIS block_id, never "some card". */
+function theCard(blockId: string): HTMLElement {
+  const card = document.querySelector(`[data-block-id="${blockId}"]`)
+  expect(card, `a card with data-block-id=${blockId} must be mounted by InlineBlocks`).not.toBeNull()
+  return card as HTMLElement
+}
+
+/** Set the CEE-sourced current graph hash exactly as `analysisFreshness` stores it. */
+function setCeeCurrentGraphHash(currentGraphHash: string | undefined): void {
+  useCanvasStore.setState({
+    analysisFreshness:
+      currentGraphHash === undefined
+        ? { freshness: 'fresh' }
+        : { freshness: 'fresh', currentGraphHash },
+    analysisFreshnessDirty: false,
+  })
+}
+
+/**
+ * Install the dirty-window state AND return the shared authority's own reading
+ * of it, so every dirty-window case pins its precondition (trap 13b): a fixture
+ * that stopped reproducing the state it names fails on the precondition, not
+ * passes by accident.
+ */
+function installDirtyWindow(
+  state: AnalysisFreshnessState | null,
+  opts: { dirty: boolean } = { dirty: true },
+): 'current' | 'changed' | 'cannot_confirm' | 'none' {
+  useCanvasStore.setState({
+    analysisFreshness: state,
+    analysisFreshnessDirty: opts.dirty,
+    importPendingServerRegistration: false,
+  })
+  return classifyFreshnessForDisplay(state, opts.dirty, false)
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    importPendingServerRegistration: false,
+  })
+})
+
+/**
+ * The three surfaces share one behaviour contract, asserted per-surface below
+ * (not in a loop over anonymous fixtures — each binding names its surface, its
+ * adapter, its testid prefix and its block id, so a failure names the card).
+ */
+
+describe('review card currency — the model moved underneath the assumption', () => {
+  const adapt = (raw: Record<string, unknown>) => {
+    const adapted = adaptTypedReviewCardBlock(raw)
+    expect(adapted, 'fixture must adapt — a null here would make every assertion vacuous').not.toBeNull()
+    return adapted as ConversationBlock
+  }
+
+  it('RED-FIRST: says the model has changed when CEE’s current hash differs from the block’s', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawReviewCard())])
+
+    const notice = within(theCard(REVIEW_ID)).getByTestId('v5-review-card-freshness')
+    expect(notice).toHaveTextContent(CHANGED_SENTENCE)
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'changed')
+  })
+
+  it('stays SILENT while the hashes agree — no "still current" noise', () => {
+    setCeeCurrentGraphHash(HASH_AT_GENERATION)
+    mount([adapt(rawReviewCard())])
+
+    expect(within(theCard(REVIEW_ID)).queryByTestId('v5-review-card-freshness')).toBeNull()
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'current')
+  })
+
+  it('a hash-less block is CANNOT-CONFIRM — never stale, never silently fresh (the witnessed control)', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    const raw = rawReviewCard()
+    delete raw.graph_hash_at_generation
+    mount([adapt(raw)])
+
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard(REVIEW_ID)).queryByTestId('v5-review-card-freshness')).toBeNull()
+  })
+
+  it('CANNOT-CONFIRM when the store holds no CEE hash — absence is never a change', () => {
+    setCeeCurrentGraphHash(undefined)
+    mount([adapt(rawReviewCard())])
+
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard(REVIEW_ID)).queryByTestId('v5-review-card-freshness')).toBeNull()
+  })
+
+  it('the PRODUCER’s own verdict wins — a pending card is not overwritten by a derived "changed"', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawReviewCard({ freshness: 'pending' }))])
+
+    const notice = within(theCard(REVIEW_ID)).getByTestId('v5-review-card-freshness')
+    expect(notice).toHaveTextContent(PENDING_SENTENCE)
+    expect(notice).not.toHaveTextContent(CHANGED_SENTENCE)
+  })
+
+  it('renders the sentence ONCE when producer and derivation agree it is stale', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawReviewCard({ freshness: 'stale' }))])
+
+    expect(within(theCard(REVIEW_ID)).getAllByTestId('v5-review-card-freshness')).toHaveLength(1)
+    expect(within(theCard(REVIEW_ID)).getByTestId('v5-review-card-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+  })
+
+  it('THE DIRTY WINDOW fills on this surface too: agreeing hashes + a local edit ⇒ changed', () => {
+    const semantic = installDirtyWindow(
+      { freshness: 'fresh', currentGraphHash: HASH_AT_GENERATION },
+      { dirty: true },
+    )
+    expect(semantic, 'precondition: the shared authority must read this state as changed').toBe('changed')
+
+    mount([adapt(rawReviewCard())])
+
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'changed')
+    expect(within(theCard(REVIEW_ID)).getByTestId('v5-review-card-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a CEE-stated stale analysis with NO local edit leaves the card alone', () => {
+    const semantic = installDirtyWindow(
+      { freshness: 'stale', graphHashAtRun: HASH_AT_RUN, currentGraphHash: HASH_AT_GENERATION },
+      { dirty: false },
+    )
+    expect(semantic, 'precondition: the authority must say CHANGED here, or this test proves nothing').toBe('changed')
+
+    mount([adapt(rawReviewCard())])
+
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'current')
+    expect(within(theCard(REVIEW_ID)).queryByTestId('v5-review-card-freshness')).toBeNull()
+  })
+})
+
+describe('evidence block currency — the model moved underneath the evidence gap', () => {
+  const adapt = (raw: Record<string, unknown>) => {
+    const adapted = adaptTypedEvidenceBlock(raw)
+    expect(adapted, 'fixture must adapt — a null here would make every assertion vacuous').not.toBeNull()
+    return adapted as ConversationBlock
+  }
+
+  it('RED-FIRST: says the model has changed when CEE’s current hash differs from the block’s', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawEvidence())])
+
+    const notice = within(theCard(EVIDENCE_ID)).getByTestId('v5-evidence-freshness')
+    expect(notice).toHaveTextContent(CHANGED_SENTENCE)
+    expect(theCard(EVIDENCE_ID)).toHaveAttribute('data-currency', 'changed')
+  })
+
+  it('stays SILENT while the hashes agree', () => {
+    setCeeCurrentGraphHash(HASH_AT_GENERATION)
+    mount([adapt(rawEvidence())])
+
+    expect(within(theCard(EVIDENCE_ID)).queryByTestId('v5-evidence-freshness')).toBeNull()
+    expect(theCard(EVIDENCE_ID)).toHaveAttribute('data-currency', 'current')
+  })
+
+  it('a hash-less block is CANNOT-CONFIRM (the witnessed control)', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    const raw = rawEvidence()
+    delete raw.graph_hash_at_generation
+    mount([adapt(raw)])
+
+    expect(theCard(EVIDENCE_ID)).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard(EVIDENCE_ID)).queryByTestId('v5-evidence-freshness')).toBeNull()
+  })
+
+  it('CANNOT-CONFIRM when the store holds no CEE hash', () => {
+    setCeeCurrentGraphHash(undefined)
+    mount([adapt(rawEvidence())])
+
+    expect(theCard(EVIDENCE_ID)).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard(EVIDENCE_ID)).queryByTestId('v5-evidence-freshness')).toBeNull()
+  })
+
+  it('the PRODUCER’s own verdict wins — pending is not overwritten by a derived "changed"', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawEvidence({ freshness: 'pending' }))])
+
+    const notice = within(theCard(EVIDENCE_ID)).getByTestId('v5-evidence-freshness')
+    expect(notice).toHaveTextContent(PENDING_SENTENCE)
+    expect(notice).not.toHaveTextContent(CHANGED_SENTENCE)
+  })
+
+  it('renders the sentence ONCE when producer and derivation agree it is stale', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawEvidence({ freshness: 'stale' }))])
+
+    expect(within(theCard(EVIDENCE_ID)).getAllByTestId('v5-evidence-freshness')).toHaveLength(1)
+  })
+
+  it('THE DIRTY WINDOW fills on this surface too', () => {
+    const semantic = installDirtyWindow(
+      { freshness: 'fresh', currentGraphHash: HASH_AT_GENERATION },
+      { dirty: true },
+    )
+    expect(semantic, 'precondition: the shared authority must read this state as changed').toBe('changed')
+
+    mount([adapt(rawEvidence())])
+
+    expect(theCard(EVIDENCE_ID)).toHaveAttribute('data-currency', 'changed')
+    expect(within(theCard(EVIDENCE_ID)).getByTestId('v5-evidence-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+  })
+})
+
+describe('exercise card currency — the model moved underneath the exercise', () => {
+  const adapt = (raw: Record<string, unknown>) => {
+    const adapted = adaptTypedExerciseBlock(raw)
+    expect(adapted, 'fixture must adapt — a null here would make every assertion vacuous').not.toBeNull()
+    return adapted as ConversationBlock
+  }
+
+  it('RED-FIRST: says the model has changed when CEE’s current hash differs from the block’s', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawExercise())])
+
+    const notice = within(theCard(EXERCISE_ID)).getByTestId('v5-exercise-freshness')
+    expect(notice).toHaveTextContent(CHANGED_SENTENCE)
+    expect(theCard(EXERCISE_ID)).toHaveAttribute('data-currency', 'changed')
+  })
+
+  it('stays SILENT while the hashes agree', () => {
+    setCeeCurrentGraphHash(HASH_AT_GENERATION)
+    mount([adapt(rawExercise())])
+
+    expect(within(theCard(EXERCISE_ID)).queryByTestId('v5-exercise-freshness')).toBeNull()
+    expect(theCard(EXERCISE_ID)).toHaveAttribute('data-currency', 'current')
+  })
+
+  it('a hash-less block is CANNOT-CONFIRM (the witnessed control)', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    const raw = rawExercise()
+    delete raw.graph_hash_at_generation
+    mount([adapt(raw)])
+
+    expect(theCard(EXERCISE_ID)).toHaveAttribute('data-currency', 'cannot_confirm')
+    expect(within(theCard(EXERCISE_ID)).queryByTestId('v5-exercise-freshness')).toBeNull()
+  })
+
+  it('the PRODUCER’s own verdict wins — pending is not overwritten by a derived "changed"', () => {
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([adapt(rawExercise({ freshness: 'pending' }))])
+
+    const notice = within(theCard(EXERCISE_ID)).getByTestId('v5-exercise-freshness')
+    expect(notice).toHaveTextContent(PENDING_SENTENCE)
+    expect(notice).not.toHaveTextContent(CHANGED_SENTENCE)
+  })
+
+  it('THE DIRTY WINDOW fills on this surface too', () => {
+    const semantic = installDirtyWindow(
+      { freshness: 'fresh', currentGraphHash: HASH_AT_GENERATION },
+      { dirty: true },
+    )
+    expect(semantic, 'precondition: the shared authority must read this state as changed').toBe('changed')
+
+    mount([adapt(rawExercise())])
+
+    expect(theCard(EXERCISE_ID)).toHaveAttribute('data-currency', 'changed')
+    expect(within(theCard(EXERCISE_ID)).getByTestId('v5-exercise-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+  })
+})
+
+describe('the witnessed scene — review cards and a coaching card on one superseded turn', () => {
+  it('every hash-bearing card on the turn tells the same truth after the model moves', async () => {
+    // The exact A1-03 scene: review cards above a coaching card, one content
+    // lineage. After the edit, ALL of them must carry the sentence — not just
+    // the coaching card.
+    const { adaptTypedCoachingBlock } = await import('../../phase3TypedBlocks')
+    const coaching = adaptTypedCoachingBlock({
+      type: 'coaching',
+      block_id: COACHING_ID,
+      title: 'An assumption to check',
+      body: 'The link assumes the current timeline holds.',
+      coaching_kind: 'assumption_check',
+      source: 'decision_review',
+      target_refs: [],
+      priority_rank: 101,
+      freshness: 'fresh',
+      graph_hash_at_generation: HASH_AT_GENERATION,
+    })
+    expect(coaching).not.toBeNull()
+    const review = adaptTypedReviewCardBlock(rawReviewCard())
+    expect(review).not.toBeNull()
+
+    setCeeCurrentGraphHash(HASH_AFTER_EDIT)
+    mount([review as ConversationBlock, coaching as ConversationBlock])
+
+    expect(theCard(REVIEW_ID)).toHaveAttribute('data-currency', 'changed')
+    expect(theCard(COACHING_ID)).toHaveAttribute('data-currency', 'changed')
+    expect(within(theCard(REVIEW_ID)).getByTestId('v5-review-card-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+    expect(within(theCard(COACHING_ID)).getByTestId('v5-coaching-freshness')).toHaveTextContent(
+      CHANGED_SENTENCE,
+    )
+  })
+})
+
+describe('adapter carry — graph_hash_at_generation rides verbatim or not at all', () => {
+  it('adaptTypedReviewCardBlock carries the producer hash VERBATIM', () => {
+    const adapted = adaptTypedReviewCardBlock(rawReviewCard())
+    expect(adapted?.graph_hash_at_generation).toBe(HASH_AT_GENERATION)
+  })
+
+  it('adaptTypedReviewCardBlock OMITS the field when the producer sent none — never invents', () => {
+    const raw = rawReviewCard()
+    delete raw.graph_hash_at_generation
+    const adapted = adaptTypedReviewCardBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('adaptTypedReviewCardBlock OMITS a non-string hash rather than coercing it', () => {
+    const adapted = adaptTypedReviewCardBlock(rawReviewCard({ graph_hash_at_generation: 12345 }))
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('a missing hash never costs the review CARD — the block still adapts', () => {
+    const raw = rawReviewCard()
+    delete raw.graph_hash_at_generation
+    expect(adaptTypedReviewCardBlock(raw)).not.toBeNull()
+  })
+
+  it('adaptTypedEvidenceBlock carries the producer hash VERBATIM', () => {
+    const adapted = adaptTypedEvidenceBlock(rawEvidence())
+    expect(adapted?.graph_hash_at_generation).toBe(HASH_AT_GENERATION)
+  })
+
+  it('adaptTypedEvidenceBlock OMITS the field when the producer sent none', () => {
+    const raw = rawEvidence()
+    delete raw.graph_hash_at_generation
+    const adapted = adaptTypedEvidenceBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('adaptTypedEvidenceBlock OMITS a non-string hash rather than coercing it', () => {
+    const adapted = adaptTypedEvidenceBlock(rawEvidence({ graph_hash_at_generation: 12345 }))
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('adaptTypedExerciseBlock carries the producer hash VERBATIM', () => {
+    const adapted = adaptTypedExerciseBlock(rawExercise())
+    expect(adapted?.graph_hash_at_generation).toBe(HASH_AT_GENERATION)
+  })
+
+  it('adaptTypedExerciseBlock OMITS the field when the producer sent none', () => {
+    const raw = rawExercise()
+    delete raw.graph_hash_at_generation
+    const adapted = adaptTypedExerciseBlock(raw)
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+
+  it('adaptTypedExerciseBlock OMITS a non-string hash rather than coercing it', () => {
+    const adapted = adaptTypedExerciseBlock(rawExercise({ graph_hash_at_generation: 12345 }))
+    expect(adapted).not.toBeNull()
+    expect(adapted && 'graph_hash_at_generation' in adapted).toBe(false)
+  })
+})

--- a/src/v5/blocks/coachingCurrency.ts
+++ b/src/v5/blocks/coachingCurrency.ts
@@ -152,6 +152,7 @@
  * this module exists to end, and inferring `changed` would cry wolf.
  */
 import type { FreshnessDisplaySemantic } from '../../canvas/store/analysisFreshness'
+import type { V5Phase3Freshness } from '../../canvas/conversation/types'
 
 /**
  * The three answers a coaching card can honestly give about its own currency.
@@ -160,6 +161,47 @@ import type { FreshnessDisplaySemantic } from '../../canvas/store/analysisFreshn
  * the ANALYSIS, not about whether this card's model still exists.
  */
 export type CoachingCurrency = Exclude<FreshnessDisplaySemantic, 'none'>
+
+/**
+ * Plain-English sentences for the freshness verdict — #644's copy, made
+ * reachable by #670 and shared here VERBATIM when the mechanism was extended
+ * to the other hash-carrying transcript cards (review_card / evidence /
+ * exercise). `fresh` is deliberately absent from this map: a current card
+ * says nothing, because a "this is current" badge on every card is noise that
+ * teaches the reader to ignore the one time it matters.
+ *
+ * ⚠ ONE copy, exported from the mechanism module. A per-renderer copy of
+ * these sentences is the same-named-twin defect this estate keeps paying for
+ * (trap 12): four cards drifting to three wordings of the same fact.
+ */
+export const FRESHNESS_NOTICE: Partial<Record<string, string>> = {
+  stale: 'Your model has changed since this was written — it may no longer apply.',
+  pending: 'This is still being written.',
+  failed: 'This could not be generated.',
+}
+
+/**
+ * The producer's verdict WINS when it has said anything at all.
+ *
+ * `freshness` answers "did this card generate correctly?" (pending / failed)
+ * and currency answers "is it still about your model?" — two questions, and
+ * trap 21 is what happens when two questions share one channel. So the
+ * derived verdict FILLS THE PRODUCER'S SILENCE and never overwrites its
+ * speech. When both point at staleness they resolve to the same sentence, so
+ * the notice renders once and cannot contradict itself.
+ *
+ * (Extracted verbatim from V5CoachingBlock when the mechanism was extended —
+ * the resolution rule is part of the mechanism, not of any one card.)
+ */
+export function resolveFreshnessNotice(
+  producerFreshness: V5Phase3Freshness | undefined,
+  currency: CoachingCurrency,
+): string | undefined {
+  return (
+    (producerFreshness ? FRESHNESS_NOTICE[producerFreshness] : undefined) ??
+    (currency === 'changed' ? FRESHNESS_NOTICE.stale : undefined)
+  )
+}
 
 /** A hash is usable only as a non-empty string; `''` is absence, not a value. */
 function usableHash(v: string | undefined | null): string | undefined {

--- a/src/v5/blocks/useCoachingCurrency.ts
+++ b/src/v5/blocks/useCoachingCurrency.ts
@@ -1,0 +1,54 @@
+/**
+ * useCoachingCurrency — THE ONE WAY a transcript card consults the currency
+ * authority.
+ *
+ * #670 built the authority (`deriveCoachingCurrency`) and one consumer
+ * (`V5CoachingBlock`). Extending the mechanism to the other hash-carrying
+ * Phase 3 cards (review_card / evidence / exercise) would have meant four
+ * copies of the SAME consumption boilerplate — three store subscriptions plus
+ * the `classifyFreshnessForDisplay` call — and four copies is how one of them
+ * eventually drops the import-hold argument, or reads a different store field,
+ * and two surfaces answer "has your model moved?" differently on the same
+ * turn. That is trap 21 by increments. So the consumption seam lives HERE,
+ * once, and every renderer calls this hook.
+ *
+ * NOTHING IS DERIVED IN THIS FILE. The verdict is `deriveCoachingCurrency`'s
+ * (see `coachingCurrency.ts` for the whole argument: CEE-hash-vs-CEE-hash,
+ * the dirty-window borrow, why absence is cannot-confirm). The dirtiness
+ * reading is `classifyFreshnessForDisplay`'s — byte-for-byte the call
+ * `V7FreshnessStrip.tsx` makes. This hook only wires store state to the
+ * authority's parameters.
+ *
+ * ⚠ BOTH HASH ARGUMENTS MUST BE CEE-PRODUCED. `blockGraphHash` is the block's
+ * `graph_hash_at_generation`; the current hash read here is
+ * `analysisFreshness.currentGraphHash` (`analysis_ready.current_graph_hash`).
+ * The UI's own `generateGraphHash` is a different algorithm over different
+ * inputs and MUST NOT be substituted on either side — the category error
+ * `guidanceStore.ts` §2b names. The executable pin for this lives in
+ * `V5CoachingBlock.currencyDirtyWindow.spec.tsx` §"the current hash is
+ * CEE-sourced", which now guards the seam for all four consumers at once.
+ */
+import { useCanvasStore } from '../../canvas/store'
+import { classifyFreshnessForDisplay } from '../../canvas/store/analysisFreshness'
+import { deriveCoachingCurrency, type CoachingCurrency } from './coachingCurrency'
+
+/**
+ * Read at RENDER time, on store subscriptions, so a card already on screen
+ * starts telling the truth the moment the model moves underneath it — the
+ * same render-time contract `TargetRefPill` documents ("a pill never points
+ * at a guess"). At ingest the two hashes are always equal, which is exactly
+ * why an ingest-time verdict would be worthless.
+ *
+ * @param blockGraphHash the block's `graph_hash_at_generation` (CEE `aag_v1`)
+ */
+export function useCoachingCurrency(
+  blockGraphHash: string | undefined | null,
+): CoachingCurrency {
+  const freshnessState = useCanvasStore((s) => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+  const importHold = useCanvasStore((s) => s.importPendingServerRegistration)
+  return deriveCoachingCurrency(blockGraphHash, freshnessState?.currentGraphHash, {
+    dirty: freshnessDirty,
+    displaySemantic: classifyFreshnessForDisplay(freshnessState, freshnessDirty, importHold),
+  })
+}

--- a/src/v5/phase3TypedBlocks.ts
+++ b/src/v5/phase3TypedBlocks.ts
@@ -22,9 +22,12 @@
  * though the schema declares it, and review_card may omit the optional
  * action fields. Adaptation therefore requires only the render-relevant
  * fields and deliberately ignores schema-required-but-render-irrelevant
- * metadata (signal_id, created_at, source_handler,
- * graph_hash_at_generation) — a real producer block must not be
- * suppressed over metadata the UI never shows.
+ * metadata (signal_id, created_at, source_handler) — a real producer
+ * block must not be suppressed over metadata the UI never shows.
+ * `graph_hash_at_generation` moved OUT of that ignored set when #670 made
+ * it render-relevant (the derived staleness sentence): every adapter now
+ * carries it VERBATIM when present, and its ABSENCE still never suppresses
+ * the block — it costs the currency verdict (cannot-confirm), not the card.
  *
  * Validation-strictness choices:
  *   - `severity` (review_card) must be one of the 0.13.x enum values —
@@ -117,6 +120,12 @@ export function adaptTypedReviewCardBlock(raw: unknown): V5ReviewCardBlock | nul
 
   const actionIntent = nonEmptyString(raw.action_intent)
   const actionLabel = nonEmptyString(raw.action_label)
+  // CEE's graph hash at authoring time, carried verbatim so the card can
+  // compare it — at RENDER time — against CEE's CURRENT graph hash (#670's
+  // mechanism, extended to this surface). A non-string is DROPPED rather
+  // than coerced: a fabricated hash would compare unequal to everything and
+  // manufacture a permanent false "changed".
+  const graphHashAtGeneration = nonEmptyString(raw.graph_hash_at_generation)
 
   return {
     type: 'v5_review_card',
@@ -130,6 +139,7 @@ export function adaptTypedReviewCardBlock(raw: unknown): V5ReviewCardBlock | nul
     freshness: fresh,
     ...(actionIntent ? { action_intent: actionIntent } : {}),
     ...(actionLabel ? { action_label: actionLabel } : {}),
+    ...(graphHashAtGeneration ? { graph_hash_at_generation: graphHashAtGeneration } : {}),
   }
 }
 
@@ -311,9 +321,10 @@ function optionalRef(v: unknown): V5BlockTargetRef | undefined {
  * current_confidence (data-* discriminator, non-empty string — NOT
  * enum-narrowed), priority_rank, severity (visual channel — enum-checked
  * like review_card), freshness, target_refs. Schema-declared metadata the
- * UI never shows (signal_id, created_at, source_handler,
- * graph_hash_at_generation) is deliberately NOT required — live staging
- * omits it on the other Phase 3 types.
+ * UI never shows (signal_id, created_at, source_handler) is deliberately
+ * NOT required — live staging omits it on the other Phase 3 types.
+ * `graph_hash_at_generation` is carried verbatim when present (render-
+ * relevant since the #670 staleness extension) and never required.
  */
 export function adaptTypedEvidenceBlock(raw: unknown): V5EvidenceBlock | null {
   if (!isPlainObject(raw)) return null
@@ -341,6 +352,8 @@ export function adaptTypedEvidenceBlock(raw: unknown): V5EvidenceBlock | null {
   const factorRef = optionalRef(raw.factor_ref)
   const actionIntent = nonEmptyString(raw.action_intent)
   const actionLabel = nonEmptyString(raw.action_label)
+  // #670's staleness mechanism, extended: verbatim carry, non-strings dropped.
+  const graphHashAtGeneration = nonEmptyString(raw.graph_hash_at_generation)
 
   return {
     type: 'v5_evidence',
@@ -357,6 +370,7 @@ export function adaptTypedEvidenceBlock(raw: unknown): V5EvidenceBlock | null {
     freshness: fresh,
     ...(actionIntent ? { action_intent: actionIntent } : {}),
     ...(actionLabel ? { action_label: actionLabel } : {}),
+    ...(graphHashAtGeneration ? { graph_hash_at_generation: graphHashAtGeneration } : {}),
   }
 }
 
@@ -444,6 +458,8 @@ export function adaptTypedExerciseBlock(raw: unknown): V5ExerciseBlock | null {
 
   const targetElementRef = optionalRef(raw.target_element_ref)
   const dskProvenance = dskProtocolProvenance(raw.dsk_provenance)
+  // #670's staleness mechanism, extended: verbatim carry, non-strings dropped.
+  const graphHashAtGeneration = nonEmptyString(raw.graph_hash_at_generation)
 
   return {
     type: 'v5_exercise',
@@ -459,5 +475,6 @@ export function adaptTypedExerciseBlock(raw: unknown): V5ExerciseBlock | null {
     ...(targetElementRef ? { target_element_ref: targetElementRef } : {}),
     target_refs: refs,
     freshness: fresh,
+    ...(graphHashAtGeneration ? { graph_hash_at_generation: graphHashAtGeneration } : {}),
   }
 }


### PR DESCRIPTION
## What a user now sees

A "load-bearing assumption" review card, an evidence block or a pre-mortem exercise card that was written about a model the user has since changed now says so, in #670's exact words: **"Your model has changed since this was written — it may no longer apply."** — instead of sitting silent directly above a coaching card that admits it is out of date.

#670's own browser witness caught the gap (`browser-witness-670-2026-08-12/WITNESS.md` §F1): on one superseded turn, `graph_hash_at_generation: 535e857ac14881b5` was carried by **4 review_card + 2 evidence + 4 coaching** blocks; after the edit, 0 of 4 review cards carried `data-currency` or the sentence.

## Carrier domain (derived, trap 22)

All four Phase 3 typed block types carry the hash on the live wire (7 fixtures swept; exercise carries it in the T3 + no-critiques captures). Schemas 0.39.0: REQUIRED on `ReviewCardBlockSchema`/`EvidenceBlockSchema` (blocks.d.ts:1074/1452), optional on coaching/exercise (:1184/:1669). Coaching was done in #670; this PR extends to **review_card, evidence and exercise**.

**Deliberate exclusions:** legacy review-card bridge (dead on the current wire — every fixture review_card adapts typed); guidanceStore surfaces (#670's transcript-only ruling — cleared on edit, replaced per turn); no visible `cannot_confirm` sentence on the three new cards (they have no depth layer; #670 deliberately keeps cannot-confirm off the face, and minting a disclosure would be new design — it rides as `data-currency`).

## One authority, one seam, zero new sentences

- Adapters carry the hash **verbatim** (non-strings dropped, never coerced); absence costs the verdict (`cannot_confirm`), never the card — #670's witnessed discriminating control, unchanged.
- `useCoachingCurrency` is the ONE consumption seam (3 store reads + `classifyFreshnessForDisplay` + `deriveCoachingCurrency`), shared by all four renderers — no surface can drift on how it feeds the authority.
- `FRESHNESS_NOTICE` + the producer-wins resolution moved **verbatim** from V5CoachingBlock-private to `coachingCurrency.ts` exports (a per-renderer copy of the sentences is the same-named-twin defect, trap 12). Producer's verdict wins where it has spoken (stale/pending/failed); derivation fills silence only.
- V5CoachingBlock folded onto the seam — behaviour identical, and both #670 spec files run against it unchanged and green (trap 5: the fold is re-verified by the pins that already exist).

## Evidence

- **RED-first at pristine `f04e756d`**: 24 failed / 7 passed (31 collected) — named signatures (`data-currency` null, `v5-review-card-freshness` not found, adapter carry `undefined`). The 7 pristine-green are omission guards, covered by mutants instead.
- **GREEN**: 31/31 new spec by name; 232 files / 3385 passed / 22 skipped across `src/v5/blocks/__tests__`, `src/v5/__tests__`, `src/canvas/conversation/__tests__`, `schema-adoption-contract.test.ts`; `pnpm typecheck` gate PASSED (2 diagnostics fixed, none added — baseline untouched); eslint 0 errors on changed files.
- **Mutant kit (7, isolated worktree, write-proven isolation, HEAD-relative restores, applied-checks exact, pristine controls 55/55 both ends):**
  - **M1 discriminating pair**: review-card wiring dropped → 5 RED, ALL of them review-card pins + the witnessed-scene test, while BOTH #670 coaching specs stay GREEN.
  - M2/M3: evidence / exercise drops → only their own pins RED.
  - M4: producer-wins inverted → RED on every surface.
  - **M5 family identity** (mirrors #670's M5): seam substitutes UI `generateGraphHash` for the CEE current hash → 11 RED across all three spec files.
  - M6: `cannot_confirm` collapsed to `current` → 9 RED (the witnessed control discriminates).
  - M7: adapter drops the hash for review_card only → 6 RED, review-only (second discriminating arm at the adapter level).
- Full stream: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/coaching-surface-2026-08-12/STALENESS-EXTENSION.md`.

## Residual risk

- `cannot_confirm` is invisible copy-wise on the three new card types (attribute only) — a follow-up may add a depth layer if design authorises one.
- The three new notices render from the same producer-wins rule as coaching, so a producer `stale`/`pending`/`failed` on these types now renders a sentence that was previously data-* only — same copy, previously unreachable for the same reason #670 documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
