### PR TITLE
fix(canvas): a malformed `fragile_edges` element no longer crashes the edge surfaces

### DIFF
--- a/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
+++ b/src/canvas/utils/__tests__/fragileEdgeMatch.spec.ts
@@ -192,3 +192,99 @@ describe('isTopFragileEdge — E4 single default-view fragility badge', () => {
   })
 })
 
+// ─── Malformed wire elements ────────────────────────────────────────────────
+//
+// `fragileEdges` is `report.robustness.fragile_edges` — producer data crossing
+// a service boundary (ISL → PLoT → CEE → UI), so the declared element type is
+// a compile-time claim, not a runtime guarantee. A `null` element made all
+// three exported functions throw `TypeError: Cannot read properties of null`,
+// crashing every live caller: StyledEdge (per-edge memo), useMenuItems,
+// useLensFilter and EdgePanel ("NN% flip risk").
+//
+// Each case asserts BOTH halves: the malformed element is survived, AND the
+// well-formed row after it is unaffected — bound to its object by IDENTITY
+// (its own edge_id / from_id-to_id pair and its own probability), never by a
+// value predicate a neighbouring row could also satisfy.
+
+describe('fragileEdgeMatch — a malformed element is skipped, never fatal', () => {
+  // Every non-record shape the wire can deliver. `null`/`undefined` are the
+  // ones that threw; the primitives and the nested array are the rest of the
+  // non-record domain, kept here so the guard is pinned across it, not just
+  // against the reproduction.
+  const MALFORMED = [null, undefined, 'not-an-object', 42, false, ['nested']]
+
+  describe('isEdgeFragile', () => {
+    it('survives a null element, and the row AFTER it still matches by its own edge_id', () => {
+      const fragile = [
+        null,
+        { edge_id: 'e-target', switch_probability: 0.35 },
+      ] as unknown as FragileEdgeCandidate[]
+
+      expect(() => isEdgeFragile('e-target', 'a', 'b', fragile)).not.toThrow()
+      expect(isEdgeFragile('e-target', 'a', 'b', fragile)).toBe(true)
+      // Identity binding: the survived null must not become a wildcard match.
+      expect(isEdgeFragile('e-other', 'a', 'b', fragile)).toBe(false)
+    })
+
+    it('survives a null element and still matches the row AFTER it by its own from_id/to_id pair', () => {
+      const fragile = [
+        null,
+        { from_id: 'n1', to_id: 'n2', switch_probability: 0.35 },
+      ] as unknown as FragileEdgeCandidate[]
+
+      expect(isEdgeFragile('any-id', 'n1', 'n2', fragile)).toBe(true)
+      expect(isEdgeFragile('any-id', 'n1', 'n9', fragile)).toBe(false)
+    })
+
+    it('survives every non-record element shape, and an all-malformed array is simply not fragile', () => {
+      const fragile = MALFORMED as unknown as FragileEdgeCandidate[]
+      expect(() => isEdgeFragile('e1', 'a', 'b', fragile)).not.toThrow()
+      expect(isEdgeFragile('e1', 'a', 'b', fragile)).toBe(false)
+    })
+  })
+
+  describe('isTopFragileEdge', () => {
+    it('survives a null element, and the top row after it is still picked by its own identity', () => {
+      const fragile = [
+        null,
+        { edge_id: 'e-runner-up', switch_probability: 0.35 },
+        { edge_id: 'e-top', switch_probability: 0.62 },
+      ] as unknown as FragileEdgeCandidate[]
+
+      expect(() => isTopFragileEdge('e-top', 'a', 'b', fragile)).not.toThrow()
+      expect(isTopFragileEdge('e-top', 'a', 'b', fragile)).toBe(true)
+      // Identity binding: the runner-up is still NOT the top, and the survived
+      // null has not been elected top either (which would make everything false).
+      expect(isTopFragileEdge('e-runner-up', 'a', 'b', fragile)).toBe(false)
+    })
+
+    it('survives every non-record element shape, and an all-malformed array has no top', () => {
+      const fragile = MALFORMED as unknown as FragileEdgeCandidate[]
+      expect(() => isTopFragileEdge('e1', 'a', 'b', fragile)).not.toThrow()
+      expect(isTopFragileEdge('e1', 'a', 'b', fragile)).toBe(false)
+    })
+  })
+
+  describe('getFragileEdgeSwitchProbability', () => {
+    it('survives a null element, and returns the measured value of the row AFTER it, by identity', () => {
+      const fragile = [
+        null,
+        { edge_id: 'e-other', switch_probability: 0.91 },
+        { edge_id: 'e-target', switch_probability: 0.35 },
+      ] as unknown as FragileEdgeCandidate[]
+
+      expect(() => getFragileEdgeSwitchProbability('e-target', 'a', 'b', fragile)).not.toThrow()
+      // 0.35 is e-target's OWN value — a neighbouring row carries 0.91, so a
+      // wrong-object read would be visible rather than coincidentally equal.
+      expect(getFragileEdgeSwitchProbability('e-target', 'a', 'b', fragile)).toBeCloseTo(0.35)
+      expect(getFragileEdgeSwitchProbability('e-other', 'a', 'b', fragile)).toBeCloseTo(0.91)
+    })
+
+    it('survives every non-record element shape, and an all-malformed array yields no display value', () => {
+      const fragile = MALFORMED as unknown as FragileEdgeCandidate[]
+      expect(() => getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).not.toThrow()
+      expect(getFragileEdgeSwitchProbability('e1', 'a', 'b', fragile)).toBeNull()
+    })
+  })
+})
+

--- a/src/canvas/utils/fragileEdgeMatch.ts
+++ b/src/canvas/utils/fragileEdgeMatch.ts
@@ -7,7 +7,19 @@
  */
 
 import { THRESHOLDS } from '../../lib/mappers/constants'
+import { isRecord } from '../conversation/ceeRecovery'
 
+/**
+ * `fragileEdges` is always `report.robustness.fragile_edges` — producer data
+ * that crosses a service boundary (ISL → PLoT → CEE → UI), so the element type
+ * below is a compile-time claim, not a runtime guarantee. Every entry point
+ * here therefore skips any element that is not a plain record before reading a
+ * field: a single `null` on the wire otherwise threw
+ * `TypeError: Cannot read properties of null` out of StyledEdge's per-edge
+ * memo, useMenuItems, useLensFilter and EdgePanel's "NN% flip risk".
+ * Skipping is the correct degradation — a shape we cannot read is a shape we
+ * cannot call fragile.
+ */
 export interface FragileEdgeCandidate {
   edge_id?: string
   edgeId?: string
@@ -34,6 +46,8 @@ export function isEdgeFragile(
   fragileEdges: FragileEdgeCandidate[],
 ): boolean {
   return fragileEdges.some(fe => {
+    if (!isRecord(fe)) return false
+
     const switchProb = fe.switch_probability ?? fe.switchProbability ??
                        fe.marginal_switch_probability ?? fe.marginalSwitchProbability
     if (typeof switchProb !== 'number' || switchProb <= THRESHOLDS.FRAGILE_EDGE_FILTER) return false
@@ -49,8 +63,15 @@ export function isEdgeFragile(
   })
 }
 
-/** The switch probability an entry reports (above the visibility floor), else null. */
+/**
+ * The switch probability an entry reports (above the visibility floor), else
+ * null. This is the ONLY place `isTopFragileEdge` reads an entry's fields, so
+ * the non-record guard here is what keeps that loop safe; the winner it hands
+ * back is a record by construction.
+ */
 function entrySwitchProb(fe: FragileEdgeCandidate): number | null {
+  if (!isRecord(fe)) return null
+
   const p = fe.switch_probability ?? fe.switchProbability ??
             fe.marginal_switch_probability ?? fe.marginalSwitchProbability
   return typeof p === 'number' && p > THRESHOLDS.FRAGILE_EDGE_FILTER ? p : null
@@ -105,6 +126,8 @@ export function getFragileEdgeSwitchProbability(
   fragileEdges: FragileEdgeCandidate[],
 ): number | null {
   for (const fe of fragileEdges) {
+    if (!isRecord(fe)) continue
+
     const measured = fe.switch_probability ?? fe.switchProbability
     if (typeof measured !== 'number' || measured <= THRESHOLDS.FRAGILE_EDGE_FILTER) continue
 


### PR DESCRIPTION
## Defect

`src/canvas/utils/fragileEdgeMatch.ts` read fields off every element of `fragileEdges` with no shape guard. That array is always `report.robustness.fragile_edges` — **producer data crossing a service boundary** (ISL → PLoT → CEE → UI), so the declared `FragileEdgeCandidate[]` element type is a compile-time claim, not a runtime guarantee. A single `null` element threw `TypeError: Cannot read properties of null`.

**All three exported functions were affected**, not just the one first reported:

| Function | Unguarded read (pre-fix line) |
|---|---|
| `isEdgeFragile` | `:36` — `fe.switch_probability ?? …` inside `.some()` |
| `isTopFragileEdge` | `:73` — via `entrySwitchProb(fe)` in its `for` loop |
| `getFragileEdgeSwitchProbability` | `:108` — `fe.switch_probability ?? fe.switchProbability` |

Live callers that would crash: `StyledEdge` (per-edge memo), `useMenuItems`, `useLensFilter`, and `EdgePanel.tsx:238` ("NN% flip risk").

## Reproduction (at pristine `97df1fc5`)

```ts
getFragileEdgeSwitchProbability('e-target', 'a', 'b',
  [null, { edge_id: 'e-target', switch_probability: 0.35 }])
// TypeError: Cannot read properties of null (reading 'switch_probability')
```

Reproduced identically for `isEdgeFragile` and `isTopFragileEdge`.

## Fix

Each entry point skips any element that is not a plain record, using the repo's existing `isRecord` helper exported from `src/canvas/conversation/ceeRecovery` (a self-contained module — no imports, so no dependency weight added to a leaf util).

- `isEdgeFragile` — `if (!isRecord(fe)) return false` in the `.some()` callback
- `entrySwitchProb` — `if (!isRecord(fe)) return null`; this is the **only** place `isTopFragileEdge` reads an entry's fields, so the winner it returns is a record by construction
- `getFragileEdgeSwitchProbability` — `if (!isRecord(fe)) continue`

Skipping is the correct degradation: a shape we cannot read is a shape we cannot call fragile.

**Deliberately unchanged**: matching semantics · the `THRESHOLDS.FRAGILE_EDGE_FILTER` floor · the documented rule that `marginal_switch_probability` is never a fallback for the displayed number.

## RED → GREEN, per function

7 new tests, all RED at pristine with the exact `TypeError`, all GREEN after. Collected count asserted **33 by name** in every run — identical RED and GREEN, so nothing was silently un-collected.

| Function | New tests | At pristine | After fix |
|---|---|---|---|
| `isEdgeFragile` | 3 | RED (TypeError) | GREEN |
| `isTopFragileEdge` | 2 | RED (TypeError) | GREEN |
| `getFragileEdgeSwitchProbability` | 2 | RED (TypeError) | GREEN |

Each test asserts **both halves**: the malformed element is survived, **and** the well-formed row after it is unaffected — bound to its object by **identity** (its own `edge_id` / `from_id`-`to_id` pair and its own probability), never by a value predicate a neighbouring row could satisfy. In the `getFragileEdgeSwitchProbability` case the target row carries `0.35` while a neighbouring row carries `0.91`, so a wrong-object read would be visible rather than coincidentally equal. Each also asserts the survived `null` has not become a **wildcard match** (a different id must still return `false`).

## Mutant evidence

Run in a **detached worktree outside the source repo root**, mutating committed state only. Isolation proven by a **sentinel write test** — distinct inodes, sentinel confirmed landed in the worktree, source file byte-identical afterwards. (A first attempt at this probe was **vacuous** and reported "PROVEN" while the worktree had failed to create; it was caught and rewritten to assert its own preconditions.) Restores are `git checkout HEAD --` (never index-relative). Applied-check scoped to `src/`; collected count asserted `= 33` on every run; an unreadable result is a hard error.

| Mutant | Result |
|---|---|
| **Control** (no mutation) | applied = **0** exactly · 33/33 pass |
| **M1** revert `isEdgeFragile` guard | 3 RED — **exactly its own 3 tests**, nothing else |
| **M2** revert `entrySwitchProb` guard | 2 RED — **exactly the 2 `isTopFragileEdge` tests** |
| **M3** revert `getFragileEdgeSwitchProbability` guard | 2 RED — **exactly its own 2 tests** |
| **M4** revert **all three** guards | **all 7 RED** |
| **M5** loosen floor `0.15 → 0.05` | **6 pre-existing tests RED, 0 new tests RED** |
| **Trailing control** | applied = **0** · 33/33 pass · HEAD unchanged |

M1–M3 biting *only* their own function's tests is the discriminating evidence that each of the three guards is **separately load-bearing** — a single combined mutant could not show that.

**M5 answers the brief's open question**: the filter floor **is** already covered — loosening it REDs 6 existing tests (`G5`, `G4`, the two threshold tests, the null-at-threshold test, and `isTopFragileEdge`'s below-floor case). No scope was added. M5 is also the kit's **discrimination control**: its expected answer *differs* from M1–M4 (existing tests RED, new tests GREEN), so the kit is provably not returning a uniform answer regardless of input.

## Gates

- `pnpm run lint` — **exit 0**, 0 errors; hooks ratchet exactly at baseline (232 known violations / 15 files). Neither changed file produces a lint finding.
- `pnpm run typecheck` — **exit 0**; ratchet **2485 / baseline 2485**, i.e. zero new diagnostics. No `--update-baseline` prompt was raised or accepted.
- Consuming surfaces (`canvas/utils`, `canvas/edges`, `canvas/hooks`, `canvas/contextMenu`) — **153 files / 2373 tests, 0 failures**.
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every vitest run.

## Scope note

The container itself is still unguarded — a non-array `fragileEdges` would throw at `.some()`/`for…of`. That is outside this brief's scope and is **not** the reported defect (every caller passes an array); flagging it rather than fixing it silently.
