### PR TITLE
Make Resolve Next strength confirmation truthful

### DIFF
--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -333,6 +333,7 @@ export const ACTION_LABELS = {
   addConstraint: '+ Add constraint',
   seeAllDrivers: 'See all drivers',
   compareOptions: 'Compare all options',
+  confirmCurrentStrength: 'Confirm this estimate',
 } as const
 
 // ─── Empty description placeholders ───────────────────────────────

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -21,6 +21,7 @@ import { useEdgeMutations } from '../useInspectorMutations'
 import {
   GROUP_LABELS,
   INLINE_LABELS,
+  ACTION_LABELS,
   EDGE_LINK_NOTICES,
   EDGE_COPY,
   resolveEdgeLinkTemplate,
@@ -194,6 +195,19 @@ export const EdgePanel = memo(function EdgePanel({
     [edge?.data],
   )
 
+  // A confirm-as-is action is licensed only by a real producer value. A bare
+  // UI default has no source and is not an estimate the user can honestly
+  // confirm. Keep the exact store number visible beside the action so consent
+  // covers the number that will receive the user provenance stamp.
+  const currentEstimatedWeight = useMemo(() => {
+    const data = edge?.data as Record<string, unknown> | undefined
+    const value = data?.weight
+    return edgeValueSource(data, 'weight') === 'cee' &&
+      typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+      ? value
+      : null
+  }, [edge?.data])
+
   // UI-SEM-029: Edge weight/direction defaults for display (0.5 / 'positive').
   const weight = edge?.data?.weight ?? 0.5
   const direction = edge?.data?.direction ?? 'positive'
@@ -273,11 +287,23 @@ export const EdgePanel = memo(function EdgePanel({
     // Reuse the canonical strength writer, then close the same confirmation
     // seam the fine-tune slider closes on blur so stale analysis exposes the
     // existing rerun affordance.
-    handleStrengthChange(v)
+    setLocalStrength(v)
+    // Presets choose magnitude only. The sign is retained visually by
+    // StrengthBandButtons, but retaining a sign is not the same as the user
+    // stating it: preserve both direction and directionSource byte-for-byte.
+    mutations.setStrength(v, { preserveDirection: true })
     clearPreview()
     origStrengthRef.current = v
     confirmEdit('strength')
-  }, [handleStrengthChange, clearPreview, confirmEdit])
+  }, [mutations, clearPreview, confirmEdit])
+
+  const handleConfirmCurrentStrength = useCallback(() => {
+    if (currentEstimatedWeight === null) return
+    // Confirm the exact live canonical magnitude, not a band midpoint or local
+    // slider draft. Magnitude confirmation says nothing about causal direction.
+    mutations.setStrength(currentEstimatedWeight, { preserveDirection: true })
+    confirmEdit('strength')
+  }, [currentEstimatedWeight, mutations, confirmEdit])
 
   const handleBeliefChange = useCallback((v: number) => {
     setLocalBelief(v)
@@ -354,6 +380,21 @@ export const EdgePanel = memo(function EdgePanel({
               </p>
               <StrengthBandButtons value={localStrength} onChange={handleStrengthPresetChange} />
               <ExpertAnnotation techMode={techMode} editable value={localStrength} onChange={(v) => { handleStrengthChange(v); }} suffix="β =" step={0.01} min={-1} max={1} />
+              {currentEstimatedWeight !== null && (
+                <div className="mt-2 rounded-md border border-accent/20 bg-panel px-2 py-1.5">
+                  <p className={`${typography.panelMeta} text-text-body`}>
+                    Olumi’s current estimate is <span className="font-mono">{String(currentEstimatedWeight)}</span>.
+                  </p>
+                  <button
+                    type="button"
+                    data-testid="edge-confirm-current-strength"
+                    onClick={handleConfirmCurrentStrength}
+                    className={`${typography.panelMeta} mt-1 text-accent underline underline-offset-2`}
+                  >
+                    {ACTION_LABELS.confirmCurrentStrength}
+                  </button>
+                </div>
+              )}
               {/* Edit feedback */}
               {lastConfirmed?.field === 'strength' && (
                 <div className="flex items-center gap-2 mt-1">

--- a/src/canvas/ui/inspector-v2/shared/StrengthBandButtons.tsx
+++ b/src/canvas/ui/inspector-v2/shared/StrengthBandButtons.tsx
@@ -2,8 +2,9 @@
  * StrengthBandButtons — quick-select buttons for edge strength bands (B.4).
  *
  * Renders a row of outlined pill buttons for Slight / Moderate / Strong / Very strong.
- * Clicking a button sets the edge strength magnitude to the band midpoint while
- * preserving the current direction sign. The active band is highlighted.
+ * Each button discloses the exact midpoint it will write; a categorical label
+ * must not silently become an exact number attributed to the user. Clicking a
+ * button preserves the current direction sign. The active band is highlighted.
  *
  * Thresholds align with inspectorStrings.ts getStrengthLabel():
  *   Very strong >= 0.70, Strong >= 0.40, Moderate >= 0.20, Slight < 0.20
@@ -65,7 +66,8 @@ export const StrengthBandButtons = memo(function StrengthBandButtons({
             key={band.label}
             type="button"
             onClick={() => handleClick(band.midpoint)}
-            className={`${typography.panelMeta} px-2 py-1 rounded-full bg-transparent border transition-colors cursor-pointer
+            aria-label={`${band.label}: set strength to ${band.midpoint.toFixed(2)}`}
+            className={`${typography.panelMeta} px-2 py-1 rounded-full bg-transparent border transition-colors cursor-pointer inline-flex flex-col items-center leading-tight
               ${isActive
                 ? 'border-primary text-primary'
                 : 'border-panel-border text-text-light hover:border-text-light hover:bg-panel-hover'
@@ -73,7 +75,8 @@ export const StrengthBandButtons = memo(function StrengthBandButtons({
             aria-pressed={isActive}
             data-testid={`strength-band-${band.label.toLowerCase().replace(/\s+/g, '-')}`}
           >
-            {band.label}
+            <span>{band.label}</span>
+            <span className="font-mono text-[9px] opacity-75">{band.midpoint.toFixed(2)}</span>
           </button>
         )
       })}

--- a/src/canvas/ui/inspector-v2/shared/__tests__/StrengthBandButtons.spec.tsx
+++ b/src/canvas/ui/inspector-v2/shared/__tests__/StrengthBandButtons.spec.tsx
@@ -1,6 +1,7 @@
 /**
  * StrengthBandButtons unit tests (B.4)
- * Verifies: rendering, click behaviour, active state detection, sign preservation.
+ * Verifies: rendering, disclosed numeric consequence, click behaviour, active
+ * state detection, sign preservation.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
@@ -11,10 +12,11 @@ describe('StrengthBandButtons', () => {
     const { container } = render(<StrengthBandButtons value={0.5} onChange={() => {}} />)
     const buttons = container.querySelectorAll('button')
     expect(buttons).toHaveLength(4)
-    expect(buttons[0].textContent).toBe('Slight')
-    expect(buttons[1].textContent).toBe('Moderate')
-    expect(buttons[2].textContent).toBe('Strong')
-    expect(buttons[3].textContent).toBe('Very strong')
+    expect(buttons[0].textContent).toBe('Slight0.10')
+    expect(buttons[1].textContent).toBe('Moderate0.30')
+    expect(buttons[2].textContent).toBe('Strong0.55')
+    expect(buttons[3].textContent).toBe('Very strong0.85')
+    expect(buttons[2].getAttribute('aria-label')).toBe('Strong: set strength to 0.55')
   })
 
   it('marks "Strong" as active when value is within the strong band (0.50)', () => {

--- a/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
@@ -56,6 +56,7 @@ const SELECTED: AssumedStrengthDecision = {
     toLabel: 'Revenue growth',
     switchProbability: 0.35,
     alternativeWinnerLabel: 'Consolidate',
+    strengthProvenance: 'ai_inferred',
   },
   refusalReason: null,
   assumedFragileCount: 3,

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -17,7 +17,7 @@
  * runs where it is the only thing we have to offer. It therefore sits as its own
  * block with its own presence rule, and the two never contend: one ranks
  * FACTORS by value of information, this one names an EDGE whose strength is a
- * placeholder.
+ * still unconfirmed.
  *
  * ── THE ACTION REACHES THE EDITOR, AND WRITES NOTHING ───────────────────────
  * The button calls `openEdgeStrengthEditor`, which selects the edge, stands the
@@ -52,9 +52,9 @@
 import { memo } from 'react'
 import {
   ASSUMED_STRENGTH_ACTION,
-  ASSUMED_STRENGTH_ASK,
   ASSUMED_STRENGTH_REFUSAL_COPY,
   ASSUMED_STRENGTH_TITLE,
+  assumedStrengthAsk,
   assumedStrengthLead,
   assumedStrengthOthers,
   assumedStrengthWhy,
@@ -110,7 +110,7 @@ function AssumedStrengthCardImpl({ decision, onResolve }: AssumedStrengthCardPro
         {assumedStrengthWhy(selected)}
       </p>
       <p className={`${typography.panelBody} text-text-body`} data-testid="assumed-strength-ask">
-        {ASSUMED_STRENGTH_ASK}
+        {assumedStrengthAsk(selected)}
       </p>
       {others !== null && (
         <p className={`${typography.panelMeta} text-text-muted`} data-testid="assumed-strength-others">

--- a/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
@@ -15,9 +15,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   ASSUMED_STRENGTH_ACTION,
-  ASSUMED_STRENGTH_ASK,
   ASSUMED_STRENGTH_REFUSAL_COPY,
   ASSUMED_STRENGTH_TITLE,
+  assumedStrengthAsk,
   assumedStrengthLead,
   assumedStrengthOthers,
   assumedStrengthWhy,
@@ -30,6 +30,7 @@ const sel = (over: Partial<AssumedStrengthSelection> = {}): AssumedStrengthSelec
   toLabel: 'Revenue growth',
   switchProbability: 0.35,
   alternativeWinnerLabel: 'Consolidate',
+  strengthProvenance: 'ai_inferred',
   ...over,
 })
 
@@ -37,13 +38,14 @@ const sel = (over: Partial<AssumedStrengthSelection> = {}): AssumedStrengthSelec
 function allSentences(): string[] {
   const out: string[] = [
     ASSUMED_STRENGTH_TITLE,
-    ASSUMED_STRENGTH_ASK,
     ASSUMED_STRENGTH_ACTION,
     ...Object.values(ASSUMED_STRENGTH_REFUSAL_COPY).filter((s): s is string => s !== null),
   ]
-  for (const alt of ['Consolidate', null]) {
-    const s = sel({ alternativeWinnerLabel: alt })
-    out.push(assumedStrengthLead(s), assumedStrengthWhy(s))
+  for (const strengthProvenance of ['ai_inferred', 'missing'] as const) {
+    for (const alt of ['Consolidate', null]) {
+      const s = sel({ alternativeWinnerLabel: alt, strengthProvenance })
+      out.push(assumedStrengthLead(s), assumedStrengthWhy(s), assumedStrengthAsk(s))
+    }
   }
   for (const n of [0, 1, 2, 5]) {
     const o = assumedStrengthOthers(n)
@@ -99,8 +101,11 @@ describe('assumedStrengthCopy — the claim boundary, held mechanically', () => 
     // rewritten INTO a promise; this catches the deferral being quietly taken
     // OUT — "re-run to see it change the answer" would pass every ban and still
     // be the defect. One without the other leaves half the door open.
-    expect(ASSUMED_STRENGTH_ASK).toMatch(/\bwhether\b/i)
-    expect(ASSUMED_STRENGTH_ASK).toMatch(/re-run/i)
+    for (const strengthProvenance of ['ai_inferred', 'missing'] as const) {
+      const ask = assumedStrengthAsk(sel({ strengthProvenance }))
+      expect(ask).toMatch(/\bwhether\b/i)
+      expect(ask).toMatch(/re-run/i)
+    }
   })
 
   it('never prints the ASSUMED weight as if it were a measurement', () => {
@@ -137,6 +142,24 @@ describe('assumedStrengthCopy — the claim boundary, held mechanically', () => 
     const s = assumedStrengthLead(sel())
     expect(s).toContain('Customer demand')
     expect(s).toContain('Revenue growth')
+  })
+
+  it('distinguishes a producer estimate from an unstamped default without inventing provenance', () => {
+    const estimated = assumedStrengthLead(sel({ strengthProvenance: 'ai_inferred' }))
+    expect(estimated).toContain('Olumi estimated')
+    expect(estimated).toContain('has not confirmed')
+    expect(estimated).not.toMatch(/placeholder/i)
+
+    const missing = assumedStrengthLead(sel({ strengthProvenance: 'missing' }))
+    expect(missing).toContain('Nobody has set')
+    expect(missing).not.toMatch(/estimated|placeholder/i)
+  })
+
+  it('explains the maximum using only the measured conditional rate', () => {
+    const why = assumedStrengthWhy(sel({ switchProbability: 0.548 }))
+    expect(why).toContain('55%')
+    expect(why).toContain('highest such rate')
+    expect(why).not.toMatch(/most (important|valuable|decision-sensitive)/i)
   })
 
   it('the “others” clause counts the REMAINDER, and is silent at 0 and 1', () => {

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -20,9 +20,9 @@
  * remain separate from this in-process mounted proof.
  */
 import { createElement } from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   selectAssumedStrengthToResolve,
   type ElicitationCanvasEdge,
@@ -38,6 +38,10 @@ import { AssumedStrengthCard } from '../AssumedStrengthCard'
 import { openEdgeStrengthEditor } from '../../../../canvas/utils/openEdgeStrengthEditor'
 import { useCanvasStore } from '../../../../canvas/store'
 import { InspectorModal } from '../../../../canvas/components/InspectorModal'
+import { buildV2RequestFromAnalysisReady } from '../../../../adapters/plot/v2/adapter'
+import type { CEEAnalysisReady } from '../../../../adapters/cee/types'
+import { projectAutosaveData } from '../../../../canvas/store/autosaveProjection'
+import { clearAutosave, loadAutosave, saveAutosave } from '../../../../canvas/store/scenarios'
 
 vi.mock('../../../../canvas/utils/focusHelpers', async () => {
   const actual = await vi.importActual<typeof import('../../../../canvas/utils/focusHelpers')>(
@@ -60,7 +64,10 @@ const draftedEdge = (): ElicitationCanvasEdge => ({
   target: 'n_rev',
   data: {
     ...DEFAULT_EDGE_DATA,
+    weight: 0.52,
     weightSource: 'cee',
+    direction: 'negative',
+    directionSource: 'cee',
     provenanceDisplay: 'ai_inferred',
     origin: 'ai',
   },
@@ -69,6 +76,24 @@ const draftedEdge = (): ElicitationCanvasEdge => ({
 const fragileEdges = [
   { from_id: 'n_demand', to_id: 'n_rev', switch_probability: ABOVE, alternative_winner_label: 'Consolidate' },
 ]
+
+const validAnalysisReady = {
+  status: 'ready',
+  goal_node_id: 'n_rev',
+  suggested_seed: '71152',
+  options: [{
+    id: 'opt-control',
+    label: 'Control',
+    status: 'ready',
+    interventions: {
+      n_demand: { value: 0.6, source: 'user_specified' },
+    },
+  }],
+} satisfies CEEAnalysisReady
+
+afterEach(() => {
+  clearAutosave()
+})
 
 describe('P4 chain: elicitation → resolve → stale → rerun → loop closed', () => {
   it('LINK 1 — elicitation names the assumed relationship, by edge identity', () => {
@@ -188,23 +213,170 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
     ))
     expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Very strong' }))
+    fireEvent.click(screen.getByTestId('strength-band-very-strong'))
 
     const edited = useCanvasStore.getState()
     const data = edited.edges.find(edge => edge.id === 'e_demand_rev')?.data as Record<string, unknown>
     expect(data.weight).toBe(0.85)
     expect(data.weightSource).toBe('user')
+    // A preset is a magnitude choice. The existing negative causal direction
+    // and its producer provenance survive because the user did not choose sign.
+    expect(data.direction).toBe('negative')
+    expect(data.directionSource).toBe('cee')
     // Editing the field does not rewrite the edge's creation/display provenance.
     expect(data.provenanceDisplay).toBe('ai_inferred')
     expect(data.origin).toBe('ai')
     expect(edited.analysisFreshnessDirty).toBe(true)
     expect(screen.getByRole('button', { name: 'Re-run the analysis' })).toBeInTheDocument()
     expect(screen.getByText('Re-run to see how this affects the results')).toBeInTheDocument()
+
+    // The real canonical request builder consumes the changed store value on a
+    // contract-valid readiness premise (`options[].id`, persisted goal id).
+    const { request } = buildV2RequestFromAnalysisReady(
+      edited.nodes as never,
+      edited.edges as never,
+      validAnalysisReady,
+    )
+    expect(request.graph.edges).toHaveLength(1)
+    expect(request.graph.edges[0].strength.mean).toBe(-0.85)
   })
 
-  it('HONESTY — confirming the placeholder AS-IS is not an analytical change, so no rerun is promised', () => {
+  it('MOUNTED — confirm-current uses the exact live estimate, preserves direction, persists, and does not false-stale', () => {
+    const first = draftedEdge()
+    const second: ElicitationCanvasEdge = {
+      id: 'e_cost_rev',
+      source: 'n_cost',
+      target: 'n_rev',
+      data: {
+        ...DEFAULT_EDGE_DATA,
+        weight: 0.34,
+        weightSource: 'cee',
+        direction: 'positive',
+        directionSource: 'cee',
+        provenanceDisplay: 'ai_inferred',
+        origin: 'ai',
+      },
+    }
+    const ranked = [
+      ...fragileEdges,
+      { from_id: 'n_cost', to_id: 'n_rev', switch_probability: ABOVE - 0.05 },
+    ]
+    const labels = new Map([...nodeLabels, ['n_cost', 'Delivery cost']])
+    const decision = selectAssumedStrengthToResolve({
+      fragileEdges: ranked,
+      edges: [first, second],
+      nodeLabels: labels,
+    })
+    expect(decision.selected?.edgeId).toBe(first.id)
+
+    useCanvasStore.setState({
+      currentScenarioId: '11111111-2222-4333-8444-555555555555',
+      nodes: [
+        { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+        { id: 'n_cost', type: 'factor', position: { x: 0, y: 120 }, data: { label: 'Delivery cost' } },
+        { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      ] as never,
+      edges: [first, second] as never,
+      showResultsPanel: true,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+      history: { past: [], future: [] },
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null } as never,
+    })
+
+    render(createElement(AssumedStrengthCard, { decision, onResolve: openEdgeStrengthEditor }))
+    fireEvent.click(screen.getByTestId('assumed-strength-action'))
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: first.id, onClose: () => {} }),
+    ))
+
+    expect(screen.getByText(/Olumi’s current estimate is/)).toHaveTextContent('0.52')
+    expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
+
+    // Server/store refresh after mount: the click must confirm 0.6147, not the
+    // value captured on first render, a rounded display value, or the active
+    // band's 0.55 midpoint.
+    act(() => {
+      const refreshedEdges = useCanvasStore.getState().edges.map((edge) => edge.id === first.id
+        ? { ...edge, data: { ...edge.data, weight: 0.6147 } }
+        : edge)
+      // This is a controlled server/store refresh, not a user edit; bypass the
+      // canonical mutation path deliberately so the test can prove the action
+      // reads the live value rather than the first-render closure.
+      useCanvasStore.setState({ edges: refreshedEdges } as never)
+    })
+    expect(screen.getByText(/Olumi’s current estimate is/)).toHaveTextContent('0.6147')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm this estimate' }))
+
+    const confirmed = useCanvasStore.getState()
+    const data = confirmed.edges.find((edge) => edge.id === first.id)?.data as Record<string, unknown>
+    expect(data.weight).toBe(0.6147)
+    expect(data.weight).not.toBe(0.55)
+    expect(data.weightSource).toBe('user')
+    expect(data.direction).toBe('negative')
+    expect(data.directionSource).toBe('cee')
+    expect(data.provenanceDisplay).toBe('ai_inferred')
+    expect(data.origin).toBe('ai')
+    expect(confirmed.analysisFreshnessDirty).toBe(false)
+    expect(screen.getByText('Updated')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Confirm this estimate' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Re-run the analysis' })).toBeNull()
+
+    const next = selectAssumedStrengthToResolve({
+      fragileEdges: ranked,
+      edges: confirmed.edges as ElicitationCanvasEdge[],
+      nodeLabels: labels,
+    })
+    expect(next.selected?.edgeId).toBe(second.id)
+
+    saveAutosave(projectAutosaveData({
+      nodes: confirmed.nodes,
+      edges: confirmed.edges,
+      scenarioId: confirmed.currentScenarioId,
+      ceeAnalysisReady: validAnalysisReady,
+      selectedGoalNode: 'n_rev',
+      analysis: null,
+      goalConstraints: null,
+    }, 123))
+    const restored = loadAutosave()
+    const restoredData = restored?.edges.find((edge) => edge.id === first.id)?.data as Record<string, unknown>
+    expect(restoredData.weight).toBe(0.6147)
+    expect(restoredData.weightSource).toBe('user')
+    expect(restoredData.direction).toBe('negative')
+    expect(restoredData.directionSource).toBe('cee')
+  })
+
+  it('MUTANT CONTROL — a hidden default has no confirm-as-estimate action', () => {
+    const data = { ...DEFAULT_EDGE_DATA } as Record<string, unknown>
+    const edge: ElicitationCanvasEdge = {
+      id: 'e_demand_rev',
+      source: 'n_demand',
+      target: 'n_rev',
+      data,
+    }
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n_demand', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Customer demand' } },
+        { id: 'n_rev', type: 'outcome', position: { x: 200, y: 0 }, data: { label: 'Revenue growth' } },
+      ] as never,
+      edges: [edge] as never,
+      analysisFreshness: { freshness: 'fresh' },
+      analysisFreshnessDirty: false,
+    })
+    render(createElement(
+      ReactFlowProvider,
+      null,
+      createElement(InspectorModal, { nodeId: null, edgeId: edge.id, onClose: () => {} }),
+    ))
+    expect(screen.queryByRole('button', { name: 'Confirm this estimate' })).toBeNull()
+    expect(screen.queryByText(/Olumi’s current estimate is/)).toBeNull()
+  })
+
+  it('HONESTY — confirming an AI estimate AS-IS is not an analytical change, so no rerun is promised', () => {
     // The interaction must not promise a consequence it cannot deliver. If the
-    // user looks at the placeholder and decides 0.5 was right all along, the
+    // user looks at the estimate and decides 0.52 was right all along, the
     // MODEL is more trustworthy (the value is now theirs) but the NUMBERS are
     // identical — so a rerun would show nothing, and the staleness machinery
     // correctly declines to claim otherwise. `weightSource` is deliberately NOT

--- a/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/selectAssumedStrengthToResolve.spec.ts
@@ -13,6 +13,10 @@ import {
 } from '../selectAssumedStrengthToResolve'
 import { THRESHOLDS } from '../../../../lib/mappers/constants'
 import { DEFAULT_EDGE_DATA, USER_EDGE_DEFAULTS } from '../../../../canvas/domain/edges'
+// COMMITTED CAPTURES, not fixtures this spec authored. A hand-written array
+// encodes the author's model of ISL; these are what ISL actually emitted.
+import nonDescendingCapture from '../../../../v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json'
+import descendingCapture from '../../../../v5/__tests__/fixtures/live-analysis-turn-walkA-2026-08-04.json'
 
 const labels = new Map<string, string>([
   ['n_demand', 'Customer demand'],
@@ -53,19 +57,19 @@ const fragileRow = (
 ) => ({ from_id: from, to_id: to, switch_probability, ...extra })
 
 describe('selectAssumedStrengthToResolve — the assumed × decision-relevant join', () => {
-  it('names the FIRST assumed edge in PRODUCER ORDER, bound by edge id', () => {
+  it('names the eligible edge with the HIGHEST measured switch probability', () => {
     const d = selectAssumedStrengthToResolve({
       fragileEdges: [
-        fragileRow('n_demand', 'n_rev', ABOVE, { alternative_winner_label: 'Consolidate' }),
-        fragileRow('n_price', 'n_cost', ALSO_ABOVE),
+        fragileRow('n_demand', 'n_rev', ALSO_ABOVE),
+        fragileRow('n_price', 'n_cost', ABOVE, { alternative_winner_label: 'Consolidate' }),
       ],
       edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev'), assumedEdge('e_price_cost', 'n_price', 'n_cost')],
       nodeLabels: labels,
     })
-    expect(d.selected?.edgeId).toBe('e_demand_rev')
+    expect(d.selected?.edgeId).toBe('e_price_cost')
     expect(d.refusalReason).toBeNull()
-    expect(d.selected?.fromLabel).toBe('Customer demand')
-    expect(d.selected?.toLabel).toBe('Revenue growth')
+    expect(d.selected?.fromLabel).toBe('Pricing power')
+    expect(d.selected?.toLabel).toBe('Unit cost')
     expect(d.selected?.alternativeWinnerLabel).toBe('Consolidate')
     expect(d.assumedFragileCount).toBe(2)
   })
@@ -73,7 +77,7 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
   it('SKIPS a higher-ranked edge whose strength somebody SET, and names the next assumed one', () => {
     // The discriminating case: rank 1 is the MORE fragile edge, but it is not an
     // assumption — it is a number the user chose. Re-eliciting it would be
-    // telling a team its own decision is a placeholder.
+    // telling a team its own confirmed judgement is still unresolved.
     const d = selectAssumedStrengthToResolve({
       fragileEdges: [
         fragileRow('n_demand', 'n_rev', ABOVE),
@@ -167,6 +171,7 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
       nodeLabels: labels,
     })
     expect(ai.selected?.edgeId).toBe('e_demand_rev')
+    expect(ai.selected?.strengthProvenance).toBe('ai_inferred')
 
     // The editor writes the field-specific user stamp and correctly leaves the
     // edge's AI creation provenance intact. Same number, opposite eligibility.
@@ -194,6 +199,28 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
       nodeLabels: labels,
     })
     expect(d.selected?.edgeId).toBe('e_demand_rev')
+    expect(d.selected?.strengthProvenance).toBe('ai_inferred')
+  })
+
+  it('classifies an unstamped default as missing, never as an AI estimate', () => {
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: [fragileRow('n_demand', 'n_rev', ABOVE)],
+      edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev')],
+      nodeLabels: labels,
+    })
+    expect(d.selected?.strengthProvenance).toBe('missing')
+  })
+
+  it('does not let AI edge-creation provenance launder an unstamped default into an estimate', () => {
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: [fragileRow('n_demand', 'n_rev', ABOVE)],
+      edges: [{
+        ...assumedEdge('e_demand_rev', 'n_demand', 'n_rev'),
+        data: { ...DEFAULT_EDGE_DATA, origin: 'ai', provenanceDisplay: 'ai_inferred' },
+      }],
+      nodeLabels: labels,
+    })
+    expect(d.selected?.strengthProvenance).toBe('missing')
   })
 
   it.each([
@@ -327,13 +354,12 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
     expect(d.assumedFragileCount).toBe(1)
   })
 
-  it('uses the FIRST eligible producer identity and never re-ranks in the UI', () => {
-    // Deliberately put a larger number second. The producer owns ranking and
-    // communicates it through row order; sorting these rows locally would mint
-    // a second ranking authority and select a different edge.
+  it('F4 — an unsorted producer payload cannot make array position outrank the measured score', () => {
+    // This is the load-bearing contrast refuted by committed captures. It REDs
+    // under the old first-row implementation and under a min-score mutant.
     const rows = [
-      fragileRow('n_demand', 'n_rev', 0.20),
-      fragileRow('n_price', 'n_cost', 0.45),
+      fragileRow('n_demand', 'n_rev', 0.22),
+      fragileRow('n_price', 'n_cost', 0.548),
     ]
 
     const d = selectAssumedStrengthToResolve({
@@ -341,9 +367,48 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
       edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev'), assumedEdge('e_price_cost', 'n_price', 'n_cost')],
       nodeLabels: labels,
     })
+    expect(d.selected?.edgeId).toBe('e_price_cost')
+    expect(d.selected?.switchProbability).toBe(0.548)
+    expect(d.selected?.edgeId).not.toBe('e_demand_rev')
+  })
+
+  it('breaks an equal-score tie by stable edge identity without claiming one score is larger', () => {
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: [
+        fragileRow('n_price', 'n_cost', ABOVE),
+        fragileRow('n_demand', 'n_rev', ABOVE),
+      ],
+      edges: [
+        assumedEdge('z-price-cost', 'n_price', 'n_cost'),
+        assumedEdge('a-demand-rev', 'n_demand', 'n_rev'),
+      ],
+      nodeLabels: labels,
+    })
+    expect(d.selected?.edgeId).toBe('a-demand-rev')
+    expect(d.selected?.switchProbability).toBe(ABOVE)
+  })
+
+  it('a duplicated edge row cannot lend its score to its twin — each row is scored on its OWN number', () => {
+    // The header claims this ("prevents a duplicated edge row earlier in the
+    // payload from lending its number to a later row") and, until this test,
+    // nothing held it: a mutant that passed ALL rows to the score helper
+    // SURVIVED the whole suite. Unreachable on observed data — zero duplicated
+    // edge identities across all 29 distinct committed arrays — which is
+    // exactly why it is pinned rather than trusted: a producer change would
+    // make it reachable silently.
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: [
+        fragileRow('n_demand', 'n_rev', 0.20),
+        fragileRow('n_demand', 'n_rev', 0.55),
+      ],
+      edges: [assumedEdge('e_demand_rev', 'n_demand', 'n_rev')],
+      nodeLabels: labels,
+    })
+    // Bound by identity, and by the number that belongs to the winning ROW.
     expect(d.selected?.edgeId).toBe('e_demand_rev')
-    expect(d.selected?.switchProbability).toBe(0.20)
-    expect(d.selected?.edgeId).not.toBe('e_price_cost')
+    expect(d.selected?.switchProbability).toBe(0.55)
+    // One canvas edge is ONE assumption, however many rows name it.
+    expect(d.assumedFragileCount).toBe(1)
   })
 
   it('tolerates malformed rows without dropping the whole decision', () => {
@@ -353,5 +418,128 @@ describe('selectAssumedStrengthToResolve — the assumed × decision-relevant jo
       nodeLabels: labels,
     })
     expect(d.selected?.edgeId).toBe('e_demand_rev')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 1.01])(
+    'does not let an invalid probability (%s) poison the maximum',
+    (invalid) => {
+      const d = selectAssumedStrengthToResolve({
+        fragileEdges: [
+          fragileRow('n_demand', 'n_rev', invalid),
+          fragileRow('n_price', 'n_cost', 0.548),
+        ],
+        edges: [
+          assumedEdge('e_demand_rev', 'n_demand', 'n_rev'),
+          assumedEdge('e_price_cost', 'n_price', 'n_cost'),
+        ],
+        nodeLabels: labels,
+      })
+      expect(d.selected?.edgeId).toBe('e_price_cost')
+      expect(d.selected?.switchProbability).toBe(0.548)
+    },
+  )
+})
+
+/**
+ * ── THE PRODUCER'S OWN PAYLOADS ────────────────────────────────────────────
+ *
+ * Both arrays below are COMMITTED CAPTURES of real ISL output. The canvas
+ * edges and node labels are DERIVED FROM THE ROWS THEMSELVES (`edge_id`,
+ * `from_id`/`to_id`, `from_label`/`to_label`), so nothing in this section is a
+ * shape this spec invented — the point of the defect was that a self-authored
+ * fixture had certified an ordering the producer never promised.
+ *
+ * Each test PINS ITS OWN PRECONDITION before asserting the outcome. Without
+ * that, a later fixture edit could remove the property under test and both
+ * tests would keep passing while proving nothing.
+ */
+interface CaptureRow {
+  readonly edge_id: string
+  readonly from_id: string
+  readonly to_id: string
+  readonly from_label: string
+  readonly to_label: string
+  readonly switch_probability: number
+}
+
+/** Every captured row becomes an UNRESOLVED canvas edge keyed by the producer's own id. */
+const capturedEdges = (rows: readonly CaptureRow[]): ElicitationCanvasEdge[] =>
+  rows.map((r) => ({
+    id: r.edge_id,
+    source: r.from_id,
+    target: r.to_id,
+    data: { ...DEFAULT_EDGE_DATA },
+  }))
+
+const capturedLabels = (rows: readonly CaptureRow[]): Map<string, string> => {
+  const m = new Map<string, string>()
+  for (const r of rows) {
+    m.set(r.from_id, r.from_label)
+    m.set(r.to_id, r.to_label)
+  }
+  return m
+}
+
+/** Rows the visibility floor admits — the only population the surface can name. */
+const aboveFloor = (rows: readonly CaptureRow[]): CaptureRow[] =>
+  rows.filter((r) => r.switch_probability > THRESHOLDS.FRAGILE_EDGE_FILTER)
+
+const NON_DESCENDING_ROWS = (nonDescendingCapture as unknown as {
+  block: { enrichment: { robustness: { fragile_edges: CaptureRow[] } } }
+}).block.enrichment.robustness.fragile_edges
+
+const DESCENDING_ROWS = (descendingCapture as unknown as {
+  blocks: { enrichment: { robustness: { fragile_edges: CaptureRow[] } } }[]
+}).blocks[0].enrichment.robustness.fragile_edges
+
+describe('selectAssumedStrengthToResolve — against COMMITTED ISL captures', () => {
+  it('CAPTURE (max NOT at index 0): names the highest-scoring edge by IDENTITY, not the first row', () => {
+    const rows = aboveFloor(NON_DESCENDING_ROWS)
+
+    // PRECONDITION — this capture must actually exhibit the defect, or the
+    // assertion below proves nothing. Bound by identity, not by position.
+    expect(rows.length).toBeGreaterThan(1)
+    const maxRow = rows.reduce((a, b) => (b.switch_probability > a.switch_probability ? b : a))
+    expect(maxRow.edge_id).toBe('fac_marketing_expertise->out_campaign_effectiveness')
+    expect(rows[0].edge_id).toBe('fac_ad_spend->risk_budget_overrun')
+    expect(rows[0].edge_id).not.toBe(maxRow.edge_id) // the defect, present in this payload
+
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: NON_DESCENDING_ROWS,
+      edges: capturedEdges(NON_DESCENDING_ROWS),
+      nodeLabels: capturedLabels(NON_DESCENDING_ROWS),
+    })
+
+    // RED under the `fragile_edges[0]` rule, which names the 0.164 row.
+    expect(d.selected?.edgeId).toBe('fac_marketing_expertise->out_campaign_effectiveness')
+    expect(d.selected?.edgeId).not.toBe('fac_ad_spend->risk_budget_overrun')
+    expect(d.selected?.switchProbability).toBe(maxRow.switch_probability)
+    expect(d.selected?.fromLabel).toBe('Marketing Strategy Quality')
+    expect(d.selected?.toLabel).toBe('Campaign Conversion Effectiveness')
+    expect(d.refusalReason).toBeNull()
+  })
+
+  it('CAPTURE (already descending): selects exactly the edge the producer-order rule selected — a strict improvement, not a swap', () => {
+    const rows = aboveFloor(DESCENDING_ROWS)
+
+    // PRECONDITION — this capture must be the OPPOSITE case: already ordered,
+    // so first row and maximum row are the same edge. If a fixture edit broke
+    // that, this test would silently stop testing the no-regression direction.
+    expect(rows.length).toBeGreaterThan(1)
+    const maxRow = rows.reduce((a, b) => (b.switch_probability > a.switch_probability ? b : a))
+    expect(rows[0].edge_id).toBe(maxRow.edge_id)
+    expect(rows[0].edge_id).toBe('fac_selfserve->out_product_led_growth')
+
+    const d = selectAssumedStrengthToResolve({
+      fragileEdges: DESCENDING_ROWS,
+      edges: capturedEdges(DESCENDING_ROWS),
+      nodeLabels: capturedLabels(DESCENDING_ROWS),
+    })
+
+    // GREEN both before and after the fix. The old rule took `[0]`; the new
+    // rule takes the maximum; on this payload they are the same edge.
+    expect(d.selected?.edgeId).toBe('fac_selfserve->out_product_led_growth')
+    expect(d.selected?.switchProbability).toBe(rows[0].switch_probability)
+    expect(d.refusalReason).toBeNull()
   })
 })

--- a/src/components/results/strengthElicitation/assumedStrengthCopy.ts
+++ b/src/components/results/strengthElicitation/assumedStrengthCopy.ts
@@ -19,11 +19,12 @@
  * MAY SAY:
  *   · "if this link is weaker than we assumed, {alt} came out ahead in NN% of runs"
  *     — the conditional, which is exactly what was measured.
- *   · "nobody has set this strength" — a fact about our own graph state, read
- *     from `edgeValueSource`, carrying no producer claim at all.
- *   · "this is the one to pin down first" — an ordering claim licensed ONLY by
- *     the producer's own sort, and phrased as a suggestion about where to spend
- *     attention, never as a statement about the model's structure.
+ *   · "your team has not confirmed this estimate" — only when existing graph
+ *     provenance says the value is `ai_inferred`.
+ *   · "nobody has set this strength" — only when the value source is absent.
+ *   · "highest such rate" — because the selector takes the maximum existing
+ *     `switch_probability` among eligible unresolved strengths. It is a claim
+ *     about that conditional rate, never about structural importance or VOI.
  *
  * MUST NOT SAY:
  *   (a) "the most important relationship" / "this link decides it" — an
@@ -63,7 +64,9 @@ export const ASSUMED_STRENGTH_TITLE = 'One assumption worth pinning down'
  * `{from} → {to}` are canvas labels — the team's own words for their own model.
  */
 export function assumedStrengthLead(s: AssumedStrengthSelection): string {
-  return `Nobody has set how strongly ${s.fromLabel} affects ${s.toLabel} — the model is using a placeholder.`
+  return s.strengthProvenance === 'ai_inferred'
+    ? `Olumi estimated how strongly ${s.fromLabel} affects ${s.toLabel}, but your team has not confirmed it.`
+    : `Nobody has set how strongly ${s.fromLabel} affects ${s.toLabel} yet.`
 }
 
 /**
@@ -73,14 +76,18 @@ export function assumedStrengthLead(s: AssumedStrengthSelection): string {
  */
 export function assumedStrengthWhy(s: AssumedStrengthSelection): string {
   const pct = Math.round(s.switchProbability * 100)
-  return s.alternativeWinnerLabel !== null
-    ? `In the runs where that link came out weak, ${s.alternativeWinnerLabel} was the stronger option ${pct}% of the time. So the placeholder is doing real work in the answer you are looking at.`
-    : `In the runs where that link came out weak, a different option came out ahead ${pct}% of the time. So the placeholder is doing real work in the answer you are looking at.`
+  const measured = s.alternativeWinnerLabel !== null
+    ? `In the runs where that link came out weak, ${s.alternativeWinnerLabel} was the stronger option ${pct}% of the time.`
+    : `In the runs where that link came out weak, a different option came out ahead ${pct}% of the time.`
+  return `${measured} Of the unconfirmed relationship strengths you can resolve here, this had the highest such rate in this run.`
 }
 
 /** The ask. An invitation to supply judgement, never an instruction to agree. */
-export const ASSUMED_STRENGTH_ASK =
-  'Set it to what your team actually believes, then re-run to see whether it changes the answer.'
+export function assumedStrengthAsk(s: AssumedStrengthSelection): string {
+  return s.strengthProvenance === 'ai_inferred'
+    ? 'Confirm Olumi’s estimate or change it to what your team believes. If the value changes, re-run to see whether it changes the answer.'
+    : 'Set it to what your team believes, then re-run to see whether it changes the answer.'
+}
 
 /**
  * The "and others" clause. Only ever rendered when the count EXCEEDS one, and it
@@ -91,8 +98,8 @@ export function assumedStrengthOthers(assumedFragileCount: number): string | nul
   if (assumedFragileCount <= 1) return null
   const n = assumedFragileCount - 1
   return n === 1
-    ? 'One other relationship driving this result also has a placeholder strength.'
-    : `${n} other relationships driving this result also have placeholder strengths.`
+    ? 'One other sensitive relationship also has an unconfirmed strength.'
+    : `${n} other sensitive relationships also have unconfirmed strengths.`
 }
 
 /**
@@ -126,5 +133,5 @@ export const ASSUMED_STRENGTH_REFUSAL_COPY: Record<AssumedStrengthRefusal, strin
   all_strengths_set:
     'No unresolved assumed strength was found among the relationships this run was sensitive to.',
   no_fragile_edges:
-    'No single relationship stood out as driving this run’s answer, so there is no one assumption to pin down first.',
+    'This run found no relationship with a measured weak-link rate high enough to surface here.',
 }

--- a/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
+++ b/src/components/results/strengthElicitation/selectAssumedStrengthToResolve.ts
@@ -15,9 +15,9 @@
  * set (`edgeValueSource`). Nothing joined the two, so a team was never told
  * which of its own assumptions to pin down first.
  *
- * This module is that join and NOTHING else. It mints no ranking: it walks the
- * producer's own order and returns the first row that is BOTH decision-relevant
- * AND still assumed.
+ * This module is that join and NOTHING else. It mints no metric: among rows that
+ * are BOTH decision-relevant AND still assumed, it selects the maximum of the
+ * producer's existing `switch_probability` measurement.
  *
  * ── THE THREE AUTHORITIES THIS CONSUMES (none of them re-derived here) ──────
  *   1. WHICH EDGE MATTERS — `getFragileEdgeSwitchProbability`
@@ -35,12 +35,49 @@
  *      stamped `weightSource: 'cee'`. Edge creation provenance never overrides
  *      the more specific user value stamp, so an AI-created edge stops being
  *      eligible after the user sets its strength through the existing editor.
- *   3. PRODUCER ORDER — ISL emits `fragile_edges` sorted descending by
+ *   3. WHICH ELIGIBLE EDGE COMES FIRST — `switch_probability` itself, BY VALUE.
+ *      The ISL response model declares the score but makes NO ordering promise,
+ *      and the producer returns enhanced rows in its edge-map insertion order.
+ *
+ *      ⚠ THIS REVERSES THE #704/#707 RULING THAT USED TO SIT HERE, AND THE
+ *      REASON MATTERS MORE THAN THE VERDICT — otherwise the next lane reverts
+ *      it. That ruling read: "ISL emits `fragile_edges` sorted descending by
  *      `switch_probability` (measured across all nine committed live captures).
  *      We preserve that order exactly and take the FIRST qualifying row. No
- *      `Math.max`, no re-sort, no tie-break of our own: re-ranking would be a
- *      second opinion about importance computed from a subset of the producer's
- *      inputs, and it is the one thing the surface shows.
+ *      `Math.max`, no re-sort." **Re-measured at staging `7153fbd7`, that
+ *      sentence is TRUE INSIDE ITS OWN SCOPE and FALSE AS A GENERALISATION.**
+ *      It was never a lie; it was a corpus that excluded the counter-examples.
+ *
+ *      Measured over EVERY committed JSON carrying `fragile_edges` (25 files;
+ *      20 distinct arrays with ≥2 numeric rows, after collapsing the debug
+ *      bundles that repeat one array at six JSON paths each):
+ *        • THE NINE LIVE CAPTURES  — 10 arrays, 10 descending, 0 not.
+ *        • EVERYTHING ELSE         — 10 arrays,  5 descending, 5 not.
+ *      The nine are identified by the `factor_evppi` magnitude this same header
+ *      cites below (26 rows), which lands on exactly nine files. So re-running
+ *      the original measurement REPRODUCES the original answer — which is
+ *      precisely why array position must stop being read as rank.
+ *
+ *      Two of those non-descending arrays change the ANSWER once the visibility
+ *      floor (`THRESHOLDS.FRAGILE_EDGE_FILTER`, 0.15) is applied, i.e. the old
+ *      `[0]` rule named a relationship that was NOT the most switch-prone one
+ *      on screen:
+ *        • `staging-bundles/olumi-debug-a4b32ee2-20260510.pre-fix.json`
+ *          above-floor [0.22, 0.544, …, 0.548, 0.344] — took 0.22, max 0.548
+ *        • `v5/__tests__/fixtures/v5-analysis-result.bundle-45c9b625.json`
+ *          above-floor [0.164, 0.24, 0.213] — took 0.164, max 0.24
+ *      ⚠ SCOPE, STATED PRECISELY: 2 of 17 above-floor arrays, not "about half".
+ *      Non-descending is NOT the same claim as index-0-is-not-the-maximum —
+ *      three further non-descending arrays (including the staging-real-shape
+ *      capture, whose 0.084 sits BELOW the floor) still have their maximum at
+ *      index 0 and are unaffected by this change. Correcting the rule is still
+ *      right: an untruthful superlative does not need a high hit-rate to be
+ *      untruthful, and nothing upstream bounds the rate.
+ *
+ *      So: take the MAXIMUM existing score among eligible rows, and use edge id
+ *      only to make equal-score ties deterministic. The tie-break carries no
+ *      scientific claim, and no new metric is minted — the value compared is the
+ *      producer's own, unmodified.
  *
  * ── WHAT `switch_probability` ACTUALLY MEANS, AND WHAT THE COPY MAY THEREFORE
  *    CLAIM ──────────────────────────────────────────────────────────────────
@@ -134,6 +171,8 @@ export interface AssumedStrengthSelection {
   readonly switchProbability: number
   /** ISL's "option that wins when edge is weak". `null` when the producer omitted it. */
   readonly alternativeWinnerLabel: string | null
+  /** Existing graph provenance, reduced only to the two unresolved copy cases. */
+  readonly strengthProvenance: 'ai_inferred' | 'missing'
 }
 
 export interface AssumedStrengthDecision {
@@ -141,7 +180,7 @@ export interface AssumedStrengthDecision {
   readonly refusalReason: AssumedStrengthRefusal | null
   /**
    * How many fragile edges (above the floor, canvas-matched) still have an
-   * assumed strength. `selected` is the first of them in producer order. Drives
+   * assumed strength. `selected` has their highest measured switch probability. Drives
    * the "and N others" clause, so it counts the SAME population the selection
    * came from — never all edges, never all fragile rows.
    */
@@ -179,20 +218,27 @@ function nonEmptyString(value: unknown): string | null {
  * Unknown/older provenance keeps the previous absence-safe rule: only a
  * recognised value source counts as resolved. No new provenance is inferred.
  */
-function hasUnresolvedAssumedStrength(data: Record<string, unknown> | undefined): boolean {
+function unresolvedStrengthProvenance(
+  data: Record<string, unknown> | undefined,
+): AssumedStrengthSelection['strengthProvenance'] | null {
   const valueSource = edgeValueSource(data, 'weight')
 
   // The strength editor writes this field-specific stamp and deliberately
   // leaves the edge's creation origin intact. It therefore has precedence.
   if (valueSource === 'user') {
-    return false
+    return null
   }
 
   if (data?.provenanceDisplay === 'ai_inferred' || data?.origin === 'ai') {
-    return true
+    // Edge-creation provenance cannot prove a numeric strength was estimated.
+    // The field-specific source does: `cee` means a producer supplied it; null
+    // means the AI-created edge is still carrying a UI fallback/default.
+    if (valueSource === 'cee') return 'ai_inferred'
+    if (valueSource === null) return 'missing'
+    return null
   }
 
-  return valueSource === null
+  return valueSource === null ? 'missing' : null
 }
 
 /**
@@ -229,16 +275,6 @@ export function selectAssumedStrengthToResolve({
     return { selected: null, refusalReason: 'no_robustness_data', assumedFragileCount: 0 }
   }
 
-  // SANITISE BEFORE DELEGATING. `getFragileEdgeSwitchProbability` reads
-  // `fe.switch_probability` with no null guard (`fragileEdgeMatch.ts:108`), so a
-  // payload carrying a null element throws inside the shared helper — measured,
-  // not assumed. Filtering to plain records here fixes it for THIS caller
-  // without reaching into a helper three other live surfaces share; the defect
-  // is reported separately rather than patched in passing. Non-record rows could
-  // never match an edge anyway, so dropping them changes no outcome, and the
-  // surviving rows keep the producer's relative order.
-  const candidates = fragileEdges.filter((r) => readRecord(r) !== null) as FragileEdgeCandidate[]
-
   let selected: AssumedStrengthSelection | null = null
   let assumedFragileCount = 0
   /** A row cleared the floor and matched a canvas edge — so the block is not vacuous. */
@@ -248,8 +284,6 @@ export function selectAssumedStrengthToResolve({
   /** Canvas edges already counted — one edge is one assumption, however many rows name it. */
   const countedEdgeIds = new Set<string>()
 
-  // PRODUCER ORDER, consumed not re-derived. The first qualifying row wins;
-  // every later one only increments the count.
   for (const raw of fragileEdges) {
     const row = readRecord(raw)
     if (row === null) continue
@@ -263,8 +297,18 @@ export function selectAssumedStrengthToResolve({
     // The floor, the dual-format match and the never-fall-back-to-marginal rule
     // all come from the ONE helper. `null` here means below the floor or not
     // measured — both "do not surface this row".
-    const measured = getFragileEdgeSwitchProbability(edge.id, edge.source, edge.target, candidates)
-    if (measured === null) continue
+    // Pass THIS row only. Besides keeping the score bound to the row whose
+    // identity/copy we carry, this prevents a duplicated edge row earlier in the
+    // payload from lending its number to a later row.
+    const measured = getFragileEdgeSwitchProbability(
+      edge.id,
+      edge.source,
+      edge.target,
+      [row as FragileEdgeCandidate],
+    )
+    // Producer contract is a probability in [0, 1]. A non-finite/out-of-range
+    // wire value cannot license either a maximum or user-facing percentage.
+    if (measured === null || !Number.isFinite(measured) || measured > 1) continue
 
     const fromLabel = nonEmptyString(nodeLabels.get(edge.source))
     const toLabel = nonEmptyString(nodeLabels.get(edge.target))
@@ -281,28 +325,38 @@ export function selectAssumedStrengthToResolve({
     // A CEE number is still provisional when the edge says AI inferred it.
     // Conversely, the field-specific user stamp wins over the edge's retained
     // AI creation origin after the existing editor writes the user's value.
-    if (!hasUnresolvedAssumedStrength(edge.data)) continue
+    const strengthProvenance = unresolvedStrengthProvenance(edge.data)
+    if (strengthProvenance === null) continue
 
     // COUNT DISTINCT EDGES, NOT ROWS. The producer may name one canvas edge in
     // more than one row (a repeated pair, or an `edge_id` row alongside its
     // from/to twin), and "and N others" is a claim about how many RELATIONSHIPS
-    // still rest on a placeholder. Counting rows would inflate it — and the
+    // still carry an unconfirmed strength. Counting rows would inflate it — and the
     // inflation would be invisible, because the sentence reads perfectly well
     // with a wrong number in it. Not reachable on observed data (nine captures,
     // zero duplicates), which is exactly why it needs pinning rather than
     // trusting: a producer change would make it reachable silently.
-    if (countedEdgeIds.has(edge.id)) continue
-    countedEdgeIds.add(edge.id)
-    assumedFragileCount += 1
-    if (selected === null) {
-      selected = {
-        edgeId: edge.id,
-        fromLabel,
-        toLabel,
-        switchProbability: measured,
-        alternativeWinnerLabel:
-          nonEmptyString(row.alternative_winner_label) ?? nonEmptyString(row.alternativeWinnerLabel),
-      }
+    if (!countedEdgeIds.has(edge.id)) {
+      countedEdgeIds.add(edge.id)
+      assumedFragileCount += 1
+    }
+
+    const candidate: AssumedStrengthSelection = {
+      edgeId: edge.id,
+      fromLabel,
+      toLabel,
+      switchProbability: measured,
+      alternativeWinnerLabel:
+        nonEmptyString(row.alternative_winner_label) ?? nonEmptyString(row.alternativeWinnerLabel),
+      strengthProvenance,
+    }
+    if (
+      selected === null ||
+      candidate.switchProbability > selected.switchProbability ||
+      (candidate.switchProbability === selected.switchProbability &&
+        candidate.edgeId.localeCompare(selected.edgeId) < 0)
+    ) {
+      selected = candidate
     }
   }
 

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -1189,9 +1189,10 @@ export interface ResultsSectionDataReturn {
   /**
    * P4 — the ONE assumed relationship worth pinning down next, or a named
    * refusal. The join between "which relationship is this result sensitive to"
-   * (producer `fragile_edges`) and "whose strength nobody set"
-   * (`edgeValueSource`). Never a ranking of our own: the producer's wire order
-   * is walked and the first qualifying row wins.
+   * (producer `fragile_edges`) and "which strength is still unconfirmed"
+   * (`edgeValueSource` plus the existing AI-inferred provisional marker). The
+   * wire does not promise row order, so the selector uses the maximum existing
+   * `switch_probability` among eligible rows — no second score or VOI proxy.
    *
    * Deliberately NOT derived from `factor_evppi`, which this hook already reads
    * for `voiRanking`. Measured across all nine committed live captures, no


### PR DESCRIPTION
## Why

Resolve Next treated `fragile_edges[0]` as authoritative even though ISL does not promise an order. The editor also rounded a live estimate, conflated AI estimates with missing values, and strength presets could stamp direction provenance the user had not chosen.

## What changed

- Select the deterministic maximum existing `switch_probability` among eligible, unconfirmed relationships; no new metric or scientific claim.
- Distinguish AI-estimated strength from a genuinely missing/default strength in copy.
- Confirm the exact live CEE strength value while preserving direction, direction source, and the provisional `ai_inferred` ruling; provenance-only confirmation does not falsely stale results.
- Make preset mappings visible. A preset changes magnitude only, preserves direction/provenance, and follows the normal stale/rerun path.
- Add mounted, identity-bound tests including an unsorted `[0.22, 0.548]` contrast, exact `0.6147` confirmation mutant, invalid-score mutants, persistence projection, and real request-builder coverage.

## Contract findings

- ISL's `fragile_edges` response is an unordered score-bearing set. Its producer preserves insertion order and does not sort by `switch_probability`.
- `switch_probability` is already the licensed proportion of Monte Carlo samples where the alternative wins when the edge is weak.
- The canonical strength writer supports `preserveDirection`; this lane reuses it and does not change schema or backend contracts.

## Validation

- Focused real/mounted suite: 89 passed.
- Typecheck ratchet: exact baseline, 618 files / 2,485 existing diagnostics; no new errors.
- Full lint: 0 errors; 1,268 pre-existing warnings.
- Production staging-flag build: passed.
- `git diff --check`: passed.
- Local production-preview browser witness on a valid UUID scenario and canonical readiness premise (`options[].id`):
  - unsorted `0.22, 0.548` selects Customer demand at 55%;
  - editor displays exact live `0.6147`;
  - confirm writes `0.6147/user`, preserves `negative/cee`, stays current, and advances to the next unresolved relationship;
  - choosing `0.85` preserves `negative/cee`, marks analysis dirty, and exposes the real rerun control.
  - only expected dummy local BFF failures occurred; no UI exception.

## Rollback / coexistence

- Implementation base / prior good: `12b94aaf86c2874102a8d8ecc3e17ecc268c6487`
- Current staging target: `623aa80043ff4e5083482df9db4ce4ee51d00823`
- Head / exact revert target: `51496dcaad22d88a35e5f5442adf49047c872980`
- Revert: `git revert 51496dcaad22d88a35e5f5442adf49047c872980`
- Current-staging overlap: zero files. Synthetic merge tree `450f2b4421ac8cc088c91e3e9ebb0c127e3efd93` is conflict-free and preserves both this lane's 12 blobs and #713's two citation-copy blobs.
- Functional evidence above is against the frozen P4 head on its original base. Current-staging evidence is structural coexistence only; the head was not rebased or silently extended.

No migration, deployment, merge, destructive change, or unrelated refactor.