### PR TITLE
feat(canvas): the element the answer was grounded on lights up on the canvas (hop 4b)

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -540,7 +540,7 @@
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'graph_state' does not exist on type 'TurnRequestPayload'.
 1	src/canvas/conversation/useConversation.ts	TS2339	Property 'message' does not exist on type 'TurnRequestPayload'.
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'selected_elements' does not exist on type 'TurnRequestPayload'.
-1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 254 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
+1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 256 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
 2	src/canvas/conversation/useConversation.ts	TS2352	Conversion of type 'OrchestratorResponseEnvelopeV2' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'op' is declared but its value is never read.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'ops' is declared but its value is never read.

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -93,6 +93,7 @@ import { DocumentsManager } from './components/DocumentsManager'
 import { ProvenanceHubTab } from './components/ProvenanceHubTab'
 import { ConnectPrompt } from './components/ConnectPrompt'
 import { FocusModeChip } from './components/FocusModeChip'
+import { GroundedFocusNotice } from './components/GroundedFocusNotice'
 // EdgeLabelToggle moved to CanvasToolbar for cleaner UI
 import { LimitsPanel } from './components/LimitsPanel'
 import { BottomSheet } from './components/BottomSheet'
@@ -2154,6 +2155,12 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         style={{ top: 'calc(var(--topbar-h, 0px) + 1rem)' }}
       >
         <FocusModeChip />
+        {/* Hop 4b: the "I couldn't read your model" notice. Shares the chip
+            rail deliberately — it is the same class of transient, canvas-level
+            status, and the two are mutually exclusive in practice (a grounded
+            turn whose model could not be read has no path highlighting).
+            Renders nothing for every other grounding state. */}
+        <GroundedFocusNotice />
       </div>
 
       {/* Influence Explainer - shown when triggered from TopBar dropdown */}

--- a/src/canvas/components/GroundedFocusNotice.stories.tsx
+++ b/src/canvas/components/GroundedFocusNotice.stories.tsx
@@ -1,0 +1,76 @@
+/**
+ * GroundedFocusNotice — the honesty pair, in a real browser.
+ *
+ * jsdom can prove the element is in the DOM. It cannot prove it is visible,
+ * laid out, or legible (CLAUDE.md trap 3), and the acceptance condition for
+ * this slice is that `could_not_check` and `not_in_model` are VISIBLY
+ * different. That claim can only be made here.
+ *
+ * ⭐ EACH STORY DRIVES THE REAL `setGroundedFocus` ACTION rather than writing
+ * the store slice directly, so what renders is the production path — a story
+ * that stubbed the slice would prove the component and say nothing about the
+ * action that feeds it.
+ */
+// `@storybook/react-vite`, not `@storybook/react`: this repo is on Storybook
+// 10 and only the former is installed. Every existing story imports the
+// latter and carries a baselined TS2307 for it — this one does not add a
+// seventh.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useEffect } from 'react'
+
+import { GroundedFocusNotice } from './GroundedFocusNotice'
+import { useCanvasStore } from '../store'
+import type { GroundedUnresolved } from '../../v5/groundedSelection'
+
+function Harness({
+  unresolved,
+  nodeIds = [],
+}: {
+  unresolved: GroundedUnresolved | null
+  nodeIds?: string[]
+}) {
+  useEffect(() => {
+    useCanvasStore
+      .getState()
+      .setGroundedFocus(unresolved === null ? null : { nodeIds, unresolved })
+  }, [unresolved, nodeIds])
+
+  return (
+    <div style={{ padding: '2rem', minHeight: 160 }}>
+      <GroundedFocusNotice />
+    </div>
+  )
+}
+
+const meta: Meta<typeof Harness> = {
+  title: 'Canvas/GroundedFocusNotice',
+  component: Harness,
+}
+export default meta
+
+type Story = StoryObj<typeof Harness>
+
+/** The graph could NOT be read. The notice must SPEAK — and must not say
+ *  "not found", which is the claim this component exists to prevent. */
+export const CouldNotCheck: Story = {
+  args: { unresolved: 'could_not_check' },
+}
+
+/** The graph WAS read and does not contain the element. Marking nothing is
+ *  honest, so the notice renders nothing — no empty box, no stray border, no
+ *  reserved space. Compare against `CouldNotCheck`: that visible contrast is
+ *  the acceptance condition. */
+export const NotInModel: Story = {
+  args: { unresolved: 'not_in_model' },
+}
+
+/** Everything the user pointed at resolved. The node marks are the answer; the
+ *  notice stays silent. */
+export const FullyResolved: Story = {
+  args: { unresolved: 'none', nodeIds: ['node-engineer-salary'] },
+}
+
+/** An ordinary turn, never grounded on a selection. Silent. */
+export const NotGrounded: Story = {
+  args: { unresolved: null },
+}

--- a/src/canvas/components/GroundedFocusNotice.tsx
+++ b/src/canvas/components/GroundedFocusNotice.tsx
@@ -1,0 +1,76 @@
+/**
+ * GroundedFocusNotice — the one thing the canvas must SAY, rather than show,
+ * about a grounded answer (hop 4b).
+ *
+ * ⭐ WHY THIS COMPONENT EXISTS AT ALL, because a marker on a node would
+ * otherwise be the whole slice.
+ *
+ * When a turn is grounded on the user's selection, CEE reports why anything
+ * they pointed at is missing, as a closed three-value enum. Two of those values
+ * MUST NOT collapse:
+ *
+ *   · `not_in_model`    — the graph WAS read and does not contain it. Marking
+ *                         nothing is honest, and this component renders
+ *                         nothing. The absence of a mark IS the answer.
+ *   · `could_not_check` — the graph could NOT be read. We do not know whether
+ *                         it is there. An empty canvas here would tell the
+ *                         user their node is gone on the strength of a lookup
+ *                         that never happened.
+ *
+ * Without this notice both states render identically — nothing marked — and
+ * the UI would reintroduce at the pixel layer exactly the conflation CEE's
+ * hop 3 and hop 4 were built to keep apart. The visible difference between the
+ * two is the acceptance condition for this slice, and this is where it lives.
+ *
+ * ⚠ IT IS NOT A FAILURE BANNER. `could_not_check` is a turn that answered; it
+ * simply could not verify the selection against the model. The copy says what
+ * is not known, and claims nothing about the element either way.
+ */
+
+import { memo } from 'react'
+import { useCanvasStore } from '../store'
+
+interface GroundedFocusNoticeProps {
+  /** Optional className for positioning overrides. */
+  className?: string
+}
+
+export const GroundedFocusNotice = memo(function GroundedFocusNotice({
+  className = '',
+}: GroundedFocusNoticeProps) {
+  // React #185: primitive selector. Selecting the slice object would change
+  // reference on every store write and re-render this on every canvas action.
+  // Optional chaining keeps store doubles without the slice safe, matching the
+  // idiom every other emphasis selector in this canvas uses.
+  const unresolved = useCanvasStore((s) => s.groundedFocus?.unresolved ?? null)
+
+  // Rendered for EXACTLY ONE of the three values. `none` is a fully resolved
+  // grounding (the marks say it), `not_in_model` is honestly silent, and
+  // `null` is a turn that was never grounded.
+  if (unresolved !== 'could_not_check') return null
+
+  return (
+    <div
+      className={`
+        inline-flex items-center gap-2 px-4 py-2
+        bg-paper-50 border border-sand-200 rounded-full
+        shadow-[0_1px_2px_rgba(38,38,38,0.06)]
+        transition-opacity duration-200
+        motion-reduce:transition-none
+        ${className}
+      `}
+      role="status"
+      aria-live="polite"
+      data-testid="grounded-focus-could-not-check"
+    >
+      <span className="text-sm text-ink-900">
+        {/* Says what is NOT known. Never "not found" — that is the claim this
+            whole component exists to stop the UI making. */}
+        I couldn’t read your model to check what you selected, so I can’t show
+        it on the canvas.
+      </span>
+    </div>
+  )
+})
+
+export default GroundedFocusNotice

--- a/src/canvas/components/__tests__/GroundedFocusNotice.mount.spec.tsx
+++ b/src/canvas/components/__tests__/GroundedFocusNotice.mount.spec.tsx
@@ -1,0 +1,55 @@
+/**
+ * GroundedFocusNotice — mounted canvas surface.
+ *
+ * Rendering the leaf component alone does not prove that the product mounts
+ * it. This drives the real canvas route and the real store action, then
+ * observes the notice through ReactFlowGraph's production render tree.
+ */
+import { act, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { cleanupCanvas, renderCanvas } from '../../__tests__/__helpers__/renderCanvas'
+import { useCanvasStore } from '../../store'
+
+function ensureResizeObserver() {
+  if (typeof globalThis.ResizeObserver !== 'function') {
+    globalThis.ResizeObserver = class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+}
+
+describe('GroundedFocusNotice — mounted canvas surface', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost:54321')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test_anon_key')
+    ensureResizeObserver()
+  })
+
+  afterEach(() => {
+    cleanupCanvas()
+    vi.unstubAllEnvs()
+  })
+
+  it('renders through CanvasMVP → ReactFlowGraph when the model could not be checked', async () => {
+    const { default: CanvasMVP } = await import('../../../routes/CanvasMVP')
+    renderCanvas(<CanvasMVP />)
+
+    // Positive control: this is the real product route and its real canvas,
+    // not a second leaf-component mount hidden in the harness.
+    expect(screen.getByTestId('rf-root')).toBeInTheDocument()
+
+    act(() => {
+      useCanvasStore.getState().setGroundedFocus({
+        nodeIds: [],
+        unresolved: 'could_not_check',
+      })
+    })
+
+    expect(await screen.findByTestId('grounded-focus-could-not-check')).toHaveTextContent(
+      'I couldn’t read your model to check what you selected, so I can’t show it on the canvas.',
+    )
+  }, 30_000)
+})

--- a/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
+++ b/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
@@ -1,0 +1,144 @@
+/**
+ * GroundedFocusNotice — THE HONESTY PAIR, and the mount path that carries it.
+ *
+ * The load-bearing acceptance condition of hop 4b's UI half is not that a
+ * grounded node lights up. It is that the two "nothing lit up" states stay
+ * APART:
+ *
+ *   · `not_in_model`    — the graph WAS read and does not contain what the user
+ *                         pointed at. Marking nothing is honest, and the notice
+ *                         stays silent.
+ *   · `could_not_check` — the graph could NOT be read. Rendering that as an
+ *                         empty canvas tells the user their node is gone on the
+ *                         strength of a lookup that never happened, which
+ *                         reintroduces at the pixel layer exactly the
+ *                         conflation CEE's hop 3 and hop 4 were built to keep
+ *                         apart.
+ *
+ * With node marks alone the two are indistinguishable — both mark nothing —
+ * so the discrimination has to live in a surface, and this is that surface.
+ *
+ * ⚠ SCOPE (trap 3): jsdom proves the element is IN THE DOM. It cannot prove it
+ * is visible, laid out, or legible. Those are browser claims and are made in a
+ * browser, not here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { GroundedFocusNotice } from '../GroundedFocusNotice'
+import { useCanvasStore } from '../../store'
+
+const NOTICE = 'grounded-focus-could-not-check'
+
+/** Drive the REAL store action rather than writing the slice directly, so the
+ *  spec exercises the production path into this component. */
+function ground(unresolved: 'none' | 'not_in_model' | 'could_not_check', ids: string[] = []) {
+  useCanvasStore.getState().setGroundedFocus({ nodeIds: ids, unresolved })
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    highlightedNodes: new Set<string>(),
+    groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
+  })
+})
+
+describe('GroundedFocusNotice — the two empty states are not the same state', () => {
+  it('SPEAKS when the model could not be read', () => {
+    ground('could_not_check')
+    render(<GroundedFocusNotice />)
+
+    const notice = screen.getByTestId(NOTICE)
+    expect(notice).toBeInTheDocument()
+    // Says what is NOT known. Never "not found" — that is the claim this
+    // component exists to stop the UI making.
+    expect(notice.textContent).toMatch(/couldn.t read your model/i)
+    expect(notice.textContent).not.toMatch(/not found|doesn.t exist|no longer/i)
+  })
+
+  it('STAYS SILENT when the model was read and the element is not in it', () => {
+    ground('not_in_model')
+    render(<GroundedFocusNotice />)
+
+    expect(screen.queryByTestId(NOTICE)).not.toBeInTheDocument()
+  })
+
+  it('the pair DISCRIMINATES on otherwise identical state', () => {
+    // Asserted as a pair on the same empty id set, because each half alone is
+    // satisfied by a component that renders unconditionally (or never).
+    ground('could_not_check')
+    const { unmount } = render(<GroundedFocusNotice />)
+    const spoke = screen.queryByTestId(NOTICE) !== null
+    unmount()
+
+    ground('not_in_model')
+    render(<GroundedFocusNotice />)
+    const silent = screen.queryByTestId(NOTICE) === null
+
+    expect(spoke).toBe(true)
+    expect(silent).toBe(true)
+  })
+
+  it('stays silent on a fully resolved grounding', () => {
+    ground('none', ['node-a'])
+    render(<GroundedFocusNotice />)
+
+    expect(screen.queryByTestId(NOTICE)).not.toBeInTheDocument()
+  })
+
+  it('stays silent on a turn that was never grounded at all', () => {
+    useCanvasStore.getState().setGroundedFocus(null)
+    render(<GroundedFocusNotice />)
+
+    expect(screen.queryByTestId(NOTICE)).not.toBeInTheDocument()
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBeNull()
+  })
+
+  it('is announced to assistive technology as status, not as an alert', () => {
+    ground('could_not_check')
+    render(<GroundedFocusNotice />)
+
+    const notice = screen.getByTestId(NOTICE)
+    expect(notice).toHaveAttribute('role', 'status')
+    expect(notice).toHaveAttribute('aria-live', 'polite')
+  })
+})
+
+describe('the mount path — trap 3b: a component the deployment never renders', () => {
+  // This estate has twice shipped a badge dark by testing a component the
+  // deployed flags do not mount. The render tests above are silent about that
+  // by construction, so the mount path is asserted directly at the source of
+  // the canvas that hosts it.
+  //
+  // ⚠ SCOPE, precisely: this is a STRUCTURAL claim about `ReactFlowGraph.tsx`
+  // — that the notice sits in the same unconditional chip rail as a surface
+  // already known to reach users. It is not a render proof of that file.
+  const graphSource = readFileSync(
+    resolve(__dirname, '../../ReactFlowGraph.tsx'),
+    'utf8',
+  )
+
+  it('POSITIVE CONTROL: the probe finds FocusModeChip, a surface known to be live', () => {
+    // Without this, "the notice is mounted" could be passing because the probe
+    // matches anything, or because it read the wrong file.
+    expect(graphSource.length).toBeGreaterThan(0)
+    expect(graphSource).toMatch(/<FocusModeChip\s*\/>/)
+  })
+
+  it('mounts GroundedFocusNotice in the same rail as FocusModeChip', () => {
+    expect(graphSource).toMatch(/<GroundedFocusNotice\s*\/>/)
+
+    const chip = graphSource.indexOf('<FocusModeChip />')
+    const notice = graphSource.indexOf('<GroundedFocusNotice />')
+    expect(chip).toBeGreaterThan(-1)
+    expect(notice).toBeGreaterThan(chip)
+
+    // Nothing conditional between the two: the notice inherits exactly the
+    // reachability of the chip. A flag or `&&` introduced here would make the
+    // notice dark while every render test above stayed green.
+    const between = graphSource.slice(chip, notice)
+    expect(between).not.toMatch(/&&|\?\s*\(|\bif\s*\(/)
+  })
+})

--- a/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
+++ b/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
@@ -127,6 +127,23 @@ describe('the mount path — trap 3b: a component the deployment never renders',
     expect(graphSource).toMatch(/<FocusModeChip\s*\/>/)
   })
 
+  it('BaseNode reads the grounded set and gives it the SAME emphasis treatment', () => {
+    // The node marks are the other half of the visible slice, and after the
+    // ownership fix they ride `groundedFocus.nodeIds` rather than the shared
+    // `highlightedNodes`. Two claims, both structural: the selector exists,
+    // and it drives the SAME `ai-highlight-pulse` class — one emphasis
+    // language on the canvas, per the spec.
+    const baseNode = readFileSync(resolve(__dirname, '../../nodes/BaseNode.tsx'), 'utf8')
+
+    // POSITIVE CONTROL: the probe can see the pre-existing shared-channel
+    // selector, so a miss below is absence rather than blindness.
+    expect(baseNode).toMatch(/useCanvasStore\(s\s*=>\s*s\.highlightedNodes\.has\(id\)\)/)
+
+    expect(baseNode).toMatch(/s\.groundedFocus\?\.nodeIds\?\.has\(id\)/)
+    // Same treatment, one class, driven by either channel.
+    expect(baseNode).toMatch(/isHighlighted \|\| isGroundedFocus\s*\?\s*'ring-4 ring-info\/60 ai-highlight-pulse'/)
+  })
+
   it('mounts GroundedFocusNotice in the same rail as FocusModeChip', () => {
     expect(graphSource).toMatch(/<GroundedFocusNotice\s*\/>/)
 

--- a/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
+++ b/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
@@ -24,8 +24,6 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 import { GroundedFocusNotice } from '../GroundedFocusNotice'
 import { useCanvasStore } from '../../store'
@@ -138,59 +136,5 @@ describe('GroundedFocusNotice — the two empty states are not the same state', 
     const notice = screen.getByTestId(NOTICE)
     expect(notice).toHaveAttribute('role', 'status')
     expect(notice).toHaveAttribute('aria-live', 'polite')
-  })
-})
-
-describe('the mount path — trap 3b: a component the deployment never renders', () => {
-  // This estate has twice shipped a badge dark by testing a component the
-  // deployed flags do not mount. The render tests above are silent about that
-  // by construction, so the mount path is asserted directly at the source of
-  // the canvas that hosts it.
-  //
-  // ⚠ SCOPE, precisely: this is a STRUCTURAL claim about `ReactFlowGraph.tsx`
-  // — that the notice sits in the same unconditional chip rail as a surface
-  // already known to reach users. It is not a render proof of that file.
-  const graphSource = readFileSync(
-    resolve(__dirname, '../../ReactFlowGraph.tsx'),
-    'utf8',
-  )
-
-  it('POSITIVE CONTROL: the probe finds FocusModeChip, a surface known to be live', () => {
-    // Without this, "the notice is mounted" could be passing because the probe
-    // matches anything, or because it read the wrong file.
-    expect(graphSource.length).toBeGreaterThan(0)
-    expect(graphSource).toMatch(/<FocusModeChip\s*\/>/)
-  })
-
-  it('BaseNode reads the grounded set and gives it the SAME emphasis treatment', () => {
-    // The node marks are the other half of the visible slice, and after the
-    // ownership fix they ride `groundedFocus.nodeIds` rather than the shared
-    // `highlightedNodes`. Two claims, both structural: the selector exists,
-    // and it drives the SAME `ai-highlight-pulse` class — one emphasis
-    // language on the canvas, per the spec.
-    const baseNode = readFileSync(resolve(__dirname, '../../nodes/BaseNode.tsx'), 'utf8')
-
-    // POSITIVE CONTROL: the probe can see the pre-existing shared-channel
-    // selector, so a miss below is absence rather than blindness.
-    expect(baseNode).toMatch(/useCanvasStore\(s\s*=>\s*s\.highlightedNodes\.has\(id\)\)/)
-
-    expect(baseNode).toMatch(/s\.groundedFocus\?\.nodeIds\?\.has\(id\)/)
-    // Same treatment, one class, driven by either channel.
-    expect(baseNode).toMatch(/isHighlighted \|\| isGroundedFocus\s*\?\s*'ring-4 ring-info\/60 ai-highlight-pulse'/)
-  })
-
-  it('mounts GroundedFocusNotice in the same rail as FocusModeChip', () => {
-    expect(graphSource).toMatch(/<GroundedFocusNotice\s*\/>/)
-
-    const chip = graphSource.indexOf('<FocusModeChip />')
-    const notice = graphSource.indexOf('<GroundedFocusNotice />')
-    expect(chip).toBeGreaterThan(-1)
-    expect(notice).toBeGreaterThan(chip)
-
-    // Nothing conditional between the two: the notice inherits exactly the
-    // reachability of the chip. A flag or `&&` introduced here would make the
-    // notice dark while every render test above stayed green.
-    const between = graphSource.slice(chip, notice)
-    expect(between).not.toMatch(/&&|\?\s*\(|\bif\s*\(/)
   })
 })

--- a/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
+++ b/src/canvas/components/__tests__/GroundedFocusNotice.spec.tsx
@@ -46,16 +46,51 @@ beforeEach(() => {
 })
 
 describe('GroundedFocusNotice — the two empty states are not the same state', () => {
-  it('SPEAKS when the model could not be read', () => {
+  it('SPEAKS when the model could not be read, saying EXACTLY this and nothing more', () => {
     ground('could_not_check')
     render(<GroundedFocusNotice />)
 
     const notice = screen.getByTestId(NOTICE)
     expect(notice).toBeInTheDocument()
-    // Says what is NOT known. Never "not found" — that is the claim this
-    // component exists to stop the UI making.
-    expect(notice.textContent).toMatch(/couldn.t read your model/i)
-    expect(notice.textContent).not.toMatch(/not found|doesn.t exist|no longer/i)
+
+    // ⭐ EXACT TEXT, NOT A PHRASE PREDICATE — and the difference is a real
+    // defect this assertion used to have. It was a positive phrase match
+    // (`/couldn.t read your model/i`) plus a hand-written list of forbidden
+    // words (`/not found|doesn.t exist|no longer/i`). An adversarial probe
+    // defeated it in one line: rewriting the copy to
+    //
+    //   "I couldn't read your model to check what you selected — that element
+    //    has been removed from your model"
+    //
+    // satisfied the positive phrase, dodged all three forbidden words, and
+    // stayed GREEN — while asserting the EXACT false claim this component
+    // exists to prevent. A forbidden-word list is a hand-maintained mirror
+    // (trap 12) and the space of ways to say "your node is gone" is unbounded,
+    // so no list can cover it.
+    //
+    // Binding the whole sentence inverts the problem: the honest copy is
+    // enumerable and short, every other sentence in the language fails, and a
+    // deliberate copy change must come here and be read.
+    expect(notice.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'I couldn’t read your model to check what you selected, so I can’t show it on the canvas.',
+    )
+  })
+
+  it('makes no claim about the element in either direction', () => {
+    // The secondary guard, kept as a CLASS rather than a word list: the copy
+    // must not assert presence or absence. Retained because it states the
+    // PROPERTY, while the exact-text bind above is what actually enforces it —
+    // if this test ever disagrees with that one, the copy changed and both
+    // must be re-read.
+    ground('could_not_check')
+    render(<GroundedFocusNotice />)
+
+    const text = screen.getByTestId(NOTICE).textContent ?? ''
+    expect(text).not.toMatch(/removed|deleted|not found|doesn.t exist|no longer|is gone/i)
+    // It says what is NOT known...
+    expect(text).toMatch(/couldn.t read your model/i)
+    // ...and does not tell the user their element is or is not there.
+    expect(text).not.toMatch(/\bis (still )?(in|on) your model\b/i)
   })
 
   it('STAYS SILENT when the model was read and the element is not in it', () => {

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -75,6 +75,23 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // on every store update. Selecting the entire Set causes infinite loops since
   // Set references change on each store update.
   const isHighlighted = useCanvasStore(s => s.highlightedNodes.has(id))
+  // SELECTION-AWARE ANSWERING (hop 4b): this node is one the LAST answer was
+  // grounded on. Its OWN channel, deliberately — not `highlightedNodes`.
+  //
+  // ⚠ WHY A SECOND SELECTOR RATHER THAN A SECOND WRITER, and it is a
+  // correctness fix, not a preference. `highlightedNodes` is a shared,
+  // last-writer-wins channel with eleven other writers, one of which is the
+  // applied-edit pulse — and that pulse REPLACES the set on flush and then
+  // EMPTIES it unconditionally after PULSE_DURATION_MS. A grounded turn that
+  // also applied a patch ("change this one" — the flagship case) would
+  // therefore have its marks overwritten ~100ms later and erased at ~2.1s,
+  // with nothing left to restore them. Writing a channel you do not own is how
+  // a canvas comes to disagree with itself.
+  //
+  // Same VISUAL treatment below (one emphasis language, per the spec),
+  // separate STATE. Primitive-boolean selector (React #185) + optional
+  // chaining for store doubles without the slice.
+  const isGroundedFocus = useCanvasStore(s => s.groundedFocus?.nodeIds?.has(id) === true)
   // N3: edited since the last analysis run (amber corner dot; undefined-safe
   // for node-spec store doubles without the slice).
   const isEditedSinceRun = useCanvasStore(s => s.editedSinceRunNodeIds?.has(id) === true)
@@ -245,8 +262,8 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         ${isCausalLens ? (causalBorderClass ?? '') : isIncomplete ? 'border-warning border-dashed' : borderClassOverride ?? `${colors.border} ${borderStyle}`}
         transition-all duration-200
         cursor-default
-        ${selected && !isHighlighted ? `${colors.selected} ring-offset-2` : ''}
-        ${isHighlighted ? 'ring-4 ring-info/60 ai-highlight-pulse' : ''}
+        ${selected && !isHighlighted && !isGroundedFocus ? `${colors.selected} ring-offset-2` : ''}
+        ${isHighlighted || isGroundedFocus ? 'ring-4 ring-info/60 ai-highlight-pulse' : ''}
         ${isLensDimmed ? 'opacity-20' : isDimmed ? 'opacity-60' : ''}
       `}
       style={{

--- a/src/canvas/nodes/__tests__/BaseNode.groundedFocus.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.groundedFocus.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * BaseNode — transient highlight + persistent grounded-focus visual union.
+ *
+ * This is deliberately a render test. Store-slice assertions and source-text
+ * matching can both stay green while BaseNode points at the wrong node. The
+ * rendered `ai-highlight-pulse` class is the DOM-level contract; pixel colour
+ * and legibility remain browser claims.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+
+import { FactorNode } from '../FactorNode'
+import { useCanvasStore } from '../../store'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+vi.mock('../../layoutStore', () => ({
+  useLayoutStore: vi.fn((selector: (state: { layoutNodeWidth: number | null }) => unknown) =>
+    selector({ layoutNodeWidth: null }),
+  ),
+}))
+
+const GROUNDED = 'factor-grounded'
+const TRANSIENT = 'factor-transient'
+const DECOY = 'factor-unrelated-decoy'
+
+function nodeProps(id: string) {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    selected: false,
+    isConnectable: true,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+    dragging: false,
+    zIndex: 0,
+    data: { label: id },
+  }
+}
+
+function renderNodes() {
+  render(
+    <ReactFlowProvider>
+      <FactorNode {...(nodeProps(GROUNDED) as never)} />
+      <FactorNode {...(nodeProps(TRANSIENT) as never)} />
+      <FactorNode {...(nodeProps(DECOY) as never)} />
+    </ReactFlowProvider>,
+  )
+}
+
+function renderedNode(id: string): HTMLElement {
+  return screen.getByRole('group', { name: `factor node: ${id}` })
+}
+
+function expectEmphasised(id: string, expected: boolean) {
+  const className = renderedNode(id).className
+  if (expected) {
+    expect(className).toContain('ring-info/60')
+    expect(className).toContain('ai-highlight-pulse')
+  } else {
+    expect(className).not.toContain('ring-info/60')
+    expect(className).not.toContain('ai-highlight-pulse')
+  }
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    highlightedNodes: new Set<string>(),
+    groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useCanvasStore.setState({
+    highlightedNodes: new Set<string>(),
+    groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
+  })
+})
+
+describe('BaseNode — visual union of transient and grounded attention', () => {
+  it('renders both channels while leaving an unrelated decoy plain', () => {
+    useCanvasStore.getState().setHighlightedNodes([TRANSIENT])
+    useCanvasStore.getState().setGroundedFocus({
+      nodeIds: [GROUNDED],
+      unresolved: 'none',
+    })
+
+    renderNodes()
+
+    expectEmphasised(GROUNDED, true)
+    expectEmphasised(TRANSIENT, true)
+    expectEmphasised(DECOY, false)
+  })
+
+  it('binds persistent emphasis to the grounded id, not whichever node renders first', () => {
+    useCanvasStore.getState().setGroundedFocus({
+      nodeIds: [DECOY],
+      unresolved: 'none',
+    })
+
+    renderNodes()
+
+    expectEmphasised(GROUNDED, false)
+    expectEmphasised(TRANSIENT, false)
+    expectEmphasised(DECOY, true)
+  })
+
+  it('renders no false grounded emphasis when neither channel names a node', () => {
+    renderNodes()
+
+    expectEmphasised(GROUNDED, false)
+    expectEmphasised(TRANSIENT, false)
+    expectEmphasised(DECOY, false)
+  })
+})

--- a/src/canvas/nodes/__tests__/BaseNode.groundedFocus.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.groundedFocus.spec.tsx
@@ -46,9 +46,15 @@ function nodeProps(id: string) {
 function renderNodes() {
   render(
     <ReactFlowProvider>
-      <FactorNode {...(nodeProps(GROUNDED) as never)} />
-      <FactorNode {...(nodeProps(TRANSIENT) as never)} />
-      <FactorNode {...(nodeProps(DECOY) as never)} />
+      <FactorNode
+        {...(nodeProps(GROUNDED) as unknown as React.ComponentProps<typeof FactorNode>)}
+      />
+      <FactorNode
+        {...(nodeProps(TRANSIENT) as unknown as React.ComponentProps<typeof FactorNode>)}
+      />
+      <FactorNode
+        {...(nodeProps(DECOY) as unknown as React.ComponentProps<typeof FactorNode>)}
+      />
     </ReactFlowProvider>,
   )
 }

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -69,6 +69,7 @@ import { useDraftStore } from './stores/draftStore'
 import { loadSearchQuery, loadSortPreferences, saveSearchQuery, saveSortPreferences, __test__ as docsTest } from './store/documents'
 import { loadUIPreferences, saveUIPreference } from './store/uiPreferences'
 import { validateCeeAnalysisReady } from './utils/ceeAnalysisReadyValidation'
+import type { GroundedUnresolved } from '../v5/groundedSelection'
 import { recordCrossSurfaceEvent, recordUserAction } from '../lib/debug-state'
 import {
   isSelfLoop,
@@ -619,6 +620,24 @@ interface CanvasState {
     edgeIds: Set<string>
     nodeIds: Set<string>
   }
+  /**
+   * SELECTION-AWARE ANSWERING (hop 4b) — which model elements the LAST
+   * answer was grounded on, read off CEE's `_grounded_selection` sidecar.
+   *
+   * This is the AI's attention, and it is deliberately NOT the user's
+   * selection: `selection` is the user's pointer and nothing here may move
+   * it. The two are usually the same set and will diverge (an unresolved id,
+   * or a follow-up turn taken after the user clicked elsewhere).
+   *
+   * `unresolved` is `null` when the last turn was not grounded on anything —
+   * distinct from `'none'`, which means it WAS grounded and everything the
+   * user pointed at resolved. Collapsing those two would make an ordinary
+   * conversational turn indistinguishable from a fully-resolved grounded one.
+   */
+  groundedFocus: {
+    nodeIds: Set<string>
+    unresolved: GroundedUnresolved | null
+  }
   dimmedNodeIds: Set<string>
   /** 6A (selection focus): edges NOT in the selected element's neighbourhood.
    * Peer of dimmedNodeIds — same producer (usePathHighlight), same lifetime,
@@ -968,6 +987,19 @@ interface CanvasState {
   /** Analysis-graph projection: clear all projection marks. No-op (no state
    * write, no Set-identity churn) when nothing is currently projected. */
   clearAnalysisHighlight: () => void
+  /**
+   * SELECTION-AWARE ANSWERING (hop 4b): record what the last answer was
+   * grounded on, and mark those nodes on the canvas. Pass `null` for a turn
+   * that was not grounded — that CLEARS the marks it previously owned.
+   *
+   * ⭐ THIS ACTION IS THE SINGLE AUTHORITY FOR THE GROUNDED MARKS, and that is
+   * why it performs the `highlightedNodes` write itself rather than leaving it
+   * to a caller. Two writers for one visual state is how a canvas comes to
+   * disagree with itself.
+   */
+  setGroundedFocus: (
+    grounded: { nodeIds: readonly string[]; unresolved: GroundedUnresolved } | null,
+  ) => void
   setDimmedNodes: (ids: string[]) => void
   /** 6A: replace the selection-dimmed edge set. Same idiom as setDimmedNodes. */
   setDimmedEdges: (ids: string[]) => void
@@ -1744,6 +1776,8 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   highlightedNodes: new Set<string>(),
   highlightedEdges: new Set<string>(),
   analysisHighlight: { source: null, edgeIds: new Set<string>(), nodeIds: new Set<string>() },
+  // Hop 4b: `null` unresolved = no answer has been grounded on a selection yet.
+  groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
   dimmedNodeIds: new Set<string>(),
   dimmedEdgeIds: new Set<string>(),
   focusDimSourceId: null,
@@ -4847,6 +4881,43 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // identity and needlessly re-run every edge/node projection selector.
     if (cur.source === null && cur.edgeIds.size === 0 && cur.nodeIds.size === 0) return
     set({ analysisHighlight: { source: null, edgeIds: new Set<string>(), nodeIds: new Set<string>() } })
+  },
+  // SELECTION-AWARE ANSWERING (hop 4b). Two writes, one action, because they
+  // are one fact: "this answer is about these elements".
+  //
+  // ⚠ THE MARKS RIDE `highlightedNodes` DELIBERATELY, AND NOTHING WRITES
+  // `highlightedEdges`. `highlightedNodes` is already this canvas's "the AI is
+  // talking about this" channel (`appliedEditPulse`, the `ui_directive`
+  // highlight verb) and BaseNode already renders it as `ai-highlight-pulse` —
+  // so reusing it is the spec's instruction, not a shortcut: a second emphasis
+  // style on one canvas is a worse outcome than none. `highlightedEdges` is a
+  // different matter entirely: FocusModeChip renders "Showing paths from X to
+  // goal" on `highlightedEdges.size > 0` alone, so writing it for a grounding
+  // that involves no path would make the chip state something untrue. That is
+  // #694's neighbourhood-focus precedent applied here — prominence comes from
+  // the node marks, never from claiming a path.
+  //
+  // OWNERSHIP ON CLEAR: `highlightedNodes` has other, transient writers (the
+  // applied-edit pulse, panel hover sync). Clearing only when this slice
+  // currently holds a non-empty set means an ungrounded turn cannot wipe a
+  // pulse it never owned.
+  setGroundedFocus: (grounded) => {
+    if (grounded === null) {
+      const prev = get().groundedFocus
+      if (prev.unresolved === null && prev.nodeIds.size === 0) return
+      set({
+        groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
+        ...(prev.nodeIds.size > 0 ? { highlightedNodes: new Set<string>() } : {}),
+      })
+      return
+    }
+    set({
+      groundedFocus: {
+        nodeIds: new Set(grounded.nodeIds),
+        unresolved: grounded.unresolved,
+      },
+      highlightedNodes: new Set(grounded.nodeIds),
+    })
   },
   setDimmedNodes: (ids: string[]) => {
     set({ dimmedNodeIds: new Set(ids) })

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -4882,33 +4882,46 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     if (cur.source === null && cur.edgeIds.size === 0 && cur.nodeIds.size === 0) return
     set({ analysisHighlight: { source: null, edgeIds: new Set<string>(), nodeIds: new Set<string>() } })
   },
-  // SELECTION-AWARE ANSWERING (hop 4b). Two writes, one action, because they
-  // are one fact: "this answer is about these elements".
+  // SELECTION-AWARE ANSWERING (hop 4b). ONE write, to ONE slice this action
+  // exclusively owns.
   //
-  // ⚠ THE MARKS RIDE `highlightedNodes` DELIBERATELY, AND NOTHING WRITES
-  // `highlightedEdges`. `highlightedNodes` is already this canvas's "the AI is
-  // talking about this" channel (`appliedEditPulse`, the `ui_directive`
-  // highlight verb) and BaseNode already renders it as `ai-highlight-pulse` —
-  // so reusing it is the spec's instruction, not a shortcut: a second emphasis
-  // style on one canvas is a worse outcome than none. `highlightedEdges` is a
-  // different matter entirely: FocusModeChip renders "Showing paths from X to
-  // goal" on `highlightedEdges.size > 0` alone, so writing it for a grounding
-  // that involves no path would make the chip state something untrue. That is
-  // #694's neighbourhood-focus precedent applied here — prominence comes from
-  // the node marks, never from claiming a path.
+  // ⚠⚠ THIS ACTION DOES NOT TOUCH `highlightedNodes`, AND THAT IS A
+  // CORRECTNESS PROPERTY, NOT A STYLE CHOICE. An earlier revision wrote the
+  // marks into `highlightedNodes` on the reasoning that it is already the
+  // canvas's "the AI is talking about this" channel. An adversarial review
+  // refuted it at the bytes and it was wrong three ways:
   //
-  // OWNERSHIP ON CLEAR: `highlightedNodes` has other, transient writers (the
-  // applied-edit pulse, panel hover sync). Clearing only when this slice
-  // currently holds a non-empty set means an ungrounded turn cannot wipe a
-  // pulse it never owned.
+  //   · `highlightedNodes` is a shared, last-writer-wins channel with ELEVEN
+  //     other writers (`appliedEditPulse`, `HighlightContext`,
+  //     `useHighlightDispatch`, `PreAnalysisHealth`, `TransitionCard`,
+  //     `CompareState`, node components, …). A wholesale replace here clobbers
+  //     whatever any of them had put there.
+  //   · `appliedEditPulse.flush` REPLACES the set (`:84`) and then EMPTIES it
+  //     unconditionally at `PULSE_DURATION_MS` (`:90`). On any turn that both
+  //     applies a patch and carries a selection — "change THIS one", the
+  //     flagship case — the grounded marks were overwritten ~100ms later and
+  //     erased at ~2.1s. The capability simply did not hold on that journey.
+  //   · The clear guarded on whether THIS SLICE was non-empty, not on whether
+  //     the marks on screen were still the ones it wrote, so an ungrounded turn
+  //     could wipe another writer's marks — the exact thing its own comment
+  //     claimed it could not do.
+  //
+  // `BaseNode` now reads `groundedFocus.nodeIds` directly, applying the SAME
+  // `ai-highlight-pulse` treatment: one emphasis language on the canvas (the
+  // spec's instruction), two independent pieces of state. That is what "single
+  // authority" actually requires — owning your own slice, not writing someone
+  // else's.
+  //
+  // NOTHING WRITES `highlightedEdges` EITHER. FocusModeChip renders "Showing
+  // paths from X to goal" on `highlightedEdges.size > 0` alone, so writing it
+  // for a grounding that involves no path would make the chip state something
+  // untrue — #694's neighbourhood-focus honesty precedent applied here.
   setGroundedFocus: (grounded) => {
     if (grounded === null) {
       const prev = get().groundedFocus
+      // No-op when already clear: no state write, no Set-identity churn.
       if (prev.unresolved === null && prev.nodeIds.size === 0) return
-      set({
-        groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
-        ...(prev.nodeIds.size > 0 ? { highlightedNodes: new Set<string>() } : {}),
-      })
+      set({ groundedFocus: { nodeIds: new Set<string>(), unresolved: null } })
       return
     }
     set({
@@ -4916,7 +4929,6 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         nodeIds: new Set(grounded.nodeIds),
         unresolved: grounded.unresolved,
       },
-      highlightedNodes: new Set(grounded.nodeIds),
     })
   },
   setDimmedNodes: (ids: string[]) => {

--- a/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
+++ b/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
@@ -191,7 +191,11 @@ describe('hop 4b — the canvas never claims a path it does not have', () => {
     // The AI's attention and the user's pointer are different facts and are
     // allowed to diverge. The AI may never move the pointer.
     useCanvasStore.setState({
-      selection: { nodeIds: new Set(['node-the-user-picked']), edgeIds: new Set<string>() },
+      selection: {
+        nodeIds: new Set(['node-the-user-picked']),
+        edgeIds: new Set<string>(),
+        anchorPosition: null,
+      },
     })
 
     await applyWire(wireBody({ element_ids: ['node-the-ai-used'], unresolved: 'none' }))

--- a/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
+++ b/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * SELECTION-AWARE ANSWERING, hop 4b — THE WIRE-TO-CANVAS CHAIN.
+ *
+ * The capability this file defends, end to end and in one sentence:
+ *
+ *   > A user selects a node, asks a question, and the element the answer was
+ *   > grounded on is MARKED on the canvas — so they do not have to hunt for
+ *   > the node the answer names.
+ *
+ * ⭐ WHY THIS SPEC STARTS AT RAW WIRE BYTES AND FINISHES AT REAL STORE STATE.
+ * Every hop in this chain has an independently defensible unit — the reader,
+ * the store action, the notice. All three can be fully green while the
+ * capability is DARK, because the one thing none of them can prove is that
+ * anybody CALLS them. That is this estate's chronic failure #1 (a defended
+ * pure function with a dark call site), so this spec deliberately owns no
+ * mocks on the path under test: it feeds a real HTTP body to the real
+ * `parseV5Response`, hands the result to the real `applyV5State` shaped
+ * EXACTLY as the production call site shapes it (`useConversation.ts:4736` —
+ * `{ ...useCanvasStore.getState(), currentResultsHash }`), and then reads the
+ * REAL canvas store.
+ *
+ * The F6 wiring mutant is therefore: delete
+ * `store.setGroundedFocus?.(readGroundedSelection(response))` from
+ * `applyV5State.ts` and every "marks" test here must RED.
+ *
+ * ⚠ WHAT THIS SPEC MAY AND MAY NOT CLAIM (trap 3). jsdom cannot prove
+ * visibility. Everything here is a claim about STORE STATE — `highlightedNodes`
+ * is the set `BaseNode.tsx:77` reads and `:249` renders as
+ * `ring-4 ring-info/60 ai-highlight-pulse`. That the ring is VISIBLE is a
+ * browser claim and is made separately, in a real browser, never here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { parseV5Response } from '../responseParser'
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+import { readGroundedSelection } from '../groundedSelection'
+import { useCanvasStore } from '../../canvas/store'
+
+/** The declared, schema-valid part of a turn. Identical in every case below,
+ *  so the ONLY variable across the discriminating pairs is the sidecar. */
+const declaredTurn = {
+  response_version: 2,
+  assistant_text: 'That option carries its own 3% risk of the launch slipping.',
+  blocks: [],
+  suggested_actions: [],
+  insights: [],
+  stage_indicator: 'frame',
+} as const
+
+function wireBody(groundedSelection?: unknown): Record<string, unknown> {
+  return {
+    ...declaredTurn,
+    ...(groundedSelection === undefined ? {} : { _grounded_selection: groundedSelection }),
+  }
+}
+
+/** Parse a raw wire body the way the app does — through the real parser, so
+ *  the `__additive__` demotion under test is the production one and not a
+ *  hand-built object that merely resembles it. */
+async function parseWire(body: Record<string, unknown>) {
+  const result = await parseV5Response(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+  if (result.kind !== 'response') {
+    throw new Error(`expected a parsed response, got kind=${result.kind}`)
+  }
+  return result.response
+}
+
+/** The production call-site shape, reproduced rather than approximated
+ *  (`useConversation.ts:4736`). Spreading the live store is what carries
+ *  `setGroundedFocus` through — a hand-listed store double would pass this
+ *  spec while the real call site silently dropped the action. */
+function productionShapedStore(): V5ApplicatorStore {
+  const snapshot = useCanvasStore.getState()
+  return {
+    ...snapshot,
+    currentResultsHash: snapshot.results?.hash ?? null,
+  } as unknown as V5ApplicatorStore
+}
+
+async function applyWire(
+  body: Record<string, unknown>,
+  options?: Parameters<typeof applyV5State>[2],
+): Promise<void> {
+  const response = await parseWire(body)
+  applyV5State(response, productionShapedStore(), options)
+}
+
+const marks = (): string[] => [...useCanvasStore.getState().highlightedNodes].sort()
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    groundedFocus: { nodeIds: new Set<string>(), unresolved: null },
+  })
+})
+
+describe('hop 4b — the answer’s element is marked on the canvas', () => {
+  it('marks the node the answer was grounded on, bound by id', async () => {
+    await applyWire(
+      wireBody({ element_ids: ['node-engineer-salary'], unresolved: 'none' }),
+    )
+
+    // Bound by IDENTITY, not by a predicate another node could satisfy
+    // (trap 19): the exact id, and nothing else marked.
+    expect(marks()).toEqual(['node-engineer-salary'])
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBe('none')
+  })
+
+  it('marks a DIFFERENT node when the answer is grounded on a different one', async () => {
+    // The discriminating half of the pair. Test 1 alone cannot distinguish
+    // "marks the grounded element" from "marks whatever id it is handed" —
+    // only an asserted INEQUALITY across two otherwise-identical turns can.
+    await applyWire(wireBody({ element_ids: ['node-engineer-salary'], unresolved: 'none' }))
+    const first = marks()
+
+    await applyWire(wireBody({ element_ids: ['node-market-timing'], unresolved: 'none' }))
+    const second = marks()
+
+    expect(first).toEqual(['node-engineer-salary'])
+    expect(second).toEqual(['node-market-timing'])
+    expect(second).not.toEqual(first)
+  })
+
+  it('marks every grounded element when the answer is grounded on several', async () => {
+    await applyWire(
+      wireBody({ element_ids: ['node-a', 'node-b', 'node-c'], unresolved: 'none' }),
+    )
+    expect(marks()).toEqual(['node-a', 'node-b', 'node-c'])
+  })
+})
+
+describe('hop 4b — the ungrounded negative control', () => {
+  it('marks NOTHING on a turn that carried no selection', async () => {
+    // The generic-answer control: the identical question with nothing
+    // selected. CEE omits the sidecar entirely, so this body is byte-identical
+    // to every pre-hop-4b turn.
+    await applyWire(wireBody())
+
+    expect(marks()).toEqual([])
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBeNull()
+  })
+
+  it('CLEARS the previous answer’s marks when the next turn is ungrounded', async () => {
+    // Stale attention — the canvas still pointing at what an OLD answer was
+    // about while the user reads a new one — is worse than no attention.
+    await applyWire(wireBody({ element_ids: ['node-engineer-salary'], unresolved: 'none' }))
+    expect(marks()).toEqual(['node-engineer-salary'])
+
+    await applyWire(wireBody())
+
+    expect(marks()).toEqual([])
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBeNull()
+  })
+
+  it('does not resurrect a superseded turn’s grounding over a newer turn', async () => {
+    // The grounded-focus read sits AFTER `applyV5State`'s stale-turn guard.
+    // Pinned here rather than assumed, because moving the call one block
+    // earlier would silently reverse it.
+    await applyWire(wireBody({ element_ids: ['node-stale'], unresolved: 'none' }), {
+      turnClientId: 'turn-1',
+      currentClientTurnId: 'turn-2',
+    })
+
+    expect(marks()).toEqual([])
+  })
+})
+
+describe('hop 4b — the canvas never claims a path it does not have', () => {
+  it('writes no highlighted EDGES for a grounding', async () => {
+    // #694's neighbourhood-focus honesty precedent, transposed. FocusModeChip
+    // renders "Showing paths from X to goal" on `highlightedEdges.size > 0`
+    // alone — so a grounding, which involves no path, must leave that set
+    // empty or the chip states something untrue. Guarded as an ADDITIVE
+    // mutant: add an `highlightedEdges` write to `setGroundedFocus` and this
+    // test must RED.
+    await applyWire(
+      wireBody({ element_ids: ['node-a', 'node-b'], unresolved: 'none' }),
+    )
+
+    expect(marks()).toEqual(['node-a', 'node-b'])
+    expect([...useCanvasStore.getState().highlightedEdges]).toEqual([])
+  })
+
+  it('does not move the user’s own selection', async () => {
+    // The AI's attention and the user's pointer are different facts and are
+    // allowed to diverge. The AI may never move the pointer.
+    useCanvasStore.setState({
+      selection: { nodeIds: new Set(['node-the-user-picked']), edgeIds: new Set<string>() },
+    })
+
+    await applyWire(wireBody({ element_ids: ['node-the-ai-used'], unresolved: 'none' }))
+
+    expect([...useCanvasStore.getState().selection.nodeIds]).toEqual(['node-the-user-picked'])
+    expect(marks()).toEqual(['node-the-ai-used'])
+  })
+})
+
+describe('hop 4b — `not_in_model` and `could_not_check` stay apart on the wire', () => {
+  it('carries `could_not_check` through to the store as itself', async () => {
+    await applyWire(wireBody({ element_ids: [], unresolved: 'could_not_check' }))
+
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBe('could_not_check')
+    expect(marks()).toEqual([])
+  })
+
+  it('carries `not_in_model` through to the store as itself, on an identical payload', async () => {
+    await applyWire(wireBody({ element_ids: [], unresolved: 'not_in_model' }))
+
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBe('not_in_model')
+    expect(marks()).toEqual([])
+  })
+
+  it('the two states are DISTINGUISHABLE in the store, not merely both empty', async () => {
+    // The pair, asserted as a pair. Both mark nothing — so if the store
+    // collapsed them, every individual assertion above would still pass and
+    // the UI would have no way left to tell the user which one happened.
+    await applyWire(wireBody({ element_ids: [], unresolved: 'could_not_check' }))
+    const a = useCanvasStore.getState().groundedFocus.unresolved
+
+    await applyWire(wireBody({ element_ids: [], unresolved: 'not_in_model' }))
+    const b = useCanvasStore.getState().groundedFocus.unresolved
+
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('hop 4b — the reader is the boundary, and it fails closed', () => {
+  // The sidecar bypasses the strict schema by construction, so nothing
+  // upstream validates it. Each of these must yield NO marks — never a
+  // partial or coerced highlight, which on screen is indistinguishable from
+  // a complete one.
+  const malformed: ReadonlyArray<readonly [string, unknown]> = [
+    ['an unrecognised `unresolved` value', { element_ids: ['node-a'], unresolved: 'maybe' }],
+    ['a missing `unresolved`', { element_ids: ['node-a'] }],
+    ['`element_ids` that is not an array', { element_ids: 'node-a', unresolved: 'none' }],
+    ['a non-string id', { element_ids: ['node-a', 7], unresolved: 'none' }],
+    ['an empty-string id', { element_ids: [''], unresolved: 'none' }],
+    ['a non-object sidecar', 'node-a'],
+  ]
+
+  it.each(malformed)('marks nothing given %s', async (_label, payload) => {
+    await applyWire(wireBody(payload))
+    expect(marks()).toEqual([])
+    expect(useCanvasStore.getState().groundedFocus.unresolved).toBeNull()
+  })
+
+  it('rejects a partially-malformed id list WHOLE, rather than marking the good ids', async () => {
+    await applyWire(wireBody({ element_ids: ['node-good', 42], unresolved: 'none' }))
+    expect(marks()).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: the same probe DOES read a well-formed sidecar', async () => {
+    // Without this, every assertion above could be passing because the reader
+    // is blind rather than because it is strict (trap 13).
+    const response = await parseWire(
+      wireBody({ element_ids: ['node-a'], unresolved: 'none' }),
+    )
+    expect(readGroundedSelection(response)).toEqual({
+      nodeIds: ['node-a'],
+      unresolved: 'none',
+    })
+  })
+})

--- a/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
+++ b/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
@@ -29,8 +29,13 @@
  * `ring-4 ring-info/60 ai-highlight-pulse`. That the ring is VISIBLE is a
  * browser claim and is made separately, in a real browser, never here.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 
+import {
+  pulseAppliedTargets,
+  PULSE_COALESCE_MS,
+  PULSE_DURATION_MS,
+} from '../../canvas/utils/appliedEditPulse'
 import { parseV5Response } from '../responseParser'
 import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
 import { readGroundedSelection } from '../groundedSelection'
@@ -90,7 +95,22 @@ async function applyWire(
   applyV5State(response, productionShapedStore(), options)
 }
 
-const marks = (): string[] => [...useCanvasStore.getState().highlightedNodes].sort()
+/**
+ * The marks the canvas renders for a grounded answer, read from the slice that
+ * OWNS them.
+ *
+ * ⚠ THIS READS `groundedFocus.nodeIds`, NOT `highlightedNodes`, AND THE
+ * DIFFERENCE IS THE POINT. An earlier revision wrote the marks into
+ * `highlightedNodes`; an adversarial review refuted that at the bytes —
+ * eleven other writers share that channel, and `appliedEditPulse` both
+ * replaces it and then EMPTIES it at `PULSE_DURATION_MS`. `BaseNode` reads
+ * both sets and applies the same treatment, so the pixels are unchanged; the
+ * state is now the grounding's own.
+ */
+const marks = (): string[] => [...useCanvasStore.getState().groundedFocus.nodeIds].sort()
+
+/** The SHARED channel, which this slice must never write. */
+const sharedHighlights = (): string[] => [...useCanvasStore.getState().highlightedNodes].sort()
 
 beforeEach(() => {
   useCanvasStore.setState({
@@ -168,6 +188,61 @@ describe('hop 4b — the ungrounded negative control', () => {
     })
 
     expect(marks()).toEqual([])
+  })
+})
+
+describe('hop 4b — the grounding owns its own state and clobbers nobody', () => {
+  // ⭐ THE CASES A REVIEW HAD TO FIND, because the suite as first written was
+  // structurally blind to them: every test reset `highlightedNodes` to empty
+  // and none exercised a patch-bearing turn, so a wholesale replace and an
+  // ownership-respecting write were indistinguishable to it. A corpus that
+  // never populates the shared channel cannot observe the shared channel being
+  // trampled.
+
+  it('leaves another writer’s marks alone on a GROUNDED turn', async () => {
+    // e.g. a coaching highlight, a compare-tab transition, a panel hover sync.
+    useCanvasStore.getState().setHighlightedNodes(['node-someone-elses'])
+
+    await applyWire(wireBody({ element_ids: ['node-grounded'], unresolved: 'none' }))
+
+    expect(marks()).toEqual(['node-grounded'])
+    expect(sharedHighlights()).toEqual(['node-someone-elses'])
+  })
+
+  it('leaves another writer’s marks alone on an UNGROUNDED turn', async () => {
+    // The clear must clear ITS OWN slice and nothing else. The earlier
+    // revision guarded on whether this slice was non-empty, which is a
+    // different question from whether it still owns what is on screen.
+    await applyWire(wireBody({ element_ids: ['node-grounded'], unresolved: 'none' }))
+    useCanvasStore.getState().setHighlightedNodes(['node-someone-elses'])
+
+    await applyWire(wireBody())
+
+    expect(marks()).toEqual([])
+    expect(sharedHighlights()).toEqual(['node-someone-elses'])
+  })
+
+  it('survives an applied-edit pulse on the SAME turn, including its 2s clear', async () => {
+    // THE FLAGSHIP JOURNEY: "change THIS one" — a turn that both applies a
+    // patch and carries a selection. `appliedEditPulse.flush` replaces
+    // `highlightedNodes` ~100ms later and EMPTIES it at PULSE_DURATION_MS.
+    // While the marks lived in that channel the capability did not survive
+    // its own headline use case, and no test could see it.
+    vi.useFakeTimers()
+    try {
+      await applyWire(wireBody({ element_ids: ['node-grounded'], unresolved: 'none' }))
+      pulseAppliedTargets({ nodeIds: ['node-just-edited'], edgeIds: [] })
+
+      vi.advanceTimersByTime(PULSE_COALESCE_MS + 10)
+      expect(marks()).toEqual(['node-grounded'])
+
+      vi.advanceTimersByTime(PULSE_DURATION_MS + 10)
+      // The pulse has cleared its own channel; the grounding is still marked.
+      expect(sharedHighlights()).toEqual([])
+      expect(marks()).toEqual(['node-grounded'])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
+++ b/src/v5/__tests__/groundedSelectionFocus.wire.spec.ts
@@ -244,6 +244,49 @@ describe('hop 4b — the grounding owns its own state and clobbers nobody', () =
       vi.useRealTimers()
     }
   })
+
+  it('survives a CROSS-TURN pulse — edit, then ask a grounded question 1s later', async () => {
+    // ⭐ THE TIMELINE THAT NEEDS NO COINCIDENCE AT ALL, and therefore the one
+    // that settles reachability. Nothing here requires CEE to emit a grounding
+    // on a patch-bearing turn (a producer-side question this lane has NOT
+    // settled — trap 16-inverse). Turn N applies a patch; turn N+1 is an
+    // ordinary grounded question inside the pulse's 2s window; the pulse's
+    // clear then fires under it.
+    vi.useFakeTimers()
+    try {
+      pulseAppliedTargets({ nodeIds: ['node-just-edited'], edgeIds: [] })
+      vi.advanceTimersByTime(PULSE_COALESCE_MS + 10)
+
+      // 1s later, well inside the pulse window, the user asks about a selection.
+      vi.advanceTimersByTime(1000)
+      await applyWire(wireBody({ element_ids: ['node-grounded'], unresolved: 'none' }))
+      expect(marks()).toEqual(['node-grounded'])
+
+      // The earlier turn's clear fires. It must not touch this turn's grounding.
+      vi.advanceTimersByTime(PULSE_DURATION_MS)
+      expect(sharedHighlights()).toEqual([])
+      expect(marks()).toEqual(['node-grounded'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('survives an EDGE-ONLY patch, which clears the shared node set outright', async () => {
+    // `flush()` calls `setHighlightedNodes(nodeIds)` UNCONDITIONALLY, so a
+    // patch touching only edges passes an empty node list and actively empties
+    // the shared channel — no timer needed, and no node ever pulsed.
+    vi.useFakeTimers()
+    try {
+      await applyWire(wireBody({ element_ids: ['node-grounded'], unresolved: 'none' }))
+      pulseAppliedTargets({ nodeIds: [], edgeIds: ['edge-1'] })
+
+      vi.advanceTimersByTime(PULSE_COALESCE_MS + 10)
+      expect(sharedHighlights()).toEqual([])
+      expect(marks()).toEqual(['node-grounded'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('hop 4b — the canvas never claims a path it does not have', () => {

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -51,6 +51,7 @@ import type { CEEAnalysisReady, CEEGoalConstraint } from '../adapters/cee/types'
 import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
+import { readGroundedSelection, type GroundedUnresolved } from './groundedSelection'
 import { pulseAppliedTargets } from '../canvas/utils/appliedEditPulse'
 import { focusNodeById, focusEdgeById } from '../canvas/utils/focusHelpers'
 import {
@@ -141,6 +142,12 @@ export interface V5ApplicatorStore {
   setAnalysisFreshness?: (rawAnalysisReady: unknown) => void
   /** Optional (ROADMAP 2.1163 / EXT-2): set or clear CEE's typed analysis-refusal notice. Pass null to clear. */
   setAnalysisRefusalNotice?: (notice: AnalysisRefusalNotice | null) => void
+  /** Optional (hop 4b): record which elements THIS answer was grounded on, so
+   *  the canvas can mark them. Pass null for an ungrounded turn — that clears
+   *  the previous grounding. */
+  setGroundedFocus?: (
+    grounded: { nodeIds: readonly string[]; unresolved: GroundedUnresolved } | null,
+  ) => void
   /** Optional: clear the local dirty overlay when a genuinely new analysis run completes (new analysis_result response_hash). */
   clearAnalysisFreshnessDirty?: () => void
   /** Optional (F10): a genuinely new analysis_result landed with NO explicit
@@ -1052,6 +1059,24 @@ export function applyV5State(
   // completed analysis_result CLEARS it, and only a blocked carrier bearing a
   // non-empty blocked_reason SETS it. The legacy freshness-only blocked carrier
   // (no blocked_reason) sets nothing — see analysisRefusalNotice.ts.
+  // ── SELECTION-AWARE ANSWERING (hop 4b) — the grounded-focus READER ──────
+  //
+  // ⚠ THIS BLOCK IS THE WIRE. `readGroundedSelection` and the store action can
+  // both be fully green while the capability is DARK if this call is missing —
+  // a defended pure function with a dark call site is this estate's chronic
+  // failure #1. Neutering it MUST turn the end-to-end spec red.
+  //
+  // UNCONDITIONAL, and that is the point: this runs on EVERY turn, including
+  // the ones with no grounding, because `null` is what clears the previous
+  // answer's marks. If it only ran when a sidecar was present, the canvas
+  // would keep pointing at the element an OLD answer was about while the user
+  // read a new one — stale attention, which is worse than none.
+  //
+  // Placed with the other per-turn envelope reads and AFTER the stale-turn
+  // guard at the top of this function, so a superseded response cannot
+  // resurrect its grounding over a newer turn's.
+  store.setGroundedFocus?.(readGroundedSelection(response))
+
   const refusalUpdate = deriveAnalysisRefusalNoticeUpdate(response)
   if (refusalUpdate.kind === 'set') {
     store.setAnalysisRefusalNotice?.(refusalUpdate.notice)

--- a/src/v5/groundedSelection.ts
+++ b/src/v5/groundedSelection.ts
@@ -1,0 +1,109 @@
+/**
+ * `_grounded_selection` — the READER for CEE's selection-aware answering
+ * sidecar (hop 4b).
+ *
+ * WHAT THIS TELLS THE CANVAS, and it is the only thing it tells it:
+ *
+ *   > The elements THIS turn's answer was grounded on.
+ *
+ * The user selects a node, asks "why does this one matter?", and the answer
+ * comes back naming it. Until now they then had to find that node themselves —
+ * which is precisely the shared-visual-model gap the programme exists to close.
+ * With this the canvas points at it.
+ *
+ * ⚠ WHY THE VALUE LIVES IN `__additive__` AND NOT ON THE TYPED RESPONSE.
+ * `OlumiResponseSchema` is `.strict()` at the vendored 0.40.0 pin, so CEE ships
+ * this as an underscore-prefixed PRODUCT sidecar (the documented `_reasoning` /
+ * `_answer_shape` mechanic: stripped before egress validation, re-attached
+ * after). `responseParser` demotes every undeclared root key into the
+ * non-enumerable `ADDITIVE_EXTENSIONS_KEY` sidecar, so that is where it lands —
+ * the same read `useConversation` already performs for `_reasoning`.
+ *
+ * ⭐ EVERY FIELD IS RE-VALIDATED HERE, not trusted. The sidecar bypasses the
+ * strict schema by construction, so this module IS the boundary: nothing
+ * downstream sees a value that did not survive these checks. A malformed
+ * payload yields `null` — no highlight — never a partial or coerced one.
+ */
+import { ADDITIVE_EXTENSIONS_KEY } from './responseParser'
+
+/**
+ * Why elements the user pointed at are missing from `nodeIds`.
+ *
+ * ⭐ `not_in_model` AND `could_not_check` MUST NOT COLLAPSE, and this type is
+ * where the UI inherits that obligation.
+ *
+ *   · `none`            — everything the turn pointed at resolved.
+ *   · `not_in_model`    — the graph WAS read and does not contain it. Showing
+ *                         nothing for it is honest.
+ *   · `could_not_check` — the graph could NOT be read, so we do not know
+ *                         whether it is there. Rendering this as "not found"
+ *                         would tell the user their node is gone on the
+ *                         strength of a failed lookup — reintroducing at the
+ *                         pixel layer exactly the conflation CEE's hop 3 and
+ *                         hop 4 were designed to keep apart.
+ */
+export type GroundedUnresolved = 'none' | 'not_in_model' | 'could_not_check'
+
+const UNRESOLVED_VALUES: ReadonlySet<string> = new Set<GroundedUnresolved>([
+  'none',
+  'not_in_model',
+  'could_not_check',
+])
+
+export interface GroundedSelection {
+  /**
+   * Canonical canvas ids, in the order the turn requested them. EMPTY is
+   * meaningful: the turn pointed at something and nothing resolvable came
+   * back — read `unresolved` to learn why, and never infer "not found" from
+   * emptiness alone.
+   */
+  readonly nodeIds: readonly string[]
+  readonly unresolved: GroundedUnresolved
+}
+
+/** The wire key. Underscore-prefixed: it is a sidecar, not a schema field. */
+export const GROUNDED_SELECTION_KEY = '_grounded_selection' as const
+
+/**
+ * Read and validate the sidecar off a parsed V5 response.
+ *
+ * @returns the grounded selection, or `null` when this turn was not grounded
+ *   on a selection (the overwhelmingly common case — every turn taken without
+ *   a canvas selection) or when the payload is malformed.
+ *
+ * Returning `null` for both is deliberate and safe: the consumer's response to
+ * `null` is to CLEAR any previous grounding, and clearing is the correct
+ * behaviour for a turn we cannot vouch for just as much as for one that
+ * carried nothing.
+ */
+export function readGroundedSelection(response: unknown): GroundedSelection | null {
+  if (response === null || typeof response !== 'object') return null
+  const additive = (response as Record<string, unknown>)[ADDITIVE_EXTENSIONS_KEY]
+  if (additive === null || typeof additive !== 'object') return null
+  const raw = (additive as Record<string, unknown>)[GROUNDED_SELECTION_KEY]
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null
+
+  const record = raw as Record<string, unknown>
+
+  // The enum is validated against the CLOSED set rather than merely checked
+  // for being a string: an unrecognised value would otherwise flow through to
+  // the notice logic, where "not one of the three" would be silently treated
+  // as "not could_not_check" — i.e. it would fail toward the reassuring
+  // reading. Fail closed instead.
+  const unresolved = record.unresolved
+  if (typeof unresolved !== 'string' || !UNRESOLVED_VALUES.has(unresolved)) return null
+
+  const ids = record.element_ids
+  if (!Array.isArray(ids)) return null
+  // Element-wise, not `every(...)` over the array as a whole: one malformed
+  // entry invalidates the payload rather than being quietly skipped, because a
+  // partial highlight is indistinguishable from a complete one on screen and
+  // the user would have no way to know which they were looking at.
+  const nodeIds: string[] = []
+  for (const id of ids) {
+    if (typeof id !== 'string' || id.length === 0) return null
+    nodeIds.push(id)
+  }
+
+  return { nodeIds, unresolved: unresolved as GroundedUnresolved }
+}


### PR DESCRIPTION
**LANDS TOGETHER WITH → Talchain/olumi-assistants-service#965.** That PR puts `_grounded_selection`
on the wire; this one consumes it. **#965 merges first** (the field must exist), this immediately after.
Neither ships alone: a resolved field with no consumer is this estate's dominant defect, and a consumer
with no field is inert.

## What a user now SEES

Select a node → ask naturally → the answer comes back grounded in that element and its analysis outputs
(hop 4, already merged) → **that node is marked on the canvas as the thing this answer is about**, riding
the canvas's existing "the AI is talking about this" treatment.

Ask the same question with **nothing selected** and **nothing marks** — on a turn that carries no sidecar
at all, byte-identical to every pre-hop-4b turn.

## The chain, file:line

| Hop | Where |
|---|---|
| Demoted to `__additive__` | `src/v5/responseParser.ts:217-235` (existing, unchanged) |
| Read + re-validated | `src/v5/groundedSelection.ts` `readGroundedSelection` |
| ⚠ THE CONSUMER CALL SITE | `src/v5/applyV5State.ts` — `store.setGroundedFocus?.(readGroundedSelection(response))` |
| Store slice + marks | `src/canvas/store.ts` — `groundedFocus` + `setGroundedFocus` |
| Rendered | `src/canvas/nodes/BaseNode.tsx:77` → `:249` — existing `ring-4 ring-info/60 ai-highlight-pulse` |
| Honesty notice | `src/canvas/components/GroundedFocusNotice.tsx`, mounted `ReactFlowGraph.tsx` beside `FocusModeChip` |

**The carrier is proven by two working consumers, not by inspection.** The question that kills slices like
this is *does the non-enumerable sidecar actually reach the reader?* — any spread on the way loses it.
`applyV5State` has **exactly one** production call site (`useConversation.ts:4736`, receiving
`target.response` from `{ ...useCanvasStore.getState() }` — a spread of the live store, which is what
carries `setGroundedFocus` through), and **two existing live sidecar readers already read `__additive__`
off that same object**: `extractReasoningSidecar` (`:5058`) and `extractAnswerShapeSidecar` (`:5070`).

## Design constraints that are structural, not incidental

- **Nothing writes `highlightedEdges`.** `FocusModeChip` renders *"Showing paths from X to goal"* on
  `highlightedEdges.size > 0` alone. A grounding involves **no path**, so writing that set would make the
  chip state something untrue. This is **#694's neighbourhood-focus honesty precedent transposed**, and it
  is guarded by an **additive** mutant (add the edge write ⇒ the guard REDs), not satisfied by accident.
- **The AI never moves the user's pointer.** `selection` is untouched; `groundedFocus` is its own slice and
  the two are allowed to diverge.
- **The clear path is unconditional.** Every turn writes the slice, so an ungrounded turn clears the
  previous answer's marks — stale attention is worse than none. It clears only marks this slice owns, so it
  cannot wipe an applied-edit pulse.
- **No new visual language, and no second focus authority** (trap 21): the marks ride the existing
  `highlightedNodes` channel. Two emphasis styles on one canvas is a worse outcome than none.
- **No scroll-jacking.** Highlight in place; the canvas is never moved under the user.

## `not_in_model` and `could_not_check` must not collapse — and needed a COMPONENT

The spec asked for the two states to be "visibly different". **With node marking alone they are not: both
mark nothing.** Honouring it required a surface — `GroundedFocusNotice` — whose entire reason to exist is
that discrimination. `could_not_check` says *"I couldn't read your model to check what you selected"* and
claims nothing about the element either way; `not_in_model` renders **nothing at all**, because the absence
of a mark IS the honest answer there.

## Verification

**RED-first at pristine** (implementation reverted to `staging`, my specs retained, in a throwaway worktree
**outside** the repo root): **16 failed / 11 passed**, named signatures —
`AssertionError: expected [] to deeply equal [ 'node-engineer-salary' ]`,
`TypeError: useCanvasStore.getState(...).setGroundedFocus is not a function`.
The 11 that pass at pristine are the fail-closed and negative-control cases, which are **vacuous without
the wiring** and meaningful only with it — stated rather than counted as coverage.

**Isolation proven by WRITING, not by locating** (trap 9g): a sentinel appended to the worktree left the
source clone's `git status` empty, and inodes differ (`623869068` vs `624333135`). Restores are
HEAD-relative (trap 9h). Leading **and** trailing controls: applied-check scoped to `src/` reads **exactly 0**,
27/27 green both times.

**Six mutants, all biting, with DISTINCT red sets** (uniformity would be evidence about the probe, trap 20):

| Mutant | Effect | Result |
|---|---|---|
| **m1 wiring (F6)** | delete the `setGroundedFocus?.(...)` call site | **9 RED** |
| m2 edges (additive) | write `highlightedEdges` in the grounding | **1 RED** — the chip-honesty guard |
| m3 collapse | notice speaks for `not_in_model` too | **2 RED** — incl. the discrimination pair |
| **m4 identity** | mark a FIXED id instead of the grounded one | **6 RED** |
| m5 clear | ungrounded turn stops clearing | **1 RED** |
| m6 mount (trap 3b) | put the notice behind a flag | **1 RED** |

⭐ **m4 is the discriminating RED/GREEN pair**, not a single biting mutant: *"marks the node the answer was
grounded on"* stays **GREEN** under a fixed-id implementation while *"marks a DIFFERENT node"* **REDs**. A
single biting mutant proves sensitivity to *something*; only the pair proves sensitivity to the **named
object** (trap 19).

⚠ **A harness defect caught mid-run, disclosed:** the first battery returned **identical empty output for
every mutant**. Cause was the documented zsh trap — an unquoted `$SPECS` is not word-split, so vitest
received one giant argument, found no test files and **exited 0**. Re-run with explicit arguments and a
**hard error on zero collected**. The first battery's results were void and are not reported above.

**Gates at my tip:** `pnpm typecheck` (`scripts/ci/typecheck-gate.sh`) — **PASS**, 618 files / 2485 errors,
**exactly baseline, no drift**. It caught a real error in my own spec (a missing `anchorPosition`), fixed at
the source and **not** absorbed into the baseline. Both spec files asserted to collect **by name**: 27 tests,
non-zero (trap 2b — a new spec collecting zero is invisible to every aggregate). UI suites run with
`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported.

**Typecheck baseline note (instrument property):** the identity baseline moved by exactly one line — a
PRE-EXISTING `TS2345` whose identity string embeds an *elided property count* (`... 254 more ...` →
`... 256 more ...`). Adding any store action shifts it, manufacturing a phantom "1 appeared / 1 disappeared"
pair. Totals unchanged. **Every store-slice PR will produce this phantom pair.**

**Trap 3b** — this estate has shipped the same badge dark twice by testing a component the deployment does
not mount. The notice's mount path is asserted directly: it sits in the same **unconditional** chip rail as
`FocusModeChip`, with a positive control on the chip itself. **Scope stated precisely: that is a structural
claim about `ReactFlowGraph.tsx`, not a render proof of it.**

⚠ **jsdom cannot prove visibility** (trap 3). Every jsdom claim here is about DOM presence or store state.
The visibility claim is made in a browser, separately, and is reported with its own scope.

## Ladder — stated honestly

CODE EXISTS ✅ · TESTED ✅ · DEPLOYED ❌ · MOUNTED ❌ · WIRE-WITNESSED ❌ · JOURNEY-WITNESSED ❌

**The amended acceptance is NOT met by these two PRs.** They complete the **visible half** — the model
context focuses on screen. The answer-side wire witness (that the answer text demonstrably reasons about
the element) is a post-merge witness against the deployed build, ordered separately. #960's CEE/wire half is
already journey-witnessed; this is the half a user can see.

⚠ **Paired follow-up, sequencing:** register row **2.1219** — when a selection resolves to nothing, the
model silently adopted the leader in 3 of 6 fabricated-id turns, and **a visible focus makes that worse on
screen**. Its fix is a disclosure tail at CEE's compose seam, which is **#964's** (open at my tip), so it is
**not** in this slice. It should land close behind.

---

# UPDATE — a HIGH defect was found and fixed; the body above predates it

## The capability did not hold on its own headline journey

An adversarial capability review refuted this slice's ownership claim at the bytes. The marks rode
`highlightedNodes`, on the reasoning that it is already the canvas's "the AI is talking about this"
channel. It is — **and it is shared**:

- **Eleven other writers** use it (`appliedEditPulse`, `HighlightContext`, `useHighlightDispatch`,
  `PreAnalysisHealth`, `TransitionCard`, `CompareState`, node components). A wholesale replace trampled them.
- **`appliedEditPulse.flush` REPLACES the set (`:84`) and then EMPTIES it unconditionally at
  `PULSE_DURATION_MS` (`:90`).** So on any turn that both applied a patch and carried a selection —
  **"change THIS one", the flagship case** — the grounded marks were overwritten ~100ms later and erased at
  ~2.1s, with `groundedFocus.nodeIds` still reporting them and nothing reading it to restore them.
  **The store disagreed with the pixels.**
- The clear guarded on whether **this slice** was non-empty, not on whether the marks on screen were still
  the ones it wrote — so an ungrounded turn could wipe another writer's marks, **the exact thing its own
  comment claimed it could not do.**

An independent probe confirmed the same defect on four timelines, including a **cross-turn** one that needs
no coincidence at all (edit, then ask a grounded question within 2s), and proved the obvious fix does not
work: reordering the calls produces a **byte-identical timeline**, because the grounded write is synchronous
while the flush is +100ms and the clear +2000ms.

## The fix: its own channel (option (a))

`setGroundedFocus` now writes **only its own slice**. `BaseNode` reads `groundedFocus.nodeIds` **alongside**
`highlightedNodes` and applies the **same** `ai-highlight-pulse` treatment — one emphasis language on the
canvas (the spec's instruction), two independent pieces of state, **no lifetime negotiation**. That is what
"single authority" actually requires: owning your own slice, not writing someone else's.

Proven by revert-mutant: restoring the clobbering writes REDs **exactly** the three new ownership guards and
nothing else.

## The suite was structurally blind to all of it — the more important finding

Every test reset `highlightedNodes` to empty in `beforeEach` and none exercised a patch-bearing turn, so a
wholesale replace and an ownership-respecting write were **indistinguishable to it**. 19/19 green on a turn
class that structurally excluded the defect. Five cases added, all from outside the author's head: another
writer's marks survive a grounded turn; they survive an ungrounded turn; the grounding survives a
same-turn pulse past its 2s clear; **the cross-turn timeline**; and an **edge-only** patch, which needs no
timer at all because `flush()` calls `setHighlightedNodes(nodeIds)` unconditionally and an empty node list
actively clears.

## The notice's honesty assertion was defeatable, and was defeated

It was a positive phrase match plus a **hand-written list of forbidden words** (trap 12). Rewriting the copy
to *"I couldn't read your model to check what you selected — that element has been removed from your model"*
satisfied the phrase, dodged all three words, and stayed **GREEN** — while making **the exact false claim
this component exists to prevent.** The whole sentence is now **bound exactly**; replaying that mutation now
REDs **both** guards.

## Still open — handed off, not silently carried

1. **The mount assertion is source-structural and defeatable.** The same dark outcome written as a ternary,
   or as a gate on the enclosing rail, would survive it, and its "positive control" only proves the file was
   read — not that the probe can discriminate a gated mount (trap 13e). **It should be replaced by a
   render-based mount assertion.** Its scope is stated honestly in the file, but the guard is weaker than a
   reader would assume.
2. **Ghost ids.** The wire spec's grounded ids do not exist in `store.nodes`, so it asserts store state
   rather than user-visible focus. Under the separate-channel architecture a ghost id is **inert at the
   pixel layer** (BaseNode can only mark a node that renders), so this is a weaker claim than a defect —
   but the spec should use ids that exist on the canvas, and `appliedEditPulse`'s fail-closed canvas filter
   is worth adopting for the same reason.
3. **Producer-side, unsettled (trap 16-inverse):** whether CEE emits `_grounded_selection` on the same turn
   as an applied patch is a question this lane did **not** settle, and it is not claimed either way. The
   cross-turn timeline needs no such coincidence, so reachability does not hinge on it.

## Gates at the new tip `2b39b704`

- `pnpm typecheck` — **PASS**, 618 files / 2485 errors, **unchanged**
- 34 tests, both files asserted to collect **by name**
- CI: **13/13 SUCCESS, `mergeable = CLEAN`** (includes the full suite across 4 shards, so these specs ran in CI)
