### PR TITLE
Selection-aware AI hop 1: the node the user pointed at rides the turn

### DIFF
--- a/src/v5/__tests__/selectionCarriage.spec.ts
+++ b/src/v5/__tests__/selectionCarriage.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * SELECTION RIDES THE WIRE — the click path, bound by identity.
+ *
+ * ── WHY THIS FILE EXISTS ──────────────────────────────────────────────────
+ * A user pointing at a node and asking "why does this matter?" got an answer
+ * that never knew which node they meant. The selection lived in
+ * `useCanvasStore.selection` and stopped there: `buildV5Payload` — the SOLE
+ * live V5 outbound builder — read no selection of any name, and the only UI
+ * code that ever emitted `selected_elements` was the V4 request builder, which
+ * posts to the 410'd v1 route and is unreachable under the deployed
+ * `VITE_ENABLE_V5_ORCHESTRATOR="true"` bake. Verified on the wire
+ * (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/selection-aware-ai-2026-08-14/`):
+ * one node demonstrably selected at send time, 215-byte turn body, no
+ * `selected_elements`.
+ *
+ * ── WHAT THIS FILE BINDS TO ───────────────────────────────────────────────
+ * The tests drive the REAL store through React Flow's REAL selection callback
+ * (`onSelectionChange`), not a hand-made selection object. That matters twice
+ * over:
+ *   · trap 3b — a test bound to a surface the deployed flags do not mount
+ *     proves nothing; `onSelectionChange` is the path the mounted canvas uses;
+ *   · trap 19 — every assertion binds to the node's EXACT ID, and the
+ *     discriminating pair below proves the payload follows the selection
+ *     rather than merely containing "some node".
+ *
+ * ── AND WHAT IT DELIBERATELY DOES NOT CLAIM ───────────────────────────────
+ * This is a UNIT-seam witness: it proves the id leaves the builder on the wire
+ * payload. It says nothing about CEE consuming it — at the pin in
+ * package.json, CEE's ingress mirror still parses the V4-era
+ * `{node_ids, edge_ids}` shape and drops an array-of-refs silently. That is
+ * hop 3, a separate PR in a separate repo. Recorded here so a later reader
+ * cannot mistake a green file for a live capability.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { MessageTurnPayloadSchema, OrchestratorTurnPayloadSchema } from '@talchain/schemas/boundary'
+
+import { buildV5Payload, MAX_SELECTED_ELEMENTS } from '../buildPayload'
+import { useCanvasStore } from '../../canvas/store'
+import type { NodeData } from '../../canvas/domain/nodes'
+
+const TURN_ID = '11111111-1111-4111-8111-111111111111'
+const SCENARIO_ID = '22222222-2222-4222-8222-222222222222'
+
+function node(id: string, type: string, label: string): Node<NodeData> {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: { label, type } as unknown as NodeData,
+  } as Node<NodeData>
+}
+
+const PRICE = node('factor_price', 'factor', 'Price sensitivity')
+const CHURN = node('factor_churn', 'factor', 'Churn rate')
+const BUILD_IT = node('option_build', 'option', 'Build in-house')
+
+const GRAPH = [PRICE, CHURN, BUILD_IT]
+
+/** The real React-Flow-driven selection path, exactly as the canvas uses it. */
+function selectOnCanvas(nodes: readonly Node<NodeData>[]): void {
+  useCanvasStore.getState().onSelectionChange({
+    nodes: nodes as never,
+    edges: [],
+  } as never)
+}
+
+/**
+ * PRECONDITION PIN (trap 13b). Every absence assertion below is vacuous if the
+ * fixture silently failed to select anything, so the selection is asserted from
+ * the store — the same state the builder reads — before the payload is built.
+ */
+function assertStoreSelection(expected: readonly string[]): void {
+  const actual = [...useCanvasStore.getState().selection.nodeIds]
+  expect(actual.sort()).toEqual([...expected].sort())
+}
+
+function messagePayload(message = 'Why does this one matter?') {
+  const r = buildV5Payload({
+    turnId: TURN_ID,
+    scenarioId: SCENARIO_ID,
+    stage: 'analyse',
+    turnClass: 'clarify',
+    mode: 'user',
+    message,
+  })
+  if (!r.ok) throw new Error(`expected ok; got ${r.reason} ${r.detail ?? ''}`)
+  return r.payload as Extract<typeof r.payload, { kind: 'message' }>
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    nodes: GRAPH as never,
+    edges: [],
+    selection: { nodeIds: new Set<string>(), edgeIds: new Set<string>(), anchorPosition: null },
+  })
+})
+
+describe('selection carriage — the selected node rides the turn payload', () => {
+  it('click path: the exact selected node id reaches the wire payload', () => {
+    selectOnCanvas([PRICE])
+    assertStoreSelection(['factor_price'])
+
+    const payload = messagePayload()
+
+    expect(payload.selected_elements).toEqual([
+      { id: 'factor_price', kind: 'factor', label: 'Price sensitivity' },
+    ])
+  })
+
+  it('DISCRIMINATING PAIR: selecting a different node changes the id on the wire', () => {
+    // Same graph, same message, same everything except which node is selected.
+    // If the builder emitted "some node" rather than "the selected node", these
+    // two would agree and both assertions would still pass individually.
+    selectOnCanvas([PRICE])
+    assertStoreSelection(['factor_price'])
+    const first = messagePayload().selected_elements
+
+    selectOnCanvas([BUILD_IT])
+    assertStoreSelection(['option_build'])
+    const second = messagePayload().selected_elements
+
+    expect(first).toEqual([{ id: 'factor_price', kind: 'factor', label: 'Price sensitivity' }])
+    expect(second).toEqual([{ id: 'option_build', kind: 'option', label: 'Build in-house' }])
+    expect(first).not.toEqual(second)
+  })
+
+  it('multi-select carries every selected node, in stable graph order', () => {
+    selectOnCanvas([BUILD_IT, PRICE])
+    assertStoreSelection(['factor_price', 'option_build'])
+
+    // Graph order (PRICE, CHURN, BUILD_IT) — NOT the order the caller listed
+    // them in, so the payload is a pure function of the selection SET.
+    expect(messagePayload().selected_elements?.map((e) => e.id)).toEqual([
+      'factor_price',
+      'option_build',
+    ])
+  })
+
+  it('empty selection omits the field entirely — absence, never an empty array', () => {
+    assertStoreSelection([])
+    const payload = messagePayload()
+    expect(payload.selected_elements).toBeUndefined()
+    expect('selected_elements' in payload).toBe(false)
+  })
+
+  it('the built payload still satisfies the strict published contract', () => {
+    selectOnCanvas([PRICE])
+    assertStoreSelection(['factor_price'])
+    const payload = messagePayload()
+    // MessageTurnPayloadSchema is .strict(): a wrongly-shaped or wrongly-named
+    // selection field fails HERE rather than as a 422 on a user's turn.
+    expect(() => OrchestratorTurnPayloadSchema.parse(payload)).not.toThrow()
+  })
+})
+
+describe('selection carriage — the refusals, each for a stated reason', () => {
+  it('a selected id with no node in the graph is dropped, never fabricated', () => {
+    // Stale selection (node deleted underneath it). There is no label and no
+    // kind to state truthfully, and `kind` is REQUIRED by the contract, so the
+    // only honest options are "omit" or "invent". Omit.
+    useCanvasStore.setState({
+      selection: {
+        nodeIds: new Set(['ghost_node']),
+        edgeIds: new Set<string>(),
+        anchorPosition: null,
+      },
+    })
+    assertStoreSelection(['ghost_node'])
+    expect(messagePayload().selected_elements).toBeUndefined()
+  })
+
+  it('a selection larger than the contract cap omits the field rather than truncating', () => {
+    // The contract caps `selected_elements` at 20. Sending 20 of 34 would be a
+    // FALSE statement about what the user selected — CEE would ground an answer
+    // in a selection that never existed. Absence says nothing; a truncation
+    // says something wrong.
+    const many = Array.from({ length: 34 }, (_, i) => node(`f_${i}`, 'factor', `Factor ${i}`))
+    useCanvasStore.setState({ nodes: many as never })
+    selectOnCanvas(many)
+    expect(useCanvasStore.getState().selection.nodeIds.size).toBe(34)
+
+    expect(messagePayload().selected_elements).toBeUndefined()
+  })
+
+  it('exactly the cap (20) is carried — the boundary is inclusive, as the contract declares', () => {
+    const twenty = Array.from({ length: 20 }, (_, i) => node(`f_${i}`, 'factor', `Factor ${i}`))
+    useCanvasStore.setState({ nodes: twenty as never })
+    selectOnCanvas(twenty)
+    expect(useCanvasStore.getState().selection.nodeIds.size).toBe(20)
+
+    const payload = messagePayload()
+    expect(payload.selected_elements).toHaveLength(20)
+    expect(() => OrchestratorTurnPayloadSchema.parse(payload)).not.toThrow()
+  })
+
+  it('an edge-only selection carries nothing — edge_ids is out of this slice', () => {
+    // Deliberate scope: the contract admits any element ref, but nothing in CEE
+    // reads an edge selection today, and shipping a field no consumer reads is
+    // the estate's dominant defect. Edge answers are a second slice.
+    useCanvasStore.setState({
+      selection: {
+        nodeIds: new Set<string>(),
+        edgeIds: new Set(['edge_a']),
+        anchorPosition: null,
+      },
+    })
+    expect(useCanvasStore.getState().selection.edgeIds.size).toBe(1)
+    expect(messagePayload().selected_elements).toBeUndefined()
+  })
+
+  it('system-event turns never carry selection — the contract has no such field on them', () => {
+    selectOnCanvas([PRICE])
+    assertStoreSelection(['factor_price'])
+
+    const r = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'analyse',
+      turnClass: 'clarify',
+      mode: 'system',
+      systemEvent: { type: 'patch_accepted', payload: { patch_id: 'p1' } } as never,
+    })
+    if (!r.ok) throw new Error(`expected ok; got ${r.reason}`)
+    expect(r.payload.kind).toBe('system_event')
+    expect('selected_elements' in r.payload).toBe(false)
+    expect(() => OrchestratorTurnPayloadSchema.parse(r.payload)).not.toThrow()
+  })
+})
+
+/**
+ * DERIVED CARRIAGE GUARD (trap 12), the sibling of
+ * `factorValueEditWireCarriage.spec.ts`. The ref this builder emits is a
+ * HAND-MAINTAINED MIRROR of `SelectedElementRefSchema`. That is exactly how
+ * `applied_from` shipped dark: the contract grew a member, the mirror did not,
+ * and nothing anywhere went red. So the expectation is read off the published
+ * Zod schema at the pin, never from a list in this file.
+ *
+ * ⚠ A derived guard proves AGREEMENT, never COMPLETENESS (trap 12d). It cannot
+ * notice that the CONTRACT lacks a field the product needs. The corpus that
+ * covers the other face is the click-path suite above.
+ */
+describe('selection carriage — the ref shape is derived from the contract, not mirrored', () => {
+  /**
+   * Ref fields the builder is allowed NOT to carry.
+   *
+   * ⚠ A CONFESSION, NOT A CONVENIENCE. Every entry is a field the wire declares
+   * and the client deliberately withholds, and each needs a reason a reviewer
+   * can check. EMPTY today.
+   */
+  const DELIBERATELY_NOT_CARRIED: Readonly<Record<string, string>> = Object.freeze({})
+
+  function contractRefKeys(): string[] {
+    // `MessageTurnPayloadSchema` is the union member itself. Walking down from
+    // `OrchestratorTurnPayloadSchema` is NOT an option here: the root is wrapped
+    // in `.superRefine`, i.e. a ZodEffects, so `_def.options` is absent and the
+    // walk reads `undefined` — which is precisely the shape a guard silently
+    // measuring nothing takes. The union's acceptance of the built payload is
+    // proved separately, by the strict round-trip cases above.
+    const field = (
+      MessageTurnPayloadSchema as never as { shape: Record<string, unknown> }
+    ).shape['selected_elements'] as
+      | { _def?: { innerType?: { _def?: { type?: { shape?: Record<string, unknown> } } } } }
+      | undefined
+    // optional( array( object ) ) — unwrap to the element object's shape.
+    const element = field?._def?.innerType?._def?.type
+    const shape = element?.shape
+    if (shape === undefined) {
+      throw new Error(
+        'could not reach SelectedElementRefSchema through ' +
+          'MessageTurnPayloadSchema.selected_elements — the contract shape changed and this ' +
+          'guard is measuring nothing',
+      )
+    }
+    return Object.keys(shape)
+  }
+
+  it('the guard can actually reach the contract (positive control)', () => {
+    // Without this, every assertion below could pass on an empty key list.
+    const keys = contractRefKeys()
+    expect(keys.length).toBeGreaterThan(0)
+    expect(keys).toContain('id')
+  })
+
+  it('every field the contract declares on a selected-element ref is carried', () => {
+    selectOnCanvas([PRICE])
+    assertStoreSelection(['factor_price'])
+    const ref = messagePayload().selected_elements?.[0]
+    expect(ref).toBeDefined()
+
+    const missing = contractRefKeys().filter(
+      (k) => !(k in (ref as Record<string, unknown>)) && !(k in DELIBERATELY_NOT_CARRIED),
+    )
+    expect(missing).toEqual([])
+  })
+
+  it("the builder's cap is the contract's cap — derived, not taken on trust", () => {
+    // `MAX_SELECTED_ELEMENTS` is a literal in the send path (deliberately: the
+    // alternative binds production sends to zod's private internals). This is
+    // the guard that stops it drifting from the contract it mirrors.
+    const field = (
+      MessageTurnPayloadSchema as never as { shape: Record<string, unknown> }
+    ).shape['selected_elements'] as
+      | { _def?: { innerType?: { _def?: { maxLength?: { value?: number } } } } }
+      | undefined
+    const contractMax = field?._def?.innerType?._def?.maxLength?.value
+    expect(typeof contractMax).toBe('number') // positive control: the walk landed
+    expect(MAX_SELECTED_ELEMENTS).toBe(contractMax)
+  })
+
+  it('nothing beyond the contract is smuggled onto the ref', () => {
+    selectOnCanvas([PRICE])
+    const ref = messagePayload().selected_elements?.[0] as Record<string, unknown>
+    // SelectedElementRefSchema is .strict(); an extra key 422s the whole turn.
+    expect(Object.keys(ref).sort()).toEqual(contractRefKeys().sort())
+  })
+})

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -34,6 +34,17 @@ import type {
 import { ActionType, Intent } from '@talchain/schemas/boundary'
 
 import type { SystemEvent } from '../canvas/conversation/types'
+// VALUE import, and deliberately so: the selection this module puts on the wire
+// must be the one the canvas holds AT SEND TIME, read at the moment the payload
+// is built. Passing it in from useConversation would be purer, but the store is
+// the single authority for what the user has selected and re-plumbing it through
+// the call site adds a second place for the two to disagree. There is no import
+// cycle: `canvas/store.ts` reaches this module only through a TYPE-only import
+// of `v5/decisionReviewAdapter` (erased at compile time), and no value-import
+// path from `canvas/store.ts` reaches `v5/buildPayload.ts` or
+// `canvas/conversation/useConversation.ts` — derived by transitive closure over
+// the 66 value-imported modules reachable from the store, not assumed.
+import { useCanvasStore } from '../canvas/store'
 
 export interface BuildV5PayloadInput {
   turnId: string
@@ -181,7 +192,98 @@ export function buildV5Payload(input: BuildV5PayloadInput): BuildV5PayloadResult
     base.retry_of = input.retryOf
   }
 
+  // selected_elements — what the user had selected on the canvas at send time.
+  // Omitted (absent, never `[]`) when there is nothing to say. See
+  // `deriveSelectedElements` for every reason a selection can be withheld.
+  const selectedElements = deriveSelectedElements()
+  if (selectedElements !== undefined) {
+    base.selected_elements = selectedElements
+  }
+
   return { ok: true, payload: base }
+}
+
+/**
+ * The contract's cap on `selected_elements` (`MAX_SELECTED_ELEMENTS` in
+ * @talchain/schemas `turn-payload.ts`).
+ *
+ * ⚠ A HAND-MAINTAINED MIRROR OF A CONTRACT CONSTANT — the exact defect class
+ * that shipped `applied_from` dark. It is a literal here rather than read out of
+ * the Zod schema at runtime because unwrapping `_def.innerType._def.maxLength`
+ * in PRODUCTION code binds the send path to zod's private internals, which move
+ * between minor versions; a wrong read there would drop selection on every turn.
+ * The drift is closed on the TEST side instead: `selectionCarriage.spec.ts`
+ * derives the cap from the published schema and REDs if this number stops
+ * matching it. Exported solely so that guard can see it.
+ *
+ * Direction of the failure if it ever does drift: a cap that is too HIGH sends
+ * an over-long array and 422s the turn; too LOW silently withholds selection on
+ * large selections. Both are visible to the guard before they are visible to a
+ * user.
+ */
+export const MAX_SELECTED_ELEMENTS = 20
+
+/**
+ * Read the live canvas selection and shape it as the contract's typed refs.
+ *
+ * WHY THIS EXISTS: the selection lived in the store and stopped there. The only
+ * UI code that ever emitted `selected_elements` was the V4 request builder,
+ * which posts to the 410'd v1 route and cannot execute under the deployed
+ * `VITE_ENABLE_V5_ORCHESTRATOR="true"` bake — so a user pointing at a node and
+ * asking "why does this matter?" sent a turn that never named the node.
+ *
+ * ⚠ TWO DIFFERENTLY-SHAPED FIELDS SHARE THIS NAME, and picking the wrong one
+ * is silent. The V4/extension shape is `{node_ids?, edge_ids?}`; the V5
+ * message-turn shape published at our pin is `Array<{id, kind, label?}>`, capped
+ * at 20. This builds the V5 shape, because that is what
+ * `MessageTurnPayloadSchema` — the `.strict()` schema this payload is validated
+ * against — declares. (CEE's *ingress* still mirrors the V4 shape and drops an
+ * array-of-refs best-effort; that is a CEE-side widening, tracked as hop 3 of
+ * this slice. Until it lands, this field is carried and not consumed. It cannot
+ * 422 anything in the meantime: CEE's pre-flight strips the key off the body
+ * before the strict validator runs, and its extension re-parse is fail-soft.)
+ *
+ * Returns `undefined` — i.e. the key is ABSENT — rather than an empty array
+ * whenever the client has nothing truthful to say:
+ *
+ *   · nothing selected;
+ *   · an edge-only selection (`edge_ids` is deliberately out of this slice:
+ *     nothing reads an edge selection, and shipping a field with no consumer is
+ *     this estate's dominant defect);
+ *   · a selected id with no matching node — a stale selection over a deleted
+ *     node. `kind` is REQUIRED by the contract and there is nothing truthful to
+ *     put in it, so the ref is dropped rather than invented;
+ *   · a node carrying no `type` — same reason, no fabricated kind;
+ *   · a selection LARGER than the contract cap. Sending 20 of 34 would be a
+ *     false statement about what the user selected, and CEE would ground an
+ *     answer in a selection that never existed. Absence says nothing; a silent
+ *     truncation says something wrong.
+ *
+ * Order is the STORE'S NODE ORDER, not the selection Set's iteration order, so
+ * the payload is a pure function of the selected SET.
+ */
+function deriveSelectedElements(): MessageTurnPayload['selected_elements'] | undefined {
+  // Defensive read: this is the one place the wire builder depends on store
+  // shape, and a selection-less store (an early boot, a test that stubbed the
+  // store) must degrade to "no selection", never throw on the send path.
+  const state = useCanvasStore.getState()
+  const selectedIds = state?.selection?.nodeIds
+  if (!selectedIds || selectedIds.size === 0) return undefined
+  if (selectedIds.size > MAX_SELECTED_ELEMENTS) return undefined
+
+  const refs: NonNullable<MessageTurnPayload['selected_elements']> = []
+  for (const node of state.nodes ?? []) {
+    if (!selectedIds.has(node.id)) continue
+    const kind = typeof node.type === 'string' ? node.type.trim() : ''
+    if (kind.length === 0) continue
+    const rawLabel = (node.data as { label?: unknown } | undefined)?.label
+    const label = typeof rawLabel === 'string' ? rawLabel.trim() : ''
+    // `label` is optional on the contract and `.min(1)` when present — omit it
+    // rather than send an empty string, which would 422 the whole turn.
+    refs.push(label.length > 0 ? { id: node.id, kind, label } : { id: node.id, kind })
+  }
+
+  return refs.length > 0 ? refs : undefined
 }
 
 function buildSystemEventPayload(input: BuildV5PayloadInput): BuildV5PayloadResult {


### PR DESCRIPTION
## What a user gets

Select a node, ask *"why does this one matter?"* — the turn now names the node. Before this, it did not: the selection lived in `useCanvasStore.selection` and stopped there.

**Witnessed absent on the wire before this change** (`olumi-docs/PHASE0-EVIDENCE-2026-07-28/selection-aware-ai-2026-08-14/CHAIN-VERDICT.md`): a node demonstrably selected at send time (`domSelectedIds: ["goal_cdp"]`, pinned in-run), a 215-byte turn body, **no `selected_elements`**. The only UI code that ever emitted the field is the V4 request builder, which posts to the 410'd v1 route and cannot execute under the deployed `VITE_ENABLE_V5_ORCHESTRATOR="true"` bake (`rm({flag:"true"})` ×3 in the deployed bundle).

## ⚠ THIS SHIPS CARRIED-BUT-NOT-YET-CONSUMED — SAYING SO UP FRONT

CEE's ingress parser (`request-extensions.ts:138`) still mirrors the **V4-era** `{node_ids?, edge_ids?}` shape. An array of typed refs matches neither of its union branches, so at CEE's current tip this field is **dropped best-effort** and nothing reads it. Widening that parser and threading the selection into `EnrichedTurnContext` is **hop 3** — a separate PR in `olumi-assistants-service` from this same lane.

**It cannot 422 anything in the meantime, and that is derived rather than hoped:** CEE's pre-flight strips `selected_elements` off the body *before* the strict B1 validator runs (`route-v2-preflight.ts:96`, itself derived from `Object.keys(V5RequestExtensionsSchema.shape)`), and the extension re-parse is explicitly fail-soft — *"a structurally invalid value does not abort the turn"*. So the landing order is free, and this PR is safe to land first.

## ⭐ Corrected premise: two differently-shaped fields share this name

The slice spec said the contract field is `{node_ids?, edge_ids?}` and that the UI should send "the shape CEE already accepts". **Derived at the vendored bytes** (`vendor/talchain-schemas-0.40.0.tgz` → `dist/boundary/turn-payload.js`; both repos pin 0.40.0, so no skew):

```ts
export const SelectedElementRefSchema = z.object({
  id: z.string().min(1), kind: z.string().min(1), label: z.string().min(1).optional(),
}).strict();
const MAX_SELECTED_ELEMENTS = 20;
export const MessageTurnPayloadSchema = z.object({
  ...
  selected_elements: z.array(SelectedElementRefSchema).max(MAX_SELECTED_ELEMENTS).optional(),
}).strict();
```

It is on the **base message schema**, not an extension. The schema's own comment names the fork: the V4 field *"is not touched by this change; the two simply coexist under the same name on different schema versions/turn shapes."*

This PR emits the **published V5 shape**, because that is what the `.strict()` schema this payload is validated against declares. Emitting `{node_ids}` would have failed the `OrchestratorTurnPayloadSchema.parse()` round-trip that every existing `buildPayload` test performs — i.e. the spec's instruction would have gone red on contact.

## What it withholds, and why each one

Absence (the key omitted), never `[]`:

| Case | Why |
|---|---|
| nothing selected | nothing to say |
| edge-only selection | `edge_ids` is deliberately out of this slice — nothing reads an edge selection, and shipping a field with no consumer is this estate's dominant defect |
| stale id, no matching node | `kind` is REQUIRED by the contract and there is nothing truthful to put in it. Drop, never invent |
| node with no `type` | same reason |
| selection larger than the cap (20) | sending 20 of 34 would be a **false statement** about what the user selected, and CEE would ground an answer in a selection that never existed. **Absence says nothing; a silent truncation says something wrong.** |

Order is the **store's node order**, not the selection `Set`'s iteration order, so the payload is a pure function of the selected set.

## Tests — `src/v5/__tests__/selectionCarriage.spec.ts` (14)

- **RED-first at pristine:** 13 collected, **6 red** on the presence direction, positive control green. (The absence cases pass at pristine by construction — they guard the fix from over-reaching, and are not offered as RED-first proofs.)
- **Bound to the mounted surface** (trap 3b): the click path drives the real store through React Flow's real `onSelectionChange`, not a hand-made selection object.
- **Bound by identity** (trap 19), with a **DISCRIMINATING PAIR**: selecting a different node must change the id on the wire. A test that merely found "a node" would pass on both and prove nothing.
- **Every absence case pins its own precondition** from the store before building (trap 13b), so none can pass because the fixture silently failed to select.
- **Derived, not mirrored** (trap 12): the ref's field set *and* the cap are both read off the published Zod schema, with a positive control asserting the walk landed. This is the guard discipline #692 added for `applied_from` — whose omission from a hand-maintained mirror is exactly how that field shipped dark. `MAX_SELECTED_ELEMENTS` stays a literal in the send path (production sends must not depend on zod's private internals) and the guard is what stops it drifting.

## Design note — why the store is read here

The store is read at build time rather than plumbed through `useConversation`: it is the single authority for what is selected, and a second copy is a second place for the two to disagree. **No import cycle** — derived by transitive closure over the 66 value-imported modules reachable from `canvas/store.ts` (no value-import path reaches `v5/buildPayload.ts` or `useConversation.ts`), not assumed.

`buildDirectAnalysisRunMessage` (the explicit Run button) deliberately does **not** carry selection: that turn is about the whole model.

## Gates

- `pnpm run typecheck` **PASSED** — coverage 3431/3471, ratchet **618 files / 2485 errors**, byte-identical to a **pristine worktree at `9c75be0b`** (2485), so this change adds **zero** diagnostics. The "drift shrank 2487→2485" notice is pre-existing and deliberately **not** banked here.
- `eslint` clean on both changed files.
- Neighbouring payload suites green alongside: `buildPayload` (22), `factorValueEdit.wire` (23), `factorValueEditWireCarriage` (14), `systemEventParity` (12) — 85 total, `applied_from` carriage undisturbed.

## Status rung (honest)

**TESTED** at the unit seam. Not deployed, not wire-witnessed with this build, and **semantically dark until hop 3 lands in CEE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)