### PR TITLE
feat(collab): "Ask a teammate" — unresolved estimate row → pre-filled blind-round mint (capability A hop)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/CalibrateDrillIn.tsx
@@ -85,10 +85,13 @@
  */
 
 import { memo, useCallback, useState } from 'react'
-import { Check, MessageSquare } from 'lucide-react'
+import { Check, MessageSquare, Users } from 'lucide-react'
 import Tooltip from '../../../../components/Tooltip'
 import { typography, typo } from '../../../../styles/typography'
 import { FIELD_FEEDBACK_COPY } from '../constants'
+import { useAuth } from '../../../../contexts/AuthContext'
+import { isPersistenceActive } from '../../../../lib/persistenceActive'
+import { ownerPanelHash } from '../../../../collab/panelRoute'
 import { useCanvasStore } from '../../../store'
 import { getObservedState, type ObservedStateData } from '../../../utils/observedStateHelpers'
 import { useOptionalConversationContext } from '../../../conversation/ConversationContext'
@@ -182,6 +185,41 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
   const canDescribeInWords = useCanvasStore(s =>
     acceptsElicitedBelief(s.nodes.find(n => n.id === row.nodeId)?.data),
   )
+
+  /**
+   * CAPABILITY A — "Ask a teammate": the hop from an unresolved unknown to a
+   * pre-filled blind-round mint. An anchor to the EXISTING setup page via
+   * `ownerPanelHash` (the single href authority), carrying `{factorId, label,
+   * unit}` in the hash query; the mint, blindness and reveal machinery
+   * downstream are byte-untouched. No value rides — CEE's `parseTargets`
+   * structurally refuses value fields, and the prefill type has nowhere to
+   * put one; a teammate is asked BLIND, which is the point.
+   *
+   * THE GUARD is the #672 pattern (TopBar's panel entry): render ONLY where
+   * the mint can succeed — a PERSISTED scenario (CEE refuses a guest
+   * scenario: no immutable model version to pin) under a SIGNED-IN NON-GUEST
+   * user (the mint is owner-JWT; note `useAuth()` reports guests as
+   * `authenticated: true`, so the guest check inside `isPersistenceActive` is
+   * load-bearing). Anywhere else the affordance would be an advertised action
+   * terminating in refusal — the Research-CTA anti-pattern.
+   *
+   * Offered on UNRESOLVED rows only (`!row.reviewed`, including rows that
+   * still need a value): a reviewed row is no longer an unknown, and its
+   * drill-in is the repair surface, not the elicitation one.
+   */
+  const { user, authenticated } = useAuth()
+  const scenarioId = useCanvasStore(s => s.currentScenarioId)
+  // The factor's own unit, by the same predicate `refusesNormalisedScaleEntry`
+  // uses; the row model carries no unit. Primitive selector result (string |
+  // null) — the fresh-object zustand guard applies here too.
+  const factorUnit = useCanvasStore(s => {
+    const unit = getObservedState(s.nodes.find(n => n.id === row.nodeId)?.data).unit
+    return unit != null && String(unit).trim() !== '' ? String(unit) : null
+  })
+  const askTeammateHref =
+    !row.reviewed && isPersistenceActive(authenticated, user) && scenarioId != null && scenarioId !== ''
+      ? ownerPanelHash(scenarioId, { factorId: row.nodeId, label: row.label, unit: factorUnit })
+      : null
 
   // The sanctioned setter (the `NODE_SETTER_FIELDS` manifest the writtenFields
   // guard spec enforces), not a hand-rolled `updateNode` — the same one both
@@ -522,6 +560,25 @@ export const CalibrateDrillIn = memo(function CalibrateDrillIn({ row, onDone }: 
           >
             <MessageSquare className="h-3.5 w-3.5" aria-hidden />
           </PanelIconButton>
+        </Tooltip>
+      )}
+      {/* CAPABILITY A: an anchor, not a navigate() — the app is a HashRouter
+          and this is TopBar's panel-entry pattern, so middle-click/new-tab
+          work. Guard + href derivation above. */}
+      {askTeammateHref !== null && (
+        <Tooltip content="Ask your team — everyone answers privately, then compare" delay={300}>
+          <a
+            href={askTeammateHref}
+            aria-label={`Ask a teammate about ${row.label}`}
+            data-testid={`pre-analysis-v3-ask-team-${row.nodeId}`}
+            className={typo(
+              'panelMeta',
+              'inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-panel-border bg-transparent px-2.5 py-1 text-text-body no-underline outline-none transition-colors hover:bg-panel-hover focus-visible:bg-panel-hover focus-visible:ring-2 focus-visible:ring-info/40',
+            )}
+          >
+            <Users className="h-3 w-3" aria-hidden />
+            Ask a teammate
+          </a>
         </Tooltip>
       )}
       {hint && (

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/askTeammateAffordance.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/askTeammateAffordance.spec.tsx
@@ -1,0 +1,193 @@
+/**
+ * Capability A — "Ask a teammate" from an unresolved estimate row.
+ *
+ * The ONE new hop: an unresolved unknown in the pre-analysis panel links to
+ * the EXISTING blind-round setup page with `{factorId, label, unit}`
+ * pre-filled through `ownerPanelHash` (the single href authority). Everything
+ * downstream — mint, blindness, reveal — is untouched machinery.
+ *
+ * THE GUARD (the #672 pattern, TopBar:403/CanvasMVP:276): the affordance
+ * renders ONLY where the mint can succeed — a PERSISTED scenario under a
+ * SIGNED-IN (non-guest) user. CEE's mint is owner-JWT and refuses guests and
+ * unpersisted scenarios; an affordance shown there would be an advertised
+ * action terminating in refusal (the Research-CTA anti-pattern).
+ *
+ * THE IDENTITY BINDING (trap 19): the href must carry THE ROW'S OWN factor id
+ * — the discriminating fixture puts a DIFFERENT factor FIRST in the store, so
+ * a mutant that binds to "the first row" REDs here while every value-predicate
+ * assertion would have stayed green.
+ *
+ * ANTI-ANCHORING IS INHERITED, NOT RE-IMPLEMENTED: the href carries no value
+ * field — pinned by the query-key manifest test, and structurally refused at
+ * CEE's `parseTargets` even if a future caller tried.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+vi.mock('../../../../../contexts/AuthContext', async (importOriginal) => {
+  // Spread the real module (trap 12): a hand-listed factory REPLACES it and
+  // silently drops every export added later.
+  const actual = await importOriginal<typeof import('../../../../../contexts/AuthContext')>()
+  return { ...actual, useAuth: vi.fn() }
+})
+
+import { useAuth } from '../../../../../contexts/AuthContext'
+import { CalibrateDrillIn } from '../CalibrateDrillIn'
+import { ownerPanelHash, readPanelPrefill } from '../../../../../collab/panelRoute'
+import { useCanvasStore } from '../../../../store'
+import type { EstimateRowModel } from '../../types'
+
+const SCENARIO_ID = 'scn-persisted-11111111'
+/** The DECOY sits FIRST in the store — a first-row binding must RED. */
+const DECOY_FIRST_FACTOR = 'fac_decoy_first_in_store'
+const ROW_FACTOR = 'fac_churn_risk_THE_ROW'
+const ROW_LABEL = 'Churn risk after a price rise'
+
+const row: EstimateRowModel = {
+  nodeId: ROW_FACTOR,
+  label: ROW_LABEL,
+  rankLabel: 'top',
+  weight: 1,
+  reviewed: false,
+  aiSourced: true,
+  attribution: { kind: 'olumi' },
+  displayText: '30%',
+  rawPrefill: 30,
+  cap: 100,
+  canEditValue: true,
+  needsValue: false,
+}
+
+function factorNode(id: string, label: string, unit: string | null): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'factor',
+      label,
+      provenance: 'ai_inferred',
+      observedState: {
+        value: 0.3,
+        raw_value: 30,
+        cap: 100,
+        source: 'cee_inference',
+        ...(unit !== null ? { unit } : {}),
+      },
+    },
+  } as Node
+}
+
+function seedStore(over: { scenarioId?: string | null; rowUnit?: string | null } = {}): void {
+  useCanvasStore.setState({
+    nodes: [
+      // Decoy FIRST: the wrong-factor mutant binds here and must RED.
+      factorNode(DECOY_FIRST_FACTOR, 'A decoy factor', 'engineers'),
+      factorNode(ROW_FACTOR, ROW_LABEL, over.rowUnit === undefined ? '%' : over.rowUnit),
+    ] as never,
+    edges: [] as never,
+    currentScenarioId: over.scenarioId === undefined ? SCENARIO_ID : over.scenarioId,
+  } as never)
+}
+
+function signIn(kind: 'owner' | 'guest' | 'signed-out'): void {
+  const value =
+    kind === 'owner'
+      ? { user: { id: 'user-real-owner-1' }, authenticated: true }
+      : kind === 'guest'
+        ? { user: { id: 'guest' }, authenticated: true } // guests ARE authenticated in this app
+        : { user: null, authenticated: false }
+  vi.mocked(useAuth).mockReturnValue(value as ReturnType<typeof useAuth>)
+}
+
+function renderDrillIn(overrides: Partial<EstimateRowModel> = {}) {
+  return render(<CalibrateDrillIn row={{ ...row, ...overrides }} onDone={vi.fn()} />)
+}
+
+const TESTID = `pre-analysis-v3-ask-team-${ROW_FACTOR}`
+
+beforeEach(() => {
+  cleanup()
+  seedStore()
+  signIn('owner')
+})
+
+describe('the affordance renders where the mint can succeed', () => {
+  it('signed-in owner + persisted scenario + unresolved row → "Ask a teammate" is offered', () => {
+    renderDrillIn()
+    const link = screen.getByTestId(TESTID)
+    expect(link.tagName).toBe('A')
+    expect(link).toHaveTextContent('Ask a teammate')
+  })
+
+  it('a row that still NEEDS a value is exactly the ask-a-teammate case — offered', () => {
+    renderDrillIn({ needsValue: true, displayText: null, rawPrefill: null, canEditValue: true })
+    expect(screen.getByTestId(TESTID)).toBeInTheDocument()
+  })
+})
+
+describe('the guard — never an advertised action ending in refusal', () => {
+  it('GUEST: authenticated-but-guest cannot mint (owner-JWT) → no affordance', () => {
+    signIn('guest')
+    renderDrillIn()
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+
+  it('SIGNED OUT: no affordance', () => {
+    signIn('signed-out')
+    renderDrillIn()
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+
+  it('UNPERSISTED: no scenario id → CEE has no immutable model version to pin → no affordance', () => {
+    seedStore({ scenarioId: null })
+    renderDrillIn()
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+
+  it('RESOLVED: a reviewed row is not an unresolved unknown → no affordance', () => {
+    renderDrillIn({ reviewed: true, provenanceKind: 'confirmed', aiSourced: false })
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+})
+
+describe('the href is bound to THIS row by identity (trap 19)', () => {
+  function hrefOf(): string {
+    const href = screen.getByTestId(TESTID).getAttribute('href')
+    expect(href).not.toBeNull()
+    return href as string
+  }
+
+  it('DISCRIMINATING: carries the ROW factor id — not the store-first decoy', () => {
+    renderDrillIn()
+    const search = hrefOf().slice(hrefOf().indexOf('?'))
+    const prefill = readPanelPrefill(search)
+    expect(prefill?.factorId).toBe(ROW_FACTOR)
+    expect(prefill?.factorId).not.toBe(DECOY_FIRST_FACTOR)
+    expect(hrefOf()).not.toContain(DECOY_FIRST_FACTOR)
+  })
+
+  it('the whole href is the single authority’s output for THIS scenario, factor, label and unit', () => {
+    renderDrillIn()
+    expect(hrefOf()).toBe(
+      ownerPanelHash(SCENARIO_ID, { factorId: ROW_FACTOR, label: ROW_LABEL, unit: '%' }),
+    )
+  })
+
+  it('a factor with no unit sends unit null — never an invented one', () => {
+    seedStore({ rowUnit: null })
+    renderDrillIn()
+    const search = hrefOf().slice(hrefOf().indexOf('?'))
+    expect(readPanelPrefill(search)?.unit).toBeNull()
+  })
+
+  it('NO VALUE RIDES: the query carries only factor/label/unit — no value, no estimate, no anchor', () => {
+    renderDrillIn()
+    const search = hrefOf().slice(hrefOf().indexOf('?'))
+    const keys = [...new URLSearchParams(search).keys()].sort()
+    expect(keys.every((k) => ['factor', 'label', 'unit'].includes(k))).toBe(true)
+    expect(keys).toContain('factor')
+  })
+})

--- a/src/collab/__tests__/panelRoutePrefill.spec.ts
+++ b/src/collab/__tests__/panelRoutePrefill.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * COLLAB — the owner-panel href carries a PREFILL, and the bare href still works.
+ *
+ * Capability A's one new hop ("Ask a teammate" from an unresolved estimate row)
+ * navigates to the existing setup page with `{factorId, label, unit}` carried
+ * in the hash query. This file pins the carriage contract at the single href
+ * authority:
+ *
+ *   • BACKWARDS-COMPATIBLE — a bare call builds byte-exactly the old href, so
+ *     every existing caller (TopBar) is untouched;
+ *   • ROUND-TRIP — what `ownerPanelHash` writes, `readPanelPrefill` reads back
+ *     EXACTLY (identity, not normalisation): producer and consumer live in the
+ *     same module precisely so the two spellings cannot drift (trap 12);
+ *   • CONTAINMENT — hostile values are data, never structure: no factor id or
+ *     label can break out of the query into the route.
+ *
+ * NOTE WHAT IS NOT HERE: no value field. Anti-anchoring is CEE-enforced at the
+ * mint (`parseTargets` structurally refuses value-bearing fields); the prefill
+ * type simply has nowhere to put one, and this file's shape assertions keep it
+ * that way.
+ */
+import { describe, it, expect } from 'vitest'
+import { ownerPanelHash, readPanelPrefill, type PanelPrefill } from '../panelRoute'
+
+const PREFILL: PanelPrefill = {
+  factorId: 'factor-churn-risk',
+  label: 'Churn risk after a price rise',
+  unit: '%',
+}
+
+/** The query half of a prefilled href — what a HashRouter hands useLocation(). */
+function searchOf(href: string): string {
+  const at = href.indexOf('?')
+  expect(at, `href must carry a query: ${href}`).toBeGreaterThan(-1)
+  return href.slice(at)
+}
+
+describe('ownerPanelHash — backwards-compatible prefill carriage', () => {
+  it('BACKWARDS-COMPATIBLE: a bare call builds byte-exactly the old href — no query, no trailing "?"', () => {
+    expect(ownerPanelHash('scn-1')).toBe('#/scenario/scn-1/panel')
+  })
+
+  it('an undefined prefill is the bare href too (the optional parameter changes nothing by existing)', () => {
+    expect(ownerPanelHash('scn-1', undefined)).toBe('#/scenario/scn-1/panel')
+  })
+
+  it('carries {factorId, label, unit} in the hash query, on the unchanged route', () => {
+    const href = ownerPanelHash('scn-1', PREFILL)
+    expect(href.split('?')[0]).toBe('#/scenario/scn-1/panel')
+    expect(readPanelPrefill(searchOf(href))).toEqual(PREFILL)
+  })
+
+  it('IDENTITY: the factor id round-trips byte-exact — never trimmed, cased or normalised', () => {
+    const exact = 'Factor_A-7.b'
+    const read = readPanelPrefill(searchOf(ownerPanelHash('scn-1', { factorId: exact, label: null, unit: null })))
+    expect(read?.factorId).toBe(exact)
+  })
+
+  it('CONTAINMENT: hostile values are data, not structure — the route segment cannot be changed', () => {
+    const hostile: PanelPrefill = { factorId: 'a&factor=b#/panel/x?y', label: 'x&label=y#z', unit: null }
+    const href = ownerPanelHash('scn-1', hostile)
+    // The route half is untouched…
+    expect(href.split('?')[0]).toBe('#/scenario/scn-1/panel')
+    // …and the participant route cannot be smuggled in ahead of the query.
+    expect(href.startsWith('#/panel/')).toBe(false)
+    // The values come back exactly, proving they were encoded, not interpreted.
+    const read = readPanelPrefill(searchOf(href))
+    expect(read).toEqual(hostile)
+  })
+
+  it('blank label/unit are omitted from the query and read back as null (no empty-string smuggling)', () => {
+    const href = ownerPanelHash('scn-1', { factorId: 'factor-a', label: '', unit: '  ' })
+    const read = readPanelPrefill(searchOf(href))
+    expect(read).toEqual({ factorId: 'factor-a', label: null, unit: null })
+  })
+
+  it('a blank factor id builds the BARE href — a prefill with no target is no prefill', () => {
+    expect(ownerPanelHash('scn-1', { factorId: '   ', label: 'x', unit: 'y' })).toBe(
+      '#/scenario/scn-1/panel',
+    )
+  })
+})
+
+describe('readPanelPrefill — the bare hash keeps working', () => {
+  it('returns null for an empty or query-less search (every pre-existing navigation)', () => {
+    expect(readPanelPrefill('')).toBeNull()
+    expect(readPanelPrefill('?')).toBeNull()
+  })
+
+  it('returns null when factor is absent or blank — label/unit alone are not a prefill', () => {
+    expect(readPanelPrefill('?label=Churn')).toBeNull()
+    expect(readPanelPrefill('?factor=')).toBeNull()
+    expect(readPanelPrefill('?factor=%20%20')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: the reader really reads — a hand-written query parses', () => {
+    expect(readPanelPrefill('?factor=factor-a&label=Churn+risk&unit=%25')).toEqual({
+      factorId: 'factor-a',
+      label: 'Churn risk',
+      unit: '%',
+    })
+  })
+
+  it('SHAPE: the prefill has exactly three keys — nowhere to carry a value or an anchor', () => {
+    const read = readPanelPrefill('?factor=factor-a&value=0.7&estimate=42&label=L')
+    expect(read).not.toBeNull()
+    expect(Object.keys(read as PanelPrefill).sort()).toEqual(['factorId', 'label', 'unit'])
+  })
+})

--- a/src/collab/__tests__/panelSetupPrefill.spec.tsx
+++ b/src/collab/__tests__/panelSetupPrefill.spec.tsx
@@ -1,0 +1,183 @@
+/**
+ * COLLAB — the setup page READS the prefill, and the MINT is bound to it by
+ * IDENTITY.
+ *
+ * Capability A's hop lands the owner here with `?factor=…&label=…&unit=…` in
+ * the hash query. Today the owner hand-types factor ids (placeholder
+ * "factor-churn-risk"); with a prefill the form arrives filled and the mint
+ * payload's `targets[0].target.id` is the PREFILLED factor — not whatever
+ * happens to be first anywhere.
+ *
+ * THE DISCRIMINATING CASES (trap 19 — bind by identity, never a predicate
+ * another object could satisfy):
+ *   • prefill factor A → the minted round targets A, byte-exact;
+ *   • the owner RETARGETS by editing the id → the mint follows the EDIT, and
+ *     the prefilled unit is DROPPED (it described A, not the new target — a
+ *     unit that follows the owner to a different factor is a false claim about
+ *     that factor).
+ *
+ * NOTE WHAT IS NOT ASSERTED: no value field anywhere in the mint body — the
+ * blindness property is CEE-enforced at intake and the payload shape here has
+ * nowhere to put a value; the no-value assertion pins that the prefill did not
+ * smuggle one in.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module (trap 12): a hand-listed factory REPLACES the
+  // module and silently drops every export added later.
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage from '../../pages/PanelSetupPage'
+
+const OWNER_ROUTE_PATH = '/scenario/:id/panel'
+const SCENARIO_ID = 'scn-11111111-2222-3333-4444-555555555555'
+const ROUND_ID = 'rnd-66666666-7777-8888-9999-aaaaaaaaaaaa'
+const OWNER_TOKEN = 'owner-access-token-prefill-IDENTITY'
+const MINT_URL = '/bff/collab/rounds'
+
+/** Distinctive ids: an assertion naming them cannot be met by chance. */
+const PREFILLED_FACTOR = 'factor-churn-risk-PREFILLED-A'
+const RETARGETED_FACTOR = 'factor-retention-spend-EDITED-B'
+const PREFILLED_LABEL = 'Churn risk after a price rise'
+const PREFILLED_UNIT = 'percentage points'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+function renderAt(search: string): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel${search}`]}>
+      <Routes>
+        <Route path={OWNER_ROUTE_PATH} element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** The one mint request's parsed JSON body, selected by its own URL. */
+function mintBody(): Record<string, unknown> {
+  const calls = fetchMock.mock.calls.filter((c) => String(c[0]) === MINT_URL)
+  expect(calls.length, 'exactly one mint request must have been issued').toBe(1)
+  return JSON.parse(String((calls[0][1] ?? {}).body)) as Record<string, unknown>
+}
+
+async function mint(): Promise<void> {
+  fireEvent.click(screen.getByTestId('panel-mint'))
+  await waitFor(() => expect(screen.getByTestId('panel-close')).toBeInTheDocument())
+}
+
+const PREFILL_SEARCH = `?factor=${encodeURIComponent(PREFILLED_FACTOR)}&label=${encodeURIComponent(
+  PREFILLED_LABEL,
+)}&unit=${encodeURIComponent(PREFILLED_UNIT)}`
+
+beforeEach(() => {
+  cleanup()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input) === MINT_URL) {
+      return jsonResponse({
+        round_id: ROUND_ID,
+        graph_version_ref: 'gv-1',
+        participants: [{ participant_id: 'p-a', display_name: 'Ada', token: 'tok-a' }],
+      })
+    }
+    return jsonResponse({ code: 'not_stubbed', message: String(input) }, 404)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(getSessionIdentity).mockResolvedValue({ userId: 'user-abc', accessToken: OWNER_TOKEN })
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('the prefill lands in the form', () => {
+  it('arriving with ?factor&label&unit pre-fills the target id and label inputs', () => {
+    renderAt(PREFILL_SEARCH)
+    expect(screen.getByTestId('panel-target-id')).toHaveValue(PREFILLED_FACTOR)
+    expect(screen.getByTestId('panel-target-label')).toHaveValue(PREFILLED_LABEL)
+  })
+
+  it('says the form was pre-filled from the model (and the owner may change it)', () => {
+    renderAt(PREFILL_SEARCH)
+    expect(screen.getByTestId('panel-prefill-note')).toBeInTheDocument()
+  })
+
+  it('BARE HASH UNCHANGED: no query → empty inputs, no prefill note (every existing caller)', () => {
+    renderAt('')
+    expect(screen.getByTestId('panel-target-id')).toHaveValue('')
+    expect(screen.getByTestId('panel-target-label')).toHaveValue('')
+    expect(screen.queryByTestId('panel-prefill-note')).toBeNull()
+  })
+})
+
+describe('the mint is bound to the prefill by IDENTITY', () => {
+  it('DISCRIMINATING: prefill factor A → the minted round targets A, byte-exact, unit riding', async () => {
+    renderAt(PREFILL_SEARCH)
+    await mint()
+
+    const body = mintBody()
+    const targets = body.targets as Array<{
+      target: { kind: string; id: string }
+      label: string
+      unit: string | null
+    }>
+    expect(targets).toHaveLength(1)
+    expect(targets[0].target).toEqual({ kind: 'factor', id: PREFILLED_FACTOR })
+    expect(targets[0].label).toBe(PREFILLED_LABEL)
+    expect(targets[0].unit).toBe(PREFILLED_UNIT)
+  })
+
+  it('RETARGET: editing the id to factor B mints B (the edit wins) and DROPS the unit (it described A)', async () => {
+    renderAt(PREFILL_SEARCH)
+    fireEvent.change(screen.getByTestId('panel-target-id'), {
+      target: { value: RETARGETED_FACTOR },
+    })
+    await mint()
+
+    const body = mintBody()
+    const targets = body.targets as Array<{
+      target: { kind: string; id: string }
+      unit: string | null
+    }>
+    expect(targets[0].target.id).toBe(RETARGETED_FACTOR)
+    expect(targets[0].target.id).not.toBe(PREFILLED_FACTOR)
+    expect(targets[0].unit).toBeNull()
+  })
+
+  it('NO VALUE ANYWHERE: the prefilled mint body carries no value-bearing field (blindness inherited, not re-implemented)', async () => {
+    renderAt(PREFILL_SEARCH)
+    await mint()
+
+    const raw = JSON.stringify(mintBody())
+    // POSITIVE CONTROL first: the serialised body really is the mint payload.
+    expect(raw).toContain(PREFILLED_FACTOR)
+    for (const forbidden of ['"value"', '"raw_value"', '"estimate"', '"model_value"']) {
+      expect(raw, `mint body must not carry ${forbidden}`).not.toContain(forbidden)
+    }
+  })
+
+  it('HAND-TYPED PATH UNCHANGED: bare hash + typed id mints exactly the typed id with unit null', async () => {
+    renderAt('')
+    fireEvent.change(screen.getByTestId('panel-target-id'), {
+      target: { value: RETARGETED_FACTOR },
+    })
+    await mint()
+
+    const body = mintBody()
+    const targets = body.targets as Array<{ target: { id: string }; unit: string | null }>
+    expect(targets[0].target.id).toBe(RETARGETED_FACTOR)
+    expect(targets[0].unit).toBeNull()
+  })
+})

--- a/src/collab/panelRoute.ts
+++ b/src/collab/panelRoute.ts
@@ -7,7 +7,68 @@
  * spelling, and `__tests__/panelRoute.spec.ts` binds it to the route AppPoC
  * actually declares (derived from the source, not retyped), so a route move
  * REDs the suite instead of stranding the entry point on a dead href.
+ *
+ * ── THE PREFILL (capability A's one new hop) ──────────────────────────────
+ * "Ask a teammate" on an unresolved estimate row lands the owner here with
+ * the target already named: `{factorId, label, unit}` ride the HASH QUERY
+ * (`#/scenario/<id>/panel?factor=…&label=…&unit=…`). The HashRouter parses
+ * everything after `#` as a full location, so `useLocation().search` carries
+ * the query and the ROUTE PATTERN IS UNCHANGED — a bare hash is still every
+ * existing caller's href, byte-identical.
+ *
+ * Producer (`ownerPanelHash`) and consumer (`readPanelPrefill`) live in this
+ * one module so the two spellings of the query keys cannot drift (trap 12).
+ *
+ * ⚠ NOTE WHAT THE PREFILL CANNOT CARRY: a value. The type has no value field,
+ * `panelRoutePrefill.spec.ts` pins the key manifest, and CEE's `parseTargets`
+ * structurally refuses value-bearing fields at the mint anyway — blindness is
+ * inherited from the round machinery, never re-implemented here.
  */
-export function ownerPanelHash(scenarioId: string): string {
-  return `#/scenario/${encodeURIComponent(scenarioId)}/panel`
+
+export interface PanelPrefill {
+  /** The factor the round is about — the model's own id (`row.nodeId` is the wire factor id). */
+  factorId: string
+  /** Initial wording for the panel (the setup page's label field). Null = owner writes their own. */
+  label: string | null
+  /**
+   * The factor's display unit, identity-bound to `factorId`: the setup page
+   * carries it into the mint's `targets[0].unit` ONLY while the target id
+   * still names this factor.
+   */
+  unit: string | null
+}
+
+/** Trimmed-non-empty, or null — blank strings never ride the query. */
+function presence(value: string | null | undefined): string | null {
+  if (value == null) return null
+  return value.trim() === '' ? null : value
+}
+
+export function ownerPanelHash(scenarioId: string, prefill?: PanelPrefill): string {
+  const base = `#/scenario/${encodeURIComponent(scenarioId)}/panel`
+  // A prefill with no target is no prefill: the bare href is the honest form.
+  if (prefill === undefined || presence(prefill.factorId) === null) return base
+  const query = new URLSearchParams()
+  query.set('factor', prefill.factorId)
+  const label = presence(prefill.label)
+  if (label !== null) query.set('label', label)
+  const unit = presence(prefill.unit)
+  if (unit !== null) query.set('unit', unit)
+  return `${base}?${query.toString()}`
+}
+
+/**
+ * Read the prefill back from `useLocation().search` (leading `?` optional).
+ * Null when there is no usable prefill — the bare hash keeps working, and
+ * label/unit without a factor are not a prefill (they would describe nothing).
+ */
+export function readPanelPrefill(search: string): PanelPrefill | null {
+  const query = new URLSearchParams(search)
+  const factorId = presence(query.get('factor'))
+  if (factorId === null) return null
+  return {
+    factorId,
+    label: presence(query.get('label')),
+    unit: presence(query.get('unit')),
+  }
 }

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -38,7 +38,7 @@
  */
 
 import { useCallback, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import { AlertTriangle, Check, Copy, Loader2, LogIn, Users } from 'lucide-react'
 
 import { Button } from '../components/ui/Button'
@@ -53,6 +53,7 @@ import {
   type RevealView,
 } from '../collab/collabService'
 import { requireOwnerAccessToken } from '../collab/ownerAccessToken'
+import { readPanelPrefill } from '../collab/panelRoute'
 import {
   forgetOpenRound,
   recallOpenRound,
@@ -217,6 +218,7 @@ async function writeToClipboard(text: string): Promise<boolean> {
 
 export default function PanelSetupPage(): JSX.Element {
   const { id: scenarioId } = useParams<{ id: string }>()
+  const location = useLocation()
 
   // ⚠ The token is read PER ACTION, from `requireOwnerAccessToken()`, and never
   // held in component state. Two reasons, and the second is the one that bit:
@@ -227,8 +229,13 @@ export default function PanelSetupPage(): JSX.Element {
   //     indistinguishable from sending no header. There is now no cast here and
   //     no `?? ''`: an absent session throws, and the owner is told to sign in.
 
-  const [targetId, setTargetId] = useState('')
-  const [targetLabel, setTargetLabel] = useState('')
+  // CAPABILITY A — the "Ask a teammate" hop lands here with the target
+  // pre-filled in the hash query (see `collab/panelRoute.ts`). Read ONCE at
+  // mount: the prefill SEEDS the form and is then the owner's to edit — a
+  // later location change must never stomp what they have typed.
+  const [prefill] = useState(() => readPanelPrefill(location.search))
+  const [targetId, setTargetId] = useState(() => prefill?.factorId ?? '')
+  const [targetLabel, setTargetLabel] = useState(() => prefill?.label ?? '')
   const [contextNote, setContextNote] = useState('')
   const [nameA, setNameA] = useState('')
   const [nameB, setNameB] = useState('')
@@ -260,7 +267,12 @@ export default function PanelSetupPage(): JSX.Element {
             target: { kind: 'factor', id: targetId.trim() },
             label: targetLabel.trim() === '' ? targetId.trim() : targetLabel.trim(),
             description: null,
-            unit: null,
+            // The prefilled unit is IDENTITY-BOUND to the prefilled factor: it
+            // arrived describing THAT factor's scale, so it rides only while
+            // the target id still names it. An owner who retargets the round
+            // by editing the id gets `null` — a unit that followed them to a
+            // different factor would be a false claim about that factor.
+            unit: prefill !== null && targetId.trim() === prefill.factorId ? prefill.unit : null,
           },
         ],
         participants: [{ display_name: nameA.trim() }, { display_name: nameB.trim() }].filter(
@@ -282,7 +294,7 @@ export default function PanelSetupPage(): JSX.Element {
     } finally {
       setBusyAction(null)
     }
-  }, [scenarioId, targetId, targetLabel, contextNote, nameA, nameB])
+  }, [scenarioId, targetId, targetLabel, contextNote, nameA, nameB, prefill])
 
   // Parameterised by round id because there are now TWO callers: the fresh
   // mint on screen, and the recovery banner's RECORDED round.
@@ -413,6 +425,19 @@ export default function PanelSetupPage(): JSX.Element {
 
           {minted === null ? (
             <div className="mt-8 space-y-6">
+              {/* CAPABILITY A: the owner arrived from an estimate row, so the
+                  form is already filled in. Said quietly, once — the fields
+                  below are theirs to change, and the copy promises nothing
+                  about what happens downstream. */}
+              {prefill !== null && (
+                <p
+                  data-testid="panel-prefill-note"
+                  className={`${typography.bodySmall} rounded-md border border-info/30 bg-panel p-3 text-text-body`}
+                >
+                  The factor below is pre-filled from your model. You can change anything before
+                  you open the round.
+                </p>
+              )}
               <div>
                 <label
                   htmlFor="panel-target-id-input"


### PR DESCRIPTION
Capability A's single missing hop (design: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/draft-reliability-2026-08-12/ELICITATION-CAPABILITY-DESIGN.md`).

An unresolved estimate row in the pre-analysis panel now links to a pre-filled blind-round mint, so "I don't know — ask the team" becomes one click instead of hand-typing a factor id. Blindness/anti-anchoring are inherited from the existing round machinery (CEE's mint structurally refuses value fields); no schema change.

## ✅ GATES COMPLETE — verification finished by a second lane

The original lane was killed by a usage-credit exhaustion mid-verification. Everything it left owed has now been run **independently, from a fresh blobless clone at `03b5f8a0`** — no number below is inherited from the first lane's notes.

### 1. Full named gate (env: the workflow's own `TZ/CI/VITE_*` block)

The required check is `Staging Gate`; its `TypeScript + Lint` job is a **five-step** sequence, all run locally at this head:

| Step | Result |
|---|---|
| `pnpm run lint` | **PASS** — 0 errors (1265 pre-existing warnings); hooks-ratchet 232 violations across 15 files, **exactly** baseline, no new conditional hooks |
| `pnpm run typecheck` (`scripts/ci/typecheck-gate.sh`) | **PASS** — coverage 3383/3423 files; ratchet **2485 vs baseline 2487** (shrank by 2, none added; **baseline deliberately NOT banked** — not this PR's change) |
| `pnpm run ci:guard:zustand` | **PASS** — React-185 guard clean on the two new `useCanvasStore` selectors |
| `pnpm run ci:guard:starters` | **PASS** |
| `pnpm run check:vendor` | **PASS** |

### 2. The affected pre-existing battery — **derived, not guessed**

The battery was derived by sweeping `src/` for every spec referencing `panelRoute` / `PanelSetupPage` / `CalibrateDrillIn` / `ownerPanelHash` → **21 affected specs**, then run as a superset (both owning directories + every other affected spec):

**50 files / 708 tests / 0 failed.**

Collected counts asserted **by name** (trap 2b — a spec collecting zero is invisible to any aggregate). No file collected zero. The three new specs:

- `askTeammateAffordance.spec.tsx` — **10**
- `panelRoutePrefill.spec.ts` — **11**
- `panelSetupPrefill.spec.tsx` — **7** (= the claimed 28, independently reproduced)

…and the pre-existing pins that guard the changed seams, all green: `panelRoute` 4, `TopBar.panelEntry` 5, `panelSetupOwnerAuth` 15, `panelSetupRoundRecovery` 12, `collabFirstRunFriction` 17, `panelSetupOwnerOnly403` 5, `panelSetupCloseFailureCopy` 4, `openRoundRecord` 6, `calibrateDrillInElicit` 16, `calibrateDrillInReceipt` 11, `calibrateDrillInParse` 7, `calibrateDrillInRange` 6, `unconfirmAffordance` 9, `FactorControllablePanel.elicit` 17, `observedStateHelpers` 12, `valueProvenance` 7, `unconfirmValue` 7, `useScienceIcons.userOwned` 3.

### 2b. Full test suite — run in the gate's own 4-way sharded shape

Not a hand-rolled subset: the same `vitest run --shard=N/4` the required check runs.

| Shard | Exit | Files | Tests |
|---|---|---|---|
| 1/4 | 0 | 406 passed, 1 skipped (407) | 5869 passed, 1 skipped (5870) |
| 2/4 | 0 | 406 passed, 1 skipped (407) | 5306 passed, 29 skipped (5335) |
| 3/4 | 0 | 407 passed (407) | 5483 passed (5483) |
| 4/4 | 0 | 403 passed, 1 skipped (404) | 6709 passed, 36 skipped (6745) |
| **total** | **0** | **1622 passed, 3 skipped (1625)** | **23367 passed, 66 skipped (23433)** |

**0 failed, 0 unhandled errors/OOM across all four shards.**

### 3. Mutation kit — **7 cases, 7 matched expectation**

Throwaway worktree at an **absolute path outside the repo root**, detached at `03b5f8a0`. **Isolation proven by WRITING, not by locating** (trap 9g): distinct inodes (600358423 vs 600624284) **and** a sentinel appended in the worktree left the source file's SHA-256 byte-identical. Restores are **HEAD-relative** (`git checkout HEAD -- src/`, never index-relative — trap 9h); clean tree asserted before and after every mutant; applied-check scoped to `src/` with controls asserting **exactly zero**; **37 collected on every single run** (no shrink).

| # | Mutant | Expected | Result |
|---|---|---|---|
| — | **pristine control** | GREEN | **GREEN** 37/37, 0 files mutated |
| M1 | `ownerPanelHash` drops the prefill, returns the bare href | RED | **RED ×7** |
| M2 | **identity:** drill-in binds `factorId` to `nodes[0]` (the decoy) not `row.nodeId` | RED | **RED ×2** |
| M2b | **discriminating twin:** prefill suppressed for the *decoy* factor only | GREEN | **GREEN** |
| M3 | `PanelSetupPage` reads `readPanelPrefill('')` — consumer drops it | RED | **RED ×4** |
| M4 | minted `unit` rides even after the owner retargets (identity conjunct removed) | RED | **RED ×1** |
| M5 | `isPersistenceActive` guard short-circuited to `true` | RED | **RED ×2** |
| M6 | `!row.reviewed` scope removed | RED | **RED ×1** |
| — | **trailing control** | GREEN | **GREEN** 37/37 — tree restored, not polluted |

**The mandatory identity pair (trap 19) is M2 + M2b, and it is the RED/GREEN pair, not a single biting mutant.** The affordance fixture deliberately seats a **decoy factor FIRST in the store**. M2 binds the href to the first row → REDs exactly `DISCRIMINATING: carries the ROW factor id — not the store-first decoy` and `the whole href is the single authority's output…`. M2b changes behaviour for the **decoy only** and stays **GREEN** — proving the assertions bind to *this* row by identity rather than passing via the decoy. A single biting mutant would only have shown sensitivity to *something*; the pair shows sensitivity to *the named object*.

M4/M5/M6 each RED **only** their named discriminator (the RETARGET test; the GUEST + SIGNED-OUT tests; the RESOLVED test) — the four guard-absence tests that pass vacuously at pristine are exactly the ones M5/M6 prove can fail.

### 4. Guard direction verified **both ways**

*Does it ever advertise an action that ends in refusal?* No. `requireOwnerAccessToken()` resolves to a non-empty bearer **or throws** — so `isPersistenceActive` false ⇒ the mint genuinely cannot succeed, and M5 proves the guard bites for guests and signed-out users.

*Is it ever hidden from a user who could succeed?* No, and this is settled by **exact predicate parity with the already-deployed entry point**, derived at the bytes rather than asserted:

- TopBar's panel entry (#672) is visible ⟺ `isPersistenceActive(authenticated, user) && currentScenarioId` — `CanvasMVP.tsx:276` passes exactly that, `useScenario.ts:238` computes it via the canonical `lib/persistenceActive.ts` from `useAuth()`, and `currentScenarioId` is read from the same `useCanvasStore` field (`CanvasMVP.tsx:174`).
- The new affordance is visible ⟺ **the same predicate**, plus `!row.reviewed`.

So it is a strict subset of a live, working entry point: it cannot appear where that entry is absent, and the only extra narrowing is the reviewed-row scope. `AuthProvider` (`src/poc/AppPoC.tsx:889`) wraps both `/scenario/:id` and `/scenario/:id/panel`, so the fail-closed `useAuth` default never fires for a real user — and the four pre-existing `calibrateDrillIn*` specs (40 tests) render the component with **no** AuthProvider and still pass, so the new hook call cannot throw in an unprovided host.

**Two things for the reviewer's judgement, neither a defect, both deliberately left unfixed as out-of-scope:**

1. **Reviewed rows are hidden but could succeed.** A reviewed row's drill-in still opens (its own `!row.reviewed` mount guard was removed earlier as a "dead-end half"), and TopBar's panel entry is still on screen — so the capability is *not denied*, merely not offered on that row. This is the trap-21 shape (one predicate, two questions) resolved the *correct* way: the mount asks "may this value be repaired?", the affordance asks "is this still an unknown?". Worth a conscious ratification rather than silent inheritance.
2. **Inherited, not introduced:** a signed-in user whose `currentScenarioId` exists locally but is not yet server-persisted would see the affordance while the mint could refuse. This is the **identical** predicate already shipped and deployed for the TopBar entry; closing it needs a persistence-confirmed signal outside these three files, i.e. scope expansion. Reported rather than fixed.

### 5. Merge posture

- No fix was required — **no new commit; head remains `03b5f8a0`**, whose CI is green (13/13 checks incl. `Staging Gate`, `Full Test Suite` 4/4 shards).
- Branch is **1 commit behind `staging`** (`1800a83b`, the #677 staleness PR) with **zero file overlap** (derived by `comm` on the two name-only diffs); `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`. Not rebased — it would burn a CI cycle for no risk reduction.

### Still owed (NOT done here)

- **Independent review** (this lane finished verification; it is not the reviewer).
- **Browser rung** — jsdom proves presence, never visibility. Deferred to the orchestrator, per brief.
- Then merge → deploy → live witness.

Evidence appended to `ELICITATION-HOP.md`.
