### PR TITLE
No rank, no probability, no client-minted placeholder for an unanalysed option

### DIFF
--- a/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.goalFitParity.spec.tsx
@@ -204,12 +204,44 @@ describe('Model-tab goal card — per-option goal fit (real ModelTabBody→GoalS
 
 describe('honest gates — no partial rankings, no rows without a basis', () => {
   it('one option without an admissible figure → NO rows at all (complete-field rule)', () => {
+    // ⚠ FIXTURE CORRECTED BY THE NO-RANK LANE (14 Aug 2026), AND THE
+    // CORRECTION IS ITSELF THE FINDING.
+    //
+    // This test's NAME says "without an admissible figure". Its fixture said
+    // `delete probs.opt_statusquo` — which is a DIFFERENT FACT: not "analysed
+    // and unscoreable" but "never analysed at all". The two arrived at one
+    // `return null` inside `buildGoalFitRows`, and that conflation is exactly
+    // what Paul's ruling separates (CLAUDE.md trap 21: two questions under one
+    // return). The name was right and the fixture was wrong, so the fixture is
+    // what changed: the entry is now PRESENT and carries no goal figure, which
+    // is what the complete-field rule was written to catch.
+    //
+    // The other fact — an option the run never analysed — is pinned by its own
+    // twin below, where it now renders rows instead of blanking the card.
     const probs = walkOptionProbabilities()
-    delete probs.opt_statusquo
+    probs.opt_statusquo = { win_probability: 0.0145 }
     setResults(probs)
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
     expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
     expect(screen.queryByTestId('goal-fit-parity')).toBeNull()
+  })
+
+  it('OPPOSITE TWIN — an option the run NEVER ANALYSED still leaves rows for the analysed ones', () => {
+    // Paul's ruling, 14 Aug 2026: an unanalysable option is not in the
+    // comparison — it must not be ranked, and it must not delete the ranking.
+    // Before this lane, `delete probs.opt_statusquo` blanked the ENTIRE
+    // goal-fit card for the three options that WERE scored.
+    const probs = walkOptionProbabilities()
+    delete probs.opt_statusquo
+    setResults(probs)
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={makeNodes()} edges={[]} />)
+    const parity = screen.getByTestId('goal-fit-parity')
+    // The three analysed options keep their rows, by label identity.
+    expect(parity).toHaveTextContent('Invest in Content Marketing')
+    expect(parity).toHaveTextContent('Hire Two Sales Reps')
+    expect(parity).toHaveTextContent('Build Self-Serve Tier')
+    // And the never-analysed option contributes none — no row, no figure.
+    expect(parity).not.toHaveTextContent('Continue Current Approach')
   })
 
   it('no target set on the goal → no rows even with full figures', () => {

--- a/src/canvas/components/model-tab/buildGoalFitRows.ts
+++ b/src/canvas/components/model-tab/buildGoalFitRows.ts
@@ -10,11 +10,35 @@
  *    reads those fields itself; it hands each `option_probabilities` entry
  *    to the owner and reads the decision.
  *  · Complete-field rule (the V7 goal lens / OptionCards "Hits target"
- *    gate): rows are returned ONLY when every option node has an admissible
- *    figure. A partial list would be a ranking over a subset presented as a
- *    ranking over the options — return null instead and render nothing.
+ *    gate): rows are returned ONLY when every ANALYSED option node has an
+ *    admissible figure. A partial list would be a ranking over a subset
+ *    presented as a ranking over the options — return null instead and render
+ *    nothing.
  *  · Producer order preserved — rows follow the caller's option order; no
  *    re-sorting, no winner designation minted here.
+ *
+ * ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — TWO QUESTIONS WERE SHARING ONE
+ * `return null`, AND THE ANSWER TO ONE OF THEM WAS WRONG.
+ *
+ * The loop used to `return null` — from the WHOLE builder, not the iteration —
+ * on `!entry || typeof entry !== 'object'`. Two different facts arrive at that
+ * line:
+ *
+ *   (a) **the option was never analysed** (CEE excluded it from the submission,
+ *       so there is no entry). ONE such option blanked the entire goal-fit card
+ *       for every option that WAS analysed.
+ *   (b) **the entry is present and malformed.** A producer defect, and the
+ *       complete-field rule above is exactly right about it.
+ *
+ * The complete-field rule was written for a THIRD case, on the line below: an
+ * option that WAS analysed and carries no goal figure. It was never written for
+ * "never analysed", and applying it there answers a question nobody asked
+ * (CLAUDE.md trap 21). (a) now SKIPS; (b) and the analysed-but-no-figure case
+ * keep `return null` unchanged.
+ *
+ * The domain guard matches the results hook's: a run that returned NOTHING for
+ * ANY option is a whole-run producer gap, not a set of excluded options, and
+ * still yields `null` rather than an empty card.
  */
 
 import type { Node } from '@xyflow/react'
@@ -22,6 +46,7 @@ import {
   selectGoalProbability,
   type GoalProbabilityInput,
 } from '../../../components/results/utils/selectGoalProbability'
+import { isAnalysedOption } from '../../../components/results/utils/notAnalysedOptions'
 
 export interface GoalFitRow {
   id: string
@@ -67,10 +92,18 @@ export function buildGoalFitRows(
   optionProbabilities: Record<string, unknown> | null | undefined,
 ): GoalFitRow[] | null {
   if (!optionProbabilities || optionNodes.length === 0) return null
+  // THE DOMAIN GUARD (see the header). "No entry" only means "this option was
+  // excluded" when the run produced entries for other options; when it
+  // produced none at all, every option reads missing and the honest answer is
+  // still the whole-card null.
+  const analysedNodes = optionNodes.filter((node) => isAnalysedOption(optionProbabilities, node.id))
+  if (analysedNodes.length === 0) return null
   const rows: GoalFitRow[] = []
-  for (const node of optionNodes) {
+  for (const node of analysedNodes) {
     const entry = optionProbabilities[node.id]
-    if (!entry || typeof entry !== 'object') return null
+    // Present but malformed — a producer defect, and the complete-field rule
+    // is right about it. Absence never reaches here; it was filtered above.
+    if (typeof entry !== 'object') return null
     const decision = selectGoalProbability(entry as GoalProbabilityInput)
     if (decision.goalProbability == null) return null
     const data = node.data as Record<string, unknown> | undefined

--- a/src/components/results/NotAnalysedOptionCard.tsx
+++ b/src/components/results/NotAnalysedOptionCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * NotAnalysedOptionCard — the option that was NOT in the analysis.
+ *
+ * ⭐ NO-RANK RULING (Paul, 14 Aug 2026): an unanalysable/placeholder option must
+ * NOT be included in comparative ranking or probabilities. It stays visible as
+ * a proposed/unanalysed alternative with a clear reason and an action to
+ * resolve it.
+ *
+ * ## Why this is a SEPARATE COMPONENT and not eight `&& !notAnalysed` guards
+ *
+ * `OptionCard` renders a rank swatch, a stable "Option N", a win percentage, a
+ * coloured fill bar, goal stat bars, a range bar and a downside block — seven
+ * places a number or an ordinal can appear. Adding a conjunct to each would
+ * make the ruling a HAND-MAINTAINED LIST: every future stat row added to that
+ * card would have to remember the eighth guard, and forgetting one is silent
+ * (CLAUDE.md trap 12 — the mirror that drifts always reads green). Forking at
+ * the top means a marked option CANNOT reach the ranked chrome at all, and the
+ * mutant that proves it is a single deletion.
+ *
+ * ## What it deliberately does NOT render
+ *
+ * No rank marker · no ordinal · no win percentage · no expected value · no fill
+ * bar · no goal bar · no range bar. Not "rendered as zero", not "rendered as
+ * '—'": absent. A dash in a ranked column still asserts membership in the
+ * ranking, and this option is not in it.
+ *
+ * ## The resolve affordance uses the SAME route as the sibling cards
+ *
+ * `openAskOlumi` prefills the drawer with an editable draft rather than
+ * auto-sending — the established pattern on this surface (Codex finding 6), so
+ * the ruling's "action to resolve it" arrives by the route the product already
+ * has rather than a second one built beside it. The draft itself is CEE's own
+ * documented sentence; see `utils/notAnalysedCopy.ts`.
+ */
+
+import { typography } from '../../styles/typography'
+import { openAskOlumi } from './coaching/askOlumiStore'
+import {
+  NOT_ANALYSED_BADGE,
+  notAnalysedActionLabel,
+  notAnalysedReasonCopy,
+  resolveOptionPrompt,
+} from './utils/notAnalysedCopy'
+import type { OptionResult } from './types'
+
+export interface NotAnalysedOptionCardProps {
+  /** Must carry `notAnalysed === true`; the caller owns that fork. */
+  option: OptionResult
+  /** Focus this option's node on the canvas, when the host offers it. */
+  onFocusNode?: (nodeId: string) => void
+}
+
+export function NotAnalysedOptionCard({ option, onFocusNode }: NotAnalysedOptionCardProps) {
+  // Absent reason ⇒ the conservative arm. `not_returned` prescribes no step,
+  // so an unrecognised state cannot invent a configure action for an option we
+  // cannot prove is unconfigured.
+  const reason = option.notAnalysedReason ?? 'not_returned'
+  const actionLabel = notAnalysedActionLabel(reason)
+
+  return (
+    <div
+      className="bg-panel p-3 border border-dashed border-panel-border rounded-lg space-y-2"
+      data-testid={`option-card-not-analysed-${option.id}`}
+      data-option-id={option.id}
+    >
+      <div className="flex items-center gap-2">
+        {/* No rank swatch and no "Option N" — the two ordinals the ranked card
+            renders in this slot. The gap is the point. */}
+        <span className={`${typography.panelHeader} text-text-header`}>{option.label}</span>
+        <span
+          className={`${typography.panelMeta} inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border border-panel-border text-text-light flex-shrink-0`}
+          data-testid={`not-analysed-badge-${option.id}`}
+        >
+          {NOT_ANALYSED_BADGE}
+        </span>
+      </div>
+
+      <p
+        className={`${typography.panelBody} text-text-light`}
+        data-testid={`not-analysed-reason-${option.id}`}
+      >
+        {notAnalysedReasonCopy(reason)}
+      </p>
+
+      {(actionLabel != null || onFocusNode) && (
+        <div className="flex items-center gap-1 pt-1.5">
+          {actionLabel != null && (
+            <button
+              type="button"
+              data-testid={`not-analysed-resolve-${option.id}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                openAskOlumi({
+                  context: `About "${option.label}"`,
+                  draft: resolveOptionPrompt(option.label),
+                  label: actionLabel,
+                })
+              }}
+              className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer`}
+            >
+              {actionLabel}
+            </button>
+          )}
+          {onFocusNode && (
+            <button
+              type="button"
+              data-testid={`not-analysed-focus-${option.id}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onFocusNode(option.id)
+              }}
+              className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer`}
+            >
+              Show on canvas
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NotAnalysedOptionCard

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -38,6 +38,7 @@ import {
   isBelowSimulationResolution,
 } from '../../utils/formatPercent'
 import { ExpertBlock } from './ExpertBlock'
+import { NotAnalysedOptionCard } from './NotAnalysedOptionCard'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import { OptionRangeBar, computeOptionScale, isFiniteNumber, type OptionScale } from './shared/OptionRangeBar'
@@ -1106,8 +1107,22 @@ export function OptionCards({
   // over-suppression failure mode, arrived at by trying to save a flag.
   const designationsWithheld = hasLeadingOption === false
 
-  // V11: Conditional "Hits target" — hide unless EVERY option has goalProbability
-  const allGoalProbability = options.every(o => o.goalProbability != null)
+  // ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — the options that were actually in
+  // the comparison. Every completeness quantifier on this surface asks about
+  // THEM; an option the run never analysed cannot make a field incomplete
+  // because it was never part of the field.
+  const analysedOptions = options.filter(o => o.notAnalysed !== true)
+
+  // V11: Conditional "Hits target" — hide unless EVERY option has goalProbability.
+  //
+  // NO-RANK: quantified over the ANALYSED options. As an `every` over ALL of
+  // them, one never-analysed option deleted the "Hits target" bar from every
+  // analysed card — a real regression in what the user could see about options
+  // that WERE scored, caused by one that was not. Same defect class as
+  // `sortOptionsForDisplay`'s `allHaveWinProb` and
+  // `determineWinnerSelection`'s coverage check.
+  const allGoalProbability =
+    analysedOptions.length > 0 && analysedOptions.every(o => o.goalProbability != null)
   const showHitsTarget = hasGoalThreshold && allGoalProbability
 
   // V14.2: Sort by win probability descending (same order as WinGauge segments).
@@ -1156,9 +1171,29 @@ export function OptionCards({
     lensHighlightedId != null &&
     !truncated.some((o) => o.id === lensHighlightedId) &&
     sorted.some((o) => o.id === lensHighlightedId)
-  const visibleOptions = lensPickHidden
+  const withLensPick = lensPickHidden
     ? [...truncated, ...sorted.filter((o) => o.id === lensHighlightedId)]
     : truncated
+
+  // ⭐ NO-RANK RULING — A NOT-ANALYSED OPTION IS ALWAYS RENDERED.
+  //
+  // The ruling's own words: it "stays visible as a proposed/unanalysed
+  // alternative". Unranked options sort LAST, so with two analysed options the
+  // truncation to TOP_N would put every one of them behind "Show all" — the
+  // product would silently drop the option it is supposed to be disclosing,
+  // and the disclosure would be reachable only by a click nobody has a reason
+  // to make.
+  //
+  // Appended by the SAME mechanism as the lens pick two blocks up (ROADMAP
+  // 2.237), and for the same reason: appending keeps it out of the ranked
+  // sequence, whereas promoting it into the top N would re-order the list and
+  // hand it a position it must not have.
+  const hiddenNotAnalysed = sorted.filter(
+    (o) => o.notAnalysed === true && !withLensPick.some((v) => v.id === o.id),
+  )
+  const visibleOptions = hiddenNotAnalysed.length > 0
+    ? [...withLensPick, ...hiddenNotAnalysed]
+    : withLensPick
   // Derived from what is actually rendered — `sorted.length - TOP_N` would say
   // "1 more" while that one was already on screen.
   const hiddenCount = sorted.length - visibleOptions.length
@@ -1209,6 +1244,23 @@ export function OptionCards({
   return (
     <div className="space-y-2" data-testid="option-cards">
       {visibleOptions.map((option, index) => {
+        // ⭐ NO-RANK RULING — THE FORK, AND THE ONLY PLACE IT IS MADE.
+        //
+        // Everything below this line is ranked chrome: a rank swatch, an
+        // ordinal, a win percentage, a fill bar, goal bars, a range bar. An
+        // option the run never analysed must reach NONE of it, so it forks
+        // here rather than being guarded seven times inside `OptionCard` —
+        // see `NotAnalysedOptionCard`'s header for why a list of guards would
+        // rot and this cannot.
+        if (option.notAnalysed === true) {
+          return (
+            <NotAnalysedOptionCard
+              key={option.id}
+              option={option}
+              onFocusNode={onFocusNode}
+            />
+          )
+        }
         const isWinner = option.id === winnerId
         const isRunnerUp = option.id === runnerId
         const headline = storyHeadlines?.[option.id]

--- a/src/components/results/__tests__/OptionCards.notAnalysed.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.notAnalysed.spec.tsx
@@ -1,0 +1,194 @@
+/**
+ * OptionCards — an option the run never analysed renders as PROPOSED, not RANKED.
+ *
+ * Ruling (Paul, 14 Aug 2026): an unanalysable/placeholder option must NOT be
+ * included in comparative ranking or probabilities. It stays visible as a
+ * proposed/unanalysed alternative with a clear reason and an action to resolve
+ * it.
+ *
+ * ## What is pinned, and why each pin exists
+ *
+ * The ranked card has SEVEN places a number or an ordinal can appear (rank
+ * swatch, "Option N", win percentage, fill bar, goal bar, low-goal badge, range
+ * bar). This file asserts their ABSENCE on the marked option and their PRESENCE
+ * on an analysed sibling **in the same render** — the contrast control that
+ * separates "the ruling is enforced" from "this suite cannot see chrome at all"
+ * (CLAUDE.md trap 13e: a control must be plausible, not merely present).
+ *
+ * Every query binds to its option by ID (`option-card-not-analysed-<id>`,
+ * `rank-marker-<id>`, `win-pct-<id>`), never by a value predicate another card
+ * could satisfy (trap 19).
+ *
+ * ## Deployed-flag posture (trap 3b)
+ *
+ * `OptionCards` is mounted from `ResultsBody:609` with NO feature-flag gate —
+ * only `!isSingleOption && allOptions.length > 1` — and `ResultsBody` is the
+ * Analysis tab body mounted from `OutputsDock`. So this component is the
+ * surface staging renders, on every flag posture. The mount path itself is
+ * asserted by `ResultsBody.notAnalysedMountPath.spec.tsx`, so this file's
+ * greenness is a claim about something a user loads.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import { NOT_ANALYSED_BADGE } from '../utils/notAnalysedCopy'
+import type { OptionResult } from '../types'
+
+const ANALYSED_A = 'opt-analysed-a'
+const ANALYSED_B = 'opt-analysed-b'
+const NOT_ANALYSED = 'opt-not-analysed'
+const NOT_ANALYSED_LABEL = 'Migrate to Salesforce'
+
+function analysed(id: string, overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id,
+    label: `Analysed ${id}`,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: false,
+    winProbability: 0.35,
+    goalProbability: 0.55,
+    ...overrides,
+  }
+}
+
+/** Exactly the shape `useResultsSectionData` produces for an excluded option. */
+function notAnalysed(overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id: NOT_ANALYSED,
+    label: NOT_ANALYSED_LABEL,
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    notAnalysed: true,
+    notAnalysedReason: 'no_interventions',
+    ...overrides,
+  }
+}
+
+/**
+ * Two analysed options plus the excluded one. `hasLeadingOption` is TRUE on
+ * purpose: on a withheld run the ranked chrome is suppressed for EVERY card, so
+ * the absence assertions below would pass without the fix — the fixture has to
+ * be a run that DOES rank, or this whole file is a tautology (trap 13b: a
+ * discriminator must pin its own precondition).
+ */
+function renderCards(options: OptionResult[], props: Record<string, unknown> = {}) {
+  return render(
+    <OptionCards
+      options={options}
+      winnerId={ANALYSED_A}
+      hasLeadingOption
+      hasGoalThreshold
+      stableNumbers={{ [ANALYSED_A]: 1, [ANALYSED_B]: 2, [NOT_ANALYSED]: 3 }}
+      {...props}
+    />,
+  )
+}
+
+const MIXED: OptionResult[] = [
+  analysed(ANALYSED_A, { isRecommended: true, winProbability: 0.6 }),
+  analysed(ANALYSED_B, { winProbability: 0.25 }),
+  notAnalysed(),
+]
+
+describe('OptionCards — the option that was never analysed', () => {
+  it('PRECONDITION: the run ranks, so the ranked chrome is genuinely on screen', () => {
+    renderCards(MIXED)
+    // If these ever go missing the absence assertions below stop discriminating
+    // and start agreeing with a blank screen.
+    expect(screen.getByTestId(`rank-marker-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`win-pct-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`stable-number-${ANALYSED_A}`)).toBeInTheDocument()
+  })
+
+  it('renders NO rank swatch, NO ordinal, NO win percentage for it', () => {
+    renderCards(MIXED)
+    expect(screen.queryByTestId(`rank-marker-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`stable-number-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`win-pct-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`goal-readout-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`low-goal-warning-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    // It never reaches the ranked card at all.
+    expect(screen.queryByTestId(`option-card-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-not-analysed-${NOT_ANALYSED}`)).toBeInTheDocument()
+  })
+
+  it('states the reason and offers the resolve action', () => {
+    renderCards(MIXED)
+    expect(screen.getByTestId(`not-analysed-badge-${NOT_ANALYSED}`)).toHaveTextContent(NOT_ANALYSED_BADGE)
+    expect(screen.getByTestId(`not-analysed-reason-${NOT_ANALYSED}`).textContent ?? '').toContain(
+      'no rank and no probability',
+    )
+    expect(screen.getByTestId(`not-analysed-resolve-${NOT_ANALYSED}`)).toBeInTheDocument()
+    // Its own label is still on screen — "not analysed" is not "hidden".
+    expect(screen.getByText(NOT_ANALYSED_LABEL)).toBeInTheDocument()
+  })
+
+  it('the resolve action drafts CEE’s own documented sentence', async () => {
+    const store = await import('../coaching/askOlumiStore')
+    const spy = vi.spyOn(store, 'openAskOlumi')
+    renderCards(MIXED)
+    fireEvent.click(screen.getByTestId(`not-analysed-resolve-${NOT_ANALYSED}`))
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0].draft).toBe(`Help me configure ${NOT_ANALYSED_LABEL}.`)
+    spy.mockRestore()
+  })
+
+  it('OPPOSITE TWIN — not_returned prescribes no action', () => {
+    // The reason the user cannot act on. A configure button here would send
+    // them to fix something that is not broken on their side.
+    renderCards([
+      analysed(ANALYSED_A, { isRecommended: true, winProbability: 0.6 }),
+      analysed(ANALYSED_B, { winProbability: 0.25 }),
+      notAnalysed({ notAnalysedReason: 'not_returned' }),
+    ])
+    expect(screen.getByTestId(`option-card-not-analysed-${NOT_ANALYSED}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`not-analysed-resolve-${NOT_ANALYSED}`)).not.toBeInTheDocument()
+    expect(screen.getByTestId(`not-analysed-reason-${NOT_ANALYSED}`).textContent ?? '').toContain(
+      'returned no result',
+    )
+  })
+
+  it('stays VISIBLE past the top-2 truncation, with no expand click', () => {
+    // Unranked options sort last, so the truncation would otherwise hide the
+    // very option being disclosed. Two analysed options fill the top 2.
+    renderCards(MIXED)
+    expect(screen.getByTestId(`option-card-not-analysed-${NOT_ANALYSED}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-${ANALYSED_B}`)).toBeInTheDocument()
+  })
+
+  it('does not manufacture a "Show all (0 more)" control', () => {
+    // The 2.237 collision, re-checkable here because this file adds a second
+    // appender to the same list.
+    renderCards(MIXED, { onSendMessage: () => {} })
+    expect(screen.queryByTestId('option-cards-toggle')).not.toBeInTheDocument()
+  })
+
+  it('keeps the "Hits target" bar on the ANALYSED cards', () => {
+    // `allGoalProbability` was an `every` over ALL options, so the marked
+    // option — which has no goal probability by construction — deleted this bar
+    // from every analysed card.
+    renderCards(MIXED)
+    expect(screen.getByTestId(`goal-readout-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`goal-readout-${ANALYSED_B}`)).toBeInTheDocument()
+  })
+
+  it('UNCHANGED BEHAVIOUR — a list with no marked option renders exactly as before', () => {
+    renderCards([
+      analysed(ANALYSED_A, { isRecommended: true, winProbability: 0.6 }),
+      analysed(ANALYSED_B, { winProbability: 0.25 }),
+    ])
+    expect(screen.getByTestId(`option-card-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-${ANALYSED_B}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(/option-card-not-analysed-/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
@@ -1,0 +1,190 @@
+/**
+ * NO-RANK RULING — ON THE MOUNT PATH, AT THE DEPLOYED FLAG POSTURE.
+ *
+ * ## Why this file exists at all
+ *
+ * `OptionCards.notAnalysed.spec.tsx` renders `<OptionCards>` in isolation. This
+ * estate has shipped the same feature dark TWICE past exactly that kind of
+ * suite (CLAUDE.md trap 3b: rows 2.466 and 2.491 — a full mutant kit, RED-first
+ * and positive controls all passed while every instrument pointed at a
+ * component the deployed flags do not mount). A green component suite is not
+ * evidence about a surface a user loads.
+ *
+ * So this file asserts the MOUNT PATH itself: `<ResultsBody>` — `OptionCards`'
+ * only production parent — renders the not-analysed card.
+ *
+ * ## The deployed posture, derived
+ *
+ * `ResultsBody.tsx` mounts `<OptionCards>` inside a block gated ONLY on
+ * `!recommendation.isSingleOption && allOptions.length > 1`. There is NO
+ * feature flag on that path — the surrounding comment states it deliberately
+ * ("full options block renders identically regardless of V17 flag"). The flags
+ * `netlify.toml` sets for staging (`VITE_FEATURE_ANALYSIS_HERO_PANEL = "1"`,
+ * `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"`) switch OTHER surfaces around it and
+ * cannot unmount this one. `ResultsBody` itself is the Analysis tab body,
+ * mounted unconditionally from `OutputsDock` on the `results` tab.
+ *
+ * That is why this file makes no flag assertion: there is no flag to assert.
+ * The gate it DOES pin is the real one — `allOptions.length > 1` — because a
+ * never-analysed option is still an option node, and if it were filtered out
+ * upstream a two-option scenario would fall below the gate and the whole
+ * comparison block would vanish. That failure mode is silent and is pinned
+ * below.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+const ANALYSED_A = 'opt_hire'
+const ANALYSED_B = 'opt_partner'
+const EXCLUDED = 'opt_migrate'
+const EXCLUDED_LABEL = 'Migrate to Salesforce'
+
+function analysed(id: string, label: string, win: number, isRecommended = false): OptionResult {
+  return {
+    id,
+    label,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended,
+    winProbability: win,
+    goalProbability: 0.5,
+    nValidSamples: 10000,
+  } as unknown as OptionResult
+}
+
+/** The hook's own output shape for an option CEE excluded from the submission. */
+const EXCLUDED_OPTION = {
+  id: EXCLUDED,
+  label: EXCLUDED_LABEL,
+  expected: null,
+  outcome: { mean: null, p10: null, p50: null, p90: null },
+  p10: null,
+  p50: null,
+  p90: null,
+  isRecommended: false,
+  notAnalysed: true,
+  notAnalysedReason: 'no_interventions',
+} as unknown as OptionResult
+
+function makeData(options: OptionResult[]): ResultsSectionDataReturn {
+  const recommendation = {
+    recommendedOption: options.find((o) => o.isRecommended) ?? null,
+    allOptions: options,
+    goalLabel: 'Cut support cost per ticket',
+    goalThreshold: 0.4,
+    isSingleOption: options.length <= 1,
+    analysisStatus: 'computed',
+    recommendationStability: 0.9,
+    robustnessLevel: 'medium',
+    isNormalised: true,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.6, robustness: 0.6, clarity: 0.6 },
+    // A run that DOES rank: on a withheld run the ranked chrome is suppressed
+    // for every card and the absence assertions would pass for free.
+    verdict: { hasLeadingOption: true },
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [], topDrivers: [], driversStatus: 'computed', totalCount: 0, hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'fair', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 60,
+    uncertainties: [], topUncertainties: [], improvements: [], topImprovements: [],
+    evidenceGaps: [], topEvidenceGaps: [], nextActions: [], topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = { improvements: [], count: 0, hasHighPriority: false }
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Cut support cost per ticket',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody(options: OptionResult[]) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(options)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      expertMode={false}
+    />,
+  )
+}
+
+const MIXED = [
+  analysed(ANALYSED_A, 'Hire two developers', 0.6, true),
+  analysed(ANALYSED_B, 'Partner with a consultancy', 0.25),
+  EXCLUDED_OPTION,
+]
+
+afterEach(() => cleanup())
+
+describe('ResultsBody — the not-analysed card on the mount path', () => {
+  it('PRECONDITION: the options block is mounted and the ranked chrome is on screen', () => {
+    renderBody(MIXED)
+    // If the block itself stopped mounting, every absence assertion below
+    // would pass against an empty tree (trap 13 — an absence claim needs a
+    // demonstrated presence).
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-${ANALYSED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`rank-marker-${ANALYSED_A}`)).toBeInTheDocument()
+  })
+
+  it('renders the not-analysed card through ResultsBody, with no ranked chrome on it', () => {
+    renderBody(MIXED)
+    expect(screen.getByTestId(`option-card-not-analysed-${EXCLUDED}`)).toBeInTheDocument()
+    expect(screen.getByText(EXCLUDED_LABEL)).toBeInTheDocument()
+    expect(screen.queryByTestId(`option-card-${EXCLUDED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`rank-marker-${EXCLUDED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`stable-number-${EXCLUDED}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`win-pct-${EXCLUDED}`)).not.toBeInTheDocument()
+  })
+
+  it('the WinGauge draws no segment for it', () => {
+    // The gauge already filters to numeric win probabilities, so this is a
+    // REGRESSION pin rather than a fix — it is exactly the surface a future
+    // "treat missing as zero" convenience would break, and it would break
+    // silently.
+    renderBody(MIXED)
+    expect(screen.queryByText(new RegExp(EXCLUDED_LABEL + '\\s*\\d'))).not.toBeInTheDocument()
+  })
+
+  it('the excluded option still COUNTS toward the comparison gate', () => {
+    // `allOptions.length > 1` is what mounts the whole block. A future change
+    // that filtered marked options out of `allOptions` upstream would take a
+    // two-option scenario below the gate and delete the comparison entirely —
+    // a silent whole-section regression. One analysed option plus one excluded
+    // must still mount.
+    renderBody([analysed(ANALYSED_A, 'Hire two developers', 0.6, true), EXCLUDED_OPTION])
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-not-analysed-${EXCLUDED}`)).toBeInTheDocument()
+  })
+
+  it('UNCHANGED BEHAVIOUR — a run with no excluded option mounts exactly as before', () => {
+    renderBody([
+      analysed(ANALYSED_A, 'Hire two developers', 0.6, true),
+      analysed(ANALYSED_B, 'Partner with a consultancy', 0.25),
+    ])
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+    expect(screen.queryByTestId(/option-card-not-analysed-/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/notAnalysedDivisionOfLabour.spec.tsx
+++ b/src/components/results/__tests__/notAnalysedDivisionOfLabour.spec.tsx
@@ -1,0 +1,125 @@
+/**
+ * THE DIVISION OF LABOUR BETWEEN THE CHAT AND THE RESULTS PANEL — pinned so it
+ * cannot drift into "we thought the chat named them".
+ *
+ * ## The rule
+ *
+ * CEE's egress grammar carries ONE label slot. It names a SINGLE excluded
+ * option; for two or more it gives only a COUNT. **Per-option visibility is
+ * therefore the RESULTS PANEL's job**, and the ruling's "stays visible … with a
+ * clear reason and an action to resolve it" is discharged HERE, per option, or
+ * it is not discharged at all.
+ *
+ * ## Why it needs its own file
+ *
+ * This is a cross-service assumption, and cross-service assumptions are the
+ * ones that rot silently: nothing in either repo's types says the chat can only
+ * name one, so a later reader could reasonably decide the panel need only show
+ * a summary — and the two surfaces would then BOTH give a count and neither
+ * would name the second option. Nobody would see a red.
+ *
+ * ## The producer half is grounded in a LIVE CAPTURE, not in an assertion
+ *
+ * `live-analysis-turn-critique-degenerate-2026-08-08.json` is a captured turn
+ * carrying CEE's own sentence with exactly one label interpolated
+ * (*"'Migrate to Salesforce' was left out of this comparison …"*) and the
+ * follow-up user message it prescribes. That file is a HISTORIC RECORD (trap
+ * 14b): read here, never edited — its evidential value is that it is what the
+ * product actually said on a dated build.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import { resolveOptionPrompt } from '../utils/notAnalysedCopy'
+import type { OptionResult } from '../types'
+import liveTurn from '../../../v5/__tests__/fixtures/live-analysis-turn-critique-degenerate-2026-08-08.json'
+
+const ANALYSED = 'opt_keep_crm'
+const EXCLUDED_ONE = 'opt_migrate'
+const EXCLUDED_TWO = 'opt_rebuild'
+const LABEL_ONE = 'Migrate to Salesforce'
+const LABEL_TWO = 'Rebuild in-house'
+
+function analysed(id: string): OptionResult {
+  return {
+    id,
+    label: 'Keep Current CRM (Status Quo)',
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60, p50: 100, p90: 140,
+    isRecommended: true,
+    winProbability: 0.8,
+    goalProbability: 0.5,
+  } as unknown as OptionResult
+}
+
+function excluded(id: string, label: string): OptionResult {
+  return {
+    id,
+    label,
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null, p50: null, p90: null,
+    isRecommended: false,
+    notAnalysed: true,
+    notAnalysedReason: 'no_interventions',
+  } as unknown as OptionResult
+}
+
+afterEach(() => cleanup())
+
+describe('division of labour — the chat names one, the panel names each', () => {
+  it('PRODUCER EVIDENCE: the captured CEE turn carries ONE label slot', () => {
+    // Read-only against the historic capture. If CEE ever gains a multi-label
+    // grammar this assertion is the place that notices, rather than the panel
+    // quietly duplicating a job the chat has taken over.
+    const text = JSON.stringify(liveTurn)
+    expect(text).toContain(`'${LABEL_ONE}' was left out of this comparison`)
+    // And the route it prescribes is the one our resolve affordance drafts.
+    expect(text).toContain(resolveOptionPrompt(LABEL_ONE))
+  })
+
+  it('the panel renders a card PER excluded option, never a count', () => {
+    render(
+      <OptionCards
+        options={[analysed(ANALYSED), excluded(EXCLUDED_ONE, LABEL_ONE), excluded(EXCLUDED_TWO, LABEL_TWO)]}
+        winnerId={ANALYSED}
+        hasLeadingOption
+      />,
+    )
+    // Two options, two cards, each addressed by its OWN id and showing its OWN
+    // label — the exact case where the chat degrades to a count.
+    expect(screen.getByTestId(`option-card-not-analysed-${EXCLUDED_ONE}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-not-analysed-${EXCLUDED_TWO}`)).toBeInTheDocument()
+    expect(screen.getByText(LABEL_ONE)).toBeInTheDocument()
+    expect(screen.getByText(LABEL_TWO)).toBeInTheDocument()
+  })
+
+  it('each card carries its OWN resolve action, addressed to its OWN option', () => {
+    render(
+      <OptionCards
+        options={[analysed(ANALYSED), excluded(EXCLUDED_ONE, LABEL_ONE), excluded(EXCLUDED_TWO, LABEL_TWO)]}
+        winnerId={ANALYSED}
+        hasLeadingOption
+      />,
+    )
+    expect(screen.getByTestId(`not-analysed-resolve-${EXCLUDED_ONE}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`not-analysed-resolve-${EXCLUDED_TWO}`)).toBeInTheDocument()
+  })
+
+  it('the panel takes the label from the OPTION, not from any chat text', () => {
+    // The chat could only ever have named one of these. If the panel ever
+    // started reading a producer sentence for its labels, this arm goes red:
+    // the second option's label appears nowhere in the captured turn.
+    expect(JSON.stringify(liveTurn)).not.toContain(LABEL_TWO)
+    render(
+      <OptionCards
+        options={[analysed(ANALYSED), excluded(EXCLUDED_ONE, LABEL_ONE), excluded(EXCLUDED_TWO, LABEL_TWO)]}
+        winnerId={ANALYSED}
+        hasLeadingOption
+      />,
+    )
+    expect(screen.getByText(LABEL_TWO)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/notAnalysedQuantifiers.spec.ts
+++ b/src/components/results/__tests__/notAnalysedQuantifiers.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * THE `every`-QUANTIFIER FAMILY — one never-analysed option must not degrade
+ * what the user sees about the options that WERE analysed.
+ *
+ * ## The class, not the instances
+ *
+ * `useResultsSectionData.notAnalysed.spec.ts` pins the join. This file pins the
+ * three OTHER places the same defect lived, each of which is a completeness
+ * quantifier that took ALL options as its domain when its question was only
+ * ever about the ones in the comparison:
+ *
+ *  1. `sortOptionsForDisplay` — `allHaveWinProb` (`every`) → the whole list
+ *     re-sorted onto the expected-value comparator.
+ *  2. `buildV7Lenses` — `hasCompleteGoalField` over all options → the entire
+ *     goal lens collapsed to a `producer_gap` line, which was also the wrong
+ *     DIAGNOSIS (the producer had no gap; it was never asked).
+ *  3. `buildGoalFitRows` — `return null` from inside the loop returns from the
+ *     WHOLE builder, so one option blanked the entire goal-fit card. Two
+ *     different questions were sharing that `return null` (CLAUDE.md trap 21):
+ *     "never analysed" and "analysed, no goal figure".
+ *
+ * Each is pinned with a CONTRAST CONTROL in the same describe: the same input
+ * with the marked option removed must produce the ranked/complete result, so a
+ * green assertion is a claim about the marked option and not about a builder
+ * that returns nothing under every condition (trap 13e).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { sortOptionsForDisplay } from '../utils/optionDisplayOrder'
+import { buildV7Lenses } from '../v7/buildV7Lenses'
+import { buildGoalFitRows } from '../../../canvas/components/model-tab/buildGoalFitRows'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { OptionResult } from '../types'
+import type { Node } from '@xyflow/react'
+
+const A = 'opt_a'
+const B = 'opt_b'
+const X = 'opt_excluded'
+
+function analysed(id: string, win: number, expected: number, goalProb: number | null = 0.5): OptionResult {
+  return {
+    id,
+    label: `Option ${id}`,
+    expected,
+    outcome: { mean: expected, p10: expected - 10, p50: expected, p90: expected + 10 },
+    p10: expected - 10,
+    p50: expected,
+    p90: expected + 10,
+    isRecommended: false,
+    winProbability: win,
+    goalProbability: goalProb,
+  } as unknown as OptionResult
+}
+
+/** The hook's output for an option the run never analysed: no numbers at all. */
+function excluded(): OptionResult {
+  return {
+    id: X,
+    label: 'Excluded option',
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    notAnalysed: true,
+    notAnalysedReason: 'no_interventions',
+  } as unknown as OptionResult
+}
+
+/**
+ * ⚠ DISCRIMINATING BY CONSTRUCTION. Win-probability order (A .60 > B .30) is
+ * the REVERSE of expected-value order (B 40 > A 10), so no single ordering
+ * satisfies both comparators and a test cannot pass under the wrong one.
+ */
+const ANALYSED_PAIR = [analysed(A, 0.6, 10), analysed(B, 0.3, 40)]
+
+describe('sortOptionsForDisplay — an unranked option does not re-rank the ranked ones', () => {
+  it('keeps win-probability order for the analysed options', () => {
+    const out = sortOptionsForDisplay([excluded(), ...ANALYSED_PAIR], { designationsWithheld: false })
+    expect(out.map((o) => o.id)).toEqual([A, B, X])
+  })
+
+  it('CONTRAST CONTROL — the same pair without it sorts identically', () => {
+    const out = sortOptionsForDisplay(ANALYSED_PAIR, { designationsWithheld: false })
+    expect(out.map((o) => o.id)).toEqual([A, B])
+  })
+
+  it('unranked options keep the CALLER’s order among themselves', () => {
+    const x2 = { ...excluded(), id: 'opt_excluded_2' } as OptionResult
+    const out = sortOptionsForDisplay([x2, ...ANALYSED_PAIR, excluded()], { designationsWithheld: false })
+    // Last two, in the order the caller supplied them — never re-sorted, since
+    // there is no quantity to sort them by.
+    expect(out.map((o) => o.id)).toEqual([A, B, 'opt_excluded_2', X])
+  })
+
+  it('UNCHANGED — a withheld run still returns the caller’s order untouched', () => {
+    const input = [excluded(), ...ANALYSED_PAIR]
+    const out = sortOptionsForDisplay(input, { designationsWithheld: true })
+    expect(out.map((o) => o.id)).toEqual(input.map((o) => o.id))
+  })
+})
+
+function lensData(allOptions: OptionResult[], goalThreshold: number | null): ResultsSectionDataReturn {
+  return {
+    recommendation: {
+      allOptions,
+      recommendedOption: allOptions[0] ?? null,
+      goalThreshold,
+      outcomeUnit: 'count',
+      verdict: { hasLeadingOption: true },
+    },
+    drivers: { drivers: [] },
+    confidence: { challengeFragileEdges: [], conditionalWinners: [] },
+    voiRanking: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+describe('buildV7Lenses — an unanalysed option does not collapse the goal lens', () => {
+  it('the goal lens stays available and lists only the analysed options', () => {
+    const model = buildV7Lenses(lensData([excluded(), ...ANALYSED_PAIR], 0.4))
+    expect(model.goal.available).toBe(true)
+    expect(model.goal.gate).toBe('none')
+    expect(model.goal.options.map((o) => o.id).sort()).toEqual([A, B].sort())
+  })
+
+  it('CONTRAST CONTROL — the same pair without it is equally available', () => {
+    const model = buildV7Lenses(lensData(ANALYSED_PAIR, 0.4))
+    expect(model.goal.available).toBe(true)
+    expect(model.goal.options.map((o) => o.id).sort()).toEqual([A, B].sort())
+  })
+
+  it('the outcome lens draws no row for it', () => {
+    const model = buildV7Lenses(lensData([excluded(), ...ANALYSED_PAIR], 0.4))
+    expect(model.outcome.options.map((o) => o.id)).not.toContain(X)
+  })
+
+  it('UNCHANGED — a genuine producer gap still reports producer_gap', () => {
+    // The honest gate must survive: an ANALYSED option with no goal figure is
+    // a different fact and still closes the lens. Without this arm the fix
+    // above could have been "always available", which would render NaN bars.
+    const model = buildV7Lenses(
+      lensData([analysed(A, 0.6, 10, null), analysed(B, 0.3, 40, null)], 0.4),
+    )
+    expect(model.goal.available).toBe(false)
+    expect(model.goal.gate).toBe('producer_gap')
+  })
+})
+
+function optionNode(id: string): Node {
+  return { id, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: `Option ${id}` } } as Node
+}
+
+const GOAL_ENTRY = { goal_probability: 0.42, outcome: { n_valid_samples: 10000 } }
+
+describe('buildGoalFitRows — an unanalysed option does not blank the whole card', () => {
+  it('returns rows for the analysed options and omits the excluded one', () => {
+    const rows = buildGoalFitRows([optionNode(X), optionNode(A), optionNode(B)], {
+      [A]: GOAL_ENTRY,
+      [B]: GOAL_ENTRY,
+    })
+    expect(rows).not.toBeNull()
+    expect(rows!.map((r) => r.id)).toEqual([A, B])
+  })
+
+  it('CONTRAST CONTROL — the same entries with no excluded node behave identically', () => {
+    const rows = buildGoalFitRows([optionNode(A), optionNode(B)], { [A]: GOAL_ENTRY, [B]: GOAL_ENTRY })
+    expect(rows!.map((r) => r.id)).toEqual([A, B])
+  })
+
+  it('UNCHANGED — an ANALYSED option with no admissible figure still returns null', () => {
+    // The complete-field rule, which the original `return null` was written
+    // for. Separating the two questions must not delete this one.
+    const rows = buildGoalFitRows([optionNode(A), optionNode(B)], {
+      [A]: GOAL_ENTRY,
+      [B]: { outcome: { n_valid_samples: 10000 } },
+    })
+    expect(rows).toBeNull()
+  })
+
+  it('UNCHANGED — a present but MALFORMED entry still returns null', () => {
+    // A producer defect is not an exclusion, and must not be silently
+    // re-badged as one (trap 21 — the two questions, kept apart).
+    const rows = buildGoalFitRows([optionNode(A), optionNode(B)], {
+      [A]: GOAL_ENTRY,
+      [B]: 'not-an-object' as unknown as Record<string, unknown>,
+    })
+    expect(rows).toBeNull()
+  })
+
+  it('DOMAIN GUARD — a run that returned nothing for any option still returns null', () => {
+    // Not "every option is excluded"; a whole-run producer gap. Rendering an
+    // empty goal card there would say something false about the graph.
+    const rows = buildGoalFitRows([optionNode(A), optionNode(B)], {})
+    expect(rows).toBeNull()
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.notAnalysed.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.notAnalysed.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * NO RANK, NO PROBABILITY, NO PLACEHOLDER FOR AN OPTION THAT WAS NEVER ANALYSED.
+ *
+ * Ruling (Paul, 14 Aug 2026): an unanalysable/placeholder option must NOT be
+ * included in comparative ranking or probabilities. It stays visible as a
+ * proposed/unanalysed alternative with a clear reason and an action to resolve
+ * it.
+ *
+ * ## Why the READER half is mandatory
+ *
+ * CEE now EXCLUDES an option with no interventions from the PLoT submission, so
+ * the producer mints nothing for it. But this hook does not iterate the result
+ * array — it enumerates the USER'S GRAPH option nodes and LEFT-JOINS the result
+ * (`optionNodes.map(node => optionProbs[node.id] || {})`). An excluded option
+ * therefore does not vanish; it arrives here as an option with an EMPTY join,
+ * and everything downstream treats "empty" as "zero-ish" rather than "absent".
+ *
+ * Three measured consequences, each pinned below:
+ *
+ *  1. **A FABRICATED EXPECTED VALUE.** `const optionBands = prob.bands ??
+ *     sharedBands ?? {}` where `sharedBands = report.run?.bands`, and the V2
+ *     response mapper builds `run.bands` from the FIRST option's
+ *     `confidence_interval` (`responseMapper.ts:585`, `ciMid = (lo + hi) / 2`).
+ *     `rawExpected` then resolves via `?? optionBands.p50`, so the excluded
+ *     option renders ANOTHER option's midpoint as its own number.
+ *  2. **A RE-SORT OF THE ANALYSED OPTIONS.** `sortOptionsForDisplay`'s
+ *     `allHaveWinProb` is an `every` over ALL options, so one option without a
+ *     win probability drops every ANALYSED option onto the
+ *     `expected ?? goalProbability ?? -Infinity` comparator.
+ *  3. **A CHANGE OF WINNER-SELECTION METHOD.** `determineWinnerSelection`'s
+ *     `hasCompleteWinProbabilityCoverage` is the same `every` one level up, so
+ *     the same single absence silently re-decides the winner by expected value
+ *     and reports `determinedBy: 'expected_outcome'` to the user.
+ *
+ * ## Fixture provenance and discrimination
+ *
+ * Driven through the REAL V2 response mapper (`mapV2ResponseToReportV1`), so
+ * `run.bands` is the producer's own construction rather than this lane's model
+ * of it. The V2 run path is live: `OutputsDock.tsx:1084` calls `runV2Analysis()`
+ * ungated when the canonical dispatcher is not registered.
+ *
+ * ⚠ SCOPE OF THE `run.bands` LEAK, stated precisely (CLAUDE.md trap 20):
+ * `mapV5AnalysisToReport` emits NO `bands` key EVER (its own block says so and
+ * it was verified at the bytes), so consequence 1 requires a V1/V2-mapped
+ * report. Consequences 2 and 3 need no bands at all and are reachable on EVERY
+ * path, V5 included. The three are pinned separately for that reason.
+ *
+ * The fixture is DISCRIMINATING by construction: win-probability order
+ * (hire .60 > partner .30) is the REVERSE of expected-value order (partner 40 >
+ * hire 10), so a test that passes under either comparator is impossible. The
+ * excluded option's fabricated number (10) is the analysed LEADER's own mean,
+ * which is what the live defect produces — not a value invented to be spotted.
+ *
+ * Every assertion binds to its option by ID (CLAUDE.md trap 19); none uses a
+ * value predicate another option could satisfy.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import { useResultsSectionData } from '../useResultsSectionData'
+import { determineWinnerSelection } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { OptionResult } from '../types'
+
+// ── Identities ────────────────────────────────────────────────────────────
+const HIRE = 'opt_hire'
+const PARTNER = 'opt_partner'
+/** The option CEE excluded: no interventions, so it was never submitted. */
+const MIGRATE = 'opt_migrate'
+
+const LABELS: Record<string, string> = {
+  [HIRE]: 'Hire Two Developers Only',
+  [PARTNER]: 'Partner with a specialist consultancy',
+  [MIGRATE]: 'Migrate to Salesforce',
+}
+
+/**
+ * The leader's mean, and therefore `ciMid` and therefore `run.bands.p50` —
+ * the exact number the defect writes onto the excluded option.
+ */
+const LEADER_MEAN = 10
+const PARTNER_MEAN = 40
+
+interface AnalysedShape {
+  id: string
+  mean: number
+  winProbability: number
+}
+
+/** Only the SUBMITTED options appear in `option_comparison`. */
+const ANALYSED: AnalysedShape[] = [
+  { id: HIRE, mean: LEADER_MEAN, winProbability: 0.6 },
+  { id: PARTNER, mean: PARTNER_MEAN, winProbability: 0.3 },
+]
+
+function makeV2Response(analysed: AnalysedShape[]): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: analysed.map((o) => ({
+      option_id: o.id,
+      option_label: LABELS[o.id],
+      // [0, 20] on the leader ⇒ ciMid 10 ⇒ run.bands.p50 = 10.
+      confidence_interval: [o.mean - 10, o.mean + 10],
+      win_probability: o.winProbability,
+      outcome: {
+        mean: o.mean, std: 5, p10: o.mean - 10, p50: o.mean, p90: o.mean + 10,
+        n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+      },
+    })),
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    // A producer leader claim is REQUIRED, not decoration: without one
+    // `deriveDecisionVerdict` returns `unknown`, `designationsWithheld` becomes
+    // true, and `sortOptionsForDisplay` short-circuits to canonical order — the
+    // ordering assertions below would then pass while testing nothing.
+    robustness: {
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      near_tie: { is_tie: false, top_option_id: HIRE },
+    },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as unknown as V2RunResponse
+}
+
+function optionNode(id: string) {
+  return { id, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: LABELS[id] } }
+}
+
+/** A factor the analysed options intervene on. */
+const FACTOR = 'fac_capacity'
+
+/**
+ * Intervention edges: option → factor. The analysed options each have one; the
+ * excluded option has NONE, which is the graph-side fact the reason is derived
+ * from.
+ */
+const INTERVENTION_EDGES = [
+  { id: 'e_hire', source: HIRE, target: FACTOR },
+  { id: 'e_partner', source: PARTNER, target: FACTOR },
+]
+
+interface SeedOptions {
+  /** Option nodes on the canvas, in the user's creation order. */
+  readonly nodeIds?: readonly string[]
+  /** Which analysed options the producer returned. */
+  readonly analysed?: AnalysedShape[]
+  readonly edges?: ReadonlyArray<{ id: string; source: string; target: string }>
+}
+
+/**
+ * ⚠ THE EXCLUDED OPTION IS FIRST IN CREATION ORDER, DELIBERATELY.
+ *
+ * With it last, the pristine expected-value comparator happens to leave it at
+ * the bottom anyway (its fabricated 10 ties the leader's 10 and the sort is
+ * stable), so an "it sits outside the ranking" assertion would pass at pristine
+ * by luck — a test agreeing with itself. First in creation order, the pristine
+ * order is PARTNER, MIGRATE, HIRE: the never-analysed option renders ABOVE an
+ * analysed one, which is both the RED signature and the worse live shape.
+ */
+const CANONICAL_NODE_IDS = [MIGRATE, HIRE, PARTNER] as const
+
+function seedStore({
+  nodeIds = CANONICAL_NODE_IDS,
+  analysed = ANALYSED,
+  edges = INTERVENTION_EDGES,
+}: SeedOptions = {}): void {
+  const report = mapV2ResponseToReportV1(makeV2Response(analysed), { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as never,
+    runMeta: {} as never,
+    nodes: [
+      ...nodeIds.map(optionNode),
+      { id: FACTOR, type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Capacity' } },
+    ] as never,
+    edges: edges as never,
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+function renderOptions(): OptionResult[] {
+  const { result } = renderHook(() => useResultsSectionData())
+  return (result.current.recommendation?.allOptions ?? []) as OptionResult[]
+}
+
+/** Bound by IDENTITY — never `find(o => o.expected === 10)`. */
+function byId(options: readonly OptionResult[], id: string): OptionResult {
+  const found = options.find((o) => o.id === id)
+  if (!found) throw new Error(`fixture precondition failed: no option ${id} in [${options.map((o) => o.id).join(', ')}]`)
+  return found
+}
+
+describe('useResultsSectionData — an option the run never analysed', () => {
+  beforeEach(() => {
+    seedStore()
+  })
+
+  it('PRECONDITION: the producer returned entries for the analysed options only, and run.bands carries the leader midpoint', () => {
+    // The fixture's own preconditions, asserted in-test so a later refactor of
+    // the mapper cannot quietly turn every assertion below into a tautology
+    // (CLAUDE.md trap 13b — a discriminator must pin its own precondition).
+    const report = (useCanvasStore.getState() as unknown as { results: { report: Record<string, never> } }).results.report as unknown as {
+      option_probabilities?: Record<string, unknown>
+      run?: { bands?: { p50?: number | null } }
+    }
+    expect(Object.keys(report.option_probabilities ?? {}).sort()).toEqual([HIRE, PARTNER].sort())
+    expect(report.option_probabilities?.[MIGRATE]).toBeUndefined()
+    // THE FABRICATION SOURCE. If this ever stops being a number the
+    // placeholder pin below can no longer fail for the right reason.
+    expect(report.run?.bands?.p50).toBe(LEADER_MEAN)
+  })
+
+  it('mints no placeholder numbers for it', () => {
+    const options = renderOptions()
+    const migrate = byId(options, MIGRATE)
+
+    // The measured RED: `expected === 10`, the LEADER's mean rendered as the
+    // excluded option's own number.
+    expect(migrate.expected).toBeNull()
+    expect(migrate.outcome?.mean ?? null).toBeNull()
+    expect(migrate.outcome?.p10 ?? null).toBeNull()
+    expect(migrate.outcome?.p50 ?? null).toBeNull()
+    expect(migrate.outcome?.p90 ?? null).toBeNull()
+    expect(migrate.p50).toBeNull()
+    expect(migrate.winProbability).toBeUndefined()
+    expect(migrate.goalProbability ?? null).toBeNull()
+    // A per-option sample count belongs to a computation that never ran.
+    expect(migrate.nValidSamples).toBeUndefined()
+
+    // CONTRAST CONTROL in the same render (trap 13e): the analysed options
+    // keep every number, so this is a claim about THIS option and not a
+    // suite-wide blindness to numbers.
+    expect(byId(options, HIRE).expected).toBe(LEADER_MEAN)
+    expect(byId(options, HIRE).winProbability).toBe(0.6)
+  })
+
+  it('marks it not-analysed, and marks only it', () => {
+    const options = renderOptions()
+    expect(byId(options, MIGRATE).notAnalysed).toBe(true)
+    expect(byId(options, HIRE).notAnalysed).not.toBe(true)
+    expect(byId(options, PARTNER).notAnalysed).not.toBe(true)
+  })
+
+  it('derives the reason from the GRAPH: no intervention edges ⇒ no_interventions', () => {
+    const options = renderOptions()
+    expect(byId(options, MIGRATE).notAnalysedReason).toBe('no_interventions')
+  })
+
+  it('OPPOSITE TWIN — an option WITH intervention edges that the run did not return is not_returned', () => {
+    // Same absence at the join, a DIFFERENT question about why (trap 21). The
+    // user has nothing to configure here, so the copy must not prescribe one.
+    seedStore({
+      edges: [...INTERVENTION_EDGES, { id: 'e_migrate', source: MIGRATE, target: FACTOR }],
+    })
+    const options = renderOptions()
+    expect(byId(options, MIGRATE).notAnalysed).toBe(true)
+    expect(byId(options, MIGRATE).notAnalysedReason).toBe('not_returned')
+  })
+
+  it('DOMAIN GUARD — a run that analysed NO option marks nothing not-analysed', () => {
+    // The predicate is "this option is missing from a result set that HAS
+    // results", never "this option is missing". A whole-run producer gap is a
+    // different fact and must not be re-badged as "you did not configure
+    // these" (trap 22 — audit the predicate's DOMAIN, not just the invariant).
+    seedStore({ analysed: [] })
+    const options = renderOptions()
+    for (const o of options) {
+      expect(o.notAnalysed, `option ${o.id} must not be marked when the run returned nothing`).not.toBe(true)
+    }
+    // The guard is not vacuous: the options are all still here.
+    expect(options.map((o) => o.id).sort()).toEqual([HIRE, PARTNER, MIGRATE].sort())
+  })
+
+  it('does not re-sort the ANALYSED options onto the expected-value comparator', () => {
+    const options = renderOptions()
+    const ids = options.map((o) => o.id)
+    // Win-probability order among the analysed options. The fixture makes this
+    // the REVERSE of expected-value order, so only one comparator can produce
+    // it.
+    expect(ids.indexOf(HIRE)).toBeLessThan(ids.indexOf(PARTNER))
+  })
+
+  it('places the not-analysed option outside the ranking, after every analysed option', () => {
+    const ids = renderOptions().map((o) => o.id)
+    expect(ids.indexOf(MIGRATE)).toBe(ids.length - 1)
+  })
+
+  it('does not change how the winner is selected', () => {
+    // `determineWinnerSelection` is exported and called with the mapped
+    // options; the `every` inside it is the same quantifier defect one level
+    // up from the sort.
+    const options = renderOptions()
+    const { recommendedId, determinedBy } = determineWinnerSelection(options)
+    expect(determinedBy).toBe('win_probability')
+    expect(recommendedId).toBe(HIRE)
+  })
+
+  it('UNCHANGED BEHAVIOUR — a run where every option was analysed is untouched', () => {
+    // The no-op arm. Nothing is marked, nothing is reordered, every number
+    // survives — so the change cannot be paying for itself with a regression
+    // on the ordinary path.
+    seedStore({ nodeIds: [HIRE, PARTNER] })
+    const options = renderOptions()
+    expect(options.map((o) => o.id)).toEqual([HIRE, PARTNER])
+    for (const o of options) expect(o.notAnalysed).not.toBe(true)
+    expect(byId(options, HIRE).expected).toBe(LEADER_MEAN)
+    expect(byId(options, PARTNER).expected).toBe(PARTNER_MEAN)
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -17,6 +17,7 @@ import type { V2FactorSensitivity, V2OptionComparison } from '../../adapters/plo
 import type { KnownFlipReason } from './utils/flipReasonVocabulary'
 import type { PercentilesSource } from './utils/downsideCopy'
 import type { MappedDecisionQualityPrompt } from './utils/decisionQualityPrompts'
+import type { NotAnalysedReason } from './utils/notAnalysedOptions'
 
 // Re-export M1 coaching type for component use
 export type { M1CoachingReadiness }
@@ -268,6 +269,33 @@ export interface OptionResult {
    * `GOAL_ANCHOR_COPY.noTarget`.
    */
   goalFitWithheld?: boolean
+  /**
+   * ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — true when this option node was NOT
+   * in the analysis at all: the run returned per-option results and carried no
+   * entry for this one.
+   *
+   * It is NOT a wire field. CEE excludes an option with no interventions from
+   * the PLoT submission, so the producer already says this by OMISSION, and the
+   * hook derives it at the left join (`utils/notAnalysedOptions.ts`). A wire
+   * boolean would be a second authority on a fact already on the wire.
+   *
+   * ⚠ ABSENT/false MEANS "IN THE ANALYSIS", INCLUDING ON A RUN THAT RETURNED
+   * NOTHING AT ALL. The derivation is guarded on the run having produced SOME
+   * per-option result, so a whole-run producer gap leaves every option
+   * unmarked rather than telling a user who configured everything that they
+   * configured nothing.
+   *
+   * Render sites MUST show no rank, no ordinal, no probability, no expected
+   * value and no fill bar for a marked option — see `NotAnalysedOptionCard`,
+   * which is the one place that decision is made.
+   */
+  notAnalysed?: boolean
+  /**
+   * Why {@link notAnalysed} is true — a property of the GRAPH, not of the
+   * result, and a DIFFERENT question from whether it was analysed. Only one of
+   * the two reasons is user-actionable; `utils/notAnalysedCopy.ts` owns which.
+   */
+  notAnalysedReason?: NotAnalysedReason
 }
 
 /** Outcome unit type for formatting - from goal node observed_state.unit */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -2188,7 +2188,17 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         return hasWarningCritiques || hasFragileEdges
       })(),
     }
-  }, [hasCompletedFirstRun, report, nodes, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds, rawFlipThresholdsStatus, rawFlipThresholdsStatusReason, rawMetaNSamples, rawHeadlineBanded, rawRobustnessDisplayVerdict, rawRobustnessDisplayVerdictReason])
+    // ⭐ `edges` ADDED BY THE NO-RANK LANE, AND IT IS A CORRECTNESS DEPENDENCY,
+    // NOT A LINT APPEASEMENT. `deriveNotAnalysedReason` reads the option's
+    // intervention edges to tell "you have not configured this" from "the
+    // engine returned nothing for it". Those are the two facts the card's copy
+    // and its resolve affordance branch on, and connecting an option to a
+    // factor changes `edges` ALONE — with a stale closure the card would keep
+    // telling a user to configure an option they had just configured.
+    // (Measured: at pristine this memo's exhaustive-deps warning named only
+    // `reviewStatus`; without this entry the lane would have added `edges` to
+    // it.)
+  }, [hasCompletedFirstRun, report, nodes, edges, goalLabel, goalNodeId, outcomeUnit, outcomeUnitSymbol, currentScenarioFraming, m1Coaching, nodeLabelMap, goalThreshold, goalThresholdCap, effectiveGoalThreshold, ceeAnalysisReady, m1ReviewAssumptions, rawV2FlipThresholds, rawFlipThresholdsStatus, rawFlipThresholdsStatusReason, rawMetaNSamples, rawHeadlineBanded, rawRobustnessDisplayVerdict, rawRobustnessDisplayVerdictReason])
 
   // ==========================================================================
   // Drivers Section Data (with dynamic normalisation)

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -65,6 +65,11 @@ import { mapDecisionQualityPrompts } from './utils/decisionQualityPrompts'
 import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
+import {
+  deriveNotAnalysedReason,
+  isAnalysedOption,
+  runAnalysedAnyOption,
+} from './utils/notAnalysedOptions'
 import { readInferenceWarnings } from './utils/readInferenceWarnings'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
@@ -78,9 +83,22 @@ import { readDecisionVoi, type DecisionVoiVerdict } from './voi/decisionVoi'
 // =============================================================================
 
 export function determineWinnerSelection(
-  options: OptionResult[],
+  allOptions: OptionResult[],
   backendRecommendedId?: string | null
 ): { recommendedId: string | null; determinedBy: WinnerDeterminedBy } {
+  // ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — an option the run never analysed
+  // takes no part in selecting the winner.
+  //
+  // This is the SAME `every`-quantifier defect as `sortOptionsForDisplay`'s
+  // `allHaveWinProb`, one level up: `hasCompleteWinProbabilityCoverage` below
+  // is an `every` over ALL options, so a single never-analysed option silently
+  // dropped winner selection from win probability to the p50/mean tie-breaker
+  // — and `determinedBy` is user-facing copy, so the product then TOLD the
+  // user its answer came from expected value. Filtering here rather than
+  // loosening the coverage rule keeps the rule's own question intact: the
+  // coverage must still be COMPLETE, over the options that were in the
+  // comparison.
+  const options = allOptions.filter((o) => o.notAnalysed !== true)
   if (options.length === 0) {
     return { recommendedId: null, determinedBy: 'unknown' }
   }
@@ -1525,12 +1543,37 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // Build option results with percentile extraction
     const sharedBands = report.run?.bands
 
+    // ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — WHICH OPTIONS WERE IN THE
+    // ANALYSIS AT ALL.
+    //
+    // THIS LINE IS THE LEFT JOIN. `optionNodes` is the USER'S GRAPH; the result
+    // is joined onto it. CEE excludes an option with no interventions from the
+    // PLoT submission, so an excluded option arrives here as an EMPTY join —
+    // and every expression below treated "empty" as "zero-ish" rather than
+    // "absent". Measured consequence: `optionBands` fell through to
+    // `sharedBands` (the FIRST option's confidence-interval midpoint, built by
+    // `responseMapper.ts:585`) and `rawExpected` resolved via
+    // `?? optionBands.p50`, so an option that was never analysed rendered
+    // ANOTHER option's mean as its own number. The producer removed a disclosed
+    // placeholder; the reader minted an undisclosed one.
+    //
+    // Derived, never a wire field, and guarded on the run having produced SOME
+    // per-option result — see `utils/notAnalysedOptions.ts` for why the domain
+    // guard is the load-bearing half.
+    const optionNodeIds = optionNodes.map((n) => n.id)
+    const runAnalysedAny = runAnalysedAnyOption(optionProbs, optionNodeIds)
+
     // v7: Pre-scan all options to detect already-denormalized values.
     // If any option has raw outcome magnitudes > 2, the data is already in user units
     // even when goalThresholdCap is missing — so we should NOT label as "Relative score".
+    //
+    // NO-RANK: an option with no analysis has no values to vote with. Left in,
+    // it voted with the SHARED bands — i.e. another option's numbers counted
+    // twice in a scan whose whole job is to read this option's magnitudes.
     const capValid = goalThresholdCap != null && goalThresholdCap > 0
     let anyAlreadyDenormalized = false
     for (const node of optionNodes) {
+      if (runAnalysedAny && !isAnalysedOption(optionProbs, node.id)) continue
       const prob = optionProbs[node.id] || {}
       const ob = prob.outcome ?? {}
       const ob2 = prob.bands ?? sharedBands ?? {}
@@ -1546,9 +1589,18 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     const unsortedOptions: OptionResult[] = optionNodes.map((node) => {
       const nodeId = node.id
       const prob = optionProbs[nodeId] || {}
+      // NO-RANK RULING — see the block above the pre-scan.
+      const notAnalysed = runAnalysedAny && !isAnalysedOption(optionProbs, nodeId)
 
-      // Per-option bands take precedence over shared bands
-      const optionBands = prob.bands ?? sharedBands ?? {}
+      // Per-option bands take precedence over shared bands.
+      //
+      // ⛔ AND AN OPTION THAT WAS NEVER ANALYSED TAKES NEITHER. The
+      // `?? sharedBands` step is a legitimate second source of the SAME
+      // option's statistic when the producer sent per-option bands separately;
+      // for an option the producer never scored it is a different option's
+      // number wearing this option's name. This is the C5 fabrication, killed
+      // at its one source rather than at each render site.
+      const optionBands = notAnalysed ? {} : (prob.bands ?? sharedBands ?? {})
       // Per-option outcome object (new structure with explicit expected)
       const optionOutcome = prob.outcome ?? {}
 
@@ -1639,8 +1691,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // formatting happens at render time.
       const rawNValid = (optionOutcome as { n_valid_samples?: number }).n_valid_samples
       const rawNTotal = (optionOutcome as { n_samples?: number }).n_samples
-      const nValidSamples =
-        typeof rawNValid === 'number' && Number.isFinite(rawNValid) && rawNValid > 0
+      // NO-RANK: the root-meta arm of this chain is a RUN-level count. For an
+      // option that was never simulated it would state the resolution of a
+      // computation that never touched it — the same shared-value leak as
+      // `sharedBands`, one field along.
+      const nValidSamples = notAnalysed
+        ? undefined
+        : typeof rawNValid === 'number' && Number.isFinite(rawNValid) && rawNValid > 0
           ? rawNValid
           : typeof rawNTotal === 'number' && Number.isFinite(rawNTotal) && rawNTotal > 0
             ? rawNTotal
@@ -1696,6 +1753,15 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         goalFitWithheld: goalDecision.jointSubstitutionWithheld,
         // Multi-constraint analysis (from ISL when goal_constraints were provided)
         constraintAnalysis: prob.constraint_analysis,
+        // ⭐ NO-RANK RULING. Omitted entirely when false so the ordinary path
+        // is byte-identical to before and `notAnalysed` cannot be read as
+        // "someone considered this option and said no".
+        ...(notAnalysed
+          ? {
+              notAnalysed: true as const,
+              notAnalysedReason: deriveNotAnalysedReason(nodeId, edges, optionNodeIds),
+            }
+          : {}),
       }
     })
 

--- a/src/components/results/utils/notAnalysedCopy.ts
+++ b/src/components/results/utils/notAnalysedCopy.ts
@@ -1,0 +1,74 @@
+/**
+ * notAnalysedCopy — THE single source for what the results panel says about an
+ * option the run never analysed.
+ *
+ * ## Why a new module rather than reusing existing wording
+ *
+ * The nearest existing copy is the pre-analysis V2 "Needs mapping" pill
+ * (`pre-analysis/OptionPreview.tsx`). It is DARK on staging: `netlify.toml`
+ * sets `VITE_FEATURE_PRE_ANALYSIS_V3 = "1"` and `OutputsDock` mounts
+ * `PreAnalysisPanelV3` on that flag, so the V2 panel that hosts the pill never
+ * renders. There is therefore no results-path copy source to reuse, and this
+ * module is a genuine single source rather than a fourth mirror of an existing
+ * one (CLAUDE.md trap 12 — the hand-maintained mirror is this estate's dominant
+ * defect, so the test is whether the thing being mirrored is LIVE).
+ *
+ * ## The resolve prompt is the PRODUCER's route, not one we invented
+ *
+ * `resolveOptionPrompt` reproduces the sentence CEE itself tells users to say.
+ * Witnessed on a live captured turn
+ * (`src/v5/__tests__/fixtures/live-analysis-turn-critique-degenerate-2026-08-08.json`):
+ * CEE emits *"To score it separately, say 'Help me configure Migrate to
+ * Salesforce.'"* and the captured user message that follows is exactly
+ * `"Help me configure Migrate to Salesforce."`. That fixture is a HISTORIC
+ * RECORD (trap 14b): read, never edited. Minting our own phrasing here would
+ * be a second route to one capability, and only one of them would be the one
+ * the assistant is trained to answer.
+ *
+ * ## One reason gets an action and one does not, deliberately
+ *
+ * `no_interventions` is user-actionable: the option has nothing set, and saying
+ * what it changes fixes it. `not_returned` is not — the user has already done
+ * their part and the engine returned nothing. Offering a configure step there
+ * would prescribe a futile action, which is worse than a disclosure that simply
+ * reports. Same rule CEE applies to its own status-quo hold disclosure.
+ */
+
+import type { NotAnalysedReason } from './notAnalysedOptions'
+
+/** The pill on the card. Names the state; claims nothing about quality. */
+export const NOT_ANALYSED_BADGE = 'Not analysed'
+
+/**
+ * Why this option carries no rank and no probability.
+ *
+ * Both sentences state the CONSEQUENCE explicitly ("no rank and no
+ * probability") rather than leaving the reader to infer it from an empty card.
+ * A card that silently omits numbers reads as a rendering gap; a card that says
+ * why reads as a decision.
+ */
+export function notAnalysedReasonCopy(reason: NotAnalysedReason): string {
+  return reason === 'no_interventions'
+    ? 'This option has no values set yet, so it was left out of the comparison. It has no rank and no probability.'
+    : 'The analysis returned no result for this option, so it has no rank and no probability.'
+}
+
+/**
+ * The label on the resolve affordance, or `null` when there is nothing for the
+ * user to do. `null` is meaningful and must not be defaulted to a generic
+ * "Fix it" — see the module header.
+ */
+export function notAnalysedActionLabel(reason: NotAnalysedReason): string | null {
+  return reason === 'no_interventions' ? 'Tell Olumi what it changes' : null
+}
+
+/**
+ * The chat message the resolve affordance sends — CEE's own documented route.
+ *
+ * The label is interpolated verbatim from the graph node, exactly as CEE does
+ * with its own label slot, so the assistant receives the same string it would
+ * have received had the user typed the sentence CEE suggested.
+ */
+export function resolveOptionPrompt(optionLabel: string): string {
+  return `Help me configure ${optionLabel}.`
+}

--- a/src/components/results/utils/notAnalysedOptions.ts
+++ b/src/components/results/utils/notAnalysedOptions.ts
@@ -1,0 +1,114 @@
+/**
+ * notAnalysedOptions — "was this option in the analysis at all?", derived.
+ *
+ * Ruling (Paul, 14 Aug 2026): an unanalysable/placeholder option must NOT be
+ * included in comparative ranking or probabilities. It stays visible as a
+ * proposed/unanalysed alternative with a clear reason and an action to resolve
+ * it.
+ *
+ * ## Why this is DERIVED and not a wire field
+ *
+ * CEE excludes an option with no interventions from the PLoT submission, so the
+ * producer already tells us by OMISSION: there is no `option_probabilities`
+ * entry for it. Adding a boolean to the wire for a fact that is already on the
+ * wire would be a second authority on one question (CLAUDE.md trap 21) and a
+ * new field with one reader is exactly the dark-field failure this estate keeps
+ * paying for. The fact is derivable at the join; it is derived at the join.
+ *
+ * ## TWO QUESTIONS, KEPT APART (trap 21)
+ *
+ *   1. **WAS IT ANALYSED?** — {@link isAnalysedOption} / {@link runAnalysedAnyOption}.
+ *      A property of the RESULT.
+ *   2. **WHY NOT?** — {@link deriveNotAnalysedReason}. A property of the GRAPH.
+ *
+ * They have different sources, different failure modes and different honest
+ * copy. Collapsing them would produce the estate's signature defect: one
+ * `return null` answering two questions.
+ *
+ * ## THE DOMAIN GUARD IS THE LOAD-BEARING PART
+ *
+ * "No entry for this option" is true in three worlds, and only one of them is
+ * this ruling's:
+ *
+ *   (a) the run analysed other options and left this one out — the ruling's case;
+ *   (b) the run produced NO per-option results at all (a failed/degenerate run,
+ *       a producer gap, a schema-pin skew that ate the block);
+ *   (c) the result ids do not match the graph ids at all.
+ *
+ * In (b) and (c) EVERY option reads "missing", and marking them all
+ * not-analysed would tell a user who configured everything correctly that they
+ * configured nothing. So the predicate is *"absent from a result set that HAS
+ * results"*, never *"absent"* — {@link runAnalysedAnyOption} is that guard, and
+ * it also makes this change a strict no-op on every run that has no excluded
+ * option. It fails toward saying less.
+ */
+
+/** Why an option carries no analysis. Two facts, never one boolean. */
+export type NotAnalysedReason =
+  /**
+   * The option has no intervention edges on the graph, so there was nothing to
+   * submit. USER-ACTIONABLE: saying what it changes resolves it.
+   */
+  | 'no_interventions'
+  /**
+   * The option looks configured and the run still returned nothing for it.
+   * NOT user-actionable — the honest copy reports it and prescribes no step
+   * (a disclosure that prescribes a futile action is worse than one that
+   * reports).
+   */
+  | 'not_returned'
+
+/** The shape this module needs off a canvas edge. */
+export interface OptionEdgeLike {
+  readonly source: string
+  readonly target: string
+}
+
+/**
+ * True when the run returned a per-option result for this node.
+ *
+ * `null` counts as absent: a null entry is not a computation. A present
+ * non-object entry counts as PRESENT — that is a malformed producer payload,
+ * a different defect, and silently re-badging it as "you did not configure
+ * this option" would be a lie about whose fault it is.
+ */
+export function isAnalysedOption(
+  optionProbabilities: Readonly<Record<string, unknown>> | null | undefined,
+  nodeId: string,
+): boolean {
+  if (!optionProbabilities) return false
+  const entry = optionProbabilities[nodeId]
+  return entry !== undefined && entry !== null
+}
+
+/**
+ * THE DOMAIN GUARD. True when at least one of the graph's option nodes has a
+ * result — i.e. the run actually produced per-option output, so an absence is
+ * about THIS option rather than about the whole run.
+ */
+export function runAnalysedAnyOption(
+  optionProbabilities: Readonly<Record<string, unknown>> | null | undefined,
+  optionNodeIds: readonly string[],
+): boolean {
+  return optionNodeIds.some((id) => isAnalysedOption(optionProbabilities, id))
+}
+
+/**
+ * Why this option was not analysed, read off the GRAPH the user built.
+ *
+ * The intervention predicate is deliberately the SAME one the pre-run
+ * validator already uses to raise `OPTIONS_NEED_MAPPING`
+ * (`usePreRunValidation.ts`: an edge from the option to a non-option node), so
+ * the results panel and the pre-analysis panel cannot disagree about whether
+ * an option is configured. A second spelling of "configured" is how two
+ * surfaces end up contradicting each other about one option.
+ */
+export function deriveNotAnalysedReason(
+  nodeId: string,
+  edges: readonly OptionEdgeLike[],
+  optionNodeIds: readonly string[],
+): NotAnalysedReason {
+  const optionIds = new Set(optionNodeIds)
+  const hasInterventionEdge = edges.some((e) => e.source === nodeId && !optionIds.has(e.target))
+  return hasInterventionEdge ? 'not_returned' : 'no_interventions'
+}

--- a/src/components/results/utils/optionDisplayOrder.ts
+++ b/src/components/results/utils/optionDisplayOrder.ts
@@ -45,7 +45,10 @@
  */
 import type { OptionResult } from '../types'
 
-type DisplayOrderFields = Pick<OptionResult, 'winProbability' | 'expected' | 'goalProbability'>
+type DisplayOrderFields = Pick<
+  OptionResult,
+  'winProbability' | 'expected' | 'goalProbability' | 'notAnalysed'
+>
 
 export interface DisplayOrderOptions {
   /**
@@ -72,13 +75,37 @@ export function sortOptionsForDisplay<T extends DisplayOrderFields>(
   // number. The copy keeps callers free to mutate the result as before.
   if (designationsWithheld) return [...options]
 
+  // ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — AN OPTION THE RUN NEVER ANALYSED IS
+  // NOT IN THE RANKING, AND MUST NOT DECIDE HOW THE RANKING IS DRAWN.
+  //
+  // Two distinct harms, and the `every` below caused the second one:
+  //
+  //  1. RANKING IT. It has no comparative quantity, so any position it takes
+  //     among the ranked options is a claim nothing supports.
+  //  2. RE-RANKING EVERYONE ELSE. `allHaveWinProb` was an `every` over ALL
+  //     options, so ONE option with no win probability dropped every ANALYSED
+  //     option onto the `expected ?? goalProbability ?? -Infinity` comparator.
+  //     On a run whose two comparators disagree — the ordinary case — the
+  //     user's list silently re-ordered because of an option that took no part
+  //     in it. That is a regression in the ranking of options that WERE
+  //     analysed, caused by one that was not.
+  //
+  // The partition fixes both at once and keeps the completeness rule's own
+  // question intact: coverage must still be COMPLETE, over the options that
+  // are actually being compared. Unranked options keep the CALLER's order and
+  // go last — last is not a rank, it is "outside the list", and the cards
+  // render them with no ordinal at all.
+  const ranked = options.filter(o => o.notAnalysed !== true)
+  const unranked = options.filter(o => o.notAnalysed === true)
+
   // Number.isFinite (not `!= null`): a NaN winProbability would pass the
   // null check, poison the comparator (NaN ?? 0 stays NaN), and make the
   // order arbitrary — mixed/invalid coverage must fall back to expected.
   const allHaveWinProb =
-    options.length > 0 && options.every(o => typeof o.winProbability === 'number' && Number.isFinite(o.winProbability))
-  return [...options].sort((a, b) => {
+    ranked.length > 0 && ranked.every(o => typeof o.winProbability === 'number' && Number.isFinite(o.winProbability))
+  const sortedRanked = [...ranked].sort((a, b) => {
     if (allHaveWinProb) return (b.winProbability ?? 0) - (a.winProbability ?? 0)
     return (b.expected ?? b.goalProbability ?? -Infinity) - (a.expected ?? a.goalProbability ?? -Infinity)
   })
+  return [...sortedRanked, ...unranked]
 }

--- a/src/components/results/v7/buildV7Lenses.ts
+++ b/src/components/results/v7/buildV7Lenses.ts
@@ -149,7 +149,31 @@ function driverDirection(d: DriverItem): 'positive' | 'negative' | null {
 
 export function buildV7Lenses(data: ResultsSectionDataReturn): V7LensesModel {
   const { recommendation, drivers, confidence, voiRanking } = data
-  const options = recommendation.allOptions ?? []
+  // ⭐ NO-RANK RULING (Paul, 14 Aug 2026) — THE LENSES ARE COMPARATIVE VIEWS,
+  // AND AN OPTION THE RUN NEVER ANALYSED IS NOT IN THE COMPARISON.
+  //
+  // Filtering here rather than at each lens closes two defects with one line:
+  //
+  //  1. THE GOAL LENS COLLAPSED FOR EVERYONE. `hasCompleteGoalField` below is
+  //     a complete-field gate over ALL options, so ONE never-analysed option
+  //     set `goal.available = false` and the entire goal lens degraded to a
+  //     `producer_gap` line — for the analysed options too. `producer_gap` was
+  //     also the wrong DIAGNOSIS: the producer had no gap, we handed the gate
+  //     an option the producer was never asked about.
+  //  2. THE OUTCOME LENS WOULD HAVE DRAWN IT. `V7OutcomeLens.options` is this
+  //     array; a member with null bands and no win probability is a row with
+  //     nothing in it, in a group whose whole subject is comparison.
+  //
+  // `hasCompleteGoalField` itself is deliberately UNTOUCHED. It is shared with
+  // `selectGoalLeader`, its question ("may I claim a superlative over this
+  // field?") is right, and changing what a shared predicate MEANS to fix who
+  // it is asked ABOUT is how two surfaces end up disagreeing (trap 21). The
+  // question stays; the candidate set is corrected.
+  //
+  // Per-option VISIBILITY of an unanalysed option is the results panel's job
+  // (`NotAnalysedOptionCard`), not this group's — see the division of labour
+  // pinned by `notAnalysedDivisionOfLabour.spec.ts`.
+  const options = (recommendation.allOptions ?? []).filter((o) => o.notAnalysed !== true)
   // ROADMAP 1.267. `winnerId` drives the ONLY thing the V7 rows do with a
   // leader: bold + darken that row's label and readout
   // (`V7LensGroup.tsx`). On a withheld run the V7 HEADLINE above these rows


### PR DESCRIPTION
Implements Paul's ruling (14 Aug 2026): **an unanalysable/placeholder option must NOT be included in comparative ranking or probabilities. It stays visible as a proposed/unanalysed alternative with a clear reason and an action to resolve it.**

This is the UI half. The CEE half (`lane/norank-placeholder-options` on `olumi-assistants-service`) excludes an option with no interventions from the PLoT submission, so the producer mints nothing for it.

## Why the reader half is mandatory, not a nicety

The results panel does not iterate the result array — it enumerates the **user's graph option nodes** and LEFT-JOINS the analysis (`useResultsSectionData.ts`). An excluded option therefore does not vanish; it arrives as an empty join, and three expressions read "empty" as "zero-ish" rather than "absent":

1. **A fabricated expected value.** `optionBands = prob.bands ?? sharedBands ?? {}` fell through to `report.run.bands` — the *first* option's confidence-interval midpoint (`responseMapper.ts:585`) — and `rawExpected` resolved via `?? optionBands.p50`. **Measured: `expected === 10` on an option that was never analysed** — the leading option's mean rendered as the excluded option's own number. *The producer removed a disclosed placeholder; the reader minted an undisclosed one.*
2. **A re-sort of the analysed options.** `sortOptionsForDisplay`'s `allHaveWinProb` is an `every` over ALL options, so one unanalysed option dropped every *analysed* option onto the expected-value comparator.
3. **A change of winner-selection method.** `determineWinnerSelection`'s coverage check is the same `every` one level up — it re-decided the winner *and* told the user the answer came from expected value.

Two more of the same class, found in review of the surrounding code: `OptionCards.allGoalProbability` (one unanalysed option deleted the "Hits target" bar from every analysed card) and `buildV7Lenses.hasCompleteGoalField` (collapsed the whole goal lens to a `producer_gap` line — also the wrong *diagnosis*, since the producer had no gap).

And `buildGoalFitRows`, where `return null` exits the **whole builder**, so one unanalysed option blanked the entire goal-fit card. Two different questions under one `return null` — "never analysed" and "analysed, no goal figure" — now separated.

## Design

**No new wire field.** CEE already says this by OMISSION, and a dark field is this estate's chronic failure. `notAnalysed` is derived at the join, guarded on the run having produced *some* per-option result — so a whole-run producer gap leaves every option unmarked rather than telling a user who configured everything that they configured nothing.

`NotAnalysedOptionCard` is a **single fork**, not seven guards inside `OptionCard`. The ranked card has seven places a number or an ordinal can appear; a list of guards would rot silently the first time an eighth stat row was added.

Unranked options sort **last** and are **always rendered** — appended past the top-2 truncation by the same mechanism as the lens pick (ROADMAP 2.237), because truncation would otherwise hide the very option being disclosed.

Copy is a genuine new single source: the nearest existing wording (the V2 "Needs mapping" pill) is **dark** on staging (`VITE_FEATURE_PRE_ANALYSIS_V3 = "1"` mounts `PreAnalysisPanelV3` instead). The resolve action drafts CEE's **own documented sentence** (`Help me configure <label>.`), witnessed on a live captured turn.

## Evidence

**RED-first, measured at pristine `9c75be0b`: 7 failed / 3 passed / 10 collected** (assertion failures, not a collection error), headline `expected 10 to be null`.

Five spec files, per-file collected counts asserted by name: 10 / 9 / 5 / 13 / 4 = **41**.

A **mount-path** spec renders `<ResultsBody>` — `OptionCards`' only production parent — because this estate has twice shipped a feature dark past a green component suite pointed at a surface the deployed flags do not mount (trap 3b).

Gates run in the required check's own order (lint gates typecheck): `pnpm lint` → **0 errors**, hooks ratchet exact; `npm run typecheck` → **PASSED**; results + model-tab suites → **291 files / 5083 tests, all passing**.

## Do not merge without review

Requesting independent review per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
