### PR TITLE
Fix panel apply handoff reachability

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -101,6 +101,7 @@ import { OutputsDock } from './components/OutputsDock'
 import { DraftChat } from './components/DraftChat'
 import { isAiPanelV2Enabled } from '../flags'
 import { ConversationProvider } from './conversation/ConversationContext'
+import { PanelApplyDrainHost } from './conversation/PanelApplyDrainHost'
 import { FloatingOlumiPanel } from './components/FloatingOlumiPanel'
 import { FirstUseComposer } from './components/FirstUseComposer'
 import { StarterProvenanceBanner } from './components/StarterProvenanceBanner'
@@ -2418,17 +2419,21 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
 
 /**
  * Conditionally wraps children in <ConversationProvider> when aiPanelV2 is ON.
- * Mounts a single useConversation() instance shared by the docked Olumi tab
- * (via OutputsDock) and the floating Olumi panel. When OFF, renders children
- * directly so OutputsDock + DraftChat continue to own their own
- * useConversation() instances as today.
+ * Mounts a single useConversation() instance shared by the docked Olumi tab,
+ * floating panel and the headless panel-apply drain. When OFF, renders children
+ * directly so OutputsDock + DraftChat continue to own their existing paths.
  *
  * Critical: exactly ONE useConversation() instance must be mounted at runtime
  * (see useConversation.ts scenario-hydration race + telemetry duplication).
  */
-function MaybeConversationProvider({ children }: { children: import('react').ReactNode }) {
+export function MaybeConversationProvider({ children }: { children: import('react').ReactNode }) {
   if (isAiPanelV2Enabled()) {
-    return <ConversationProvider>{children}</ConversationProvider>
+    return (
+      <ConversationProvider>
+        <PanelApplyDrainHost />
+        {children}
+      </ConversationProvider>
+    )
   }
   return <>{children}</>
 }

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { useParams } from 'react-router-dom'
 import { ChevronDown, ChevronUp, Paperclip, Settings, Sparkles, X } from 'lucide-react'
 import { useCEEDraft } from '../../hooks/useCEEDraft'
 import { DraftLoadingAnimation } from './DraftLoadingAnimation'
@@ -51,6 +52,7 @@ function useOrchestratorV2Flag(): boolean {
 
 export function DraftChat() {
   const isOrchV2 = useOrchestratorV2Flag()
+  const { id: scenarioIdFromRoute } = useParams<{ id: string }>()
 
   // Initialize description from stored value to maintain context across panel close/reopen
   const lastDraftDescription = useDraftStore(s => s.lastDraftDescription)
@@ -158,8 +160,12 @@ export function DraftChat() {
   // so it records an intent and this drains it through the ONE real sender —
   // rather than the panel page growing a second turn transport.
   usePanelApplyDrain({
-    scenarioId: currentScenarioId ?? undefined,
-    graphReady: currentScenarioId !== null,
+    // Bind to the requested route, not whatever scenario the store happened to
+    // hold for the render before hydration. On /scenario/B, an A graph/pending
+    // action is inert until the store also names B.
+    scenarioId: scenarioIdFromRoute,
+    graphReady:
+      scenarioIdFromRoute !== undefined && currentScenarioId === scenarioIdFromRoute,
     graphRevision: panelApplyGraphRevision,
     lookupNodeData: lookupNodeDataForApply,
     sendSystemEvent: conversation.sendSystemEvent,

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -132,9 +132,12 @@ export function DraftChat() {
   // Task 2: Watch for full_draft signal (set by useConversation when ≥3 nodes added at once)
   const fullDraftAppliedAt = useDraftStore(s => s.fullDraftAppliedAt)
   const currentScenarioId = useCanvasStore(s => s.currentScenarioId)
-  // Read through `getState()` rather than a subscribing selector: this is a
-  // point lookup performed once when an intent drains, and subscribing to the
-  // whole node array here would re-render the chat on every graph change.
+  // The node-array identity is the explicit hydration revision that retriggers
+  // a deferred drain. The lookup itself still reads through getState() so it
+  // does not close over a stale graph snapshot.
+  const panelApplyGraphRevision = useCanvasStore(s => s.nodes)
+  // Read the target through `getState()` rather than capturing the subscribed
+  // array: this point lookup happens only when an intent is eligible to drain.
   const lookupNodeDataForApply = useCallback(
     (targetId: string): unknown =>
       useCanvasStore.getState().nodes.find((n) => n.id === targetId)?.data,
@@ -156,6 +159,8 @@ export function DraftChat() {
   // rather than the panel page growing a second turn transport.
   usePanelApplyDrain({
     scenarioId: currentScenarioId ?? undefined,
+    graphReady: currentScenarioId !== null,
+    graphRevision: panelApplyGraphRevision,
     lookupNodeData: lookupNodeDataForApply,
     sendSystemEvent: conversation.sendSystemEvent,
   })

--- a/src/canvas/components/__tests__/DraftChat.panelApplyRouteBinding.spec.tsx
+++ b/src/canvas/components/__tests__/DraftChat.panelApplyRouteBinding.spec.tsx
@@ -1,0 +1,134 @@
+/**
+ * The real FF-off DraftChat host must bind panel apply to the requested route.
+ * A store can still hold scenario A for a render after navigation requests B;
+ * that transition must never drain A's pending action on B's route.
+ */
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+const SCENARIO_A = '22222222-3333-4444-8555-666677778888'
+const SCENARIO_B = '33333333-4444-4555-8666-777788889999'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+const TARGET_ID = 'factor-churn-risk'
+
+const controls = vi.hoisted(() => ({
+  sendSystemEvent: vi.fn(async (_event: unknown, _opts?: unknown): Promise<undefined> => undefined),
+  sendMessage: vi.fn(async () => ({})),
+}))
+
+vi.mock('../../../hooks/useCEEDraft', () => ({
+  useCEEDraft: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    draft: vi.fn(),
+    guidance: null,
+    retryAfterSeconds: null,
+  }),
+}))
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    sendMessage: controls.sendMessage,
+    sendSystemEvent: controls.sendSystemEvent,
+  }),
+}))
+vi.mock('../../conversation/useGraphEditEvents', () => ({
+  useGraphEditEvents: () => undefined,
+}))
+vi.mock('../../conversation/useAnalysisCompleteEvent', () => ({
+  useAnalysisCompleteEvent: () => undefined,
+}))
+
+import { DraftChat } from '../DraftChat'
+import { rememberPendingApply, readPendingApply } from '../../../collab/panelApplyHandoff'
+import { isAiPanelV2Enabled } from '../../../flags'
+import { useCanvasStore } from '../../store'
+
+function graphA(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_A,
+    showDraftChat: false,
+    nodes: [
+      {
+        id: TARGET_ID,
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Churn risk', observedState: { value: 0.5 } },
+      },
+    ],
+    edges: [],
+  })
+}
+
+function rememberA(): void {
+  rememberPendingApply({
+    scenarioId: SCENARIO_A,
+    roundId: ROUND_ID,
+    participantId: GRACE_ID,
+    targetId: TARGET_ID,
+    value: 0.85,
+  })
+}
+
+function mountDraftChatAt(routeScenarioId: string): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[`/scenario/${routeScenarioId}`]}>
+      <Routes>
+        <Route path="/scenario/:id" element={<DraftChat />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  window.localStorage.setItem('feature.aiPanelV2', 'false')
+  controls.sendSystemEvent.mockReset()
+  controls.sendSystemEvent.mockResolvedValue(undefined)
+  controls.sendMessage.mockClear()
+  useCanvasStore.getState().resetCanvas()
+  graphA()
+})
+
+afterEach(() => {
+  cleanup()
+  useCanvasStore.getState().resetCanvas()
+})
+
+describe('DraftChat panel apply route binding (aiPanelV2 off)', () => {
+  it('MUTANT — /scenario/B with A still in the store does not emit A pending', async () => {
+    expect(isAiPanelV2Enabled()).toBe(false)
+    rememberA()
+
+    mountDraftChatAt(SCENARIO_B)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controls.sendSystemEvent).not.toHaveBeenCalled()
+    expect(readPendingApply(SCENARIO_A)).not.toBeNull()
+  })
+
+  it('same route and hydrated scenario still drains once through DraftChat', async () => {
+    expect(isAiPanelV2Enabled()).toBe(false)
+    rememberA()
+
+    mountDraftChatAt(SCENARIO_A)
+
+    await waitFor(() => expect(controls.sendSystemEvent).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(readPendingApply(SCENARIO_A)).toBeNull())
+    expect(controls.sendSystemEvent.mock.calls[0]?.[0]).toMatchObject({
+      type: 'factor_value_edit',
+      payload: {
+        field: 'value',
+        target_id: TARGET_ID,
+        value: 0.85,
+        applied_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+      },
+    })
+  })
+})

--- a/src/canvas/conversation/PanelApplyDrainHost.tsx
+++ b/src/canvas/conversation/PanelApplyDrainHost.tsx
@@ -1,0 +1,41 @@
+/**
+ * Headless aiPanelV2 host for the panel-to-canvas apply handoff.
+ *
+ * The legacy DraftChat owns this drain while aiPanelV2 is OFF. With the flag
+ * ON, DraftChat is deliberately unmounted, so the drain lives here under the
+ * canvas's existing ConversationProvider and consumes its singleton sender.
+ * It never creates a second conversation or turn transport.
+ */
+
+import { useCallback } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useCanvasStore } from '../store'
+import { useConversationContext } from './ConversationContext'
+import { usePanelApplyDrain } from './usePanelApplyDrain'
+
+export function PanelApplyDrainHost(): null {
+  const { id: scenarioIdFromRoute } = useParams<{ id: string }>()
+  const currentScenarioId = useCanvasStore((state) => state.currentScenarioId)
+  const graphRevision = useCanvasStore((state) => state.nodes)
+  const { sendSystemEvent } = useConversationContext()
+
+  const lookupNodeData = useCallback(
+    (targetId: string): unknown =>
+      useCanvasStore.getState().nodes.find((node) => node.id === targetId)?.data,
+    [],
+  )
+
+  usePanelApplyDrain({
+    // The route is the requested model's identity. The store may still name
+    // the previous scenario for a render while async hydration catches up.
+    scenarioId: scenarioIdFromRoute,
+    graphReady:
+      scenarioIdFromRoute !== undefined && currentScenarioId === scenarioIdFromRoute,
+    graphRevision,
+    lookupNodeData,
+    sendSystemEvent,
+  })
+
+  return null
+}

--- a/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
+++ b/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
@@ -93,6 +93,8 @@ const NODE_DATA = { label: 'Churn risk', observedState: { value: 0.5 } }
 function CanvasHarness({ onWire }: { onWire: (event: unknown) => void }): JSX.Element {
   usePanelApplyDrain({
     scenarioId: SCENARIO_ID,
+    graphReady: true,
+    graphRevision: NODE_DATA,
     lookupNodeData: (id) => (id === TARGET_ID ? NODE_DATA : undefined),
     sendSystemEvent: async (event) => {
       // THE LAST REAL HOP — the one that was dropping the field. The event here

--- a/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
+++ b/src/canvas/conversation/__tests__/panelApplyClickToWire.spec.tsx
@@ -109,7 +109,7 @@ function CanvasHarness({ onWire }: { onWire: (event: unknown) => void }): JSX.El
       })
       if (!result.ok) throw new Error(`payload refused: ${JSON.stringify(result)}`)
       onWire((result.payload as unknown as { event: unknown }).event)
-      return {}
+      return undefined
     },
   })
   return <div data-testid="canvas" />

--- a/src/canvas/conversation/__tests__/panelApplyReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/panelApplyReachability.production.spec.tsx
@@ -13,6 +13,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { StrictMode } from 'react'
 
 const SCENARIO_ID = '22222222-3333-4444-8555-666677778888'
 const OTHER_SCENARIO_ID = '33333333-4444-4555-8666-777788889999'
@@ -25,9 +26,9 @@ const harness = vi.hoisted(() => {
   const systemEvents: unknown[] = []
   return {
     systemEvents,
-    sendSystemEvent: vi.fn(async (event: unknown) => {
+    sendSystemEvent: vi.fn(async (event: unknown, _opts?: unknown): Promise<unknown> => {
       systemEvents.push(event)
-      return {}
+      return undefined
     }),
     getSessionIdentity: vi.fn(async () => ({
       userId: 'owner-user-id',
@@ -39,6 +40,8 @@ const harness = vi.hoisted(() => {
 // The headless host must consume the existing ConversationProvider singleton.
 // Mock only the transport implementation; the provider and host are real.
 vi.mock('../useConversation', () => ({
+  SEND_DEFERRED: 'send_deferred',
+  SEND_BLOCKED: 'send_blocked',
   useConversation: () => ({ sendSystemEvent: harness.sendSystemEvent }),
 }))
 
@@ -92,6 +95,7 @@ import { MaybeConversationProvider } from '../../ReactFlowGraph'
 import { buildV5Payload } from '../../../v5/buildPayload'
 import { useCanvasStore } from '../../store'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { SEND_BLOCKED, SEND_DEFERRED } from '../useConversation'
 
 const REVEAL = {
   round_id: ROUND_ID,
@@ -139,8 +143,11 @@ function readyGraph(scenarioId = SCENARIO_ID): void {
   })
 }
 
-function renderBoundaryAt(routeScenarioId: string): ReturnType<typeof render> {
-  return render(
+function renderBoundaryAt(
+  routeScenarioId: string,
+  options?: { strict?: boolean },
+): ReturnType<typeof render> {
+  const boundary = (
     <MemoryRouter initialEntries={[`/scenario/${routeScenarioId}`]}>
       <Routes>
         <Route
@@ -152,8 +159,9 @@ function renderBoundaryAt(routeScenarioId: string): ReturnType<typeof render> {
           }
         />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   )
+  return render(options?.strict === true ? <StrictMode>{boundary}</StrictMode> : boundary)
 }
 
 beforeEach(() => {
@@ -162,7 +170,11 @@ beforeEach(() => {
   window.history.replaceState({}, '', `/#/scenario/${SCENARIO_ID}/panel`)
   window.localStorage.setItem('feature.aiPanelV2', 'true')
   harness.systemEvents.length = 0
-  harness.sendSystemEvent.mockClear()
+  harness.sendSystemEvent.mockReset()
+  harness.sendSystemEvent.mockImplementation(async (event: unknown, _opts?: unknown) => {
+    harness.systemEvents.push(event)
+    return undefined
+  })
   harness.getSessionIdentity.mockClear()
   readyGraph()
 })
@@ -263,6 +275,128 @@ describe('production panel-apply route', () => {
       useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
     })
     expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('an unresolved send survives re-render, remount, and StrictMode without double-dispatch', async () => {
+    let resolveSend: (() => void) | undefined
+    harness.sendSystemEvent.mockImplementationOnce(
+      () => new Promise<undefined>((resolve) => {
+        resolveSend = () => resolve(undefined)
+      }),
+    )
+    rememberPendingApply({
+      scenarioId: SCENARIO_ID,
+      roundId: ROUND_ID,
+      participantId: GRACE_ID,
+      targetId: TARGET_ID,
+      value: 0.85,
+    })
+    const storageKey = `olumi.collab.pending-apply.${SCENARIO_ID}`
+    const exactPending = window.localStorage.getItem(storageKey)
+
+    const firstMount = renderBoundaryAt(SCENARIO_ID, { strict: true })
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1))
+    expect(harness.sendSystemEvent.mock.calls[0]?.[1]).toEqual({ deferIfBusy: false })
+    expect(window.localStorage.getItem(storageKey)).toBe(exactPending)
+
+    // MUTANT: removing the in-flight guard sends again on this graph revision.
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+      await Promise.resolve()
+    })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(storageKey)).toBe(exactPending)
+
+    // MUTANT: a component-local-only guard is lost here and dispatches a
+    // second copy when StrictMode (or route churn) mounts a fresh host.
+    firstMount.unmount()
+    renderBoundaryAt(SCENARIO_ID, { strict: true })
+    await act(async () => { await Promise.resolve() })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(storageKey)).toBe(exactPending)
+
+    await act(async () => {
+      resolveSend?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(readPendingApply(SCENARIO_ID)).toBeNull())
+
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('a rejected send retains the exact action and a later revision retries it successfully once', async () => {
+    harness.sendSystemEvent.mockRejectedValueOnce(new Error('transport rejected'))
+    rememberPendingApply({
+      scenarioId: SCENARIO_ID,
+      roundId: ROUND_ID,
+      participantId: GRACE_ID,
+      targetId: TARGET_ID,
+      value: 0.85,
+    })
+    const storageKey = `olumi.collab.pending-apply.${SCENARIO_ID}`
+    const exactPending = window.localStorage.getItem(storageKey)
+
+    renderBoundaryAt(SCENARIO_ID)
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(window.localStorage.getItem(storageKey)).toBe(exactPending)
+
+    // MUTANT: stamping drainedFor on rejection prevents this retry; forgetting
+    // before success makes the exact-pending assertion above fail.
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(readPendingApply(SCENARIO_ID)).toBeNull())
+
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    ['SEND_DEFERRED', SEND_DEFERRED],
+    ['SEND_BLOCKED', SEND_BLOCKED],
+    ['a generic resolved no-op', { status: 'no-op' }],
+  ])('%s retains the exact action and releases it for one later accepted retry', async (_label, outcome) => {
+    harness.sendSystemEvent.mockResolvedValueOnce(outcome)
+    rememberPendingApply({
+      scenarioId: SCENARIO_ID,
+      roundId: ROUND_ID,
+      participantId: GRACE_ID,
+      targetId: TARGET_ID,
+      value: 0.85,
+    })
+    const storageKey = `olumi.collab.pending-apply.${SCENARIO_ID}`
+    const exactPending = window.localStorage.getItem(storageKey)
+
+    renderBoundaryAt(SCENARIO_ID)
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(window.localStorage.getItem(storageKey)).toBe(exactPending)
+    expect(harness.sendSystemEvent.mock.calls[0]?.[1]).toEqual({ deferIfBusy: false })
+
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(readPendingApply(SCENARIO_ID)).toBeNull())
+
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(2)
   })
 
   it('does not drain a pending apply when the route and hydrated graph name different scenarios', () => {

--- a/src/canvas/conversation/__tests__/panelApplyReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/panelApplyReachability.production.spec.tsx
@@ -1,0 +1,316 @@
+/**
+ * Panel apply reachability — the production route and feature-flag boundary.
+ *
+ * This is intentionally broader than `panelApplyClickToWire.spec.tsx`. That
+ * spec pins the data transforms; this one mounts AppPoC's real HashRouter and
+ * the real aiPanelV2 boundary, closes a recovered round through the real owner
+ * page, clicks RevealBody's real Apply control, then clicks the real return
+ * Link. The canvas body is a lightweight route harness, but the conversation
+ * boundary and headless drain it mounts are the production components.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const SCENARIO_ID = '22222222-3333-4444-8555-666677778888'
+const OTHER_SCENARIO_ID = '33333333-4444-4555-8666-777788889999'
+const ROUND_ID = 'c3d4e5f6-a7b8-4901-9234-56789abcdef0'
+const GRACE_ID = '9f1c7d2e-4b3a-4c11-8e6f-0a2b5c8d7e10'
+const TARGET_ID = 'factor-churn-risk'
+const TURN_ID = '11111111-2222-4333-8444-555566667777'
+
+const harness = vi.hoisted(() => {
+  const systemEvents: unknown[] = []
+  return {
+    systemEvents,
+    sendSystemEvent: vi.fn(async (event: unknown) => {
+      systemEvents.push(event)
+      return {}
+    }),
+    getSessionIdentity: vi.fn(async () => ({
+      userId: 'owner-user-id',
+      accessToken: 'owner-access-token',
+    })),
+  }
+})
+
+// The headless host must consume the existing ConversationProvider singleton.
+// Mock only the transport implementation; the provider and host are real.
+vi.mock('../useConversation', () => ({
+  useConversation: () => ({ sendSystemEvent: harness.sendSystemEvent }),
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getSessionIdentity: harness.getSessionIdentity,
+}))
+
+// Auth is not the seam under test. Keep AppPoC's real route table while making
+// its guarded branch deterministically reachable in jsdom.
+vi.mock('../../../contexts/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: unknown }) => children,
+  useAuth: () => ({ loading: false, authenticated: true, user: { id: 'owner-user-id' } }),
+}))
+vi.mock('../../../components/auth/AuthGuard', async () => {
+  const { Outlet } = await import('react-router-dom')
+  return { default: Outlet }
+})
+vi.mock('../../../lib/monitoring', () => ({
+  initMonitoring: vi.fn(),
+  setSentryUser: vi.fn(),
+  clearSentryUser: vi.fn(),
+}))
+vi.mock('../../../components/debug/debugPanelVisibility', () => ({
+  useShouldShowDebugPanel: () => false,
+}))
+
+// AppPoC still owns the real HashRouter and route declarations. The canvas
+// route body is narrowed to the production conversation boundary so this test
+// settles the apply handoff without mounting the entire ReactFlow renderer.
+vi.mock('../../../routes/CanvasMVP', async () => {
+  const { MaybeConversationProvider } = await import('../../ReactFlowGraph')
+  return {
+    default: function CanvasRouteHarness() {
+      return (
+        <MaybeConversationProvider>
+          <div data-testid="production-canvas-route" />
+        </MaybeConversationProvider>
+      )
+    },
+  }
+})
+
+import AppPoC from '../../../poc/AppPoC'
+import { isAiPanelV2Enabled } from '../../../flags'
+import { rememberOpenRound } from '../../../collab/openRoundRecord'
+import {
+  readPendingApply,
+  rememberPendingApply,
+} from '../../../collab/panelApplyHandoff'
+import { MaybeConversationProvider } from '../../ReactFlowGraph'
+import { buildV5Payload } from '../../../v5/buildPayload'
+import { useCanvasStore } from '../../store'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+const REVEAL = {
+  round_id: ROUND_ID,
+  status: 'closed',
+  graph_version_ref: 'mv-1',
+  per_target: [
+    {
+      target: { kind: 'factor', id: TARGET_ID },
+      label: 'Churn risk',
+      model_value_at_version: 0.5,
+      responses: [
+        {
+          participant_id: GRACE_ID,
+          display_label: 'Grace',
+          value: 0.85,
+          expression_raw: 'pretty likely',
+          confidence: 0.7,
+          kind: 'belief_submitted',
+        },
+      ],
+    },
+  ],
+}
+
+function jsonResponse(body: unknown, status = 200): Pick<Response, 'ok' | 'status' | 'json'> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }
+}
+
+function readyGraph(scenarioId = SCENARIO_ID): void {
+  useCanvasStore.setState({
+    currentScenarioId: scenarioId,
+    nodes: [
+      {
+        id: TARGET_ID,
+        type: 'factor',
+        position: { x: 0, y: 0 },
+        data: { label: 'Churn risk', observedState: { value: 0.5 } },
+      },
+    ],
+    edges: [],
+  })
+}
+
+function renderBoundaryAt(routeScenarioId: string): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[`/scenario/${routeScenarioId}`]}>
+      <Routes>
+        <Route
+          path="/scenario/:id"
+          element={
+            <MaybeConversationProvider>
+              <div data-testid="boundary-child" />
+            </MaybeConversationProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  window.sessionStorage.clear()
+  window.history.replaceState({}, '', `/#/scenario/${SCENARIO_ID}/panel`)
+  window.localStorage.setItem('feature.aiPanelV2', 'true')
+  harness.systemEvents.length = 0
+  harness.sendSystemEvent.mockClear()
+  harness.getSessionIdentity.mockClear()
+  readyGraph()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useCanvasStore.getState().resetCanvas()
+})
+
+describe('production panel-apply route', () => {
+  it('real reveal Apply + canonical return Link reaches one uncited wire edit exactly once', async () => {
+    expect(isAiPanelV2Enabled()).toBe(true)
+
+    rememberOpenRound({
+      roundId: ROUND_ID,
+      scenarioId: SCENARIO_ID,
+      participants: [{ participant_id: GRACE_ID, display_name: 'Grace' }],
+    })
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === `/bff/collab/rounds/${ROUND_ID}/close`) return jsonResponse({})
+      if (url === `/bff/collab/rounds/${ROUND_ID}/reveal`) return jsonResponse(REVEAL)
+      if (url === `/bff/collab/rounds/${ROUND_ID}/disagreement`) {
+        return jsonResponse({ code: 'not_available', message: 'not available' }, 404)
+      }
+      return jsonResponse({ code: 'not_stubbed', message: url }, 404)
+    }))
+
+    render(<AppPoC />)
+
+    fireEvent.click(await screen.findByTestId('panel-resume-close'))
+    const apply = await screen.findByTestId(`reveal-apply-${TARGET_ID}-${GRACE_ID}`)
+    fireEvent.click(apply)
+
+    expect(readPendingApply(SCENARIO_ID)).toMatchObject({
+      round_id: ROUND_ID,
+      participant_id: GRACE_ID,
+      target_id: TARGET_ID,
+      value: 0.85,
+    })
+
+    const returnLink = screen.getByTestId('reveal-back-to-model')
+    expect(returnLink.getAttribute('href')).toBe(`#/scenario/${SCENARIO_ID}`)
+    fireEvent.click(returnLink)
+
+    await screen.findByTestId('production-canvas-route')
+    expect(screen.queryByTestId(`reveal-apply-${TARGET_ID}-${GRACE_ID}`)).toBeNull()
+    expect((window.location.href.match(/#/g) ?? []).length).toBe(1)
+    expect(window.location.hash).toBe(`#/scenario/${SCENARIO_ID}`)
+
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1))
+    expect(readPendingApply(SCENARIO_ID)).toBeNull()
+
+    const built = buildV5Payload({
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'frame' as never,
+      turnClass: 'system' as never,
+      mode: 'system',
+      systemEvent: harness.systemEvents[0] as never,
+    })
+    expect(built.ok).toBe(true)
+    if (!built.ok) throw new Error('positive control: factor edit payload was refused')
+
+    const wire = (built.payload as unknown as { event: Record<string, unknown> }).event
+    expect(wire).toMatchObject({
+      kind: 'factor_value_edit',
+      target_id: TARGET_ID,
+      value: 0.85,
+      applied_from: { round_id: ROUND_ID, participant_id: GRACE_ID },
+    })
+    expect(wire).not.toHaveProperty('cited_evidence')
+    expect(wire).not.toHaveProperty('evidence')
+  })
+
+  it('delayed target hydration retriggers the pending drain once, then removal prevents replay', async () => {
+    useCanvasStore.setState({ currentScenarioId: SCENARIO_ID, nodes: [], edges: [] })
+    rememberPendingApply({
+      scenarioId: SCENARIO_ID,
+      roundId: ROUND_ID,
+      participantId: GRACE_ID,
+      targetId: TARGET_ID,
+      value: 0.85,
+    })
+
+    renderBoundaryAt(SCENARIO_ID)
+    expect(harness.sendSystemEvent).not.toHaveBeenCalled()
+    expect(readPendingApply(SCENARIO_ID)).not.toBeNull()
+
+    await act(async () => {
+      readyGraph()
+    })
+    await waitFor(() => expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1))
+    expect(readPendingApply(SCENARIO_ID)).toBeNull()
+
+    await act(async () => {
+      useCanvasStore.setState((state) => ({ nodes: [...state.nodes] }))
+    })
+    expect(harness.sendSystemEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not drain a pending apply when the route and hydrated graph name different scenarios', () => {
+    rememberPendingApply({
+      scenarioId: SCENARIO_ID,
+      roundId: ROUND_ID,
+      participantId: GRACE_ID,
+      targetId: TARGET_ID,
+      value: 0.85,
+    })
+    readyGraph(SCENARIO_ID)
+
+    renderBoundaryAt(OTHER_SCENARIO_ID)
+
+    expect(harness.sendSystemEvent).not.toHaveBeenCalled()
+    expect(readPendingApply(SCENARIO_ID)).not.toBeNull()
+  })
+
+  it('does not drain an expired pending apply', () => {
+    window.localStorage.setItem(
+      `olumi.collab.pending-apply.${SCENARIO_ID}`,
+      JSON.stringify({
+        scenario_id: SCENARIO_ID,
+        round_id: ROUND_ID,
+        participant_id: GRACE_ID,
+        target_id: TARGET_ID,
+        value: 0.85,
+        recorded_at: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+      }),
+    )
+
+    renderBoundaryAt(SCENARIO_ID)
+
+    expect(harness.sendSystemEvent).not.toHaveBeenCalled()
+    expect(readPendingApply(SCENARIO_ID)).toBeNull()
+  })
+
+  it('production mount and rollback paths stay explicit', () => {
+    const graphSource = readFileSync(resolve(process.cwd(), 'src/canvas/ReactFlowGraph.tsx'), 'utf8')
+    const legacySource = readFileSync(resolve(process.cwd(), 'src/canvas/components/DraftChat.tsx'), 'utf8')
+
+    // Mutation guards: removing the production boundary mount, inverting its
+    // flag branch, or deleting the flag-off legacy drain makes one fail.
+    expect(graphSource).toContain('<MaybeConversationProvider>')
+    expect(graphSource).toContain('</MaybeConversationProvider>')
+    expect(graphSource).toContain('if (isAiPanelV2Enabled()) {')
+    expect(graphSource.match(/<PanelApplyDrainHost \/>/g)).toHaveLength(1)
+    expect(legacySource).toContain('usePanelApplyDrain({')
+    expect(graphSource).toContain('{!isAiPanelV2Enabled() && <DraftChat />}')
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.deferredSystemSends.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.deferredSystemSends.spec.ts
@@ -60,7 +60,7 @@ vi.mock('../../../flags', async (importOriginal) => {
   return { ...actual, isOrchestratorV2Enabled: () => true, isOrchestratorStreamingEnabled: () => false }
 })
 
-import { useConversation, SEND_DEFERRED } from '../useConversation'
+import { SEND_BLOCKED, SEND_DEFERRED, useConversation } from '../useConversation'
 
 const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
 
@@ -121,6 +121,28 @@ describe('system-mode sends blocked by the in-flight lock', () => {
     // indistinguishable from a dispatched turn.
     expect(outcome).toBe(SEND_DEFERRED)
     expect(dispatchedEdits(), 'not on the wire yet — the lock is still held').toHaveLength(0)
+  })
+
+  it('a durable caller can keep retry ownership instead of creating a hidden queued copy', async () => {
+    const { result } = renderHook(() => useConversation())
+    act(() => { void result.current.sendMessage('run the analysis') })
+    await flush()
+
+    let outcome: unknown = 'not-set'
+    await act(async () => {
+      outcome = await result.current.sendSystemEvent(
+        edit('fac_a', 0.4, 20000),
+        { deferIfBusy: false },
+      )
+    })
+
+    expect(outcome).toBe(SEND_BLOCKED)
+    expect(dispatchedEdits()).toHaveLength(0)
+
+    // Releasing the lock must not flush a second copy behind the caller's
+    // durable pending record; the caller alone decides when to retry.
+    await act(async () => { resolveInFlight?.(undefined); await flush() })
+    expect(dispatchedEdits()).toHaveLength(0)
   })
 
   it('a deferred edit is NOT LOST — it reaches the wire once the lock clears', async () => {

--- a/src/canvas/conversation/__tests__/useConversation.systemEvents.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.systemEvents.spec.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useConversation, SYSTEM_MESSAGE_SENTINEL } from '../useConversation'
+import { SEND_BLOCKED, useConversation, SYSTEM_MESSAGE_SENTINEL } from '../useConversation'
 import { useCanvasStore } from '../../store'
 import type { WireSystemEvent } from '../types'
 
@@ -145,13 +145,15 @@ describe('sendSystemEvent', () => {
 
     const { result } = renderHook(() => useConversation())
 
+    let outcome: unknown = 'not-set'
     await act(async () => {
-      await result.current.sendSystemEvent({
+      outcome = await result.current.sendSystemEvent({
         type: 'direct_graph_edit',
         payload: { changed_node_ids: ['n1'] },
       })
     })
 
+    expect(outcome).toBe(SEND_BLOCKED)
     expect(mockCallTurn).not.toHaveBeenCalled()
     expect(result.current.messages).toHaveLength(0)
   })
@@ -272,6 +274,7 @@ describe('sendSystemEvent', () => {
 
     const { result } = renderHook(() => useConversation())
 
+    let outcome: unknown = 'not-set'
     await act(async () => {
       // DELIBERATE type violation, and the cast is the point of the test rather
       // than a workaround for it. `session_resume` is an InternalSystemEventType,
@@ -281,12 +284,13 @@ describe('sendSystemEvent', () => {
       // state, a hydrated thread, a JS caller). Casting through `unknown` is how
       // this test reaches the runtime guard at all; without it the assertion
       // below could only ever be vacuous.
-      await result.current.sendSystemEvent(
+      outcome = await result.current.sendSystemEvent(
         { type: 'session_resume', payload: {} } as unknown as WireSystemEvent,
       )
     })
 
     // Pre-filter drops session_resume before sendTurn — no network call
+    expect(outcome).toBe(SEND_BLOCKED)
     expect(mockCallTurn).not.toHaveBeenCalled()
     expect(result.current.messages).toHaveLength(0)
   })

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2331,6 +2331,14 @@ export interface SendTurnOpts {
    * `SEND_DEFERRED` long before the reply existed.
    */
   optimisticFactorEdit?: OptimisticFactorEdit
+  /**
+   * Keep this system event with its caller when another turn owns the lock.
+   *
+   * Default true preserves the established singleton sender queue. Callers
+   * that already own a durable retry record set false so `SEND_BLOCKED` is
+   * returned instead of creating a second, hidden copy of the same action.
+   */
+  deferIfBusy?: boolean
 }
 
 /** One send held back by the in-flight lock. */
@@ -2389,6 +2397,7 @@ const MAX_FLUSH_ATTEMPTS = 3
 export const SEND_DEFERRED = 'send_deferred' as const
 /** Blocked and NOT queued (retry-class callers). Detectable, never silent. */
 export const SEND_BLOCKED = 'send_blocked' as const
+/** `undefined` is the only accepted/dispatched outcome. */
 export type SendTurnOutcome = typeof SEND_DEFERRED | typeof SEND_BLOCKED | undefined
 
 export class SystemEventSendError extends Error {
@@ -2436,6 +2445,8 @@ export interface UseConversationReturn {
      * canvas showing a number (and a "User edited" stamp) the engine declined.
      */
     optimisticFactorEdit?: OptimisticFactorEdit
+    /** Return `SEND_BLOCKED` instead of queueing behind an in-flight turn. */
+    deferIfBusy?: boolean
     // Resolves to SEND_DEFERRED when the in-flight lock queued the send instead
     // of dispatching it, so a caller can tell "queued" from "sent" — the old
     // `Promise<void>` made those two indistinguishable, which is how an
@@ -4129,6 +4140,9 @@ export function useConversation(): UseConversationReturn {
           // newer turn's lock or analysing state.
           isThinkingRef.current = false
         } else if (opts.mode === 'system' && opts.systemEvent) {
+          if (opts.deferIfBusy === false) {
+            return SEND_BLOCKED
+          }
           // DEFER, do not drop. Returns a sentinel so the caller can tell this
           // apart from a dispatched turn — the old bare `return` could not be
           // distinguished from success by any caller, in prod or in a test.
@@ -6093,9 +6107,10 @@ export function useConversation(): UseConversationReturn {
       debugInitiatedBy?: 'user' | 'automatic'
       debugSourceSurface?: string
       optimisticFactorEdit?: OptimisticFactorEdit
+      deferIfBusy?: boolean
     }) => {
       // No-op when orchestrator V2 is OFF
-      if (!isOrchestratorV2Enabled()) return
+      if (!isOrchestratorV2Enabled()) return SEND_BLOCKED
 
       // Pre-check: skip the entire network turn if the event type is not
       // supported by the CEE v3 schema. Prevents phantom [system] turns
@@ -6105,7 +6120,7 @@ export function useConversation(): UseConversationReturn {
         if (import.meta.env.DEV) {
           console.warn(`[sendSystemEvent] Dropped unsupported event: ${event.type}`)
         }
-        return
+        return SEND_BLOCKED
       }
 
       recordCrossSurfaceEvent({
@@ -6128,6 +6143,7 @@ export function useConversation(): UseConversationReturn {
         initiatedBy: opts?.debugInitiatedBy ?? 'automatic',
         sourceSurface: opts?.debugSourceSurface,
         optimisticFactorEdit: opts?.optimisticFactorEdit,
+        deferIfBusy: opts?.deferIfBusy,
       })
     },
     [sendTurn],

--- a/src/canvas/conversation/usePanelApplyDrain.ts
+++ b/src/canvas/conversation/usePanelApplyDrain.ts
@@ -8,9 +8,11 @@
  * `factor_value_edit` carrying `applied_from`.
  *
  * ── THE THREE PROPERTIES THAT MAKE THIS SAFE ──────────────────────────────
- * 1. EXACTLY ONCE. The intent is forgotten BEFORE the send, and a ref guards
- *    against a re-render racing a second drain. A double drain would post two
- *    turns and write two entries into the user's transcript for one click.
+ * 1. ONE IN FLIGHT; CLEAR ONLY AFTER CONFIRMED ACCEPTANCE. An ephemeral claim
+ *    prevents re-render, remount, and React StrictMode from dispatching the same
+ *    intent while its promise is unresolved. The pending record is retained for
+ *    rejected, deferred, blocked, and no-op outcomes, so a later readiness or
+ *    revision change can retry without reconstructing the owner's action.
  * 2. IT ASSERTS NOTHING IT DID NOT VERIFY. The hook attaches `applied_from` as
  *    a CLAIM. CEE checks it against its own collab store and refuses the whole
  *    edit on any mismatch, so the worst a stale or wrong intent achieves is a
@@ -24,6 +26,7 @@ import { useEffect, useRef } from 'react'
 
 import { buildFactorValueEditEvent } from './factorValueEdit'
 import type { WireSystemEvent } from './types'
+import type { SendTurnOutcome } from './useConversation'
 import {
   forgetPendingApply,
   readPendingApply,
@@ -56,9 +59,37 @@ export interface PanelApplyDrainArgs {
    */
   lookupNodeData: (targetId: string) => unknown | undefined
   /** The one real turn sender, from the conversation context. */
-  sendSystemEvent: ((event: WireSystemEvent) => Promise<unknown>) | undefined
+  sendSystemEvent: ((
+    event: WireSystemEvent,
+    opts: { deferIfBusy: false },
+  ) => Promise<SendTurnOutcome>) | undefined
   /** Notified after a successful dispatch, for the canvas confirmation. */
   onApplied?: (intent: PendingPanelApply) => void
+}
+
+/**
+ * Process-local transport claims only. The pending localStorage record remains
+ * the sole retry authority; this set carries no payload and is deleted on every
+ * settlement. Keeping the claim outside a component is what closes the brief
+ * unmount/remount window created by React StrictMode.
+ */
+const inFlightIntentKeys = new Set<string>()
+
+/**
+ * Stable identity for one recorded action. `recorded_at` distinguishes two
+ * clicks with otherwise identical fields; the explicit -0 spelling preserves
+ * the same Object.is-sensitive number semantics as the server binding.
+ */
+function intentKey(intent: PendingPanelApply): string {
+  const value = Object.is(intent.value, -0) ? '-0' : String(intent.value)
+  return JSON.stringify([
+    intent.scenario_id,
+    intent.round_id,
+    intent.participant_id,
+    intent.target_id,
+    value,
+    intent.recorded_at,
+  ])
 }
 
 export function usePanelApplyDrain({
@@ -69,19 +100,18 @@ export function usePanelApplyDrain({
   sendSystemEvent,
   onApplied,
 }: PanelApplyDrainArgs): void {
-  // Guards the exactly-once property across re-renders and StrictMode's double
-  // effect invocation. Keyed by scenario so navigating between models still
-  // drains each one's own intent.
+  // Successful action identity, retained when localStorage removal itself is
+  // unavailable so a fulfilled send cannot replay during this mount.
   const drainedFor = useRef<string | null>(null)
-
   useEffect(() => {
     if (scenarioId === undefined || scenarioId === '') return
     if (!graphReady) return
     if (sendSystemEvent === undefined) return
-    if (drainedFor.current === scenarioId) return
-
     const intent = readPendingApply(scenarioId)
     if (intent === null) return
+    const key = intentKey(intent)
+    if (drainedFor.current === key) return
+    if (inFlightIntentKeys.has(key)) return
 
     // DEFER, do not drop: the graph may still be loading. Returning without
     // stamping `drainedFor` leaves the intent in place for the next render,
@@ -99,29 +129,46 @@ export function usePanelApplyDrain({
       },
     })
 
-    // Fail CLOSED. The builder refuses a model-scale number outside [0,1] or on
-    // a magnitude-scaled factor, for every caller. Forget the intent so a
-    // permanently-unencodable one cannot wedge the drain on every visit.
-    if (event === null) {
-      drainedFor.current = scenarioId
-      forgetPendingApply(scenarioId)
-      return
-    }
+    // Fail CLOSED. Keep the exact pending action: a later graph revision may
+    // provide node scale metadata that makes the shared builder able to encode
+    // it, and staleness bounds an action that remains permanently invalid.
+    if (event === null) return
 
-    // Order is load-bearing: mark and forget BEFORE sending, so a rejected send
-    // cannot be replayed. See `forgetPendingApply`'s header.
-    drainedFor.current = scenarioId
-    forgetPendingApply(scenarioId)
+    // Mark in-flight BEFORE invoking the sender. Wrapping the invocation also
+    // turns a synchronous throw into the same rejected-promise retry posture.
+    inFlightIntentKeys.add(key)
+    void Promise.resolve()
+      // This caller already owns the durable pending record. Opting out of the
+      // singleton sender's hidden queue means SEND_BLOCKED is returned while a
+      // turn is busy, so there can never be a queued copy plus a later retry.
+      .then(() => sendSystemEvent(event, { deferIfBusy: false }))
+      .then((outcome) => {
+        // The real sender contract names undefined as the sole accepted send.
+        // SEND_DEFERRED, SEND_BLOCKED, and any defensive unknown/no-op result
+        // retain the exact pending action and simply release its transport
+        // claim for a later dependency-driven retry.
+        if (outcome !== undefined) {
+          inFlightIntentKeys.delete(key)
+          return
+        }
 
-    void Promise.resolve(sendSystemEvent(event))
-      .then(() => {
+        // Confirmed acceptance is the first point at which replay suppression
+        // and removal are truthful. Clear only if storage still contains THIS
+        // action; a newer click must never be deleted by an older completion.
+        drainedFor.current = key
+        const pendingNow = readPendingApply(scenarioId)
+        if (pendingNow !== null && intentKey(pendingNow) === key) {
+          forgetPendingApply(scenarioId)
+        }
+        inFlightIntentKeys.delete(key)
         onApplied?.(intent)
       })
       .catch(() => {
-        // The turn failed in transit. Deliberately silent HERE: CEE's own
-        // refusal copy is the honest message and arrives on the turn, and a
-        // second client-invented sentence about a server outcome would be the
-        // product guessing. The value simply does not change.
+        // Transport rejection proves no successful dispatch. Retain the exact
+        // pending action and release only the in-flight guard; a later graph or
+        // sender revision may retry through this same effect. No second client
+        // sentence guesses at a server outcome.
+        inFlightIntentKeys.delete(key)
       })
   }, [scenarioId, graphReady, graphRevision, lookupNodeData, sendSystemEvent, onApplied])
 }

--- a/src/canvas/conversation/usePanelApplyDrain.ts
+++ b/src/canvas/conversation/usePanelApplyDrain.ts
@@ -34,6 +34,22 @@ export interface PanelApplyDrainArgs {
   /** The scenario the canvas is showing. Empty until it resolves. */
   scenarioId: string | undefined
   /**
+   * True only after the graph in the store belongs to `scenarioId`.
+   *
+   * Route navigation can mount the canvas while the previous scenario's graph
+   * is still in the store. Reading that graph would make a same-id factor look
+   * ready and send the new scenario's pending apply against stale node data.
+   */
+  graphReady: boolean
+  /**
+   * Changes whenever graph hydration/replacement changes the available nodes.
+   *
+   * `lookupNodeData` is deliberately stable, so a first pass that defers while
+   * the target is absent needs this explicit dependency to run again after a
+   * delayed server hydration supplies it.
+   */
+  graphRevision: unknown
+  /**
    * The node's `data` for the intent's target, read for its OWN cap/unit — the
    * builder needs it to decide the scale. `undefined` when the graph has not
    * loaded yet, which DEFERS the drain rather than dropping it.
@@ -47,6 +63,8 @@ export interface PanelApplyDrainArgs {
 
 export function usePanelApplyDrain({
   scenarioId,
+  graphReady,
+  graphRevision,
   lookupNodeData,
   sendSystemEvent,
   onApplied,
@@ -58,6 +76,7 @@ export function usePanelApplyDrain({
 
   useEffect(() => {
     if (scenarioId === undefined || scenarioId === '') return
+    if (!graphReady) return
     if (sendSystemEvent === undefined) return
     if (drainedFor.current === scenarioId) return
 
@@ -104,5 +123,5 @@ export function usePanelApplyDrain({
         // second client-invented sentence about a server outcome would be the
         // product guessing. The value simply does not change.
       })
-  }, [scenarioId, lookupNodeData, sendSystemEvent, onApplied])
+  }, [scenarioId, graphReady, graphRevision, lookupNodeData, sendSystemEvent, onApplied])
 }

--- a/src/collab/panelApplyHandoff.ts
+++ b/src/collab/panelApplyHandoff.ts
@@ -136,12 +136,11 @@ export function readPendingApply(scenarioId: string): PendingPanelApply | null {
 /**
  * Drop a recorded intent.
  *
- * ⚠ CALLED BEFORE THE TURN IS SENT, NOT AFTER. An intent that survives its own
- * dispatch is an intent that can be drained twice — and because the apply is
- * idempotent server-side only in its RESULT, not in its transcript, a double
- * drain would post two turns and write two entries into the user's history for
- * one click. Losing an intent to a failed send costs one more click; replaying
- * one costs the user's trust in what the transcript says happened.
+ * Called only after the sender confirms an accepted dispatch (or when an
+ * explicit caller deliberately abandons an intent). `usePanelApplyDrain` keeps
+ * one ephemeral in-flight claim so re-renders/remounts cannot double-dispatch
+ * while the promise is unresolved, and identity-checks the stored record before
+ * calling this so an older completion cannot delete a newer click.
  */
 export function forgetPendingApply(scenarioId: string): void {
   if (scenarioId === '') return

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -461,7 +461,7 @@ export default function PanelSetupPage(): JSX.Element {
         <RevealBody reveal={reveal} apply={applyState} disagreement={disagreement} />
         <div className="mx-auto w-full max-w-[820px] px-4 pb-10 sm:px-6">
           <Link
-            to={`#/scenario/${scenarioId ?? ''}`}
+            to={`/scenario/${scenarioId ?? ''}`}
             data-testid="reveal-back-to-model"
             className={`${typography.body} text-info hover:underline`}
           >


### PR DESCRIPTION
## What changed

- changes the owner reveal's internal return Link to the canonical HashRouter path `/scenario/:id`, preventing a nested `#`
- mounts exactly one headless panel-apply drain inside the existing aiPanelV2 canvas `ConversationProvider`
- leaves the legacy `DraftChat` drain in place when aiPanelV2 is off, now bound to the requested route scenario rather than stale store state
- gates the drain on route/store scenario agreement and explicitly retriggers it when node hydration changes the graph revision
- gives each exact pending intent one ephemeral in-flight claim across rerender, remount, and StrictMode
- retains the exact durable pending action for unresolved, rejected, `SEND_DEFERRED`, `SEND_BLOCKED`, and resolved no-op sends; only a confirmed accepted dispatch clears it
- calls the existing singleton sender with `deferIfBusy: false`, so retry ownership stays with the persisted panel intent and no hidden second queue can duplicate it

## Why

The panel page correctly recorded an apply intent, but its return Link nested a second hash and the aiPanelV2 canvas did not mount the drain because `DraftChat` is unmounted when that flag is on. A drain that deferred before the target node hydrated also had no dependency that could retry it.

The first draft head cleared pending state before the asynchronous send was known to have succeeded and the flag-off host could use stale store scenario state. This repair makes dispatch acknowledgement and route identity explicit without adding another durable authority.

## User impact

An owner can click a revealed participant value, return to the model, and send exactly one attributed `factor_value_edit` through the existing conversation transport. Unresolved, rejected, blocked, deferred, no-op, cross-scenario, and stale cases do not lose or misroute the action.

## Acceptance coverage

- real production `AppPoC` HashRouter with the real aiPanelV2 flag on
- real reveal Apply control and canonical return Link: exactly one hash, panel unmounted, canvas mounted
- exactly one uncited `factor_value_edit` with the exact round, participant, target, and value
- successful accepted send clears pending and does not replay
- delayed graph/node hydration drains once
- unresolved send retains the byte-identical pending record across rerender, remount, and StrictMode, then clears once after confirmed acceptance
- rejected send retains pending and retries once after readiness revision
- actual `SEND_DEFERRED`, `SEND_BLOCKED`, and resolved no-op outcomes retain pending and permit a later accepted retry
- actual singleton sender with an in-flight turn returns blocked under `deferIfBusy: false` and does not secretly queue a duplicate
- real flag-off `DraftChat`: route A/store A positive; route B/store A negative
- stale and cross-scenario records remain inert
- mutation guards cover nested hash, missing/inverted flag-on host, omitted readiness dependency, wrong scenario, premature clear, and double send

## Validation

- focused suites: **50 passed / 50**
- changed-impact suite: **2,561 passed / 31 skipped** across 225 test files
- `pnpm run typecheck`: passed at the existing 2,485-diagnostic ratchet baseline
- `pnpm run lint`: 0 errors; 1,267 standing warnings; hooks ratchet exactly matched the existing 232 known violations in 15 files
- `pnpm run build`: passed (3,858 modules; existing chunk-size warning only)
- staged diff check: clean; generated validator files match the base byte-for-byte

## Rollback / scope

- exact restored staging base / prior-good SHA: `917e9ea2f792eacdca7ea3fd8eca4d41dcb20c37`
- base tree: `a00b0024b45a387f958087d56528cff77433fa66`
- superseded review-blocked draft head: `ad1b70abaa8d4ecb80beed8075352fc2efb3adb6`
- exact frozen branch head SHA: `746067f9a1d8fb6e508affca84cf9878741979ee`
- frozen branch head tree: `fdf24e1f054914301559c0909947694537f5137f`
- exact whole-lane revert target: `917e9ea2f792eacdca7ea3fd8eca4d41dcb20c37`
- independent rollback: revert this PR's eventual merge commit to restore the prior UI behavior; no other lane needs reverting
- no merge or deployment performed; draft branch and commits remain intact
- UI only: no CEE, schema, citation/0.41, data migration, refactor, cleanup, or PR #706 changes
- residual coupling: the drain intentionally uses the existing conversation singleton sender and existing panel-handoff localStorage record; neither requires another lane to roll back
