### PR TITLE
Option cards: stop inventing a percentage for unframed factors; clearer target copy

### DIFF
--- a/src/canvas/nodes/GoalNode.tsx
+++ b/src/canvas/nodes/GoalNode.tsx
@@ -3,7 +3,7 @@
  *
  * Layer 1 (always visible):
  *  - No threshold pre-analysis: "What does success look like for you?" + chip
- *  - No threshold post-analysis: "Analysis complete. Set a target to see your chances." + chip
+ *  - No threshold post-analysis: "Analysis complete. Set a target to see how likely you are to reach it." + chip
  *  - With threshold: "Target: [value]" + provenance icon
  *  - Post-analysis with threshold: achievement probability (danger if <10%), actionable guidance
  *  - No risks chip (always)
@@ -330,7 +330,7 @@ export const GoalNode = memo((props: NodeProps) => {
           <>
             <p className={`${typography.nodeLabel} text-text-body mt-1 m-0`}>
               {hasAnyProbability
-                ? 'Analysis complete. Set a target to see your chances.'
+                ? 'Analysis complete. Set a target to see how likely you are to reach it.'
                 : 'Analysis finished. Set a target and check the graph for incomplete inputs.'}
             </p>
             {helpSetTargetChip}
@@ -397,7 +397,7 @@ export const GoalNode = memo((props: NodeProps) => {
             goal_probability even when the USER set no target (UI-SEM-071 class),
             so without this gate the "N% chance of reaching target" line would
             crown a target the user never set AND co-render with the "Set a target
-            to see your chances" invitation above. hasThreshold makes the two
+            to see how likely you are to reach it" invitation above. hasThreshold makes the two
             mutually exclusive by construction. */}
         {hasThreshold && displayMetadata.isResultsMode && displayMetadata.achievementProbability !== null && (
           <div className={`${typography.nodeLabel} mt-1 ${

--- a/src/canvas/nodes/__tests__/FactorNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/FactorNode.spec.tsx
@@ -1151,13 +1151,13 @@ describe('FactorNode — intervention hover', () => {
       category: 'controllable',
       observedState: { value: 0.5, factor_type: 'quality' },
     })
-    // Tier labels ("High", "Very high", …) are suppressed. Audit §8 P0-4:
-    // the annotation now routes through the single formatter, so it shows
-    // the same "70%" the option card's popover shows for this intervention
-    // (previously the annotation said "Increases …" while the card said
-    // "70%" — two statements for one datum).
-    expect(screen.queryByText(/High/)).toBeNull()
-    expect(screen.getByText('→ 70%')).toBeDefined()
+    // ⚠ RE-PINNED 14 Aug. The coherence property this test was written for —
+    // annotation and option card show ONE statement for one datum — is intact
+    // and is exactly why the value moved: both now route through the single
+    // formatter, which no longer invents a percentage for an unframed
+    // 'quality' factor. 0.7 → 'High' per qualitativeTierLabel.
+    expect(screen.getByText('→ High')).toBeDefined()
+    expect(screen.queryByText(/70%/)).toBeNull()
   })
 
   it('unwraps a CEEInterventionV3 {value} object and renders the shared formatted value', () => {
@@ -1168,7 +1168,9 @@ describe('FactorNode — intervention hover', () => {
       category: 'controllable',
       observedState: { value: 0.5, factor_type: 'quality' },
     })
-    expect(screen.getByText('→ 70%')).toBeDefined()
+    // ⚠ RE-PINNED 14 Aug — see the primitive-number test above. The UNWRAP is
+    // what this test guards; the formatted value moved for the same reason.
+    expect(screen.getByText('→ High')).toBeDefined()
     // Regression assertion: none of the pre-fix corrupt strings should appear anywhere.
     expect(screen.queryByText(/\[object Object\]/)).toBeNull()
     expect(screen.queryByText(/NaN/)).toBeNull()

--- a/src/canvas/nodes/__tests__/GoalNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/GoalNode.spec.tsx
@@ -372,7 +372,7 @@ describe('GoalNode', () => {
       selector(makeStoreState({ results: { status: 'complete', report: {} } }) as any)
     )
     renderGoal({ success_threshold: 15, threshold_source: 'user', goal_threshold_raw: null })
-    expect(screen.queryByText('Analysis complete. Set a target to see your chances.')).toBeNull()
+    expect(screen.queryByText('Analysis complete. Set a target to see how likely you are to reach it.')).toBeNull()
     expect(screen.getByText(/Target:/)).toBeDefined()
   })
 
@@ -733,7 +733,7 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
     expect(screen.queryByText(/Rerun the analysis/)).toBeNull()
     // The live bug: card said "Analysis complete. Set a target to see your
     // chances." while a target was set. Must never render here.
-    expect(screen.queryByText(/Set a target to see your chances/)).toBeNull()
+    expect(screen.queryByText(/Set a target to see how likely you are to reach it/)).toBeNull()
     expect(screen.queryByText('Help me set a target')).toBeNull()
   })
 
@@ -837,7 +837,7 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
     renderGoal({ goal_threshold_raw: '100', goal_threshold_unit: '%' })
     expect(screen.getByText(/73.*% chance of reaching target/)).toBeDefined()
     expect(screen.queryByText(/Rerun the analysis/)).toBeNull()
-    expect(screen.queryByText(/Set a target to see your chances/)).toBeNull()
+    expect(screen.queryByText(/Set a target to see how likely you are to reach it/)).toBeNull()
   })
 
   // Lane 4 (Paul ruled: GATE ON USER TARGET) — UI-SEM-082, extends UI-SEM-071.
@@ -871,7 +871,7 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
     )
     renderGoal() // no goal_threshold_raw / success_threshold → hasThreshold === false
     // Invitation shown…
-    expect(screen.getByText('Analysis complete. Set a target to see your chances.')).toBeDefined()
+    expect(screen.getByText('Analysis complete. Set a target to see how likely you are to reach it.')).toBeDefined()
     // …and the goal-fit claim SUPPRESSED — the two strings never co-render.
     expect(screen.queryByText(/chance of reaching target/)).toBeNull()
     expect(screen.queryByText(/Rerun the analysis/)).toBeNull()
@@ -903,7 +903,7 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
       }) as any)
     )
     renderGoal() // hasThreshold === false
-    expect(screen.getByText('Analysis complete. Set a target to see your chances.')).toBeDefined()
+    expect(screen.getByText('Analysis complete. Set a target to see how likely you are to reach it.')).toBeDefined()
     expect(screen.queryByText(/chance of reaching target/)).toBeNull()
     expect(screen.queryByText(/Target may be ambitious/)).toBeNull()
   })
@@ -930,7 +930,7 @@ describe('GoalNode — goal-state copy matrix (audit §8 P1)', () => {
     )
     renderGoal({ goal_threshold_raw: '60', goal_threshold_unit: '%' }) // hasThreshold === true
     expect(screen.getByText(/40.*% chance of reaching target/)).toBeDefined()
-    expect(screen.queryByText(/Set a target to see your chances/)).toBeNull()
+    expect(screen.queryByText(/Set a target to see how likely you are to reach it/)).toBeNull()
   })
 })
 

--- a/src/canvas/nodes/__tests__/OptionNode.spec.tsx
+++ b/src/canvas/nodes/__tests__/OptionNode.spec.tsx
@@ -441,7 +441,18 @@ describe('OptionNode', () => {
       }) as any)
     )
     renderOption()
-    expect(screen.getByText((t: string) => t.includes('0%') && t.includes('100%') && t.includes('→'))).toBeDefined()
+    // ⚠ RE-PINNED 14 Aug — AND THIS ONE IS A KNOWN COST, NOT A CLEAN WIN.
+    // 'Tech lead in place' is a PRESENCE factor mis-typed as 'quality' with no
+    // unit, cap, raw anchor or encoding_map, so it degrades to tier words like
+    // any other unframed qualitative factor: 0 → 'Very low', 1 → 'Very high'.
+    // For a 0↔1 presence traversal "0% → 100%" was arguably the better read.
+    // It is not reinstated here because the formatter sees ONE value at a time
+    // and cannot know the other endpoint, so it cannot decide "full traversal"
+    // coherently — a per-value rule that emitted '0%' for the baseline and
+    // 'Low' for a 0.4 target would render "0% → Low", mixing two frames in one
+    // chip. The real fix for this factor is an encoding_map or a binary
+    // factor_type, not a reinstated percentage. Flagged for review.
+    expect(screen.getByText((t: string) => t.includes('Very low') && t.includes('Very high') && t.includes('→'))).toBeDefined()
     // Scope A's both-labels branch did NOT fire: no fabricated target label.
     expect(screen.queryByText((t: string) => t.includes('→ Tech lead in place'))).toBeNull()
   })
@@ -663,8 +674,12 @@ describe('OptionNode', () => {
     renderOption()
     // arrow format: label and value are separate spans (no colon)
     expect(screen.getAllByText('Product-market fit').length).toBeGreaterThan(0)
-    // 0.7 with factor_type 'quality' → '70%' (tier labels banned in v1.1)
-    expect(screen.getByText('70%')).toBeDefined()
+    // ⚠ RE-PINNED 14 Aug. Previously '70%', commented "tier labels banned in
+    // v1.1". That ban is what produced "Development headcount 0% → 40%" on the
+    // live hiring graph: a 'quality' factor with no unit/cap/raw has no scale,
+    // so the percentage was invented. 0.7 → 'High' per qualitativeTierLabel.
+    expect(screen.getByText('High')).toBeDefined()
+    expect(screen.queryByText('70%')).toBeNull()
   })
 
   it('shows numeric value for factor with unit even if factor_type is qualitative', () => {
@@ -1433,9 +1448,11 @@ describe('OptionNode — QA Brief C-series', () => {
       }) as any)
     )
     renderOption({ label: 'Hire lead' })
-    // Qualitative: no unit, no scale — shows percentage (tier labels banned in v1.1)
+    // ⚠ RE-PINNED 14 Aug — same reversal as the 'quality' test above. "No unit,
+    // no scale" is precisely the condition under which a percentage cannot be
+    // honest; the tier word is what the factor actually supports.
     // Arrow separator is present between label and value (not a delta indicator)
-    expect(screen.getByText('70%')).toBeDefined()
+    expect(screen.getByText('High')).toBeDefined()
   })
 
   // C5: Near-zero baseline — no spurious percentage (guard: abs(denormedBaseline) <= 0.01)

--- a/src/canvas/utils/__tests__/interventionDisplay.spec.ts
+++ b/src/canvas/utils/__tests__/interventionDisplay.spec.ts
@@ -57,10 +57,21 @@ describe('formatInterventionChange — no-change semantics', () => {
     expect(change.changed).toBe(true)
     expect(change.arrow).toBe('up')
     expect(change.text).not.toMatch(/does not change/i)
-    // Qualitative unitless value renders as a percentage, not a tier label
-    expect(change.targetText).toBe('60%')
-    expect(change.baselineText).toBe('50%')
-    expect(change.text).toBe('Team seniority → 60%')
+    // ⚠ KNOWN COARSENING, pinned deliberately so it REDs if it changes.
+    // These three previously asserted '60%' / '50%' / 'Team seniority → 60%'.
+    // That percentage was fabricated: a unitless qualitative factor has no
+    // scale, so 0.6 is an ordinal position, not 60% of anything.
+    // Rendering the honest tier word costs resolution — 0.5 and 0.6 both sit in
+    // qualitativeTierLabel's `<= 0.6` Medium band, so the change now reads
+    // "Medium → Medium". The DIRECTION is not lost: `changed` and `arrow` above
+    // are derived from the raw values and still assert up-movement, which is
+    // why those assertions are the load-bearing ones in this test.
+    // Trade-off accepted: a coarse-but-true label over a precise-but-invented
+    // unit. If sub-tier resolution is wanted here, the fix is a real scale on
+    // the factor, not a reinstated percentage.
+    expect(change.targetText).toBe('Medium')
+    expect(change.baselineText).toBe('Medium')
+    expect(change.text).toBe('Team seniority → Medium')
   })
 
   it('small placeholder-scale shifts (old ±0.1 epsilon bug) count as change', () => {
@@ -151,8 +162,35 @@ describe('formatInterventionTargetText', () => {
     expect(formatInterventionTargetText({ label: 'Runway', value: 0.1, unit: 'months', cap: 10 })).toBe('1 months')
   })
 
-  it('converts tier-label fallbacks to percentages', () => {
-    expect(formatInterventionTargetText({ label: 'Quality', value: 0.6, factorType: 'quality' })).toBe('60%')
+  // ⚠ This test previously asserted `'60%'` under the name "converts
+  // tier-label fallbacks to percentages" — it PINNED THE DEFECT. A factor with
+  // no unit, no cap and no raw anchor has an ordinal 0–1 value, not a
+  // proportion, so rendering it as a percentage invents a frame. Witnessed on
+  // the 14 Aug hiring graph as "Development headcount 0% → 40%".
+  it('keeps tier-label fallbacks as tier words (never invents a percentage)', () => {
+    // 0.6 → 'Medium' per qualitativeTierLabel's `value <= 0.6` band
+    // (labelUtils.ts:262) — derived from the producer, not guessed.
+    expect(formatInterventionTargetText({ label: 'Quality', value: 0.6, factorType: 'quality' })).toBe('Medium')
+  })
+
+  // Guard the specific witnessed shape: a COUNT factor carrying no frame must
+  // never render as a percentage of anything.
+  it('renders an unframed count factor as level words, not a percentage', () => {
+    const text = formatInterventionTargetText({
+      label: 'Development headcount',
+      value: 0.4,
+      factorType: 'quality',
+    })
+    expect(text).not.toMatch(/%/)
+    expect(text).toBe('Low')
+  })
+
+  // The legitimate percentage path must survive: a factor that genuinely
+  // carries a unit still denormalises through the trusted chain.
+  it('still formats genuinely united factors through the scale path', () => {
+    expect(
+      formatInterventionTargetText({ label: 'Runway', value: 0.1, unit: 'months', cap: 10 }),
+    ).toBe('1 months')
   })
 })
 

--- a/src/canvas/utils/interventionDisplay.ts
+++ b/src/canvas/utils/interventionDisplay.ts
@@ -118,8 +118,12 @@ function singulariseCountUnitText(text: string, unit: string | null | undefined)
  *   1. CEE display_value verbatim
  *   2. formatFactorDisplayValue contextual (raw_value + unit, binary text, …)
  *   3. formatInterventionValue numeric fallback
- *   4. tier labels / raw normalised decimals → percentage
+ *   4. tier labels kept verbatim; raw normalised decimals → percentage
  * plus count-unit singularisation on UI-formatted output.
+ *
+ * Step 4 deliberately does NOT convert tier words into percentages: reaching
+ * the tier fallback means no unit, cap or raw anchor was recoverable, so the
+ * value is an ordinal position and a "%" would assert a frame nothing set.
  */
 export function formatInterventionTargetText(chip: InterventionValueInput): string {
   // CEE-provided display_value wins over any UI-side formatting (verbatim).
@@ -151,9 +155,28 @@ export function formatInterventionTargetText(chip: InterventionValueInput): stri
   if (contextual) return singulariseCountUnitText(contextual, effectiveUnit)
   // Fallback: prefer numeric formatting over qualitative tier labels and raw normalised values
   const fallback = formatInterventionValue(chip.value, chip.unit, chip.factorType, chip.cap, chip.observedValue, chip.observedRawValue)
-  // Tier labels → percentage (tier words are meaningless as change targets)
+  // Tier labels stay tier labels.
+  //
+  // ⚠ This branch used to read "tier words are meaningless as change targets"
+  // and rewrite them into `formatPercent(value, {fromDecimal:true})`. That
+  // premise is false and the rewrite invented a unit. We reach here only when
+  // BOTH the contextual formatter and every scale-recovery path declined —
+  // i.e. the factor has no unit, no cap and no raw anchor, so its 0–1 value is
+  // an ORDINAL POSITION, not a proportion of anything. Multiplying it by 100
+  // and appending "%" asserts a frame nothing established.
+  //
+  // Witnessed on Paul's hiring graph (14 Aug): `fac_eng_headcount`
+  // (factor_type "quality", no unit/cap/raw_value) rendered
+  // "Development headcount 0% → 40%". A headcount is a COUNT — there is no
+  // percentage of a headcount, and 40% of an unknown establishment is not a
+  // quantity the user can act on.
+  //
+  // A tier word is the honest rendering of an unframed ordinal, and it is
+  // already what FactorNode and GraphTextView show for the same factor via
+  // `preserveTierLabel`. Returning it here makes the option card agree with
+  // them instead of contradicting them with a fabricated percentage.
   if (isTierLabel(fallback)) {
-    return formatPercent(chip.value, { fromDecimal: true })
+    return fallback
   }
   // Raw normalised number (no unit, value in [0,1] like "0.15") → percentage
   if (!effectiveUnit && chip.value >= 0 && chip.value <= 1 && /^0\.\d+$/.test(fallback)) {


### PR DESCRIPTION
Surgical hotfix lane, 14 Aug. Base: UI \`5ee5d114\`. **Do not merge without review** — this reverses a prior deliberate policy (see below).

## Item 3 — unit/frame error (the witnessed defect)

Option cards rendered **"Development headcount 0% → 40%"**. A headcount is a COUNT; there is no percentage of one.

One branch in the declared single formatter (`src/canvas/utils/interventionDisplay.ts`, `formatInterventionTargetText`):

```ts
if (isTierLabel(fallback)) return formatPercent(chip.value, { fromDecimal: true })
```

commented *"tier words are meaningless as change targets"*. **That premise is false.** We reach the tier fallback only when the contextual formatter and every scale-recovery path have already declined — the factor has no unit, no cap, no raw anchor — so its 0–1 value is an **ordinal position, not a proportion**. `×100 + "%"` asserts a frame nothing established.

Repro trace confirmed against the real fixture (`fac_eng_headcount`, `factor_type: "quality"`, no unit/cap/raw_value):
`formatFactorDisplayValue` → `null` → `formatInterventionValue` → `"Low"` → `isTierLabel` → `formatPercent(0.4)` → `"40%"`; baseline 0 → `"0%"`.

**Fix: return the tier word.** Because this is the single formatter, it corrects the canvas pill, the "What this option changes" list, the FactorNode hover annotation and the differentiator line in one edit — and makes the option card *agree* with FactorNode/GraphTextView, which already show tier words for the same factor via `preserveTierLabel`.

Positive controls intact: the currency path (`raw_value 5000, unit £, cap 10000` → `£25,000`) and the united-factor path (`1 months`) both still pass, so the legitimate scale chain is untouched.

## ⚠ This reverses a deliberate v1.1 policy

Five specs carried the comment **"tier labels banned in v1.1"**. That ban is what produced the live defect. All are re-pinned here with reasoning inline rather than silently edited.

## ⚠ Two known costs — pinned, not hidden

1. **Coarsening.** `0.5 → 0.6` both sit in the `<= 0.6` Medium band, so that change now reads **"Medium → Medium"**. Direction is *not* lost — `changed` and `arrow` derive from raw values and still assert up-movement.
2. **Presence factors.** `"Tech lead in place"` (mis-typed `quality`, no `encoding_map`, `0 → 1`) now reads **"Very low → Very high"** where `"0% → 100%"` was arguably better. Not reinstated: the formatter sees **one value at a time** and cannot know the other endpoint, so a per-value rule would render `"0% → Low"` for a `0 → 0.4` change — two frames in one chip. The real fix is an `encoding_map` or a binary `factor_type`. **Flagged for review — happy to revert this branch of the change if preferred.**

## Item 4 — target copy

`"Set a target to see your chances"` did not say what the chances were *of*. Now **"Set a target to see how likely you are to reach it."** Updated at source, in the file's header doc and rationale comment, and across all 6 `GoalNode.spec.tsx` assertions.

## Verification

- **321/321 pass** across `interventionDisplay`, `GoalNode`, `OptionNode`, `FactorNode`, `render-matrix`. `VITE_SUPABASE_*` set; each target spec asserted to collect a non-zero count rather than inferred from the suite total.
- **`pnpm typecheck` (the named gate) PASSED** — 3425/3465 files covered, drift 2487 → 2485, none added. `--update-baseline` deliberately not accepted.
- Sibling-lane files (`TopBar`, `ScenarioSwitcher`, `v5/buildPayload.ts`) untouched and not on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)