### PR TITLE
P4: confirm the current Resolve Next strength

### DIFF
--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -326,6 +326,7 @@ export const ACTION_LABELS = {
   addConstraint: '+ Add constraint',
   seeAllDrivers: 'See all drivers',
   compareOptions: 'Compare all options',
+  useCurrentStrength: 'Use current strength',
 } as const
 
 // ─── Empty description placeholders ───────────────────────────────

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -21,6 +21,7 @@ import { useEdgeMutations } from '../useInspectorMutations'
 import {
   GROUP_LABELS,
   INLINE_LABELS,
+  ACTION_LABELS,
   EDGE_LINK_NOTICES,
   EDGE_COPY,
   resolveEdgeLinkTemplate,
@@ -273,6 +274,15 @@ export const EdgePanel = memo(function EdgePanel({
     confirmEdit('strength')
   }, [handleStrengthChange, clearPreview, confirmEdit])
 
+  const handleUseCurrentStrength = useCallback(() => {
+    // Confirm the exact canonical value on the edge, not a band midpoint or a
+    // possibly stale slider draft. This is a magnitude-only judgement: a user
+    // accepting the strength has not thereby stated a direction, so preserve
+    // both direction fields exactly — including their absence.
+    mutations.setStrength(edge?.data?.weight ?? 0.5, { preserveDirection: true })
+    confirmEdit('strength')
+  }, [edge?.data?.weight, mutations, confirmEdit])
+
   const handleBeliefChange = useCallback((v: number) => {
     setLocalBelief(v)
     mutations.setExistsProbability(v)
@@ -348,6 +358,16 @@ export const EdgePanel = memo(function EdgePanel({
               </p>
               <StrengthBandButtons value={localStrength} onChange={handleStrengthPresetChange} />
               <ExpertAnnotation techMode={techMode} editable value={localStrength} onChange={(v) => { handleStrengthChange(v); }} suffix="β =" step={0.01} min={-1} max={1} />
+              {edgeValueSource(edge.data as Record<string, unknown>, 'weight') !== 'user' && (
+                <button
+                  type="button"
+                  data-testid="edge-use-current-strength"
+                  onClick={handleUseCurrentStrength}
+                  className={`${typography.panelMeta} mt-2 font-medium text-accent underline underline-offset-2`}
+                >
+                  {ACTION_LABELS.useCurrentStrength}
+                </button>
+              )}
               {/* Edit feedback */}
               {lastConfirmed?.field === 'strength' && (
                 <div className="flex items-center gap-2 mt-1">

--- a/src/canvas/utils/__tests__/mergeServerGraph.edgePresence.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.edgePresence.spec.ts
@@ -169,7 +169,13 @@ describe('§1 a server edge value that equals a UI default still lands at boot',
 
 describe('§2 the no-op and no-overwrite guarantees survive the fix', () => {
   it('a server value EQUAL to the local value is still a STRICT no-op', () => {
-    seedGraph({ weight: 0.5, direction: 'positive' })
+    seedGraph({
+      weight: 0.5,
+      direction: 'positive',
+      weightSource: 'user',
+      provenanceDisplay: 'ai_inferred',
+      origin: 'ai',
+    })
     const before = useCanvasStore.getState().edges
     const res = mergeServerGraphOnHydrate({
       nodes: NODES,
@@ -177,6 +183,31 @@ describe('§2 the no-op and no-overwrite guarantees survive the fix', () => {
     })
     expect(res.updatedEdgeCount).toBe(0)
     expect(useCanvasStore.getState().edges).toBe(before)
+    expect(theEdge().data.weightSource).toBe('user')
+    expect(theEdge().data.provenanceDisplay).toBe('ai_inferred')
+    expect(theEdge().data.origin).toBe('ai')
+  })
+
+  it('a DIFFERENT server strength replaces the local confirmation and reopens review honestly', () => {
+    seedGraph({
+      weight: 0.5,
+      direction: 'negative',
+      weightSource: 'user',
+      provenanceDisplay: 'ai_inferred',
+      origin: 'ai',
+    })
+    const res = mergeServerGraphOnHydrate({
+      nodes: NODES,
+      edges: [{ from: 'factor-1', to: 'goal-1', strength: { mean: 0.73 } }],
+    })
+    expect(res.updatedEdgeCount).toBe(1)
+    const data = theEdge().data
+    expect(data.weight).toBe(0.73)
+    expect(data.weightSource).toBe('cee')
+    // Edge-creation provenance remains true: this is still an AI-origin edge,
+    // now carrying a new producer value that the user has not confirmed.
+    expect(data.provenanceDisplay).toBe('ai_inferred')
+    expect(data.origin).toBe('ai')
   })
 
   it('a field the wire did NOT carry keeps its local value', () => {

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -20,9 +20,9 @@
  * remain separate from this in-process mounted proof.
  */
 import { createElement } from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   selectAssumedStrengthToResolve,
   type ElicitationCanvasEdge,
@@ -38,6 +38,9 @@ import { AssumedStrengthCard } from '../AssumedStrengthCard'
 import { openEdgeStrengthEditor } from '../../../../canvas/utils/openEdgeStrengthEditor'
 import { useCanvasStore } from '../../../../canvas/store'
 import { InspectorModal } from '../../../../canvas/components/InspectorModal'
+import { computeGraphHash } from '../../../../canvas/hooks/useAutosave'
+import { projectAutosaveData } from '../../../../canvas/store/autosaveProjection'
+import { clearAutosave, loadAutosave, saveAutosave } from '../../../../canvas/store/scenarios'
 
 vi.mock('../../../../canvas/utils/focusHelpers', async () => {
   const actual = await vi.importActual<typeof import('../../../../canvas/utils/focusHelpers')>(
@@ -69,6 +72,10 @@ const draftedEdge = (): ElicitationCanvasEdge => ({
 const fragileEdges = [
   { from_id: 'n_demand', to_id: 'n_rev', switch_probability: ABOVE, alternative_winner_label: 'Consolidate' },
 ]
+
+afterEach(() => {
+  clearAutosave()
+})
 
 describe('P4 chain: elicitation → resolve → stale → rerun → loop closed', () => {
   it('LINK 1 — elicitation names the assumed relationship, by edge identity', () => {
@@ -200,6 +207,186 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     expect(edited.analysisFreshnessDirty).toBe(true)
     expect(screen.getByRole('button', { name: 'Re-run the analysis' })).toBeInTheDocument()
     expect(screen.getByText('Re-run to see how this affects the results')).toBeInTheDocument()
+  })
+
+  it('MOUNTED — using the exact current strength resolves provenance without fabricating a rerun', () => {
+    const first = {
+      ...draftedEdge(),
+      data: {
+        ...draftedEdge().data,
+        // Non-midpoint and negative: a band-snap or signed rewrite must RED.
+        weight: 0.52,
+        direction: 'negative',
+        directionSource: 'cee',
+      },
+    }
+    const second: ElicitationCanvasEdge = {
+      id: 'e_cost_margin',
+      source: 'n_cost',
+      target: 'n_margin',
+      data: {
+        ...DEFAULT_EDGE_DATA,
+        weight: 0.34,
+        weightSource: 'cee',
+        provenanceDisplay: 'ai_inferred',
+        origin: 'ai',
+      },
+    }
+    const ranked = [
+      ...fragileEdges,
+      { from_id: 'n_cost', to_id: 'n_margin', switch_probability: ABOVE - 0.05, alternative_winner_label: 'Build' },
+    ]
+    const labels = new Map([
+      ...nodeLabels,
+      ['n_cost', 'Delivery cost'],
+      ['n_margin', 'Operating margin'],
+    ])
+    const decision = selectAssumedStrengthToResolve({ fragileEdges: ranked, edges: [first, second], nodeLabels: labels })
+    expect(decision.selected?.edgeId).toBe(first.id)
+
+    const mountedNodes = [
+      { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+      { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      { id: 'n_cost', type: 'factor', position: { x: 0, y: 200 }, data: { label: 'Delivery cost' } },
+      { id: 'n_margin', type: 'outcome', position: { x: 200, y: 200 }, data: { label: 'Operating margin' } },
+    ]
+    useCanvasStore.setState({
+      nodes: mountedNodes as never,
+      edges: [first, second] as never,
+      showResultsPanel: true,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+      history: { past: [], future: [] },
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null } as never,
+    })
+    const hashBefore = computeGraphHash(mountedNodes, [first, second])
+
+    render(createElement(AssumedStrengthCard, { decision, onResolve: openEdgeStrengthEditor }))
+    fireEvent.click(screen.getByTestId('assumed-strength-action'))
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: first.id, onClose: () => {} }),
+    ))
+
+    expect(screen.getByRole('button', { name: 'Use current strength' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Use current strength' }))
+
+    const confirmed = useCanvasStore.getState()
+    const confirmedData = confirmed.edges.find((edge) => edge.id === first.id)?.data as Record<string, unknown>
+    expect(confirmedData.weight).toBe(0.52)
+    expect(confirmedData.weightSource).toBe('user')
+    expect(confirmedData.direction).toBe('negative')
+    expect(confirmedData.directionSource).toBe('cee')
+    expect(confirmedData.provenanceDisplay).toBe('ai_inferred')
+    expect(confirmedData.origin).toBe('ai')
+    expect(confirmed.analysisFreshnessDirty).toBe(false)
+    expect(computeGraphHash(confirmed.nodes, confirmed.edges)).not.toBe(hashBefore)
+    expect(screen.getByText('Updated')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Use current strength' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
+
+    // The SAME ranking authority advances in producer order; the confirmation
+    // does not locally re-rank or hide the queue.
+    const next = selectAssumedStrengthToResolve({
+      fragileEdges: ranked,
+      edges: confirmed.edges as ElicitationCanvasEdge[],
+      nodeLabels: labels,
+    })
+    expect(next.selected?.edgeId).toBe(second.id)
+
+    // The production autosave projection and serializer preserve the source-only
+    // change even though the analytical number stayed byte-identical.
+    clearAutosave()
+    saveAutosave(projectAutosaveData({
+      nodes: confirmed.nodes,
+      edges: confirmed.edges,
+      scenarioId: 'scenario-strength-confirmation',
+      ceeAnalysisReady: undefined,
+      selectedGoalNode: null,
+      analysis: null,
+      goalConstraints: null,
+    }, 123))
+    const restored = loadAutosave()
+    const restoredData = restored?.edges.find((edge) => edge.id === first.id)?.data as Record<string, unknown>
+    expect(restoredData.weight).toBe(0.52)
+    expect(restoredData.weightSource).toBe('user')
+
+    // Existing graph history is the independent user-level reversal: undo puts
+    // the producer stamp back and makes the same ranked item eligible again.
+    act(() => useCanvasStore.getState().undo())
+    const undone = useCanvasStore.getState()
+    const undoneData = undone.edges.find((edge) => edge.id === first.id)?.data as Record<string, unknown>
+    expect(undoneData.weight).toBe(0.52)
+    expect(undoneData.weightSource).toBe('cee')
+    const afterUndo = selectAssumedStrengthToResolve({
+      fragileEdges: ranked,
+      edges: undone.edges as ElicitationCanvasEdge[],
+      nodeLabels: labels,
+    })
+    expect(afterUndo.selected?.edgeId).toBe(first.id)
+  })
+
+  it('MUTANT CONTROL — confirming magnitude preserves absent direction fields', () => {
+    const directionlessData = { ...draftedEdge().data, weight: 0.37 } as Record<string, unknown>
+    delete directionlessData.direction
+    delete directionlessData.directionSource
+    const edge = { ...draftedEdge(), data: directionlessData }
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+        { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      ] as never,
+      edges: [edge] as never,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+      history: { past: [], future: [] },
+    })
+
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: edge.id, onClose: () => {} }),
+    ))
+    fireEvent.click(screen.getByRole('button', { name: 'Use current strength' }))
+
+    const data = useCanvasStore.getState().edges.find((candidate) => candidate.id === edge.id)?.data as Record<string, unknown>
+    expect(data.weight).toBe(0.37)
+    expect(data.weightSource).toBe('user')
+    expect(Object.prototype.hasOwnProperty.call(data, 'direction')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(data, 'directionSource')).toBe(false)
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(false)
+  })
+
+  it('POSITIVE CONTROL — materialising an absent strength is analytical and offers the canonical rerun', () => {
+    const absentData = { ...draftedEdge().data } as Record<string, unknown>
+    delete absentData.weight
+    delete absentData.weightSource
+    const edge = { ...draftedEdge(), data: absentData }
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+        { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      ] as never,
+      edges: [edge] as never,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+      history: { past: [], future: [] },
+    })
+
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: edge.id, onClose: () => {} }),
+    ))
+    fireEvent.click(screen.getByRole('button', { name: 'Use current strength' }))
+
+    const data = useCanvasStore.getState().edges.find((candidate) => candidate.id === edge.id)?.data as Record<string, unknown>
+    expect(data.weight).toBe(0.5)
+    expect(data.weightSource).toBe('user')
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    expect(screen.getByRole('button', { name: 'Re-run the analysis' })).toBeInTheDocument()
   })
 
   it('HONESTY — confirming the placeholder AS-IS is not an analytical change, so no rerun is promised', () => {


### PR DESCRIPTION
## What changed

Adds one explicit **Use current strength** action to the existing Resolve Next edge-strength inspector flow.

When the current strength came from CEE, a template, or an unstamped default, the action sends the exact stored magnitude through the canonical `useEdgeMutations.setStrength` writer with `preserveDirection: true`. This stamps only `weightSource: user`; it does not rewrite the edge's AI origin, display provenance, direction, or direction provenance.

The action disappears once the strength is user-owned. Existing changed-strength controls remain unchanged.

## Why

PR #707 already routes the highest-ranked unresolved fragile edge into the real inspector, but confirming the current value was not expressible: selecting the active qualitative band snaps to that band's midpoint and becomes an analytical edit. This closes the smaller missing loop without adding a new ranking, writer, collaboration path, schema, or deferral authority.

An unchanged confirmation makes the model more truthful without changing the analytical number, so it intentionally does not mark results stale. A changed or previously absent strength continues through the existing stale/rerun machinery.

## Scope

Exact base / prior good / revert target: `d47346c0222511985b30fdc3960264d55a179e85`

Head commit: `1105d1ad1dc833ffa27c1bc6c449f496b18371cd`

Head tree: `384cbb1c819b031f9aa2cd63facc5bf111162f68`

Four files only:

- `src/canvas/ui/inspector-v2/panels/EdgePanel.tsx`
- `src/canvas/ui/inspector-v2/inspectorStrings.ts`
- `src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts`
- `src/canvas/utils/__tests__/mergeServerGraph.edgePresence.spec.ts`

No selector, store, schema, collaboration, citation, CEE, PLoT, or ISL changes. No migration or destructive write.

## Validation

- Focused mounted/authority suite: 6 files, 83 tests passed.
- Typecheck coverage + ratchet: passed; unchanged baseline of 2,485 diagnostics.
- Full lint: 0 errors; rules-of-hooks ratchet exactly matches the existing 232-warning baseline.
- Production build: passed.
- Deliberate mutants proved the controls fail when the writer is skipped, `preserveDirection` is omitted, or a band midpoint replaces the exact value.

The mounted acceptance proves exact non-midpoint retention, source-only user attribution, negative and absent direction preservation, AI-origin preservation, no false rerun, producer-order queue advancement, undo, graph-hash change, autosave round-trip, and the analytical stale/rerun positive control. Hydration controls prove equal server values preserve the confirmation while a different server value wins and truthfully reopens review.

## Rollback and coupling

Revert this PR alone to restore the exact #707 behavior. #709/#710 collaboration handoff and #971 citation behavior remain intact and do not need reverting.

The only semantic dependency is the existing #707 Resolve Next selector/editor entry point and its established `weightSource` authority.