### PR TITLE
feat: keep assistant canvas focus independent

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -94,6 +94,7 @@ import { DocumentsManager } from './components/DocumentsManager'
 import { ProvenanceHubTab } from './components/ProvenanceHubTab'
 import { ConnectPrompt } from './components/ConnectPrompt'
 import { FocusModeChip } from './components/FocusModeChip'
+import { AssistantFocusChip } from './components/AssistantFocusChip'
 // EdgeLabelToggle moved to CanvasToolbar for cleaner UI
 import { LimitsPanel } from './components/LimitsPanel'
 import { BottomSheet } from './components/BottomSheet'
@@ -2159,12 +2160,16 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
         onFitView={handleFitView}
         onAutoArrange={handleAutoArrange}
       />
-      {/* Focus Mode Chip - shows when single node selected with path highlighting */}
+      {/* Two independent attention owners may coexist here: assistant focus is
+          dismissible/expiring; FocusModeChip is ordinary user selection. */}
       <div
         className="absolute z-[100] left-1/2 -translate-x-1/2 pointer-events-auto"
         style={{ top: 'calc(var(--topbar-h, 0px) + 1rem)' }}
       >
-        <FocusModeChip />
+        <div className="flex flex-col items-center gap-2">
+          <AssistantFocusChip />
+          <FocusModeChip />
+        </div>
       </div>
 
       {/* Influence Explainer - shown when triggered from TopBar dropdown */}

--- a/src/canvas/components/AssistantFocusChip.tsx
+++ b/src/canvas/components/AssistantFocusChip.tsx
@@ -1,0 +1,64 @@
+/**
+ * Visible ownership + dismissal surface for assistant-directed canvas focus.
+ *
+ * The assistant focus is intentionally independent of FocusModeChip (ordinary
+ * user selection) and the two-second applied-edit pulse. Both chips may be on
+ * screen together without either authority clearing the other.
+ */
+import { memo, useEffect } from 'react'
+import { Sparkles, X } from 'lucide-react'
+import { useCanvasStore } from '../store'
+import {
+  dismissAssistantFocus,
+  useAssistantFocusStore,
+} from '../stores/assistantFocusStore'
+
+export const AssistantFocusChip = memo(function AssistantFocusChip() {
+  const target = useAssistantFocusStore((state) => state.target)
+  const currentScenarioId = useCanvasStore((state) => state.currentScenarioId)
+  const targetExists = useCanvasStore((state) => {
+    if (!target) return false
+    return target.kind === 'edge'
+      ? state.edges.some((edge) => edge.id === target.id)
+      : state.nodes.some((node) => node.id === target.id)
+  })
+
+  const scenarioMatches =
+    target?.scenarioId == null || target.scenarioId === currentScenarioId
+
+  // Deletion and scenario replacement are identity boundaries. Hide in the
+  // same render and retire the authority immediately afterwards; a same-id
+  // node in another scenario must never inherit the prior focus.
+  useEffect(() => {
+    if (target && (!targetExists || !scenarioMatches)) dismissAssistantFocus()
+  }, [target, targetExists, scenarioMatches])
+
+  if (!target || !targetExists || !scenarioMatches) return null
+
+  return (
+    <div
+      className="inline-flex max-w-[min(32rem,calc(100vw-2rem))] items-center gap-2 rounded-full border border-info/40 bg-panel px-3 py-2 shadow-2"
+      role="status"
+      aria-live="polite"
+      data-testid="assistant-focus-chip"
+      data-focus-id={target.id}
+      data-focus-kind={target.kind}
+    >
+      <Sparkles size={15} className="shrink-0 text-info" aria-hidden="true" />
+      <span className="truncate text-sm text-text-body">
+        Olumi focus: <strong className="font-medium">{target.label}</strong>
+      </span>
+      <button
+        type="button"
+        onClick={dismissAssistantFocus}
+        className="shrink-0 rounded-full p-1 text-text-light transition-colors hover:bg-panel-hover hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info motion-reduce:transition-none"
+        aria-label={`Dismiss Olumi focus on ${target.label}`}
+        title="Dismiss focus"
+      >
+        <X size={15} aria-hidden="true" />
+      </button>
+    </div>
+  )
+})
+
+export default AssistantFocusChip

--- a/src/canvas/conversation/__tests__/useConversation.assistantFocusScenarioFence.spec.tsx
+++ b/src/canvas/conversation/__tests__/useConversation.assistantFocusScenarioFence.spec.tsx
@@ -1,0 +1,239 @@
+/**
+ * Delayed V5 response ownership on the mounted production conversation path.
+ *
+ * A and B intentionally reuse the same node id. That makes this regression
+ * distinguish a real response fence from a presentation-only identity check:
+ * without the fence, applyV5State can resolve the id in B, publish an
+ * assistant focus, move the mounted camera bridge, and advance B's stage.
+ */
+import { useState } from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Node } from '@xyflow/react'
+
+import { AssistantFocusChip } from '../../components/AssistantFocusChip'
+import { useCanvasStore } from '../../store'
+import {
+  dismissAssistantFocus,
+  useAssistantFocusStore,
+} from '../../stores/assistantFocusStore'
+import { useResultsStore } from '../../stores/resultsStore'
+import { registerAssistantFocusCamera } from '../../utils/assistantFocusCamera'
+import {
+  ConversationProvider,
+  useConversationContext,
+} from '../ConversationContext'
+
+const mockCallTurn = vi.fn()
+const mockStreamTurn = vi.fn()
+
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockStreamTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+const mockCallV5Turn = vi.fn()
+vi.mock('../../../v5/v5Adapter', () => ({
+  callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+  getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
+}))
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true as const }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+const SCENARIO_A = '11111111-2222-4333-8444-555555555555'
+const SCENARIO_B = '66666666-7777-4888-8999-aaaaaaaaaaaa'
+const SHARED_ID = 'factor-shared'
+const USER_B_ID = 'factor-user-b'
+
+const A_SHARED: Node = {
+  id: SHARED_ID,
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  data: { label: 'Scenario A factor' },
+}
+
+const B_SHARED: Node = {
+  id: SHARED_ID,
+  type: 'factor',
+  position: { x: 400, y: 0 },
+  data: { label: 'Scenario B factor' },
+}
+
+const B_USER_NODE: Node = {
+  id: USER_B_ID,
+  type: 'factor',
+  position: { x: 0, y: 200 },
+  data: { label: 'B user selection' },
+  selected: true,
+}
+
+function lateFocusResponse() {
+  return {
+    kind: 'response' as const,
+    response: {
+      response_version: 2,
+      assistant_text: 'Late answer for scenario A',
+      blocks: [{
+        type: 'ui_directive',
+        verb: 'focus',
+        targets: [{ id: SHARED_ID, kind: 'factor', label: 'Scenario A factor' }],
+        duration_ms: 10_000,
+      }],
+      suggested_actions: [],
+      insights: [],
+      stage_indicator: 'analyse',
+    },
+  }
+}
+
+function Harness() {
+  const { messages, sendMessage } = useConversationContext()
+  const [settled, setSettled] = useState(false)
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          void sendMessage('Question from scenario A').finally(() => setSettled(true))
+        }}
+      >
+        Send from A
+      </button>
+      <output data-testid="turn-state">{settled ? 'settled' : 'pending'}</output>
+      <div data-testid="transcript">
+        {messages.map((message) => <p key={message.id}>{message.content}</p>)}
+      </div>
+      <AssistantFocusChip />
+    </>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  mockCallTurn.mockReset()
+  mockStreamTurn.mockReset()
+  mockCallV5Turn.mockReset()
+  dismissAssistantFocus()
+
+  useResultsStore.setState({
+    results: {
+      status: 'idle',
+      progress: 0,
+      analysisSummary: undefined,
+      lastSnapshotId: undefined,
+    },
+  } as never)
+
+  useCanvasStore.getState().resetCanvas()
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_A,
+    currentStage: 'frame',
+    nodes: [A_SHARED] as never,
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    highlightedNodes: new Set(),
+    highlightedEdges: new Set(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  dismissAssistantFocus()
+  vi.clearAllMocks()
+})
+
+describe('useConversation — delayed response scenario ownership', () => {
+  it('drops an A response after switching to B even when B reuses the focus id', async () => {
+    let resolveResponse!: (value: ReturnType<typeof lateFocusResponse>) => void
+    mockCallV5Turn.mockImplementation(() => new Promise((resolve) => {
+      resolveResponse = resolve
+    }))
+
+    const focusNode = vi.fn()
+    const focusEdge = vi.fn()
+    const unregisterCamera = registerAssistantFocusCamera(focusNode, focusEdge)
+
+    render(
+      <ConversationProvider>
+        <Harness />
+      </ConversationProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send from A' }))
+    await waitFor(() => expect(mockCallV5Turn).toHaveBeenCalledTimes(1))
+    expect(mockCallV5Turn.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ scenario_id: SCENARIO_A }),
+    )
+
+    // The user moves to B while A is still on the wire. B deliberately has
+    // the same target id, plus independent selection and pulse authorities.
+    act(() => {
+      useCanvasStore.setState({
+        currentScenarioId: SCENARIO_B,
+        currentStage: 'frame',
+        nodes: [B_SHARED, B_USER_NODE] as never,
+        edges: [],
+        selection: {
+          nodeIds: new Set([USER_B_ID]),
+          edgeIds: new Set(),
+          anchorPosition: null,
+        },
+        highlightedNodes: new Set([USER_B_ID]),
+        highlightedEdges: new Set(),
+      })
+    })
+
+    await act(async () => {
+      resolveResponse(lateFocusResponse())
+    })
+    await waitFor(() => expect(screen.getByTestId('turn-state')).toHaveTextContent('settled'))
+
+    const live = useCanvasStore.getState()
+    expect(live.currentScenarioId).toBe(SCENARIO_B)
+    expect(live.currentStage).toBe('frame')
+    expect([...live.selection.nodeIds]).toEqual([USER_B_ID])
+    expect([...live.highlightedNodes]).toEqual([USER_B_ID])
+    expect(live.nodes.find((node) => node.id === SHARED_ID)?.data.label).toBe('Scenario B factor')
+
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect(focusNode).not.toHaveBeenCalled()
+    expect(focusEdge).not.toHaveBeenCalled()
+    expect(screen.getByTestId('transcript')).not.toHaveTextContent('Late answer for scenario A')
+
+    unregisterCamera()
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -4317,6 +4317,10 @@ export function useConversation(): UseConversationReturn {
           useCanvasStore.setState({ currentScenarioId: newId })
           setCurrentScenarioId(newId)
         }
+        // Response ownership is the scenario that actually goes on the wire.
+        // Capture it once after lazy UUID allocation; never re-derive it from
+        // the live store when this request eventually settles.
+        const scenarioIdAtDispatch = currentScenarioId
 
         const resolvedTurnType: TurnType = isSystemEvent
           ? 'system_event'
@@ -4347,12 +4351,12 @@ export function useConversation(): UseConversationReturn {
         })
         // Stop-fence: refine the dispatch-time capture with the id that is
         // actually going on the wire — this branch may have minted a scenario.
-        inFlightTurnIdentityRef.current = currentScenarioId
-          ? { scenarioId: currentScenarioId, turnId: turnClientId }
+        inFlightTurnIdentityRef.current = scenarioIdAtDispatch
+          ? { scenarioId: scenarioIdAtDispatch, turnId: turnClientId }
           : inFlightTurnIdentityRef.current
         const build = buildV5Payload({
           turnId: turnClientId,
-          scenarioId: currentScenarioId,
+          scenarioId: scenarioIdAtDispatch,
           stage: derivedStage,
           turnClass: 'frame',
           mode,
@@ -4456,7 +4460,7 @@ export function useConversation(): UseConversationReturn {
           const streamedPreviewStanding = streamedPreviewStandingFor(
             useDraftStore.getState(),
             turnClientId,
-            currentScenarioId,
+            scenarioIdAtDispatch,
           )
           if (mode === 'user' && !hidden && !streamedPreviewStanding) {
             // ROADMAP 2.665 — TRANSCRIPT HONESTY, CORRECTED.
@@ -4580,7 +4584,7 @@ export function useConversation(): UseConversationReturn {
             const streamed = await runStreamedDraftTurn({
               payload: build.payload,
               turnClientId,
-              scenarioIdAtDispatch: currentScenarioId,
+              scenarioIdAtDispatch,
               headers: v5Headers,
               signal: controller.signal,
             })
@@ -4599,6 +4603,20 @@ export function useConversation(): UseConversationReturn {
           if (controller.signal.aborted) {
             if (import.meta.env.DEV) {
               console.warn('[sendTurn V5] Response arrived after abort; discarding')
+            }
+            return
+          }
+
+          // Scenario-response fence: the request belongs to the scenario id
+          // captured in its wire payload. If the user has moved elsewhere,
+          // discard the complete late response before routing it. This must
+          // precede optimistic-edit resolution, transcript delivery updates,
+          // applyV5State (including assistant focus/camera), Phase 3 writes,
+          // and graph receipt ingestion: same element ids may legitimately
+          // exist in two scenarios and must not bridge their authority.
+          if (useCanvasStore.getState().currentScenarioId !== scenarioIdAtDispatch) {
+            if (import.meta.env.DEV) {
+              console.warn('[sendTurn V5] Scenario changed before response; discarding')
             }
             return
           }
@@ -4860,7 +4878,6 @@ export function useConversation(): UseConversationReturn {
             // `streamedDraftTurn.spec.ts`; mutant M2 restores the narrow test.
             const canvasIsEmpty =
               useCanvasStore.getState().nodes.length === 0 || streamedPreviewOwnsCanvas
-            const scenarioIdAtDispatch = currentScenarioId
             // The helper reads analysis_ready, the response-root
             // goal_constraints (ROADMAP 1.22 residual) and the sidecar-borne
             // root `coaching` (Leg 3) off the full parsed response

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -46,6 +46,7 @@ import { existenceCertaintyToLineStyle, calculateEdgeImportance, weightMagnitude
 import { typography } from '../../styles/typography'
 import { useEdgeEditHint } from '../hooks/useFirstTimeHints'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+import { useAssistantFocusStore } from '../stores/assistantFocusStore'
 
 /**
  * StyledEdge with semantic visual properties
@@ -111,6 +112,9 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // here for the new selector rather than adding a third baselined error.
   // Fixing the pre-existing two is a typing change outside this lane's fence.
   const edgeIdKey = String(id)
+  const isAssistantFocused = useAssistantFocusStore(
+    (state) => state.target?.kind === 'edge' && state.target.id === edgeIdKey,
+  )
 
   // ── Consolidated store selectors (2 subscriptions instead of 13) ──
   // Group 1: Core store data (results, review, actions)
@@ -727,6 +731,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         data-analysis-fragile={isAnalysisFragileEdge && !isStructuralEdge ? 'true' : undefined}
+        data-assistant-focused={isAssistantFocused ? 'true' : undefined}
       >
       {/* Invisible hitbox — wider than visual stroke; carries test-id and
           structural tooltip. pointer-events:stroke so the <g> receives events
@@ -741,6 +746,18 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
       >
         {isStructuralEdge && structuralTooltip && <title>{structuralTooltip}</title>}
       </path>
+      {isAssistantFocused && (
+        <path
+          d={edgePath}
+          fill="none"
+          stroke="var(--semantic-info)"
+          strokeWidth={8}
+          opacity={0.32}
+          pointerEvents="none"
+          vectorEffect="non-scaling-stroke"
+          data-testid={`assistant-focus-edge-halo-${edgeIdKey}`}
+        />
+      )}
       <BaseEdge
         id={id}
         path={edgePath}

--- a/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.projection.spec.tsx
@@ -8,9 +8,13 @@
  * (directionColour.spec); the marker composes via a separate CSS channel.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { act, render, cleanup, screen } from '@testing-library/react'
 import { StyledEdge } from '../StyledEdge'
 import { Position } from '@xyflow/react'
+import {
+  activateAssistantFocus,
+  dismissAssistantFocus,
+} from '../../stores/assistantFocusStore'
 
 vi.mock('@xyflow/react', async () => {
   const actual = await vi.importActual('@xyflow/react')
@@ -97,6 +101,7 @@ const edgeProps = {
 
 afterEach(() => {
   cleanup()
+  dismissAssistantFocus()
   analysisHighlight = { source: null, edgeIds: new Set(), nodeIds: new Set() }
 })
 
@@ -122,5 +127,25 @@ describe('StyledEdge — analysis-graph projection marker', () => {
     analysisHighlight = { source: 'drivers', edgeIds: new Set(['e1']), nodeIds: new Set() }
     const { container } = render(<StyledEdge {...(edgeProps as any)} />)
     expect(container.querySelector('g[data-analysis-fragile="true"]')).toBeNull()
+  })
+})
+
+describe('StyledEdge — assistant focus render', () => {
+  it('renders an independent static halo on the exact edge', () => {
+    act(() => {
+      activateAssistantFocus({ id: 'e1', kind: 'edge', label: 'One → Two' })
+    })
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-assistant-focused="true"]')).not.toBeNull()
+    expect(screen.getByTestId('assistant-focus-edge-halo-e1')).toBeInTheDocument()
+  })
+
+  it('discriminating identity: another edge receives no halo', () => {
+    act(() => {
+      activateAssistantFocus({ id: 'e9', kind: 'edge', label: 'Other' })
+    })
+    const { container } = render(<StyledEdge {...(edgeProps as any)} />)
+    expect(container.querySelector('g[data-assistant-focused="true"]')).toBeNull()
+    expect(screen.queryByTestId('assistant-focus-edge-halo-e1')).not.toBeInTheDocument()
   })
 })

--- a/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
+++ b/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
@@ -23,6 +23,11 @@ import { renderHook, act } from '@testing-library/react'
 import { useCanvasStore } from '../../store'
 import { useFocusCamera } from '../useFocusCamera'
 import { focusNodeById, focusEdgeById, fitNodesOnCanvas } from '../../utils/focusHelpers'
+import { focusAssistantTarget } from '../../utils/assistantFocusCamera'
+import {
+  dismissAssistantFocus,
+  useAssistantFocusStore,
+} from '../../stores/assistantFocusStore'
 
 const fitViewSpy = vi.fn()
 const setCenterSpy = vi.fn()
@@ -119,6 +124,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  dismissAssistantFocus()
   vi.restoreAllMocks()
 })
 
@@ -285,5 +291,77 @@ describe('useFocusCamera — F4 no-churn through the real bridge (finding 7)', (
     renderHook(() => useFocusCamera())
     act(() => focusEdgeById('e1'))
     expect(setCenterSpy.mock.calls[0]![2].duration).toBe(0)
+  })
+})
+
+describe('useFocusCamera — assistant focus is camera-only', () => {
+  it('frames a node without changing the user selection, pulse, or focus dim', () => {
+    stubCanvas()
+    useCanvasStore.setState({
+      nodes: NODES.map((candidate) => ({ ...candidate, selected: candidate.id === 'a' })),
+      selection: { nodeIds: new Set(['a']), edgeIds: new Set(), anchorPosition: null },
+      highlightedNodes: new Set(['b']),
+      focusDimSourceId: 'a',
+      dimmedNodeIds: new Set(['far']),
+    } as any)
+    const { result } = renderHook(() => useFocusCamera())
+
+    act(() => {
+      focusAssistantTarget({ id: 'far', kind: 'node', label: 'Far factor' })
+    })
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    expect([...useCanvasStore.getState().selection.nodeIds]).toEqual(['a'])
+    expect(useCanvasStore.getState().nodes.find((candidate) => candidate.id === 'a')?.selected).toBe(true)
+    expect(useCanvasStore.getState().nodes.find((candidate) => candidate.id === 'far')?.selected).not.toBe(true)
+    expect([...useCanvasStore.getState().highlightedNodes]).toEqual(['b'])
+    expect(focusDim()).toBe('a')
+    expect(dimmed()).toEqual(['far'])
+    expect(useAssistantFocusStore.getState().target?.id).toBe('far')
+
+    // The fit's own move-start consumes the exemption but cannot clear the
+    // user's existing focus dim.
+    act(() => emitMoveStart(result.current.onMoveStart))
+    expect(focusDim()).toBe('a')
+  })
+
+  it('frames both endpoints of an off-screen edge without selecting the edge', () => {
+    stubCanvas()
+    useCanvasStore.setState({
+      nodes: NODES.map((candidate) => ({ ...candidate, selected: candidate.id === 'a' })),
+      edges: [{ id: 'edge-far', source: 'a', target: 'far', selected: false }] as any,
+      selection: { nodeIds: new Set(['a']), edgeIds: new Set(), anchorPosition: null },
+    } as any)
+    renderHook(() => useFocusCamera())
+
+    act(() => {
+      focusAssistantTarget({ id: 'edge-far', kind: 'edge', label: 'A → Far' })
+    })
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    expect(fitViewSpy.mock.calls[0]![0].nodes.map((candidate: { id: string }) => candidate.id))
+      .toEqual(['a', 'far'])
+    expect([...useCanvasStore.getState().selection.nodeIds]).toEqual(['a'])
+    expect([...useCanvasStore.getState().selection.edgeIds]).toEqual([])
+    expect(useCanvasStore.getState().edges[0]?.selected).toBe(false)
+  })
+
+  it('does not churn the camera when an assistant edge is already comfortably visible', () => {
+    stubCanvas()
+    renderHook(() => useFocusCamera())
+    act(() => {
+      focusAssistantTarget({ id: 'e1', kind: 'edge', label: 'A → B' })
+    })
+    expect(fitViewSpy).not.toHaveBeenCalled()
+    expect(setCenterSpy).not.toHaveBeenCalled()
+  })
+
+  it('canvas unmount clears the focus so it cannot reappear on a later mount', () => {
+    stubCanvas()
+    const { unmount } = renderHook(() => useFocusCamera())
+    act(() => {
+      focusAssistantTarget({ id: 'a', kind: 'node', label: 'A' })
+    })
+    expect(useAssistantFocusStore.getState().target?.id).toBe('a')
+    act(() => unmount())
+    expect(useAssistantFocusStore.getState().target).toBeNull()
   })
 })

--- a/src/canvas/hooks/useFocusCamera.ts
+++ b/src/canvas/hooks/useFocusCamera.ts
@@ -22,6 +22,8 @@ import { computeFocusPlan } from '../utils/focusNeighbourhood'
 import { readFocusCamera, nodesComfortablyVisible } from '../utils/cameraComfort'
 import { createFocusFitSuppressor } from '../utils/focusLens'
 import { registerFocusHelpers, registerFitNodes } from '../utils/focusHelpers'
+import { registerAssistantFocusCamera } from '../utils/assistantFocusCamera'
+import { dismissAssistantFocus } from '../stores/assistantFocusStore'
 import { usePrefersReducedMotion } from './usePrefersReducedMotion'
 
 export interface FocusCameraHandlers {
@@ -142,6 +144,71 @@ export function useFocusCamera(): FocusCameraHandlers {
   useEffect(() => {
     return registerFocusHelpers(handleFocusNode, handleFocusEdge)
   }, [handleFocusNode, handleFocusEdge])
+
+  // Assistant-directed focus has a separate authority and lifetime from user
+  // selection. These callbacks therefore do camera work ONLY: no `selected`
+  // flags, no selection Set, no focus dim and no highlight pulse writes.
+  // The static marker + dismiss/expiry lifecycle live in assistantFocusStore.
+  const handleAssistantFocusNode = useCallback((nodeId: string) => {
+    const store = useCanvasStore.getState()
+    const camera = readFocusCamera(getViewportRef.current)
+    const plan = computeFocusPlan(nodeId, store.nodes, store.edges, camera)
+    if (!plan || !plan.moveCamera) return
+
+    const focusNodes = store.nodes.filter((node) => plan.focusNodeIds.has(node.id))
+    focusFitSuppressorRef.current.begin()
+    fitViewRef.current({
+      nodes: focusNodes,
+      padding: camera?.padding ?? 0.3,
+      maxZoom: 1.2,
+      duration: cameraDuration(400, reducedMotionRef.current),
+    })
+  }, [])
+
+  const handleAssistantFocusEdge = useCallback((edgeId: string) => {
+    const store = useCanvasStore.getState()
+    const edge = store.edges.find((candidate) => candidate.id === edgeId)
+    if (!edge) return
+    const sourceNode = store.nodes.find((node) => node.id === edge.source)
+    const targetNode = store.nodes.find((node) => node.id === edge.target)
+    if (!sourceNode || !targetNode) return
+
+    const camera = readFocusCamera(getViewportRef.current)
+    const endpointNodes = [sourceNode, targetNode]
+    if (
+      camera &&
+      nodesComfortablyVisible(
+        endpointNodes,
+        camera.viewport,
+        camera.paneWidth,
+        camera.paneHeight,
+        camera.insets,
+      )
+    ) {
+      return
+    }
+
+    focusFitSuppressorRef.current.begin()
+    fitViewRef.current({
+      nodes: endpointNodes,
+      padding: camera?.padding ?? 0.3,
+      maxZoom: 1.2,
+      duration: cameraDuration(400, reducedMotionRef.current),
+    })
+  }, [])
+
+  useEffect(() => {
+    const unregister = registerAssistantFocusCamera(
+      handleAssistantFocusNode,
+      handleAssistantFocusEdge,
+    )
+    return () => {
+      unregister()
+      // Canvas lifetime is the outer bound: a focus must not reappear if the
+      // workspace unmounts/remounts before its timer fires.
+      dismissAssistantFocus()
+    }
+  }, [handleAssistantFocusNode, handleAssistantFocusEdge])
 
   // F4 (graph-visuals): registered multi-node fit — the applied-edit pulse
   // choke point (appliedEditPulse.flush) routes every feeder here so pulse

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -31,6 +31,7 @@ import { NodeShapeIndicator } from './NodeShapeIndicator'
 import { NODE_REGISTRY } from '../domain/nodes'
 import Tooltip from '../../components/Tooltip'
 import { StatusPill } from './shared/StatusPill'
+import { useAssistantFocusStore } from '../stores/assistantFocusStore'
 
 const NODE_TYPE_DESCRIPTIONS: Record<string, string> = {
   decision: 'The choice you\'re making',
@@ -75,6 +76,12 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
   // on every store update. Selecting the entire Set causes infinite loops since
   // Set references change on each store update.
   const isHighlighted = useCanvasStore(s => s.highlightedNodes.has(id))
+  // Assistant focus is a static, independently-owned marker. It does not use
+  // React Flow's `selected` prop and does not enter the transient highlight
+  // Set, so it can coexist with both without borrowing either lifetime.
+  const isAssistantFocused = useAssistantFocusStore(
+    (state) => state.target?.kind === 'node' && state.target.id === id,
+  )
   // N3: edited since the last analysis run (amber corner dot; undefined-safe
   // for node-spec store doubles without the slice).
   const isEditedSinceRun = useCanvasStore(s => s.editedSinceRunNodeIds?.has(id) === true)
@@ -240,6 +247,7 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
       {...(isIncomplete ? { 'data-testid': nodeType === 'goal' ? 'overlay-missing-threshold-node' : 'overlay-missing-value' } : {})}
       {...(nodeType === 'factor' && data?.category === 'external' ? { title: 'Outside your control' } : {})}
       {...(isAnalysisDriver ? { 'data-analysis-driver': 'true' } : {})}
+      {...(isAssistantFocused ? { 'data-assistant-focused': 'true' } : {})}
       className={`
         relative rounded-lg ${isCausalLens ? 'border' : isIncomplete ? 'border-2' : borderWidth} shadow-1
         ${isCausalLens ? (causalBorderClass ?? '') : isIncomplete ? 'border-warning border-dashed' : borderClassOverride ?? `${colors.border} ${borderStyle}`}
@@ -274,6 +282,14 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
         minHeight: isExpanded ? '120px' : undefined,
       }}
     >
+      {isAssistantFocused && (
+        <span
+          aria-hidden="true"
+          data-testid={`assistant-focus-node-halo-${id}`}
+          className="pointer-events-none absolute -inset-1 z-[1] rounded-xl border-2 border-info ring-2 ring-info/30 ring-offset-1"
+        />
+      )}
+
       {/* Context menu: Assumption flag badge (Hard rule 3 — UI-only annotation) */}
       {Boolean(data?.flagged_as_assumption) && (
         <div

--- a/src/canvas/nodes/__tests__/BaseNode.assistantFocus.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.assistantFocus.spec.tsx
@@ -1,0 +1,111 @@
+/** Actual node render: assistant focus is a static overlay, not selection/pulse. */
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { Circle } from 'lucide-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BaseNode } from '../BaseNode'
+import { useCanvasStore } from '../../store'
+import {
+  activateAssistantFocus,
+  dismissAssistantFocus,
+} from '../../stores/assistantFocusStore'
+import {
+  __resetAppliedEditPulseForTests,
+  PULSE_COALESCE_MS,
+  PULSE_DURATION_MS,
+  pulseAppliedTargets,
+} from '../../utils/appliedEditPulse'
+
+const props = {
+  id: 'factor-focus',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  selected: true,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  zIndex: 0,
+  data: { label: 'Demand', type: 'factor', observed_state: { value: 4 } },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  __resetAppliedEditPulseForTests()
+  dismissAssistantFocus()
+  useCanvasStore.setState({
+    nodes: [props] as never,
+    edges: [],
+    highlightedNodes: new Set<string>(),
+    dimmedNodeIds: new Set<string>(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  __resetAppliedEditPulseForTests()
+  dismissAssistantFocus()
+  vi.useRealTimers()
+})
+
+describe('BaseNode — assistant focus render', () => {
+  it('adds and removes its own halo while the selected prop remains user-owned', () => {
+    render(
+      <ReactFlowProvider>
+        <BaseNode {...(props as any)} nodeType="factor" icon={Circle} />
+      </ReactFlowProvider>,
+    )
+    const node = screen.getByRole('group', { name: /factor node: demand/i })
+    expect(node).not.toHaveAttribute('data-assistant-focused')
+
+    act(() => {
+      activateAssistantFocus({ id: props.id, kind: 'node', label: 'Demand' })
+    })
+    expect(node).toHaveAttribute('data-assistant-focused', 'true')
+    expect(screen.getByTestId(`assistant-focus-node-halo-${props.id}`)).toBeInTheDocument()
+    // Selection styling still comes only from the selected prop.
+    expect(node.className).toContain('ring-factor/50')
+
+    act(() => dismissAssistantFocus())
+    expect(node).not.toHaveAttribute('data-assistant-focused')
+    expect(node.className).toContain('ring-factor/50')
+  })
+
+  it('discriminating identity: a different node id does not receive the halo', () => {
+    act(() => {
+      activateAssistantFocus({ id: 'factor-other', kind: 'node', label: 'Other' })
+    })
+    render(
+      <ReactFlowProvider>
+        <BaseNode {...(props as any)} nodeType="factor" icon={Circle} />
+      </ReactFlowProvider>,
+    )
+    expect(screen.getByRole('group', { name: /factor node: demand/i }))
+      .not.toHaveAttribute('data-assistant-focused')
+  })
+
+  it('remains visibly focused after the production 2s edit pulse has ended', () => {
+    render(
+      <ReactFlowProvider>
+        <BaseNode {...(props as any)} selected={false} nodeType="factor" icon={Circle} />
+      </ReactFlowProvider>,
+    )
+    const node = screen.getByRole('group', { name: /factor node: demand/i })
+
+    act(() => {
+      pulseAppliedTargets({ nodeIds: [props.id] })
+      vi.advanceTimersByTime(PULSE_COALESCE_MS)
+    })
+    expect(node.className).toContain('ai-highlight-pulse')
+
+    act(() => {
+      activateAssistantFocus({ id: props.id, kind: 'node', label: 'Demand' })
+    })
+    expect(node).toHaveAttribute('data-assistant-focused', 'true')
+
+    act(() => vi.advanceTimersByTime(PULSE_DURATION_MS))
+    expect(node.className).not.toContain('ai-highlight-pulse')
+    expect(node).toHaveAttribute('data-assistant-focused', 'true')
+    expect(screen.getByTestId(`assistant-focus-node-halo-${props.id}`)).toBeInTheDocument()
+  })
+})

--- a/src/canvas/stores/__tests__/assistantFocusStore.spec.ts
+++ b/src/canvas/stores/__tests__/assistantFocusStore.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ASSISTANT_FOCUS_DEFAULT_DURATION_MS,
+  activateAssistantFocus,
+  dismissAssistantFocus,
+  normaliseAssistantFocusDuration,
+  useAssistantFocusStore,
+} from '../assistantFocusStore'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-15T01:00:00Z'))
+  dismissAssistantFocus()
+})
+
+afterEach(() => {
+  dismissAssistantFocus()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('assistantFocusStore — independent bounded lifetime', () => {
+  it('uses the bounded default and expires without touching another store', () => {
+    activateAssistantFocus({ id: 'n1', kind: 'node', label: 'Demand' })
+    const target = useAssistantFocusStore.getState().target
+    expect(target).toMatchObject({ id: 'n1', kind: 'node', label: 'Demand' })
+    expect(target?.expiresAt).toBe(Date.now() + ASSISTANT_FOCUS_DEFAULT_DURATION_MS)
+
+    vi.advanceTimersByTime(ASSISTANT_FOCUS_DEFAULT_DURATION_MS - 1)
+    expect(useAssistantFocusStore.getState().target?.id).toBe('n1')
+    vi.advanceTimersByTime(1)
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+  })
+
+  it('identity swap: an old queued expiry cannot clear the newer focus', () => {
+    const queued: Array<() => void> = []
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+      queued.push(callback as () => void)
+      return queued.length as unknown as ReturnType<typeof setTimeout>
+    }) as unknown as typeof setTimeout)
+    // Model the hard race: cancellation has no effect because the old callback
+    // is already queued at the event-loop boundary.
+    vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => undefined)
+
+    activateAssistantFocus({ id: 'node-a', kind: 'node', label: 'A', durationMs: 500 })
+    activateAssistantFocus({ id: 'node-b', kind: 'node', label: 'B', durationMs: 10_000 })
+    expect(queued).toHaveLength(2)
+
+    queued[0]!()
+    expect(useAssistantFocusStore.getState().target?.id).toBe('node-b')
+    queued[1]!()
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+  })
+
+  it('defensively clamps bypass callers to the published 500–10,000 ms bounds', () => {
+    expect(normaliseAssistantFocusDuration(-50)).toBe(500)
+    expect(normaliseAssistantFocusDuration(801.6)).toBe(802)
+    expect(normaliseAssistantFocusDuration(90_000)).toBe(10_000)
+    expect(normaliseAssistantFocusDuration(Number.NaN)).toBe(10_000)
+  })
+
+  it('is session-memory only: activation writes neither local nor session storage', () => {
+    const storageWrite = vi.spyOn(Storage.prototype, 'setItem')
+    activateAssistantFocus({ id: 'n1', kind: 'node', label: 'Demand' })
+    expect(storageWrite).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/stores/assistantFocusStore.ts
+++ b/src/canvas/stores/assistantFocusStore.ts
@@ -1,0 +1,108 @@
+/**
+ * Session-only authority for an assistant-directed canvas focus.
+ *
+ * This is deliberately not part of React Flow selection and deliberately not
+ * one of the applied-edit highlight Sets:
+ *
+ *   - selection is authored by the user and may be carried on the next turn;
+ *   - highlightedNodes/highlightedEdges own the short applied-edit pulse;
+ *   - this store owns one persistent, explicitly dismissible assistant focus.
+ *
+ * A focus expires even when it is not dismissed. The token check in the timer
+ * is load-bearing: an old target's timer must never clear a newer target after
+ * an identity swap.
+ */
+import { create } from 'zustand'
+
+export const ASSISTANT_FOCUS_MIN_DURATION_MS = 500
+export const ASSISTANT_FOCUS_MAX_DURATION_MS = 10_000
+// Default to the wire contract's longest permitted window: this makes focus
+// meaningfully persistent beyond the 2s edit pulse, while the explicit close
+// action and hard 10s ceiling prevent a stale, indefinite assistant takeover.
+export const ASSISTANT_FOCUS_DEFAULT_DURATION_MS = ASSISTANT_FOCUS_MAX_DURATION_MS
+
+export type AssistantFocusKind = 'node' | 'edge'
+
+export interface AssistantFocusTarget {
+  id: string
+  kind: AssistantFocusKind
+  label: string
+  /** Scenario identity at dispatch, when one exists. Never persisted. */
+  scenarioId: string | null
+  expiresAt: number
+  /** Monotonic timer ownership token; not a graph identity. */
+  token: number
+}
+
+export interface ActivateAssistantFocusInput {
+  id: string
+  kind: AssistantFocusKind
+  label: string
+  scenarioId?: string | null
+  durationMs?: number
+}
+
+interface AssistantFocusState {
+  target: AssistantFocusTarget | null
+  activate: (input: ActivateAssistantFocusInput) => void
+  dismiss: () => void
+}
+
+let expiryTimer: ReturnType<typeof setTimeout> | null = null
+let nextToken = 0
+
+function cancelExpiryTimer(): void {
+  if (expiryTimer === null) return
+  clearTimeout(expiryTimer)
+  expiryTimer = null
+}
+
+/** Defensive clamp for callers that bypass the already-bounded wire schema. */
+export function normaliseAssistantFocusDuration(durationMs: unknown): number {
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs)) {
+    return ASSISTANT_FOCUS_DEFAULT_DURATION_MS
+  }
+  return Math.min(
+    ASSISTANT_FOCUS_MAX_DURATION_MS,
+    Math.max(ASSISTANT_FOCUS_MIN_DURATION_MS, Math.round(durationMs)),
+  )
+}
+
+export const useAssistantFocusStore = create<AssistantFocusState>((set, get) => ({
+  target: null,
+  activate: (input) => {
+    cancelExpiryTimer()
+    const durationMs = normaliseAssistantFocusDuration(input.durationMs)
+    const token = ++nextToken
+    set({
+      target: {
+        id: input.id,
+        kind: input.kind,
+        label: input.label,
+        scenarioId: input.scenarioId ?? null,
+        expiresAt: Date.now() + durationMs,
+        token,
+      },
+    })
+    expiryTimer = setTimeout(() => {
+      // A replaced focus owns a different token. Its predecessor's queued
+      // callback is therefore harmless even if cancellation raced with it.
+      if (get().target?.token !== token) return
+      expiryTimer = null
+      set({ target: null })
+    }, durationMs)
+  },
+  dismiss: () => {
+    cancelExpiryTimer()
+    if (get().target === null) return
+    set({ target: null })
+  },
+}))
+
+export function activateAssistantFocus(input: ActivateAssistantFocusInput): void {
+  useAssistantFocusStore.getState().activate(input)
+}
+
+export function dismissAssistantFocus(): void {
+  useAssistantFocusStore.getState().dismiss()
+}

--- a/src/canvas/utils/assistantFocusCamera.ts
+++ b/src/canvas/utils/assistantFocusCamera.ts
@@ -1,0 +1,45 @@
+/**
+ * Imperative bridge for assistant-directed canvas focus.
+ *
+ * The registered camera callbacks may move the viewport, but they must never
+ * write ordinary React Flow selection or the transient applied-edit pulse.
+ * Visual/lifetime authority lives in assistantFocusStore; this bridge only
+ * asks the mounted canvas to frame the exact target.
+ */
+import {
+  activateAssistantFocus,
+  type ActivateAssistantFocusInput,
+} from '../stores/assistantFocusStore'
+
+type AssistantNodeCameraFn = (nodeId: string) => void
+type AssistantEdgeCameraFn = (edgeId: string) => void
+
+let nodeCameraImpl: AssistantNodeCameraFn | null = null
+let edgeCameraImpl: AssistantEdgeCameraFn | null = null
+
+export function registerAssistantFocusCamera(
+  focusNode: AssistantNodeCameraFn,
+  focusEdge: AssistantEdgeCameraFn,
+): () => void {
+  nodeCameraImpl = focusNode
+  edgeCameraImpl = focusEdge
+  return () => {
+    // Ownership guard: stale cleanup from an old canvas mount cannot remove a
+    // newer mount's callbacks.
+    if (nodeCameraImpl === focusNode) {
+      nodeCameraImpl = null
+      edgeCameraImpl = null
+    }
+  }
+}
+
+/**
+ * Publish the persistent visual focus, then frame it when a canvas is mounted.
+ * Store publication does not depend on camera availability, so the dispatcher
+ * never reports a selection mutation as a substitute for missing camera work.
+ */
+export function focusAssistantTarget(input: ActivateAssistantFocusInput): void {
+  activateAssistantFocus(input)
+  if (input.kind === 'edge') edgeCameraImpl?.(input.id)
+  else nodeCameraImpl?.(input.id)
+}

--- a/src/v5/__tests__/applyV5State.uiDirective.test.ts
+++ b/src/v5/__tests__/applyV5State.uiDirective.test.ts
@@ -9,8 +9,9 @@
  *
  * - `highlight` targets join the SAME coalesced pulse the applied-edit path
  *   uses (fail-closed in-graph filter, one 2s ring, no viewport movement).
- * - `focus` centres the viewport on a single target via the guidance
- *   click-to-focus seam (focusNodeById / focusEdgeById).
+ * - `focus` publishes a separately-owned, dismissible/expiring assistant
+ *   focus and asks its camera-only bridge to frame one target. It never
+ *   borrows ordinary user selection.
  * - `open_inspector` selects a single target via the user-selection seam
  *   (selectNodeWithoutHistory / selectEdgeWithoutHistory) so inspector-v2
  *   opens/retargets — selection only, no camera move.
@@ -34,13 +35,9 @@ vi.mock('../../canvas/utils/appliedEditPulse', () => ({
   PULSE_DURATION_MS: 2000,
 }))
 
-const { focusNodeMock, focusEdgeMock } = vi.hoisted(() => ({
-  focusNodeMock: vi.fn(),
-  focusEdgeMock: vi.fn(),
-}))
-vi.mock('../../canvas/utils/focusHelpers', () => ({
-  focusNodeById: focusNodeMock,
-  focusEdgeById: focusEdgeMock,
+const { assistantFocusMock } = vi.hoisted(() => ({ assistantFocusMock: vi.fn() }))
+vi.mock('../../canvas/utils/assistantFocusCamera', () => ({
+  focusAssistantTarget: assistantFocusMock,
 }))
 
 import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
@@ -74,6 +71,7 @@ function makeStore(
     goalConstraints: null,
     nodes,
     edges,
+    currentScenarioId: 'scenario-a',
   }
 }
 
@@ -84,8 +82,7 @@ const directive = (
 
 beforeEach(() => {
   pulseMock.mockClear()
-  focusNodeMock.mockClear()
-  focusEdgeMock.mockClear()
+  assistantFocusMock.mockClear()
 })
 
 describe('applyV5State — ui_directive dispatcher (R4)', () => {
@@ -142,29 +139,39 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
   })
 
   // ── focus ────────────────────────────────────────────────────────────────
-  it('focus verb centres the viewport on a NODE via focusNodeById (guidance seam)', () => {
+  it('focus verb publishes a NODE to the separate assistant-focus authority', () => {
     const result = applyV5State(
       baseResponse({
         blocks: [directive('focus', [{ id: 'opt_a', label: 'A', kind: 'option' }])],
       }),
       makeStore([{ id: 'opt_a', data: {} } as never]),
     )
-    expect(focusNodeMock).toHaveBeenCalledTimes(1)
-    expect(focusNodeMock).toHaveBeenCalledWith('opt_a')
-    expect(focusEdgeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).toHaveBeenCalledTimes(1)
+    expect(assistantFocusMock).toHaveBeenCalledWith({
+      id: 'opt_a',
+      kind: 'node',
+      label: 'opt_a',
+      scenarioId: 'scenario-a',
+      durationMs: undefined,
+    })
     expect(pulseMock).not.toHaveBeenCalled()
     expect(result.applied).toContain('ui_directive:focus:opt_a')
   })
 
-  it('focus verb centres the viewport on an EDGE via focusEdgeById', () => {
+  it('focus verb publishes an EDGE with its live endpoint labels', () => {
     const result = applyV5State(
       baseResponse({
         blocks: [directive('focus', [{ id: 'e1', label: 'Influence', kind: 'edge' }])],
       }),
       makeStore([], [{ id: 'e1', source: 'a', target: 'b' } as never]),
     )
-    expect(focusEdgeMock).toHaveBeenCalledWith('e1')
-    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).toHaveBeenCalledWith({
+      id: 'e1',
+      kind: 'edge',
+      label: 'a → b',
+      scenarioId: 'scenario-a',
+      durationMs: undefined,
+    })
     expect(result.applied).toContain('ui_directive:focus:e1')
   })
 
@@ -175,8 +182,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
       }),
       makeStore([{ id: 'opt_a', data: {} } as never]),
     )
-    expect(focusNodeMock).not.toHaveBeenCalled()
-    expect(focusEdgeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).not.toHaveBeenCalled()
     expect(result.applied.some((a) => a.startsWith('ui_directive:focus'))).toBe(false)
     expect(
       result.deferred.some(
@@ -200,8 +206,8 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
         { id: 'opt_b', data: {} } as never,
       ]),
     )
-    expect(focusNodeMock).toHaveBeenCalledTimes(1)
-    expect(focusNodeMock).toHaveBeenCalledWith('opt_a')
+    expect(assistantFocusMock).toHaveBeenCalledTimes(1)
+    expect(assistantFocusMock.mock.calls[0]![0]).toMatchObject({ id: 'opt_a', kind: 'node' })
     expect(result.applied).toContain('ui_directive:focus:opt_a')
     expect(
       result.deferred.some(
@@ -221,7 +227,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
     )
     expect(store.selectNodeWithoutHistory).toHaveBeenCalledWith('opt_a')
     expect(store.selectEdgeWithoutHistory).not.toHaveBeenCalled()
-    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).not.toHaveBeenCalled()
     expect(pulseMock).not.toHaveBeenCalled()
     expect(result.applied).toContain('ui_directive:open_inspector:opt_a')
   })
@@ -265,7 +271,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
       makeStore(),
     )
     expect(pulseMock).not.toHaveBeenCalled()
-    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).not.toHaveBeenCalled()
     expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(true)
   })
 
@@ -297,7 +303,7 @@ describe('applyV5State — ui_directive dispatcher (R4)', () => {
         { id: 'opt_b', data: {} } as never,
       ]),
     )
-    expect(focusNodeMock).toHaveBeenCalledTimes(1)
+    expect(assistantFocusMock).toHaveBeenCalledTimes(1)
     expect(pulseMock).not.toHaveBeenCalled()
     expect(result.deferred.some((d) => d.reason === 'ui_directive_rate_limited')).toBe(true)
   })
@@ -519,7 +525,7 @@ describe('applyV5State — ui_directive panel verbs (0.32.0, P3)', () => {
       makeStore([{ id: 'opt_a', data: {} } as never]),
     )
     expect(result.applied).toContain('ui_directive:open_panel:compare')
-    expect(focusNodeMock).not.toHaveBeenCalled()
+    expect(assistantFocusMock).not.toHaveBeenCalled()
     expect(result.deferred.some((d) => d.reason === 'ui_directive_rate_limited')).toBe(true)
   })
 
@@ -556,8 +562,7 @@ describe('applyV5State — ui_directive panel verbs (0.32.0, P3)', () => {
       expect(store.setGoalConstraints).not.toHaveBeenCalled()
       expect(result.deferred.some((d) => d.reason === 'ui_directive_verb_deferred')).toBe(false)
       expect(pulseMock).not.toHaveBeenCalled()
-      expect(focusNodeMock).not.toHaveBeenCalled()
-      expect(focusEdgeMock).not.toHaveBeenCalled()
+      expect(assistantFocusMock).not.toHaveBeenCalled()
     }
   })
 

--- a/src/v5/__tests__/assistantFocus.mounted.spec.tsx
+++ b/src/v5/__tests__/assistantFocus.mounted.spec.tsx
@@ -1,0 +1,178 @@
+/**
+ * Mounted production seam for ui_directive:focus.
+ *
+ * Drives the real applicator into the real assistant-focus store and renders
+ * the real dismissal surface. The discriminating controls prove that user
+ * selection remains the sole outbound-grounding authority and that the
+ * transient pulse Sets are untouched.
+ */
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Node } from '@xyflow/react'
+import type { OlumiResponse } from '@talchain/schemas/boundary'
+import { AssistantFocusChip } from '../../canvas/components/AssistantFocusChip'
+import { useCanvasStore } from '../../canvas/store'
+import {
+  dismissAssistantFocus,
+  useAssistantFocusStore,
+} from '../../canvas/stores/assistantFocusStore'
+import { buildV5Payload } from '../buildPayload'
+import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+
+const USER_NODE = {
+  id: 'factor-user',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  data: { label: 'User selected', type: 'factor' },
+  selected: true,
+} as Node
+
+const ASSISTANT_NODE = {
+  id: 'factor-assistant',
+  type: 'factor',
+  position: { x: 300, y: 0 },
+  data: { label: 'Assistant target', type: 'factor' },
+  selected: false,
+} as Node
+
+function responseFor(id: string, durationMs = 10_000): OlumiResponse {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [{
+      type: 'ui_directive',
+      verb: 'focus',
+      targets: [{ id, label: 'Producer label is not the authority', kind: 'factor' }],
+      duration_ms: durationMs,
+    }],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'frame',
+  } as OlumiResponse
+}
+
+function apply(response: OlumiResponse) {
+  const store = useCanvasStore.getState()
+  return applyV5State(response, {
+    ...store,
+    currentResultsHash: store.results.hash ?? null,
+  } as unknown as V5ApplicatorStore)
+}
+
+function messagePayload() {
+  const result = buildV5Payload({
+    turnId: '11111111-1111-4111-8111-111111111111',
+    scenarioId: '22222222-2222-4222-8222-222222222222',
+    stage: 'frame',
+    turnClass: 'clarify',
+    mode: 'user',
+    message: 'Why does this matter?',
+  })
+  if (!result.ok) throw new Error(result.reason)
+  return result.payload as Extract<typeof result.payload, { kind: 'message' }>
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  dismissAssistantFocus()
+  useCanvasStore.setState({
+    currentScenarioId: 'scenario-a',
+    nodes: [USER_NODE, ASSISTANT_NODE] as never,
+    edges: [],
+    selection: {
+      nodeIds: new Set([USER_NODE.id]),
+      edgeIds: new Set<string>(),
+      anchorPosition: null,
+    },
+    highlightedNodes: new Set([USER_NODE.id]),
+    highlightedEdges: new Set<string>(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  dismissAssistantFocus()
+  vi.useRealTimers()
+})
+
+describe('ui_directive focus — mounted browser surface', () => {
+  it('renders a persistent, dismissible focus without changing selection, pulse, or grounding', () => {
+    render(<AssistantFocusChip />)
+    let result!: ReturnType<typeof apply>
+    act(() => {
+      result = apply(responseFor(ASSISTANT_NODE.id))
+    })
+
+    const chip = screen.getByTestId('assistant-focus-chip')
+    expect(chip).toHaveAttribute('data-focus-id', ASSISTANT_NODE.id)
+    // Live canvas identity/copy wins over the producer's potentially stale label.
+    expect(chip).toHaveTextContent('Olumi focus: Assistant target')
+    expect(result.applied).toContain(`ui_directive:focus:${ASSISTANT_NODE.id}`)
+
+    const canvas = useCanvasStore.getState()
+    expect([...canvas.selection.nodeIds]).toEqual([USER_NODE.id])
+    expect(canvas.nodes.find((node) => node.id === USER_NODE.id)?.selected).toBe(true)
+    expect(canvas.nodes.find((node) => node.id === ASSISTANT_NODE.id)?.selected).toBe(false)
+    expect([...canvas.highlightedNodes]).toEqual([USER_NODE.id])
+    expect(messagePayload().selected_elements).toEqual([
+      { id: USER_NODE.id, kind: 'factor', label: 'User selected' },
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss olumi focus/i }))
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+    expect([...useCanvasStore.getState().selection.nodeIds]).toEqual([USER_NODE.id])
+  })
+
+  it("expires at duration_ms while preserving the user's selection", () => {
+    render(<AssistantFocusChip />)
+    act(() => {
+      apply(responseFor(ASSISTANT_NODE.id, 500))
+    })
+    expect(screen.getByTestId('assistant-focus-chip')).toBeInTheDocument()
+
+    act(() => vi.advanceTimersByTime(499))
+    expect(screen.getByTestId('assistant-focus-chip')).toBeInTheDocument()
+    act(() => vi.advanceTimersByTime(1))
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect([...useCanvasStore.getState().selection.nodeIds]).toEqual([USER_NODE.id])
+  })
+
+  it('negative control: an unknown identity renders nothing and records a truthful defer', () => {
+    render(<AssistantFocusChip />)
+    let result!: ReturnType<typeof apply>
+    act(() => {
+      result = apply(responseFor('ghost-node'))
+    })
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+    expect(result.applied.some((entry) => entry.startsWith('ui_directive:focus'))).toBe(false)
+    expect(result.deferred).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reason: 'ui_directive_target_not_found', detail: 'ghost-node' }),
+    ]))
+  })
+
+  it('scenario identity swap clears even when the next graph reuses the same node id', () => {
+    render(<AssistantFocusChip />)
+    act(() => {
+      apply(responseFor(ASSISTANT_NODE.id))
+    })
+    expect(screen.getByTestId('assistant-focus-chip')).toBeInTheDocument()
+
+    act(() => {
+      useCanvasStore.setState({ currentScenarioId: 'scenario-b' })
+    })
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+  })
+
+  it('target deletion clears the focus rather than leaving a ghost chip', () => {
+    render(<AssistantFocusChip />)
+    act(() => {
+      apply(responseFor(ASSISTANT_NODE.id))
+      useCanvasStore.setState({ nodes: [USER_NODE] as never })
+    })
+    expect(screen.queryByTestId('assistant-focus-chip')).not.toBeInTheDocument()
+    expect(useAssistantFocusStore.getState().target).toBeNull()
+  })
+})

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -22,8 +22,9 @@
  *      normalisation) writes nothing. Also: ui_directive verbs
  *      (highlight / focus / open_inspector on graph targets; 0.32.0 adds
  *      open_panel / open_section on `ui_target`) — the AI's "point at the
- *      graph" and "open this surface" gestures, each reusing the seam its
- *      user-driven equivalent uses.
+ *      graph" and "open this surface" gestures. `focus` owns a distinct,
+ *      expiring assistant-focus authority: it never writes ordinary user
+ *      selection and never enters outbound grounding.
  *   3. analysis_result.enrichment.decision_review → runMeta. TWO different
  *      payloads share that key and go to two different fields: the live 0.30
  *      shape → `runMeta.decisionReview030`, the M1 REST shape →
@@ -52,7 +53,7 @@ import type { CeeDecisionReviewPayloadV1 } from '../types/cee'
 import type { ScenarioStage } from '../types/scenario'
 import { logV5StateStep } from './debugLog'
 import { pulseAppliedTargets } from '../canvas/utils/appliedEditPulse'
-import { focusNodeById, focusEdgeById } from '../canvas/utils/focusHelpers'
+import { focusAssistantTarget } from '../canvas/utils/assistantFocusCamera'
 import {
   useUIStore,
   type OutputTab,
@@ -81,6 +82,8 @@ export interface V5ApplicatorStore {
   updateEdgeData: (id: string, data: Partial<Record<string, unknown>>) => void
   nodes: Node[]
   edges: Edge[]
+  /** Optional session identity used to stop a focus crossing scenario boundaries. */
+  currentScenarioId?: string | null
   /** Partial merge into runMeta — only provided fields are updated. */
   setRunMeta: (meta: {
     ceeReviewV1: CeeDecisionReviewPayloadV1 | null
@@ -755,9 +758,11 @@ export function applyV5State(
       //                       ring, fail-closed in-graph filter, no viewport
       //                       or selection change) — the AI cannot hijack what
       //                       the user is doing.
-      //   - focus          → focusNodeById / focusEdgeById, the guidance
-      //                       click-to-focus seam (centre viewport + select +
-      //                       brief glow). Single-target.
+      //   - focus          → assistantFocusStore + its camera-only bridge.
+      //                       Persistent static marker + visible dismissal +
+      //                       bounded expiry. It never writes ordinary user
+      //                       selection or the outbound-grounding authority.
+      //                       Single-target.
       //   - open_inspector → selectNodeWithoutHistory / selectEdgeWithoutHistory,
       //                       the user-selection seam that opens/retargets
       //                       inspector-v2. Selection only, no camera move.
@@ -774,7 +779,8 @@ export function applyV5State(
       //                       "See all relationships" handoff (0.32.0, P3).
       //                       Dispatches on `ui_target` {kind:'model_section'}.
       // Unknown verbs (a newer producer) defer fail-closed. duration_ms is a
-      // producer hint not yet honoured (the highlight ring is a fixed 2s).
+      // duration_ms remains irrelevant to the fixed 2s highlight pulse, but
+      // it owns the bounded lifetime of an assistant focus.
       // Every verb is fail-closed on its target: an off-canvas / unknown graph
       // id is recorded not-found and never executed, and a panel verb with a
       // missing or verb-mismatched ui_target defers without executing (keeps
@@ -862,10 +868,10 @@ export function applyV5State(
         for (const t of targets) {
           if (!t?.id) continue
           const isEdge = t.kind === 'edge'
-          const exists = isEdge
-            ? store.edges.some((e) => e.id === t.id)
-            : store.nodes.some((n) => n.id === t.id)
-          if (!exists) {
+          const graphTarget = isEdge
+            ? store.edges.find((e) => e.id === t.id)
+            : store.nodes.find((n) => n.id === t.id)
+          if (!graphTarget) {
             deferred.push({
               reason: 'ui_directive_target_not_found',
               block,
@@ -891,8 +897,23 @@ export function applyV5State(
             continue
           }
           if (verb === 'focus') {
-            if (isEdge) focusEdgeById(t.id)
-            else focusNodeById(t.id)
+            const labelOfNode = (nodeId: string): string => {
+              const node = store.nodes.find((candidate) => candidate.id === nodeId)
+              const rawLabel = (node?.data as { label?: unknown } | undefined)?.label
+              return typeof rawLabel === 'string' && rawLabel.trim().length > 0
+                ? rawLabel.trim()
+                : nodeId
+            }
+            const targetLabel = isEdge
+              ? `${labelOfNode((graphTarget as Edge).source)} → ${labelOfNode((graphTarget as Edge).target)}`
+              : labelOfNode(t.id)
+            focusAssistantTarget({
+              id: t.id,
+              kind: isEdge ? 'edge' : 'node',
+              label: targetLabel,
+              scenarioId: store.currentScenarioId ?? null,
+              durationMs: block.duration_ms,
+            })
             applied.push(`ui_directive:focus:${t.id}`)
             singleTargetActioned = true
           } else {
@@ -1311,4 +1332,3 @@ function isStaleTurn(options?: ApplyV5StateOptions): boolean {
   if (!current || !incoming) return false
   return incoming !== current
 }
-


### PR DESCRIPTION
## What changed

- Replaces assistant `ui_directive:focus` reuse of the human selection helper with a separate, session-only assistant-focus authority.
- Adds exact node/edge focus halos plus a visible `Olumi focus` chip with explicit dismissal.
- Keeps camera framing camera-only: it never writes React Flow selection, the transient applied-edit pulse, focus dimming, or outbound `selected_elements`.
- Gives assistant focus a bounded 500–10,000 ms lifetime (10,000 ms default), safe replacement tokens, and clearing on expiry, dismissal, target deletion, scenario change, canvas unmount, and reload.

## Why

The previous focus directive called the same helper as a human focus action. That helper selected the target, so an assistant gesture could silently replace the user's selection and then ride the next request as grounding. This lane separates the three authorities and lifetimes: user selection, the two-second edit pulse, and assistant-directed focus.

## User impact

Olumi can visibly keep attention on one live canvas element long enough to be useful without stealing what the user is editing or changing what the next turn is grounded on. The chip names the live canvas target, can be dismissed, and expires automatically.

## Rollback

- Exact prior good / PR base: `ab5662b2d055a76b36c6d973b3825c4034508b14` (staging after #715)
- Lane commits: `11ff5e4d9a0852c0a9d12aa6060753f6fff915c4` (capability) then `8042891494df6070a397b2172ff73befde69efad` (late-response scenario fence); exact PR head is `8042891494df6070a397b2172ff73befde69efad`.
- Before merge, exact full-lane reversal is `git revert 8042891494df6070a397b2172ff73befde69efad` followed by `git revert 11ff5e4d9a0852c0a9d12aa6060753f6fff915c4`. After merge, revert the eventual #716 merge/squash commit.
- No schema, persistence, migration, or data change. Reverting the full lane restores the prior focus behavior without reverting #715 or #714.
- Coexistence: zero changed-file overlap with merged #715 or frozen #714. The exact synthetic #714 merge is conflict-free; assistant focus deliberately does not write the selection authority consumed by #715.

## Validation

- 84/84 focused + merged-#715 selection-carriage tests pass on exact base `ab5662b2…`.
- 66/66 assistant-focus/applicator/render/camera tests pass.
- Exact-base typecheck ratchet passes at the existing 2,485-diagnostic baseline.
- Full lint passes with 0 errors; hook ratchet exactly matches its 232 known violations.
- Production build passes.
- Mounted controls cover live-label identity, replacement-timer race, explicit dismissal, duration expiry, unknown ids, target deletion, scenario id reuse, canvas unmount, and no Storage writes.
- Real browser and minified-production browser: an actual V5 chat response renders `Olumi focus: Evidence gap`; the assistant halo remains after the real two-second edit pulse clears while `User context` stays selected; dismiss removes only assistant focus; reload restores no assistant focus.
- Mutation controls: a forbidden ordinary-selection write and a forbidden outbound-grounding write each make the mounted test fail and were reverted.
- Exact combined tree with frozen #714: `329897466335e41170cd4847bff8ca41bcfc1cb9`; 173 targeted focus/#715/#714 tests pass with the required guest test environment.

Draft only. No merge or deploy requested.
