### PR TITLE
UI: one model-name control in the top bar — inline rename, "model" not "decision", and the rename now reaches every surface

### DIFF
--- a/e2e/topbar-model-name.spec.ts
+++ b/e2e/topbar-model-name.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Real-browser verification of the single model-name control (Paul, 14 Aug 2026).
+ *
+ * jsdom proves wiring, never layout (trap 3): a jsdom spec cannot tell you that
+ * two controls were VISIBLE side by side, only that two nodes existed. These
+ * assertions are the ones that need a real engine — visibility, bounding boxes,
+ * real focus, real keyboard.
+ *
+ * Run: npx playwright test e2e/topbar-model-name.spec.ts
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('TopBar — one model-name control', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#/canvas')
+    await expect(page.getByTestId('scenario-name-button')).toBeVisible({ timeout: 30_000 })
+  })
+
+  test('shows exactly ONE visible name control, and the old title is gone', async ({ page }) => {
+    // The removed control, by both of its accessible names.
+    await expect(page.getByRole('button', { name: /edit decision title/i })).toHaveCount(0)
+
+    // Exactly one visible name control in the banner.
+    const banner = page.getByRole('banner')
+    await expect(banner.getByTestId('scenario-name-button')).toHaveCount(1)
+
+    // ...and it really occupies space (a jsdom test cannot say this).
+    const box = await page.getByTestId('scenario-name-button').boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.width).toBeGreaterThan(20)
+    expect(box!.height).toBeGreaterThan(10)
+
+    // No element anywhere on screen still says "Untitled decision".
+    await expect(page.getByText('Untitled decision', { exact: false })).toHaveCount(0)
+  })
+
+  test('renames inline in ONE click, Enter commits', async ({ page }) => {
+    await page.getByTestId('scenario-name-button').click()
+
+    const input = page.getByTestId('scenario-name-input')
+    await expect(input).toBeVisible()
+    await expect(input).toBeFocused()          // real focus, not a jsdom attribute
+
+    await input.fill('Opex reduction model')
+    await input.press('Enter')
+
+    await expect(page.getByTestId('scenario-name-input')).toHaveCount(0)
+    await expect(page.getByTestId('scenario-name-button')).toHaveText('Opex reduction model')
+  })
+
+  test('Escape cancels and keeps the previous name', async ({ page }) => {
+    const before = await page.getByTestId('scenario-name-button').innerText()
+
+    await page.getByTestId('scenario-name-button').click()
+    const input = page.getByTestId('scenario-name-input')
+    await input.fill('Discarded name')
+    await input.press('Escape')
+
+    await expect(page.getByTestId('scenario-name-input')).toHaveCount(0)
+    await expect(page.getByTestId('scenario-name-button')).toHaveText(before)
+  })
+
+  test('an empty name is refused', async ({ page }) => {
+    const before = await page.getByTestId('scenario-name-button').innerText()
+
+    await page.getByTestId('scenario-name-button').click()
+    const input = page.getByTestId('scenario-name-input')
+    await input.fill('   ')
+    await input.press('Enter')
+
+    await expect(page.getByTestId('scenario-name-button')).toHaveText(before)
+  })
+
+  test('the dropdown still opens from its own chevron, and does not overlap the name', async ({ page }) => {
+    await page.getByTestId('scenario-switcher-trigger').click()
+    const menu = page.getByTestId('scenario-switcher-menu')
+    await expect(menu).toBeVisible()
+
+    // Opens BELOW the trigger in the fixed top bar (would leave the viewport
+    // upward) — a geometric claim, so it needs the real engine.
+    const menuBox = await menu.boundingBox()
+    const pillBox = await page.getByTestId('scenario-switcher-pill').boundingBox()
+    expect(menuBox!.y).toBeGreaterThan(pillBox!.y)
+  })
+
+  test('the kebab Rename opens the same inline editor', async ({ page }) => {
+    await page.getByRole('button', { name: 'More options' }).click()
+    await page.getByRole('menuitem', { name: 'Rename' }).click()
+    await expect(page.getByTestId('scenario-name-input')).toBeFocused()
+  })
+
+  test('evidence screenshot of the top bar', async ({ page }) => {
+    await page.getByRole('banner').screenshot({
+      path: 'e2e-artifacts/topbar-model-name-2026-08-14.png',
+    })
+  })
+})

--- a/src/canvas/components/ScenarioSwitcher.tsx
+++ b/src/canvas/components/ScenarioSwitcher.tsx
@@ -1,12 +1,15 @@
 /**
- * ScenarioSwitcher - Dropdown UI for switching between saved scenarios
+ * ScenarioSwitcher - the model's name control + dropdown for saved scenarios
  *
  * Features:
- * - Shows current scenario name (or "Unsaved scenario")
+ * - Shows the current model name, INLINE-EDITABLE in one click
  * - Dropdown with all scenarios (sorted by most recently updated)
  * - Actions: Save, Duplicate, Rename, Delete
  * - Dirty indicator (unsaved changes)
  * - Keyboard accessible (Tab, Enter, Escape)
+ *
+ * ⭐ 14 Aug 2026 (Paul's ruling) — this is now the SINGLE NAME AUTHORITY. The
+ * TopBar's separate plain-title control is gone. See `displayName`/`onRename`.
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react'
@@ -18,6 +21,13 @@ import { SaveStatusPill } from './SaveStatusPill'
 import { exportScenario } from '../export/exportScenario'
 import { useToast } from '../ToastContext'
 import { typography } from '../../styles/typography'
+import { SCENARIO_RENAME_REQUEST_EVENT } from './scenarioRenameEvent'
+
+/** Matches the character budget the removed TopBar title input enforced. */
+const MAX_NAME_LENGTH = 60
+
+/** Paul, 14 Aug 2026: "decision" -> "model" on the naming surface. */
+export const UNTITLED_MODEL = 'Untitled model'
 
 interface ScenarioSwitcherProps {
   /**
@@ -27,9 +37,38 @@ interface ScenarioSwitcherProps {
    * viewport.
    */
   dropdownPosition?: 'above' | 'below'
+  /**
+   * ⭐ THE NAME THIS CONTROL DISPLAYS, when the mount is the name authority.
+   *
+   * Absent, the switcher falls back to the localStorage scenario record — which
+   * is what it did exclusively until 14 Aug 2026, and why it LIED on the
+   * authenticated path: `loadSupabaseScenario` hydrates `currentScenarioId`
+   * with a Supabase UUID and never writes a localStorage row, so `getScenario`
+   * returned null and the trigger read "Untitled decision" for every persisted
+   * model, whatever its real name.
+   *
+   * The TopBar passes the name CanvasMVP derives (localStorage name, else
+   * `framing.title`, else the fallback), so the control tells the truth in both
+   * guest and authenticated sessions.
+   */
+  displayName?: string
+  /**
+   * Commit handler for a rename. Absent, renames go to the localStorage record
+   * only (`renameCurrentScenario`).
+   *
+   * The TopBar passes CanvasMVP's `handleTitleChange`, which writes BOTH the
+   * framing title (-> Supabase `scenarios.framing`) and the localStorage name.
+   * Supplying this prop is also what marks a mount as the name AUTHORITY: only
+   * that mount answers a kebab rename request.
+   */
+  onRename?: (name: string) => void
 }
 
-export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitcherProps = {}) {
+export function ScenarioSwitcher({
+  dropdownPosition = 'above',
+  displayName,
+  onRename,
+}: ScenarioSwitcherProps = {}) {
   const currentScenarioId = useCanvasStore(s => s.currentScenarioId)
   const isDirty = useCanvasStore(s => s.isDirty)
   const isSaving = useCanvasStore(s => s.isSaving)
@@ -44,13 +83,74 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
   const [isOpen, setIsOpen] = useState(false)
   const [scenarios, setScenarios] = useState<Scenario[]>([])
   const [showSaveDialog, setShowSaveDialog] = useState(false)
-  const [showRenameDialog, setShowRenameDialog] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const dropdownRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { showToast } = useToast()
 
   const currentScenario = currentScenarioId ? getScenario(currentScenarioId) : null
+
+  // ---------------------------------------------------------------------
+  // Inline rename (Paul, 14 Aug 2026) — replaces the buried modal dialog AND
+  // the TopBar's separate plain-title control.
+  // ---------------------------------------------------------------------
+
+  /**
+   * The name on screen. `displayName` wins when the mount is the authority;
+   * the localStorage record is the fallback for the toolbar mount.
+   */
+  const resolvedName = (displayName ?? currentScenario?.name ?? '').trim() || UNTITLED_MODEL
+
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
+
+  /**
+   * Escape must not be undone by the blur that follows it, and Enter must not
+   * commit twice when the unmounting input fires a trailing blur. One ref
+   * settles both: the first terminal action for an editing session wins.
+   */
+  const renameSettledRef = useRef(false)
+
+  const startRename = useCallback(() => {
+    renameSettledRef.current = false
+    setRenameValue(resolvedName)
+    setIsRenaming(true)
+    setIsOpen(false)
+  }, [resolvedName])
+
+  const commitRename = useCallback(() => {
+    if (renameSettledRef.current) return
+    renameSettledRef.current = true
+
+    const next = renameValue.trim().slice(0, MAX_NAME_LENGTH)
+    // An empty name is REFUSED — the previous name stands. A model with no name
+    // is worse than one called "Untitled model": the fallback at least tells the
+    // truth about being unnamed.
+    if (next && next !== resolvedName) {
+      if (onRename) {
+        onRename(next)
+      } else {
+        renameCurrentScenario(next)
+      }
+    }
+    setIsRenaming(false)
+  }, [renameValue, resolvedName, onRename, renameCurrentScenario])
+
+  const cancelRename = useCallback(() => {
+    renameSettledRef.current = true
+    setIsRenaming(false)
+  }, [])
+
+  // The kebab menu's "Rename" item reaches us through this. Only the authority
+  // mount answers: a non-authoritative switcher opening an editor would write
+  // to a different place than the one the user is looking at.
+  const isNameAuthority = onRename != null
+  useEffect(() => {
+    if (!isNameAuthority) return
+    const handler = () => startRename()
+    window.addEventListener(SCENARIO_RENAME_REQUEST_EVENT, handler)
+    return () => window.removeEventListener(SCENARIO_RENAME_REQUEST_EVENT, handler)
+  }, [isNameAuthority, startRename])
 
   // Refresh scenarios when dropdown opens
   const refreshScenarios = useCallback(() => {
@@ -107,22 +207,6 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
       refreshScenarios()
     }
   }, [currentScenarioId, currentScenario, duplicateCurrentScenario, refreshScenarios])
-
-  const handleRename = useCallback(() => {
-    if (currentScenarioId && currentScenario) {
-      setShowRenameDialog(true)
-      setInputValue(currentScenario.name)
-    }
-  }, [currentScenarioId, currentScenario])
-
-  const handleRenameDialogSubmit = useCallback(() => {
-    if (inputValue.trim() && currentScenarioId) {
-      renameCurrentScenario(inputValue.trim())
-      setShowRenameDialog(false)
-      setInputValue('')
-      refreshScenarios()
-    }
-  }, [inputValue, currentScenarioId, renameCurrentScenario, refreshScenarios])
 
   const handleDelete = useCallback((id: string) => {
     const scenario = getScenario(id)
@@ -215,26 +299,68 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
   return (
     <>
       <div className="relative" ref={dropdownRef}>
-        {/* Trigger button */}
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className={`flex items-center gap-2 px-3 py-1.5 ${typography.label} text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-info focus:ring-offset-2 transition-colors`}
-          type="button"
-          aria-expanded={isOpen}
-          aria-haspopup="true"
-          data-testid="scenario-switcher-trigger"
+        {/* Trigger pill. TWO controls in one shell, deliberately: clicking the
+            NAME edits it (Paul: renaming must be obvious and quick — one
+            click), clicking the chevron opens the scenario menu. Nested
+            buttons are invalid HTML, so the shell is a div. */}
+        <div
+          className={`flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 ${typography.label} text-gray-700 bg-white border border-gray-300 rounded-lg focus-within:ring-2 focus-within:ring-info focus-within:ring-offset-2 transition-colors`}
+          data-testid="scenario-switcher-pill"
         >
-          <Folder className="w-4 h-4 text-gray-500" />
-          <span className="max-w-[150px] truncate">
-            {currentScenario?.name || 'Untitled decision'}
-          </span>
+          <Folder className="w-4 h-4 shrink-0 text-gray-500" aria-hidden="true" />
+
+          {isRenaming ? (
+            <input
+              type="text"
+              value={renameValue}
+              onChange={e => setRenameValue(e.target.value.slice(0, MAX_NAME_LENGTH))}
+              onBlur={commitRename}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  commitRename()
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  cancelRename()
+                }
+              }}
+              maxLength={MAX_NAME_LENGTH}
+              className="w-[150px] bg-transparent border-b border-info outline-none px-0.5"
+              aria-label="Model name"
+              data-testid="scenario-name-input"
+              autoFocus
+            />
+          ) : (
+            <button
+              onClick={startRename}
+              className="max-w-[150px] truncate cursor-text text-left rounded px-0.5 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-info transition-colors"
+              type="button"
+              title="Rename model"
+              aria-label={`Rename model, currently ${resolvedName}`}
+              data-testid="scenario-name-button"
+            >
+              {resolvedName}
+            </button>
+          )}
+
           {/* P0-2: Replace dot with reactive save status */}
           <SaveStatusPill
             isSaving={isSaving}
             lastSavedAt={lastSavedAt}
           />
-          <ChevronDown className="w-4 h-4 text-gray-400" />
-        </button>
+
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className="shrink-0 p-0.5 rounded hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-info transition-colors"
+            type="button"
+            aria-expanded={isOpen}
+            aria-haspopup="true"
+            aria-label="Open model menu"
+            data-testid="scenario-switcher-trigger"
+          >
+            <ChevronDown className="w-4 h-4 text-gray-400" aria-hidden="true" />
+          </button>
+        </div>
 
         {/* Dropdown menu */}
         {isOpen && (
@@ -278,7 +404,7 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
                         <Copy className="w-4 h-4" />
                       </button>
                       <button
-                        onClick={handleRename}
+                        onClick={startRename}
                         className={`px-3 py-2 ${typography.body} text-gray-700 hover:bg-gray-100 rounded transition-colors`}
                         type="button"
                         role="menuitem"
@@ -444,49 +570,10 @@ export function ScenarioSwitcher({ dropdownPosition = 'above' }: ScenarioSwitche
         </div>
       )}
 
-      {/* Rename dialog */}
-      {showRenameDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[2001]">
-          <div className="bg-white rounded-lg p-6 w-96 shadow-panel">
-            <h3 className={`${typography.h4} text-gray-900 mb-4`}>Rename scenario</h3>
-            <input
-              type="text"
-              value={inputValue}
-              onChange={e => setInputValue(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') handleRenameDialogSubmit()
-                if (e.key === 'Escape') {
-                  setShowRenameDialog(false)
-                  setInputValue('')
-                }
-              }}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-info focus:ring-offset-2"
-              placeholder="Scenario name"
-              autoFocus
-            />
-            <div className="flex gap-2 mt-4">
-              <button
-                onClick={handleRenameDialogSubmit}
-                disabled={!inputValue.trim()}
-                className="flex-1 px-4 py-2 text-text-on-color bg-info-600 hover:bg-info-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                type="button"
-              >
-                Rename
-              </button>
-              <button
-                onClick={() => {
-                  setShowRenameDialog(false)
-                  setInputValue('')
-                }}
-                className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
-                type="button"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* The rename DIALOG is gone (14 Aug 2026): rename is inline on the
+          trigger, and the dropdown's pencil opens that same editor. One rename
+          path, not two — and the old dialog was dead on the authenticated path
+          anyway (it required a localStorage record that never exists there). */}
     </>
   )
 }

--- a/src/canvas/components/__tests__/ScenarioSwitcher.s6-operations.spec.tsx
+++ b/src/canvas/components/__tests__/ScenarioSwitcher.s6-operations.spec.tsx
@@ -86,7 +86,12 @@ describe('S6-SCENARIO: Rename/Duplicate/Save As Operations', () => {
   })
 
   describe('Rename Scenario', () => {
-    it('should open rename dialog when rename button clicked', async () => {
+    // ⭐ 14 Aug 2026 (Paul's ruling): rename moved from a buried MODAL DIALOG to
+    // an INLINE editor on the trigger. These seven tests keep their original
+    // intent — open, pre-populate, commit, commit-on-Enter, cancel-on-Escape,
+    // dropdown behaviour, refuse-empty — retargeted at the interaction that
+    // now ships. Coverage is preserved, not dropped; only the affordance moved.
+    it('should open the inline editor when the rename button is clicked', async () => {
       render(<ScenarioSwitcher />)
 
       // Open dropdown
@@ -98,51 +103,39 @@ describe('S6-SCENARIO: Rename/Duplicate/Save As Operations', () => {
       })
 
       // Click rename button
-      const renameButton = screen.getByRole('menuitem', { name: /rename/i })
-      fireEvent.click(renameButton)
+      fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
 
-      // Rename dialog should appear
+      // Inline editor should appear
       await waitFor(() => {
-        expect(screen.getByText('Rename scenario')).toBeInTheDocument()
+        expect(screen.getByTestId('scenario-name-input')).toBeInTheDocument()
       })
     })
 
-    it('should pre-populate rename dialog with current scenario name', async () => {
+    it('should pre-populate the inline editor with the current scenario name', async () => {
       render(<ScenarioSwitcher />)
 
-      // Open dropdown
-      fireEvent.click(screen.getByRole('button', { expanded: false }))
-
-      // Click rename
-      await waitFor(() => {
-        const renameButton = screen.getByRole('menuitem', { name: /rename/i })
-        fireEvent.click(renameButton)
-      })
-
-      // Input should have current scenario name
-      await waitFor(() => {
-        const input = screen.getByPlaceholderText('Scenario name') as HTMLInputElement
-        expect(input.value).toBe('Test Scenario')
-      })
-    })
-
-    it('should call renameCurrentScenario when rename submitted', async () => {
-      render(<ScenarioSwitcher />)
-
-      // Open dropdown and click rename
       fireEvent.click(screen.getByRole('button', { expanded: false }))
       await waitFor(() => {
         fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      // Change name and submit
       await waitFor(() => {
-        const input = screen.getByPlaceholderText('Scenario name')
-        fireEvent.change(input, { target: { value: 'New Scenario Name' } })
+        const input = screen.getByTestId('scenario-name-input') as HTMLInputElement
+        expect(input.value).toBe('Test Scenario')
+      })
+    })
+
+    it('should call renameCurrentScenario when the edit is committed by blur', async () => {
+      render(<ScenarioSwitcher />)
+
+      fireEvent.click(screen.getByRole('button', { expanded: false }))
+      await waitFor(() => {
+        fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      const submitButton = screen.getByRole('button', { name: 'Rename' })
-      fireEvent.click(submitButton)
+      const input = await screen.findByTestId('scenario-name-input')
+      fireEvent.change(input, { target: { value: 'New Scenario Name' } })
+      fireEvent.blur(input)
 
       expect(mockRenameCurrentScenario).toHaveBeenCalledWith('New Scenario Name')
     })
@@ -150,81 +143,65 @@ describe('S6-SCENARIO: Rename/Duplicate/Save As Operations', () => {
     it('should submit rename on Enter key', async () => {
       render(<ScenarioSwitcher />)
 
-      // Open dropdown and click rename
       fireEvent.click(screen.getByRole('button', { expanded: false }))
       await waitFor(() => {
         fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      // Change name and press Enter
-      await waitFor(() => {
-        const input = screen.getByPlaceholderText('Scenario name')
-        fireEvent.change(input, { target: { value: 'Renamed via Enter' } })
-        fireEvent.keyDown(input, { key: 'Enter' })
-      })
+      const input = await screen.findByTestId('scenario-name-input')
+      fireEvent.change(input, { target: { value: 'Renamed via Enter' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
 
       expect(mockRenameCurrentScenario).toHaveBeenCalledWith('Renamed via Enter')
     })
 
-    it('should close rename dialog on Escape key', async () => {
+    it('should close the inline editor on Escape WITHOUT renaming', async () => {
       render(<ScenarioSwitcher />)
 
-      // Open dropdown and click rename
       fireEvent.click(screen.getByRole('button', { expanded: false }))
       await waitFor(() => {
         fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      // Press Escape
+      const input = await screen.findByTestId('scenario-name-input')
+      fireEvent.change(input, { target: { value: 'Discarded name' } })
+      fireEvent.keyDown(input, { key: 'Escape' })
+
       await waitFor(() => {
-        const input = screen.getByPlaceholderText('Scenario name')
-        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(screen.queryByTestId('scenario-name-input')).not.toBeInTheDocument()
+      })
+      // Escape must survive the blur that follows it — the old dialog had a
+      // Cancel button for this; inline editing has only the key.
+      expect(mockRenameCurrentScenario).not.toHaveBeenCalled()
+    })
+
+    it('should close the dropdown when the inline editor opens', async () => {
+      render(<ScenarioSwitcher />)
+
+      fireEvent.click(screen.getByRole('button', { expanded: false }))
+      await waitFor(() => {
+        fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      // Dialog should be gone
       await waitFor(() => {
-        expect(screen.queryByText('Rename scenario')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('scenario-switcher-menu')).not.toBeInTheDocument()
       })
     })
 
-    it('should close rename dialog on Cancel button', async () => {
+    it('should refuse an empty or whitespace name, keeping the previous one', async () => {
       render(<ScenarioSwitcher />)
 
-      // Open dropdown and click rename
       fireEvent.click(screen.getByRole('button', { expanded: false }))
       await waitFor(() => {
         fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
       })
 
-      // Click Cancel
-      await waitFor(() => {
-        const cancelButton = screen.getByRole('button', { name: 'Cancel' })
-        fireEvent.click(cancelButton)
-      })
+      const input = await screen.findByTestId('scenario-name-input')
+      fireEvent.change(input, { target: { value: '   ' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
 
-      // Dialog should be gone
-      await waitFor(() => {
-        expect(screen.queryByText('Rename scenario')).not.toBeInTheDocument()
-      })
-    })
-
-    it('should disable Rename button if name is empty or whitespace', async () => {
-      render(<ScenarioSwitcher />)
-
-      // Open dropdown and click rename
-      fireEvent.click(screen.getByRole('button', { expanded: false }))
-      await waitFor(() => {
-        fireEvent.click(screen.getByRole('menuitem', { name: /rename/i }))
-      })
-
-      // Clear input
-      await waitFor(() => {
-        const input = screen.getByPlaceholderText('Scenario name')
-        fireEvent.change(input, { target: { value: '   ' } })
-      })
-
-      const submitButton = screen.getByRole('button', { name: 'Rename' })
-      expect(submitButton).toBeDisabled()
+      expect(mockRenameCurrentScenario).not.toHaveBeenCalled()
+      expect(screen.getByTestId('scenario-name-button')).toHaveTextContent('Test Scenario')
     })
 
     it('should not show rename button when no current scenario', () => {
@@ -718,7 +695,7 @@ describe('S6-SCENARIO: Rename/Duplicate/Save As Operations', () => {
       render(<ScenarioSwitcher />)
 
       // Open dropdown and save dialog
-      const button = screen.getByRole('button', { name: /untitled decision/i })
+      const button = screen.getByTestId('scenario-switcher-trigger')
       fireEvent.click(button)
       await waitFor(() => {
         fireEvent.click(screen.getByRole('menuitem', { name: /save as\.\.\./i }))

--- a/src/canvas/components/__tests__/ScenarioSwitcher.spec.tsx
+++ b/src/canvas/components/__tests__/ScenarioSwitcher.spec.tsx
@@ -211,18 +211,15 @@ describe('ScenarioSwitcher (A3)', () => {
     const renameButton = screen.getByRole('menuitem', { name: /rename/i })
     fireEvent.click(renameButton)
 
-    // Wait for rename dialog to appear
+    // 14 Aug 2026: rename is now the INLINE editor on the trigger, not a modal.
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('Scenario name')).toBeInTheDocument()
+      expect(screen.getByTestId('scenario-name-input')).toBeInTheDocument()
     })
 
-    // Type new name
-    const input = screen.getByPlaceholderText('Scenario name')
+    // Type new name and commit
+    const input = screen.getByTestId('scenario-name-input')
     fireEvent.change(input, { target: { value: 'New Name' } })
-
-    // Click "Rename" button in dialog
-    const submitButton = screen.getByRole('button', { name: 'Rename' })
-    fireEvent.click(submitButton)
+    fireEvent.keyDown(input, { key: 'Enter' })
 
     // Should call renameCurrentScenario with new name
     await waitFor(() => {
@@ -230,7 +227,64 @@ describe('ScenarioSwitcher (A3)', () => {
     })
   })
 
-  it('displays "Untitled decision" when no current scenario', () => {
+  // ⭐ 14 Aug 2026 — THE AUTHENTICATED-PATH FIX, pinned where it is observable.
+  //
+  // `loadSupabaseScenario` hydrates `currentScenarioId` with a Supabase UUID and
+  // never writes a localStorage row, so `getScenario` returns null (or, worse, a
+  // STALE row from an earlier guest session). Reading localStorage first is what
+  // made this control display "Untitled decision" for every persisted model.
+  //
+  // These two cases need a localStorage name that DIFFERS from `displayName`;
+  // the TopBar spec cannot see the precedence at all, because no localStorage
+  // record exists there and both orderings resolve to the same string.
+  it('prefers the displayName prop over a stale localStorage name', () => {
+    vi.mocked(scenarios.getScenario).mockReturnValue({
+      id: 'scenario-1',
+      name: 'Stale local name',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      graph: { nodes: [], edges: [] }
+    })
+
+    render(
+      <ToastProvider>
+        <ScenarioSwitcher displayName="Real model name" onRename={vi.fn()} />
+      </ToastProvider>
+    )
+
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent('Real model name')
+    expect(screen.queryByText('Stale local name')).not.toBeInTheDocument()
+  })
+
+  it('commits a rename through onRename, NOT through renameCurrentScenario', () => {
+    const onRename = vi.fn()
+    vi.mocked(scenarios.getScenario).mockReturnValue({
+      id: 'scenario-1',
+      name: 'Stale local name',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      graph: { nodes: [], edges: [] }
+    })
+
+    render(
+      <ToastProvider>
+        <ScenarioSwitcher displayName="Real model name" onRename={onRename} />
+      </ToastProvider>
+    )
+
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input')
+    fireEvent.change(input, { target: { value: 'Renamed model' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // The authority writer reaches BOTH the framing title (-> Supabase) and the
+    // localStorage record. `renameCurrentScenario` reaches only the latter, and
+    // is a silent no-op on the authenticated path.
+    expect(onRename).toHaveBeenCalledWith('Renamed model')
+    expect(mockRenameCurrentScenario).not.toHaveBeenCalled()
+  })
+
+  it('displays "Untitled model" when no current scenario', () => {
     vi.mocked(useCanvasStore).mockImplementation((selector: any) => {
       const state = {
         currentScenarioId: null,
@@ -250,7 +304,9 @@ describe('ScenarioSwitcher (A3)', () => {
 
     renderWithToast()
 
-    expect(screen.getByText('Untitled decision')).toBeInTheDocument()
+    // Paul, 14 Aug 2026: "decision" -> "model" on the naming surface.
+    expect(screen.getByText('Untitled model')).toBeInTheDocument()
+    expect(screen.queryByText('Untitled decision')).not.toBeInTheDocument()
   })
 
   it('pill does not show when not saving and no lastSavedAt', () => {

--- a/src/canvas/components/scenarioRenameEvent.ts
+++ b/src/canvas/components/scenarioRenameEvent.ts
@@ -1,0 +1,19 @@
+/**
+ * Rename-request signal for the single model-name control.
+ *
+ * The TopBar's kebab menu carries a "Rename" item. Before 14 Aug 2026 it flipped
+ * the bar's own `isEditing` state, because the bar hosted a plain title control.
+ * That control is gone (Paul's ruling: one name control, not two), and the name
+ * now lives inside `ScenarioSwitcher` — a sibling, not a child, of the kebab.
+ *
+ * This reuses the bar's existing cross-component idiom (`MENU_EXCLUSIVE_EVENT`,
+ * `HELP_EVENTS`): a window CustomEvent, rather than lifting editor state into a
+ * parent that has no other use for it. The constant lives HERE, next to the
+ * component that owns the behaviour, so `TopBar` -> `ScenarioSwitcher` stays a
+ * one-way import and no cycle is created.
+ *
+ * Only the switcher instance acting as the NAME AUTHORITY (the one given an
+ * `onRename` prop) responds — a second, non-authoritative mount must not open an
+ * editor that would write somewhere else.
+ */
+export const SCENARIO_RENAME_REQUEST_EVENT = 'olumi:scenario-rename-request'

--- a/src/components/layout/KebabMenu.tsx
+++ b/src/components/layout/KebabMenu.tsx
@@ -1,7 +1,7 @@
 /**
  * KebabMenu — restructured "More" dropdown menu for the top bar.
  *
- * Groups: Decision (Rename, Export, Import, Snapshots, Reset canvas) |
+ * Groups: Model (Rename, Export, Import, Snapshots, Reset canvas) |
  * View (Fullscreen) | Help (Keyboard shortcuts, How influence works) |
  * Canvas settings (flattened toggles).
  *
@@ -130,8 +130,8 @@ export function KebabMenu({
 
         {isOpen && (
           <div className={styles.dropdownMenu} role="menu">
-            {/* Decision group */}
-            <div className={styles.dropdownMenuLabel}>Decision</div>
+            {/* Model group (Paul, 14 Aug 2026: "decision" -> "model") */}
+            <div className={styles.dropdownMenuLabel}>Model</div>
             <button
               type="button"
               role="menuitem"

--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -49,58 +49,6 @@
   margin: 0 4px;
 }
 
-.titleButton {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background 150ms;
-}
-
-.titleButton:hover {
-  background: var(--bg-panel-hover, #FEF9F3);
-}
-
-.titleButton:focus {
-  outline: 2px solid var(--info);
-  outline-offset: 2px;
-}
-
-.titleText {
-  font-size: 14px;
-  font-weight: 400;
-  color: var(--text-body, #3F3F3E);
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chevronIcon {
-  color: var(--text-light, #6E6B6B);
-  transition: transform 150ms;
-}
-
-.titleButton:hover .chevronIcon {
-  transform: translateY(1px);
-}
-
-.titleInput {
-  font-size: 14px;
-  font-weight: 400;
-  padding: 4px 8px;
-  border: 2px solid var(--info, #277A9D);
-  border-radius: 6px;
-  background: white;
-  max-width: 200px;
-  outline: none;
-  color: var(--text-body, #3F3F3E);
-}
-
 .dirtyIndicator {
   width: 6px;
   height: 6px;
@@ -450,9 +398,3 @@
   }
 }
 
-@media (max-width: 600px) {
-  /* On small screens, constrain title */
-  .titleText {
-    max-width: 120px;
-  }
-}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -7,6 +7,7 @@ import { useStagePill } from '../../canvas/hooks/useStagePill'
 import { UserAvatarMenu } from './UserAvatarMenu'
 import { KebabMenu } from './KebabMenu'
 import { ScenarioSwitcher } from '../../canvas/components/ScenarioSwitcher'
+import { SCENARIO_RENAME_REQUEST_EVENT } from '../../canvas/components/scenarioRenameEvent'
 import { ownerPanelHash } from '../../collab/panelRoute'
 import { MENU_EXCLUSIVE_EVENT } from './LeftSidebar'
 import { useUIStore } from '../../stores/uiStore'
@@ -53,8 +54,6 @@ export const TopBar = ({
   isPersisted = false,
   panelScenarioId = null,
 }: TopBarProps) => {
-  const [isEditing, setIsEditing] = useState(false)
-  const [editValue, setEditValue] = useState(scenarioTitle)
   const [showSavedPill, setShowSavedPill] = useState(false)
 
   // The kebab menu's open-state lives in uiStore, NOT in component-local
@@ -103,18 +102,6 @@ export const TopBar = ({
       root.style.setProperty('--topbar-h', previous || '0px')
     }
   }, [])
-
-  useEffect(() => {
-    setEditValue(scenarioTitle)
-  }, [scenarioTitle])
-
-  const handleTitleSubmit = () => {
-    const next = editValue.trim()
-    if (next && next !== scenarioTitle) {
-      onTitleChange(next)
-    }
-    setIsEditing(false)
-  }
 
   const handleSave = async () => {
     if (!onSave) return
@@ -231,57 +218,27 @@ export const TopBar = ({
           />
         </a>
 
-        {/* Divider between logo and title */}
+        {/* Divider between logo and the model name */}
         <div className={styles.divider} aria-hidden="true" />
 
-        {/* Editable title */}
-        {isEditing ? (
-          <input
-            type="text"
-            value={editValue}
-            onChange={e => setEditValue(e.target.value.slice(0, 60))}
-            onBlur={handleTitleSubmit}
-            onKeyDown={e => {
-              if (e.key === 'Enter') handleTitleSubmit()
-              if (e.key === 'Escape') {
-                setEditValue(scenarioTitle)
-                setIsEditing(false)
-              }
-            }}
-            className={styles.titleInput}
-            autoFocus
-            aria-label="Edit decision title"
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => setIsEditing(true)}
-            className={styles.titleButton}
-            aria-label="Edit decision title"
-          >
-            <span className={styles.titleText}>{scenarioTitle}</span>
-            <svg
-              width="9"
-              height="9"
-              viewBox="0 0 12 12"
-              className={styles.chevronIcon}
-              aria-hidden="true"
-            >
-              <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
-            </svg>
-          </button>
-        )}
+        {/* ⭐ THE SINGLE MODEL-NAME CONTROL (Paul, 14 Aug 2026).
+            This bar used to render a plain title here AND the switcher below
+            it — two controls, both reading "Untitled decision". The plain title
+            is removed; the switcher now displays the name this bar is given and
+            commits renames through `onTitleChange`, which reaches the framing
+            title (-> Supabase) as well as the localStorage record. It also
+            still carries scenario switching, save-as, duplicate, delete and
+            scenario export/import (.olumi.json). */}
+        <ScenarioSwitcher
+          dropdownPosition="below"
+          displayName={scenarioTitle}
+          onRename={onTitleChange}
+        />
 
         {/* Dirty indicator (localStorage mode only) */}
         {!isPersisted && isDirty && saveStatus !== 'saving' && (
           <span className={styles.dirtyIndicator} aria-label="Unsaved changes" />
         )}
-
-        {/* Lane 4 (P5): scenario switching, save-as, duplicate, rename,
-            delete, and scenario export/import (.olumi.json) — previously
-            only reachable from the production-unmounted CanvasToolbar. */}
-        <div className={styles.divider} aria-hidden="true" />
-        <ScenarioSwitcher dropdownPosition="below" />
 
       </div>
 
@@ -450,7 +407,13 @@ export const TopBar = ({
             setOverlaySurface(showMenu ? null : 'top_bar_menu')
           }}
           onClose={closeMenu}
-          onStartRename={() => { setIsEditing(true); closeMenu() }}
+          // The name control is a SIBLING now, not this bar's own state, so the
+          // request travels by the same window-event idiom the bar already uses
+          // for its other cross-component signals.
+          onStartRename={() => {
+            window.dispatchEvent(new CustomEvent(SCENARIO_RENAME_REQUEST_EVENT))
+            closeMenu()
+          }}
           onShowKeyboardLegend={handleShowKeyboardLegend}
           onShowInfluenceExplainer={handleShowInfluenceExplainer}
           menuRef={menuRef}

--- a/src/components/layout/__tests__/TopBar.singleModelName.spec.tsx
+++ b/src/components/layout/__tests__/TopBar.singleModelName.spec.tsx
@@ -1,0 +1,215 @@
+/**
+ * Paul's ruling, 14 Aug 2026 — the top bar showed TWO controls both reading
+ * "Untitled decision". This pins the end state:
+ *
+ *   1. ONE name control, not two. The left plain title is GONE.
+ *   2. The surviving control (the scenario switcher) is the SINGLE NAME
+ *      AUTHORITY: it displays the name CanvasMVP derives (`scenarioTitle`) and
+ *      commits through `onTitleChange` — the writer that reaches BOTH the
+ *      framing title (Supabase `scenarios.framing`) and the localStorage
+ *      scenario name. Before this change the switcher read localStorage ONLY,
+ *      so on the authenticated path (`loadSupabaseScenario` never writes a
+ *      localStorage row) it displayed "Untitled decision" permanently and its
+ *      Rename was a silent no-op — a control that lied.
+ *   3. Rename is INLINE and obvious: one click on the name. Enter commits,
+ *      Escape cancels, an empty name is refused and keeps the previous one.
+ *   4. Copy: "Untitled decision" -> "Untitled model" on this surface.
+ *
+ * DEPLOYED-MOUNT BINDING (trap 3b): `<TopBar>` is rendered unconditionally at
+ * `CanvasMVP.tsx:264` — no flag gates it, and there is no alternate top bar.
+ * These specs therefore bind to the surface the deployed build mounts.
+ *
+ * IDENTITY BINDING (trap 19): every assertion binds by data-testid or by exact
+ * accessible name, never by "the only textbox on screen" — the bar contains
+ * other buttons and the kebab menu can mount further inputs.
+ *
+ * jsdom proves wiring, never pixels (trap 3). The browser walk is in the lane
+ * report / evidence dir.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TopBar } from '../TopBar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+
+const MODEL_NAME = 'Pricing model 2025'
+
+function renderTopBar(overrides: Partial<React.ComponentProps<typeof TopBar>> = {}) {
+  const onTitleChange = vi.fn()
+  const utils = render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar
+          scenarioTitle={MODEL_NAME}
+          onTitleChange={onTitleChange}
+          onSave={vi.fn()}
+          onShare={vi.fn()}
+          {...overrides}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+  return { ...utils, onTitleChange }
+}
+
+describe('TopBar — single model-name control (Paul, 14 Aug 2026)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // --- 1. the left control is gone, and only ONE control names the model ----
+
+  it('no longer renders the left plain-title control', () => {
+    renderTopBar()
+    // The removed control's two accessible names, both exact-matched.
+    expect(screen.queryByRole('button', { name: /edit decision title/i })).toBeNull()
+    expect(screen.queryByRole('textbox', { name: /edit decision title/i })).toBeNull()
+  })
+
+  it('shows exactly ONE name-bearing control in the bar', () => {
+    // ⚠ This test was first written as `getAllByText(MODEL_NAME)` and PASSED at
+    // pristine — a guard agreeing with itself (trap 13b). It could not see the
+    // defect, because the two controls displayed DIFFERENT strings: the left
+    // rendered the prop, the right rendered its localStorage fallback
+    // ("Untitled decision"). Counting one string therefore found one match
+    // while two name controls sat side by side on screen.
+    //
+    // Rendered in the exact state Paul screenshotted — the fallback name — and
+    // counting name-BEARING CONTROLS instead of string occurrences. Both old
+    // controls are sibling <button>s (never ancestors of one another), so the
+    // count is stable. Pristine = 2, fixed = 1.
+    renderTopBar({ scenarioTitle: 'Untitled model' })
+    const banner = screen.getByRole('banner')
+    const nameBearing = within(banner)
+      .getAllByRole('button')
+      .filter(b => /untitled (model|decision)/i.test(b.textContent ?? ''))
+    expect(nameBearing).toHaveLength(1)
+  })
+
+  it('renders that one place as the scenario-switcher name control', () => {
+    renderTopBar()
+    const nameControl = screen.getByTestId('scenario-name-button')
+    expect(nameControl).toHaveTextContent(MODEL_NAME)
+    // ...and it lives inside the top bar's banner landmark, not elsewhere.
+    expect(within(screen.getByRole('banner')).getByTestId('scenario-name-button')).toBe(nameControl)
+  })
+
+  it('binds the name to the DERIVED scenarioTitle prop, not to localStorage', () => {
+    // The whole point of the rewire: the authenticated path has no localStorage
+    // scenario row, so a switcher reading `getScenario()` would show the
+    // fallback here. It must show what CanvasMVP derived.
+    renderTopBar({ scenarioTitle: 'Q3 pricing rethink' })
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent('Q3 pricing rethink')
+  })
+
+  // --- 2. inline rename: one click, Enter commits ---------------------------
+
+  it('opens an inline editor on ONE click of the name', () => {
+    renderTopBar()
+    expect(screen.queryByTestId('scenario-name-input')).toBeNull()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input') as HTMLInputElement
+    expect(input).toHaveFocus()
+    expect(input.value).toBe(MODEL_NAME)
+  })
+
+  it('commits the rename on Enter, through onTitleChange', () => {
+    const { onTitleChange } = renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input')
+    fireEvent.change(input, { target: { value: 'Opex reduction model' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onTitleChange).toHaveBeenCalledTimes(1)
+    expect(onTitleChange).toHaveBeenCalledWith('Opex reduction model')
+    // editor closes
+    expect(screen.queryByTestId('scenario-name-input')).toBeNull()
+  })
+
+  it('commits the rename on blur', () => {
+    const { onTitleChange } = renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input')
+    fireEvent.change(input, { target: { value: 'Blur-committed model' } })
+    fireEvent.blur(input)
+    expect(onTitleChange).toHaveBeenCalledWith('Blur-committed model')
+  })
+
+  // --- 3. Escape cancels, empty refused ------------------------------------
+
+  it('cancels on Escape — no write, previous name kept', () => {
+    const { onTitleChange } = renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input')
+    fireEvent.change(input, { target: { value: 'Discarded name' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onTitleChange).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('scenario-name-input')).toBeNull()
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent(MODEL_NAME)
+  })
+
+  it('refuses an empty name — no write, previous name kept', () => {
+    const { onTitleChange } = renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    const input = screen.getByTestId('scenario-name-input')
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onTitleChange).not.toHaveBeenCalled()
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent(MODEL_NAME)
+  })
+
+  it('does not write when the name is unchanged', () => {
+    const { onTitleChange } = renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    fireEvent.keyDown(screen.getByTestId('scenario-name-input'), { key: 'Enter' })
+    expect(onTitleChange).not.toHaveBeenCalled()
+  })
+
+  // --- 4. the dropdown still opens, and is a SEPARATE control ---------------
+
+  it('keeps the scenario dropdown reachable from its own trigger', () => {
+    renderTopBar()
+    expect(screen.queryByTestId('scenario-switcher-menu')).toBeNull()
+    fireEvent.click(screen.getByTestId('scenario-switcher-trigger'))
+    expect(screen.getByTestId('scenario-switcher-menu')).toBeInTheDocument()
+  })
+
+  it('editing the name does NOT open the dropdown', () => {
+    renderTopBar()
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
+    expect(screen.queryByTestId('scenario-switcher-menu')).toBeNull()
+  })
+
+  // --- 5. the kebab Rename still reaches the surviving control --------------
+
+  it('kebab "Rename" opens the inline editor on the surviving control', () => {
+    renderTopBar()
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }))
+    expect(screen.getByTestId('scenario-name-input')).toBeInTheDocument()
+  })
+
+  // --- 6. copy: model, not decision ----------------------------------------
+
+  it('falls back to "Untitled model", never "Untitled decision"', () => {
+    renderTopBar({ scenarioTitle: 'Untitled model' })
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent('Untitled model')
+    expect(screen.queryByText(/untitled decision/i)).toBeNull()
+  })
+
+  it('carries no "decision" wording on the naming surface', () => {
+    renderTopBar()
+    // The name control and its rename affordances only — scoped, not a
+    // product-wide sweep (Paul: top-bar naming surface only).
+    const nameControl = screen.getByTestId('scenario-name-button')
+    expect(nameControl.getAttribute('aria-label') ?? '').not.toMatch(/decision/i)
+    expect(nameControl.getAttribute('title') ?? '').not.toMatch(/decision/i)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }))
+    // The kebab group label that heads "Rename".
+    expect(screen.queryByText('Decision')).toBeNull()
+    expect(screen.getByText('Model')).toBeInTheDocument()
+  })
+})

--- a/src/components/layout/__tests__/TopBar.test.tsx
+++ b/src/components/layout/__tests__/TopBar.test.tsx
@@ -25,17 +25,23 @@ describe('TopBar', () => {
     onShare: vi.fn(),
   }
 
-  it('renders decision title', () => {
+  // ⭐ 14 Aug 2026 (Paul's ruling): the bar's own plain-title control is gone.
+  // The model name now lives on the ScenarioSwitcher, which this bar feeds with
+  // `scenarioTitle` and `onTitleChange`. These three tests keep their original
+  // intent — renders the name, edits it, caps it at 60 chars — retargeted at
+  // the surviving control by testid. Full coverage of the new interaction is in
+  // TopBar.singleModelName.spec.tsx.
+  it('renders the model name', () => {
     renderTopBar(mockProps)
-    expect(screen.getByText('Pricing Decision 2025')).toBeInTheDocument()
+    expect(screen.getByTestId('scenario-name-button')).toHaveTextContent('Pricing Decision 2025')
   })
 
-  it('allows title editing', async () => {
+  it('allows name editing', async () => {
     renderTopBar(mockProps)
 
-    fireEvent.click(screen.getByRole('button', { name: /edit decision title/i }))
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
 
-    const input = screen.getByRole('textbox') as HTMLInputElement
+    const input = screen.getByTestId('scenario-name-input') as HTMLInputElement
     expect(input).toHaveFocus()
 
     fireEvent.change(input, { target: { value: '' } })
@@ -46,12 +52,12 @@ describe('TopBar', () => {
     expect(mockProps.onTitleChange).toHaveBeenCalledWith('New Title')
   })
 
-  it('limits title to 60 characters', async () => {
+  it('limits the name to 60 characters', async () => {
     renderTopBar(mockProps)
 
-    fireEvent.click(screen.getByRole('button', { name: /edit decision title/i }))
+    fireEvent.click(screen.getByTestId('scenario-name-button'))
 
-    const input = screen.getByRole('textbox') as HTMLInputElement
+    const input = screen.getByTestId('scenario-name-input') as HTMLInputElement
     const longTitle = 'A'.repeat(70)
     fireEvent.change(input, { target: { value: longTitle } })
 

--- a/src/hooks/__tests__/useScenario.spec.ts
+++ b/src/hooks/__tests__/useScenario.spec.ts
@@ -792,6 +792,226 @@ describe('useScenario', () => {
   })
 
   // -----------------------------------------------------------------------
+  // ⭐ 14 Aug 2026 — A USER RENAME MUST REACH THE `scenarios.title` COLUMN.
+  //
+  // Three entities carry a model's name:
+  //   A `currentScenarioFraming.title` -> Supabase `scenarios.framing` (saveFraming)
+  //   B localStorage `scenario.name`
+  //   C the Supabase `scenarios.title` COLUMN
+  //
+  // Until now C had exactly ONE writer: the auto-title below, derived from
+  // `framing.goal`, written at most once per scenario load. No user-facing
+  // rename wrote it. `ScenarioListPage` renders C — so a user renamed their
+  // model in the top bar, opened the list, and saw the OLD auto-generated
+  // title, indefinitely. A surface stating an untruth.
+  //
+  // The write rides the EXISTING framing-autosave seam rather than being added
+  // at the rename call site: that seam already owns the persistence gate, the
+  // single-autosave-owner guard (F4) and the debounce. Duplicating any of those
+  // at a second call site would give two writers racing on one column.
+  //
+  // Subscribers are driven by IDENTITY, not by index: every captured callback
+  // is invoked and each filters for what it cares about, so the assertions do
+  // not silently rebind if effect order changes.
+  // -----------------------------------------------------------------------
+
+  describe('rename propagation to the title column', () => {
+    function driveFramingChange(
+      prevFraming: Record<string, unknown> | null,
+      nextFraming: Record<string, unknown> | null,
+    ) {
+      const base = { nodes: [], edges: [], results: { status: 'idle' } }
+      const prev = { ...base, currentScenarioFraming: prevFraming }
+      const next = { ...base, currentScenarioFraming: nextFraming }
+      // getState() is read inside the debounce timer, so it must agree.
+      setStoreState({ currentScenarioFraming: nextFraming })
+      for (const cb of mockSubscribeCallbacks) cb(next, prev)
+    }
+
+    it('writes the renamed title to the title COLUMN', async () => {
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Old name', goal: 'Increase revenue' },
+      })
+
+      renderUseScenario()
+      expect(mockSubscribeCallbacks.length).toBeGreaterThan(0)
+      mockSaveTitle.mockClear()
+
+      driveFramingChange(
+        { title: 'Old name', goal: 'Increase revenue' },
+        { title: 'Opex reduction model', goal: 'Increase revenue' },
+      )
+
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      // Both halves: the framing JSONB AND the column the scenario list reads.
+      expect(mockSaveFraming).toHaveBeenCalledWith(
+        'scenario-1',
+        expect.objectContaining({ title: 'Opex reduction model' }),
+      )
+      expect(mockSaveTitle).toHaveBeenCalledWith('scenario-1', 'Opex reduction model')
+    })
+
+    it('does NOT rewrite the column when framing changes but the title does not', async () => {
+      // ⚠ Written first as a SINGLE goal-only change with an unprimed ref, and
+      // it failed — correctly. With no prior load the hook does not know what
+      // the column holds, so writing is the safe action, not a defect. The
+      // claim being made here is IDEMPOTENCE, so it has to be reached through
+      // the real mechanism: rename once (which writes), then change only the
+      // goal (which must not write again).
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Old name', goal: 'Old goal' },
+      })
+
+      renderUseScenario()
+
+      // 1st change: the rename — primes the column.
+      driveFramingChange(
+        { title: 'Old name', goal: 'Old goal' },
+        { title: 'Stable name', goal: 'Old goal' },
+      )
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+      expect(mockSaveTitle).toHaveBeenCalledWith('scenario-1', 'Stable name')
+
+      // 2nd change: goal only. The name column must be left alone.
+      mockSaveTitle.mockClear()
+      mockSaveFraming.mockClear()
+      driveFramingChange(
+        { title: 'Stable name', goal: 'Old goal' },
+        { title: 'Stable name', goal: 'A different goal' },
+      )
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      expect(mockSaveFraming).toHaveBeenCalled()
+      expect(mockSaveTitle).not.toHaveBeenCalled()
+    })
+
+    it('refuses to write an empty title to the column', async () => {
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Real name', goal: 'g' },
+      })
+
+      renderUseScenario()
+      mockSaveTitle.mockClear()
+
+      driveFramingChange(
+        { title: 'Real name', goal: 'g' },
+        { title: '   ', goal: 'g' },
+      )
+
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      expect(mockSaveTitle).not.toHaveBeenCalled()
+    })
+
+    it('does not write the column for a guest session', async () => {
+      setAuth('guest', true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Old name', goal: 'g' },
+      })
+
+      renderUseScenario()
+      mockSaveTitle.mockClear()
+
+      driveFramingChange({ title: 'Old name', goal: 'g' }, { title: 'New name', goal: 'g' })
+
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      expect(mockSaveTitle).not.toHaveBeenCalled()
+    })
+
+    it('flushes the renamed title on UNMOUNT, before the debounce fires', async () => {
+      // ⭐ Added because a mutant that deleted the unmount title flush SURVIVED
+      // — the branch had no coverage at all. It is not a corner case: it is the
+      // journey the defect is actually reached by. Renaming on the canvas and
+      // then clicking through to the scenario list unmounts this hook inside
+      // the 1500ms debounce window, so without the flush the list shows the
+      // stale name and the write is simply lost.
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Old name', goal: 'g' },
+      })
+
+      const { unmount } = renderUseScenario()
+      mockSaveTitle.mockClear()
+
+      driveFramingChange(
+        { title: 'Old name', goal: 'g' },
+        { title: 'Renamed on the way out', goal: 'g' },
+      )
+
+      // Deliberately do NOT run the timers — this is the navigate-away race.
+      expect(mockSaveTitle).not.toHaveBeenCalled()
+
+      unmount()
+
+      expect(mockSaveTitle).toHaveBeenCalledWith('scenario-1', 'Renamed on the way out')
+    })
+
+    it('does not flush an UNCHANGED title on unmount', async () => {
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Steady name', goal: 'g' },
+      })
+
+      const { unmount } = renderUseScenario()
+
+      // Prime the column through the real mechanism, then change only the goal.
+      driveFramingChange({ title: 'Steady name', goal: 'g' }, { title: 'Steady name', goal: 'g2' })
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+      mockSaveTitle.mockClear()
+
+      driveFramingChange({ title: 'Steady name', goal: 'g2' }, { title: 'Steady name', goal: 'g3' })
+      unmount()
+
+      expect(mockSaveTitle).not.toHaveBeenCalled()
+    })
+
+    it('the auto-title never overwrites a user rename on a later load', async () => {
+      // PROVEN, not assumed (Paul's instruction). After a rename, framing.title
+      // is non-empty and is persisted to `scenarios.framing`; a later load
+      // hydrates it, so `tryAutoTitle`'s existing-title guard short-circuits
+      // before it can derive anything from `framing.goal`.
+      setAuth(REAL_USER_ID, true)
+      setStoreState({
+        currentScenarioId: 'scenario-1',
+        currentScenarioFraming: { title: 'Opex reduction model', goal: 'Increase revenue' },
+      })
+
+      renderUseScenario()
+
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      // The goal is present and would have produced 'Increase revenue' — the
+      // guard is what stops it, so this asserts the SPECIFIC wrong value too.
+      expect(mockSaveTitle).not.toHaveBeenCalledWith('scenario-1', 'Increase revenue')
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // P0-1: Analysis hydration on load
   // -----------------------------------------------------------------------
 

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -331,6 +331,20 @@ export function useScenario(): UseScenarioReturn {
   // because the flush barrier must agree with the autosave on cleanliness.
   const lastSavedFramingRef = useRef<string>('')
 
+  // ⭐ The last value written to the `scenarios.title` COLUMN (14 Aug 2026).
+  //
+  // Three things carry a model's name: `framing.title` (-> `scenarios.framing`),
+  // the localStorage scenario record, and the `title` COLUMN. Until now the
+  // column had exactly ONE writer — the auto-title below, derived from
+  // `framing.goal` and written at most once per load — so a user rename never
+  // reached it and `ScenarioListPage`, which renders the column, showed the old
+  // auto-generated name indefinitely.
+  //
+  // This ref is what keeps the column write IDEMPOTENT: framing autosave fires
+  // on any framing change (goal, constraints, …), and only a change to the NAME
+  // should touch the name column.
+  const lastSavedTitleRef = useRef<string | null>(null)
+
   // Stable reference to the current scenario ID for use inside timers
   const scenarioIdRef = useRef(currentScenarioId)
   scenarioIdRef.current = currentScenarioId
@@ -472,6 +486,20 @@ export function useScenario(): UseScenarioReturn {
           if (currentFraming) {
             await scenarioService.saveFraming(saveSid, currentFraming)
             lastSavedFramingRef.current = JSON.stringify(currentFraming)
+
+            // A RENAME MUST REACH THE COLUMN THE SCENARIO LIST RENDERS.
+            // Ordered AFTER the framing write and after its ref update, so a
+            // failure here cannot cost us the framing save we already made.
+            // Empty is refused: the column falling back to "Untitled ..." is
+            // honest, blanking a name the user can still see is not.
+            const nextTitle =
+              typeof (currentFraming as Record<string, unknown>).title === 'string'
+                ? ((currentFraming as Record<string, unknown>).title as string).trim()
+                : ''
+            if (nextTitle && nextTitle !== lastSavedTitleRef.current) {
+              await scenarioService.saveTitle(saveSid, nextTitle)
+              lastSavedTitleRef.current = nextTitle
+            }
           }
         } catch {
           if (import.meta.env.DEV) {
@@ -528,6 +556,20 @@ export function useScenario(): UseScenarioReturn {
           scenarioService.saveFraming(sid, f).catch((err) => {
             console.error('[useScenario] Unmount framing flush failed:', err)
           })
+          // ⭐ AND THE TITLE COLUMN — this is the exact journey the defect is
+          // reached by: rename on the canvas, then navigate to the scenario
+          // list, which UNMOUNTS this hook before the 1500ms debounce fires.
+          // Without this the list would show the stale name until the user
+          // happened to change some other framing field.
+          const pendingTitle =
+            typeof (f as Record<string, unknown>).title === 'string'
+              ? ((f as Record<string, unknown>).title as string).trim()
+              : ''
+          if (pendingTitle && pendingTitle !== lastSavedTitleRef.current) {
+            scenarioService.saveTitle(sid, pendingTitle).catch((err) => {
+              console.error('[useScenario] Unmount title flush failed:', err)
+            })
+          }
         }
       }
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
@@ -676,6 +718,11 @@ export function useScenario(): UseScenarioReturn {
         goalConstraints: loadedGoalConstraints,
       })
       lastSavedFramingRef.current = JSON.stringify(row.framing ?? null)
+      // Seed from the COLUMN, not from framing.title. If they already disagree
+      // (every scenario renamed before this fix), the next framing save
+      // CORRECTS the column — seeding from framing.title would make the
+      // divergence permanent by declaring it already written.
+      lastSavedTitleRef.current = row.title ?? null
 
       // Hydrate graph slice (resets history, selection, reseeds IDs).
       // B3: goalConstraints is passed on EVERY load — the value or null. It

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -184,7 +184,7 @@ export default function CanvasMVP() {
       const scenario = getScenario(currentScenarioId)
       if (scenario?.name) return scenario.name
     }
-    return framing?.title?.trim() || 'Untitled decision'
+    return framing?.title?.trim() || 'Untitled model'
   })()
 
   const lastSaved = lastSavedAt ? new Date(lastSavedAt) : null
@@ -200,7 +200,7 @@ export default function CanvasMVP() {
   )
 
   const handleSave = useCallback(async () => {
-    const name = scenarioTitle || 'Untitled decision'
+    const name = scenarioTitle || 'Untitled model'
     if (currentScenarioId) {
       await saveCurrentScenario()
     } else {


### PR DESCRIPTION
Two commits, one capability: **a model has one name, you can change it in one click, and the change is true everywhere.** Rebased onto the current staging tip `5ee5d114`.

Paul's ruling, 14 Aug 2026, from a screenshot: the top bar showed **two** controls both reading "Untitled decision". (1) remove the left one, (2) make the survivor easy to rename, (3) say **model**, not decision, on this surface. Commit 2 is Paul's follow-on dispatch of the propagation gap commit 1 documented.

---

## Commit 1 — one name control, inline rename, "model" copy

### ⭐ The derivation changed the shape of the fix

The two controls named **different entities**, and the one Paul asked to keep was the **broken** one.

| | LEFT (plain title) | RIGHT (folder dropdown) |
|---|---|---|
| Displayed | CanvasMVP's derived `scenarioTitle` | `currentScenario?.name` — **localStorage only** |
| Wrote | `currentScenarioFraming.title` (→ Supabase `scenarios.framing`) **and** the localStorage name | the localStorage name only |

`loadSupabaseScenario` hydrates `currentScenarioId` with a Supabase UUID and **never writes a localStorage row**. So on the authenticated path `getScenario` returned `null`, and the switcher displayed **"Untitled decision" permanently** whatever the model was called, while its Rename pencil was a **silent no-op** (the handler required a record that never exists there). Removing the left control alone would have deleted the only working name control and left a permanent lie on screen.

**So the switcher becomes the single name authority** — it takes the name the bar already receives (`displayName`) and commits through the bar's existing writer (`onRename` = `CanvasMVP.handleTitleChange`).

### Changes

- **TopBar** — plain title control removed (state, submit handler, four dead CSS classes + a media query). Kebab "Rename" now dispatches `SCENARIO_RENAME_REQUEST_EVENT`, the bar's existing window-event idiom.
- **ScenarioSwitcher** — trigger split into a **name control** (one click → inline edit; Enter commits, Escape cancels, blur commits, empty refused, 60-char cap) and a **chevron control** (dropdown). The rename **modal is deleted**; the dropdown pencil opens the same inline editor. One rename path, not two. The editor reuses the codebase's existing idiom (`inspector-v2/shared/EditableLabel`).
- **Copy** — `Untitled decision` → `Untitled model` (CanvasMVP ×2, switcher fallback); kebab group label `Decision` → `Model`; `Edit decision title` → `Rename model`. `Import scenario…`, `Save scenario` and the scenario list keep **scenario** wording.

---

## Commit 2 — the rename reaches the column the scenario list renders

**Paul's follow-on dispatch.** Re-derived at `5ee5d114` with a contrast control in the same sweep (`saveFraming` returned two production callers, so the sweep can see): `saveTitle` still had **exactly one** production caller — `useScenario.ts:570`, an auto-title derived from `framing.goal`, written at most once per load.

Three entities carry a model's name: **A** `framing.title` → `scenarios.framing`; **B** the localStorage record; **C** the `scenarios.title` **column**. Nothing user-facing wrote **C**, and `ScenarioListPage` renders **C**. So: rename in the top bar → open the scenario list → **see the old auto-generated title, indefinitely.** A surface stating an untruth — and it is reached by the very journey commit 1 ships.

**The fix rides the existing framing-autosave seam** rather than being bolted to the rename call site: that seam already owns the persistence gate, the single-autosave-owner guard (F4) and the debounce. A second call site would mean two writers racing on one column.

- Debounced path writes the column when — and only when — the **name** changes (`lastSavedTitleRef` keeps it idempotent; framing autosave also fires for goal/constraint edits).
- **Unmount flush** writes it too. This is the journey: renaming and then clicking through to the scenario list unmounts the hook *inside* the 1500 ms window, so without it the write is simply lost.
- The ref is seeded on load from **`row.title` (the column)**, not from `framing.title` — so every scenario renamed *before* this fix **heals** on its next framing save. Seeding from `framing.title` would have made the divergence permanent.
- **Proven, not assumed** (Paul's instruction): the auto-title cannot overwrite a user rename on a later load. After a rename `framing.title` is non-empty and persisted, so `tryAutoTitle`'s existing-title guard short-circuits. The test asserts the specific wrong value (`'Increase revenue'`) is never written, and mutant N6 removes that guard and REDs.

---

## Verification

- **RED-first** — commit 1's spec **14/15 RED** at pristine (the 1 passer is a deliberate preservation assertion). Commit 2's positive claim RED at pristine.
- **Mutants 11/11 and 7/7 as specified**, in throwaway worktrees outside the repo root with isolation proven by a **sentinel write** and distinct inodes. Applied-check control exactly 0; restores HEAD-relative; trailing controls green. Both kits carry a **RED/GREEN discrimination control**.
  - ⚠ **N5 initially SURVIVED** — the unmount title flush had *no coverage at all*. Not a corner case: it is the exact navigate-away path. Two tests written, N5 now REDs.
- **Instrument defects caught and fixed mid-lane** (both would have shipped a false green):
  1. `getAllByText(name)).toHaveLength(1)` **passed at pristine** while two name controls sat side by side — they displayed *different* strings. Rewritten to count name-**bearing controls** in the state Paul screenshotted: pristine 2, fixed 1.
  2. The "binds to the derived prop" claim **cannot discriminate** in the TopBar spec (no localStorage record there, both orderings resolve alike). Re-pinned in `ScenarioSwitcher.spec.tsx` with a localStorage name that differs; mutants M2/M3 confirm it bites.
  3. An idempotence test asserted "no write when the goal changes" with an **unprimed ref** — it failed, correctly: with no prior load the hook does not know the column's value, so writing is the safe action. Rewritten to prime through the real mechanism.
- **Typecheck gate PASSED**; drift *shrank* 2487 → 2485. `--update-baseline` **declined** — a shrink passes, and regenerating would bank other lanes' churn.
- **eslint** 0 errors; hooks ratchet exactly at baseline.
- **Real browser** (Playwright chromium, new `e2e/topbar-model-name.spec.ts`): **7/7** — one visible name control with a real bounding box, real focus, real keyboard, dropdown geometry below the pill. Plus an ad-hoc responsive pass at **375 / 768 / 1280 px** (no horizontal overflow; the removed control also removed a mobile media query, so this needed proving).
- **Suites**: 24 files, **281 passed, 1 skipped**. Existing specs were **retargeted, not dropped** (TopBar ×3, s6 rename ×7, switcher rename flow), each keeping its original intent.

## Still not fixed (reported)

- `ScenarioListPage.tsx:536,562` and `supabase/migrations/20260306000000_auth_hub_profiles.sql:85` still say **"Untitled decision"** — the list page and a DB function. The latter needs a new migration.
- Adjacent top-bar copy that is not *naming*: `Decision stage: …`, `aria-label="Share decision"`, the "decision brief" alert.

## 60-second manual acceptance (staging, once deployed)

1. Open `/#/canvas` → **one** name control reading **"Untitled model"**.
2. **Click the name once** → it becomes a focused input.
3. Type `Opex reduction model`, **Enter** → updates in place.
4. Click it, type, **Escape** → previous name kept.
5. Click it, clear it, **Enter** → refused.
6. **Chevron** → menu opens below; its pencil opens the same editor.
7. Kebab (⋮) → group headed **Model**; **Rename** opens the same editor.
8. **Signed in**: after step 3, go to the scenario list → it shows **Opex reduction model**, not a stale auto-title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)