### PR TITLE
chore(canvas): delete the unreachable edge strokeHover token (keeps the live strokeSelected twin)

### DIFF
--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -261,7 +261,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
 
   // Apply visual properties (O(1), pure function)
   const visualProps = useMemo(
-    () => applyEdgeVisualProps(weight, style, curvature, selected || false, false, isDark),
+    () => applyEdgeVisualProps(weight, style, curvature, selected || false, isDark),
     [weight, style, curvature, selected, isDark]
   )
 

--- a/src/canvas/theme/edges.ts
+++ b/src/canvas/theme/edges.ts
@@ -12,7 +12,6 @@ import { weightToStrokeWidth, styleToDashArray, clampCurvature } from '../domain
  */
 interface EdgeThemeTokens {
   stroke: string
-  strokeHover: string
   strokeSelected: string
   label: string
   labelBackground: string
@@ -28,7 +27,6 @@ interface EdgeThemeTokens {
  */
 const LIGHT_THEME: EdgeThemeTokens = {
   stroke: '#94A3B8', // Slate 400
-  strokeHover: '#64748B', // Slate 500
   strokeSelected: 'var(--semantic-info)', // Olumi v1.2: sky-500
   label: '#1E293B', // Slate 800
   labelBackground: '#FFFFFF',
@@ -45,7 +43,6 @@ const LIGHT_THEME: EdgeThemeTokens = {
  */
 const DARK_THEME: EdgeThemeTokens = {
   stroke: 'var(--edge-stroke, #5B6CFF)',
-  strokeHover: 'var(--info-hover)', // Olumi v1.2: info hover state
   strokeSelected: 'var(--semantic-info)', // Olumi v1.2: sky-500
   label: 'var(--edge-label-text, #E8ECF5)',
   labelBackground: 'var(--edge-label-bg, #0E1116)',
@@ -86,20 +83,39 @@ export interface EdgeVisualProps {
   stroke: string
 }
 
+/**
+ * ⚠ There is deliberately NO hover branch here, and no `strokeHover` token.
+ *
+ * One existed until 14 Aug 2026 and was unreachable: the sole call site
+ * (StyledEdge) passed `isHovered` as a hardcoded `false`, so the token could
+ * never be applied.
+ *
+ * It was DELETED rather than wired up, and that was the considered choice.
+ * Wiring it would not have worked: StyledEdge resolves its stroke as
+ * `isHighlightedEdge ? info : (directionStroke ?? visualProps.stroke)`, so an
+ * edge carrying direction POLARITY (green/red) never reaches `visualProps.stroke`
+ * at all. A hover colour would therefore be invisible on exactly the edges that
+ * matter, and where it did apply it would OVERWRITE polarity — a semantic
+ * change, not a visual one.
+ *
+ * Hover and selection emphasis are delivered instead as a composable
+ * `filter: drop-shadow` in StyledEdge, which is a separate CSS channel and so
+ * coexists with polarity colour. That is the pattern this file's neighbours
+ * already use for the fragile halo and the sensitivity glow.
+ *
+ * If you are adding hover styling: add it to that filter chain, not here.
+ */
 export function applyEdgeVisualProps(
   weight: number,
   style: EdgeStyle,
   curvature: number,
   isSelected: boolean,
-  isHovered: boolean,
   isDark = false
 ): EdgeVisualProps {
   const theme = getEdgeTheme(isDark)
-  
-  let stroke = theme.stroke
-  if (isSelected) stroke = theme.strokeSelected
-  else if (isHovered) stroke = theme.strokeHover
-  
+
+  const stroke = isSelected ? theme.strokeSelected : theme.stroke
+
   return {
     strokeWidth: weightToStrokeWidth(weight),
     strokeDasharray: styleToDashArray(style),


### PR DESCRIPTION
Addendum to #694, **based on `staging`** (not on the 6A/6B branch — see Ordering). **Do not merge** — for review.

`src/canvas/theme/edges.ts` defined a `strokeHover` token in both themes, applied via `else if (isHovered)` in `applyEdgeVisualProps`. Its only call site passed `isHovered` as a hardcoded `false`, so the token was **unreachable**.

**Verdict: option (a) — delete.**

## Consumer manifest

Scope: **entire repo tree at `9c75be0b`**, `rg -a` (binary-safe, so a NUL-bearing file cannot read as a false absence), case-insensitive, `node_modules` excluded. Complete, not a sample.

**`applyEdgeVisualProps` — 17 hits**
| Where | What |
|---|---|
| `src/canvas/theme/edges.ts:89` | the definition |
| `src/canvas/edges/StyledEdge.tsx:28` | the import |
| **`src/canvas/edges/StyledEdge.tsx:264`** | **the only product call site** — passes `false` |
| 13 spec files | all `vi.mock` the module wholesale, so none exercise the real function |
| `archive/dead-canvas-theme-2026-07/README.md` | archived prose, not code |

**`strokeHover` — 4 hits, all inside its own defining file**
`:15` interface field · `:31` light theme · `:48` dark theme · `:101` the unreachable branch.
**Zero consumers outside `theme/edges.ts`.**

**Contrast control — `strokeSelected`**, same family, same probe, same run: **4 hits** (`:16 :32 :49 :100`). Non-zero, so the sweep is demonstrably not blind to this class of symbol.

## ⭐ `strokeSelected` is LIVE and is deliberately kept

The obvious over-reach here would be to take the whole hover/selected pair. Independently corroborated by a **pixel diff of the running canvas**: at pristine, selecting an edge still shifts its stroke across ~594px, and `edges.ts:100` (`stroke = theme.strokeSelected`) is what produces it. Only the **hover** twin is dead.

## Why not simply pass the real `isHovered`

Rejected deliberately, per Paul's constraint. `StyledEdge` resolves stroke as `isHighlightedEdge ? info : (directionStroke ?? visualProps.stroke)` — an edge carrying direction **polarity** (green/red) never reaches `visualProps.stroke`. So a hover colour would be **invisible on exactly the edges that matter**, and where it did apply it would **overwrite polarity** — a semantic change, not a visual one.

Hover and selection emphasis are instead delivered as a composable `filter: drop-shadow` in #694 — a separate CSS channel that coexists with polarity, which is the pattern this file's neighbours already use for the fragile halo and sensitivity glow. A comment at the function now records all of this so the next reader does not "restore" the token.

## Gates

Run in the required order (`lint → typecheck → tests`) — a green typecheck alone is not sufficient:

- `eslint` on both changed files: **exit 0**, no output.
- `bash scripts/ci/typecheck-gate.sh`: **PASSED**, 618 files / 2485 errors, **"none added"**.
- `vitest src/canvas/edges src/canvas/theme`: **21 files / 272 tests, all passed.**

## Ordering

**Based on `staging`, and independent of #694.** #694 modifies `StyledEdge.tsx` but **does not touch line 264**, so the two merge cleanly in either order. No rebase dependency.

⚠ **Possible duplicate lane:** a background task on this same defect was started from a chip before this was assigned to me directly. No competing branch or PR is pushed as of this writing, but please close whichever of the two is redundant rather than merging both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
