### PR TITLE
fix(canvas): node titles wrap at word boundaries, never mid-word

### DIFF
--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -19,7 +19,7 @@ import { UnknownKindWarning } from '../components/UnknownKindWarning'
 import { NodeCoachingMarker } from './shared/NodeCoachingMarker'
 import { useCanvasStore } from '../store'
 import { useLayoutStore } from '../layoutStore'
-import { NODE_CARD_MAX_W } from '../utils/nodeLayoutConstants'
+import { NODE_CARD_MAX_W, NODE_TITLE_MIN_MEASURE_PX } from '../utils/nodeLayoutConstants'
 import { nodeColors } from './colors'
 import { typography } from '../../styles/typography'
 import { getControllabilityBorderStyle } from '../utils/graphDisplayCalculations'
@@ -388,6 +388,10 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
           alignItems: 'flex-start',
           gap: '6px',
           marginBottom: '4px',
+          // Let the header slot drop below the title rather than squeezing the
+          // title's measure below NODE_TITLE_MIN_MEASURE_PX. At normal card
+          // widths there is ample room and nothing wraps.
+          flexWrap: 'wrap',
         }}
       >
         {/* Shape indicator — type name as tooltip */}
@@ -395,8 +399,12 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
           <span className="inline-flex mt-0.5 shrink-0"><NodeShapeIndicator nodeKind={nodeType} size={14} /></span>
         </Tooltip>
 
-        {/* Title + optional badges inline */}
-        <div className="flex-1 min-w-0">
+        {/* Title + optional badges inline.
+            `min-w-0` is deliberately NOT used here: it permits the flex item to
+            collapse below its content, which at compressed card widths left a
+            77px measure and made `break-words` split ordinary words mid-word.
+            A real minimum measure keeps wrapping on word boundaries. */}
+        <div className="flex-1" style={{ minWidth: `${NODE_TITLE_MIN_MEASURE_PX}px` }}>
           {/* line-clamp-3: cap title to 3 lines with ellipsis so ELK can
               rely on uniform-ish node heights. `break-words` preserved so
               long unbroken tokens still wrap before clamping. */}

--- a/src/canvas/nodes/__tests__/BaseNode.titleWrap.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.titleWrap.spec.tsx
@@ -1,0 +1,151 @@
+/**
+ * BaseNode — node titles must wrap at WORD boundaries, never mid-word.
+ *
+ * Defect witnessed on deployed staging build f2b48fc9 (14 Aug 2026), in a real
+ * browser: when a dense tier compresses cards to NODE_LAYOUT_MIN_W (140px), the
+ * title shared its flex row with the shape indicator and the header slot,
+ * leaving a 77px measure. `overflow-wrap: break-word` is a LAST-RESORT rule —
+ * it splits a word mid-character the moment that word cannot fit the line box —
+ * so ordinary words broke mid-word:
+ *
+ *   "Team Coordination Overhead"  ->  "Team Coordinatio / n Overhead"
+ *   "Development Headcount"       ->  "Developme / nt Headcount"
+ *
+ * Measured in-browser with Range.getClientRects (line-box spans per word):
+ * 3 of 16 titles broke mid-word at the compressed width; 0 after this fix.
+ *
+ * jsdom CANNOT assert layout — it has no line boxes and no text metrics. This
+ * spec therefore binds to the CSS RULE CONTRACT that produces word-boundary
+ * wrapping, by IDENTITY (`data-testid="node-title"`), never by a value
+ * predicate another element could satisfy. The visual witness is the browser
+ * screenshot / Range measurement recorded on the PR, not this file.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { Target } from 'lucide-react'
+import { BaseNode } from '../BaseNode'
+import { NODE_TITLE_MIN_MEASURE_PX } from '../../utils/nodeLayoutConstants'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    Handle: () => null,
+    useUpdateNodeInternals: () => vi.fn(),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector) =>
+    selector({
+      highlightedNodes: new Set(),
+      dimmedNodeIds: new Set(),
+      lens: { _dimmedNodeIds: new Set() },
+      results: { status: 'idle' },
+      goalThreshold: null,
+      goalConstraints: [],
+      edges: [],
+      viewMode: 'expert',
+    })
+  ),
+}))
+
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    winRate: null,
+    isResultsMode: false,
+  })),
+}))
+
+const baseProps = {
+  id: 'node-1',
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  type: 'factor',
+  xPos: 0,
+  yPos: 0,
+  deletable: true,
+  selectable: true,
+  draggable: true,
+}
+
+/** The exact labels Paul reported breaking mid-word on staging f2b48fc9. */
+const REPORTED_LABEL = 'Team Coordination Overhead'
+
+/**
+ * Render at the compressed card width the layout pipeline actually produces
+ * (NODE_LAYOUT_MIN_W = 140) — the only width at which the defect appears.
+ */
+function renderTitle(label: string = REPORTED_LABEL) {
+  const { container } = render(
+    <BaseNode
+      {...baseProps}
+      data={{ label }}
+      nodeType="factor"
+      icon={Target}
+      maxWidth={140}
+    />
+  )
+  const title = container.querySelector('[data-testid="node-title"]') as HTMLElement | null
+  expect(title, 'node-title must exist — bind by testid, not by class').toBeTruthy()
+  return { container, title: title as HTMLElement }
+}
+
+describe('BaseNode — titles wrap at word boundaries (never mid-word)', () => {
+  it('reserves a minimum title measure wide enough for an ordinary word', () => {
+    const { title } = renderTitle()
+    const wrapper = title.parentElement as HTMLElement
+
+    // The title's flex wrapper must carry a real minimum measure. Without it
+    // (`min-w-0`), the wrapper collapses to 77px inside a 140px card and
+    // break-word splits "Coordination" mid-word.
+    expect(wrapper.style.minWidth).toBe(`${NODE_TITLE_MIN_MEASURE_PX}px`)
+    expect(NODE_TITLE_MIN_MEASURE_PX).toBeGreaterThanOrEqual(96)
+  })
+
+  it('does not let the title shrink to zero (min-w-0 must not govern the title)', () => {
+    const { title } = renderTitle()
+    const wrapper = title.parentElement as HTMLElement
+
+    // `min-w-0` is precisely the rule that permits a sub-word measure.
+    expect(wrapper.className).not.toContain('min-w-0')
+    expect(wrapper.style.minWidth).not.toBe('0px')
+    expect(wrapper.style.minWidth).not.toBe('')
+  })
+
+  it('lets the header row wrap so the header slot yields instead of the title', () => {
+    const { title } = renderTitle()
+    const row = title.parentElement?.parentElement as HTMLElement
+
+    // With a minimum title measure but a non-wrapping row, the shape indicator
+    // and header slot would overflow the card instead of moving below.
+    expect(row.style.flexWrap).toBe('wrap')
+    expect(row.style.display).toBe('flex')
+  })
+
+  it('keeps break-words so a genuinely unbreakable token still wraps', () => {
+    // break-word must REMAIN: a single 40-char token with no spaces has no word
+    // boundary to wrap at, and must break rather than overflow the card.
+    const { title } = renderTitle('Supercalifragilisticexpialidociousness')
+    expect(title.className).toContain('break-words')
+  })
+
+  it('applies the contract to the exact label reported on staging f2b48fc9', () => {
+    const { title } = renderTitle(REPORTED_LABEL)
+    const wrapper = title.parentElement as HTMLElement
+
+    expect(title.textContent).toBe(REPORTED_LABEL)
+    // Bind the regression to the reported string by identity.
+    expect(wrapper.style.minWidth).toBe(`${NODE_TITLE_MIN_MEASURE_PX}px`)
+  })
+})

--- a/src/canvas/utils/nodeLayoutConstants.ts
+++ b/src/canvas/utils/nodeLayoutConstants.ts
@@ -19,6 +19,28 @@ export const NODE_LAYOUT_MIN_W = 140
 /** Maximum rendered card width. Used by BaseNode and as the ELK pinned width. */
 export const NODE_CARD_MAX_W = 320
 
+/**
+ * Minimum horizontal measure (px) reserved for a node's TITLE.
+ *
+ * `overflow-wrap: break-word` (Tailwind `break-words`) is a LAST-RESORT rule:
+ * it splits a word mid-character as soon as that word cannot fit its line box.
+ * It is therefore only as good as the measure it is given.
+ *
+ * Witnessed on deployed staging f2b48fc9 (14 Aug 2026): when a dense tier
+ * compresses cards to NODE_LAYOUT_MIN_W, the title shared its flex row with the
+ * shape indicator (14px + 6px gap) and the header slot, leaving a **77px**
+ * measure inside a 140px card. Ordinary English words are wider than that at
+ * `typography.nodeTitle` — "Coordination" ~90px, "Development" ~83px — so they
+ * broke mid-word ("Team Coordinatio / n Overhead").
+ *
+ * 96px fits a ~12-character word at the node-title size. The header row is
+ * allowed to WRAP, so the header slot moves below the title rather than the
+ * title being squeezed below a readable measure. This is a text-measure floor
+ * only: it does not change the card's width, so the rendered card still matches
+ * ELK's computed box and node spacing/collision behaviour is untouched.
+ */
+export const NODE_TITLE_MIN_MEASURE_PX = 96
+
 /** Horizontal padding added around the rendered card to form the ELK box. */
 export const LAYOUT_PADDING_X = 24
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — review only

Branch-only, as briefed. Opened for review of the diagnosis and the fix.

## Verdict

**LONG-STANDING, not a recent regression.** Reported by Paul on deployed staging **f2b48fc9**; reproduced in a real browser on that exact build.

## What Paul saw

Decision-graph node titles splitting mid-word — `Team Coordinatio / n Overhead`, `Developme / nt Headcount`.

## Root cause — a text MEASURE collapse, not a bad word-break rule

The title already carried `break-words` (`overflow-wrap: break-word`), which is the *correct* rule. But it is a **last-resort** rule: it splits a word mid-character the moment that word cannot fit its line box. It is therefore only as good as the measure it is given.

The title sat in a flex row with the shape indicator (14px + 6px gap) and the header slot, under **`min-w-0`** — which explicitly permits a flex item to collapse below its content width. When a dense tier compresses cards to `NODE_LAYOUT_MIN_W` (140px), that left a **77px** measure. Ordinary English words are wider at `typography.nodeTitle`: `Coordination` ~90px, `Development` ~83px.

`nodeLayoutConstants.ts` had already predicted this in a comment: *"nodes at this width will have heavy text wrapping."*

### Trigger condition (derived from `layout.ts:102-120`)

Compression fires when `floor((canvasWidth*0.85 - (N-1)*MIN_GAP) / N) < NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X`, i.e. **N ≥ 7 nodes in the widest tier** at the default `FALLBACK_CANVAS` width of 1300px. Factors, actions and constraints all share tier 2, so a live-drafted model reaches 7 easily. The 5-factor saved examples do **not** trigger it — which is why this needs a specific data shape, not just any graph.

## Dating — every ingredient is months old

| Ingredient | Commit | Date |
|---|---|---|
| `min-w-0` on the title wrapper | `88677f94` | 31 Mar 2026 |
| `break-words line-clamp-3` | `21d48155` | 22 Apr 2026 |
| Width-compression branch | `0b6d8ecc` | 21 May 2026 |
| `NODE_LAYOUT_MIN_W` 200 → **140** | `575b1696` | 22 May 2026 |

The proximate cause is `575b1696` ("revert PR #174"), which dropped the floor from 200 back to 140. At 200px the title measure would have been ~137px and these words would have fitted. Independently corroborated: **canvas node/layout geometry is byte-identical from 23 Jul to tip** — `layout.ts`, `nodeLayoutConstants.ts`, `layoutStore.ts`, `typography.ts` all unchanged blob hashes.

## Evidence — measured in a real browser (jsdom cannot prove layout)

Line-box spans per word via `Range.getClientRects()` on the deployed build, 16 real node cards at the product's own compressed width:

| | mid-word breaks | title measure |
|---|---|---|
| **Before** | **3 / 16** (incl. `Coordination`, `Development`, `Headcount`) | 77px |
| **After** | **0 / 16** | 96–115px |

Visual witness: before → `Team Coordinatio / n Overhead`; after → `Team / Coordination / Overhead`, with the header slot moving to its own line and **card width unchanged**.

## The fix

- `NODE_TITLE_MIN_MEASURE_PX = 96` — a documented floor, wide enough for a ~12-character word at the node-title size.
- The title wrapper gets that real minimum instead of `min-w-0`.
- The header row may **wrap**, so the header slot yields instead of the title.
- `break-words` is **retained** — a genuinely unbreakable token must still wrap rather than overflow.

**Card width is untouched**, so the rendered card still matches ELK's computed box: node spacing and collision behaviour are unchanged. This deliberately does *not* touch `NODE_LAYOUT_MIN_W` — that constant has a documented revert history (`575b1696`) and changing it would alter ELK geometry and multi-row splitting. Raising it to ~200 remains the more thorough fix and is a separate, higher-blast-radius decision for Paul.

## Verification

- **RED-first**: 4 of 5 assertions failed at pristine. The 5th (`break-words` must remain) passed by design — it guards against the fix removing it.
- **Mutants** (throwaway worktree *outside* the repo root; isolation proven by **writing a sentinel** and asserting the source was unchanged, plus distinct inodes — not by locating the path):

| Mutant | Result |
|---|---|
| Control (no mutation) | applied=0, **5 passed** |
| Restore `min-w-0`, drop `minWidth` | applied=1, **3 failed** |
| Remove `flexWrap: 'wrap'` | applied=1, **1 failed** ← discriminates: only the row-wrap assertion |
| `NODE_TITLE_MIN_MEASURE_PX` 96 → 0 | applied=1, **2 failed** |
| Trailing control | applied=0, **5 passed** |

Mutants fail on *different* assertions, so the assertions bind to distinct rules rather than agreeing with each other. Restores were `HEAD`-relative.
- Assertions bind by **identity** (`data-testid="node-title"`), never by a value predicate another element could satisfy.
- **Gates** (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported), run in CI's own step order — lint **before** typecheck:
  - `pnpm run lint` — PASS (0 errors; hooks ratchet exactly at baseline)
  - `pnpm run typecheck` — PASS. It **caught a real error** in the new spec (missing `deletable`/`selectable`/`draggable`); fixed at source, **not** absorbed into the baseline. No `--update-baseline`.
  - `pnpm run ci:guard:zustand`, `ci:guard:duplicates` — PASS
  - `src/canvas/nodes` — **36 files / 588 tests passed**; the new spec collects **5 tests by name** (asserted, not inferred from a suite total); `BaseNode.maxWidth.spec.tsx` still green.

## Disclosed limits

- `pnpm run test:coverage` (CI's named test gate) **could not run locally** — `@vitest/coverage-v8` is not installed in this environment. Full `pnpm run test:unit` was still running at the time of writing; CI is the authority.
- jsdom cannot assert layout, so the spec binds to the **CSS rule contract**; the browser measurement above is the layout evidence.
- The after-state was witnessed by applying the patch's two rules to the deployed build, not by deploying this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)