### PR TITLE
P4: resolve AI-inferred assumed strengths

### DIFF
--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -262,6 +262,17 @@ export const EdgePanel = memo(function EdgePanel({
     confirmEdit('strength')
   }, [clearPreview, localStrength, confirmEdit])
 
+  const handleStrengthPresetChange = useCallback((v: number) => {
+    // A preset click is a complete edit, not a continuously-dragged preview.
+    // Reuse the canonical strength writer, then close the same confirmation
+    // seam the fine-tune slider closes on blur so stale analysis exposes the
+    // existing rerun affordance.
+    handleStrengthChange(v)
+    clearPreview()
+    origStrengthRef.current = v
+    confirmEdit('strength')
+  }, [handleStrengthChange, clearPreview, confirmEdit])
+
   const handleBeliefChange = useCallback((v: number) => {
     setLocalBelief(v)
     mutations.setExistsProbability(v)
@@ -335,7 +346,7 @@ export const EdgePanel = memo(function EdgePanel({
               <p className={`${typography.panelBody} text-text-body mb-1.5`}>
                 {INLINE_LABELS.strengthQuestion}
               </p>
-              <StrengthBandButtons value={localStrength} onChange={handleStrengthChange} />
+              <StrengthBandButtons value={localStrength} onChange={handleStrengthPresetChange} />
               <ExpertAnnotation techMode={techMode} editable value={localStrength} onChange={(v) => { handleStrengthChange(v); }} suffix="β =" step={0.01} min={-1} max={1} />
               {/* Edit feedback */}
               {lastConfirmed?.field === 'strength' && (

--- a/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
@@ -163,4 +163,14 @@ describe('assumedStrengthCopy — the claim boundary, held mechanically', () => 
       expect(s).not.toMatch(/no further/i)
     }
   })
+
+  it('the no-candidate copy reports only the bounded search — never false human authorship or no-placeholder claims', () => {
+    const copy = ASSUMED_STRENGTH_REFUSAL_COPY.all_strengths_set
+    expect(copy).toBe(
+      'No unresolved assumed strength was found among the relationships this run was sensitive to.',
+    )
+    expect(copy).not.toMatch(/somebody set/i)
+    expect(copy).not.toMatch(/no placeholders/i)
+    expect(copy).not.toMatch(/driving this answer/i)
+  })
 })

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -39,12 +39,17 @@ const nodeLabels = new Map([
 
 const ABOVE = THRESHOLDS.FRAGILE_EDGE_FILTER + 0.2
 
-/** The drafted edge: a fragile relationship whose strength nobody has set. */
+/** An ordinary CEE draft: numeric strength, but explicitly AI-inferred. */
 const draftedEdge = (): ElicitationCanvasEdge => ({
   id: 'e_demand_rev',
   source: 'n_demand',
   target: 'n_rev',
-  data: { ...DEFAULT_EDGE_DATA },
+  data: {
+    ...DEFAULT_EDGE_DATA,
+    weightSource: 'cee',
+    provenanceDisplay: 'ai_inferred',
+    origin: 'ai',
+  },
 })
 
 const fragileEdges = [
@@ -73,8 +78,10 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     // `updateEdge` calls exactly this predicate to decide whether to invalidate
     // analysis readiness. If `weight` ever left the stale registry, the edit
     // would land and the analysis would keep claiming to be fresh.
-    const before = { ...draftedEdge(), data: { ...DEFAULT_EDGE_DATA } } as unknown as Edge
-    const patch = { data: { ...DEFAULT_EDGE_DATA, weight: 0.85, weightSource: 'user' as const } }
+    const before = draftedEdge() as unknown as Edge
+    const patch = {
+      data: { ...draftedEdge().data, weight: 0.85, weightSource: 'user' as const },
+    }
     expect(hasAnalyticalEdgeChange(before, patch)).toBe(true)
   })
 
@@ -101,7 +108,7 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     // The same graph, with the one edit the interaction asked for applied.
     const resolved: ElicitationCanvasEdge = {
       ...draftedEdge(),
-      data: { ...DEFAULT_EDGE_DATA, weight: 0.85, weightSource: 'user' },
+      data: { ...draftedEdge().data, weight: 0.85, weightSource: 'user' },
     }
     expect(edgeValueSource(resolved.data, 'weight')).toBe('user')
 
@@ -144,8 +151,10 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     // correctly declines to claim otherwise. `weightSource` is deliberately NOT
     // in the analytical registry, and this pins that as intended behaviour
     // rather than an oversight.
-    const before = { ...draftedEdge(), data: { ...DEFAULT_EDGE_DATA } } as unknown as Edge
-    const confirmedAsIs = { data: { ...DEFAULT_EDGE_DATA, weightSource: 'user' as const } }
+    const before = draftedEdge() as unknown as Edge
+    const confirmedAsIs = {
+      data: { ...draftedEdge().data, weightSource: 'user' as const },
+    }
     expect(hasAnalyticalEdgeChange(before, confirmedAsIs)).toBe(false)
 
     // But the elicitation still stops asking — the assumption HAS been resolved.

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -14,12 +14,15 @@
  * rather than it. So this walks the real selector, the real declared setter
  * manifest, the real analytical-change registry and the real freshness reducer.
  *
- * WHAT IT DELIBERATELY DOES NOT CLAIM. This proves the links compose, in-process.
- * It is NOT a journey witness: nothing here renders the deployed surface, drives
- * a browser, or touches the wire. The rung this evidence reaches is TESTED, and
- * the deploy/journey rungs are named in the lane report as still owed.
+ * WHAT THE MOUNTED CONTROL ADDS. The final discriminator renders the real card
+ * and inspector, drives the card CTA and preset, and observes the real store and
+ * rerun control. It is still not a deployed journey or wire witness; those rungs
+ * remain separate from this in-process mounted proof.
  */
-import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { describe, it, expect, vi } from 'vitest'
 import {
   selectAssumedStrengthToResolve,
   type ElicitationCanvasEdge,
@@ -31,6 +34,17 @@ import { resolveDisplayedFreshness, classifyFreshnessForDisplay } from '../../..
 import { DEFAULT_EDGE_DATA } from '../../../../canvas/domain/edges'
 import { THRESHOLDS } from '../../../../lib/mappers/constants'
 import { edgeValueSource } from '../../../../canvas/domain/edgeValueProvenance'
+import { AssumedStrengthCard } from '../AssumedStrengthCard'
+import { openEdgeStrengthEditor } from '../../../../canvas/utils/openEdgeStrengthEditor'
+import { useCanvasStore } from '../../../../canvas/store'
+import { InspectorModal } from '../../../../canvas/components/InspectorModal'
+
+vi.mock('../../../../canvas/utils/focusHelpers', async () => {
+  const actual = await vi.importActual<typeof import('../../../../canvas/utils/focusHelpers')>(
+    '../../../../canvas/utils/focusHelpers',
+  )
+  return { ...actual, focusEdgeById: vi.fn() }
+})
 
 const nodeLabels = new Map([
   ['n_demand', 'Customer demand'],
@@ -141,6 +155,51 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     const after = selectAssumedStrengthToResolve({ fragileEdges, edges: nextEdges, nodeLabels })
     expect(after.selected).toBeNull()
     expect(after.refusalReason).toBe('all_strengths_set')
+  })
+
+  it('MOUNTED — CTA → editor → canonical write → stale → real rerun control', () => {
+    const edges = [draftedEdge()]
+    const decision = selectAssumedStrengthToResolve({ fragileEdges, edges, nodeLabels })
+    expect(decision.selected?.edgeId).toBe('e_demand_rev')
+
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+        { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      ] as never,
+      edges: edges as never,
+      showResultsPanel: true,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null } as never,
+    })
+
+    render(createElement(AssumedStrengthCard, { decision, onResolve: openEdgeStrengthEditor }))
+    fireEvent.click(screen.getByTestId('assumed-strength-action'))
+
+    const routed = useCanvasStore.getState()
+    expect([...routed.selection.edgeIds]).toEqual(['e_demand_rev'])
+    expect(routed.showResultsPanel).toBe(false)
+
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: 'e_demand_rev', onClose: () => {} }),
+    ))
+    expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Very strong' }))
+
+    const edited = useCanvasStore.getState()
+    const data = edited.edges.find(edge => edge.id === 'e_demand_rev')?.data as Record<string, unknown>
+    expect(data.weight).toBe(0.85)
+    expect(data.weightSource).toBe('user')
+    // Editing the field does not rewrite the edge's creation/display provenance.
+    expect(data.provenanceDisplay).toBe('ai_inferred')
+    expect(data.origin).toBe('ai')
+    expect(edited.analysisFreshnessDirty).toBe(true)
+    expect(screen.getByRole('button', { name: 'Re-run the analysis' })).toBeInTheDocument()
+    expect(screen.getByText('Re-run to see how this affects the results')).toBeInTheDocument()
   })
 
   it('HONESTY — confirming the placeholder AS-IS is not an analytical change, so no rerun is promised', () => {

--- a/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
@@ -122,13 +122,66 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
     expect(d.refusalReason).toBe('all_strengths_set')
   })
 
-  it('excludes a row AT or BELOW the visibility floor', () => {
+  it('AI-inferred 0.5 is unresolved; a USER-SET 0.5 on the same AI-created edge is resolved', () => {
+    const ceeDraft: ElicitationCanvasEdge = {
+      id: 'e_demand_rev',
+      source: 'n_demand',
+      target: 'n_rev',
+      data: {
+        weight: 0.5,
+        weightSource: 'cee',
+        provenanceDisplay: 'ai_inferred',
+        origin: 'ai',
+      },
+    }
+    const rows = [fragileRow('n_demand', 'n_rev', ABOVE)]
+
+    const ai = selectAssumedStrengthToResolve({
+      fragileEdges: rows,
+      edges: [ceeDraft],
+      nodeLabels: labels,
+    })
+    expect(ai.selected?.edgeId).toBe('e_demand_rev')
+
+    // The editor writes the field-specific user stamp and correctly leaves the
+    // edge's AI creation provenance intact. Same number, opposite eligibility.
+    const user = selectAssumedStrengthToResolve({
+      fragileEdges: rows,
+      edges: [{ ...ceeDraft, data: { ...ceeDraft.data, weightSource: 'user' } }],
+      nodeLabels: labels,
+    })
+    expect(user.selected).toBeNull()
+    expect(user.refusalReason).toBe('all_strengths_set')
+  })
+
+  it.each([
+    ['provenanceDisplay=ai_inferred', { provenanceDisplay: 'ai_inferred' }],
+    ['origin=ai', { origin: 'ai' }],
+  ])('%s independently keeps a CEE numeric strength unresolved', (_label, provenance) => {
     const d = selectAssumedStrengthToResolve({
-      fragileEdges: [fragileRow('n_demand', 'n_rev', THRESHOLDS.FRAGILE_EDGE_FILTER)],
+      fragileEdges: [fragileRow('n_demand', 'n_rev', ABOVE)],
+      edges: [{
+        id: 'e_demand_rev',
+        source: 'n_demand',
+        target: 'n_rev',
+        data: { weight: 0.5, weightSource: 'cee', ...provenance },
+      }],
+      nodeLabels: labels,
+    })
+    expect(d.selected?.edgeId).toBe('e_demand_rev')
+  })
+
+  it.each([
+    THRESHOLDS.FRAGILE_EDGE_FILTER,
+    THRESHOLDS.FRAGILE_EDGE_FILTER - 0.01,
+  ])('keeps a candidate silent at or below the visibility floor (%s)', (switchProbability) => {
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: [fragileRow('n_demand', 'n_rev', switchProbability)],
       edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev')],
       nodeLabels: labels,
     })
     expect(d.selected).toBeNull()
+    expect(d.assumedFragileCount).toBe(0)
     expect(d.refusalReason).toBe('no_fragile_edges')
   })
 
@@ -249,33 +302,23 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
     expect(d.assumedFragileCount).toBe(1)
   })
 
-  it('F4 — the FIRST-ROW rule is only correct because the producer sorts DESCENDING', () => {
-    // The selector consumes wire order and never re-ranks. That is right ONLY
-    // while ISL emits `fragile_edges` sorted by `switch_probability`
-    // descending — verified across every committed live capture. This pins the
-    // PRECONDITION in-test, so if the producer ever stopped sorting, this REDs
-    // here (a named, explained failure) instead of the product quietly naming
-    // the wrong relationship as the one that matters most.
+  it('uses the FIRST eligible producer identity and never re-ranks in the UI', () => {
+    // Deliberately put a larger number second. The producer owns ranking and
+    // communicates it through row order; sorting these rows locally would mint
+    // a second ranking authority and select a different edge.
     const rows = [
-      fragileRow('n_demand', 'n_rev', 0.45),
-      fragileRow('n_price', 'n_cost', 0.20),
+      fragileRow('n_demand', 'n_rev', 0.20),
+      fragileRow('n_price', 'n_cost', 0.45),
     ]
-    const probs = rows.map(r => r.switch_probability)
-    expect(
-      probs.every((p, i) => i === 0 || probs[i - 1] >= p),
-      'this fixture must be in producer (descending) order, or the assertion below proves nothing',
-    ).toBe(true)
 
     const d = selectAssumedStrengthToResolve({
-      rows: undefined,
       fragileEdges: rows,
       edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev'), assumedEdge('e_price_cost', 'n_price', 'n_cost')],
       nodeLabels: labels,
-    } as Parameters<typeof selectAssumedStrengthToResolve>[0])
-    // First in wire order === highest switch probability, so "first" and
-    // "most decision-relevant" coincide. Both facts asserted, not just one.
+    })
     expect(d.selected?.edgeId).toBe('e_demand_rev')
-    expect(d.selected?.switchProbability).toBe(Math.max(...probs))
+    expect(d.selected?.switchProbability).toBe(0.20)
+    expect(d.selected?.edgeId).not.toBe('e_price_cost')
   })
 
   it('tolerates malformed rows without dropping the whole decision', () => {

--- a/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
@@ -111,6 +111,31 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
     expect(d.selected?.edgeId).toBe('e_demand_rev')
   })
 
+  it('creation origin cannot resolve a field: origin=user stays assumed until weightSource=user', () => {
+    const rows = [fragileRow('n_demand', 'n_rev', ABOVE)]
+    const userCreated: ElicitationCanvasEdge = {
+      id: 'e_demand_rev',
+      source: 'n_demand',
+      target: 'n_rev',
+      data: { ...USER_EDGE_DEFAULTS, origin: 'user' },
+    }
+
+    const defaultStrength = selectAssumedStrengthToResolve({
+      fragileEdges: rows,
+      edges: [userCreated],
+      nodeLabels: labels,
+    })
+    expect(defaultStrength.selected?.edgeId).toBe('e_demand_rev')
+
+    const userSetStrength = selectAssumedStrengthToResolve({
+      fragileEdges: rows,
+      edges: [{ ...userCreated, data: { ...userCreated.data, weightSource: 'user' } }],
+      nodeLabels: labels,
+    })
+    expect(userSetStrength.selected).toBeNull()
+    expect(userSetStrength.refusalReason).toBe('all_strengths_set')
+  })
+
   it('counts a user who CHOSE 0.5 as SET — the same number, the opposite verdict', () => {
     expect(DEFAULT_EDGE_DATA.weight).toBe(0.5)
     const d = selectAssumedStrengthToResolve({

--- a/src/components/results/strengthElicitation/assumedStrengthCopy.ts
+++ b/src/components/results/strengthElicitation/assumedStrengthCopy.ts
@@ -113,9 +113,10 @@ export const ASSUMED_STRENGTH_ACTION = 'Set this strength'
  * honest response to our own gap is silence, not an apology that reads as a
  * finding about their model).
  *
- * `all_strengths_set` DOES speak, because it is the good state and it is the
- * one the interaction is trying to reach: a team that has pinned every fragile
- * strength should be told so, or the work they did is invisible.
+ * `all_strengths_set` DOES speak, but it reports only the selector's bounded
+ * result. It must not infer that a person supplied every numeric strength or
+ * that no placeholder affects the answer: older edges can carry a producer
+ * value without the finer provenance that would license either claim.
  * `no_fragile_edges` speaks for the same reason, and both are careful to be
  * about THIS RUN — "nothing stood out in this run", never "your model is sound".
  */
@@ -123,7 +124,7 @@ export const ASSUMED_STRENGTH_REFUSAL_COPY: Record<AssumedStrengthRefusal, strin
   no_robustness_data: null,
   no_edge_identity: null,
   all_strengths_set:
-    'Every relationship this run was sensitive to has a strength somebody set — no placeholders are driving this answer.',
+    'No unresolved assumed strength was found among the relationships this run was sensitive to.',
   no_fragile_edges:
     'No single relationship stood out as driving this run’s answer, so there is no one assumption to pin down first.',
 }

--- a/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
+++ b/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
@@ -172,8 +172,9 @@ function nonEmptyString(value: unknown): string | null {
  *
  * `weightSource` is field-specific, while `provenanceDisplay` / `origin` describe
  * how the edge entered the model. That fixes the precedence: a later user edit
- * resolves an AI-created edge, but a CEE numeric estimate does not resolve
- * itself merely because ingestion stamped `weightSource: 'cee'`.
+ * resolves an AI-created edge, but merely drawing an edge does not resolve its
+ * default strength, and a CEE numeric estimate does not resolve itself merely
+ * because ingestion stamped `weightSource: 'cee'`.
  *
  * Unknown/older provenance keeps the previous absence-safe rule: only a
  * recognised value source counts as resolved. No new provenance is inferred.
@@ -183,11 +184,7 @@ function hasUnresolvedAssumedStrength(data: Record<string, unknown> | undefined)
 
   // The strength editor writes this field-specific stamp and deliberately
   // leaves the edge's creation origin intact. It therefore has precedence.
-  if (
-    valueSource === 'user'
-    || data?.provenanceDisplay === 'user_set'
-    || data?.origin === 'user'
-  ) {
+  if (valueSource === 'user') {
     return false
   }
 

--- a/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
+++ b/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
@@ -28,13 +28,13 @@
  *      NEVER a fallback for a rendered number. Calling that helper rather than
  *      reading `row.switch_probability` here is what keeps those three rules in
  *      ONE place; a local read would be a fourth copy of the floor.
- *   2. IS IT ASSUMED — `edgeValueSource(data, 'weight')`
- *      (`canvas/domain/edgeValueProvenance.ts:135`). `null` means DEFAULTED.
- *      The invariant is ABSENT MEANS DEFAULTED, so a construction site that
- *      forgets to stamp under-discloses ("not set" on a value that was set) and
- *      never over-claims. We inherit that direction deliberately: the failure
- *      mode of this module is staying SILENT about a genuinely assumed edge,
- *      never inventing an assumption the user actually set.
+ *   2. IS IT ASSUMED — the canvas's existing value and edge provenance:
+ *      `edgeValueSource(data, 'weight')`, `provenanceDisplay`, and `origin`.
+ *      A user-set strength is resolved. `ai_inferred` / `origin: 'ai'` remains
+ *      provisional even when CEE supplied a numeric strength and therefore
+ *      stamped `weightSource: 'cee'`. Edge creation provenance never overrides
+ *      the more specific user value stamp, so an AI-created edge stops being
+ *      eligible after the user sets its strength through the existing editor.
  *   3. PRODUCER ORDER — ISL emits `fragile_edges` sorted descending by
  *      `switch_probability` (measured across all nine committed live captures).
  *      We preserve that order exactly and take the FIRST qualifying row. No
@@ -115,7 +115,7 @@ export type AssumedStrengthRefusal =
   | 'no_robustness_data'
   /** The block exists but nothing clears the visibility floor. */
   | 'no_fragile_edges'
-  /** Fragile edges exist, and EVERY one of them has a strength somebody set. */
+  /** Fragile edges exist, but none has an unresolved assumed strength. */
   | 'all_strengths_set'
   /** Fragile rows exist but none matched a canvas edge we can name and focus. */
   | 'no_edge_identity'
@@ -165,6 +165,37 @@ function readRecord(value: unknown): Record<string, unknown> | null {
 
 function nonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+/**
+ * Whether this strength still needs human judgement.
+ *
+ * `weightSource` is field-specific, while `provenanceDisplay` / `origin` describe
+ * how the edge entered the model. That fixes the precedence: a later user edit
+ * resolves an AI-created edge, but a CEE numeric estimate does not resolve
+ * itself merely because ingestion stamped `weightSource: 'cee'`.
+ *
+ * Unknown/older provenance keeps the previous absence-safe rule: only a
+ * recognised value source counts as resolved. No new provenance is inferred.
+ */
+function hasUnresolvedAssumedStrength(data: Record<string, unknown> | undefined): boolean {
+  const valueSource = edgeValueSource(data, 'weight')
+
+  // The strength editor writes this field-specific stamp and deliberately
+  // leaves the edge's creation origin intact. It therefore has precedence.
+  if (
+    valueSource === 'user'
+    || data?.provenanceDisplay === 'user_set'
+    || data?.origin === 'user'
+  ) {
+    return false
+  }
+
+  if (data?.provenanceDisplay === 'ai_inferred' || data?.origin === 'ai') {
+    return true
+  }
+
+  return valueSource === null
 }
 
 /**
@@ -250,9 +281,10 @@ export function selectAssumedStrengthToResolve({
 
     sawAnyFragibleAboveFloor = true
 
-    // ABSENT MEANS DEFAULTED. A stamped edge — 'user', 'cee' or 'template' — is
-    // somebody's number, not ours to re-elicit.
-    if (edgeValueSource(edge.data, 'weight') !== null) continue
+    // A CEE number is still provisional when the edge says AI inferred it.
+    // Conversely, the field-specific user stamp wins over the edge's retained
+    // AI creation origin after the existing editor writes the user's value.
+    if (!hasUnresolvedAssumedStrength(edge.data)) continue
 
     // COUNT DISTINCT EDGES, NOT ROWS. The producer may name one canvas edge in
     // more than one row (a repeated pair, or an `edge_id` row alongside its


### PR DESCRIPTION
## What changed

- Keeps a numeric CEE-drafted strength eligible for Resolve next when existing edge provenance says `ai_inferred` or `origin: ai`.
- Treats the existing field-specific user source as authoritative after the user sets the strength, even though the edge retains its AI creation origin.
- Preserves the producer-owned `fragile_edges` row order and the existing strict `THRESHOLDS.FRAGILE_EDGE_FILTER` floor; there is no UI reranking, threshold change, or VOI inference.
- Replaces the false no-candidate claim with bounded, truthful copy: “No unresolved assumed strength was found among the relationships this run was sensitive to.”
- Leaves the existing #704 editor route, mutation, stale-state, rerun, and loop-closing path unchanged.

## Corrected premises

- A numeric strength is not necessarily resolved: existing `ai_inferred` / `origin: ai` provenance identifies an AI estimate that still needs human judgement.
- An explicit user-set field source resolves the strength, including on an AI-created edge.
- “No candidate in this bounded selector” does not prove that every value was human-set or that no placeholder affects the answer.

## Scope and overlap

- One UI capability/root change only; no refactor, schema change, data migration, destructive write, or new authority.
- Reviewed open UI PRs #705 and #706: no file overlap and no semantic collision with this selector/copy boundary.

## Checks

- Focused selector/copy/chain/editor/mount tests: 69/69 passed across 5 files.
- Impacted test selection: 2,064/2,064 passed across 166 files.
- Repository TypeScript gate: passed (baseline error ratchet unchanged).
- Full lint: passed with 0 errors; existing warning baseline unchanged.

## Rollback

- Prior known-good / PR base: `7c779859e5472c79114405fc2ad271012444acb2` (`staging`).
- Change commit / exact revert target: `d995bf24e487e25a038313b2dd626597558ae5c3` (verified on the remote branch).
- Revert this PR alone to restore the prior Resolve-next eligibility and copy. No unrelated lane needs to be reverted; there is no schema/data rollback.

## Review posture

- Draft only. Do not merge or deploy as part of this overnight implementation step.
