### PR TITLE
feat(2.1163 / EXT-2): render CEE's typed analysis refusal — `analysis_ready.blocked_reason` had zero readers

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -540,7 +540,7 @@
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'graph_state' does not exist on type 'TurnRequestPayload'.
 1	src/canvas/conversation/useConversation.ts	TS2339	Property 'message' does not exist on type 'TurnRequestPayload'.
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'selected_elements' does not exist on type 'TurnRequestPayload'.
-1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 250 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
+1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 252 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
 2	src/canvas/conversation/useConversation.ts	TS2352	Conversion of type 'OrchestratorResponseEnvelopeV2' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'op' is declared but its value is never read.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'ops' is declared but its value is never read.

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -38,6 +38,7 @@ import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectR
 import { resolveDisplayedFreshness } from '../store/analysisFreshness'
 import { getScenario } from '../store/scenarios'
 import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
+import { AnalysisRefusalNotice } from '../../components/results/AnalysisRefusalNotice'
 import { DecisionOverviewCard } from '../../components/results/decision-overview/DecisionOverviewCard'
 import { isDecisionOverviewEnabled } from '../../flags'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
@@ -2616,6 +2617,27 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 {isDecisionOverviewEnabled() && !isPreRun && hasInlineSummary && resultsSectionData && (
                   <DecisionOverviewCard title={overviewTitle} />
                 )}
+                {/* ROADMAP 2.1163 / EXT-2 — CEE's typed analysis refusal
+                    (`analysis_ready.blocked_reason`, PR #942), which had ZERO
+                    readers repo-wide until this mount.
+
+                    ⚠ DELIBERATELY NOT GATED ON `!isPreRun && hasInlineSummary &&
+                    resultsSectionData` like its neighbours. Those gates mean
+                    "there are results to decorate"; a refused analysis is
+                    exactly the case where there are NONE, so borrowing them
+                    would hide the notice in the state it exists to explain —
+                    and a user who asked for an analysis and got silence is the
+                    harm this row closes. The component owns its own gate
+                    (renders null when the slice is empty), so this costs one
+                    primitive-selector subscription and nothing else.
+
+                    It sits ABOVE the dim wrapper for the same reason the
+                    freshness strip does: the signal must never be inside an
+                    aria-disabled region. It is a SIBLING of DecisionOverview-
+                    Card, not a state of it — that card's `liveState` derivation
+                    is untouched ('unassessed'/collapsed on a cleared readiness
+                    slice is correct, per the 2026-08-14 deployed-UI trace). */}
+                <AnalysisRefusalNotice />
                 {/* The freshness strip states fresh/stale/unknown (informational
                     only — the anchor footer below owns the Rerun). It mounts
                     ABOVE the dim wrapper at full opacity so the freshness signal

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -22,6 +22,7 @@ import {
 import { trackResultsViewed, trackIssuesOpened } from './utils/sandboxTelemetry'
 import { addRun, generateGraphHash, loadRuns, type StoredRun, type RestorableRun } from './store/runHistory'
 import { RUN_COMPLETED_WITHOUT_VERDICT, VERDICT_ABSENT_FROM_PAYLOAD, deriveAnalysisFreshnessUpdate, type AnalysisFreshnessState } from './store/analysisFreshness'
+import type { AnalysisRefusalNotice } from './store/analysisRefusalNotice'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
 // Value import, and deliberately so: `resetCanvas` must forget the persisted
@@ -478,6 +479,13 @@ interface CanvasState {
   // fabricating 'stale'. Cleared when a new analysis_ready arrives or on
   // scenario switch/load/import/reset. NOT a graph hash; see analysisFreshness.ts.
   analysisFreshnessDirty: boolean
+  // ROADMAP 2.1163 / EXT-2: CEE's TYPED analysis refusal (analysis_ready
+  // status 'blocked' + a specific blocked_reason). Deliberately NOT the
+  // readiness slice — the readiness normaliser rejects that carrier on
+  // purpose, and that rejection is load-bearing. Session-local — never
+  // persisted: a refusal is a fact about ONE turn, so restoring it into a
+  // later session would assert a refusal that did not happen there.
+  analysisRefusalNotice: AnalysisRefusalNotice | null
   /**
    * Interim 2.467 mitigation (P0 trust, live-witnessed 2026-08-04,
    * rewalk-2459b attempt 2): true while the canvas graph came from a local
@@ -891,6 +899,8 @@ interface CanvasState {
   setV5AnalysisFact: (fact: V5AnalysisFactState | null) => void
   /** Update the freshness slice from a raw response.analysis_ready (retain / order-by-computed_at / never absence→fresh). */
   setAnalysisFreshness: (rawAnalysisReady: unknown) => void
+  /** ROADMAP 2.1163 / EXT-2: set or clear CEE's typed analysis-refusal notice. Pass null to clear. Never persisted. */
+  setAnalysisRefusalNotice: (notice: AnalysisRefusalNotice | null) => void
   /** Public dirty-overlay setter for external graph mutators (e.g. accepted CEE graph patches) that bypass the internal edit chokepoints. */
   markAnalysisFreshnessDirty: () => void
   /** Atomically set all three staleness flags — the entry point for external structural mutators. */
@@ -1682,6 +1692,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   analysisFreshness: null,
   // Local dirty overlay — false at cold start (no edits to invalidate a verdict).
   analysisFreshnessDirty: false,
+  // ROADMAP 2.1163 / EXT-2: no analysis has been refused at cold start.
+  analysisRefusalNotice: null,
   // Interim 2.467: no import has happened at cold start.
   importPendingServerRegistration: false,
   // No edit can be awaiting dispatch before any edit has been made.
@@ -2587,6 +2599,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // overlay (no pending edit applies to a brand-new graph).
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // ROADMAP 2.1163 / EXT-2: a refusal describes ONE turn against ONE model.
+      // Carrying it across an import/reset/scenario switch would claim a refusal
+      // that never happened for the model now on the canvas.
+      analysisRefusalNotice: null,
       // Interim 2.467 mitigation (P0 trust, rewalk-2459b attempt 2): an import
       // must never leave a pre-import analysis renderable-as-current. The
       // pre-import results re-bound BY NODE ID to the imported graph's labels
@@ -2917,6 +2933,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // that only agreed with the spread by coincidence.)
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // ROADMAP 2.1163 / EXT-2: a refusal describes ONE turn against ONE model.
+      // Carrying it across an import/reset/scenario switch would claim a refusal
+      // that never happened for the model now on the canvas.
+      analysisRefusalNotice: null,
       // Interim 2.467 — release. ⚠ NOT derived (same correction as the
       // empty-graph branch above): resetCanvas installs an EMPTY graph, for
       // which the digest is null by the empty-graph rule, so a derivation here
@@ -3901,6 +3921,10 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // cannot leak into this one.
       analysisFreshness: null,
       analysisFreshnessDirty: false,
+      // ROADMAP 2.1163 / EXT-2: a refusal describes ONE turn against ONE model.
+      // Carrying it across an import/reset/scenario switch would claim a refusal
+      // that never happened for the model now on the canvas.
+      analysisRefusalNotice: null,
       // Interim 2.467, DERIVED: `scenarios.getScenario` is localStorage, not
       // the server — a scenario saved while an imported graph was on the canvas
       // restores an unregistered graph. Derive from what is being installed.
@@ -4433,6 +4457,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
 
   setV5AnalysisFact: (fact: V5AnalysisFactState | null) => {
     set({ v5AnalysisFact: fact })
+  },
+
+  // ROADMAP 2.1163 / EXT-2. Deliberately a plain assignment with NO
+  // sessionStorage/localStorage write: this store has no persist() middleware,
+  // so persistence is opt-in per setter (contrast setCeeAnalysisReady, which
+  // writes 'olumi-cee-analysis-ready'). Adding a write here — or adding this
+  // field to the autosave projection — would restore a refusal into a session
+  // where no analysis was refused.
+  setAnalysisRefusalNotice: (notice: AnalysisRefusalNotice | null) => {
+    set({ analysisRefusalNotice: notice })
   },
 
   setAnalysisFreshness: (rawAnalysisReady: unknown) => {
@@ -5483,6 +5517,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       // dirty overlay so neither leaks from the previous graph/scenario.
       updates.analysisFreshness = null
       updates.analysisFreshnessDirty = false
+      // ROADMAP 2.1163 / EXT-2 — same argument as the verdict: a refusal
+      // belongs to the graph it was refused for.
+      updates.analysisRefusalNotice = null
       // Interim 2.467, DERIVED (see the field's doc): this path's live callers
       // pass the localStorage AUTOSAVE or loadState() — NOT a server-known
       // graph. Re-deriving from the graph being installed is what makes a

--- a/src/canvas/store/__tests__/analysisRefusalNotice.spec.ts
+++ b/src/canvas/store/__tests__/analysisRefusalNotice.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * ROADMAP 2.1163 / golden-journey EXT-2 — the analysis-refusal notice slice.
+ *
+ * CEE PR #942 puts a TYPED analysis refusal on the wire:
+ *
+ *   analysis_ready: { status: 'blocked', blocked_reason: <specific>, options: [],
+ *                     goal_node_id: '', freshness, freshness_reason, computed_at }
+ *
+ * `blocked_reason` had ZERO readers repo-wide. An honest refusal nobody renders
+ * is indistinguishable from a silent failure, so this slice is the reader.
+ *
+ * ⚠ THE LOAD-BEARING DISTINCTION — TWO `status: 'blocked'` CARRIERS EXIST, and
+ * only one of them is a refusal. Derived at the CEE bytes (PR #942 head
+ * 2ca6c079), not inferred:
+ *
+ *   1. REFUSAL   `buildAnalysisRefusalReadiness()`
+ *                src/orchestrator/tools/analysis-ready-helper.ts:400-409
+ *                -> ALWAYS carries a non-empty `blocked_reason`.
+ *   2. LEGACY    `synthesiseFreshnessOnlyAnalysisReady()`
+ *                src/orchestrator-v5/compose/analysis-ready-emit.ts:59-61
+ *                -> `{ status:'blocked', goal_node_id:'', options:[], bias_findings:[] }`
+ *                   and NO `blocked_reason`. It is a freshness carrier emitted on
+ *                   legacy/unparseable RELOADS — it says nothing about a refusal.
+ *
+ * Treating (2) as a refusal would fabricate "this analysis did not run" on every
+ * legacy reload. The discriminator is therefore the PRESENCE of a non-empty
+ * `blocked_reason`, never `status` alone. Carrier (2) is already pinned by
+ * `src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx`.
+ *
+ * The readiness slice's rejection of this carrier is DELIBERATE and unchanged
+ * (applyV5State normaliseV5AnalysisReady rejects empty goal_node_id/options);
+ * this slice is a separate, session-local field, never persisted.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  deriveAnalysisRefusalNoticeUpdate,
+  describeAnalysisRefusalReason,
+  ANALYSIS_REFUSAL_REASON_COPY,
+  type AnalysisRefusalNoticeUpdate,
+} from '../analysisRefusalNotice'
+
+/** Exact CEE refusal wire shape (buildAnalysisRefusalReadiness + attachComputedAt). */
+function refusalPayload(blockedReason: string) {
+  return {
+    status: 'blocked',
+    blocked_reason: blockedReason,
+    options: [] as unknown[],
+    goal_node_id: '',
+    freshness: 'stale',
+    freshness_reason: 'graph_changed_since_run',
+    computed_at: '2026-08-14T10:00:00.000Z',
+  }
+}
+
+/** Exact CEE legacy freshness-only carrier (synthesiseFreshnessOnlyAnalysisReady). */
+const LEGACY_FRESHNESS_ONLY_CARRIER = {
+  status: 'blocked',
+  goal_node_id: '',
+  options: [] as unknown[],
+  bias_findings: [] as unknown[],
+  computed_at: '2026-07-07T10:00:00.000Z',
+  freshness: 'unknown',
+  freshness_reason: 'legacy_fact_missing_hash',
+}
+
+function responseWith(analysisReady: unknown, blocks: unknown[] = []) {
+  return { analysis_ready: analysisReady, blocks }
+}
+
+describe('deriveAnalysisRefusalNoticeUpdate — the two blocked carriers', () => {
+  it('SETS a notice for the typed refusal carrier (blocked + non-empty blocked_reason)', () => {
+    const update = deriveAnalysisRefusalNoticeUpdate(
+      responseWith(refusalPayload('mixed_scale_unresolved')),
+    )
+
+    expect(update).toEqual<AnalysisRefusalNoticeUpdate>({
+      kind: 'set',
+      notice: {
+        blockedReason: 'mixed_scale_unresolved',
+        computedAt: '2026-08-14T10:00:00.000Z',
+      },
+    })
+  })
+
+  it('RETAINS (never sets) for the LEGACY freshness-only blocked carrier — no blocked_reason', () => {
+    // The opposite-direction twin. A legacy reload is not an analysis refusal;
+    // claiming "this analysis did not run" here would be a fabrication.
+    const update = deriveAnalysisRefusalNoticeUpdate(
+      responseWith(LEGACY_FRESHNESS_ONLY_CARRIER),
+    )
+
+    expect(update.kind).toBe('retain')
+  })
+
+  it('RETAINS for a blocked carrier whose blocked_reason is whitespace-only or non-string', () => {
+    expect(deriveAnalysisRefusalNoticeUpdate(
+      responseWith({ ...refusalPayload('x'), blocked_reason: '   ' }),
+    ).kind).toBe('retain')
+    expect(deriveAnalysisRefusalNoticeUpdate(
+      responseWith({ ...refusalPayload('x'), blocked_reason: 42 }),
+    ).kind).toBe('retain')
+  })
+
+  it('CLEARS on an accepted (non-blocked) analysis_ready — CEE stated readiness', () => {
+    const update = deriveAnalysisRefusalNoticeUpdate(
+      responseWith({
+        status: 'ready',
+        goal_node_id: 'goal_1',
+        options: [{ id: 'opt_1', interventions: {} }],
+        computed_at: '2026-08-14T11:00:00.000Z',
+      }),
+    )
+
+    expect(update.kind).toBe('clear')
+  })
+
+  it('CLEARS on a successful analysis_result block with no analysis_ready key', () => {
+    const update = deriveAnalysisRefusalNoticeUpdate(
+      responseWith(undefined, [{ type: 'analysis_result' }]),
+    )
+
+    expect(update.kind).toBe('clear')
+  })
+
+  it('RETAINS on an ordinary conversational turn (no analysis_ready, no analysis_result)', () => {
+    // Retention is what makes the notice survive the turns AFTER the refusal.
+    expect(deriveAnalysisRefusalNoticeUpdate(
+      responseWith(undefined, [{ type: 'coaching' }]),
+    ).kind).toBe('retain')
+  })
+
+  it('RETAINS on malformed input rather than clearing or fabricating', () => {
+    expect(deriveAnalysisRefusalNoticeUpdate(null).kind).toBe('retain')
+    expect(deriveAnalysisRefusalNoticeUpdate(undefined).kind).toBe('retain')
+    expect(deriveAnalysisRefusalNoticeUpdate('nonsense').kind).toBe('retain')
+    expect(deriveAnalysisRefusalNoticeUpdate(responseWith('not-an-object')).kind).toBe('retain')
+  })
+
+  it('carries computedAt as null when CEE omitted it (never fabricates a timestamp)', () => {
+    const payload = refusalPayload('analysis_engine_busy') as Record<string, unknown>
+    delete payload.computed_at
+    const update = deriveAnalysisRefusalNoticeUpdate(responseWith(payload))
+
+    expect(update).toEqual<AnalysisRefusalNoticeUpdate>({
+      kind: 'set',
+      notice: { blockedReason: 'analysis_engine_busy', computedAt: null },
+    })
+  })
+})
+
+describe('describeAnalysisRefusalReason — mapped vocabulary derived from the CEE producer', () => {
+  /**
+   * Vocabulary derived at the CEE bytes, NOT from our own reading (trap 13c):
+   *   blockedReasonForHandlerFailure() (handler-errors.ts:196-202) returns
+   *   `details.reason_code` when present, else `cause_kind`.
+   * Scope is `run_analysis` ONLY (ANALYSE_HANDLER_ID, handler-errors.ts:173).
+   */
+  const CAUSE_KINDS_REACHABLE_FROM_RUN_ANALYSIS = [
+    // (cause_kinds run_analysis throws) INTERSECT RECOVERABLE_HANDLER_CAUSES
+    'args_validation_failed',
+    'analysis_not_ready',
+    'options_not_configured',
+    'analysis_engine_busy',
+    'analysis_blocked',
+  ] as const
+
+  const REASON_CODES_REACHABLE_FROM_RUN_ANALYSIS = [
+    // scale block (plot-intervention-scale.ts:808-833, run-analysis.ts:541/612)
+    'mixed_scale_unresolved',
+    'baseline_scale_unresolved',
+    'scale_postcondition_violated',
+    // ReadinessReasonCode (analysis-ready-core.ts:53-66) via run-analysis.ts:313
+    'NO_CAP_UNRECOVERABLE',
+    'UNIT_MISMATCH',
+    'OPTION_INTERVENTION_UNRESOLVABLE',
+    'OPTIONS_NOT_CONFIGURED',
+    'SCHEMA_INVALID',
+    'NO_GRAPH',
+    'INTERNAL_ERROR',
+    // StructuralViolationCode (graph-structure-validator.ts:22-32)
+    'ORPHAN_NODE',
+    'NO_PATH_TO_GOAL',
+    'CYCLE_DETECTED',
+    'NODE_LIMIT_EXCEEDED',
+    'EDGE_LIMIT_EXCEEDED',
+    'NO_GOAL',
+    'NO_DECISION',
+    'FEWER_THAN_TWO_OPTIONS',
+    'OPTION_NO_FACTOR_EDGES',
+    'OPTION_NOT_LINKED_TO_DECISION',
+  ] as const
+
+  it.each(CAUSE_KINDS_REACHABLE_FROM_RUN_ANALYSIS)(
+    'maps the reachable cause_kind %s to specific copy',
+    (code) => {
+      const copy = describeAnalysisRefusalReason(code)
+      expect(copy).toBeTypeOf('string')
+      expect((copy as string).length).toBeGreaterThan(0)
+    },
+  )
+
+  it.each(REASON_CODES_REACHABLE_FROM_RUN_ANALYSIS)(
+    'maps the reachable reason_code %s to specific copy',
+    (code) => {
+      const copy = describeAnalysisRefusalReason(code)
+      expect(copy).toBeTypeOf('string')
+      expect((copy as string).length).toBeGreaterThan(0)
+    },
+  )
+
+  /**
+   * ⚠ CORRECTED PREMISE, and the correction is load-bearing.
+   *
+   * The lane brief listed `parameter_invalid_at_execute` as an example
+   * blocked_reason. It is in RECOVERABLE_HANDLER_CAUSES but `run_analysis`
+   * NEVER throws it — the D1 mutation handlers do (set_factor_value /
+   * add_constraint / adjust_edge_strength). CEE turn-executor.ts:8684-8697
+   * documents this BY NAME as the defect an adversarial review caught: a
+   * failed CONSTRAINT EDIT emitting `blocked_reason:
+   * 'parameter_invalid_at_execute'` was "a false claim that the ANALYSIS is
+   * blocked", and the ANALYSE_HANDLER_ID gate was added to remove it.
+   *
+   * Mapping these to specific ANALYSIS copy here would re-assert exactly the
+   * claim #942 deleted, one layer up. They stay UNMAPPED on purpose.
+   */
+  const D1_CAUSES_NOT_REACHABLE_ON_THIS_CARRIER = [
+    'parameter_invalid_at_execute',
+    'entity_not_found_in_graph',
+    'entity_kind_mismatch_at_execute',
+    'precondition_unmet_at_execute',
+  ] as const
+
+  it.each(D1_CAUSES_NOT_REACHABLE_ON_THIS_CARRIER)(
+    'leaves the D1 mutation cause %s UNMAPPED (never fabricates analysis-specific copy)',
+    (code) => {
+      expect(describeAnalysisRefusalReason(code)).toBeNull()
+      expect(ANALYSIS_REFUSAL_REASON_COPY).not.toHaveProperty(code)
+    },
+  )
+
+  it('returns null for an unknown code rather than a fabricated specific', () => {
+    expect(describeAnalysisRefusalReason('a_brand_new_cee_code')).toBeNull()
+    expect(describeAnalysisRefusalReason('')).toBeNull()
+  })
+
+  it('matches producer tokens EXACTLY — no case-folding onto a specific meaning', () => {
+    // The producer emits both SCREAMING_SNAKE (ReadinessReasonCode) and
+    // lower_snake (cause_kind / scale reason_code). Case-folding would let an
+    // unknown variant inherit a specific sentence it was never entitled to.
+    expect(describeAnalysisRefusalReason('NO_GRAPH')).toBeTypeOf('string')
+    expect(describeAnalysisRefusalReason('no_graph')).toBeNull()
+    expect(describeAnalysisRefusalReason('MIXED_SCALE_UNRESOLVED')).toBeNull()
+    expect(describeAnalysisRefusalReason('mixed_scale_unresolved')).toBeTypeOf('string')
+  })
+
+  it('never instructs a control this surface does not render', () => {
+    // #684 review, D2: copy may name a LOCATION or a model fact, never a button
+    // the notice does not offer. CEE owns the recovery chip, in the chat.
+    for (const copy of Object.values(ANALYSIS_REFUSAL_REASON_COPY)) {
+      expect(copy).not.toMatch(/\bclick\b|\bpress\b|\btap\b|\bbutton\b/i)
+    }
+  })
+
+  it('avoids amber "proceed with care" vocabulary (row 2.1127 is correcting that family)', () => {
+    for (const copy of Object.values(ANALYSIS_REFUSAL_REASON_COPY)) {
+      expect(copy).not.toMatch(/proceed with care|use caution|treat .* with care/i)
+    }
+  })
+})

--- a/src/canvas/store/analysisRefusalNotice.ts
+++ b/src/canvas/store/analysisRefusalNotice.ts
@@ -1,0 +1,233 @@
+/**
+ * Analysis-refusal notice slice — sourced ONLY from a TYPED refusal on
+ * `response.analysis_ready` (CEE PR #942, ROADMAP 2.1085 root 2.1041 / EXT-2).
+ *
+ * WHY THIS SLICE EXISTS, AND WHY IT IS NOT THE READINESS SLICE
+ * ------------------------------------------------------------
+ * CEE now emits, on a refused analyse turn:
+ *
+ *   analysis_ready: { status: 'blocked', blocked_reason: <specific code>,
+ *                     options: [], goal_node_id: '', freshness, computed_at }
+ *
+ * `applyV5State`'s readiness normaliser REJECTS that carrier (empty
+ * `goal_node_id` / empty `options`) and clears `ceeAnalysisReady`. That
+ * rejection is CORRECT and deliberate — a deployed-UI trace (2026-08-14)
+ * established the clearing kills two harms, and the R1-R3 dynamics are
+ * premised on it. So the refusal is NOT routed back into readiness. It gets
+ * this separate, lightweight, SESSION-LOCAL field instead, extracted from the
+ * raw payload before validation.
+ *
+ * ⚠ TWO DISTINCT `status: 'blocked'` CARRIERS EXIST — derived at the CEE bytes
+ * (PR #942 head 2ca6c079), not inferred. Only one is a refusal:
+ *
+ *   1. REFUSAL  `buildAnalysisRefusalReadiness()`
+ *               src/orchestrator/tools/analysis-ready-helper.ts:400-409
+ *               ALWAYS carries a non-empty `blocked_reason`.
+ *   2. LEGACY   `synthesiseFreshnessOnlyAnalysisReady()`
+ *               src/orchestrator-v5/compose/analysis-ready-emit.ts:59-61
+ *               `{ status:'blocked', goal_node_id:'', options:[], bias_findings:[] }`
+ *               and NO `blocked_reason` — a freshness carrier emitted on
+ *               legacy/unparseable RELOADS. It says nothing about a refusal.
+ *
+ * The discriminator is therefore the PRESENCE of a non-empty `blocked_reason`,
+ * never `status` alone. Keying on `status === 'blocked'` would fabricate "this
+ * analysis did not run" on every legacy reload — a surface claiming a refusal
+ * that never happened. Carrier (2) is pinned by
+ * `src/v5/__tests__/applyV5State.blockedAnalysisReady.spec.tsx`.
+ *
+ * NEVER PERSISTED. The canvas store has no `persist()` middleware — persistence
+ * is opt-in per setter (sessionStorage in `setCeeAnalysisReady`, the autosave
+ * projection allow-list). This field is deliberately in none of them: a refusal
+ * is a fact about ONE turn, and restoring it into a later session would assert
+ * a refusal that did not occur in that session.
+ */
+
+/** What CEE told us about the refusal. Technical fields — never user copy. */
+export interface AnalysisRefusalNotice {
+  /** CEE's `blocked_reason`, verbatim. Machine-readable; shown only in the details disclosure. */
+  readonly blockedReason: string
+  /** CEE's `computed_at` when present. Debug/ordering only — never fabricated. */
+  readonly computedAt: string | null
+}
+
+/**
+ * Three-valued because "no determination" is a real, distinct outcome and
+ * collapsing it into `clear` would drop the notice on the very next
+ * conversational turn — i.e. before the user had a chance to read it.
+ */
+export type AnalysisRefusalNoticeUpdate =
+  | { kind: 'set'; notice: AnalysisRefusalNotice }
+  | { kind: 'clear' }
+  | { kind: 'retain' }
+
+/** Past tense, factual. States what happened; claims nothing about why on its own. */
+export const ANALYSIS_REFUSAL_HEADLINE = 'This analysis did not run.'
+
+/**
+ * Honest generic for an unmapped code. Deliberately says LESS than the mapped
+ * lines: an unrecognised code is not licence to guess a specific cause.
+ */
+export const ANALYSIS_REFUSAL_GENERIC_REASON =
+  'The analysis was stopped before it ran.'
+
+/**
+ * The one pointer line. TRUE BY CONSTRUCTION, not by convention: CEE's
+ * `composeHandlerFailureBody` sets `assistant_text` on EVERY recoverable
+ * branch (handler-failure-responses.ts:72-330), and the recovery chip lives
+ * in that reply. So this names a LOCATION that always exists rather than
+ * instructing a control this notice does not render (#684 review, D2).
+ */
+export const ANALYSIS_REFUSAL_POINTER =
+  "The assistant's reply explains the next step."
+
+/**
+ * `blocked_reason` -> ONE precise, actionable sentence.
+ *
+ * ⚠ EVERY KEY IS DERIVED FROM THE CEE PRODUCER, NEVER FROM OUR OWN READING OF
+ * WHAT A FIELD "OUGHT" TO MEAN (CLAUDE.md trap 13c). `blockedReasonForHandler-
+ * Failure` (handler-errors.ts:196-202) returns `details.reason_code` when
+ * present, else the typed `cause_kind`; the scope gate is `run_analysis` only
+ * (ANALYSE_HANDLER_ID, handler-errors.ts:173). Sentences are aligned with the
+ * copy CEE puts in the chat for the same code, so the two surfaces cannot
+ * contradict each other.
+ *
+ * ⚠ LOOKUP IS EXACT, NEVER CASE-FOLDED. The producer emits both
+ * SCREAMING_SNAKE (ReadinessReasonCode / StructuralViolationCode) and
+ * lower_snake (cause_kind / scale reason_code). Folding case would let an
+ * unrecognised variant inherit a specific sentence it was never entitled to —
+ * the fabrication this whole slice exists to prevent.
+ *
+ * ⚠ DELIBERATELY ABSENT: `parameter_invalid_at_execute`,
+ * `entity_not_found_in_graph`, `entity_kind_mismatch_at_execute`,
+ * `precondition_unmet_at_execute`. They are on RECOVERABLE_HANDLER_CAUSES but
+ * `run_analysis` never throws them — the D1 mutation handlers do. CEE
+ * turn-executor.ts:8684-8697 records that emitting a blocked analysis readiness
+ * for them was "a false claim that the ANALYSIS is blocked", and added the
+ * ANALYSE_HANDLER_ID gate to stop it. Giving them analysis-specific copy here
+ * would re-assert that exact claim one layer up. They fall to the generic.
+ */
+export const ANALYSIS_REFUSAL_REASON_COPY: Readonly<Record<string, string>> = {
+  // ── cause_kind fallbacks reachable from run_analysis ──────────────────
+  // (run_analysis throws) INTERSECT RECOVERABLE_HANDLER_CAUSES
+  args_validation_failed:
+    'The analysis request was not valid, so nothing was computed.',
+  analysis_not_ready:
+    'Your model needs a change before it can be analysed.',
+  options_not_configured:
+    "Your options don't have intervention values yet, so there was nothing to compare.",
+  analysis_engine_busy:
+    'The analysis engine was busy with other runs. Nothing is wrong with your model.',
+  analysis_blocked:
+    'The analysis engine could not proceed with this scenario as it stands.',
+
+  // ── reason_code, scale family (plot-intervention-scale.ts:808-833) ────
+  mixed_scale_unresolved:
+    'Your option values mix different scales, and the analysis could not tell which was meant.',
+  baseline_scale_unresolved:
+    'The baseline for one or more option values could not be established, so their scale was ambiguous.',
+  scale_postcondition_violated:
+    'The option values did not resolve to a consistent scale.',
+
+  // ── reason_code, ReadinessReasonCode (analysis-ready-core.ts:53-66) ───
+  OPTIONS_NOT_CONFIGURED:
+    "Your options don't have intervention values yet, so there was nothing to compare.",
+  NO_GRAPH: 'There is no saved model to analyse yet.',
+  SCHEMA_INVALID: 'The saved model could not be read.',
+  UNIT_MISMATCH: 'Your option values use units that do not match.',
+  NO_CAP_UNRECOVERABLE:
+    'An option value has no upper bound to scale against.',
+  OPTION_INTERVENTION_UNRESOLVABLE:
+    "An option's effect could not be resolved to a value.",
+  INTERNAL_ERROR:
+    'The analysis stopped on an internal error. This is on our side, not your model.',
+
+  // ── reason_code, StructuralViolationCode (graph-structure-validator.ts:22-32)
+  NO_GOAL: 'The model has no goal, so there was nothing to analyse towards.',
+  NO_DECISION: 'The model has no decision to analyse.',
+  FEWER_THAN_TWO_OPTIONS:
+    'The decision needs at least two options before they can be compared.',
+  NO_PATH_TO_GOAL:
+    'No option connects to the goal through the model, so there was nothing to compute.',
+  CYCLE_DETECTED:
+    'The model contains a circular chain of influence, which the analysis cannot resolve.',
+  ORPHAN_NODE: 'The model has a node that is not connected to anything.',
+  OPTION_NO_FACTOR_EDGES:
+    'An option is not linked to any factor, so it has no measurable effect.',
+  OPTION_NOT_LINKED_TO_DECISION: 'An option is not linked to the decision.',
+  NODE_LIMIT_EXCEEDED: 'The model has more nodes than the analysis can handle.',
+  EDGE_LIMIT_EXCEEDED:
+    'The model has more connections than the analysis can handle.',
+}
+
+/**
+ * The mapped sentence for a `blocked_reason`, or `null` when the code is not in
+ * the derived vocabulary. `null` means "say the honest generic and disclose the
+ * raw code" — never "invent a plausible specific".
+ */
+export function describeAnalysisRefusalReason(
+  blockedReason: string,
+): string | null {
+  return Object.prototype.hasOwnProperty.call(
+    ANALYSIS_REFUSAL_REASON_COPY,
+    blockedReason,
+  )
+    ? ANALYSIS_REFUSAL_REASON_COPY[blockedReason]
+    : null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/**
+ * Decide what this turn says about a refusal.
+ *
+ *   set    — a typed refusal carrier (blocked + non-empty blocked_reason).
+ *   clear  — CEE stated readiness (a non-blocked analysis_ready), or a run
+ *            produced an analysis_result. Either supersedes a prior refusal.
+ *   retain — everything else, including the LEGACY blocked carrier and any
+ *            malformed input. Silence is not evidence that the refusal is over.
+ *
+ * Total over unknown input by construction: anything unrecognised retains.
+ */
+export function deriveAnalysisRefusalNoticeUpdate(
+  response: unknown,
+): AnalysisRefusalNoticeUpdate {
+  const envelope = asRecord(response)
+  if (!envelope) return { kind: 'retain' }
+
+  const raw = asRecord(envelope.analysis_ready)
+  if (raw) {
+    if (raw.status !== 'blocked') {
+      // CEE spoke about readiness and did not refuse — any prior refusal is
+      // superseded. (Includes 'ready', 'needs_user_mapping', 'needs_encoding'.)
+      return { kind: 'clear' }
+    }
+    const reason = raw.blocked_reason
+    if (typeof reason === 'string' && reason.trim().length > 0) {
+      const computedAt = raw.computed_at
+      return {
+        kind: 'set',
+        notice: {
+          blockedReason: reason,
+          computedAt: typeof computedAt === 'string' ? computedAt : null,
+        },
+      }
+    }
+    // Blocked with NO reason = the legacy freshness-only carrier. It is not a
+    // refusal statement, so it neither sets nor clears one.
+    return { kind: 'retain' }
+  }
+
+  const blocks = envelope.blocks
+  if (Array.isArray(blocks)) {
+    for (const block of blocks) {
+      const b = asRecord(block)
+      if (b?.type === 'analysis_result') return { kind: 'clear' }
+    }
+  }
+
+  return { kind: 'retain' }
+}

--- a/src/components/results/AnalysisRefusalNotice.tsx
+++ b/src/components/results/AnalysisRefusalNotice.tsx
@@ -1,0 +1,111 @@
+/**
+ * AnalysisRefusalNotice — the reader for CEE's TYPED analysis refusal.
+ *
+ * ROADMAP 2.1163 / golden-journey EXT-2. CEE PR #942 puts
+ * `analysis_ready: { status: 'blocked', blocked_reason: <specific code>, ... }`
+ * on the wire for a refused analyse turn. Until this component,
+ * `blocked_reason` had ZERO readers repo-wide — and an honest refusal that
+ * nobody renders is indistinguishable, to the user, from a silent failure.
+ *
+ * WHAT IT SAYS, AND WHY IN THAT ORDER
+ *   1. that the analysis did not run — past tense, factual, no hedging;
+ *   2. ONE precise reason, mapped from `blocked_reason` at the CEE producer's
+ *      declared semantics (see analysisRefusalNotice.ts — trap 13c: expectations
+ *      are derived from the PRODUCER, never from our own reading of a field);
+ *   3. where the next step is. It names the assistant's reply — a LOCATION that
+ *      always exists (CEE's composeHandlerFailureBody sets `assistant_text` on
+ *      every recoverable branch) — rather than instructing a control this notice
+ *      does not render (#684 review, D2).
+ *
+ * An UNMAPPED code gets the honest generic plus the raw code in a details
+ * disclosure. It never gets a fabricated specific: guessing which cause a new
+ * CEE code represents is precisely the confident wrongness this row exists to
+ * end. The raw code is technical — it appears as user-visible text ONLY in that
+ * disclosure, and never when the code is mapped.
+ *
+ * TONE: neutral-informational. Deliberately NOT the amber "proceed with care"
+ * family that ROADMAP 2.1127 is correcting, and deliberately not alarm-red
+ * either — "the engine was busy, nothing is wrong with your model" is one of
+ * the reachable reasons, and a danger tone would contradict its own sentence.
+ *
+ * SEPARATE FROM THE READINESS SURFACES BY DESIGN. `DecisionOverviewCard`'s
+ * `liveState` derivation is untouched: a cleared `ceeAnalysisReady` correctly
+ * yields 'unassessed'/collapsed there (verified against a deployed-UI trace,
+ * 2026-08-14). This notice is a sibling element, not a state of that card.
+ */
+import { useCanvasStore } from '@/canvas/store'
+import { typography } from '@/styles/typography'
+import {
+  ANALYSIS_REFUSAL_GENERIC_REASON,
+  ANALYSIS_REFUSAL_HEADLINE,
+  ANALYSIS_REFUSAL_POINTER,
+  describeAnalysisRefusalReason,
+  type AnalysisRefusalNotice as AnalysisRefusalNoticeState,
+} from '@/canvas/store/analysisRefusalNotice'
+
+export interface AnalysisRefusalNoticeProps {
+  /** Override the store slice (tests / Storybook). `undefined` → read the store. */
+  notice?: AnalysisRefusalNoticeState | null
+  className?: string
+}
+
+export function AnalysisRefusalNotice({
+  notice: noticeProp,
+  className = '',
+}: AnalysisRefusalNoticeProps) {
+  // Primitive selector (one field, referentially stable) — required by
+  // `ci:guard:zustand`, which fails a bare object selector.
+  const storeNotice = useCanvasStore((s) => s.analysisRefusalNotice)
+  const notice = noticeProp !== undefined ? noticeProp : storeNotice
+
+  // Never assert a refusal we do not hold.
+  if (!notice) return null
+
+  const mappedReason = describeAnalysisRefusalReason(notice.blockedReason)
+
+  return (
+    <div
+      data-testid="analysis-refusal-notice"
+      // Technical provenance for tests/debug — never user copy.
+      data-blocked-reason={notice.blockedReason}
+      data-reason-mapped={mappedReason ? 'true' : 'false'}
+      data-computed-at={notice.computedAt ?? undefined}
+      role="status"
+      className={`flex items-start gap-2 rounded-md border border-panel-border bg-panel px-3 py-2 ${className}`.trim()}
+    >
+      <span
+        className="flex-none mt-1.5 w-2 h-2 rounded-full bg-text-light"
+        aria-hidden="true"
+        data-testid="analysis-refusal-dot"
+      />
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        <span className={`${typography.panelBody} text-text-header`}>
+          {ANALYSIS_REFUSAL_HEADLINE}
+        </span>
+        <span className={`${typography.panelBody} text-text-body`}>
+          {mappedReason ?? ANALYSIS_REFUSAL_GENERIC_REASON}
+        </span>
+        <span className={`${typography.caption} text-text-light`}>
+          {ANALYSIS_REFUSAL_POINTER}
+        </span>
+        {/* Unmapped only. Disclosing the code we could not interpret is the
+            honest alternative to guessing what it meant. */}
+        {!mappedReason && (
+          <details className="mt-1">
+            <summary className={`${typography.caption} text-text-light cursor-pointer`}>
+              Details
+            </summary>
+            <code
+              data-testid="analysis-refusal-raw-reason"
+              className={`${typography.caption} text-text-light break-all`}
+            >
+              {notice.blockedReason}
+            </code>
+          </details>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AnalysisRefusalNotice

--- a/src/components/results/__tests__/AnalysisRefusalNotice.spec.tsx
+++ b/src/components/results/__tests__/AnalysisRefusalNotice.spec.tsx
@@ -1,0 +1,124 @@
+/**
+ * ROADMAP 2.1163 / golden-journey EXT-2 — the refusal notice, rendered.
+ *
+ * `analysis_ready.blocked_reason` had ZERO readers repo-wide. This is the
+ * surface that reads it. What the spec pins:
+ *
+ *  1. no notice in the slice -> renders NOTHING (never claims a refusal);
+ *  2. a mapped code -> the past-tense headline + ONE precise reason + the
+ *     pointer, and the raw machine code is NEVER user copy;
+ *  3. an UNMAPPED code -> the honest generic + the raw code in a details
+ *     disclosure — never a fabricated specific;
+ *  4. NOT amber "proceed with care" vocabulary (row 2.1127 corrects that
+ *     family) and no instruction to a control this surface does not render
+ *     (#684 review, D2).
+ *
+ * Assertions bind by data-testid and by the module's exported copy constants —
+ * never by a value predicate another element could satisfy.
+ */
+
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+import { AnalysisRefusalNotice } from '../AnalysisRefusalNotice'
+import {
+  ANALYSIS_REFUSAL_HEADLINE,
+  ANALYSIS_REFUSAL_GENERIC_REASON,
+  ANALYSIS_REFUSAL_POINTER,
+  ANALYSIS_REFUSAL_REASON_COPY,
+  type AnalysisRefusalNotice as Notice,
+} from '../../../canvas/store/analysisRefusalNotice'
+
+const TESTID = 'analysis-refusal-notice'
+const RAW_TESTID = 'analysis-refusal-raw-reason'
+
+function notice(blockedReason: string): Notice {
+  return { blockedReason, computedAt: '2026-08-14T10:00:00.000Z' }
+}
+
+describe('AnalysisRefusalNotice', () => {
+  it('renders NOTHING when the slice holds no refusal', () => {
+    const { container } = render(<AnalysisRefusalNotice notice={null} />)
+
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByTestId(TESTID)).toBeNull()
+  })
+
+  it('states the analysis did not run, in the past tense, for a mapped code', () => {
+    render(<AnalysisRefusalNotice notice={notice('options_not_configured')} />)
+
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_HEADLINE)
+    expect(el).toHaveTextContent(
+      ANALYSIS_REFUSAL_REASON_COPY.options_not_configured,
+    )
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_POINTER)
+    // Identity binding: the code rides on a data attribute for tests/debug.
+    expect(el).toHaveAttribute('data-blocked-reason', 'options_not_configured')
+    expect(el).toHaveAttribute('data-reason-mapped', 'true')
+  })
+
+  it('never shows the raw machine code as user copy when the code is mapped', () => {
+    render(<AnalysisRefusalNotice notice={notice('mixed_scale_unresolved')} />)
+
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(
+      ANALYSIS_REFUSAL_REASON_COPY.mixed_scale_unresolved,
+    )
+    expect(el).not.toHaveTextContent('mixed_scale_unresolved')
+    expect(screen.queryByTestId(RAW_TESTID)).toBeNull()
+    // It must not silently substitute the generic for a code it CAN map.
+    expect(el).not.toHaveTextContent(ANALYSIS_REFUSAL_GENERIC_REASON)
+  })
+
+  it('falls back to the honest generic + a details disclosure for an UNMAPPED code', () => {
+    render(<AnalysisRefusalNotice notice={notice('a_brand_new_cee_code')} />)
+
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_HEADLINE)
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_GENERIC_REASON)
+    expect(el).toHaveAttribute('data-reason-mapped', 'false')
+    // The raw code IS disclosed here — honestly, and only here.
+    expect(screen.getByTestId(RAW_TESTID)).toHaveTextContent(
+      'a_brand_new_cee_code',
+    )
+  })
+
+  it('gives the D1 mutation causes the generic, never fabricated analysis copy', () => {
+    // CEE turn-executor.ts:8684-8697 removed their reachability on this carrier
+    // BY NAME as "a false claim that the ANALYSIS is blocked". If one ever
+    // arrives anyway, the notice must not invent a specific analysis cause.
+    render(<AnalysisRefusalNotice notice={notice('parameter_invalid_at_execute')} />)
+
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_GENERIC_REASON)
+    expect(el).toHaveAttribute('data-reason-mapped', 'false')
+    expect(screen.getByTestId(RAW_TESTID)).toHaveTextContent(
+      'parameter_invalid_at_execute',
+    )
+  })
+
+  it('is announced politely and is not amber "proceed with care" styling', () => {
+    render(<AnalysisRefusalNotice notice={notice('analysis_engine_busy')} />)
+
+    const el = screen.getByTestId(TESTID)
+    expect(el).toHaveAttribute('role', 'status')
+    // Row 2.1127 is correcting the amber family — this notice must not join it.
+    expect(el.className).not.toMatch(/warning/)
+    expect(el).not.toHaveTextContent(/proceed with care/i)
+  })
+
+  it('never instructs a control this surface does not render (#684 D2)', () => {
+    for (const code of Object.keys(ANALYSIS_REFUSAL_REASON_COPY)) {
+      const { unmount } = render(<AnalysisRefusalNotice notice={notice(code)} />)
+      expect(screen.getByTestId(TESTID)).not.toHaveTextContent(
+        /\bclick\b|\bpress\b|\btap\b|\bbutton\b/i,
+      )
+      // The notice carries no actionable control of its own; CEE owns the
+      // recovery chip and it lives in the chat, which the pointer names.
+      expect(screen.queryAllByRole('button')).toHaveLength(0)
+      unmount()
+    }
+  })
+})

--- a/src/v5/__tests__/applyV5State.analysisRefusalNotice.spec.tsx
+++ b/src/v5/__tests__/applyV5State.analysisRefusalNotice.spec.tsx
@@ -1,0 +1,240 @@
+/**
+ * ROADMAP 2.1163 / golden-journey EXT-2 — the refusal SEAM.
+ *
+ * CEE PR #942 emits, on a refused analyse turn:
+ *
+ *   analysis_ready: { status: 'blocked', blocked_reason: <specific>, options: [],
+ *                     goal_node_id: '', freshness, freshness_reason, computed_at }
+ *   stage_indicator: 'analyse'
+ *
+ * ⚠⚠ THE CONSTRAINT THIS SPEC EXISTS TO PROTECT, AS MUCH AS THE FEATURE.
+ * The readiness normaliser REJECTS this carrier (empty goal_node_id / empty
+ * options) → `setCeeAnalysisReady(null)` + a deferred
+ * `analysis_ready_invalid_shape`. That is CORRECT and must NOT change: a
+ * deployed-UI trace (2026-08-14) established the clearing kills two harms and
+ * the R1–R3 dynamics are premised on it, and
+ * `applyV5State.blockedAnalysisReady.spec.tsx` pins it independently. So the
+ * refusal is routed into its OWN slice, and the tests below assert the
+ * readiness and freshness behaviour is BYTE-FOR-BYTE what it was.
+ *
+ * The three-valued update is the point of the seam:
+ *   set    — blocked + non-empty blocked_reason
+ *   clear  — an accepted analysis_ready, or a completed analysis_result
+ *   retain — everything else (setter NOT called), so the notice survives the
+ *            conversational turns that follow a refusal.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+import { AnalysisRefusalNotice } from '../../components/results/AnalysisRefusalNotice'
+import {
+  ANALYSIS_REFUSAL_HEADLINE,
+  ANALYSIS_REFUSAL_REASON_COPY,
+} from '../../canvas/store/analysisRefusalNotice'
+
+/** Exact CEE refusal wire shape (buildAnalysisRefusalReadiness + attachComputedAt). */
+const REFUSAL_ANALYSIS_READY = {
+  status: 'blocked',
+  blocked_reason: 'options_not_configured',
+  options: [] as unknown[],
+  goal_node_id: '',
+  freshness: 'stale',
+  freshness_reason: 'graph_changed_since_run',
+  computed_at: '2026-08-14T10:00:00.000Z',
+}
+
+/**
+ * Exact CEE LEGACY carrier (synthesiseFreshnessOnlyAnalysisReady) — blocked,
+ * but with NO blocked_reason. Emitted on legacy/unparseable reloads. It is the
+ * opposite-direction twin: same `status`, and it must produce NO notice.
+ */
+const LEGACY_FRESHNESS_ONLY_ANALYSIS_READY = {
+  status: 'blocked',
+  goal_node_id: '',
+  options: [] as unknown[],
+  bias_findings: [] as unknown[],
+  computed_at: '2026-07-07T10:00:00.000Z',
+  freshness: 'unknown',
+  freshness_reason: 'legacy_fact_missing_hash',
+}
+
+const ACCEPTED_ANALYSIS_READY = {
+  status: 'ready',
+  goal_node_id: 'goal_1',
+  options: [{ id: 'opt_1', interventions: {}, status: 'ready' }],
+  computed_at: '2026-08-14T11:00:00.000Z',
+}
+
+function baseResponse(overrides: Partial<OlumiResponse> = {}): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+    ...overrides,
+  }
+}
+
+function makeStore() {
+  const setCeeAnalysisReady = vi.fn()
+  const setAnalysisFreshness = vi.fn()
+  const setAnalysisRefusalNotice = vi.fn()
+  const store: V5ApplicatorStore = {
+    setCurrentStage: vi.fn(),
+    updateNode: vi.fn(),
+    updateEdgeData: vi.fn(),
+    setRunMeta: vi.fn(),
+    setCeeAnalysisReady,
+    setAnalysisFreshness,
+    setAnalysisRefusalNotice,
+    nodes: [],
+    edges: [],
+  }
+  return { store, setCeeAnalysisReady, setAnalysisFreshness, setAnalysisRefusalNotice }
+}
+
+describe('applyV5State — CEE typed analysis refusal (EXT-2)', () => {
+  it('routes the refusal into its OWN slice, with the specific blocked_reason', () => {
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledTimes(1)
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledWith({
+      blockedReason: 'options_not_configured',
+      computedAt: '2026-08-14T10:00:00.000Z',
+    })
+    expect(result.applied).toContain('analysis_refusal_notice:set')
+  })
+
+  it('LEAVES THE ACCEPTANCE GATE UNCHANGED — the readiness slice is still cleared and still deferred', () => {
+    // The gate rejects this carrier BY DESIGN. Routing the refusal elsewhere
+    // must not have softened it.
+    const { store, setCeeAnalysisReady } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setCeeAnalysisReady).toHaveBeenCalledWith(null)
+    expect(result.applied).not.toContain('analysis_ready:set')
+    expect(
+      result.deferred.some((d) => d.reason === 'analysis_ready_invalid_shape'),
+    ).toBe(true)
+  })
+
+  it('LEAVES THE FRESHNESS SLICE UNCHANGED — it still consumes the raw payload', () => {
+    const { store, setAnalysisFreshness } = makeStore()
+
+    applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisFreshness).toHaveBeenCalledTimes(1)
+    expect(setAnalysisFreshness).toHaveBeenCalledWith(REFUSAL_ANALYSIS_READY)
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: the legacy freshness-only blocked carrier sets NO notice', () => {
+    // Same `status: 'blocked'`, no `blocked_reason`. Keying on status alone
+    // would fabricate a refusal on every legacy reload.
+    const { store, setAnalysisRefusalNotice, setCeeAnalysisReady } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        analysis_ready: LEGACY_FRESHNESS_ONLY_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).not.toHaveBeenCalled()
+    expect(result.applied).not.toContain('analysis_refusal_notice:set')
+    expect(result.applied).not.toContain('analysis_refusal_notice:cleared')
+    // ...and the pre-existing behaviour for that carrier is untouched.
+    expect(setCeeAnalysisReady).toHaveBeenCalledWith(null)
+  })
+
+  it('CLEARS on the next accepted analysis_ready', () => {
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: ACCEPTED_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledWith(null)
+    expect(result.applied).toContain('analysis_refusal_notice:cleared')
+  })
+
+  it('CLEARS on a successful analysis_result turn that carries no analysis_ready', () => {
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        blocks: [{ type: 'analysis_result' }],
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledWith(null)
+  })
+
+  it('RETAINS across an ordinary conversational turn — the setter is not called at all', () => {
+    // If this turn cleared, the notice would vanish before the user read it.
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({ stage_indicator: 'frame', assistant_text: 'Tell me more.' }),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).not.toHaveBeenCalled()
+    expect(result.applied).not.toContain('analysis_refusal_notice:cleared')
+  })
+
+  it('WIRE→DOM: a refused turn produces the rendered notice with its specific reason', () => {
+    // The whole point of the row: blocked_reason reaches a surface.
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    const routed = setAnalysisRefusalNotice.mock.calls[0]?.[0]
+    render(<AnalysisRefusalNotice notice={routed} />)
+
+    const el = screen.getByTestId('analysis-refusal-notice')
+    expect(el).toHaveTextContent(ANALYSIS_REFUSAL_HEADLINE)
+    expect(el).toHaveTextContent(
+      ANALYSIS_REFUSAL_REASON_COPY.options_not_configured,
+    )
+    expect(el).toHaveAttribute('data-blocked-reason', 'options_not_configured')
+  })
+})

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -64,6 +64,10 @@ import {
 } from './decisionReviewAdapter'
 import { mapV5AnalysisToReport } from './mapV5AnalysisToReport'
 import { v5StageToScenarioStage } from './stageMapper'
+import {
+  deriveAnalysisRefusalNoticeUpdate,
+  type AnalysisRefusalNotice,
+} from '../canvas/store/analysisRefusalNotice'
 
 /**
  * Minimal store-shape interface. useCanvasStore.getState() returns a larger
@@ -135,6 +139,8 @@ export interface V5ApplicatorStore {
   }) => void
   /** Optional: update the freshness slice from a raw response.analysis_ready (retain / order / never absence→fresh). */
   setAnalysisFreshness?: (rawAnalysisReady: unknown) => void
+  /** Optional (ROADMAP 2.1163 / EXT-2): set or clear CEE's typed analysis-refusal notice. Pass null to clear. */
+  setAnalysisRefusalNotice?: (notice: AnalysisRefusalNotice | null) => void
   /** Optional: clear the local dirty overlay when a genuinely new analysis run completes (new analysis_result response_hash). */
   clearAnalysisFreshnessDirty?: () => void
   /** Optional (F10): a genuinely new analysis_result landed with NO explicit
@@ -1025,6 +1031,35 @@ export function applyV5State(
   // Freshness slice: retain on absence, order by computed_at, never absence→fresh.
   // Independent of ceeAnalysisReady (which clears on analyse-turns-without-analysis_ready).
   store.setAnalysisFreshness?.(rawAnalysisReady)
+
+  // ── ROADMAP 2.1163 / EXT-2 — the refusal READER ────────────────────────
+  // CEE PR #942 puts a TYPED analysis refusal on the wire
+  // (`analysis_ready.status: 'blocked'` + a specific `blocked_reason`).
+  // `blocked_reason` had ZERO readers repo-wide, and an honest refusal nobody
+  // renders is indistinguishable from a silent failure.
+  //
+  // ⚠ IT IS DELIBERATELY NOT ROUTED INTO THE READINESS SLICE. The normaliser
+  // below REJECTS this carrier (empty goal_node_id / empty options) and clears
+  // `ceeAnalysisReady`; a deployed-UI trace (2026-08-14) established that
+  // clearing is correct and load-bearing, and
+  // `applyV5State.blockedAnalysisReady.spec.tsx` pins it. So the refusal is
+  // extracted HERE, from the raw payload while it is still in hand and BEFORE
+  // validation, into its own session-local slice. Nothing about the readiness
+  // slice's behaviour changes.
+  //
+  // Three-valued on purpose: a conversational turn RETAINS the notice (silence
+  // is not evidence the refusal is over), an accepted analysis_ready or a
+  // completed analysis_result CLEARS it, and only a blocked carrier bearing a
+  // non-empty blocked_reason SETS it. The legacy freshness-only blocked carrier
+  // (no blocked_reason) sets nothing — see analysisRefusalNotice.ts.
+  const refusalUpdate = deriveAnalysisRefusalNoticeUpdate(response)
+  if (refusalUpdate.kind === 'set') {
+    store.setAnalysisRefusalNotice?.(refusalUpdate.notice)
+    applied.push('analysis_refusal_notice:set')
+  } else if (refusalUpdate.kind === 'clear') {
+    store.setAnalysisRefusalNotice?.(null)
+    applied.push('analysis_refusal_notice:cleared')
+  }
 
   // NOTE: there is intentionally no response-ROOT goal_constraints read here.
   // Constraints reach the store via the two LIVE paths only: CEE's


### PR DESCRIPTION
**DO NOT MERGE without independent review.** Branch-only, as briefed.

## What this ships

CEE #942 puts a typed refusal on the wire for a refused analyse turn — `analysis_ready: { status: 'blocked', blocked_reason: <specific>, options: [], goal_node_id: '', freshness, computed_at }`. **`blocked_reason` had ZERO readers repo-wide** (row 2.1163). An honest refusal that nobody renders is indistinguishable, to the user, from a silent failure. This is the reader.

Pure addition: **8 files, 1,072 insertions, 0 deletions.**

## ⚠ The acceptance gate is UNCHANGED, deliberately

`applyV5State`'s readiness normaliser still rejects the blocked carrier (empty `goal_node_id`/`options`) → `setCeeAnalysisReady(null)` + deferred `analysis_ready_invalid_shape`. `applyV5State.blockedAnalysisReady.spec.tsx` passes **untouched**, and this PR adds three tests that assert the readiness and freshness behaviour is byte-for-byte what it was. `DecisionOverviewCard`'s `liveState` derivation is not touched — `'unassessed'`/collapsed remains correct for the readiness slice.

The refusal is instead extracted from the **raw** payload while it is still in hand, before validation, into its own session-local slice.

## ⚠ Two `status: 'blocked'` carriers exist and only one is a refusal

Derived at the CEE bytes (PR #942 head `2ca6c079`), and this is the crux:

| | producer | carries `blocked_reason`? |
|---|---|---|
| **Refusal** | `buildAnalysisRefusalReadiness()` `analysis-ready-helper.ts:400-409` | **always** |
| **Legacy** | `synthesiseFreshnessOnlyAnalysisReady()` `analysis-ready-emit.ts:59-61` | **never** — a freshness carrier on legacy/unparseable **reloads** |

Keying on `status` alone would fabricate *"this analysis did not run"* on every legacy reload. **The discriminator is a non-empty `blocked_reason`.** The legacy carrier is pinned as an explicit opposite-direction twin.

## ⚠ Corrected premise (deliverable)

The brief named `parameter_invalid_at_execute` as an example `blocked_reason`. **It is not reachable on this carrier.** It is in `RECOVERABLE_HANDLER_CAUSES`, but `run_analysis` never throws it — the D1 mutation handlers do. CEE `turn-executor.ts:8684-8697` records it **by name** as the defect an adversarial review caught: a failed *constraint edit* emitting a blocked analysis readiness was *"a false claim that the ANALYSIS is blocked"*, and the `ANALYSE_HANDLER_ID` gate was added to remove it. Mapping it to specific analysis copy here would re-assert exactly the claim #942 deleted, one layer up. It and the other three D1 causes are **deliberately unmapped** → honest generic.

## Copy

Derived from the producer's declared semantics, never from our own reading of the fields (trap 13c). Vocabulary = (`cause_kind`s `run_analysis` actually throws) ∩ `RECOVERABLE_HANDLER_CAUSES`, plus the `reason_code` families (scale block, `ReadinessReasonCode`, `StructuralViolationCode`).

- Past-tense factual headline: *"This analysis did not run."*
- **One** precise reason, aligned with the sentence CEE puts in the chat for the same code, so the two surfaces cannot contradict each other.
- A pointer naming the assistant's reply — **true by construction**: `composeHandlerFailureBody` sets `assistant_text` on every recoverable branch. It names a *location*, never a control this notice does not render (#684 review, D2 — tested).
- Unknown code → honest generic + the raw code in a `<details>` disclosure. Never a fabricated specific.
- Lookup is **exact, never case-folded** (the producer emits both `SCREAMING_SNAKE` and `lower_snake`; folding would let an unknown variant inherit a sentence it was not entitled to).
- Neutral-informational tone — **not** the amber "proceed with care" family that row 2.1127 is correcting, and not alarm-red either (*"the engine was busy, nothing is wrong with your model"* is one of the reachable reasons).

## Seams — exact hunks

| file | hunks |
|---|---|
| `src/v5/applyV5State.ts` | `@@ -64,6 +64,10` (import) · `@@ -135,6 +139,8` (one optional field on `V5ApplicatorStore`) · `@@ -1026,6 +1032,35` (the raw-extraction hook) |
| `src/canvas/components/OutputsDock.tsx` | `@@ -38,6 +38,7` (import) · `@@ -2616,6 +2617,27` (mount) |

Adjacency checked as briefed: the only body hunk in `applyV5State.ts` is at **:1032**, clear of the merged #683 dispatch region (~:741-900) and the `graph_patch` applicator (~:617-648) by >120 lines. `useResultsSectionData` and `userFriendlyErrors`/`USER_RERUN_BLOCKED_CODES` are untouched.

**Mount is deliberately NOT gated on `!isPreRun && hasInlineSummary && resultsSectionData`** like its neighbours. Those gates mean "there are results to decorate"; a refused analysis is exactly the case where there are none, so borrowing them would hide the notice in the very state it exists to explain. The component owns its own gate (renders `null` on an empty slice).

## Never persisted

The canvas store has no `persist()` middleware — persistence is opt-in per setter. The field is in none of the three seams (`setCeeAnalysisReady`'s `sessionStorage` block, the autosave projection allow-list, the crash-flush provider). It is additionally cleared on import / reset / scenario switch / graph load, because a refusal belongs to the graph it was refused for.

## Verification

Fresh blobless clone at a unique `/private/tmp` path; `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run; all three new specs RED-first at pristine (named signatures) and collected non-zero **by name**; assertions bind by `data-testid`/identity.

**Gates** (`pnpm` named gates, not `tsc -p tsconfig.json`): `lint` ✅ 0 errors, hooks-ratchet exactly at baseline · `typecheck` ✅ (gate script) · `ci:guard:zustand` ✅ · `ci:guard:starters` ✅ · `check:vendor` ✅ · `ci:guard:schemas-version` ✅.

**Affected suites**: 680 files / **10,308 passed**, 0 failed (`src/canvas/components`, `src/components/results`, `src/canvas/store`, `src/v5`).

**Mutants** — throwaway worktree *outside* the repo root, isolation proven by **writing a sentinel and asserting the source was byte-unchanged** (distinct inodes), HEAD-relative restores, applied-check scoped to `src/`, leading **and** trailing controls both `applied=0` / 60 green (so no mutation leaked):

| mutant | result |
|---|---|
| M1 drop the store routing | **RED** (2) |
| M2a treat any blocked carrier as a refusal | **RED** (3) |
| M2b loosen for a **different** status only | **GREEN** |
| M3 drop the clear branch (stale notice survives success) | **RED** (2) |
| M4 mapper always returns null | **RED** (29) |

**M2a RED + M2b GREEN is the discriminating pair**: neither alone shows binding — together they prove the twin binds to the *legacy carrier by identity*, not merely to "any change in this function".

## Instrument finding — and the correction CI forced

**First reported here as "no baseline change needed". That was wrong, and the required check caught it.** Recording both, because the mistake is the useful part.

The typecheck gate's identity key is `<file>\t<TScode>\t<message>`, and one diagnostic's message embeds a **property count of `CanvasState`**. Adding `analysisRefusalNotice` + `setAnalysisRefusalNotice` re-renders `... 250 more ...` as `... 252 more ...`, so a pre-existing error (the `resultsComplete`/`enrichment` incompatibility in `useConversation.ts`) reads as a *new identity*. The local gate treats that as a non-failing notice and **PASSED** — so I concluded no baseline change was needed. But `Typecheck Gate Self-Test` **1/7 asserts a clean tree prints no "appeared" notice**, and it failed (17 passed / 1 failed), taking `Staging Gate` with it. *A green named local gate is necessary and not sufficient; the required check is the authority.*

Fixed in `ea68d4bf`, **deliberately not with a full `--update-baseline`**. A regenerate also banks an unrelated `useAnalysisMetadata.ts` TS2339 shrink (3 → 1; file total 7 → 5; count 2487 → 2485) that this PR did not cause — **measured with a pristine control** at `staging` `d48da4fd`, where the gate already reports that same shrink and no "appeared" line. Banking another lane's churn under this PR's name is the attribution defect trap 2b names, so the regenerated rows for it and the header count were reverted and only the attributable row kept. **Net diff: one line.** Self-test now **18 passed / 0 failed**.

Any future lane adding a `CanvasState` member will hit this same notice.

## What I could not reach

**A live witness of a real refused turn.** CEE #942 is still **OPEN** (head `2ca6c079`, not merged), so no deployed build emits this carrier yet. Every claim above about the wire is derived from the #942 branch bytes, not from a capture. The live witness is post-merge, after #942 deploys to staging — until then this is CODE EXISTS → TESTED, not journey-witnessed.
