### PR TITLE
fix(2.1127): a failed analysis must not present the previous run's numbers as received and valid

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2245,10 +2245,32 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     )
                   }
 
+                  // ⚠ ROADMAP 2.1127 — `hasPartialResults` used to be fed
+                  // `Boolean(report)`, and that conflated two different things.
+                  // `report` at status 'error' is ALWAYS the RETAINED PREVIOUS
+                  // run's snapshot: `store.ts :: resultsError` preserves it by
+                  // design, every `resultsError` call site in `useV2Run` leaves
+                  // it untouched, and the one genuinely partial path
+                  // (`analysis_status === 'partial'`) settles through
+                  // `resultsComplete`, never through the error path. So the
+                  // failed run's partial results were never what was on screen
+                  // — the previous run's results were — and the flag made this
+                  // banner append "Your core results are still valid." to EVERY
+                  // failure that followed a success.
+                  //
+                  // The previous run's output stays on screen (deliberate — it
+                  // is the user's best available context) and is attributed by
+                  // `stale-results-banner` below, which names it as the previous
+                  // analysis. This banner speaks only for the run that failed.
+                  //
+                  // `canRetry` now carries the PRODUCER's own answer rather than
+                  // the unconditional `true` the partial-results limb forced:
+                  // `useV2Run` sets `canRetry: false` exactly where the user must
+                  // change the model before a rerun can succeed.
                   const friendlyError = getUserFriendlyError({
                     code: error.code,
                     message: error.message,
-                    hasPartialResults: Boolean(report),
+                    canRetry: error.canRetry,
                   })
 
                   // Task P.3.4: CEE timeout with complexity context (>15 nodes)

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -34,7 +34,7 @@ import { runStatusRegion } from './analysisRunStatus'
 import { registerCanonicalRunner, type CanonicalRunOptions, type CanonicalRunOutcome } from '../analysis/canonicalRunRegistry'
 import { useShowToastSafe } from '../ToastContext'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
-import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource, selectResultsStartedAt } from '../store'
+import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource, selectResultsStartedAt, selectReportIsFromEarlierRun } from '../store'
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
@@ -680,6 +680,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const resultsStartedAt = useCanvasStore(selectResultsStartedAt)
   const report = useCanvasStore(selectReport)
   const error = useCanvasStore(selectError)
+  // ROADMAP 2.1127 — provenance of the report on screen, PROVEN from the store's
+  // run-epoch stamps rather than inferred from `status === 'error'`.
+  const reportIsFromEarlierRun = useCanvasStore(selectReportIsFromEarlierRun)
   const resultsSource = useCanvasStore(selectResultsSource)
 
   // A.9: Auto-dismiss conversation indicator after 5 seconds
@@ -2263,14 +2266,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   // `stale-results-banner` below, which names it as the previous
                   // analysis. This banner speaks only for the run that failed.
                   //
-                  // `canRetry` now carries the PRODUCER's own answer rather than
-                  // the unconditional `true` the partial-results limb forced:
-                  // `useV2Run` sets `canRetry: false` exactly where the user must
-                  // change the model before a rerun can succeed.
+                  // ⚠ `canRetry` is deliberately NOT passed. The store's
+                  // `error.canRetry` carries `ApiError.retryable`, which answers
+                  // "would an AUTOMATIC retry help?" (false for
+                  // `ProcessingError` and `MalformedApiResponseError`) — a
+                  // different question from "may the USER re-run?". Passing it
+                  // through removed "Try Again" from the two classes whose own
+                  // copy tells the user to try again. `getUserFriendlyError`
+                  // owns the user-facing decision via `USER_RERUN_BLOCKED_CODES`
+                  // (CLAUDE.md trap 21 — two questions under one name).
                   const friendlyError = getUserFriendlyError({
                     code: error.code,
                     message: error.message,
-                    canRetry: error.canRetry,
                   })
 
                   // Task P.3.4: CEE timeout with complexity context (>15 nodes)
@@ -2520,9 +2527,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     onDismiss={() => setDegradedBannerDismissed(true)}
                   />
                 )}
-                {/* I.2c: Stale results indicator — shown when current run errored
-                    but previous results are still visible */}
-                {isError && report && (
+                {/* I.2c: Stale results indicator — shown when the current run
+                    errored AND the results still on screen are PROVABLY from an
+                    earlier run.
+                    ⚠ ROADMAP 2.1127: this used to render on `isError && report`,
+                    which is not the same claim. `useV2Run` stores this run's
+                    report at `:991` and then runs ~120 unguarded lines before
+                    returning, so a throw in that window settles a failure with
+                    THIS run's numbers on screen — and the chip called them the
+                    previous analysis. `selectReportIsFromEarlierRun` compares
+                    the store's run-epoch stamps and fails CLOSED on unknown
+                    provenance: no stamp, no claim. */}
+                {isError && report && reportIsFromEarlierRun && (
                   <div
                     className="flex items-center gap-2 px-3 py-2 bg-panel border border-warning/30 rounded"
                     role="status"

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2326,6 +2326,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                                     ? 'bg-warning text-text-on-color hover:bg-warning-hover'
                                     : 'bg-info text-text-on-color hover:bg-info-hover'
                               } disabled:opacity-50`}
+                              // ROADMAP 2.1127 — the re-run affordance needs an
+                              // IDENTITY a test can bind to. Its LABEL is
+                              // per-code ("Try Again", "Review Model", "Refresh
+                              // Page"…), so a guard written against the words
+                              // silently stops seeing the button whenever the
+                              // copy changes — which is how a mutant that
+                              // re-opened the affordance for every code
+                              // survived a suite that looked for /try again/i.
+                              data-testid="error-primary-action"
                             >
                               {friendlyError.actionText}
                             </button>

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -894,23 +894,28 @@ describe('I.2b: Cancel button during analysis', () => {
 describe('I.2c: Stale results indicator', () => {
   beforeEach(cleanupDockState)
   it('shows stale results banner when error occurs with previous results', () => {
-    const baseResults = useCanvasStore.getState().results
-
     useCanvasStore.setState({
       nodes: testNodes,
       edges: testEdges,
       hasCompletedFirstRun: true,
-      results: {
-        ...baseResults,
-        status: 'error',
-        report: fakeReportForTests,
-        error: {
-          code: 'NETWORK_ERROR',
-          message: 'Failed to fetch',
-          canRetry: true,
-        },
-      },
     } as any)
+
+    // ROADMAP 2.1127 — drive the REAL transitions rather than hand-writing the
+    // end state. The chip's sentence ("results from previous analysis") is only
+    // true when the report belongs to an EARLIER run, and the store proves that
+    // from run-epoch stamps that only the real actions write. A hand-written
+    // `{ status: 'error', report }` has no provenance at all, so it was never
+    // evidence for the claim this test makes.
+    const store = useCanvasStore.getState()
+    store.resultsStart({ seed: 1 })
+    store.resultsComplete({ report: fakeReportForTests, hash: 'previous-run-hash' } as any)
+    // A NEW run begins and fails — this is what makes the results "previous".
+    useCanvasStore.getState().resultsStart({ seed: 2 })
+    useCanvasStore.getState().resultsError({
+      code: 'NETWORK_ERROR',
+      message: 'Failed to fetch',
+      canRetry: true,
+    })
 
     renderOutputsDock()
 

--- a/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
@@ -1,0 +1,307 @@
+/**
+ * OutputsDock — a FAILED analysis must not present the PREVIOUS run's numbers
+ * as received and valid (ROADMAP 2.1127).
+ *
+ * ⚠ The witnessed defect (staging, 13 Aug 2026). After an analysis fails
+ * FOLLOWING an earlier successful one, the dock keeps the previous run's
+ * numbers on screen (deliberate — `store.ts :: resultsError` preserves
+ * `results.report`, and `OutputsDock`'s `hasInlineSummary` renders it through
+ * every status) and shows an amber banner reading:
+ *
+ *   "We received the analysis results but had trouble displaying them.
+ *    Please try again. Your core results are still valid."
+ *
+ * Both sentences are false:
+ *   1. RECEIPT — `PROCESSING_ERROR` is produced by `useV2Run`'s residual
+ *      `ProcessingError.wrap(err)` bucket (the catch-all for a throw that is
+ *      neither a typed API error nor a network error). Nothing about that path
+ *      establishes that analysis results arrived.
+ *   2. VALIDITY — the suffix came from `getUserFriendlyError`'s
+ *      `hasPartialResults` limb, which the dock fed with `Boolean(report)`.
+ *      `report` at `status === 'error'` is ALWAYS the RETAINED PREVIOUS run's
+ *      snapshot: every `resultsError` call site in `useV2Run` leaves the report
+ *      untouched, and the one genuinely partial path
+ *      (`analysis_status === 'partial'`) settles through `resultsComplete`, not
+ *      through the error path. So "partial results" was never true here, and
+ *      nothing assessed the retained numbers' validity in any case.
+ *
+ * ⚠ The mechanism is GENERAL, not error-specific: the validity suffix fired for
+ * EVERY error code whenever a previous report was retained. The second
+ * describe below pins that with a different code (NETWORK_ERROR) so a fix that
+ * only special-cased PROCESSING_ERROR cannot pass.
+ *
+ * ⚠ Surface binding (CLAUDE.md trap 3b). Bound to the surface the DEPLOYED
+ * staging flags mount. `netlify.toml [context.staging.environment]` sets
+ * VITE_FEATURE_AI_PANEL_V2="true", VITE_FEATURE_PRE_ANALYSIS_V3="1",
+ * VITE_FEATURE_ANALYSIS_HERO_PANEL="1", VITE_FEATURE_COMPARE_TAB="1" and
+ * [build.environment] sets VITE_ENABLE_ORCHESTRATOR_V2="true"; there is no
+ * VITE_FEATURE_JOURNEY_TAB entry, so the Journey tab is off. The mock below
+ * matches that posture and the control asserts the MOUNT PATH itself
+ * (`outputs-dock-body` → `outputs-error-banner`), so this binding fails loud if
+ * the deployment ever stops mounting the banner under test.
+ *
+ * ⚠ Scope (CLAUDE.md trap 3): DOM-content assertions only. Nothing here claims
+ * anything about layout, visibility or above-the-fold placement.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OutputsDock } from '../OutputsDock'
+import { ToastProvider } from '../../ToastContext'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { useCanvasStore } from '../../store'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+// importOriginal-spread (CLAUDE.md trap 12): a `vi.mock` factory REPLACES the
+// module, so a hand-listed allowlist goes silently short as flags are added.
+// Only the flags `netlify.toml` pins for staging are overridden here.
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isAiPanelV2Enabled: () => true, // VITE_FEATURE_AI_PANEL_V2 = "true"
+    isPreAnalysisV3Enabled: () => true, // VITE_FEATURE_PRE_ANALYSIS_V3 = "1"
+    isCompareTabEnabled: () => true, // VITE_FEATURE_COMPARE_TAB = "1"
+    isOrchestratorV2Enabled: () => true, // VITE_ENABLE_ORCHESTRATOR_V2 = "true"
+    isJourneyTabEnabled: () => false, // no VITE_FEATURE_JOURNEY_TAB entry
+  }
+})
+
+vi.mock('../../hooks/useV2Run', () => ({
+  useV2Run: () => ({ runV2Analysis: vi.fn(), cancelRun: vi.fn() }),
+  resolveActiveGoalNodeId: () => 'goal-1',
+}))
+
+/**
+ * The PREVIOUS run's snapshot, carrying an identity no other object in this
+ * fixture can produce, so the "the previous run is still being presented"
+ * assertion binds to THIS snapshot rather than to whatever happens to render
+ * (CLAUDE.md trap 19).
+ *
+ * ⚠ Scope of the control, stated honestly. The deployed witness saw the
+ * previous run's NUMBERS. Reproducing the numeric hero at component level needs
+ * the full enrichment chain `useResultsSectionData` consumes (per-option
+ * outcomes, goal probabilities); this minimal report drives the same results
+ * body but its numeric surfaces render "unknown". The control therefore binds
+ * to the retained snapshot's IDENTITY (its run hash, rendered in the results
+ * body's Analysis details) plus the mounted results body itself — which is the
+ * property the copy under test lies about: a failed run presenting the previous
+ * run's output as this run's.
+ */
+const PREVIOUS_RUN_HASH = 'prev-4242'
+const PREVIOUS_RUN_REPORT: any = {
+  results: { conservative: 41, likely: 4242, optimistic: 4343, units: 'percent', unitSymbol: '%' },
+  run: { bands: { p10: 41, p50: 4242, p90: 4343 } },
+}
+
+const NODES = [
+  { id: 'goal-1', type: 'goal', data: { label: 'Test Goal' }, position: { x: 0, y: 0 } },
+  { id: 'decision-1', type: 'decision', data: { label: 'Test Decision' }, position: { x: 100, y: 100 } },
+]
+const EDGES = [{ id: 'e1', source: 'decision-1', target: 'goal-1' }]
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/**
+ * Drive the REAL state machine, not a hand-written end state: a successful run
+ * settles through `resultsComplete`, then the next run fails through
+ * `resultsError`. That is the exact witnessed sequence (failure AFTER success),
+ * and it means these tests would notice if the store ever stopped retaining the
+ * previous report — which is the precondition the whole file is about.
+ */
+function seedFailureAfterSuccess(errorCode: string, message: string) {
+  ensureMatchMedia()
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+  useCanvasStore.setState({
+    nodes: NODES,
+    edges: EDGES,
+    hasCompletedFirstRun: true,
+    results: { status: 'idle', progress: 0 },
+  } as any)
+
+  const store = useCanvasStore.getState()
+  // 1. The earlier SUCCESSFUL run.
+  store.resultsComplete({ report: PREVIOUS_RUN_REPORT, hash: PREVIOUS_RUN_HASH } as any)
+  // 2. The rerun that FAILS.
+  useCanvasStore.getState().resultsError({ code: errorCode, message, canRetry: true })
+
+  // Precondition, pinned in-test (CLAUDE.md trap 13b): this fixture only says
+  // anything if the store really is in "failed, with the previous run retained".
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeTruthy()
+  expect((after.report as any).run.bands.p50).toBe(4242)
+}
+
+/** The SAME failure, on a first run — nothing retained to be honest or dishonest about. */
+function seedFirstRunFailure(errorCode: string, message: string) {
+  ensureMatchMedia()
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+  useCanvasStore.setState({
+    nodes: NODES,
+    edges: EDGES,
+    hasCompletedFirstRun: true,
+    results: { status: 'idle', progress: 0, report: null },
+  } as any)
+  useCanvasStore.getState().resultsError({ code: errorCode, message, canRetry: true })
+
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeFalsy()
+}
+
+function renderDock() {
+  return render(
+    <ToastProvider>
+      <ConversationProvider>
+        <OutputsDock />
+      </ConversationProvider>
+    </ToastProvider>,
+  )
+}
+
+describe('OutputsDock → a failed analysis after a successful one (2.1127)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+  })
+
+  // ── Control: the mount path, and that the defect's PRECONDITION is real ──
+  //
+  // Both halves matter. The mount assertion is trap 3b — it fails loud if the
+  // deployed flags stop mounting this banner, instead of the file quietly
+  // testing a component nobody renders. The retained-numbers assertion is trap
+  // 13 — it proves the previous run's numbers really are on screen in this
+  // state, so the "must not claim validity" assertions below cannot pass by
+  // testing nothing.
+  it('control — the error banner mounts and the PREVIOUS run is still being presented', () => {
+    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    const body = screen.getByTestId('outputs-dock-body')
+    // The mount path itself (trap 3b).
+    expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
+    // The results body is mounted AT status 'error' — this is what puts the
+    // previous run's output under the banner in the first place.
+    const resultsBody = within(body).getByTestId('results-body-stale-wrapper')
+    // …and it is THAT snapshot, bound by its own run hash, not "some results".
+    expect(resultsBody).toHaveTextContent(PREVIOUS_RUN_HASH)
+  })
+
+  it('does not claim the analysis results were received', () => {
+    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    const banner = screen.getByTestId('outputs-error-banner')
+    // The witnessed sentence. Nothing on the PROCESSING_ERROR path establishes
+    // that results arrived — it is the residual wrap of an unclassified throw.
+    expect(banner).not.toHaveTextContent(/We received the analysis results/i)
+    expect(banner).not.toHaveTextContent(/received the analysis results/i)
+  })
+
+  it('does not assert the retained numbers are valid', () => {
+    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    const banner = screen.getByTestId('outputs-error-banner')
+    // The witnessed sentence. Nothing assessed the retained run's validity, and
+    // the numbers on screen are not this run's results at all.
+    expect(banner).not.toHaveTextContent(/core results are still valid/i)
+  })
+
+  it('attributes the on-screen numbers to the previous run', () => {
+    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    // Removing a false claim is only half of honest: the numbers stay on
+    // screen, so something must say whose they are. This is the dock's existing
+    // stale-results banner — pinned here so the attribution cannot silently
+    // disappear while the numbers remain.
+    const stale = screen.getByTestId('stale-results-banner')
+    expect(stale).toHaveTextContent('Showing results from previous analysis')
+  })
+
+  // ── The invariant the whole row reduces to ──
+  //
+  // The error banner speaks for the run that FAILED. Whether an earlier run's
+  // snapshot happens to be retained is a fact about the results body below it,
+  // not about this run — so it must not change one character of what this
+  // banner says or offers. That is precisely what `hasPartialResults:
+  // Boolean(report)` violated: the retained snapshot reached in and rewrote the
+  // banner's claim.
+  it('says exactly the same thing whether or not a previous run is retained', () => {
+    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    const afterSuccess = renderDock()
+    const withRetained = screen.getByTestId('outputs-error-banner').textContent
+    afterSuccess.unmount()
+
+    seedFirstRunFailure('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+    const withoutRetained = screen.getByTestId('outputs-error-banner').textContent
+
+    // Non-empty on both sides before comparing them (CLAUDE.md trap 13 / the
+    // zsh-empty-extraction lesson): two empty strings agree about nothing.
+    expect(withRetained).toBeTruthy()
+    expect(withoutRetained).toBeTruthy()
+    expect(withRetained).toBe(withoutRetained)
+  })
+})
+
+describe('OutputsDock → the validity claim was NOT error-code-specific (2.1127)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+  })
+
+  // The defect's mechanism was `hasPartialResults: Boolean(report)` — true for
+  // ANY failure with a retained report. A fix that only rewrote the
+  // PROCESSING_ERROR copy would leave this case lying, so it is pinned with a
+  // different code and a different headline.
+  it('a NETWORK_ERROR after a successful run does not assert the retained numbers are valid', () => {
+    seedFailureAfterSuccess('NETWORK_ERROR', 'Failed to fetch')
+    renderDock()
+
+    const banner = screen.getByTestId('outputs-error-banner')
+    // Control: this IS the network-error banner, so the absence assertion below
+    // is about the right surface (trap 13 — prove a presence before an absence).
+    expect(banner).toHaveTextContent(/Connection issue/i)
+    expect(banner).not.toHaveTextContent(/core results are still valid/i)
+  })
+
+  it('a TIMEOUT after a successful run does not assert the retained numbers are valid', () => {
+    seedFailureAfterSuccess('TIMEOUT', 'Request timed out')
+    renderDock()
+
+    const banner = screen.getByTestId('outputs-error-banner')
+    expect(banner).toHaveTextContent(/took too long/i)
+    expect(banner).not.toHaveTextContent(/core results are still valid/i)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
@@ -424,18 +424,27 @@ describe('OutputsDock → the banner speaks only for the run that failed (2.1127
       renderDock()
 
       const banner = screen.getByTestId('outputs-error-banner')
-      expect(within(banner).getByRole('button', { name: /try again/i })).toBeInTheDocument()
+      // Bound to the affordance by IDENTITY, then to its label — not to the
+      // label alone. A label-only assertion cannot see a button that reappears
+      // under a different name, which is exactly how a mutant re-opening the
+      // re-run for every code survived an earlier version of this file.
+      const action = within(banner).getByTestId('error-primary-action')
+      expect(action).toBeInTheDocument()
+      expect(action).toHaveTextContent(/try again/i)
     },
   )
 
   it('still withholds the rerun where the user must fix the model first', () => {
-    // Discriminating twin: the same surface, a code on the blocked list. Without
-    // this, "always show Try Again" would pass the test above.
+    // Discriminating twin: the same surface, a code the user must act on first.
+    // Without this, "always offer the re-run" would pass the test above.
     seedFailureAfterEarlierSuccess('VALIDATION_BLOCKED', 'Each option needs intervention values')
     renderDock()
 
     const banner = screen.getByTestId('outputs-error-banner')
-    expect(within(banner).queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+    // ⚠ The affordance, not the word. VALIDATION_BLOCKED's actionText is
+    // "Review Model", so `queryByRole({ name: /try again/i })` was absent
+    // whether or not the button rendered — a vacuous assertion.
+    expect(within(banner).queryByTestId('error-primary-action')).not.toBeInTheDocument()
     expect(banner.textContent ?? '').not.toMatch(/try again/i)
   })
 })

--- a/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
@@ -1,44 +1,65 @@
 /**
- * OutputsDock — a FAILED analysis must not present the PREVIOUS run's numbers
- * as received and valid (ROADMAP 2.1127).
+ * OutputsDock — after a FAILED analysis, no sentence on screen may be false in
+ * ANY reachable cell (ROADMAP 2.1127).
  *
  * ⚠ The witnessed defect (staging, 13 Aug 2026). After an analysis fails
- * FOLLOWING an earlier successful one, the dock keeps the previous run's
+ * following an earlier successful one, the dock keeps the previous run's
  * numbers on screen (deliberate — `store.ts :: resultsError` preserves
- * `results.report`, and `OutputsDock`'s `hasInlineSummary` renders it through
- * every status) and shows an amber banner reading:
+ * `results.report`, and `hasInlineSummary` renders it through every status) and
+ * showed an amber banner reading:
  *
  *   "We received the analysis results but had trouble displaying them.
  *    Please try again. Your core results are still valid."
  *
- * Both sentences are false:
- *   1. RECEIPT — `PROCESSING_ERROR` is produced by `useV2Run`'s residual
- *      `ProcessingError.wrap(err)` bucket (the catch-all for a throw that is
- *      neither a typed API error nor a network error). Nothing about that path
- *      establishes that analysis results arrived.
- *   2. VALIDITY — the suffix came from `getUserFriendlyError`'s
- *      `hasPartialResults` limb, which the dock fed with `Boolean(report)`.
- *      `report` at `status === 'error'` is ALWAYS the RETAINED PREVIOUS run's
- *      snapshot: every `resultsError` call site in `useV2Run` leaves the report
- *      untouched, and the one genuinely partial path
- *      (`analysis_status === 'partial'`) settles through `resultsComplete`, not
- *      through the error path. So "partial results" was never true here, and
- *      nothing assessed the retained numbers' validity in any case.
+ * ⚠⚠ THE CELL MATRIX IS THE POINT OF THIS FILE. The first fix removed those two
+ * false sentences and introduced a third ("so this run produced no results"),
+ * because it reasoned about ONE cell. The reachable cells are the product of
+ * TWO independent axes:
  *
- * ⚠ The mechanism is GENERAL, not error-specific: the validity suffix fired for
- * EVERY error code whenever a previous report was retained. The second
- * describe below pins that with a different code (NETWORK_ERROR) so a fix that
- * only special-cased PROCESSING_ERROR cannot pass.
+ *   axis A — the error code       (which producer minted the failure)
+ *   axis B — the report's origin  (whose numbers are on screen, if any)
+ *
+ * Axis B has FOUR values, and the third is the one that gets missed:
+ *   B1 NONE            — genuine first run: no report at all.
+ *   B2 EARLIER RUN     — the failure landed before this run stored anything.
+ *   B3 THIS RUN        — `useV2Run` calls `resultsComplete` at `:991` and then
+ *                        runs ~120 UNGUARDED lines before its success return at
+ *                        `:1109`; a synchronous throw in `generateGraphHash`
+ *                        (`:1038`), `persistAnalysisSuccess` (`:1039`, whose
+ *                        `.catch` only handles rejection), `setRunMeta`
+ *                        (`:1056`), `setGate` (`:1073`/`:1079`/`:1090`) or
+ *                        `updateRobustnessGateFromV2` (`:1098`) lands in the
+ *                        catch at `:1150` → `PROCESSING_ERROR` with THIS run's
+ *                        report stored and on screen.
+ *   B4 UNKNOWN         — a report with no run-epoch stamps (e.g. hydrated
+ *                        state). Provenance cannot be proven.
+ *
+ * In B3 "this run produced no results" is false AND "Showing results from
+ * previous analysis" is false. In B4 neither can be proven, so nothing may be
+ * claimed. Both are pinned below.
+ *
+ * ⚠ Fixture honesty. Every seed drives the REAL store transitions in the real
+ * order, and every error is seeded with the `canRetry` its REAL producer emits
+ * — derived at the producers, not invented here:
+ *   PROCESSING_ERROR    `useV2Run:1188` → `typedError.retryable`; `ProcessingError`
+ *                       hardcodes false (api-errors.ts:159)          → false
+ *   MALFORMED_RESPONSE  same line; `MalformedApiResponseError` hardcodes false
+ *                       (api-errors.ts:107)                          → false
+ *   NETWORK_ERROR       same line; `NetworkError` hardcodes true
+ *                       (api-errors.ts:67)                           → true
+ *   UNEXPECTED_STATE    `useV2Run:1114` literal                      → true
+ *   VALIDATION_BLOCKED  `useV2Run:824` literal                       → false
+ *   (envelope path)     `useConversation:3528` passes NO canRetry    → undefined
+ * A fixture I wrote myself is not evidence about the wire (CLAUDE.md trap 16).
  *
  * ⚠ Surface binding (CLAUDE.md trap 3b). Bound to the surface the DEPLOYED
  * staging flags mount. `netlify.toml [context.staging.environment]` sets
  * VITE_FEATURE_AI_PANEL_V2="true", VITE_FEATURE_PRE_ANALYSIS_V3="1",
- * VITE_FEATURE_ANALYSIS_HERO_PANEL="1", VITE_FEATURE_COMPARE_TAB="1" and
+ * VITE_FEATURE_ANALYSIS_HERO_PANEL="1", VITE_FEATURE_COMPARE_TAB="1";
  * [build.environment] sets VITE_ENABLE_ORCHESTRATOR_V2="true"; there is no
- * VITE_FEATURE_JOURNEY_TAB entry, so the Journey tab is off. The mock below
- * matches that posture and the control asserts the MOUNT PATH itself
- * (`outputs-dock-body` → `outputs-error-banner`), so this binding fails loud if
- * the deployment ever stops mounting the banner under test.
+ * VITE_FEATURE_JOURNEY_TAB entry, so the Journey tab is off. The controls
+ * assert the MOUNT PATH itself (`outputs-dock-body` → `outputs-error-banner`),
+ * so this binding fails loud if the deployment stops mounting the banner.
  *
  * ⚠ Scope (CLAUDE.md trap 3): DOM-content assertions only. Nothing here claims
  * anything about layout, visibility or above-the-fold placement.
@@ -78,26 +99,25 @@ vi.mock('../../hooks/useV2Run', () => ({
   resolveActiveGoalNodeId: () => 'goal-1',
 }))
 
-/**
- * The PREVIOUS run's snapshot, carrying an identity no other object in this
- * fixture can produce, so the "the previous run is still being presented"
- * assertion binds to THIS snapshot rather than to whatever happens to render
- * (CLAUDE.md trap 19).
- *
- * ⚠ Scope of the control, stated honestly. The deployed witness saw the
- * previous run's NUMBERS. Reproducing the numeric hero at component level needs
- * the full enrichment chain `useResultsSectionData` consumes (per-option
- * outcomes, goal probabilities); this minimal report drives the same results
- * body but its numeric surfaces render "unknown". The control therefore binds
- * to the retained snapshot's IDENTITY (its run hash, rendered in the results
- * body's Analysis details) plus the mounted results body itself — which is the
- * property the copy under test lies about: a failed run presenting the previous
- * run's output as this run's.
- */
-const PREVIOUS_RUN_HASH = 'prev-4242'
-const PREVIOUS_RUN_REPORT: any = {
+/** A run's stored snapshot, carrying an identity nothing else here can produce. */
+const RUN_HASH_A = 'run-a-4242'
+const RUN_HASH_B = 'run-b-8181'
+const REPORT: any = {
   results: { conservative: 41, likely: 4242, optimistic: 4343, units: 'percent', unitSymbol: '%' },
   run: { bands: { p10: 41, p50: 4242, p90: 4343 } },
+}
+
+/**
+ * The `canRetry` each producer really emits (see the file header for the
+ * derivation). `undefined` is a real value here — the deployed envelope path
+ * passes no `canRetry` at all.
+ */
+const PRODUCER_CAN_RETRY: Record<string, boolean | undefined> = {
+  PROCESSING_ERROR: false,
+  MALFORMED_RESPONSE: false,
+  NETWORK_ERROR: true,
+  UNEXPECTED_STATE: true,
+  VALIDATION_BLOCKED: false,
 }
 
 const NODES = [
@@ -105,6 +125,12 @@ const NODES = [
   { id: 'decision-1', type: 'decision', data: { label: 'Test Decision' }, position: { x: 100, y: 100 } },
 ]
 const EDGES = [{ id: 'e1', source: 'decision-1', target: 'goal-1' }]
+
+/** Sentences that must never appear, whatever the cell. */
+const RECEIPT_CLAIM = /received the analysis results/i
+const VALIDITY_CLAIM = /still valid/i
+const NO_OUTPUT_CLAIM = /produced no results|no results were|nothing was returned/i
+const PREVIOUS_RUN_CLAIM = /from previous analysis/i
 
 function ensureMatchMedia() {
   if (typeof window.matchMedia !== 'function') {
@@ -124,14 +150,7 @@ function ensureMatchMedia() {
   }
 }
 
-/**
- * Drive the REAL state machine, not a hand-written end state: a successful run
- * settles through `resultsComplete`, then the next run fails through
- * `resultsError`. That is the exact witnessed sequence (failure AFTER success),
- * and it means these tests would notice if the store ever stopped retaining the
- * previous report — which is the precondition the whole file is about.
- */
-function seedFailureAfterSuccess(errorCode: string, message: string) {
+function resetCanvas({ hasCompletedFirstRun }: { hasCompletedFirstRun: boolean }) {
   ensureMatchMedia()
   try {
     sessionStorage.clear()
@@ -141,43 +160,87 @@ function seedFailureAfterSuccess(errorCode: string, message: string) {
   useCanvasStore.setState({
     nodes: NODES,
     edges: EDGES,
-    hasCompletedFirstRun: true,
-    results: { status: 'idle', progress: 0 },
-  } as any)
-
-  const store = useCanvasStore.getState()
-  // 1. The earlier SUCCESSFUL run.
-  store.resultsComplete({ report: PREVIOUS_RUN_REPORT, hash: PREVIOUS_RUN_HASH } as any)
-  // 2. The rerun that FAILS.
-  useCanvasStore.getState().resultsError({ code: errorCode, message, canRetry: true })
-
-  // Precondition, pinned in-test (CLAUDE.md trap 13b): this fixture only says
-  // anything if the store really is in "failed, with the previous run retained".
-  const after = useCanvasStore.getState().results
-  expect(after.status).toBe('error')
-  expect(after.report).toBeTruthy()
-  expect((after.report as any).run.bands.p50).toBe(4242)
-}
-
-/** The SAME failure, on a first run — nothing retained to be honest or dishonest about. */
-function seedFirstRunFailure(errorCode: string, message: string) {
-  ensureMatchMedia()
-  try {
-    sessionStorage.clear()
-  } catch {
-    /* jsdom quirk */
-  }
-  useCanvasStore.setState({
-    nodes: NODES,
-    edges: EDGES,
-    hasCompletedFirstRun: true,
+    hasCompletedFirstRun,
     results: { status: 'idle', progress: 0, report: null },
   } as any)
-  useCanvasStore.getState().resultsError({ code: errorCode, message, canRetry: true })
+}
+
+function fail(code: string, message: string) {
+  useCanvasStore.getState().resultsError({
+    code,
+    message,
+    // The producer's real answer, not a convenient one.
+    canRetry: PRODUCER_CAN_RETRY[code],
+  })
+}
+
+/** B1 — genuine first run: no earlier run, `hasCompletedFirstRun` false. */
+function seedFirstRunFailure(code: string, message: string) {
+  resetCanvas({ hasCompletedFirstRun: false })
+  useCanvasStore.getState().resultsStart({ seed: 7 })
+  fail(code, message)
 
   const after = useCanvasStore.getState().results
   expect(after.status).toBe('error')
   expect(after.report).toBeFalsy()
+  expect(useCanvasStore.getState().hasCompletedFirstRun).toBe(false)
+}
+
+/** B2 — the witnessed cell: run 1 succeeded, run 2 failed before storing anything. */
+function seedFailureAfterEarlierSuccess(code: string, message: string) {
+  resetCanvas({ hasCompletedFirstRun: false })
+  const store = useCanvasStore.getState()
+  store.resultsStart({ seed: 7 })
+  store.resultsComplete({ report: REPORT, hash: RUN_HASH_A } as any)
+  // A NEW run begins, and fails.
+  useCanvasStore.getState().resultsStart({ seed: 8 })
+  fail(code, message)
+
+  // Preconditions pinned in-test (CLAUDE.md trap 13b): without these the cell
+  // could silently become a different one and every assertion below would be
+  // about the wrong state.
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeTruthy()
+  expect(after.hash).toBe(RUN_HASH_A)
+  expect(typeof after.reportEpoch).toBe('number')
+  expect(typeof after.errorEpoch).toBe('number')
+  expect(after.reportEpoch).not.toBe(after.errorEpoch)
+}
+
+/**
+ * B3 — the cell the first fix got wrong: the SAME run stored its report and
+ * THEN threw (useV2Run's unguarded `:991`→`:1109` window). No new run starts,
+ * so the report and the error carry the same epoch.
+ */
+function seedFailureAfterThisRunStoredResults(code: string, message: string) {
+  resetCanvas({ hasCompletedFirstRun: false })
+  const store = useCanvasStore.getState()
+  store.resultsStart({ seed: 7 })
+  store.resultsComplete({ report: REPORT, hash: RUN_HASH_B } as any)
+  // Same run — the throw happens after resultsComplete, inside the same call.
+  fail(code, message)
+
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeTruthy()
+  expect(after.hash).toBe(RUN_HASH_B)
+  expect(typeof after.reportEpoch).toBe('number')
+  expect(after.reportEpoch).toBe(after.errorEpoch)
+}
+
+/** B4 — a report with no provenance stamps (hydrated / restored state). */
+function seedFailureWithUnprovenReport(code: string, message: string) {
+  resetCanvas({ hasCompletedFirstRun: true })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report: REPORT, hash: RUN_HASH_A },
+  } as any)
+  fail(code, message)
+
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeTruthy()
+  expect(after.reportEpoch).toBeUndefined()
 }
 
 function renderDock() {
@@ -190,118 +253,189 @@ function renderDock() {
   )
 }
 
-describe('OutputsDock → a failed analysis after a successful one (2.1127)', () => {
-  beforeEach(() => {
-    ensureMatchMedia()
-  })
+function bannerText(): string {
+  const banner = screen.getByTestId('outputs-error-banner')
+  return banner.textContent ?? ''
+}
 
-  // ── Control: the mount path, and that the defect's PRECONDITION is real ──
-  //
-  // Both halves matter. The mount assertion is trap 3b — it fails loud if the
-  // deployed flags stop mounting this banner, instead of the file quietly
-  // testing a component nobody renders. The retained-numbers assertion is trap
-  // 13 — it proves the previous run's numbers really are on screen in this
-  // state, so the "must not claim validity" assertions below cannot pass by
-  // testing nothing.
-  it('control — the error banner mounts and the PREVIOUS run is still being presented', () => {
-    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+beforeEach(() => {
+  ensureMatchMedia()
+})
+
+describe('OutputsDock → B2: failure after an EARLIER run succeeded (2.1127)', () => {
+  // ── Control: the mount path, and that the cell's precondition is real ──
+  it('control — the banner mounts and the earlier run is still being presented', () => {
+    seedFailureAfterEarlierSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
     renderDock()
 
     const body = screen.getByTestId('outputs-dock-body')
-    // The mount path itself (trap 3b).
     expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
-    // The results body is mounted AT status 'error' — this is what puts the
-    // previous run's output under the banner in the first place.
     const resultsBody = within(body).getByTestId('results-body-stale-wrapper')
-    // …and it is THAT snapshot, bound by its own run hash, not "some results".
-    expect(resultsBody).toHaveTextContent(PREVIOUS_RUN_HASH)
+    // Bound to THAT snapshot by its own run hash, not to "some results".
+    expect(resultsBody).toHaveTextContent(RUN_HASH_A)
   })
 
-  it('does not claim the analysis results were received', () => {
-    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+  it('claims neither receipt, nor validity, nor an absence of output', () => {
+    seedFailureAfterEarlierSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
     renderDock()
 
-    const banner = screen.getByTestId('outputs-error-banner')
-    // The witnessed sentence. Nothing on the PROCESSING_ERROR path establishes
-    // that results arrived — it is the residual wrap of an unclassified throw.
-    expect(banner).not.toHaveTextContent(/We received the analysis results/i)
-    expect(banner).not.toHaveTextContent(/received the analysis results/i)
+    const text = bannerText()
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).not.toMatch(RECEIPT_CLAIM)
+    expect(text).not.toMatch(VALIDITY_CLAIM)
+    expect(text).not.toMatch(NO_OUTPUT_CLAIM)
   })
 
-  it('does not assert the retained numbers are valid', () => {
-    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+  it('attributes the on-screen numbers to the previous run — the one cell where that is true', () => {
+    seedFailureAfterEarlierSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
     renderDock()
 
-    const banner = screen.getByTestId('outputs-error-banner')
-    // The witnessed sentence. Nothing assessed the retained run's validity, and
-    // the numbers on screen are not this run's results at all.
-    expect(banner).not.toHaveTextContent(/core results are still valid/i)
-  })
-
-  it('attributes the on-screen numbers to the previous run', () => {
-    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
-    renderDock()
-
-    // Removing a false claim is only half of honest: the numbers stay on
-    // screen, so something must say whose they are. This is the dock's existing
-    // stale-results banner — pinned here so the attribution cannot silently
-    // disappear while the numbers remain.
     const stale = screen.getByTestId('stale-results-banner')
     expect(stale).toHaveTextContent('Showing results from previous analysis')
   })
+})
 
-  // ── The invariant the whole row reduces to ──
-  //
-  // The error banner speaks for the run that FAILED. Whether an earlier run's
-  // snapshot happens to be retained is a fact about the results body below it,
-  // not about this run — so it must not change one character of what this
-  // banner says or offers. That is precisely what `hasPartialResults:
-  // Boolean(report)` violated: the retained snapshot reached in and rewrote the
-  // banner's claim.
-  it('says exactly the same thing whether or not a previous run is retained', () => {
-    seedFailureAfterSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
-    const afterSuccess = renderDock()
-    const withRetained = screen.getByTestId('outputs-error-banner').textContent
-    afterSuccess.unmount()
-
-    seedFirstRunFailure('PROCESSING_ERROR', 'Cannot read properties of undefined')
+describe('OutputsDock → B3: failure AFTER this run stored its own results (2.1127)', () => {
+  // This is the cell useV2Run's unguarded post-`resultsComplete` window reaches.
+  it('control — the banner mounts and THIS run\'s results are on screen', () => {
+    seedFailureAfterThisRunStoredResults('PROCESSING_ERROR', 'setGate threw')
     renderDock()
-    const withoutRetained = screen.getByTestId('outputs-error-banner').textContent
 
-    // Non-empty on both sides before comparing them (CLAUDE.md trap 13 / the
-    // zsh-empty-extraction lesson): two empty strings agree about nothing.
-    expect(withRetained).toBeTruthy()
-    expect(withoutRetained).toBeTruthy()
-    expect(withRetained).toBe(withoutRetained)
+    const body = screen.getByTestId('outputs-dock-body')
+    expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
+    expect(within(body).getByTestId('results-body-stale-wrapper')).toHaveTextContent(RUN_HASH_B)
+  })
+
+  it('does not claim this run produced no results — it produced these', () => {
+    seedFailureAfterThisRunStoredResults('PROCESSING_ERROR', 'setGate threw')
+    renderDock()
+
+    const text = bannerText()
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).not.toMatch(NO_OUTPUT_CLAIM)
+    expect(text).not.toMatch(RECEIPT_CLAIM)
+    expect(text).not.toMatch(VALIDITY_CLAIM)
+  })
+
+  it('does not call this run\'s own numbers the previous analysis', () => {
+    seedFailureAfterThisRunStoredResults('PROCESSING_ERROR', 'setGate threw')
+    renderDock()
+
+    // The chip's sentence is false here: these numbers are the failed run's own.
+    expect(screen.queryByTestId('stale-results-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId('outputs-dock-body').textContent ?? '').not.toMatch(PREVIOUS_RUN_CLAIM)
   })
 })
 
-describe('OutputsDock → the validity claim was NOT error-code-specific (2.1127)', () => {
-  beforeEach(() => {
-    ensureMatchMedia()
+describe('OutputsDock → B4: a report whose provenance cannot be proven (2.1127)', () => {
+  it('control — the banner mounts and a report is on screen', () => {
+    seedFailureWithUnprovenReport('PROCESSING_ERROR', 'hydrated then failed')
+    renderDock()
+
+    const body = screen.getByTestId('outputs-dock-body')
+    expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
+    expect(within(body).getByTestId('results-body-stale-wrapper')).toHaveTextContent(RUN_HASH_A)
   })
 
+  it('makes no provenance claim it cannot prove', () => {
+    seedFailureWithUnprovenReport('PROCESSING_ERROR', 'hydrated then failed')
+    renderDock()
+
+    // Unknown fails CLOSED: no stamp, no claim. Silence is not a false sentence.
+    expect(screen.queryByTestId('stale-results-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId('outputs-dock-body').textContent ?? '').not.toMatch(PREVIOUS_RUN_CLAIM)
+  })
+})
+
+describe('OutputsDock → B1: a genuine FIRST-run failure (2.1127)', () => {
+  // hasCompletedFirstRun === false, so this is the pre-run surface — a
+  // different mount path from B2/B3/B4, and the one a new user hits first.
+  it('control — the banner mounts on the pre-run surface with no results body', () => {
+    seedFirstRunFailure('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    const body = screen.getByTestId('outputs-dock-body')
+    expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
+    expect(within(body).queryByTestId('results-body-stale-wrapper')).not.toBeInTheDocument()
+  })
+
+  it('claims nothing about results, and no previous run exists to attribute to', () => {
+    seedFirstRunFailure('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+
+    const text = bannerText()
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).not.toMatch(RECEIPT_CLAIM)
+    expect(text).not.toMatch(VALIDITY_CLAIM)
+    expect(screen.queryByTestId('stale-results-banner')).not.toBeInTheDocument()
+  })
+})
+
+describe('OutputsDock → axis A: the claims were never error-code-specific (2.1127)', () => {
   // The defect's mechanism was `hasPartialResults: Boolean(report)` — true for
-  // ANY failure with a retained report. A fix that only rewrote the
-  // PROCESSING_ERROR copy would leave this case lying, so it is pinned with a
-  // different code and a different headline.
-  it('a NETWORK_ERROR after a successful run does not assert the retained numbers are valid', () => {
-    seedFailureAfterSuccess('NETWORK_ERROR', 'Failed to fetch')
+  // ANY failure with a retained report. Codes below are ones producers really
+  // emit, each seeded with the `canRetry` its producer really sends.
+  it.each([
+    ['NETWORK_ERROR', 'Failed to fetch', /Connection issue/i],
+    ['UNEXPECTED_STATE', 'Received unexpected response format', /Something went wrong/i],
+    ['MALFORMED_RESPONSE', 'Response failed validation', /Something went wrong/i],
+  ])('%s after an earlier success asserts neither validity nor receipt', (code, message, presence) => {
+    seedFailureAfterEarlierSuccess(code as string, message as string)
     renderDock()
 
-    const banner = screen.getByTestId('outputs-error-banner')
-    // Control: this IS the network-error banner, so the absence assertion below
-    // is about the right surface (trap 13 — prove a presence before an absence).
-    expect(banner).toHaveTextContent(/Connection issue/i)
-    expect(banner).not.toHaveTextContent(/core results are still valid/i)
+    const text = bannerText()
+    // Presence before absence (CLAUDE.md trap 13): this IS that code's banner.
+    expect(text).toMatch(presence as RegExp)
+    expect(text).not.toMatch(VALIDITY_CLAIM)
+    expect(text).not.toMatch(RECEIPT_CLAIM)
+  })
+})
+
+describe('OutputsDock → the banner speaks only for the run that failed (2.1127)', () => {
+  // Whether an earlier run's snapshot is retained is a fact about the results
+  // body below, not about this run — so it must not change one character of
+  // what this banner says. That is exactly what `hasPartialResults:
+  // Boolean(report)` violated.
+  it('says exactly the same thing with a retained report as without one', () => {
+    seedFailureAfterEarlierSuccess('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    const withRetained = renderDock()
+    const retainedText = bannerText()
+    withRetained.unmount()
+
+    seedFirstRunFailure('PROCESSING_ERROR', 'Cannot read properties of undefined')
+    renderDock()
+    const freshText = bannerText()
+
+    // Non-empty on both sides before comparing them: two empty strings agree
+    // about nothing (CLAUDE.md trap 13 / the zsh empty-extraction lesson).
+    expect(retainedText.length).toBeGreaterThan(0)
+    expect(freshText.length).toBeGreaterThan(0)
+    expect(retainedText).toBe(freshText)
   })
 
-  it('a TIMEOUT after a successful run does not assert the retained numbers are valid', () => {
-    seedFailureAfterSuccess('TIMEOUT', 'Request timed out')
+  // Copy and affordance must agree. `PROCESSING_ERROR` and `MALFORMED_RESPONSE`
+  // both carry copy that instructs a retry, and both have
+  // `ApiError.retryable === false`; feeding that into the banner deleted the
+  // button while leaving the instruction.
+  it.each(['PROCESSING_ERROR', 'MALFORMED_RESPONSE'])(
+    '%s offers the rerun its own copy tells the user to make',
+    (code) => {
+      seedFailureAfterEarlierSuccess(code, 'boom')
+      renderDock()
+
+      const banner = screen.getByTestId('outputs-error-banner')
+      expect(within(banner).getByRole('button', { name: /try again/i })).toBeInTheDocument()
+    },
+  )
+
+  it('still withholds the rerun where the user must fix the model first', () => {
+    // Discriminating twin: the same surface, a code on the blocked list. Without
+    // this, "always show Try Again" would pass the test above.
+    seedFailureAfterEarlierSuccess('VALIDATION_BLOCKED', 'Each option needs intervention values')
     renderDock()
 
     const banner = screen.getByTestId('outputs-error-banner')
-    expect(banner).toHaveTextContent(/took too long/i)
-    expect(banner).not.toHaveTextContent(/core results are still valid/i)
+    expect(within(banner).queryByRole('button', { name: /try again/i })).not.toBeInTheDocument()
+    expect(banner.textContent ?? '').not.toMatch(/try again/i)
   })
 })

--- a/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.failedRunHonesty.spec.tsx
@@ -31,8 +31,17 @@
  *                        `updateRobustnessGateFromV2` (`:1098`) lands in the
  *                        catch at `:1150` → `PROCESSING_ERROR` with THIS run's
  *                        report stored and on screen.
- *   B4 UNKNOWN         — a report with no run-epoch stamps (e.g. hydrated
- *                        state). Provenance cannot be proven.
+ *   B4 UNKNOWN         — a report with no run-epoch stamps. Provenance cannot
+ *                        be proven.
+ *   B5 COLD-LOADED     — a scenario opened from Supabase with a saved analysis,
+ *                        then re-run, and the re-run fails. The restored report
+ *                        IS from an earlier run, and the chip must say so. This
+ *                        cell exists because `resultsHydrateFromSupabase`
+ *                        installs the report by SPREAD and
+ *                        `hydrateAnalysis.ts:138-152` returns no epoch keys, so
+ *                        the stamp has to be asserted by the store action
+ *                        itself — otherwise the cell silently becomes B4 and a
+ *                        TRUE disclosure is suppressed.
  *
  * In B3 "this run produced no results" is false AND "Showing results from
  * previous analysis" is false. In B4 neither can be proven, so nothing may be
@@ -243,6 +252,55 @@ function seedFailureWithUnprovenReport(code: string, message: string) {
   expect(after.reportEpoch).toBeUndefined()
 }
 
+/**
+ * B5 — a COLD scenario load from Supabase, then a failed rerun.
+ *
+ * The payload's key set is exactly what `hydrateAnalysisFromV2Response` returns
+ * (`hydrateAnalysis.ts:138-152`) — status, progress, seed, hash, report,
+ * enrichment, error, startedAt, finishedAt — and, decisively, NO epoch keys.
+ * That absence is the whole point of this cell, so it is asserted below rather
+ * than assumed: if the producer ever starts stamping provenance itself, this
+ * fixture stops standing for the cell it claims to cover and says so.
+ */
+function seedFailureAfterColdScenarioLoad(code: string, message: string) {
+  resetCanvas({ hasCompletedFirstRun: false })
+  // A genuinely COLD store: nothing has run in this session.
+  expect(useCanvasStore.getState().results.reportEpoch).toBeUndefined()
+  expect(useCanvasStore.getState().results.runEpoch).toBeUndefined()
+
+  const hydrated = {
+    results: {
+      status: 'complete' as const,
+      progress: 100,
+      seed: undefined,
+      hash: RUN_HASH_A,
+      report: REPORT,
+      enrichment: undefined,
+      error: undefined,
+      startedAt: 1,
+      finishedAt: 2,
+    },
+    runMeta: {},
+  }
+  // Precondition: the producer's payload carries no provenance of its own.
+  expect(Object.keys(hydrated.results)).not.toContain('reportEpoch')
+  expect(Object.keys(hydrated.results)).not.toContain('runEpoch')
+
+  useCanvasStore.getState().resultsHydrateFromSupabase(hydrated as never)
+  // The user hits Rerun, and it fails.
+  useCanvasStore.getState().resultsStart({ seed: 9 })
+  fail(code, message)
+
+  const after = useCanvasStore.getState().results
+  expect(after.status).toBe('error')
+  expect(after.report).toBeTruthy()
+  expect(after.hash).toBe(RUN_HASH_A)
+  expect(typeof after.errorEpoch).toBe('number')
+  // The store had to supply this — the payload did not.
+  expect(after.reportEpoch).toBe(0)
+  expect(after.reportEpoch).not.toBe(after.errorEpoch)
+}
+
 function renderDock() {
   return render(
     <ToastProvider>
@@ -344,6 +402,40 @@ describe('OutputsDock → B4: a report whose provenance cannot be proven (2.1127
     // Unknown fails CLOSED: no stamp, no claim. Silence is not a false sentence.
     expect(screen.queryByTestId('stale-results-banner')).not.toBeInTheDocument()
     expect(screen.getByTestId('outputs-dock-body').textContent ?? '').not.toMatch(PREVIOUS_RUN_CLAIM)
+  })
+})
+
+describe('OutputsDock → B5: a saved scenario opened cold, then a failed rerun (2.1127)', () => {
+  // The live path: `useScenario.ts:727-734` hydrates whenever
+  // `row.analysis_status === 'ready'`. The restored numbers ARE from an earlier
+  // run, so this is a cell where the chip's sentence is TRUE and withholding it
+  // would suppress a real disclosure.
+  it('control — the banner mounts and the restored run is on screen', () => {
+    seedFailureAfterColdScenarioLoad('PROCESSING_ERROR', 'rerun threw')
+    renderDock()
+
+    const body = screen.getByTestId('outputs-dock-body')
+    expect(within(body).getByTestId('outputs-error-banner')).toBeInTheDocument()
+    expect(within(body).getByTestId('results-body-stale-wrapper')).toHaveTextContent(RUN_HASH_A)
+  })
+
+  it('attributes the restored numbers to the previous run', () => {
+    seedFailureAfterColdScenarioLoad('PROCESSING_ERROR', 'rerun threw')
+    renderDock()
+
+    const stale = screen.getByTestId('stale-results-banner')
+    expect(stale).toHaveTextContent('Showing results from previous analysis')
+  })
+
+  it('and still claims neither receipt nor validity', () => {
+    seedFailureAfterColdScenarioLoad('PROCESSING_ERROR', 'rerun threw')
+    renderDock()
+
+    const text = bannerText()
+    expect(text.length).toBeGreaterThan(0)
+    expect(text).not.toMatch(RECEIPT_CLAIM)
+    expect(text).not.toMatch(VALIDITY_CLAIM)
+    expect(text).not.toMatch(NO_OUTPUT_CLAIM)
   })
 })
 

--- a/src/canvas/components/__tests__/OutputsDock.rerunContinuity.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.rerunContinuity.spec.tsx
@@ -144,7 +144,6 @@ const fakeReport: Record<string, unknown> = {
 }
 
 function seedCompletedRun() {
-  const baseResults = useCanvasStore.getState().results
   useCanvasStore.setState({
     hasCompletedFirstRun: true,
     nodes: [
@@ -154,10 +153,24 @@ function seedCompletedRun() {
     edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
     graphHealth: { status: 'healthy', score: 100, issues: [] },
     ceeAnalysisReady: { goal_node_id: 'goal-1', options: [{ id: 'opt-a', label: 'A', interventions: {} }] },
-    results: { ...baseResults, status: 'complete', progress: 100, report: fakeReport },
+    showDraftChat: false,
+  } as never)
+
+  // ROADMAP 2.1127 — the completed run is seeded through the REAL transitions,
+  // not hand-written. `resultsComplete` stamps the run-epoch provenance the
+  // stale-results chip needs: without it the store cannot prove the report
+  // belongs to an earlier run, and the chip (correctly) makes no claim.
+  useCanvasStore.getState().resultsStart({ seed: 1 })
+  useCanvasStore.getState().resultsComplete({
+    report: fakeReport,
+    hash: 'seeded-completed-run',
+  } as never)
+
+  // Set AFTER the action: `resultsComplete` is a real transition with real
+  // side effects, and these fixtures describe the state this suite tests.
+  useCanvasStore.setState({
     analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
     analysisFreshnessDirty: false,
-    showDraftChat: false,
   } as never)
 }
 

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -5599,7 +5599,13 @@ export const selectProgress = (state: CanvasState): number => state.results.prog
 export const selectResultsStartedAt = (state: CanvasState): number | undefined => state.results.startedAt
 export const selectReport = (state: CanvasState): ReportV1 | null | undefined => state.results.report
 export const selectDrivers = (state: CanvasState): Array<{ kind: 'node' | 'edge'; id: string }> | undefined => state.results.drivers
-export const selectError = (state: CanvasState): { code: string; message: string; retryAfter?: number; request_id?: string; affectedOptions?: Array<{ id: string; label: string }> } | null | undefined => state.results.error
+// ⚠ ROADMAP 2.1127 — this selector's return type was a HAND-COPIED duplicate of
+// the `results.error` field type (`:202`) and had drifted: `canRetry` is
+// accepted by `resultsError`, written into the state, and declared on the state
+// — but was missing here, so every consumer reading through this selector was
+// blind to a field the store actually carries. Derived from the state type now,
+// so it cannot drift again (CLAUDE.md trap 12: derive, don't mirror).
+export const selectError = (state: CanvasState): CanvasState['results']['error'] => state.results.error
 export const selectRunId = (state: CanvasState): string | undefined => state.results.runId
 export const selectSeed = (state: CanvasState): number | undefined => state.results.seed
 export const selectHash = (state: CanvasState): string | undefined => state.results.hash

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -219,6 +219,31 @@ export interface ResultsState {
    * genuine completion.
    */
   settledWithoutNewReport?: boolean
+  /**
+   * ROADMAP 2.1127 — run identity, so a surface can PROVE whether the report it
+   * is displaying belongs to the run that just failed or to an earlier one.
+   *
+   * `status === 'error'` alone cannot answer that. `useV2Run` calls
+   * `resultsComplete` (`:991`) and then runs ~120 more lines UNGUARDED before
+   * its success return: a synchronous throw in `generateGraphHash` (`:1038`),
+   * `persistAnalysisSuccess` (`:1039`), `setRunMeta` (`:1056`), `setGate`
+   * (`:1073`/`:1079`/`:1090`) or `updateRobustnessGateFromV2` (`:1098`) lands in
+   * the catch at `:1150` and settles a failure with THIS run's report in the
+   * store. A chip reading "showing results from previous analysis" off `isError`
+   * is simply false there.
+   *
+   * The counter is stamped inside the store's own transitions, so every
+   * producer (useV2Run, useResultsRun, useConversation, applyV5State) gets it
+   * with no call-site change and none can forget to pass it.
+   *
+   * ⚠ Absent stamps mean UNKNOWN, never "previous" — a surface that cannot
+   * prove the provenance must make no provenance claim.
+   */
+  runEpoch?: number
+  /** The `runEpoch` of the run that produced the report currently held. */
+  reportEpoch?: number
+  /** The `runEpoch` of the run that produced the error currently held. */
+  errorEpoch?: number
 }
 
 /**
@@ -3167,7 +3192,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         drivers: prevResults.drivers,
         runId: undefined,
         finishedAt: undefined,
-        isDuplicateRun: undefined
+        isDuplicateRun: undefined,
+        // ROADMAP 2.1127 — a new run begins. The retained report keeps the
+        // epoch of the run that produced it, so a failure settled by THIS run
+        // is distinguishable from a report left over from an earlier one.
+        runEpoch: (prevResults.runEpoch ?? 0) + 1,
+        reportEpoch: prevResults.reportEpoch,
+        errorEpoch: undefined
       },
       // Graph Lens: auto-reset on new analysis run
       lens: createDefaultLensState(),
@@ -3260,6 +3291,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         enrichment: enrichment ?? null, // Phase 1B: Persist enrichment from PLoT
         resultsSource: resultsSource ?? 'direct', // A.9: provenance
         settledWithoutNewReport: undefined, // Lane 3: a REAL completion
+        // ROADMAP 2.1127 — this report belongs to the run currently in flight.
+        // Stamped here, inside the store, so every producer gets it and none
+        // can forget to pass it.
+        reportEpoch: s.results.runEpoch,
       },
       graphHealth: (() => {
         if (!healthFromQuality) return s.graphHealth ?? null
@@ -3492,7 +3527,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         status: 'error',
         // retryAfter: reserved for future rate-limit handling, not currently displayed
         error: { code, message, retryAfter, request_id, canRetry, affectedOptions },
-        finishedAt: Date.now()
+        finishedAt: Date.now(),
+        // ROADMAP 2.1127 — which run failed. Compared against `reportEpoch` by
+        // any surface that wants to say whose numbers are on screen: equal
+        // means the retained report is THIS run's (the failure landed after
+        // `resultsComplete`), different means it is genuinely a previous run's,
+        // and a missing stamp on either side means UNKNOWN — claim nothing.
+        errorEpoch: s.results.runEpoch,
       },
       // Run failed — the prior snapshot (preserved on the results object)
       // may still be the user's best available context, but the new-run
@@ -3555,7 +3596,11 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         finishedAt: undefined,
         error: undefined,
         settledWithoutNewReport: undefined, // Lane 3: new run in flight
-        // Everything else (report/hash/seed/drivers) preserved so a
+        // ROADMAP 2.1127 — resultsStart parity: a new run begins here too (this
+        // is the V5/conversation path's opener, useConversation.ts:4318).
+        runEpoch: (s.results.runEpoch ?? 0) + 1,
+        errorEpoch: undefined,
+        // Everything else (report/hash/seed/drivers/reportEpoch) preserved so a
         // settle-back after a resultless turn restores the prior run intact.
       },
       // Graph Lens: auto-reset on new analysis run (resultsStart parity).
@@ -5606,6 +5651,26 @@ export const selectDrivers = (state: CanvasState): Array<{ kind: 'node' | 'edge'
 // blind to a field the store actually carries. Derived from the state type now,
 // so it cannot drift again (CLAUDE.md trap 12: derive, don't mirror).
 export const selectError = (state: CanvasState): CanvasState['results']['error'] => state.results.error
+
+/**
+ * ROADMAP 2.1127 — is the report currently on screen PROVABLY from a run
+ * EARLIER than the one that just failed?
+ *
+ * Three outcomes, and the third is the point:
+ *   true  — stamps present and different: a genuinely previous run's results.
+ *   false — stamps present and equal: the failure landed AFTER this run's own
+ *           `resultsComplete` (useV2Run's unguarded window, `:991`→`:1109`), so
+ *           the numbers on screen ARE this run's.
+ *   false — either stamp missing: provenance UNKNOWN. A surface may not claim
+ *           "previous analysis" on an unknown, so unknown fails CLOSED to no
+ *           claim rather than to the more convenient one.
+ */
+export const selectReportIsFromEarlierRun = (state: CanvasState): boolean => {
+  const { reportEpoch, errorEpoch, report } = state.results
+  if (!report) return false
+  if (typeof reportEpoch !== 'number' || typeof errorEpoch !== 'number') return false
+  return reportEpoch !== errorEpoch
+}
 export const selectRunId = (state: CanvasState): string | undefined => state.results.runId
 export const selectSeed = (state: CanvasState): number | undefined => state.results.seed
 export const selectHash = (state: CanvasState): string | undefined => state.results.hash

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -3750,6 +3750,24 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       results: {
         ...s.results,
         ...hydratedResults,
+        // ROADMAP 2.1127 — the SAME reasoning as `resultsLoadHistorical`, and
+        // it must be repeated here because this action installs a restored
+        // report by SPREAD: `hydrateAnalysis.ts:138-152` returns no epoch keys,
+        // so on a COLD scenario load (`useScenario.ts:727-734`, whenever
+        // `row.analysis_status === 'ready'`) `reportEpoch` would stay
+        // `undefined`. A later failed rerun then reads UNKNOWN and SUPPRESSES
+        // the attribution chip while the restored numbers stay mounted — an
+        // under-claim, but a lost TRUE disclosure.
+        //
+        // A restored report is by definition not the output of the run that
+        // fails next, and `runEpoch` only ever counts up from 1, so the
+        // sentinel can never collide with a future `errorEpoch`.
+        //
+        // ⚠ These two keys must stay AFTER the spreads: a hydrated payload that
+        // one day carries its own epoch fields must not overwrite the provenance
+        // this action is asserting.
+        reportEpoch: HISTORICAL_REPORT_EPOCH,
+        errorEpoch: undefined,
       },
       runMeta: {
         ...s.runMeta,

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -247,6 +247,14 @@ export interface ResultsState {
 }
 
 /**
+ * ROADMAP 2.1127 — the `reportEpoch` stamped on a report RESTORED from history
+ * rather than produced by a run in this session. `runEpoch` counts from 1, so
+ * this can never equal a future `errorEpoch`: a restored report is provably not
+ * the output of the run that fails next.
+ */
+export const HISTORICAL_REPORT_EPOCH = 0
+
+/**
  * V5 analysis-fact state — written when a CEE V5 OlumiResponse carries an
  * `analysis_result` block plus the explicit run_analysis fact signals
  * (analysis_freshness, has_run_analysis_fact) emitted by Phase 3A.
@@ -3674,7 +3682,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         startedAt: run.ts,
         finishedAt: run.ts,
         drivers: run.drivers as any,
-        error: undefined
+        error: undefined,
+        // ROADMAP 2.1127 — this action REPLACES the whole results object, so it
+        // must carry the provenance stamps or a restored run would read as
+        // UNKNOWN and a later failure could make no attribution at all. A
+        // historical run is BY DEFINITION not the run that fails next: the
+        // counter only ever increments from 1, so the sentinel epoch below can
+        // never collide with a future `errorEpoch`.
+        runEpoch: s.results.runEpoch,
+        reportEpoch: HISTORICAL_REPORT_EPOCH,
+        errorEpoch: undefined
       },
       runMeta: {
         diagnostics: undefined,

--- a/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
+++ b/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
@@ -20,7 +20,12 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { getUserFriendlyError } from '../userFriendlyErrors'
+import {
+  ALL_ERROR_CODES,
+  ALL_STATUS_CODES,
+  USER_RERUN_BLOCKED_CODES,
+  getUserFriendlyError,
+} from '../userFriendlyErrors'
 
 describe('getUserFriendlyError — partial results are not a validity verdict (2.1127)', () => {
   // Control (CLAUDE.md trap 13b): pin the PRECONDITION in-test. These
@@ -78,5 +83,81 @@ describe('getUserFriendlyError — PROCESSING_ERROR claims no receipt (2.1127)',
     expect(processing.explanation).not.toMatch(/we received/i)
     expect(processing.explanation).not.toMatch(/received the analysis results/i)
     expect(processing.headline).not.toMatch(/received/i)
+  })
+
+  // The first fix replaced a false claim of receipt with a false claim of
+  // ABSENCE. `useV2Run` stores this run's report at `:991` and then runs ~120
+  // unguarded lines before returning, so a throw in that window settles
+  // PROCESSING_ERROR with results already on screen. The copy must assert
+  // nothing about output in EITHER direction.
+  it('does not claim the run produced no results either', () => {
+    const processing = getUserFriendlyError({ code: 'PROCESSING_ERROR' })
+    const whole = `${processing.headline} ${processing.explanation}`
+    expect(whole).not.toMatch(/produced no results/i)
+    expect(whole).not.toMatch(/no results were/i)
+    expect(whole).not.toMatch(/nothing was returned/i)
+  })
+})
+
+describe('getUserFriendlyError — copy and affordance must agree (2.1127)', () => {
+  // ⚠ TWO QUESTIONS, ONE NAME (CLAUDE.md trap 21). `ApiError.retryable` answers
+  // "would an AUTOMATIC retry help?" and defaults false; `ProcessingError` and
+  // `MalformedApiResponseError` hardcode it false. The banner's `canRetry`
+  // answers "may the USER re-run?". Feeding the first into the second removed
+  // "Try Again" from exactly the classes whose copy says to try again.
+  //
+  // The corpus is DERIVED from the map (trap 12), so a code added later cannot
+  // slip past this invariant.
+  const INSTRUCTS_RETRY = /try again|wait and retry|retry/i
+
+  it('control — the corpus is non-empty and includes the classes at issue', () => {
+    expect(ALL_ERROR_CODES.length).toBeGreaterThan(5)
+    expect(ALL_ERROR_CODES).toContain('PROCESSING_ERROR')
+    expect(ALL_STATUS_CODES.length).toBeGreaterThan(3)
+  })
+
+  it.each([...ALL_ERROR_CODES])(
+    '%s — if the copy instructs a retry, the retry is offered',
+    (code) => {
+      const e = getUserFriendlyError({ code })
+      const instructs = INSTRUCTS_RETRY.test(`${e.explanation} ${e.actionText}`)
+      if (instructs) expect(e.canRetry).toBe(true)
+    },
+  )
+
+  it.each([...ALL_STATUS_CODES])(
+    'status %s — if the copy instructs a retry, the retry is offered',
+    (status) => {
+      const e = getUserFriendlyError({ status })
+      const instructs = INSTRUCTS_RETRY.test(`${e.explanation} ${e.actionText}`)
+      if (instructs) expect(e.canRetry).toBe(true)
+    },
+  )
+
+  it('the unknown-code fallback instructs a retry AND offers it', () => {
+    const fallback = getUserFriendlyError({ code: 'MALFORMED_RESPONSE' })
+    // MALFORMED_RESPONSE has no entry of its own, so it lands on DEFAULT_ERROR
+    // — whose copy says "Please try again". That is the exact cell where the
+    // producer's `retryable: false` used to delete the button.
+    expect(fallback.explanation).toMatch(/try again/i)
+    expect(fallback.canRetry).toBe(true)
+  })
+
+  it('PROCESSING_ERROR permits a user re-run despite ProcessingError.retryable === false', () => {
+    expect(getUserFriendlyError({ code: 'PROCESSING_ERROR' }).canRetry).toBe(true)
+  })
+
+  // Discriminating twin: without this, "always true" would pass everything above.
+  it.each([...USER_RERUN_BLOCKED_CODES])(
+    '%s withholds the re-run AND does not instruct one',
+    (code) => {
+      const e = getUserFriendlyError({ code })
+      expect(e.canRetry).toBe(false)
+      expect(`${e.explanation} ${e.actionText}`).not.toMatch(INSTRUCTS_RETRY)
+    },
+  )
+
+  it('an explicit caller-supplied canRetry still wins', () => {
+    expect(getUserFriendlyError({ code: 'NETWORK_ERROR', canRetry: false }).canRetry).toBe(false)
   })
 })

--- a/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
+++ b/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
@@ -147,9 +147,40 @@ describe('getUserFriendlyError — copy and affordance must agree (2.1127)', () 
     expect(getUserFriendlyError({ code: 'PROCESSING_ERROR' }).canRetry).toBe(true)
   })
 
-  // Discriminating twin: without this, "always true" would pass everything above.
+  // ⚠ A HAND-WRITTEN CORPUS, DELIBERATELY NOT DERIVED FROM THE LIST (CLAUDE.md
+  // trap 12d). A derived guard proves the consumers AGREE with the list; it can
+  // never prove the LIST IS RIGHT. Measured: emptying
+  // `USER_RERUN_BLOCKED_CODES` made the derived `it.each` below simply VANISH —
+  // the run went 60 tests to 55 and stayed green, because a table parameterised
+  // over the mutated list deletes its own cases instead of failing them. Only
+  // these literals notice. The collected-count drop was the only tell.
+  const MUST_BLOCK_RERUN = [
+    'UNAUTHORIZED', // re-running cannot fix an expired session
+    'FORBIDDEN', // nor a permission the user does not have
+    'INVALID_INPUT', // the model must change first
+    'EMPTY_GRAPH', // there is nothing to analyse yet
+    'VALIDATION_BLOCKED', // options need intervention values first
+  ] as const
+
+  it('the blocked set still contains every code a re-run cannot fix', () => {
+    for (const code of MUST_BLOCK_RERUN) {
+      expect(USER_RERUN_BLOCKED_CODES).toContain(code)
+    }
+  })
+
+  it.each([...MUST_BLOCK_RERUN])(
+    '%s withholds the re-run AND does not instruct one (hand-written corpus)',
+    (code) => {
+      const e = getUserFriendlyError({ code })
+      expect(e.canRetry).toBe(false)
+      expect(`${e.explanation} ${e.actionText}`).not.toMatch(INSTRUCTS_RETRY)
+    },
+  )
+
+  // Kept alongside the corpus, not instead of it: this one notices a code ADDED
+  // to the list whose copy still tells the user to retry.
   it.each([...USER_RERUN_BLOCKED_CODES])(
-    '%s withholds the re-run AND does not instruct one',
+    '%s (derived from the list) withholds the re-run AND does not instruct one',
     (code) => {
       const e = getUserFriendlyError({ code })
       expect(e.canRetry).toBe(false)

--- a/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
+++ b/src/lib/__tests__/userFriendlyErrors.noUnassessedClaims.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * userFriendlyErrors — an error panel may not claim RECEIPT it cannot support,
+ * nor assert a VALIDITY nothing assessed (ROADMAP 2.1127).
+ *
+ * The witnessed staging banner composed both falsehoods out of this module:
+ *
+ *   "We received the analysis results but had trouble displaying them.
+ *    Please try again. Your core results are still valid."
+ *
+ * — the first sentence from the `PROCESSING_ERROR` entry, the second appended
+ * by the `hasPartialResults` limb of `getUserFriendlyError`.
+ *
+ * ⚠ Why this file exists ALONGSIDE `OutputsDock.failedRunHonesty.spec.tsx`.
+ * The fix has two independent halves: the dock stopped passing a retained
+ * PREVIOUS report as this run's partial results, and this module stopped
+ * asserting validity when told there are partial results. Either half alone
+ * removes the witnessed sentence, so a mutant reverting only one survives a
+ * suite that tests only the composed surface. This spec pins the module's half
+ * directly, so both halves are load-bearing and both mutants bite.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { getUserFriendlyError } from '../userFriendlyErrors'
+
+describe('getUserFriendlyError — partial results are not a validity verdict (2.1127)', () => {
+  // Control (CLAUDE.md trap 13b): pin the PRECONDITION in-test. These
+  // assertions only mean something if the `hasPartialResults` limb is the one
+  // being taken — `secondaryActionText` is that limb's own signature, and it is
+  // NOT part of the NETWORK_ERROR base entry.
+  it('control — hasPartialResults takes the partial limb and keeps its affordances', () => {
+    const base = getUserFriendlyError({ code: 'NETWORK_ERROR' })
+    expect(base.secondaryActionText).toBeUndefined()
+
+    const partial = getUserFriendlyError({ code: 'NETWORK_ERROR', hasPartialResults: true })
+    expect(partial.secondaryActionText).toBe('Continue Without')
+    expect(partial.canRetry).toBe(true)
+    // The base explanation is still the one being spoken — so the absence
+    // assertion below is about a real, non-empty sentence.
+    expect(partial.explanation).toBe(base.explanation)
+    expect(partial.explanation.length).toBeGreaterThan(0)
+  })
+
+  it('does not append a validity claim when told there are partial results', () => {
+    const partial = getUserFriendlyError({ code: 'NETWORK_ERROR', hasPartialResults: true })
+    expect(partial.explanation).not.toMatch(/still valid/i)
+  })
+
+  // The limb is code-agnostic: it wrapped EVERY base entry. Pinning one code
+  // would let a code-specific carve-out pass.
+  it.each(['NETWORK_ERROR', 'TIMEOUT', 'PROCESSING_ERROR', 'ANALYSIS_FAILED', 'UNEXPECTED_CODE'])(
+    'does not append a validity claim for %s',
+    (code) => {
+      const partial = getUserFriendlyError({ code, hasPartialResults: true })
+      expect(partial.explanation.length).toBeGreaterThan(0)
+      expect(partial.explanation).not.toMatch(/still valid/i)
+    },
+  )
+})
+
+describe('getUserFriendlyError — PROCESSING_ERROR claims no receipt (2.1127)', () => {
+  // Control: prove the code resolves to its OWN entry rather than falling
+  // through to DEFAULT_ERROR, so the absence assertions below are about the
+  // entry under test and not about a generic fallback (trap 19 — bind by
+  // identity, not by "some error object").
+  it('control — PROCESSING_ERROR resolves to its own entry, not the default', () => {
+    const processing = getUserFriendlyError({ code: 'PROCESSING_ERROR' })
+    const fallback = getUserFriendlyError({ code: 'NO_SUCH_CODE_EXISTS' })
+    expect(processing.headline).not.toBe(fallback.headline)
+    expect(processing.explanation).not.toBe(fallback.explanation)
+    expect(processing.explanation.length).toBeGreaterThan(0)
+  })
+
+  it('does not claim the analysis results were received', () => {
+    const processing = getUserFriendlyError({ code: 'PROCESSING_ERROR' })
+    // `PROCESSING_ERROR` is `ProcessingError.wrap(err)`'s residual bucket in
+    // `useV2Run` — the catch-all for an unclassified throw, which fires before
+    // any response arrives just as readily as after one.
+    expect(processing.explanation).not.toMatch(/we received/i)
+    expect(processing.explanation).not.toMatch(/received the analysis results/i)
+    expect(processing.headline).not.toMatch(/received/i)
+  })
+})

--- a/src/lib/userFriendlyErrors.ts
+++ b/src/lib/userFriendlyErrors.ts
@@ -150,9 +150,17 @@ const ERROR_MESSAGES: Record<string, Omit<UserFriendlyError, 'canRetry'>> = {
     actionText: 'Try Again',
     severity: 'error',
   },
+  // ⚠ ROADMAP 2.1127. This entry used to read "We received the analysis results
+  // but had trouble displaying them." — a claim of RECEIPT the code cannot
+  // support. `PROCESSING_ERROR` is minted by `ProcessingError.wrap(err)`
+  // (api-errors.ts), which `useV2Run` uses as its RESIDUAL bucket: the
+  // catch-all for a throw that is neither a typed API error nor a network
+  // error. It fires for failures BEFORE any response arrives just as readily as
+  // for failures after one. Copy names the failure and what the user is left
+  // with; it asserts nothing about what did or did not arrive.
   'PROCESSING_ERROR': {
-    headline: 'Results processing issue',
-    explanation: 'We received the analysis results but had trouble displaying them. Please try again.',
+    headline: 'Analysis couldn\'t be processed',
+    explanation: 'Something went wrong while processing this analysis, so this run produced no results.',
     actionText: 'Try Again',
     severity: 'warning',
   },
@@ -249,11 +257,20 @@ export function getUserFriendlyError(input: ErrorInput): UserFriendlyError {
     baseError = DEFAULT_ERROR
   }
 
-  // Modify for partial results
+  // Modify for partial results.
+  //
+  // ⚠ ROADMAP 2.1127. This limb used to append "Your core results are still
+  // valid." — a VALIDITY VERDICT that nothing in this module, or upstream of
+  // it, ever assessed. `hasPartialResults` is a claim about how much of a run
+  // came back; it is not, and cannot be, evidence that what came back is sound.
+  // The affordances stay (a user with something on screen may want to carry on
+  // rather than rerun); the verdict goes. Anything that genuinely wants to
+  // describe partial results must say WHICH results and on what basis, at the
+  // surface that owns them — see `stale-results-banner` in OutputsDock for the
+  // shape that does this honestly.
   if (input.hasPartialResults) {
     return {
       ...baseError,
-      explanation: `${baseError.explanation} Your core results are still valid.`,
       secondaryActionText: 'Continue Without',
       canRetry: true,
     }

--- a/src/lib/userFriendlyErrors.ts
+++ b/src/lib/userFriendlyErrors.ts
@@ -155,12 +155,19 @@ const ERROR_MESSAGES: Record<string, Omit<UserFriendlyError, 'canRetry'>> = {
   // support. `PROCESSING_ERROR` is minted by `ProcessingError.wrap(err)`
   // (api-errors.ts), which `useV2Run` uses as its RESIDUAL bucket: the
   // catch-all for a throw that is neither a typed API error nor a network
-  // error. It fires for failures BEFORE any response arrives just as readily as
-  // for failures after one. Copy names the failure and what the user is left
-  // with; it asserts nothing about what did or did not arrive.
+  // error.
+  //
+  // ⚠ AND IT MAY NOT CLAIM THE OPPOSITE EITHER. The first fix here said "so
+  // this run produced no results" — false in a reachable cell: `useV2Run` calls
+  // `resultsComplete` at `:991` and then runs ~120 UNGUARDED lines before its
+  // success return, so a throw in `generateGraphHash` (`:1038`),
+  // `persistAnalysisSuccess` (`:1039`), `setRunMeta` (`:1056`), `setGate`
+  // (`:1073`/`:1079`/`:1090`) or `updateRobustnessGateFromV2` (`:1098`) lands in
+  // the catch at `:1150` with THIS run's results already stored and on screen.
+  // The copy asserts NOTHING about output, in either direction.
   'PROCESSING_ERROR': {
-    headline: 'Analysis couldn\'t be processed',
-    explanation: 'Something went wrong while processing this analysis, so this run produced no results.',
+    headline: 'Something went wrong during this analysis',
+    explanation: 'Something went wrong while processing this analysis.',
     actionText: 'Try Again',
     severity: 'warning',
   },
@@ -188,6 +195,13 @@ const ERROR_MESSAGES: Record<string, Omit<UserFriendlyError, 'canRetry'>> = {
   },
 }
 
+/**
+ * ROADMAP 2.1127 — the code set, DERIVED from the map rather than hand-listed,
+ * so a guard over "every code" cannot go quietly short as codes are added
+ * (CLAUDE.md trap 12). Exported for the copy↔affordance invariant.
+ */
+export const ALL_ERROR_CODES: readonly string[] = Object.keys(ERROR_MESSAGES)
+
 // HTTP status code mapping
 const STATUS_MESSAGES: Record<number, Omit<UserFriendlyError, 'canRetry'>> = {
   400: ERROR_MESSAGES['INVALID_INPUT'],
@@ -210,6 +224,26 @@ const STATUS_MESSAGES: Record<number, Omit<UserFriendlyError, 'canRetry'>> = {
   503: ERROR_MESSAGES['SERVICE_UNAVAILABLE'],
   504: ERROR_MESSAGES['TIMEOUT'],
 }
+
+/** Companion to ALL_ERROR_CODES for the status-mapped entries. */
+export const ALL_STATUS_CODES: readonly number[] = Object.keys(STATUS_MESSAGES).map(Number)
+
+/**
+ * ROADMAP 2.1127 — codes where the USER must change something before a re-run
+ * could possibly succeed, so offering "Try Again" would be an empty affordance.
+ * Everything else may be re-run by the user.
+ *
+ * ⚠ This is the "may the user re-run?" answer and it is deliberately SEPARATE
+ * from `ApiError.retryable` ("would an automatic retry help?"). See the comment
+ * at the `canRetry` derivation in `getUserFriendlyError`.
+ */
+export const USER_RERUN_BLOCKED_CODES: readonly string[] = [
+  'UNAUTHORIZED',
+  'FORBIDDEN',
+  'INVALID_INPUT',
+  'EMPTY_GRAPH',
+  'VALIDATION_BLOCKED',
+]
 
 // Default error message
 const DEFAULT_ERROR: Omit<UserFriendlyError, 'canRetry'> = {
@@ -276,10 +310,26 @@ export function getUserFriendlyError(input: ErrorInput): UserFriendlyError {
     }
   }
 
-  // Use explicit canRetry if provided, otherwise determine from error code
+  // ⚠ ROADMAP 2.1127 — TWO QUESTIONS, ONE NAME (CLAUDE.md trap 21).
+  //
+  //   `ApiError.retryable`  answers "would an AUTOMATIC retry plausibly help?"
+  //                         It defaults to false, and `ProcessingError` and
+  //                         `MalformedApiResponseError` hardcode false.
+  //   this `canRetry`       answers "may the USER re-run this analysis?"
+  //
+  // They are not the same question and must not share an answer. Feeding the
+  // banner from `retryable` removed "Try Again" from exactly the two classes
+  // whose own copy tells the user to try again — an instruction with no
+  // affordance. The user-facing decision is made HERE, from the code, by the
+  // explicit list below: re-running is blocked only where the user must change
+  // something first, and permitted everywhere else (including the recoverable
+  // display/processing classes).
+  //
+  // `input.canRetry` is still honoured when a caller passes one, but the dock
+  // deliberately does NOT pass the producer's `retryable` into it.
   const canRetry = input.canRetry !== undefined
     ? input.canRetry
-    : !['UNAUTHORIZED', 'FORBIDDEN', 'INVALID_INPUT', 'EMPTY_GRAPH', 'VALIDATION_BLOCKED'].includes(input.code || '')
+    : !USER_RERUN_BLOCKED_CODES.includes(input.code || '')
 
   return {
     ...baseError,


### PR DESCRIPTION
ROADMAP **2.1127** — P0 trust. Component: **PR3 (trustworthy living workspace)**.

⛔ **DO NOT MERGE** — the deployed quartet is held stable for an external review; the orchestrator merges.

## The defect, reproduced

Witnessed on staging 13 Aug at UI tip `f2b48fc9`: after an analysis fails **following an earlier successful one**, the dock keeps the previous run's numbers on screen under an amber banner reading

> **Results processing issue** — We received the analysis results but had trouble displaying them. Please try again. **Your core results are still valid.**

Reproduced at component level in `OutputsDock.failedRunHonesty.spec.tsx`, driving the real state machine (`resultsComplete` → `resultsError`). At pristine the RED printed that exact composite sentence back.

## State-machine trace (at `f2b48fc9`)

| Hop | Location | What it does |
|---|---|---|
| failure lands | `src/canvas/hooks/useV2Run.ts:1176,1185` | any unclassified throw → `ProcessingError.wrap(err)` → `resultsError({ code: 'PROCESSING_ERROR' })` |
| state transition | `src/canvas/store.ts:3488-3503` | sets `status: 'error'`, **deliberately preserves `results.report`** — the PREVIOUS run's snapshot |
| results keep rendering | `src/canvas/components/OutputsDock.tsx:1216`, `:2554-2557` | `hasInlineSummary = Boolean(report)`; the body mounts through every status (Lane 3 / SF2, deliberate) |
| **the false input** | `src/canvas/components/OutputsDock.tsx:2251` | `hasPartialResults: Boolean(report)` — the retained PREVIOUS report passed off as THIS run's partial results |
| **the validity claim** | `src/lib/userFriendlyErrors.ts:253-260` | that limb appends `Your core results are still valid.` — to **every** error code |
| **the receipt claim** | `src/lib/userFriendlyErrors.ts:153-158` | `PROCESSING_ERROR` explanation asserts results were received |

`hasPartialResults` had exactly **one** producer repo-wide (that dock line), and the only genuinely partial path (`analysis_status === 'partial'`, `useV2Run.ts:1103`) settles through `resultsComplete` — **never** through the error path. So the flag could not be legitimately true where it was read.

## Fix — shape (b), the honest-copy shape

Shape (a) (clear the retained report on failure) would have reverted a deliberate design: the retained snapshot is the user's best available context, `store.ts:3495-3499` documents it, and the dock already attributes it honestly via `stale-results-banner` ("Showing results from previous analysis"). Shape (b) removes the two false claims and leaves the (already-attributed) context in place. Three edits:

1. `userFriendlyErrors.ts` — `PROCESSING_ERROR` copy names the failure and what the user is left with; asserts nothing about what arrived.
2. `userFriendlyErrors.ts` — the `hasPartialResults` limb keeps its affordances and drops the validity verdict.
3. `OutputsDock.tsx:2248` — stops passing a retained previous report as this run's partial results, and carries the producer's own `canRetry` instead of the unconditional `true` that limb forced.

## Evidence

- **RED-first at pristine**: 6 collected, 2 controls green, 4 assertions RED on the witnessed sentences.
- **After**: 16/16 across both new specs.
- **Mutants** (throwaway worktree outside the repo root, isolation proven by writing a sentinel, applied-check scoped to `src/`, control exactly 0, restores HEAD-relative): 6 mutants, **0 survivors**, trailing control clean.
- Surface binding (trap 3b): flags mocked to the **deployed** `netlify.toml` staging posture; the control asserts the mount path `outputs-dock-body → outputs-error-banner`.

## Out of scope, found in passing (not fixed — scope-expansion rule)

- **Amber severity.** `PROCESSING_ERROR` stays `severity: 'warning'`; the row calls the amber styling part of the misrepresentation. Presentation, not a claim — left for a decision.
- **Compare tab raw-error leak.** `OutputsDock.tsx:2792` renders `scenarioComparison.error` verbatim (the row's `:2770` before this PR's comments shifted it). Different producer, different surface.
- **`CEE_DEGRADED` / `ISL_DEGRADED`** (`userFriendlyErrors.ts:159-171`) carry the same "core results are still valid" family of claim but have **zero producers** anywhere in `src/` — dead entries, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Gate results — required check **Staging Gate** GREEN at head `f37e9610`

13/13 check-runs `success`, `running=0`, queried against the exact head SHA. Both new specs verified as **collected and passing in CI by name**: shard 3 → 9 ✓ / 0 ×, shard 4 → 7 ✓ / 0 ×.

**A second commit was needed, and the gate is why.** `f37e9610` derives `selectError`'s return type from the store instead of a hand-copied duplicate. That duplicate had drifted — `canRetry` is accepted by `resultsError`, written into the state and declared on the state at `store.ts:202`, but was missing from the selector, so every consumer reading through it was blind to a field the store carries. Commit 1 read `error.canRetry` and CI caught it: **"TypeScript + Lint" RED, and "Typecheck Gate Self-Test" RED as a knock-on** (its positive controls need a clean baseline to assert against). One diagnostic, two reds. Local `pnpm run typecheck` now passes; the gate reports drift **shrank** 2487 → 2485 and prompts for `--update-baseline` — deliberately **not** taken.

**Seam note for merge ordering:** this PR touches `OutputsDock.tsx` (error-banner region only, ~`:2248-2272`), `userFriendlyErrors.ts` and one line of `store.ts`. It does **not** touch `applyV5State.ts` — no overlap with the ui_directive dispatch lane (row 2.1132).

---

# Review round 2 — D1/D2/D3 fixed. Head `79d4e176`, **Staging Gate GREEN (13/13), `mergeable_state: clean`**

## D1 — the replacement copy was false in a reachable cell

`useV2Run` calls `resultsComplete` at `:991` and then runs ~120 **unguarded** lines before its success return at `:1109`. A synchronous throw in `generateGraphHash` (`:1038`), `persistAnalysisSuccess` (`:1039`, whose `.catch` only handles rejection), `setRunMeta` (`:1056`), `setGate` (`:1073`/`:1079`/`:1090`) or `updateRobustnessGateFromV2` (`:1098`) lands in the catch at `:1150` and settles `PROCESSING_ERROR` **with this run's report stored and on screen**. In that cell "so this run produced no results" was false — and so was the chip's "Showing results from previous analysis".

- Copy now asserts **nothing about output in either direction**: *"Something went wrong while processing this analysis."*
- The store carries run-epoch stamps (`runEpoch` / `reportEpoch` / `errorEpoch`), written **inside its own transitions**, so every producer gets them and none can forget to pass one — **zero call-site changes, `applyV5State.ts` untouched**.
- `selectReportIsFromEarlierRun` proves provenance from those stamps. Equal stamps ⇒ the report is this run's. **A missing stamp is UNKNOWN and fails CLOSED to no claim**, never to the convenient one.
- `resultsLoadHistorical` replaces the whole results object, so it stamps `HISTORICAL_REPORT_EPOCH = 0` — a restored run is by definition not the output of the run that fails next, and the counter only increments from 1, so it can never collide.

## D2 — two questions under one name (trap 21)

`ApiError.retryable` answers *"would an AUTOMATIC retry help?"* (defaults false; `ProcessingError` and `MalformedApiResponseError` hardcode false). The banner's `canRetry` answers *"may the USER re-run?"*. Feeding the first into the second deleted **Try Again** from exactly the two classes whose own copy says to try again. The dock no longer passes it; the user-facing decision is made explicitly from `USER_RERUN_BLOCKED_CODES`, and a **derived invariant over the whole code map** (16 codes + 9 status codes) fails if any entry's copy instructs a retry the affordance does not offer.

## D3 — fixture honesty

Every seed drives the real store transitions in the real order; every error carries the `canRetry` its **real producer** emits (derivation recorded in the spec header: PROCESSING_ERROR/MALFORMED_RESPONSE `false`, NETWORK_ERROR/UNEXPECTED_STATE `true`, VALIDATION_BLOCKED `false`, envelope path passes none). The **genuine first-run cell** (`hasCompletedFirstRun: false`, pre-run surface, no results body) is now covered. The specs enumerate the matrix explicitly: **error code × report origin**, origin taking all four values — none / earlier run / **this run** / unknown.

## Two vacuity holes the mutants exposed, and closed

M10 (*re-run permitted for every code*) **survived**, and the only tell was the collected count dropping **60 → 55**:
1. the blocked-codes table was parameterised over the very list the mutant empties, so it **deleted its own cases instead of failing** (trap 12d). Paired now with a **hand-written corpus**.
2. the dock's withholding twin looked for a button named `/try again/i`, but `VALIDATION_BLOCKED`'s actionText is **"Review Model"** — absent either way, so it could not see the affordance reappear. The re-run button now carries `data-testid="error-primary-action"` and the guards bind to that identity, then to its label.

M10 now REDs 7 tests. **10 mutants, 0 survivors**, trailing control clean (66/66, applied 0), isolation proven by writing a sentinel.

## Neighbouring specs repaired, not suppressed

CI shards 1–2 caught `OutputsDock.dom.spec.tsx` and `OutputsDock.rerunContinuity.spec.tsx` asserting the chip while hand-writing `{ status: 'error', report }` via `setState`. Those fixtures carry no run identity, so they land in the UNKNOWN cell — **they were never evidence for the sentence they assert**. Both now drive `resultsStart → resultsComplete → resultsStart → resultsError`, the sequence the claim is actually about.

## Correction to this description

The earlier claim that the `hasPartialResults` limb "keeps its affordances" was misleading: **`hasPartialResults` now has ZERO production producers**. The limb and its regression guard are retained deliberately — so the removed sentence cannot return through a future caller — but nothing in the product reaches it today.

**CI collection verified by name at this head:** shard 4 → 17 ✓ / 0 × (dock), shard 3 → 49 ✓ / 0 × (lib), repaired neighbour tests present in shards 1–2.

---

# Review round 3 — the cold-load cell (B5). Head `8ac17c33`, **Staging Gate GREEN (13/13), `mergeable_state: clean`**

One sweep short, and of exactly the class the previous commit named. Re-derived at the bytes before acting:

- `hydrateAnalysis.ts:138-152` returns `{status, progress, seed, hash, report, enrichment, error, startedAt, finishedAt}` — **no epoch keys**.
- `store.ts :: resultsHydrateFromSupabase` installs the restored report by **spread** (`{...s.results, ...hydratedResults}`), so on a **cold** scenario load `reportEpoch` stayed `undefined`.
- A later failed rerun therefore read **UNKNOWN** and suppressed the attribution chip while the restored numbers stayed mounted. Live path: `useScenario.ts:727-734`, whenever `row.analysis_status === 'ready'` — open a saved scenario, hit Rerun, it fails.

Direction confirmed: this could only ever **under-claim** — no path produced a false chip — but a suppressed *true* disclosure is still a loss.

**Fix:** `reportEpoch: HISTORICAL_REPORT_EPOCH` (and `errorEpoch: undefined`) stamped in that action, on the identical reasoning to `resultsLoadHistorical` — a restored report is by definition not the output of the run that fails next, and `runEpoch` only counts up from 1, so the sentinel cannot collide. **The two keys sit AFTER the spreads**, so a hydrated payload that one day carries its own epoch fields cannot overwrite the provenance this action asserts.

**B5 added to the matrix** (3 cases), seeded through the real hydration action with the producer's exact key set — and the payload's **absence** of epoch keys is asserted in-test, so if the producer ever starts stamping provenance itself the fixture says so rather than quietly standing for a cell it no longer covers.

**M11 (drop the stamp) REDs all three B5 cases**, including the control (the seed's own precondition fires). **11 mutants, 0 survivors**; two trailing controls, both clean (69/69, applied 0). Local `pnpm run typecheck` → `✅ Typecheck gate PASSED`, within baseline 618 files / 2485 errors. CI collection verified by name: shard 4 → **20 ✓ / 0 ×** (dock, incl. 9 B5 log lines), shard 3 → 49 ✓ / 0 × (lib).
