### PR TITLE
collab: mount the disagreement surface + let participants attach evidence

### DIFF
--- a/src/collab/DisagreementBody.tsx
+++ b/src/collab/DisagreementBody.tsx
@@ -214,10 +214,20 @@ export function DisagreementBody({ view }: { view: DisagreementView }): JSX.Elem
   return (
     <div data-testid="collab-disagreement">
       <h1 className={`${typography.h2} text-text-header`}>Where you differ</h1>
-      <p className={`${typography.body} mt-3 text-text-body`}>
-        These are the positions as they were given, with the reasons each person stated. They
-        are shown side by side and are not combined into a single number.
-      </p>
+      {/* ⭐ CEE'S WORDS, VERBATIM — and this paragraph is the reason the rule at
+          the top of this file needed enforcing rather than stating. It used to
+          be written HERE, which put the one sentence promising that nothing is
+          combined outside the guard that proves nothing is combined.
+
+          ⚠ Rendered only when the server sent one. There is deliberately NO
+          fallback string: a local default would be a second authority wearing
+          the clothes of resilience, and an absent sentence is honest where an
+          invented one is not. */}
+      {typeof view.standing_note === 'string' && view.standing_note !== '' && (
+        <p data-testid="disagreement-standing-note" className={`${typography.body} mt-3 text-text-body`}>
+          {view.standing_note}
+        </p>
+      )}
       {view.per_target.map((row) => (
         <TargetSection key={row.target.id} row={row} />
       ))}

--- a/src/collab/__tests__/disagreementBody.spec.tsx
+++ b/src/collab/__tests__/disagreementBody.spec.tsx
@@ -80,14 +80,43 @@ function target(overrides: Partial<DisagreementTarget> = {}): DisagreementTarget
   }
 }
 
-const view = (t: DisagreementTarget = target()): DisagreementView => ({
+const view = (
+  t: DisagreementTarget = target(),
+  overrides: Partial<DisagreementView> = {},
+): DisagreementView => ({
   round_id: 'round-1',
   graph_version_ref: 'mv-1',
+  standing_note: 'SERVED-STANDING-NOTE-SENTINEL',
   per_target: [t],
+  ...overrides,
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
+})
+
+describe('the standing sentence is served, never composed here', () => {
+  it('renders the served standing note verbatim', () => {
+    render(<DisagreementBody view={view()} />)
+    expect(screen.getByTestId('disagreement-standing-note')).toHaveTextContent(
+      'SERVED-STANDING-NOTE-SENTINEL',
+    )
+  })
+
+  /**
+   * ⭐ THE DISCRIMINATING HALF, and the one that matters. This component used
+   * to hand-write this sentence, so "renders something" is exactly the assertion
+   * that would have passed on the defect. Absent must mean ABSENT: a local
+   * fallback would silently reinstate the second authority the served field was
+   * introduced to remove, and every other test here would still pass.
+   */
+  it('renders NO standing sentence at all when the server sent none', () => {
+    render(<DisagreementBody view={view(target(), { standing_note: null })} />)
+    expect(screen.queryByTestId('disagreement-standing-note')).toBeNull()
+    // Bound to the retired wording specifically: if anyone re-introduces the
+    // old local copy as a fallback, this is what catches it.
+    expect(screen.queryByText(/are not combined into a single number/i)).toBeNull()
+  })
 })
 
 describe('the reasoning copy is rendered, never composed', () => {

--- a/src/collab/__tests__/disagreementMount.spec.tsx
+++ b/src/collab/__tests__/disagreementMount.spec.tsx
@@ -1,0 +1,458 @@
+/**
+ * COLLAB — THE DISAGREEMENT MOUNT, and the evidence that feeds it.
+ *
+ * ── WHAT WAS DARK, AND WHY A GREEN SUITE DID NOT NOTICE ───────────────────
+ * `DisagreementBody`, `fetchParticipantDisagreement`, `fetchOwnerDisagreement`
+ * and `attachEvidence` shipped complete, and shipped with ZERO product call
+ * sites — each symbol had exactly one occurrence in `src/`, its own definition.
+ * CEE was deployed and its table migrated, so every component witness was green
+ * while no user could reach any of it. A component suite proves a component
+ * renders; only a MOUNT test proves a user can get to it.
+ *
+ * ── THE SEQUENCE THIS FILE PINS, WHICH IS NOT THE OBVIOUS ONE ─────────────
+ * Evidence is attached while the round is OPEN and read after it CLOSES. That
+ * is forced by CEE and the two windows are disjoint: `elicitation-append.ts:368`
+ * refuses every append once the round is not open, and `packet-read-model.ts:182`
+ * refuses the reveal and the disagreement view while it is. So a participant
+ * cannot "attach evidence to a position they disagree with" — no position is
+ * visible until the moment nothing can be attached. They attach it beside their
+ * own answer, blind, which is also the anchoring-free order.
+ *
+ * ── BINDING ───────────────────────────────────────────────────────────────
+ * Every copy assertion uses a SENTINEL that no locally-composed sentence could
+ * produce (trap 19 — an assertion that some plausible text appeared would pass
+ * on exactly the defect being fixed). Every positive has its wrong-object or
+ * absent twin.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+vi.mock('../../canvas/hooks/useBeliefElicitation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../canvas/hooks/useBeliefElicitation')>()
+  return {
+    ...actual,
+    useBeliefElicitation: vi.fn(() => ({
+      suggestion: null,
+      loading: false,
+      error: null,
+      request: vi.fn(),
+      reset: vi.fn(),
+    })),
+  }
+})
+
+import ParticipantPacketPage, { RevealBody } from '../../pages/ParticipantPacketPage'
+import type { DisagreementView, OpenPacket, RevealView } from '../collabService'
+import {
+  __resetParticipantTokenForTests,
+  setParticipantToken,
+} from '../participantToken'
+
+const ROUND = 'rnd-disagreement-mount-1111'
+const PACKET_URL = `/bff/collab/packet/${ROUND}`
+const REVEAL_URL = `${PACKET_URL}/reveal`
+const DISAGREEMENT_URL = `${PACKET_URL}/disagreement`
+const EVENTS_URL = `${PACKET_URL}/events`
+
+const TARGET = 'factor-churn-risk'
+const LABEL = 'Churn risk after a price rise'
+const GRACE = 'p-grace-4444'
+const ADA = 'p-ada-5555'
+
+/** Sentinels. Nothing this bundle could compose would satisfy these. */
+const HEADLINE = 'SERVED-HEADLINE-SENTINEL'
+const QUESTION = 'SERVED-QUESTION-SENTINEL'
+const STANDING = 'SERVED-STANDING-NOTE-SENTINEL'
+const GRACE_BASIS = 'GRACE-STATED-BASIS-SENTINEL'
+const ADA_BASIS = 'ADA-STATED-BASIS-SENTINEL'
+const EVIDENCE_BODY = 'SERVED-EVIDENCE-BODY-SENTINEL'
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+function openPacket(): OpenPacket {
+  return {
+    round_id: ROUND,
+    status: 'open',
+    context_note: null,
+    graph_version_ref: 'gv-1',
+    targets: [
+      { target: { kind: 'factor', id: TARGET }, label: LABEL, description: null, unit: null },
+    ],
+    self: { participant_id: GRACE, display_name: 'Grace', completed_target_ids: [] },
+  }
+}
+
+function revealView(): RevealView {
+  return {
+    round_id: ROUND,
+    status: 'closed',
+    graph_version_ref: 'gv-1',
+    per_target: [
+      {
+        target: { kind: 'factor', id: TARGET },
+        label: LABEL,
+        model_value_at_version: 0.5,
+        responses: [
+          {
+            participant_id: GRACE,
+            display_label: 'Grace',
+            value: 0.85,
+            expression_raw: GRACE_BASIS,
+            confidence: null,
+            kind: 'belief_submitted',
+          },
+          {
+            participant_id: ADA,
+            display_label: 'Ada',
+            value: 0.2,
+            expression_raw: ADA_BASIS,
+            confidence: null,
+            kind: 'belief_submitted',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function disagreementView(overrides: Partial<DisagreementView> = {}): DisagreementView {
+  return {
+    round_id: ROUND,
+    graph_version_ref: 'gv-1',
+    standing_note: STANDING,
+    per_target: [
+      {
+        target: { kind: 'factor', id: TARGET },
+        label: LABEL,
+        model_value_at_version: 0.5,
+        shape: 'split',
+        answering_participants: 2,
+        distinct_values: 2,
+        spread: { low: 0.2, high: 0.85, width: 0.65 },
+        positions: [
+          {
+            participant_id: GRACE,
+            display_label: 'Grace',
+            value: 0.85,
+            stated_basis: GRACE_BASIS,
+            confidence: null,
+            kind: 'belief_submitted',
+            pole: 'high',
+          },
+          {
+            participant_id: ADA,
+            display_label: 'Ada',
+            value: 0.2,
+            stated_basis: ADA_BASIS,
+            confidence: null,
+            kind: 'belief_submitted',
+            pole: 'low',
+          },
+        ],
+        positions_with_stated_basis: 2,
+        evidence: [
+          {
+            event_id: 'evt-1',
+            authored_by: ADA,
+            author_label: 'Ada',
+            stance: 'challenges',
+            stance_phrase: 'challenges',
+            kind: 'note',
+            body: EVIDENCE_BODY,
+            url: null,
+            about_participant_id: null,
+            about_label: null,
+            created_at: '2026-08-14T11:00:00.000Z',
+          },
+        ],
+        headline: HEADLINE,
+        question: QUESTION,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+/** A closed round: the packet refuses, the page falls through to the reveal. */
+function stubClosedRound(opts: { disagreementStatus?: number } = {}): void {
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url === PACKET_URL) {
+      return jsonResponse(
+        { code: 'collab_round_closed', message: 'That round is closed.' },
+        409,
+      )
+    }
+    if (url === REVEAL_URL) return jsonResponse(revealView())
+    if (url === DISAGREEMENT_URL) {
+      const status = opts.disagreementStatus ?? 200
+      return status === 200
+        ? jsonResponse(disagreementView())
+        : jsonResponse({ code: 'collab_request_failed', message: 'nope' }, status)
+    }
+    return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+  })
+}
+
+function renderParticipant(): void {
+  render(
+    <MemoryRouter initialEntries={[`/panel/${ROUND}`]}>
+      <Routes>
+        <Route path="/panel/:round_id" element={<ParticipantPacketPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  __resetParticipantTokenForTests()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  setParticipantToken('CODE-THAT-WORKS-disagreement-mount')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  __resetParticipantTokenForTests()
+  vi.restoreAllMocks()
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * 1. THE PARTICIPANT REACHES IT.
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('a participant reaches the disagreement view after the round closes', () => {
+  it('mounts it, with CEE’s reasoning copy rendered verbatim', async () => {
+    stubClosedRound()
+    renderParticipant()
+
+    await waitFor(() => expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument())
+
+    // The served sentences, by sentinel. A component that composed its own
+    // would render something plausible and fail here — the point of sentinels.
+    expect(screen.getByTestId(`disagreement-headline-${TARGET}`)).toHaveTextContent(HEADLINE)
+    expect(screen.getByTestId(`disagreement-question-${TARGET}`)).toHaveTextContent(QUESTION)
+    expect(screen.getByTestId('disagreement-standing-note')).toHaveTextContent(STANDING)
+  })
+
+  it('shows EACH position’s stated basis verbatim, bound to its own author', async () => {
+    stubClosedRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument())
+
+    // ⭐ BOUND BY IDENTITY. Two people, two DIFFERENT sentinels, each asserted
+    // inside its own participant's node — so neither assertion can be satisfied
+    // by the other person's basis (trap 19).
+    expect(screen.getByTestId(`disagreement-basis-${GRACE}`)).toHaveTextContent(GRACE_BASIS)
+    expect(screen.getByTestId(`disagreement-basis-${ADA}`)).toHaveTextContent(ADA_BASIS)
+    expect(screen.getByTestId(`disagreement-basis-${GRACE}`)).not.toHaveTextContent(ADA_BASIS)
+  })
+
+  it('shows the evidence somebody attached, beside the positions', async () => {
+    stubClosedRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument())
+
+    expect(screen.getByTestId('disagreement-evidence-body-evt-1')).toHaveTextContent(EVIDENCE_BODY)
+    expect(screen.getByTestId('disagreement-evidence-evt-1')).toHaveAttribute(
+      'data-stance',
+      'challenges',
+    )
+  })
+
+  it('requests the disagreement view for THIS round', async () => {
+    stubClosedRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument())
+
+    const called = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(called).toContain(DISAGREEMENT_URL)
+  })
+
+  /**
+   * ⭐ THE DISCRIMINATING TWIN. Without it, a mount that rendered the section
+   * unconditionally — or one bound to the reveal rather than to the
+   * disagreement payload — would pass every test above. It also pins the
+   * deliberate trade: the reveal is what the participant came back for, and a
+   * secondary view's failure must not cost it.
+   */
+  it('still renders the reveal when the disagreement request FAILS, and mounts no disagreement', async () => {
+    stubClosedRound({ disagreementStatus: 500 })
+    renderParticipant()
+
+    await waitFor(() => expect(screen.getByTestId('collab-reveal')).toBeInTheDocument())
+    expect(screen.getByTestId(`reveal-words-${GRACE}`)).toHaveTextContent(GRACE_BASIS)
+    expect(screen.queryByTestId('collab-disagreement')).toBeNull()
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * 2. THE OWNER REACHES THE SAME SURFACE — ONE MOUNT, TWO JOURNEYS.
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('the owner reaches the same disagreement surface', () => {
+  it('RevealBody renders it for the owner shape (with an apply state present)', () => {
+    render(
+      <RevealBody
+        reveal={revealView()}
+        disagreement={disagreementView()}
+        apply={{
+          onApply: vi.fn(),
+          applyingKey: null,
+          appliedKey: null,
+          applyError: null,
+        }}
+      />,
+    )
+    expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument()
+    expect(screen.getByTestId(`disagreement-headline-${TARGET}`)).toHaveTextContent(HEADLINE)
+  })
+
+  it('renders no disagreement section when none was passed (the absent twin)', () => {
+    render(<RevealBody reveal={revealView()} />)
+    expect(screen.getByTestId('collab-reveal')).toBeInTheDocument()
+    expect(screen.queryByTestId('collab-disagreement')).toBeNull()
+  })
+
+  /**
+   * ⚠ THE OWNER PAGE'S WIRING IS NOT REACHED BY THE RENDER TESTS ABOVE, and an
+   * optional prop means deleting the call site keeps TYPECHECK GREEN. This is
+   * the mount-path assertion that fails loud instead (trap 3b): the owner page
+   * must fetch the owner view and hand it to the shared body. Comments are
+   * stripped so a mention in prose cannot satisfy it.
+   */
+  it('PanelSetupPage fetches the OWNER view and passes it to RevealBody', () => {
+    const src = readFileSync(resolve(process.cwd(), 'src/pages/PanelSetupPage.tsx'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+    expect(src).toContain('fetchOwnerDisagreement(')
+    expect(src).toMatch(/<RevealBody[^>]*disagreement=\{disagreement\}/)
+    // The wrong-credential twin: the owner page must NOT reach for the
+    // participant fetcher, which would 401 with a Supabase token.
+    expect(src).not.toContain('fetchParticipantDisagreement')
+  })
+})
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * 3. THE EVIDENCE THAT FEEDS IT — attached during the OPEN round.
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+describe('a participant attaches evidence while the round is open', () => {
+  function stubOpenRound(): { posted: Array<Record<string, unknown>> } {
+    const posted: Array<Record<string, unknown>> = []
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === EVENTS_URL && init?.method === 'POST') {
+        posted.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+        return jsonResponse({ authored_by: GRACE, event_id: 'evt-new' }, 201)
+      }
+      if (url === PACKET_URL) return jsonResponse(openPacket())
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    })
+    return { posted }
+  }
+
+  async function attach(body: string, opts: { url?: string; stance?: string } = {}): Promise<void> {
+    const card = screen.getByTestId(`packet-target-${TARGET}`)
+    fireEvent.click(within(card).getByTestId(`packet-evidence-open-${TARGET}`))
+    fireEvent.change(within(card).getByTestId(`packet-evidence-body-${TARGET}`), {
+      target: { value: body },
+    })
+    if (opts.url !== undefined) {
+      fireEvent.change(within(card).getByTestId(`packet-evidence-url-${TARGET}`), {
+        target: { value: opts.url },
+      })
+    }
+    if (opts.stance !== undefined) {
+      fireEvent.change(within(card).getByTestId(`packet-evidence-stance-${TARGET}`), {
+        target: { value: opts.stance },
+      })
+    }
+    fireEvent.click(within(card).getByTestId(`packet-evidence-submit-${TARGET}`))
+  }
+
+  it('sends the participant’s own words, the stance, and NO client-set attribution', async () => {
+    const { posted } = stubOpenRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId(`packet-target-${TARGET}`)).toBeInTheDocument())
+
+    await attach(EVIDENCE_BODY, { stance: 'challenges' })
+    await waitFor(() => expect(posted).toHaveLength(1))
+
+    const sent = posted[0]
+    expect(sent.kind).toBe('evidence_attached')
+    expect(sent.target).toEqual({ kind: 'factor', id: TARGET })
+    expect(sent.belief).toBeNull()
+    expect(sent.evidence).toEqual({
+      kind: 'note',
+      body: EVIDENCE_BODY,
+      url: null,
+      stance: 'challenges',
+      // Blind round: the roster is withheld, so there is nobody to aim at.
+      about_participant_id: null,
+    })
+    // ⚠ The server stamps authorship from the token. A payload offering one is
+    // REFUSED by CEE, not ignored — so this bundle must never send it.
+    expect(Object.keys(sent)).not.toContain('provenance')
+    expect(JSON.stringify(sent)).not.toContain('authored_by')
+  })
+
+  it('derives kind=link from the URL field rather than offering a second control', async () => {
+    const { posted } = stubOpenRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId(`packet-target-${TARGET}`)).toBeInTheDocument())
+
+    await attach(EVIDENCE_BODY, { url: 'https://example.com/renewals' })
+    await waitFor(() => expect(posted).toHaveLength(1))
+
+    const evidence = posted[0].evidence as Record<string, unknown>
+    expect(evidence.kind).toBe('link')
+    expect(evidence.url).toBe('https://example.com/renewals')
+  })
+
+  it('confirms what was attached, in the person’s own words', async () => {
+    stubOpenRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId(`packet-target-${TARGET}`)).toBeInTheDocument())
+
+    await attach(EVIDENCE_BODY)
+    await waitFor(() =>
+      expect(screen.getByTestId(`packet-evidence-attached-${TARGET}`)).toHaveTextContent(
+        EVIDENCE_BODY,
+      ),
+    )
+  })
+
+  it('sends nothing at all when there are no words (the empty twin)', async () => {
+    const { posted } = stubOpenRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId(`packet-target-${TARGET}`)).toBeInTheDocument())
+
+    const card = screen.getByTestId(`packet-target-${TARGET}`)
+    fireEvent.click(within(card).getByTestId(`packet-evidence-open-${TARGET}`))
+    fireEvent.click(within(card).getByTestId(`packet-evidence-submit-${TARGET}`))
+    expect(posted).toHaveLength(0)
+  })
+
+  /**
+   * The window rule, made visible in the product rather than only in CEE: once
+   * the round is closed there is no attach affordance to press, so nobody meets
+   * `collab_round_closed` by using the UI as designed.
+   */
+  it('offers NO attach affordance once the round has closed', async () => {
+    stubClosedRound()
+    renderParticipant()
+    await waitFor(() => expect(screen.getByTestId('collab-disagreement')).toBeInTheDocument())
+    expect(screen.queryByTestId(`packet-evidence-open-${TARGET}`)).toBeNull()
+  })
+})

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -155,6 +155,19 @@ export interface DisagreementTarget {
 export interface DisagreementView {
   round_id: string
   graph_version_ref: string
+  /**
+   * ⭐ CEE'S STANDING SENTENCE about what this surface is, served rather than
+   * worded here — same rule as `headline` and `question`, and for the same
+   * reason: the copy guard lives in CEE, so a sentence composed in this bundle
+   * sits outside it. This one WAS composed here until the mount landed.
+   *
+   * ⚠ `null` IS A REAL STATE AND IS NOT AN ERROR. The two services deploy
+   * independently, so a UI that ships ahead of its CEE will receive a payload
+   * with no such member. The honest rendering of an absent sentence is no
+   * sentence — never a local fallback, which would silently reinstate exactly
+   * the second authority this field exists to remove.
+   */
+  standing_note: string | null
   per_target: DisagreementTarget[]
 }
 

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -45,11 +45,13 @@ import { Button } from '../components/ui/Button'
 import {
   CollabRequestError,
   closeRound,
+  fetchOwnerDisagreement,
   fetchOwnerReveal,
   mintRound,
   ownerSignInRequired,
   participantLink,
   type MintedRound,
+  type DisagreementView,
   type RevealView,
 } from '../collab/collabService'
 import { requireOwnerAccessToken } from '../collab/ownerAccessToken'
@@ -242,6 +244,7 @@ export default function PanelSetupPage(): JSX.Element {
   const [nameB, setNameB] = useState('')
   const [minted, setMinted] = useState<MintedRound | null>(null)
   const [reveal, setReveal] = useState<RevealView | null>(null)
+  const [disagreement, setDisagreement] = useState<DisagreementView | null>(null)
   const [failure, setFailure] = useState<OwnerFailure | null>(null)
   const [busyAction, setBusyAction] = useState<OwnerAction | null>(null)
   const [copiedIds, setCopiedIds] = useState<ReadonlySet<string>>(() => new Set())
@@ -326,6 +329,14 @@ export default function PanelSetupPage(): JSX.Element {
           }
         }
         setReveal(await fetchOwnerReveal(accessToken, roundId))
+        // The disagreement view: a SECOND request, and secondary. Its failure
+        // is swallowed to null so that an older CEE or a transient 5xx cannot
+        // cost the owner the reveal they just closed the round to see.
+        try {
+          setDisagreement(await fetchOwnerDisagreement(accessToken, roundId))
+        } catch {
+          setDisagreement(null)
+        }
         // Forget ONLY the round we actually closed. The stored record is
         // latest-wins: a second tab minting R2 overwrites R1's record, so an
         // UNCONDITIONAL forget here — reached from tab A still closing R1 —
@@ -447,7 +458,7 @@ export default function PanelSetupPage(): JSX.Element {
   if (reveal !== null) {
     return (
       <>
-        <RevealBody reveal={reveal} apply={applyState} />
+        <RevealBody reveal={reveal} apply={applyState} disagreement={disagreement} />
         <div className="mx-auto w-full max-w-[820px] px-4 pb-10 sm:px-6">
           <Link
             to={`#/scenario/${scenarioId ?? ''}`}

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -59,12 +59,17 @@ import { AlertTriangle, CheckCircle2, KeyRound, Loader2, Lock } from 'lucide-rea
 import { BeliefElicitationField } from '../canvas/components/BeliefElicitationField'
 import { useBeliefElicitation } from '../canvas/hooks/useBeliefElicitation'
 import { Button } from '../components/ui/Button'
+import { DisagreementBody } from '../collab/DisagreementBody'
 import {
+  attachEvidence,
   CollabRequestError,
   declineTarget,
   fetchOpenPacket,
+  fetchParticipantDisagreement,
   fetchParticipantReveal,
   submitBelief,
+  type DisagreementView,
+  type EvidenceStance,
   type OpenPacket,
   type PacketTarget,
   type RevealView,
@@ -90,7 +95,16 @@ const FIELD =
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'packet'; packet: OpenPacket }
-  | { kind: 'reveal'; reveal: RevealView }
+  /**
+   * ⚠ `disagreement` IS NULLABLE AND ITS ABSENCE MUST NOT COST THE REVEAL.
+   * The two views come from two requests; the reveal is the thing the
+   * participant was promised when the round closed. If the second call fails —
+   * an older CEE, a transient 5xx — the answers still render. Binding them into
+   * one state member would have made a secondary view's failure delete the
+   * primary one, which is the wrong trade in the one moment the user came back
+   * for.
+   */
+  | { kind: 'reveal'; reveal: RevealView; disagreement: DisagreementView | null }
   | { kind: 'error'; message: string; code: string; status: number }
 
 /**
@@ -238,6 +252,203 @@ function formatRecordedTime(createdAt: string | null): string | null {
 }
 
 /** One target, with its own phrase state (the field is caller-owned). */
+/**
+ * Attach evidence to one target.
+ *
+ * ── ⚠⚠ WHY THIS LIVES ON THE OPEN PACKET AND NOT ON THE DISAGREEMENT VIEW ──
+ * The obvious design — "read the positions, then attach evidence against the
+ * one you disagree with" — IS NOT BUILDABLE, and the constraint is structural
+ * rather than a matter of taste. Derived at the CEE bytes:
+ *
+ *   • `elicitation-append.ts:368` refuses every append once the round is not
+ *     `open`, so nothing can be attached after the close; and
+ *   • `packet-read-model.ts:182` refuses the reveal and the disagreement view
+ *     while the round IS open, so no position is visible before it.
+ *
+ * The two windows are disjoint. Evidence is therefore attached DURING the blind
+ * round, beside the answer it accompanies, and read AFTER it — which is also
+ * the scientifically correct order: a person who could see the others first
+ * would be attaching evidence to a position they had already been anchored by.
+ *
+ * ── AND WHY THERE IS NO "whose position" PICKER ───────────────────────────
+ * `attachEvidence` accepts `aboutParticipantId`, and this passes `null` every
+ * time — deliberately, not as a simplification. A participant cannot see the
+ * roster before the close (blindness item 4), so there is no honest way to
+ * offer the choice: any picker here would be listing people the packet does not
+ * contain. `DisagreementBody` already renders the null case as "this factor".
+ */
+function EvidenceAttach({
+  target,
+  roundId,
+}: {
+  target: PacketTarget
+  roundId: string
+}): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [body, setBody] = useState('')
+  const [url, setUrl] = useState('')
+  const [stance, setStance] = useState<EvidenceStance>('supports')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [attached, setAttached] = useState<string[]>([])
+
+  const nothingToAttach = body.trim() === ''
+
+  const handleAttach = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const trimmedUrl = url.trim()
+      await attachEvidence(roundId, {
+        targetId: target.target.id,
+        targetKind: target.target.kind,
+        // A URL makes it a link; CEE refuses a note that carries one, and
+        // refuses a link that does not, so the kind is DERIVED from the field
+        // rather than offered as a second control the two could contradict.
+        kind: trimmedUrl === '' ? 'note' : 'link',
+        body: body.trim(),
+        url: trimmedUrl === '' ? null : trimmedUrl,
+        stance,
+        aboutParticipantId: null,
+      })
+      // Keep the person's own words in the confirmation: this is a record of
+      // what they contributed, and it must survive them clearing the form.
+      setAttached((prev) => [...prev, body.trim()])
+      setBody('')
+      setUrl('')
+      setOpen(false)
+    } catch (err) {
+      setError(
+        err instanceof CollabRequestError ? err.message : 'That did not attach. Please try again.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }, [roundId, target, body, url, stance])
+
+  return (
+    <div className="mt-5 border-t border-panel-border pt-4">
+      {attached.map((words, i) => (
+        <p
+          key={`${words}-${i}`}
+          data-testid={`packet-evidence-attached-${target.target.id}`}
+          className={`${typography.bodySmall} mb-3 flex gap-2 text-text-body`}
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-success" aria-hidden="true" />
+          <span>
+            Attached: &ldquo;{words}&rdquo; — everyone will see this when the round closes.
+          </span>
+        </p>
+      ))}
+
+      {!open ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          data-testid={`packet-evidence-open-${target.target.id}`}
+          onClick={() => setOpen(true)}
+        >
+          Attach evidence
+        </Button>
+      ) : (
+        <div data-testid={`packet-evidence-form-${target.target.id}`}>
+          <label
+            htmlFor={`evidence-body-${target.target.id}`}
+            className={`${typography.label} block text-text-header`}
+          >
+            What is the evidence?
+          </label>
+          <p className={`${typography.bodySmall} mt-1 text-text-light`}>
+            In your own words. It stays private until the round closes, then it is shown beside
+            the answers, attributed to you.
+          </p>
+          <textarea
+            id={`evidence-body-${target.target.id}`}
+            data-testid={`packet-evidence-body-${target.target.id}`}
+            className={`${FIELD} ${typography.body} mt-2 min-h-[88px]`}
+            value={body}
+            onChange={(e) => {
+              setBody(e.target.value)
+              if (error !== null) setError(null)
+            }}
+            placeholder="e.g. Our Q3 cohort held at 12% after the last price rise"
+          />
+
+          <label
+            htmlFor={`evidence-url-${target.target.id}`}
+            className={`${typography.label} mt-4 block text-text-header`}
+          >
+            Link (optional)
+          </label>
+          <input
+            id={`evidence-url-${target.target.id}`}
+            data-testid={`packet-evidence-url-${target.target.id}`}
+            className={`${FIELD} ${typography.body} mt-2`}
+            value={url}
+            autoComplete="off"
+            spellCheck={false}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://…"
+          />
+
+          <label
+            htmlFor={`evidence-stance-${target.target.id}`}
+            className={`${typography.label} mt-4 block text-text-header`}
+          >
+            This evidence…
+          </label>
+          <select
+            id={`evidence-stance-${target.target.id}`}
+            data-testid={`packet-evidence-stance-${target.target.id}`}
+            className={`${FIELD} ${typography.body} mt-2`}
+            value={stance}
+            onChange={(e) => setStance(e.target.value as EvidenceStance)}
+          >
+            {/* The three stances CEE accepts. The WORDS shown beside it on the
+                disagreement view are CEE's (`stance_phrase`), never these. */}
+            <option value="supports">supports this</option>
+            <option value="challenges">challenges this</option>
+            <option value="qualifies">qualifies this</option>
+          </select>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <Button
+              size="sm"
+              data-testid={`packet-evidence-submit-${target.target.id}`}
+              onClick={handleAttach}
+              disabled={busy || nothingToAttach}
+            >
+              {busy ? 'Attaching…' : 'Attach'}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              data-testid={`packet-evidence-cancel-${target.target.id}`}
+              onClick={() => {
+                setOpen(false)
+                setError(null)
+              }}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+          </div>
+
+          {error !== null && (
+            <p
+              role="alert"
+              data-testid={`packet-evidence-error-${target.target.id}`}
+              className={`${typography.bodySmall} mt-3 text-danger`}
+            >
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function TargetCard({
   target,
   roundId,
@@ -437,6 +648,11 @@ function TargetCard({
           {error}
         </p>
       )}
+
+      {/* Evidence is independent of the answer: a participant may attach a
+          source without giving a number, or decline and still contribute what
+          they know. It is deliberately NOT gated on `alreadyAnswered`. */}
+      <EvidenceAttach target={target} roundId={roundId} />
     </section>
   )
 }
@@ -495,7 +711,16 @@ export default function ParticipantPacketPage(): JSX.Element {
       if (code === 'collab_round_closed') {
         try {
           const reveal = await fetchParticipantReveal(roundId)
-          setState({ kind: 'reveal', reveal })
+          // The disagreement view is a SECOND request and a secondary surface:
+          // it is fetched after the reveal has already succeeded, and its own
+          // failure is swallowed to null rather than propagated. See LoadState.
+          let disagreement: DisagreementView | null = null
+          try {
+            disagreement = await fetchParticipantDisagreement(roundId)
+          } catch {
+            disagreement = null
+          }
+          setState({ kind: 'reveal', reveal, disagreement })
           return
         } catch (revealErr) {
           setState({
@@ -713,7 +938,7 @@ export default function ParticipantPacketPage(): JSX.Element {
   }
 
   if (state.kind === 'reveal') {
-    return <RevealBody reveal={state.reveal} />
+    return <RevealBody reveal={state.reveal} disagreement={state.disagreement} />
   }
 
   const { packet } = state
@@ -802,9 +1027,27 @@ export interface RevealApplyState {
 export function RevealBody({
   reveal,
   apply,
+  disagreement,
 }: {
   reveal: RevealView
   apply?: RevealApplyState
+  /**
+   * ⭐⭐ THE DISAGREEMENT MOUNT, AND IT IS DELIBERATELY ONE MOUNT.
+   *
+   * This component is rendered by BOTH collaboration journeys — the participant
+   * reaches it through `ParticipantPacketPage`, the owner through
+   * `PanelSetupPage` — so hanging the disagreement view here reaches both with
+   * a single call site and invents no navigation. The alternative, a route or a
+   * tab per page, would have been two surfaces to keep in step and two places
+   * for one of them to go dark unnoticed.
+   *
+   * ⚠ IT ARRIVES AS A PROP, ALREADY FETCHED, AND THAT IS THE CREDENTIAL RULE
+   * MADE STRUCTURAL. The two journeys authenticate differently — a participant
+   * bearer token, an owner Supabase JWT — and this component holds neither. It
+   * cannot fetch, so it cannot fetch with the wrong one. Each page calls its own
+   * fetcher and passes the result down, exactly as `apply` already works.
+   */
+  disagreement?: DisagreementView | null
 }): JSX.Element {
   const rows = useMemo(() => reveal.per_target, [reveal])
   return (
@@ -972,6 +1215,23 @@ export function RevealBody({
             )}
           </section>
         ))}
+
+        {/* ⭐ WHERE YOU DIFFER, and why. The reveal above answers "what did
+            everyone say?"; this answers "where do you differ, on what basis,
+            and what should you ask about it?" — the evidence people attached,
+            each position's stated reason, and CEE's question about it.
+
+            Below the reveal rather than instead of it: the positions are what
+            the participant was promised, and the interrogation is what makes
+            them a shared piece of reasoning rather than a list of numbers.
+
+            ⚠ ABSENT IS A REAL STATE — an older CEE, or a failed second
+            request. The reveal stands alone when it is. */}
+        {disagreement != null && (
+          <div className="mt-12">
+            <DisagreementBody view={disagreement} />
+          </div>
+        )}
       </div>
     </main>
   )


### PR DESCRIPTION
Lane B (P2 — collaboration). **This is the mount that register 2.1216 is about.**

**⚠ REVIEW TIER:** one **capability review** + a browser proof. The
privacy-adjacent work is in the sibling CEE PR
(Talchain/olumi-assistants-service#963), which wants a full review; nothing in
this PR touches an authorisation decision.

---

## What a user can now DO

Before this PR, `DisagreementBody`, `fetchParticipantDisagreement`,
`fetchOwnerDisagreement` and `attachEvidence` all existed and **none of them had
a single product call site** — each symbol occurred exactly once in `src/`, its
own definition. CEE was deployed and its table migrated, so every component
witness was green while no user could reach any of it.

Now, in the two-person round:

1. while the round is **open**, a participant can attach evidence to a factor —
   their own words, an optional link, and a stance (supports / challenges /
   qualifies) — alongside or instead of a number;
2. once the owner **closes** it, **both** the participant and the owner get
   *"Where you differ"* beneath the reveal: each position with **its author's
   stated basis verbatim**, the range as two attributed endpoints, the evidence
   people attached, and CEE's question about it.

## The mount is ONE mount

`RevealBody` was **already shared** — `ParticipantPacketPage.tsx:825` exports it
and `PanelSetupPage.tsx:67` imports it — so the disagreement view hangs there
and reaches both journeys from a single call site, inventing no navigation.

It arrives as an **already-fetched prop**. The two journeys authenticate
differently (participant bearer token vs owner Supabase JWT); the shared
component holds neither credential, so it *cannot* use the wrong one. Each page
calls its own fetcher, exactly as `apply` already works.

## ⚠ Corrected premise — evidence cannot be attached "to a position"

The brief's acceptance said *"a participant attaches evidence to a position"*.
**That is not buildable, and the constraint is structural.** Derived at the CEE
bytes:

- `elicitation-append.ts:368` refuses every append once the round is not
  `open`; and
- `packet-read-model.ts:182` refuses the reveal **and** the disagreement view
  while it is.

**The two windows are disjoint** — there is no moment at which a participant can
see a position *and* attach anything to it. Evidence is therefore attached
during the blind round beside the person's own answer, and read after the close.
That is also the anchoring-free order: someone who could read the others first
would be attaching evidence to a position they had already been anchored by.

For the same reason there is **no "whose position" picker**: `attachEvidence`
accepts `aboutParticipantId` and this passes `null` every time, because the
roster is withheld before the close (blindness item 4) and any picker would be
listing people the packet does not contain. `DisagreementBody` already renders
the null case as *"this factor"*.

## Evidence

| gate | result |
|---|---|
| `pnpm typecheck` | **PASSED** — baseline **unchanged at 2485**; coverage 3444/3484 files |
| `npx vitest run src/collab …` | **19 files / 201 tests passed** (the whole collab blast radius) |
| new spec `disagreementMount.spec.tsx` | **13 tests, asserted BY NAME** — never inferred from a suite total (trap 2b) |
| `eslint` (changed files) | clean |
| `lint:hooks-ratchet` | 232 known violations across 15 files, **exactly** baseline — no new conditional hooks |

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run.

**The gate caught a real error and it was fixed at the source, not absorbed.**
Making `standing_note` required surfaced a stale fixture in
`disagreementBody.spec.tsx:83`. The baseline was **not** regenerated.

**Mutation kit — 7 mutants, all bitten.** Isolation proven by **writing**
(trap 9g): distinct inodes asserted and a sentinel written into the throwaway
worktree left the source unchanged. Restores are `HEAD`-relative (trap 9h), the
applied-check is scoped to `src/` and asserts exactly one changed file, and the
worktree sat outside the repo root and was removed before the gates ran.
Control 38 / trailing control 38.

| mutant | bitten |
|---|---|
| U1 the `DisagreementBody` render is deleted (**= the dark state this PR ends**) | 6 failed |
| U2 the participant never *fetches* the view | 5 failed |
| U3 rendered unconditionally, ignoring absence | 2 failed |
| U4 `PanelSetupPage` stops passing the prop | 1 failed |
| U5 a local fallback sentence is reinstated | 1 failed |
| U6 the client invents an attribution target | 1 failed |
| U7 `kind` no longer derived from the URL field | 1 failed |

**U1 vs U2 is the discriminating pair.** U1 REDs six tests *including* the owner
`RevealBody` render; U2 REDs five, because the owner test passes the prop
directly and stays green. That difference is what separates "the shared render
works" from "the participant journey is wired" — either mutant alone would
conflate them.

**U4 matters more than its size suggests:** `disagreement` is an *optional*
prop, so deleting the owner page's call site keeps **typecheck green** and no
render test would notice. The mount-path ratchet is what fails loud instead
(trap 3b).

## Mount chain

- `AppPoC.tsx:916` `/panel/:round_id` → `ParticipantPacketPage` (public,
  outside `AuthGuard`) — **no feature flag**
- `AppPoC.tsx:926` `/scenario/:id/panel` → `PanelSetupPage` (inside `AuthGuard`)
  — **no feature flag**
- both → `RevealBody` → `DisagreementBody`

Derived at the route table: neither route is flag-gated, so the deployed build
does mount these surfaces.

## Sequencing

`standing_note` is **absent-tolerant by design** (`string | null`, no local
fallback), so this PR is safe to deploy **before or after** CEE #963. Until CEE
ships, the sentence is simply absent — never invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)