### PR TITLE
fix(canvas): reloading a CEE-written scenario no longer blanks the canvas (P0)

### DIFF
--- a/src/canvas/ErrorBoundary.tsx
+++ b/src/canvas/ErrorBoundary.tsx
@@ -14,6 +14,19 @@ interface State {
   dismissed: boolean
   errorCount: number
   lastErrorTime: number
+  /**
+   * Did the crash-moment flush actually WRITE a snapshot?
+   *
+   * The panel's closing line makes a guarantee about the user's data, so it may
+   * only be shown when that guarantee holds. `flushWorkToAutosave` already
+   * returns exactly this fact and `componentDidCatch` already captured it; it
+   * simply was not consulted, so the promise was printed even when nothing had
+   * been saved (P0 2026-08-13 — a CEE-shaped store fails every plausibility
+   * gate in crashFlush, so the flush returns false WITHOUT writing).
+   *
+   * Defaults to FALSE: before we know, we do not promise.
+   */
+  workFlushed: boolean
 }
 
 // GitHub issues URL for reporting
@@ -74,6 +87,7 @@ export class CanvasErrorBoundary extends Component<Props, State> {
       dismissed: false,
       errorCount: 0,
       lastErrorTime: 0,
+      workFlushed: false,
     }
   }
 
@@ -135,6 +149,9 @@ export class CanvasErrorBoundary extends Component<Props, State> {
       // If user dismissed but errors keep recurring, un-dismiss to show error panel
       // but with the recurring flag they'll see a different message
       dismissed: isRecurring ? false : this.state.dismissed,
+      // Record what the flush ACTUALLY did, so the closing line can describe it
+      // rather than assert a guarantee we may not hold.
+      workFlushed: flushed,
     })
 
     // Mirror canvas errors into the same SAFE_DEBUG structure used by main.tsx
@@ -419,8 +436,20 @@ export class CanvasErrorBoundary extends Component<Props, State> {
               )}
             </div>
 
+            {/*
+              FULL-ASSURANCE COPY. This line makes a claim about the user's
+              data, so it is bound to what the crash flush actually did — not
+              printed unconditionally. When the flush wrote nothing (a store the
+              plausibility gates reject, no provider, or a throw), promising a
+              restore would be false at the exact moment it is read. The
+              failure branch says what happened and stops short of claiming the
+              work is LOST: `flushWorkToAutosave` deliberately leaves an older
+              autosave intact, so a restore may still recover something.
+            */}
             <p className="text-xs text-text-light text-center mt-6">
-              Your work is auto-saved. Reloading will restore your latest work.
+              {this.state.workFlushed
+                ? 'Your work is auto-saved. Reloading will restore your latest work.'
+                : 'We could not save your most recent changes. Reloading may not restore your latest work.'}
             </p>
           </div>
         </div>

--- a/src/canvas/__tests__/ErrorBoundary.autosaveClaimHonesty.spec.tsx
+++ b/src/canvas/__tests__/ErrorBoundary.autosaveClaimHonesty.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * FULL-ASSURANCE COPY — the crash panel may not promise a save it did not make.
+ *
+ * The canvas error panel printed, unconditionally:
+ *
+ *     "Your work is auto-saved. Reloading will restore your latest work."
+ *
+ * On the 2026-08-13 P0 that sentence was FALSE AT THE MOMENT IT WAS SHOWN, and
+ * provably so:
+ *
+ *   · the store held CEE-shaped nodes/edges (no `position`, no `source`/`target`);
+ *   · `crashFlush.isPlausibleNode` REQUIRES a finite `position.x`/`.y` and
+ *     `isPlausibleEdge` REQUIRES string `source`/`target`, so every element was
+ *     filtered out;
+ *   · `flushWorkToAutosave` then hit `nodes.length === 0 && edges.length === 0`
+ *     and returned **false WITHOUT WRITING** — deliberately, so an empty store
+ *     cannot clobber the last good autosave;
+ *   · `componentDidCatch` ALREADY captured that result in a local `flushed` and
+ *     logged it as `flushedWorkToAutosave` — and then rendered the promise
+ *     regardless.
+ *
+ * So the product asserted a guarantee about the user's data while holding, in
+ * hand, the evidence that the guarantee did not hold. This is the same defect
+ * class as the crash it sits under, one level up: the machinery to tell the
+ * truth existed and was not consulted.
+ *
+ * THE RULE APPLIED: the product may describe what IT did; it may not assert
+ * something it cannot support. So:
+ *   · flush SUCCEEDED → the original sentence is true and is kept verbatim;
+ *   · flush FAILED    → say what happened ("could not save your most recent
+ *     changes") and do not promise a restore we cannot vouch for. It must not
+ *     claim the work is LOST either — an older autosave may well exist, and
+ *     `flushWorkToAutosave` deliberately preserved it.
+ *
+ * RED at pristine: the panel renders the promise in BOTH arms, so the
+ * flush-failed case asserts a guarantee that is false.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CanvasErrorBoundary as ErrorBoundary } from '../ErrorBoundary'
+import { registerCrashSnapshotProvider, __resetCrashSnapshotProviderForTests } from '../persist/crashFlush'
+import ceeRow from '../hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+function Boom(): JSX.Element {
+  throw new Error('canvas exploded')
+}
+
+const PROMISE = /Your work is auto-saved/i
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    localStorage.clear()
+  } catch {
+    /* jsdom without storage — the assertions below do not depend on it */
+  }
+})
+
+describe('the crash panel does not promise a save that did not happen', () => {
+  it('FLUSH FAILED (the P0 shape): does NOT claim the work is auto-saved', () => {
+    // The exact condition of the P0: the store holds CEE-shaped elements, so
+    // every plausibility gate rejects and the flush writes nothing.
+    registerCrashSnapshotProvider(() => ({
+      nodes: ceeRow.nodes as unknown[],
+      edges: ceeRow.edges as unknown[],
+      scenarioId: 'scenario-under-test',
+      ceeAnalysisReady: undefined,
+      selectedGoalNode: null,
+      analysis: null,
+      goalConstraints: null,
+    }))
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    )
+
+    // The panel is up …
+    expect(screen.getByText(/Something went wrong/i)).toBeTruthy()
+    // … and it must NOT assert the guarantee.
+    expect(screen.queryByText(PROMISE)).toBeNull()
+    // It should say what actually happened, without claiming the work is gone.
+    expect(screen.getByText(/could not save your most recent changes/i)).toBeTruthy()
+  })
+
+  it('FLUSH SUCCEEDED: keeps the original promise verbatim', () => {
+    registerCrashSnapshotProvider(() => ({
+      nodes: [
+        { id: 'n1', type: 'factor', position: { x: 1, y: 2 }, data: { label: 'A' } },
+      ] as unknown[],
+      edges: [] as unknown[],
+      scenarioId: 'scenario-under-test',
+      ceeAnalysisReady: undefined,
+      selectedGoalNode: null,
+      analysis: null,
+      goalConstraints: null,
+    }))
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText(PROMISE)).toBeTruthy()
+  })
+
+  it('NO PROVIDER AT ALL (crash before the canvas store loaded): no promise', () => {
+    __resetCrashSnapshotProviderForTests()
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.queryByText(PROMISE)).toBeNull()
+  })
+})

--- a/src/canvas/__tests__/store.ceeShapedHydration.p0.spec.ts
+++ b/src/canvas/__tests__/store.ceeShapedHydration.p0.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * P0 — the SECOND crash on reloading a CEE-written scenario, and the one that
+ * fires FIRST.
+ *
+ * The witness (`WITNESS-978d073c.md` §8) named the fatal render-time throw in
+ * `useAutosave.computeGraphHash`. Sweeping `src/` for the same class at that SHA
+ * found an earlier one on the very same path:
+ *
+ *     store.ts  getMaxNumericId → `id.replace(/\D/g, '')`
+ *     store.ts  reseedIds       → getMaxNumericId(edges.map(e => e.id))
+ *     store.ts  hydrateGraphSlice → get().reseedIds(loaded.nodes, loaded.edges)
+ *
+ * CEE-written edges carry **no `id` key at all**, so `id` is `undefined` and
+ * `undefined.replace(...)` throws. The `try { … } finally { … }` around the
+ * `reseedIds` call only decrements a counter — it does NOT catch — so the
+ * TypeError propagates out of `hydrateGraphSlice`, out of `loadScenario`, and
+ * lands in the `.catch()` at `routes/CanvasMVP.tsx:64`, which outside DEV
+ * swallows it in silence.
+ *
+ * ⭐ THE ORDERING IS THE INTERESTING PART, AND IT RECONCILES TWO RECORDS THAT
+ * LOOKED CONTRADICTORY. `hydrateGraphSlice` calls `set(...)` with the new nodes
+ * and edges BEFORE it calls `reseedIds`. So on a CEE row:
+ *
+ *   · the graph DOES land in the store (ROADMAP 2.1096's premise — correct), and
+ *   · everything in `loadScenario` AFTER the hydrate — framing, `currentStage`,
+ *     `lastSavedAt`, the analysis-status reset, and the `analysis_status ===
+ *     'ready'` hydration — silently never runs (2.1096's "silent partial
+ *     hydration" — also correct), and
+ *   · the user still sees a BLANK canvas, because the separate render-time throw
+ *     in `useAutosave` then takes the error boundary (the witness — also correct).
+ *
+ * Two authorities answering two different questions, both right. What was wrong
+ * was reading either as the whole account.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../store'
+import { normalisePersistedGraph } from '../utils/normalisePersistedGraph'
+import ceeRow from '../hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+const CEE_NODES = ceeRow.nodes as unknown as any[]
+const CEE_EDGES = ceeRow.edges as unknown as any[]
+
+/** Precondition pin — these assertions are vacuous if the fixture drifts. */
+describe('fixture precondition', () => {
+  it('is a real CEE row: edges carry no id, nodes carry no position', () => {
+    expect(CEE_EDGES.filter((e) => 'id' in e)).toHaveLength(0)
+    expect(CEE_NODES.filter((n) => 'position' in n)).toHaveLength(0)
+    expect(CEE_EDGES).toHaveLength(28)
+  })
+})
+
+describe('P0: hydrating a CEE-written row must not throw out of the store', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ nodes: [], edges: [] })
+  })
+
+  /**
+   * RED at pristine with:
+   *   TypeError: Cannot read properties of undefined (reading 'replace')
+   *     at getMaxNumericId … at reseedIds … at hydrateGraphSlice
+   */
+  it('hydrateGraphSlice survives edges with no `id` (defence in depth)', () => {
+    expect(() =>
+      useCanvasStore.getState().hydrateGraphSlice({
+        nodes: CEE_NODES as any,
+        edges: CEE_EDGES as any,
+        currentScenarioId: 'scenario-under-test',
+        goalConstraints: null,
+      }),
+    ).not.toThrow()
+  })
+
+  it('and the id reseed still advances past the ids that ARE numeric', () => {
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: [{ id: 'n7' }, { id: 'n2' }] as any,
+      edges: [{ id: 'e4' }, { from: 'a', to: 'b' } as any] as any,
+      currentScenarioId: 's',
+      goalConstraints: null,
+    })
+    // A malformed (id-less) element must be SKIPPED, not allowed to reset the
+    // seed — otherwise the next created edge collides with an existing one.
+    expect(useCanvasStore.getState().nextNodeId).toBe(8)
+    expect(useCanvasStore.getState().nextEdgeId).toBe(5)
+  })
+})
+
+describe('P0: the normalised row is what should reach the store', () => {
+  it('normalisePersistedGraph turns the real CEE row into canvas shape', () => {
+    const { nodes, edges } = normalisePersistedGraph(ceeRow)
+
+    expect(nodes).toHaveLength(15)
+    expect(edges).toHaveLength(28)
+
+    // Every node now has the geometry React Flow requires and a `data` bag.
+    expect(nodes.filter((n: any) => n.position && typeof n.position.x === 'number')).toHaveLength(15)
+    expect(nodes.filter((n: any) => n.data && typeof n.data === 'object')).toHaveLength(15)
+
+    // Every edge now has React Flow endpoints AND an id.
+    expect(edges.filter((e: any) => typeof e.source === 'string' && typeof e.target === 'string'))
+      .toHaveLength(28)
+    expect(edges.filter((e: any) => typeof e.id === 'string')).toHaveLength(28)
+  })
+
+  it('carries the CEE label and kind through to where the canvas reads them', () => {
+    const { nodes } = normalisePersistedGraph(ceeRow)
+    const decision: any = nodes.find((n: any) => n.id === CEE_NODES[0].id)
+    // The canvas renders `data.label`; CEE puts it at the top level. If this
+    // regressed, the user's decision would render as unlabelled empty boxes.
+    expect(decision.data.label).toBe(CEE_NODES[0].label)
+    expect(decision.data.kind).toBe(CEE_NODES[0].kind)
+    expect(decision.type).toBe(CEE_NODES[0].kind)
+  })
+
+  it('preserves the real endpoint identities (no collapse to a constant)', () => {
+    const { edges } = normalisePersistedGraph(ceeRow)
+    expect(edges[0].source).toBe(CEE_EDGES[0].from)
+    expect(edges[0].target).toBe(CEE_EDGES[0].to)
+    // Distinct edges stay distinct.
+    expect(new Set(edges.map((e: any) => `${e.source}>${e.target}`)).size)
+      .toBe(new Set(CEE_EDGES.map((e: any) => `${e.from}>${e.to}`)).size)
+  })
+
+  it('hydrating the NORMALISED row leaves a canvas the store can render', () => {
+    const { nodes, edges } = normalisePersistedGraph(ceeRow)
+    useCanvasStore.getState().hydrateGraphSlice({
+      nodes: nodes as any,
+      edges: edges as any,
+      currentScenarioId: 'scenario-under-test',
+      goalConstraints: null,
+    })
+    expect(useCanvasStore.getState().nodes).toHaveLength(15)
+    expect(useCanvasStore.getState().edges).toHaveLength(28)
+  })
+})
+
+/**
+ * IDENTITY for the shape that already worked. A React-Flow-shaped row must not
+ * be re-mapped — those rows reload correctly today and re-mapping them would be
+ * a silent behaviour change for the majority path.
+ */
+describe('a React-Flow-shaped row passes through unchanged', () => {
+  const rfRow = {
+    nodes: [
+      { id: 'n1', type: 'factor', position: { x: 5, y: 6 }, data: { kind: 'factor', label: 'A' } },
+      { id: 'n2', type: 'goal', position: { x: 7, y: 8 }, data: { kind: 'goal', label: 'B' } },
+    ],
+    edges: [{ id: 'e1', source: 'n1', target: 'n2', type: 'styled', data: { weight: 1 } }],
+  }
+
+  it('returns the SAME node objects by reference', () => {
+    const { nodes } = normalisePersistedGraph(rfRow)
+    expect(nodes[0]).toBe(rfRow.nodes[0])
+    expect(nodes[1]).toBe(rfRow.nodes[1])
+  })
+
+  it('keeps edge endpoints and ids, and applies only the DEFAULT_EDGE_DATA backfill', () => {
+    const { edges } = normalisePersistedGraph(rfRow)
+    expect(edges[0].id).toBe('e1')
+    expect(edges[0].source).toBe('n1')
+    expect(edges[0].target).toBe('n2')
+    expect((edges[0].data as any).weight).toBe(1)
+  })
+
+  it('tolerates a null / empty column without inventing a graph', () => {
+    expect(normalisePersistedGraph(null)).toEqual({ nodes: [], edges: [] })
+    expect(normalisePersistedGraph({})).toEqual({ nodes: [], edges: [] })
+  })
+})

--- a/src/canvas/__tests__/store.ceeShapedHydration.p0.spec.ts
+++ b/src/canvas/__tests__/store.ceeShapedHydration.p0.spec.ts
@@ -85,6 +85,28 @@ describe('P0: hydrating a CEE-written row must not throw out of the store', () =
   })
 })
 
+/**
+ * `historyHash` read `n.position.x` unguarded and runs on EVERY graph edit via
+ * `pushToHistory`. With the normaliser in place a position-less node should not
+ * reach the store by the reload route — but this is the same defence-in-depth
+ * argument as the id guard, and an unpinned guard is one a tidy-up deletes.
+ */
+describe('P0: an edit does not throw when a node somehow lacks geometry', () => {
+  it('pushToHistory tolerates a position-less node (historyHash guard)', () => {
+    useCanvasStore.setState({
+      nodes: [{ id: 'n1', type: 'factor', data: { label: 'A' } } as any],
+      edges: [],
+      history: { past: [], future: [] },
+    } as any)
+
+    // updateNode routes through the store's edit chokepoint → pushToHistory →
+    // historyHash. RED before the guard: `Cannot read properties of undefined
+    // (reading 'x')` — which is the OTHER TypeError the witness recorded firing
+    // on reload (WITNESS-978d073c.md §8 item 1), the non-fatal one.
+    expect(() => useCanvasStore.getState().updateNode('n1', { label: 'B' } as any)).not.toThrow()
+  })
+})
+
 describe('P0: the normalised row is what should reach the store', () => {
   it('normalisePersistedGraph turns the real CEE row into canvas shape', () => {
     const { nodes, edges } = normalisePersistedGraph(ceeRow)

--- a/src/canvas/hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json
+++ b/src/canvas/hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json
@@ -1,0 +1,1354 @@
+{
+  "nodes": [
+    {
+      "id": "dec_crm",
+      "kind": "decision",
+      "label": "CRM Platform Strategy",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "fac_adoption_speed",
+      "kind": "factor",
+      "label": "Sales Team Adoption Speed",
+      "category": "external",
+      "prior": {
+        "distribution": "uniform",
+        "range_min": 0.2,
+        "range_max": 0.8
+      },
+      "display_value": "0.2 to 0.8",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "fac_build_completion",
+      "kind": "factor",
+      "label": "In-House Build Commitment",
+      "observed_state": {
+        "value": 0,
+        "source": "cee_inference",
+        "extractionType": "inferred",
+        "factor_type": "other",
+        "uncertainty_drivers": [
+          "Not provided"
+        ]
+      },
+      "category": "controllable",
+      "encoding_map": {
+        "0": "Not pursuing in-house completion",
+        "1": "Fully committed to in-house build"
+      },
+      "display_value": "Low (0)",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "fac_completion_risk",
+      "kind": "factor",
+      "label": "Delivery Risk",
+      "category": "external",
+      "prior": {
+        "distribution": "uniform",
+        "range_min": 0.05,
+        "range_max": 0.45
+      },
+      "display_value": "0.05 to 0.45",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "fac_switch_cost",
+      "kind": "factor",
+      "label": "Salesforce Adoption Investment",
+      "observed_state": {
+        "value": 0,
+        "source": "cee_inference",
+        "extractionType": "inferred",
+        "factor_type": "other",
+        "uncertainty_drivers": [
+          "Not provided"
+        ]
+      },
+      "category": "controllable",
+      "encoding_map": {
+        "0": "No Salesforce adoption",
+        "1": "Full Salesforce adoption"
+      },
+      "display_value": "Low (0)",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "goal_crm",
+      "kind": "goal",
+      "label": "Achieve Effective CRM Capability",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "opt_finish_build",
+      "kind": "option",
+      "label": "Finish In-House CRM Build",
+      "interventions": {
+        "fac_build_completion": {
+          "value": 1,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_build_completion",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        },
+        "fac_switch_cost": {
+          "value": 0,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_switch_cost",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        }
+      },
+      "is_baseline": false,
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "opt_hybrid",
+      "kind": "option",
+      "label": "Salesforce Core + Custom Integration",
+      "interventions": {
+        "fac_build_completion": {
+          "value": 0.4,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_build_completion",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        },
+        "fac_switch_cost": {
+          "value": 0.6,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_switch_cost",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        }
+      },
+      "is_baseline": false,
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "opt_status_quo",
+      "kind": "option",
+      "label": "Pause and Reassess (Status Quo)",
+      "interventions": {
+        "fac_build_completion": {
+          "value": 0,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_build_completion",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        },
+        "fac_switch_cost": {
+          "value": 0,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_switch_cost",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        }
+      },
+      "is_baseline": true,
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "opt_switch_salesforce",
+      "kind": "option",
+      "label": "Switch to Salesforce Now",
+      "interventions": {
+        "fac_build_completion": {
+          "value": 0,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_build_completion",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        },
+        "fac_switch_cost": {
+          "value": 1,
+          "source": "cee_hypothesis",
+          "target_match": {
+            "node_id": "fac_switch_cost",
+            "match_type": "exact_id",
+            "confidence": "high"
+          },
+          "value_confidence": "low",
+          "reasoning": "Model-chosen intervention level; this amount is not stated in the brief"
+        }
+      },
+      "is_baseline": false,
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "out_crm_capability",
+      "kind": "outcome",
+      "label": "CRM Capability Delivered",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "out_time_to_value",
+      "kind": "outcome",
+      "label": "Time to Productive CRM Use",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "risk_adoption_failure",
+      "kind": "risk",
+      "label": "User Adoption Failure",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "risk_opportunity_cost",
+      "kind": "risk",
+      "label": "Revenue Opportunity Cost During Delay",
+      "provenance": "ai_inferred"
+    },
+    {
+      "id": "risk_overrun",
+      "kind": "risk",
+      "label": "Cost and Schedule Overrun",
+      "provenance": "ai_inferred"
+    }
+  ],
+  "edges": [
+    {
+      "from": "dec_crm",
+      "to": "opt_finish_build",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "dec_crm",
+      "to": "opt_hybrid",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "dec_crm",
+      "to": "opt_status_quo",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "dec_crm",
+      "to": "opt_switch_salesforce",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "fac_adoption_speed",
+      "to": "out_time_to_value",
+      "strength": {
+        "mean": 0.19532710280373833,
+        "std": 0.10654205607476637
+      },
+      "exists_probability": 0.7,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip"
+        ],
+        "pass1": {
+          "strength_mean": 0.22,
+          "strength_std": 0.12,
+          "exists_probability": 0.7
+        },
+        "pass2": {
+          "strength_mean": -0.3,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Faster sales adoption speeds typically reduce time to productive use significantly.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.17499999999999996,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_adoption_speed",
+      "to": "risk_adoption_failure",
+      "strength": {
+        "mean": -0.35,
+        "std": 0.15
+      },
+      "exists_probability": 0.78,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "agreed",
+        "contested_reasons": [],
+        "pass1": {
+          "strength_mean": -0.35,
+          "strength_std": 0.15,
+          "exists_probability": 0.78
+        },
+        "pass2": {
+          "strength_mean": -0.4,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Faster adoption reduces failure risk in practice.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.275,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.1499999999999999,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_build_completion",
+      "to": "out_crm_capability",
+      "strength": {
+        "mean": 0.45,
+        "std": 0.18
+      },
+      "exists_probability": 0.75,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "strength_band_change"
+        ],
+        "pass1": {
+          "strength_mean": 0.45,
+          "strength_std": 0.18,
+          "exists_probability": 0.75
+        },
+        "pass2": {
+          "strength_mean": 0.7,
+          "strength_std": 0.05,
+          "exists_probability": 0.95,
+          "reasoning": "Completing the in-house build mechanically delivers CRM capability.",
+          "basis": "structural_inference",
+          "needs_user_input": false,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.825,
+          "strength_std": 0.08,
+          "exists_probability": 0.865
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.7499999999999999,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_build_completion",
+      "to": "out_time_to_value",
+      "strength": {
+        "mean": -0.2663551401869159,
+        "std": 0.12429906542056077
+      },
+      "exists_probability": 0.82,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "strength_band_change"
+        ],
+        "pass1": {
+          "strength_mean": -0.3,
+          "strength_std": 0.14,
+          "exists_probability": 0.82
+        },
+        "pass2": {
+          "strength_mean": -0.3,
+          "strength_std": 0.05,
+          "exists_probability": 0.95,
+          "reasoning": "Finishing the build directly accelerates time to value.",
+          "basis": "structural_inference",
+          "needs_user_input": false,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.17499999999999996,
+          "strength_std": 0.08,
+          "exists_probability": 0.865
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.3333333333333333,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_build_completion",
+      "to": "risk_opportunity_cost",
+      "strength": {
+        "mean": 0.3,
+        "std": 0.2
+      },
+      "exists_probability": 0.75,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "repair",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "confidence_band_change",
+          "existence_boundary_crossing"
+        ],
+        "pass1": {
+          "strength_mean": 0,
+          "strength_std": 0,
+          "exists_probability": 0
+        },
+        "pass2": {
+          "strength_mean": -0.7,
+          "strength_std": 0.15,
+          "exists_probability": 0.9,
+          "reasoning": "Achieving build completion removes delay-related opportunity costs.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.575,
+          "strength_std": 0.18,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_build_completion",
+      "to": "risk_overrun",
+      "strength": {
+        "mean": 0.55,
+        "std": 0.15
+      },
+      "exists_probability": 0.88,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip"
+        ],
+        "pass1": {
+          "strength_mean": 0.55,
+          "strength_std": 0.15,
+          "exists_probability": 0.88
+        },
+        "pass2": {
+          "strength_mean": -0.4,
+          "strength_std": 0.15,
+          "exists_probability": 0.85,
+          "reasoning": "Reaching completion reduces the chance of cost and schedule overruns.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.275,
+          "strength_std": 0.18,
+          "exists_probability": 0.765
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_completion_risk",
+      "to": "out_time_to_value",
+      "strength": {
+        "mean": -0.17757009345794394,
+        "std": 0.10654205607476637
+      },
+      "exists_probability": 0.75,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip",
+          "strength_band_change"
+        ],
+        "pass1": {
+          "strength_mean": -0.2,
+          "strength_std": 0.12,
+          "exists_probability": 0.75
+        },
+        "pass2": {
+          "strength_mean": 0.2,
+          "strength_std": 0.1,
+          "exists_probability": 0.85,
+          "reasoning": "Higher delivery risk tends to slow time to value through delays.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.32500000000000007,
+          "strength_std": 0.13,
+          "exists_probability": 0.765
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_completion_risk",
+      "to": "risk_overrun",
+      "strength": {
+        "mean": 0.3,
+        "std": 0.15
+      },
+      "exists_probability": 0.8,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "raw_magnitude"
+        ],
+        "pass1": {
+          "strength_mean": 0.3,
+          "strength_std": 0.15,
+          "exists_probability": 0.8
+        },
+        "pass2": {
+          "strength_mean": 0.4,
+          "strength_std": 0.1,
+          "exists_probability": 0.85,
+          "reasoning": "Greater delivery risk correlates with cost and schedule overruns.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.525,
+          "strength_std": 0.13,
+          "exists_probability": 0.765
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.45000000000000007,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_switch_cost",
+      "to": "out_crm_capability",
+      "strength": {
+        "mean": 0.5,
+        "std": 0.1
+      },
+      "exists_probability": 0.85,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "agreed",
+        "contested_reasons": [],
+        "pass1": {
+          "strength_mean": 0.5,
+          "strength_std": 0.1,
+          "exists_probability": 0.85
+        },
+        "pass2": {
+          "strength_mean": 0.3,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Investing in Salesforce adoption directly yields CRM capability via the platform.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.42500000000000004,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.1499999999999999,
+        "distance_to_goal": 1,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_switch_cost",
+      "to": "out_time_to_value",
+      "strength": {
+        "mean": 0.3107476635514019,
+        "std": 0.10654205607476637
+      },
+      "exists_probability": 0.8,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip",
+          "strength_band_change"
+        ],
+        "pass1": {
+          "strength_mean": 0.35,
+          "strength_std": 0.12,
+          "exists_probability": 0.8
+        },
+        "pass2": {
+          "strength_mean": -0.15,
+          "strength_std": 0.1,
+          "exists_probability": 0.85,
+          "reasoning": "More investment in Salesforce adoption can speed time to value.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.024999999999999967,
+          "strength_std": 0.13,
+          "exists_probability": 0.765
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "fac_switch_cost",
+      "to": "risk_adoption_failure",
+      "strength": {
+        "mean": 0.28,
+        "std": 0.14
+      },
+      "exists_probability": 0.72,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip"
+        ],
+        "pass1": {
+          "strength_mean": 0.28,
+          "strength_std": 0.14,
+          "exists_probability": 0.72
+        },
+        "pass2": {
+          "strength_mean": -0.3,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Greater adoption investment reduces user adoption failure risk.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": false
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.17499999999999996,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 1,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": []
+      }
+    },
+    {
+      "from": "opt_finish_build",
+      "to": "fac_build_completion",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_finish_build",
+      "to": "fac_switch_cost",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_hybrid",
+      "to": "fac_build_completion",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_hybrid",
+      "to": "fac_switch_cost",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_status_quo",
+      "to": "fac_build_completion",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_status_quo",
+      "to": "fac_switch_cost",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_switch_salesforce",
+      "to": "fac_build_completion",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "opt_switch_salesforce",
+      "to": "fac_switch_cost",
+      "strength": {
+        "mean": 1,
+        "std": 0.01
+      },
+      "exists_probability": 1,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai"
+    },
+    {
+      "from": "out_crm_capability",
+      "to": "goal_crm",
+      "strength": {
+        "mean": 0.55,
+        "std": 0.1
+      },
+      "exists_probability": 0.92,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "agreed",
+        "contested_reasons": [],
+        "pass1": {
+          "strength_mean": 0.55,
+          "strength_std": 0.1,
+          "exists_probability": 0.92
+        },
+        "pass2": {
+          "strength_mean": 0.29268292682926833,
+          "strength_std": 0.05,
+          "exists_probability": 0.95,
+          "reasoning": "Delivered CRM capability directly fulfills the CRM goal.",
+          "basis": "structural_inference",
+          "needs_user_input": false,
+          "lint_corrected": true
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.41768292682926833,
+          "strength_std": 0.08,
+          "exists_probability": 0.865
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.2646341463414634,
+        "distance_to_goal": 0,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": [
+          {
+            "code": "LINT_BUDGET_RESCALE",
+            "edge_key": "out_crm_capability->goal_crm",
+            "before": 0.6,
+            "after": 0.29268292682926833
+          }
+        ]
+      }
+    },
+    {
+      "from": "out_time_to_value",
+      "to": "goal_crm",
+      "strength": {
+        "mean": 0.3,
+        "std": 0.1
+      },
+      "exists_probability": 0.88,
+      "effect_direction": "positive",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip"
+        ],
+        "pass1": {
+          "strength_mean": 0.3,
+          "strength_std": 0.1,
+          "exists_probability": 0.88
+        },
+        "pass2": {
+          "strength_mean": -0.19512195121951223,
+          "strength_std": 0.05,
+          "exists_probability": 0.95,
+          "reasoning": "Longer time to value undermines CRM goal fulfillment.",
+          "basis": "structural_inference",
+          "needs_user_input": false,
+          "lint_corrected": true
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.0701219512195122,
+          "strength_std": 0.08,
+          "exists_probability": 0.865
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 0,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": [
+          {
+            "code": "LINT_BUDGET_RESCALE",
+            "edge_key": "out_time_to_value->goal_crm",
+            "before": -0.4,
+            "after": -0.19512195121951223
+          }
+        ]
+      }
+    },
+    {
+      "from": "risk_adoption_failure",
+      "to": "goal_crm",
+      "strength": {
+        "mean": -0.2,
+        "std": 0.1
+      },
+      "exists_probability": 0.78,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "agreed",
+        "contested_reasons": [],
+        "pass1": {
+          "strength_mean": -0.2,
+          "strength_std": 0.1,
+          "exists_probability": 0.78
+        },
+        "pass2": {
+          "strength_mean": -0.24390243902439027,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Adoption failure risk directly hampers CRM goal completion.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": true
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.11890243902439024,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.16219512195121955,
+        "distance_to_goal": 0,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": [
+          {
+            "code": "LINT_BUDGET_RESCALE",
+            "edge_key": "risk_adoption_failure->goal_crm",
+            "before": -0.5,
+            "after": -0.24390243902439027
+          }
+        ]
+      }
+    },
+    {
+      "from": "risk_opportunity_cost",
+      "to": "goal_crm",
+      "strength": {
+        "mean": -0.25,
+        "std": 0.12
+      },
+      "exists_probability": 0.82,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "sign_flip",
+          "confidence_band_change",
+          "existence_boundary_crossing"
+        ],
+        "pass1": {
+          "strength_mean": -0.25,
+          "strength_std": 0.12,
+          "exists_probability": 0.82
+        },
+        "pass2": {
+          "strength_mean": -0.02439024390243903,
+          "strength_std": 0.019512195121951223,
+          "exists_probability": 0.5,
+          "reasoning": "Opportunity cost risk minimally affects the CRM capability goal directly.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": true
+        },
+        "pass2_adjusted": {
+          "strength_mean": 0.100609756097561,
+          "strength_std": 0.04951219512195122,
+          "exists_probability": 0.41500000000000004
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 1,
+        "distance_to_goal": 0,
+        "sign_unstable": true,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": [
+          {
+            "code": "LINT_BUDGET_RESCALE",
+            "edge_key": "risk_opportunity_cost->goal_crm",
+            "before": -0.05,
+            "after": -0.02439024390243903
+          },
+          {
+            "code": "LINT_STD_CLAMPED",
+            "edge_key": "risk_opportunity_cost->goal_crm",
+            "before": 0.05,
+            "after": 0.019512195121951223
+          }
+        ]
+      }
+    },
+    {
+      "from": "risk_overrun",
+      "to": "goal_crm",
+      "strength": {
+        "mean": -0.35,
+        "std": 0.12
+      },
+      "exists_probability": 0.9,
+      "effect_direction": "negative",
+      "provenance": {
+        "source": "cee_hypothesis"
+      },
+      "provenance_display": "ai_inferred",
+      "origin": "ai",
+      "validation": {
+        "status": "contested",
+        "contested_reasons": [
+          "strength_band_change"
+        ],
+        "pass1": {
+          "strength_mean": -0.35,
+          "strength_std": 0.12,
+          "exists_probability": 0.9
+        },
+        "pass2": {
+          "strength_mean": -0.24390243902439027,
+          "strength_std": 0.1,
+          "exists_probability": 0.9,
+          "reasoning": "Cost and schedule overruns directly impede achieving the CRM goal.",
+          "basis": "domain_prior",
+          "needs_user_input": true,
+          "lint_corrected": true
+        },
+        "pass2_adjusted": {
+          "strength_mean": -0.11890243902439024,
+          "strength_std": 0.13,
+          "exists_probability": 0.8150000000000001
+        },
+        "bias_correction": {
+          "strength_mean_offset": 0.12500000000000003,
+          "strength_std_offset": 0.03,
+          "exists_probability_offset": -0.08499999999999996
+        },
+        "max_divergence": 0.4621951219512195,
+        "distance_to_goal": 0,
+        "sign_unstable": false,
+        "pass2_missing": false,
+        "evoi_rank": null,
+        "evoi_impact": null,
+        "was_shown": false,
+        "user_action": "pending",
+        "resolved_value": null,
+        "resolved_by": "default",
+        "validation_lint_log": [
+          {
+            "code": "LINT_BUDGET_RESCALE",
+            "edge_key": "risk_overrun->goal_crm",
+            "before": -0.5,
+            "after": -0.24390243902439027
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
@@ -131,11 +131,18 @@ describe('P0: the CEE-shaped signature is FAITHFUL, not merely non-throwing', ()
     expect(computeGraphHash(CEE_NODES, swapped)).not.toBe(baseline())
   })
 
-  it('actually carries the CEE endpoint identities into the signature', () => {
+  it('actually carries the CEE endpoint identities into the EDGE component', () => {
     const hash = computeGraphHash(CEE_NODES, CEE_EDGES)
-    // If the projection collapsed endpoints to '' or undefined, these are absent.
-    expect(hash).toContain(CEE_EDGES[0].from)
-    expect(hash).toContain(CEE_EDGES[0].to)
+    // ⚠ BIND TO THE EDGE PROJECTION, NOT TO THE BARE ID (trap 19). A CEE edge's
+    // `from` is also a NODE id, and node ids are in the hash too — so a bare
+    // `toContain(CEE_EDGES[0].from)` passes even when every edge endpoint has
+    // collapsed to null. Measured: that weaker form survived the
+    // revert-the-edge-projection mutant. `"from":"…"` only ever comes from the
+    // edge half, because nodes project `"id":`.
+    expect(hash).toContain(`"from":${JSON.stringify(CEE_EDGES[0].from)}`)
+    expect(hash).toContain(`"to":${JSON.stringify(CEE_EDGES[0].to)}`)
+    // And the collapsed form must be absent entirely.
+    expect(hash).not.toContain('"from":null')
   })
 
   it('notices a CEE node label edit (label is top-level on CEE nodes, not in data)', () => {

--- a/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * P0 — reloading a CEE-written scenario crashes the canvas.
+ *
+ * WITNESSED ON THE DEPLOYED BUILD, 2026-08-13, UI `978d073c`
+ * (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/analysis-500-p0-2026-08-13/WITNESS-978d073c.md`
+ * §8, Arm F). Reloading `#/scenario/:id` on a row CEE last wrote produced:
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'localeCompare')
+ *         at ReactFlowGraph-wf6K1mco.js:23:465004
+ *         at Array.sort (<anonymous>)
+ *         at Object.Gu [as useMemo]
+ *
+ * — thrown during render, so React's error boundary took the whole canvas:
+ * **0 nodes, 0 edges**, under a panel reading "Your work is auto-saved."
+ * Witnessed 3/3 on CEE-written rows and 0/2 on React-Flow-written rows, i.e. a
+ * discriminating pair: the failure is specific to the shape CEE writes.
+ *
+ * MECHANISM. `useScenario.loadScenario` hydrates the `scenarios.graph` column
+ * into the canvas store VERBATIM (`useScenario.ts:648-689` — the only transform
+ * spreads DEFAULT_EDGE_DATA into `edge.data`). CEE-written edges carry `from`/`to`
+ * and have **no** `source`/`target`, so `computeGraphHash`'s edge projection read
+ * `e.source` → `undefined`, and the `.sort()` comparator then called
+ * `undefined.localeCompare(...)`.
+ *
+ * ⭐ THE ASYMMETRY THAT NAMES THE DEFECT: eleven lines apart in the same function,
+ * the NODE half was already defensive (`n.position?.x ?? 0`) and the EDGE half was
+ * not. One half of a mirrored projection was hardened and the other was not.
+ *
+ * ⚠ WHY "DOES NOT THROW" IS NOT THE ACCEPTANCE CONDITION. `computeGraphHash` is
+ * the autosave's DIRTY-DETECTION signature: it is compared only against itself
+ * in-memory (`lastSavedHashRef`) to decide whether to write. A "fix" that merely
+ * stopped the throw — `e.source ?? ''` — would make every CEE-shaped edge project
+ * the SAME endpoints, so rewiring an edge would not flip the hash, the autosave
+ * would skip, and the edit would be silently lost on reload. That is the #457 loss
+ * class this module's own header exists to prevent, and it is WORSE than the crash
+ * because nothing reports it. Hence the FIDELITY tests below, not just the
+ * no-throw test.
+ *
+ * FIXTURE PROVENANCE — REAL PRODUCER BYTES, NOT HAND-AUTHORED.
+ * `fixtures/cee-persisted-graph-wire-2026-08-12.json` is the `.body.draft_graph`
+ * of a real captured CEE draft turn
+ * (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/coaching-surface-2026-08-12/wire2-02-draft-raw.json`,
+ * captured 2026-08-12). Node and edge objects are VERBATIM — no field was added,
+ * removed or rewritten; only the enclosing `{nodes, edges}` was lifted out. Its
+ * edge key manifest matches the witness's persisted-row manifest character for
+ * character. Its node objects carry three keys the witnessed row did not show
+ * (`encoding_map`, `is_baseline`, `prior`) — a SUPERSET, which cannot make the
+ * defect easier to hit, since what triggers it is the ABSENCE of `source`/`target`.
+ * A fixture I authored myself would only encode my model of the producer; this is
+ * the producer's own output.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAutosave, computeGraphHash } from '../useAutosave'
+import { useCanvasStore } from '../../store'
+import ceeRow from './fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+const CEE_NODES = ceeRow.nodes as unknown as any[]
+const CEE_EDGES = ceeRow.edges as unknown as any[]
+
+/**
+ * PRECONDITION PIN (trap 13b). Every assertion below is only meaningful while the
+ * fixture is genuinely in the defect class. If a later tidy-up "helpfully" adds
+ * `source`/`target` or `position` to the fixture, these tests would keep passing
+ * while testing nothing at all. This block makes that failure LOUD instead.
+ */
+describe('the fixture is a real CEE-shaped row (precondition — not the defect itself)', () => {
+  it('carries CEE edge endpoints and NONE of the React Flow markers', () => {
+    expect(CEE_NODES).toHaveLength(15)
+    expect(CEE_EDGES).toHaveLength(28)
+
+    // The React Flow markers that MUST be absent, or the defect cannot fire.
+    expect(CEE_NODES.filter((n) => 'position' in n)).toHaveLength(0)
+    expect(CEE_NODES.filter((n) => 'data' in n)).toHaveLength(0)
+    expect(CEE_EDGES.filter((e) => 'source' in e)).toHaveLength(0)
+    expect(CEE_EDGES.filter((e) => 'target' in e)).toHaveLength(0)
+    expect(CEE_EDGES.filter((e) => 'id' in e)).toHaveLength(0)
+
+    // The CEE markers that MUST be present.
+    expect(CEE_EDGES.filter((e) => typeof e.from === 'string' && typeof e.to === 'string'))
+      .toHaveLength(28)
+    expect(CEE_NODES.filter((n) => typeof n.id === 'string')).toHaveLength(15)
+  })
+})
+
+describe('P0: computeGraphHash over a CEE-written row', () => {
+  it('does not throw — RED at pristine with "Cannot read properties of undefined (reading \'localeCompare\')"', () => {
+    expect(() => computeGraphHash(CEE_NODES, CEE_EDGES)).not.toThrow()
+  })
+
+  it('renders the autosave hook without taking the error boundary (the deployed failure)', () => {
+    useCanvasStore.setState({ nodes: CEE_NODES as any, edges: CEE_EDGES as any })
+
+    // renderHook throws if the useMemo throws — which is exactly what took the
+    // canvas on the deployed build. Surviving render is the behavioural claim.
+    expect(() => renderHook(() => useAutosave())).not.toThrow()
+
+    // And the graph is still there afterwards: the deployed symptom was 0 nodes.
+    expect(useCanvasStore.getState().nodes).toHaveLength(15)
+    expect(useCanvasStore.getState().edges).toHaveLength(28)
+  })
+})
+
+/**
+ * FIDELITY — the half that stops a crash-fix becoming a silent-data-loss fix.
+ * Each case changes exactly ONE thing about a CEE-shaped graph and requires the
+ * dirty signature to notice. A projection that collapsed CEE edges to a constant
+ * would pass the no-throw test above and fail every one of these.
+ */
+describe('P0: the CEE-shaped signature is FAITHFUL, not merely non-throwing', () => {
+  const baseline = () => computeGraphHash(CEE_NODES, CEE_EDGES)
+
+  it('notices an edge endpoint being rewired', () => {
+    const rewired = CEE_EDGES.map((e, i) =>
+      i === 0 ? { ...e, to: CEE_NODES[CEE_NODES.length - 1].id } : e,
+    )
+    // Guard the case is real: the rewire must actually change the endpoint.
+    expect(rewired[0].to).not.toBe(CEE_EDGES[0].to)
+    expect(computeGraphHash(CEE_NODES, rewired)).not.toBe(baseline())
+  })
+
+  it('notices an edge being removed', () => {
+    expect(computeGraphHash(CEE_NODES, CEE_EDGES.slice(1))).not.toBe(baseline())
+  })
+
+  it('notices two DIFFERENT edges swapping endpoints (order-insensitive sort still discriminates)', () => {
+    const swapped = CEE_EDGES.map((e, i) =>
+      i === 0 ? { ...e, from: CEE_EDGES[1].from, to: CEE_EDGES[1].to } : e,
+    )
+    expect(computeGraphHash(CEE_NODES, swapped)).not.toBe(baseline())
+  })
+
+  it('actually carries the CEE endpoint identities into the signature', () => {
+    const hash = computeGraphHash(CEE_NODES, CEE_EDGES)
+    // If the projection collapsed endpoints to '' or undefined, these are absent.
+    expect(hash).toContain(CEE_EDGES[0].from)
+    expect(hash).toContain(CEE_EDGES[0].to)
+  })
+
+  it('notices a CEE node label edit (label is top-level on CEE nodes, not in data)', () => {
+    const relabelled = CEE_NODES.map((n, i) => (i === 0 ? { ...n, label: 'Renamed by the user' } : n))
+    expect(relabelled[0].label).not.toBe(CEE_NODES[0].label)
+    expect(computeGraphHash(relabelled, CEE_EDGES)).not.toBe(baseline())
+  })
+})
+
+/**
+ * NON-REGRESSION for the shape that already worked. The fix must not change the
+ * signature behaviour of React-Flow-shaped graphs — those reload fine today
+ * (witnessed 2/2) and every existing autosave pin depends on them.
+ */
+describe('React-Flow-shaped graphs are unaffected', () => {
+  const rfNodes = [
+    { id: 'n1', type: 'factor', position: { x: 10, y: 20 }, data: { kind: 'factor', label: 'A' } },
+    { id: 'n2', type: 'goal', position: { x: 30, y: 40 }, data: { kind: 'goal', label: 'B' } },
+  ]
+  const rfEdges = [{ id: 'e1', source: 'n1', target: 'n2', data: { weight: 1 } }]
+
+  it('still projects source/target and still discriminates a rewire', () => {
+    const before = computeGraphHash(rfNodes, rfEdges)
+    expect(before).toContain('n1')
+    expect(before).toContain('n2')
+    const rewired = [{ ...rfEdges[0], target: 'n1' }]
+    expect(computeGraphHash(rfNodes, rewired)).not.toBe(before)
+  })
+
+  it('still discriminates a React Flow node label edit', () => {
+    const before = computeGraphHash(rfNodes, rfEdges)
+    const edited = rfNodes.map((n, i) => (i === 0 ? { ...n, data: { ...n.data, label: 'A2' } } : n))
+    expect(computeGraphHash(edited, rfEdges)).not.toBe(before)
+  })
+})

--- a/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.ceeShapedRowReload.p0.spec.ts
@@ -50,7 +50,7 @@
  * the producer's own output.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useAutosave, computeGraphHash } from '../useAutosave'
 import { useCanvasStore } from '../../store'

--- a/src/canvas/hooks/__tests__/useAutosave.signatureByteStability.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.signatureByteStability.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * BYTE-STABILITY of the autosave dirty signature for React-Flow-shaped graphs.
+ *
+ * WHY THIS FILE EXISTS. `computeGraphHash` is the autosave's DIRTY GATE: its
+ * output is compared against `lastSavedHashRef` to decide whether to write. So a
+ * change to the projection is never "just a refactor" — if the signature of an
+ * unchanged graph moves, every previously-clean scenario reads dirty; if two
+ * different graphs start colliding, a real edit reads clean and STOPS SAVING.
+ * The second failure mode is silent and loses user work.
+ *
+ * The P0 fix of 2026-08-13 had to teach this projector a second graph shape
+ * (CEE/GraphV3), which is exactly the kind of change that can shift the
+ * signature for the shape that already worked. It was verified by DIFFERENTIAL
+ * at the time: the corpus below was hashed in a pristine worktree at
+ * `978d073c` and in the fixed tree, and the two outputs were byte-identical
+ * across all 16 entries — with a positive control proving the harness could see
+ * a deliberate one-character signature change.
+ *
+ * A differential needs two trees, which CI does not have. This file pins the
+ * SAME evidence as a golden corpus: the expected strings below are the MEASURED
+ * pristine output, not values written by hand. Any future change that moves the
+ * signature for a React-Flow-shaped graph turns this RED and names the entry.
+ *
+ * ⚠ If you are here because this went red: that is the guard working. Do not
+ * update the expectations to match new output unless you can say why every
+ * affected scenario reading dirty (or clean) is acceptable.
+ *
+ * The corpus deliberately includes the awkward canvas-shaped cases — a missing
+ * `data.label`, a missing `type`, a TOP-LEVEL `label` alongside `position`, an
+ * empty `data`, a `{0,0}` position, and single-element malformed graphs that did
+ * not throw before because a 1-element `.sort()` never invokes its comparator.
+ * Those are precisely where a careless `??` limb shifts the projection.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { computeGraphHash } from '../useAutosave'
+
+function rf(id: string, extra: Record<string, unknown> = {}) {
+  return { id, type: 'factor', position: { x: 10, y: 20 }, data: { kind: 'factor', label: 'L' + id }, ...extra }
+}
+function rfEdge(id: string, s: string, t: string, extra: Record<string, unknown> = {}) {
+  return { id, source: s, target: t, type: 'styled', data: { weight: 1, confidence: 0.5 }, ...extra }
+}
+
+const CORPUS: Record<string, { nodes: any[]; edges: any[] }> = {
+  empty: { nodes: [], edges: [] },
+  singleNode: { nodes: [rf('n1')], edges: [] },
+  simple: { nodes: [rf('n1'), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2')] },
+  threeNodes: { nodes: [rf('n1'), rf('n2'), rf('n3')], edges: [rfEdge('e1', 'n1', 'n2'), rfEdge('e2', 'n2', 'n3')] },
+  unsortedIds: { nodes: [rf('n3'), rf('n1'), rf('n2')], edges: [rfEdge('e2', 'n2', 'n3'), rfEdge('e1', 'n1', 'n2')] },
+  noDataLabel: { nodes: [rf('n1', { data: { kind: 'factor' } }), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2')] },
+  emptyData: { nodes: [rf('n1', { data: {} }), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2')] },
+  noType: { nodes: [rf('n1', { type: undefined }), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2')] },
+  topLevelLabelWithPosition: {
+    nodes: [rf('n1', { label: 'TOP', data: { kind: 'factor' } }), rf('n2')],
+    edges: [rfEdge('e1', 'n1', 'n2')],
+  },
+  topLevelKindWithPosition: {
+    nodes: [rf('n1', { kind: 'goal', type: undefined, data: {} }), rf('n2')],
+    edges: [rfEdge('e1', 'n1', 'n2')],
+  },
+  zeroPosition: { nodes: [rf('n1', { position: { x: 0, y: 0 } }), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2')] },
+  edgeNoData: { nodes: [rf('n1'), rf('n2')], edges: [rfEdge('e1', 'n1', 'n2', { data: undefined })] },
+  edgeExtraFields: {
+    nodes: [rf('n1'), rf('n2')],
+    edges: [rfEdge('e1', 'n1', 'n2', { data: { weight: 2, confidence: 0.9, direction: 'negative', validation: { x: 1 } } })],
+  },
+  richData: {
+    nodes: [
+      rf('n1', { data: { kind: 'factor', label: 'A', description: 'd', category: 'c', state_space: [0, 1] } }),
+      rf('n2', { data: { kind: 'goal', label: 'B', success_threshold: 80, threshold_source: 'user' } }),
+    ],
+    edges: [rfEdge('e1', 'n1', 'n2')],
+  },
+  singleNodeNoId: { nodes: [{ type: 'factor', position: { x: 1, y: 2 }, data: {} }], edges: [] },
+  singleEdgeNoEndpoints: { nodes: [rf('n1')], edges: [{ id: 'e1', data: {} }] },
+}
+
+/** MEASURED at pristine `978d073c`. Generated, not hand-written. */
+const GOLDEN: Record<string, string> = {
+  "empty": "{\"edges\":[],\"nodes\":[]}",
+  "singleNode": "{\"edges\":[],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20}]}",
+  "simple": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "threeNodes": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5},{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n2\",\"to\":\"n3\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln3\"},\"id\":\"n3\",\"kind\":\"factor\",\"label\":\"Ln3\",\"x\":10,\"y\":20}]}",
+  "unsortedIds": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5},{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n2\",\"to\":\"n3\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln3\"},\"id\":\"n3\",\"kind\":\"factor\",\"label\":\"Ln3\",\"x\":10,\"y\":20}]}",
+  "noDataLabel": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "emptyData": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "noType": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "topLevelLabelWithPosition": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "topLevelKindWithPosition": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{},\"id\":\"n1\",\"kind\":null,\"label\":\"\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "zeroPosition": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":0,\"y\":0},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "edgeNoData": "{\"edges\":[{\"data\":{},\"from\":\"n1\",\"to\":\"n2\",\"weight\":\"\"}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "edgeExtraFields": "{\"edges\":[{\"data\":{\"confidence\":0.9,\"direction\":\"negative\",\"validation\":{\"x\":1},\"weight\":2},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.9}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"factor\",\"label\":\"Ln2\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"Ln2\",\"x\":10,\"y\":20}]}",
+  "richData": "{\"edges\":[{\"data\":{\"confidence\":0.5,\"weight\":1},\"from\":\"n1\",\"to\":\"n2\",\"weight\":0.5}],\"nodes\":[{\"data\":{\"category\":\"c\",\"description\":\"d\",\"kind\":\"factor\",\"label\":\"A\",\"state_space\":[0,1]},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"A\",\"x\":10,\"y\":20},{\"data\":{\"kind\":\"goal\",\"label\":\"B\",\"success_threshold\":80,\"threshold_source\":\"user\"},\"id\":\"n2\",\"kind\":\"factor\",\"label\":\"B\",\"x\":10,\"y\":20}]}",
+  "singleNodeNoId": "{\"edges\":[],\"nodes\":[{\"data\":{},\"id\":null,\"kind\":\"factor\",\"label\":\"\",\"x\":1,\"y\":2}]}",
+  "singleEdgeNoEndpoints": "{\"edges\":[{\"data\":{},\"from\":null,\"to\":null,\"weight\":\"\"}],\"nodes\":[{\"data\":{\"kind\":\"factor\",\"label\":\"Ln1\"},\"id\":\"n1\",\"kind\":\"factor\",\"label\":\"Ln1\",\"x\":10,\"y\":20}]}",}
+
+describe('computeGraphHash — React-Flow signature is byte-stable vs pristine 978d073c', () => {
+  it('covers every corpus entry (the golden map cannot silently shrink)', () => {
+    expect(Object.keys(GOLDEN).sort()).toEqual(Object.keys(CORPUS).sort())
+    expect(Object.keys(CORPUS)).toHaveLength(16)
+  })
+
+  for (const name of Object.keys(CORPUS)) {
+    it(`${name} — signature unchanged`, () => {
+      const g = CORPUS[name]
+      expect(computeGraphHash(g.nodes, g.edges)).toBe(GOLDEN[name])
+    })
+  }
+})

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -22,6 +22,7 @@ import { saveAutosave, loadAutosave } from '../store/scenarios'
 import { projectAutosaveData, analysisSnapshotFromStore } from '../store/autosaveProjection'
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
 import { EPHEMERAL_NODE_FIELDS, EPHEMERAL_EDGE_FIELDS } from '../domain/analyticalNodeFields'
+import { isCanvasShapedNode } from '../utils/normalisePersistedGraph'
 
 // The autosave hash now covers node/edge `data.*` BY DEFAULT (Codex P1-1) and
 // EXCLUDES only the small ephemeral denylist below (transient UI/session state +
@@ -93,29 +94,81 @@ const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
  *
  * Exported for the drift guard's behavioural cross-check: an ephemeral field must
  * NOT flip this hash; any non-ephemeral data field MUST.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * SHAPE — THIS PROJECTOR SEES **TWO** GRAPH SHAPES, NOT ONE (P0, 2026-08-13)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `scenarios.graph` holds either React-Flow-shaped bytes (`position`, `data`,
+ * edge `source`/`target`) or CEE/GraphV3 bytes (`kind`/`label` top-level, edge
+ * `from`/`to`, and NO `position`, `data`, `id`, `source` or `target` on edges).
+ * `useScenario.loadScenario` hydrates that column into the canvas store VERBATIM,
+ * so BOTH shapes reach this function. Before the fix the edge half read only
+ * `e.source`, so a CEE-written row projected `undefined` endpoints and the
+ * comparator threw `undefined.localeCompare(...)` DURING RENDER — React's error
+ * boundary then took the whole canvas (0 nodes) on every reload of a
+ * CEE-drafted decision. Witnessed on deployed `978d073c`, 3/3 on CEE rows and
+ * 0/2 on React-Flow rows.
+ *
+ * ⚠ NOT-THROWING IS NOT THE REQUIREMENT. This hash is the autosave's dirty gate.
+ * Defaulting the endpoints to a constant would stop the crash and silently break
+ * dirty-detection for every CEE-shaped graph — an edge rewire would not flip the
+ * hash, the save would skip, and the edit would be lost on reload (the #457 loss
+ * class described above). So each field is read in BOTH spellings, and
+ * `useAutosave.ceeShapedRowReload.p0.spec.ts` pins the fidelity, not just the
+ * absence of a throw.
+ *
+ * The dual-shape read matches the estate's existing precedent for this exact
+ * problem — `canvas/utils/mergeServerGraph.ts` already resolves endpoints as
+ * `e.from ?? e.source` on the server-hydration path.
+ *
+ * ⚠ RESIDUAL, deliberately not closed here: for a CEE-shaped node the analytical
+ * payload (`observed_state`, `display_value`, `category`, `interventions`) lives
+ * at the TOP LEVEL, not under `data`, so it is not covered by the `data.*`
+ * hash-by-default rule and an edit to it would not flip this hash. That is a
+ * symptom of CEE-shaped objects being in the store at all; the fix belongs at the
+ * hydration boundary (see the lane report / ROADMAP 2.1096), not in this
+ * projector, which would otherwise become a fourth hand-mirrored copy of the
+ * CEE→React-Flow mapping.
  */
 export function computeGraphHash(nodes: any[], edges: any[]): string {
   const canonical = {
     nodes: nodes
       .map(n => {
         const data = (n.data ?? {}) as Record<string, unknown>
+        // BYTE-STABILITY GATE. A canvas-shaped node projects through the EXACT
+        // original expressions — no `??` limb is added on that branch — so the
+        // signature of every graph that worked before this change is unchanged
+        // to the byte. The CEE fallbacks apply only to a node that is NOT
+        // canvas-shaped, i.e. one that could not have been projected correctly
+        // before anyway. Verified by differential in
+        // useAutosave.ceeShapedRowReload.p0.spec.ts.
+        const canvasShaped = isCanvasShapedNode(n)
         return {
           id: n.id,
-          kind: n.type ?? n.data?.kind,
-          label: n.data?.label ?? '',
+          kind: canvasShaped ? (n.type ?? n.data?.kind) : (n.type ?? n.data?.kind ?? n.kind),
+          label: canvasShaped ? (n.data?.label ?? '') : (n.data?.label ?? n.label ?? ''),
           x: Math.round(n.position?.x ?? 0),
           y: Math.round(n.position?.y ?? 0),
           // All node data by default, minus the ephemeral denylist.
           data: serializableData(data, EPHEMERAL_NODE_SET),
         }
       })
-      .sort((a, b) => a.id.localeCompare(b.id)),
+      // Comparator coerces so a malformed element cannot throw here. The
+      // PROJECTED value above is left exactly as it was, so this changes no
+      // signature — it only stops `undefined.localeCompare` taking the render.
+      .sort((a, b) => String(a.id ?? '').localeCompare(String(b.id ?? ''))),
     edges: edges
       .map(e => {
         const data = (e.data ?? {}) as Record<string, unknown>
         return {
-          from: e.source,
-          to: e.target,
+          // Dual-shape read. React Flow edges carry `source`/`target`;
+          // CEE-written rows carry `from`/`to` and NO `source`/`target` at all.
+          // No trailing `?? ''`: on a canvas-shaped edge `e.source` is a string,
+          // so this is byte-identical to the original `from: e.source`, and on a
+          // malformed edge it stays `undefined` exactly as before. The SORT
+          // below, not the projection, is what stops the throw.
+          from: e.source ?? e.from,
+          to: e.target ?? e.to,
           // Legacy composite kept inline to preserve exact dirty-detection for the
           // old callers; redundant with `data.confidence`/`data.weight` below.
           weight: e.data?.confidence ?? e.data?.weight ?? '',
@@ -123,7 +176,13 @@ export function computeGraphHash(nodes: any[], edges: any[]): string {
           data: serializableData(data, EPHEMERAL_EDGE_SET),
         }
       })
-      .sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to)),
+      // Coerced for the same reason as the node comparator: this line is where
+      // the P0 threw (`undefined.localeCompare`) and took the canvas.
+      .sort(
+        (a, b) =>
+          String(a.from ?? '').localeCompare(String(b.from ?? '')) ||
+          String(a.to ?? '').localeCompare(String(b.to ?? '')),
+      ),
   }
   return stableStringify(canonical)
 }

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -1067,7 +1067,12 @@ function historyHash(nodes: Node[], edges: Edge[]): string {
   // hash, pushToHistory dedups it away, and Undo jumps past both edits instead of
   // stepping 80 → 60. Including it makes each target edit a distinct history entry
   // that undo/redo's deriveGoalThresholdFromNode then reconstructs correctly.
-  const n = nodes.map(n => `${n.id}@${n.position.x},${n.position.y}:${n.type ?? ''}:${n.data?.label ?? ''}:${(n.data as { success_threshold?: unknown })?.success_threshold ?? ''}:${(n.data as { threshold_source?: unknown })?.threshold_source ?? ''}`).join('|')
+  // P0 2026-08-13: `position` is optional-chained for the same reason
+  // `useAutosave.computeGraphHash` optional-chains it — a persisted graph that
+  // reaches the store without geometry (CEE/GraphV3 carries none) would
+  // otherwise make this `undefined.x` and throw on the FIRST edit after a load.
+  // Defaulting to 0 matches the sibling projector exactly.
+  const n = nodes.map(n => `${n.id}@${n.position?.x ?? 0},${n.position?.y ?? 0}:${n.type ?? ''}:${n.data?.label ?? ''}:${(n.data as { success_threshold?: unknown })?.success_threshold ?? ''}:${(n.data as { threshold_source?: unknown })?.threshold_source ?? ''}`).join('|')
   const e = edges.map(e => `${e.id}:${e.source}>${e.target}:${e.label ?? ''}:${(e.data as any)?.schemaVersion ?? ''}`).join('|')
   return `${n}#${e}`
 }
@@ -1487,6 +1492,16 @@ function maybeInvalidateOnEdgeDelete(
 
 function getMaxNumericId(ids: string[]): number {
   return ids.reduce((max, id) => {
+    // P0 2026-08-13: `id` is NOT guaranteed to be a string here. CEE-written
+    // `scenarios.graph` edges carry no `id` key at all, so a persisted graph
+    // reaching `reseedIds` un-normalised made this `undefined.replace(...)` —
+    // a TypeError thrown OUT of `hydrateGraphSlice`, swallowed by the
+    // `.catch()` in CanvasMVP, which silently abandoned the REST of
+    // `loadScenario` (framing, stage, analysis) after the graph had already
+    // been set. `normalisePersistedGraph` now fixes the shape at the boundary;
+    // this guard is defence in depth, because the crash is catastrophic and
+    // this helper is reachable from several graph-replacement paths.
+    if (typeof id !== 'string') return max
     const num = parseInt(id.replace(/\D/g, ''), 10)
     return isNaN(num) ? max : Math.max(max, num)
   }, 0)

--- a/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
+++ b/src/canvas/utils/__tests__/edgeDataRebuildScan.spec.ts
@@ -326,14 +326,25 @@ describe('edge-data rebuilds — derived source guard (A-3a)', () => {
   /**
    * POSITIVE CONTROL (trap 13). If the detector finds nothing, the assertion
    * below passes by testing nothing — which is precisely how the unpinned class
-   * survived until now. `useScenario.ts` (the Supabase resume hop) and
-   * `store.ts` (the rehydrate + three repair hops) are the known homes; the scan
-   * must SEE them, by file, not merely return a non-zero count.
+   * survived until now. The Supabase resume hop and `store.ts` (the rehydrate +
+   * three repair hops) are the known homes; the scan must SEE them, by file, not
+   * merely return a non-zero count.
+   *
+   * ⚠ RELOCATED 2026-08-13 (P0 CEE-row reload fix), NOT weakened. The Supabase
+   * resume hop's edge-data rebuild moved OUT of `hooks/useScenario.ts` and INTO
+   * `canvas/utils/normalisePersistedGraph.ts`, which is now the single place a
+   * persisted `scenarios.graph` row is turned into canvas shape (the hop itself
+   * is unchanged — it still spreads DEFAULT_EDGE_DATA then the edge's own data).
+   * This control RED'd on exactly that move, which is the guard doing its job:
+   * it holds a manifest of where the class lives, so relocating a site is a
+   * decision someone has to make in a diff. Verified at the time of the move:
+   * the scan reports 6 findings across `canvas/domain/migrations.ts`,
+   * `canvas/store.ts` and `canvas/utils/normalisePersistedGraph.ts`.
    */
   it('the detector can see the real edge-data rebuilds (non-vacuous)', () => {
     expect(findings.length).toBeGreaterThan(0)
     const files = new Set(findings.map((f) => f.file))
-    expect(files.has('hooks/useScenario.ts')).toBe(true)
+    expect(files.has('canvas/utils/normalisePersistedGraph.ts')).toBe(true)
     expect(files.has('canvas/store.ts')).toBe(true)
     // The five hops `edgeValidationRebuildHops.spec.ts` drives end to end. Not a
     // hand-maintained list of WHERE to look — the scan found these — but a floor

--- a/src/canvas/utils/normalisePersistedGraph.ts
+++ b/src/canvas/utils/normalisePersistedGraph.ts
@@ -1,0 +1,119 @@
+/**
+ * normalisePersistedGraph — the ONE place a `scenarios.graph` row is turned into
+ * canvas (React Flow) shape before it reaches the store.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS EXISTS (P0, witnessed on deployed `978d073c`, 2026-08-13)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The `scenarios.graph` column holds TWO mutually incompatible shapes:
+ *
+ *   · CEE / GraphV3 — nodes `{id, kind, label, observed_state, …}` with NO
+ *     `position` and NO `data`; edges `{from, to, strength, …}` with NO `id`,
+ *     NO `source` and NO `target`.  (1,970 rows in staging, back to 22 April.)
+ *   · React Flow — nodes `{id, type, position, data}`; edges
+ *     `{id, source, target, data}`.
+ *
+ * `useScenario.loadScenario` used to hydrate that column into the canvas store
+ * VERBATIM. On a CEE-written row that put CEE-shaped objects into a store whose
+ * every consumer assumes React Flow shape, which produced, on **every reload of
+ * a decision Olumi drafted**:
+ *
+ *   1. `reseedIds` → `getMaxNumericId(edges.map(e => e.id))` → `undefined.replace`
+ *      → TypeError thrown OUT of `hydrateGraphSlice`, swallowed by the
+ *      `.catch()` at `routes/CanvasMVP.tsx:64`. The graph HAD already been
+ *      `set()` into the store, so the rest of `loadScenario` — framing, stage,
+ *      `lastSavedAt`, analysis hydration — silently never ran.
+ *   2. `computeGraphHash` → `from: e.source` → `undefined.localeCompare` thrown
+ *      inside a `useMemo` DURING RENDER → React's error boundary took the whole
+ *      canvas: **0 nodes**, under a panel reading "Your work is auto-saved."
+ *
+ * Hardening each consumer is whack-a-mole: a sweep of `src/` at this SHA found
+ * ten store-reachable sites across three severity tiers, plus 64 unguarded
+ * `node.data.*` reads. Every such patch is a NEW place that has to remember
+ * both shapes. Normalising ONCE at the hydration boundary retires the class.
+ *
+ * ⚠ NO NEW MAPPER. This deliberately reuses `mapDraftNodeToCanvas` /
+ * `mapDraftEdgeToCanvas` from `applyDraftResult.ts` — the mappers the DRAFT path
+ * has always used for exactly this conversion. `applyDraftResult`'s header
+ * already warns that it is "HOP 1 OF 3" of a hand-mirrored family; a fourth
+ * hand-written copy here is precisely the defect this estate keeps paying for.
+ * The reload path was not missing a mapper — it was missing a CALL to the one
+ * that already existed.
+ *
+ * ⚠ PER-ELEMENT, NOT PER-GRAPH. Shape is decided element by element, so a mixed
+ * row (a CEE graph a client partially overwrote, or vice versa) normalises
+ * correctly rather than being classified by whichever element happens to be
+ * first.
+ *
+ * ⚠ IDENTITY FOR ALREADY-CANVAS-SHAPED INPUT. A row already in React Flow shape
+ * must come through byte-identical — those rows reload correctly today
+ * (witnessed 2/2) and every existing autosave/history pin depends on their
+ * projection not moving. `normalisePersistedGraph` returns the SAME node objects
+ * by reference in that case; only the documented `DEFAULT_EDGE_DATA` backfill,
+ * which `loadScenario` already performed, is applied to edges.
+ */
+
+import type { Edge } from '@xyflow/react'
+import { mapDraftNodeToCanvas, mapDraftEdgeToCanvas } from './applyDraftResult'
+import { DEFAULT_EDGE_DATA, type EdgeData } from '../domain/edges'
+
+/**
+ * Is this persisted node already in canvas shape?
+ *
+ * `position` is the discriminator: React Flow requires it on every node and
+ * CEE's GraphV3 carries no geometry at all — `mergeServerGraph`'s header states
+ * that CEE measures `layout_present` as false for every real graph. Testing for
+ * the field's PRESENCE (not its truthiness) keeps a legitimately-persisted
+ * `{x: 0, y: 0}` on the canvas-shaped side.
+ */
+export function isCanvasShapedNode(n: unknown): boolean {
+  return typeof n === 'object' && n !== null && 'position' in (n as object)
+}
+
+/**
+ * Is this persisted edge already in canvas shape?
+ *
+ * Both endpoints must be strings. A CEE edge carries neither key; a React Flow
+ * edge carries both. Requiring BOTH means a half-written edge is normalised
+ * (where the mapper's `from`/`to` fallback can still recover it) rather than
+ * passed through with one endpoint undefined.
+ */
+export function isCanvasShapedEdge(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false
+  const { source, target } = e as { source?: unknown; target?: unknown }
+  return typeof source === 'string' && typeof target === 'string'
+}
+
+export interface NormalisedGraph {
+  nodes: any[]
+  edges: Edge<EdgeData>[]
+}
+
+/**
+ * Normalise a persisted `scenarios.graph` payload to canvas shape.
+ *
+ * Edges always receive the `DEFAULT_EDGE_DATA` backfill — that is not new
+ * behaviour, it is what `loadScenario` already did to every persisted edge, and
+ * several consumers (including the DEV assertion in `useConversation`) rely on
+ * `edge.data` being present.
+ */
+export function normalisePersistedGraph(graph: unknown): NormalisedGraph {
+  const g = (graph ?? {}) as { nodes?: unknown[]; edges?: unknown[] }
+  const rawNodes = Array.isArray(g.nodes) ? g.nodes : []
+  const rawEdges = Array.isArray(g.edges) ? g.edges : []
+
+  const nodes = rawNodes.map((n) => (isCanvasShapedNode(n) ? n : mapDraftNodeToCanvas(n)))
+
+  const edges = rawEdges.map((e, i) => {
+    const canvasEdge: any = isCanvasShapedEdge(e) ? e : mapDraftEdgeToCanvas(e, i)
+    return {
+      ...canvasEdge,
+      data: {
+        ...DEFAULT_EDGE_DATA,
+        ...((canvasEdge.data as Partial<EdgeData> | undefined) ?? {}),
+      },
+    } as Edge<EdgeData>
+  })
+
+  return { nodes, edges }
+}

--- a/src/hooks/__tests__/useScenario.ceeRowHydrationWiring.p0.spec.ts
+++ b/src/hooks/__tests__/useScenario.ceeRowHydrationWiring.p0.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * THE WIRING PIN for the P0 reload fix.
+ *
+ * `normalisePersistedGraph` is unit-tested in
+ * `canvas/__tests__/store.ceeShapedHydration.p0.spec.ts`. That proves the
+ * FUNCTION is correct and proves nothing about whether `loadScenario` calls it.
+ *
+ * ⚠ THIS FILE EXISTS BECAUSE THE GAP WAS MEASURED, NOT IMAGINED. Replacing the
+ * `normalisePersistedGraph(row.graph)` call in `useScenario.loadScenario` with
+ * the old verbatim `{ nodes: row.graph.nodes, edges: row.graph.edges }` left the
+ * unit spec at **10/10 GREEN** — the fix would have been deletable in a tidy-up
+ * with no red anywhere, which is exactly the trap-19 proof obligation
+ * (delete the producer and the tests must go red) left unmet at the call site.
+ * Same shape as `CanvasMVP.serverGraphHydration.spec.tsx`, which was written
+ * after the same class of finding one layer up.
+ *
+ * So this drives the REAL hook against a REAL CEE-shaped row and asserts on the
+ * STORE — the thing the canvas actually renders from — not on the mapper.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import ceeRow from '../../canvas/hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+const REAL_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+const mockAuthValue = { user: { id: REAL_USER_ID }, authenticated: true }
+
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => mockAuthValue }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+const mockLoadScenario = vi.fn()
+vi.mock('../../services/scenarioService', () => ({
+  loadScenario: (...a: unknown[]) => mockLoadScenario(...a),
+  createScenario: vi.fn(),
+  saveGraph: vi.fn(),
+  saveFraming: vi.fn(),
+  storeAnalysis: vi.fn(),
+  resetAnalysisStatus: vi.fn(),
+  createSharedBrief: vi.fn(),
+  updateStage: vi.fn(),
+}))
+
+import { useScenario } from '../useScenario'
+import { useCanvasStore } from '../../canvas/store'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+beforeEach(() => {
+  mockLoadScenario.mockReset()
+  useCanvasStore.setState({ nodes: [], edges: [] })
+})
+
+describe('P0 wiring: loadScenario normalises a CEE-written row before it reaches the store', () => {
+  beforeEach(() => {
+    mockLoadScenario.mockResolvedValue({
+      id: SCENARIO_ID,
+      graph: ceeRow,
+      framing: null,
+      stage: 'draft',
+      updated_at: new Date().toISOString(),
+      analysis_status: 'none',
+      analysis: null,
+    })
+  })
+
+  it('puts CANVAS-shaped nodes in the store — every node has a position', async () => {
+    const { result } = renderHook(() => useScenario())
+    await result.current.loadScenario(SCENARIO_ID)
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().nodes).toHaveLength(15)
+    })
+    const nodes = useCanvasStore.getState().nodes as any[]
+    // RED if the normaliser call is removed: CEE nodes carry no `position`.
+    expect(nodes.filter((n) => n.position && typeof n.position.x === 'number')).toHaveLength(15)
+  })
+
+  it('puts CANVAS-shaped edges in the store — every edge has string source/target', async () => {
+    const { result } = renderHook(() => useScenario())
+    await result.current.loadScenario(SCENARIO_ID)
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().edges).toHaveLength(28)
+    })
+    const edges = useCanvasStore.getState().edges as any[]
+    // RED if the normaliser call is removed: CEE edges carry `from`/`to` only.
+    expect(edges.filter((e) => typeof e.source === 'string' && typeof e.target === 'string'))
+      .toHaveLength(28)
+    expect(edges.filter((e) => typeof e.id === 'string')).toHaveLength(28)
+  })
+
+  it('carries the label through to where the canvas reads it (not blank boxes)', async () => {
+    const { result } = renderHook(() => useScenario())
+    await result.current.loadScenario(SCENARIO_ID)
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().nodes.length).toBeGreaterThan(0)
+    })
+    const nodes = useCanvasStore.getState().nodes as any[]
+    const first: any = nodes.find((n) => n.id === (ceeRow.nodes as any[])[0].id)
+    expect(first.data.label).toBe((ceeRow.nodes as any[])[0].label)
+  })
+
+  it('COMPLETES the load: the rest of loadScenario runs (it used to throw out of hydrate)', async () => {
+    const { result } = renderHook(() => useScenario())
+    await result.current.loadScenario(SCENARIO_ID)
+
+    // `currentStage` is set AFTER hydrateGraphSlice. Before the fix, reseedIds
+    // threw out of the hydrate and this was never reached.
+    await waitFor(() => {
+      expect(useCanvasStore.getState().currentStage).toBe('draft')
+    })
+    expect(useCanvasStore.getState().currentScenarioId).toBe(SCENARIO_ID)
+  })
+})
+
+describe('a React-Flow-shaped row still hydrates unchanged', () => {
+  it('keeps the persisted positions rather than re-mapping them to {0,0}', async () => {
+    mockLoadScenario.mockResolvedValue({
+      id: SCENARIO_ID,
+      graph: {
+        nodes: [{ id: 'n1', type: 'factor', position: { x: 123, y: 456 }, data: { label: 'A' } }],
+        edges: [{ id: 'e1', source: 'n1', target: 'n1', data: {} }],
+      },
+      framing: null,
+      stage: 'draft',
+      updated_at: new Date().toISOString(),
+      analysis_status: 'none',
+      analysis: null,
+    })
+
+    const { result } = renderHook(() => useScenario())
+    await result.current.loadScenario(SCENARIO_ID)
+
+    await waitFor(() => {
+      expect(useCanvasStore.getState().nodes).toHaveLength(1)
+    })
+    const n: any = (useCanvasStore.getState().nodes as any[])[0]
+    expect(n.position).toEqual({ x: 123, y: 456 })
+  })
+})

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -23,8 +23,9 @@ import * as scenarioService from '../services/scenarioService'
 import type { ScenarioStage, AnalysisProvenance, AnalysisStatus } from '../types/scenario'
 import { hydrateAnalysisFromV2Response } from './hydrateAnalysis'
 import type { Edge } from '@xyflow/react'
-import { DEFAULT_EDGE_DATA, type EdgeData } from '../canvas/domain/edges'
+import { type EdgeData } from '../canvas/domain/edges'
 import { readPersistedGoalConstraints } from '../canvas/utils/persistedGraph'
+import { normalisePersistedGraph } from '../canvas/utils/normalisePersistedGraph'
 import { isPersistenceActive as computeIsPersistenceActive } from '../lib/persistenceActive'
 import { shouldPersistGraphForScenario } from '../canvas/stores/draftStore'
 // P0 2026-08-13 — may this client write `scenarios.graph` at all? Its own module
@@ -644,21 +645,20 @@ export function useScenario(): UseScenarioReturn {
         return
       }
 
-      // The graph JSONB column stores { nodes: Node[], edges: Edge[] }
-      const graph = row.graph as { nodes?: unknown[]; edges?: unknown[] } | null
-      const graphNodes = (graph?.nodes ?? []) as Parameters<
+      // The graph JSONB column stores { nodes, edges } in ONE OF TWO SHAPES —
+      // CEE/GraphV3 or React Flow. Normalise to canvas shape BEFORE anything
+      // touches it (P0, 2026-08-13): this used to hydrate verbatim, which put
+      // CEE-shaped objects into a store whose every consumer assumes React Flow,
+      // crashing `reseedIds` inside `hydrateGraphSlice` and then `computeGraphHash`
+      // during render — a blank canvas on every reload of a CEE-drafted decision.
+      // A React-Flow-shaped row is passed through unchanged (same objects by
+      // reference); the DEFAULT_EDGE_DATA backfill this path always applied is
+      // preserved inside the normaliser.
+      const normalised = normalisePersistedGraph(row.graph)
+      const graphNodes = normalised.nodes as Parameters<
         ReturnType<typeof useCanvasStore.getState>['hydrateGraphSlice']
       >[0]['nodes']
-      // Upgrade persisted edges to strongly-typed Edge<EdgeData>,
-      // matching the pattern in store.ts loadScenario
-      const rawEdges = (graph?.edges ?? []) as Edge[]
-      const graphEdges: Edge<EdgeData>[] = rawEdges.map((edge) => ({
-        ...edge,
-        data: {
-          ...DEFAULT_EDGE_DATA,
-          ...((edge.data as Partial<EdgeData> | undefined) ?? {}),
-        },
-      }))
+      const graphEdges: Edge<EdgeData>[] = normalised.edges
 
       // B3: the scenario's persisted hard constraints. Read defensively —
       // this is untyped JSONB and the value feeds the run request.


### PR DESCRIPTION
## Can a user now return to their own decision and see it?

**Yes — at unit/integration level, witnessed by execution against real CEE bytes. Not yet journey-witnessed on staging** (this PR is not merged or deployed, so the top rung is not claimed).

Before: reloading **any** decision Olumi drafted gave *"Something went wrong — The canvas encountered an unexpected error"* and **0 nodes**, under a panel reading *"Your work is auto-saved."* Witnessed 3/3 on CEE-written rows, 0/2 on React-Flow-written rows (deployed `978d073c`).

After: the real 15-node/28-edge CEE row hydrates to 15 nodes / 28 edges in the store, every node with a position, every edge with string endpoints, **and labels intact** — the last of which is the difference between "the canvas renders" and "the canvas renders fifteen blank boxes".

---

## What was actually wrong — TWO throws, not one

`scenarios.graph` holds two shapes. `useScenario.loadScenario` hydrated the column into the canvas store **verbatim**, so CEE/GraphV3 objects reached a store whose every consumer assumes React Flow.

| # | throw | where | what the user got |
|---|---|---|---|
| 1 | `undefined.replace` | `getMaxNumericId` ← `reseedIds` ← `hydrateGraphSlice` | thrown OUT of `loadScenario`, swallowed by `CanvasMVP.tsx:64`'s `.catch()`. The graph had **already** been `set()`, so framing, stage, `lastSavedAt` and analysis hydration silently never ran |
| 2 | `undefined.localeCompare` | `useAutosave.computeGraphHash` `:117`/`:126` | thrown inside a `useMemo` **during render** → error boundary → blank canvas. **This is the one the user saw** |

### ⭐ This reconciles two records that looked contradictory

My brief said ROADMAP **2.1096 is "REFUTED as written"** because it describes a *silent partial hydration* where *"the graph does land"*, whereas the witness measured a loud crash with nothing landing.

**Measured: 2.1096 is correct, and so is the witness. They answer different questions** (trap 21). 2.1096 describes the **hydrate path** — the store `set` precedes the `try { reseedIds }`, so the graph genuinely does land and the rest of the load is genuinely abandoned in silence. The witness describes the **render path** — a second, independent throw that blanks the canvas. Both true, simultaneously, for different reasons.

I did **not** rewrite 2.1096 to say "the graph does not land". That would have deleted an accurate, independently-reproduced record and replaced it with a description of the *other* defect. The row is updated to carry both halves and the reconciliation.

⚠ 2.1096's own prescribed "minimal repair" (guard `getMaxNumericId` — "a two-token change") was **necessary but not sufficient**: it leaves throw #2 live and the canvas still blank.

---

## The fix — at the boundary, not the ten call sites

A sweep of `src/` at `978d073c` found **10 store-reachable sites across 3 tiers**, plus 64 unguarded `node.data.*` reads. Hardening each is whack-a-mole, and every patch becomes a new place that must remember both shapes.

**`normalisePersistedGraph`** (new) converts a persisted row to canvas shape once, at the hydration boundary — **reusing the existing `mapDraftNodeToCanvas` / `mapDraftEdgeToCanvas`** the draft path has always used for exactly this conversion. `applyDraftResult`'s own header warns it is already "HOP 1 OF 3" of a hand-mirrored family; a fourth hand-written copy is the defect this estate keeps paying for. **The reload path was not missing a mapper — it was missing a call to the one that already existed.**

React-Flow-shaped rows pass through **by reference**, so the majority path is untouched.

Plus defence in depth, because the crash is catastrophic and these are reachable from several paths:
- `computeGraphHash` reads both shapes; comparators coerce so no element can take the render.
- `getMaxNumericId` skips non-string ids; `historyHash` optional-chains `position`.

---

## ⚠ The trap: this hash feeds dirty-detection

`computeGraphHash` is the autosave's **dirty gate**. A fix that merely stopped the throw could have made every CEE edge project identical endpoints — so a rewire would not flip the hash, the save would skip, and the edit would be **silently lost**. That is worse than the crash, because nothing reports it.

**Byte-stability was measured, not argued.** A 16-entry React-Flow corpus was hashed in a pristine worktree at `978d073c` and in the fixed tree:

- **16/16 byte-identical**, nothing in the corpus threw at pristine
- **positive control fired** — a deliberate one-word change to the projection produced a visible diff, so the harness is not blind
- the CEE fallbacks are **gated on shape**, so canvas-shaped nodes project through the *original* expressions — byte-stability is structural, not luck
- the corpus is pinned as a golden spec (`useAutosave.signatureByteStability.spec.ts`) so CI holds the line

The corpus deliberately includes the awkward cases (`topLevelLabelWithPosition`, `topLevelKindWithPosition`, missing `data.label`, `{0,0}` position, single-element malformed graphs whose 1-element `.sort()` never invoked its comparator).

Separately, fidelity **for CEE input** is asserted directly: a rewire, a removal, an endpoint swap, and a label edit must each flip the signature.

---

## Copy: the panel no longer promises a save it did not make

The crash panel printed *"Your work is auto-saved. Reloading will restore your latest work."* **unconditionally**.

On this P0 that was false at the moment shown, and provably: a CEE-shaped store fails every plausibility gate in `crashFlush` (`isPlausibleNode` requires a finite `position.x/y`; `isPlausibleEdge` requires string `source`/`target`), so `flushWorkToAutosave()` returned **false without writing** — a fact `componentDidCatch` **already had in hand** as `flushed` and logged, then ignored.

The line is now bound to what the flush actually did. The failure branch says what happened (*"We could not save your most recent changes"*) and stops short of claiming the work is **lost** — `flushWorkToAutosave` deliberately preserves an older autosave, so a restore may still recover something.

---

## Evidence

**Fixture is real producer bytes, not hand-authored.** `.body.draft_graph` of a captured CEE draft turn (2026-08-12); node/edge objects **verbatim**. Its edge key manifest matches the witness's persisted-row manifest character for character. Its nodes carry three keys the witnessed row did not show — a superset, which cannot make the defect easier to hit, since what triggers it is the *absence* of `source`/`target`.

⚠ My brief named `armA2-row-final.json` as a real banked row to hydrate. **That file does not exist** — searched the named path, all of `olumi-docs`, and the whole of `~/Documents/GitHub` (positive control fired on the witness doc; contrast control returned zero). The only `armA2*` artefacts are PNGs from an unrelated earlier probe.

**RED-first at pristine, named signatures:**
```
TypeError: Cannot read properties of undefined (reading 'localeCompare')   useAutosave.ts:126:30
TypeError: Cannot read properties of undefined (reading 'replace')          getMaxNumericId ← reseedIds ← hydrateGraphSlice
```

**Discriminating mutant pair** (throwaway worktree outside the repo root; isolation proven by writing a sentinel and comparing inodes; HEAD-relative restores; restores byte-compared against a pristine archive; controls exactly 0):

| mutant | reload spec |
|---|---|
| control (unmutated) | 10/10 green |
| **A1** revert edge projection only | **3 RED** (silent-collapse caught by the fidelity tests) |
| **A2** revert both limbs = the deployed defect | **7 RED** — exactly the pristine result |
| **B1** break the ErrorBoundary copy (same path, unrelated concern) | **stays green** ✓ |
| **B2** break the store id guard (same path, unrelated function) | **stays green** ✓ |

Each B mutant REDs **its own** spec (B1 → 2 RED, B2 → 2 RED), so nothing here is unpinned.

**Two findings the mutants produced that inspection did not:**
1. `actually carries the CEE endpoint identities` originally used `toContain(edge.from)` and **survived A1** — because a CEE edge's `from` is also a *node* id, and node ids are in the hash. It was passing on the wrong object (trap 19). Now bound to `"from":"…"`, which only the edge half emits.
2. Deleting the `normalisePersistedGraph` **call** in `loadScenario` left the unit spec **10/10 green** — the fix was deletable in a tidy-up with no red anywhere. Hence `useScenario.ceeRowHydrationWiring.p0.spec.ts`, which drives the real hook and asserts on the **store**. That mutant now REDs 3.

---

## Scope call — flagging this for your judgement

My brief scoped the fix to the projector and fenced `useScenario.ts`'s *write-gating*. I have changed `useScenario.ts`'s **read/hydration** path, which is a larger move than "patch `useAutosave`". Stating it rather than drifting into it, as instructed:

**Why the projector patch alone is not enough.** It stops the error boundary, but the store still holds CEE-shaped nodes: no `position` (React Flow's required field) and no `data`, while the canvas renders `data.label`. The user would get an un-laid-out canvas of **unlabelled boxes**, and throw #1 would still abandon framing, stage and analysis hydration. That does not meet "return to your decision and see it".

Happy to split the normaliser into a follow-up if you'd rather land the projector guard alone first — the layers are independent and each is separately pinned.

## One guard edit, disclosed

CI RED'd on the first push — `edgeDataRebuildScan.spec.ts`, a **derived source guard** whose non-vacuity control names the files where an edge-data rebuild is known to live. It named `hooks/useScenario.ts`; the P0 fix **relocated** that hop into `canvas/utils/normalisePersistedGraph.ts`.

**The guard was right and I updated the manifest, not the invariant.** The hop itself is unchanged — it still spreads `DEFAULT_EDGE_DATA` then the edge's own data — and the guard's four substantive invariants (`spreads wholesale`, `nothing written after the spread`, `disclosed override set`, `comment-blindness`) passed on the new site throughout. The `>= 5` floor is untouched; the scan now reports 6 findings across `migrations.ts`, `store.ts` and `normalisePersistedGraph.ts`. Flagging it because a guard edit in a fix PR is exactly the thing a reviewer should not have to discover.

## CI at the exact head `c3e3d722`

**13/13 green, including the required `Staging Gate`.** `mergeable=MERGEABLE`, `state=CLEAN`. Locally: typecheck gate PASSED (ratchet drift shrank 2487 → 2485, baseline deliberately NOT regenerated), lint 0 errors, rules-of-hooks ratchet exactly at baseline.

## Not done, stated rather than generalised

- **Not journey-witnessed.** Unmerged and undeployed; only rungs up to integration-tested are claimed.
- The manifest's Tier-2/Tier-3 sites are no longer reachable **via the reload route** because the shape is fixed upstream of them. I did **not** prove every other route into the store is closed — `importCanvas` takes user-supplied JSON of arbitrary shape and was out of scope.
- The four already-poisoned rows (ROADMAP 2.1100) are unaffected by this PR.
- The mixed-scale analysis refusal (witness §A1b/§3) is untouched and remains the other blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
