### PR TITLE
fix(v5): carry applied_from to the wire — the panel apply was dark through the product's own button

### DIFF
--- a/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
+++ b/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
@@ -1,0 +1,227 @@
+/**
+ * ⭐ ACCEPTANCE: THE BUTTON, NOT A FIXTURE. Click "Use Grace's 0.85" and assert
+ * the WIRE payload carries `applied_from`.
+ *
+ * ── WHY THIS EXISTS, AND WHY IT IS SHAPED LIKE THIS ───────────────────────
+ * The 14 Aug deploy witness for #689 PASSED on the deployed build — both pills
+ * visually confirmed, identity binding proven — and still missed that the whole
+ * feature was unreachable through the product's own click path, because
+ * `adaptFactorValueEdit` dropped `applied_from` on the way to the wire. **Every
+ * capture in that witness was of a payload the witness itself constructed.** A
+ * hand-built payload proves the server honours a claim; it cannot prove the
+ * client ever makes one.
+ *
+ * So this spec is built from the REAL parts, end to end, with nothing
+ * hand-assembled at the seam under test:
+ *
+ *   RevealBody's real button  (the component the deployed page renders)
+ *     → the real `rememberPendingApply` handoff  (localStorage)
+ *       → the real `usePanelApplyDrain`
+ *         → the real `buildFactorValueEditEvent`
+ *           → the real `buildV5Payload` / `adaptFactorValueEdit`
+ *             → the payload asserted here
+ *
+ * The test supplies only what a user or a server supplies: a reveal fixture, a
+ * node's data, and a click. **If any link in that chain drops the attribution,
+ * this REDs** — which is the property the witness could not have, and the reason
+ * a green component test and a green deploy witness coexisted with a dark
+ * capability.
+ *
+ * ⚠ NOT A BROWSER TEST, STATED PLAINLY. It runs in jsdom, so it proves the
+ * DATA reaches the wire and cannot prove the button is visible or clickable at
+ * a real viewport (jsdom cannot settle layout). The deploy witness covers the
+ * visual half; this covers the half the witness structurally could not.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { RevealBody } from '../../../pages/ParticipantPacketPage'
+// RevealView lives on the SERVICE, not the page — the page re-exports the type it
+// consumes. Importing it from its owner keeps this fixture bound to the wire
+// shape rather than to a component's local view of it.
+import type { RevealView } from '../../../collab/collabService'
+import { rememberPendingApply, forgetPendingApply } from '../../../collab/panelApplyHandoff'
+import { usePanelApplyDrain } from '../usePanelApplyDrain'
+import { buildV5Payload } from '../../../v5/buildPayload'
+
+const SCENARIO_ID = '22222222-3333-4444-8555-666677778888'
+const TURN_ID = '11111111-2222-4333-8444-555566667777'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+const NADIA_ID = 'e1e1e1e1-2222-4333-8444-555566667777'
+const TARGET_ID = 'factor-churn-risk'
+
+/** Grace is deliberately row 0 — see the identity-binding case below. */
+const REVEAL: RevealView = {
+  round_id: ROUND_ID,
+  status: 'closed',
+  graph_version_ref: 'mv-1',
+  per_target: [
+    {
+      target: { kind: 'factor', id: TARGET_ID },
+      label: 'Churn risk',
+      model_value_at_version: 0.5,
+      responses: [
+        {
+          participant_id: GRACE_ID,
+          display_label: 'Grace',
+          value: 0.85,
+          expression_raw: 'pretty likely',
+          confidence: 0.7,
+          kind: 'belief_submitted',
+        },
+        {
+          participant_id: NADIA_ID,
+          display_label: 'Nadia',
+          value: 0.4,
+          expression_raw: 'not very likely',
+          confidence: 0.6,
+          kind: 'belief_submitted',
+        },
+      ],
+    },
+  ],
+} as unknown as RevealView
+
+/** A plain model-scale factor: no cap, no unit, so the builder stays model-scale. */
+const NODE_DATA = { label: 'Churn risk', observedState: { value: 0.5 } }
+
+/**
+ * The canvas half. Mounts the REAL drain and pushes whatever the real builder
+ * produced through the REAL payload builder, capturing the wire event.
+ */
+function CanvasHarness({ onWire }: { onWire: (event: unknown) => void }): JSX.Element {
+  usePanelApplyDrain({
+    scenarioId: SCENARIO_ID,
+    lookupNodeData: (id) => (id === TARGET_ID ? NODE_DATA : undefined),
+    sendSystemEvent: async (event) => {
+      // THE LAST REAL HOP — the one that was dropping the field. The event here
+      // is exactly what the conversation context would hand `sendTurn`.
+      const result = buildV5Payload({
+        turnId: TURN_ID,
+        scenarioId: SCENARIO_ID,
+        stage: 'frame' as never,
+        turnClass: 'system' as never,
+        mode: 'system',
+        systemEvent: event as never,
+      })
+      if (!result.ok) throw new Error(`payload refused: ${JSON.stringify(result)}`)
+      onWire((result.payload as unknown as { event: unknown }).event)
+      return {}
+    },
+  })
+  return <div data-testid="canvas" />
+}
+
+/** The panel half: the real button, wired to the real handoff, as the owner page wires it. */
+function PanelHarness(): JSX.Element {
+  return (
+    <RevealBody
+      reveal={REVEAL}
+      apply={{
+        // Mirrors PanelSetupPage's handler at its load-bearing line: record the
+        // intent. The page's extra work (read-back assertion, confirmation copy)
+        // is not on the wire path and has its own specs.
+        onApply: (args) =>
+          rememberPendingApply({
+            scenarioId: SCENARIO_ID,
+            roundId: REVEAL.round_id,
+            participantId: args.participantId,
+            targetId: args.targetId,
+            value: args.value,
+          }),
+        applyingKey: null,
+        appliedKey: null,
+        applyError: null,
+      }}
+    />
+  )
+}
+
+/** Click the REAL button by the label a user reads, then drain on the canvas. */
+async function clickApplyThenDrain(buttonLabel: string): Promise<unknown> {
+  render(<PanelHarness />)
+  const button = screen.getByText(buttonLabel)
+  await act(async () => {
+    button.click()
+  })
+
+  let wire: unknown = null
+  render(<CanvasHarness onWire={(e) => { wire = e }} />)
+  await act(async () => {
+    await Promise.resolve()
+  })
+  return wire
+}
+
+describe('panel apply — click to wire', () => {
+  beforeEach(() => {
+    forgetPendingApply(SCENARIO_ID)
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    forgetPendingApply(SCENARIO_ID)
+  })
+
+  it('POSITIVE CONTROL — the real button exists with the label a user reads', () => {
+    // If the label or the component changes, this fails FIRST and by name,
+    // rather than the wire assertions failing for an unrelated reason and
+    // sending a reader to look at the adapter.
+    render(<PanelHarness />)
+    expect(screen.getByText('Use Grace’s 0.85')).toBeTruthy()
+    expect(screen.getByText('Use Nadia’s 0.4')).toBeTruthy()
+    // Both rows keep their button — the minority position is never retired.
+    expect(screen.getByTestId(`reveal-apply-${TARGET_ID}-${NADIA_ID}`)).toBeTruthy()
+  })
+
+  it('⭐ clicking "Use Grace’s 0.85" puts applied_from ON THE WIRE', async () => {
+    const wire = (await clickApplyThenDrain('Use Grace’s 0.85')) as Record<string, unknown>
+
+    expect(wire, 'no turn reached the wire at all').not.toBeNull()
+    expect(wire.kind).toBe('factor_value_edit')
+    expect(wire.target_id).toBe(TARGET_ID)
+    expect(wire.value).toBe(0.85)
+
+    // THE ASSERTION THIS FILE EXISTS FOR. Without it CEE stamps
+    // `source: 'user_override'` with no `elicited_from`, and the owner who
+    // clicked "Use Grace's 0.85" is told "Set by you".
+    expect(wire.applied_from).toEqual({
+      round_id: ROUND_ID,
+      participant_id: GRACE_ID,
+    })
+  })
+
+  it('⭐ IDENTITY BINDING — clicking Nadia’s row claims NADIA, not row 0', async () => {
+    // Grace is row 0 in the fixture on purpose. A chain that carried a
+    // participant id but resolved it from the first response would pass the
+    // previous test and fail this one — the same confound the deploy witness
+    // had to plant Grace at index 0 to expose.
+    const wire = (await clickApplyThenDrain('Use Nadia’s 0.4')) as Record<string, unknown>
+
+    expect(wire.value).toBe(0.4)
+    expect(wire.applied_from).toEqual({
+      round_id: ROUND_ID,
+      participant_id: NADIA_ID,
+    })
+  })
+
+  it('sends NO applied_from when no panel intent was recorded', async () => {
+    // The discriminating negative: the drain must not invent an attribution for
+    // an ordinary visit. Proves the field above came from the click.
+    let wire: unknown = null
+    render(<CanvasHarness onWire={(e) => { wire = e }} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(wire).toBeNull()
+  })
+
+  it('carries the value VERBATIM as the reveal served it', async () => {
+    // CEE compares the applied value to its own record with `Object.is` and
+    // refuses on any difference, so a re-rounded number anywhere in this chain
+    // would refuse every apply server-side while looking right on screen.
+    const wire = (await clickApplyThenDrain('Use Grace’s 0.85')) as Record<string, unknown>
+    expect(Object.is(wire.value, 0.85)).toBe(true)
+  })
+})

--- a/src/v5/__tests__/factorValueEditWireCarriage.spec.ts
+++ b/src/v5/__tests__/factorValueEditWireCarriage.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * THE ADAPTER MUST CARRY EVERY FIELD THE CONTRACT DECLARES — derived from the
+ * contract, never from a hand-written list.
+ *
+ * ── WHY THIS FILE EXISTS ──────────────────────────────────────────────────
+ * `adaptFactorValueEdit` copied `target_id`, `value`, `raw_value`, `unit` and
+ * `field` field-by-field, and silently dropped `applied_from`. The consequence
+ * was not a type error or a 422 — it was a capability that looked shipped and
+ * was dark: an owner clicking "Use Grace's 0.85" sent a `factor_value_edit`
+ * with no attribution claim, CEE stamped `source: 'user_override'` with no
+ * `elicited_from`, and the pill said "Set by you". Two merged PRs of
+ * attribution work rendered unreachable by one absent line in a third file
+ * neither of them touched.
+ *
+ * **The field list was a hand-maintained mirror of the wire shape, and that is
+ * HOW it shipped dark** (CLAUDE.md trap 12). The contract grew a member; the
+ * mirror did not; nothing anywhere went red. A second hand-written list —
+ * "fields the adapter should carry" — would be the same defect wearing a test's
+ * clothes, and would have to be remembered by the same person who forgot the
+ * first one.
+ *
+ * ── SO THE EXPECTATION IS DERIVED FROM THE PUBLISHED ZOD SCHEMA ───────────
+ * `SystemEventTurnPayloadSchema` is a discriminated union of `.strict()`
+ * members. This file walks it to the `factor_value_edit` member and reads its
+ * ACTUAL key set at the pin in `package.json`. When the contract gains a field,
+ * this guard starts demanding it on the next run, with no edit here and nobody
+ * needing to remember.
+ *
+ * ⚠ A DERIVED GUARD PROVES AGREEMENT, NOT COMPLETENESS (trap 12d). This one
+ * cannot notice that the CONTRACT is missing a field the product needs — only
+ * that the adapter has fallen behind the contract. That is the exact defect
+ * class that shipped here, and it is the one being closed; the other face needs
+ * a corpus, which is what the click-to-wire acceptance spec is.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SystemEventTurnPayloadSchema } from '@talchain/schemas/boundary'
+import { buildV5Payload } from '../buildPayload'
+
+/**
+ * Fields the adapter is allowed NOT to carry from the caller's payload.
+ *
+ * ⚠ THIS LIST IS A CONFESSION, NOT A CONVENIENCE. Every entry is a field the
+ * wire declares and the client deliberately refuses to forward, and each needs
+ * a reason a reviewer can check. It is EMPTY today: there is no field on this
+ * event the client is entitled to withhold.
+ *
+ * `kind` is not an exception — the adapter sets it itself, so it is present in
+ * the output and the assertion below passes on it for the right reason.
+ */
+const DELIBERATELY_NOT_CARRIED: Readonly<Record<string, string>> = Object.freeze({})
+
+/** Walk the union to the factor_value_edit member and read its real keys. */
+function contractKeysForFactorValueEdit(): string[] {
+  const eventSchema = (SystemEventTurnPayloadSchema as never as {
+    shape: { event: { _def: { options: unknown[] } } }
+  }).shape.event
+  const options = eventSchema._def.options as Array<{
+    shape: Record<string, { _def?: { value?: unknown } }>
+  }>
+  const member = options.find(
+    (o) => o.shape?.kind?._def?.value === 'factor_value_edit',
+  )
+  if (member === undefined) {
+    throw new Error(
+      'could not reach the factor_value_edit member of SystemEventTurnPayloadSchema — ' +
+        'the union shape changed and this guard is measuring nothing',
+    )
+  }
+  return Object.keys(member.shape)
+}
+
+// Real uuids and a real stage literal: the final case parses the built payload
+// against the contract, so a placeholder id would fail on the ID FORMAT and
+// disguise whether the event body is right.
+const TURN_ID = '11111111-2222-4333-8444-555566667777'
+const SCENARIO_ID = '22222222-3333-4444-8555-666677778888'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+const PARTICIPANT_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+
+/**
+ * A payload populating EVERY contract field with a valid value.
+ *
+ * ⚠ `applied_from` and `raw_value`/`unit` are mutually exclusive in the
+ * PRODUCT (a verified apply is model-scale, so the builder never attaches
+ * user-unit fields beside an attribution). They are populated together HERE on
+ * purpose: this guard is about the adapter's CARRIAGE, and it must be able to
+ * observe every field's carriage independently of the product rule that decides
+ * which combinations occur. The product rule has its own tests.
+ */
+const MAXIMAL_PAYLOAD: Record<string, unknown> = {
+  target_id: 'factor-1',
+  value: 0.85,
+  raw_value: 85,
+  unit: '%',
+  field: 'value',
+  applied_from: { round_id: ROUND_ID, participant_id: PARTICIPANT_ID },
+}
+
+function wireEventFor(payload: Record<string, unknown>): Record<string, unknown> {
+  const result = buildV5Payload({
+    turnId: TURN_ID,
+    scenarioId: SCENARIO_ID,
+    stage: 'frame' as never,
+    turnClass: 'system' as never,
+    mode: 'system',
+    systemEvent: { type: 'factor_value_edit', payload } as never,
+  })
+  if (!result.ok) {
+    throw new Error(`buildV5Payload refused the event: ${JSON.stringify(result)}`)
+  }
+  return (result.payload as unknown as { event: Record<string, unknown> }).event
+}
+
+describe('factor_value_edit — the adapter carries the whole contract', () => {
+  it('POSITIVE CONTROL — the contract walk reaches a real, non-trivial key set', () => {
+    // Without this, a walk that silently returned [] would make every
+    // assertion below pass by iterating nothing — the vacuity this repo has
+    // been bitten by before.
+    const keys = contractKeysForFactorValueEdit()
+    expect(keys.length).toBeGreaterThanOrEqual(5)
+    expect(keys).toContain('kind')
+    expect(keys).toContain('target_id')
+    expect(keys).toContain('value')
+    // And the walk discriminates — it did not hand back some other member.
+    expect(keys).not.toContain('patch_id')
+  })
+
+  it('⭐ carries EVERY field the contract declares (derived, not a hand list)', () => {
+    const contractKeys = contractKeysForFactorValueEdit()
+    const event = wireEventFor(MAXIMAL_PAYLOAD)
+
+    const dropped = contractKeys.filter(
+      (k) => !(k in event) && !(k in DELIBERATELY_NOT_CARRIED),
+    )
+
+    expect(
+      dropped,
+      dropped.length === 0
+        ? ''
+        : `adaptFactorValueEdit DROPS contract field(s) [${dropped.join(', ')}]. ` +
+          'A field the wire declares and the adapter does not copy is a capability ' +
+          'that ships dark — it is how applied_from was lost. Carry it, or add it ' +
+          'to DELIBERATELY_NOT_CARRIED with a reason a reviewer can check.',
+    ).toEqual([])
+  })
+
+  it('every declared exception is real — no stale entry silently excuses a live field', () => {
+    // The exception list is itself a hand-maintained list, so it gets the
+    // treatment: an entry naming a field the contract no longer has is a
+    // standing permission to drop nothing, and it would quietly excuse a
+    // future field that happened to share the name.
+    const contractKeys = new Set(contractKeysForFactorValueEdit())
+    for (const key of Object.keys(DELIBERATELY_NOT_CARRIED)) {
+      expect(contractKeys.has(key), `${key} is excepted but is not in the contract`).toBe(true)
+    }
+  })
+
+  it('⭐ carries applied_from specifically, with BOTH members intact', () => {
+    // Named separately from the derived sweep on purpose: the sweep proves the
+    // key is PRESENT, and a carriage that forwarded `applied_from: {}` would
+    // satisfy it while losing the identity that is the entire point.
+    const event = wireEventFor(MAXIMAL_PAYLOAD)
+    expect(event.applied_from).toEqual({
+      round_id: ROUND_ID,
+      participant_id: PARTICIPANT_ID,
+    })
+  })
+
+  it('omits applied_from when the caller did not claim one — absence stays absence', () => {
+    const { applied_from: _omitted, ...withoutClaim } = MAXIMAL_PAYLOAD
+    const event = wireEventFor(withoutClaim)
+    expect('applied_from' in event).toBe(false)
+  })
+
+  it.each([
+    ['a claim with no participant_id', { round_id: ROUND_ID }],
+    ['a claim with no round_id', { participant_id: PARTICIPANT_ID }],
+    ['a claim with a blank round_id', { round_id: '  ', participant_id: PARTICIPANT_ID }],
+    ['a claim with a blank participant_id', { round_id: ROUND_ID, participant_id: '' }],
+    ['a claim that is not an object', 'grace'],
+    ['a claim whose members are not strings', { round_id: 1, participant_id: 2 }],
+  ])('⭐ FAILS CLOSED on %s — refuses the event rather than dropping the claim', (_l, claim) => {
+    // The asymmetry that decides this: refusing gives the owner a visible
+    // nothing they can retry, whereas dropping the claim APPLIES the value and
+    // stamps it as the owner's own edit — the exact attribution untruth this
+    // seam exists to end, silent and permanent in the model. This is also the
+    // behaviour `field` already has one branch up, so the two agree.
+    const result = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'frame' as never,
+      turnClass: 'system' as never,
+      mode: 'system',
+      systemEvent: {
+        type: 'factor_value_edit',
+        payload: { ...MAXIMAL_PAYLOAD, applied_from: claim },
+      } as never,
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('a null claim is treated as absent, not as malformed', () => {
+    // `null` is what an "I have no attribution" producer emits; refusing the
+    // whole edit for it would break ordinary value edits from any caller that
+    // initialises the field.
+    const event = wireEventFor({ ...MAXIMAL_PAYLOAD, applied_from: null })
+    expect('applied_from' in event).toBe(false)
+    expect(event.target_id).toBe('factor-1')
+  })
+
+  it('does not launder EXTRA members of the claim onto a strict wire', () => {
+    // The caller's object is a client-side record. A spread would put whatever
+    // else it carries onto a `.strict()` union member and 422 the whole turn.
+    const event = wireEventFor({
+      ...MAXIMAL_PAYLOAD,
+      applied_from: {
+        round_id: ROUND_ID,
+        participant_id: PARTICIPANT_ID,
+        display_name: 'Grace',
+        note: 'local only',
+      },
+    })
+    expect(event.applied_from).toEqual({
+      round_id: ROUND_ID,
+      participant_id: PARTICIPANT_ID,
+    })
+    // And specifically: no PII rode along. A display name on the wire would be
+    // persisted into the graph, beyond the R-2 redaction routine's reach.
+    expect(JSON.stringify(event)).not.toContain('Grace')
+  })
+
+  it('the event still validates against the contract it was derived from', () => {
+    // Closes the loop: carrying a field is only correct if the result parses.
+    const result = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'frame' as never,
+      turnClass: 'system' as never,
+      mode: 'system',
+      systemEvent: { type: 'factor_value_edit', payload: MAXIMAL_PAYLOAD } as never,
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const parsed = SystemEventTurnPayloadSchema.safeParse(result.payload)
+    expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true)
+  })
+})

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -510,6 +510,58 @@ function adaptFactorValueEdit(
     event.field = 'value'
   }
 
+  // ── `applied_from` — the attribution claim (0.40.0) ──────────────────────
+  //
+  // ⚠ THIS WAS MISSING, AND ITS ABSENCE MADE A WHOLE FEATURE DARK. The panel
+  // apply path builds `applied_from` in `buildFactorValueEditEvent`, and this
+  // adapter — the SOLE construction site of the wire event — did not copy it.
+  // No type error (the field is optional), no 422, no failing test: just an
+  // owner clicking "Use Grace's 0.85", CEE stamping `source: 'user_override'`
+  // with no `elicited_from` because no claim ever arrived, and the pill reading
+  // "Set by you" over a colleague's number. Two merged PRs of attribution work
+  // were unreachable through the product's own click path.
+  //
+  // The generator was that this function is a HAND-MAINTAINED MIRROR of the
+  // wire shape (trap 12): the contract grew a member and the mirror did not.
+  // `__tests__/factorValueEditWireCarriage.spec.ts` now derives the expected
+  // field set from the published Zod schema and REDs on the next omission, so
+  // the mirror can no longer drift silently. Do not add a field here without
+  // letting that guard see it.
+  //
+  // FAIL CLOSED on a malformed claim, exactly as `field` above does, and for a
+  // sharper reason. The two failure directions are not symmetric:
+  //   · refuse the event  → nothing happens, the owner can click again;
+  //   · drop the claim    → the value IS applied and stamped as the owner's own
+  //                         edit, which is precisely the attribution untruth
+  //                         this seam exists to end — silent, and permanent in
+  //                         the model.
+  // A visible nothing beats a confident wrong stamp.
+  const appliedFrom = eventPayload?.applied_from
+  if (appliedFrom !== undefined && appliedFrom !== null) {
+    if (typeof appliedFrom !== 'object') return null
+    const round_id = stringField(appliedFrom as Record<string, unknown>, 'round_id')
+    const participant_id = stringField(
+      appliedFrom as Record<string, unknown>,
+      'participant_id',
+    )
+    // BOTH or NEITHER. A claim naming a participant with no round cannot be
+    // verified against a round's roster, and CEE would refuse it — but more to
+    // the point, a half-claim is not a claim, and forwarding one would ask the
+    // server to guess which round a person answered in.
+    //
+    // ⚠ TRIMMED FOR THE TEST, NOT FOR THE VALUE. `stringField` accepts any
+    // string of `length > 0`, so a whitespace-only id passes it; the contract
+    // requires uuids, so such a claim would 422 the whole turn at CEE. The ids
+    // are checked trimmed and then forwarded VERBATIM — a trimmed id is not
+    // "repaired", because silently rewriting an identifier is guessing at which
+    // round or which person was meant.
+    if (round_id.trim() === '' || participant_id.trim() === '') return null
+    // PICKED, never spread: the caller's object is a client-side record, and a
+    // spread would put whatever else it carries onto a `.strict()` wire member,
+    // turning an extra local field into a 422 for the whole turn.
+    event.applied_from = { round_id, participant_id }
+  }
+
   return event
 }
 


### PR DESCRIPTION
## The defect

`adaptFactorValueEdit` (`src/v5/buildPayload.ts`) is the **sole construction site** of the wire `factor_value_edit` event. It copied `target_id`, `value`, `raw_value`, `unit` and `field` field-by-field, and **silently dropped `applied_from`**.

No type error (the field is optional). No 422. No failing test. Just an owner clicking **"Use Grace's 0.85"**, CEE stamping `source: 'user_override'` with no `elicited_from` because no claim ever arrived, and the pill reading **"Set by you"** over a colleague's number.

**Two merged PRs of attribution work (#687, #689) were unreachable through the product's own click path.** Neither touched this file. Found by the 14 Aug deploy witness for #689 — which itself **passed**.

## The generator, named

The adapter's field list was a **hand-maintained mirror of the wire shape** (CLAUDE.md trap 12). The contract grew a member; the mirror did not; nothing anywhere went red.

So the fix is two halves — the line, and the mechanism that stops the next one.

### 1. Carriage, validated, failing closed

Fails closed on a malformed claim, exactly as `field` already does one branch up. **The two failure directions are not symmetric:**

| | consequence |
|---|---|
| refuse the event | nothing happens; the owner can click again |
| drop the claim | the value **is** applied and stamped as the owner's own edit — the precise attribution untruth this seam exists to end, silent and permanent in the model |

A visible nothing beats a confident wrong stamp.

Ids are **picked, never spread** (a `display_name` riding along would be persisted into the graph, beyond R-2's reach — and a spread onto a `.strict()` union member 422s the whole turn), and forwarded **verbatim**: a whitespace-only id is refused, never trimmed-and-repaired, because rewriting an identifier is guessing at which round or which person was meant.

### 2. A DERIVED completeness guard, so the mirror cannot drift again

`src/v5/__tests__/factorValueEditWireCarriage.spec.ts` walks the published Zod schema to the `factor_value_edit` member, reads its **actual key set at the `package.json` pin**, and asserts the adapter carries every one.

A second hand-written list — "fields the adapter should carry" — would have been the same defect wearing a test's clothes, and would have to be remembered by the same person who forgot the first one. The exception list is **empty**, is documented as *a confession, not a convenience*, and is itself checked for stale entries.

⚠ **Its limit, stated:** a derived guard proves **agreement**, never **completeness** (trap 12d). It cannot notice the *contract* lacking a field the product needs. That other face is what the acceptance spec is for.

## ⭐ Acceptance is the BUTTON this time

The deploy witness passed while this was broken because **every payload it captured was one it had constructed itself**. A hand-built payload proves the server honours a claim; it cannot prove the client ever makes one. That was its precise blind spot.

`src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx` clicks the **real** `RevealBody` button — the component the deployed page renders — and runs the real chain with nothing hand-assembled at the seam under test:

```
RevealBody's real button
  → real rememberPendingApply (localStorage)
    → real usePanelApplyDrain
      → real buildFactorValueEditEvent
        → real buildV5Payload / adaptFactorValueEdit
          → the payload asserted here
```

The test supplies only what a user or a server supplies: a reveal fixture, a node's data, and a click. **If any link drops the attribution, this REDs.**

Grace sits at **row 0** so the Nadia case discriminates identity from position — the same confound the witness had to plant for.

⚠ **Not a browser test, stated plainly.** jsdom, so it proves the *data* reaches the wire and cannot prove the button is visible or clickable at a real viewport. The deploy witness covers the visual half; this covers the half the witness structurally could not.

## RED-first, measured at pristine `5ee5d114` BEFORE the fix

```
carriage guard   2 failed / 4 passed   dropped field: [applied_from]
click-to-wire    2 failed / 3 passed   applied_from undefined on the wire
```

**Positive controls passed in both**, so the RED was the defect and not a broken harness.

## Mutation kit — 6/6 BIT

Throwaway worktree outside the repo root; isolation **proven by writing** a sentinel (absent from source); inodes differ (`615252981` vs `615257631`); HEAD-relative restores; clean tree asserted before and after each mutant; applied-check exactly 1 each; zero and trailing controls both **19 passed / 0 failed**.

| Mutant | Verdict |
|---|---|
| P1 **delete the carriage entirely** (the shipped defect) | BIT (11) |
| P2 drop a malformed claim instead of failing closed (the untruth direction) | BIT (5) |
| P3 spread the claim instead of picking (PII + strict-wire laundering) | BIT (1) |
| P4 carry only `round_id` (half a claim) | BIT (5) |
| P5 accept a half-claim (drop the BOTH-or-NEITHER rule) | BIT (4) |
| P6 hardcode participant to the claim's round (identity confusion) | BIT (4) |

## Gates

- `pnpm run typecheck` **PASSED**, `none added`. ⚠ It **caught two real errors in my own new spec first** (a `RevealView` import from the page rather than its owning service, and an unused import) — the ratchet did its job; both fixed, `RevealView` now imported from `collabService` where it is defined.
- `npm run lint` (**named** gate) — **0 errors**; hooks ratchet **232/15 exactly matching baseline**.
- Targeted regression `src/v5 src/canvas/conversation src/collab` — **264 files / 3677 tests pass**, 22 skipped.
- New specs collected **by name, non-zero**: carriage **14**, click-to-wire **5**.

## Scope

`src/v5/buildPayload.ts` (+52 lines, one adapter branch) plus two new specs. **No schemas pin change, no CEE change, no other production file touched.** Independently deployable.

Deliberately **not** fixed here: the witness confirmed **W-F1 still reproduces at CEE** (round close with a JSON content-type and no body → 500; body `'{}'` still needed). CEE-side and rowed.

**Not merged — branch only.**