### PR TITLE
fix(item13): path-allowlist the BFF service-key proxies before credential injection

### DIFF
--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -48,8 +48,14 @@
  *   no new decision about where a secret lives.
  *
  * SECURITY:
- * - Uses explicit origin allow-list (no wildcard CORS)
- * - The API key is never returned to the client and never enters the bundle
+ * - Origin is a CORS control, NOT identity (see the origin check below). The
+ *   real bound on this seam is the EXPLICIT UPSTREAM PATH ALLOWLIST added for
+ *   disposition item 13: the caller-auth key is injected ONLY for a rewritten
+ *   `/assist/v1/*` target on `ALLOWED_TARGETS`; every off-list path is answered
+ *   404 and never reaches CEE, so an allowed (or absent) Origin can no longer
+ *   turn this proxy into an authenticated caller for the whole assist surface.
+ * - Enforces an explicit HTTP-method set and an explicit forwarded-HEADER set.
+ * - The API key is never returned to the client and never enters the bundle.
  * See SECURITY.md for compliance requirements.
  *
  * ── COMPLETE DIVERGENCE SET FROM THE SIBLING PROXIES ────────────────────────
@@ -112,6 +118,53 @@ function getCorsHeaders(requestOrigin: string): Record<string, string> {
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-correlation-id, x-request-id, x-user-id',
     'Vary': 'Origin, Access-Control-Request-Headers',
   }
+}
+
+/**
+ * SECURITY (item 13) — EXPLICIT UPSTREAM PATH ALLOWLIST.
+ *
+ * Matched against the REWRITTEN `/assist/v1/*` target (query stripped) BEFORE the
+ * caller-auth key is injected. Off-list ⇒ 404, no key forwarded. Without it the
+ * blind prefix rewrite made this seam an authenticated caller for the whole
+ * ~24-route assist surface (draft-graph, bias-check, ask, review, decision-review,
+ * elicitation, …) — no UUID and, for this proxy, no Origin required.
+ *
+ * DERIVED from the UI's real `/bff/cee/*` call sites at f2b48fc9 (see the PR body
+ * for the file-by-file evidence and the live-capture cross-check). Dynamic id
+ * segments are matched permissively (`[^/]+`) so a real scenario/record UUID never
+ * false-404s; the ROUTE SHAPE is what is bounded, and `isTraversal` (below) closes
+ * encoded-slash / `..` smuggling through those permissive segments.
+ */
+const ALLOWED_TARGETS: readonly RegExp[] = [
+  /^\/assist\/v1\/health$/,
+  /^\/assist\/v1\/graph-readiness$/,
+  /^\/assist\/v1\/ask$/,
+  /^\/assist\/v1\/bias-check$/,
+  /^\/assist\/v1\/sensitivity-coach$/,
+  /^\/assist\/v1\/elicit-belief$/,
+  /^\/assist\/v1\/suggest-edge-function$/,
+  /^\/assist\/v1\/prompts\/warm$/,
+  /^\/assist\/v1\/draft-graph$/,
+  /^\/assist\/v1\/scenarios\/[^/]+\/graph$/,
+  /^\/assist\/v1\/scenarios\/[^/]+\/graph\/register$/,
+  /^\/assist\/v1\/decision-records\/commit$/,
+  /^\/assist\/v1\/decision-records\/[^/]+\/outcome$/,
+]
+
+function isAllowedTarget(pathname: string): boolean {
+  return ALLOWED_TARGETS.some((re) => re.test(pathname))
+}
+
+/**
+ * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
+ * literal `..` path segment before the allowlist runs. WHATWG `new URL()` resolves
+ * an un-encoded `../` at parse time, but edge runtimes differ on whether the
+ * ENCODED forms survive into `request.url`; this closes them regardless, so a
+ * permissive dynamic segment cannot carry a path escape to the upstream.
+ */
+function isTraversal(rawUrl: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+  return targetPath.split('/').some((segment) => segment === '..')
 }
 
 export default async function handler(request: Request, _context: Context) {
@@ -177,7 +230,21 @@ export default async function handler(request: Request, _context: Context) {
   const targetPath = url.pathname.replace(/^\/bff\/cee/, '/assist/v1')
   const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
 
-  // SECURITY: Build headers from scratch with explicit allowlist.
+  // SECURITY (item 13): reject anything the UI does not call BEFORE the key is
+  // injected. An off-list or traversal path is answered 404 and NO credential is
+  // forwarded — this is the bound on the assist blast radius.
+  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+    return new Response(
+      JSON.stringify({ error: 'Not found' }),
+      {
+        status: 404,
+        headers: { ...(corsHeaders ?? {}), 'Content-Type': 'application/json' },
+      },
+    )
+  }
+
+  // SECURITY: Build the forwarded-header set from scratch with an explicit HEADER
+  // allowlist (distinct from the upstream PATH allowlist checked just above).
   // 'authorization' carries the user's Supabase access token (same rationale
   // as orchestrator-proxy.ts: CEE's flag-gated JWT half verifies identity from
   // it). It is the USER token; the caller-auth X-Olumi-Assist-Key is injected

--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -161,9 +161,15 @@ function isAllowedTarget(pathname: string): boolean {
  * an un-encoded `../` at parse time, but edge runtimes differ on whether the
  * ENCODED forms survive into `request.url`; this closes them regardless, so a
  * permissive dynamic segment cannot carry a path escape to the upstream.
+ *
+ * ⚠ SCOPED TO THE PATHNAME, NEVER THE WHOLE URL. Scanning `request.url` also scanned
+ * the QUERY STRING, so an on-list route 404'd whenever a parameter happened to carry
+ * an encoded slash — `encodeURIComponent` emits `%2F` for any value containing one
+ * (a URL, base64). The query cannot change the upstream route, so excluding it is
+ * strictly safer as well as correct.
  */
-function isTraversal(rawUrl: string, targetPath: string): boolean {
-  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+function isTraversal(rawPathname: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawPathname)) return true
   return targetPath.split('/').some((segment) => segment === '..')
 }
 
@@ -233,7 +239,7 @@ export default async function handler(request: Request, _context: Context) {
   // SECURITY (item 13): reject anything the UI does not call BEFORE the key is
   // injected. An off-list or traversal path is answered 404 and NO credential is
   // forwarded — this is the bound on the assist blast radius.
-  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+  if (isTraversal(url.pathname, targetPath) || !isAllowedTarget(targetPath)) {
     return new Response(
       JSON.stringify({ error: 'Not found' }),
       {

--- a/netlify/edge-functions/collab-proxy.ts
+++ b/netlify/edge-functions/collab-proxy.ts
@@ -92,6 +92,40 @@ function getCorsHeaders(requestOrigin: string): Record<string, string> {
   }
 }
 
+/**
+ * SECURITY (item 13) — EXPLICIT UPSTREAM PATH ALLOWLIST.
+ *
+ * Matched against the REWRITTEN `/collab/v1/*` target (query stripped) BEFORE the
+ * caller-auth key is injected. Off-list ⇒ 404, no key forwarded. CEE authenticates
+ * the PERSON on these routes (participant token / owner JWT), but this proxy still
+ * injects the caller-auth key, so an unbounded rewrite still hands an authenticated
+ * request to any collab route that exists. DERIVED from `src/collab/collabService.ts`
+ * (the only `/bff/collab/*` caller) at f2b48fc9. Dynamic round/packet ids are
+ * matched permissively (`[^/]+`); `isTraversal` closes encoded-slash / `..`.
+ */
+const ALLOWED_TARGETS: readonly RegExp[] = [
+  /^\/collab\/v1\/rounds$/,
+  /^\/collab\/v1\/rounds\/[^/]+\/close$/,
+  /^\/collab\/v1\/rounds\/[^/]+\/reveal$/,
+  /^\/collab\/v1\/packet\/[^/]+$/,
+  /^\/collab\/v1\/packet\/[^/]+\/events$/,
+  /^\/collab\/v1\/packet\/[^/]+\/reveal$/,
+]
+
+function isAllowedTarget(pathname: string): boolean {
+  return ALLOWED_TARGETS.some((re) => re.test(pathname))
+}
+
+/**
+ * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
+ * literal `..` path segment before the allowlist, so a permissive id segment
+ * cannot carry a path escape to the upstream.
+ */
+function isTraversal(rawUrl: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+  return targetPath.split('/').some((segment) => segment === '..')
+}
+
 export default async function handler(request: Request, _context: Context) {
   const origin = request.headers.get('origin')
 
@@ -125,6 +159,18 @@ export default async function handler(request: Request, _context: Context) {
   const url = new URL(request.url)
   const targetPath = url.pathname.replace(/^\/bff\/collab/, '/collab/v1')
   const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
+
+  // SECURITY (item 13): reject off-list / traversal paths BEFORE the key is
+  // injected. Off-list ⇒ 404, NO credential forwarded.
+  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+    return new Response(
+      JSON.stringify({ error: 'Not found' }),
+      {
+        status: 404,
+        headers: { ...(corsHeaders ?? {}), 'Content-Type': 'application/json' },
+      },
+    )
+  }
 
   const headers = new Headers()
   for (const headerName of ALLOWED_FORWARD_HEADERS) {

--- a/netlify/edge-functions/collab-proxy.ts
+++ b/netlify/edge-functions/collab-proxy.ts
@@ -120,9 +120,15 @@ function isAllowedTarget(pathname: string): boolean {
  * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
  * literal `..` path segment before the allowlist, so a permissive id segment
  * cannot carry a path escape to the upstream.
+ *
+ * ⚠ SCOPED TO THE PATHNAME, NEVER THE WHOLE URL. Scanning `request.url` also scanned
+ * the QUERY STRING, so an on-list route 404'd whenever a parameter happened to carry
+ * an encoded slash — `encodeURIComponent` emits `%2F` for any value containing one
+ * (a URL, base64). The query cannot change the upstream route, so excluding it is
+ * strictly safer as well as correct.
  */
-function isTraversal(rawUrl: string, targetPath: string): boolean {
-  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+function isTraversal(rawPathname: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawPathname)) return true
   return targetPath.split('/').some((segment) => segment === '..')
 }
 
@@ -162,7 +168,7 @@ export default async function handler(request: Request, _context: Context) {
 
   // SECURITY (item 13): reject off-list / traversal paths BEFORE the key is
   // injected. Off-list ⇒ 404, NO credential forwarded.
-  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+  if (isTraversal(url.pathname, targetPath) || !isAllowedTarget(targetPath)) {
     return new Response(
       JSON.stringify({ error: 'Not found' }),
       {

--- a/netlify/edge-functions/isl-proxy.ts
+++ b/netlify/edge-functions/isl-proxy.ts
@@ -8,7 +8,16 @@
  * - ISL_API_KEY: API key for ISL service authentication
  *
  * SECURITY:
- * - Uses explicit origin allow-list (no wildcard CORS)
+ * - Origin is a CORS control, NOT identity.
+ * - The bound on this seam is the EXPLICIT UPSTREAM PATH ALLOWLIST added for
+ *   disposition item 13: the ISL bearer is injected ONLY for a target on
+ *   `ALLOWED_TARGETS`; every off-list path is answered 404 and never reaches ISL.
+ *   ⚠ ISL's authoritative route table was NOT read for this change, so the compute
+ *   subtrees (`/api/v1/*`, `/explain/*`) are matched PERMISSIVELY on purpose — a
+ *   false 404 on a real compute call would break the product, and correctness of
+ *   the live product outranks tightness here. This still rejects root-level
+ *   admin/debug/metrics routes, which is the meaningful bound. Tighten once the
+ *   ISL route table is enumerated (flagged in the PR).
  * See SECURITY.md for compliance requirements.
  */
 
@@ -57,6 +66,42 @@ function getCorsHeaders(requestOrigin: string | null): Record<string, string> | 
   }
 }
 
+/**
+ * SECURITY (item 13) — EXPLICIT UPSTREAM PATH ALLOWLIST.
+ *
+ * Matched against the target (prefix `/bff/isl` already stripped, query stripped)
+ * BEFORE the ISL bearer is injected. Off-list ⇒ 404, no bearer forwarded. DERIVED
+ * from the UI's `/bff/isl/*` call sites at f2b48fc9: `src/adapters/isl/client.ts`
+ * (`/validate`, `/api/v1/robustness/analyze`, `/api/v1/causal/counterfactual/conformal`,
+ * `/conformal`, `/compare`, `/explain/contrastive`) and `src/lib/service-health.ts`
+ * (`/health`). The `/api/v1/*` and `/explain/*` subtrees are PERMISSIVE because the
+ * ISL route table was not authoritatively read; `isTraversal` closes any encoded
+ * escape through them.
+ */
+const ALLOWED_TARGETS: readonly RegExp[] = [
+  /^\/health$/,
+  /^\/validate$/,
+  /^\/conformal$/,
+  /^\/compare$/,
+  /^\/explain\/.+$/,
+  /^\/api\/v1\/.+$/,
+]
+
+function isAllowedTarget(pathname: string): boolean {
+  return ALLOWED_TARGETS.some((re) => re.test(pathname))
+}
+
+/**
+ * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
+ * literal `..` path segment before the allowlist. This is load-bearing here: the
+ * `/api/v1/*` and `/explain/*` patterns are permissive, so an encoded escape would
+ * otherwise ride them to the upstream.
+ */
+function isTraversal(rawUrl: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+  return targetPath.split('/').some((segment) => segment === '..')
+}
+
 export default async function handler(request: Request, context: Context) {
   const origin = request.headers.get('origin')
   const corsHeaders = getCorsHeaders(origin)
@@ -78,15 +123,26 @@ export default async function handler(request: Request, context: Context) {
     return new Response(null, { status: 204, headers: corsHeaders })
   }
 
-  const apiKey = Deno.env.get('ISL_API_KEY')
-
   // Extract the path after /bff/isl/
   // e.g., /bff/isl/api/v1/analysis/robustness → /api/v1/analysis/robustness
   const url = new URL(request.url)
   const targetPath = url.pathname.replace(/^\/bff\/isl/, '')
   const targetUrl = `${ISL_TARGET}${targetPath}${url.search}`
 
-  // SECURITY: Build headers from scratch with explicit allowlist
+  // SECURITY (item 13): reject off-list / traversal paths BEFORE the bearer is
+  // injected. Off-list ⇒ 404, NO credential forwarded.
+  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+    return new Response(
+      JSON.stringify({ error: 'Not found' }),
+      {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    )
+  }
+
+  // SECURITY: Build the forwarded-header set from scratch with an explicit HEADER
+  // allowlist (distinct from the upstream PATH allowlist checked just above)
   const ALLOWED_FORWARD_HEADERS = [
     'content-type',
     'accept',
@@ -104,7 +160,10 @@ export default async function handler(request: Request, context: Context) {
     }
   }
 
-  // Add API key for ISL authentication (both formats for compatibility)
+  // Add API key for ISL authentication (both formats for compatibility).
+  // Read only after the path guard has passed — a rejected request never touches
+  // the credential.
+  const apiKey = Deno.env.get('ISL_API_KEY')
   if (apiKey) {
     headers.set('Authorization', `Bearer ${apiKey}`)
     headers.set('x-api-key', apiKey)

--- a/netlify/edge-functions/isl-proxy.ts
+++ b/netlify/edge-functions/isl-proxy.ts
@@ -11,13 +11,12 @@
  * - Origin is a CORS control, NOT identity.
  * - The bound on this seam is the EXPLICIT UPSTREAM PATH ALLOWLIST added for
  *   disposition item 13: the ISL bearer is injected ONLY for a target on
- *   `ALLOWED_TARGETS`; every off-list path is answered 404 and never reaches ISL.
- *   ⚠ ISL's authoritative route table was NOT read for this change, so the compute
- *   subtrees (`/api/v1/*`, `/explain/*`) are matched PERMISSIVELY on purpose — a
- *   false 404 on a real compute call would break the product, and correctness of
- *   the live product outranks tightness here. This still rejects root-level
- *   admin/debug/metrics routes, which is the meaningful bound. Tighten once the
- *   ISL route table is enumerated (flagged in the PR).
+ *   `ALLOWED_TARGETS` — SEVEN anchored literals, one per browser call site — and
+ *   every off-list path is answered 404 and never reaches ISL.
+ * - An explicit METHOD gate (`ALLOWED_METHODS`) enforces the same set it advertises;
+ *   before it, an authenticated PUT/DELETE forwarded with the bearer.
+ * - The bearer is read only AFTER both gates pass, so a rejected request never
+ *   touches the credential.
  * See SECURITY.md for compliance requirements.
  */
 
@@ -60,7 +59,9 @@ function getCorsHeaders(requestOrigin: string | null): Record<string, string> | 
 
   return {
     'Access-Control-Allow-Origin': requestOrigin,
-    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    // Advertised == ENFORCED (see ALLOWED_METHODS). This previously advertised
+    // PUT and DELETE, which nothing enforced and no call site uses.
+    'Access-Control-Allow-Methods': ALLOWED_METHODS.join(', '),
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-correlation-id, x-api-key, X-Request-Id',
     'Vary': 'Origin, Access-Control-Request-Headers',
   }
@@ -69,23 +70,46 @@ function getCorsHeaders(requestOrigin: string | null): Record<string, string> | 
 /**
  * SECURITY (item 13) — EXPLICIT UPSTREAM PATH ALLOWLIST.
  *
- * Matched against the target (prefix `/bff/isl` already stripped, query stripped)
- * BEFORE the ISL bearer is injected. Off-list ⇒ 404, no bearer forwarded. DERIVED
- * from the UI's `/bff/isl/*` call sites at f2b48fc9: `src/adapters/isl/client.ts`
+ * Matched against the target (prefix `/bff/isl` already stripped, query excluded)
+ * BEFORE the ISL bearer is injected. Off-list ⇒ 404, no bearer forwarded.
+ *
+ * DERIVED from the UI's `/bff/isl/*` call sites at f2b48fc9 — `src/adapters/isl/client.ts`
  * (`/validate`, `/api/v1/robustness/analyze`, `/api/v1/causal/counterfactual/conformal`,
  * `/conformal`, `/compare`, `/explain/contrastive`) and `src/lib/service-health.ts`
- * (`/health`). The `/api/v1/*` and `/explain/*` subtrees are PERMISSIVE because the
- * ISL route table was not authoritatively read; `isTraversal` closes any encoded
- * escape through them.
+ * (`/health`). Those SEVEN calls are the complete browser-reachable set.
+ *
+ * ⚠ THESE ARE ANCHORED LITERALS, NOT SUBTREE WILDCARDS, AND THAT IS THE WHOLE POINT.
+ * The first version of this list used `/^\/api\/v1\/.+$/` and `/^\/explain\/.+$/`
+ * "because the ISL route table was not authoritatively read". That reasoning was
+ * wrong and the guard was hollow: `/bff/isl/api/v1/admin/secrets` and
+ * `/bff/isl/explain/anything/at/all` both forwarded WITH the bearer — the wildcards
+ * re-admitted the whole surface the allowlist exists to narrow, and the off-list
+ * test picked the one shape (`/admin/secrets`) that happened to avoid them, so the
+ * suite agreed with itself. The allowlist does not need ISL's route table: it bounds
+ * what the UI CALLS, and that set is enumerated above.
  */
 const ALLOWED_TARGETS: readonly RegExp[] = [
   /^\/health$/,
   /^\/validate$/,
   /^\/conformal$/,
   /^\/compare$/,
-  /^\/explain\/.+$/,
-  /^\/api\/v1\/.+$/,
+  /^\/explain\/contrastive$/,
+  /^\/api\/v1\/robustness\/analyze$/,
+  /^\/api\/v1\/causal\/counterfactual\/conformal$/,
 ]
+
+/**
+ * SECURITY (item 13, D2) — the verbs this seam forwards. GET/HEAD for `/health`,
+ * POST for the six compute calls, OPTIONS for preflight.
+ *
+ * This function injects a bearer on every request it forwards, so an unrestricted
+ * verb set handed an authenticated PUT/DELETE to ISL from anywhere the origin check
+ * let through — the exact posture `cee-proxy.ts` documents as "the gap not to copy",
+ * and it was real here (PUT and DELETE both forwarded with the bearer). ENFORCED
+ * below and ADVERTISED verbatim in Access-Control-Allow-Methods: an allow-list that
+ * advertises more than it enforces is a false guarantee.
+ */
+const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'OPTIONS'] as const
 
 function isAllowedTarget(pathname: string): boolean {
   return ALLOWED_TARGETS.some((re) => re.test(pathname))
@@ -93,12 +117,16 @@ function isAllowedTarget(pathname: string): boolean {
 
 /**
  * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
- * literal `..` path segment before the allowlist. This is load-bearing here: the
- * `/api/v1/*` and `/explain/*` patterns are permissive, so an encoded escape would
- * otherwise ride them to the upstream.
+ * literal `..` path segment, before the allowlist runs.
+ *
+ * ⚠ SCOPED TO THE PATHNAME, NEVER THE WHOLE URL. Scanning `request.url` also scanned
+ * the QUERY STRING, so an on-list route 404'd whenever a parameter happened to carry
+ * an encoded slash — `encodeURIComponent` emits `%2F` for any value containing one
+ * (a URL, base64). The query cannot change the upstream route, so excluding it is
+ * strictly safer as well as correct.
  */
-function isTraversal(rawUrl: string, targetPath: string): boolean {
-  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+function isTraversal(rawPathname: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawPathname)) return true
   return targetPath.split('/').some((segment) => segment === '..')
 }
 
@@ -123,6 +151,22 @@ export default async function handler(request: Request, context: Context) {
     return new Response(null, { status: 204, headers: corsHeaders })
   }
 
+  // SECURITY (item 13, D2): refuse any verb outside the advertised set BEFORE the
+  // bearer is injected. Without this, an authenticated PUT/DELETE reached ISL.
+  if (!(ALLOWED_METHODS as readonly string[]).includes(request.method)) {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      {
+        status: 405,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          Allow: ALLOWED_METHODS.join(', '),
+        },
+      }
+    )
+  }
+
   // Extract the path after /bff/isl/
   // e.g., /bff/isl/api/v1/analysis/robustness → /api/v1/analysis/robustness
   const url = new URL(request.url)
@@ -131,7 +175,7 @@ export default async function handler(request: Request, context: Context) {
 
   // SECURITY (item 13): reject off-list / traversal paths BEFORE the bearer is
   // injected. Off-list ⇒ 404, NO credential forwarded.
-  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+  if (isTraversal(url.pathname, targetPath) || !isAllowedTarget(targetPath)) {
     return new Response(
       JSON.stringify({ error: 'Not found' }),
       {

--- a/netlify/edge-functions/orchestrator-proxy.ts
+++ b/netlify/edge-functions/orchestrator-proxy.ts
@@ -16,7 +16,13 @@
  * Verified 2026-03-13 — no additional configuration needed.
  *
  * SECURITY:
- * - Uses explicit origin allow-list (no wildcard CORS)
+ * - Origin is a CORS control, NOT identity — a non-browser client can set any
+ *   Origin it likes, so origin-gating is not the security boundary here.
+ * - The boundary is the EXPLICIT UPSTREAM PATH ALLOWLIST added for disposition
+ *   item 13: the caller-auth key is injected ONLY for a rewritten `/orchestrate/*`
+ *   target on `ALLOWED_TARGETS` (the three turn routes: turn, turn/stream,
+ *   turn/stop). Every off-list path is answered 404 and never reaches CEE.
+ * - Enforces POST-only and an explicit forwarded-HEADER allowlist.
  * See SECURITY.md for compliance requirements.
  */
 
@@ -54,6 +60,35 @@ function getCorsHeaders(requestOrigin: string | null): Record<string, string> | 
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-correlation-id, x-request-id, x-user-id',
     'Vary': 'Origin, Access-Control-Request-Headers',
   }
+}
+
+/**
+ * SECURITY (item 13) — EXPLICIT UPSTREAM PATH ALLOWLIST.
+ *
+ * Matched against the REWRITTEN `/orchestrate/*` target (query stripped) BEFORE the
+ * caller-auth key is injected. Off-list ⇒ 404, no key forwarded. CEE mounts exactly
+ * the turn family under `/orchestrate/*`; anything else must not become an
+ * authenticated call. `v\d+` covers the live v2 path and the legacy v1 reference.
+ */
+const ALLOWED_TARGETS: readonly RegExp[] = [
+  /^\/orchestrate\/v\d+\/turn$/,
+  /^\/orchestrate\/v\d+\/turn\/stream$/,
+  /^\/orchestrate\/v\d+\/turn\/stop$/,
+]
+
+function isAllowedTarget(pathname: string): boolean {
+  return ALLOWED_TARGETS.some((re) => re.test(pathname))
+}
+
+/**
+ * Reject encoded traversal (`%2e` / `%2f` / `%5c`, case-insensitive) and any
+ * literal `..` path segment before the allowlist runs — closing the
+ * `/bff/orchestrate/%2e%2e/assist/v1/*` escape hypothesis by construction,
+ * independent of how the edge runtime normalises `request.url`.
+ */
+function isTraversal(rawUrl: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+  return targetPath.split('/').some((segment) => segment === '..')
 }
 
 export default async function handler(request: Request, _context: Context) {
@@ -94,7 +129,20 @@ export default async function handler(request: Request, _context: Context) {
   const targetPath = url.pathname.replace(/^\/bff\/orchestrate/, '/orchestrate')
   const targetUrl = `${CEE_TARGET}${targetPath}${url.search}`
 
-  // SECURITY: Build headers from scratch with explicit allowlist.
+  // SECURITY (item 13): reject anything outside the turn family BEFORE the key is
+  // injected. Off-list or traversal ⇒ 404, NO credential forwarded.
+  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+    return new Response(
+      JSON.stringify({ error: 'Not found' }),
+      {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    )
+  }
+
+  // SECURITY: Build the forwarded-header set from scratch with an explicit HEADER
+  // allowlist (distinct from the upstream PATH allowlist checked just above).
   // 'authorization' carries the user's Supabase access token (login 3.4 —
   // LOGIN-CEE-HALF-SPEC item 4: the DGAI edge function passes the user
   // token through so CEE's flag-gated JWT half can verify identity). It is

--- a/netlify/edge-functions/orchestrator-proxy.ts
+++ b/netlify/edge-functions/orchestrator-proxy.ts
@@ -85,9 +85,15 @@ function isAllowedTarget(pathname: string): boolean {
  * literal `..` path segment before the allowlist runs — closing the
  * `/bff/orchestrate/%2e%2e/assist/v1/*` escape hypothesis by construction,
  * independent of how the edge runtime normalises `request.url`.
+ *
+ * ⚠ SCOPED TO THE PATHNAME, NEVER THE WHOLE URL. Scanning `request.url` also scanned
+ * the QUERY STRING, so an on-list route 404'd whenever a parameter happened to carry
+ * an encoded slash — `encodeURIComponent` emits `%2F` for any value containing one
+ * (a URL, base64). The query cannot change the upstream route, so excluding it is
+ * strictly safer as well as correct.
  */
-function isTraversal(rawUrl: string, targetPath: string): boolean {
-  if (/%2e|%2f|%5c/i.test(rawUrl)) return true
+function isTraversal(rawPathname: string, targetPath: string): boolean {
+  if (/%2e|%2f|%5c/i.test(rawPathname)) return true
   return targetPath.split('/').some((segment) => segment === '..')
 }
 
@@ -131,7 +137,7 @@ export default async function handler(request: Request, _context: Context) {
 
   // SECURITY (item 13): reject anything outside the turn family BEFORE the key is
   // injected. Off-list or traversal ⇒ 404, NO credential forwarded.
-  if (isTraversal(request.url, targetPath) || !isAllowedTarget(targetPath)) {
+  if (isTraversal(url.pathname, targetPath) || !isAllowedTarget(targetPath)) {
     return new Response(
       JSON.stringify({ error: 'Not found' }),
       {

--- a/scripts/bff-allowlist-probe.sh
+++ b/scripts/bff-allowlist-probe.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# POST-DEPLOY PROBE — BFF service-key path allowlist (disposition item 13).
+#
+# This is the deploy-verify for the change that added a per-proxy upstream PATH
+# allowlist + traversal guard + ISL method gate to the four credential-injecting
+# Netlify edge functions. Run it against the deployed host AFTER the deploy goes
+# live; a green run is the witness that the bound is real and that no live UI call
+# was false-404'd by it.
+#
+#   bash scripts/bff-allowlist-probe.sh [BASE_URL]
+#
+# Default BASE_URL is https://staging--olumi.netlify.app.
+#
+# ── WHAT IT ASSERTS, AND WHY THE BODY MATTERS ──────────────────────────────────
+# MATRIX A — on-list routes MUST NOT be blocked by the edge. These are the paths
+#   the deployed UI genuinely calls. Any status is acceptable EXCEPT an edge block
+#   (a 404 whose body is exactly the edge's `{"error":"Not found"}`, or a 405).
+#   Upstream 401/404/422/500 are all fine here: the point is that the request
+#   REACHED the upstream. ⚠ Asserting only the status could not tell an edge block
+#   from an upstream 404 — hence the body check.
+# MATRIX B — off-list routes MUST be blocked BY THE EDGE: HTTP 404 with body
+#   exactly {"error":"Not found"}. An upstream 404 would have a different body and
+#   would mean the credential was forwarded — a FAIL, not a pass.
+# MATRIX C — the four defects the #685 review witnessed pre-fix. Each MUST now be
+#   edge-blocked. If any of these forwards, the fix has regressed.
+#
+# Every probe sends an allow-listed Origin, because the proxies reject an unknown
+# origin at 403 before any of this logic runs — without it the whole matrix would
+# "pass" for the wrong reason.
+#
+# NO CREDENTIALS are sent or printed. The proxies inject the service key
+# server-side; this script never sees it.
+
+set -euo pipefail
+
+BASE="${1:-https://staging--olumi.netlify.app}"
+ORIGIN="https://staging--olumi.netlify.app"
+EDGE_BLOCK_BODY='{"error":"Not found"}'
+
+pass=0; fail=0
+FAILURES=()
+
+# probe <method> <path> -> sets REPLY_STATUS / REPLY_BODY
+probe() {
+  local method="$1" path="$2" out
+  if [ "$method" = "GET" ] || [ "$method" = "HEAD" ]; then
+    out="$(curl -sS -X "$method" -H "Origin: $ORIGIN" -w $'\n%{http_code}' --max-time 30 "$BASE$path" 2>/dev/null || true)"
+  else
+    out="$(curl -sS -X "$method" -H "Origin: $ORIGIN" -H 'Content-Type: application/json' \
+             --data '{}' -w $'\n%{http_code}' --max-time 30 "$BASE$path" 2>/dev/null || true)"
+  fi
+  REPLY_STATUS="$(printf '%s' "$out" | tail -n1)"
+  REPLY_BODY="$(printf '%s' "$out" | sed '$d' | tr -d '\r\n')"
+}
+
+is_edge_block() {
+  # An edge block is 405, or a 404 whose body is exactly the edge's sentinel.
+  [ "$REPLY_STATUS" = "405" ] && return 0
+  [ "$REPLY_STATUS" = "404" ] && [ "$REPLY_BODY" = "$EDGE_BLOCK_BODY" ] && return 0
+  return 1
+}
+
+ok()   { pass=$((pass+1)); printf '  PASS  %-6s %-58s -> %s\n' "$1" "$2" "$3"; }
+bad()  { fail=$((fail+1)); FAILURES+=("$1 $2 :: $3"); printf '  FAIL  %-6s %-58s -> %s\n' "$1" "$2" "$3"; }
+
+must_not_be_edge_blocked() {
+  probe "$1" "$2"
+  if is_edge_block; then
+    bad "$1" "$2" "EDGE-BLOCKED ($REPLY_STATUS $REPLY_BODY) — a real UI call was false-blocked"
+  else
+    ok "$1" "$2" "reached upstream ($REPLY_STATUS)"
+  fi
+}
+
+must_be_edge_blocked() {
+  probe "$1" "$2"
+  if [ "$REPLY_STATUS" = "404" ] && [ "$REPLY_BODY" = "$EDGE_BLOCK_BODY" ]; then
+    ok "$1" "$2" "404 edge-blocked, body verified"
+  elif [ "$REPLY_STATUS" = "404" ]; then
+    bad "$1" "$2" "404 but body=[$REPLY_BODY] — looks like an UPSTREAM 404, i.e. the key was forwarded"
+  else
+    bad "$1" "$2" "NOT blocked ($REPLY_STATUS) — credential forwarded off-list"
+  fi
+}
+
+must_be_method_blocked() {
+  probe "$1" "$2"
+  if [ "$REPLY_STATUS" = "405" ]; then
+    ok "$1" "$2" "405 method-blocked at the edge"
+  else
+    bad "$1" "$2" "NOT method-blocked ($REPLY_STATUS) — authenticated verb reached upstream"
+  fi
+}
+
+echo "BFF allowlist probe — base: $BASE"
+echo
+
+echo "── MATRIX A: on-list routes MUST NOT be edge-blocked (real UI calls) ──"
+# cee (13)
+must_not_be_edge_blocked GET  /bff/cee/health
+must_not_be_edge_blocked POST /bff/cee/graph-readiness
+must_not_be_edge_blocked POST /bff/cee/ask
+must_not_be_edge_blocked POST /bff/cee/bias-check
+must_not_be_edge_blocked POST /bff/cee/sensitivity-coach
+must_not_be_edge_blocked POST /bff/cee/elicit-belief
+must_not_be_edge_blocked POST /bff/cee/suggest-edge-function
+must_not_be_edge_blocked POST /bff/cee/prompts/warm
+must_not_be_edge_blocked POST /bff/cee/draft-graph
+must_not_be_edge_blocked POST /bff/cee/scenarios/00000000-0000-0000-0000-000000000000/graph
+must_not_be_edge_blocked POST /bff/cee/scenarios/00000000-0000-0000-0000-000000000000/graph/register
+must_not_be_edge_blocked POST /bff/cee/decision-records/commit
+must_not_be_edge_blocked POST /bff/cee/decision-records/00000000-0000-0000-0000-000000000000/outcome
+# orchestrate (6) — BOTH version families; v1 is live in turnService.ts
+must_not_be_edge_blocked POST /bff/orchestrate/v1/turn
+must_not_be_edge_blocked POST /bff/orchestrate/v1/turn/stream
+must_not_be_edge_blocked POST /bff/orchestrate/v1/turn/stop
+must_not_be_edge_blocked POST /bff/orchestrate/v2/turn
+must_not_be_edge_blocked POST /bff/orchestrate/v2/turn/stream
+must_not_be_edge_blocked POST /bff/orchestrate/v2/turn/stop
+# collab (6)
+must_not_be_edge_blocked POST /bff/collab/rounds
+must_not_be_edge_blocked POST /bff/collab/rounds/00000000-0000-0000-0000-000000000000/close
+must_not_be_edge_blocked GET  /bff/collab/rounds/00000000-0000-0000-0000-000000000000/reveal
+must_not_be_edge_blocked GET  /bff/collab/packet/00000000-0000-0000-0000-000000000000
+must_not_be_edge_blocked POST /bff/collab/packet/00000000-0000-0000-0000-000000000000/events
+must_not_be_edge_blocked GET  /bff/collab/packet/00000000-0000-0000-0000-000000000000/reveal
+# isl (7)
+must_not_be_edge_blocked GET  /bff/isl/health
+must_not_be_edge_blocked POST /bff/isl/validate
+must_not_be_edge_blocked POST /bff/isl/conformal
+must_not_be_edge_blocked POST /bff/isl/compare
+must_not_be_edge_blocked POST /bff/isl/explain/contrastive
+must_not_be_edge_blocked POST /bff/isl/api/v1/robustness/analyze
+must_not_be_edge_blocked POST /bff/isl/api/v1/causal/counterfactual/conformal
+echo
+
+echo "── MATRIX B: off-list routes MUST be edge-blocked (404 + exact body) ──"
+must_be_edge_blocked POST /bff/cee/decision-review
+must_be_edge_blocked POST /bff/cee/review
+must_be_edge_blocked POST /bff/cee/options
+must_be_edge_blocked POST /bff/cee/isl-synthesis
+must_be_edge_blocked POST /bff/orchestrate/v2/turn/replay
+must_be_edge_blocked POST /bff/orchestrate/admin
+must_be_edge_blocked POST /bff/collab/admin
+must_be_edge_blocked GET  /bff/isl/admin/secrets
+must_be_edge_blocked POST /bff/cee/scenarios/abc%2f..%2fsecret/graph
+must_be_edge_blocked POST /bff/cee/%2e%2e/assist/v1/decision-review
+echo
+
+echo "── MATRIX C: the four #685-review defects — MUST now be blocked ──"
+must_be_edge_blocked   GET    /bff/isl/api/v1/admin/secrets    # D1: was 200 FORWARDED with bearer
+must_be_edge_blocked   GET    /bff/isl/explain/anything/at/all # D1: was 200 FORWARDED
+must_be_method_blocked PUT    /bff/isl/validate                # D2: was forwarded with bearer
+must_be_method_blocked DELETE /bff/isl/validate                # D2: was forwarded with bearer
+echo
+
+echo "── D3 regression: an on-list route with an encoded slash in the QUERY ──"
+must_not_be_edge_blocked POST '/bff/cee/ask?q=a%2Fb'
+echo
+
+echo "════════════════════════════════════════════"
+echo "PASS: $pass    FAIL: $fail"
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "FAILURES:"
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+echo "ALL PROBES GREEN"

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * SECURITY GUARD — disposition item 13: bound the BFF service-key blast radius.
+ *
+ * Each of the four credential-injecting edge proxies rewrites `/bff/<x>/*` to an
+ * upstream prefix and injects a service key/bearer. Before this guard the rewrite
+ * was BLIND: any path under the seam (or an encoded traversal out of it) became an
+ * authenticated service caller across the whole upstream surface — for `/bff/cee/*`
+ * that is ~24 `/assist/v1/*` routes, ~20 of them LLM-invoking, reachable with no
+ * UUID and (for cee/collab) no Origin.
+ *
+ * This spec drives the ACTUAL handlers (Deno + fetch stubbed) and asserts, by
+ * IDENTITY on the exact route strings:
+ *   • an ON-LIST path is forwarded WITH the injected credential;
+ *   • an OFF-LIST path is answered 404 and fetch is NEVER called, so NO key leaves
+ *     the edge;
+ *   • an encoded-traversal path is answered 404 and fetch is never called.
+ *
+ * The two guards are independently load-bearing (see the mutant notes in the PR):
+ *   • remove the allowlist  → the plain OFF-LIST cases forward (RED);
+ *   • remove the traversal check → the encoded-slash cases forward (RED), because
+ *     the dynamic id segment is deliberately permissive (`[^/]+`) so real UUIDs
+ *     never false-404.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import ceeHandler from '../../netlify/edge-functions/cee-proxy.ts'
+import orchestratorHandler from '../../netlify/edge-functions/orchestrator-proxy.ts'
+import collabHandler from '../../netlify/edge-functions/collab-proxy.ts'
+import islHandler from '../../netlify/edge-functions/isl-proxy.ts'
+
+const ALLOWED_ORIGIN = 'https://staging--olumi.netlify.app'
+const FAKE_KEY = 'FAKE_SERVICE_KEY_VALUE'
+
+type Handler = (request: Request, context: unknown) => Promise<Response>
+
+interface InvokeResult {
+  status: number
+  fetchCalled: boolean
+  calledUrl: string | null
+  requestHeaders: Headers | null
+}
+
+/** Invoke a handler with Deno + fetch stubbed; report status and upstream call. */
+async function invoke(
+  handler: Handler,
+  opts: { path: string; method?: string; withOrigin?: boolean },
+): Promise<InvokeResult> {
+  ;(globalThis as unknown as { Deno: unknown }).Deno = {
+    env: { get: (_k: string) => FAKE_KEY },
+  }
+
+  const fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(new Response('upstream-ok', { status: 200 }))
+
+  const method = opts.method ?? 'POST'
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (opts.withOrigin !== false) headers.origin = ALLOWED_ORIGIN
+  // collab participant routes require this header to build; harmless elsewhere.
+  headers['x-collab-participant-token'] = 'ptoken'
+
+  const init: RequestInit = { method, headers }
+  if (method !== 'GET' && method !== 'HEAD') init.body = '{}'
+
+  const req = new Request(`https://staging--olumi.netlify.app${opts.path}`, init)
+  const res = await handler(req, {})
+
+  const call = fetchSpy.mock.calls[0]
+  return {
+    status: res.status,
+    fetchCalled: fetchSpy.mock.calls.length > 0,
+    calledUrl: call ? String(call[0]) : null,
+    requestHeaders: call ? ((call[1] as RequestInit)?.headers as Headers) ?? null : null,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as unknown as { Deno?: unknown }).Deno
+})
+
+/* ── /bff/cee/* → /assist/v1/* — the HIGH blast-radius seam ─────────────────── */
+describe('cee-proxy path allowlist (/bff/cee/* → /assist/v1/*)', () => {
+  it('ON-LIST /bff/cee/graph-readiness forwards to /assist/v1/graph-readiness WITH the injected key', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/graph-readiness' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/assist/v1/graph-readiness')
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+    expect(r.status).toBe(200)
+  })
+
+  it('ON-LIST /bff/cee/scenarios/{uuid}/graph forwards (dynamic id honoured)', async () => {
+    const uuid = 'd495a487-6ed7-4a90-a220-17a6986acc1d'
+    const r = await invoke(ceeHandler as Handler, { path: `/bff/cee/scenarios/${uuid}/graph` })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(`https://cee-staging.onrender.com/assist/v1/scenarios/${uuid}/graph`)
+  })
+
+  it('OFF-LIST /bff/cee/decision-review (a real LLM route the UI never calls) is 404 with NO key sent', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/decision-review' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('OFF-LIST /bff/cee/anything-not-enumerated is 404 with NO key sent', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/prompts/preload-all' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('TRAVERSAL /bff/cee/scenarios/abc%2f..%2fsecret/graph is 404 with NO key sent', async () => {
+    const r = await invoke(ceeHandler as Handler, {
+      path: '/bff/cee/scenarios/abc%2f..%2fsecret/graph',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('TRAVERSAL /bff/cee/%2e%2e/assist/v1/decision-review is 404 with NO key sent', async () => {
+    const r = await invoke(ceeHandler as Handler, {
+      path: '/bff/cee/%2e%2e/assist/v1/decision-review',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+})
+
+/* ── /bff/orchestrate/* → /orchestrate/* — the three turn routes ───────────── */
+describe('orchestrator-proxy path allowlist (/bff/orchestrate/* → /orchestrate/*)', () => {
+  it('ON-LIST /bff/orchestrate/v2/turn forwards WITH the injected key', async () => {
+    const r = await invoke(orchestratorHandler as Handler, {
+      path: '/bff/orchestrate/v2/turn',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/orchestrate/v2/turn')
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('ON-LIST /bff/orchestrate/v2/turn/stream forwards', async () => {
+    const r = await invoke(orchestratorHandler as Handler, {
+      path: '/bff/orchestrate/v2/turn/stream',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/orchestrate/v2/turn/stream')
+  })
+
+  it('ON-LIST /bff/orchestrate/v2/turn/stop forwards', async () => {
+    const r = await invoke(orchestratorHandler as Handler, {
+      path: '/bff/orchestrate/v2/turn/stop',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/orchestrate/v2/turn/stop')
+  })
+
+  it('OFF-LIST /bff/orchestrate/v2/turn/replay is 404 with NO key sent', async () => {
+    const r = await invoke(orchestratorHandler as Handler, {
+      path: '/bff/orchestrate/v2/turn/replay',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('OFF-LIST /bff/orchestrate/admin is 404 with NO key sent', async () => {
+    const r = await invoke(orchestratorHandler as Handler, { path: '/bff/orchestrate/admin' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+})
+
+/* ── /bff/collab/* → /collab/v1/* — person-authed, but still key-injecting ──── */
+describe('collab-proxy path allowlist (/bff/collab/* → /collab/v1/*)', () => {
+  it('ON-LIST /bff/collab/rounds forwards WITH the injected key', async () => {
+    const r = await invoke(collabHandler as Handler, { path: '/bff/collab/rounds' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/collab/v1/rounds')
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('ON-LIST /bff/collab/packet/{uuid} (GET) forwards', async () => {
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/packet/${uuid}`,
+      method: 'GET',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(`https://cee-staging.onrender.com/collab/v1/packet/${uuid}`)
+  })
+
+  it('OFF-LIST /bff/collab/admin is 404 with NO key sent', async () => {
+    const r = await invoke(collabHandler as Handler, { path: '/bff/collab/admin' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('TRAVERSAL /bff/collab/rounds/abc%2f..%2fadmin/close is 404 with NO key sent', async () => {
+    const r = await invoke(collabHandler as Handler, {
+      path: '/bff/collab/rounds/abc%2f..%2fadmin/close',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+})
+
+/* ── /bff/isl/* → /* — route table unread; permissive-prefix allowlist ──────── */
+describe('isl-proxy path allowlist (/bff/isl/* → /*)', () => {
+  it('ON-LIST /bff/isl/health forwards WITH the injected bearer', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/health', method: 'GET' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://isl-staging.onrender.com/health')
+    expect(r.requestHeaders?.get('Authorization')).toBe(`Bearer ${FAKE_KEY}`)
+  })
+
+  it('ON-LIST /bff/isl/api/v1/robustness/analyze forwards', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/api/v1/robustness/analyze' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://isl-staging.onrender.com/api/v1/robustness/analyze')
+  })
+
+  it('OFF-LIST /bff/isl/admin/secrets is 404 with NO bearer sent', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/admin/secrets' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('TRAVERSAL /bff/isl/api/v1/robustness%2f..%2f..%2fadmin is 404 with NO bearer sent', async () => {
+    const r = await invoke(islHandler as Handler, {
+      path: '/bff/isl/api/v1/robustness%2f..%2f..%2fadmin',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+})

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -229,4 +229,117 @@ describe('isl-proxy path allowlist (/bff/isl/* → /*)', () => {
     expect(r.status).toBe(404)
     expect(r.fetchCalled).toBe(false)
   })
+
+  /**
+   * D1 (review of #685) — the wildcard forms admitted the whole surface they were
+   * meant to narrow. The original off-list case (`/bff/isl/admin/secrets`) picked
+   * the ONE shape that avoids the wildcard, so it was a guard agreeing with itself:
+   * it passed while `/api/v1/admin/secrets` forwarded WITH the bearer. These bind
+   * the anchored-literal set by identity.
+   */
+  it('D1 OFF-LIST /bff/isl/api/v1/admin/secrets (UNDER the old /api/v1/.+ wildcard) is 404, NO bearer', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/api/v1/admin/secrets' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('D1 OFF-LIST /bff/isl/explain/anything/at/all (UNDER the old /explain/.+ wildcard) is 404, NO bearer', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/explain/anything/at/all' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('D1 ON-LIST /bff/isl/api/v1/causal/counterfactual/conformal still forwards (literal, not wildcard)', async () => {
+    const r = await invoke(islHandler as Handler, {
+      path: '/bff/isl/api/v1/causal/counterfactual/conformal',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      'https://isl-staging.onrender.com/api/v1/causal/counterfactual/conformal',
+    )
+  })
+
+  it('D1 ON-LIST /bff/isl/explain/contrastive still forwards (literal, not wildcard)', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/explain/contrastive' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://isl-staging.onrender.com/explain/contrastive')
+  })
+
+  /**
+   * D2 (review of #685) — isl-proxy had NO method gate while injecting a bearer,
+   * the exact posture `cee-proxy.ts` names as "the gap not to copy". PUT/DELETE
+   * forwarded with the credential.
+   */
+  it('D2 PUT on an ON-LIST isl path is 405 with NO bearer sent', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/validate', method: 'PUT' })
+    expect(r.status).toBe(405)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('D2 DELETE on an ON-LIST isl path is 405 with NO bearer sent', async () => {
+    const r = await invoke(islHandler as Handler, { path: '/bff/isl/validate', method: 'DELETE' })
+    expect(r.status).toBe(405)
+    expect(r.fetchCalled).toBe(false)
+  })
+
+  it('D2 the advertised Access-Control-Allow-Methods matches what is ENFORCED (no false guarantee)', async () => {
+    ;(globalThis as unknown as { Deno: unknown }).Deno = { env: { get: () => FAKE_KEY } }
+    const res = await (islHandler as Handler)(
+      new Request('https://staging--olumi.netlify.app/bff/isl/health', {
+        method: 'OPTIONS',
+        headers: { origin: ALLOWED_ORIGIN },
+      }),
+      {},
+    )
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET, HEAD, POST, OPTIONS')
+  })
+})
+
+/* ── D3 + regex-tightening pins (review of #685) ────────────────────────────── */
+describe('traversal check is scoped to the PATH, not the query string (D3)', () => {
+  it('ON-LIST /bff/cee/ask?q=a%2Fb forwards — an encoded slash in the QUERY must not 404', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/ask?q=a%2Fb' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/assist/v1/ask?q=a%2Fb')
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('the PATH form is still rejected — scoping to pathname does not weaken the guard', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/scenarios/a%2Fb/graph' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+})
+
+describe('orchestrator v1 turn family is allowed (pins the v\\d+ regex against a tightening)', () => {
+  // turnService.ts builds `/bff/orchestrate/v1/turn` and derives `/stream` from it.
+  it.each([
+    ['/bff/orchestrate/v1/turn', 'https://cee-staging.onrender.com/orchestrate/v1/turn'],
+    [
+      '/bff/orchestrate/v1/turn/stream',
+      'https://cee-staging.onrender.com/orchestrate/v1/turn/stream',
+    ],
+    ['/bff/orchestrate/v1/turn/stop', 'https://cee-staging.onrender.com/orchestrate/v1/turn/stop'],
+  ])('ON-LIST %s forwards WITH the injected key', async (path, expectedUrl) => {
+    const r = await invoke(orchestratorHandler as Handler, { path })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(expectedUrl)
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+})
+
+describe('double-encoded traversal is harmless BY SHAPE (pinned, not left unobserved)', () => {
+  /**
+   * `%252e` does NOT match the traversal regex (`%2e` is not a substring of `%252e`).
+   * It is rejected by the ALLOWLIST instead: the literal segment cannot match any
+   * enumerated route. Pinned so the mechanism is observed rather than assumed — if a
+   * future decode step were added, this case would change hands and the test says so.
+   */
+  it('/bff/cee/%252e%252e/assist/v1/decision-review is 404 with NO key sent', async () => {
+    const r = await invoke(ceeHandler as Handler, {
+      path: '/bff/cee/%252e%252e/assist/v1/decision-review',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
 })


### PR DESCRIPTION
## What & why (disposition item 13 — bound the BFF service-key blast radius)

The four credential-injecting Netlify edge proxies each **blind-prefix-rewrote** `/bff/<x>/*` to an upstream prefix and injected a service key/bearer with **no path allowlist**. An allowed Origin (or, for `cee`/`collab`, an *absent* Origin) therefore became an **authenticated service caller across the whole upstream surface**. For `/bff/cee/*` that is ~24 `/assist/v1/*` routes, ~20 of them LLM-invoking (`draft-graph`, `bias-check`, `ask`, `review`, `decision-review`, elicitation, …), reachable **with no UUID and no prior state** — only the per-IP rate limit between an untrusted tester and unbounded authenticated model spend. CEE auth is a single global key hook with no per-route ACL, so one injected key authenticates the whole non-public surface.

This adds a **per-proxy explicit upstream PATH allowlist**, checked against the rewritten target **before** the credential is injected; off-list ⇒ **404, no key forwarded**. Plus a **traversal guard** (reject `%2e`/`%2f`/`%5c` and literal `..`) run before the allowlist, closing the `/bff/orchestrate/%2e%2e/assist/v1/*` escape by construction. Misleading comments corrected (the "explicit allowlist" that was header-only; the origin-as-security framing).

**⛔ DO NOT MERGE** — the deployed quartet is held stable for external review. This is external-link-readiness work; it does not gate the semantic exit.

## Derived per-proxy allowlist + evidence

All sets derived from the UI's real `/bff/<x>/*` call sites at `f2b48fc9`, cross-checked against live wire captures in `olumi-docs/PHASE0-EVIDENCE-2026-07-28/`. Dynamic id segments are matched **permissively** (`[^/]+`) so a real UUID never false-404s — the **route shape** is what is bounded; `isTraversal` closes encoded escapes through those segments.

### `/bff/cee/*` → `/assist/v1/*` (HIGH blast radius)
| Allowed target | Source call site |
|---|---|
| `/assist/v1/health` | `src/lib/service-health.ts` |
| `/assist/v1/graph-readiness` | `src/canvas/stores/readinessStore.ts` |
| `/assist/v1/ask` | `src/hooks/useAsk.ts` |
| `/assist/v1/bias-check` | `src/adapters/cee/client.ts` (`biasCheck`) |
| `/assist/v1/sensitivity-coach` | `src/adapters/cee/client.ts` (`sensitivityCoach`) |
| `/assist/v1/elicit-belief` | `src/adapters/cee/client.ts` (`elicitBelief`) |
| `/assist/v1/suggest-edge-function` | `src/canvas/hooks/useFormRecommendations.ts` |
| `/assist/v1/prompts/warm` | `src/lib/prompt-preloader.ts` |
| `/assist/v1/draft-graph` | `src/adapters/cee/client.ts` (non-browser base) + `DraftChat.tsx` legacy path |
| `/assist/v1/scenarios/{id}/graph` | `src/adapters/cee/scenarioGraph.ts` |
| `/assist/v1/scenarios/{id}/graph/register` | `src/adapters/cee/registerScenarioGraph.ts` |
| `/assist/v1/decision-records/commit` | `src/services/decisionRecordCommitService.ts` |
| `/assist/v1/decision-records/{id}/outcome` | CEE route being developed (`improve-slice-2026-08-13/outcome-write-gate.mjs`); not UI-wired at `f2b48fc9`, allowed permissively — see risk note |

Captures confirming real browser traffic (UUIDs collapsed): `/bff/cee/scenarios/{id}/graph`, `/bff/cee/elicit-belief`, `/bff/cee/decision-records/commit`, `/bff/cee/decision-records/:record_id/outcome`, `/bff/cee/draft-graph`, `/bff/cee/health`, `/bff/cee/prompts/warm`, `/assist/v1/graph-readiness` (62×), `/assist/v1/bias-check`.

**Note:** `/assist/v1/review` and `/assist/v1/decision-review` appear in captures but as **internal PLoT→CEE** downstream calls, not browser→`/bff/cee` calls (the browser reaches them via `/bff/engine`→PLoT). They are correctly **off-list** for this proxy — and the primary demonstration of the bound (`OFF-LIST /bff/cee/decision-review` → 404, no key).

### `/bff/orchestrate/*` → `/orchestrate/*`
`/orchestrate/v{N}/turn`, `/orchestrate/v{N}/turn/stream`, `/orchestrate/v{N}/turn/stop` — the three turn routes CEE mounts. `v\d+` covers live v2 (`src/v5/v5Adapter.ts`, `streamedTurnTransport.ts`, `stopTurn.ts`) and the legacy v1 reference (`src/canvas/conversation/turnService.ts`). Captures: `/bff/orchestrate/v2/turn`, `/bff/orchestrate/v2/turn/stream`.

### `/bff/collab/*` → `/collab/v1/*`
`/collab/v1/rounds`, `/collab/v1/rounds/{id}/close`, `/collab/v1/rounds/{id}/reveal`, `/collab/v1/packet/{id}`, `/collab/v1/packet/{id}/events`, `/collab/v1/packet/{id}/reveal` — the complete set from `src/collab/collabService.ts` (the only `/bff/collab/*` caller). Captures: `/bff/collab/rounds`, `/bff/collab/rounds/{id}/close`.

### `/bff/isl/*` → `/*` (prefix stripped)
Exact: `/health`, `/validate`, `/conformal`, `/compare`; permissive subtrees: `/explain/.+`, `/api/v1/.+`. Source: `src/adapters/isl/client.ts` (`/validate`, `/api/v1/robustness/analyze`, `/api/v1/causal/counterfactual/conformal`, `/conformal`, `/compare`, `/explain/contrastive`) + `src/lib/service-health.ts` (`/health`). **ISL's authoritative route table was NOT read** (enumeration §5d UNKNOWN), so the compute subtrees are permissive on purpose — this still rejects root-level admin/debug/metrics routes, which is the meaningful bound. Tighten once the ISL route table is enumerated.

## Traversal-close proof (no live probe fired — proven at the handler)
- WHATWG `new URL()` resolves an **un-encoded** `../` and the **`%2e%2e`** form at parse, so `/bff/orchestrate/%2e%2e/assist/v1/*` collapses to a path that no longer matches the `/bff/orchestrate` rewrite → falls off the allowlist → 404. (Spec: `TRAVERSAL /bff/cee/%2e%2e/assist/v1/decision-review` → 404.)
- The **`%2f`** encoded-slash form **survives** URL parsing; it is caught by `isTraversal` (`/%2e|%2f|%5c/i`). (Spec: `.../scenarios/abc%2f..%2fsecret/graph`, `.../rounds/abc%2f..%2fadmin/close`, `/api/v1/robustness%2f..%2f..%2fadmin` → all 404, no key.)

## RED-first signatures (named, at pristine)
Before the guard, exactly the **10 off-list/traversal assertions failed**, all **9 on-list passed** — e.g.:
- `OFF-LIST /bff/cee/decision-review … is 404 with NO key sent` — `expected 200 to be 404`
- `OFF-LIST /bff/isl/admin/secrets is 404 with NO bearer sent` — `expected 200 to be 404`

After the guard: **19/19 pass**. Assertions bind by **identity** (exact route strings) and assert **fetch was never called** (⇒ no credential left the edge) on rejection.

## Mutant table (throwaway worktree outside repo root; isolation proven by sentinel write + inode compare; restores HEAD-relative; applied-check scoped to `netlify/edge-functions`, control = 0)
| Mutation | Applied | Result | Proves |
|---|---|---|---|
| **Control** (guard intact) | 0 | 19/19 pass | baseline |
| **Remove allowlist** disjunct (keep traversal) | 4 files | **7 RED** (all plain off-list + the `%2e%2e`-normalised-off-list case); the three `%2f` traversal tests stay green | the **allowlist** independently binds plain off-list |
| **Remove traversal** disjunct (keep allowlist) | 4 files | **3 RED** (the `%2f` encoded-slash cases, which the permissive `[^/]+`/`.+` patterns would otherwise allow) | the **traversal guard** is independently load-bearing |

Both guards independently necessary. Restore left zero residual diff each time.

## Gate results (head `1ddf0ed8`)

**CI — all 13 check-runs SUCCESS, zero in progress, queried by exact head SHA:**

```
SUCCESS  Staging Gate                      <- the required check
SUCCESS  TypeScript + Lint
SUCCESS  Typecheck Gate Self-Test
SUCCESS  Full Test Suite (shard 1/4 .. 4/4)
SUCCESS  Full Test Suite Summary
SUCCESS  Production Build
SUCCESS  Security Audit (pnpm)
SUCCESS  CEE Contract Validation
SUCCESS  Install & Cache
SUCCESS  Flag Deployment Drift (report only)
total_count=13   in_progress=[]
mergeable=true  mergeable_state=clean
```

**My spec is proven to have RUN in CI, not collected-zero** — all 19 tests appear individually by name in the shard 1/4 log, e.g.:

```
✓ tests/ci-guards/bffProxyPathAllowlist.spec.ts > cee-proxy path allowlist > OFF-LIST /bff/cee/decision-review (a real LLM route the UI never calls) is 404 with NO key sent
✓ tests/ci-guards/bffProxyPathAllowlist.spec.ts > isl-proxy path allowlist > TRAVERSAL /bff/isl/api/v1/robustness%2f..%2f..%2fadmin is 404 with NO bearer sent
```

**Local:**
- `pnpm typecheck` — phase 1 coverage: **3396/3436 tracked files loaded** (40 declared out of scope; new spec included). Phase 2 ratchet did not finish inside the session on this machine; CI's `TypeScript + Lint` and `Typecheck Gate Self-Test` ran the same gate on this SHA and both passed, so the gate verdict is CI's, not an unfinished local run.
- `eslint` (5 changed files): **0 errors** (1 pre-existing warning in `isl-proxy.ts`: `context` unused — present at HEAD~1, untouched).
- Spec `tests/ci-guards/bffProxyPathAllowlist.spec.ts`: **19/19**.
- 7 pre-existing edge-adjacent specs re-run: **80/80 pass** (no regression).

## Shared-handler refactor — ROWED, not done here
The four proxies are near-identical clones and the security helpers (`ALLOWED_TARGETS` / `isAllowedTarget` / `isTraversal`) are now duplicated across them. Factoring one shared edge handler would touch four files that deploy with the frozen quartet, and a shared module in `netlify/edge-functions/` risks edge-function auto-discovery surprises. Per the brief, the security bound ships per-file first; **the shared-handler + shared-guard-module refactor is rowed separately.**

## False-404 risk I could not fully rule out
- **`/bff/cee/decision-records/{id}/outcome`** — a CEE route under active development, not UI-wired at `f2b48fc9`; allowed permissively so an imminent wiring doesn't 404.
- **ISL compute subtrees** — allowed as permissive `/api/v1/.+` and `/explain/.+` because the ISL route table was not read; a real compute route with a different top-level prefix (none seen in source) would 404. Low risk; flagged.
- `draft-graph` in the browser routes via `/bff/engine` (PLoT), not `/bff/cee`; it is kept in the cee allowlist for the non-browser and legacy `DraftChat` paths.

## What I could not reach
- **Deployed Netlify env** — whether `ASSIST_API_KEY`/`ISL_API_KEY`/origins are actually set (dashboard, not in-repo).
- **ISL authoritative route table + auth** (enumeration §5d UNKNOWN) — hence the permissive ISL subtrees.
- **Live wire behaviour of the deployed edge functions** — not exercised (frozen quartet; no live probe fired). Guard proven at the handler under vitest.

---

## Review round 2 — D1/D2/D3 closed (head `8616a317`)

The #685 review returned FIX-FIRST: CEE/collab/orchestrate bounds sound and complete (31/31 across three independent derivations), both guard disjuncts load-bearing — but **three defects, all reproduced at the handler before fixing**.

### D1 (MUST) — the ISL wildcards re-admitted the surface they were meant to narrow
`/^\/api\/v1\/.+$/` and `/^\/explain\/.+$/` meant `/bff/isl/api/v1/admin/secrets` and `/bff/isl/explain/anything/at/all` **forwarded with the bearer**. My own off-list test picked `/bff/isl/admin/secrets` — the one shape that avoids the wildcard — so the suite agreed with itself. The reviewer's point is exactly right: **the allowlist never needed ISL's route table**, because it bounds what the UI *calls*, and those seven call sites were already enumerated in the comment sitting directly above the wildcard I wrote.

Replaced with seven anchored literals: `/health`, `/validate`, `/conformal`, `/compare`, `/explain/contrastive`, `/api/v1/robustness/analyze`, `/api/v1/causal/counterfactual/conformal`.

### D2 (MUST, compounds D1) — no method gate on isl-proxy
PUT and DELETE forwarded **with the bearer**, while `cee-proxy.ts`'s own comment names this as "the gap not to copy", and the CORS header advertised PUT/DELETE that nothing enforced. Added `ALLOWED_METHODS = GET, HEAD, POST, OPTIONS`, enforced before the bearer is read and advertised verbatim (a test pins advertised == enforced).

### D3 (SHOULD) — traversal check scanned the query string
`isTraversal(request.url, …)` 404'd on-list `/bff/cee/ask?q=a%2Fb`. `encodeURIComponent` emits `%2F` for any value containing a slash (a URL, base64), so this was a latent bear trap. Scoped to `url.pathname` in **all four** proxies — strictly safer, since the query cannot change the upstream route.

### Also done
- **v1 turn family pinned** — `turnService.ts` builds `/bff/orchestrate/v1/turn`; the spec exercised v2 only. Three `it.each` cases now pin v1 so a regex tightening cannot silently kill the live path.
- **`%252e` double-encoding pinned as harmless-by-shape** — it does not match the traversal regex (`%2e` is not a substring of `%252e`); it is caught by the **allowlist**. Pinned so the mechanism is observed, not assumed.
- **Stale comments corrected** — the isl banner and traversal doc still described the permissive wildcards after the fix removed them. A false comment is the exact defect class this PR exists to fix.

### RED-first (round 2)
All three defects reproduced at the handler before any fix: **6 RED** — 2×D1, 3×D2 (PUT, DELETE, CORS advertisement), 1×D3. The v1 and `%252e` pins passed immediately (they guard against regression, not defects). After: **32/32**.

### Mutant table (round 2 — throwaway worktree outside repo root, sentinel-write isolation, HEAD-relative restores, control 0)
| Mutant | Applied | RED | Proves |
|---|---|---|---|
| Control | 0 | 0 (32 pass) | baseline |
| Restore `/api/v1/.+` wildcard | 1 | **1** (D1 api) | anchored literal binds |
| Restore `/explain/.+` wildcard | 1 | **1** (D1 explain) | anchored literal binds |
| Remove method gate | 1 | **2** (PUT, DELETE) | D2 gate load-bearing |
| Revert traversal scope to whole URL | 4 | **1** (D3 query) | pathname scoping load-bearing |
| CORS advertises PUT/DELETE again | 1 | **1** (advertised==enforced) | no false guarantee |
| *(round 1, re-verified)* remove allowlist disjunct | 4 | **10** | allowlist binds |
| *(round 1, re-verified)* remove traversal disjunct | 4 | **3** | traversal binds |

Each bites exactly its intended test — zero collateral. Trailing control clean.

## Post-deploy probe — `scripts/bff-allowlist-probe.sh`
Runnable deploy-verify, Origin sent on every probe, no credentials touched.
- **Matrix A (33)** — on-list routes that must NOT be edge-blocked, incl. the **v1 turn pair**. Any upstream status is a pass; only an edge block fails.
- **Matrix B (10)** — must be edge-blocked: 404 **with body exactly `{"error":"Not found"}`**. Asserting the body is what distinguishes an edge block from an upstream 404 — a status-only assertion could not tell "blocked" from "key forwarded, upstream said 404".
- **Matrix C (4)** — the D1/D2 defects; must flip.

**The probe was itself controlled** (a probe that cannot fail is theatre): I transpiled the real handlers, hosted them with a stubbed upstream, and ran the script against **both** versions — **47/47 green on the fixed code, 5 FAIL against the pre-fix code** (both D1s, both D2s, and D3). It discriminates.

## Surplus-but-bounded rows, kept deliberately
- **`/assist/v1/decision-records/{id}/outcome`** — zero UI callers at `f2b48fc9`; the route is under active development (`improve-slice-2026-08-13`). Kept so imminent wiring does not 404.
- **`/assist/v1/draft-graph`** — browser-unreachable *via this seam* (the browser goes `/bff/engine`→PLoT); retained for the non-browser/legacy `DraftChat` path.

Both are inside the bound and named rather than silently included.
