### PR TITLE
feat(2.1204): disclose rephrase absorption as an attributed, non-destructible drafting note

### DIFF
--- a/src/canvas/ui/inspector-v2/__tests__/OptionPanel.rephraseAbsorptionDisclosure.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/OptionPanel.rephraseAbsorptionDisclosure.spec.tsx
@@ -1,60 +1,57 @@
 /**
  * ROADMAP 2.1204 — the rephrase-absorption disclosure the user can actually READ.
  *
- * ── WHAT THE WIRE CARRIES ────────────────────────────────────────────────
- * When CEE's drafter (#953) absorbs a rephrase-twin option, the surviving
- * option's `description` carries `"Also drafted as: <absorbed label>"`.
- * Ruling R2 (Paul): auto-merge is correct, but the user must be able to SEE
- * that it happened.
+ * ── WHAT THE PRODUCER ACTUALLY WRITES ────────────────────────────────────
+ * Derived at CEE's bytes, tip `ae0b4af`,
+ * `src/cee/transforms/option-rephrase-merge.ts:459-462`:
  *
- * ── ⭐⭐ THE PREMISE THIS FILE CORRECTS ────────────────────────────────────
- * Row 2.1204 was minted from the closing battery's DOM-2 arm, which reported
- * the trace **"appears NOWHERE in the rendered page"**. That is FALSE, and the
- * refutation sits inside DOM-2's own output directory: its screenshot
- * (`closing-witness-20260814/driver/dom-postbatch/dom2-final/d2-inspector.png`)
- * shows `Also drafted as: Hire two Developers` rendering in the option
- * inspector's Context group.
+ *     const alsoDraftedAs = `Also drafted as: ${twin.label}`;
+ *     const appendDescription = (existing) =>
+ *       existing && existing.trim().length > 0
+ *         ? `${existing}\n\n${alsoDraftedAs}`
+ *         : alsoDraftedAs;
  *
- * DOM-2 scraped with `page.locator('body').innerText()`. `OptionPanel` renders
- * the description into a **React-controlled `<textarea>`**, and React sets a
- * controlled textarea's `value` as a DOM *property* with no child text node —
- * so the string is fully visible to a human and carries ZERO text content.
- * The probe was structurally blind to the one element class its claim rested
- * on. Both of its controls fired and neither could have caught this: they read
- * a canvas label and `PanelGroup` headings, both ordinary text nodes (trap 13e
- * — a control proves the probe sees SOMETHING, never that it sees the thing
- * under test).
+ * So the note is **APPENDED**, separated by a BLANK LINE, and stands alone only
+ * when the description was empty. The enclosing loop runs **per twin**, so a
+ * second absorption appends again: notes accumulate as a trailing run of
+ * `\n\n`-separated lines.
  *
- * ── SO THE REAL DEFECT IS NOT ABSENCE. IT IS ATTRIBUTION AND DESTRUCTION ──
- * The note renders **inside the user's own editable description field**:
- *   1. UNATTRIBUTED — it reads as the user's own prose; nothing says a drafter
- *      wrote it, which is precisely what R2 asks the user to be able to see.
- *   2. DESTRUCTIVE — that textarea is the description editor and `onBlur`
- *      commits it. A user typing their own description silently and
- *      permanently destroys the absorption provenance.
- *   3. OBSTRUCTIVE — it squats in the description field, so a user wanting to
- *      describe the option must first delete machine-authored text, and
- *      `EmptyDescriptionPrompt` never invites them to write one at all.
+ * ⚠ THE FIRST VERSION OF THIS FILE ASSERTED THE OPPOSITE — that CEE PREFIXES —
+ * and its parser used `startsWith`, which is INERT on every option that already
+ * had a description. That class is wire-reachable on a first draft (V3
+ * `description` = the drafter's `node.body`, CEE `schema-v3.ts:207`).
  *
- * The fix therefore SEPARATES rather than adds: the note is lifted out of the
- * editable description into a distinct attributed line, and is recomposed on
- * write-back so editing the description cannot destroy it.
+ * **Why the original corpus could not catch it:** every absorbed option in the
+ * closing-witness captures had an EMPTY description — the one class where
+ * "whole string" and "leading prefix" coincide, so both the right and the wrong
+ * parser agree on all 12 samples (trap 13d — a corpus that omits a class the
+ * contract admits cannot certify the code over that class). The producer's join
+ * was one grep away and the code was never asked. T7 is that missing class.
+ *
+ * ── THE DEFECT THIS FILE PINS ────────────────────────────────────────────
+ * The note was never invisible: it rendered inside the option's **editable
+ * description textarea**. (The closing battery's DOM-2 arm called it "DARK to
+ * the reader" because it scraped `body.innerText()`, which cannot see a
+ * React-controlled textarea's `value` — the string is a DOM property with no
+ * child text node. Its own screenshot shows the sentence on screen.) The real
+ * defect is that the note was **unattributed** — indistinguishable from the
+ * user's own prose — and **destructible**: typing over it erased the only
+ * record that two options had been merged.
  *
  * ── HOW THIS FILE BINDS ──────────────────────────────────────────────────
- * · It mounts `InspectorModal`, the DEPLOYED v2 path (`USE_INSPECTOR_V2 = true`
- *   is hardcoded at `InspectorModal.tsx:16`), not a panel in isolation — so a
- *   flag or router change that stops mounting this panel fails the file loudly
- *   rather than silently testing a component no user loads (trap 3b).
- * · Every test asserts the INSPECTOR IS OPEN as its own precondition, by the
- *   exact identity anchors `role="dialog" aria-label="Node inspector"` and
- *   `role="region" aria-label="Inspector panel"`. A closed inspector satisfies
- *   any absence assertion vacuously (trap 13), so the absence claims in T4/T5
- *   are worthless without it.
- * · Fixtures bind by IDENTITY — exact node id, exact label — never by a value
- *   predicate another node could satisfy (trap 19).
- * · Expected user-facing strings are written out LITERALLY here rather than
- *   imported from `inspectorStrings`. Importing the constant under test would
- *   make the assertion agree with itself whatever the copy became.
+ * · Mounts `InspectorModal`, the DEPLOYED v2 path (`USE_INSPECTOR_V2 = true`
+ *   hardcoded at `InspectorModal.tsx:16`), so a router or flag change that
+ *   stops mounting this panel fails loudly rather than silently testing a
+ *   component no user loads (trap 3b).
+ * · Asserts the inspector is OPEN as an explicit precondition in every test —
+ *   a closed inspector satisfies any absence assertion vacuously (trap 13).
+ * · Fixtures bind by IDENTITY — exact node id, exact label (trap 19).
+ * · Expected user-facing strings are written LITERALLY, never imported from
+ *   `inspectorStrings`; importing the constant under test would make the
+ *   assertion agree with itself whatever the copy became.
+ * · T10 reaches the tech-mode editor THROUGH THE REAL CONTROLS (toggle, then
+ *   disclosure) rather than rendering it directly — the erase path is only a
+ *   defect because a user can reach it.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -70,21 +67,22 @@ vi.mock('@xyflow/react', async importOriginal => ({
   useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
 }))
 
-/** The exact wire sentence, from the live capture (node `be215545`). */
+/** The exact wire sentences, in the producer's own format. */
 const ABSORBED_LABEL = 'Hire two Developers'
-const WIRE_NOTE = `Also drafted as: ${ABSORBED_LABEL}`
+const NOTE = `Also drafted as: ${ABSORBED_LABEL}`
+const SECOND_NOTE = 'Also drafted as: Bring on two engineers'
+const USER_PROSE = 'We would run both squads in parallel.'
 
 /** Identity anchors — the deployed v2 mount path. */
 const NODE_INSPECTOR = 'div[role="dialog"][aria-label="Node inspector"]'
 const INSPECTOR_SHELL = '[role="region"][aria-label="Inspector panel"]'
 
-/** The survivor option, bound by exact id and exact label. */
 const SURVIVOR_ID = 'be215545'
 const SURVIVOR_LABEL = 'two developers'
-
-/** A non-option node carrying the SAME description — the scoping control. */
 const GOAL_ID = 'goal-increase-productivity'
 const GOAL_LABEL = 'increase productivity'
+
+const OPTION_PLACEHOLDER = 'What would choosing this option actually mean in practice?'
 
 function seedStore(nodes: unknown[]) {
   useCanvasStore.setState({
@@ -125,29 +123,28 @@ function goalNode(description?: string) {
   }
 }
 
-/**
- * Mounts the inspector for `nodeId` and PROVES IT OPENED before returning.
- *
- * This is the precondition, asserted in-test rather than assumed: without it
- * "the note is not on screen" would pass on an inspector that never mounted.
- */
+/** Mounts the inspector and PROVES IT OPENED before returning. */
 function openInspector(nodeId: string) {
   const utils = render(<InspectorModal nodeId={nodeId} edgeId={null} onClose={vi.fn()} />)
 
   const dialog = utils.container.querySelector(NODE_INSPECTOR)
   expect(dialog, 'PRECONDITION: the node inspector dialog must be mounted').not.toBeNull()
-
   const shell = utils.container.querySelector(INSPECTOR_SHELL)
   expect(shell, 'PRECONDITION: the InspectorShell must have rendered inside it').not.toBeNull()
 
-  return { ...utils, dialog: dialog as HTMLElement, shell: shell as HTMLElement }
+  return { ...utils, dialog: dialog as HTMLElement }
 }
 
 /** The option description editor, bound by its exact placeholder. */
 function descriptionEditor(): HTMLTextAreaElement | null {
-  return screen.queryByPlaceholderText(
-    'What would choosing this option actually mean in practice?',
-  ) as HTMLTextAreaElement | null
+  return screen.queryByPlaceholderText(OPTION_PLACEHOLDER) as HTMLTextAreaElement | null
+}
+
+/** What is actually stored on the node right now. */
+function storedDescription(nodeId = SURVIVOR_ID): string {
+  return String(
+    useCanvasStore.getState().nodes.find(n => n.id === nodeId)?.data?.description ?? '',
+  )
 }
 
 beforeEach(() => {
@@ -157,93 +154,152 @@ beforeEach(() => {
 
 describe('ROADMAP 2.1204 — the absorption note is disclosed as a DRAFTING note', () => {
   it('⭐ T1 renders the wire sentence on an attributed drafting-note line', () => {
-    seedStore([optionNode(WIRE_NOTE)])
+    seedStore([optionNode(NOTE)])
     const { dialog } = openInspector(SURVIVOR_ID)
 
-    // The panel really is the survivor's — identity, not a value predicate.
     expect(within(dialog).getByText(SURVIVOR_LABEL)).toBeTruthy()
 
     const note = within(dialog).getByTestId('option-drafting-note')
-
     // The wire sentence, verbatim. No invented copy about what was merged.
-    expect(note.textContent).toContain(WIRE_NOTE)
-
-    // ⭐ AND IT IS ATTRIBUTED. This is the half R2 actually asks for: the user
-    // must be able to tell a drafter wrote this, not them.
+    expect(note.textContent).toContain(NOTE)
+    // ⭐ AND IT IS ATTRIBUTED — the half ruling R2 actually asks for.
     expect(note.textContent).toContain('Drafted by Olumi')
   })
 
   it('⭐ T2 does NOT leave the note squatting in the editable description', () => {
-    seedStore([optionNode(WIRE_NOTE)])
+    seedStore([optionNode(NOTE)])
     openInspector(SURVIVOR_ID)
 
-    // With the note lifted out there is no user description left, so the
-    // description field is genuinely empty and the user is invited to write
-    // one — the prompt the raw note used to suppress.
     expect(descriptionEditor()).toBeNull()
-    expect(
-      screen.getByText('What would choosing this option actually mean in practice?'),
-    ).toBeTruthy()
+    expect(screen.getByText(OPTION_PLACEHOLDER)).toBeTruthy()
   })
 
-  it('⭐ T3 separates the note from a description the user HAS written', () => {
-    seedStore([optionNode(`${WIRE_NOTE}\nWe would run both squads in parallel.`)])
+  it('⭐⭐ T7 PRODUCER FORM — a DESCRIBED option carries the note at the END', () => {
+    // THE CLASS THE ORIGINAL CORPUS OMITTED. CEE appends `\n\n<note>` to an
+    // existing description; a `startsWith` parser is inert on every option in
+    // this class, which is reachable on a first draft.
+    seedStore([optionNode(`${USER_PROSE}\n\n${NOTE}`)])
     const { dialog } = openInspector(SURVIVOR_ID)
 
     const note = within(dialog).getByTestId('option-drafting-note')
-    expect(note.textContent).toContain(WIRE_NOTE)
-    // The user's own prose must NOT be swept into the drafting note.
-    expect(note.textContent).not.toContain('We would run both squads in parallel.')
+    expect(note.textContent).toContain(NOTE)
+    // The user's prose must NOT be swept into the drafting note.
+    expect(note.textContent).not.toContain(USER_PROSE)
 
     const editor = descriptionEditor()
-    expect(editor).not.toBeNull()
-    expect(editor!.value).toBe('We would run both squads in parallel.')
+    expect(editor, 'the user description must still be editable').not.toBeNull()
+    expect(editor!.value).toBe(USER_PROSE)
     expect(editor!.value).not.toContain('Also drafted as:')
   })
 
-  it('⭐ T4 renders NO drafting-note line when the description carries no note', () => {
-    // The absence claim below is only meaningful because openInspector has
-    // already proven the inspector mounted AND the editor below proves the
-    // description reached this panel.
-    seedStore([optionNode('We would run both squads in parallel.')])
+  it('⭐⭐ T8 STACKED absorptions — every note is attributed, none left in the body', () => {
+    // The producer loop runs per twin, so two absorptions append twice.
+    seedStore([optionNode(`${USER_PROSE}\n\n${NOTE}\n\n${SECOND_NOTE}`)])
     const { dialog } = openInspector(SURVIVOR_ID)
 
-    expect(descriptionEditor()!.value).toBe('We would run both squads in parallel.')
+    const note = within(dialog).getByTestId('option-drafting-note')
+    expect(note.textContent).toContain(NOTE)
+    expect(note.textContent).toContain(SECOND_NOTE)
+
+    expect(descriptionEditor()!.value).toBe(USER_PROSE)
+  })
+
+  it('⭐⭐ T9 ROUND-TRIP — the edit is stored back in the PRODUCER’s exact format', () => {
+    // Not a third storage format: what we write must be what CEE would write,
+    // or the next consumer parses something no producer emits.
+    seedStore([optionNode(`${USER_PROSE}\n\n${NOTE}`)])
+    openInspector(SURVIVOR_ID)
+
+    const editor = descriptionEditor()!
+    fireEvent.change(editor, { target: { value: 'Two hires, starting in Q3.' } })
+    fireEvent.blur(editor)
+
+    expect(storedDescription()).toBe(`Two hires, starting in Q3.\n\n${NOTE}`)
+  })
+
+  it('⭐⭐ T10 TECH MODE — the advanced editor cannot erase the note either', () => {
+    // Reached through the REAL controls: this path is only a defect because a
+    // user can get to it. Enumerating EVERY path that reaches the marking is
+    // the review-doctrine rule the first round of this work missed.
+    seedStore([optionNode(`${USER_PROSE}\n\n${NOTE}`)])
+    openInspector(SURVIVOR_ID)
+
+    fireEvent.click(screen.getByLabelText('Show technical detail'))
+    fireEvent.click(screen.getByText('Show model detail'))
+
+    const advanced = screen.getByPlaceholderText('Option description') as HTMLTextAreaElement
+    expect(
+      advanced.value,
+      'PRECONDITION: the advanced editor must show the user body, not the raw note',
+    ).toBe(USER_PROSE)
+
+    fireEvent.change(advanced, { target: { value: 'Rewritten in tech mode.' } })
+    fireEvent.blur(advanced)
+
+    const stored = storedDescription()
+    expect(stored).toContain(NOTE)
+    expect(stored).toContain('Rewritten in tech mode.')
+  })
+
+  it('⭐ T11 KNOWN LIMIT (F3) — user prose that OPENS with the literal is re-attributed', () => {
+    // Documented, not fixed: with the note carried in a free-text description
+    // there is no way to tell a drafter's line from a user who typed the same
+    // words. The durable fix is a dedicated wire field, which rides the
+    // contract wave with OPTION_REPHRASE_ABSORBED. This test exists so the
+    // behaviour is PINNED rather than discovered — it REDs if the boundary
+    // moves in either direction.
+    seedStore([optionNode('Also drafted as: my own shorthand for this plan')])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    expect(within(dialog).getByTestId('option-drafting-note').textContent).toContain(
+      'Also drafted as: my own shorthand for this plan',
+    )
+  })
+
+  it('⭐ T12 tolerates the legacy single-newline form and MIGRATES it on commit', () => {
+    // A form only this UI ever produced (first round of 2.1204). Tolerated on
+    // read so nothing is stranded, and rewritten to the producer's format the
+    // first time the description is committed.
+    seedStore([optionNode(`${NOTE}\n${USER_PROSE}`)])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    expect(within(dialog).getByTestId('option-drafting-note').textContent).toContain(NOTE)
+    const editor = descriptionEditor()!
+    expect(editor.value).toBe(USER_PROSE)
+
+    fireEvent.change(editor, { target: { value: 'Migrated body.' } })
+    fireEvent.blur(editor)
+    expect(storedDescription()).toBe(`Migrated body.\n\n${NOTE}`)
+  })
+
+  it('⭐ T4 renders NO drafting-note line when the description carries no note', () => {
+    seedStore([optionNode(USER_PROSE)])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    expect(descriptionEditor()!.value).toBe(USER_PROSE)
     expect(within(dialog).queryByTestId('option-drafting-note')).toBeNull()
   })
 
   it('⭐ T5 SCOPING — a non-option node with the same description gets no note line', () => {
-    seedStore([goalNode(WIRE_NOTE)])
+    seedStore([goalNode(`${USER_PROSE}\n\n${NOTE}`)])
     const { dialog } = openInspector(GOAL_ID)
 
-    // Positive control: this is genuinely the goal inspector, open and
-    // populated. Without it "no note line" would pass on an empty render.
+    // Positive control: this really is the goal inspector, open and populated.
     expect(within(dialog).getByText(GOAL_LABEL)).toBeTruthy()
-
     expect(within(dialog).queryByTestId('option-drafting-note')).toBeNull()
   })
 
-  it('⭐ T6 editing the description does not DESTROY the absorption trace', () => {
-    seedStore([optionNode(WIRE_NOTE)])
+  it('⭐ T6 editing a previously-empty description does not DESTROY the trace', () => {
+    seedStore([optionNode(NOTE)])
     openInspector(SURVIVOR_ID)
 
-    // Start typing a description: the empty prompt opens the editor.
-    fireEvent.click(
-      screen.getByText('What would choosing this option actually mean in practice?'),
-    )
+    fireEvent.click(screen.getByText(OPTION_PLACEHOLDER))
     const editor = descriptionEditor()
     expect(editor, 'PRECONDITION: clicking the prompt must open the editor').not.toBeNull()
 
     fireEvent.change(editor!, { target: { value: 'Two hires, starting in Q3.' } })
     fireEvent.blur(editor!)
 
-    // The committed description carries BOTH: the user's words and the trace.
-    // This case CAN trigger the write-back path — a "does no harm" test whose
-    // fixture cannot reach the transformation asserts nothing (trap 22b).
-    const committed = String(
-      useCanvasStore.getState().nodes.find(n => n.id === SURVIVOR_ID)?.data?.description ?? '',
-    )
-    expect(committed).toContain(WIRE_NOTE)
-    expect(committed).toContain('Two hires, starting in Q3.')
+    expect(storedDescription()).toBe(`Two hires, starting in Q3.\n\n${NOTE}`)
   })
 })

--- a/src/canvas/ui/inspector-v2/__tests__/OptionPanel.rephraseAbsorptionDisclosure.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/OptionPanel.rephraseAbsorptionDisclosure.spec.tsx
@@ -1,0 +1,249 @@
+/**
+ * ROADMAP 2.1204 — the rephrase-absorption disclosure the user can actually READ.
+ *
+ * ── WHAT THE WIRE CARRIES ────────────────────────────────────────────────
+ * When CEE's drafter (#953) absorbs a rephrase-twin option, the surviving
+ * option's `description` carries `"Also drafted as: <absorbed label>"`.
+ * Ruling R2 (Paul): auto-merge is correct, but the user must be able to SEE
+ * that it happened.
+ *
+ * ── ⭐⭐ THE PREMISE THIS FILE CORRECTS ────────────────────────────────────
+ * Row 2.1204 was minted from the closing battery's DOM-2 arm, which reported
+ * the trace **"appears NOWHERE in the rendered page"**. That is FALSE, and the
+ * refutation sits inside DOM-2's own output directory: its screenshot
+ * (`closing-witness-20260814/driver/dom-postbatch/dom2-final/d2-inspector.png`)
+ * shows `Also drafted as: Hire two Developers` rendering in the option
+ * inspector's Context group.
+ *
+ * DOM-2 scraped with `page.locator('body').innerText()`. `OptionPanel` renders
+ * the description into a **React-controlled `<textarea>`**, and React sets a
+ * controlled textarea's `value` as a DOM *property* with no child text node —
+ * so the string is fully visible to a human and carries ZERO text content.
+ * The probe was structurally blind to the one element class its claim rested
+ * on. Both of its controls fired and neither could have caught this: they read
+ * a canvas label and `PanelGroup` headings, both ordinary text nodes (trap 13e
+ * — a control proves the probe sees SOMETHING, never that it sees the thing
+ * under test).
+ *
+ * ── SO THE REAL DEFECT IS NOT ABSENCE. IT IS ATTRIBUTION AND DESTRUCTION ──
+ * The note renders **inside the user's own editable description field**:
+ *   1. UNATTRIBUTED — it reads as the user's own prose; nothing says a drafter
+ *      wrote it, which is precisely what R2 asks the user to be able to see.
+ *   2. DESTRUCTIVE — that textarea is the description editor and `onBlur`
+ *      commits it. A user typing their own description silently and
+ *      permanently destroys the absorption provenance.
+ *   3. OBSTRUCTIVE — it squats in the description field, so a user wanting to
+ *      describe the option must first delete machine-authored text, and
+ *      `EmptyDescriptionPrompt` never invites them to write one at all.
+ *
+ * The fix therefore SEPARATES rather than adds: the note is lifted out of the
+ * editable description into a distinct attributed line, and is recomposed on
+ * write-back so editing the description cannot destroy it.
+ *
+ * ── HOW THIS FILE BINDS ──────────────────────────────────────────────────
+ * · It mounts `InspectorModal`, the DEPLOYED v2 path (`USE_INSPECTOR_V2 = true`
+ *   is hardcoded at `InspectorModal.tsx:16`), not a panel in isolation — so a
+ *   flag or router change that stops mounting this panel fails the file loudly
+ *   rather than silently testing a component no user loads (trap 3b).
+ * · Every test asserts the INSPECTOR IS OPEN as its own precondition, by the
+ *   exact identity anchors `role="dialog" aria-label="Node inspector"` and
+ *   `role="region" aria-label="Inspector panel"`. A closed inspector satisfies
+ *   any absence assertion vacuously (trap 13), so the absence claims in T4/T5
+ *   are worthless without it.
+ * · Fixtures bind by IDENTITY — exact node id, exact label — never by a value
+ *   predicate another node could satisfy (trap 19).
+ * · Expected user-facing strings are written out LITERALLY here rather than
+ *   imported from `inspectorStrings`. Importing the constant under test would
+ *   make the assertion agree with itself whatever the copy became.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { InspectorModal } from '../../../components/InspectorModal'
+import { useCanvasStore } from '../../../store'
+
+// importOriginal-spread, NOT a hand-listed factory: `vi.mock` REPLACES the
+// module, so a bare `{ useViewport }` factory silently removes every other
+// @xyflow/react export the subtree imports (CLAUDE.md trap 12).
+vi.mock('@xyflow/react', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+/** The exact wire sentence, from the live capture (node `be215545`). */
+const ABSORBED_LABEL = 'Hire two Developers'
+const WIRE_NOTE = `Also drafted as: ${ABSORBED_LABEL}`
+
+/** Identity anchors — the deployed v2 mount path. */
+const NODE_INSPECTOR = 'div[role="dialog"][aria-label="Node inspector"]'
+const INSPECTOR_SHELL = '[role="region"][aria-label="Inspector panel"]'
+
+/** The survivor option, bound by exact id and exact label. */
+const SURVIVOR_ID = 'be215545'
+const SURVIVOR_LABEL = 'two developers'
+
+/** A non-option node carrying the SAME description — the scoping control. */
+const GOAL_ID = 'goal-increase-productivity'
+const GOAL_LABEL = 'increase productivity'
+
+function seedStore(nodes: unknown[]) {
+  useCanvasStore.setState({
+    nodes: nodes as never[],
+    edges: [],
+    results: { status: 'idle' },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: { x: 0, y: 0 } },
+    goalThreshold: null,
+    confirmedNodeIds: new Set(),
+    _internal: {},
+  } as never)
+}
+
+function optionNode(description?: string) {
+  return {
+    id: SURVIVOR_ID,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'option',
+      label: SURVIVOR_LABEL,
+      provenance: 'from_brief',
+      ...(description === undefined ? {} : { description }),
+    },
+  }
+}
+
+function goalNode(description?: string) {
+  return {
+    id: GOAL_ID,
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'goal',
+      label: GOAL_LABEL,
+      ...(description === undefined ? {} : { description }),
+    },
+  }
+}
+
+/**
+ * Mounts the inspector for `nodeId` and PROVES IT OPENED before returning.
+ *
+ * This is the precondition, asserted in-test rather than assumed: without it
+ * "the note is not on screen" would pass on an inspector that never mounted.
+ */
+function openInspector(nodeId: string) {
+  const utils = render(<InspectorModal nodeId={nodeId} edgeId={null} onClose={vi.fn()} />)
+
+  const dialog = utils.container.querySelector(NODE_INSPECTOR)
+  expect(dialog, 'PRECONDITION: the node inspector dialog must be mounted').not.toBeNull()
+
+  const shell = utils.container.querySelector(INSPECTOR_SHELL)
+  expect(shell, 'PRECONDITION: the InspectorShell must have rendered inside it').not.toBeNull()
+
+  return { ...utils, dialog: dialog as HTMLElement, shell: shell as HTMLElement }
+}
+
+/** The option description editor, bound by its exact placeholder. */
+function descriptionEditor(): HTMLTextAreaElement | null {
+  return screen.queryByPlaceholderText(
+    'What would choosing this option actually mean in practice?',
+  ) as HTMLTextAreaElement | null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seedStore([])
+})
+
+describe('ROADMAP 2.1204 — the absorption note is disclosed as a DRAFTING note', () => {
+  it('⭐ T1 renders the wire sentence on an attributed drafting-note line', () => {
+    seedStore([optionNode(WIRE_NOTE)])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    // The panel really is the survivor's — identity, not a value predicate.
+    expect(within(dialog).getByText(SURVIVOR_LABEL)).toBeTruthy()
+
+    const note = within(dialog).getByTestId('option-drafting-note')
+
+    // The wire sentence, verbatim. No invented copy about what was merged.
+    expect(note.textContent).toContain(WIRE_NOTE)
+
+    // ⭐ AND IT IS ATTRIBUTED. This is the half R2 actually asks for: the user
+    // must be able to tell a drafter wrote this, not them.
+    expect(note.textContent).toContain('Drafted by Olumi')
+  })
+
+  it('⭐ T2 does NOT leave the note squatting in the editable description', () => {
+    seedStore([optionNode(WIRE_NOTE)])
+    openInspector(SURVIVOR_ID)
+
+    // With the note lifted out there is no user description left, so the
+    // description field is genuinely empty and the user is invited to write
+    // one — the prompt the raw note used to suppress.
+    expect(descriptionEditor()).toBeNull()
+    expect(
+      screen.getByText('What would choosing this option actually mean in practice?'),
+    ).toBeTruthy()
+  })
+
+  it('⭐ T3 separates the note from a description the user HAS written', () => {
+    seedStore([optionNode(`${WIRE_NOTE}\nWe would run both squads in parallel.`)])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    const note = within(dialog).getByTestId('option-drafting-note')
+    expect(note.textContent).toContain(WIRE_NOTE)
+    // The user's own prose must NOT be swept into the drafting note.
+    expect(note.textContent).not.toContain('We would run both squads in parallel.')
+
+    const editor = descriptionEditor()
+    expect(editor).not.toBeNull()
+    expect(editor!.value).toBe('We would run both squads in parallel.')
+    expect(editor!.value).not.toContain('Also drafted as:')
+  })
+
+  it('⭐ T4 renders NO drafting-note line when the description carries no note', () => {
+    // The absence claim below is only meaningful because openInspector has
+    // already proven the inspector mounted AND the editor below proves the
+    // description reached this panel.
+    seedStore([optionNode('We would run both squads in parallel.')])
+    const { dialog } = openInspector(SURVIVOR_ID)
+
+    expect(descriptionEditor()!.value).toBe('We would run both squads in parallel.')
+    expect(within(dialog).queryByTestId('option-drafting-note')).toBeNull()
+  })
+
+  it('⭐ T5 SCOPING — a non-option node with the same description gets no note line', () => {
+    seedStore([goalNode(WIRE_NOTE)])
+    const { dialog } = openInspector(GOAL_ID)
+
+    // Positive control: this is genuinely the goal inspector, open and
+    // populated. Without it "no note line" would pass on an empty render.
+    expect(within(dialog).getByText(GOAL_LABEL)).toBeTruthy()
+
+    expect(within(dialog).queryByTestId('option-drafting-note')).toBeNull()
+  })
+
+  it('⭐ T6 editing the description does not DESTROY the absorption trace', () => {
+    seedStore([optionNode(WIRE_NOTE)])
+    openInspector(SURVIVOR_ID)
+
+    // Start typing a description: the empty prompt opens the editor.
+    fireEvent.click(
+      screen.getByText('What would choosing this option actually mean in practice?'),
+    )
+    const editor = descriptionEditor()
+    expect(editor, 'PRECONDITION: clicking the prompt must open the editor').not.toBeNull()
+
+    fireEvent.change(editor!, { target: { value: 'Two hires, starting in Q3.' } })
+    fireEvent.blur(editor!)
+
+    // The committed description carries BOTH: the user's words and the trace.
+    // This case CAN trigger the write-back path — a "does no harm" test whose
+    // fixture cannot reach the transformation asserts nothing (trap 22b).
+    const committed = String(
+      useCanvasStore.getState().nodes.find(n => n.id === SURVIVOR_ID)?.data?.description ?? '',
+    )
+    expect(committed).toContain(WIRE_NOTE)
+    expect(committed).toContain('Two hires, starting in Q3.')
+  })
+})

--- a/src/canvas/ui/inspector-v2/draftingNote.ts
+++ b/src/canvas/ui/inspector-v2/draftingNote.ts
@@ -1,71 +1,125 @@
 /**
- * draftingNote — separates a drafter-authored absorption note from the user's
+ * draftingNote — separates drafter-authored absorption notes from the user's
  * own description.
  *
- * ── WHY THIS EXISTS (ROADMAP 2.1204) ─────────────────────────────────────
- * When CEE's drafter absorbs a rephrase-twin option, it prefixes the surviving
- * option's `description` with `"Also drafted as: <absorbed label>"`. That note
- * is the only user-reachable trace of the merge, and ruling R2 requires the
- * user be able to SEE the absorption happened.
+ * ── THE PRODUCER'S FORMAT, DERIVED AT THE BYTES ──────────────────────────
+ * CEE tip `ae0b4af`, `src/cee/transforms/option-rephrase-merge.ts:459-462`:
  *
- * It arrived rendered — but rendered INSIDE the option's editable description
- * textarea, where it reads as the user's own prose and is destroyed the moment
- * they type their own. This module makes the two separable so the panel can
- * attribute the note and still hand the user an empty description field.
+ *     const alsoDraftedAs = `Also drafted as: ${twin.label}`;
+ *     const appendDescription = (existing) =>
+ *       existing && existing.trim().length > 0
+ *         ? `${existing}\n\n${alsoDraftedAs}`
+ *         : alsoDraftedAs;
  *
- * ── BOUND TO THE KNOWN PREFIX ONLY ───────────────────────────────────────
- * A census of every JSON capture in `closing-witness-20260814/driver/` found
- * option descriptions carrying ONLY this note (12 occurrences, one distinct
- * value, zero carrying anything else). That says what the corpus contained,
- * never what the field admits (trap 12d) — a user can type a description and
- * CEE may emit other content — so the split is anchored to the literal prefix
- * and everything else is treated as the user's, never guessed at.
+ * The note is **APPENDED** to any existing description, separated by a BLANK
+ * LINE, and stands alone only when the description was empty. The enclosing
+ * loop runs **per absorbed twin**, so notes accumulate as a trailing run of
+ * `\n\n`-separated lines.
+ *
+ * ⚠ THE FIRST VERSION OF THIS MODULE CLAIMED CEE *PREFIXES*, AND PARSED WITH
+ * `startsWith`. That was wrong, and inert on every option that already had a
+ * description — a class reachable on a first draft, where V3 `description` is
+ * the drafter's `node.body` (CEE `schema-v3.ts:207`). The corpus it was
+ * written against contained only absorbed options with EMPTY descriptions, the
+ * single class where "whole string" and "leading prefix" coincide, so every
+ * sample agreed with the wrong parser (trap 13d). The producer's join was one
+ * grep away and was never read. This header now states what the producer does;
+ * re-derive it rather than trusting this paragraph.
+ *
+ * ── WHAT WE WRITE BACK ───────────────────────────────────────────────────
+ * `composeDescription` emits the PRODUCER'S format, never a third one. If the
+ * UI invented its own storage shape, the next consumer would have to parse
+ * something no producer emits — and the last round of this work did exactly
+ * that (`note\nbody`, single newline). That legacy form is tolerated on READ
+ * so nothing written by it is stranded, and migrated on the first commit.
+ *
+ * ── KNOWN LIMIT ──────────────────────────────────────────────────────────
+ * A user whose own prose is exactly a line reading `Also drafted as: …` in the
+ * trailing position is re-attributed to Olumi. That is inherent to carrying
+ * provenance inside a free-text field: nothing in the string distinguishes a
+ * drafter's line from a user who typed the same words. The durable fix is a
+ * dedicated wire field, which rides the contract wave with
+ * `OPTION_REPHRASE_ABSORBED`. Pinned by test rather than left to be
+ * rediscovered.
  */
 
-/** The literal the drafter writes. Matched at the START of the description. */
+/** The literal the drafter writes, once per absorbed twin. */
 export const DRAFTING_NOTE_PREFIX = 'Also drafted as: '
+
+/** The producer's block separator — a blank line. */
+const BLOCK_SEPARATOR = '\n\n'
 
 export interface ParsedDescription {
   /**
-   * The drafter's note, VERBATIM from the wire including its prefix, or null
-   * when the description carries none. Rendered as-is: the product must not
-   * invent copy about what was merged.
+   * The drafter's notes, VERBATIM from the wire including their prefix, in
+   * producer order. Empty when the description carries none. Rendered as-is:
+   * the product must not invent copy about what was merged.
    */
-  note: string | null
-  /** What remains after the note — the user's own description. */
+  notes: string[]
+  /** What remains — the user's own description. */
   body: string
 }
 
-/**
- * Splits a raw node description into the drafter's note and the user's body.
- *
- * Only a description that BEGINS with the prefix carries a note, and only its
- * first line is the note — a later line that happens to mention the phrase is
- * the user's prose and stays theirs.
- */
-export function parseDraftingNote(raw: string | null | undefined): ParsedDescription {
-  const text = typeof raw === 'string' ? raw : ''
-  if (!text.startsWith(DRAFTING_NOTE_PREFIX)) return { note: null, body: text }
-
-  const breakAt = text.indexOf('\n')
-  if (breakAt === -1) return { note: text, body: '' }
-
-  return {
-    note: text.slice(0, breakAt),
-    body: text.slice(breakAt + 1).replace(/^\n+/, ''),
-  }
+/** A note block is a SINGLE line that is exactly one `Also drafted as:` note. */
+function isNoteBlock(block: string): boolean {
+  const trimmed = block.trim()
+  return (
+    trimmed.startsWith(DRAFTING_NOTE_PREFIX)
+    && trimmed.length > DRAFTING_NOTE_PREFIX.length
+    && !trimmed.includes('\n')
+  )
 }
 
 /**
- * Rebuilds the stored description from a note and an edited body.
+ * Splits a raw node description into the drafter's notes and the user's body.
  *
- * This is the half that stops the disclosure being DESTRUCTIBLE: the panel
- * edits only the body, and every commit re-attaches the note, so a user
- * writing their own description can no longer silently erase the record that
- * two of their options were merged.
+ * Notes are the maximal run of TRAILING blank-line-separated blocks that are
+ * each a lone `Also drafted as: …` line — which is exactly the set the
+ * producer can have appended. Anything earlier is the user's, including a line
+ * that merely mentions the phrase mid-paragraph.
  */
-export function composeDescription(note: string | null, body: string): string {
+export function parseDraftingNotes(raw: string | null | undefined): ParsedDescription {
+  const text = typeof raw === 'string' ? raw : ''
+  if (!text.trim()) return { notes: [], body: '' }
+
+  const blocks = text.split(BLOCK_SEPARATOR)
+  let firstNote = blocks.length
+  while (firstNote > 0 && isNoteBlock(blocks[firstNote - 1]!)) firstNote -= 1
+
+  if (firstNote < blocks.length) {
+    return {
+      notes: blocks.slice(firstNote).map(b => b.trim()),
+      body: blocks.slice(0, firstNote).join(BLOCK_SEPARATOR).trim(),
+    }
+  }
+
+  // Legacy tolerance: the single-newline LEADING form this UI briefly wrote.
+  // No producer emits it; migrated to the producer's format on first commit.
+  if (text.startsWith(DRAFTING_NOTE_PREFIX)) {
+    const breakAt = text.indexOf('\n')
+    if (breakAt !== -1) {
+      return {
+        notes: [text.slice(0, breakAt).trim()],
+        body: text.slice(breakAt + 1).trim(),
+      }
+    }
+  }
+
+  return { notes: [], body: text }
+}
+
+/**
+ * Rebuilds the stored description from the drafter's notes and an edited body,
+ * in the PRODUCER's format.
+ *
+ * This is the half that stops the disclosure being DESTRUCTIBLE: every surface
+ * that can edit the description edits only the body and recomposes here, so a
+ * user writing their own description can no longer silently erase the record
+ * that two of their options were merged.
+ */
+export function composeDescription(notes: string[], body: string): string {
   const trimmed = body.trim()
-  if (!note) return trimmed
-  return trimmed ? `${note}\n${trimmed}` : note
+  if (notes.length === 0) return trimmed
+  const joined = notes.join(BLOCK_SEPARATOR)
+  return trimmed ? `${trimmed}${BLOCK_SEPARATOR}${joined}` : joined
 }

--- a/src/canvas/ui/inspector-v2/draftingNote.ts
+++ b/src/canvas/ui/inspector-v2/draftingNote.ts
@@ -1,0 +1,71 @@
+/**
+ * draftingNote — separates a drafter-authored absorption note from the user's
+ * own description.
+ *
+ * ── WHY THIS EXISTS (ROADMAP 2.1204) ─────────────────────────────────────
+ * When CEE's drafter absorbs a rephrase-twin option, it prefixes the surviving
+ * option's `description` with `"Also drafted as: <absorbed label>"`. That note
+ * is the only user-reachable trace of the merge, and ruling R2 requires the
+ * user be able to SEE the absorption happened.
+ *
+ * It arrived rendered — but rendered INSIDE the option's editable description
+ * textarea, where it reads as the user's own prose and is destroyed the moment
+ * they type their own. This module makes the two separable so the panel can
+ * attribute the note and still hand the user an empty description field.
+ *
+ * ── BOUND TO THE KNOWN PREFIX ONLY ───────────────────────────────────────
+ * A census of every JSON capture in `closing-witness-20260814/driver/` found
+ * option descriptions carrying ONLY this note (12 occurrences, one distinct
+ * value, zero carrying anything else). That says what the corpus contained,
+ * never what the field admits (trap 12d) — a user can type a description and
+ * CEE may emit other content — so the split is anchored to the literal prefix
+ * and everything else is treated as the user's, never guessed at.
+ */
+
+/** The literal the drafter writes. Matched at the START of the description. */
+export const DRAFTING_NOTE_PREFIX = 'Also drafted as: '
+
+export interface ParsedDescription {
+  /**
+   * The drafter's note, VERBATIM from the wire including its prefix, or null
+   * when the description carries none. Rendered as-is: the product must not
+   * invent copy about what was merged.
+   */
+  note: string | null
+  /** What remains after the note — the user's own description. */
+  body: string
+}
+
+/**
+ * Splits a raw node description into the drafter's note and the user's body.
+ *
+ * Only a description that BEGINS with the prefix carries a note, and only its
+ * first line is the note — a later line that happens to mention the phrase is
+ * the user's prose and stays theirs.
+ */
+export function parseDraftingNote(raw: string | null | undefined): ParsedDescription {
+  const text = typeof raw === 'string' ? raw : ''
+  if (!text.startsWith(DRAFTING_NOTE_PREFIX)) return { note: null, body: text }
+
+  const breakAt = text.indexOf('\n')
+  if (breakAt === -1) return { note: text, body: '' }
+
+  return {
+    note: text.slice(0, breakAt),
+    body: text.slice(breakAt + 1).replace(/^\n+/, ''),
+  }
+}
+
+/**
+ * Rebuilds the stored description from a note and an edited body.
+ *
+ * This is the half that stops the disclosure being DESTRUCTIBLE: the panel
+ * edits only the body, and every commit re-attaches the note, so a user
+ * writing their own description can no longer silently erase the record that
+ * two of their options were merged.
+ */
+export function composeDescription(note: string | null, body: string): string {
+  const trimmed = body.trim()
+  if (!note) return trimmed
+  return trimmed ? `${note}\n${trimmed}` : note
+}

--- a/src/canvas/ui/inspector-v2/editors/OptionAdvancedEditor.tsx
+++ b/src/canvas/ui/inspector-v2/editors/OptionAdvancedEditor.tsx
@@ -10,6 +10,7 @@ import { AdvancedField } from '../shared/AdvancedField'
 import { AdvancedFieldGroup } from '../shared/AdvancedFieldGroup'
 import { typography } from '../../../../styles/typography'
 import { unwrapInterventionValue } from '../../../utils/labelUtils'
+import { parseDraftingNotes, composeDescription } from '../draftingNote'
 
 interface OptionAdvancedEditorProps {
   nodeId: string
@@ -77,10 +78,22 @@ export function OptionAdvancedEditor({ nodeId }: OptionAdvancedEditorProps) {
       <AdvancedFieldGroup title="Metadata">
         <AdvancedField label="Node ID" value={nodeId} type="readonly" />
         <AdvancedField label="Kind" value="option" type="readonly" />
+        {/* ROADMAP 2.1204 — the SECOND path that reaches the description. It
+            bound the raw field and wrote back raw, so a tech-mode user could
+            silently erase a rephrase-absorption note that the main panel had
+            just gone to trouble to protect. Same parse/compose as OptionPanel:
+            a guarantee that holds on only one of its paths is not a guarantee. */}
         <AdvancedField
           label="Description"
-          value={(data?.description as string) ?? ''}
-          onChange={v => mutations.setDescription(v as string)}
+          value={parseDraftingNotes(data?.description as string | undefined).body}
+          onChange={v =>
+            mutations.setDescription(
+              composeDescription(
+                parseDraftingNotes(data?.description as string | undefined).notes,
+                v as string,
+              ),
+            )
+          }
           type="textarea"
           placeholder="Option description"
         />

--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -386,6 +386,16 @@ export const GOAL_STRINGS = {
 // ─── Option panel strings ────────────────────────────────────────
 export const OPTION_STRINGS = {
   impactUnavailable: 'Option impact data unavailable for this analysis run.',
+  /**
+   * ROADMAP 2.1204 — attribution for the drafter's rephrase-absorption note.
+   *
+   * The note's SENTENCE comes from the wire and is rendered verbatim; this is
+   * the attribution that keeps it from reading as the user's own description.
+   * It states authorship and nothing more — the same attribute-without-
+   * endorsing rule the value-provenance labels follow (Paul's ruling: a
+   * provenance label must never become a verdict).
+   */
+  draftingNoteAttribution: 'Drafted by Olumi',
 } as const
 
 // --- Goal constraint UI copy -------------------------------------------

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -7,7 +7,7 @@
 import { memo, useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { Sparkles } from 'lucide-react'
 import { useCanvasStore } from '../../../store'
-import { parseDraftingNote, composeDescription } from '../draftingNote'
+import { parseDraftingNotes, composeDescription } from '../draftingNote'
 import type { NodeType, OptionNodeData } from '../../../domain/nodes'
 import { InspectorCoaching } from '../shared/InspectorCoaching'
 import { useNodeDisplayMetadata } from '../../../hooks/useNodeDisplayMetadata'
@@ -66,14 +66,17 @@ export const OptionPanel = memo(function OptionPanel({
   const mutations = useNodeMutations(nodeId ?? '')
   const displayMetadata = useNodeDisplayMetadata(nodeId ?? '', 'option')
 
-  // ROADMAP 2.1204 — the drafter's rephrase-absorption note is separated from
-  // the user's description. It rides the wire prefixed onto `description`, so
-  // before this split it rendered inside the editable textarea: unattributed
-  // (indistinguishable from the user's own prose) and destroyed the moment the
-  // user typed over it. `note` is rendered as an attributed line below; only
-  // `body` is editable, and every commit recomposes the two.
-  const { note: draftingNote, body: descriptionBody } = parseDraftingNote(
-    node?.data?.description as string | undefined,
+  // ROADMAP 2.1204 — the drafter's rephrase-absorption notes are separated
+  // from the user's description. CEE APPENDS `\n\n<note>` per absorbed twin
+  // (option-rephrase-merge.ts:459-462), so before this split they rendered
+  // inside the editable textarea: unattributed (indistinguishable from the
+  // user's own prose) and destroyed the moment the user typed over them.
+  // `notes` render as attributed lines below; only `body` is editable, and
+  // every commit recomposes the two in the producer's format.
+  const rawDescription = node?.data?.description as string | undefined
+  const { notes: draftingNotes, body: descriptionBody } = useMemo(
+    () => parseDraftingNotes(rawDescription),
+    [rawDescription],
   )
 
   // Description — EmptyDescriptionPrompt pattern
@@ -81,8 +84,8 @@ export const OptionPanel = memo(function OptionPanel({
   const [isEditingDescription, setIsEditingDescription] = useState(false)
 
   const commitDescription = useCallback(
-    (next: string) => mutations.setDescription(composeDescription(draftingNote, next)),
-    [mutations, draftingNote],
+    (next: string) => mutations.setDescription(composeDescription(draftingNotes, next)),
+    [mutations, draftingNotes],
   )
 
   // Dropdown state for "Add a change"
@@ -236,7 +239,7 @@ export const OptionPanel = memo(function OptionPanel({
             is the wire's, verbatim; the attribution is what tells the reader a
             drafter wrote it rather than them. Option panel only: no other node
             type carries a drafter absorption note. */}
-        {draftingNote && (
+        {draftingNotes.length > 0 && (
           <div
             className="mb-2 flex items-start gap-1.5"
             data-testid="option-drafting-note"
@@ -247,7 +250,7 @@ export const OptionPanel = memo(function OptionPanel({
                 {OPTION_STRINGS.draftingNoteAttribution}
               </span>
               {' — '}
-              {draftingNote}
+              {draftingNotes.join('; ')}
             </p>
           </div>
         )}

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -5,7 +5,9 @@
  */
 
 import { memo, useState, useMemo, useCallback, useRef, useEffect } from 'react'
+import { Sparkles } from 'lucide-react'
 import { useCanvasStore } from '../../../store'
+import { parseDraftingNote, composeDescription } from '../draftingNote'
 import type { NodeType, OptionNodeData } from '../../../domain/nodes'
 import { InspectorCoaching } from '../shared/InspectorCoaching'
 import { useNodeDisplayMetadata } from '../../../hooks/useNodeDisplayMetadata'
@@ -64,9 +66,24 @@ export const OptionPanel = memo(function OptionPanel({
   const mutations = useNodeMutations(nodeId ?? '')
   const displayMetadata = useNodeDisplayMetadata(nodeId ?? '', 'option')
 
+  // ROADMAP 2.1204 — the drafter's rephrase-absorption note is separated from
+  // the user's description. It rides the wire prefixed onto `description`, so
+  // before this split it rendered inside the editable textarea: unattributed
+  // (indistinguishable from the user's own prose) and destroyed the moment the
+  // user typed over it. `note` is rendered as an attributed line below; only
+  // `body` is editable, and every commit recomposes the two.
+  const { note: draftingNote, body: descriptionBody } = parseDraftingNote(
+    node?.data?.description as string | undefined,
+  )
+
   // Description — EmptyDescriptionPrompt pattern
-  const [description, setDescription] = useState(String(node?.data?.description ?? ''))
+  const [description, setDescription] = useState(descriptionBody)
   const [isEditingDescription, setIsEditingDescription] = useState(false)
+
+  const commitDescription = useCallback(
+    (next: string) => mutations.setDescription(composeDescription(draftingNote, next)),
+    [mutations, draftingNote],
+  )
 
   // Dropdown state for "Add a change"
   const [showDropdown, setShowDropdown] = useState(false)
@@ -215,12 +232,32 @@ export const OptionPanel = memo(function OptionPanel({
           </div>
         )}
 
+        {/* ROADMAP 2.1204 — the absorption disclosure, attributed. The sentence
+            is the wire's, verbatim; the attribution is what tells the reader a
+            drafter wrote it rather than them. Option panel only: no other node
+            type carries a drafter absorption note. */}
+        {draftingNote && (
+          <div
+            className="mb-2 flex items-start gap-1.5"
+            data-testid="option-drafting-note"
+          >
+            <Sparkles size={12} className="text-info mt-0.5 shrink-0" aria-hidden="true" />
+            <p className={`${typography.panelMeta} text-text-light`}>
+              <span className="font-medium text-text-body">
+                {OPTION_STRINGS.draftingNoteAttribution}
+              </span>
+              {' — '}
+              {draftingNote}
+            </p>
+          </div>
+        )}
+
         {description || isEditingDescription ? (
           <textarea
             value={description}
             onChange={e => setDescription(e.target.value)}
             onBlur={() => {
-              mutations.setDescription(description)
+              commitDescription(description)
               if (!description.trim()) setIsEditingDescription(false)
             }}
             autoFocus={isEditingDescription && !description}


### PR DESCRIPTION
## ROADMAP 2.1204 — the rephrase-absorption disclosure, attributed and non-destructible

When CEE's drafter (#953) absorbs a rephrase-twin option, the survivor's `description` carries
`Also drafted as: <absorbed label>`. Ruling **R2** (Paul): auto-merge is correct, but the user must
be able to SEE it happened.

> **Revised after review (head `f6531b7a`).** The first round of this PR asserted that CEE
> *prefixes* the note and parsed with `startsWith`. **That was wrong** — see F1 below. The claim has
> been corrected here and in `draftingNote.ts`; left standing it would have become a
> hand-maintained mirror the next session inherited.

---

## ⭐⭐ Corrected premise 1 — the string was never invisible. The probe was blind.

The row was minted from the closing battery's **DOM-2** arm, which reported the trace *"appears
NOWHERE in the rendered page"*. **False, and the refutation sits in DOM-2's own output directory**:
its screenshot (`closing-witness-20260814/driver/dom-postbatch/dom2-final/d2-inspector.png`), taken
by the failing arm on the failing draw, shows the sentence rendering in the option inspector.

DOM-2 scraped with `page.locator('body').innerText()` (`dom-driver.mjs:570`). `OptionPanel` renders
the description into a **React-controlled `<textarea>`**, whose `value` is a DOM *property* with no
child text node — visible to a human, **zero text content**. Both DOM-2 controls fired and neither
could ever have caught this: they read a canvas label and `PanelGroup` headings, both ordinary text
nodes (trap 13e — *a control proves the probe sees something, never that it sees the thing under
test*).

**The real defect is attribution and destruction**: the note sat inside the user's own editable
description field, unattributed, and was erased the moment they typed over it.

## ⭐⭐ Corrected premise 2 (F1, from review) — CEE APPENDS. It does not prefix.

Re-derived at CEE tip `ae0b4af`, `src/cee/transforms/option-rephrase-merge.ts:459-462`:

```ts
const alsoDraftedAs = `Also drafted as: ${twin.label}`;
const appendDescription = (existing) =>
  existing && existing.trim().length > 0 ? `${existing}\n\n${alsoDraftedAs}` : alsoDraftedAs;
```

The note goes at the **END**, blank-line separated, standing alone only when the description was
empty — and the loop runs **per absorbed twin**, so notes accumulate as a trailing run.

My `startsWith` parser was therefore **inert on every option that already had a description**, a
class reachable on a first draft (V3 `description` = the drafter's `node.body`, `schema-v3.ts:207`).

**Why my corpus could not discriminate (trap 13d):** every absorbed option in the closing-witness
captures had an **empty** description — the one class where "whole string" and "leading prefix"
coincide, so all 12 samples agree with the wrong parser. I checked what the corpus *contained*, not
what it *excluded* — the exact caveat I had written into my own module header. The producer's join
was one grep away.

## What shipped

- **`draftingNote.ts`** — `parseDraftingNotes` takes the maximal run of TRAILING blank-line
  separated blocks that are each a lone `Also drafted as: …` line, exactly the set the producer can
  append. `composeDescription` writes back **in the producer's format**, never a third shape. The
  single-newline form the first round invented is tolerated on read and migrated on first commit.
- **`OptionPanel.tsx`** — the notes render on a distinct attributed line
  (`data-testid="option-drafting-note"`): wire sentences **verbatim**, prefixed by
  **"Drafted by Olumi"**. Attribution only, never endorsement, per the existing provenance-label
  rule. Option panel only.
- **`OptionAdvancedEditor.tsx` (F2)** — the tech-mode editor bound and wrote back the *raw*
  description, so a tech-mode user could still erase the note. Routed through the same
  parse/compose. My earlier "can no longer be erased" claim was over-broad; every path that reaches
  the marking is now enumerated and pinned.
- **F5 fixed, not disclosed** — because the block model matches the producer, stacked absorptions
  are attributed in full.

## ⚠ Known limit (F3), disclosed

A user whose own prose is a trailing line reading `Also drafted as: …` is re-attributed to Olumi.
Inherent to carrying provenance inside a free-text field — nothing in the string distinguishes a
drafter's line from a user who typed the same words. **Pinned by T11** so it REDs if the boundary
moves in either direction. The durable fix is a dedicated wire field, riding the contract wave with
`OPTION_REPHRASE_ABSORBED` (rowed). F4 (500-char cap on re-attachment at snapshot import) is rowed
separately.

## Evidence

`olumi-docs/PHASE0-EVIDENCE-2026-07-28/rephrase-disclosure-render-2026-08-14/`

**RED at the pre-fix parser** — `Tests 6 failed | 5 passed (11)`. T7 (described option + trailing
note) and T8 (stacked): `Unable to find [data-testid="option-drafting-note"]`. T9: stored
`'Two hires, starting in Q3.'` — **the note destroyed**. T10: tech-mode editor showed raw
note+body. T1/T2/T11/T4/T5 passed — the empty-description class, which is why the original corpus
was blind. **After the fix: 11/11.**

**Mutant kit** — worktree outside the repo root, isolation proven by **sentinel write test**
(distinct inodes; source byte-identical), `HEAD`-relative restores, applied-check scoped to `src/`,
collect-count asserted at 11 by name every run:

| run | applied | RED |
|---|---|---|
| CONTROL (leading) | **0** | — |
| **M1** render deleted | 1 | T1 T7 T8 T11 T12 |
| **M2** note on a NON-OPTION node | 1 | **T5** |
| **M3** panel write-back reverted | 1 | T6 T9 T12 |
| **M4** trailing-form parse disabled (**F1 restored**) | 1 | T1 T2 T6 T7 T8 T9 T10 T11 |
| **M5** tech-mode editor reverted to raw (**F2 restored**) | 1 | **T10** |
| **M6** compose emits a non-producer format | 1 | T6 T9 T12 |
| CONTROL (trailing) | **0** | — |

**M3 vs M5 is a discriminating pair across the two write paths** — reverting the panel write-back
REDs T6/T9/T12 with T10 green; reverting the tech-mode editor REDs T10 alone. Closing one path
while reopening the other cannot pass. **M2 still REDs T5 alone** (scoping binds to node TYPE).
**M4 is the F1 regression mutant** — restoring the defect REDs 8 tests.

The spec mounts **`InspectorModal`** (the deployed v2 path) and asserts the inspector is **OPEN** as
an explicit precondition in every test; T10 reaches the tech-mode editor through the real controls.

**Gates:** `pnpm typecheck` PASSED (ratchet 2485 vs baseline 2485) · `pnpm lint` 0 errors, hooks
ratchet exactly at baseline (targeted lint on the three touched files: 2 warnings, both
pre-existing) · affected surface **114 files / 1278 tests passed**. No `--update-baseline` prompt
offered or accepted. **Zero file overlap** with all 20 open UI PRs.

## Acceptance

The closing battery's **DOM-2 arm re-run flips FAIL → PASS on a fresh draw** — but the arm itself
must be corrected first or the result means nothing: it decides on `body.innerText()`, which cannot
see a textarea's value and would now report PASS *by accident*, while remaining blind to whether the
note was lifted out of the description or merely duplicated beside it. The arm should (1) assert the
attributed line by its testid, (2) assert the description textarea's **`value` property** does not
carry the literal, and (3) keep a control proving the textarea was found at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
