### PR TITLE
feat(2.1132): attribute the assistant's live open_panel/open_section gestures on the surface that fires

### DIFF
--- a/src/canvas/components/AssistantOpenedNotice.tsx
+++ b/src/canvas/components/AssistantOpenedNotice.tsx
@@ -73,7 +73,17 @@ export function AssistantOpenedNotice() {
   // and a stamp older than the window is already over, so it never shows at all.
   const elapsed = stampedAt === null ? 0 : Date.now() - stampedAt
   const remaining = Math.max(0, ASSISTANT_OPENED_NOTICE_MS - elapsed)
-  const expired = stampedAt !== null && remaining === 0
+  // ⚠ `elapsed < 0` IS THE FAIL-CLOSED HALF, AND WITHOUT IT THIS FAILED OPEN.
+  // A BACKWARD clock — NTP step, suspend/resume, a manual change; all reachable
+  // in a long-lived SPA — makes `elapsed` negative, so `remaining` GROWS rather
+  // than shrinks: `max(0, 8000 - (-3600000))` is an HOUR, and the notice would
+  // sit there attributing a gesture nobody can remember. A stamp dated in the
+  // FUTURE (clock corrected backwards after the stamp) does the same for
+  // minutes. Negative elapsed means the stamp cannot be trusted at all, so it
+  // is treated as expired — which is what `uiStore`'s "null is the FAIL-CLOSED
+  // default in every direction" already promised, and what this line makes true
+  // for the one direction that could still fail open. Pinned by CLOCK-1/CLOCK-2.
+  const expired = stampedAt !== null && (elapsed < 0 || remaining === 0)
 
   const showing = origin === 'assistant' && !expired && dismissedSeq !== seq
 

--- a/src/canvas/components/AssistantOpenedNotice.tsx
+++ b/src/canvas/components/AssistantOpenedNotice.tsx
@@ -1,0 +1,114 @@
+/**
+ * ROADMAP 2.1132 — PR3 (living workspace): the honest, non-blocking
+ * attribution for a dock activation the ASSISTANT performed.
+ *
+ * ── WHY IT SAYS SO LITTLE ─────────────────────────────────────────────────────
+ * `ui_directive` is the block that moves this surface, and its ONLY free-text
+ * field is `note`. CEE never sets it — derived at CEE staging tip
+ * `dbd012ebb24ffd7c3a4fd121664595111deb98e9`: zero `note:` assignments in
+ * `src/orchestrator-v5/compose/ui-directive.ts`, against a contrast control of
+ * four `source:` assignments in the same file (so the sweep could see a
+ * presence). **No rationale is reachable on the wire**, so this component
+ * states only the fact of the gesture. Inventing a plausible reason on the one
+ * channel whose entire purpose is truthfulness would be worse than showing
+ * nothing at all.
+ *
+ * It also does not NAME the surface. That is correctness, not brevity: the E1
+ * sync effect in `OutputsDock.tsx` REDIRECTS a directive at a flag-disabled tab
+ * to `results` (`resolvedTab`), so a notice naming the requested tab would name
+ * a tab the user is not looking at. The unnamed sentence stays true under the
+ * redirect.
+ *
+ * ── WHY IT CANNOT BECOME A LIE ────────────────────────────────────────────────
+ * The claim "Olumi opened this" is only true while the assistant's activation
+ * is still what the user is looking at. `outputSurfaceOrigin` is therefore
+ * cleared by `setActiveOutputTab` (every dock tab click), by any `'user'`-origin
+ * force-activate, by this component's dismiss control, and by its transient
+ * timeout. See `uiStore.ts` — the clearing rules live with the state, not here.
+ *
+ * ── WHY IT CANNOT GET IN THE WAY ──────────────────────────────────────────────
+ * `role="status"` + `aria-live="polite"` announces to a screen-reader user —
+ * the person most disoriented by a panel that moves unprompted — WITHOUT
+ * interrupting them. Nothing here autofocuses, nothing traps focus, nothing is
+ * modal, and there is no animation. A user who did not notice the dock move is
+ * not startled by the explanation of it.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { Sparkles, X } from 'lucide-react'
+
+import { useUIStore } from '../../stores/uiStore'
+import { typography } from '../../styles/typography'
+
+/**
+ * How long the notice stays up before clearing itself.
+ *
+ * Transient by design: the notice answers a question the user asks in the
+ * moment ("why did that just move?"). Left up, it becomes furniture, and
+ * furniture explaining a gesture that has scrolled out of memory is noise.
+ */
+export const ASSISTANT_OPENED_NOTICE_MS = 8000
+
+/**
+ * The one sentence this notice is allowed to say.
+ *
+ * ⚠ Deliberately NOT imported by the spec. A shared constant would let a rename
+ * drift the component and its test together and keep the suite green — the
+ * hand-maintained-mirror defect one level up (trap 12). The spec pins the
+ * literal independently, so a copy change must be made twice, on purpose.
+ */
+const NOTICE_TEXT = 'Opened by Olumi'
+
+export function AssistantOpenedNotice() {
+  const origin = useUIStore((s) => s.outputSurfaceOrigin)
+  const seq = useUIStore((s) => s.outputSurfaceOriginSeq)
+  // Dismissal is keyed to the GESTURE, not to the component: a later gesture is
+  // a new fact and re-raises the notice (spec CLEAR-4).
+  const [dismissedSeq, setDismissedSeq] = useState<number | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showing = origin === 'assistant' && dismissedSeq !== seq
+
+  useEffect(() => {
+    if (!showing) return
+    timerRef.current = setTimeout(() => {
+      useUIStore.getState().clearOutputSurfaceOrigin()
+    }, ASSISTANT_OPENED_NOTICE_MS)
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    // Re-armed per gesture: a second directive restarts the window rather than
+    // inheriting the remainder of the first one's.
+  }, [showing, seq])
+
+  if (!showing) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="assistant-opened-notice"
+      className="flex items-center gap-1.5 px-2 pb-1.5 -mt-0.5"
+    >
+      <span
+        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-info/30 bg-transparent ${typography.panelMeta} text-text-body`}
+      >
+        <Sparkles className="w-3 h-3 shrink-0" aria-hidden="true" />
+        {NOTICE_TEXT}
+      </span>
+      <button
+        type="button"
+        // Named, not iconographic-only: the accessible name is what a screen
+        // reader announces and what the spec binds to by identity.
+        aria-label="Dismiss"
+        onClick={() => {
+          setDismissedSeq(seq)
+          useUIStore.getState().clearOutputSurfaceOrigin()
+        }}
+        className="inline-flex items-center justify-center w-4 h-4 rounded text-text-light hover:text-text-body focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1"
+      >
+        <X className="w-3 h-3" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/src/canvas/components/AssistantOpenedNotice.tsx
+++ b/src/canvas/components/AssistantOpenedNotice.tsx
@@ -61,24 +61,42 @@ const NOTICE_TEXT = 'Opened by Olumi'
 export function AssistantOpenedNotice() {
   const origin = useUIStore((s) => s.outputSurfaceOrigin)
   const seq = useUIStore((s) => s.outputSurfaceOriginSeq)
+  const stampedAt = useUIStore((s) => s.outputSurfaceOriginAt)
   // Dismissal is keyed to the GESTURE, not to the component: a later gesture is
   // a new fact and re-raises the notice (spec CLEAR-4).
   const [dismissedSeq, setDismissedSeq] = useState<number | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const showing = origin === 'assistant' && dismissedSeq !== seq
+  // How much of the window is LEFT, derived from the stamp rather than from
+  // however long this component happens to have been mounted. On a remount the
+  // notice therefore inherits the remainder instead of restarting the window —
+  // and a stamp older than the window is already over, so it never shows at all.
+  const elapsed = stampedAt === null ? 0 : Date.now() - stampedAt
+  const remaining = Math.max(0, ASSISTANT_OPENED_NOTICE_MS - elapsed)
+  const expired = stampedAt !== null && remaining === 0
+
+  const showing = origin === 'assistant' && !expired && dismissedSeq !== seq
+
+  // A stamp found already-expired at mount is swept, so the store does not keep
+  // a dead flag around for something else to read as live.
+  useEffect(() => {
+    if (origin === 'assistant' && expired) {
+      useUIStore.getState().clearOutputSurfaceOrigin()
+    }
+  }, [origin, expired])
 
   useEffect(() => {
     if (!showing) return
     timerRef.current = setTimeout(() => {
       useUIStore.getState().clearOutputSurfaceOrigin()
-    }, ASSISTANT_OPENED_NOTICE_MS)
+    }, remaining)
     return () => {
       if (timerRef.current !== null) clearTimeout(timerRef.current)
       timerRef.current = null
     }
-    // Re-armed per gesture: a second directive restarts the window rather than
-    // inheriting the remainder of the first one's.
+    // Keyed to the gesture, not to `remaining` (which changes on every render):
+    // a second directive restarts the window, a re-render does not.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showing, seq])
 
   if (!showing) return null

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -140,6 +140,7 @@ import { useGraphReadiness } from '../hooks/useGraphReadiness'
 // run actually goes out, not as it was when the gate was computed.
 import { useReadinessStore } from '../stores/readinessStore'
 import { AskOlumiDrawer } from '../../components/results/coaching/AskOlumiDrawer'
+import { AssistantOpenedNotice } from './AssistantOpenedNotice'
 import { DefineSuccessModal, DecisionRecordModal, HowComputedModal } from '../../components/results/modals'
 
 /**
@@ -2081,6 +2082,14 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             </button>
           </div>
         )}
+        {/* ROADMAP 2.1132 — when the ASSISTANT fronted this dock via an
+            `open_panel` / `open_section` ui_directive, say so, here, directly
+            under the tab strip that just moved. The answer belongs where the
+            question is asked ("why did that open?"), not somewhere the user has
+            to hunt. Renders null on every user-driven activation; see
+            AssistantOpenedNotice.tsx for the clearing rules and for why the
+            copy names neither a reason nor a surface. */}
+        {effectiveIsOpen && <AssistantOpenedNotice />}
       </div>
 
       {!effectiveIsOpen && (

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1767,6 +1767,19 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     // anything to localStorage, so returning users still get the rail on
     // a fresh empty canvas).
     userExplicitlyOpenedRailRef.current = true
+    // ROADMAP 2.1132 — the user working the dock's own open/close control is
+    // the same "this is mine" signal `setActiveOutputTab` already honours, so
+    // it spends the assistant's attribution outright.
+    //
+    // ⚠ THIS LINE IS LOAD-BEARING AND ITS ABSENCE WAS A SHIPPED LIE. The
+    // notice mounts under `{effectiveIsOpen && …}`, so a collapse UNMOUNTS it
+    // and the effect cleanup kills the 8s timeout — but the STORE STAMP
+    // survived, with nothing left alive to clear it. The stamp then outlived
+    // its own window indefinitely, and the next expand — performed BY THE
+    // USER — re-mounted a notice saying "Opened by Olumi". Clearing the flag
+    // here is what makes `uiStore`'s "NOT A LATCH" doctrine true on this path
+    // as well as on the tab-click path. Pinned by UNMOUNT-1 / UNMOUNT-2.
+    useUIStore.getState().clearOutputSurfaceOrigin()
     setState(prev => {
       const nextIsOpen = nextVisible
       // Keep showResultsPanel in sync primarily for highlighting & telemetry when

--- a/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
@@ -491,6 +491,95 @@ describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actu
     expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
   })
 
+  // ── THE STAMP MUST NOT SURVIVE AN UNMOUNT (review FIX-FIRST, 14 Aug 2026) ──
+  //
+  // My own harvest report called this "honest and left alone". It is NOT
+  // honest, and the reviewer proved it by execution. `toggleOpen`
+  // (OutputsDock.tsx) never touches uiStore — it only flips local `isOpen`.
+  // Because the notice is mounted under `{effectiveIsOpen && …}`, collapsing
+  // the dock UNMOUNTS it, and the effect cleanup kills the 8s timeout WITHOUT
+  // clearing the store stamp. The stamp then outlives its own window
+  // indefinitely, and the next time the dock is opened — BY THE USER — the
+  // notice claims Olumi opened it.
+  //
+  // The invariant was already written down, in this feature's own store
+  // doctrine (`uiStore.ts`: "NOT A LATCH … a provenance flag that outlives the
+  // fact tells the user Olumi opened something they opened themselves"). The
+  // enumeration beneath it simply omitted the unmount path. A stated invariant
+  // with an incomplete clearing list is exactly trap 22's shape: the rule was
+  // right, its BREADTH was never checked.
+
+  it('UNMOUNT-1: collapsing the dock and re-expanding it shows NO notice (the user opened that)', () => {
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+
+    // The user collapses the dock — their action, their dock.
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse outputs dock' }))
+    expect(notice()).not.toBeInTheDocument()
+
+    // …and re-expands it THEMSELVES.
+    fireEvent.click(screen.getByRole('button', { name: 'Expand outputs dock' }))
+    expect(notice()).not.toBeInTheDocument()
+  })
+
+  it('UNMOUNT-2: the stamp does not outlive its own transient window while the dock is collapsed', () => {
+    // The reviewer's PROBE-B: origin still 'assistant' long after the window
+    // should have expired, because the only thing that clears it died with the
+    // component. Bound to the STORE, because that is where the lie is stored.
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(useUIStore.getState().outputSurfaceOrigin).toBe('assistant')
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse outputs dock' }))
+    expect(useUIStore.getState().outputSurfaceOrigin).toBeNull()
+  })
+
+  it('UNMOUNT-3: a stamp older than its window never shows again, on any remount path', () => {
+    // The residual I found by probing AFTER the reviewer's fix landed: a full
+    // unmount/remount (leaving the canvas and coming back) calls no
+    // `toggleOpen`, so the toggleOpen clear cannot reach it. Measured at that
+    // point: `outputSurfaceOrigin` read 'assistant' after the component was
+    // gone, and the notice REAPPEARED on remount. Same lie, different door.
+    //
+    // The window is now derived from the stamp's timestamp, so it expires on
+    // schedule whatever is or is not mounted.
+    vi.useFakeTimers()
+    const view = renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+
+    // Leave the canvas entirely — nothing calls toggleOpen.
+    view.unmount()
+    // Time passes with NOTHING mounted: no component, so no live timer.
+    act(() => {
+      vi.advanceTimersByTime(9000)
+    })
+    // Come back.
+    renderDock()
+    expect(notice()).not.toBeInTheDocument()
+    expect(useUIStore.getState().outputSurfaceOrigin).toBeNull()
+  })
+
+  it('UNMOUNT-4: a remount INSIDE the window inherits the remainder rather than restarting it', () => {
+    // The other half of deriving the window: a remount must not hand the user
+    // a fresh 8 seconds it has not earned.
+    vi.useFakeTimers()
+    const view = renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    act(() => {
+      vi.advanceTimersByTime(6000)
+    })
+    view.unmount()
+    renderDock()
+    // 2s of the window remain, so it is still up…
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    // …and it expires on the ORIGINAL schedule, not 8s from the remount.
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(notice()).not.toBeInTheDocument()
+  })
+
   // ── IT MUST NOT GET IN THE WAY ──────────────────────────────────────────────
 
   it('NONBLOCKING-1: the notice never takes focus, and announces politely', () => {

--- a/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
@@ -1,0 +1,508 @@
+/**
+ * ROADMAP 2.1132 — PR3 (living workspace): the assistant's LIVE workspace
+ * gestures say so, on the surface that actually fires.
+ *
+ * ── THE DEFECT ────────────────────────────────────────────────────────────────
+ * CEE has emitted `ui_directive` blocks on real turns since #660, and since
+ * #939 (CEE staging `dbd012eb`) it emits `verb: open_section, source: "gate"`
+ * on blocked-analysis questions, so the panel gestures fire MORE often. The
+ * UI's five-verb dispatcher (`applyV5State.ts`, the `ui_directive` branch)
+ * executes them: `open_panel` → `forceActivateOutputTab(tab)`, `open_section`
+ * → `requestModelTabSection(section)` + `forceActivateOutputTab('diagnostics')`.
+ *
+ * The dock therefore FRONTS ITSELF and SWITCHES TAB under the user, with **zero
+ * attribution of any kind**. Measured at this tip before the fix: `rg -a
+ * 'Opened by Olumi' src/` → 0 files, while the contrast control
+ * `overlaySurfaceOrigin` → 4 files (so the sweep could see a presence).
+ * The workspace appears to move on its own.
+ *
+ * PR #646 built an attribution badge for this harm but bound it to
+ * `requestOverlaySurface`, which has ZERO production call sites and no wire
+ * verb — trap 16-inverse, the code path is live and the producer cannot feed
+ * it. This file binds to the path the producer DOES feed.
+ *
+ * ── WHAT THE NOTICE MAY SAY, AND WHY IT SAYS SO LITTLE ────────────────────────
+ * `ui_directive.note` is the block's ONLY free-text field and CEE NEVER SETS
+ * IT: derived at CEE staging tip `dbd012ebb24ffd7c3a4fd121664595111deb98e9`,
+ * `rg -a 'note:' src/orchestrator-v5/compose/ui-directive.ts` → 0, contrast
+ * control `rg -a 'source:'` → 4 (non-zero, so the probe was not blind). No
+ * rationale is reachable on the wire, so the notice states ONLY the fact that
+ * the assistant opened something. A plausible-sounding reason on the one
+ * channel whose entire purpose is truthfulness is worse than no notice.
+ *
+ * It also does not NAME the surface, and that is a correctness requirement,
+ * not brevity: `open_panel` at a flag-disabled tab is REDIRECTED to 'results'
+ * by the E1 sync effect (`OutputsDock.tsx` `resolvedTab`), so a notice naming
+ * the requested tab would name a tab the user is not looking at. Test
+ * `HONESTY-2` pins exactly that case.
+ *
+ * ── WHAT THIS FILE CAN AND CANNOT PROVE (trap 3) ──────────────────────────────
+ * jsdom proves PRESENCE, MOUNT PATH, TEXT, CLEARING and FOCUS BEHAVIOUR. It
+ * cannot prove VISIBILITY, contrast or layout — no paint. A staging witness is
+ * owed separately and is not claimed here.
+ */
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+
+// Harness mirrors OutputsDock.overlayOcclusion.spec.tsx — the sibling spec for
+// the same panel-directive seam: real dock, real canvas + ui stores, heavy
+// children stubbed. Nothing about the attribution rule is mocked.
+const {
+  mockIsV5CanonicalAnalysisEnabled,
+  mockIsV5Eligible,
+  mockUseV2Run,
+  mockShowToast,
+  mockIsJourneyTabEnabled,
+  mockIsCompareTabEnabled,
+  mockIsAiPanelV2Enabled,
+} = vi.hoisted(() => ({
+  mockIsV5CanonicalAnalysisEnabled: vi.fn(() => false),
+  mockIsV5Eligible: vi.fn((_input?: { flag: string | undefined }) => ({ eligible: false, reason: 'flag_off' })),
+  mockUseV2Run: vi.fn(() => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })),
+  mockShowToast: vi.fn(),
+  // ⚠ TRAP 3b — THESE DEFAULTS ARE THE DEPLOYED POSTURE, NOT A CONVENIENCE.
+  // Derived 13 Aug 2026 from `netlify.toml` `[context.staging.environment]`
+  // AND from a live DOM capture of https://staging--olumi.netlify.app
+  // (`dist/version.json` commit f2b48fc99c3dff5b46f37f53be2c6190aca23f0e —
+  // the same tip this branch forks from). The deployed tab strip read
+  // ["Olumi","Analysis","Alt view","Compare","Model"]: aiPanelV2 ON,
+  // compareTab ON, journeyTab OFF. `MOUNT-1` asserts that exact strip, so if
+  // a flag moves under this spec the binding fails LOUD instead of quietly
+  // testing a component the deployment does not render.
+  mockIsJourneyTabEnabled: vi.fn(() => false),
+  mockIsCompareTabEnabled: vi.fn(() => true),
+  mockIsAiPanelV2Enabled: vi.fn(() => true),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => true,
+    isJourneyTabEnabled: mockIsJourneyTabEnabled,
+    isCompareTabEnabled: mockIsCompareTabEnabled,
+    isAiPanelV2Enabled: mockIsAiPanelV2Enabled,
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: mockIsV5Eligible,
+    isV5CanonicalRunPath: () =>
+      flags.isV5CanonicalAnalysisEnabled() &&
+      mockIsV5Eligible({ flag: import.meta.env.VITE_ENABLE_V5_ORCHESTRATOR }).eligible,
+  }
+})
+
+vi.mock('../../hooks/useV2Run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useV2Run')>()
+  return { ...actual, useV2Run: () => mockUseV2Run() }
+})
+
+vi.mock('../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../ToastContext')>()
+  return {
+    ...actual,
+    useShowToast: () => mockShowToast,
+    useShowToastSafe: () => mockShowToast,
+  }
+})
+
+vi.mock('../pre-analysis/hooks/usePreAnalysisData', () => ({
+  usePreAnalysisData: () => ({}),
+}))
+
+vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useGraphReadiness')>()
+  return {
+    ...actual,
+    useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }),
+  }
+})
+
+vi.mock('../pre-analysis', () => ({
+  PreAnalysisPanel: () => <div data-testid="pre-analysis-stub" />,
+}))
+
+vi.mock('../../../components/results/ResultsBody', () => ({
+  ResultsBody: () => <div data-testid="mock-results-body" />,
+}))
+
+// The directive path under test is driven through the REAL applicator with a
+// REAL envelope shape, never by calling `forceActivateOutputTab` by hand — the
+// attribution has to hold for what the producer actually sends (trap 16: a
+// fixture you wrote yourself is not evidence about the wire; here the fixture
+// is at least routed through the same consumer the wire reaches).
+import { applyV5State, type V5ApplicatorStore } from '../../../v5/applyV5State'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+/** The one string this notice is allowed to say. Pinned as a literal here AND
+ *  in the component — a shared constant would let a rename drift both at once
+ *  and keep the suite green (trap 12: a mirror that cannot fail loud). */
+const NOTICE_TEXT = 'Opened by Olumi'
+
+/** Words that would constitute an INVENTED rationale — nothing on the 0.39.0
+ *  wire can justify any of them. Hand-written from outside the component
+ *  author's head-model of "what the copy says" (trap 22): the point is not
+ *  that today's copy avoids them, it is that a later edit adding one REDs. */
+const FABRICATION_CORPUS = [
+  'because',
+  'so that',
+  'to help',
+  'we think',
+  'you asked',
+  'relevant',
+  'recommend',
+  'suggest',
+  'important',
+  'best',
+  'should',
+]
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+const fakeReport: Record<string, unknown> = {
+  results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },
+  run: { bands: { p10: 10, p50: 20, p90: 30 } },
+}
+
+function seedCompletedRun() {
+  const baseResults = useCanvasStore.getState().results
+  useCanvasStore.setState({
+    hasCompletedFirstRun: true,
+    nodes: [
+      { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+      { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    ],
+    edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    ceeAnalysisReady: { goal_node_id: 'goal-1', options: [{ id: 'opt-a', label: 'A', interventions: {} }] },
+    results: { ...baseResults, status: 'complete', progress: 100, report: fakeReport },
+    analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
+    analysisFreshnessDirty: false,
+    showDraftChat: false,
+  } as never)
+}
+
+function renderDock() {
+  return render(
+    <ConversationProvider>
+      <OutputsDock />
+    </ConversationProvider>,
+  )
+}
+
+function makeApplicatorStore(): V5ApplicatorStore {
+  return {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    setGoalConstraints: vi.fn(),
+    backfillGoalThreshold: vi.fn(),
+    selectNodeWithoutHistory: vi.fn(),
+    selectEdgeWithoutHistory: vi.fn(),
+    goalConstraints: null,
+    nodes: [],
+    edges: [],
+  }
+}
+
+/** One envelope carrying one `open_panel` directive at the named tab. */
+function openPanelEnvelope(tabId: string): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [
+      { type: 'ui_directive', verb: 'open_panel', targets: [], ui_target: { kind: 'tab', id: tabId } },
+    ],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+  } as unknown as OlumiResponse
+}
+
+/** One envelope carrying one `open_section` directive — the shape CEE #939's
+ *  gate-remedy builder emits, `source: 'gate'` and NO `note`. */
+function openSectionEnvelope(sectionId: string): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [
+      {
+        type: 'ui_directive',
+        verb: 'open_section',
+        targets: [],
+        ui_target: { kind: 'model_section', id: sectionId },
+        source: 'gate',
+      },
+    ],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+  } as unknown as OlumiResponse
+}
+
+function driveDirective(envelope: OlumiResponse) {
+  let result: ReturnType<typeof applyV5State> | undefined
+  act(() => {
+    result = applyV5State(envelope, makeApplicatorStore())
+  })
+  // The applicator's own truthful record of what it executed. Binding to this
+  // (rather than to a store field a consumer may already have drained) keeps
+  // the precondition pinned in-test: the notice is not decoration on a no-op.
+  return result as ReturnType<typeof applyV5State>
+}
+
+/** The tab's own label text, excluding the freshness icons and the
+ *  verify-count badge that render as siblings inside the same span. Reading
+ *  `button.textContent` would fold the badge count into the label ('Model1')
+ *  and make this assertion depend on unrelated canvas state. */
+function tabLabels(strip: HTMLElement): (string | undefined)[] {
+  return Array.from(strip.querySelectorAll('button')).map((b) =>
+    b.querySelector('span')?.firstChild?.textContent?.trim(),
+  )
+}
+
+const notice = () => screen.queryByTestId('assistant-opened-notice')
+
+describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actually fires', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    vi.clearAllMocks()
+    mockUseV2Run.mockReturnValue({ runV2Analysis: vi.fn(), cancelRun: vi.fn() })
+    mockIsJourneyTabEnabled.mockReturnValue(false)
+    mockIsCompareTabEnabled.mockReturnValue(true)
+    mockIsAiPanelV2Enabled.mockReturnValue(true)
+    seedCompletedRun()
+    useUIStore.setState({
+      activeRightPanel: null,
+      activeOutputTab: 'results',
+      activeOutputTabVersion: 0,
+      pendingModelTabSection: null,
+      outputSurfaceOrigin: null,
+      outputSurfaceOriginSeq: 0,
+    } as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    useUIStore.setState({
+      activeRightPanel: null,
+      activeOutputTab: 'results',
+      activeOutputTabVersion: 0,
+      pendingModelTabSection: null,
+      outputSurfaceOrigin: null,
+      outputSurfaceOriginSeq: 0,
+    } as never)
+    useCanvasStore.setState({
+      results: { status: 'idle', progress: 0 },
+      hasCompletedFirstRun: false,
+    } as never)
+  })
+
+  // ── MOUNT PATH (trap 3b) ────────────────────────────────────────────────────
+  // A green suite about a component the deployed flags do not mount is not
+  // evidence. These two tests assert the DEPLOYED posture and the DOM ANCESTRY,
+  // so a flag move or a relocation REDs here rather than silently hollowing
+  // every capability test below.
+
+  it('MOUNT-1: the deployed flag posture is the one under test, and the notice mounts inside the dock header that fires', () => {
+    renderDock()
+    // Positive control (trap 13): the harness can SEE the header furniture
+    // before anything below asserts a presence or an absence inside it.
+    const strip = screen.getByRole('navigation', { name: 'Outputs sections' })
+    expect(strip).toBeInTheDocument()
+    expect(tabLabels(strip)).toEqual(['Olumi', 'Analysis', 'Alt view', 'Compare', 'Model'])
+
+    // Absent before any gesture — so the presence below is the gesture's doing.
+    expect(notice()).not.toBeInTheDocument()
+
+    driveDirective(openPanelEnvelope('diagnostics'))
+
+    const el = screen.getByTestId('assistant-opened-notice')
+    // ANCESTRY, by identity — not "somewhere in the document". The notice must
+    // live inside the dock, in the same sticky header as the tab strip it
+    // explains. `contains` on the header proves adjacency, not just presence.
+    const dock = screen.getByTestId('outputs-dock')
+    expect(dock).toContainElement(el)
+    expect(strip.parentElement?.parentElement).toContainElement(el)
+  })
+
+  it('MOUNT-2: the notice does not depend on the optional tab flags — it mounts under the minimal posture too', () => {
+    // If a flag moved and switched the notice off, MOUNT-1 alone could not tell
+    // us: it pins one posture. This pins the other end of the range.
+    mockIsJourneyTabEnabled.mockReturnValue(false)
+    mockIsCompareTabEnabled.mockReturnValue(false)
+    mockIsAiPanelV2Enabled.mockReturnValue(false)
+    renderDock()
+    const strip = screen.getByRole('navigation', { name: 'Outputs sections' })
+    expect(tabLabels(strip)).toEqual(['Analysis', 'Alt view', 'Model'])
+
+    driveDirective(openPanelEnvelope('results'))
+    expect(screen.getByTestId('outputs-dock')).toContainElement(
+      screen.getByTestId('assistant-opened-notice'),
+    )
+  })
+
+  // ── CAPABILITY ──────────────────────────────────────────────────────────────
+
+  it('CAP-1: a real open_panel directive raises the notice', () => {
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+  })
+
+  it('CAP-2: a real open_section directive (the CEE #939 gate shape) raises the notice', () => {
+    renderDock()
+    const result = driveDirective(openSectionEnvelope('relationships'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    // The gesture really did both halves — the notice is not decoration on a
+    // no-op (trap 13b: a guard whose precondition nothing pins).
+    //
+    // ⚠ Bound to the applicator's `applied` record, NOT to
+    // `pendingModelTabSection`: `ModelTabBody` DRAINS that field the moment the
+    // Model tab renders (`requestModelTabSection(null)`, ModelTabBody.tsx), so
+    // reading it after render measures the consumer, not the gesture. Measured
+    // here: it reads null by the time this line runs.
+    expect(result.applied).toContain('ui_directive:open_section:relationships')
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+  })
+
+  it('CAP-3: the user opening a tab themselves raises NO notice', () => {
+    renderDock()
+    fireEvent.click(screen.getByTestId('outputs-dock-tab-diagnostics'))
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
+    expect(notice()).not.toBeInTheDocument()
+  })
+
+  it('CAP-4: a non-assistant programmatic force-activate (Dock-back / reveal-Olumi) raises NO notice', () => {
+    renderDock()
+    act(() => {
+      // The exact call `revealOlumi.ts` and `ReactFlowGraph`'s Dock-back make.
+      useUIStore.getState().forceActivateOutputTab('olumi')
+    })
+    expect(useUIStore.getState().activeOutputTab).toBe('olumi')
+    expect(notice()).not.toBeInTheDocument()
+  })
+
+  // ── HONESTY ─────────────────────────────────────────────────────────────────
+
+  it('HONESTY-1: the notice states only that Olumi opened it — no rationale the wire cannot carry', () => {
+    renderDock()
+    driveDirective(openSectionEnvelope('relationships'))
+    const el = screen.getByTestId('assistant-opened-notice')
+    const text = (el.textContent ?? '').toLowerCase()
+    expect(el).toHaveTextContent(NOTICE_TEXT)
+    for (const word of FABRICATION_CORPUS) {
+      expect(text).not.toContain(word)
+    }
+    // The copy is EXACTLY the pinned sentence — nothing may accrete without
+    // this test going red. (The dismiss control is icon-only with an
+    // `aria-label`, so it contributes no text content.)
+    expect((el.textContent ?? '').replace(/\s+/g, ' ').trim()).toBe(NOTICE_TEXT)
+  })
+
+  it('HONESTY-2: a directive at a flag-disabled tab is redirected, and the notice still cannot mis-name the surface', () => {
+    // journeyTab is OFF in the deployed posture, so `resolvedTab` redirects
+    // 'journey' → 'results'. A notice naming the REQUESTED tab would name a tab
+    // the user is not looking at.
+    renderDock()
+    driveDirective(openPanelEnvelope('journey'))
+    const redirected = (screen.getByTestId('assistant-opened-notice').textContent ?? '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    expect(useUIStore.getState().activeOutputTab).toBe('journey')
+    // …and the dock resolved it away from the disabled tab.
+    expect(screen.getByTestId('outputs-dock-tab-diagnostics')).toBeInTheDocument()
+    expect(screen.queryByText('Journey')).not.toBeInTheDocument()
+    expect(redirected).toBe(NOTICE_TEXT)
+  })
+
+  // ── CLEARING — the notice must never outlive the fact ───────────────────────
+
+  it('CLEAR-1: the user changing tab clears the notice (it does not latch)', () => {
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('outputs-dock-tab-olumi'))
+    expect(notice()).not.toBeInTheDocument()
+  })
+
+  it('CLEAR-2: the notice is dismissible, and stays gone for that gesture', () => {
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(notice()).not.toBeInTheDocument()
+    expect(useUIStore.getState().outputSurfaceOrigin).toBeNull()
+  })
+
+  it('CLEAR-3: the notice self-clears after its transient window', () => {
+    vi.useFakeTimers()
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(9000)
+    })
+    expect(notice()).not.toBeInTheDocument()
+  })
+
+  it('CLEAR-4: a later gesture re-raises the notice after a dismissal', () => {
+    renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(notice()).not.toBeInTheDocument()
+    driveDirective(openSectionEnvelope('relationships'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+  })
+
+  // ── IT MUST NOT GET IN THE WAY ──────────────────────────────────────────────
+
+  it('NONBLOCKING-1: the notice never takes focus, and announces politely', () => {
+    renderDock()
+    const before = document.activeElement
+    driveDirective(openPanelEnvelope('diagnostics'))
+    const el = screen.getByTestId('assistant-opened-notice')
+    expect(document.activeElement).toBe(before)
+    expect(el).not.toContainElement(document.activeElement as HTMLElement)
+    // A polite live region announces to a screen-reader user without
+    // interrupting them or moving the caret.
+    expect(el).toHaveAttribute('role', 'status')
+    expect(el).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
@@ -580,6 +580,54 @@ describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actu
     expect(notice()).not.toBeInTheDocument()
   })
 
+  // ── A MOVING CLOCK MUST NOT EXTEND THE WINDOW (re-review, 14 Aug 2026) ─────
+  //
+  // Deriving the window from a timestamp closed the unmount doors, but it also
+  // made the notice depend on the WALL CLOCK, and the wall clock moves
+  // backwards in this product's normal life: NTP steps, laptop suspend/resume,
+  // a user correcting their clock — all reachable in a long-lived SPA.
+  //
+  // The arithmetic failed OPEN, which is the opposite of what this module's own
+  // header promises ("null is the FAIL-CLOSED default in every direction"):
+  // a negative `elapsed` makes `remaining = max(0, 8000 - elapsed)` GROW, so an
+  // hour-long backward step left the notice up for an hour, attributing a
+  // gesture no user could still remember. Negative elapsed means the stamp
+  // cannot be trusted, so it now counts as expired.
+
+  it('CLOCK-1: a BACKWARD clock step does not extend the window — the notice fails closed', () => {
+    vi.useFakeTimers()
+    const view = renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(screen.getByTestId('assistant-opened-notice')).toBeInTheDocument()
+    view.unmount()
+
+    // NTP step / suspend-resume / manual correction: the clock goes BACK an hour.
+    vi.setSystemTime(new Date(Date.now() - 60 * 60 * 1000))
+
+    renderDock()
+    expect(notice()).not.toBeInTheDocument()
+    expect(useUIStore.getState().outputSurfaceOrigin).toBeNull()
+  })
+
+  it('CLOCK-2: a stamp dated in the FUTURE is treated as expired, not as fresh for minutes', () => {
+    vi.useFakeTimers()
+    const origin = Date.now()
+
+    // The gesture is stamped while the clock is running an hour FAST…
+    vi.setSystemTime(new Date(origin + 60 * 60 * 1000))
+    const view = renderDock()
+    driveDirective(openPanelEnvelope('diagnostics'))
+    expect(useUIStore.getState().outputSurfaceOriginAt).toBe(origin + 60 * 60 * 1000)
+    view.unmount()
+
+    // …and is then corrected, leaving a stamp an hour in the future.
+    vi.setSystemTime(new Date(origin))
+
+    renderDock()
+    expect(notice()).not.toBeInTheDocument()
+    expect(useUIStore.getState().outputSurfaceOrigin).toBeNull()
+  })
+
   // ── IT MUST NOT GET IN THE WAY ──────────────────────────────────────────────
 
   it('NONBLOCKING-1: the notice never takes focus, and announces politely', () => {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -96,9 +96,28 @@ export interface UIStoreState {
   pendingModelTabSection: string | null
   /** Which transient overlay surface is raised right now. Null when none. */
   activeOverlaySurface: OverlaySurfaceId | null
-  /** Who raised it. Null exactly when no surface is raised. */
+  /** Who raised it. Null exactly when no surface is raised.
+   *  ⚠ NOT `outputSurfaceOrigin` (below) — that one is about the OUTPUTS DOCK
+   *  TAB and is wire-reachable; this one is about the top-bar kebab menu and is
+   *  not. See the block comment on `outputSurfaceOrigin`. */
   overlaySurfaceOrigin: OverlaySurfaceOrigin | null
   /**
+   * ⚠⚠ NOT `overlaySurfaceOrigin`, THE FIELD DECLARED DIRECTLY ABOVE. The two
+   * names differ by ONE WORD and share a suffix, and they answer DIFFERENT
+   * QUESTIONS — the estate's chronic "similar names, different concepts"
+   * defect, introduced here deliberately-but-legibly rather than by accident:
+   *
+   *   · `overlaySurfaceOrigin` — who raised the TOP-BAR KEBAB MENU
+   *     (`activeOverlaySurface`). Set by `setOverlaySurface` /
+   *     `requestOverlaySurface`. ⚠ `requestOverlaySurface` has NO production
+   *     call site and no wire verb, so on a real turn this is only ever
+   *     `'user'`.
+   *   · `outputSurfaceOrigin` — this field — who activated the OUTPUTS DOCK
+   *     TAB. Set by `forceActivateOutputTab`. REACHABLE from the wire today.
+   *
+   * Do not reconcile them, do not fold one into the other, and do not assume a
+   * fix to one applies to the other (trap 21).
+   *
    * ROADMAP 2.1132 — P3/P4 provenance for the dock activations the assistant
    * ACTUALLY performs on a real turn (`open_panel` / `open_section`, executed
    * by `applyV5State`'s ui_directive branch via `forceActivateOutputTab`).

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -98,15 +98,56 @@ export interface UIStoreState {
   activeOverlaySurface: OverlaySurfaceId | null
   /** Who raised it. Null exactly when no surface is raised. */
   overlaySurfaceOrigin: OverlaySurfaceOrigin | null
+  /**
+   * ROADMAP 2.1132 — P3/P4 provenance for the dock activations the assistant
+   * ACTUALLY performs on a real turn (`open_panel` / `open_section`, executed
+   * by `applyV5State`'s ui_directive branch via `forceActivateOutputTab`).
+   *
+   * `'assistant'` exactly while the CURRENT dock activation is the assistant's
+   * doing and the user has not yet taken it back. Null otherwise — and null is
+   * the FAIL-CLOSED default in every direction, because the harm this exists
+   * to prevent is the product claiming an action the user took.
+   *
+   * ⚠ NOT A LATCH. It is cleared by `setActiveOutputTab` (the seam every dock
+   * tab click runs), by a `'user'`-origin force-activate, and by the notice's
+   * own dismissal/timeout. A provenance flag that outlives the fact tells the
+   * user Olumi opened something they opened themselves — a lie on the one
+   * channel whose whole purpose is truthfulness.
+   */
+  outputSurfaceOrigin: 'assistant' | null
+  /**
+   * Monotonic; bumped on every assistant-origin activation. The notice keys its
+   * transient window and its dismissal to this, so a SECOND gesture re-raises a
+   * notice the user already dismissed — the second gesture is a new fact, not a
+   * repeat of the dismissed one.
+   */
+  outputSurfaceOriginSeq: number
 }
 
+/**
+ * WHO caused a dock activation. `'user'` is the default at every call site that
+ * does not say otherwise, so a new caller cannot accidentally attribute its own
+ * navigation to the assistant.
+ */
+export type OutputSurfaceOrigin = 'user' | 'assistant'
+
 export interface UIStoreActions {
+  /** The user's own tab choice. ALWAYS clears `outputSurfaceOrigin`: once the
+   *  user has moved the dock themselves, no assistant attribution is true of
+   *  what is on screen. */
   setActiveOutputTab: (tab: OutputTab) => void
   /** Force OutputsDock to open AND activate the given tab on the next render,
    *  regardless of whether `activeOutputTab` actually changes value. Used by
    *  auto-dock and Dock-back when we cannot rely on a value-diff to trigger
-   *  the sync. */
-  forceActivateOutputTab: (tab: OutputTab) => void
+   *  the sync.
+   *
+   *  `origin` defaults to `'user'` — fail-closed. Existing callers
+   *  (`revealOlumi`, `FirstUseComposer`, `ReactFlowGraph`'s Dock-back) pass
+   *  nothing and are therefore never attributed to the assistant. */
+  forceActivateOutputTab: (tab: OutputTab, origin?: OutputSurfaceOrigin) => void
+  /** Clear the assistant-origin stamp — the notice's dismiss control and its
+   *  transient timeout. Idempotent. */
+  clearOutputSurfaceOrigin: () => void
   /** Open a right panel (closes any other). Pass null to close all. */
   openRightPanel: (mode: RightPanelMode) => void
   /** Close the active right panel */
@@ -165,7 +206,21 @@ export interface UIStoreActions {
  * (ModelTabBody clears it once it has acted), never a gesture.
  */
 export interface AssistantUiSurfaceActions {
-  forceActivateOutputTab: (tab: OutputTab) => void
+  /**
+   * ⚠ ROADMAP 2.1132 — THE `'assistant'` ARGUMENT IS REQUIRED HERE, AND THAT IS
+   * THE POINT. The store's own signature defaults `origin` to `'user'`, which
+   * is the right fail-closed default for the three ordinary callers. But the
+   * assistant seam must never be able to move the user's dock WITHOUT stamping
+   * the provenance the notice reads: an unattributed gesture is precisely the
+   * defect this row exists to close, and "remember to pass 'assistant'" is
+   * discipline, which this file's header already declines to rely on.
+   *
+   * Narrowing the parameter to the literal `'assistant'` carries the rule in
+   * the TYPE: `applyV5State`'s call site does not compile without it. The
+   * store's `(tab, origin?: OutputSurfaceOrigin) => void` remains assignable to
+   * this, so `useUIStore.getState()` still satisfies the interface.
+   */
+  forceActivateOutputTab: (tab: OutputTab, origin: 'assistant') => void
   requestModelTabSection: (sectionId: string) => void
   requestOverlaySurface: (surface: OverlaySurfaceId) => boolean
 }
@@ -177,10 +232,25 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set, get) => ({
   pendingModelTabSection: null,
   activeOverlaySurface: null,
   overlaySurfaceOrigin: null,
+  outputSurfaceOrigin: null,
+  outputSurfaceOriginSeq: 0,
 
-  setActiveOutputTab: (tab) => set({ activeOutputTab: tab }),
-  forceActivateOutputTab: (tab) =>
-    set((s) => ({ activeOutputTab: tab, activeOutputTabVersion: s.activeOutputTabVersion + 1 })),
+  // A user tab choice is the strongest "this is mine" signal there is, and it
+  // is the seam OutputsDock's `handleTabClick` runs. Clearing here is the
+  // anti-latch guarantee (spec CLEAR-1).
+  setActiveOutputTab: (tab) => set({ activeOutputTab: tab, outputSurfaceOrigin: null }),
+  forceActivateOutputTab: (tab, origin = 'user') =>
+    set((s) => ({
+      activeOutputTab: tab,
+      activeOutputTabVersion: s.activeOutputTabVersion + 1,
+      outputSurfaceOrigin: origin === 'assistant' ? 'assistant' : null,
+      // Bump ONLY on the assistant path: a user-driven force-activate is not a
+      // new attributable fact, and bumping there would let a dismissed notice
+      // reappear on a Dock-back the user performed themselves.
+      outputSurfaceOriginSeq:
+        origin === 'assistant' ? s.outputSurfaceOriginSeq + 1 : s.outputSurfaceOriginSeq,
+    })),
+  clearOutputSurfaceOrigin: () => set({ outputSurfaceOrigin: null }),
   openRightPanel: (mode) => set({ activeRightPanel: mode }),
   closeRightPanel: () => set({ activeRightPanel: null }),
   requestModelTabSection: (sectionId) => set({ pendingModelTabSection: sectionId }),

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -141,6 +141,20 @@ export interface UIStoreState {
    * repeat of the dismissed one.
    */
   outputSurfaceOriginSeq: number
+  /**
+   * When the stamp was made (`Date.now()`), or null when there is no stamp.
+   *
+   * ⚠ THE WINDOW IS DERIVED FROM THIS, NOT SCHEDULED BY A TIMER — and the
+   * difference is a shipped defect, not a preference. The transient window
+   * used to live ONLY in a `setTimeout` inside the notice component, so any
+   * unmount killed the timer and left the stamp alive forever: proven by
+   * execution for a dock collapse (the reviewer's probe) and again, by me,
+   * for a plain unmount/remount, where `outputSurfaceOrigin` read
+   * `'assistant'` after the component was gone and the notice reappeared on
+   * remount. A scheduled window is a hand-maintained mirror of "has the
+   * window elapsed"; a timestamp cannot drift from it (trap 12).
+   */
+  outputSurfaceOriginAt: number | null
 }
 
 /**
@@ -253,23 +267,26 @@ export const useUIStore = create<UIStoreState & UIStoreActions>((set, get) => ({
   overlaySurfaceOrigin: null,
   outputSurfaceOrigin: null,
   outputSurfaceOriginSeq: 0,
+  outputSurfaceOriginAt: null,
 
   // A user tab choice is the strongest "this is mine" signal there is, and it
   // is the seam OutputsDock's `handleTabClick` runs. Clearing here is the
   // anti-latch guarantee (spec CLEAR-1).
-  setActiveOutputTab: (tab) => set({ activeOutputTab: tab, outputSurfaceOrigin: null }),
+  setActiveOutputTab: (tab) =>
+    set({ activeOutputTab: tab, outputSurfaceOrigin: null, outputSurfaceOriginAt: null }),
   forceActivateOutputTab: (tab, origin = 'user') =>
     set((s) => ({
       activeOutputTab: tab,
       activeOutputTabVersion: s.activeOutputTabVersion + 1,
       outputSurfaceOrigin: origin === 'assistant' ? 'assistant' : null,
+      outputSurfaceOriginAt: origin === 'assistant' ? Date.now() : null,
       // Bump ONLY on the assistant path: a user-driven force-activate is not a
       // new attributable fact, and bumping there would let a dismissed notice
       // reappear on a Dock-back the user performed themselves.
       outputSurfaceOriginSeq:
         origin === 'assistant' ? s.outputSurfaceOriginSeq + 1 : s.outputSurfaceOriginSeq,
     })),
-  clearOutputSurfaceOrigin: () => set({ outputSurfaceOrigin: null }),
+  clearOutputSurfaceOrigin: () => set({ outputSurfaceOrigin: null, outputSurfaceOriginAt: null }),
   openRightPanel: (mode) => set({ activeRightPanel: mode }),
   closeRightPanel: () => set({ activeRightPanel: null }),
   requestModelTabSection: (sectionId) => set({ pendingModelTabSection: sectionId }),

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -808,12 +808,23 @@ export function applyV5State(
           })
         } else if (verb === 'open_panel' && uiTarget.kind === 'tab') {
           uiDirectiveExecuted = true
-          assistantSurfaces.forceActivateOutputTab(uiTarget.id as OutputTab)
+          // ROADMAP 2.1132 — the `'assistant'` origin is what makes the dock
+          // ATTRIBUTE this activation instead of appearing to move on its own.
+          // `AssistantUiSurfaceActions` types the parameter as the literal
+          // `'assistant'`, so this seam cannot front the user's dock silently:
+          // omitting it does not compile.
+          assistantSurfaces.forceActivateOutputTab(uiTarget.id as OutputTab, 'assistant')
           applied.push(`ui_directive:open_panel:${String(uiTarget.id)}`)
         } else if (verb === 'open_section' && uiTarget.kind === 'model_section') {
           uiDirectiveExecuted = true
           assistantSurfaces.requestModelTabSection(String(uiTarget.id))
-          assistantSurfaces.forceActivateOutputTab('diagnostics')
+          // Same attribution as open_panel: `open_section` fronts the dock on
+          // the Model tab, so the same "who did this?" question is raised and
+          // the same answer is owed. Stamped on the force-activate rather than
+          // on `requestModelTabSection` because the force-activate is the call
+          // BOTH panel verbs share — one stamp site, no second authority to
+          // drift from it (trap 21).
+          assistantSurfaces.forceActivateOutputTab('diagnostics', 'assistant')
           applied.push(`ui_directive:open_section:${String(uiTarget.id)}`)
         } else {
           deferred.push({


### PR DESCRIPTION
## Acceptance measure (one falsifiable sentence)

**A user whose Analysis/Model panel was fronted by the assistant can now read, inside the dock header that just moved, that Olumi opened it — and we would observe it by driving a real `open_panel`/`open_section` envelope through `applyV5State` and finding `data-testid="assistant-opened-notice"` inside the dock's sticky header with the exact text "Opened by Olumi", while the same tab opened by the user renders nothing.**

Both halves are asserted, and the binding is proven with a discriminating mutant pair.

---

## ✅ Premise verification — CONFIRMED, at the bytes, on both sides of the wire

The brief's premise held in full. Derived, not inherited:

| claim | verdict | evidence |
|---|---|---|
| CEE emits `ui_directive` on real turns | ✅ | CEE `staging` @ `dbd012ebb24ffd7c3a4fd121664595111deb98e9` — 3 emit sites in `src/orchestrator-v5/compose/ui-directive.ts` |
| #939 emits `verb: open_section, source: "gate"` | ✅ | `buildGateRemedyDirective` → `directiveFromUiTarget('open_section', {kind:'model_section', …}, GATE_SOURCE)`, `GATE_SOURCE = 'gate'` |
| UI dispatcher executes the five verbs | ✅ | `applyV5State.ts` ui_directive branch: `open_panel` → `forceActivateOutputTab(tab)`; `open_section` → `requestModelTabSection(id)` + `forceActivateOutputTab('diagnostics')` |
| **zero** attribution today | ✅ | `rg -a 'Opened by Olumi' src/` → **0 files**, with contrast control `overlaySurfaceOrigin` → **4 files** (trap 13e: the sweep could see a presence, so the zero is real) |
| `note` is absent on the wire, so no rationale is reachable | ✅ | `rg -a 'note:' src/orchestrator-v5/compose/ui-directive.ts` → **0**, contrast control `rg -a 'source:'` → **4**. `note` is the block's only free-text field. |
| #646 is bound to an unreachable surface | ✅ | its own body records `requestOverlaySurface` has **zero production call sites**. Read for intent/copy; **not merged, not rebased.** |

## Deployed-posture derivation (trap 3b) — a live capture, not a config read

`netlify.toml` alone is a mirror read, so this was settled at the deployed DOM.

```
https://staging--olumi.netlify.app/#/canvas  →  /version.json
commit f2b48fc99c3dff5b46f37f53be2c6190aca23f0e   ← the exact tip this branch forks from
```

| reading | value |
|---|---|
| `[data-testid="outputs-dock"]` | **present**, `aria-label="Outputs dock"`, not `hidden` |
| tab strip | `["Olumi","Analysis","Alt view","Compare","Model"]` |
| ⇒ flag posture | aiPanelV2 **ON**, compareTab **ON**, journeyTab **OFF** |

**The dock is not flag-gated** — the `<aside>` and its sticky header render unconditionally; only the tab *set* varies. So the notice's host cannot be switched off by a flag. `MOUNT-1` pins the deployed strip exactly, and `MOUNT-2` pins the opposite (minimal) posture, so a flag moving under this spec REDs instead of quietly hollowing every test below it.

## What the user sees

An outlined pill in the dock's sticky header, directly under the tab strip that just moved:

> ✨ ⟨Opened by Olumi⟩  ✕

- **Where:** inside the surface it explains. The answer belongs where the question is asked ("why did that open?"), not somewhere the user has to hunt.
- **Calm:** no animation, no colour alarm, no modal, no focus steal. `role="status"` + `aria-live="polite"` announces it to a screen-reader user — the person most disoriented by a panel that moves unprompted — without interrupting them.
- **Clears** on any of: the user clicking a tab · a `'user'`-origin force-activate · the ✕ · 8 seconds.

### It refuses to say two things, and both are correctness, not brevity

1. **No reason.** `ui_directive.note` is the only free-text carrier and CEE never sets it (measured above). A plausible-sounding rationale on the one channel whose entire purpose is truthfulness is worse than no notice. `HONESTY-1` pins the copy to an exact literal and screens it against a hand-written fabrication corpus.
2. **No surface name.** The E1 sync effect **redirects** a directive at a flag-disabled tab to `results` (`resolvedTab`, `OutputsDock.tsx`), so a notice naming the *requested* tab would name a tab the user is not looking at. `HONESTY-2` drives `open_panel` at `journey` (OFF in the deployed posture) and asserts the copy is byte-identical to the non-redirected case.

## Design — one stamp site, and the type carries the rule

`forceActivateOutputTab` gains an optional `origin`, **defaulting to `'user'`**. The three existing callers (`revealOlumi`, `FirstUseComposer`, `ReactFlowGraph` Dock-back) pass nothing and are therefore never attributed to the assistant — fail-closed in the direction that matters, since the harm is claiming an action the user took.

The stamp sits **only** on `forceActivateOutputTab`, because *both* panel verbs route through it. One authority, so there is no second one to drift from it (trap 21).

`AssistantUiSurfaceActions` narrows the parameter to the literal `'assistant'`:

```ts
forceActivateOutputTab: (tab: OutputTab, origin: 'assistant') => void
```

so the assistant seam **cannot move the user's dock without stamping provenance — it does not compile.** This follows the rule `uiStore.ts` already sets for itself: carry the constraint in the type, not in discipline. The store's `(tab, origin?: OutputSurfaceOrigin) => void` stays assignable, so `useUIStore.getState()` still satisfies the interface.

**Anti-latch:** `setActiveOutputTab` — the seam every dock tab click runs — always clears the stamp. A provenance flag that outlives the fact tells the user Olumi opened something they opened themselves.

## RED-first at pristine — 11 RED / 2 GREEN of 13

Run at `f2b48fc9` with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported. **Collected count asserted by name: 13.**

```
× MOUNT-1  × MOUNT-2  × CAP-1  × CAP-2  ✓ CAP-3  ✓ CAP-4
× HONESTY-1  × HONESTY-2  × CLEAR-1  × CLEAR-2  × CLEAR-3  × CLEAR-4  × NONBLOCKING-1
Tests  11 failed | 2 passed (13)
```

The two GREEN are the **negatives** (`CAP-3`/`CAP-4`: "the user's own tab change raises NO notice"). They pass at pristine because no notice exists at all — that is honest, not vacuous, and **M2 is the mutant that proves they discriminate.**

### Two of my own assertions were wrong and the run caught them

Reported because a corrected premise is a deliverable:

- `MOUNT-1` read the tab label as `button.textContent` and got **`'Model1'`** — the verify-count badge renders inside the same span. Re-bound to the label's own text node, so the assertion no longer depends on unrelated canvas state.
- `CAP-2` asserted `pendingModelTabSection === 'relationships'` after render and measured **`null`**: `ModelTabBody` **drains** that field the moment the Model tab mounts. It was reading the consumer, not the gesture. Re-bound to the applicator's own `applied` record (`ui_directive:open_section:relationships`) — a stronger, non-transient pin.

## Mutation kit — 10/10 bit, each on the expected test

Throwaway worktree at an **absolute** path outside the repo root. **Isolation proven by WRITING, not by locating** (trap 9g): inodes `607962323` vs `608038467`, and a sentinel appended to the worktree left the source SHA-256 **identical** (`971f0dde…` before and after). Every restore came from a pristine **`git archive` tar**, never from the other copy (trap 9h). Clean-tree asserted before *and* after each mutant. Applied-check scoped to `src/`. **Collected asserted == 13 every run, or hard error.**

| mutant | expected | result |
|---|---|---|
| **M1** notice never renders | broad RED | 🔴 11 RED (all but the two negatives) |
| **M2** **loosen for ALL** — stamp `'assistant'` on every force-activate | **CAP-4 RED, capability GREEN** | 🔴 **1 RED: CAP-4** |
| **M3** **loosen for a DIFFERENT seam** — stamp on `setActiveOutputTab` | **CAP-4 GREEN, CAP-3 RED** | 🔴 **2 RED: CAP-3, CLEAR-1** |
| **M4** fabricate a rationale in the copy | honesty RED | 🔴 2 RED: HONESTY-1, HONESTY-2 |
| **M5** name the surface in the copy | honesty RED | 🔴 2 RED: HONESTY-1, HONESTY-2 |
| **M6** latch the origin (stop clearing on user tab change) | CLEAR-1 RED | 🔴 1 RED: CLEAR-1 |
| **M7** remove the transient window | CLEAR-3 RED | 🔴 1 RED: CLEAR-3 |
| **M8** the notice steals focus | NONBLOCKING-1 RED | 🔴 1 RED: NONBLOCKING-1 |
| **M9** relocate out of the sticky header (still inside the dock) | MOUNT-1 RED | 🔴 **1 RED: MOUNT-1** |
| **M10** dismissal latches forever | CLEAR-4 RED | 🔴 1 RED: CLEAR-4 |

**M2 + M3 are the discriminating pair (trap 19).** M2 loosens the guard for *every* origin and REDs `CAP-4` while the capability tests stay green — sensitivity to the *named* origin, not merely to *something*. M3 loosens a *different* seam and leaves `CAP-4` green while `CAP-3` REDs. Neither alone shows binding; the pair does.

**M9 is the mount-path discriminator:** moving the notice out of the header but leaving it inside the dock REDs `MOUNT-1` while `CAP-1` stays green — so `MOUNT-1` binds to the header specifically, not to mere presence anywhere in the document.

**Controls:** opening control `applied(src/) = 0`, 13/13 green. **Trailing control reproduces it exactly** — `applied(src/) = 0`, 13/13 green.

**One mutant was rejected, not scored.** M9's first form produced a syntax error; the harness **hard-errored on `collected 0`** rather than recording a survivor. An unapplied mutation is indistinguishable from an equivalent one without that check (trap 22d).

## Gates — the required check's full step sequence, run verbatim

`Staging Tests → TypeScript + Lint` is **lint → typecheck → 4 guards**, derived from `.github/workflows/staging-full-tests.yml` at this tip. All six run, not just the habitual two (trap 22e).

```
pnpm run lint            ✅ EXIT=0   ✖ 1266 problems (0 errors, 1266 warnings)   [all pre-existing]
                                     rules-of-hooks ratchet: 232 known violations, exactly matching baseline

pnpm run typecheck       ✅ EXIT=0   phase 1 coverage: 3397 / 3437 files loaded (40 out of scope)
                                     phase 2 ratchet : 618 files / 2485 errors (baseline 2487)
                                     ✅ Typecheck gate PASSED (coverage + ratchet)

pnpm run ci:guard:zustand         ✅ EXIT=0  React-185 guard PASS
pnpm run ci:guard:starters        ✅ EXIT=0  all starter fixtures match their source captures
pnpm run check:vendor             ✅ EXIT=0
pnpm run ci:guard:schemas-version ✅ EXIT=0  talchainSchemasVersion.ts up to date (0.39.0)
```

**Coverage proves my files are gated, derived not assumed:** pristine `f2b48fc9` loads **3395/3435**; this branch loads **3397/3437** — exactly **+2**, my two new files. Neither is in the exception list.

**The ratchet "shrink" (2487 → 2485) is PRE-EXISTING and I did not bank it.** Measured in a separate worktree at pristine `f2b48fc9`: **identical** `618 file(s) / 2485 error(s)`. My change contributes zero diagnostics, so `--update-baseline` is not mine to run (and a shrink is exactly the prompt this estate has been burned accepting).

### Suites

| suite | result |
|---|---|
| **`OutputsDock.assistantOpenedAttribution.spec.tsx`** (mine) | ✅ **13/13** — collected count asserted by name |
| `applyV5State.assistantSurfaces` + `applyV5State.uiDirective` + `TopBar.overlaySurface` + `FirstUseComposer` | ✅ **68/68** |
| `OutputsDock.overlayOcclusion` + `.dom` + `.runReturnsToOlumi` + `src/stores` | ✅ **111/111** (6 files) |

`applyV5State.assistantSurfaces.test.ts` is the file carrying the `@ts-expect-error` guards that the narrowed `AssistantUiSurfaceActions` could have turned into unused directives — green, and the typecheck gate covers tests, so that risk is closed both ways.

## Rendered output (jsdom, real component)

```html
<div role="status" aria-live="polite" data-testid="assistant-opened-notice"
     class="flex items-center gap-1.5 px-2 pb-1.5 -mt-0.5">
  <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full
               border border-info/30 bg-transparent
               text-[11px] font-sans leading-snug text-text-body">
    <svg class="lucide-sparkles w-3 h-3" aria-hidden="true">…</svg>Opened by Olumi</span>
  <button type="button" aria-label="Dismiss" class="… w-4 h-4 …">
    <svg class="lucide-x w-3 h-3" aria-hidden="true">…</svg></button>
</div>
```

Every colour token resolves in `tailwind.config.js` — `info.DEFAULT`, `text.body`, `text.light` — and `border-info/30` + `text-text-body` have shipped precedent in `src/`. That rules out the "className that generates no CSS" defect #646 flagged, **but it is a derivation, not a paint.**

## ⚠ What I could NOT reach — named, not glossed

1. **No real-browser contrast/visibility reading.** The Chrome extension disconnected mid-session, after the deployed-posture capture and before the style probe. So **contrast ratio, paint and occlusion are UNMEASURED by this lane.** #646 measured `--text-body` on the same white dock ground at 10.54:1, but that is *its* reading of *its* surface and I am not inheriting it. Status-ladder rung: **TESTED + DEPLOYED-POSTURE-DERIVED; NOT wire-witnessed, NOT journey-witnessed.**
2. **No live staging witness of the notice itself** — it is not deployed yet. Owed after merge: a real turn that fires a `gate` `open_section` and the notice appearing on the dock.
3. **Full suite not run to completion** — a whole-repo `vitest` run exceeded the 10-minute session cap. I ran the changed seams' 57-spec neighbourhood by targeting; the shards in CI are the authority.
4. **`requestModelTabSection` is not stamped.** Deliberate: it never fires on the assistant path without the following `forceActivateOutputTab`. If a future directive calls it alone, that gesture would be unattributed — noted rather than pre-solved.
5. **Notice state survives a dock collapse/re-expand within the 8s window.** The timer lives in the component, so collapsing unmounts it. Re-expanding re-shows the notice if the user has not changed tabs. Judged honest (the assistant *did* open that tab and the user has not taken it back) and left alone rather than expanded into `toggleOpen`.

## Scope

No new flags (ships on), no new dependencies, no redesign, no CEE or schemas change. 5 files: `uiStore.ts`, `applyV5State.ts`, `OutputsDock.tsx` (+2 lines and an import), one new 100-line component, one new spec. No overlap with any open PR — #646 is `TopBar`, #682 is the PLoT bearer.

⛔ **Integration freeze — do not merge.** The orchestrator merges after semantic exit.

---

## CI — 13/13 GREEN at head `07b1d749`, polled to conclusion

Pinned to the exact head SHA and filtered on `.status == "completed"` first, so an in-flight check is never bucketed as a failure (trap 24b). `total_count = 13`, so this is not the "zero checks reads as success" case (trap 24).

```
success  Staging Gate                      success  TypeScript + Lint
success  Full Test Suite (shard 1/4)       success  Typecheck Gate Self-Test
success  Full Test Suite (shard 2/4)       success  Production Build
success  Full Test Suite (shard 3/4)       success  Security Audit (pnpm)
success  Full Test Suite (shard 4/4)       success  CEE Contract Validation
success  Full Test Suite Summary           success  Flag Deployment Drift (report only)
success  Install & Cache

{"total":13, "success":13, "failure":0, "other":0}
mergeable: MERGEABLE   mergeStateStatus: CLEAN
```

**This supersedes limitation 3 above** — the full sharded suite that exceeded my local session cap ran green in CI across all four shards.

### Second commit (`07b1d749`) — comments only

`docs(2.1132): name apart outputSurfaceOrigin and overlaySurfaceOrigin`. The new field sits **one word** from the existing `overlaySurfaceOrigin` in the same file and shares its suffix — the estate's chronic "similar names, different concepts" hazard (trap 21), which I was introducing. Cross-referenced in both directions: which surface each governs, which action sets it, and that only one of the two is reachable from the wire. Verified comments-only by diff; re-ran the gate (typecheck PASSED, **identical** ratchet 618/2485; the sole eslint warning is `OutputsDock.tsx:1152`, **proven pre-existing** by re-running eslint against the stashed tree).

---

# ⚠ FIX-FIRST ROUND — the review found a real defect, and my own judgement call was the cause

Head is now **`be6746ce`**. **13/13 CI green.**

## The defect (the reviewer's, proven by execution)

My harvest report listed the collapse/re-expand behaviour as limitation 5 and judged it *"honest and left alone"*. **That judgement was wrong.**

`toggleOpen` (`OutputsDock.tsx`) never touched `uiStore` — it only flips local `isOpen`. The notice mounts under `{effectiveIsOpen && …}`, so collapsing the dock **unmounts** it and the effect cleanup kills the 8s timeout **while the store stamp survives, with nothing left alive to clear it**. Sequence: assistant gesture stamps `'assistant'` → user collapses within 8s → timer dies, stamp lives → **user re-expands it themselves** → notice re-mounts saying "Opened by Olumi" about a dock the user opened.

My reasoning was "the assistant did open that tab". The error: **the re-expansion is the user's action**, so the notice takes credit for it. And this feature's own store doctrine already stated the invariant — `uiStore.ts`, *"NOT A LATCH … a provenance flag that outlives the fact tells the user Olumi opened something they opened themselves"*. **The rule was right; its clearing enumeration omitted the unmount path.** That is trap 22's shape exactly — I checked the invariant and never checked its breadth.

## A second door, found by probing my own fix

Before accepting the prescription I probed whether other unmount paths reproduced it. **They do**, measured:

```
===PROBE-ROUTE=== origin after unmount: "assistant"
===PROBE-ROUTE=== notice present after remount: true
```

A plain unmount/remount (leaving the canvas and returning) calls **no `toggleOpen`**, so a `toggleOpen`-only fix cannot reach it. Same lie, different door. Fixing only the probed path would have repeated the mistake I was being corrected for.

**This also settles the fix shape the review left to me:** a store-durable timer *alone* would NOT fix the collapse case — a collapse at 2s and re-expand at 3s is still inside the window, and still a lie. Both halves are needed, and they close different doors.

## The fix (2 code changes, 3 files I already own)

1. **`toggleOpen` clears the stamp.** The user working the dock's own open/close control is the same "this is mine" signal `setActiveOutputTab` already honours.
2. **The window is DERIVED from a stamp timestamp** (`outputSurfaceOriginAt`) instead of scheduled by a timer that dies with the component. A remount inherits the **remainder**; an already-expired stamp never shows and is swept. A scheduled window is a hand-maintained mirror of "has the window elapsed"; a timestamp cannot drift from it (trap 12).

## Tests — 17/17, RED-first

`UNMOUNT-1` (collapse → re-expand shows NO notice) and `UNMOUNT-2` (stamp does not outlive its window while collapsed) were written first and measured **RED at `07b1d749`** with all 13 originals green. `UNMOUNT-3` (expired stamp never shows on any remount path) and `UNMOUNT-4` (a remount inherits the remainder rather than restarting) pin the second door.

## Mutants — 4/4 bit, both controls clean

Fresh worktree, isolation **proven by writing** (inodes `611111339` vs `611202446`; sentinel into the worktree left the source SHA-256 identical), restores from a pristine `git archive` tar, clean-tree asserted before and after each, **collected asserted == 17 or hard error**.

| mutant | expected | result |
|---|---|---|
| **N1** remove the clear from `toggleOpen` (the defect restored) | UNMOUNT RED | 🔴 UNMOUNT-1, UNMOUNT-2 |
| **N2** clear on a **different** action (`handleTabClick`) instead | collapse pins RED, **CLEAR-1 GREEN** | 🔴 UNMOUNT-1, UNMOUNT-2 — CLEAR-1 stayed 🟢 |
| **N3** stamp no timestamp | derived-window RED | 🔴 UNMOUNT-3, UNMOUNT-4 |
| **N4** remount restarts the window (`elapsed = 0`) | derived-window RED | 🔴 UNMOUNT-3, UNMOUNT-4 |

**N1 + N2 are the binding pair.** N2 proves the collapse pins are **not** satisfiable by "a clear exists somewhere" — moving it to another action leaves them RED while `CLEAR-1` (the tab-click pin) stays green, so the two pins bind to their own named seams and do not cross-satisfy.

One mutation was **rejected, not scored**: N2's first anchor matched twice and the harness hard-errored rather than mutate ambiguously.

## Gates at `be6746ce`

```
pnpm run lint            ✅ EXIT=0   0 errors, 1266 warnings (count UNCHANGED — no new warnings)
                                     rules-of-hooks ratchet 232, matching baseline
pnpm run typecheck       ✅ EXIT=0   coverage 3397/3437 (unchanged) · ratchet 618 files / 2485 errors
                                     ✅ Typecheck gate PASSED — my change adds ZERO diagnostics
4 guards                 ✅ EXIT=0   zustand · starters · vendor · schemas-version
eslint on my 3 files     ✅ EXIT=0   zero output

CI: {"total":13,"success":13,"failure":0,"other":0}   mergeable: MERGEABLE   mergeStateStatus: CLEAN
```

The ratchet shrink (2487→2485) remains **pre-existing** and still **not banked**.

## Review points accepted without change

Contrast 10.54:1 AAA, occlusion, dismiss target and announce-once all survived refutation — that closes limitation 1 above (the browser half I could not measure), on the reviewer's instruments rather than mine. On **M3**: the earlier table's *result* column did record `2 RED: CAP-3, CLEAR-1` correctly; the *expected* column understated it. Noted, no action.

**Corrected in my own record:** limitation 5 of the original body is **withdrawn** — it was not honest, and it is now fixed and pinned.

---

# ⚠ RE-REVIEW HARDENING — the clock cell

Head is now **`cf47ac5a`**.

## The cell

Deriving the window from a timestamp closed the unmount doors, but it made the notice depend on the **wall clock**, and the wall clock moves BACKWARD in this product's normal life: NTP steps, laptop suspend/resume, a user correcting their clock — all reachable in a long-lived SPA.

The arithmetic **failed OPEN**, which is the exact opposite of what this module's own header promises (*"null is the FAIL-CLOSED default in every direction"*):

```
elapsed   = Date.now() - stampedAt       // NEGATIVE after a backward step
remaining = max(0, 8000 - elapsed)       // → max(0, 8000 + 3600000) = an HOUR
```

So an hour-long backward step left the notice up for an hour, attributing a gesture no user could still remember; and a stamp dated in the **future** (clock corrected back after stamping) showed for minutes. My own comment claimed a posture the arithmetic did not have in one direction.

## The fix — one line, exactly as prescribed

```ts
const expired = stampedAt !== null && (elapsed < 0 || remaining === 0)
```

Negative elapsed means the stamp cannot be trusted at all, so it counts as expired.

## Tests + mutant — the same run proves both

| | |
|---|---|
| **CLOCK-1** | a BACKWARD clock step (−1h, via `vi.setSystemTime`) does not extend the window |
| **CLOCK-2** | a stamp dated an hour in the FUTURE is treated as expired, not fresh |

Both drive the real applicator and assert the STORE is swept (`outputSurfaceOrigin === null`), not merely that the notice is absent.

**Mutant C1** — drop the `elapsed < 0` disjunct, restoring the fail-open cell:

```
CONTROL           applied=0   collected=19  19 passed  0 failed   RED: <none>
C1                applied=1   collected=19  17 passed  2 failed   RED: CLOCK-1, CLOCK-2
TRAILING CONTROL  applied=0   collected=19  19 passed  0 failed   RED: <none>
```

Both CLOCK tests RED and **nothing else** — so C1 is simultaneously the prescribed mutant and the RED-first proof. Fresh worktree, isolation proven by writing (inodes `612145693` vs `612306244`, source SHA-256 unchanged), restores from a pristine `git archive` tar, collected asserted == 19 or hard error.

## Gates at `cf47ac5a`

```
pnpm run lint     ✅ EXIT=0  0 errors, 1266 warnings (count UNCHANGED)
                             rules-of-hooks ratchet 232, matching baseline
pnpm run typecheck ✅ EXIT=0 coverage 3397/3437 (unchanged) · ratchet 618 files / 2485 errors
                             ✅ Typecheck gate PASSED
4 guards          ✅ EXIT=0  zustand · starters · vendor · schemas-version
eslint, my files  ✅ EXIT=0  empty output
suite             ✅ 19/19, collected count asserted by name
```

## Scope

**Untouched, as instructed:** the three error-path close buttons (`OutputsDock.tsx:2248/:2329/:2344`) that bypass the clear — rowed as a separate seam-lift, not this PR's. Nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
