### PR TITLE
feat(collab/D1): name the colleague whose panel answer a value came from, resolved at render

### DIFF
--- a/netlify/edge-functions/collab-proxy.ts
+++ b/netlify/edge-functions/collab-proxy.ts
@@ -54,9 +54,17 @@ function isOriginAllowed(origin: string): boolean {
 }
 
 /**
- * GET for the packet and the reveal; POST for mint, close and contributions.
- * ENFORCED below and ADVERTISED verbatim — an allow-list that advertises more
- * than it enforces (or less) is a false guarantee.
+ * GET for the packet, the preview and the reveal; POST for mint, close and
+ * contributions. ENFORCED below and ADVERTISED verbatim — an allow-list that
+ * advertises more than it enforces (or less) is a false guarantee.
+ *
+ * ⚠ THIS SENTENCE HAD DRIFTED AND WAS THE DEFECT IT WARNS ABOUT (found 14 Aug
+ * 2026, D1). It omitted `preview` while `ALLOWED_FORWARD_HEADERS` below
+ * advertised the owner bearer as being for "mint / close / **preview** /
+ * reveal" — and `ALLOWED_TARGETS` enforced neither, so the route CEE has
+ * exposed all along was unreachable from the browser. Two comments in one file
+ * disagreeing about one route is exactly the "advertises more than it enforces"
+ * failure this paragraph exists to forbid.
  */
 const ALLOWED_METHODS = ['GET', 'HEAD', 'POST', 'OPTIONS'] as const
 
@@ -106,6 +114,19 @@ function getCorsHeaders(requestOrigin: string): Record<string, string> {
 const ALLOWED_TARGETS: readonly RegExp[] = [
   /^\/collab\/v1\/rounds$/,
   /^\/collab\/v1\/rounds\/[^/]+\/close$/,
+  /**
+   * D1 (14 Aug 2026) — the ROSTER read behind render-time name resolution.
+   *
+   * Owner-gated at CEE by `requireOwnerUser`, and its response is the round's
+   * status, its target manifest and a three-field roster projection
+   * (`participant_id`, R-2-resolved `display_name`, `status`) — no beliefs, no
+   * token hashes, no `supabase_user_id`. A participant token is worthless on it.
+   * Added because attribution surfaces must resolve a NAME from round data
+   * rather than print a persisted id; the alternative source, `/reveal`, is
+   * already on this list and would hand the canvas every participant's number
+   * to render one person's name.
+   */
+  /^\/collab\/v1\/rounds\/[^/]+\/preview$/,
   /^\/collab\/v1\/rounds\/[^/]+\/reveal$/,
   /^\/collab\/v1\/packet\/[^/]+$/,
   /^\/collab\/v1\/packet\/[^/]+\/events$/,

--- a/src/canvas/domain/nodes.ts
+++ b/src/canvas/domain/nodes.ts
@@ -116,6 +116,32 @@ export const ObservedStateSchema = z.object({
   cap: z.number().nullable().optional(),
   extractionType: z.enum(['explicit', 'inferred', 'external']).nullable().optional(),
   uncertainty_drivers: z.array(z.string()).nullable().optional(),
+  /**
+   * schemas 0.40.0 `RoundParticipantRefSchema` — WHICH round, WHOSE stated
+   * value. Server-stamped by CEE alongside `source: 'panel_elicited'`, and only
+   * after it verified the owner's apply claim against its own collab store.
+   *
+   * IDS ONLY BY CONTRACT: a display name is never persisted here, because a name
+   * inside `scenarios.graph` would sit beyond the R-2 redaction routine's reach.
+   * Names are resolved at render from round data — `collab/participantNames.ts`.
+   *
+   * ⚠ DECLARED PERMISSIVELY ON PURPOSE. It rode `.passthrough()` untyped until
+   * now, so this adds a READER without adding a rejection: the members are
+   * optional here and `readElicitedFrom` is the single place that decides
+   * whether a reference is usable. Tightening this object instead would turn a
+   * malformed reference into a parse warning on a schema whose own contract is
+   * "validation is warning-only — do not reject drafts that omit fields", and
+   * the honest outcome for a malformed reference is an unnamed pill, not a
+   * complaint about the graph.
+   */
+  elicited_from: z
+    .object({
+      round_id: z.string().optional(),
+      participant_id: z.string().optional(),
+    })
+    .passthrough()
+    .nullable()
+    .optional(),
 }).passthrough()
 export type ObservedState = z.infer<typeof ObservedStateSchema>
 

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorMountChain.spec.ts
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorMountChain.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * F2 (review of #689) — BIND THE MOUNT PATH, do not merely document it.
+ *
+ * The three factor panels D1 changed are deployed-mounted, and until now that
+ * was asserted only in comments and in a review's prose. Trap 3b's rule is that
+ * a UI test bound to a component the deployed flags do not mount is worthless
+ * evidence — and the estate has shipped that defect twice in one feature. The
+ * mitigation there was that the mount is a hardcoded constant rather than a
+ * flag, so the classic 3b lever does not exist today. **"No lever today" is a
+ * fact about today.** This file makes the chain fail loud the moment someone
+ * adds one.
+ *
+ * ── WHY A SOURCE-DERIVED ASSERTION AND NOT A RENDER ───────────────────────
+ * A render test proves the chain works under the props the test supplies. What
+ * needs pinning here is different: that the mount is not CONDITIONAL on anything
+ * a deployment can move. That is a property of the source, and reading the source
+ * is the only way to assert the absence of a gate rather than the presence of one
+ * path through it.
+ *
+ * ⚠ EVERY FILE READ IS ASSERTED NON-EMPTY BEFORE ANY MATCH IS BELIEVED.
+ * An extraction that silently produced nothing agrees with every other
+ * extraction that produced nothing, and `expect(...).not.toContain(...)` passes
+ * beautifully against an empty string. That failure mode has cost this estate a
+ * false "LADDER-IDENTICAL" verdict already, so the non-empty guard and the
+ * negative control below are the load-bearing parts of this file, not decoration.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROOT = resolve(__dirname, '../../../../..')
+
+/** Read a source file, refusing to return anything a match could pass against. */
+function source(relPath: string): string {
+  const text = readFileSync(resolve(ROOT, relPath), 'utf8')
+  if (text.trim().length < 200) {
+    throw new Error(
+      `refusing to assert against ${relPath}: read ${text.length} chars — ` +
+        `an empty or truncated read makes every assertion in this file vacuous`,
+    )
+  }
+  return text
+}
+
+const CANVAS_MVP = 'src/routes/CanvasMVP.tsx'
+const REACT_FLOW_GRAPH = 'src/canvas/ReactFlowGraph.tsx'
+const INSPECTOR_MODAL = 'src/canvas/components/InspectorModal.tsx'
+const INSPECTOR_ROUTER = 'src/canvas/ui/inspector-v2/InspectorRouter.tsx'
+
+describe('the inspector mount chain that carries D1 to a real user', () => {
+  it('POSITIVE + NEGATIVE CONTROL — the detector reads real bytes and discriminates', () => {
+    const modal = source(INSPECTOR_MODAL)
+    // Positive: something known to be present.
+    expect(modal).toContain('InspectorRouter')
+    // Negative: a fabricated name must NOT match. Without this, a detector that
+    // matched everything (or a read that returned the whole repo) would pass
+    // every assertion below.
+    expect(modal).not.toContain('InspectorRouterV99Fabricated')
+  })
+
+  it('CanvasMVP mounts ReactFlowGraph', () => {
+    const mvp = source(CANVAS_MVP)
+    expect(mvp).toMatch(/import\s+ReactFlowGraph\s+from\s+'\.\.\/canvas\/ReactFlowGraph'/)
+    expect(mvp).toMatch(/<ReactFlowGraph\b/)
+  })
+
+  it('ReactFlowGraph mounts InspectorModal', () => {
+    const graph = source(REACT_FLOW_GRAPH)
+    expect(graph).toMatch(/import\s+\{\s*InspectorModal\s*\}\s+from\s+'\.\/components\/InspectorModal'/)
+    expect(graph).toMatch(/<InspectorModal\b/)
+  })
+
+  it('⭐ InspectorModal chooses inspector-v2 UNCONDITIONALLY — not from a flag', () => {
+    const modal = source(INSPECTOR_MODAL)
+
+    // The exact literal. This is the assertion that REDs if anyone converts the
+    // constant into a flag read (`= isInspectorV2Enabled()`, `= flags.x`,
+    // `= import.meta.env.VITE_…`), which is precisely the trap-3b lever that
+    // does not exist today.
+    expect(modal).toMatch(/^const USE_INSPECTOR_V2 = true$/m)
+
+    // And it is actually consulted, and the v2 router is what it reaches for.
+    expect(modal).toMatch(/if\s*\(\s*USE_INSPECTOR_V2\s*\)/)
+    expect(modal).toMatch(/<InspectorRouter\b/)
+  })
+
+  it('⭐ InspectorRouter maps all three factor panel types D1 touched', () => {
+    const router = source(INSPECTOR_ROUTER)
+    // Bound BY IDENTITY — panel type to the specific component — not by "the
+    // file mentions the panels somewhere". A router that mapped
+    // `factor-observable` to the wrong panel would satisfy a mere-mention check.
+    expect(router).toMatch(/'factor-controllable':\s*FactorControllablePanel/)
+    expect(router).toMatch(/'factor-observable':\s*FactorObservablePanel/)
+    expect(router).toMatch(/'factor-external':\s*FactorExternalPanel/)
+  })
+
+  it('records the router default that makes a category-less fixture test the wrong panel', () => {
+    // Not a mount assertion — a tripwire on the trap that makes component tests
+    // in this area lie. `resolvePanelType` falls through to
+    // 'factor-controllable', so a fixture omitting `data.category` silently
+    // exercises a different panel and passes. If this default ever changes, the
+    // fixtures in panelAttributionNaming.spec.tsx need re-reading.
+    const router = source(INSPECTOR_ROUTER)
+    expect(router).toMatch(/default:\s*return 'factor-controllable'/)
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/panelAttributionNaming.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/panelAttributionNaming.spec.tsx
@@ -1,0 +1,205 @@
+/**
+ * D1 — the attribution pill NAMES the colleague whose answer it is.
+ *
+ * ── WHAT THE EXISTING SUITE ALREADY COVERS, AND WHY THAT IS NOT ENOUGH ─────
+ * `domain/__tests__/panelProvenance.spec.ts` pins that a `panel_elicited` value
+ * is never credited to Olumi, never pilled "Set by you", and never leaks the raw
+ * wire literal. Every one of those assertions is about what the pill must NOT
+ * say, and all of them pass on the unnamed copy — which is why the copy stayed
+ * unnamed for a whole slice while reading as fully covered. This file is the
+ * positive half: it pins what the pill DOES say when the person is known, and
+ * that it degrades to the truthful unnamed sentence when they are not.
+ *
+ * ⚠ THE COMPONENT TEST SETS `data.category` EXPLICITLY, AND MUST.
+ * `InspectorRouter.resolvePanelType` (`InspectorRouter.tsx:82-89`) falls through
+ * to `'factor-controllable'` for a missing or misspelled category, so a fixture
+ * that omits it renders a DIFFERENT panel than the test names and passes anyway.
+ * The panels are imported directly here, which sidesteps that — but the fixtures
+ * carry the category regardless, so this file cannot start lying if it is ever
+ * rewritten to go through the router.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { getProvenanceLabel, getExtractionLabel } from '../inspectorStrings'
+import type { ParticipantNameResolution } from '../../../../collab/participantNames'
+
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+
+const NAMED: ParticipantNameResolution = { state: 'named', label: 'Grace' }
+const UNRESOLVED: ParticipantNameResolution = {
+  state: 'unresolved',
+  reason: 'roster_unavailable',
+}
+
+describe('the label functions — named attribution', () => {
+  it.each([
+    ['getProvenanceLabel', getProvenanceLabel],
+    ['getExtractionLabel', getExtractionLabel],
+  ])('%s names the participant for panel_elicited', (_name, fn) => {
+    expect(fn('panel_elicited', NAMED)).toBe("From Grace's panel answer")
+  })
+
+  it.each([
+    ['getProvenanceLabel', getProvenanceLabel],
+    ['getExtractionLabel', getExtractionLabel],
+  ])('%s falls back to the TRUTHFUL unnamed sentence when unresolved', (_name, fn) => {
+    // Still says the value came from the panel — the fallback is not a neutral
+    // shrug, and it is not "Estimated by Olumi".
+    expect(fn('panel_elicited', UNRESOLVED)).toBe('From your panel')
+    expect(fn('panel_elicited')).toBe('From your panel')
+  })
+
+  it.each([
+    ['getProvenanceLabel', getProvenanceLabel],
+    ['getExtractionLabel', getExtractionLabel],
+  ])('%s never renders the raw literal or an id, resolved or not', (_name, fn) => {
+    for (const arg of [NAMED, UNRESOLVED, undefined]) {
+      const label = fn('panel_elicited', arg)
+      expect(label).not.toContain('panel_elicited')
+      expect(label).not.toContain(GRACE_ID)
+      expect(label).not.toContain(ROUND_ID)
+    }
+  })
+
+  it('⭐ ATTRIBUTES WITHOUT ENDORSING — "apply Grace\'s value" is not "Grace was correct"', () => {
+    const label = getProvenanceLabel('panel_elicited', NAMED)
+    expect(label).toContain('Grace')
+    // Any of these would convert a provenance label into a verdict on whose
+    // number is right. The owner adopting a value is the owner's decision.
+    for (const verdict of ['correct', 'verified', 'validated', 'confirmed', 'agreed', 'best']) {
+      expect(label.toLowerCase()).not.toContain(verdict)
+    }
+  })
+
+  it('⭐ a resolution does NOT relabel a value that is not a panel value', () => {
+    // The discriminating case for the `cls.kind === 'panel'` gate. A stale or
+    // unrelated resolution in scope must not touch the owner's own edit — this
+    // fails if the gate is dropped and the name is applied to any attributed
+    // kind.
+    expect(getProvenanceLabel('user_override', NAMED)).toBe('Set by you')
+    expect(getProvenanceLabel('user_confirmed', NAMED)).toBe('Confirmed by you')
+    expect(getExtractionLabel('brief_extraction', NAMED)).toBe('From your brief')
+    expect(getProvenanceLabel('cee_inference', NAMED)).toBe('Estimated by Olumi')
+  })
+
+  it('an unknown literal is unaffected by a resolution', () => {
+    expect(getProvenanceLabel('some_new_source', NAMED)).toBe('Source: some_new_source')
+  })
+})
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * The DEPLOYED-MOUNTED surface. FactorObservablePanel reaches a real user via
+ * InspectorRouter → InspectorModal (`USE_INSPECTOR_V2` is a hardcoded `true`,
+ * no flag gates it) → ReactFlowGraph → CanvasMVP.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const ROSTER_RESPONSE = {
+  round_id: ROUND_ID,
+  status: 'closed',
+  targets: [],
+  roster: [{ participant_id: GRACE_ID, display_name: 'Grace', status: 'active' }],
+}
+
+vi.mock('../../../../lib/supabase', async (importOriginal) => {
+  // importOriginal-spread, not a hand-listed mock: a `vi.mock` factory REPLACES
+  // the module, so any other export this file's import graph needs would go
+  // silently missing (CLAUDE.md trap 12 — it has killed 51 tests here before).
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getSessionIdentity: vi.fn(async () => ({ userId: 'owner-1', accessToken: 'tok' })),
+  }
+})
+
+function factorNode(observedState: Record<string, unknown>) {
+  return {
+    id: 'factor-1',
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Churn risk',
+      kind: 'factor',
+      // EXPLICIT — see the file header. Never rely on the router's default.
+      category: 'observable',
+      observedState,
+    },
+  }
+}
+
+async function renderObservablePanel(observedState: Record<string, unknown>) {
+  const { useCanvasStore } = await import('../../../store')
+  const { FactorObservablePanel } = await import('../panels/FactorObservablePanel')
+  useCanvasStore.setState({ nodes: [factorNode(observedState)] as never, edges: [] })
+  return render(
+    <FactorObservablePanel nodeId="factor-1" techMode={false} onClose={() => {}} onNavigate={() => {}} />,
+  )
+}
+
+describe('FactorObservablePanel — render-time name resolution on a live surface', () => {
+  beforeEach(async () => {
+    const { __resetRosterCacheForTests } = await import('../../../../collab/roundRosterCache')
+    __resetRosterCacheForTests()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(ROSTER_RESPONSE), { status: 200 })),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('⭐ names Grace once the roster lands, on the deployed-mounted panel', async () => {
+    await renderObservablePanel({
+      value: 0.85,
+      source: 'panel_elicited',
+      elicited_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+    })
+
+    // The first paint is honest before the roster arrives...
+    expect(screen.getAllByText('From your panel').length).toBeGreaterThan(0)
+    // ...and the name replaces it when round data resolves.
+    expect(
+      (await screen.findAllByText("From Grace's panel answer")).length,
+    ).toBeGreaterThan(0)
+    expect(screen.queryByText('From your panel')).toBeNull()
+  })
+
+  it('⭐ requests the ROSTER route, with the owner bearer and no name in the URL', async () => {
+    await renderObservablePanel({
+      value: 0.85,
+      source: 'panel_elicited',
+      elicited_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+    })
+    await screen.findAllByText("From Grace's panel answer")
+
+    const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    expect(calls.length).toBe(1)
+    const [url, init] = calls[0] as [string, RequestInit]
+    expect(url).toBe(`/bff/collab/rounds/${ROUND_ID}/preview`)
+    // The roster read, not the reveal — one round's names, not every belief.
+    expect(url).not.toContain('/reveal')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+  })
+
+  it('stays on the truthful unnamed sentence when the roster read fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 403 })))
+    await renderObservablePanel({
+      value: 0.85,
+      source: 'panel_elicited',
+      elicited_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+    })
+    // Deliberately NOT "Estimated by Olumi" and NOT a blank pill: the value did
+    // come from the panel, and that remains true when the name cannot be read.
+    expect(screen.getAllByText('From your panel').length).toBeGreaterThan(0)
+    expect(screen.queryByText(/Estimated by Olumi/)).toBeNull()
+  })
+
+  it('⭐ fetches NOTHING for an ordinary value — the hook is inert off the panel path', async () => {
+    await renderObservablePanel({ value: 0.5, source: 'user_override' })
+    expect(screen.getAllByText('Set by you').length).toBeGreaterThan(0)
+    expect((globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.length).toBe(0)
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/panelAttributionNaming.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/panelAttributionNaming.spec.tsx
@@ -113,6 +113,19 @@ vi.mock('../../../../lib/supabase', async (importOriginal) => {
   }
 })
 
+/**
+ * Let every already-queued promise chain settle.
+ *
+ * `setTimeout(0)` rather than a bare `await Promise.resolve()`: the roster path
+ * awaits the session AND the response body, so a single microtask tick is not
+ * enough to reach the `fetch` call. Its sufficiency is not assumed — the
+ * positive control below asserts this same flush observes a request that IS
+ * made.
+ */
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 function factorNode(observedState: Record<string, unknown>) {
   return {
     id: 'factor-1',
@@ -200,6 +213,28 @@ describe('FactorObservablePanel — render-time name resolution on a live surfac
   it('⭐ fetches NOTHING for an ordinary value — the hook is inert off the panel path', async () => {
     await renderObservablePanel({ value: 0.5, source: 'user_override' })
     expect(screen.getAllByText('Set by you').length).toBeGreaterThan(0)
+
+    // ⚠ THE FLUSH IS LOAD-BEARING, AND THE FIRST VERSION OF THIS TEST DID NOT
+    // HAVE IT AND WAS VACUOUS. `ensureRoster` awaits the session before it
+    // fetches, so a synchronous `calls.length === 0` assertion runs a microtask
+    // BEFORE any request could have been issued — it passed for every mutant,
+    // including one that removed BOTH inertness guards at once. An absence
+    // assertion that resolves before the thing it forbids could happen is
+    // measuring its own timing. Caught by the mutation kit, not by review.
+    await flushAsync()
+
     expect((globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.length).toBe(0)
+  })
+
+  it('POSITIVE CONTROL for the flush — the SAME flush DOES see a legitimate fetch', async () => {
+    // Proves `flushAsync` is long enough to observe a request that is made, so
+    // the zero above is a real absence rather than a shorter race.
+    await renderObservablePanel({
+      value: 0.85,
+      source: 'panel_elicited',
+      elicited_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+    })
+    await flushAsync()
+    expect((globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.length).toBe(1)
   })
 })

--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -5,6 +5,7 @@
 
 import type { NodeType, FactorCategory } from '../../domain/nodes'
 import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
+import type { ParticipantNameResolution } from '../../../collab/participantNames'
 
 // ─── Section titles (spec §3.1) ────────────────────────────────────
 export const SECTION_TITLES = {
@@ -106,10 +107,40 @@ const ATTRIBUTED_LABEL: Record<ValueProvenanceKind, string | null> = {
   // it. Totality bought a type error, not an answer — the compiler was satisfied
   // by `null` and the copy was a lie.
   //
-  // No name here, per D1: only `participant_id` is persisted, so a name on this
-  // surface could not be reached by the R-2 redaction routine. The named
-  // sentence belongs on the reveal, which re-derives it from round data.
+  // ⭐ THE UNNAMED FALLBACK, AND IT IS NOW A FALLBACK RATHER THAN THE ONLY COPY
+  // (D1, 14 Aug 2026). Reached whenever the person cannot be named: the value
+  // carries no `elicited_from`, round data has not loaded, the round has no row
+  // for that participant, or the row's label is blank.
+  //
+  // It stays exactly as it was, deliberately, because it is TRUE in all four
+  // cases — the value did come from the owner's panel. That is what makes the
+  // named version safe to add: a name that arrives one paint later ADDS detail
+  // to a true sentence instead of replacing a placeholder. Never render the id
+  // here; a uuid in this pill is a name for nobody, and `participantNames.ts`
+  // cannot produce one.
+  //
+  // The ORIGINAL version of this comment said a name could not live on this
+  // surface at all, "because only `participant_id` is persisted, so a name here
+  // could not be reached by the R-2 redaction routine". The premise was right
+  // and the conclusion did not follow: R-2 is beyond reach only for a name
+  // PERSISTED in the graph. A name RESOLVED AT RENDER from CEE's roster
+  // (`pseudonym ?? display_name`) is redaction-correct by construction, which
+  // is what schemas 0.40.0's own header prescribes — "display names are
+  // resolved at render time from round data".
   panel: 'From your panel',
+}
+
+/**
+ * The named form of the `panel` attribution.
+ *
+ * ⚠ IT ATTRIBUTES AND MUST NOT ENDORSE (Paul's ruling: "apply Grace's value" is
+ * not "Grace was correct"). "From Grace's panel answer" records whose number it
+ * is; anything in the register of "Grace's estimate is the right one" —
+ * "verified by", "per Grace", "Grace's figure" — smuggles a verdict into a
+ * provenance label. The owner adopting a value is a decision the owner owns.
+ */
+function namedPanelLabel(label: string): string {
+  return `From ${label}'s panel answer`
 }
 
 /**
@@ -125,16 +156,29 @@ const ATTRIBUTED_LABEL: Record<ValueProvenanceKind, string | null> = {
  * user-owned ones are non-null, `brief` and `ai` are null) and is the only
  * version that can answer for a kind that is attributed to somebody else.
  */
-function attributedLabelFor(source: string): string | null {
+function attributedLabelFor(
+  source: string,
+  attributedTo?: ParticipantNameResolution,
+): string | null {
   const cls = classifyValueProvenance(source)
   if (!cls) return null
+  // The name is consulted ONLY for the kind it can describe. Passing a
+  // resolution alongside `user_override` must not change that value's copy —
+  // the number is the owner's, whatever a round happens to say about somebody
+  // else, and this gate is what keeps a stale resolution from relabelling it.
+  if (cls.kind === 'panel' && attributedTo?.state === 'named') {
+    return namedPanelLabel(attributedTo.label)
+  }
   return ATTRIBUTED_LABEL[cls.kind]
 }
 
 // ─── Provenance labels (spec §3.4) ────────────────────────────────
-export function getProvenanceLabel(source?: string): string {
+export function getProvenanceLabel(
+  source?: string,
+  attributedTo?: ParticipantNameResolution,
+): string {
   if (!source) return 'No evidence yet'
-  const attributed = attributedLabelFor(source)
+  const attributed = attributedLabelFor(source, attributedTo)
   if (attributed) return attributed
   switch (source) {
     case 'brief_extraction': return 'Generated from your brief'
@@ -149,9 +193,12 @@ export function getProvenanceLabel(source?: string): string {
 }
 
 /** Extraction type user-facing labels */
-export function getExtractionLabel(source?: string): string {
+export function getExtractionLabel(
+  source?: string,
+  attributedTo?: ParticipantNameResolution,
+): string {
   if (!source) return 'Estimated by Olumi'
-  const attributed = attributedLabelFor(source)
+  const attributed = attributedLabelFor(source, attributedTo)
   if (attributed) return attributed
   switch (source) {
     case 'brief_extraction': return 'From your brief'

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -51,6 +51,7 @@ import {
   BeliefElicitationField,
   describeInWordsToggleLabel,
 } from '../../../components/BeliefElicitationField'
+import { useParticipantName } from '../../../../collab/useParticipantName'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -107,6 +108,15 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
   const cap = unwrapInterventionValue(obs?.cap).value ?? undefined
   const unit = obs?.unit as string | undefined
   const source = obs?.source as string | undefined
+  /**
+   * D1 — resolve a `panel_elicited` value's AUTHOR to a name, at render.
+   *
+   * Called unconditionally and before this component's `!nodeId || !node` early
+   * return, because it is a hook. For every non-panel value it is a no-op: no
+   * `elicited_from` means `no_attribution`, which fetches nothing and leaves
+   * both labels below byte-identical to what they rendered before.
+   */
+  const attributedTo = useParticipantName(obs?.elicited_from as unknown)
   // Canonical location is observedState.uncertainty_drivers (per ObservedStateSchema).
   // Fall back to legacy top-level node.data.uncertainty_drivers for in-flight data
   // that predates the schema consolidation.
@@ -407,7 +417,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
             </span>
           )}
           <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
-            {getExtractionLabel(source)}
+            {getExtractionLabel(source, attributedTo)}
           </span>
         </div>
 
@@ -528,7 +538,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
           {source && (
             <div className="flex items-center gap-1 mt-2 pt-2 border-t border-panel-border">
               <Link size={12} className="text-info" />
-              <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source)}</span>
+              <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source, attributedTo)}</span>
             </div>
           )}
           {uncertaintyDrivers && uncertaintyDrivers.length > 0 && (

--- a/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
@@ -32,6 +32,7 @@ import { resolveCoaching } from '../coachingConfig'
 import { FactorExternalEditor } from '../editors/FactorExternalEditor'
 import { factorDisplayText } from '../../../../utils/formatFactorDisplayValue'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import { useParticipantName } from '../../../../collab/useParticipantName'
 
 // Quick-set presets
 const QUICK_SET = {
@@ -71,6 +72,15 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
   // Source for extraction label (from observedState if present)
   const obs = (node?.data as Record<string, unknown>)?.observedState as Record<string, unknown> | undefined
   const source = obs?.source as string | undefined
+  /**
+   * D1 — resolve a `panel_elicited` value's AUTHOR to a name, at render.
+   *
+   * Called unconditionally and before this component's `!nodeId || !node` early
+   * return, because it is a hook. For every non-panel value it is a no-op: no
+   * `elicited_from` means `no_attribution`, which fetches nothing and leaves
+   * both labels below byte-identical to what they rendered before.
+   */
+  const attributedTo = useParticipantName(obs?.elicited_from as unknown)
 
   // Prior range
   const prior = (node?.data as Record<string, unknown>)?.prior as Record<string, unknown> | number | undefined
@@ -175,7 +185,7 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
             Outside your control
           </span>
           <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
-            {getExtractionLabel(source)}
+            {getExtractionLabel(source, attributedTo)}
           </span>
         </div>
 

--- a/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
@@ -38,6 +38,7 @@ import type { InspectorPanelProps } from '../types'
 import { resolveCoaching } from '../coachingConfig'
 import { FactorObservableEditor } from '../editors/FactorObservableEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import { useParticipantName } from '../../../../collab/useParticipantName'
 
 export const FactorObservablePanel = memo(function FactorObservablePanel({
   nodeId,
@@ -69,6 +70,15 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
   const cap = unwrapInterventionValue(obs?.cap).value ?? undefined
   const unit = obs?.unit as string | undefined
   const source = obs?.source as string | undefined
+  /**
+   * D1 — resolve a `panel_elicited` value's AUTHOR to a name, at render.
+   *
+   * Called unconditionally and before this component's `!nodeId || !node` early
+   * return, because it is a hook. For every non-panel value it is a no-op: no
+   * `elicited_from` means `no_attribution`, which fetches nothing and leaves
+   * both labels below byte-identical to what they rendered before.
+   */
+  const attributedTo = useParticipantName(obs?.elicited_from)
 
   // Description — conditional edit state for EmptyDescriptionPrompt pattern
   const [description, setDescription] = useState(String(node?.data?.description ?? ''))
@@ -148,7 +158,7 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
           </span>
           {source && (
             <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
-              {getExtractionLabel(source)}
+              {getExtractionLabel(source, attributedTo)}
             </span>
           )}
         </div>
@@ -224,7 +234,7 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
           {source && (
             <div className="flex items-center gap-1 mt-2 pt-2 border-t border-panel-border">
               <Link size={12} className="text-info" />
-              <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source)}</span>
+              <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source, attributedTo)}</span>
             </div>
           )}
         </PrimaryControlCard>

--- a/src/collab/__tests__/participantNames.spec.ts
+++ b/src/collab/__tests__/participantNames.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * D1 — render-time participant-name resolution.
+ *
+ * The load-bearing test in this file is `never leaks an identifier where a name
+ * belongs`, and it carries a POSITIVE CONTROL: an absence assertion that has
+ * never been shown detecting a presence is an assertion that passes by testing
+ * nothing. The control poisons a result with the very ids the real assertions
+ * demand are absent, and requires the SAME detector to find them.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  readElicitedFrom,
+  resolveParticipantName,
+  type RosterEntry,
+} from '../participantNames'
+
+/** A uuid-shaped id, so a leak would look exactly like the real thing. */
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+const ABSENT_ID = '00000000-1111-2222-3333-444444444444'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+
+const ELICITED_FROM = { round_id: ROUND_ID, participant_id: GRACE_ID }
+
+const ROSTER: readonly RosterEntry[] = [
+  { participant_id: GRACE_ID, display_name: 'Grace' },
+  { participant_id: 'e1e1e1e1-2222-4333-8444-555566667777', display_name: 'Nadia' },
+]
+
+/**
+ * The detector used by BOTH the absence assertions and their control. It walks
+ * the serialised result, so a name-shaped id smuggled in on a NEW member is
+ * caught without this test knowing the member exists.
+ */
+function identifiersIn(result: unknown): string[] {
+  const serialised = JSON.stringify(result) ?? ''
+  return [GRACE_ID, ROUND_ID, ABSENT_ID].filter((id) => serialised.includes(id))
+}
+
+describe('readElicitedFrom — the passthrough boundary', () => {
+  it('reads a well-formed reference', () => {
+    expect(readElicitedFrom(ELICITED_FROM)).toEqual({
+      round_id: ROUND_ID,
+      participant_id: GRACE_ID,
+    })
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'grace'],
+    ['a number', 7],
+    ['an empty object', {}],
+    ['a participant_id that is not a string', { round_id: ROUND_ID, participant_id: 42 }],
+    ['a blank participant_id', { round_id: ROUND_ID, participant_id: '   ' }],
+    ['a missing round_id', { participant_id: GRACE_ID }],
+    ['a blank round_id', { round_id: '  ', participant_id: GRACE_ID }],
+  ])('refuses %s', (_label, input) => {
+    expect(readElicitedFrom(input)).toBeNull()
+  })
+
+  it('refuses a reference missing round_id even though the lookup only needs participant_id', () => {
+    // Pins the DELIBERATE strictness: without a round_id there is no way to know
+    // which roster is the right one, and resolving against whichever roster
+    // happens to be loaded would attribute a value to a same-id person on
+    // another round. The looser version of this function passes the test above
+    // and fails this one.
+    expect(readElicitedFrom({ participant_id: GRACE_ID })).toBeNull()
+  })
+})
+
+describe('resolveParticipantName', () => {
+  it('names the participant when the roster has them', () => {
+    expect(resolveParticipantName(ELICITED_FROM, ROSTER)).toEqual({
+      state: 'named',
+      label: 'Grace',
+    })
+  })
+
+  it('binds the name to the REFERENCED participant, not to the first row', () => {
+    // Identity binding (not a value predicate another row could satisfy): the
+    // roster's first row is Grace, so a lookup that ignored participant_id
+    // would still return 'Grace' for Nadia's reference and look correct.
+    const nadiaRef = { round_id: ROUND_ID, participant_id: ROSTER[1].participant_id }
+    expect(resolveParticipantName(nadiaRef, ROSTER)).toEqual({
+      state: 'named',
+      label: 'Nadia',
+    })
+  })
+
+  it('reports no_attribution when the value carries no reference', () => {
+    expect(resolveParticipantName(undefined, ROSTER)).toEqual({
+      state: 'unresolved',
+      reason: 'no_attribution',
+    })
+  })
+
+  it('reports roster_unavailable when round data is not loaded', () => {
+    expect(resolveParticipantName(ELICITED_FROM, null)).toEqual({
+      state: 'unresolved',
+      reason: 'roster_unavailable',
+    })
+  })
+
+  it('distinguishes an EMPTY roster (a fact) from an ABSENT one (transient)', () => {
+    // These two must not collapse: one says "this round has no participants",
+    // the other says "I could not find out". A caller that retries does so on
+    // exactly one of them.
+    expect(resolveParticipantName(ELICITED_FROM, [])).toEqual({
+      state: 'unresolved',
+      reason: 'not_on_roster',
+    })
+    expect(resolveParticipantName(ELICITED_FROM, null)).toEqual({
+      state: 'unresolved',
+      reason: 'roster_unavailable',
+    })
+  })
+
+  it('reports not_on_roster when the round has no row for that participant', () => {
+    const ref = { round_id: ROUND_ID, participant_id: ABSENT_ID }
+    expect(resolveParticipantName(ref, ROSTER)).toEqual({
+      state: 'unresolved',
+      reason: 'not_on_roster',
+    })
+  })
+
+  it('reports label_unusable for a present row with a blank label', () => {
+    const roster: RosterEntry[] = [{ participant_id: GRACE_ID, display_name: '   ' }]
+    expect(resolveParticipantName(ELICITED_FROM, roster)).toEqual({
+      state: 'unresolved',
+      reason: 'label_unusable',
+    })
+  })
+
+  it('trims a usable label rather than rejecting it', () => {
+    const roster: RosterEntry[] = [{ participant_id: GRACE_ID, display_name: '  Grace  ' }]
+    expect(resolveParticipantName(ELICITED_FROM, roster)).toEqual({
+      state: 'named',
+      label: 'Grace',
+    })
+  })
+
+  it('resolves to the R-2 PSEUDONYM when that is what the server served', () => {
+    // The module must use the label it is given and hold no opinion about the
+    // person's original name. CEE serves `pseudonym ?? display_name`, so a
+    // redacted participant arrives already pseudonymised; anything that
+    // preferred a remembered original would reinstate the name R-2 detached.
+    const redacted: RosterEntry[] = [
+      { participant_id: GRACE_ID, display_name: 'Participant 2' },
+    ]
+    expect(resolveParticipantName(ELICITED_FROM, redacted)).toEqual({
+      state: 'named',
+      label: 'Participant 2',
+    })
+  })
+
+  it.each(['owner', 'assistant'])(
+    'gives a truthful unresolved answer for the reserved literal %s, never invented copy',
+    (reserved) => {
+      // `AuthoredBySchema` admits these alongside a uuid. CEE only stamps
+      // `elicited_from` after checking the id against the round's own
+      // participant rows, so one arriving here means something changed
+      // upstream — and the honest answer is "cannot name them", not a guess.
+      const ref = { round_id: ROUND_ID, participant_id: reserved }
+      expect(resolveParticipantName(ref, ROSTER)).toEqual({
+        state: 'unresolved',
+        reason: 'not_on_roster',
+      })
+    },
+  )
+})
+
+describe('⭐ never leaks an identifier where a name belongs', () => {
+  it('POSITIVE CONTROL — the detector finds ids when they ARE present', () => {
+    // Without this, every assertion below could pass because the detector is
+    // broken rather than because the results are clean.
+    expect(identifiersIn({ state: 'named', label: GRACE_ID })).toEqual([GRACE_ID])
+    expect(identifiersIn({ state: 'unresolved', reason: 'x', ref: ELICITED_FROM })).toEqual([
+      GRACE_ID,
+      ROUND_ID,
+    ])
+    expect(identifiersIn({ state: 'unresolved', debug: `round ${ABSENT_ID}` })).toEqual([
+      ABSENT_ID,
+    ])
+  })
+
+  it.each([
+    ['a roster miss', { round_id: ROUND_ID, participant_id: ABSENT_ID }, ROSTER],
+    ['an unavailable roster', ELICITED_FROM, null],
+    ['an empty roster', ELICITED_FROM, []],
+    ['a blank label', ELICITED_FROM, [{ participant_id: GRACE_ID, display_name: ' ' }]],
+    ['a reserved literal', { round_id: ROUND_ID, participant_id: 'owner' }, ROSTER],
+  ])(
+    'carries no participant_id and no round_id for %s',
+    (_label, ref, roster: readonly RosterEntry[] | null) => {
+      const result = resolveParticipantName(ref, roster)
+      expect(result.state).toBe('unresolved')
+      expect(identifiersIn(result)).toEqual([])
+    },
+  )
+
+  it('carries no identifier on the NAMED path either', () => {
+    const result = resolveParticipantName(ELICITED_FROM, ROSTER)
+    expect(result).toEqual({ state: 'named', label: 'Grace' })
+    expect(identifiersIn(result)).toEqual([])
+  })
+})

--- a/src/collab/__tests__/roundRosterCache.ttl.spec.ts
+++ b/src/collab/__tests__/roundRosterCache.ttl.spec.ts
@@ -75,6 +75,25 @@ describe('roundRosterCache — the TTL freshness bound (R-2)', () => {
     vi.unstubAllGlobals()
   })
 
+  it('⭐ the TTL is a SHORT ABSOLUTE BOUND — every other test here is relative to it', async () => {
+    const { ROSTER_TTL_MS } = await import('../roundRosterCache')
+
+    // ⚠ WHY THIS ASSERTION EXISTS, found by this file's own mutation kit.
+    // Every other test advances the clock by `ROSTER_TTL_MS` imported from the
+    // module — so they prove the cache honours ITS OWN declared TTL, and are
+    // structurally blind to the TTL's VALUE. A mutant multiplying it by 100,000
+    // (a ~347-day window, i.e. the freshness bound abolished) left all five
+    // green, because the tests grew with it. That is trap 12b: a control pinned
+    // to "whatever the code currently says" decays into a tautology.
+    //
+    // So the magnitude is pinned ABSOLUTELY, in literal milliseconds. This is
+    // the R-2 bound: a redaction must reach an open tab in minutes. A
+    // name-freshness window measured in hours is not a bound, however
+    // self-consistent the cache is about it.
+    expect(ROSTER_TTL_MS).toBeGreaterThan(0)
+    expect(ROSTER_TTL_MS).toBeLessThanOrEqual(15 * 60 * 1000)
+  })
+
   it('POSITIVE CONTROL — a warm roster is peekable and cost exactly one request', async () => {
     // Without this, every expiry assertion below could pass because the cache
     // never worked, not because the TTL fired.

--- a/src/collab/__tests__/roundRosterCache.ttl.spec.ts
+++ b/src/collab/__tests__/roundRosterCache.ttl.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * F1 (review of #689) — the roster TTL is the R-2 FRESHNESS BOUND, and it was
+ * untested.
+ *
+ * The reviewer's mutant deleting the TTL (`fresh()` reduced to a presence check)
+ * **survived 43/43 green**, and it is not an equivalent mutant: with it, a
+ * redacted participant's cached REAL NAME would be served for the life of the
+ * tab instead of for at most `ROSTER_TTL_MS`. The redaction CORRECTNESS path was
+ * already covered — the resolver uses the label it is served, and the only name
+ * source is the server — but the BOUND on how long a stale label survives was
+ * covered by nothing at all.
+ *
+ * ⚠ SCOPE, STATED PRECISELY. This file tests the CACHE's freshness contract:
+ * after the TTL, a peek reports "nothing known" and a fresh request re-reads the
+ * server. It deliberately does NOT assert that an already-mounted panel
+ * re-fetches on expiry — that is review finding F3(a), separately rowed, and its
+ * current behaviour is to degrade to the truthful unnamed sentence until
+ * remount. Testing the cache contract here and claiming the component contract
+ * would be the wider claim that trap 20 is about.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // importOriginal-spread rather than a hand-listed factory: a `vi.mock` factory
+  // REPLACES the module, and a hand list of exports has killed 51 tests in this
+  // repo before (CLAUDE.md trap 12).
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getSessionIdentity: vi.fn(async () => ({ userId: 'owner-1', accessToken: 'tok' })),
+  }
+})
+
+/**
+ * Two DIFFERENT responses in sequence, so a refetch is provable by its CONTENT
+ * and not only by a call count. The second is the R-2 case the TTL exists for:
+ * the owner has redacted Grace, and CEE now serves the pseudonym.
+ */
+function rosterResponse(displayName: string) {
+  return {
+    round_id: ROUND_ID,
+    status: 'closed',
+    targets: [],
+    roster: [{ participant_id: GRACE_ID, display_name: displayName, status: 'active' }],
+  }
+}
+
+function fetchCount(): number {
+  return (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.length
+}
+
+describe('roundRosterCache — the TTL freshness bound (R-2)', () => {
+  beforeEach(async () => {
+    const { __resetRosterCacheForTests } = await import('../roundRosterCache')
+    __resetRosterCacheForTests()
+    vi.useFakeTimers()
+    let call = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        call += 1
+        // First read: the real name. Every later read: the pseudonym.
+        const body = rosterResponse(call === 1 ? 'Grace' : 'Participant 2')
+        return new Response(JSON.stringify(body), { status: 200 })
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('POSITIVE CONTROL — a warm roster is peekable and cost exactly one request', async () => {
+    // Without this, every expiry assertion below could pass because the cache
+    // never worked, not because the TTL fired.
+    const { ensureRoster, peekRoster } = await import('../roundRosterCache')
+    await ensureRoster(ROUND_ID)
+    expect(fetchCount()).toBe(1)
+    expect(peekRoster(ROUND_ID)).toEqual([
+      { participant_id: GRACE_ID, display_name: 'Grace' },
+    ])
+  })
+
+  it('serves from cache while still fresh — no second request just before expiry', async () => {
+    const { ensureRoster, peekRoster, ROSTER_TTL_MS } = await import('../roundRosterCache')
+    await ensureRoster(ROUND_ID)
+    expect(fetchCount()).toBe(1)
+
+    vi.advanceTimersByTime(ROSTER_TTL_MS - 1)
+
+    expect(peekRoster(ROUND_ID)).toEqual([
+      { participant_id: GRACE_ID, display_name: 'Grace' },
+    ])
+    await ensureRoster(ROUND_ID)
+    // The pairing that makes this test discriminate: one instant before expiry
+    // the answer is BOTH still peekable AND still free. A TTL set too short
+    // fails here; a TTL deleted fails the next test.
+    expect(fetchCount()).toBe(1)
+  })
+
+  it('⭐ AFTER THE TTL a peek reports NOTHING KNOWN, never a stale name', async () => {
+    const { ensureRoster, peekRoster, ROSTER_TTL_MS } = await import('../roundRosterCache')
+    await ensureRoster(ROUND_ID)
+    expect(peekRoster(ROUND_ID)).not.toBeUndefined()
+
+    vi.advanceTimersByTime(ROSTER_TTL_MS + 1)
+
+    // `undefined` is "nothing known" — which resolves to `roster_unavailable`,
+    // whose copy still says the value came from the panel. It is NOT `null`
+    // ("this round has no participants") and NOT the stale entry.
+    expect(peekRoster(ROUND_ID)).toBeUndefined()
+  })
+
+  it('⭐ AFTER THE TTL a fresh request RE-READS THE SERVER and picks up the redaction', async () => {
+    const { ensureRoster, peekRoster, ROSTER_TTL_MS } = await import('../roundRosterCache')
+    await ensureRoster(ROUND_ID)
+    expect(fetchCount()).toBe(1)
+
+    vi.advanceTimersByTime(ROSTER_TTL_MS + 1)
+    const refreshed = await ensureRoster(ROUND_ID)
+
+    expect(fetchCount()).toBe(2)
+    // Bound by CONTENT, not only by the call count: this is the whole point of
+    // the TTL. The name Grace must be gone, replaced by what the server now
+    // serves — a cache without expiry would still be answering 'Grace'.
+    expect(refreshed).toEqual([
+      { participant_id: GRACE_ID, display_name: 'Participant 2' },
+    ])
+    expect(peekRoster(ROUND_ID)).toEqual([
+      { participant_id: GRACE_ID, display_name: 'Participant 2' },
+    ])
+    expect(JSON.stringify(refreshed)).not.toContain('Grace')
+  })
+
+  it('the TTL bounds a FAILED read too, so a signed-out moment is not permanent', async () => {
+    // Both arms share the TTL deliberately: a cached failure that outlived a
+    // sign-in would leave the surface unable to name anybody for the life of the
+    // tab — the same defect as a stale name, pointing the other way.
+    const { __resetRosterCacheForTests, ensureRoster, ROSTER_TTL_MS } = await import(
+      '../roundRosterCache'
+    )
+    __resetRosterCacheForTests()
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 403 })))
+    expect(await ensureRoster(ROUND_ID)).toBeNull()
+    expect(fetchCount()).toBe(1)
+
+    // Still inside the window: the failure is reused, not retried on sight.
+    await ensureRoster(ROUND_ID)
+    expect(fetchCount()).toBe(1)
+
+    vi.advanceTimersByTime(ROSTER_TTL_MS + 1)
+    await ensureRoster(ROUND_ID)
+    expect(fetchCount()).toBe(2)
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -71,6 +71,30 @@ export interface RevealView {
   }>
 }
 
+/**
+ * The owner's roster view of a round (CEE `OpenPacketLikePreview`).
+ *
+ * ⚠ `display_name` HERE IS ALREADY R-2 RESOLVED. CEE projects it as
+ * `p.pseudonym ?? p.display_name` (`collab/rounds-service.ts:217`), so a
+ * redacted participant arrives pseudonymised and no client needs to know the
+ * rule. That is precisely why render-time name resolution reads THIS and not
+ * `openRoundRecord`'s `localStorage` copy, which a later redaction cannot reach.
+ *
+ * `targets` is declared because the route sends it, not because this UI uses it
+ * — an undeclared field on a response type is how a reader concludes the server
+ * does not send one.
+ */
+export interface RoundRosterView {
+  round_id: string
+  status: string
+  targets: PacketTarget[]
+  roster: Array<{
+    participant_id: string
+    display_name: string
+    status: string
+  }>
+}
+
 export interface CollabError {
   code: string
   message: string
@@ -284,6 +308,37 @@ export async function fetchOwnerReveal(
   })
   if (!res.ok) throw await parseError(res)
   return (await res.json()) as RevealView
+}
+
+/**
+ * Fetch a round's ROSTER — the owner-facing name source for render-time
+ * attribution (D1).
+ *
+ * ── WHY THE PREVIEW ROUTE AND NOT THE REVEAL ──────────────────────────────
+ * `/reveal` would also answer the question: it carries `display_label` per
+ * response. It is the wrong choice on data minimisation, which is the same
+ * principle that makes the graph persist ids only. Resolving one pill's name
+ * would pull EVERY participant's number, verbatim wording and confidence into
+ * the canvas — a whole round's beliefs to render one person's name. `/preview`
+ * returns the roster and nothing else.
+ *
+ * ⚠ THE PREVIEW ROUTE IS NOT OPEN-ROUND-ONLY, despite its "pre-close" comment
+ * at CEE. `ownerPreview` refuses only on a missing round or a non-owner caller
+ * and returns `round.status` verbatim, so it answers for a CLOSED round too —
+ * which is the only kind that can produce an attribution, because CEE refuses
+ * an apply whose round is not applyable. Derived at
+ * `collab/rounds-service.ts:192-221`, not inferred from the route's comment.
+ */
+export async function fetchRoundRoster(
+  accessToken: string,
+  roundId: string,
+): Promise<RoundRosterView> {
+  const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/preview`, {
+    method: 'GET',
+    headers: { Authorization: ownerAuthorization(accessToken) },
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as RoundRosterView
 }
 
 /**

--- a/src/collab/participantNames.ts
+++ b/src/collab/participantNames.ts
@@ -1,0 +1,143 @@
+/**
+ * COLLAB — resolving a persisted `elicited_from` reference to a PERSON'S NAME,
+ * at render time.
+ *
+ * ── WHY RESOLUTION IS A MODULE AND NOT A LOOKUP AT EACH SURFACE ────────────
+ * schemas 0.40.0's `RoundParticipantRefSchema` persists `{round_id,
+ * participant_id}` and NOTHING ELSE, and its header states the reason as a
+ * rule rather than a preference:
+ *
+ *   "IDS ONLY, `.strict()`, DELIBERATELY. Display names are resolved at render
+ *    time from round data and are NEVER persisted into the graph — a display
+ *    name inside `scenarios.graph` would sit beyond the R-2 redaction
+ *    routine's reach."
+ *
+ * So every attribution surface faces the same question ("who is
+ * `participant_id`?") and has the same two ways to get it wrong: print the raw
+ * id as though it were a name, or guess. This module is the ONE answer, and it
+ * is a pure function so the answer can be tested without a network, a session,
+ * or a rendered tree.
+ *
+ * ── THE INVARIANT THAT IS THE WHOLE POINT ─────────────────────────────────
+ * **A `named` result carries a name a human wrote. An unresolved result carries
+ * NO IDENTIFIER AT ALL** — not the participant id, not the round id, not a
+ * truncated or prefixed form of either. A uuid rendered where a name belongs
+ * reads to the user as a name (it sits in the same sentence position, in the
+ * same pill), and it is a name for nobody. `__tests__/participantNames.spec.ts`
+ * asserts this against the SERIALISED result, so a future field cannot
+ * reintroduce an id by riding along.
+ *
+ * ── WHY THE REASONS ARE DISTINCT AND NOT ONE `null` ───────────────────────
+ * Four different things can stop a name resolving, and they are not the same
+ * fact about the world:
+ *   · `no_attribution`     — the value was never applied from a panel answer.
+ *                            The ordinary case for almost every factor.
+ *   · `roster_unavailable` — round data is not loaded YET, or could not be
+ *                            loaded. TRANSIENT; a later render may resolve.
+ *   · `not_on_roster`      — the round has no row for this participant.
+ *   · `label_unusable`     — a row exists and its label is empty.
+ * A surface that collapses these into "no name" renders the same copy for "this
+ * number is nobody's panel answer" and "this IS somebody's panel answer and I
+ * cannot say whose" — and the second must keep saying the value came from the
+ * panel. That is why callers get the reason, not a bare `string | null`.
+ *
+ * ⚠ THE LABEL IS ALREADY R-2 RESOLVED WHEN IT ARRIVES, AND MUST BE.
+ * `display_name` on a roster entry is CEE's `p.pseudonym ?? p.display_name`
+ * (`collab/rounds-service.ts:217`, the preview projection). This module must
+ * therefore be fed SERVER round data and never a client-side copy of a name:
+ * `collab/openRoundRecord.ts` keeps names in `localStorage`, and a name cached
+ * there survives the redaction that replaced it, so resolving from that record
+ * would reinstate a name R-2 exists to detach. Named here because the record is
+ * the nearest available source and the wrong one.
+ */
+
+/**
+ * The persisted attribution reference (schemas 0.40.0
+ * `RoundParticipantRefSchema`), as it is READ rather than as it is written.
+ *
+ * `participant_id` consumes `AuthoredBySchema`, which admits the reserved
+ * literals `'owner'` and `'assistant'` as well as a uuid — so it is a string
+ * here, not a uuid-shaped type, and a reserved literal is handled by ordinary
+ * roster lookup (it has no roster row, so it lands on `not_on_roster`, which is
+ * truthful). Deliberately NOT special-cased into invented copy: CEE only stamps
+ * this field after verifying the id against the round's own participant rows,
+ * so a reserved literal arriving here would mean something has changed upstream
+ * and the honest answer is that this surface cannot name them.
+ */
+export interface RoundParticipantRef {
+  round_id: string
+  participant_id: string
+}
+
+/**
+ * One row of a round's roster, as CEE's owner preview serves it.
+ *
+ * `display_name` IS the R-2-resolved label (pseudonym after redaction) — the
+ * field name is CEE's, kept verbatim so the two sides grep to each other.
+ */
+export interface RosterEntry {
+  participant_id: string
+  display_name: string
+}
+
+export type NameUnresolvedReason =
+  | 'no_attribution'
+  | 'roster_unavailable'
+  | 'not_on_roster'
+  | 'label_unusable'
+
+export type ParticipantNameResolution =
+  | { readonly state: 'named'; readonly label: string }
+  | { readonly state: 'unresolved'; readonly reason: NameUnresolvedReason }
+
+/**
+ * Read a `{round_id, participant_id}` reference off a value that came through a
+ * `.passthrough()` schema.
+ *
+ * `ObservedStateSchema` is `.passthrough()`, so `elicited_from` reaches the
+ * client as whatever the wire carried — this function is the boundary that
+ * turns "whatever the wire carried" into a typed reference or nothing. It
+ * validates both members even though only `participant_id` is used for the
+ * lookup: a reference missing its `round_id` cannot be resolved against the
+ * right round's roster, and treating it as attribution would invite a lookup
+ * against WHICHEVER roster happened to be loaded.
+ */
+export function readElicitedFrom(value: unknown): RoundParticipantRef | null {
+  if (typeof value !== 'object' || value === null) return null
+  const ref = value as { round_id?: unknown; participant_id?: unknown }
+  if (typeof ref.round_id !== 'string' || ref.round_id.trim() === '') return null
+  if (typeof ref.participant_id !== 'string' || ref.participant_id.trim() === '') return null
+  return { round_id: ref.round_id, participant_id: ref.participant_id }
+}
+
+/**
+ * Resolve one attribution reference against one round's roster.
+ *
+ * `roster === null` means "not available" (not loaded yet, or the load failed)
+ * and is DISTINCT from `[]`, which means "this round genuinely has no
+ * participants" — the first is transient and the second is a fact. They return
+ * different reasons for that reason.
+ */
+export function resolveParticipantName(
+  elicitedFrom: unknown,
+  roster: readonly RosterEntry[] | null | undefined,
+): ParticipantNameResolution {
+  const ref = readElicitedFrom(elicitedFrom)
+  if (ref === null) return { state: 'unresolved', reason: 'no_attribution' }
+
+  if (roster === null || roster === undefined) {
+    return { state: 'unresolved', reason: 'roster_unavailable' }
+  }
+
+  const row = roster.find((entry) => entry.participant_id === ref.participant_id)
+  if (row === undefined) return { state: 'unresolved', reason: 'not_on_roster' }
+
+  // A row can exist with an unusable label: CEE's redaction writes a pseudonym,
+  // but an owner-entered display name is only `.min(1)` at the mint boundary
+  // and whitespace passes that. Trimming here — rather than at the surface —
+  // keeps "is this label printable" one decision in one place.
+  const label = typeof row.display_name === 'string' ? row.display_name.trim() : ''
+  if (label === '') return { state: 'unresolved', reason: 'label_unusable' }
+
+  return { state: 'named', label }
+}

--- a/src/collab/roundRosterCache.ts
+++ b/src/collab/roundRosterCache.ts
@@ -1,0 +1,148 @@
+/**
+ * COLLAB — the round-roster cache behind render-time participant names (D1).
+ *
+ * ── WHY A CACHE AT ALL ────────────────────────────────────────────────────
+ * Name resolution happens during RENDER, on a surface that re-renders whenever
+ * the inspector's node changes. Without memoisation every render of an
+ * attributed factor is a network request, and several attributed factors from
+ * one round would each fetch the same roster. So the cache is not an
+ * optimisation bolted on afterwards — it is what makes render-time resolution
+ * a sane thing to do at all.
+ *
+ * ── THREE STATES, NOT TWO ─────────────────────────────────────────────────
+ * `undefined` (never asked) · a roster · `null` (asked, and it did not work).
+ * The third is stored rather than retried-on-sight, because a signed-out owner
+ * or a round on another scenario fails EVERY time and a render-triggered retry
+ * loop would hammer the seam for as long as the panel is open.
+ *
+ * ⚠ FRESHNESS IS AN R-2 CONCERN, WHICH IS WHY THE TTL EXISTS AND IS SHORT.
+ * A cached label is a cached PERSON'S NAME. When the owner redacts a
+ * participant, CEE starts serving the pseudonym — and any cache without an
+ * expiry would keep rendering the detached name for the life of the tab, which
+ * is the redaction routine failing quietly at the last hop. The TTL bounds that
+ * window to `ROSTER_TTL_MS`; it is deliberately not "cache for the session".
+ *
+ * ── WHAT THIS MODULE DELIBERATELY DOES NOT DO ─────────────────────────────
+ * It never falls back to `openRoundRecord`'s `localStorage` names. That record
+ * exists so an owner can return to an open round, and its copy of a name
+ * survives the redaction that replaced it — reading it here would reinstate
+ * exactly what R-2 detached. The only name source is the server.
+ */
+
+import { fetchRoundRoster } from './collabService'
+import { requireOwnerAccessToken } from './ownerAccessToken'
+import type { RosterEntry } from './participantNames'
+
+/**
+ * How long a roster answer (success OR failure) is reused.
+ *
+ * Five minutes: long enough that opening several attributed factors costs one
+ * request, short enough that a redaction reaches every open tab without a
+ * reload. Both arms share it — a failure that outlived a sign-in would leave
+ * the surface permanently unable to name anybody.
+ */
+export const ROSTER_TTL_MS = 5 * 60 * 1000
+
+interface CacheEntry {
+  /** null = asked and could not answer. */
+  roster: readonly RosterEntry[] | null
+  storedAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const inFlight = new Map<string, Promise<readonly RosterEntry[] | null>>()
+
+/** Listeners woken when an entry lands, so a render can be re-run. */
+const subscribers = new Set<() => void>()
+
+function notify(): void {
+  // A copy, because a subscriber may unsubscribe itself while being called.
+  for (const fn of [...subscribers]) fn()
+}
+
+export function subscribeToRosters(fn: () => void): () => void {
+  subscribers.add(fn)
+  return () => {
+    subscribers.delete(fn)
+  }
+}
+
+function fresh(entry: CacheEntry | undefined): entry is CacheEntry {
+  return entry !== undefined && Date.now() - entry.storedAt < ROSTER_TTL_MS
+}
+
+/**
+ * The synchronous read a render uses.
+ *
+ * `undefined` means "nothing known yet" and is what makes the caller's first
+ * paint honest: it resolves to `roster_unavailable`, whose copy still says the
+ * value came from the panel. It never means "no participants".
+ */
+export function peekRoster(roundId: string): readonly RosterEntry[] | null | undefined {
+  const entry = cache.get(roundId)
+  return fresh(entry) ? entry.roster : undefined
+}
+
+/**
+ * Ensure a roster is being fetched, and return it when it lands.
+ *
+ * Idempotent per round while a request is in flight — the dedup is the whole
+ * reason several attributed factors from one round cost one request. Never
+ * rejects: a failure is a cached `null`, because a surface that cannot name
+ * somebody must keep rendering, and a thrown promise inside a render is how a
+ * missing name becomes a blank panel.
+ */
+export function ensureRoster(roundId: string): Promise<readonly RosterEntry[] | null> {
+  if (roundId === '') return Promise.resolve(null)
+
+  const entry = cache.get(roundId)
+  if (fresh(entry)) return Promise.resolve(entry.roster)
+
+  const existing = inFlight.get(roundId)
+  if (existing !== undefined) return existing
+
+  const request = (async (): Promise<readonly RosterEntry[] | null> => {
+    try {
+      const accessToken = await requireOwnerAccessToken()
+      const view = await fetchRoundRoster(accessToken, roundId)
+      // PICKED, never spread. The response also carries `status` per row and the
+      // round's whole target manifest; the resolver's contract is two fields,
+      // and a spread would quietly widen what the cache holds about a person.
+      const roster: RosterEntry[] = Array.isArray(view?.roster)
+        ? view.roster
+            .filter(
+              (row): row is { participant_id: string; display_name: string; status: string } =>
+                row !== null &&
+                typeof row === 'object' &&
+                typeof row.participant_id === 'string' &&
+                typeof row.display_name === 'string',
+            )
+            .map((row) => ({
+              participant_id: row.participant_id,
+              display_name: row.display_name,
+            }))
+        : []
+      cache.set(roundId, { roster, storedAt: Date.now() })
+      return roster
+    } catch {
+      // Signed out, a round the caller does not own, a network failure. All
+      // three are "cannot name them" at the surface, and none is worth
+      // distinguishing there — the copy is the same and it is truthful.
+      cache.set(roundId, { roster: null, storedAt: Date.now() })
+      return null
+    } finally {
+      inFlight.delete(roundId)
+      notify()
+    }
+  })()
+
+  inFlight.set(roundId, request)
+  return request
+}
+
+/** Test seam. Never called by product code. */
+export function __resetRosterCacheForTests(): void {
+  cache.clear()
+  inFlight.clear()
+  subscribers.clear()
+}

--- a/src/collab/useParticipantName.ts
+++ b/src/collab/useParticipantName.ts
@@ -1,0 +1,53 @@
+/**
+ * COLLAB — `useParticipantName`: the React half of render-time name resolution.
+ *
+ * Takes the `elicited_from` value straight off a node's `observed_state` (which
+ * reaches the client through a `.passthrough()` schema, so it is `unknown` by
+ * honest typing) and answers with a resolution the surface can render.
+ *
+ * ── WHY IT NEVER SUSPENDS AND NEVER THROWS ────────────────────────────────
+ * The first paint of an attributed factor happens before any roster can have
+ * arrived, so the hook's FIRST answer is always `roster_unavailable` and the
+ * surface must already be truthful in that state. That is the point of the
+ * fallback copy being the existing "From your panel" rather than a spinner or a
+ * blank: a name appearing a moment later ADDS detail to a sentence that was
+ * already true, instead of replacing a placeholder that was not.
+ *
+ * ── ONE REQUEST PER ROUND, NOT ONE PER SURFACE ────────────────────────────
+ * Every instance calls `ensureRoster`, which dedups in flight and memoises the
+ * result, so N attributed factors from one round cost one request. The
+ * subscription exists so the instances that did not initiate the fetch still
+ * re-render when it lands.
+ */
+
+import { useEffect, useState } from 'react'
+import { ensureRoster, peekRoster, subscribeToRosters } from './roundRosterCache'
+import {
+  readElicitedFrom,
+  resolveParticipantName,
+  type ParticipantNameResolution,
+} from './participantNames'
+
+export function useParticipantName(elicitedFrom: unknown): ParticipantNameResolution {
+  const ref = readElicitedFrom(elicitedFrom)
+  const roundId = ref?.round_id ?? ''
+
+  // A revision counter, not the roster itself: the cache owns the data, and
+  // duplicating it into component state is how two copies start disagreeing.
+  const [, bumpRevision] = useState(0)
+
+  useEffect(() => {
+    if (roundId === '') return
+    const unsubscribe = subscribeToRosters(() => bumpRevision((n) => n + 1))
+    // Fire-and-forget: `ensureRoster` never rejects, and the re-render comes
+    // from the subscription rather than from this promise, so an instance that
+    // mounts while another's request is in flight is woken by the same event.
+    void ensureRoster(roundId)
+    return unsubscribe
+  }, [roundId])
+
+  // Resolution happens during RENDER from the cache's current answer, so a
+  // roster that was already warm names the person on the FIRST paint with no
+  // intermediate unresolved frame.
+  return resolveParticipantName(elicitedFrom, roundId === '' ? undefined : peekRoster(roundId))
+}

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -186,6 +186,36 @@ describe('collab-proxy path allowlist (/bff/collab/* → /collab/v1/*)', () => {
     expect(r.calledUrl).toBe(`https://cee-staging.onrender.com/collab/v1/packet/${uuid}`)
   })
 
+  it('ON-LIST /bff/collab/rounds/{uuid}/preview (GET) forwards — D1 name resolution', async () => {
+    // The roster read behind render-time participant names. It was OFF-LIST
+    // until 14 Aug 2026 while two comments in the proxy advertised it, so the
+    // route CEE had exposed all along answered 404 at the edge.
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/rounds/${uuid}/preview`,
+      method: 'GET',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      `https://cee-staging.onrender.com/collab/v1/rounds/${uuid}/preview`,
+    )
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('OFF-LIST /bff/collab/rounds/{uuid}/participants is 404 — preview did not widen the segment', async () => {
+    // The DISCRIMINATING half of the pair above. `preview` was added as a
+    // literal final segment; had it been written permissively (or the id
+    // segment loosened), every sibling sub-route under /rounds/{id}/ would have
+    // opened with it. This case fails if the new entry admits more than one word.
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/rounds/${uuid}/participants`,
+      method: 'GET',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
   it('OFF-LIST /bff/collab/admin is 404 with NO key sent', async () => {
     const r = await invoke(collabHandler as Handler, { path: '/bff/collab/admin' })
     expect(r.status).toBe(404)


### PR DESCRIPTION
## What this is

Lane D of the 14 Aug capability wave, **PRIORITY 2: collaboration → evidence/challenge → attributed model change**. Ships D1, the rowed follow-up to the 0.40.0 apply slice.

The apply slice stamps `observed_state.source = 'panel_elicited'` plus `elicited_from {round_id, participant_id}`, server-verified. The attribution pill then said **"From your panel"** — true, but never *whose* answer it was. The identity CEE verified and persisted **reached no screen**.

Measured at this tip, with a contrast control:
- `elicited_from` in UI `src/`: **exactly one occurrence, inside a JSDoc comment.** Zero functional readers.
- Contrast control `panel_elicited`: live in the same file, 10+ occurrences including a map entry and dedicated spec assertions — so the probe can see presences where it looked.

## Why render-time, and never persisted

Not a preference — schemas 0.40.0's own header prescribes it, verbatim from the vendored tarball bytes:

> **IDS ONLY, `.strict()`, DELIBERATELY. Display names are resolved at render time from round data and are NEVER persisted into the graph** — a display name inside `scenarios.graph` would sit beyond the R-2 redaction routine's reach.

Which also settles the comment this PR replaces. The prior slice wrote *"no name here, per D1: only `participant_id` is persisted, so a name on this surface could not be reached by the R-2 redaction routine."* The premise is right; the conclusion does not follow. R-2 is beyond reach only for a name **persisted** in the graph. A name **resolved at render** from CEE's roster (`pseudonym ?? display_name`) is redaction-correct by construction.

## The pieces

| File | Job |
|---|---|
| `collab/participantNames.ts` | The pure resolver. Never emits an identifier where a name belongs. |
| `collab/roundRosterCache.ts` | One request per round, TTL-bounded so a redaction reaches open tabs. |
| `collab/useParticipantName.ts` | The React half. Never suspends, never throws. |
| `collabService.fetchRoundRoster` | The `/preview` **roster** route. |
| `inspectorStrings.ts` | Optional resolution on both label functions. Additive. |
| 3 inspector factor panels | Consume it. All three deployed-mounted. |

**The invariant that is the whole point:** a `named` result carries a name a human wrote; an unresolved result carries **no identifier at all** — not the participant id, not the round id, not a truncated form. Pinned against the *serialised* result, so a future field cannot smuggle one back, and carrying a positive control that poisons a result with those very ids and requires the same detector to find them.

**Four distinct unresolved reasons**, not one `null`: "this is nobody's panel answer" and "this **is** somebody's and I cannot say whose" are different facts, and the second must keep saying the value came from the panel.

**The named copy attributes without endorsing** (Paul's ruling: *"apply Grace's value" ≠ "Grace was correct"*). `From Grace's panel answer`. A test forbids `correct`/`verified`/`validated`/`confirmed`/`agreed`/`best` in that label.

**Why `/preview` and not `/reveal`:** the same data-minimisation principle that makes the graph persist ids only. `/reveal` would answer the question, and would pull *every* participant's number, verbatim wording and confidence into the canvas to render one person's name.

**Never reads `openRoundRecord`'s localStorage names.** That copy survives the redaction that replaced it, so resolving from it would reinstate exactly what R-2 detached. It is the nearest available source and the wrong one.

## ⚠ The route was unreachable and two comments in the same file said otherwise

CEE has exposed `GET /collab/v1/rounds/:id/preview` all along — owner-gated by `requireOwnerUser`, roster-only, R-2-resolved (`rounds-service.ts:217`). The edge proxy's `ALLOWED_TARGETS` **never listed it**, while its own `ALLOWED_FORWARD_HEADERS` comment advertised the owner bearer as being for *"mint / close / **preview** / reveal"*. The proxy's own doctrine: *"an allow-list that advertises more than it enforces (or less) is a false guarantee."*

Added, with a **discriminating pair**: an ON-LIST case proving it forwards with the injected key, and an OFF-LIST twin (`/rounds/{id}/participants`) proving the new entry did not widen the segment. Neither alone shows the binding.

⚠ **Reviewer note, reported not fixed** (scope-expansion rule): `tests/ci-guards/bffProxyPathAllowlist.spec.ts` is a **hand-written corpus**, not derived from `collabService`. It is a trap-12 mirror — a seventh route added to the service is not automatically checked against the allowlist. That is how this gap shipped.

## Gates

- `pnpm run typecheck` **PASSED** — 3413/3453 files, **zero new diagnostics**. Drift shrank 2487→2485; **shrink DECLINED** (attribution churn in files this PR never touched).
- `npm run lint` (the **named** gate, not a scoped subset) — **0 errors**. Hooks ratchet **232 violations / 15 files, exactly matching baseline** — the three new hook calls are unconditional, before each panel's early return.
- `ci:guard:schemas-version` — up to date at 0.40.0. No pin change.
- Targeted regression: **82 files / 1010 tests, all pass.**
- New specs collected **by name**, non-zero: `participantNames` 29 · `panelAttributionNaming` 14 · `bffProxyPathAllowlist` 34.

## Mutation kit — 10/11 bit, and it caught a defect in my own test

Throwaway worktree **outside** the repo root. Isolation proven **by writing** a sentinel and asserting it did not appear in the source; inodes compared (`613841414` vs `614006591`, no APFS hard link). Restores **HEAD-relative**, from a pristine archive outside both trees. Clean tree asserted before **and** after every mutant. Applied-check scoped to `src/`+`netlify/`+`tests/`, asserting **exactly 1** changed file per mutant — an unapplied mutation is a false survivor. Zero control and trailing control both 84 passed / 0 failed.

| Mutant | Verdict |
|---|---|
| M1 `readElicitedFrom` stops requiring `round_id` | BIT (3) |
| M2 **leak the participant_id as the label** | BIT (7) |
| M3 collapse `roster_unavailable` into `not_on_roster` | BIT (2) |
| M4 **ignore identity — take the first roster row** | BIT (6) |
| M5 drop the blank-label check | BIT (2) |
| M6 apply the name to ANY attributed kind | BIT (1) |
| M7 ignore the resolution entirely | BIT (5) |
| M8 named copy **endorses** rather than attributes | BIT (5) |
| M9 remove the cache inertness guard | SURVIVOR — equivalent, **demonstrated** |
| M10 remove `preview` from the allowlist | BIT (1) |
| M11 `preview` regex written permissively | BIT (1) |

### ⭐ M9 exposed a vacuous assertion of mine — the honest account

M9 survived. Rather than assert equivalence, I ran the discriminating triple:

```
M9  cache guard only   -> SURVIVOR
M9b hook guard only    -> SURVIVOR
M9c BOTH guards        -> SURVIVOR   ← this is the finding
```

Both guards removed and the test still passed. Cause: `ensureRoster` awaits the session before it fetches, so a synchronous `fetch.mock.calls.length === 0` assertion ran a microtask **before any request could have been issued**. The test was measuring its own timing, not the code — an absence assertion that resolves before the thing it forbids could happen.

Fixed with an explicit async flush **plus a positive control** asserting the same flush observes a request that *is* made (a too-short flush would restore the vacuity silently). Re-run at the fixed tip:

```
M9  cache guard only   -> SURVIVOR  (equivalent: the hook guard is sufficient)
M9b hook guard only    -> SURVIVOR  (equivalent: the cache guard is sufficient)
M9c BOTH guards        -> BIT       (the property IS pinned)
```

So the two guards are individually redundant and **jointly load-bearing** — defence in depth, now demonstrated rather than claimed. Caught by the kit, not by review.

## Deployed-mount posture (trap 3b) — derived, not inherited

All three panels mount with **no flag gate**: `InspectorModal.tsx:16` is a hardcoded `const USE_INSPECTOR_V2 = true`, chain `FactorXPanel → InspectorRouter:262 → InspectorModal:174 → ReactFlowGraph:2172 → CanvasMVP:282` (unconditional) → `AppPoC:922/927`. `InspectorShell`'s `isAiPanelV2Enabled()` gates only a "Back to results" button. The legacy `NodeInspector` is reachable only from the dead `USE_INSPECTOR_V2 === false` branch.

⚠ **Data-shaped trap the component test defends against:** `InspectorRouter.resolvePanelType` (`:82-89`) falls through to `'factor-controllable'` for a missing or misspelled `data.category`, so a fixture that omits it renders a *different* panel than the test names and passes anyway. The fixtures set `category` explicitly.

## Scope — what this PR does NOT touch

`turn-executor.ts` (not this repo; named for the record) · `uiStore.ts` · `OutputsDock.tsx` · `TopBar.tsx` · `applyV5State.ts` · `useResultsSectionData.ts` · **no schemas pin bump** · **no CEE change** (the route already exists, so there is no deploy-order dependency — this PR is independently deployable).

`GraphTextView.tsx` also calls `getProvenanceLabel` and was deliberately left on the unnamed fallback: it has no `elicited_from` in scope, and its copy stays truthful. Named here rather than silently skipped.

## The rationale/evidence half — STOPPED AT THE BOUNDARY

Per the brief. **The 0.40.0 contract does not admit a rationale field**, derived at the vendored tarball bytes. `ElicitationBeliefSchema` is `.strict()` over exactly `{value, expression_raw, confidence}`; there are **zero `.passthrough()` calls in the entire collab boundary module**; and the event union's `declined`/`clarification_requested` arms do not declare `belief` at all. `expression_raw` is **not** a rationale — it is the verbatim wording that produced the number, required and `.min(1)`, so the numeric path already fills it with the typed digits. Reusing it would be a trap-21 concept split. The exact contract change needed is in the lane report; it rides the batched contract wave with F4.

## Two-person wire acceptance probe (post-deploy)

Extends the existing PR4 witness. Sketched in `olumi-docs/PHASE0-EVIDENCE-2026-07-28/collab-evidence-lane-2026-08-14/`.

**Not merged — branch only. Independent review gates every merge.**