### PR TITLE
collab: describe apply evidence as a citation

### DIFF
--- a/src/collab/__tests__/panelApplyCitation.spec.tsx
+++ b/src/collab/__tests__/panelApplyCitation.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * THE CITATION ON THE APPLY — "use Grace's number, because of Ada's challenge".
+ * THE CITATION ON THE APPLY — "use Grace's number, citing Ada's challenge".
  *
  * ── WHAT THIS LINK IS FOR ─────────────────────────────────────────────────
  * CEE can already verify a citation (binding (f)) and stamp it onto the graph
@@ -11,9 +11,9 @@
  * link.
  *
  * ── THE RULE BEING PINNED, AND WHY IT IS NOT "CITE WHATEVER IS THERE" ─────
- * The stamp asserts that the model changed BECAUSE OF that evidence. With two
- * or more notes on a target, choosing one would be the product inventing the
- * owner's reason and writing it into the graph as a server-verified fact. So:
+ * The stamp records which evidence row the change cites. With two or more notes
+ * on a target, choosing one would be the product inventing the owner's citation
+ * choice and writing it into the graph as a server-verified fact. So:
  *
  *   0 evidence  → no sentence, no claim
  *   1 evidence  → the sentence NAMES it, and the click claims exactly it
@@ -180,14 +180,17 @@ describe('the apply affordance — the citation is disclosed, then claimed', () 
     // The disclosure exists and names the author — the owner is consenting to a
     // stated fact, not having an inference recorded for them.
     const line = screen.getByTestId(`reveal-apply-citation-${TARGET}`)
-    expect(line.textContent).toContain('Ada')
-    expect(line.textContent).toContain('note')
+    expect(line.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'This change will cite Ada’s note.',
+    )
+    expect(line.textContent).not.toContain('reason')
+    expect(line.textContent).not.toContain('because')
 
     fireEvent.click(screen.getByTestId(`reveal-apply-${TARGET}-${GRACE}`))
 
     expect(calls).toHaveLength(1)
     // ⭐ THE ASYMMETRY THIS WHOLE HOP EXISTS FOR: the value applied is GRACE's,
-    // and the reason cited is ADA's. Bound by identity to both, so a build that
+    // and the note cited is ADA's. Bound by identity to both, so a build that
     // tied the citation to the applied participant would fail here.
     expect(calls[0]?.participantId).toBe(GRACE)
     expect(calls[0]?.value).toBe(0.85)
@@ -283,7 +286,7 @@ describe('the apply affordance — the citation is disclosed, then claimed', () 
     expect(
       'evidenceEventId' in (calls[0] as object),
       `the affordance INVENTED a citation (${String(calls[0]?.evidenceEventId)}) where the ` +
-        'owner was shown no reason — the stamp would record a motive nobody stated',
+        'owner was shown no citation — the stamp would record a choice nobody made',
     ).toBe(false)
     // The apply itself still works: refusing to cite must not refuse to apply.
     expect(calls[0]?.participantId).toBe(GRACE)
@@ -335,7 +338,7 @@ describe('the apply affordance — the citation is disclosed, then claimed', () 
     // Factor and edge ids occupy different domains. The secondary disagreement
     // response deliberately contains only an EDGE target with the same string
     // id as the FACTOR reveal row: an id-only lookup promises and claims the
-    // edge note as the factor's reason.
+    // edge note as the factor's citation.
     const view = disagreementWith([
       evidence({
         event_id: SECOND_EVIDENCE_ID,
@@ -464,7 +467,7 @@ describe('the handoff — the citation survives the hop the apply actually takes
       }),
     )
     // Refusing costs one more click. Draining it uncited would apply the value
-    // and silently discard the reason the owner was shown — unrecoverable,
+    // and silently discard the citation the owner was shown — unrecoverable,
     // because no reader downstream can tell that absence from an honest one.
     expect(readPendingApply(SCENARIO)).toBeNull()
   })

--- a/src/pages/ParticipantPacketPage.tsx
+++ b/src/pages/ParticipantPacketPage.tsx
@@ -1022,8 +1022,8 @@ export interface RevealApplyState {
     value: number
     /**
      * 0.41.0 — the evidence row named in the line above the button, when there
-     * was exactly one to name. See `citableEvidenceFor`: absent whenever the
-     * owner was shown no reason, so the claim never says more than the screen.
+     * was exactly one to name. See `citableEvidenceFor`: absent whenever no
+     * citation was disclosed, so the claim never says more than the screen.
      */
     evidenceEventId?: string
   }) => void
@@ -1066,20 +1066,18 @@ export function RevealBody({
    * The evidence a click on THIS target is entitled to cite, or null.
    *
    * ⭐⭐ EXACTLY ONE, OR NONE — AND THE RULE IS ABOUT FABRICATION, NOT TIDINESS.
-   * The stamp this feeds says "the model changed because of that evidence". With
-   * two or more notes on a target, picking one would be the product inventing
-   * the owner's reason and writing it into the graph as a server-verified fact
-   * — the same fabrication class every binding in `apply-verification.ts`
-   * exists to refuse, arriving through the client instead of the wire. So a
-   * choice that cannot be made honestly is not made: the apply proceeds
-   * UNCITED, which is a true record of a reason the owner never stated.
+   * The stamp records WHICH evidence row the change cites. With two or more
+   * notes on a target, picking one would be the product inventing the owner's
+   * citation choice and writing it into the graph as a server-verified fact —
+   * the same fabrication class every binding in `apply-verification.ts` exists
+   * to refuse, arriving through the client instead of the wire. So a choice
+   * that cannot be made honestly is not made: the apply proceeds UNCITED.
    *
-   * ⚠ AND ONE PIECE OF EVIDENCE IS NOT AUTOMATICALLY THE REASON EITHER. What
-   * makes the single-row case honest is not the arithmetic — it is that the
-   * button DISCLOSES the citation before the click, so the owner is consenting
-   * to a stated fact rather than having an inference recorded on their behalf.
-   * If that disclosure is ever removed, this rule stops being defensible and
-   * the citation must go with it.
+   * ⚠ A CITATION IS NOT A CAUSAL CLAIM. What makes the single-row case honest
+   * is not the arithmetic — it is that the button DISCLOSES the citation before
+   * the click, so the owner is consenting to a stated fact rather than having an
+   * inference recorded on their behalf. If that disclosure is ever removed,
+   * this rule stops being defensible and the citation must go with it.
    *
    * The multi-evidence case wants an explicit picker; until that exists it is
    * honestly uncited rather than dishonestly cited.
@@ -1168,8 +1166,8 @@ export function RevealBody({
                 data-testid={`reveal-apply-citation-${row.target.id}`}
                 className={`${typography.bodySmall} mt-3 text-text-light`}
               >
-                Your model will record {citation.author_label}&rsquo;s{' '}
-                {citation.kind === 'link' ? 'link' : 'note'} as the reason for this change.
+                This change will cite {citation.author_label}&rsquo;s{' '}
+                {citation.kind === 'link' ? 'link' : 'note'}.
               </p>
             )}
 


### PR DESCRIPTION
## What changed

- Replaces the causal disclosure “as the reason for this change” with the bounded statement “This change will cite …”.
- Pins the wording in the mounted `RevealBody` test while retaining the asymmetric assertion: Grace’s value can cite Ada’s evidence.
- Updates adjacent comments to describe citation identity rather than inferred motive.

## Why

CEE schema 0.41 verifies that the cited evidence exists in the same round and targets the same graph object. It does not establish that the evidence caused the change, and it intentionally does not require the value author and evidence author to be equal. The prior copy overstated that contract.

## Scope and rollback

- UI-only, additive truth correction; no wire, schema, persistence, selector, or author-equality changes.
- Exact base / prior good staging SHA: `12b94aaf86c2874102a8d8ecc3e17ecc268c6487`.
- Revert target after merge would be this PR’s merge commit only.
- Persisted citation readback is banked: there is no bounded event-by-ID read seam in the existing inspector surface.
- The stale-attribution sibling writer belongs to the CEE ordinary-chat edit provenance path and is not bundled here.

## Verification

- `pnpm exec vitest run src/collab/__tests__/panelApplyCitation.spec.tsx --reporter=verbose` — 16/16 passed
- `VITE_SUPABASE_URL=http://example.invalid VITE_SUPABASE_ANON_KEY=dummy pnpm exec vitest run --changed --bail=1` — 139/139 passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — 0 errors; rules-of-hooks ratchet exactly matches baseline
