### PR TITLE
PX-D: Model tab v2 — design + unmounted editor surface (DRAFT, awaiting Paul's KEEP/CUT verdict)

### DIFF
--- a/docs/Design/MODEL-EDITOR-V2.md
+++ b/docs/Design/MODEL-EDITOR-V2.md
@@ -148,6 +148,14 @@ relationships · assumptions/provenance · evidence/review state.
 - **attention marker** — present when the row needs the user: no value · unconfirmed AI estimate ·
   contested · fragile · missing intervention. It is the same predicate the attention chips count,
   derived once.
+- **deferred marker** — present when the user has explicitly chosen to leave this row unresolved
+  (§5.3, Paul's ruling 16 Aug 2026). ⚠ **It sits BESIDE the attention marker and never replaces
+  it.** Deferring does not make the gap go away, so the row keeps saying it has one; what the
+  deferred marker adds is that *somebody has already decided it can wait*. The two answer different
+  questions — *does this need attention?* and *has a human ruled on it?* — and collapsing them into
+  one marker would recreate the dismiss button the design just cut, because a row that stopped
+  reporting its gap once deferred would be hiding it. The marker carries the deferral's provenance
+  (who, when) in its label, for the same reason every other value on this surface does.
 
 Clicking anywhere else on the row **selects** it and opens the detail region.
 
@@ -266,6 +274,49 @@ provenance discipline that stamps an accepted producer estimate `cee` rather tha
 (`ModelHealthSection.tsx:182-195`: *"N factors have no value set. This reduces analysis
 reliability."*). Today that sentence is a dead end; it becomes a queue, and it also closes F9.
 
+#### The third beat of every queue: **Defer / Leave unresolved** *(Paul's ruling, 16 Aug 2026)*
+
+**Every queue item carries a Defer action alongside its resolve action.** Confirm / Apply / Resolve
+is one answer; *"I have seen this and I am choosing to leave it"* is another, and it is a legitimate
+one. A queue that offers only the resolving action is not respecting the user's judgement — it is
+insisting they agree with it.
+
+```
+Sales cycle length       Olumi estimated 45 days     [Confirm]  [Change]  [Leave unresolved]
+   Inferred from model structure
+
+▸ Left unresolved (2)                                       ← de-emphasised, still on screen
+   Win rate               Olumi estimated 22%               [Resume]
+      Left unresolved by Paul, 16 Aug
+```
+
+**⚠ THE INVARIANT THAT SEPARATES THIS FROM THE DISMISS BUTTON WE JUST CUT.** The `×` on the
+defaulted-factor coaching card is cut (§7.0 A6) and stays cut. Deferral is its opposite, and the
+difference is exactly two properties — **neither is optional, and a Defer that lacks either one IS
+the dismiss button wearing a better name**:
+
+1. **A deferred item NEVER LEAVES THE SURFACE.** It moves to a collapsed, de-emphasised *"Left
+   unresolved"* group **within the same queue**. It is not removed, not filtered out, not hidden
+   behind a preference. The count of real gaps in the model does not change because somebody
+   deferred one — only the count of gaps *awaiting a decision* does, and the two are reported
+   separately.
+2. **A deferral CARRIES PROVENANCE — who, and when.** The honest state is *"the user chose to leave
+   this unresolved"*, and it must never decay into *"this was never a gap"*. An anonymous or
+   undated deferral is indistinguishable from a bug that dropped the row, which is why `by` and
+   `at` are both required rather than optional.
+
+Three consequences worth stating, because each is a place the invariant could be lost quietly:
+
+- **"Apply all shown" must SKIP deferred items.** A batch that swept them back in would silently
+  overrule a recorded human decision — the one thing a repair queue must never do. Deferred items
+  are shown; they are not *shown-and-pending*.
+- **Deferral is REVERSIBLE, and reversal is equally explicit.** A deferred item offers **Resume**,
+  which returns it to the active list. A choice you cannot revisit is a trap, not agency.
+- **Deferral is a WRITE.** It is persisted model state carrying a person and a timestamp, so it
+  belongs to the write authority exactly as an edit does (§9.1), and it waits for the same frozen
+  API. Until then the affordance renders **disabled with an honest label** — the design would rather
+  offer nothing than record a choice it cannot actually persist.
+
 ### 5.4 Re-analysis
 
 Unchanged: the sticky `ReanalyseBar` stays exactly as it is, and stays the tab's only re-analyse
@@ -339,7 +390,7 @@ into a rubber stamp. The row is corrected in §7.0 and §7.2, and the general le
 | 3 | Factors' click-the-card-body to expand (`cardExpanded`) | The only route to a factor's baseline, influence and stability | **No chevron, no visible affordance** — undiscoverable by design accident (F7). Replaced by row selection. |
 | 4 | Factors' static `factor-{id}-not-set` text | Nothing — it is an inert label | It occupies the slot where the editor belongs, so a factor with no value **cannot be given one** (F9). |
 | 5 | Factors' `factor-{id}-refine-range` button | A button that looks like it edits the prior range | It only focuses the node on the canvas (F10). A button that does not do what it says is worse than no button. |
-| 6 | Factors' `factor-{id}-coaching-dismiss` (`×`) | The ability to dismiss the defaulted-factor nag | The nag becomes a **queue item**, and a queue item is resolved by fixing it, not by hiding it. Dismissal is how a real gap becomes invisible. |
+| 6 | Factors' `factor-{id}-coaching-dismiss` (`×`) | The ability to dismiss the defaulted-factor nag | The nag becomes a **queue item**, and dismissal is how a real gap becomes invisible. ⚠ **Ruled by Paul, 16 Aug 2026: the cut stands, but it must not cost the user their agency.** The queues gain an explicit **Defer / Leave unresolved** action in its place (§5.3) — a *recorded choice* rather than a hidden gap: the item stays on screen in a de-emphasised "Left unresolved" group and carries provenance (who deferred it, when). Removing the `×` removes a way to make a gap disappear; it does not remove the user's right to decide the gap can wait. |
 | 7 | Relationships' click-the-card to reveal editing | The only route to an edge's strength, direction and likelihood | Costs 3 interactions. Editing moves into the row at 1. |
 | 8 | Relationships' `relationships-show-more` ("+N more relationships") | A one-way "show the rest" button | **One-way — no re-collapse** — in a list you are trying to edit. Replaced by the working filter. |
 | 9 | Relationships' `relationships-separator` ("All relationships") | A divider between contested and ordinary edges | Contested edges move into **Queue C**, so there are no longer two piles to divide. |
@@ -377,7 +428,8 @@ unchanged), `ReanalyseBar`, `StreamingDiagnostics`, `CoachingCard`, `InlineEdit`
 **The shape of the removal:** of the 13 user-visible losses, **three are dead ends** (2, 5, 10),
 **three are undiscoverable or one-way** (3, 7, 8), **one blocks the job outright** (4), **two are
 disclosure axes being collapsed** (13, and the card-expands in 3/7), **two are the tier-as-layout
-defect** (11, 12), **one is a dismissal that hides a real gap** (6), and **two are replaced by
+defect** (11, 12), **one is a dismissal that hides a real gap and is replaced by an explicit,
+provenanced deferral** (6), and **two are replaced by
 something cheaper in the same place** (1, 9).
 
 ### 7.1 The container — `ModelTabBody.tsx`
@@ -494,7 +546,7 @@ something cheaper in the same place** (1, 9).
 | — `factor-{id}-inline-norm` ("n:0.42") | **DEMOTE** | |
 | — `factor-{id}-confirm` (✓) | **KEEP+FIX** | Must stamp **`user_confirmed`, not `user`** (F8) and become a real proposal→confirm. **Queue B depends on it.** |
 | — `factor-{id}-coaching` (defaulted controllable) | **MERGE** → marker + Queue D | |
-| — `factor-{id}-coaching-dismiss` | **CUT** | A queue item is resolved by fixing it, not by hiding it. |
+| — `factor-{id}-coaching-dismiss` | **CUT** | Dismissal hides a real gap. Replaced by the queues' **Defer / Leave unresolved** action (§5.3, Paul 16 Aug) — visible, provenanced and reversible, which dismissal is not. |
 | — `Baseline` InlineEdit | **KEEP+FIX** | Moves into the detail region — reachable, rather than behind an invisible expander. |
 | — influence bar + `{n}%` | **KEEP** | Plain-language, and absent (not defaulted) when the factor is not in the map. |
 | — `AttributionStabilityPill` | **DEMOTE** | Keep its "suppress unless >1 distinct label" rule — it refuses to render a non-differentiating badge. |
@@ -683,7 +735,9 @@ producer's estimate that must not be laundered as the user's. A contract answere
 | **C8** | `proposeGoalTarget(nodeId, raw, unit?)` | **no** — local only (`setGoalThresholdAndUpdateNode`) | Will this exist, and does it take the **raw** target plus unit (not a pre-normalised number)? |
 | **C9** | `proposeFactorConfirmation(nodeId)` | **no** — a local annotation, and **stamped wrong** | Will confirming stamp **`user_confirmed`**, not `user`? ⚠ Today the Model tab writes `'user'` → class `edited` → pill **"User edited"**, for a gesture that ratified *somebody else's* number; pre-analysis writes `'user_confirmed'` → **"Confirmed by you"** for the identical act (F8). **Queue B depends on this.** |
 
-**The shape.** These five are asked once and apply to all of C1–C9.
+| **C15** | `proposeDeferral(rowId, { deferred })` — records *"a human chose to leave this unresolved"*, with **who** and **when**; `deferred: false` resumes it | Will this exist, and will the record carry an **identified person and a timestamp**? ⚠ Added by Paul's ruling of 16 Aug 2026 (§5.3). It is a WRITE — persisted model state, not a client-side preference — and it must not be implemented as one, because a deferral kept in `localStorage` is invisible to every other member of the team and reappears as an unexplained gap for them. **An anonymous or undated deferral is indistinguishable from a row that was dropped by a bug**, which is why neither field is optional. |
+
+**The shape.** These five are asked once and apply to all of C1–C9 and C15.
 
 | ID | The ask | The closed question |
 |---|---|---|

--- a/docs/Design/MODEL-EDITOR-V2.md
+++ b/docs/Design/MODEL-EDITOR-V2.md
@@ -1,0 +1,782 @@
+# Model tab v2 — the structured model editor
+
+**Status:** DESIGN, for Paul's veto — **§7 is the removal review; nothing is removed until he rules.**
+**Lane:** PX-D (design-first). **Derived at:** UI `staging` tip `a3c71513`, 15 Aug 2026.
+
+**What exists in code, stated precisely so this header cannot drift into a false claim.** Nothing on
+the Model tab changes, and **nothing in this design is mounted**: no route, no tab registration, no
+import from any live surface. What does exist is an **unmounted component set** under
+`src/canvas/model-tab-v2/` — the row (§4.2), the outline and its tier (§4.3), the detail region
+(§4.4), keyboard navigation (§5.2) and the repair-queue lists (§5.3), all render-only, all taking
+typed read-only projections as props. **Every write waits for the frozen transaction API** (§8, §9.1):
+each control that would cause one renders **disabled, with a label saying why**. A guard spec proves
+both halves of that claim — no live file imports this directory, and no file in it writes the store
+or constructs a success state. **`src/canvas/model-tab-v2/` is deletable in one `rm -rf` if Paul
+vetoes the design**, which is the property that makes building it before the verdict safe.
+**Supersedes:** nothing. The complement to the ROADMAP 2.121 work recorded in
+`olumi-docs/docs-designs/MODEL-TAB-REDESIGN-2026-07-29.md` (a different repo): that fixed the
+*write path*; this fixes the *surface*.
+
+**⚠ Path note:** this file lives in `docs/Design/` (capital D) — the repo's real, tracked design
+directory. `docs/design/` does not exist; on a case-insensitive macOS filesystem the lowercase path
+silently resolves here, and on Linux CI it would have created a third near-identical directory
+beside `docs/Design/` and `docs/designs/`.
+
+---
+
+## 1. Verdict
+
+The Model tab is not an editor. It is a **report with a few editable numbers**, and four
+independently-derived facts explain Paul's "the more I play with it, the less I feel like I can
+actually directly edit the decision model":
+
+1. **You cannot change the model's structure from it at all.** No add, no delete, for any element.
+   The two "+ Add" affordances send a chat message.
+2. **The chat message goes into a panel that stays hidden.** Nothing on the tab fronts Olumi.
+   So the only structural affordance the tab has terminates in silence.
+3. **Editing costs up to three nested disclosures**, one of which has no visible affordance.
+4. **Identical-looking edits have different consequences.** A factor value reaches the server.
+   An edge strength, an option's intervention value and the goal target do not. Nothing says which.
+
+And the advanced toggle overwhelms non-scientists because **it is two controls wearing one switch**:
+it changes the scientific detail *and* the layout mode at the same time.
+
+**The v2 proposal:** replace the accordion-of-report-sections with **one filterable outline of the
+model's contents**, where every element is a row, the row's primary value is editable in place, and
+all scientific parameters live behind **one consistently-placed Advanced block** that never changes
+the layout.
+
+---
+
+## 2. What the tab is today (derived, not remembered)
+
+Every claim below was derived at the bytes at `a3c71513`. Absence claims carry contrast controls.
+
+| # | Finding | Evidence |
+|---|---|---|
+| **F1** | The advanced toggle drives **two orthogonal things**: layout mode *and* scientific detail. | `ModelTabBody.tsx:116-122` (`makeSectionProps` returns `{}` when expert ⇒ multi-open; controlled ⇒ single-open) and `:761` (`showDetail={expertMode}` → `DetailToggleContext`). The control itself is the `</>` pill in the dock chrome, `OutputsDock.tsx:2078-2091`, persisted `localStorage['olumi.expertMode']`. |
+| **F2** | Default view is a **single-open accordion**; opening Options closes Factors. | `ModelTabBody.tsx:114` — `useState<string\|null>('factors')`. |
+| **F3** | **The search box filters nothing.** | Complete manifest: `searchQuery` occurs in `ModelTabBody.tsx` at exactly two lines — `:110` (declaration) and `:861` (prop to `ModelFooter`). It is passed to no section. Scope searched: `ModelTabBody.tsx` + all `*.tsx` in `model-tab/`. Claim type: **no-consumer**. Contrast control green (`ModelFooter.tsx` has 5 hits). |
+| **F4** | **No structural editing anywhere.** | `addNode\|addEdge\|removeNode\|deleteNode\|removeEdge\|deleteEdge\|onAdd\|onDelete\|"Add ` → **zero** hits across `ModelTabBody.tsx` + all `model-tab/*.tsx`. Contrast control green: `src/canvas/store.ts` = 9 hits. |
+| **F5** | **No send-to-AI affordance fronts the Olumi panel** — on the tab that has the most of them. | `revealOlumiSurface()` (`src/canvas/conversation/revealOlumi.ts`) is the estate's fronting primitive. Production call sites (specs excluded): **10, across 4 consuming modules** — `InspectorCoaching.tsx` ×2, `pre-analysis-v3/hooks/useConversationActions.ts` ×5, `focus-now/useFocusNow.ts` ×1, `AnalysisHeroV17.tsx` ×1. In the model-tab scope: **zero**. Contrast control green — the same scope has **12** `onSendMessage` call sites. So four other surfaces front the panel before they send, and the one with the most hand-offs never does. The Olumi tab stays mounted but `hidden` (`OutputsDock.tsx:2797-2805`), and the one auto-expand path requires `dockCollapsed`, which is false while the Model tab is visible. |
+| **F6** | **Only one class of edit reaches CEE.** | `sendSystemEvent` in `model-tab/*.tsx`: **FactorsSection only** (`:177/:254/:260`, emitting `factor_value_edit`). Zero in Goal / Options / Relationships / Risks. Plus `edge_adjudication` from the container (`ModelTabBody.tsx:579-671`). In `useInspectorMutations.ts`, `sendSystemEvent` is called at exactly one line (`:235`, inside `setPriorRange`); every other setter — including all five edge setters — is a local store write. |
+| **F7** | **Three independent disclosure axes**, one of them invisible. | (i) section accordion; (ii) per-card `cardExpanded`, toggled by clicking the card body with **no chevron and no visible affordance** (`FactorsSection.tsx:157/:352`, `RelationshipsSection.tsx:106/:268`); (iii) global `showDetail`, whose control lives **outside the tab** in the dock chrome. An edge's detail row needs all three. |
+| **F8** | The same human gesture is stamped **two different ways** on two surfaces. | Model tab's Confirm writes `setObservedSource('user')` (`FactorsSection.tsx:334`) → class `edited` → pill **"User edited"**. Pre-analysis writes `'user_confirmed'` (`PreAnalysisPanel.tsx:1154`) → class `confirmed` → pill **"Confirmed by you"**. Classifier: `src/canvas/domain/valueProvenance.ts:117-138`. |
+| **F9** | **A factor with no value cannot be given one from its card.** | `FactorsSection.tsx` renders static `Not set` text (testid `factor-{id}-not-set`) instead of an `InlineEdit`. |
+| **F10** | **"Refine range" is a dead end.** | It only calls `focusNodeById` (`FactorsSection.tsx`, testid `factor-{id}-refine-range`). |
+| **F11** | The attention bar **scrolls to collapsed sections**. | `StatusBar.tsx:27-30/:101` does `querySelector(...).scrollIntoView` and does **not** open the target accordion. Under the single-open default, clicking "3 contested" scrolls to a closed Relationships section. |
+| **F12** | Dead or mis-wired surfaces. | `isContested` pill is always passed `false` (`RelationshipsSection.tsx:795`); `postRunRepairs` is never passed to `ModelAdjustments`; the Accordion `tierLabel` tooltip is hardcoded to a confidence-about-factors sentence (`src/components/results/Accordion.tsx:183`) and is wrong on Relationships and Model card; `likelihoodColour` (`RelationshipsSection.tsx:208-210`) hand-copies `EDGE_VALUE_BAND_CUTS` instead of calling `edgeValueBand()`; two different strength vocabularies coexist (`model-tab/strengthBands.ts` vs `inspector-v2/inspectorStrings.ts:98`). |
+| **F13** | The container's elaborate sort **orders the clipboard, not the screen** — and says the opposite. | `sortedFactors` / `sortedEdges` (`ModelTabBody.tsx:478-499` / `:503-538`) are built with provenance-gated comparators and consumed **only** by `handleCopyText` (`:678`, `:686`) and `handleCopyJson` (`:700`, `:713`). The sections receive the **unsorted** `grouped.factor` (`:789`) and `causalEdges` (`:803`) and re-sort internally (`FactorsSection.tsx:671-694`, `RelationshipsSection.tsx:627-646`). The in-file comment at `:522-523` claims it "brings the on-screen order into line with the copied JSON". It does not. Contrast control: `grouped.option` IS passed to a renderer at `:780`, so passing from these memos is possible — these two simply are not passed. |
+| **F14** | The container's own children have **no error boundary**, while all six sections do. | `SectionErrorBoundary` is imported at `ModelTabBody.tsx:27` and **never used** — one hit in the file. So the run cover, header, status bar, entity bar, adjustments, diagnostics, re-analyse bar and footer are unprotected. Contrast control green: the same symbol is used in `GoalSection.tsx:297`, `OptionsSection.tsx:538`, `FactorsSection.tsx:760`, `RelationshipsSection.tsx:842`, `RisksSection.tsx:158`, `ModelHealthSection.tsx:318`. |
+| **F15** | A **stale type nobody imports** still describes this tab. | `model-tab/types.ts`'s `ModelTabProps` has no importer anywhere in `src/` (scope: `rg -al '\bModelTabProps\b' src/ --glob '!**/__tests__/**'` → its own file only). It has drifted from the live inline `ModelTabBodyProps` (`ModelTabBody.tsx:56-75`): it declares `critique?: CritiqueItemV1[]` and lacks `expertMode` and `onSendMessage`. Contrast control green: `ObservedState` and `FactorInfluenceMap`, from the same file, resolve to real importers. |
+
+### The interaction budget today
+
+| Target | Interactions from tab open |
+|---|---|
+| Goal target | 1 |
+| Factor value · Confirm ✓ · prior min/max | 1 |
+| Factor baseline | 2 — via the **invisible** card-expand |
+| Option intervention value | 2 — and expanding Options **collapses Factors** |
+| Edge strength · likelihood · direction | **3** — open section → open card → open field |
+| Any scientific parameter | 3 + a toggle that lives outside the tab |
+| Set a factor that currently has no value | **impossible** (F9) |
+| Add or remove any element | **impossible** (F4); the CTA messages a hidden panel (F5) |
+
+---
+
+## 3. The job
+
+> A capable non-scientist opens the Model tab, sees the whole model, finds the thing they want to
+> change, changes it, and can tell what happened — without learning what a β coefficient is.
+
+Two modes of use, one surface:
+- **Fast structured editing** — repair and adjust many values quickly.
+- **Deep inspection** — understand where one value came from and what it does.
+
+Both act on **the same canonical model**. The canvas remains the rich structural view; this is its
+tabular twin.
+
+---
+
+## 4. Information architecture
+
+### 4.1 Shape
+
+One scroll container. No single-open accordion. Seven groups, all present, each collapsible and
+**independently remembered** (multi-open always, in both tiers).
+
+```
+┌─ HEADER (sticky) ───────────────────────────────────────────────────┐
+│ 12 factors · 18 relationships · 3 options · 2 risks                  │
+│ [🔍 Filter the model…                    ]      ( Plain | Advanced ) │
+│ [6 to verify] [4 option values missing] [2 contested] [3 fragile]    │  ← attention chips
+└─────────────────────────────────────────────────────────────────────┘
+┌─ BODY (one scroll) ─────────────────────────────────────────────────┐
+│ ▾ Goal                                                              │
+│ ▾ Options                                                           │
+│ ▾ Factors                                                           │
+│ ▾ Outcomes & risks                                                  │
+│ ▾ Relationships                                                     │
+│ ▾ Assumptions & provenance                                          │
+│ ▾ Evidence & review state                                           │
+└─────────────────────────────────────────────────────────────────────┘
+┌─ Re-analyse bar (sticky, unchanged) ────────────────────────────────┐
+```
+
+The seven groups map 1:1 onto the brief's IA: goal · options · factors · outcomes/risks ·
+relationships · assumptions/provenance · evidence/review state.
+
+### 4.2 The row — one anatomy for every element
+
+```
+[◇]  Reach £2m ARR by Q4        £2,000,000 ▸   (From brief)   
+[○]  Hire two AEs               3 changes  ▸   (AI estimate)  ⚠
+[●]  Sales cycle length         45 days    ▸   (AI estimate)  ⚠
+[→]  Sales cycle → Revenue      Strong positive effect ▸  (Set by you)
+[▲]  Key account churns         Triggered by: Renewal rate
+```
+
+- **glyph** — element kind, reusing the shapes `EntityBar` already teaches (◇ goal, □ decision,
+  ○ option, ● factor, ▲ risk, ★ outcome, → relationship).
+- **label** — click focuses the element on the canvas (keeps today's `focusNodeById` behaviour).
+- **primary value** — **editable in the row itself**. One interaction. Plain language: a
+  relationship reads "Strong positive effect", not `β = 0.71`.
+- **provenance chip** — `SourceProvenancePill`, **reused unchanged**. It is the estate's best
+  provenance artefact: a `Record` that is *total* over `ValueProvenanceKind`, so a new kind is a
+  type error rather than a silent "Not set".
+- **attention marker** — present when the row needs the user: no value · unconfirmed AI estimate ·
+  contested · fragile · missing intervention. It is the same predicate the attention chips count,
+  derived once.
+
+Clicking anywhere else on the row **selects** it and opens the detail region.
+
+### 4.3 Two tiers, and only two
+
+| | Plain (default) | Advanced |
+|---|---|---|
+| What it shows | values, labels, units, plain-language qualifiers, provenance chips, what-changed | parameters and scientific detail |
+| Examples | "Strong positive effect", "45 days", "Confirmed by you", "Olumi adjusted this" | priors, std/σ, β/signed effect, exists-probability, elasticity, rank-flip rate, attribution stability, quality sub-scores, seed, response hash, node/edge IDs |
+| Where it lives | the row and the top of the detail region | **one block, always last, always titled the same way**: *"Advanced — model parameters"* |
+
+**Three rules that make the tier survive contact:**
+
+1. **Advanced is a content switch, never a layout switch.** It adds and removes the Advanced block.
+   It must never change how many groups are open, how rows are ordered, or which cards expand.
+   This is the direct fix for F1.
+2. **Never mixed inline.** A parameter never appears beside a plain value in the same row.
+   If a parameter must be visible in Plain (e.g. a unit), it is not a parameter.
+3. **One tier control, in the tab.** A `Plain | Advanced` segmented control in the tab header.
+   *(This deliberately re-splits the product-wide expert mode — see Open question 1.)*
+
+### 4.4 The detail region — replacing the invisible third axis
+
+Selecting a row opens **one** detail region (a right rail where width allows, otherwise an expanded
+region beneath the selected row). It replaces `cardExpanded` entirely, which kills the invisible
+disclosure (F7) and drops the axes from three to two: **group open/closed** and **selection**.
+
+Detail content, in fixed order:
+1. **What this is** — label, kind, description, editable.
+2. **Its value** — primary value, unit, and every secondary value that is still plain (baseline,
+   likelihood, direction, per-option fit).
+3. **Where it came from** — provenance chip, the basis sentence, what Olumi adjusted and why
+   (reusing `ModelAdjustments`' `sanitiseDetail`, which strips engine field paths from user-facing
+   text and is worth keeping).
+4. **What it affects** — influence bar, the relationships it participates in, the risks it triggers.
+5. **Advanced — model parameters** — the single block. Absent entirely in Plain.
+
+---
+
+## 5. Editing grammar
+
+### 5.1 The three-beat, uniform across every field
+
+```
+   inline edit            proposal chip                    receipt
+┌──────────────┐   ┌───────────────────────────┐   ┌─────────────────────┐
+│ 45 → [ 60 ]  │ → │ 45 → 60  [Confirm][Discard]│ → │ 60   (Set by you)   │
+│  type, Enter │   │  nothing has changed yet   │   │  provenance flips   │
+└──────────────┘   └───────────────────────────┘   └─────────────────────┘
+```
+
+This matches the transactional pattern: **intent → validate → propose → confirm →
+server-authoritative write**. The row never writes the model itself.
+
+**Row edit state** (the contract the row component takes):
+
+`idle → editing → proposed → inflight → applied | refused`
+
+- `proposed` — the user has stated an intent; the model is unchanged; the old value stays visible
+  beside the new one.
+- `inflight` — dispatched; the row is marked pending and is not re-editable.
+- `applied` — receipt received; provenance chip flips; pending mark clears.
+- `refused` — the server declined; **the row says so in words and reverts**. A refusal must never
+  look like a success, and must never look like nothing happened.
+
+This is what makes F6 impossible to reproduce: a row can only render `applied` when a receipt says
+so, so an edit with no server authority cannot silently masquerade as one that has it.
+
+### 5.2 Keyboard
+
+Enter commits intent · Escape cancels · Tab moves to the next editable value in the outline
+(the outline is a list, so tab-through-and-fix is the fast path) · `⌘/Ctrl+Enter` confirms a
+proposal without reaching for the button.
+
+### 5.3 The repair queues — Paul's two cases, as one-click-per-item lists
+
+A queue is **a filtered view of the same outline**, entered from an attention chip. Not a modal, not
+a separate screen, no forked state — the user never loses their place, and there is only ever one
+rendering of a row.
+
+**Queue A — "Set option values"** *(chip: "N option values missing")*
+
+```
+Hire two AEs — 2 factors have no target value
+  Sales cycle length     45 days now  →  [ 30      ] days   [Apply]
+  Pipeline coverage      3.0x now     →  [ 4.0     ] x      [Apply]
+                                                     [Apply all shown]
+```
+One row per (option × factor) lacking an intervention, prefilled with the factor's baseline, one
+input and one Apply each. This replaces the current `allUnmapped` coaching card, which tells the
+user to go and talk to the AI and offers no way to do the thing.
+
+**Queue B — "Confirm estimates"** *(chip: "N to verify")*
+
+```
+Sales cycle length       Olumi estimated 45 days     [Confirm]  [Change]
+   Inferred from model structure
+Win rate                 Olumi estimated 22%         [Confirm]  [Change]
+   Based on general domain knowledge
+                                          [Confirm all shown]
+```
+One row per factor whose `observed_state.source` is absent or `cee_inference` — exactly the existing
+`countFactorsToVerify` predicate (`model-tab/utils.ts:118-124`), so the tab badge and the queue can
+never disagree. **This is the first time that badge becomes actionable.**
+
+Confirming must stamp `user_confirmed`, not `user` — closing F8, so the pill reads
+**"Confirmed by you"** rather than **"User edited"**, which is what actually happened.
+
+**Queue C — "Contested relationships"** *(chip: "N contested")* — already exists and already works.
+`ContestedEdgeCard` is kept **wholesale**; it is the best-designed artefact on the tab (four named
+verdicts, band quick-sets, a signed slider, an EVOI sentence gated on the number existing, and
+provenance discipline that stamps an accepted producer estimate `cee` rather than laundering it as
+`user`). It is simply hosted in the queue instead of buried in a collapsed section.
+
+**Queue D — "Factors with no value"**, from the root-node warning the Model card already computes
+(`ModelHealthSection.tsx:182-195`: *"N factors have no value set. This reduces analysis
+reliability."*). Today that sentence is a dead end; it becomes a queue, and it also closes F9.
+
+### 5.4 Re-analysis
+
+Unchanged: the sticky `ReanalyseBar` stays exactly as it is, and stays the tab's only re-analyse
+control. A queue that applies eight edits produces one "Model changed. Results may be out of date."
+state, not eight. *(Whether a confirmed edit should ever auto-run is Open question 3.)*
+
+---
+
+## 6. Send-to-AI rule
+
+**No Model-tab control may call `onSendMessage` directly.** Every hand-off goes through one helper:
+
+```ts
+handOffToOlumi({ message, reason }): 'fronted' | 'deferred'
+```
+
+which **fronts the Olumi panel first, then sends** — and returns whether the panel actually moved,
+so the tab never claims Olumi is working on something while the user is looking at a surface that
+did not change.
+
+This closes F5 across the whole tab. Measured at `a3c71513`: **12 `onSendMessage` call sites in
+6 components, carrying 11 distinct messages** — Options 4 (one message is duplicated across two
+mutually-exclusive branches), Relationships 2, Risks 2, Factors 2, Goal 1, Model card 1.
+
+It matters most for the structural CTAs — "Add a factor", "Add a relationship", "Map interventions",
+"Explore other strategies". Those terminate in a conversation, not a mutation, so if the
+conversation is invisible the affordance is a dead end. **A hand-off that cannot front the panel
+must say so rather than send silently.**
+
+PX-A owns the dock mechanism; the contract I need from it is in §9.2.
+
+---
+
+## 7. KEEP / CUT — every current Model-tab surface
+
+**⭐ THIS SECTION IS PAUL'S REMOVAL-ONLY REVIEW.** Read §7.0 alone to veto; §7.1–§7.5 are the
+complete backing manifest.
+
+**Verdicts:** **KEEP** (as-is) · **KEEP+FIX** (survives, defect repaired) · **MERGE** (folded into a
+v2 group, no copy deleted) · **DEMOTE** (moves behind the Advanced switch, still one click away) ·
+**CUT** (gone).
+
+**Scope and method, stated precisely.** Derived at `a3c71513` by reading, in full, `ModelTabBody.tsx`
+(the container) plus all 19 `.ts`/`.tsx` files directly in `src/canvas/components/model-tab/`
+(`__tests__/` excluded). Every surface those files render is listed below with a verdict — sections,
+cards, rows, buttons, pills, badges, chips, coaching cards, warnings, disclosures, inputs, toggles,
+tooltips and blocks of copy. **Two surface families are rendered BY in-scope files but DEFINED
+outside `model-tab/`** — `Accordion` (which supplies the section chrome) and four leaf visuals — and
+they are carried in §7.4 rather than dropped, because a review that silently excluded the chrome
+would be reviewing less than the user sees. **Absence claims below carry contrast controls.**
+
+**⚠ THE FIRST DRAFT OF THIS SECTION WAS INCOMPLETE, AND ITS WORST OMISSION WAS IN THE REMOVAL LIST
+ITSELF.** It cut `ModelTabHeader` with the justification *"Nothing visible changes"* and *"its two
+jobs (count line, context provider)"*. The header in fact renders **seven** surfaces, three of them
+visible and none of them a count line: an `· expert` indicator, a `header-sort-note` that prints the
+literal word `alphabetical`, and an **expert framing border that wraps every section**. A removal
+review that understates what disappears is worse than no removal review, because it converts a veto
+into a rubber stamp. The row is corrected in §7.0 and §7.2, and the general lesson is recorded here:
+**the removal list is derived from the component tree, never from memory of what the tab looks like.**
+
+### 7.0 ⭐ WHAT DISAPPEARS — the removal-only review
+
+*Everything proposed for removal is in this sub-section. Nothing else is.*
+
+**A. Gone entirely, and the user loses something that is on screen today (13 items)**
+
+| # | What goes | What the user loses | Why it should go |
+|---|---|---|---|
+| 1 | `EntityBar` — the 6px composition bar, its hover tooltip and its legend | A decorative bar and a legend showing node-type proportions | Purely decorative: no buttons, no handlers. Its counts move into the header summary line, so the information survives; the bar does not. |
+| 2 | Options' `options-unmapped-coaching` card, its option list and its `option-{id}-map-cta` | A sentence telling you to go and talk to the AI, plus a button that sends a chat message | This is the dead end Paul hit. Replaced by **Queue A**, which lets you actually set the values. |
+| 3 | Factors' click-the-card-body to expand (`cardExpanded`) | The only route to a factor's baseline, influence and stability | **No chevron, no visible affordance** — undiscoverable by design accident (F7). Replaced by row selection. |
+| 4 | Factors' static `factor-{id}-not-set` text | Nothing — it is an inert label | It occupies the slot where the editor belongs, so a factor with no value **cannot be given one** (F9). |
+| 5 | Factors' `factor-{id}-refine-range` button | A button that looks like it edits the prior range | It only focuses the node on the canvas (F10). A button that does not do what it says is worse than no button. |
+| 6 | Factors' `factor-{id}-coaching-dismiss` (`×`) | The ability to dismiss the defaulted-factor nag | The nag becomes a **queue item**, and a queue item is resolved by fixing it, not by hiding it. Dismissal is how a real gap becomes invisible. |
+| 7 | Relationships' click-the-card to reveal editing | The only route to an edge's strength, direction and likelihood | Costs 3 interactions. Editing moves into the row at 1. |
+| 8 | Relationships' `relationships-show-more` ("+N more relationships") | A one-way "show the rest" button | **One-way — no re-collapse** — in a list you are trying to edit. Replaced by the working filter. |
+| 9 | Relationships' `relationships-separator` ("All relationships") | A divider between contested and ordinary edges | Contested edges move into **Queue C**, so there are no longer two piles to divide. |
+| 10 | Options' "The AI hasn't mapped how this option changes your factors yet" | A sentence describing a gap | Same dead end as item 2 at the single-option level; becomes a row attention marker + Queue A. |
+| 11 | `ModelTabHeader`'s `· expert` indicator | A word appearing beside the counts when expert mode is on | The v2 tier control is a labelled `Plain \| Advanced` switch **in the tab**. A separate word reporting the state of a control you can see is redundant. |
+| 12 | `ModelTabHeader`'s **expert framing border** (`border border-info/40` wrapping every section) | A blue frame around the sections when expert mode is on | **This is F1 in its purest form** — a *detail* toggle silently changing the *layout*. It is the clearest single thing to delete to make the tier a content switch. |
+| 13 | `ModelAdjustments`' per-row "Details / Hide details" local disclosure | An in-card expander for one adjustment's technical detail | A fourth disclosure axis inside a card inside a section. Its content moves to the detail region, which is where "where did this come from" already lives. |
+
+**B. Gone as a standalone component; every word of copy is preserved (7 items)**
+`GoalSection` · `OptionsSection` · `FactorsSection` · `RelationshipsSection` · `RisksSection` ·
+`ModelHealthSection` · `ModelAdjustments` — each becomes a **group** in the single outline. The
+accordion chrome goes; the content does not. **No user-visible loss.**
+
+**C. Dead or internal — removal is invisible to the user (9 items)**
+`EdgeCard`'s `isContested` pill (always passed `false`) · `ModelAdjustments`' `postRunRepairs`
+disclosure and list (prop never passed) · `likelihoodColour`'s hand-copied band thresholds ·
+`ModelTabBody`'s single-open `openSection` state and `makeSectionProps` mode switch ·
+`model-tab/types.ts`'s `ModelTabProps` (no importer anywhere in `src/`; a drifted mirror of the live
+inline props) · `utils.ts`'s `mapSourceToTooltip` and `isGenericUnit` (no production importer) ·
+`StatusBar`'s stale docstring segment.
+
+**D. Moved behind the Advanced switch — NOT removed, still one click away**
+Goal's normalised target / unit / node ID · Options' normalised-targets grid and node ID · Factors'
+inline normalised readout, `(normalised)` labels, cap, prior range, sensitivity block (elasticity,
+rank-flip, confidence), attribution stability and node ID · Relationships' signed scalar, σ and p
+inline readouts, e-value, signed effect, std, exists-probability, provenance grid and edge ID ·
+`ContestedEdgeCard`'s parameter grid · Risks' node ID · Model card's quality sub-scores, full audit
+trail, methodology line and stability-penalty tail · `StatusBar`'s stability segment · the Text/JSON
+copy buttons.
+
+**E. Explicitly NOT removed** — `ContestedEdgeCard` (kept wholesale), `SourceProvenancePill` (reused
+unchanged), `ReanalyseBar`, `StreamingDiagnostics`, `CoachingCard`, `InlineEdit`, `DeltaChip`,
+`RangeDerivationBadge`, the goal-fit block, and **every honesty resolver**.
+
+**The shape of the removal:** of the 13 user-visible losses, **three are dead ends** (2, 5, 10),
+**three are undiscoverable or one-way** (3, 7, 8), **one blocks the job outright** (4), **two are
+disclosure axes being collapsed** (13, and the card-expands in 3/7), **two are the tier-as-layout
+defect** (11, 12), **one is a dismissal that hides a real gap** (6), and **two are replaced by
+something cheaper in the same place** (1, 9).
+
+### 7.1 The container — `ModelTabBody.tsx`
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `model-tab` root + `aria-busy` | **KEEP** | Correct busy semantics; the v2 outline mounts inside it. |
+| `AnalysisRunStateCover` (running banner / `analysis-run-skeleton`) | **KEEP** | Honest run-state cover, retains content when nodes exist. Out of scope. |
+| sections wrapper `div.space-y-4` | **MERGE** | Becomes the single scroll container of §4.1. |
+| `openSection` single-open state | **CUT** | F2 — opening Options closes Factors. Multi-open always. |
+| `makeSectionProps` accordion-mode switch | **CUT** | F1 — this is the code that makes the detail toggle a layout toggle. |
+| `pendingModelTabSection` deep-link effect (opens **and** scrolls) | **KEEP + PROMOTE** | The mechanism F11 needs and `StatusBar` does not use. Becomes the chips' navigation path. |
+| `searchQuery` state | **KEEP+FIX** | Held and passed, read by nothing (F3). Wire it to the filter. |
+| `handleCopyText` / `handleCopyJson` | **KEEP** | Work correctly; the JSON export carries provenance stamps beside values. Demoted to an overflow menu (§7.3). |
+| `sortedFactors` / `sortedEdges` | **KEEP+FIX** | ⚠ **New finding (F13).** Elaborate provenance-gated comparators that order **the clipboard only** — the sections receive unsorted collections and re-sort internally. The in-file comment claims it "brings the on-screen order into line with the copied JSON"; it does not. The outline should consume them, making the claim true. |
+| `handleResolveContested` (`edge_adjudication`) | **KEEP** | Server-authoritative, with the provenance discipline intact. |
+| its direct `updateEdge` call | **KEEP** | A rowed, documented deviation: no sanctioned setter writes edge `validation`, and `setStrength` would launder a producer estimate as `user`. |
+| `SectionErrorBoundary` import | **KEEP+FIX** | ⚠ **New finding (F14).** Imported and **never used** — so the container's own children (run cover, header, status bar, entity bar, adjustments, diagnostics, re-analyse bar, footer) have **no error boundary**, while all six sections do. Contrast control: the same symbol is used in six sibling files. |
+
+### 7.2 Chrome
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `ModelTabHeader` — count line | **MERGE** | Becomes the header summary line. |
+| — `· {n} fragile` | **MERGE** | Becomes an attention chip. |
+| — `header-contested-count` | **MERGE** | Becomes an attention chip. |
+| — `header-expert-indicator` (`· expert`) | **CUT** | Redundant beside a labelled, visible tier control. |
+| — `header-sort-note` (prints `alphabetical`) | **KEEP+FIX** | An order note belongs on the group whose order it describes, and it is only true pre-analysis. |
+| — expert framing border | **CUT** | F1 at its purest: a detail toggle changing layout. |
+| — `DetailToggleContext.Provider` | **KEEP, re-source** | Same context, fed by the in-tab tier control. |
+| `StatusBar` container | **KEEP+FIX** | Becomes the attention-chip row. |
+| — `status-verify` | **KEEP + PROMOTE** | Opens **Queue B**. First time this badge becomes actionable. |
+| — `status-fragile` | **KEEP + PROMOTE** | Opens the filtered outline. |
+| — `status-contested` | **KEEP + PROMOTE** | Opens **Queue C**. |
+| — `status-stability` (`{n}% stability`) | **DEMOTE** | A model-quality figure, not a repair prompt; it belongs with the evidence. |
+| — its navigation (`scrollIntoView` only) | **KEEP+FIX** | F11 — must **open** the target and apply the filter. `uiStore.requestModelTabSection(id)` already does both and `StatusBar` has zero references to it. |
+| — colour dot | **KEEP** | `aria-hidden`, decorative, cheap. |
+| `EntityBar` (container, bar, tooltip, legend) | **CUT** | Purely decorative — no buttons, no handlers. Counts fold into the header. |
+| `ModelFooter` bar | **CUT** | Its three contents relocate; the bar itself has no other job. |
+| — `model-search` | **KEEP+FIX** | Move to the header and **wire it** (F3). A working filter is the backbone of fast structured editing. |
+| — `model-copy` (Text) | **DEMOTE** | Works; simply not primary. |
+| — `model-copy-json` (JSON) | **DEMOTE** | Works, and correctly carries provenance stamps beside values. |
+| `ReanalyseBar` | **KEEP UNCHANGED** | Sticky, honest, `aria-live`, and the tab's only re-analyse control. |
+| — its `disabled` state | **KEEP** | Unreachable in production (`onReanalyse` is always supplied); harmless, and correct in isolation. |
+| `StreamingDiagnostics` | **KEEP UNCHANGED** | Shift+D dev surface, DEV-only, out of scope. |
+| `CoachingCard` | **KEEP** as a primitive | Still wanted for genuinely advisory content; not for actionable repairs. |
+| `SourceProvenancePill` | **KEEP UNCHANGED — REUSE** | Total over `ValueProvenanceKind`. Do not fork it. |
+| `InlineEdit` | **KEEP+EXTEND** | Add `proposed / inflight / applied / refused`. Preserve its numeric-aware no-op guard (`0.40` ≡ `0.4`). |
+| `DetailToggleContext` | **KEEP, re-source** | Same context, new source. |
+
+### 7.3 Sections and cards
+
+**Goal**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `GoalSection` card | **MERGE** → Goal group | Content is sound; the bespoke card layout becomes rows. |
+| — goal diamond icon | **MERGE** | Becomes the row's `◇` glyph. |
+| — goal label heading | **KEEP+FIX** | A model editor must be able to rename its goal. |
+| — `Target:` label | **KEEP** | |
+| — `goal-threshold` InlineEdit | **KEEP+FIX** | Needs `proposeGoalTarget`; today it is a local write (F6). |
+| — `goal-threshold-not-set` InlineEdit | **KEEP+FIX** | Already the right pattern — a null value that can still be set. Keep it and give it the authority. |
+| — `SourceProvenancePill` | **KEEP** | Correctly `showWhenAbsent={false}` here. |
+| — `goal-threshold-coaching` | **MERGE** | Becomes a row attention marker. |
+| — `goal-fit-parity` block + per-option rows | **KEEP** | Honest per-option fit, real complete-field gate, and a `< 1%` floor that never prints `0%`. |
+| — `goal-fit-modelled-caveat` | **KEEP** | States the basis; deleting it would leave the figures over-claiming. |
+| — `goal-feasibility-warning` | **KEEP** | Cheap, true, and fires only on a derived condition. |
+| — `goal-discuss` | **KEEP+FIX** | Route through `handOffToOlumi` (F5). |
+| — `showDetail` grid (normalised target, unit, node ID) | **DEMOTE** | Textbook Advanced content. |
+
+**Options**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `OptionsSection` Accordion | **MERGE** → Options group | |
+| — `options-unmapped-coaching` + its option list | **CUT** → Queue A | The dead end Paul hit: it names the gap and offers no way to close it. |
+| — `option-{id}-map-cta` | **CUT** → Queue A | Sends a chat message into a hidden panel (F5). |
+| — `options-explore-cta` | **KEEP+FIX** | ⚠ **One testid, two render sites** (mutually exclusive branches). Collapse to one and route through `handOffToOlumi`. |
+| — `options-discuss` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `option-card` | **KEEP** re-skinned as a row | The content is right; the nesting is not. |
+| — option name button (`focusNodeById`) | **KEEP** | The row keeps click-to-focus-on-canvas. |
+| — `conditional-winner-{id}` | **KEEP** | States only the bucket fact the producer established; no "leads overall" claim. |
+| — pre-analysis coaching ("Run analysis to see when each option leads and lags") | **KEEP** | True, and correctly gated on there being no analysis. |
+| — "The AI hasn't mapped how this option changes your factors yet" | **CUT** | Becomes an attention marker + Queue A. |
+| — `option-status-quo-{id}` ("No changes to any factors") | **KEEP** | A real, derived fact about a real option. |
+| — `option-interventions-{id}` list | **MERGE** | Becomes rows. |
+| — factor-name button, baseline span, `ArrowRight` | **KEEP** | |
+| — `intervention-{opt}-{factor}` InlineEdit | **KEEP+FIX** | **Queue A depends on `proposeOptionIntervention`**; today it is local-only and reaches CEE as a value-less ping (F6). |
+| — `DeltaChip` | **KEEP** | Its cross-unit-space suppression — refusing to subtract a raw baseline from a normalised target — is exactly the honesty we want. |
+| — `showDetail` normalised-targets grid + node ID | **DEMOTE** | |
+
+**Factors**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `FactorsSection` Accordion | **MERGE** → Factors group | |
+| — `tierLabel` "{n} to verify" pill | **MERGE** | Becomes an attention chip. |
+| — `coaching-card-factors-verify` | **MERGE** → chip + Queue B | A dismissible nag becomes an actionable queue. |
+| — `factors-add-cta` ("+ Add a factor") | **KEEP+FIX** | Route through `handOffToOlumi`; direct add is Open question 2. |
+| — `factors-discuss` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `factor-card` collapsed row | **KEEP** → becomes *the* row | Its collapsed state is already almost exactly the v2 row anatomy. |
+| — `cardExpanded` (click body, no chevron) | **CUT** | The invisible third disclosure axis (F7). |
+| — label button | **KEEP** | |
+| — `CategoryBadge` (Controllable / Observable / External) | **KEEP** | Plain-language, and absent when the category is unknown rather than guessed. |
+| — `SourceProvenancePill` | **KEEP+FIX** | Here it defaults to `showWhenAbsent`, so an unstamped factor gets a **"Not set"** chip asserting a fact about its provenance. Absence should render as absence. |
+| — `RangeDerivationBadge` ("Estimated range") | **KEEP** | Correctly scoped to non-confirmed derivation tiers. |
+| — `Prior` label + `prior-min` / `prior-max` InlineEdits | **KEEP+FIX** | `proposePriorRange` exists and is carry-only; keep the pair, always commit both bounds. |
+| — "· from model repair" | **KEEP** | Honest provenance for a synthesised prior. |
+| — `factor-{id}-default-range` ("0 – 1 (uniform)") | **KEEP** | States the default rather than hiding it. |
+| — `factor-{id}-normalised-range` / `-normalised-label` ("(normalised)") | **DEMOTE** | Model-space vocabulary. |
+| — `factor-{id}-refine-range` | **CUT** (fix) | F10 — it only focuses the node. Replaced by a real prior-range editor in the row. |
+| — `Value` label + `raw-value` / `value` InlineEdits | **KEEP+FIX** | The reference edit path (`factor_value_edit`); gains propose→confirm. |
+| — `factor-{id}-not-set` static text | **CUT** (fix) | F9 — the single most damning gap: a factor with no value cannot be given one. |
+| — `factor-{id}-inline-norm` ("n:0.42") | **DEMOTE** | |
+| — `factor-{id}-confirm` (✓) | **KEEP+FIX** | Must stamp **`user_confirmed`, not `user`** (F8) and become a real proposal→confirm. **Queue B depends on it.** |
+| — `factor-{id}-coaching` (defaulted controllable) | **MERGE** → marker + Queue D | |
+| — `factor-{id}-coaching-dismiss` | **CUT** | A queue item is resolved by fixing it, not by hiding it. |
+| — `Baseline` InlineEdit | **KEEP+FIX** | Moves into the detail region — reachable, rather than behind an invisible expander. |
+| — influence bar + `{n}%` | **KEEP** | Plain-language, and absent (not defaulted) when the factor is not in the map. |
+| — `AttributionStabilityPill` | **DEMOTE** | Keep its "suppress unless >1 distinct label" rule — it refuses to render a non-differentiating badge. |
+| — detail: Current state / prior range / normalised value / cap | **DEMOTE** | |
+| — detail: Sensitivity — uncertainty drivers, elasticity, rank-flip, confidence | **DEMOTE** | |
+| — detail: Metadata / node ID | **DEMOTE** | |
+
+**Relationships**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `RelationshipsSection` Accordion | **MERGE** → Relationships group | |
+| — empty-state Accordion + `relationships-empty-state` | **KEEP+FIX** | Keep the copy; give it the add affordance it describes. |
+| — `tierLabel` "{n} contested · {n} fragile" | **MERGE** | Becomes attention chips. |
+| — `relationships-summary` (3 variants) | **KEEP** | Including the EVOI variant, which is gated on the number existing. |
+| — `coaching-card-relationships-fragile` | **MERGE** | Becomes an attention chip. |
+| — `ContestedEdgeCard` list | **MERGE** → Queue C | Hosted in the queue instead of buried in a collapsed section. |
+| — `relationships-separator` | **CUT** | No two piles to divide once contested edges live in a queue. |
+| — first-5 cap on the edge list | **CUT** | Replaced by the working filter + a virtualised list. |
+| — `relationships-show-more` | **CUT** | A one-way expander in a list you are trying to edit is a trap. |
+| — `relationships-add-cta` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `relationships-discuss` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `edge-card` + its card-expand gate | **CUT** | The whole reason edge editing costs 3 interactions. |
+| — edge label button (`focusEdgeById`) | **KEEP** | |
+| — `isContested` pill | **CUT** | Dead: always passed `false` (F12). |
+| — `fragile` pill + tooltip | **KEEP** | States the flip probability it is derived from. |
+| — `edge-{id}-evalue` chip | **DEMOTE** | A scientific quantity with a scientific tooltip. |
+| — `edge-{id}-summary` collapsed row | **MERGE** | Becomes the row. |
+| — semantic strength label | **KEEP** | "Strong positive effect" is exactly the plain-language target. |
+| — signed scalar text | **DEMOTE** | |
+| — `edge-{id}-inline-std` (σ) / `-inline-p` (p) | **DEMOTE** | |
+| — likelihood `{n}%` | **KEEP** | Plain and understandable. |
+| — `Strength` label + `edge-{id}-weight` InlineEdit | **KEEP+FIX** | Needs `proposeEdgeStrength`; **`preserveDirection` semantics must survive — a magnitude never carries a sign.** |
+| — direction toggle group (`dir-positive` / `dir-negative`) | **KEEP+FIX** | Needs `proposeEdgeDirection`; local-only today (F6). |
+| — `StrengthBar` | **KEEP** | |
+| — `edge-{id}-strength-notset` / `-likelihood-notset` | **KEEP** | Renders nothing as nothing. Load-bearing honesty. |
+| — `Likelihood` label + InlineEdit + bar | **KEEP+FIX** | Needs `proposeEdgeLikelihood`; local-only today (F6). |
+| — "Source: {provenance}" | **KEEP** | |
+| — detail: Effect / signed effect / std / exists probability | **DEMOTE** | |
+| — detail: Provenance heading + row | **DEMOTE** | |
+| — detail: E-value | **DEMOTE** | |
+| — detail: Causal claim | **KEEP** | Plain-language; belongs in the detail region's "What this is". |
+| — detail: Repairs applied | **MERGE** → Assumptions & provenance | It is a provenance record, not an edge parameter. |
+| — detail: Metadata / edge ID | **DEMOTE** | |
+| — `likelihoodColour`'s hand-copied band cuts | **CUT** (fix) | Call `edgeValueBand()`; a hand-copied threshold mirror is the estate's dominant defect class. |
+| — the honesty resolvers (`resolveEdgeValueDisplay`, `resolveEdgeDirectionDisplay`, unset-sorts-last) | **KEEP — do not touch** | Direction is never inferred from a sign; unstamped values render nothing. |
+
+**Contested relationships**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `ContestedEdgeCard` — the whole card | **KEEP WHOLESALE** → Queue C | The best artefact on the tab: four named verdicts, band quick-sets, a signed slider, an EVOI sentence gated on the number existing, and provenance discipline that stamps an accepted producer estimate `cee` rather than laundering it as `user`. |
+| — `contested-why-{id}` `<details>` disclosure | **KEEP** | A genuine, labelled, native disclosure — the opposite of the invisible card-expand. |
+| — its `showDetail` parameter grid | **DEMOTE + FIX** | Also fix: it currently renders even after the edge is resolved. |
+
+**Outcomes & risks**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `RisksSection` Accordion | **MERGE** → Outcomes & risks group | |
+| — empty Accordion + `risks-empty-coaching` | **KEEP** | A good provoking question ("what would guarantee this decision fails?"). |
+| — `risks-add-cta` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `risks-fragile-coaching` | **MERGE** | Becomes an attention chip. |
+| — `risks-discuss` | **KEEP+FIX** | `handOffToOlumi`. |
+| — `risk-card-{id}` row + label button | **KEEP** | |
+| — "Triggered by: {factors}" | **KEEP** | |
+| — node ID | **DEMOTE** | |
+| — its read-only-ness | **KEEP+FIX** | `setProbability` and `setImpact` already exist and **nothing on this tab uses them**. |
+
+**Assumptions & provenance**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `ModelAdjustments` (single-item and multi-item forms) | **MERGE** → Assumptions & provenance | The "what did Olumi change and why" ledger belongs with provenance, not floating between sections. |
+| — header toggle + counts | **MERGE** | Becomes the group header. |
+| — "Constraints applied" / "Auto-fixes applied" groups | **KEEP** | |
+| — repair-action bullets | **KEEP** | |
+| — `AdjustmentRow` bullet, headline, target line | **KEEP** | |
+| — per-row "Details / Hide details" disclosure | **CUT** | A fourth disclosure axis; its content moves to the detail region. |
+| — `sanitiseDetail` | **KEEP** | Strips engine field paths out of user-facing copy. Good artefact — and the v2 detail region depends on it. |
+| — `post-run-repairs-toggle` + `post-run-repairs-list` | **CUT** | Dead: the prop is never passed (F12). |
+
+**Evidence & review state**
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `ModelHealthSection` ("Model card") | **MERGE** → Evidence & review state | |
+| — `tierLabel` "{n}% stability · {n}/10" | **MERGE** | Becomes chips / group summary. |
+| — `model-card-pre-analysis` block | **KEEP** | Correctly says what is not yet known. |
+| — "Based on {n} factors and {n} relationships" | **MERGE** | Becomes the header summary line. |
+| — "{n} factor(s) need(s) your input" | **MERGE** | Becomes the verify chip + Queue B. |
+| — "Run analysis to see stability, confidence, and reproducibility data" | **KEEP** | |
+| — `model-card-methodology` ("Based on {n} Monte Carlo simulations") | **DEMOTE** | |
+| — `root-node-warning` | **KEEP + PROMOTE** | Becomes an attention chip and **Queue D** — closing F9's other half. Today the sentence is a dead end. |
+| — its "Penalty: {n}x stability" tail | **DEMOTE** | |
+| — quality sub-scores ×4 (`quality-row-*`) | **DEMOTE** | |
+| — `model-health-audit` grid: seed, response hash, simulations, stability, auto-noise row, stability penalty, repairs summary, inference warnings | **DEMOTE** | The audit trail is the canonical Advanced block content. |
+| — every row's `!= null` gate | **KEEP** | Never a placeholder. |
+| — `modelcard-discuss` | **KEEP+FIX** | `handOffToOlumi`. |
+
+### 7.4 Chrome defined outside `model-tab/` but rendered by it
+
+Listed because a review that excluded them would be reviewing less than the user sees.
+
+| Current surface | Verdict | One-line justification |
+|---|---|---|
+| `Accordion` — chevron, `testId`, `aria-expanded`, title | **MERGE** | Becomes the v2 group header (multi-open, independently remembered). |
+| — `badgeCount` pill | **KEEP** | Becomes the group's count. |
+| — `tierLabel` pill | **KEEP+FIX** | Its tooltip is **hardcoded** to a confidence-about-factors sentence and is wrong on Relationships and Model card (F12). |
+| — `icon` | **KEEP** | |
+| — `subtitle` | **no action** | Supported by the component and **never supplied by any model-tab caller**. Shared component — not this tab's to delete. |
+| `AnalysisRunStateCover`, `DataBar`, `StrengthBar`, `SignedStrengthSlider` | **KEEP** | External leaf visuals, reused as-is. Out of scope for removal. |
+
+### 7.5 Helper modules (no surface of their own)
+
+| Module | Verdict | One-line justification |
+|---|---|---|
+| `utils.ts` | **KEEP** | Produces the value strings, the "to verify" count and the edge tone/sign. Load-bearing. |
+| — `mapSourceToTooltip`, `isGenericUnit` | **CUT** | No production importer (contrast control: `formatValueWithUnit` resolves to 10 files). |
+| `strengthBands.ts` | **KEEP + unify** | The copy source for every strength, confidence, existence, basis and contested-reason sentence. Two strength vocabularies coexist across surfaces (F12); the model editor speaks one. |
+| `buildGoalFitRows.ts` | **KEEP** | Complete-field gated — returns `null` rather than a partial row set. Exactly the honesty the goal block needs. |
+| `synthesisedPriorHelpers.ts` | **KEEP** | Supplies fallback prior bounds and the "· from model repair" annotation. |
+| `types.ts` — `ObservedState`, `FactorInfluenceMap`, `DetailContext` | **KEEP** | Live, imported. |
+| — `ModelTabProps` | **CUT** | **No importer anywhere in `src/`**; a drifted mirror of the live inline `ModelTabBodyProps` (it declares a `critique` field and lacks `expertMode` / `onSendMessage`). A stale type nobody uses is the next session's false map. |
+
+### 7.6 The interaction budget after
+
+| Target | Today | v2 |
+|---|---|---|
+| Goal target | 1 | 1 |
+| Factor value · Confirm · prior min/max | 1 | 1 |
+| Option intervention value | 2 (+ collapses Factors) | **1** |
+| Edge strength · likelihood · direction | **3** | **1** |
+| Factor baseline | 2 (invisible) | 2 (select row → detail) |
+| Any scientific parameter | 3 + an out-of-tab toggle | **2** (tier switch → select row) |
+| Set a factor that has no value | **impossible** | **1** |
+| Confirm every AI estimate | N × (find it yourself) | **1 per item in a queue** |
+| Add / remove an element | **impossible**, into a hidden panel | Open question 2 — at minimum, the CTA fronts Olumi |
+
+Every inspectable/editable thing meets the brief's **≤2 interactions from tab open**.
+
+## 8. What I deliberately do NOT redesign
+
+- **The graph.** The canvas stays the rich structural model. This tab is its tabular twin, not its
+  replacement, and every row keeps today's click-to-focus-on-canvas behaviour.
+- **The write authority.** Codex's transactional-edit vertical owns it. Every edit here is an
+  *intent* dispatched to that authority. **No new local writers.** No file in this design's scope
+  touches `edge_strength_edit`, the system-events modules, PR #714's files, or
+  `useResultsSectionData.ts`.
+- **Analysis surfaces.** PX-C owns the Analysis tab, results, and anything that explains an outcome.
+  This tab shows *what the model says*, never *what the analysis concluded*.
+- **The conversation dock.** PX-A owns fronting and layout. I name the event I need; I do not build it.
+- **The honesty resolvers and provenance classifier.** `edgeValueProvenance`, `valueProvenance`,
+  `driverConfidenceDisplayPolicy` are reused verbatim. They are the reason this tab does not lie.
+
+---
+
+## 9. Contracts this design needs
+
+**How to answer this section.** Every ask below has an **ID**, an **exact shape**, and a **closed
+question**. Each question is answerable **yes** or **no** without reading the rest of this document;
+where the answer is *no*, the useful reply is *"no — here is the shape you get instead"*. Nothing
+here asks the answering lane to adopt this design, and nothing here is a request to build UI: these
+are the seams the v2 surface binds to, and the v2 components already compile against them
+(`src/canvas/model-tab-v2/contracts.ts`, which is the machine-readable copy of §9.1).
+
+**Why the questions are this specific.** Four of the fifteen defects in §2 are seams where two
+things that look identical behave differently — an edit that reaches the server and one that does
+not (F6), one human gesture stamped two ways (F8), a magnitude that must not carry a sign, and a
+producer's estimate that must not be laundered as the user's. A contract answered at the level of
+"yes, there's an edit API" would reproduce every one of them.
+
+### 9.1 From the write authority (Codex's transactional-edit vertical)
+
+**The operations.** Status column derived at UI `staging` `a3c71513`.
+
+| ID | Operation | Status today | The closed question |
+|---|---|---|---|
+| **C1** | `proposeFactorValue(nodeId, typedValue)` | **exists** — `factor_value_edit`, server-authoritative with optimistic revert | Will this be reachable through the uniform handle (C10) with its current semantics unchanged? |
+| **C2** | `proposePriorRange(nodeId, min, max)` | **exists** — `prior_range_edit`, **carry-only** (CEE persists a typed fact and writes no graph) | When CEE persists the fact but writes no graph, does the handle settle `applied` or something weaker? ⚠ **The row renders whatever you answer**, so "applied" must mean the model changed — if it did not, the design needs a distinct outcome rather than a green tick over a no-op. |
+| **C3** | `resolveContestedEdge(edgeId, verdict, value?)` | **exists** — `edge_adjudication` | Will the provenance discipline stay exactly as it is — an accepted *producer* estimate stamped `cee`, never `user`? |
+| **C4** | `proposeEdgeStrength(edgeId, signedMean, { directionStated })` | **in flight on your lane** — `edge_strength_edit` | With `directionStated: false`, will the magnitude be written **alone**, leaving the direction and its stamp untouched, so the edge keeps reading "direction not stated"? **A magnitude must never carry a sign.** |
+| **C5** | `proposeEdgeLikelihood(edgeId, p)` — `p ∈ [0,1]` | **no** — local only (`setExistsProbability`) | Will this exist? |
+| **C6** | `proposeEdgeDirection(edgeId, 'positive' \| 'negative')` | **no** — local only (`setDirection`) | Will this exist? |
+| **C7** | `proposeOptionIntervention(optionId, factorId, value)` | **no** — local only (`setIntervention`); reaches CEE **only** as the debounced, **value-less** `direct_graph_edit` ping | Will this exist and carry **the value**? ⚠ **Queue A is unbuildable without it** — a queue that applies eight intervention values through a value-less ping is eight lies. |
+| **C8** | `proposeGoalTarget(nodeId, raw, unit?)` | **no** — local only (`setGoalThresholdAndUpdateNode`) | Will this exist, and does it take the **raw** target plus unit (not a pre-normalised number)? |
+| **C9** | `proposeFactorConfirmation(nodeId)` | **no** — a local annotation, and **stamped wrong** | Will confirming stamp **`user_confirmed`**, not `user`? ⚠ Today the Model tab writes `'user'` → class `edited` → pill **"User edited"**, for a gesture that ratified *somebody else's* number; pre-analysis writes `'user_confirmed'` → **"Confirmed by you"** for the identical act (F8). **Queue B depends on this.** |
+
+**The shape.** These five are asked once and apply to all of C1–C9.
+
+| ID | The ask | The closed question |
+|---|---|---|
+| **C10** | A handle `{ state, receipt?, error? }` where `state` is the discriminated union `idle \| editing \| proposed \| inflight \| applied \| refused` | Will each operation return a handle from which the row can render its state, so `applied` is reachable **only** because the authority said so? ⚠ This is the single most important ask in the section: it is what makes F6 structurally impossible rather than merely fixed. |
+| **C11** | `receipt: { appliedValue, provenanceLiteral }` | Will the receipt carry the **stored** value and the **raw provenance stamp**? ⚠ The row must not re-derive either from the number it sent — an echo rendered as a receipt is an optimistic write wearing a confirmation. `provenanceLiteral` is the raw stamp (`'user_confirmed'`, `'cee'`, …), classified for display by the one shared classifier, never a pre-classified kind. |
+| **C12** | `proposeBatch(edits): Promise<readonly EditProposalHandle[]>` — **per-item** outcomes | Will a batch report **per item**, and count as **one** undo step and **one** re-analysis invalidation? ⚠ Not a convenience: without it "Apply all shown" over eight rows is eight turns, eight undo steps and eight invalidations for **one** user gesture. A batch that returns one aggregate verdict cannot tell the user which three of the eight were refused. |
+| **C13** | `error`: a refusal reason **in user-facing words** | Will refusals carry prose a user can read, and **which side sanitises it**? The estate already has `ModelAdjustments.sanitiseDetail`, which strips engine field paths out of user-facing copy — the design reuses it rather than writing a second, but needs to know whether it is receiving raw engine text or already-clean prose. |
+| **C14** | Concurrency semantics for one field | If a second proposal arrives for a field with one already `inflight`, is it rejected, queued, or does it supersede? ⚠ The row renders one `EditCommitState` per value, so it needs to know whether two can ever be live at once — and tab-through-and-fix (§5.2) makes this reachable in ordinary use, not just under stress. |
+
+**Not a wire contract, but owed by whoever mounts v2 first.** When `src/canvas/model-tab-v2/`
+becomes live, **widen `model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts`** to cover
+it. That guard is derived from `src/canvas/components/model-tab/` and is **recursive within that
+directory only**, so a v2 tree living elsewhere is **unguarded** against raw
+`updateNode` / `updateEdge` / `updateEdgeData` writes — which is precisely how the class was
+re-opened last time: the inspector was fixed, the Model tab kept its own hand-rolled writes, and the
+killed defect stayed live through a different door. *(This lane ships its own boundary guard over the
+v2 directory in the meantime — `__tests__/modelTabV2Boundary.sourceScan.spec.ts` — but that guard is
+scoped to this directory and does not replace widening the original.)*
+
+### 9.2 From PX-A (panel fronting)
+
+One call, owned by PX-A, that survives the dock rework:
+
+```ts
+frontOlumiPanel(opts?: { reason?: string }): 'fronted' | 'deferred'
+```
+
+| ID | The ask | The closed question |
+|---|---|---|
+| **D1** | The call exists with that signature and fronts the Olumi conversation whether it is **docked, floating or collapsed** | Will it exist, and does it cover all three states? `revealOlumiSurface()` is the current primitive and the natural basis. |
+| **D2** | Origin is **`'user'`** | Will it avoid stamping `outputSurfaceOrigin: 'assistant'` and avoid raising the `AssistantOpenedNotice`? ⚠ These are user gestures. Telling the user Olumi opened something *they* opened is a lie on the one channel whose entire purpose is truthfulness. |
+| **D3** | The return value is **truthful about what the user can now see** | Does `'fronted'` mean the panel is actually in front of the user at the moment it returns — not merely that a request was dispatched? ⚠ The whole value of the return is that a hand-off which could not front the panel can **say so** instead of sending into silence. A return that optimistically reports success is worse than no return at all. |
+
+**Why D1–D3 matter more than they look.** Measured at `a3c71513`: **12 `onSendMessage` call sites
+across 6 Model-tab components, carrying 11 distinct messages**, every one of them posting a real turn
+into a panel that stays `hidden` — the Olumi tab is mounted but hidden
+(`OutputsDock.tsx:2797-2805`) and the one auto-expand path requires `dockCollapsed`, which is false
+while the Model tab is visible. `revealOlumiSurface()` has **10 production call sites across 4
+modules**, and **zero** of them are on the Model tab. Contrast control: the same scope has **12**
+`onSendMessage` sites. So four other surfaces front the panel before they send, and the one with the
+most hand-offs never does (F5).
+
+**I need the call and its return contract. I do not need, and will not build, any dock mechanism.**
+
+---
+
+## 10. Open questions — for Paul only
+
+**1. Does the Model tab get its own `Plain | Advanced` control, or keep obeying the global `</>`?**
+ROADMAP 2.581 deliberately unified expert mode across the product after a split control caused a real
+misreading. This design re-splits it — on purpose, because the Model tab's tier must be a *content*
+switch while the global one also changes *layout*, and because a control that governs this tab should
+be in this tab. But it reverses a ratified decision, so it is your call.
+
+**2. Should the Model tab be able to add and delete model elements directly?**
+Today it cannot (F4), and the "+ Add" buttons message a hidden panel (F5). Direct add/delete is the
+single biggest change to "I can actually edit the decision model", and it fits *"humans remain the
+authors"*. It is also the largest new surface here and it changes who authors the model — Olumi
+drafting versus the user building. My recommendation is **yes, for factors and relationships**
+(delete behind a confirm), and **no** for goal/decision. Your call on scope.
+
+**3. Should a confirmed edit ever re-run the analysis automatically?**
+Today it never does — the sticky Re-analyse bar is always explicit, and that is honest. But a repair
+queue that fixes eight factors leaves the user staring at eight-edits-worth of stale results. Options:
+stay explicit (safe, current) · auto-run once when a queue is emptied · offer "Apply all and
+re-analyse". This is a cost/latency judgement, not an evidence question.
+
+---
+
+## 11. Build sequence (if Paul approves)
+
+Ordered so each step is independently shippable and each one is visible to a user.
+
+1. **Header + working filter + attention chips that open their target.** Closes F3 and F11. No new
+   write path. Smallest change with the largest felt effect.
+2. **Multi-open groups; tier control moved in-tab; layout decoupled from detail.** Closes F1 and F2.
+3. **The row: primary value editable in place for edges and interventions.** Closes the 3-interaction
+   cost. Still on today's write paths.
+4. **The detail region replaces `cardExpanded`.** Closes F7.
+5. **Propose→confirm states in `InlineEdit`, wired to Codex's authority as each operation lands.**
+   Closes F6 progressively; rows tell the truth about which edits are authoritative.
+6. **Queues A–D.** Closes F9 and makes the badges actionable.
+7. **`handOffToOlumi` on all 12 call sites.** Closes F5. *(Can ship at any point once PX-A's call
+   exists — it is the cheapest item on this list and independently valuable.)*
+
+## 12. Acceptance
+
+The rebuild is done when a capable non-scientist can, on staging, in one sitting:
+- find any element of the model by typing part of its name;
+- change its primary value in ≤2 interactions and see, in words, whether the change was applied;
+- clear the "to verify" badge to zero without leaving the tab;
+- give a value to a factor that had none;
+- see every scientific parameter by flipping one switch, and see none of them by flipping it back;
+- and hand any of it to Olumi with the panel actually in front of them.
+
+Stop when that holds. This is a PoC surface, not a product-grade editor.

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -1,0 +1,181 @@
+/**
+ * Model tab v2 — THE DETAIL REGION (design §4.4).
+ *
+ * ⚠ UNMOUNTED. See `types.ts`.
+ *
+ * WHAT IT REPLACES. Today reaching an edge's detail costs THREE nested
+ * disclosures — the section accordion, then a per-card `cardExpanded` toggled by
+ * clicking the card body with NO CHEVRON AND NO VISIBLE AFFORDANCE, then the
+ * global `showDetail` whose control lives outside the tab in the dock chrome
+ * (design §2 F7). Selection replaces the middle one entirely, so the axes drop
+ * from three to two: group open/closed, and selection. The invisible axis is the
+ * one being deleted, and it is invisible by design accident, not by intent.
+ *
+ * TWO PROPERTIES THIS FILE EXISTS TO GUARANTEE:
+ *
+ * 1. THE ADVANCED BLOCK IS ABSENT FROM THE DOM IN PLAIN — not hidden, not
+ *    `display:none`, not zero-height. A parameter that is merely invisible is
+ *    still findable, still copyable, still read by a screen reader, and still
+ *    there to be mistaken for a plain value the moment a stylesheet changes.
+ *    "Flip one switch and see none of them" (design §12) is a claim about what
+ *    EXISTS, and it is enforced here by not rendering the subtree at all.
+ *
+ * 2. IT REFUSES TO RENDER SOMEBODY ELSE'S DETAIL. `detail.rowId` must equal the
+ *    row it was asked to describe. On a mismatch it says so, loudly, instead of
+ *    painting a confident and wrong pane — see `ModelRowDetail.rowId`.
+ */
+
+import { typography } from '../../styles/typography'
+import { SourceProvenancePill } from '../components/model-tab/SourceProvenancePill'
+import { KIND_LABEL } from './rowPresentation'
+import type { DetailField, DetailTier, ModelRow, ModelRowDetail } from './types'
+
+export interface ModelDetailRegionProps {
+  row: ModelRow
+  detail: ModelRowDetail
+  tier: DetailTier
+  onFocusOnCanvas?: (id: string) => void
+}
+
+/** Absence is rendered as absence — never as a zero, never as a blank cell. */
+function FieldList({ fields, testid }: { fields: readonly DetailField[]; testid: string }) {
+  if (fields.length === 0) return null
+  return (
+    <dl data-testid={testid} className="grid grid-cols-2 gap-x-3 gap-y-1">
+      {fields.map(f => (
+        <div key={f.label} className="contents">
+          <dt className={`${typography.caption} text-text-light`}>{f.label}</dt>
+          <dd
+            data-testid={`${testid}-${f.label}`}
+            className={`${typography.tabular} text-text-body`}
+          >
+            {f.value ?? 'Not stated'}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+export function ModelDetailRegion({
+  row,
+  detail,
+  tier,
+  onFocusOnCanvas,
+}: ModelDetailRegionProps) {
+  /*
+   * The identity gate. This is deliberately a VISIBLE refusal rather than a
+   * silent `return null`: a detail region that quietly vanishes looks like a
+   * rendering bug and gets "fixed" by removing the check, whereas a stated
+   * mismatch names the defect for whoever sees it.
+   */
+  if (detail.rowId !== row.id) {
+    return (
+      <aside data-testid="model-detail-v2" data-mismatch="true">
+        <p data-testid="model-detail-v2-mismatch" className={`${typography.bodySmall} text-danger`}>
+          This panel was given details for a different element, so it has not shown them.
+        </p>
+      </aside>
+    )
+  }
+
+  return (
+    <aside
+      data-testid="model-detail-v2"
+      data-row-id={row.id}
+      data-tier={tier}
+      aria-label={`${KIND_LABEL[row.kind]} details: ${row.label}`}
+      className="flex flex-col gap-3 p-3"
+    >
+      {/* 1 — What this is */}
+      <section data-testid="model-detail-v2-what">
+        <h3 className={`${typography.h5} text-text-header`}>{row.label}</h3>
+        <p className={`${typography.caption} text-text-light`}>{KIND_LABEL[row.kind]}</p>
+        {detail.description !== null && (
+          <p
+            data-testid="model-detail-v2-description"
+            className={`${typography.bodySmall} text-text-body`}
+          >
+            {detail.description}
+          </p>
+        )}
+      </section>
+
+      {/* 2 — Its value */}
+      <section data-testid="model-detail-v2-value">
+        <h4 className={`${typography.label} text-text-header`}>Its value</h4>
+        <p data-testid="model-detail-v2-primary" className={`${typography.tabular} text-text-body`}>
+          {row.primaryValue ?? 'Not set'}
+        </p>
+        <FieldList fields={detail.secondaryValues} testid="model-detail-v2-secondary" />
+      </section>
+
+      {/* 3 — Where it came from */}
+      <section data-testid="model-detail-v2-provenance">
+        <h4 className={`${typography.label} text-text-header`}>Where it came from</h4>
+        {row.provenanceSource !== undefined && (
+          <SourceProvenancePill source={row.provenanceSource} showWhenAbsent={false} />
+        )}
+        {detail.basis !== null && (
+          <p
+            data-testid="model-detail-v2-basis"
+            className={`${typography.bodySmall} text-text-body`}
+          >
+            {detail.basis}
+          </p>
+        )}
+        {detail.adjustments.length > 0 && (
+          <ul data-testid="model-detail-v2-adjustments">
+            {detail.adjustments.map(a => (
+              <li key={a} className={`${typography.caption} text-text-light`}>
+                {a}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* 4 — What it affects */}
+      <section data-testid="model-detail-v2-affects">
+        <h4 className={`${typography.label} text-text-header`}>What it affects</h4>
+        {detail.affects.length === 0 ? (
+          <p className={`${typography.caption} text-text-light`}>
+            Nothing in the model depends on this yet
+          </p>
+        ) : (
+          <ul>
+            {detail.affects.map(a => (
+              <li key={a.id}>
+                <button
+                  type="button"
+                  data-testid={`model-detail-v2-affects-${a.id}`}
+                  onClick={() => onFocusOnCanvas?.(a.id)}
+                  className={`${typography.bodySmall} text-info text-left`}
+                >
+                  {a.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/*
+        5 — Advanced. ⚠ NOT RENDERED AT ALL IN PLAIN. See the header: this is an
+        existence claim, not a visibility one.
+      */}
+      {tier === 'advanced' && (
+        <section data-testid="model-detail-v2-advanced">
+          <h4 className={`${typography.label} text-text-header`}>Advanced — model parameters</h4>
+          {detail.advancedParameters.length === 0 ? (
+            <p className={`${typography.caption} text-text-light`}>
+              This element has no model parameters
+            </p>
+          ) : (
+            <FieldList fields={detail.advancedParameters} testid="model-detail-v2-advanced-fields" />
+          )}
+        </section>
+      )}
+    </aside>
+  )
+}

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -1,0 +1,163 @@
+/**
+ * Model tab v2 — THE OUTLINE. Two tiers, seven groups, one scroll (design §4.3).
+ *
+ * ⚠ UNMOUNTED. See `types.ts`.
+ *
+ * ⚠ THE LOAD-BEARING PROPERTY: THE TIER IS A CONTENT SWITCH, NEVER A LAYOUT
+ * SWITCH. Today's `expertMode` drives BOTH the scientific detail AND the
+ * accordion mode — `ModelTabBody.tsx:116-122` returns `{}` when expert (making
+ * the accordion multi-open) and a controlled single-open object otherwise, while
+ * `:761` feeds the same flag to `DetailToggleContext`. So a non-scientist who
+ * merely wants two groups open at once has to switch on the scientist view, and
+ * a scientist who wants parameters silently gets a different layout. That is
+ * design §2 F1, and it is the reason the advanced toggle "overwhelms
+ * non-scientists": it is two controls wearing one switch.
+ *
+ * Here the tier governs CONTENT ONLY. `outlineLayout()` below is a pure function
+ * of (rows, filter, openGroups) and takes NO tier argument — the separation is
+ * structural, not a promise in a comment, so a future edit that made layout
+ * depend on the tier would have to change the function's signature to do it.
+ *
+ * MULTI-OPEN ALWAYS, IN BOTH TIERS, INDEPENDENTLY REMEMBERED. Opening Options
+ * never closes Factors (design §2 F2). All seven groups are always PRESENT: a
+ * filter that empties a group says so in words rather than removing the heading,
+ * so the user never has to wonder whether a group disappeared or never existed.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import { typography } from '../../styles/typography'
+import { ModelRowView } from './ModelRowView'
+import { GROUP_TITLE } from './rowPresentation'
+import { MODEL_GROUP_IDS, type DetailTier, type ModelGroupId, type ModelRow } from './types'
+
+export interface ModelOutlineProps {
+  /**
+   * The projection. RENDERED IN THE ORDER GIVEN — the outline never sorts. Order
+   * is the producer's business; re-sorting here would silently disagree with the
+   * order every other surface shows.
+   */
+  rows: readonly ModelRow[]
+  tier: DetailTier
+  /** The working filter (design §7.2 KEEP+FIX — today's search box filters nothing, F3). */
+  filter?: string
+  selectedId?: string | null
+  onSelect?: (id: string) => void
+  onFocusOnCanvas?: (id: string) => void
+  /** Groups closed at first render. Everything else is open (multi-open always). */
+  initiallyClosedGroups?: readonly ModelGroupId[]
+}
+
+/**
+ * The layout decision, isolated as a PURE function — and deliberately WITHOUT a
+ * tier parameter, so "the tier cannot change the layout" is enforced by the type
+ * system rather than asserted in prose.
+ *
+ * A row whose `group` is not one of the seven is DROPPED and reported, never
+ * silently rendered into an arbitrary group.
+ */
+export function outlineLayout(
+  rows: readonly ModelRow[],
+  filter: string,
+  openGroups: ReadonlySet<ModelGroupId>,
+): {
+  groups: readonly { id: ModelGroupId; open: boolean; rows: readonly ModelRow[] }[]
+  unknownGroupRowIds: readonly string[]
+} {
+  const needle = filter.trim().toLowerCase()
+  const known = new Set<string>(MODEL_GROUP_IDS)
+  const unknownGroupRowIds = rows.filter(r => !known.has(r.group)).map(r => r.id)
+
+  const matches = (r: ModelRow) =>
+    needle === '' || r.label.toLowerCase().includes(needle)
+
+  return {
+    groups: MODEL_GROUP_IDS.map(id => ({
+      id,
+      open: openGroups.has(id),
+      // `filter` preserves the caller's order by construction.
+      rows: rows.filter(r => r.group === id && matches(r)),
+    })),
+    unknownGroupRowIds,
+  }
+}
+
+export function ModelOutline({
+  rows,
+  tier,
+  filter = '',
+  selectedId = null,
+  onSelect,
+  onFocusOnCanvas,
+  initiallyClosedGroups,
+}: ModelOutlineProps) {
+  const [closed, setClosed] = useState<ReadonlySet<ModelGroupId>>(
+    () => new Set(initiallyClosedGroups ?? []),
+  )
+
+  const openGroups = useMemo(
+    () => new Set(MODEL_GROUP_IDS.filter(id => !closed.has(id))),
+    [closed],
+  )
+
+  /** Toggling one group NEVER touches another — design §2 F2. */
+  const toggle = useCallback((id: ModelGroupId) => {
+    setClosed(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const { groups } = outlineLayout(rows, filter, openGroups)
+
+  return (
+    <div data-testid="model-outline-v2" data-tier={tier} className="flex flex-col">
+      {groups.map(group => (
+        <section
+          key={group.id}
+          data-testid={`model-group-v2-${group.id}`}
+          data-open={group.open}
+        >
+          <button
+            type="button"
+            data-testid={`model-group-v2-${group.id}-toggle`}
+            aria-expanded={group.open}
+            onClick={() => toggle(group.id)}
+            className={`${typography.label} text-text-header w-full text-left px-2 py-1.5`}
+          >
+            {group.open ? '▾' : '▸'} {GROUP_TITLE[group.id]}
+            <span className={`${typography.caption} text-text-light ml-2`}>
+              {group.rows.length}
+            </span>
+          </button>
+
+          {group.open &&
+            (group.rows.length === 0 ? (
+              <p
+                data-testid={`model-group-v2-${group.id}-empty`}
+                className={`${typography.caption} text-text-light px-4 py-1`}
+              >
+                {filter.trim() === ''
+                  ? 'Nothing in this group yet'
+                  : 'No matches in this group'}
+              </p>
+            ) : (
+              <ul role="listbox" aria-label={GROUP_TITLE[group.id]}>
+                {group.rows.map(row => (
+                  <ModelRowView
+                    key={row.id}
+                    row={row}
+                    tier={tier}
+                    selected={row.id === selectedId}
+                    onSelect={onSelect}
+                    onFocusOnCanvas={onFocusOnCanvas}
+                  />
+                ))}
+              </ul>
+            ))}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -23,7 +23,7 @@
 
 import { typography } from '../../styles/typography'
 import { SourceProvenancePill } from '../components/model-tab/SourceProvenancePill'
-import { ATTENTION_LABEL, KIND_GLYPH, KIND_LABEL } from './rowPresentation'
+import { ATTENTION_LABEL, KIND_GLYPH, KIND_LABEL, deferralLabel } from './rowPresentation'
 import type { EditCommitState, DetailTier, ModelRow } from './types'
 
 export interface ModelRowViewProps {
@@ -129,6 +129,25 @@ export function ModelRowView({
           ⚠
         </span>
       ))}
+
+      {/*
+        The deferred marker (design §4.2, §5.3). ⚠ It is rendered AFTER the
+        attention markers and does not suppress them: deferring records that a
+        human ruled the gap can wait, it does not make the gap stop existing. A
+        row that fell silent about its gap once deferred would be the dismiss
+        button growing back. The label carries the provenance, because an
+        anonymous deferral cannot be told apart from a dropped row.
+      */}
+      {row.deferred !== undefined && (
+        <span
+          data-testid={`model-row-v2-${row.id}-deferred`}
+          title={deferralLabel(row.deferred)}
+          aria-label={deferralLabel(row.deferred)}
+          className={`${typography.caption} text-text-light`}
+        >
+          Left unresolved
+        </span>
+      )}
 
       {tier === 'advanced' && (
         <span

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -1,0 +1,252 @@
+/**
+ * Model tab v2 — THE ROW. One anatomy for every element (design §4.2).
+ *
+ * ⚠ UNMOUNTED. Nothing imports this outside `src/canvas/model-tab-v2/` and its
+ * specs; `__tests__/modelTabV2IsUnmounted.sourceScan.spec.ts` proves it.
+ *
+ * ⚠ THIS COMPONENT NEVER WRITES, AND NEVER DECIDES THAT AN EDIT SUCCEEDED.
+ * It renders `commit` — the state the WRITE AUTHORITY reports — and it renders
+ * `row.primaryValue` VERBATIM. It does not re-derive a value, re-format a
+ * number, or infer a provenance. The reason is design §2 F6: today an edge
+ * strength, an option's intervention value and the goal target are local store
+ * writes that never reach CEE, while a factor value edit is a real turn — and
+ * the two are INDISTINGUISHABLE on screen. A row that can only render `applied`
+ * from a receipt cannot reproduce that, whatever it is handed.
+ *
+ * THE DISABLED-AFFORDANCE RULE (the lane boundary, design §8). The write
+ * authority is Codex's transactional-edit vertical and it is not frozen yet. So
+ * every control here that would CAUSE a transition is rendered DISABLED, with a
+ * label saying why, whenever its callback is absent. A disabled affordance with
+ * an honest label beats a fake one: a stub that reported success would be the
+ * silent-local-write defect re-created inside the component written to kill it.
+ */
+
+import { typography } from '../../styles/typography'
+import { SourceProvenancePill } from '../components/model-tab/SourceProvenancePill'
+import { ATTENTION_LABEL, KIND_GLYPH, KIND_LABEL } from './rowPresentation'
+import type { EditCommitState, DetailTier, ModelRow } from './types'
+
+export interface ModelRowViewProps {
+  row: ModelRow
+  /**
+   * Content tier. ⚠ IT MUST NOT CHANGE LAYOUT — no reordering, no open/closed
+   * change, no selection change (design §4.3 rule 1, closing F1). In the row it
+   * governs one thing only: whether the element's ID is shown.
+   */
+  tier: DetailTier
+  selected?: boolean
+  /**
+   * The authority's answer for this row's value, if an edit is in flight or has
+   * settled. Absent means `idle` — the row shows the model's value.
+   */
+  commit?: EditCommitState
+  /** Select the row and open the detail region. Read-only navigation. */
+  onSelect?: (id: string) => void
+  /** Focus this element on the canvas — today's `focusNodeById` behaviour. */
+  onFocusOnCanvas?: (id: string) => void
+  /**
+   * Begin an edit. ABSENT UNTIL THE WRITE AUTHORITY IS FROZEN, which is why the
+   * editor affordance renders disabled rather than optimistic.
+   */
+  onBeginEdit?: (id: string) => void
+}
+
+/** Why the editor is unavailable. Shown on the disabled control, in words. */
+const NO_AUTHORITY_REASON =
+  'Editing is not connected yet — this value cannot be changed from here.'
+
+export function ModelRowView({
+  row,
+  tier,
+  selected = false,
+  commit,
+  onSelect,
+  onFocusOnCanvas,
+  onBeginEdit,
+}: ModelRowViewProps) {
+  const phase = commit?.phase ?? 'idle'
+  const editorAvailable = row.editable && typeof onBeginEdit === 'function'
+
+  return (
+    <li
+      data-testid={`model-row-v2-${row.id}`}
+      data-kind={row.kind}
+      data-phase={phase}
+      aria-selected={selected}
+      role="option"
+      className={`flex items-center gap-2 px-2 py-1.5 border-b border-panel-border ${
+        selected ? 'bg-panel-hover' : ''
+      }`}
+      onClick={() => onSelect?.(row.id)}
+    >
+      <span
+        aria-label={KIND_LABEL[row.kind]}
+        title={KIND_LABEL[row.kind]}
+        data-testid={`model-row-v2-${row.id}-glyph`}
+        className="text-text-light select-none"
+      >
+        {KIND_GLYPH[row.kind]}
+      </span>
+
+      <button
+        type="button"
+        data-testid={`model-row-v2-${row.id}-label`}
+        className={`${typography.bodySmall} text-text-body text-left truncate`}
+        onClick={e => {
+          e.stopPropagation()
+          onFocusOnCanvas?.(row.id)
+        }}
+      >
+        {row.label}
+      </button>
+
+      <ValueCell
+        row={row}
+        commit={commit}
+        editorAvailable={editorAvailable}
+        onBeginEdit={onBeginEdit}
+      />
+
+      {/*
+        showWhenAbsent={false} is deliberate: when nothing states a provenance the
+        row shows NOTHING, rather than a "Not set" chip asserting a fact about a
+        value that may be perfectly well set. Absence is rendered as absence.
+      */}
+      {row.provenanceSource !== undefined && (
+        <span data-testid={`model-row-v2-${row.id}-provenance`}>
+          <SourceProvenancePill source={row.provenanceSource} showWhenAbsent={false} />
+        </span>
+      )}
+
+      {row.attention.map(reason => (
+        <span
+          key={reason}
+          data-testid={`model-row-v2-${row.id}-attention-${reason}`}
+          title={ATTENTION_LABEL[reason]}
+          aria-label={ATTENTION_LABEL[reason]}
+          className={`${typography.caption} text-warning`}
+        >
+          ⚠
+        </span>
+      ))}
+
+      {tier === 'advanced' && (
+        <span
+          data-testid={`model-row-v2-${row.id}-id`}
+          className={`${typography.code} text-text-light`}
+        >
+          {row.id}
+        </span>
+      )}
+    </li>
+  )
+}
+
+/**
+ * The primary value, and the three-beat's visible states (design §5.1).
+ *
+ * ⚠ `proposed` KEEPS THE OLD VALUE ON SCREEN beside the new one, and says in
+ * words that nothing has changed yet. ⚠ `refused` states the reason and shows
+ * the value REVERTED. A refusal that looks like nothing happened is the same
+ * defect as a silent local write, one step later.
+ */
+function ValueCell({
+  row,
+  commit,
+  editorAvailable,
+  onBeginEdit,
+}: {
+  row: ModelRow
+  commit?: EditCommitState
+  editorAvailable: boolean
+  onBeginEdit?: (id: string) => void
+}) {
+  const testid = `model-row-v2-${row.id}-value`
+
+  if (commit && commit.phase !== 'idle') {
+    switch (commit.phase) {
+      case 'editing':
+        return (
+          <span data-testid={testid} className={typography.tabular}>
+            {commit.draft}
+          </span>
+        )
+      case 'proposed':
+        return (
+          <span data-testid={testid} className={typography.tabular}>
+            <span data-testid={`${testid}-from`}>{commit.from}</span>
+            {' → '}
+            <span data-testid={`${testid}-to`}>{commit.to}</span>
+            <span className={`${typography.caption} text-text-light ml-2`}>
+              Nothing has changed yet
+            </span>
+          </span>
+        )
+      case 'inflight':
+        return (
+          <span data-testid={testid} className={typography.tabular}>
+            {commit.to}
+            <span className={`${typography.caption} text-text-light ml-2`}>Saving…</span>
+          </span>
+        )
+      case 'applied':
+        return (
+          <span data-testid={testid} className={typography.tabular}>
+            {commit.value}
+          </span>
+        )
+      case 'refused':
+        return (
+          <span data-testid={testid} className={typography.tabular}>
+            <span data-testid={`${testid}-reverted`}>{commit.from}</span>
+            <span
+              data-testid={`${testid}-refusal`}
+              className={`${typography.caption} text-danger ml-2`}
+            >
+              {commit.reason}
+            </span>
+          </span>
+        )
+    }
+  }
+
+  /*
+   * F9 — the single most damning editing gap today: a factor with no value
+   * cannot be GIVEN one, because the card renders inert "Not set" text where the
+   * editor belongs. Here a null value still renders an editor affordance; it is
+   * disabled only because the authority is not frozen, never because the value
+   * is missing.
+   */
+  const display = row.primaryValue
+
+  if (!row.editable) {
+    return (
+      <span data-testid={testid} className={typography.tabular}>
+        {display ?? 'Not set'}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={testid}
+      disabled={!editorAvailable}
+      title={editorAvailable ? 'Change this value' : NO_AUTHORITY_REASON}
+      aria-label={
+        editorAvailable
+          ? `Change ${row.label}`
+          : `${row.label} — ${NO_AUTHORITY_REASON}`
+      }
+      className={`${typography.tabular} text-left ${
+        editorAvailable ? 'underline decoration-dotted' : 'text-text-light cursor-not-allowed'
+      }`}
+      onClick={e => {
+        e.stopPropagation()
+        onBeginEdit?.(row.id)
+      }}
+    >
+      {display ?? 'Not set'}
+    </button>
+  )
+}

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -1,0 +1,139 @@
+/**
+ * Model tab v2 — THE REPAIR QUEUE LIST, RENDER-ONLY (design §5.3).
+ *
+ * ⚠ UNMOUNTED, AND DELIBERATELY INERT. This renders the queue. It does not
+ * apply anything, and it cannot: applying is a write, writes belong to Codex's
+ * transactional-edit vertical, and that API is not frozen. Every Apply control
+ * here is DISABLED and says why.
+ *
+ * ⚠ WHY NOT STUB THE APPLY. A stub that flipped a row to "applied" would
+ * reproduce, inside the component written to kill it, the exact defect this
+ * whole design exists to close: design §2 F6, where an edge strength, an
+ * option's intervention and the goal target are local writes that never reach
+ * the server while LOOKING identical to a factor-value edit that does. A queue
+ * that reported eight successes it never had would be that defect multiplied by
+ * eight and dressed as a productivity feature. A disabled affordance with an
+ * honest label beats a fake one.
+ *
+ * ⚠ "APPLY ALL SHOWN" NEEDS THE BATCH CONTRACT, NOT A LOOP. Looping N single
+ * proposals is N turns, N undo steps and N analysis invalidations for ONE user
+ * gesture (`ModelEditAuthority.proposeBatch`, contracts.ts §1). So it is not
+ * merely unwired — it is unbuildable until that operation exists, and the label
+ * says so rather than implying the button is simply switched off.
+ *
+ * THE ORDER PROPERTY. The list renders EXACTLY the items it is given, in the
+ * order it is given them — no sort, no filter, no dedup. The queue's producer
+ * owns the order; a list that quietly re-sorted would disagree with the count on
+ * the chip that opened it, and the estate has already shipped a badge whose
+ * number and whose rows could not both be right.
+ */
+
+import { typography } from '../../styles/typography'
+import type { RepairQueue, RepairQueueItem } from './types'
+
+export interface RepairQueueListProps {
+  queue: RepairQueue
+  /** Rendered verbatim, in order. See the header. */
+  items: readonly RepairQueueItem[]
+  /** Focus the element on the canvas — read-only navigation, safe today. */
+  onFocusOnCanvas?: (rowId: string) => void
+}
+
+const NO_AUTHORITY_ITEM =
+  'Applying is not connected yet — this cannot be changed from here.'
+
+const NO_AUTHORITY_BATCH =
+  'Applying every row at once needs the batch operation that is still being built. ' +
+  'Doing it one row at a time would re-run the analysis after each one.'
+
+export function RepairQueueList({ queue, items, onFocusOnCanvas }: RepairQueueListProps) {
+  return (
+    <section data-testid={`repair-queue-v2-${queue.id}`} className="flex flex-col gap-2 p-2">
+      <header>
+        <h3 className={`${typography.h5} text-text-header`}>{queue.title}</h3>
+        <p data-testid={`repair-queue-v2-${queue.id}-count`} className={`${typography.caption} text-text-light`}>
+          {items.length === 1 ? '1 item' : `${items.length} items`}
+        </p>
+      </header>
+
+      {items.length === 0 ? (
+        <p
+          data-testid={`repair-queue-v2-${queue.id}-empty`}
+          className={`${typography.bodySmall} text-text-light`}
+        >
+          Nothing needs attention here.
+        </p>
+      ) : (
+        <ul data-testid={`repair-queue-v2-${queue.id}-items`}>
+          {items.map(item => (
+            <li
+              key={item.rowId}
+              data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}`}
+              data-row-id={item.rowId}
+              className="flex items-center gap-2 py-1 border-b border-panel-border"
+            >
+              <button
+                type="button"
+                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-label`}
+                onClick={() => onFocusOnCanvas?.(item.rowId)}
+                className={`${typography.bodySmall} text-text-body text-left truncate`}
+              >
+                {item.label}
+              </button>
+
+              <span
+                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-current`}
+                className={`${typography.tabular} text-text-light`}
+              >
+                {item.currentValue ?? 'No value set'}
+              </span>
+
+              {item.suggestedValue !== null && (
+                <span
+                  data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-suggested`}
+                  className={`${typography.tabular} text-text-body`}
+                >
+                  {'→ '}
+                  {item.suggestedValue}
+                </span>
+              )}
+
+              {item.basis !== null && (
+                <span
+                  data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-basis`}
+                  className={`${typography.caption} text-text-light`}
+                >
+                  {item.basis}
+                </span>
+              )}
+
+              <button
+                type="button"
+                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-apply`}
+                disabled
+                title={NO_AUTHORITY_ITEM}
+                aria-label={`${item.label} — ${NO_AUTHORITY_ITEM}`}
+                className={`${typography.buttonSmall} text-text-light cursor-not-allowed border border-panel-border rounded px-2 py-0.5`}
+              >
+                Apply
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {queue.supportsApplyAll && items.length > 0 && (
+        <button
+          type="button"
+          data-testid={`repair-queue-v2-${queue.id}-apply-all`}
+          disabled
+          title={NO_AUTHORITY_BATCH}
+          aria-label={NO_AUTHORITY_BATCH}
+          className={`${typography.button} text-text-light cursor-not-allowed border border-panel-border rounded px-2 py-1 self-end`}
+        >
+          Apply all shown
+        </button>
+      )}
+    </section>
+  )
+}

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -3,8 +3,8 @@
  *
  * ⚠ UNMOUNTED, AND DELIBERATELY INERT. This renders the queue. It does not
  * apply anything, and it cannot: applying is a write, writes belong to Codex's
- * transactional-edit vertical, and that API is not frozen. Every Apply control
- * here is DISABLED and says why.
+ * transactional-edit vertical, and that API is not frozen. Every Apply, Defer
+ * and Resume control here is DISABLED and says why.
  *
  * ⚠ WHY NOT STUB THE APPLY. A stub that flipped a row to "applied" would
  * reproduce, inside the component written to kill it, the exact defect this
@@ -12,28 +12,48 @@
  * option's intervention and the goal target are local writes that never reach
  * the server while LOOKING identical to a factor-value edit that does. A queue
  * that reported eight successes it never had would be that defect multiplied by
- * eight and dressed as a productivity feature. A disabled affordance with an
- * honest label beats a fake one.
+ * eight and dressed as a productivity feature.
  *
  * ⚠ "APPLY ALL SHOWN" NEEDS THE BATCH CONTRACT, NOT A LOOP. Looping N single
  * proposals is N turns, N undo steps and N analysis invalidations for ONE user
- * gesture (`ModelEditAuthority.proposeBatch`, contracts.ts §1). So it is not
- * merely unwired — it is unbuildable until that operation exists, and the label
- * says so rather than implying the button is simply switched off.
+ * gesture (`ModelEditAuthority.proposeBatch`, contracts.ts §1).
  *
- * THE ORDER PROPERTY. The list renders EXACTLY the items it is given, in the
- * order it is given them — no sort, no filter, no dedup. The queue's producer
- * owns the order; a list that quietly re-sorted would disagree with the count on
- * the chip that opened it, and the estate has already shipped a badge whose
- * number and whose rows could not both be right.
+ * ── DEFERRAL (Paul's ruling, 16 Aug 2026) ───────────────────────────────────
+ *
+ * Every item carries **Leave unresolved** alongside its resolving action. A
+ * queue offering only the resolving action is not respecting the user's
+ * judgement, it is insisting they agree with it.
+ *
+ * ⚠ THE TWO PROPERTIES THAT SEPARATE THIS FROM THE DISMISS BUTTON THE DESIGN
+ * JUST CUT — a Defer missing either one IS that button under a better name:
+ *
+ *   1. A DEFERRED ITEM NEVER LEAVES THE RENDERED QUEUE. It moves to the
+ *      de-emphasised "Left unresolved" group BELOW the active list — same
+ *      component, same surface, same `-item-<rowId>` identity. It is never
+ *      filtered out. `RepairQueueDeferral.spec` pins this by identity.
+ *   2. IT CARRIES PROVENANCE — who deferred it and when, printed, every time.
+ *
+ * ⚠ AND DEFERRED ITEMS ARE EXCLUDED FROM "APPLY ALL SHOWN". A batch that swept
+ * them back in would silently overrule a recorded human decision, which is the
+ * one thing a repair queue must never do. They are shown; they are not
+ * shown-and-pending.
+ *
+ * Deferral is itself a WRITE — persisted model state carrying a person and a
+ * timestamp (§9.1 C15) — so it waits for the same frozen API as every edit. The
+ * design would rather offer nothing than record a choice it cannot persist.
+ *
+ * THE ORDER PROPERTY. Within each group the list renders EXACTLY the items it is
+ * given, in the order it is given them — no sort, no dedup. The queue's producer
+ * owns the order.
  */
 
 import { typography } from '../../styles/typography'
+import { deferralLabel } from './rowPresentation'
 import type { RepairQueue, RepairQueueItem } from './types'
 
 export interface RepairQueueListProps {
   queue: RepairQueue
-  /** Rendered verbatim, in order. See the header. */
+  /** Rendered verbatim, in order, active first then deferred. See the header. */
   items: readonly RepairQueueItem[]
   /** Focus the element on the canvas — read-only navigation, safe today. */
   onFocusOnCanvas?: (rowId: string) => void
@@ -42,74 +62,113 @@ export interface RepairQueueListProps {
 const NO_AUTHORITY_ITEM =
   'Applying is not connected yet — this cannot be changed from here.'
 
+const NO_AUTHORITY_DEFER =
+  'Recording this decision is not connected yet — leaving it unresolved cannot be saved from here.'
+
+const NO_AUTHORITY_RESUME =
+  'Recording this decision is not connected yet — this cannot be reopened from here.'
+
 const NO_AUTHORITY_BATCH =
   'Applying every row at once needs the batch operation that is still being built. ' +
-  'Doing it one row at a time would re-run the analysis after each one.'
+  'Doing it one row at a time would re-run the analysis after each one. ' +
+  'Items left unresolved are never included.'
+
+/** The label/value cells, identical in both groups so one item reads one way. */
+function ItemCells({
+  queueId,
+  item,
+  onFocusOnCanvas,
+}: {
+  queueId: string
+  item: RepairQueueItem
+  onFocusOnCanvas?: (rowId: string) => void
+}) {
+  const base = `repair-queue-v2-${queueId}-item-${item.rowId}`
+  return (
+    <>
+      <button
+        type="button"
+        data-testid={`${base}-label`}
+        onClick={() => onFocusOnCanvas?.(item.rowId)}
+        className={`${typography.bodySmall} text-text-body text-left truncate`}
+      >
+        {item.label}
+      </button>
+
+      <span data-testid={`${base}-current`} className={`${typography.tabular} text-text-light`}>
+        {item.currentValue ?? 'No value set'}
+      </span>
+
+      {item.suggestedValue !== null && (
+        <span data-testid={`${base}-suggested`} className={`${typography.tabular} text-text-body`}>
+          {'→ '}
+          {item.suggestedValue}
+        </span>
+      )}
+
+      {item.basis !== null && (
+        <span data-testid={`${base}-basis`} className={`${typography.caption} text-text-light`}>
+          {item.basis}
+        </span>
+      )}
+    </>
+  )
+}
 
 export function RepairQueueList({ queue, items, onFocusOnCanvas }: RepairQueueListProps) {
+  // Partition, preserving the caller's order within each group.
+  const activeItems = items.filter(i => i.deferred === undefined)
+  const deferredItems = items.filter(i => i.deferred !== undefined)
+  const q = queue.id
+
   return (
-    <section data-testid={`repair-queue-v2-${queue.id}`} className="flex flex-col gap-2 p-2">
+    <section data-testid={`repair-queue-v2-${q}`} className="flex flex-col gap-2 p-2">
       <header>
         <h3 className={`${typography.h5} text-text-header`}>{queue.title}</h3>
-        <p data-testid={`repair-queue-v2-${queue.id}-count`} className={`${typography.caption} text-text-light`}>
+        {/*
+          The two counts are reported SEPARATELY and deliberately. Deferring does
+          not reduce the number of real gaps in the model — only the number
+          awaiting a decision — so a single count that fell when somebody
+          deferred would be quietly lying about the model's state.
+        */}
+        <p
+          data-testid={`repair-queue-v2-${q}-count`}
+          className={`${typography.caption} text-text-light`}
+        >
           {items.length === 1 ? '1 item' : `${items.length} items`}
+          {deferredItems.length > 0 && ` · ${deferredItems.length} left unresolved`}
         </p>
       </header>
 
       {items.length === 0 ? (
         <p
-          data-testid={`repair-queue-v2-${queue.id}-empty`}
+          data-testid={`repair-queue-v2-${q}-empty`}
           className={`${typography.bodySmall} text-text-light`}
         >
           Nothing needs attention here.
         </p>
+      ) : activeItems.length === 0 ? (
+        <p
+          data-testid={`repair-queue-v2-${q}-all-deferred`}
+          className={`${typography.bodySmall} text-text-light`}
+        >
+          Everything here has been left unresolved.
+        </p>
       ) : (
-        <ul data-testid={`repair-queue-v2-${queue.id}-items`}>
-          {items.map(item => (
+        <ul data-testid={`repair-queue-v2-${q}-items`}>
+          {activeItems.map(item => (
             <li
               key={item.rowId}
-              data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}`}
+              data-testid={`repair-queue-v2-${q}-item-${item.rowId}`}
               data-row-id={item.rowId}
+              data-deferred="false"
               className="flex items-center gap-2 py-1 border-b border-panel-border"
             >
-              <button
-                type="button"
-                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-label`}
-                onClick={() => onFocusOnCanvas?.(item.rowId)}
-                className={`${typography.bodySmall} text-text-body text-left truncate`}
-              >
-                {item.label}
-              </button>
-
-              <span
-                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-current`}
-                className={`${typography.tabular} text-text-light`}
-              >
-                {item.currentValue ?? 'No value set'}
-              </span>
-
-              {item.suggestedValue !== null && (
-                <span
-                  data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-suggested`}
-                  className={`${typography.tabular} text-text-body`}
-                >
-                  {'→ '}
-                  {item.suggestedValue}
-                </span>
-              )}
-
-              {item.basis !== null && (
-                <span
-                  data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-basis`}
-                  className={`${typography.caption} text-text-light`}
-                >
-                  {item.basis}
-                </span>
-              )}
+              <ItemCells queueId={q} item={item} onFocusOnCanvas={onFocusOnCanvas} />
 
               <button
                 type="button"
-                data-testid={`repair-queue-v2-${queue.id}-item-${item.rowId}-apply`}
+                data-testid={`repair-queue-v2-${q}-item-${item.rowId}-apply`}
                 disabled
                 title={NO_AUTHORITY_ITEM}
                 aria-label={`${item.label} — ${NO_AUTHORITY_ITEM}`}
@@ -117,15 +176,85 @@ export function RepairQueueList({ queue, items, onFocusOnCanvas }: RepairQueueLi
               >
                 Apply
               </button>
+
+              {/*
+                The user's other legitimate answer. It sits beside Apply, not
+                behind a menu: "I have seen this and it can wait" is a first-class
+                outcome, not an escape hatch.
+              */}
+              <button
+                type="button"
+                data-testid={`repair-queue-v2-${q}-item-${item.rowId}-defer`}
+                disabled
+                title={NO_AUTHORITY_DEFER}
+                aria-label={`${item.label} — ${NO_AUTHORITY_DEFER}`}
+                className={`${typography.buttonSmall} text-text-light cursor-not-allowed border border-panel-border rounded px-2 py-0.5`}
+              >
+                Leave unresolved
+              </button>
             </li>
           ))}
         </ul>
       )}
 
-      {queue.supportsApplyAll && items.length > 0 && (
+      {/*
+        ⚠ THE DEFERRED GROUP IS PART OF THE QUEUE, NOT A DIFFERENT SCREEN. Same
+        component, same `-item-<rowId>` identity, still on screen. De-emphasised,
+        never removed — that distinction is the entire ruling.
+      */}
+      {deferredItems.length > 0 && (
+        <section data-testid={`repair-queue-v2-${q}-deferred-group`} className="opacity-70">
+          <h4
+            data-testid={`repair-queue-v2-${q}-deferred-heading`}
+            className={`${typography.label} text-text-light`}
+          >
+            Left unresolved ({deferredItems.length})
+          </h4>
+          <ul data-testid={`repair-queue-v2-${q}-deferred-items`}>
+            {deferredItems.map(item => (
+              <li
+                key={item.rowId}
+                data-testid={`repair-queue-v2-${q}-item-${item.rowId}`}
+                data-row-id={item.rowId}
+                data-deferred="true"
+                className="flex items-center gap-2 py-1 border-b border-panel-border"
+              >
+                <ItemCells queueId={q} item={item} onFocusOnCanvas={onFocusOnCanvas} />
+
+                {/*
+                  The provenance. Printed, always — an anonymous or undated
+                  deferral cannot be told apart from a row a bug dropped, and the
+                  honest state ("a human chose this") would decay into "this was
+                  never a gap".
+                */}
+                <span
+                  data-testid={`repair-queue-v2-${q}-item-${item.rowId}-deferral`}
+                  className={`${typography.caption} text-text-light`}
+                >
+                  {deferralLabel(item.deferred!)}
+                </span>
+
+                {/* A choice you cannot revisit is a trap, not agency. */}
+                <button
+                  type="button"
+                  data-testid={`repair-queue-v2-${q}-item-${item.rowId}-resume`}
+                  disabled
+                  title={NO_AUTHORITY_RESUME}
+                  aria-label={`${item.label} — ${NO_AUTHORITY_RESUME}`}
+                  className={`${typography.buttonSmall} text-text-light cursor-not-allowed border border-panel-border rounded px-2 py-0.5`}
+                >
+                  Resume
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {queue.supportsApplyAll && activeItems.length > 0 && (
         <button
           type="button"
-          data-testid={`repair-queue-v2-${queue.id}-apply-all`}
+          data-testid={`repair-queue-v2-${q}-apply-all`}
           disabled
           title={NO_AUTHORITY_BATCH}
           aria-label={NO_AUTHORITY_BATCH}

--- a/src/canvas/model-tab-v2/__tests__/ModelDetailRegion.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelDetailRegion.spec.tsx
@@ -1,0 +1,173 @@
+/**
+ * Model tab v2 — THE DETAIL REGION (design §4.4).
+ *
+ * Two properties carry this file:
+ *   · the Advanced block is ABSENT FROM THE DOM in Plain, not merely invisible;
+ *   · the region REFUSES to render another element's detail.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModelDetailRegion } from '../ModelDetailRegion'
+import type { ModelRow, ModelRowDetail } from '../types'
+
+const ROW: ModelRow = {
+  id: 'f1',
+  kind: 'factor',
+  group: 'factors',
+  label: 'Sales cycle length',
+  primaryValue: '45 days',
+  provenanceSource: 'cee_inference',
+  attention: [],
+  editable: true,
+}
+
+function detail(over: Partial<ModelRowDetail> = {}): ModelRowDetail {
+  return {
+    rowId: 'f1',
+    description: 'How long a deal takes to close.',
+    secondaryValues: [{ label: 'Baseline', value: '50 days' }],
+    basis: 'Inferred from model structure',
+    adjustments: [],
+    affects: [],
+    advancedParameters: [
+      { label: 'Elasticity', value: '0.42' },
+      { label: 'Node ID', value: 'f1' },
+    ],
+    ...over,
+  }
+}
+
+describe('⭐ ModelDetailRegion — Advanced is ABSENT in Plain, not hidden', () => {
+  it('does not render the Advanced block at all in Plain', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail()} tier="plain" />)
+    expect(screen.queryByTestId('model-detail-v2-advanced')).toBeNull()
+  })
+
+  it('does not leak a single advanced PARAMETER into the Plain DOM', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail()} tier="plain" />)
+    // Absence of the container is not absence of its contents — a parameter
+    // rendered anywhere else in Plain would breach §4.3 rule 2 (never mixed
+    // inline) while leaving the assertion above perfectly green.
+    expect(screen.queryByText('Elasticity')).toBeNull()
+    expect(screen.queryByText('0.42')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: the four plain sections DO render in Plain', () => {
+    // Without this, the two absences above would also pass on a component that
+    // rendered nothing at all (trap 13).
+    render(<ModelDetailRegion row={ROW} detail={detail()} tier="plain" />)
+    expect(screen.getByTestId('model-detail-v2-what')).toBeInTheDocument()
+    expect(screen.getByTestId('model-detail-v2-value')).toBeInTheDocument()
+    expect(screen.getByTestId('model-detail-v2-provenance')).toBeInTheDocument()
+    expect(screen.getByTestId('model-detail-v2-affects')).toBeInTheDocument()
+  })
+
+  it('renders the Advanced block, with its parameters, in Advanced', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail()} tier="advanced" />)
+    expect(screen.getByTestId('model-detail-v2-advanced')).toBeInTheDocument()
+    expect(screen.getByTestId('model-detail-v2-advanced-fields-Elasticity')).toHaveTextContent('0.42')
+  })
+
+  it('flipping to Advanced adds ONLY the Advanced block — the plain sections are untouched', () => {
+    const { rerender } = render(<ModelDetailRegion row={ROW} detail={detail()} tier="plain" />)
+    const plainWhat = screen.getByTestId('model-detail-v2-what').textContent
+    const plainValue = screen.getByTestId('model-detail-v2-value').textContent
+
+    rerender(<ModelDetailRegion row={ROW} detail={detail()} tier="advanced" />)
+    expect(screen.getByTestId('model-detail-v2-what').textContent).toBe(plainWhat)
+    expect(screen.getByTestId('model-detail-v2-value').textContent).toBe(plainValue)
+  })
+
+  it('says so when an element genuinely has no parameters, rather than showing an empty block', () => {
+    render(
+      <ModelDetailRegion row={ROW} detail={detail({ advancedParameters: [] })} tier="advanced" />,
+    )
+    expect(screen.getByTestId('model-detail-v2-advanced')).toHaveTextContent(
+      'This element has no model parameters',
+    )
+  })
+})
+
+describe('⭐ ModelDetailRegion — it refuses to show another element\'s detail', () => {
+  it('renders a stated refusal when the detail belongs to a different row', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail({ rowId: 'f2' })} tier="plain" />)
+    expect(screen.getByTestId('model-detail-v2-mismatch')).toBeInTheDocument()
+    expect(screen.getByTestId('model-detail-v2')).toHaveAttribute('data-mismatch', 'true')
+  })
+
+  it('shows NONE of the mismatched content — not the description, not the parameters', () => {
+    render(
+      <ModelDetailRegion
+        row={ROW}
+        detail={detail({ rowId: 'f2', description: 'Belongs to a different factor' })}
+        tier="advanced"
+      />,
+    )
+    expect(screen.queryByText('Belongs to a different factor')).toBeNull()
+    expect(screen.queryByTestId('model-detail-v2-advanced')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: the same detail renders fully when the ids DO match', () => {
+    // Proves the refusal above is the id gate biting, and not a component that
+    // fails to render this fixture for some unrelated reason.
+    render(<ModelDetailRegion row={ROW} detail={detail({ rowId: 'f1' })} tier="plain" />)
+    expect(screen.queryByTestId('model-detail-v2-mismatch')).toBeNull()
+    expect(screen.getByTestId('model-detail-v2-description')).toBeInTheDocument()
+  })
+})
+
+describe('ModelDetailRegion — absence is rendered as absence', () => {
+  it('omits the description entirely when there is none', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail({ description: null })} tier="plain" />)
+    expect(screen.queryByTestId('model-detail-v2-description')).toBeNull()
+  })
+
+  it('renders "Not stated" for a null field rather than a blank or a zero', () => {
+    render(
+      <ModelDetailRegion
+        row={ROW}
+        detail={detail({ secondaryValues: [{ label: 'Baseline', value: null }] })}
+        tier="plain"
+      />,
+    )
+    expect(screen.getByTestId('model-detail-v2-secondary-Baseline')).toHaveTextContent('Not stated')
+  })
+
+  it('renders "Not set" for a row with no primary value', () => {
+    render(
+      <ModelDetailRegion row={{ ...ROW, primaryValue: null }} detail={detail()} tier="plain" />,
+    )
+    expect(screen.getByTestId('model-detail-v2-primary')).toHaveTextContent('Not set')
+  })
+
+  it('says nothing depends on this element rather than showing an empty list', () => {
+    render(<ModelDetailRegion row={ROW} detail={detail({ affects: [] })} tier="plain" />)
+    expect(screen.getByTestId('model-detail-v2-affects')).toHaveTextContent(
+      'Nothing in the model depends on this yet',
+    )
+  })
+})
+
+describe('ModelDetailRegion — navigation is ID-addressed', () => {
+  it('reports the id of the affected element that was clicked, not its label or index', () => {
+    const onFocusOnCanvas = vi.fn()
+    render(
+      <ModelDetailRegion
+        row={ROW}
+        detail={detail({
+          affects: [
+            { id: 'e1', label: 'Same label' },
+            { id: 'e2', label: 'Same label' },
+          ],
+        })}
+        tier="plain"
+        onFocusOnCanvas={onFocusOnCanvas}
+      />,
+    )
+    // Two entries share a label deliberately: a lookup by text could not tell
+    // them apart, so this pins the binding to the id.
+    fireEvent.click(screen.getByTestId('model-detail-v2-affects-e2'))
+    expect(onFocusOnCanvas).toHaveBeenCalledWith('e2')
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.spec.tsx
@@ -1,0 +1,220 @@
+/**
+ * Model tab v2 — THE OUTLINE (design §4.1, §4.3).
+ *
+ * The load-bearing test in this file is "the tier changes content, never
+ * layout" — design §2 F1, the defect that makes the advanced toggle overwhelm
+ * non-scientists by being two controls wearing one switch. It is asserted twice
+ * and in two different ways, deliberately: once against the PURE layout function
+ * (which cannot take a tier at all), and once against the RENDERED DOM after a
+ * real toggle, because a component is free to disobey a pure function it does
+ * not call.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModelOutline, outlineLayout } from '../ModelOutline'
+import { MODEL_GROUP_IDS, type ModelGroupId, type ModelRow } from '../types'
+
+function row(
+  id: string,
+  group: ModelGroupId,
+  over: Partial<ModelRow> = {},
+): ModelRow {
+  return {
+    id,
+    kind: 'factor',
+    group,
+    label: `Label ${id}`,
+    primaryValue: '1',
+    attention: [],
+    editable: true,
+    ...over,
+  }
+}
+
+/** Ids of the rendered rows, in DOM order — the object of every order assertion. */
+function renderedRowIds(): string[] {
+  return Array.from(document.querySelectorAll('[data-testid^="model-row-v2-"]'))
+    .filter(el => el.getAttribute('data-kind') !== null)
+    .map(el => el.getAttribute('data-testid')!.replace('model-row-v2-', ''))
+}
+
+function openGroupIds(): string[] {
+  return MODEL_GROUP_IDS.filter(
+    id => screen.getByTestId(`model-group-v2-${id}`).getAttribute('data-open') === 'true',
+  )
+}
+
+describe('ModelOutline — all seven groups, always present, in IA order', () => {
+  it('renders every group even when the model has nothing in it', () => {
+    render(<ModelOutline rows={[]} tier="plain" />)
+    for (const id of MODEL_GROUP_IDS) {
+      expect(screen.getByTestId(`model-group-v2-${id}`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders the groups in the declared IA order', () => {
+    render(<ModelOutline rows={[]} tier="plain" />)
+    const rendered = Array.from(document.querySelectorAll('[data-testid^="model-group-v2-"]'))
+      .map(el => el.getAttribute('data-testid'))
+      .filter((t): t is string => !!t && !t.endsWith('-toggle') && !t.endsWith('-empty'))
+      .map(t => t.replace('model-group-v2-', ''))
+    expect(rendered).toEqual([...MODEL_GROUP_IDS])
+  })
+})
+
+describe('ModelOutline — renders exactly the rows it is given, in the order given', () => {
+  it('does not sort, drop or invent rows', () => {
+    // Deliberately NOT alphabetical: a component that sorted would produce
+    // ['f1','f2','f3'] and pass a weaker assertion.
+    const rows = [row('f3', 'factors'), row('f1', 'factors'), row('f2', 'factors')]
+    render(<ModelOutline rows={rows} tier="plain" />)
+    expect(renderedRowIds()).toEqual(['f3', 'f1', 'f2'])
+  })
+
+  it('places each row in its DECLARED group, not one inferred from its kind', () => {
+    // A `factor`-kind row declared into the relationships group must appear
+    // there: the projection owns grouping, the outline does not second-guess it.
+    render(
+      <ModelOutline
+        rows={[row('r1', 'relationships'), row('g1', 'goal')]}
+        tier="plain"
+      />,
+    )
+    const relationships = screen.getByTestId('model-group-v2-relationships')
+    expect(relationships.querySelector('[data-testid="model-row-v2-r1"]')).not.toBeNull()
+    expect(relationships.querySelector('[data-testid="model-row-v2-g1"]')).toBeNull()
+  })
+
+  it('reports rows whose group is not one of the seven rather than rendering them somewhere', () => {
+    const rogue = { ...row('x1', 'factors'), group: 'not-a-group' as ModelGroupId }
+    const { unknownGroupRowIds, groups } = outlineLayout([rogue], '', new Set(MODEL_GROUP_IDS))
+    expect(unknownGroupRowIds).toEqual(['x1'])
+    // And it is in NO group — a silent home would be worse than dropping it.
+    expect(groups.flatMap(g => g.rows.map(r => r.id))).toEqual([])
+  })
+})
+
+describe('⭐ ModelOutline — THE TIER IS A CONTENT SWITCH, NEVER A LAYOUT SWITCH (F1)', () => {
+  it('the layout function cannot even see the tier (structural, not a promise)', () => {
+    const rows = [row('f1', 'factors'), row('o1', 'options')]
+    const open = new Set(MODEL_GROUP_IDS)
+    // One call, one result — there is no tier argument to vary. If a future edit
+    // wanted layout to depend on the tier, it would have to change this
+    // signature, which is the point of isolating it.
+    expect(outlineLayout(rows, '', open)).toEqual(outlineLayout(rows, '', open))
+    expect(outlineLayout.length).toBe(3)
+  })
+
+  it('flipping the tier does not change WHICH GROUPS ARE OPEN', () => {
+    const rows = [row('f1', 'factors'), row('o1', 'options')]
+    const { rerender } = render(<ModelOutline rows={rows} tier="plain" />)
+
+    // Close one group by hand, so the state under test is a USER's arrangement
+    // rather than the default — the default would survive almost any bug.
+    fireEvent.click(screen.getByTestId('model-group-v2-factors-toggle'))
+    const openInPlain = openGroupIds()
+    expect(openInPlain).not.toContain('factors')
+    expect(openInPlain).toContain('options')
+
+    rerender(<ModelOutline rows={rows} tier="advanced" />)
+    expect(openGroupIds()).toEqual(openInPlain)
+  })
+
+  it('flipping the tier does not change ROW ORDER', () => {
+    const rows = [row('f3', 'factors'), row('f1', 'factors'), row('f2', 'factors')]
+    const { rerender } = render(<ModelOutline rows={rows} tier="plain" />)
+    const plainOrder = renderedRowIds()
+
+    rerender(<ModelOutline rows={rows} tier="advanced" />)
+    expect(renderedRowIds()).toEqual(plainOrder)
+  })
+
+  it('flipping the tier DOES change content — the positive control', () => {
+    // Without this, the two assertions above could both pass on a tier that does
+    // nothing whatsoever, which would be a different bug wearing the same green.
+    const rows = [row('f1', 'factors')]
+    const { rerender } = render(<ModelOutline rows={rows} tier="plain" />)
+    expect(screen.queryByTestId('model-row-v2-f1-id')).toBeNull()
+
+    rerender(<ModelOutline rows={rows} tier="advanced" />)
+    expect(screen.getByTestId('model-row-v2-f1-id')).toBeInTheDocument()
+  })
+})
+
+describe('ModelOutline — multi-open, independently remembered (F2)', () => {
+  it('every group is open by default: opening Options never closes Factors', () => {
+    render(<ModelOutline rows={[row('f1', 'factors'), row('o1', 'options')]} tier="plain" />)
+    expect(openGroupIds()).toEqual([...MODEL_GROUP_IDS])
+  })
+
+  it('closing one group leaves every other group exactly as it was', () => {
+    render(<ModelOutline rows={[row('f1', 'factors'), row('o1', 'options')]} tier="plain" />)
+    fireEvent.click(screen.getByTestId('model-group-v2-options-toggle'))
+
+    const open = openGroupIds()
+    expect(open).not.toContain('options')
+    // Identity-bound: name the survivors rather than counting them.
+    expect(open).toContain('factors')
+    expect(open).toContain('goal')
+    expect(open).toContain('relationships')
+  })
+
+  it('a closed group is reopenable — the expander is not one-way', () => {
+    render(<ModelOutline rows={[row('f1', 'factors')]} tier="plain" />)
+    const toggle = screen.getByTestId('model-group-v2-factors-toggle')
+    fireEvent.click(toggle)
+    expect(screen.getByTestId('model-group-v2-factors')).toHaveAttribute('data-open', 'false')
+    fireEvent.click(toggle)
+    expect(screen.getByTestId('model-group-v2-factors')).toHaveAttribute('data-open', 'true')
+  })
+
+  it('reports open/closed to assistive technology', () => {
+    render(<ModelOutline rows={[]} tier="plain" />)
+    expect(screen.getByTestId('model-group-v2-goal-toggle')).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+describe('ModelOutline — the filter actually filters (F3)', () => {
+  it('keeps only rows whose label matches, case-insensitively', () => {
+    const rows = [
+      row('f1', 'factors', { label: 'Sales cycle length' }),
+      row('f2', 'factors', { label: 'Win rate' }),
+      row('f3', 'factors', { label: 'Pipeline coverage' }),
+    ]
+    render(<ModelOutline rows={rows} tier="plain" filter="SALES" />)
+    expect(renderedRowIds()).toEqual(['f1'])
+  })
+
+  it('preserves the caller\'s order among the rows that match', () => {
+    const rows = [
+      row('f3', 'factors', { label: 'rate three' }),
+      row('f1', 'factors', { label: 'rate one' }),
+      row('f2', 'factors', { label: 'other' }),
+    ]
+    render(<ModelOutline rows={rows} tier="plain" filter="rate" />)
+    expect(renderedRowIds()).toEqual(['f3', 'f1'])
+  })
+
+  it('keeps every group heading present and says a group has no matches', () => {
+    render(
+      <ModelOutline
+        rows={[row('f1', 'factors', { label: 'Sales cycle' })]}
+        tier="plain"
+        filter="sales"
+      />,
+    )
+    // The heading survives, so the user never wonders whether a group vanished.
+    expect(screen.getByTestId('model-group-v2-options')).toBeInTheDocument()
+    expect(screen.getByTestId('model-group-v2-options-empty')).toHaveTextContent(
+      'No matches in this group',
+    )
+  })
+
+  it('distinguishes "nothing here yet" from "nothing matched"', () => {
+    render(<ModelOutline rows={[]} tier="plain" />)
+    expect(screen.getByTestId('model-group-v2-options-empty')).toHaveTextContent(
+      'Nothing in this group yet',
+    )
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/ModelRowView.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelRowView.spec.tsx
@@ -1,0 +1,231 @@
+/**
+ * Model tab v2 — the row's HONESTY PROPERTIES (design §4.2, §5.1).
+ *
+ * Every assertion here binds to its object by IDENTITY — `model-row-v2-<id>` —
+ * never by a value predicate another row could satisfy. Several tests therefore
+ * render TWO rows whose values are deliberately confusable, so a query that
+ * matched the wrong element would fail rather than pass quietly.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ModelRowView } from '../ModelRowView'
+import type { ModelRow } from '../types'
+
+function row(over: Partial<ModelRow> & Pick<ModelRow, 'id'>): ModelRow {
+  return {
+    kind: 'factor',
+    group: 'factors',
+    label: `Label ${over.id}`,
+    primaryValue: '45 days',
+    attention: [],
+    editable: true,
+    ...over,
+  }
+}
+
+describe('ModelRowView — renders the model, never its own opinion of it', () => {
+  it('renders THIS row\'s value, bound by id, when a confusable sibling is present', () => {
+    render(
+      <>
+        <ModelRowView row={row({ id: 'f1', primaryValue: '45 days' })} tier="plain" />
+        <ModelRowView row={row({ id: 'f2', primaryValue: '90 days' })} tier="plain" />
+      </>,
+    )
+    expect(screen.getByTestId('model-row-v2-f1-value')).toHaveTextContent('45 days')
+    expect(screen.getByTestId('model-row-v2-f2-value')).toHaveTextContent('90 days')
+  })
+
+  it('renders the label verbatim and does not reformat the value', () => {
+    render(<ModelRowView row={row({ id: 'f1', primaryValue: '0.40', label: 'Win rate' })} tier="plain" />)
+    expect(screen.getByTestId('model-row-v2-f1-label')).toHaveTextContent('Win rate')
+    // Not "0.4" — the producer decided how this reads; the row does not re-derive it.
+    expect(screen.getByTestId('model-row-v2-f1-value')).toHaveTextContent('0.40')
+  })
+})
+
+describe('ModelRowView — F9: a factor with no value can still be given one', () => {
+  it('offers an EDITOR affordance for a null value, not inert text', () => {
+    const onBeginEdit = vi.fn()
+    render(
+      <ModelRowView
+        row={row({ id: 'f1', primaryValue: null })}
+        tier="plain"
+        onBeginEdit={onBeginEdit}
+      />,
+    )
+    const cell = screen.getByTestId('model-row-v2-f1-value')
+    // The defect being closed: today this slot is static text, so the value can
+    // never be supplied. Here it is a live control.
+    expect(cell.tagName).toBe('BUTTON')
+    expect(cell).toBeEnabled()
+    expect(cell).toHaveTextContent('Not set')
+  })
+
+  it('a non-editable row renders text, not a control', () => {
+    render(<ModelRowView row={row({ id: 'a1', editable: false, primaryValue: '2,485' })} tier="plain" />)
+    expect(screen.getByTestId('model-row-v2-a1-value').tagName).not.toBe('BUTTON')
+  })
+})
+
+describe('ModelRowView — the disabled-affordance rule (the lane boundary)', () => {
+  it('with NO write authority the editor is disabled and says why in words', () => {
+    render(<ModelRowView row={row({ id: 'f1' })} tier="plain" />)
+    const cell = screen.getByTestId('model-row-v2-f1-value')
+    expect(cell).toBeDisabled()
+    // The label must EXPLAIN, not merely be absent. A silently dead control is
+    // indistinguishable from a broken one.
+    expect(cell.getAttribute('title')).toMatch(/not connected yet/i)
+  })
+
+  it('with an authority wired the editor is enabled and reports the row id it was clicked for', () => {
+    const onBeginEdit = vi.fn()
+    render(
+      <>
+        <ModelRowView row={row({ id: 'f1' })} tier="plain" onBeginEdit={onBeginEdit} />
+        <ModelRowView row={row({ id: 'f2' })} tier="plain" onBeginEdit={onBeginEdit} />
+      </>,
+    )
+    screen.getByTestId('model-row-v2-f2-value').click()
+    // Identity, not call count: a handler wired to the wrong row still fires once.
+    expect(onBeginEdit).toHaveBeenCalledWith('f2')
+  })
+})
+
+describe('ModelRowView — provenance absence is rendered as absence', () => {
+  it('renders NO provenance chip when nothing states a source', () => {
+    render(<ModelRowView row={row({ id: 'f1', provenanceSource: undefined })} tier="plain" />)
+    expect(screen.queryByTestId('model-row-v2-f1-provenance')).toBeNull()
+    // Positive control: the row DID render, so the absence above is about the
+    // chip and not about a failed render (trap 13).
+    expect(screen.getByTestId('model-row-v2-f1')).toBeInTheDocument()
+  })
+
+  it('classifies the raw stamp through the shared classifier, not a local map', () => {
+    render(<ModelRowView row={row({ id: 'f1', provenanceSource: 'user_confirmed' })} tier="plain" />)
+    // `user_confirmed` → "Confirmed by you". A local literal map would be the
+    // mirror defect that once rendered "Not set" over a confirmed value.
+    expect(screen.getByTestId('model-row-v2-f1-provenance')).toHaveTextContent('Confirmed by you')
+  })
+})
+
+describe('ModelRowView — attention markers match the row exactly', () => {
+  it('renders one marker per reason and none for a clean row', () => {
+    render(
+      <>
+        <ModelRowView
+          row={row({ id: 'f1', attention: ['no-value', 'unconfirmed-estimate'] })}
+          tier="plain"
+        />
+        <ModelRowView row={row({ id: 'f2', attention: [] })} tier="plain" />
+      </>,
+    )
+    expect(screen.getByTestId('model-row-v2-f1-attention-no-value')).toBeInTheDocument()
+    expect(screen.getByTestId('model-row-v2-f1-attention-unconfirmed-estimate')).toBeInTheDocument()
+    // The clean row must not inherit its neighbour's markers.
+    expect(screen.queryByTestId('model-row-v2-f2-attention-no-value')).toBeNull()
+  })
+
+  it('every marker carries a worded label, not a bare glyph', () => {
+    render(<ModelRowView row={row({ id: 'f1', attention: ['fragile'] })} tier="plain" />)
+    expect(screen.getByTestId('model-row-v2-f1-attention-fragile')).toHaveAttribute(
+      'aria-label',
+      'Could flip the result',
+    )
+  })
+})
+
+describe('ModelRowView — the three-beat states tell the truth (design §5.1)', () => {
+  it('APPLIED renders the RECEIPT\'s value, not the value the row already had', () => {
+    render(
+      <ModelRowView
+        row={row({ id: 'f1', primaryValue: '45 days' })}
+        tier="plain"
+        commit={{ phase: 'applied', value: '60 days', provenanceSource: 'user' }}
+      />,
+    )
+    // The whole point of the union: `applied` is reachable only from a receipt,
+    // and what it shows is what the authority stored — never the optimistic echo.
+    expect(screen.getByTestId('model-row-v2-f1-value')).toHaveTextContent('60 days')
+    expect(screen.getByTestId('model-row-v2-f1-value')).not.toHaveTextContent('45 days')
+  })
+
+  it('PROPOSED keeps the old value on screen and says nothing has changed yet', () => {
+    render(
+      <ModelRowView
+        row={row({ id: 'f1' })}
+        tier="plain"
+        commit={{ phase: 'proposed', from: '45 days', to: '60 days' }}
+      />,
+    )
+    expect(screen.getByTestId('model-row-v2-f1-value-from')).toHaveTextContent('45 days')
+    expect(screen.getByTestId('model-row-v2-f1-value-to')).toHaveTextContent('60 days')
+    expect(screen.getByTestId('model-row-v2-f1-value')).toHaveTextContent(/nothing has changed yet/i)
+  })
+
+  it('REFUSED shows the value reverted AND states the reason', () => {
+    render(
+      <ModelRowView
+        row={row({ id: 'f1' })}
+        tier="plain"
+        commit={{
+          phase: 'refused',
+          from: '45 days',
+          attempted: '60 days',
+          reason: 'The server would not accept this value.',
+        }}
+      />,
+    )
+    expect(screen.getByTestId('model-row-v2-f1-value-reverted')).toHaveTextContent('45 days')
+    expect(screen.getByTestId('model-row-v2-f1-value-refusal')).toHaveTextContent(
+      'The server would not accept this value.',
+    )
+  })
+
+  it('a refusal is NOT rendered as a success: the attempted value is not shown as the value', () => {
+    render(
+      <ModelRowView
+        row={row({ id: 'f1' })}
+        tier="plain"
+        commit={{ phase: 'refused', from: '45 days', attempted: '60 days', reason: 'Declined.' }}
+      />,
+    )
+    const cell = screen.getByTestId('model-row-v2-f1-value')
+    expect(cell).toHaveTextContent('45 days')
+    // If '60 days' appeared as the value, a declined edit would look applied —
+    // the exact failure the `refused` state exists to make impossible.
+    expect(cell).not.toHaveTextContent('60 days')
+  })
+
+  it('the row exposes its phase for the outline to reason about', () => {
+    render(
+      <ModelRowView row={row({ id: 'f1' })} tier="plain" commit={{ phase: 'inflight', from: '45', to: '60' }} />,
+    )
+    expect(screen.getByTestId('model-row-v2-f1')).toHaveAttribute('data-phase', 'inflight')
+  })
+})
+
+describe('ModelRowView — the tier switches CONTENT only (design §4.3 rule 1)', () => {
+  it('shows the element id in Advanced and not in Plain', () => {
+    const { rerender } = render(<ModelRowView row={row({ id: 'f1' })} tier="plain" />)
+    expect(screen.queryByTestId('model-row-v2-f1-id')).toBeNull()
+
+    rerender(<ModelRowView row={row({ id: 'f1' })} tier="advanced" />)
+    expect(screen.getByTestId('model-row-v2-f1-id')).toHaveTextContent('f1')
+  })
+
+  it('does not change the label, the value or the provenance chip between tiers', () => {
+    const r = row({ id: 'f1', primaryValue: '45 days', provenanceSource: 'cee_inference' })
+    const { rerender } = render(<ModelRowView row={r} tier="plain" />)
+    const plain = {
+      label: screen.getByTestId('model-row-v2-f1-label').textContent,
+      value: screen.getByTestId('model-row-v2-f1-value').textContent,
+      prov: screen.getByTestId('model-row-v2-f1-provenance').textContent,
+    }
+
+    rerender(<ModelRowView row={r} tier="advanced" />)
+    expect(screen.getByTestId('model-row-v2-f1-label').textContent).toBe(plain.label)
+    expect(screen.getByTestId('model-row-v2-f1-value').textContent).toBe(plain.value)
+    expect(screen.getByTestId('model-row-v2-f1-provenance').textContent).toBe(plain.prov)
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/RepairQueueDeferral.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/RepairQueueDeferral.spec.tsx
@@ -1,0 +1,285 @@
+/**
+ * Model tab v2 — DEFERRAL (design §5.3, §4.2; Paul's ruling, 16 Aug 2026).
+ *
+ * The ruling: the dismiss `×` stays cut, but removing it must not cost the user
+ * their agency. Every queue item gains **Leave unresolved** — a RECORDED CHOICE,
+ * not a hidden gap.
+ *
+ * A Defer that lacked either of the two properties below would simply be the
+ * dismiss button under a better name, so both are pinned here, by identity:
+ *
+ *   1. a deferred item NEVER LEAVES THE RENDERED QUEUE;
+ *   2. it CARRIES PROVENANCE — who deferred it, and when.
+ *
+ * The headline test asserts the rendered id SET, not a count and not a text
+ * match: a queue that dropped one deferred item and duplicated another would
+ * keep its length, and a queue that hid the group behind CSS would keep its
+ * text. Only the set of ids actually in the document settles it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RepairQueueList } from '../RepairQueueList'
+import { ModelRowView } from '../ModelRowView'
+import type { DeferralRecord, ModelRow, RepairQueue, RepairQueueItem } from '../types'
+
+const QUEUE: RepairQueue = {
+  id: 'confirm-estimates',
+  reason: 'unconfirmed-estimate',
+  title: 'Confirm estimates',
+  supportsApplyAll: true,
+}
+
+const PAUL: DeferralRecord = { by: 'Paul', at: '2026-08-16T10:30:00.000Z' }
+
+function item(rowId: string, over: Partial<RepairQueueItem> = {}): RepairQueueItem {
+  return {
+    rowId,
+    label: `Label ${rowId}`,
+    currentValue: '45 days',
+    suggestedValue: '30 days',
+    basis: 'Inferred from model structure',
+    ...over,
+  }
+}
+
+/** Every item id actually in the document, across BOTH groups. */
+function renderedItemIds(): string[] {
+  return Array.from(
+    document.querySelectorAll(`[data-testid^="repair-queue-v2-${QUEUE.id}-item-"][data-row-id]`),
+  ).map(el => el.getAttribute('data-row-id')!)
+}
+
+describe('⭐ A deferred item NEVER leaves the rendered queue', () => {
+  it('keeps the deferred item in the rendered set, bound by id', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1'), item('f2', { deferred: PAUL }), item('f3')]}
+      />,
+    )
+    // The whole ruling in one assertion: f2 was deferred and is STILL HERE.
+    expect(new Set(renderedItemIds())).toEqual(new Set(['f1', 'f2', 'f3']))
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2`)).toBeInTheDocument()
+  })
+
+  it('keeps EVERY item rendered when all of them are deferred', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1', { deferred: PAUL }), item('f2', { deferred: PAUL })]}
+      />,
+    )
+    expect(new Set(renderedItemIds())).toEqual(new Set(['f1', 'f2']))
+  })
+
+  it('marks which group each item is in, without removing either', () => {
+    render(
+      <RepairQueueList queue={QUEUE} items={[item('f1'), item('f2', { deferred: PAUL })]} />,
+    )
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1`)).toHaveAttribute(
+      'data-deferred',
+      'false',
+    )
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2`)).toHaveAttribute(
+      'data-deferred',
+      'true',
+    )
+  })
+
+  it('renders the deferred group with a heading naming how many', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1'), item('f2', { deferred: PAUL }), item('f3', { deferred: PAUL })]}
+      />,
+    )
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-deferred-heading`)).toHaveTextContent(
+      'Left unresolved (2)',
+    )
+  })
+
+  it('renders NO deferred group when nothing has been deferred', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-deferred-group`)).toBeNull()
+    // Positive control: the item itself rendered, so the absence is about the
+    // group and not a failed render.
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1`)).toBeInTheDocument()
+  })
+
+  it('preserves the caller\'s order within each group', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[
+          item('a3'),
+          item('d2', { deferred: PAUL }),
+          item('a1'),
+          item('d1', { deferred: PAUL }),
+        ]}
+      />,
+    )
+    // Active first, in given order; then deferred, in given order.
+    expect(renderedItemIds()).toEqual(['a3', 'a1', 'd2', 'd1'])
+  })
+})
+
+describe('⭐ A deferral carries provenance — who, and when', () => {
+  it('prints the person and the date on the deferred item', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { deferred: PAUL })]} />)
+    const line = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-deferral`)
+    expect(line).toHaveTextContent('Paul')
+    expect(line).toHaveTextContent('16 Aug 2026')
+  })
+
+  it('names the deferrer of EACH item, bound by id, when several differ', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[
+          item('f1', { deferred: { by: 'Paul', at: '2026-08-16T10:30:00.000Z' } }),
+          item('f2', { deferred: { by: 'Mel', at: '2026-08-14T09:00:00.000Z' } }),
+        ]}
+      />,
+    )
+    // Identity-bound: a lookup by text could attribute either deferral to either
+    // row, which is precisely the failure that matters here.
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-deferral`)).toHaveTextContent('Paul')
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2-deferral`)).toHaveTextContent('Mel')
+  })
+
+  it('shows an unparseable timestamp verbatim rather than swallowing it', () => {
+    // A visible wrong value is a defect someone can chase; a silently dropped
+    // date is a deferral that has quietly lost half its provenance.
+    render(
+      <RepairQueueList queue={QUEUE} items={[item('f1', { deferred: { by: 'Paul', at: 'not-a-date' } })]} />,
+    )
+    const line = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-deferral`)
+    expect(line).toHaveTextContent('not-a-date')
+    expect(line).not.toHaveTextContent('Invalid Date')
+  })
+
+  it('an item that was never deferred carries no deferral line', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-deferral`)).toBeNull()
+  })
+})
+
+describe('⭐ Deferring is offered, reversible, and honest about not working yet', () => {
+  it('every ACTIVE item offers "Leave unresolved" beside Apply', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1'), item('f2')]} />)
+    for (const id of ['f1', 'f2']) {
+      expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-${id}-defer`)).toBeInTheDocument()
+      expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-${id}-apply`)).toBeInTheDocument()
+    }
+  })
+
+  it('the Defer control is DISABLED and says why — deferral is a write', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    const defer = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-defer`)
+    expect(defer).toBeDisabled()
+    expect(defer.getAttribute('title')).toMatch(/not connected yet/i)
+  })
+
+  it('every DEFERRED item offers Resume — a choice you cannot revisit is a trap', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { deferred: PAUL })]} />)
+    const resume = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-resume`)
+    expect(resume).toBeInTheDocument()
+    expect(resume).toBeDisabled()
+    expect(resume.getAttribute('title')).toMatch(/not connected yet/i)
+  })
+
+  it('a deferred item is not ALSO offered a Defer control', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { deferred: PAUL })]} />)
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-defer`)).toBeNull()
+  })
+})
+
+describe('⭐ "Apply all shown" never overrules a recorded decision', () => {
+  it('states that items left unresolved are excluded', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1'), item('f2', { deferred: PAUL })]} />)
+    const applyAll = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-apply-all`)
+    expect(applyAll.getAttribute('title')).toMatch(/left unresolved are never included/i)
+  })
+
+  it('disappears entirely when every item has been deferred', () => {
+    // Nothing is pending, so a batch affordance would be offering to act on
+    // rows a human has already ruled on.
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1', { deferred: PAUL }), item('f2', { deferred: PAUL })]}
+      />,
+    )
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-apply-all`)).toBeNull()
+    // Positive control: the items are still rendered — it is the BATCH that is
+    // gone, not the queue.
+    expect(new Set(renderedItemIds())).toEqual(new Set(['f1', 'f2']))
+  })
+
+  it('says so when everything has been left unresolved', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { deferred: PAUL })]} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-all-deferred`)).toHaveTextContent(
+      'Everything here has been left unresolved',
+    )
+  })
+})
+
+describe('⭐ Deferring does not shrink the model\'s real gap count', () => {
+  it('reports the total and the deferred count SEPARATELY', () => {
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1'), item('f2', { deferred: PAUL }), item('f3', { deferred: PAUL })]}
+      />,
+    )
+    const count = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-count`)
+    // Three gaps exist; two have been ruled on. A single number that fell to one
+    // would be quietly lying about the state of the model.
+    expect(count).toHaveTextContent('3 items')
+    expect(count).toHaveTextContent('2 left unresolved')
+  })
+
+  it('says nothing about deferrals when there are none', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-count`)).not.toHaveTextContent(
+      'left unresolved',
+    )
+  })
+})
+
+describe('⭐ The row keeps reporting its gap after it is deferred (§4.2)', () => {
+  function row(over: Partial<ModelRow> & Pick<ModelRow, 'id'>): ModelRow {
+    return {
+      kind: 'factor',
+      group: 'factors',
+      label: `Label ${over.id}`,
+      primaryValue: null,
+      attention: ['no-value'],
+      editable: true,
+      ...over,
+    }
+  }
+
+  it('renders the deferred marker BESIDE the attention marker, not instead of it', () => {
+    render(<ModelRowView row={row({ id: 'f1', deferred: PAUL })} tier="plain" />)
+    // Both. A row that fell silent about its gap once deferred would be the
+    // dismiss button growing back inside the row.
+    expect(screen.getByTestId('model-row-v2-f1-attention-no-value')).toBeInTheDocument()
+    expect(screen.getByTestId('model-row-v2-f1-deferred')).toBeInTheDocument()
+  })
+
+  it('the deferred marker carries the provenance in its label', () => {
+    render(<ModelRowView row={row({ id: 'f1', deferred: PAUL })} tier="plain" />)
+    expect(screen.getByTestId('model-row-v2-f1-deferred').getAttribute('aria-label')).toMatch(
+      /Paul/,
+    )
+  })
+
+  it('an undeferred row carries no deferred marker', () => {
+    render(<ModelRowView row={row({ id: 'f1' })} tier="plain" />)
+    expect(screen.queryByTestId('model-row-v2-f1-deferred')).toBeNull()
+    // Positive control: the row rendered and still reports its gap.
+    expect(screen.getByTestId('model-row-v2-f1-attention-no-value')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/RepairQueueList.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/RepairQueueList.spec.tsx
@@ -1,0 +1,162 @@
+/**
+ * Model tab v2 — THE REPAIR QUEUE LIST (design §5.3), render-only.
+ *
+ * The headline property, and the one the brief names: a queue renders EXACTLY
+ * the items it is given, in the order it is given them. It is asserted with
+ * exact array equality on IDS — not on length, not on text — because a list that
+ * dropped one item and invented another would keep its length, and a list that
+ * re-sorted would keep its contents.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RepairQueueList } from '../RepairQueueList'
+import type { RepairQueue, RepairQueueItem } from '../types'
+
+const QUEUE: RepairQueue = {
+  id: 'confirm-estimates',
+  reason: 'unconfirmed-estimate',
+  title: 'Confirm estimates',
+  supportsApplyAll: true,
+}
+
+function item(rowId: string, over: Partial<RepairQueueItem> = {}): RepairQueueItem {
+  return {
+    rowId,
+    label: `Label ${rowId}`,
+    currentValue: '45 days',
+    suggestedValue: '30 days',
+    basis: 'Inferred from model structure',
+    ...over,
+  }
+}
+
+/** The rendered item ids, in DOM order. The object of every order assertion. */
+function renderedItemIds(): string[] {
+  return Array.from(
+    document.querySelectorAll(`[data-testid^="repair-queue-v2-${QUEUE.id}-item-"][data-row-id]`),
+  ).map(el => el.getAttribute('data-row-id')!)
+}
+
+describe('⭐ RepairQueueList — exactly the queue\'s items, in the queue\'s order', () => {
+  it('renders every item, in the given order, and nothing else', () => {
+    // Deliberately not alphabetical and not sorted by value: a list that sorted
+    // by either would produce a different array and fail here.
+    const items = [item('f3'), item('f1'), item('f2')]
+    render(<RepairQueueList queue={QUEUE} items={items} />)
+    expect(renderedItemIds()).toEqual(['f3', 'f1', 'f2'])
+  })
+
+  it('does not drop or dedupe items that share a label', () => {
+    const items = [item('f1', { label: 'Same label' }), item('f2', { label: 'Same label' })]
+    render(<RepairQueueList queue={QUEUE} items={items} />)
+    // Identity, not text: two items indistinguishable by label must both survive.
+    expect(renderedItemIds()).toEqual(['f1', 'f2'])
+  })
+
+  it('renders each item\'s OWN values, bound by id', () => {
+    const items = [
+      item('f1', { currentValue: '45 days', suggestedValue: '30 days' }),
+      item('f2', { currentValue: '3.0x', suggestedValue: '4.0x' }),
+    ]
+    render(<RepairQueueList queue={QUEUE} items={items} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2-current`)).toHaveTextContent('3.0x')
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2-suggested`)).toHaveTextContent('4.0x')
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-current`)).toHaveTextContent('45 days')
+  })
+
+  it('the stated count matches the rendered rows — a badge and its queue cannot disagree', () => {
+    const items = [item('f1'), item('f2'), item('f3')]
+    render(<RepairQueueList queue={QUEUE} items={items} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-count`)).toHaveTextContent('3 items')
+    expect(renderedItemIds()).toHaveLength(3)
+  })
+
+  it('says the queue is empty rather than rendering an empty list', () => {
+    render(<RepairQueueList queue={QUEUE} items={[]} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-empty`)).toHaveTextContent(
+      'Nothing needs attention here',
+    )
+  })
+})
+
+describe('RepairQueueList — a missing value is a fact, not a zero', () => {
+  it('renders "No value set" for a null current value (the F9 case)', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { currentValue: null })]} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-current`)).toHaveTextContent(
+      'No value set',
+    )
+  })
+
+  it('omits the suggestion entirely when there is none, rather than suggesting a blank', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { suggestedValue: null })]} />)
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-suggested`)).toBeNull()
+    // Positive control: the row itself rendered.
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1`)).toBeInTheDocument()
+  })
+
+  it('shows the basis when one is given', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-basis`)).toHaveTextContent(
+      'Inferred from model structure',
+    )
+  })
+})
+
+describe('⭐ RepairQueueList — nothing here pretends it can apply anything', () => {
+  it('every per-item Apply is disabled and says why', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1'), item('f2')]} />)
+    for (const id of ['f1', 'f2']) {
+      const apply = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-${id}-apply`)
+      expect(apply).toBeDisabled()
+      expect(apply.getAttribute('title')).toMatch(/not connected yet/i)
+    }
+  })
+
+  it('"Apply all shown" is disabled and names the BATCH contract as the reason', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1')]} />)
+    const applyAll = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-apply-all`)
+    expect(applyAll).toBeDisabled()
+    // The reason must be the real one — batching — not a generic "coming soon".
+    // Looping single proposals is what the batch contract exists to prevent.
+    expect(applyAll.getAttribute('title')).toMatch(/batch/i)
+    expect(applyAll.getAttribute('title')).toMatch(/re-run the analysis after each one/i)
+  })
+
+  it('clicking a disabled Apply changes nothing on screen', () => {
+    render(<RepairQueueList queue={QUEUE} items={[item('f1', { currentValue: '45 days' })]} />)
+    const before = screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-current`).textContent
+    fireEvent.click(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-apply`))
+    expect(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f1-current`).textContent).toBe(before)
+  })
+
+  it('offers no "Apply all" at all for a queue that does not support it', () => {
+    render(
+      <RepairQueueList
+        queue={{ ...QUEUE, id: 'contested', supportsApplyAll: false }}
+        items={[item('f1')]}
+      />,
+    )
+    expect(screen.queryByTestId('repair-queue-v2-contested-apply-all')).toBeNull()
+  })
+
+  it('offers no "Apply all" when the queue is empty', () => {
+    render(<RepairQueueList queue={QUEUE} items={[]} />)
+    expect(screen.queryByTestId(`repair-queue-v2-${QUEUE.id}-apply-all`)).toBeNull()
+  })
+})
+
+describe('RepairQueueList — navigation is ID-addressed and safe today', () => {
+  it('reports the row id of the label that was clicked, not its position', () => {
+    const onFocusOnCanvas = vi.fn()
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('f1', { label: 'Same' }), item('f2', { label: 'Same' })]}
+        onFocusOnCanvas={onFocusOnCanvas}
+      />,
+    )
+    fireEvent.click(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2-label`))
+    expect(onFocusOnCanvas).toHaveBeenCalledWith('f2')
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
@@ -1,0 +1,434 @@
+/**
+ * Model tab v2 — THE STORE → PROJECTION ADAPTER (adapters.ts).
+ *
+ * Fixtures are built to the PRODUCER's shapes, derived at the bytes from
+ * `domain/nodes.ts` (`ObservedStateSchema`, `FactorNodeDataSchema`,
+ * `OptionNodeDataSchema`), `domain/edges.ts` (`EdgeDataSchema` and its
+ * set-vs-defaulted source stamps) and `store.ts:388` (`goalThreshold`, raw user
+ * units). A fixture invented from this file's own idea of the store would prove
+ * only that the adapter agrees with my imagination.
+ *
+ * Two things carry this file:
+ *   · THE PORT PIN — the one predicate copied out of the live tree is asserted
+ *     to agree with the live original over a corpus, so the copy cannot drift;
+ *   · THE DISCRIMINATING PAIR — a store change that MUST reach the projection,
+ *     and one that MUST NOT, so a frozen or over-eager projection both fail.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import type { EdgeData } from '../../domain/edges'
+import { countFactorsToVerify } from '../../components/model-tab/utils'
+import {
+  edgeIsContested,
+  factorNeedsVerification,
+  nodeKind,
+  optionHasNoInterventions,
+  toModelRows,
+  toRepairQueueItems,
+  toRowDetail,
+  type ModelProjectionInput,
+} from '../adapters'
+
+// ── Fixtures, shaped like the producer ───────────────────────────────────────
+
+function factorNode(
+  id: string,
+  label: string,
+  observedState: Record<string, unknown> | null,
+): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'factor', observedState },
+  }
+}
+
+function optionNode(id: string, label: string, interventions?: Record<string, number>): Node {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'option', ...(interventions ? { interventions } : {}) },
+  }
+}
+
+function goalNode(id = 'g1', label = 'Reach £2m ARR'): Node {
+  return { id, type: 'goal', position: { x: 0, y: 0 }, data: { label, type: 'goal' } }
+}
+
+function edge(id: string, source: string, target: string, data: Partial<EdgeData> = {}): Edge<EdgeData> {
+  return { id, source, target, data: data as EdgeData }
+}
+
+function input(over: Partial<ModelProjectionInput> = {}): ModelProjectionInput {
+  return { nodes: [], edges: [], goalThreshold: null, ...over }
+}
+
+/** A factor whose value the user has confirmed — the "no attention" baseline. */
+const CONFIRMED_OBS = { raw_value: 45, unit: 'days', source: 'user_confirmed' }
+
+// ── Kind and grouping ────────────────────────────────────────────────────────
+
+describe('nodeKind — resolved the way the live tree resolves it', () => {
+  it('reads node.type first, then data.kind, then data.type', () => {
+    expect(nodeKind({ type: 'factor', data: {} })).toBe('factor')
+    expect(nodeKind({ data: { kind: 'option' } })).toBe('option')
+    expect(nodeKind({ data: { type: 'risk' } })).toBe('risk')
+  })
+
+  it('returns null for kinds this surface has no group for, rather than guessing', () => {
+    // `action` and `constraint` are real NodeTypeEnum members. Filing them under
+    // an arbitrary group would put them on screen in the wrong place.
+    expect(nodeKind({ type: 'action', data: {} })).toBeNull()
+    expect(nodeKind({ type: 'constraint', data: {} })).toBeNull()
+  })
+})
+
+describe('toModelRows — every element lands in its declared group', () => {
+  it('maps kinds onto the seven groups', () => {
+    const rows = toModelRows(
+      input({
+        nodes: [goalNode(), optionNode('o1', 'Hire two AEs'), factorNode('f1', 'Sales cycle', CONFIRMED_OBS)],
+        edges: [edge('e1', 'f1', 'g1', { weight: 0.6, weightSource: 'cee' })],
+      }),
+    )
+    const byId = Object.fromEntries(rows.map(r => [r.id, r.group]))
+    expect(byId).toEqual({ g1: 'goal', o1: 'options', f1: 'factors', e1: 'relationships' })
+  })
+
+  it('drops action/constraint nodes entirely', () => {
+    const rows = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'Kept', CONFIRMED_OBS),
+          { id: 'a1', type: 'action', position: { x: 0, y: 0 }, data: { label: 'Dropped' } },
+        ],
+      }),
+    )
+    expect(rows.map(r => r.id)).toEqual(['f1'])
+  })
+})
+
+// ── Factors ──────────────────────────────────────────────────────────────────
+
+describe('toModelRows — factor values and attention', () => {
+  it('carries THIS factor\'s value, bound by id, with a confusable sibling present', () => {
+    const rows = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
+          factorNode('f2', 'Other cycle', { raw_value: 90, unit: 'days', source: 'user_confirmed' }),
+        ],
+      }),
+    )
+    const byId = Object.fromEntries(rows.map(r => [r.id, r.primaryValue]))
+    expect(byId.f1).toContain('45')
+    expect(byId.f2).toContain('90')
+  })
+
+  it('a factor with no observed state has NO value and says so', () => {
+    const rows = toModelRows(input({ nodes: [factorNode('f1', 'Unset', null)] }))
+    expect(rows[0].primaryValue).toBeNull()
+    // Not 0, not '', not 'unknown' — an explicit absence the queue can act on.
+    expect(rows[0].attention).toContain('no-value')
+  })
+
+  it('an AI estimate is flagged unconfirmed; a confirmed value is not', () => {
+    const rows = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'AI', { raw_value: 45, unit: 'days', source: 'cee_inference' }),
+          factorNode('f2', 'Confirmed', CONFIRMED_OBS),
+        ],
+      }),
+    )
+    const byId = Object.fromEntries(rows.map(r => [r.id, r.attention]))
+    expect(byId.f1).toContain('unconfirmed-estimate')
+    expect(byId.f2).toEqual([])
+  })
+
+  it('carries the RAW provenance stamp, not a classified kind', () => {
+    const rows = toModelRows(input({ nodes: [factorNode('f1', 'X', CONFIRMED_OBS)] }))
+    // The pill classifies; the projection must not pre-classify (types.ts).
+    expect(rows[0].provenanceSource).toBe('user_confirmed')
+  })
+})
+
+// ── ⭐ THE PORT PIN ──────────────────────────────────────────────────────────
+
+describe('⭐ the ported predicate agrees with the live original', () => {
+  /**
+   * A corpus spanning every shape the live filter distinguishes, INCLUDING the
+   * snake_case wire spelling and a factor with no observed state at all.
+   */
+  const CORPUS: Node[] = [
+    factorNode('a', 'no source', { raw_value: 1 }),
+    factorNode('b', 'cee_inference', { raw_value: 1, source: 'cee_inference' }),
+    factorNode('c', 'user', { raw_value: 1, source: 'user' }),
+    factorNode('d', 'user_confirmed', { raw_value: 1, source: 'user_confirmed' }),
+    factorNode('e', 'brief', { raw_value: 1, source: 'brief_extraction' }),
+    factorNode('f', 'no observed state', null),
+    {
+      id: 'g',
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      // The WIRE spelling. Reading only camelCase here would under-count.
+      data: { label: 'snake_case', type: 'factor', observed_state: { raw_value: 1, source: 'cee_inference' } },
+    },
+  ]
+
+  it('my per-factor predicate and the live COUNT agree over the corpus', () => {
+    // The live function exports only a count, which is why the predicate had to
+    // be ported at all. Pinning them against each other means the copy cannot
+    // drift from the badge without turning this red.
+    const mine = CORPUS.filter(n => factorNeedsVerification(n.data)).length
+    expect(mine).toBe(countFactorsToVerify(CORPUS))
+  })
+
+  it('and they agree on the empty case', () => {
+    expect([].filter(() => true).length).toBe(countFactorsToVerify([]))
+  })
+
+  it('the predicate identifies WHICH factors, which is what a queue needs', () => {
+    const flagged = CORPUS.filter(n => factorNeedsVerification(n.data)).map(n => n.id)
+    expect(flagged).toEqual(['a', 'b', 'f', 'g'])
+  })
+})
+
+// ── Edges: the read-side gates are not re-implemented here ───────────────────
+
+describe('toModelRows — edge values pass through the live honesty gates', () => {
+  it('an UNSTAMPED weight renders nothing rather than the UI default', () => {
+    const rows = toModelRows(
+      input({ nodes: [factorNode('f1', 'A', CONFIRMED_OBS), goalNode()], edges: [edge('e1', 'f1', 'g1', { weight: 0.6 })] }),
+    )
+    const e = rows.find(r => r.id === 'e1')!
+    // No `weightSource` ⇒ nobody set it ⇒ the number is not fit to speak.
+    expect(e.primaryValue).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: a STAMPED weight does render a label', () => {
+    // Without this the assertion above would also pass on an adapter that never
+    // renders an edge value at all.
+    const rows = toModelRows(
+      input({
+        nodes: [factorNode('f1', 'A', CONFIRMED_OBS), goalNode()],
+        edges: [edge('e1', 'f1', 'g1', { weight: 0.6, weightSource: 'cee', direction: 'positive', directionSource: 'cee' })],
+      }),
+    )
+    expect(rows.find(r => r.id === 'e1')!.primaryValue).toBeTruthy()
+  })
+
+  it('a direction nobody stated is not turned into a positive effect', () => {
+    const rows = toModelRows(
+      input({
+        nodes: [factorNode('f1', 'A', CONFIRMED_OBS), goalNode()],
+        // `direction: 'positive'` with NO directionSource is the UI default —
+        // the exact fabrication the Model tab shipped as "Strong positive effect".
+        edges: [edge('e1', 'f1', 'g1', { weight: 0.9, weightSource: 'cee', direction: 'positive' })],
+      }),
+    )
+    expect(rows.find(r => r.id === 'e1')!.primaryValue).not.toMatch(/positive/i)
+  })
+})
+
+describe('edgeIsContested — BOTH conjuncts, as the live tab reads them', () => {
+  it('is contested only while the disagreement is still pending', () => {
+    expect(edgeIsContested({ validation: { status: 'contested', user_action: 'pending' } })).toBe(true)
+  })
+
+  it('is NOT contested once the user has acted, though the status remains', () => {
+    // Dropping this conjunct would refill Queue C with decisions already made.
+    expect(edgeIsContested({ validation: { status: 'contested', user_action: 'accepted_pass1' } })).toBe(false)
+  })
+
+  it('is not contested with no validation metadata at all', () => {
+    expect(edgeIsContested({})).toBe(false)
+    expect(edgeIsContested(undefined)).toBe(false)
+  })
+})
+
+// ── Options ──────────────────────────────────────────────────────────────────
+
+describe('options — missing interventions are surfaced, present ones counted', () => {
+  it('flags an option that changes nothing', () => {
+    const rows = toModelRows(input({ nodes: [optionNode('o1', 'Hire two AEs')] }))
+    expect(rows[0].attention).toContain('missing-intervention')
+    expect(rows[0].primaryValue).toBeNull()
+  })
+
+  it('counts an option\'s interventions', () => {
+    const rows = toModelRows(input({ nodes: [optionNode('o1', 'Hire', { f1: 30, f2: 4 })] }))
+    expect(rows[0].primaryValue).toBe('2 changes')
+    expect(rows[0].attention).toEqual([])
+  })
+
+  it('says "1 change" for a single one', () => {
+    const rows = toModelRows(input({ nodes: [optionNode('o1', 'Hire', { f1: 30 })] }))
+    expect(rows[0].primaryValue).toBe('1 change')
+  })
+
+  it('optionHasNoInterventions matches the live allUnmapped body', () => {
+    expect(optionHasNoInterventions({})).toBe(true)
+    expect(optionHasNoInterventions({ interventions: {} })).toBe(true)
+    expect(optionHasNoInterventions({ interventions: { f1: 1 } })).toBe(false)
+  })
+})
+
+// ── Goal ─────────────────────────────────────────────────────────────────────
+
+describe('goal — the threshold is read raw and absence is a fact', () => {
+  it('renders the raw threshold without converting it', () => {
+    const rows = toModelRows(input({ nodes: [goalNode()], goalThreshold: 2000000 }))
+    // Raw user units per the store's own contract — never divided by a cap here.
+    expect(rows[0].primaryValue).toBeTruthy()
+    expect(rows[0].attention).toEqual([])
+  })
+
+  it('a goal with no threshold reports no value', () => {
+    const rows = toModelRows(input({ nodes: [goalNode()], goalThreshold: null }))
+    expect(rows[0].primaryValue).toBeNull()
+    expect(rows[0].attention).toContain('no-value')
+  })
+})
+
+// ── ⭐ THE DISCRIMINATING PAIR ───────────────────────────────────────────────
+
+describe('⭐ the projection tracks the store — and only where it should', () => {
+  const base = () =>
+    input({
+      nodes: [
+        factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
+        factorNode('f2', 'Win rate', { raw_value: 22, unit: '%', source: 'user_confirmed' }),
+      ],
+    })
+
+  it('A CHANGE THAT MUST REACH THE PROJECTION does: f1\'s value changes f1\'s row', () => {
+    const before = toModelRows(base()).find(r => r.id === 'f1')!
+    const after = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'Sales cycle', { raw_value: 60, unit: 'days', source: 'user_confirmed' }),
+          factorNode('f2', 'Win rate', { raw_value: 22, unit: '%', source: 'user_confirmed' }),
+        ],
+      }),
+    ).find(r => r.id === 'f1')!
+
+    // A frozen projection — one that ignored the store — fails exactly here.
+    expect(after.primaryValue).not.toBe(before.primaryValue)
+    expect(after.primaryValue).toContain('60')
+  })
+
+  it('AN UNRELATED CHANGE DOES NOT: editing f2 leaves f1\'s row byte-identical', () => {
+    const before = toModelRows(base()).find(r => r.id === 'f1')!
+    const after = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
+          // f2 changed in both value and label.
+          factorNode('f2', 'Renamed', { raw_value: 99, unit: '%', source: 'cee_inference' }),
+        ],
+      }),
+    ).find(r => r.id === 'f1')!
+
+    // This is the discrimination: without it, the assertion above would also
+    // pass on a projection that changed every row whenever anything moved.
+    expect(after).toEqual(before)
+  })
+
+  it('and the unrelated change DOES reach its own row', () => {
+    const after = toModelRows(
+      input({
+        nodes: [
+          factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
+          factorNode('f2', 'Renamed', { raw_value: 99, unit: '%', source: 'cee_inference' }),
+        ],
+      }),
+    ).find(r => r.id === 'f2')!
+    expect(after.label).toBe('Renamed')
+    expect(after.attention).toContain('unconfirmed-estimate')
+  })
+})
+
+// ── Queues ───────────────────────────────────────────────────────────────────
+
+describe('toRepairQueueItems — each queue derives from the same predicate as its chip', () => {
+  const nodes = [
+    factorNode('f1', 'Unconfirmed', { raw_value: 45, unit: 'days', source: 'cee_inference' }),
+    factorNode('f2', 'Confirmed', CONFIRMED_OBS),
+    factorNode('f3', 'No value', null),
+    optionNode('o1', 'Unmapped'),
+    optionNode('o2', 'Mapped', { f1: 30 }),
+  ]
+
+  it('confirm-estimates returns exactly the unconfirmed factors, in order', () => {
+    const items = toRepairQueueItems(input({ nodes }), 'confirm-estimates')
+    // f3 has no source either, so it is also unconfirmed — identity, not count.
+    expect(items.map(i => i.rowId)).toEqual(['f1', 'f3'])
+  })
+
+  it('no-value returns exactly the factors with nothing set', () => {
+    const items = toRepairQueueItems(input({ nodes }), 'no-value')
+    expect(items.map(i => i.rowId)).toEqual(['f3'])
+  })
+
+  it('set-option-values returns exactly the options that change nothing', () => {
+    const items = toRepairQueueItems(input({ nodes }), 'set-option-values')
+    expect(items.map(i => i.rowId)).toEqual(['o1'])
+  })
+
+  it('contested returns exactly the pending contested edges', () => {
+    const items = toRepairQueueItems(
+      input({
+        nodes: [factorNode('f1', 'A', CONFIRMED_OBS), goalNode()],
+        edges: [
+          edge('e1', 'f1', 'g1', { validation: { status: 'contested', user_action: 'pending' } } as Partial<EdgeData>),
+          edge('e2', 'f1', 'g1', { validation: { status: 'contested', user_action: 'accepted_pass1' } } as Partial<EdgeData>),
+        ],
+      }),
+      'contested',
+    )
+    expect(items.map(i => i.rowId)).toEqual(['e1'])
+  })
+
+  it('a queue item carries the factor\'s CURRENT value, not an invented suggestion', () => {
+    const items = toRepairQueueItems(input({ nodes }), 'confirm-estimates')
+    const f1 = items.find(i => i.rowId === 'f1')!
+    expect(f1.currentValue).toContain('45')
+    // Confirming ratifies what is there; the adapter must not propose a number.
+    expect(f1.suggestedValue).toBeNull()
+  })
+})
+
+// ── Detail ───────────────────────────────────────────────────────────────────
+
+describe('toRowDetail — id-addressed, and absent rather than approximate', () => {
+  it('echoes the requested rowId so the region\'s identity gate can check it', () => {
+    const detail = toRowDetail(input({ nodes: [factorNode('f1', 'A', CONFIRMED_OBS)] }), 'f1')!
+    expect(detail.rowId).toBe('f1')
+  })
+
+  it('returns null for an id that is not in the model', () => {
+    // Not a neighbour, not an empty shell — nothing.
+    expect(toRowDetail(input({ nodes: [factorNode('f1', 'A', CONFIRMED_OBS)] }), 'nope')).toBeNull()
+  })
+
+  it('renders a missing advanced parameter as absence, never as zero', () => {
+    const detail = toRowDetail(input({ nodes: [factorNode('f1', 'A', { raw_value: 1, source: 'user' })] }), 'f1')!
+    const cap = detail.advancedParameters.find(p => p.label === 'Cap')!
+    expect(cap.value).toBeNull()
+  })
+
+  it('lists what an element affects, id-addressed', () => {
+    const detail = toRowDetail(
+      input({
+        nodes: [factorNode('f1', 'A', CONFIRMED_OBS), goalNode()],
+        edges: [edge('e1', 'f1', 'g1', { weight: 0.5, weightSource: 'cee' })],
+      }),
+      'f1',
+    )!
+    expect(detail.affects.map(a => a.id)).toEqual(['e1'])
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
@@ -201,15 +201,109 @@ describe('⭐ model-tab-v2 NEVER WRITES — the write authority is another lane'
     expect(offenders).toEqual([])
   })
 
-  it('no v2 file reaches into a store at all — components take projections as props', () => {
-    const STORE_IMPORT = /\b(useCanvasStore|useUIStore|useInspectorMutations|useNodeMutations|useEdgeMutations)\b/
-    // Control first: the token must be able to match.
-    expect(STORE_IMPORT.test("import { useCanvasStore } from '../store'")).toBe(true)
+  /**
+   * ⚠ RE-AIMED. The earlier version banned any MENTION of a store hook, which
+   * was right while every component took only props, and became wrong the
+   * moment the read-only adapter landed: namespace → live READS are sanctioned,
+   * and are the whole point of `adapters.ts`.
+   *
+   * The invariant that actually matters was never "no store identifier appears"
+   * — it is **nothing here can FIRE while unmounted**. A `use*` CALL is a
+   * subscription; `import type` and a pure function invoked with explicitly
+   * passed state are not. So the ban is on INVOCATION, and the scan is written
+   * to tell those two apart rather than to tell them apart by luck.
+   *
+   * Deleting the guard would have been the easy move and the wrong one: the
+   * ratified change narrows what is banned, it does not stop banning anything.
+   */
+  it('no v2 file INVOKES a hook from OUTSIDE this namespace — nothing here can subscribe', () => {
+    /*
+     * ⚠ THE LINE IS NOT "no `use*` call". A first cut banned every `use*(` and
+     * immediately flagged `ModelOutline`'s `useState`/`useMemo`/`useCallback` —
+     * React's own primitives, which are inert until something renders the
+     * component, and nothing renders these. Banning them would have forced the
+     * components to be rewritten to satisfy a guard rather than a risk.
+     *
+     * What actually threatens "nothing fires while unmounted" is a hook that
+     * reaches OUT of this directory — a store or context subscription. So the
+     * allowed set is DERIVED PER FILE from that file's own `from 'react'`
+     * import, never hand-listed: a new React hook is allowed the day React ships
+     * it, and a new store hook is banned the day someone imports it.
+     */
+    /*
+     * ⚠ `stripComments`, NOT `blankNonCode` — AND THIS FILE ALREADY PAID FOR
+     * THAT LESSON ONCE. The module specifier `'react'` is a STRING, so
+     * `blankNonCode` erases it and the import scan below finds no React import
+     * in any file — making every legitimate `useState` read as a foreign hook.
+     * The first cut did exactly that and its own control caught it. Same trap,
+     * same file, second occurrence: when a scan's target lives inside a string
+     * literal, `blankNonCode` is the wrong transform.
+     */
+    const foreignHookCallsIn = (src: string, file: string): string[] => {
+      const code = stripComments(src, file)
+      const allowed = new Set<string>()
+      for (const m of code.matchAll(/import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]react['"]/g)) {
+        for (const raw of m[1].split(',')) {
+          const name = raw.split(/\s+as\s+/).pop()!.trim()
+          if (name) allowed.add(name)
+        }
+      }
+      // A hook DEFINED in this namespace is not a foreign one — and its own
+      // declaration `function useOutlineKeyboard(` matches the call regex below,
+      // so without this the scan reports every local hook as an offender.
+      for (const m of code.matchAll(/(?:function|const|let|var)\s+(use[A-Z]\w*)/g)) {
+        allowed.add(m[1])
+      }
+      return [...code.matchAll(/\b(use[A-Z]\w*)\s*\(/g)]
+        .map(m => m[1])
+        .filter(name => !allowed.has(name))
+    }
 
-    const offenders = v2Files.filter(f =>
-      STORE_IMPORT.test(blankNonCode(readFileSync(f, 'utf8'))),
-    )
-    expect(offenders.map(f => basename(f))).toEqual([])
+    // Controls, through the SAME pipeline as the claim below.
+    expect(foreignHookCallsIn('const s = useCanvasStore()', 'x.ts')).toEqual(['useCanvasStore'])
+    expect(
+      foreignHookCallsIn("import { useState } from 'react'\nconst [a] = useState(1)", 'x.tsx'),
+    ).toEqual([])
+    // A store hook is still caught even in a file that legitimately uses React's.
+    expect(
+      foreignHookCallsIn("import { useMemo } from 'react'\nconst s = useUIStore()\nuseMemo(() => 1)", 'x.tsx'),
+    ).toEqual(['useUIStore'])
+    // Importing without calling is a read, not a subscription.
+    expect(foreignHookCallsIn("import { useCanvasStore } from '../store'", 'x.ts')).toEqual([])
+    expect(foreignHookCallsIn("import type { CanvasState } from '../store'", 'x.ts')).toEqual([])
+    // A hook this namespace DEFINES is its own, not a foreign subscription.
+    expect(foreignHookCallsIn('export function useMine(a: number) { return a }', 'x.ts')).toEqual([])
+    // ...but defining one does not launder a store hook called beside it.
+    expect(
+      foreignHookCallsIn('export function useMine() { return useCanvasStore() }', 'x.ts'),
+    ).toEqual(['useCanvasStore'])
+
+    const offenders: string[] = []
+    for (const file of v2Files) {
+      const found = foreignHookCallsIn(readFileSync(file, 'utf8'), file)
+      if (found.length > 0) offenders.push(`${basename(file)}: ${[...new Set(found)].join(', ')}`)
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: the components DO call React hooks, so the rule above is discriminating', () => {
+    // Without this, the assertion above would also pass on a directory that
+    // called no hooks at all — and the per-file React allowance would be
+    // machinery that has never once been exercised (trap 13b).
+    const outline = v2Files.find(f => basename(f) === 'ModelOutline.tsx')!
+    expect(/\buse(State|Memo|Callback)\s*\(/.test(blankNonCode(readFileSync(outline, 'utf8')))).toBe(true)
+  })
+
+  it('the adapter reads live state by ARGUMENT, never by subscription', () => {
+    // The specific shape that makes `adapters.ts` safe to exist unmounted: it
+    // takes the slices it reads as a parameter. If this ever stops being true
+    // the file can run on its own initiative, and "nothing fires while
+    // unmounted" stops being a property of this directory.
+    const adapter = v2Files.find(f => basename(f) === 'adapters.ts')
+    expect(adapter).toBeDefined()
+    const src = blankNonCode(readFileSync(adapter!, 'utf8'))
+    expect(/\buse[A-Z]\w*\s*\(/.test(src)).toBe(false)
+    expect(/ModelProjectionInput/.test(src)).toBe(true)
   })
 })
 

--- a/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * Model tab v2 — THE LANE BOUNDARY, ENFORCED (design §8, §9.1).
+ *
+ * This lane makes three claims about itself. Each is the kind of claim that is
+ * cheap to write in a comment, invisible when it stops being true, and expensive
+ * when it does. So each is a test:
+ *
+ *   1. NOTHING IS MOUNTED — no file outside this directory references it, so the
+ *      whole directory is deletable if Paul vetoes the design.
+ *   2. NOTHING WRITES — no file here calls a store mutator or dispatches a turn.
+ *      The write authority is Codex's transactional-edit vertical (§9.1), and a
+ *      second writer appearing here is exactly how the estate previously ended
+ *      up committing one edit through three paths with three provenance stamps.
+ *   3. NOTHING FAKES SUCCESS — no runtime module here constructs an `applied`
+ *      commit state. `applied` is reachable only from an authority's receipt; a
+ *      component that could build one itself would reproduce design §2 F6 inside
+ *      the code written to kill it.
+ *
+ * Every scan is DERIVED by walking the directory, never a hand-listed file set —
+ * a new component is in scope the moment it exists. Every absence assertion
+ * carries a POSITIVE CONTROL, because a matcher broken by a typo reports a clean
+ * sweep by testing nothing.
+ *
+ * ⚠⚠ TWO OF THESE GUARDS SHIPPED STRUCTURALLY INCAPABLE OF FIRING, AND A
+ * MUTATION CHECK IS THE ONLY REASON THIS COMMENT EXISTS. Both originally ran
+ * their source text through `blankNonCode`, which blanks the CONTENTS of string
+ * literals as well as comments. But the thing scan 1 hunts lives in a string (an
+ * import specifier, `'../model-tab-v2/ModelOutline'`) and so does scan 3's
+ * (`phase: 'applied'`). So both were reading text with their targets already
+ * erased. Adding a real import from outside the directory, and a real fabricated
+ * `applied` state, left the whole suite GREEN.
+ *
+ * The fix is `stripComments`, which blanks comments and treats string literals as
+ * CODE. Scan 2 deliberately keeps `blankNonCode`, because a mutator NAME inside a
+ * string is not a call and should not redden anything — the two transforms answer
+ * different questions and the choice is per-scan, not per-file.
+ *
+ * ⭐ THE DURABLE LESSON, because it defeated the controls that were already here:
+ * the original positive controls tested the bare REGEX against a bare string.
+ * They passed. A control must exercise the **same pipeline the real assertion
+ * uses** — transform included — or it certifies a matcher that the real scan
+ * never gets to use. Every control below now goes through the same helper as the
+ * claim it guards.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname, basename, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { blankNonCode, stripComments } from '../../../../tests/helpers/stripSourceComments'
+
+const V2_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SRC_DIR = join(V2_DIR, '..', '..')
+
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__mocks__', '__snapshots__'])
+
+function sourceFilesIn(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(entry)) out.push(...sourceFilesIn(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+const v2Files = sourceFilesIn(V2_DIR)
+
+describe('model-tab-v2 — the scan sees the directory it claims to cover', () => {
+  it('walks the v2 directory and finds its components', () => {
+    const names = v2Files.map(f => basename(f))
+    for (const required of [
+      'ModelRowView.tsx',
+      'ModelOutline.tsx',
+      'ModelDetailRegion.tsx',
+      'RepairQueueList.tsx',
+      'useOutlineKeyboard.ts',
+      'types.ts',
+      'contracts.ts',
+    ]) {
+      expect(names).toContain(required)
+    }
+  })
+})
+
+// ── 1. UNMOUNTED ─────────────────────────────────────────────────────────────
+
+/**
+ * The directory name as it would appear in any import specifier reaching it.
+ * Matching the PATH SEGMENT rather than a component name is deliberate: a mount
+ * could import any symbol, or the barrel, or a deep file, and a name-based scan
+ * would miss whichever one it did not think of.
+ */
+const V2_PATH_TOKEN = /model-tab-v2/
+
+/**
+ * ⚠ `stripComments`, NOT `blankNonCode` — see the file header. An import
+ * specifier IS a string literal, so a transform that blanks string contents
+ * erases exactly what this scan exists to find.
+ */
+function referencesV2(src: string, file: string): boolean {
+  return V2_PATH_TOKEN.test(stripComments(src, file))
+}
+
+describe('⭐ model-tab-v2 is UNMOUNTED — nothing outside it references it', () => {
+  const outsideFiles = sourceFilesIn(SRC_DIR).filter(
+    f => !f.startsWith(V2_DIR + '/') && f !== V2_DIR,
+  )
+
+  it('POSITIVE CONTROL: the sweep reaches a large, plausible slice of src/', () => {
+    // A magnitude check, not a bare non-zero: a walker broken so that it
+    // returned only a handful of files would still "find nothing" below, and
+    // the clean result would be an instrument failure rather than a fact.
+    expect(outsideFiles.length).toBeGreaterThan(1000)
+  })
+
+  it('POSITIVE CONTROL: a real import survives the transform and IS detected', () => {
+    // ⚠ Through `referencesV2`, i.e. the SAME pipeline the claim below uses.
+    // The earlier version of this control tested the bare regex, passed, and
+    // certified a scan whose transform had already deleted the import path.
+    expect(
+      referencesV2("import { ModelOutline } from '@/canvas/model-tab-v2/ModelOutline'", 'x.tsx'),
+    ).toBe(true)
+    expect(
+      referencesV2("import { ModelRowView } from '../../model-tab-v2/ModelRowView'", 'x.ts'),
+    ).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: a mere mention in a COMMENT is not a mount', () => {
+    // The transform must still discriminate: prose referring to the directory
+    // is not a reference that mounts anything.
+    expect(referencesV2('// the model-tab-v2 design is unmounted\nconst x = 1', 'x.ts')).toBe(false)
+  })
+
+  it('no file outside the directory imports or mentions it', () => {
+    const offenders: string[] = []
+    for (const file of outsideFiles) {
+      if (referencesV2(readFileSync(file, 'utf8'), file)) {
+        offenders.push(relative(SRC_DIR, file))
+      }
+    }
+    // If this ever goes red, the directory is MOUNTED and three things become
+    // due at once: widen the raw-write guard (§9.1), re-read the disabled
+    // affordances, and stop describing the design as vetoable-by-deletion.
+    expect(offenders).toEqual([])
+  })
+})
+
+// ── 2. NO WRITES ─────────────────────────────────────────────────────────────
+
+/**
+ * The store mutators that accept a free-form patch, plus the turn emitter. These
+ * are the three ways a Model-tab surface has historically written: a raw store
+ * patch, a sanctioned setter, and a system event on the wire.
+ */
+const BANNED_WRITE = /\b(updateNode|updateEdge|updateEdgeData|sendSystemEvent|setIntervention|setStrength|setDirection|setExistsProbability|setObservedSource|setObservedBaseline|setPriorRange|setGoalThresholdAndUpdateNode)\s*\(/g
+
+function bannedWritesIn(src: string): string[] {
+  return [...blankNonCode(src).matchAll(BANNED_WRITE)].map(m => m[1])
+}
+
+describe('⭐ model-tab-v2 NEVER WRITES — the write authority is another lane', () => {
+  it('POSITIVE CONTROL: the matcher sees every banned call when one is present', () => {
+    const synthetic = [
+      'updateNode(id, { data })',
+      'updateEdge(edgeId, { data })',
+      'updateEdgeData(edgeId, { weight: 1 })',
+      "sendSystemEvent('factor_value_edit', payload)",
+      'setIntervention(optionId, factorId, 30)',
+      'setStrength(edgeId, 0.6)',
+      'setObservedSource(nodeId, "user")',
+    ].join('\n')
+    expect(new Set(bannedWritesIn(synthetic))).toEqual(
+      new Set([
+        'updateNode',
+        'updateEdge',
+        'updateEdgeData',
+        'sendSystemEvent',
+        'setIntervention',
+        'setStrength',
+        'setObservedSource',
+      ]),
+    )
+  })
+
+  it('POSITIVE CONTROL: a banned call inside a comment is NOT counted', () => {
+    expect(bannedWritesIn('// updateNode(id, { data })\nconst x = 1')).toEqual([])
+  })
+
+  it('no v2 file calls a store mutator or emits a turn', () => {
+    const offenders: string[] = []
+    for (const file of v2Files) {
+      const found = bannedWritesIn(readFileSync(file, 'utf8'))
+      if (found.length > 0) offenders.push(`${basename(file)}: ${[...new Set(found)].join(', ')}`)
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('no v2 file reaches into a store at all — components take projections as props', () => {
+    const STORE_IMPORT = /\b(useCanvasStore|useUIStore|useInspectorMutations|useNodeMutations|useEdgeMutations)\b/
+    // Control first: the token must be able to match.
+    expect(STORE_IMPORT.test("import { useCanvasStore } from '../store'")).toBe(true)
+
+    const offenders = v2Files.filter(f =>
+      STORE_IMPORT.test(blankNonCode(readFileSync(f, 'utf8'))),
+    )
+    expect(offenders.map(f => basename(f))).toEqual([])
+  })
+})
+
+// ── 3. NO FAKE SUCCESS ───────────────────────────────────────────────────────
+
+/**
+ * SCOPE, stated precisely: every v2 module EXCEPT `types.ts`, which DECLARES the
+ * `EditCommitState` union and is therefore the one legitimate place the token
+ * appears. The exclusion is proven real by a control below — if `types.ts` ever
+ * stopped containing it, the exclusion would be silently pointless and this
+ * whole guard would be scoped around nothing.
+ */
+const APPLIED_LITERAL = /phase:\s*['"]applied['"]/
+
+/**
+ * ⚠ `stripComments`, NOT `blankNonCode` — see the file header. `'applied'` is a
+ * string literal, so blanking string contents erases the target.
+ */
+function fabricatesApplied(src: string, file: string): boolean {
+  return APPLIED_LITERAL.test(stripComments(src, file))
+}
+
+describe('⭐ model-tab-v2 NEVER FABRICATES A SUCCESS STATE', () => {
+  it('POSITIVE CONTROL: a constructed applied state survives the transform and IS detected', () => {
+    // ⚠ Through `fabricatesApplied` — the same pipeline as the claim below.
+    expect(fabricatesApplied("setCommit({ phase: 'applied', value: '60 days' })", 'x.tsx')).toBe(true)
+    expect(fabricatesApplied('setCommit({ phase: "applied", value: v })', 'x.tsx')).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: an applied state named in a COMMENT is not a fabrication', () => {
+    expect(fabricatesApplied("// never write phase: 'applied' here\nconst x = 1", 'x.ts')).toBe(false)
+  })
+
+  it('POSITIVE CONTROL: types.ts DOES carry the token, so the exclusion is real', () => {
+    // Guards against the exclusion quietly becoming a no-op — a scope carved
+    // around a file that no longer contains what it was carved around.
+    const types = v2Files.find(f => basename(f) === 'types.ts')!
+    expect(fabricatesApplied(readFileSync(types, 'utf8'), types)).toBe(true)
+  })
+
+  it('no runtime module constructs an applied commit state', () => {
+    const offenders = v2Files
+      .filter(f => basename(f) !== 'types.ts')
+      .filter(f => fabricatesApplied(readFileSync(f, 'utf8'), f))
+    // A component that can build its own receipt can report an edit it never
+    // made — which is design §2 F6, the defect this entire surface exists to
+    // close, re-created one layer up.
+    expect(offenders.map(f => basename(f))).toEqual([])
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/useOutlineKeyboard.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/useOutlineKeyboard.spec.tsx
@@ -1,0 +1,190 @@
+/**
+ * Model tab v2 — KEYBOARD NAVIGATION (design §5.2).
+ *
+ * The honesty property here is the quiet one: with NO write authority wired,
+ * every key that would cause a mutation must do NOTHING — not swallow the
+ * gesture, not report a success, not consume the event. A keyboard user has no
+ * disabled affordance to look at, so a hook that silently absorbed Enter would
+ * be telling them the edit was taken.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { editableOrder, nextEditableId, useOutlineKeyboard } from '../useOutlineKeyboard'
+import type { OutlineKeyboardHandlers } from '../useOutlineKeyboard'
+import type { ModelRow } from '../types'
+
+function row(id: string, editable = true): ModelRow {
+  return {
+    id,
+    kind: 'factor',
+    group: 'factors',
+    label: `Label ${id}`,
+    primaryValue: '1',
+    attention: [],
+    editable,
+  }
+}
+
+/** A minimal host so the hook can be driven through real key events. */
+function Host({
+  rows,
+  focusedId,
+  handlers,
+}: {
+  rows: readonly ModelRow[]
+  focusedId: string | null
+  handlers?: OutlineKeyboardHandlers
+}) {
+  const { onKeyDown } = useOutlineKeyboard({ rows, focusedId, handlers })
+  return <div data-testid="host" tabIndex={0} onKeyDown={onKeyDown} />
+}
+
+describe('editableOrder — non-editable rows are skipped, in order', () => {
+  it('returns only editable ids, preserving the given order', () => {
+    const rows = [row('f3'), row('a1', false), row('f1'), row('a2', false), row('f2')]
+    expect(editableOrder(rows)).toEqual(['f3', 'f1', 'f2'])
+  })
+
+  it('returns nothing when no row is editable', () => {
+    expect(editableOrder([row('a1', false), row('a2', false)])).toEqual([])
+  })
+})
+
+describe('nextEditableId — movement, and the deliberate refusal to wrap', () => {
+  const rows = [row('f1'), row('a1', false), row('f2'), row('f3')]
+
+  it('moves forward past a non-editable row', () => {
+    expect(nextEditableId(rows, 'f1', 'forward')).toBe('f2')
+  })
+
+  it('moves backward past a non-editable row', () => {
+    expect(nextEditableId(rows, 'f2', 'backward')).toBe('f1')
+  })
+
+  it('returns null at the END rather than wrapping to the top', () => {
+    // Wrapping would silently return the user to the top of a queue they
+    // believe they have finished, with nothing to distinguish lap two from lap
+    // one. `null` lets the caller hand focus back to the browser.
+    expect(nextEditableId(rows, 'f3', 'forward')).toBeNull()
+  })
+
+  it('returns null at the START rather than wrapping to the bottom', () => {
+    expect(nextEditableId(rows, 'f1', 'backward')).toBeNull()
+  })
+
+  it('enters at the first editable row when nothing is focused', () => {
+    expect(nextEditableId(rows, null, 'forward')).toBe('f1')
+  })
+
+  it('enters at the last editable row when tabbing backward from outside', () => {
+    expect(nextEditableId(rows, null, 'backward')).toBe('f3')
+  })
+
+  it('treats an unknown id as entering from outside, not as an error', () => {
+    expect(nextEditableId(rows, 'not-in-this-outline', 'forward')).toBe('f1')
+  })
+
+  it('returns null when there is nothing editable to move to', () => {
+    expect(nextEditableId([row('a1', false)], null, 'forward')).toBeNull()
+  })
+})
+
+describe('useOutlineKeyboard — keys reach the handlers the host supplied', () => {
+  const rows = [row('f1'), row('a1', false), row('f2')]
+
+  it('Tab moves to the next editable row BY ID', () => {
+    const onMoveTo = vi.fn()
+    render(<Host rows={rows} focusedId="f1" handlers={{ onMoveTo }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Tab' })
+    expect(onMoveTo).toHaveBeenCalledWith('f2')
+  })
+
+  it('Shift+Tab moves backward', () => {
+    const onMoveTo = vi.fn()
+    render(<Host rows={rows} focusedId="f2" handlers={{ onMoveTo }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Tab', shiftKey: true })
+    expect(onMoveTo).toHaveBeenCalledWith('f1')
+  })
+
+  it('Enter states an intent for the FOCUSED row', () => {
+    const onStateIntent = vi.fn()
+    render(<Host rows={rows} focusedId="f2" handlers={{ onStateIntent }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter' })
+    expect(onStateIntent).toHaveBeenCalledWith('f2')
+  })
+
+  it('⌘/Ctrl+Enter confirms a proposal and does NOT also state a new intent', () => {
+    const onConfirmProposal = vi.fn()
+    const onStateIntent = vi.fn()
+    render(
+      <Host rows={rows} focusedId="f1" handlers={{ onConfirmProposal, onStateIntent }} />,
+    )
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter', metaKey: true })
+    expect(onConfirmProposal).toHaveBeenCalledWith('f1')
+    // The two must not both fire: confirming a standing proposal and opening a
+    // fresh edit on the same value are different acts.
+    expect(onStateIntent).not.toHaveBeenCalled()
+  })
+
+  it('Escape cancels on the focused row', () => {
+    const onCancel = vi.fn()
+    render(<Host rows={rows} focusedId="f1" handlers={{ onCancel }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledWith('f1')
+  })
+
+  it('does nothing when no row is focused', () => {
+    const onStateIntent = vi.fn()
+    render(<Host rows={rows} focusedId={null} handlers={{ onStateIntent }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter' })
+    expect(onStateIntent).not.toHaveBeenCalled()
+  })
+})
+
+describe('⭐ useOutlineKeyboard — with NO write authority, mutating keys do nothing', () => {
+  const rows = [row('f1'), row('f2')]
+
+  it('Enter does not consume the event when no handler exists', () => {
+    render(<Host rows={rows} focusedId="f1" />)
+    // `fireEvent` returns false when the event was cancelled. Not cancelling is
+    // the observable difference between "nothing is wired" and "the hook
+    // swallowed your keystroke" — and the user can only perceive the latter as
+    // the edit having been accepted.
+    const notCancelled = fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter' })
+    expect(notCancelled).toBe(true)
+  })
+
+  it('⌘+Enter does not consume the event when no handler exists', () => {
+    render(<Host rows={rows} focusedId="f1" />)
+    expect(
+      fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter', metaKey: true }),
+    ).toBe(true)
+  })
+
+  it('Escape does not consume the event when no handler exists', () => {
+    render(<Host rows={rows} focusedId="f1" />)
+    expect(fireEvent.keyDown(screen.getByTestId('host'), { key: 'Escape' })).toBe(true)
+  })
+
+  it('POSITIVE CONTROL: the same keys ARE consumed once handlers are supplied', () => {
+    // Proves the three assertions above measure the missing handler, and not a
+    // hook that never cancels anything.
+    render(
+      <Host
+        rows={rows}
+        focusedId="f1"
+        handlers={{ onStateIntent: vi.fn(), onCancel: vi.fn() }}
+      />,
+    )
+    expect(fireEvent.keyDown(screen.getByTestId('host'), { key: 'Enter' })).toBe(false)
+    expect(fireEvent.keyDown(screen.getByTestId('host'), { key: 'Escape' })).toBe(false)
+  })
+
+  it('navigation still works with no write authority — moving is not mutating', () => {
+    const onMoveTo = vi.fn()
+    render(<Host rows={rows} focusedId="f1" handlers={{ onMoveTo }} />)
+    fireEvent.keyDown(screen.getByTestId('host'), { key: 'Tab' })
+    expect(onMoveTo).toHaveBeenCalledWith('f2')
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -1,0 +1,608 @@
+/**
+ * Model tab v2 — THE READ-ONLY STORE → PROJECTION ADAPTER.
+ *
+ * Maps LIVE canvas state onto the typed read projections in `types.ts`, so that
+ * mounting this surface later is a wiring job rather than a design job.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT MAKES THIS SAFE TO EXIST WHILE UNMOUNTED
+ *
+ * ⚠ IT TAKES STATE AS AN ARGUMENT. It does NOT call `useCanvasStore()`, or any
+ * other hook, anywhere. Every function here is a pure function of the slices it
+ * is handed, so nothing subscribes, nothing fires, and nothing can run at all
+ * until a caller chooses to call it. The eventual mount reads the store at the
+ * component boundary and passes the slices in. `modelTabV2Boundary.sourceScan`
+ * enforces this: hook INVOCATION is banned in this directory, while `import
+ * type` and pure imports are allowed.
+ *
+ * ⚠ THE DIRECTION OF THE DEPENDENCY IS THE INVARIANT. namespace → live reads
+ * are fine and are what this file is for. live → namespace imports are what
+ * would constitute a mount, and there are none.
+ *
+ * ⚠ NO WRITES. No store mutator, no dispatch, no system event. Reading is the
+ * whole job.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHERE THE CLASSIFICATION COMES FROM — and why almost none of it is written here
+ *
+ * A second hand-written "is this factor unconfirmed / is this edge contested"
+ * would be a mirror of the live Model tab's answer, and a mirror drifts silently
+ * green. So the rule for this file is: IMPORT the live resolver wherever one is
+ * pure and exported, and where the live logic exists only INSIDE a component,
+ * port it with attribution AND pin it against the live function in the specs.
+ *
+ * IMPORTED FROM THE LIVE TREE (no copy exists here):
+ *   · `getCausalEdges`               — domain/edgeUtils
+ *   · `classifyValueProvenance`      — domain/valueProvenance
+ *   · `resolveEdgeValueDisplay`,
+ *     `resolveEdgeDirectionDisplay`  — domain/edgeValueProvenance (the read-side
+ *                                      gates: an unstamped value renders nothing
+ *                                      and a direction is never inferred from a
+ *                                      sign)
+ *   · `getDirectionalStrengthLabel`  — model-tab/strengthBands
+ *   · `getPrimaryValue`              — model-tab/utils
+ *   · `getDisplayEdgeId`             — utils/edgeIdentity
+ *
+ * PORTED, because the live logic is not exported per-item:
+ *   · `factorNeedsVerification` ← the filter body inside `countFactorsToVerify`
+ *     (`model-tab/utils.ts:118-125`). Only the COUNT is exported, and a queue
+ *     needs to know WHICH factors. ⚠ The port is pinned in
+ *     `adapters.spec.ts` by asserting my per-factor predicate and the live
+ *     COUNT agree over a corpus — so the copy cannot drift without a red.
+ *   · `edgeIsContested` ← `RelationshipsSection.tsx:610`.
+ *   · `optionHasNoInterventions` ← the `allUnmapped` body in
+ *     `OptionsSection.tsx:441-446`.
+ *
+ * ⚠ NOT DERIVED FROM THE STORE, DELIBERATELY: the detail TIER. `plain` vs
+ * `advanced` is a user preference, not model state; inventing it here would be
+ * fabricating a fact the store does not hold.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THREE NAMED DIVERGENCES FROM THE LIVE TAB — stated, not smuggled
+ *
+ * Each of these is a place where "reuse the live source" has no single answer.
+ * Naming them is the point: an unnamed divergence is how two surfaces end up
+ * quietly disagreeing about the same model.
+ *
+ * D1 — TWO LIVE "NEEDS VERIFICATION" PREDICATES EXIST, AND THEY DISAGREE.
+ *      `countFactorsToVerify` (utils.ts:118) is `!source || source ===
+ *      'cee_inference'`. The factor SORT KEY in `ModelTabBody.tsx:492-493` is
+ *      wider — it also flags an `external` factor carrying a full 0–1 prior
+ *      range. Nothing reconciles them. This adapter follows the FIRST, because
+ *      that is the one the "N to verify" badge and Queue B are counted from, and
+ *      a queue that disagreed with its own chip is the defect being closed.
+ *
+ * D2 — `'no-value'` IS AUTHORED FRESH, NOT PORTED. There is no per-factor
+ *      "has no value" predicate anywhere in the live tree. The Model card's
+ *      "N factors have no value set" is a count of the PRODUCER's
+ *      `ROOT_NODE_DEFAULT_VALUE` inference warnings
+ *      (`ModelHealthSection.tsx:93-98`) — a different question, answerable only
+ *      after an analysis has run. This adapter's `no-value` means "the client
+ *      can display no value for this factor", derived from the live
+ *      `getPrimaryValue` returning null. ⚠ The two will not always agree, and
+ *      neither is wrong; they are answers to different questions (trap 21).
+ *
+ * D3 — FRAGILITY IS THE CALLER'S TO SUPPLY, AND THE THRESHOLD IS A TRAP.
+ *      `buildFragileEdgeLookup` APPLIES the `switch_probability > 0.15` filter
+ *      (`THRESHOLDS.FRAGILE_EDGE_FILTER`); the similarly-named
+ *      `buildFragileEdgeIdSet` DOES NOT. A caller reaching for the Set builder
+ *      by name-similarity would mark every listed edge fragile. Build
+ *      `fragileEdgeIds` from the LOOKUP's keys, as `ModelTabBody.tsx:457-462`
+ *      does.
+ *
+ * D4 — THE GOAL THRESHOLD HAS TWO LIVE CARRIERS AND THIS ADAPTER READS THE
+ *      STORE ONE. `store.goalThreshold` (raw user units, with
+ *      `goalThresholdRepresentation` tagging the exception) is what the run path
+ *      uses; `GoalSection.tsx:81-98` instead reads a priority chain off the goal
+ *      NODE's data (`threshold_source`, `success_threshold`,
+ *      `goal_threshold_raw`, `goal_threshold`, `goal_threshold_unit`) — none of
+ *      which is declared by `GoalNodeDataSchema` at all; they ride passthrough.
+ *      The store scalar is the narrower, typed, single-writer carrier
+ *      (`setGoalThresholdAndUpdateNode`), so it is what this projection reads —
+ *      but a v2 goal row and today's goal card CAN disagree on a graph where the
+ *      node keys and the scalar have drifted. Reconciling them is a question for
+ *      whoever mounts this, not something to paper over here.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import type { EdgeData } from '../domain/edges'
+import type { ObservedState } from '../domain/nodes'
+// ⚠ The model-tab's NARROWER twin — see `narrowObservedState`. Both are imported
+// deliberately and named apart, because conflating same-named twins is this
+// estate's most expensive recurring defect.
+import type { ObservedState as ModelTabObservedState } from '../components/model-tab/types'
+import type { ValidationMetadata } from '../domain/validation'
+import { getCausalEdges } from '../domain/edgeUtils'
+import { resolveEdgeDirectionDisplay, resolveEdgeValueDisplay } from '../domain/edgeValueProvenance'
+import { getDirectionalStrengthLabel } from '../components/model-tab/strengthBands'
+import { getPrimaryValue, formatSmartNumber } from '../components/model-tab/utils'
+import { getDisplayEdgeId } from '../utils/edgeIdentity'
+import type {
+  AttentionReason,
+  ModelElementKind,
+  ModelGroupId,
+  ModelRow,
+  ModelRowDetail,
+  RepairQueue,
+  RepairQueueItem,
+} from './types'
+
+/**
+ * The slices this adapter reads. Deliberately NARROW rather than the whole
+ * store: `CanvasState` is not exported from `src/canvas/store.ts` (it is a bare
+ * `interface CanvasState` at :373), and naming only what is read means a reader
+ * can see the adapter's entire blast radius in one type.
+ */
+export interface ModelProjectionInput {
+  nodes: readonly Node[]
+  edges: readonly Edge<EdgeData>[]
+  /**
+   * ⚠ RAW USER UNITS. The store's own contract: "every writer stores raw values
+   * and every display reader treats it as raw" (`store.ts:383-388`). This
+   * adapter is a display reader, so it never converts.
+   */
+  goalThreshold: number | null
+  /**
+   * Edge ids the robustness report marked fragile. Absent when no analysis has
+   * run — which is a fact, not an empty result: with no analysis nothing is
+   * KNOWN to be fragile, and no row should claim otherwise.
+   *
+   * ⚠ BUILD THIS FROM `buildFragileEdgeLookup(...).keys()`, NOT from
+   * `buildFragileEdgeIdSet`. See divergence D3 in the file header: only the
+   * lookup applies the `switch_probability > 0.15` threshold, and the two are a
+   * name-similarity trap.
+   */
+  fragileEdgeIds?: ReadonlySet<string>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kind + group
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The node kind, read the way the live tree reads it — `getCausalEdges`
+ * (`domain/edgeUtils.ts:83-85`) resolves `n.type ?? data.kind ?? data.type`, and
+ * disagreeing with that would put a node in a different group here than the
+ * canvas puts it in.
+ */
+export function nodeKind(node: { type?: string; data?: unknown }): ModelElementKind | null {
+  const data = node.data as { kind?: unknown; type?: unknown } | undefined
+  const raw = (node.type ?? data?.kind ?? data?.type) as string | undefined
+  switch (raw) {
+    case 'goal':
+    case 'decision':
+    case 'option':
+    case 'factor':
+    case 'risk':
+    case 'outcome':
+      return raw
+    default:
+      // `action` and `constraint` are real `NodeTypeEnum` members with no v2
+      // group. Returning null drops them EXPLICITLY rather than filing them
+      // under a group they do not belong to.
+      return null
+  }
+}
+
+/** Total over the kinds this surface renders — a new kind is a type error. */
+const KIND_GROUP: Record<ModelElementKind, ModelGroupId> = {
+  goal: 'goal',
+  decision: 'goal',
+  option: 'options',
+  factor: 'factors',
+  risk: 'outcomes-risks',
+  outcome: 'outcomes-risks',
+  relationship: 'relationships',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ported predicates — each pinned against its live original in the specs
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * PORTED from the filter body of `countFactorsToVerify`
+ * (`src/canvas/components/model-tab/utils.ts:118-125`), verbatim in behaviour:
+ *
+ *     const obs = data?.observedState ?? data?.observed_state
+ *     return !obs?.source || obs?.source === 'cee_inference'
+ *
+ * ⚠ WHY A PORT AND NOT AN IMPORT: only the COUNT is exported, and a queue must
+ * know WHICH factors, not how many. The copy is pinned in `adapters.spec.ts`
+ * against the live `countFactorsToVerify` over a corpus, so a drift in either
+ * direction turns that spec red rather than silently disagreeing with the badge.
+ *
+ * ⚠⚠ IF YOU MUTATION-TEST THIS FUNCTION, ANCHOR ON THE FUNCTION BODY, NOT ON THE
+ * PREDICATE LINE. The comment above quotes the live source VERBATIM, so the
+ * predicate text appears twice in this file and a first-occurrence replace edits
+ * the COMMENT. That produced a FALSE SURVIVOR here once already: the file's hash
+ * changed, the applied-check passed, and the mutant was inert — an unapplied
+ * mutation is indistinguishable from an equivalent one unless the check proves
+ * the CODE moved. Anchoring on the enclosing `export function …` block cannot
+ * match a comment, and the mutant then bites six tests.
+ *
+ * ⚠ IT READS BOTH SPELLINGS. Canvas stores `observedState`; the CEE/PLoT wire
+ * uses `observed_state`, and graphs carry both. Reading one would under-count.
+ */
+export function factorNeedsVerification(data: unknown): boolean {
+  const d = data as Record<string, unknown> | undefined
+  const obs = (d?.observedState ?? d?.observed_state) as Record<string, unknown> | undefined
+  return !obs?.source || obs?.source === 'cee_inference'
+}
+
+/**
+ * PORTED from `RelationshipsSection.tsx:610`:
+ *     vm?.status === 'contested' && vm.user_action === 'pending'
+ *
+ * ⚠ BOTH CONJUNCTS MATTER. An edge whose disagreement has already been resolved
+ * still carries `status: 'contested'`; it is `user_action === 'pending'` that
+ * makes it OPEN. Dropping the second conjunct would refill Queue C with
+ * decisions the user has already made — the same harm as the batch overruling a
+ * deferral.
+ */
+export function edgeIsContested(data: unknown): boolean {
+  const vm = (data as Record<string, unknown> | undefined)?.validation as
+    | ValidationMetadata
+    | undefined
+  const v = vm as { status?: unknown; user_action?: unknown } | undefined
+  return v?.status === 'contested' && v?.user_action === 'pending'
+}
+
+/**
+ * PORTED from the `allUnmapped` body in `OptionsSection.tsx:441-446`, applied
+ * per option rather than across all of them.
+ */
+export function optionHasNoInterventions(data: unknown): boolean {
+  const interventions = (data as Record<string, unknown> | undefined)?.interventions as
+    | Record<string, unknown>
+    | undefined
+  return !interventions || Object.keys(interventions).length === 0
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Value display
+// ─────────────────────────────────────────────────────────────────────────────
+
+function observedStateOf(data: unknown): ObservedState | undefined {
+  const d = data as Record<string, unknown> | undefined
+  return (d?.observedState ?? d?.observed_state) as ObservedState | undefined
+}
+
+/**
+ * Narrow the STORE's observed state to the shape the live `getPrimaryValue`
+ * declares it accepts.
+ *
+ * ⚠ D5 — TWO `ObservedState` TYPES EXIST AND THEY ARE NOT THE SAME SHAPE. The
+ * domain type (`domain/nodes.ts:146`, what the store actually holds) allows
+ * `raw_value: string | number | null`; the model-tab type
+ * (`model-tab/types.ts:10`, what `getPrimaryValue` is typed against) allows only
+ * `raw_value?: number`. `FactorsSection.tsx:182` bridges the two with a CAST,
+ * which is why nothing has caught it — but a cast is a declared assumption, not
+ * a narrowing, and `getPrimaryValue` would hand a STRING to
+ * `formatValueWithUnit(rawValue: number, …)` and print nonsense.
+ *
+ * This adapter narrows instead of casting: a non-numeric `raw_value` yields NO
+ * displayable value rather than a fabricated one. That is a deliberate
+ * divergence from the live surface and it fails in the honest direction — the
+ * row says "not set" and the factor turns up in Queue D, instead of showing the
+ * user a mangled number.
+ */
+function narrowObservedState(obs: ObservedState): ModelTabObservedState {
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined
+  const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined)
+  return {
+    value: num(obs.value),
+    raw_value: num(obs.raw_value),
+    baseline: num(obs.baseline),
+    unit: str(obs.unit),
+    source: str(obs.source),
+    cap: num(obs.cap),
+  }
+}
+
+/**
+ * A factor's displayed value, via the live `getPrimaryValue`. `null` means
+ * nothing is stated — a fact to render, never a zero to invent.
+ */
+function factorValue(data: unknown): string | null {
+  const obs = observedStateOf(data)
+  if (!obs) return null
+  return getPrimaryValue(narrowObservedState(obs))
+}
+
+/**
+ * An edge's displayed value, through BOTH read-side gates.
+ *
+ * ⚠ THE GATES ARE THE POINT, AND THEY ARE NOT MINE. An unstamped weight renders
+ * NOTHING rather than the UI default (`resolveEdgeValueDisplay`), and a
+ * direction is never inferred from a sign (`resolveEdgeDirectionDisplay`). This
+ * surface must not be the one place in the estate that re-fabricates what those
+ * two resolvers exist to suppress — the Model tab printed "Strong positive
+ * effect" over exactly that fabrication before they were written.
+ */
+function edgeValue(data: unknown): string | null {
+  const bag = (data ?? undefined) as Record<string, unknown> | undefined
+  const weight = resolveEdgeValueDisplay(bag, 'weight')
+  if (!weight.show) return null
+
+  const direction = resolveEdgeDirectionDisplay(bag)
+  if (!direction.show) {
+    // A magnitude with no stated direction is a magnitude, not an effect.
+    return getDirectionalStrengthLabel(weight.value, direction)
+  }
+  const signed = direction.direction === 'negative' ? -weight.value : weight.value
+  return getDirectionalStrengthLabel(signed, direction)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+function attentionForFactor(data: unknown, value: string | null): AttentionReason[] {
+  const out: AttentionReason[] = []
+  if (value === null) out.push('no-value')
+  if (factorNeedsVerification(data)) out.push('unconfirmed-estimate')
+  return out
+}
+
+/**
+ * Build the outline's rows from live state.
+ *
+ * ⚠ ORDER IS THE CALLER'S NODE ORDER, then edges. The outline renders what it is
+ * given without sorting (`ModelOutline`), so ordering decisions live in exactly
+ * one place — here — and can be compared against what the canvas shows.
+ */
+export function toModelRows(input: ModelProjectionInput): ModelRow[] {
+  const rows: ModelRow[] = []
+
+  for (const node of input.nodes) {
+    const kind = nodeKind(node)
+    if (kind === null) continue
+    const data = node.data as Record<string, unknown> | undefined
+    const label = typeof data?.label === 'string' ? data.label : node.id
+
+    if (kind === 'factor') {
+      const value = factorValue(data)
+      const obs = observedStateOf(data)
+      rows.push({
+        id: node.id,
+        kind,
+        group: KIND_GROUP[kind],
+        label,
+        primaryValue: value,
+        provenanceSource: typeof obs?.source === 'string' ? obs.source : undefined,
+        attention: attentionForFactor(data, value),
+        editable: true,
+      })
+      continue
+    }
+
+    if (kind === 'goal') {
+      rows.push({
+        id: node.id,
+        kind,
+        group: KIND_GROUP[kind],
+        label,
+        // Raw user units — see `ModelProjectionInput.goalThreshold`.
+        primaryValue: input.goalThreshold === null ? null : formatSmartNumber(input.goalThreshold),
+        attention: input.goalThreshold === null ? ['no-value'] : [],
+        editable: true,
+      })
+      continue
+    }
+
+    if (kind === 'option') {
+      const unmapped = optionHasNoInterventions(data)
+      const interventions = (data?.interventions ?? {}) as Record<string, unknown>
+      const count = Object.keys(interventions).length
+      rows.push({
+        id: node.id,
+        kind,
+        group: KIND_GROUP[kind],
+        label,
+        primaryValue: unmapped ? null : `${count} ${count === 1 ? 'change' : 'changes'}`,
+        attention: unmapped ? ['missing-intervention'] : [],
+        editable: true,
+      })
+      continue
+    }
+
+    rows.push({
+      id: node.id,
+      kind,
+      group: KIND_GROUP[kind],
+      label,
+      primaryValue: null,
+      attention: [],
+      // Risks and outcomes are read-only on today's Model tab: `setProbability`
+      // and `setImpact` exist and nothing on the tab calls them (design §7.3).
+      // The projection reports what is true now, not what the design proposes.
+      editable: false,
+    })
+  }
+
+  // Only causal edges are model relationships — the same filter the live tab
+  // applies, imported rather than re-derived.
+  for (const edge of getCausalEdges(
+    input.nodes.map(n => ({ id: n.id, type: n.type, data: n.data })),
+    input.edges as Edge<EdgeData>[],
+  )) {
+    const data = edge.data as Record<string, unknown> | undefined
+    const attention: AttentionReason[] = []
+    if (edgeIsContested(data)) attention.push('contested')
+    if (input.fragileEdgeIds?.has(getDisplayEdgeId(edge))) attention.push('fragile')
+
+    rows.push({
+      id: edge.id,
+      kind: 'relationship',
+      group: 'relationships',
+      label: typeof data?.label === 'string' ? data.label : `${edge.source} → ${edge.target}`,
+      primaryValue: edgeValue(data),
+      provenanceSource: typeof data?.weightSource === 'string' ? data.weightSource : undefined,
+      attention,
+      editable: true,
+    })
+  }
+
+  return rows
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repair queues
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build one queue's items from live state.
+ *
+ * ⚠ EVERY QUEUE IS DERIVED FROM THE SAME PREDICATE AS ITS CHIP. That is the
+ * whole reason the predicates above are shared rather than re-expressed per
+ * queue: a badge and its queue that disagree is the defect the current tab
+ * already ships, where "N to verify" counts factors the user cannot reach.
+ */
+export function toRepairQueueItems(
+  input: ModelProjectionInput,
+  queueId: RepairQueue['id'],
+): RepairQueueItem[] {
+  const factorNodes = input.nodes.filter(n => nodeKind(n) === 'factor')
+
+  if (queueId === 'confirm-estimates') {
+    return factorNodes
+      .filter(n => factorNeedsVerification(n.data))
+      .map(n => {
+        const data = n.data as Record<string, unknown> | undefined
+        return {
+          rowId: n.id,
+          label: typeof data?.label === 'string' ? data.label : n.id,
+          currentValue: factorValue(data),
+          // Confirming ratifies the value that is already there; it does not
+          // propose a different one.
+          suggestedValue: null,
+          basis: typeof observedStateOf(data)?.source === 'string'
+            ? `Source: ${observedStateOf(data)!.source}`
+            : null,
+        }
+      })
+  }
+
+  if (queueId === 'no-value') {
+    return factorNodes
+      .filter(n => factorValue(n.data) === null)
+      .map(n => {
+        const data = n.data as Record<string, unknown> | undefined
+        return {
+          rowId: n.id,
+          label: typeof data?.label === 'string' ? data.label : n.id,
+          currentValue: null,
+          suggestedValue: null,
+          basis: null,
+        }
+      })
+  }
+
+  if (queueId === 'contested') {
+    return getCausalEdges(
+      input.nodes.map(n => ({ id: n.id, type: n.type, data: n.data })),
+      input.edges as Edge<EdgeData>[],
+    )
+      .filter(e => edgeIsContested(e.data))
+      .map(e => {
+        const data = e.data as Record<string, unknown> | undefined
+        return {
+          rowId: e.id,
+          label: typeof data?.label === 'string' ? data.label : `${e.source} → ${e.target}`,
+          currentValue: edgeValue(data),
+          suggestedValue: null,
+          basis: 'Two validation passes disagree',
+        }
+      })
+  }
+
+  // 'set-option-values' — one item per OPTION lacking any intervention.
+  // ⚠ Deliberately per-option, not per (option × factor): the design's Queue A
+  // is per-pair, but the pair-level "which factors should this option change?"
+  // is a judgement the store does not hold, and inventing one here would put
+  // fabricated rows in front of the user. Per-option is what the data supports.
+  return input.nodes
+    .filter(n => nodeKind(n) === 'option' && optionHasNoInterventions(n.data))
+    .map(n => {
+      const data = n.data as Record<string, unknown> | undefined
+      return {
+        rowId: n.id,
+        label: typeof data?.label === 'string' ? data.label : n.id,
+        currentValue: null,
+        suggestedValue: null,
+        basis: 'This option does not change any factor yet',
+      }
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Detail region
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the detail projection for one row, or `null` when the id is not in the
+ * model.
+ *
+ * ⚠ `rowId` IS ECHOED FROM THE REQUEST AND THE LOOKUP IS BY ID. The detail
+ * region asserts this against the row it was asked to describe and refuses on a
+ * mismatch, so a lookup that quietly returned a neighbour would surface as a
+ * visible refusal rather than a confident, wrong pane.
+ */
+export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRowDetail | null {
+  const node = input.nodes.find(n => n.id === rowId)
+  if (node) {
+    const data = node.data as Record<string, unknown> | undefined
+    const obs = observedStateOf(data)
+    const secondary =
+      obs?.baseline !== undefined && obs?.baseline !== null
+        ? [{ label: 'Baseline', value: formatSmartNumber(obs.baseline) }]
+        : []
+    return {
+      rowId,
+      description: typeof data?.description === 'string' ? data.description : null,
+      secondaryValues: secondary,
+      basis: typeof obs?.source === 'string' ? `Source: ${obs.source}` : null,
+      adjustments: [],
+      affects: input.edges
+        .filter(e => e.source === rowId)
+        .map(e => ({ id: e.id, label: e.target })),
+      advancedParameters: buildAdvancedForNode(node.id, obs),
+    }
+  }
+
+  const edge = input.edges.find(e => e.id === rowId)
+  if (!edge) return null
+  const data = edge.data as Record<string, unknown> | undefined
+  return {
+    rowId,
+    description: typeof data?.label === 'string' ? data.label : null,
+    secondaryValues: [],
+    basis: typeof data?.provenance === 'string' ? `Source: ${data.provenance}` : null,
+    adjustments: [],
+    affects: [{ id: edge.target, label: edge.target }],
+    advancedParameters: buildAdvancedForEdge(edge.id, data),
+  }
+}
+
+/** Advanced-tier parameters. Absent values render as absence, never as zero. */
+function buildAdvancedForNode(id: string, obs: ObservedState | undefined) {
+  return [
+    { label: 'Node ID', value: id },
+    {
+      label: 'Normalised value',
+      value: obs?.value !== undefined && obs?.value !== null ? String(obs.value) : null,
+    },
+    { label: 'Cap', value: obs?.cap !== undefined && obs?.cap !== null ? String(obs.cap) : null },
+  ]
+}
+
+function buildAdvancedForEdge(id: string, data: Record<string, unknown> | undefined) {
+  const std = data?.strengthStd
+  const ep = data?.exists_probability
+  return [
+    { label: 'Edge ID', value: id },
+    { label: 'Std', value: typeof std === 'number' ? String(std) : null },
+    { label: 'Exists probability', value: typeof ep === 'number' ? String(ep) : null },
+  ]
+}

--- a/src/canvas/model-tab-v2/contracts.ts
+++ b/src/canvas/model-tab-v2/contracts.ts
@@ -1,0 +1,198 @@
+/**
+ * Model tab v2 — the contracts this surface needs from OTHER lanes.
+ * TYPE DECLARATIONS ONLY. No implementations, no runtime values, nothing mounted.
+ *
+ * This file exists so the two owning lanes have a concrete shape to bind to
+ * instead of a paragraph in a design document:
+ *   · the WRITE AUTHORITY (Codex's transactional-edit vertical) — §1 below;
+ *   · the DOCK / panel-fronting mechanism (PX-A) — §2 below.
+ *
+ * ⚠ THIS LANE BUILDS NEITHER. Nothing here may be implemented in this
+ * directory. A local implementation of §1 would be exactly the "new local
+ * writer" the design forbids, and it is how the estate previously ended up
+ * with the same edit committed through three different paths with three
+ * different provenance stamps.
+ *
+ * Full rationale: `docs/Design/MODEL-EDITOR-V2.md` §9.
+ * (Capital D. `docs/design/` does not exist — it resolves on a case-insensitive
+ * macOS filesystem and would break a Linux CI checkout.)
+ */
+
+import type { EditCommitState } from './types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// § 1 — From the write authority (Codex)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The outcome of one proposed edit, as the ROW must render it.
+ *
+ * ⚠ THE ROW READS THIS; IT DOES NOT DECIDE IT. `state.phase === 'applied'` is
+ * reachable only because the authority said so. See `EditCommitState`'s header
+ * for why that matters: today an edge-strength edit and a factor-value edit
+ * look identical on screen while only one of them reaches the server.
+ */
+export interface EditProposalHandle {
+  state: EditCommitState
+  /**
+   * Present once the authority has answered. Carries whatever the receipt
+   * establishes about the applied value — the row must not re-derive it from
+   * the number it sent.
+   */
+  receipt?: { appliedValue: string; provenanceLiteral: string }
+  /**
+   * User-facing prose on refusal, never a code or a field path. The estate
+   * already has a sanitiser for this class of text
+   * (`ModelAdjustments.sanitiseDetail`) — reuse it rather than writing a second.
+   */
+  error?: string
+}
+
+/**
+ * The named operations the v2 editor dispatches. Nothing here writes; each is a
+ * request to the authority that owns the write.
+ *
+ * STATUS AT DERIVATION (UI staging `a3c71513`) — the reason this list is split
+ * three ways rather than presented as one clean interface:
+ *
+ *   ALREADY SERVER-AUTHORITATIVE (reuse as-is, do not re-plumb):
+ *     · proposeFactorValue      → `factor_value_edit`   (with optimistic revert)
+ *     · proposePriorRange       → `prior_range_edit`    (carry-only: CEE
+ *                                  persists a typed fact and writes no graph)
+ *     · resolveContestedEdge    → `edge_adjudication`
+ *
+ *   IN FLIGHT ON CODEX'S LANE:
+ *     · proposeEdgeStrength     → `edge_strength_edit`  (zero occurrences in the
+ *                                  tree at derivation time)
+ *
+ *   LOCAL-ONLY TODAY — the gap this design depends on closing:
+ *     · proposeEdgeLikelihood, proposeEdgeDirection, proposeOptionIntervention,
+ *       proposeGoalTarget, proposeFactorConfirmation
+ *     These currently terminate in the client store and reach CEE only as the
+ *     debounced, VALUE-LESS `direct_graph_edit` ping. Queue A depends on
+ *     `proposeOptionIntervention`; Queue B depends on `proposeFactorConfirmation`.
+ */
+export interface ModelEditAuthority {
+  /** Existing. Scale is decided from the node's own cap/unit, not by the row. */
+  proposeFactorValue(nodeId: string, typedValue: number): Promise<EditProposalHandle>
+
+  /** Existing. Always commits BOTH bounds; fails closed on inverted bounds. */
+  proposePriorRange(nodeId: string, min: number, max: number): Promise<EditProposalHandle>
+
+  /**
+   * Existing. ⚠ KEEP ITS PROVENANCE DISCIPLINE EXACTLY: accepting the reviewer's
+   * estimate must stamp the value `cee`, NOT `user`. Stamping a producer's
+   * number as the human's is provenance laundering, and the current
+   * implementation refuses it deliberately.
+   */
+  resolveContestedEdge(
+    edgeId: string,
+    verdict: 'accepted_pass1' | 'accepted_pass2' | 'overridden' | 'dismissed',
+    value?: number,
+  ): Promise<EditProposalHandle>
+
+  /**
+   * Codex's lane. ⚠ `directionStated` is load-bearing and must not be inferred:
+   * a MAGNITUDE CANNOT CARRY A SIGN. When nothing states a direction, the
+   * magnitude is written alone and the direction and its stamp are left
+   * untouched — the edge keeps reading "direction not stated" rather than being
+   * handed a sign taken off a number.
+   */
+  proposeEdgeStrength(
+    edgeId: string,
+    signedMean: number,
+    opts: { directionStated: boolean },
+  ): Promise<EditProposalHandle>
+
+  /** NEW — local-only today (`setExistsProbability`). `p` in [0,1]. */
+  proposeEdgeLikelihood(edgeId: string, p: number): Promise<EditProposalHandle>
+
+  /** NEW — local-only today (`setDirection`). */
+  proposeEdgeDirection(edgeId: string, direction: 'positive' | 'negative'): Promise<EditProposalHandle>
+
+  /** NEW — local-only today (`setIntervention`). Queue A depends on this. */
+  proposeOptionIntervention(
+    optionId: string,
+    factorId: string,
+    value: number,
+  ): Promise<EditProposalHandle>
+
+  /** NEW — local-only today (`setGoalThresholdAndUpdateNode`). */
+  proposeGoalTarget(nodeId: string, raw: number, unit?: string): Promise<EditProposalHandle>
+
+  /**
+   * NEW — a local annotation today, and stamped WRONG.
+   *
+   * ⚠ THIS MUST STAMP `user_confirmed`, NOT `user`. The Model tab's Confirm ✓
+   * currently writes `setObservedSource('user')`, which the shared classifier
+   * maps to the `edited` class — so the pill reads "User edited" for a gesture
+   * that ratified somebody else's number. Pre-analysis writes `user_confirmed`
+   * for the identical gesture and gets "Confirmed by you". Same act, two
+   * stamps, decided by which surface the user happened to be standing on.
+   */
+  proposeFactorConfirmation(nodeId: string): Promise<EditProposalHandle>
+
+  /**
+   * The batch form the repair queues need.
+   *
+   * ⚠ NOT A CONVENIENCE. Without it, "Apply all shown" over eight rows is eight
+   * turns, eight undo steps and eight analysis invalidations for ONE user
+   * gesture. The queues are the design's answer to Paul's two repair cases, so
+   * this operation is load-bearing, not an optimisation.
+   *
+   * Partial success must be reportable per item — a batch that reports one
+   * aggregate verdict cannot tell the user which three of eight were refused.
+   */
+  proposeBatch(
+    edits: ReadonlyArray<() => Promise<EditProposalHandle>>,
+  ): Promise<readonly EditProposalHandle[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// § 2 — From PX-A (panel fronting)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Whether the Olumi surface actually came to the front.
+ *
+ * ⚠ THE RETURN VALUE IS THE POINT. All 12 send-to-AI call sites on today's
+ * Model tab (6 components, 11 distinct messages, measured at `a3c71513`) post a
+ * real turn into a panel that stays `hidden`, so the user clicks "Discuss this
+ * with the AI" and nothing visibly happens. A hand-off that cannot front the
+ * panel must be able to SAY so rather than send into silence.
+ */
+export type PanelFrontingOutcome = 'fronted' | 'deferred'
+
+/**
+ * The one call this surface needs from the dock lane.
+ *
+ * Requirements:
+ *   · fronts the Olumi conversation whether it is DOCKED, FLOATING or COLLAPSED
+ *     (`revealOlumiSurface()` is the current primitive and the natural basis);
+ *   · ⚠ ORIGIN IS `'user'`. These are user gestures. They must not stamp
+ *     `outputSurfaceOrigin: 'assistant'` and must not raise the
+ *     `AssistantOpenedNotice` — telling the user Olumi opened something they
+ *     opened themselves is a lie on the one channel whose purpose is
+ *     truthfulness;
+ *   · returns the outcome.
+ *
+ * This lane does NOT build it.
+ */
+export type FrontOlumiPanel = (opts?: { reason?: string }) => PanelFrontingOutcome
+
+/**
+ * The single hand-off helper every v2 send-to-AI affordance goes through.
+ *
+ * ⚠ THE RULE: no Model-tab control may call `onSendMessage` directly. Fronting
+ * happens FIRST, then the send. It matters most for the structural CTAs ("Add a
+ * factor", "Add a relationship", "Map interventions", "Explore other
+ * strategies") — those terminate in a conversation rather than a mutation, so
+ * an invisible conversation makes them dead ends. That combination — the tab's
+ * only structural affordance ending in a hidden panel — is the measured
+ * mechanism behind "the less I feel like I can actually directly edit the
+ * decision model".
+ */
+export type HandOffToOlumi = (opts: {
+  message: string
+  reason?: string
+}) => PanelFrontingOutcome

--- a/src/canvas/model-tab-v2/rowPresentation.ts
+++ b/src/canvas/model-tab-v2/rowPresentation.ts
@@ -12,7 +12,36 @@
  * NOTHING HERE IS MOUNTED. See `types.ts` for the directory-level statement.
  */
 
-import type { AttentionReason, ModelElementKind, ModelGroupId } from './types'
+import type { AttentionReason, DeferralRecord, ModelElementKind, ModelGroupId } from './types'
+
+/**
+ * How a deferral reads on screen (design §5.3, Paul's ruling 16 Aug 2026).
+ *
+ * ⚠ ONE IMPLEMENTATION, SHARED BY THE ROW AND THE QUEUE. Both surfaces show a
+ * deferral and both must say the same thing about it; two copies of this
+ * sentence would be the hand-maintained mirror that is this codebase's dominant
+ * defect class, and the failure mode is ugly — the same deferral described two
+ * different ways on two screens the user can see at once.
+ *
+ * ⚠ THE PERSON AND THE DATE ARE ALWAYS BOTH PRINTED. "Left unresolved" alone
+ * would be indistinguishable from a row that vanished for some other reason; the
+ * whole point of a deferral is that it says WHO decided.
+ */
+export function deferralLabel(deferral: DeferralRecord): string {
+  return `Left unresolved by ${deferral.by}, ${formatDeferralDate(deferral.at)}`
+}
+
+/**
+ * An unparseable timestamp renders VERBATIM rather than as "Invalid Date" or a
+ * silently-omitted date. If the stored value is wrong, the surface should show
+ * what is actually stored — that is a visible defect someone can chase, whereas
+ * a swallowed date is a deferral that has quietly lost half its provenance.
+ */
+function formatDeferralDate(iso: string): string {
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return iso
+  return parsed.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
 
 /**
  * The seven group headings, mapping 1:1 onto the brief's IA (design §4.1).

--- a/src/canvas/model-tab-v2/rowPresentation.ts
+++ b/src/canvas/model-tab-v2/rowPresentation.ts
@@ -1,0 +1,71 @@
+/**
+ * Model tab v2 — how a row's kind and its attention reasons are PRESENTED.
+ *
+ * ⚠ BOTH MAPS ARE TOTAL BY CONSTRUCTION (`Record<Union, …>`). That is the whole
+ * reason they live in one small module instead of inline in the row component:
+ * adding a member to `ModelElementKind` or `AttentionReason` becomes a TYPE
+ * ERROR here rather than a silently blank glyph or an unlabelled marker on
+ * screen. Three of the twelve defects the design documents are hand-maintained
+ * mirrors that failed exactly this way — a dead search prop, a dead `isContested`
+ * prop, and a hand-copied band-threshold table (design §2, F3/F12).
+ *
+ * NOTHING HERE IS MOUNTED. See `types.ts` for the directory-level statement.
+ */
+
+import type { AttentionReason, ModelElementKind, ModelGroupId } from './types'
+
+/**
+ * The seven group headings, mapping 1:1 onto the brief's IA (design §4.1).
+ * Total over `ModelGroupId` — a new group cannot render as an untitled section.
+ */
+export const GROUP_TITLE: Record<ModelGroupId, string> = {
+  goal: 'Goal',
+  options: 'Options',
+  factors: 'Factors',
+  'outcomes-risks': 'Outcomes & risks',
+  relationships: 'Relationships',
+  'assumptions-provenance': 'Assumptions & provenance',
+  'evidence-review': 'Evidence & review state',
+}
+
+/**
+ * The row glyph. Deliberately reuses the shapes `EntityBar` already teaches, so
+ * the outline and the canvas name the same kinds the same way — the v2 outline
+ * replaces that bar's decorative segments, not its vocabulary (design §7.0 A1).
+ */
+export const KIND_GLYPH: Record<ModelElementKind, string> = {
+  goal: '◇',
+  decision: '□',
+  option: '○',
+  factor: '●',
+  risk: '▲',
+  outcome: '★',
+  relationship: '→',
+}
+
+/** Screen-reader/tooltip name for the glyph. A glyph alone is not a label. */
+export const KIND_LABEL: Record<ModelElementKind, string> = {
+  goal: 'Goal',
+  decision: 'Decision',
+  option: 'Option',
+  factor: 'Factor',
+  risk: 'Risk',
+  outcome: 'Outcome',
+  relationship: 'Relationship',
+}
+
+/**
+ * What each attention marker SAYS.
+ *
+ * British English, sentence case, and each states a fact about the model rather
+ * than an instruction — the row marker and the header chip are rendered from the
+ * SAME predicate (design §4.2), so a count and its rows can never disagree the
+ * way today's "N to verify" badge and its unreachable factors do.
+ */
+export const ATTENTION_LABEL: Record<AttentionReason, string> = {
+  'no-value': 'No value set',
+  'unconfirmed-estimate': 'Estimate not yet confirmed',
+  contested: 'Two passes disagree',
+  fragile: 'Could flip the result',
+  'missing-intervention': 'No target value for this option',
+}

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -167,10 +167,49 @@ export interface ModelRow {
    * absence, never a default to invent.
    */
   provenanceSource?: string
-  /** Empty when the row needs nothing. */
+  /**
+   * Empty when the row needs nothing.
+   *
+   * ⚠ DEFERRING DOES NOT EMPTY THIS. A deferred row keeps reporting its gap —
+   * see `deferred` below.
+   */
   attention: readonly AttentionReason[]
+  /**
+   * Present when a human has explicitly chosen to leave this row unresolved.
+   *
+   * ⚠ THIS SITS BESIDE `attention`, IT NEVER CLEARS IT. The two answer different
+   * questions — *does this need attention?* and *has a human ruled that it can
+   * wait?* — and a row that stopped reporting its gap once deferred would be
+   * hiding it, which is the dismiss button this design cut.
+   */
+  deferred?: DeferralRecord
   /** False for rows that are genuinely read-only (e.g. an audit figure). */
   editable: boolean
+}
+
+/**
+ * A recorded decision to leave something unresolved (design §5.3, Paul's ruling
+ * 16 Aug 2026). **THIS IS NOT A DISMISSAL.**
+ *
+ * The dismiss `×` on the defaulted-factor coaching card is cut, and stays cut,
+ * because it makes a real gap invisible. Deferral is its opposite and differs by
+ * exactly two properties, BOTH of which are load-bearing:
+ *
+ *   1. the item NEVER LEAVES THE SURFACE — it moves to a de-emphasised "Left
+ *      unresolved" group inside the same queue, never out of it;
+ *   2. it CARRIES PROVENANCE — who decided, and when.
+ *
+ * ⚠ BOTH FIELDS ARE REQUIRED, DELIBERATELY. An anonymous or undated deferral is
+ * indistinguishable from a row a bug dropped, and the honest state — "a human
+ * chose to leave this unresolved" — collapses into "this was never a gap" the
+ * moment you cannot say who chose or when. Optional provenance is how the
+ * dismiss button would grow back wearing a better name.
+ */
+export interface DeferralRecord {
+  /** The person who chose to defer. Never blank, never "system". */
+  by: string
+  /** When they chose it. ISO 8601. */
+  at: string
 }
 
 /** One labelled value in the detail region. Both sides already display-ready. */
@@ -244,6 +283,15 @@ export interface RepairQueueItem {
   suggestedValue: string | null
   /** Why this value is suggested, in the user's language. */
   basis: string | null
+  /**
+   * Present when the user chose to leave this item unresolved (§5.3).
+   *
+   * ⚠ A DEFERRED ITEM IS STILL IN THE QUEUE. It renders in the de-emphasised
+   * "Left unresolved" group, and it is EXCLUDED from "Apply all shown" — a batch
+   * that swept deferred items back in would silently overrule a recorded human
+   * decision, which is the one thing a repair queue must never do.
+   */
+  deferred?: DeferralRecord
 }
 
 export interface RepairQueue {

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -1,0 +1,261 @@
+/**
+ * Model tab v2 — the structured model editor. TYPE SKELETON ONLY.
+ *
+ * ⚠ NOTHING IN THIS DIRECTORY IS MOUNTED. There is no route, no tab
+ * registration, no component and no runtime value here — these are type
+ * declarations that pin the contracts in `docs/Design/MODEL-EDITOR-V2.md` (capital
+ * D — the lowercase path does not exist and resolves only on macOS) so
+ * the write-authority lane (Codex) and the dock lane (PX-A) have something
+ * concrete to bind to. Integration/mounting is the technical lead's call, and
+ * the design is Paul-vetoable before any of it is built.
+ *
+ * WHY TYPES AND NOT PROSE. Three of the twelve defects the design documents are
+ * hand-maintained mirrors (a dead search prop, a dead `isContested` prop, a
+ * hand-copied band-threshold table). A contract expressed as prose becomes the
+ * next one. Expressed as a total union it is a type error instead.
+ *
+ * ⚠ WHEN THIS DIRECTORY BECOMES LIVE, EXTEND THE RAW-WRITE GUARD.
+ * `src/canvas/components/model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts`
+ * scans `src/canvas/components/model-tab/` ONLY. A v2 component tree living
+ * here is therefore UNGUARDED against raw `updateNode` / `updateEdge` /
+ * `updateEdgeData` calls — the exact class that guard exists to prevent, and the
+ * exact way it was re-opened last time (the inspector was fixed, the Model tab
+ * kept its own hand-rolled writes, and the killed class stayed live through a
+ * different door). Widen its scope in the same PR that mounts anything here.
+ */
+
+// NOTE: this module deliberately imports NOTHING. Provenance travels as the raw
+// source literal and is classified at the point of render by the one shared
+// classifier (`classifyValueProvenance`), so no second mapping exists here to
+// drift out of step with it.
+
+// ── Disclosure ───────────────────────────────────────────────────────────────
+
+/**
+ * The ONE detail tier. See design §4.3.
+ *
+ * ⚠ THIS IS A CONTENT SWITCH, NEVER A LAYOUT SWITCH — the whole point of the
+ * v2 tier. Today's `expertMode` drives both the scientific detail AND the
+ * accordion mode (`ModelTabBody.tsx:116-122` vs `:761`), so a non-scientist who
+ * merely wants two sections open at once has to turn on the scientist view.
+ * A tier value must never decide how many groups are open, how rows are
+ * ordered, or which rows are selected.
+ */
+export type DetailTier = 'plain' | 'advanced'
+
+/**
+ * The seven groups of the outline, in render order. Total by construction:
+ * a `Record<ModelGroupId, …>` cannot silently omit one.
+ */
+export const MODEL_GROUP_IDS = [
+  'goal',
+  'options',
+  'factors',
+  'outcomes-risks',
+  'relationships',
+  'assumptions-provenance',
+  'evidence-review',
+] as const
+
+export type ModelGroupId = (typeof MODEL_GROUP_IDS)[number]
+
+/** Element kind — drives the row glyph. Mirrors the canvas node kinds + edges. */
+export type ModelElementKind =
+  | 'goal'
+  | 'decision'
+  | 'option'
+  | 'factor'
+  | 'risk'
+  | 'outcome'
+  | 'relationship'
+
+// ── The edit three-beat ──────────────────────────────────────────────────────
+
+/**
+ * The state of one editable value in one row. See design §5.1.
+ *
+ * ⚠ `applied` IS REACHABLE ONLY FROM A RECEIPT. That is the point of the union.
+ * Today a Model-tab edit to an edge strength, an option's intervention value or
+ * the goal target is a LOCAL STORE WRITE that never reaches CEE, while a factor
+ * value edit is a real turn — and the two are indistinguishable on screen
+ * (design §2, F6). A row that can only render `applied` when an authority says
+ * so cannot reproduce that.
+ *
+ * `refused` is deliberately a first-class state, not an error toast: a declined
+ * edit must be visible in the row that caused it, in words, with the value
+ * reverted. A refusal that looks like nothing happened is the same defect as a
+ * silent local write, one step later.
+ */
+export type EditCommitState =
+  /** No edit in progress; the row shows the model's value. */
+  | { phase: 'idle' }
+  /** The user is typing. Nothing has been stated yet. */
+  | { phase: 'editing'; draft: string }
+  /**
+   * The user has stated an intent. THE MODEL IS UNCHANGED and the previous
+   * value stays visible beside the proposed one until it is confirmed.
+   */
+  | { phase: 'proposed'; from: string; to: string }
+  /** Dispatched to the write authority. Not re-editable until it settles. */
+  | { phase: 'inflight'; from: string; to: string }
+  /**
+   * A receipt came back. The provenance chip flips on this transition.
+   *
+   * ⚠ BOTH FIELDS COME FROM THE RECEIPT, not from what the row sent. A row that
+   * echoed its own typed value here would render "applied" with the number it
+   * hoped for rather than the number the authority stored — which is the silent
+   * local write of design §2 F6 wearing a receipt's clothes. `provenanceSource`
+   * is the authority's raw stamp (`EditProposalHandle.receipt.provenanceLiteral`),
+   * classified for display by the one shared classifier.
+   */
+  | { phase: 'applied'; value: string; provenanceSource: string }
+  /** The authority declined. `reason` is user-facing prose, not a code. */
+  | { phase: 'refused'; from: string; attempted: string; reason: string }
+
+// ── Rows ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Why a row is asking for the user's attention. Drives both the row marker and
+ * the header chip counts — ONE predicate, counted once and rendered twice, so
+ * the badge and the queue can never disagree (today's "N to verify" badge and
+ * `countFactorsToVerify` already share a predicate; this generalises that rule
+ * rather than inventing a second one).
+ */
+export type AttentionReason =
+  /** No value is set at all. Today this row offers no editor — design F9. */
+  | 'no-value'
+  /** An AI estimate nobody has ratified (`source` absent or `cee_inference`). */
+  | 'unconfirmed-estimate'
+  /** Two validator passes disagree; hosted by the existing ContestedEdgeCard. */
+  | 'contested'
+  /** Robustness says this edge could flip the result. */
+  | 'fragile'
+  /** An option has no intervention value for a factor it should change. */
+  | 'missing-intervention'
+
+/**
+ * One element of the model, as one row. The SAME anatomy for every kind — that
+ * uniformity is what makes tab-through-and-fix possible and what lets a queue
+ * be a filtered view of the outline rather than a second rendering of it.
+ */
+export interface ModelRow {
+  /** ID-ADDRESSED. Never a label — a label retargets on rename (trap 19). */
+  id: string
+  kind: ModelElementKind
+  group: ModelGroupId
+  label: string
+  /**
+   * The value shown in the row, ALREADY RESOLVED FOR DISPLAY and in PLAIN
+   * language ("Strong positive effect", "45 days"). `null` means nothing is
+   * stated — which is a fact to render, never a zero to invent.
+   */
+  primaryValue: string | null
+  /**
+   * The RAW provenance stamp as the model recorded it (`'brief_extraction'`,
+   * `'cee_inference'`, `'user_confirmed'`, …) — NOT a classified kind.
+   *
+   * ⚠ CORRECTED FROM THE FIRST DRAFT, which typed this as `ValueProvenanceKind`.
+   * `SourceProvenancePill` takes the LITERAL and classifies it itself. Handing it
+   * a kind would force an inverse kind→literal map here, which is (a) lossy —
+   * several literals classify to one kind, so the inverse has no single answer —
+   * and (b) a second hand-maintained mirror of the classifier, which is the exact
+   * defect that pill's own header records: it once keyed on three literals,
+   * missed `user_confirmed`, and rendered "Not set" over a value the user had
+   * explicitly confirmed. Carry the literal; let the one classifier classify.
+   *
+   * Absent when nothing states a provenance. That is a fact to render as
+   * absence, never a default to invent.
+   */
+  provenanceSource?: string
+  /** Empty when the row needs nothing. */
+  attention: readonly AttentionReason[]
+  /** False for rows that are genuinely read-only (e.g. an audit figure). */
+  editable: boolean
+}
+
+/** One labelled value in the detail region. Both sides already display-ready. */
+export interface DetailField {
+  label: string
+  /** `null` renders as an explicit absence. Never a zero, never an em dash alone. */
+  value: string | null
+}
+
+/**
+ * Everything the detail region shows for ONE selected row (design §4.4).
+ *
+ * ⚠ `rowId` IS LOAD-BEARING, NOT BOOKKEEPING. The detail region asserts it
+ * against the row it was asked to describe and refuses to render on a mismatch.
+ * A detail pane silently showing another element's provenance and parameters is
+ * the worst failure available to this surface — it is confident, wrong, and
+ * indistinguishable from correct. Binding by identity rather than by position is
+ * the same rule the estate learned when a spec found a factor BY VALUE and
+ * passed against a different factor entirely.
+ */
+export interface ModelRowDetail {
+  rowId: string
+  /** §4.4.1 "What this is". */
+  description: string | null
+  /** §4.4.2 "Its value" — secondary values that are STILL PLAIN (baseline, direction…). */
+  secondaryValues: readonly DetailField[]
+  /** §4.4.3 "Where it came from" — the basis sentence, in the user's language. */
+  basis: string | null
+  /**
+   * §4.4.3 — what Olumi adjusted and why. Text must already be through the
+   * existing `sanitiseDetail`, which strips engine field paths out of
+   * user-facing copy; this surface does not sanitise a second time and must not
+   * be handed raw engine prose.
+   */
+  adjustments: readonly string[]
+  /** §4.4.4 "What it affects" — related elements, ID-addressed for navigation. */
+  affects: readonly { id: string; label: string }[]
+  /**
+   * §4.4.5 — the ONE Advanced block. ⚠ ABSENT ENTIRELY IN PLAIN, and never
+   * mixed inline beside a plain value (design §4.3 rule 2). If a "parameter"
+   * has to be visible in Plain to make sense of a value — a unit, say — it is
+   * not a parameter and does not belong in here.
+   */
+  advancedParameters: readonly DetailField[]
+}
+
+/**
+ * A repair queue = a FILTERED VIEW OF THE SAME OUTLINE, entered from an
+ * attention chip. Deliberately not a modal and not a separate screen: one
+ * rendering of a row, one state, and the user never loses their place.
+ */
+/**
+ * One item in a repair queue — a row of the outline, seen through the queue.
+ *
+ * ⚠ `rowId` IS THE SAME ID AS THE OUTLINE ROW'S, deliberately. A queue is a
+ * FILTERED VIEW of the outline, not a second rendering of it: same identity,
+ * same value, one place where the truth lives. The moment a queue carries its
+ * own copy of an element, the two can disagree, and the user is looking at two
+ * screens that both claim to describe one factor.
+ */
+export interface RepairQueueItem {
+  rowId: string
+  label: string
+  /** What the model says now. `null` when nothing is set — the F9 case. */
+  currentValue: string | null
+  /**
+   * The value the queue would apply — e.g. a factor's baseline prefilled as an
+   * option's intervention. ⚠ A SUGGESTION, NOT A FACT: it has not been applied,
+   * and until the user confirms it the model does not contain it.
+   */
+  suggestedValue: string | null
+  /** Why this value is suggested, in the user's language. */
+  basis: string | null
+}
+
+export interface RepairQueue {
+  id: 'set-option-values' | 'confirm-estimates' | 'contested' | 'no-value'
+  /** The reason whose rows this queue collects. */
+  reason: AttentionReason
+  /** Sentence-case, British English, states the count and the action. */
+  title: string
+  /**
+   * Whether an "Apply all shown" affordance is offered. It requires the write
+   * authority's BATCH form — N separate turns would mean N undo steps and N
+   * analysis invalidations for one user gesture.
+   */
+  supportsApplyAll: boolean
+}

--- a/src/canvas/model-tab-v2/useOutlineKeyboard.ts
+++ b/src/canvas/model-tab-v2/useOutlineKeyboard.ts
@@ -1,0 +1,139 @@
+/**
+ * Model tab v2 — KEYBOARD NAVIGATION (design §5.2).
+ *
+ * ⚠ UNMOUNTED. See `types.ts`.
+ *
+ * Enter states an intent · Escape cancels · Tab and Shift+Tab move to the next
+ * and previous EDITABLE value in outline order · ⌘/Ctrl+Enter confirms a
+ * standing proposal. The outline is a list, so tab-through-and-fix is the fast
+ * path for repairing many values — which is the entire point of turning the tab
+ * into an outline rather than an accordion of report cards.
+ *
+ * ⚠ THIS HOOK NEVER WRITES AND NEVER REPORTS SUCCESS. Every key that would
+ * cause a mutation calls a handler the HOST supplies. When the host supplies
+ * none — which is the situation until Codex's transactional-edit vertical
+ * freezes its API — the key press does nothing at all and says nothing. It must
+ * never swallow the gesture and report a success it cannot know about; that is
+ * the fake-success path the lane boundary forbids, and it would be worse here
+ * than in a button because a keyboard user gets no visible affordance to
+ * disbelieve.
+ *
+ * The movement logic is exported as PURE FUNCTIONS rather than buried in the
+ * hook so its specs can bind to it directly, by identity, without a DOM.
+ */
+
+import { useCallback } from 'react'
+import type { KeyboardEvent } from 'react'
+import type { ModelRow } from './types'
+
+/**
+ * The ids a keyboard user can land on, in the order the outline renders them.
+ *
+ * ⚠ NON-EDITABLE ROWS ARE SKIPPED, NOT HIDDEN. An audit figure or a derived
+ * count is still on screen and still selectable with the mouse; it is simply not
+ * a stop on the tab-through-and-fix path, because stopping on values nobody can
+ * change is what makes keyboard repair slower than the mouse.
+ */
+export function editableOrder(rows: readonly ModelRow[]): readonly string[] {
+  return rows.filter(r => r.editable).map(r => r.id)
+}
+
+/**
+ * The next editable id after `currentId`, or `null` at the end.
+ *
+ * ⚠ DELIBERATELY DOES NOT WRAP. Wrapping silently returns the user to the top
+ * of a repair queue they believe they have finished, and there is no way to tell
+ * the second lap from the first. Returning `null` lets the caller release focus
+ * to the browser, which is the behaviour a keyboard user already understands.
+ *
+ * An unknown `currentId` yields the FIRST editable id — entering the outline
+ * from outside is a legitimate state, not an error.
+ */
+export function nextEditableId(
+  rows: readonly ModelRow[],
+  currentId: string | null,
+  direction: 'forward' | 'backward' = 'forward',
+): string | null {
+  const order = editableOrder(rows)
+  if (order.length === 0) return null
+
+  const index = currentId === null ? -1 : order.indexOf(currentId)
+  if (index === -1) {
+    return direction === 'forward' ? order[0] : order[order.length - 1]
+  }
+
+  const target = direction === 'forward' ? index + 1 : index - 1
+  if (target < 0 || target >= order.length) return null
+  return order[target]
+}
+
+/**
+ * Handlers the HOST owns. Every one of them is optional, and an absent handler
+ * means the corresponding key does nothing — never a stub, never a local write.
+ */
+export interface OutlineKeyboardHandlers {
+  /** Move the keyboard's focus. Pure navigation; safe to supply today. */
+  onMoveTo?: (id: string) => void
+  /** Enter — state an intent to edit. Requires the write authority. */
+  onStateIntent?: (id: string) => void
+  /** Escape — abandon whatever is in progress on this row. */
+  onCancel?: (id: string) => void
+  /** ⌘/Ctrl+Enter — confirm a standing proposal. Requires the write authority. */
+  onConfirmProposal?: (id: string) => void
+}
+
+export interface UseOutlineKeyboardArgs {
+  rows: readonly ModelRow[]
+  focusedId: string | null
+  handlers?: OutlineKeyboardHandlers
+}
+
+export function useOutlineKeyboard({ rows, focusedId, handlers }: UseOutlineKeyboardArgs) {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const id = focusedId
+
+      if (event.key === 'Tab') {
+        const target = nextEditableId(rows, id, event.shiftKey ? 'backward' : 'forward')
+        // At either end, the event is left alone so focus leaves the outline the
+        // way the browser would normally take it.
+        if (target === null) return
+        event.preventDefault()
+        handlers?.onMoveTo?.(target)
+        return
+      }
+
+      if (id === null) return
+
+      if (event.key === 'Enter') {
+        /*
+         * ⌘/Ctrl+Enter confirms; a bare Enter states an intent. Both are checked
+         * against a handler being present: with no write authority wired, the
+         * gesture is a no-op and the row keeps saying what it said before.
+         */
+        if (event.metaKey || event.ctrlKey) {
+          if (handlers?.onConfirmProposal) {
+            event.preventDefault()
+            handlers.onConfirmProposal(id)
+          }
+          return
+        }
+        if (handlers?.onStateIntent) {
+          event.preventDefault()
+          handlers.onStateIntent(id)
+        }
+        return
+      }
+
+      if (event.key === 'Escape') {
+        if (handlers?.onCancel) {
+          event.preventDefault()
+          handlers.onCancel(id)
+        }
+      }
+    },
+    [rows, focusedId, handlers],
+  )
+
+  return { onKeyDown, editableIds: editableOrder(rows) }
+}


### PR DESCRIPTION
> **✅ APPROVED by Paul, 16 Aug 2026**, with one binding modification (the Defer beat, below).
> Recorded in **CODEX-BOARD §5**. Marked ready for review — **do not merge**; writes still wait on
> Codex's transaction API regardless of the approval.

Design-first: the removal review was the first deliverable, and nothing mounts. This PR is
additive-only and touches nothing a user can currently reach.

## What this is

`docs/Design/MODEL-EDITOR-V2.md` — the design, whose **§7 is the removal-only review**. §7.0 lists
everything proposed for removal and nothing else, so it can be read alone.

`src/canvas/model-tab-v2/` — the parts that need no write authority, built **render-only and mounted
nowhere**. The whole directory is deletable in one `rm -rf`.

## The review, in numbers

**176 surfaces** carry a verdict, derived by reading `ModelTabBody.tsx` and all 19 files in
`model-tab/`.

| Verdict | Count |
|---|---|
| KEEP | 61 |
| KEEP+FIX | 34 |
| MERGE | 28 |
| DEMOTE | 24 |
| **CUT** | **23** |
| KEEP + PROMOTE | 5 |
| no action (shared component) | 1 |

Of the 23 CUTs, **13 are user-visible losses** (itemised in §7.0 A); 10 are dead or internal.

## ⚠ Paul's modification: Defer / Leave unresolved

Cut #6 (the coaching-dismiss `×`) **stands** — dismissal-as-hiding stays dead. But the design's line
*"a queue item is resolved by fixing it, not by hiding it"* over-corrected: the queues must preserve
**explicit user agency**. Every queue item now carries **Leave unresolved** alongside its resolving
action.

**Two properties separate this from the button just cut — a Defer missing either one is that button
under a better name:**

1. **A deferred item never leaves the surface.** It moves to a de-emphasised *"Left unresolved"*
   group **inside the same queue** — same component, same `-item-<rowId>` identity. Never filtered
   out.
2. **It carries provenance — who and when**, printed every time. Both fields are **required** on
   `DeferralRecord`: an anonymous or undated deferral is indistinguishable from a row a bug dropped,
   and *"a human chose to leave this unresolved"* decays into *"this was never a gap"* the moment you
   cannot say who chose.

Consequences, each a place the invariant could be lost quietly: **"Apply all shown" skips deferred
items** and disappears entirely when everything is deferred (a batch that swept them back in would
overrule a recorded human decision); **deferral is reversible** via Resume; **the counts are reported
separately**, because deferring does not reduce the number of real gaps in the model, only the number
awaiting a decision. At the row (§4.2) the deferred marker sits **beside** the attention marker and
never replaces it — a row that fell silent about its gap once deferred would be the dismiss button
growing back inside the row.

Deferral is a **write** (persisted state carrying a person and a timestamp), so it waits for the same
frozen API and is asked for as **§9.1 C15**. Every Defer/Resume control renders disabled with an
honest label.

## ⚠ The first draft of §7 understated its own removal list

It cut `ModelTabHeader` as *"nothing visible changes… two jobs"*. The header actually renders
**seven** surfaces, three visible: an `· expert` indicator, a sort note printing the literal word
`alphabetical`, and an **expert framing border wrapping every section**. §7 is now derived from the
component tree rather than from memory. Three findings are new (F13–F15): the container's
provenance-gated sort orders the **clipboard** only while a comment claims it aligns the screen;
`SectionErrorBoundary` is imported and never used; `ModelTabProps` has no importer and has drifted.

## The boundary — every write waits

Propose/confirm, repair-queue apply, deferral, and re-analysis triggers all wait on Codex's
transactional-edit vertical. **Nothing is stubbed with a fake success path.** The keyboard's mutating
keys do nothing, *including not consuming the event*, since a keyboard user has no disabled
affordance to disbelieve.

**§9 is written to be answered**: every ask has an ID, an exact shape and a **closed yes/no
question** — C1–C15 for the write authority, D1–D3 for PX-A.

## Verification (head `801a03e1`)

**Lint** exit 0 — 0 errors, 0 warnings from this namespace, hooks ratchet exactly matching baseline.
**Typecheck gate PASSED** — coverage 3468/3508 → **3481/3521**, so all 13 new tracked files are
genuinely inside the gate rather than invisible to it; ratchet unchanged at 2485 errors / 618 files.
**118 tests** across 7 spec files, each collecting non-zero by name.

**12 mutants, 12 bitten**, in a worktree outside the repo root whose isolation was proven by *writing*
a sentinel, with restores from a pristine archive. The four newest cover the ruling: deferred items
filtered out of the queue · batch sweeping deferred items back in · the deferred marker suppressing
the row's attention marker · the deferral line dropping who deferred it.

⚠ **Two boundary guards initially shipped structurally unable to fire, and only the mutation check
found it.** Both ran input through `blankNonCode`, which blanks string-literal *contents* — but an
import specifier is a string, and so is `'applied'`. Fixed to `stripComments`. The existing controls
missed it because they tested the bare regex rather than the transform-plus-regex the real assertion
uses; every control now runs the same pipeline as the claim it guards.

## Not in scope

The graph, the write authority, the analysis surfaces (PX-C), the conversation dock (PX-A). No live
Model-tab file, no Codex transactional file, no `#714` file, and no mount.

⚠ Whoever mounts this first must widen
`model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts`, which scans
`src/canvas/components/model-tab/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
