### PR TITLE
feat(collab): render where views differ, and let a participant attach evidence

### DIFF
--- a/netlify/edge-functions/collab-proxy.ts
+++ b/netlify/edge-functions/collab-proxy.ts
@@ -131,6 +131,23 @@ const ALLOWED_TARGETS: readonly RegExp[] = [
   /^\/collab\/v1\/packet\/[^/]+$/,
   /^\/collab\/v1\/packet\/[^/]+\/events$/,
   /^\/collab\/v1\/packet\/[^/]+\/reveal$/,
+  /**
+   * D2 (14 Aug 2026) — the DISAGREEMENT read, both audiences.
+   *
+   * ⚠ THESE TWO LINES ARE THE DIFFERENCE BETWEEN THIS CAPABILITY WORKING AND
+   * SHIPPING DARK, and the allowlist is exactly the kind of derived-then-frozen
+   * list that goes stale silently: CEE can grow a route, the UI can call it, both
+   * halves can be green, and every request still 404s HERE with no error anywhere
+   * that names the cause. It is listed second in the estate's chronic-failure
+   * list for a reason.
+   *
+   * Exposes NOTHING new to either audience. The owner already reads `/reveal`;
+   * the participant already reads `/packet/:id/reveal`. This response is the same
+   * positions plus the evidence those same participants wrote, and CEE refuses it
+   * on an open round through the reveal's own gate.
+   */
+  /^\/collab\/v1\/rounds\/[^/]+\/disagreement$/,
+  /^\/collab\/v1\/packet\/[^/]+\/disagreement$/,
 ]
 
 function isAllowedTarget(pathname: string): boolean {

--- a/src/collab/DisagreementBody.tsx
+++ b/src/collab/DisagreementBody.tsx
@@ -1,0 +1,226 @@
+/**
+ * COLLAB — WHY TWO VIEWS DIFFER, rendered structurally.
+ *
+ * The reveal answers "what did everyone say?". This answers "where do you
+ * differ, on what basis, and what should you ask about it?" — which is the
+ * difference between a list of numbers and a shared piece of reasoning.
+ *
+ * ── EVERY SENTENCE OF REASONING COPY COMES FROM CEE ───────────────────────
+ * `headline` and `question` are rendered VERBATIM from the response. This
+ * component composes no interpretation of its own, and that is a hard rule
+ * rather than a style preference: those strings are pinned by a CEE suite that
+ * asserts, across every string that module can emit, that none of them averages,
+ * ranks or names a winner. Copy written HERE would sit outside that guarantee
+ * and nothing in this repo would notice it drift.
+ *
+ * ⚠ If a designer wants different words, they change `disagreement-copy.ts` in
+ * CEE, where the guard is. Do not "improve" them locally.
+ *
+ * ── AND WHAT THIS COMPONENT MUST NEVER GROW ───────────────────────────────
+ * No mean, no midpoint, no "recommended", no consensus line, no ordering of
+ * people by how well-supported their view looks. `spread` is rendered as two
+ * attributed endpoints and a distance, never as a single number standing in for
+ * the positions. A lone dissenter renders exactly like anyone else.
+ */
+
+import { AlertTriangle, ExternalLink, Quote } from 'lucide-react'
+
+import { typography } from '../styles/typography'
+import type {
+  DisagreementEvidence,
+  DisagreementTarget,
+  DisagreementView,
+} from './collabService'
+
+const CARD = 'rounded-[20px] border border-panel-border bg-panel p-6 shadow-1 sm:p-8'
+
+/**
+ * ⚠ A SECOND, INDEPENDENT SCHEME CHECK. CEE already validates evidence URLs to
+ * http/https with the URL parser and stores the normalised form, so this is
+ * defence in depth — and it is worth having precisely because the failure it
+ * guards is silent: a stored `javascript:` href renders as an ordinary link
+ * carrying a colleague's name, and the person who clicks it has every reason to
+ * trust it. Two independent gates on a stored-XSS path is the correct number
+ * when one of them lives in another service on another deploy cadence.
+ *
+ * Returns null for anything it will not render as a link. The body text is
+ * still shown — the evidence is not lost, only its link.
+ */
+export function safeHref(url: string | null): string | null {
+  if (url === null || url === '') return null
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null
+  } catch {
+    return null
+  }
+}
+
+function EvidenceCard({ evidence }: { evidence: DisagreementEvidence }): JSX.Element {
+  const href = safeHref(evidence.url)
+  return (
+    <li
+      data-testid={`disagreement-evidence-${evidence.event_id}`}
+      data-stance={evidence.stance}
+      className={`${typography.body} rounded-md border border-panel-border bg-canvas p-4 text-text-body`}
+    >
+      {/* ⭐ ATTRIBUTION FIRST, then what it does, then whose position it is
+          about. The author label is the SERVER-resolved one (pseudonymised if
+          the person has been redacted), never an id this bundle holds. */}
+      <p className={typography.bodySmall}>
+        <strong className="font-semibold text-text-header">{evidence.author_label}</strong>{' '}
+        <span className="text-text-light">
+          {evidence.stance_phrase}{' '}
+          {evidence.about_label !== null
+            ? `${evidence.about_label}’s view`
+            : 'this factor'}
+        </span>
+      </p>
+      <p className="mt-2 flex gap-2 text-text-body">
+        <Quote className="mt-1 h-3.5 w-3.5 shrink-0 text-text-light" aria-hidden />
+        {/* The person's own words, verbatim. */}
+        <span data-testid={`disagreement-evidence-body-${evidence.event_id}`}>{evidence.body}</span>
+      </p>
+      {href !== null && (
+        <a
+          data-testid={`disagreement-evidence-link-${evidence.event_id}`}
+          href={href}
+          // `noopener` is the security half (a target=_blank opener can navigate
+          // this tab); `noreferrer` keeps a private staging URL out of the
+          // destination's logs.
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${typography.bodySmall} mt-2 inline-flex items-center gap-1 text-text-header underline`}
+        >
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          Open the source
+        </a>
+      )}
+      {evidence.url !== null && href === null && (
+        // Visible, not swallowed. Somebody attached a link this product will not
+        // open, and the honest thing is to say so rather than silently drop it.
+        <p className={`${typography.bodySmall} mt-2 text-text-light`}>
+          A link was attached that cannot be opened safely, so it is not shown.
+        </p>
+      )}
+    </li>
+  )
+}
+
+function TargetSection({ row }: { row: DisagreementTarget }): JSX.Element {
+  return (
+    <section data-testid={`disagreement-target-${row.target.id}`} className={`${CARD} mt-6`}>
+      <h2 className={`${typography.h4} text-text-header`}>
+        {row.label !== '' ? row.label : row.target.id}
+      </h2>
+
+      {/* CEE's words, verbatim. */}
+      <p
+        data-testid={`disagreement-headline-${row.target.id}`}
+        data-shape={row.shape}
+        className={`${typography.bodySmall} mt-2 text-text-light`}
+      >
+        {row.headline}
+      </p>
+
+      {row.model_value_at_version !== null && (
+        <p className={`${typography.bodySmall} mt-1 text-text-light`}>
+          The model held {row.model_value_at_version} for this when the round opened.
+        </p>
+      )}
+
+      {row.spread !== null && (
+        // TWO ENDPOINTS AND A DISTANCE. Deliberately not "the average is X" and
+        // deliberately not a single bar with a midpoint marker: both would put a
+        // number on screen that nobody in the room actually said.
+        <p
+          data-testid={`disagreement-spread-${row.target.id}`}
+          className={`${typography.bodySmall} mt-1 text-text-light`}
+        >
+          The answers run from {row.spread.low} to {row.spread.high}.
+        </p>
+      )}
+
+      <ul className="mt-4 space-y-3">
+        {row.positions.map((p) => (
+          <li
+            key={p.participant_id}
+            data-testid={`disagreement-position-${p.participant_id}`}
+            data-pole={p.pole ?? 'none'}
+            className={`${typography.body} rounded-md border border-panel-border p-4 text-text-body`}
+          >
+            <strong className="font-semibold text-text-header">{p.display_label}</strong>
+            {p.kind === 'declined' ? (
+              <span className="text-text-light"> chose not to answer this one.</span>
+            ) : (
+              <>
+                <span data-testid={`disagreement-value-${p.participant_id}`}> {p.value}</span>
+                {/* ⭐ THE STATED BASIS IS THE POINT OF THIS SURFACE. Where the
+                    reveal shows it as an aside, here it is the thing being
+                    compared — and its ABSENCE is called out, because a position
+                    nobody explained is the one you cannot interrogate. */}
+                {p.stated_basis !== null && p.stated_basis !== '' ? (
+                  <p
+                    data-testid={`disagreement-basis-${p.participant_id}`}
+                    className={`${typography.bodySmall} mt-2 text-text-body`}
+                  >
+                    &ldquo;{p.stated_basis}&rdquo;
+                  </p>
+                ) : (
+                  <p
+                    data-testid={`disagreement-no-basis-${p.participant_id}`}
+                    className={`${typography.bodySmall} mt-2 text-text-light`}
+                  >
+                    No reason given.
+                  </p>
+                )}
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {row.evidence.length > 0 && (
+        <div className="mt-5">
+          <h3 className={`${typography.bodySmall} font-semibold text-text-header`}>
+            Evidence people attached
+          </h3>
+          <ul className="mt-2 space-y-3">
+            {row.evidence.map((e) => (
+              <EvidenceCard key={e.event_id} evidence={e} />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* CEE's question, verbatim, last — after the reader has the positions it
+          refers to. Absent when there is nothing to interrogate: a surface that
+          always has something to say teaches people to stop reading it. */}
+      {row.question !== null && (
+        <p
+          role="note"
+          data-testid={`disagreement-question-${row.target.id}`}
+          className={`${typography.body} mt-5 flex gap-2 rounded-md border border-panel-border bg-canvas p-4 text-text-body`}
+        >
+          <AlertTriangle className="mt-1 h-4 w-4 shrink-0 text-text-light" aria-hidden />
+          <span>{row.question}</span>
+        </p>
+      )}
+    </section>
+  )
+}
+
+export function DisagreementBody({ view }: { view: DisagreementView }): JSX.Element {
+  return (
+    <div data-testid="collab-disagreement">
+      <h1 className={`${typography.h2} text-text-header`}>Where you differ</h1>
+      <p className={`${typography.body} mt-3 text-text-body`}>
+        These are the positions as they were given, with the reasons each person stated. They
+        are shown side by side and are not combined into a single number.
+      </p>
+      {view.per_target.map((row) => (
+        <TargetSection key={row.target.id} row={row} />
+      ))}
+    </div>
+  )
+}

--- a/src/collab/__tests__/disagreementBody.spec.tsx
+++ b/src/collab/__tests__/disagreementBody.spec.tsx
@@ -1,0 +1,306 @@
+/**
+ * COLLAB — the disagreement surface, and the evidence request shape.
+ *
+ * ── WHAT THESE TESTS ARE ACTUALLY FOR ─────────────────────────────────────
+ * Two failure modes, neither of which a type would catch:
+ *
+ * 1. THE UI COMPOSES ITS OWN REASONING COPY. `headline` and `question` are
+ *    pinned in CEE by a suite that proves they never average, rank or name a
+ *    winner. A component that rewrote or "improved" them locally would sit
+ *    outside that guarantee silently. The tests below assert the rendered text
+ *    IS the served string, by identity.
+ * 2. A DANGEROUS URL IS RENDERED AS A LINK. CEE validates the scheme, but this
+ *    is a stored-XSS path on a bearer-token surface across two services with two
+ *    deploy cadences, so the client gate is independently load-bearing.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { DisagreementBody, safeHref } from '../DisagreementBody'
+import { attachEvidence } from '../collabService'
+import type { DisagreementTarget, DisagreementView } from '../collabService'
+
+vi.mock('../participantToken', () => ({
+  getParticipantToken: () => 'ptoken-for-tests',
+}))
+
+const GRACE_ID = '55555555-5555-4555-8555-555555555555'
+const ADA_ID = '66666666-6666-4666-8666-666666666666'
+const TARGET_ID = 'fac_churn_risk'
+
+function target(overrides: Partial<DisagreementTarget> = {}): DisagreementTarget {
+  return {
+    target: { kind: 'factor', id: TARGET_ID },
+    label: 'Churn risk after a price rise',
+    model_value_at_version: 0.5,
+    shape: 'split',
+    answering_participants: 2,
+    distinct_values: 2,
+    spread: { low: 0.2, high: 0.85, width: 0.65 },
+    positions: [
+      {
+        participant_id: GRACE_ID,
+        display_label: 'Grace',
+        value: 0.85,
+        stated_basis: 'we lost 8% last time',
+        confidence: null,
+        kind: 'belief_submitted',
+        pole: 'high',
+      },
+      {
+        participant_id: ADA_ID,
+        display_label: 'Ada',
+        value: 0.2,
+        stated_basis: null,
+        confidence: null,
+        kind: 'belief_submitted',
+        pole: 'low',
+      },
+    ],
+    positions_with_stated_basis: 1,
+    evidence: [
+      {
+        event_id: 'evt-1',
+        authored_by: ADA_ID,
+        author_label: 'Ada',
+        stance: 'challenges',
+        stance_phrase: 'challenges',
+        kind: 'link',
+        body: 'Renewal data for the last three rises.',
+        url: 'https://example.com/renewals',
+        about_participant_id: GRACE_ID,
+        about_label: 'Grace',
+        created_at: '2026-08-14T11:00:00.000Z',
+      },
+    ],
+    headline: 'SERVED-HEADLINE-SENTINEL',
+    question: 'SERVED-QUESTION-SENTINEL',
+    ...overrides,
+  }
+}
+
+const view = (t: DisagreementTarget = target()): DisagreementView => ({
+  round_id: 'round-1',
+  graph_version_ref: 'mv-1',
+  per_target: [t],
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('the reasoning copy is rendered, never composed', () => {
+  it('renders the served headline verbatim', () => {
+    render(<DisagreementBody view={view()} />)
+    // ⭐ SENTINEL STRINGS. A component that generated its own sentence would
+    // still render something plausible and would fail here — which is the whole
+    // point. Asserting "some text is present" would pass on locally-authored
+    // copy and prove nothing.
+    expect(screen.getByTestId(`disagreement-headline-${TARGET_ID}`)).toHaveTextContent(
+      'SERVED-HEADLINE-SENTINEL',
+    )
+  })
+
+  it('renders the served question verbatim', () => {
+    render(<DisagreementBody view={view()} />)
+    expect(screen.getByTestId(`disagreement-question-${TARGET_ID}`)).toHaveTextContent(
+      'SERVED-QUESTION-SENTINEL',
+    )
+  })
+
+  it('renders NO question block when the server sent none', () => {
+    // The discriminating twin. Absence must be absence — a component that
+    // substituted a filler question when the server declined to ask one would
+    // pass the test above and fail this.
+    render(<DisagreementBody view={view(target({ question: null }))} />)
+    expect(screen.queryByTestId(`disagreement-question-${TARGET_ID}`)).toBeNull()
+  })
+})
+
+describe('positions', () => {
+  it('shows each person’s stated basis in their own words', () => {
+    render(<DisagreementBody view={view()} />)
+    expect(screen.getByTestId(`disagreement-basis-${GRACE_ID}`)).toHaveTextContent(
+      'we lost 8% last time',
+    )
+  })
+
+  it('calls out a position with no stated basis rather than hiding it', () => {
+    render(<DisagreementBody view={view()} />)
+    // Ada gave a number and no reason. The un-interrogable position is exactly
+    // the one this surface must not let pass unremarked.
+    expect(screen.getByTestId(`disagreement-no-basis-${ADA_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`disagreement-basis-${ADA_ID}`)).toBeNull()
+  })
+
+  it('marks poles from the SERVED value, per participant', () => {
+    render(<DisagreementBody view={view()} />)
+    expect(screen.getByTestId(`disagreement-position-${GRACE_ID}`)).toHaveAttribute(
+      'data-pole',
+      'high',
+    )
+    expect(screen.getByTestId(`disagreement-position-${ADA_ID}`)).toHaveAttribute(
+      'data-pole',
+      'low',
+    )
+  })
+
+  it('renders the range as two endpoints, never as one number', () => {
+    render(<DisagreementBody view={view()} />)
+    const spread = screen.getByTestId(`disagreement-spread-${TARGET_ID}`)
+    expect(spread).toHaveTextContent('0.2')
+    expect(spread).toHaveTextContent('0.85')
+    // ⚠ 0.525 is the midpoint of this fixture. Its appearance anywhere would
+    // mean the surface had invented a number nobody in the room said.
+    expect(document.body.textContent).not.toContain('0.525')
+  })
+
+  it('never renders aggregate language', () => {
+    render(<DisagreementBody view={view()} />)
+    const text = (document.body.textContent ?? '').toLowerCase()
+    for (const banned of ['average', 'median', 'consensus', 'recommended', 'winner', 'midpoint']) {
+      expect(text).not.toContain(banned)
+    }
+  })
+})
+
+describe('evidence', () => {
+  it('attributes evidence to the server-resolved author and names whose view it is about', () => {
+    render(<DisagreementBody view={view()} />)
+    const card = screen.getByTestId('disagreement-evidence-evt-1')
+    expect(card).toHaveTextContent('Ada')
+    expect(card).toHaveTextContent('challenges')
+    expect(card).toHaveTextContent('Grace')
+    expect(card).toHaveAttribute('data-stance', 'challenges')
+  })
+
+  it('renders the author’s words verbatim', () => {
+    render(<DisagreementBody view={view()} />)
+    expect(screen.getByTestId('disagreement-evidence-body-evt-1')).toHaveTextContent(
+      'Renewal data for the last three rises.',
+    )
+  })
+
+  it('renders an https link with noopener noreferrer', () => {
+    render(<DisagreementBody view={view()} />)
+    const link = screen.getByTestId('disagreement-evidence-link-evt-1')
+    expect(link).toHaveAttribute('href', 'https://example.com/renewals')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
+describe('safeHref — the client half of the stored-XSS gate', () => {
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'file:///etc/passwd',
+    'not a url at all',
+  ])('refuses %s', (url) => {
+    expect(safeHref(url)).toBeNull()
+  })
+
+  it.each([
+    ['https://example.com/a', 'https://example.com/a'],
+    ['http://example.com/b', 'http://example.com/b'],
+  ])('accepts %s', (url, expected) => {
+    // The contrast control: proves the refusals above are about the SCHEME and
+    // not a function that returns null for everything.
+    expect(safeHref(url)).toBe(expected)
+  })
+
+  it('does not render a dangerous URL as a link, and says so', () => {
+    const t = target()
+    const withBadUrl = target({
+      evidence: [{ ...t.evidence[0], url: 'javascript:alert(1)' }],
+    })
+    render(<DisagreementBody view={view(withBadUrl)} />)
+    expect(screen.queryByTestId('disagreement-evidence-link-evt-1')).toBeNull()
+    // The BODY still renders — the evidence is not lost, only its link. And the
+    // drop is disclosed rather than silent.
+    expect(screen.getByTestId('disagreement-evidence-body-evt-1')).toHaveTextContent(
+      'Renewal data',
+    )
+    expect(screen.getByTestId('disagreement-evidence-evt-1')).toHaveTextContent(
+      'cannot be opened safely',
+    )
+    expect(document.body.innerHTML).not.toContain('javascript:')
+  })
+})
+
+describe('attachEvidence request shape', () => {
+  async function capture(): Promise<{ url: string; body: Record<string, unknown> }> {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ authored_by: GRACE_ID, event_id: 'e1' }), { status: 201 }),
+      )
+    await attachEvidence('round-1', {
+      targetId: TARGET_ID,
+      targetKind: 'factor',
+      kind: 'link',
+      body: 'Renewal data for the last three rises.',
+      url: 'https://example.com/renewals',
+      stance: 'challenges',
+      aboutParticipantId: GRACE_ID,
+    })
+    const call = spy.mock.calls[0]
+    return {
+      url: String(call[0]),
+      body: JSON.parse(String((call[1] as RequestInit).body)) as Record<string, unknown>,
+    }
+  }
+
+  it('posts to the shared events endpoint, not a second one', async () => {
+    const { url } = await capture()
+    expect(url).toBe('/bff/collab/packet/round-1/events')
+  })
+
+  it('carries NO provenance claim of any kind', async () => {
+    // ⭐ INV-F FROM THE CLIENT SIDE. The server REFUSES a smuggled
+    // `authored_by`/`provenance` rather than ignoring it, so a client that sent
+    // one would break every attach — but the reason to assert it here is that a
+    // well-meaning "include the author so the optimistic render is right" change
+    // looks entirely reasonable in review.
+    const { body } = await capture()
+    const evidence = body.evidence as Record<string, unknown>
+    expect(Object.keys(body).sort()).toEqual(['belief', 'evidence', 'kind', 'target'])
+    expect(Object.keys(evidence).sort()).toEqual([
+      'about_participant_id',
+      'body',
+      'kind',
+      'stance',
+      'url',
+    ])
+    expect(evidence).not.toHaveProperty('authored_by')
+    expect(body).not.toHaveProperty('provenance')
+  })
+
+  it('sends the words verbatim and carries no belief', async () => {
+    const { body } = await capture()
+    expect(body.belief).toBeNull()
+    expect((body.evidence as Record<string, unknown>).body).toBe(
+      'Renewal data for the last three rises.',
+    )
+  })
+
+  it('sends the participant token as a header, never in the URL', async () => {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 201 }))
+    await attachEvidence('round-1', {
+      targetId: TARGET_ID,
+      targetKind: 'factor',
+      kind: 'note',
+      body: 'x',
+      url: null,
+      stance: 'supports',
+      aboutParticipantId: null,
+    })
+    const [url, init] = spy.mock.calls[0]
+    expect(String(url)).not.toContain('ptoken-for-tests')
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers['x-collab-participant-token']).toBe('ptoken-for-tests')
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -95,6 +95,69 @@ export interface RoundRosterView {
   }>
 }
 
+/* ── the disagreement view (CEE `DisagreementView`) ──────────────────────── */
+
+export type DivergenceShape = 'no_answers' | 'single_view' | 'aligned' | 'split'
+export type EvidenceStance = 'supports' | 'challenges' | 'qualifies'
+
+export interface DisagreementPosition {
+  participant_id: string
+  display_label: string
+  value: number | null
+  /** The person's own words for why. Verbatim — render as given. */
+  stated_basis: string | null
+  confidence: number | null
+  kind: string
+  /** An end of the range, or null. NOT a ranking — ties are both marked. */
+  pole: 'low' | 'high' | null
+}
+
+export interface DisagreementEvidence {
+  event_id: string
+  /** The SERVER stamp. Never rendered from a client-held id. */
+  authored_by: string
+  author_label: string
+  stance: EvidenceStance
+  /** The fixed word for the stance, chosen by CEE, never by this bundle. */
+  stance_phrase: string
+  kind: 'note' | 'link'
+  body: string
+  /** http/https only — validated and normalised server-side at append time. */
+  url: string | null
+  about_participant_id: string | null
+  about_label: string | null
+  created_at: string
+}
+
+export interface DisagreementTarget {
+  target: { kind: 'factor' | 'edge'; id: string }
+  label: string
+  model_value_at_version: number | null
+  shape: DivergenceShape
+  answering_participants: number
+  distinct_values: number
+  /** Range endpoints. ⚠ NOT an aggregate — see the CEE type. */
+  spread: { low: number; high: number; width: number } | null
+  positions: DisagreementPosition[]
+  positions_with_stated_basis: number
+  evidence: DisagreementEvidence[]
+  /**
+   * ⭐ CODE-OWNED COPY, AUTHORED IN CEE. This bundle RENDERS these strings and
+   * must never compose its own version of them: the sentences are pinned by a
+   * CEE suite that asserts, over every string the module can emit, that none of
+   * them resolves the disagreement. A UI that rewrote them locally would sit
+   * outside that guarantee, and nothing here would notice.
+   */
+  headline: string
+  question: string | null
+}
+
+export interface DisagreementView {
+  round_id: string
+  graph_version_ref: string
+  per_target: DisagreementTarget[]
+}
+
 export interface CollabError {
   code: string
   message: string
@@ -205,6 +268,63 @@ export async function fetchParticipantReveal(roundId: string): Promise<RevealVie
   return (await res.json()) as RevealView
 }
 
+/**
+ * Attach evidence to a position.
+ *
+ * ⚠ SAME ENDPOINT AS A BELIEF, BY DESIGN — see the CEE route header. Evidence is
+ * a participant appending an attributed, round-scoped, target-bound row, with
+ * the same authorisation and the same blindness properties as an answer, so it
+ * comes through the one door rather than a second one that would need its own
+ * copy of the token check.
+ *
+ * ⚠ NO provenance member, exactly like `submitBelief`. The server stamps
+ * `authored_by` from the token; a payload that offered one would be REFUSED,
+ * not ignored, so a client cannot quietly believe it controls attribution.
+ */
+export async function attachEvidence(
+  roundId: string,
+  args: {
+    targetId: string
+    targetKind: 'factor' | 'edge'
+    kind: 'note' | 'link'
+    /** The participant's own words. Sent verbatim. */
+    body: string
+    /** http/https only. CEE refuses anything else and normalises what it keeps. */
+    url: string | null
+    stance: EvidenceStance
+    /** Whose position this speaks to, or null for the target at large. */
+    aboutParticipantId: string | null
+  },
+): Promise<{ authored_by: string; event_id: string }> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}/events`, {
+    method: 'POST',
+    headers: { ...participantHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      kind: 'evidence_attached',
+      target: { kind: args.targetKind, id: args.targetId },
+      belief: null,
+      evidence: {
+        kind: args.kind,
+        body: args.body,
+        url: args.url,
+        stance: args.stance,
+        about_participant_id: args.aboutParticipantId,
+      },
+    }),
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as { authored_by: string; event_id: string }
+}
+
+export async function fetchParticipantDisagreement(roundId: string): Promise<DisagreementView> {
+  const res = await fetch(`${COLLAB_BASE}/packet/${encodeURIComponent(roundId)}/disagreement`, {
+    method: 'GET',
+    headers: participantHeaders(),
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as DisagreementView
+}
+
 /* ── owner ───────────────────────────────────────────────────────────────── */
 
 /**
@@ -308,6 +428,18 @@ export async function fetchOwnerReveal(
   })
   if (!res.ok) throw await parseError(res)
   return (await res.json()) as RevealView
+}
+
+export async function fetchOwnerDisagreement(
+  accessToken: string,
+  roundId: string,
+): Promise<DisagreementView> {
+  const res = await fetch(`${COLLAB_BASE}/rounds/${encodeURIComponent(roundId)}/disagreement`, {
+    method: 'GET',
+    headers: { Authorization: ownerAuthorization(accessToken) },
+  })
+  if (!res.ok) throw await parseError(res)
+  return (await res.json()) as DisagreementView
 }
 
 /**

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -202,6 +202,52 @@ describe('collab-proxy path allowlist (/bff/collab/* → /collab/v1/*)', () => {
     expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
   })
 
+  it('ON-LIST /bff/collab/rounds/{uuid}/disagreement (GET) forwards — D2 owner view', async () => {
+    /**
+     * ⚠ THIS CASE EXISTS BECAUSE THE ESTATE HAS ALREADY MADE THIS EXACT MISTAKE
+     * ONCE THIS WEEK — see the `preview` case above, OFF-LIST while two comments
+     * in the proxy advertised it. A CEE route plus a UI caller plus a green
+     * suite on both sides is fully consistent with every request 404ing HERE,
+     * and nothing in either repo names the cause. The allowlist is a derived-then-
+     * frozen list: it is a hand-maintained mirror and it needs a test per entry.
+     */
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/rounds/${uuid}/disagreement`,
+      method: 'GET',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      `https://cee-staging.onrender.com/collab/v1/rounds/${uuid}/disagreement`,
+    )
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('ON-LIST /bff/collab/packet/{uuid}/disagreement (GET) forwards — D2 participant view', async () => {
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/packet/${uuid}/disagreement`,
+      method: 'GET',
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      `https://cee-staging.onrender.com/collab/v1/packet/${uuid}/disagreement`,
+    )
+  })
+
+  it('OFF-LIST /bff/collab/rounds/{uuid}/disagreements is 404 — the D2 entry is exact', async () => {
+    // The DISCRIMINATING half. One character longer, and it must still 404: a
+    // regex written without its `$` anchor, or with the segment loosened, would
+    // admit this and every other sibling under /rounds/{id}/.
+    const uuid = 'c261b74a-c7ce-4aad-96ca-04f0fdfd0fce'
+    const r = await invoke(collabHandler as Handler, {
+      path: `/bff/collab/rounds/${uuid}/disagreements`,
+      method: 'GET',
+    })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
   it('OFF-LIST /bff/collab/rounds/{uuid}/participants is 404 — preview did not widen the segment', async () => {
     // The DISCRIMINATING half of the pair above. `preview` was added as a
     // literal final segment; had it been written permissively (or the id


### PR DESCRIPTION
The UI half of **P2 — collaboration is about reasoning**. Pairs with CEE
[#959](https://github.com/Talchain/olumi-assistants-service/pull/959).

Nothing here touches the reveal, the apply affordance, or the journey-witnessed
consequence loop.

## ⚠ The most important line in this diff is the edge allowlist

`collab-proxy.ts` matches an **explicit upstream path allowlist**. A CEE route the UI
calls but the list does not carry **404s at the edge** — CEE green, UI green, and
nothing anywhere names the cause.

**That exact defect hit `/rounds/{id}/preview` on 14 Aug**: it was OFF-LIST while two
comments *in the same file* advertised it. The allowlist is a derived-then-frozen list —
a hand-maintained mirror — so both new paths are listed, each with an **ON-LIST test and
a discriminating OFF-LIST twin** (`/disagreements`, one character longer, must still 404
— a regex missing its `$` anchor would admit it).

## What ships

**`DisagreementBody.tsx`** — positions with each person's **stated basis** as the thing
being compared (the reveal shows it as an aside); positions with **no reason given**
called out rather than hidden, because that is the one you cannot interrogate; range
**endpoints** rendered, never a midpoint; evidence with its author, stance and whose view
it addresses.

**Reasoning copy is rendered verbatim from CEE and never composed here.** `headline` and
`question` are pinned by a CEE suite that asserts, over every string that module can
emit, that none of them averages, ranks or names a winner. Copy authored in this bundle
would sit outside that guarantee and nothing in this repo would notice it drift. The
tests assert the rendered text **IS** the served string using **sentinel values** — an
assertion that "some text is present" would pass on locally-authored copy and prove
nothing.

**`safeHref`** — a second, independent http/https gate on evidence links. CEE already
validates the scheme, but this is a stored-XSS path on a **bearer-token surface across
two services on two deploy cadences**, and the failure is silent: a `javascript:` href
renders as an ordinary link carrying a colleague's name. A refused URL does not vanish —
the evidence body still renders and the drop is **disclosed**.

**`attachEvidence`** — posts to the existing `/events` endpoint (one door, one token
check) with **no provenance member**, asserted by exact key sets. "Include the author so
the optimistic render is right" looks reasonable in review and the server would refuse
every attach.

## Evidence

- `pnpm typecheck` — **PASSED** (coverage + ratchet; 2485 baseline errors, **0 new**).
- New spec `disagreementBody.spec.tsx`: **23 tests**. Allowlist spec: **37**.
  Both asserted collected **BY NAME**, non-zero — never inferred from a suite total.
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run.
- **Mutants** (worktree outside the repo root, APFS isolation proven by **sentinel
  write**, HEAD-relative restores, anchor asserted present before each mutation,
  control **exactly 0**, trailing control green):

  | # | Mutation | Result |
  |---|---|---|
  | U1 | remove both disagreement allowlist entries | **2 RED** |
  | U2 | `safeHref` accepts any scheme | **5 RED** |
  | U3 | compose local copy instead of the served headline | **1 RED** |

### ⚠ An instrument defect caught mid-run, disclosed

The first mutant pass passed spec paths as an **unquoted `$SPECS`**. Under zsh that does
not word-split, so vitest received one giant path, **found no test files, and exited 0
with no `Tests` line** — U2 and U3 "passed" against a void. Caught because the control
printed empty where it must print a count. Re-run with explicit quoted arguments and a
control asserting a non-zero count first; **the numbers above are from the re-run**. The
earlier results were voided.

## Deploy order

CEE #959 must deploy **first**. Until it does, the edge forwards the new paths and CEE
404s them — the component simply never renders, which is the correct failure. The reverse
order would 404 at the edge with both halves live.

**Do not merge** — for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)