### PR TITLE
fix(pre-analysis): never claim 'Analysis available' about an unassessed model

### DIFF
--- a/src/canvas/components/pre-analysis-v3/__tests__/unansweredReadinessClaim.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/unansweredReadinessClaim.spec.tsx
@@ -1,0 +1,267 @@
+/**
+ * The pre-analysis panel never claims a readiness it has not been given.
+ *
+ * ── The defect, witnessed on deployed staging 2026-08-13 (UI `5deee0cf`) ──
+ *
+ * The panel rendered `Analysis available` beside an enabled `Analyse first
+ * pass`, while CEE refused the run outright ("Options exist but don't have
+ * effects configured yet…"). The response carried `blocks: []`, so nothing
+ * explained the refusal in the panel; it landed in the chat column. Analysis
+ * completed 0 of 4 attempts. The user presses the big blue button and nothing
+ * changes.
+ *
+ * ── Why the existing guards did not see it ──
+ *
+ * #564 / ROADMAP 2.332 / 2.339 closed the arms where the readiness check
+ * FAILS. `readinessOutageVisibility.spec.tsx` covers every one of them —
+ * transport rejection, 404, 429, 5xx — and each drives the fetch to a definite
+ * outcome before asserting. All of them set `readinessStore.error`.
+ *
+ * `usePreAnalysisModel` derives its outage slice as
+ * `readinessError ? {…} : null`, so the outage arm is reachable ONLY through a
+ * recorded error. That leaves one state uncovered, and it is the state the
+ * panel spends every cold load in:
+ *
+ *     readiness === null  &&  error === null
+ *
+ * — the check has not answered YET, or never fired at all. In it:
+ *   · `readinessCheck` is null, so PanelFooter's outage arm does not render;
+ *   · `canRun` in the model is `readiness ? … : null`, which is not `false`,
+ *     so the footer falls through to the availability copy; and
+ *   · `canRunAnalysis` blocks only on `readiness && !can_run_analysis`, so the
+ *     run gate is open and the CTA is enabled.
+ *
+ * The panel therefore asserts `Analysis available` about a model that nothing
+ * has assessed. That is the same false-positive class #564 was merged to end,
+ * on the one arm #564 did not reach — and it is not a transient frame: the
+ * readinessStore's own header records `graph-readiness` being requested ZERO
+ * times in three of four witnessed guest sessions (the 2.345 starvation
+ * deadlock), and a Render cold start holds the in-flight state for seconds.
+ *
+ * ── What this spec does and does not require ──
+ *
+ * It constrains the CLAIM, never the gate. The run stays enabled on an unknown
+ * verdict, deliberately: `readinessObjectsToRun`'s docstring settles that
+ * failing closed on an unobtainable check would brick the Run button for a
+ * healthy user whose only problem is a side-car service being down. Unknown
+ * does not object — but neither does it entitle the panel to say "available".
+ * Silence about a fact we do not hold beats a positive claim we cannot support.
+ *
+ * Scope (CLAUDE.md trap 3): PRESENCE and TEXT assertions on the real, mounted
+ * panel driven by the real store through a mocked transport. Not layout, not
+ * visibility, not above-the-fold — those belong to a walk.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { PreAnalysisPanelV3 } from '../PreAnalysisPanelV3'
+import { FOOTER_COPY } from '../constants'
+import { ToastProvider } from '../../../ToastContext'
+import { useCanvasStore } from '../../../store'
+import { useReadinessStore } from '../../../stores/readinessStore'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { useSignalSessionStore } from '../signals/signalSessionStore'
+import { clearInflightCache } from '../../../hooks/useGraphReadiness'
+
+const mockFetch = vi.fn()
+
+function node(
+  id: string,
+  kind: string,
+  label: string,
+  data: Record<string, unknown> = {},
+): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+/**
+ * The witnessed shape: a decision, a goal and two options — a model with no
+ * success target set, which is the branch that printed
+ * `readySubSuccessUnset` ("First pass will be provisional until success is
+ * defined") in the staging capture. Seeding the exact branch matters: it is
+ * the one that reaches the availability headline with `readiness === null`.
+ */
+function seedGraph() {
+  useCanvasStore.setState({
+    nodes: [
+      node('d1', 'decision', 'Should we move the whole company to a four-day week?'),
+      node('g1', 'goal', 'Maintain delivery output'),
+      node('o1', 'option', 'Pilot four-day week (one department)'),
+      node('o2', 'option', 'Keep the five-day week'),
+    ] as any,
+    edges: [] as any,
+    preAnalysisSensitivity: null,
+    ceeAnalysisReady: null,
+    draftCoaching: null,
+    currentBriefText: null,
+    goalThreshold: null,
+    goalConstraints: null,
+  })
+}
+
+/** A readiness service that accepts the request and never answers — the
+ *  Render cold-start shape, and the state a never-fired request sits in. */
+function neverAnswers() {
+  return new Promise<never>(() => {})
+}
+
+function healthyOpenResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function refusingResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 30,
+        readiness_level: 'needs_work',
+        can_run_analysis: false,
+        confidence_explanation: 'Options need intervention values',
+        improvements: [],
+        options_ready: 0,
+        options_total: 2,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function renderPanel() {
+  return render(
+    <ToastProvider>
+      {/* `canRun` is passed TRUE deliberately — it is what OutputsDock's
+          `canRunAnalysis` returns for a null verdict, and passing it true is
+          what makes this a test about the panel's CLAIM rather than about the
+          gate. A fix that merely closed the gate would not satisfy it. */}
+      <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun={true} />
+    </ToastProvider>,
+  )
+}
+
+async function settle() {
+  await act(async () => {
+    await vi.runAllTimersAsync()
+  })
+}
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.stubGlobal('fetch', mockFetch)
+  vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  clearInflightCache()
+  useSignalSessionStore.getState().reset()
+  useGuidanceStore.setState({ _sendChip: null, _prefillChat: null })
+  seedGraph()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('pre-analysis panel — an unanswered readiness check is not an availability claim', () => {
+  describe('the check has not answered', () => {
+    it('does not print the availability headline while no verdict and no error exist', async () => {
+      mockFetch.mockImplementation(() => neverAnswers())
+      renderPanel()
+      await settle()
+
+      // PIN THE PRECONDITION IN-TEST (CLAUDE.md trap 13b): this test is only
+      // about the unanswered state, so prove the store is IN it. Without this
+      // the assertion below could pass because the check failed, or answered,
+      // and the test would be silently measuring a different arm.
+      const state = useReadinessStore.getState()
+      expect(state.readiness).toBeNull()
+      expect(state.error).toBeNull()
+
+      // The claim, bound to the footer BY IDENTITY — never to whichever
+      // element happens to carry the string.
+      const footer = screen.getByTestId('pre-analysis-v3-footer')
+      expect(footer).not.toHaveTextContent(FOOTER_COPY.ready)
+    })
+
+    it('says what it actually holds — that readiness has not been established', async () => {
+      mockFetch.mockImplementation(() => neverAnswers())
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness).toBeNull()
+      expect(useReadinessStore.getState().error).toBeNull()
+
+      // Silence would satisfy the test above; this one requires the panel to
+      // account for the gap rather than merely drop the sentence.
+      const footer = screen.getByTestId('pre-analysis-v3-footer')
+      expect(footer).toHaveTextContent(FOOTER_COPY.readinessPending)
+    })
+
+    it('leaves the run enabled — an unknown verdict must not brick a healthy model', async () => {
+      mockFetch.mockImplementation(() => neverAnswers())
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness).toBeNull()
+      expect(useReadinessStore.getState().error).toBeNull()
+
+      // Over-blocking is its own defect (and would contradict
+      // `readinessObjectsToRun`'s settled reasoning). The CTA is bound by
+      // testid, not by its label.
+      expect(screen.getByTestId('pre-analysis-v3-analyse')).not.toBeDisabled()
+    })
+  })
+
+  // ── Negative controls ────────────────────────────────────────────
+  //
+  // Both exist so the fix cannot be "stop printing the headline". A blanket
+  // removal passes every assertion above and fails both of these.
+  describe('an answered check is unaffected', () => {
+    it('still prints the availability headline when the server says the model is ready', async () => {
+      mockFetch.mockResolvedValue(healthyOpenResponse())
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(true)
+      expect(useReadinessStore.getState().error).toBeNull()
+
+      const footer = screen.getByTestId('pre-analysis-v3-footer')
+      expect(footer).toHaveTextContent(FOOTER_COPY.ready)
+      expect(footer).not.toHaveTextContent(FOOTER_COPY.readinessPending)
+    })
+
+    it('still prints the not-ready copy when the server refuses the model', async () => {
+      mockFetch.mockResolvedValue(refusingResponse())
+      renderPanel()
+      await settle()
+
+      expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+
+      const footer = screen.getByTestId('pre-analysis-v3-footer')
+      expect(footer).toHaveTextContent(FOOTER_COPY.notReady)
+      expect(footer).not.toHaveTextContent(FOOTER_COPY.ready)
+      expect(footer).not.toHaveTextContent(FOOTER_COPY.readinessPending)
+    })
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -323,6 +323,35 @@ export const FOOTER_COPY = {
   readinessRetainedSub: (reason: string, takenAt: string) =>
     `${reason}. Showing the check from ${takenAt}.`,
   readinessRetry: 'Retry readiness check',
+
+  // ── The check has neither answered NOR failed ─────────────────────
+  //
+  // The arm the three lines above do not reach, and the one the panel spends
+  // every cold load in: `readiness === null && error === null`.
+  //
+  // `usePreAnalysisModel` builds its outage slice as `readinessError ? {…}
+  // : null`, so all of the copy above is gated on a RECORDED FAILURE. With no
+  // verdict and no error the footer fell through to `ready` — "Analysis
+  // available" — about a model nothing had assessed, and `canRunAnalysis`
+  // (which blocks only on `readiness && !can_run_analysis`) left the CTA
+  // enabled beside it. Witnessed on deployed staging 2026-08-13: the panel
+  // claimed availability while CEE refused the run outright, with `blocks: []`
+  // so nothing explained it in the panel.
+  //
+  // Deliberately ONE line covering both "in flight" and "never fired". It
+  // asserts neither — a check that is running and a check that never went out
+  // are the same fact to the reader (nothing has assessed this model), and a
+  // headline claiming a check is IN PROGRESS would be its own unsupported
+  // claim on the starvation path where no request exists.
+  //
+  // The subline names the consequence and keeps the affordance honest: the run
+  // is NOT gated on this (see `readinessObjectsToRun` — failing closed on an
+  // unobtainable check bricks the Run button for a healthy user), so the copy
+  // says so rather than implying the button is dead.
+  /** No verdict and no failure: nothing has assessed this model. */
+  readinessPending: 'Readiness not checked yet',
+  readinessPendingSub:
+    'Olumi has not assessed this model yet. You can still run a first pass.',
 } as const
 
 /**

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -326,6 +326,39 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // and the footer agree with the run gate (canRunAnalysis util).
   const canRun = readiness ? readiness.can_run_analysis || willScaffoldOptions : null
   const footer = useMemo(() => {
+    // ── No verdict: say so, and claim nothing ────────────────────────
+    //
+    // FIRST, because with `readiness == null` nothing below this line is
+    // entitled to make a claim about the model. `canRun` is `null` here (not
+    // `false`), so the `canRun === false` arm does not fire and the memo used
+    // to fall through to the availability copy — printing "Analysis available"
+    // about a model nothing had assessed, beside a CTA that `canRunAnalysis`
+    // leaves enabled (it blocks only on `readiness && !can_run_analysis`).
+    // Witnessed on deployed staging 2026-08-13 as the exact triple
+    // "Analysis available / First pass will be provisional until success is
+    // defined / Analyse first pass" while CEE refused the run.
+    //
+    // #564 / 2.332 / 2.339 closed the arms where the check FAILS; every one of
+    // them sets `readinessError`, and `readinessCheck` is derived as
+    // `readinessError ? {…} : null`. This is the arm none of them reach: the
+    // check has not answered YET, or never fired at all (the 2.345 starvation
+    // shape, which the readinessStore header records as ZERO graph-readiness
+    // requests in three of four witnessed guest sessions).
+    //
+    // Deliberately keyed on `readiness == null` ALONE, not on
+    // `readiness == null && readinessError == null`. When an error IS recorded
+    // the outage arm in PanelFooter outranks this value anyway, so the extra
+    // conjunct buys nothing — and omitting it means a null verdict can never
+    // produce an availability claim by any route, which is the fail-safe
+    // direction. The run gate is untouched: unknown does not object.
+    if (readiness == null) {
+      return {
+        dot: 'warning' as const,
+        headline: FOOTER_COPY.readinessPending,
+        subline: FOOTER_COPY.readinessPendingSub,
+      }
+    }
+
     // UI-SEM-091: readiness reports not-runnable, but CEE will draft the
     // remaining options — disclose the draft, never the not-ready copy.
     if (readiness?.can_run_analysis === false && willScaffoldOptions) {
@@ -366,6 +399,11 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     scaffoldOptionCount,
     success.isSet,
     top,
+    // The null/non-null transition is what the new first branch turns on.
+    // `canRun` already tracks it (null → boolean), but depending on the
+    // verdict itself keeps the memo's inputs honest rather than relying on a
+    // derived value to stand in for it.
+    readiness,
     readiness?.can_run_analysis,
     readiness?.confidence_explanation,
   ])


### PR DESCRIPTION
## What a user now sees when the server will not analyse their model

Before: the panel rendered **`Analysis available`** beside an enabled **`Analyse first pass`** about a model **nothing had assessed**, and the CTA did nothing.

After: when no readiness verdict exists, the footer says **`Readiness not checked yet`** / *"Olumi has not assessed this model yet. You can still run a first pass."* The run gate is **unchanged** — unknown does not object.

## The defect, witnessed on deployed staging 2026-08-13 (UI `5deee0cf`)

> The panel renders `Analysis available` with an enabled `Analyse first pass`, while CEE refuses. `blocks: []`, so nothing explains it in the panel — the refusal lands in the chat column. The user presses the big blue button and nothing changes.

Analysis completed **0 of 4 attempts**. Evidence: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/WITNESS-20260813-EVENING.md`.

## The derived readiness predicate

The panel's footer is a total function over `readiness`, and it had no arm for *"no verdict"*:

```
canRun = readiness ? readiness.can_run_analysis || willScaffoldOptions : null
```

With `readiness == null`, `canRun` is `null` — **not `false`** — so the `canRun === false` arm did not fire and the memo fell through to the availability copy. `canRunAnalysis` blocks only on `readiness && !can_run_analysis`, so the CTA stayed enabled beside it.

**Why the existing guards did not see it.** #564 / ROADMAP 2.332 / 2.339 closed the arms where the check *fails*, and `readinessOutageVisibility.spec.tsx` covers every one — transport, 404, 429, 5xx. All of them set `readinessError`, and `usePreAnalysisModel` derives its outage slice as `readinessError ? {…} : null`. The uncovered state is:

```
readiness === null  &&  error === null
```

— the check has not answered **yet**, or never fired at all. Not a transient frame: `readinessStore`'s own header records `graph-readiness` requested **zero** times in three of four witnessed guest sessions (the 2.345 starvation shape), and a Render cold start holds it for seconds.

**Reproduction is byte-exact.** At pristine the new spec's failure output is the witnessed staging triple verbatim:

```
Analysis availableFirst pass will be provisional until success is definedAnalyse first pass
```

That settles which arm the witness hit: `readiness === null`, **not** `can_run_analysis: true`.

## The fix

One branch, first in the footer memo, keyed on `readiness == null` **alone** — not `readiness == null && error == null`. When an error is recorded the outage arm outranks this value anyway, so the extra conjunct buys nothing, and omitting it means a null verdict can never produce an availability claim by any route (fail-safe direction).

**Deliberately not a gate change.** Failing closed on an unobtainable check would brick the Run button for a healthy user whose only problem is a side-car service being down — `readinessObjectsToRun`'s settled reasoning, and what POC-DONE's PC1 forbids. Over-blocking a working action is its own defect.

## RED-first + discriminating pair

`src/canvas/components/pre-analysis-v3/__tests__/unansweredReadinessClaim.spec.tsx` — 5 tests, collected by name on every run.

At pristine: **2 failed / 3 passed**, on the two named signatures
`does not print the availability headline while no verdict and no error exist` and
`says what it actually holds — that readiness has not been established`.

Mutants ran in a throwaway worktree **outside** the repo root, mutating committed state only. Isolation proven by **writing a sentinel** and asserting the source clone's hash was unchanged (distinct inodes; trap 9g). Restores HEAD-relative (trap 9h). Applied-check scoped to `src/`.

| Mutant | Applied-check | Result |
|---|---|---|
| Control (no mutation) | **0** | GREEN |
| 1 — revert the fix (delete the branch) | 1 | **RED** (2 failed) |
| 1b — subtler revert (`== null` → `=== undefined`) | 1 | **RED** (2 failed) |
| 2 — unrelated adjacent footer field (`readySubSuccessUnset`) | 1 | **GREEN** |
| 2b — unrelated panel section (`estimatesGroup`) | 1 | **GREEN** |
| Trailing control | **0** | GREEN |

Every run collected exactly 5 tests. Two negative controls in the spec itself (a healthy verdict still prints `Analysis available`; a refusing verdict still prints the not-ready copy) so the fix cannot be "stop printing the headline". Assertions bind by `data-testid`, never by a value predicate.

## Gate at `0262bdf6`

Required check is **`Staging Gate`** (sole required context on `staging`, derived). Its `TypeScript + Lint` step sequence run locally **in order**:

| Step | Result |
|---|---|
| `pnpm run lint` | 0 errors; hooks ratchet exactly at baseline |
| `pnpm run typecheck` | PASSED — drift **shrank** 2487 → 2485, none added |
| `ci:guard:zustand` / `ci:guard:starters` / `check:vendor` / `ci:guard:schemas-version` | all pass |
| `pnpm run build` | built in 7m38s |
| Affected suites (derived blast radius) | **145 files / 2479 tests, 0 failures** |

`--update-baseline` deliberately **not** taken.

## Out of scope, and reported rather than guessed

The other half of the brief — *make the refusal visible where the user is looking* — **cannot be done in the UI at this tip.** A sweep with a contrast control found the turn response carries **no machine-readable refusal signal**: `routeV5Response` has four kinds (`text_only | blocks | empty | typed_error`) and none is a refusal, so a refusal is byte-indistinguishable from an ordinary chat reply. Contrast control, same sweep: `analysis_ready` 296 hits, `blocks` 770, `assistant_text` 115 — against **0** for `action_outcome`, `chip_outcome`, `run_outcome`, `run_status`, `cannot_run`, `analysis_refused`.

Details and the smallest enabling change are in the lane report; this PR does not attempt it.
