### PR TITLE
PX-A: one width authority for the OutputsDock + honest fitView padding

### DIFF
--- a/src/canvas/__tests__/computeFitPadding.spec.ts
+++ b/src/canvas/__tests__/computeFitPadding.spec.ts
@@ -3,12 +3,29 @@
  *
  * Verifies the panel-aware fitView padding:
  *  - all four sides are returned as `'<n>px'` strings (xyflow v12 object form),
- *  - the no-occluder case reproduces the prior `padding: 0.2` framing,
- *  - a collapsed dock rail / thin sidebar are inert at typical widths but are
- *    legitimately reserved once the base margin shrinks at narrow widths,
+ *  - the no-occluder case reproduces the base margin,
+ *  - a collapsed dock rail / thin sidebar reserve their own overlap,
  *  - an expanded dock pushes the right side in by overlap + gap,
  *  - overlap is measured against the flow rect, not the window (offset canvas),
  *  - pathological padding is clamped so a fitting area always survives.
+ *
+ * ⚠ BASE_RATIO CHANGED 0.2 → 0.08 (15 Aug 2026), and that INVERTS two of the
+ * claims this spec used to make. It previously asserted that a collapsed dock
+ * rail and the thin left sidebar were "inert" at typical widths — true only
+ * because the old base margin (120px at 1440) was larger than what those
+ * panels occlude (68px and 80px). With a 53px base they now EXCEED it and
+ * reserve their own overlap. That is the documented intent of the function —
+ * each side is `max(baseMargin, occluderOverlap + GAP)`, so it clears the
+ * panel — it is simply no longer a no-op at those sizes. The two tests are
+ * renamed rather than renumbered, so the change of meaning is visible in the
+ * test names and not buried in an edited constant.
+ *
+ * What the change does NOT do, recorded here so this spec is never read as
+ * proof the motivating defect is closed: at 1280x800 with the conversation
+ * panel and an expanded dock both open, the post-draft `fitView` STILL clamps
+ * at the `LABEL_LEGIBLE_ZOOM` floor. Measured 15 Aug 2026 — the enlarged
+ * fitting box (843px) is short of the 1008px the drafted graph needs at that
+ * floor. This constant buys canvas back; it does not close the gap.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
@@ -40,8 +57,9 @@ function stubSelectors(map: Record<string, HTMLElement | null>) {
 const DOCK = 'aside[aria-label="Outputs dock"]'
 const SIDEBAR = 'nav[aria-label="Canvas tools"]'
 
-// baseMargin(V) = floor((V - V/1.2) * 0.5).
-//   1440 -> 120, 900 -> 75, 1000 -> 83, 600 -> 50.
+// baseMargin(V) = floor((V - V/1.08) * 0.5).
+//   1440 -> 53, 900 -> 33, 1000 -> 37, 800 -> 29, 600 -> 22, 500 -> 18, 200 -> 7.
+// (Was, at BASE_RATIO 0.2: 1440 -> 120, 900 -> 75, 1000 -> 83, 600 -> 50.)
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -56,20 +74,24 @@ describe('computeFitPadding', () => {
     }
   })
 
-  it('with no occluders, reproduces the base 0.2 margin on every side', () => {
+  it('with no occluders, applies the base margin on every side', () => {
     stubSelectors({})
     const p = computeFitPadding(fakeEl({ left: 0, right: 1440, width: 1440, top: 0, bottom: 900, height: 900 }))
-    expect(p).toEqual({ top: '75px', right: '120px', bottom: '75px', left: '120px' })
+    expect(p).toEqual({ top: '33px', right: '53px', bottom: '33px', left: '53px' })
   })
 
-  it('treats a collapsed dock rail as inert at typical width (overlap < base margin)', () => {
+  it('reserves a collapsed dock rail at typical width (overlap+gap now EXCEEDS the base margin)', () => {
+    // ⚠ This assertion INVERTED when BASE_RATIO went 0.2 → 0.08. The rail was
+    // previously swallowed by a 120px base and this test asserted '120px';
+    // against a 53px base the rail reserves its own 68px. Same function, same
+    // rule (`max(base, overlap + GAP)`) — the base simply stopped dominating.
     stubSelectors({
       // Real geometry: dock is `right: 12`, collapsed rail 40px wide.
       // left = 1440 - 12 - 40 = 1388; overlap = 1440 - 1388 = 52.
       [DOCK]: fakeEl({ left: 1388, right: 1428, width: 40, top: 12, bottom: 880, height: 868 }),
     })
     const p = computeFitPadding(fakeEl({ left: 0, right: 1440, width: 1440, top: 0, bottom: 900, height: 900 }))
-    expect(p.right).toBe('120px') // 52 + 16 = 68 < base 120 → unchanged
+    expect(p.right).toBe('68px') // 52 + 16 = 68 > base 53 → reserved
   })
 
   it('reserves an expanded dock, including its right gap (overlap + GAP)', () => {
@@ -80,9 +102,9 @@ describe('computeFitPadding', () => {
     })
     const p = computeFitPadding(fakeEl({ left: 0, right: 1440, width: 1440, top: 0, bottom: 900, height: 900 }))
     expect(p.right).toBe('444px') // 428 + 16 gap
-    expect(p.left).toBe('120px') // left untouched
-    expect(p.top).toBe('75px')
-    expect(p.bottom).toBe('75px')
+    expect(p.left).toBe('53px') // left untouched → base margin
+    expect(p.top).toBe('33px')
+    expect(p.bottom).toBe('33px')
   })
 
   it('collapsed rail is NOT inert on a narrow canvas (base margin shrinks below overlap+gap)', () => {
@@ -107,13 +129,17 @@ describe('computeFitPadding', () => {
     expect(parseInt(p.right, 10)).toBeLessThan(196)
   })
 
-  it('treats the thin left sidebar as inert on a wide canvas', () => {
+  it('reserves the thin left sidebar on a wide canvas (overlap+gap now EXCEEDS the base margin)', () => {
+    // ⚠ The second assertion that INVERTED with BASE_RATIO 0.2 → 0.08. It used
+    // to assert the sidebar was inert at 1440 ('120px'); against a 53px base
+    // its 64px overlap reserves 80px. The graph is now framed clear of the
+    // sidebar at every width rather than only at narrow ones.
     stubSelectors({
-      // sidebar at left:12 width:52 -> right = 64. overlap = 64 < base 120.
+      // sidebar at left:12 width:52 -> right = 64. overlap = 64; 64 + 16 = 80 > base 53.
       [SIDEBAR]: fakeEl({ left: 12, right: 64, width: 52, top: 100, bottom: 400, height: 300 }),
     })
     const p = computeFitPadding(fakeEl({ left: 0, right: 1440, width: 1440, top: 0, bottom: 900, height: 900 }))
-    expect(p.left).toBe('120px')
+    expect(p.left).toBe('80px')
   })
 
   it('reserves the left sidebar when it exceeds the base margin (narrow canvas)', () => {
@@ -160,10 +186,36 @@ describe('computeFitPadding', () => {
       const p = computeFitPadding() // no arg → real document.querySelector('.react-flow')
 
       expect(p.right).toBe('444px') // 428 + 16
-      expect(p.left).toBe('120px') // sidebar overlap 64 + 16 = 80 < base 120
-      expect(p.top).toBe('75px')
+      expect(p.left).toBe('80px') // sidebar overlap 64 + 16 = 80 > base 53
+      expect(p.top).toBe('33px')
     } finally {
       created.forEach((el) => el.remove())
     }
+  })
+
+  it('the motivating laptop case: 1280x800 with the responsive 333px dock leaves an 843px fitting box', () => {
+    // The exact geometry measured in the browser on 15 Aug 2026, pinned so the
+    // constants that produce it cannot drift back silently. Dock `right: 12`,
+    // responsive width 333 → left = 1280 - 12 - 333 = 935, overlap = 345.
+    stubSelectors({
+      [DOCK]: fakeEl({ left: 935, right: 1268, width: 333, top: 12, bottom: 784, height: 772 }),
+      [SIDEBAR]: fakeEl({ left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }),
+    })
+    const p = computeFitPadding(fakeEl({ left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }))
+    expect(p.right).toBe('361px') // 345 + 16
+    expect(p.left).toBe('76px') // 60 + 16 > base 47
+    expect(p.top).toBe('29px')
+
+    const fitBoxWidth = 1280 - parseInt(p.right, 10) - parseInt(p.left, 10)
+    expect(fitBoxWidth).toBe(843)
+
+    // ⚠ And the honest other half, asserted so nobody reads the number above as
+    // a fix: the drafted 17-node graph measures 2016 flow-units wide, so at the
+    // 0.5 legibility floor it needs 1008px. 843 is NOT enough — the post-draft
+    // fit still clamps. Closing that gap needs the dock collapsed, which is a
+    // workspace-shell decision, not a padding constant.
+    const GRAPH_FLOW_WIDTH = 2016
+    const LEGIBILITY_FLOOR = 0.5
+    expect(fitBoxWidth).toBeLessThan(GRAPH_FLOW_WIDTH * LEGIBILITY_FLOOR)
   })
 })

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -57,6 +57,7 @@ import { CogPopover } from './CogPopover'
 import { useConversationContext, useOptionalConversationContext } from '../conversation/ConversationContext'
 import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
 import { dockHostsOlumi } from './olumiSurface'
+import { dockWidthBounds, parseStoredDockWidth, resolveDockWidth } from './dockWidth'
 import {
   shouldAutoExpandDockForResponse,
   latestRealMessageIsAssistantReply,
@@ -1734,21 +1735,51 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       root.style.setProperty('--dock-right-offset', '0rem')
     }
   }, [state.isOpen, isFirstUse])
+  // Dock width: responsive by default, re-derived on every viewport change.
+  //
+  // Previously this ran ONCE on mount (deps `[]`) and only ever applied a
+  // PERSISTED width, so (a) a user who had never dragged the dock got a fixed
+  // 416px at every viewport — 32.5% of a 1280px laptop, and 444px removed
+  // from the graph's fitView box — and (b) a width persisted on a wide screen
+  // survived unclamped into a narrow one. Both are fixed by deriving the width
+  // from `resolveDockWidth` and re-running it on `resize`.
   useEffect(() => {
     if (typeof document === 'undefined' || typeof window === 'undefined') return
-    try {
-      const stored = localStorage.getItem('panel.results.width')
-      if (!stored) return
-      const parsed = Number(stored)
-      if (!Number.isFinite(parsed)) return
-      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0
+    const root = document.documentElement
+
+    const apply = () => {
+      let stored: number | null = null
+      try {
+        stored = parseStoredDockWidth(localStorage.getItem('panel.results.width'))
+      } catch {
+        // localStorage can throw (private mode / disabled storage). Treat it
+        // as "no explicit preference" rather than skipping the responsive
+        // default entirely — the old code returned early and left 416px.
+        stored = null
+      }
+      const viewportWidth = window.innerWidth || root.clientWidth || 0
       if (!viewportWidth) return
-      const minWidth = 280
-      const maxWidth = Math.min(480, Math.floor(viewportWidth * 0.4))
-      const clamped = Math.max(minWidth, Math.min(maxWidth, parsed))
-      const root = document.documentElement
-      root.style.setProperty('--dock-right-expanded', `${clamped}px`)
-    } catch {}
+      root.style.setProperty('--dock-right-expanded', `${resolveDockWidth(viewportWidth, stored)}px`)
+    }
+
+    apply()
+
+    // rAF-coalesced: a drag-resize of the window fires `resize` continuously,
+    // and each apply writes a CSS var that re-lays-out the dock AND is read
+    // back by computeFitPadding/measureDockInset.
+    let frame: number | null = null
+    const onResize = () => {
+      if (frame !== null) return
+      frame = window.requestAnimationFrame(() => {
+        frame = null
+        apply()
+      })
+    }
+    window.addEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+      if (frame !== null) window.cancelAnimationFrame(frame)
+    }
   }, [])
   const transitionClass = prefersReducedMotion ? '' : 'transition-[width,opacity] duration-200 ease-in-out'
 
@@ -1864,8 +1895,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0
     if (!viewportWidth) return
 
-    const minWidth = 280
-    const maxWidth = Math.min(480, Math.floor(viewportWidth * 0.4))
+    // Same bounds as the mount/resize path — derived from ONE source so the
+    // two cannot drift (they were separate hand-copied literals).
+    const { min: minWidth, max: maxWidth } = dockWidthBounds(viewportWidth)
     const root = document.documentElement
 
     const handleMove = (e: MouseEvent) => {

--- a/src/canvas/components/__tests__/dockWidth.spec.ts
+++ b/src/canvas/components/__tests__/dockWidth.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * The single width authority for the right-hand OutputsDock.
+ *
+ * Why this spec exists: the bounds used to be three hand-copied inline
+ * literals (mount path, resize path, drag path). They agreed on the day they
+ * were written and nothing would have gone red when they stopped — the
+ * dominant defect class in this codebase. The rules now live in one module,
+ * and this spec pins them against the SPEC as stated in `dockWidth.ts`, not
+ * against the single viewport that motivated the change.
+ *
+ * Assertions bind to the named function and the named viewport, and the
+ * property tests sweep the whole admissible input range rather than the two
+ * or three sizes a laptop-shaped bug would suggest.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DOCK_MIN_WIDTH,
+  DOCK_RESPONSIVE_MAX_WIDTH,
+  DOCK_VIEWPORT_RATIO,
+  dockWidthBounds,
+  responsiveDockWidth,
+  resolveDockWidth,
+  parseStoredDockWidth,
+} from '../dockWidth'
+
+/** Viewport widths spanning phone → ultrawide, used by the property sweeps. */
+const VIEWPORTS = [0, 320, 480, 600, 768, 900, 1024, 1280, 1366, 1440, 1600, 1920, 2560, 3840]
+
+describe('dockWidthBounds — the HARD bounds a user drag may reach', () => {
+  it('keeps the pre-existing rule: min 280, max min(480, 40% of viewport)', () => {
+    // These are the exact literals the three inline copies used, so an
+    // existing persisted width keeps behaving as it did before the refactor.
+    expect(dockWidthBounds(1280)).toEqual({ min: 280, max: 480 }) // 40% = 512, capped at 480
+    expect(dockWidthBounds(900)).toEqual({ min: 280, max: 360 }) // 40% = 360, under the cap
+    expect(dockWidthBounds(1200)).toEqual({ min: 280, max: 480 }) // 40% = 480, exactly the cap
+  })
+
+  it('never returns max < min, however narrow the viewport', () => {
+    // Ordering matters: a max below min would make the clamp order-dependent,
+    // so `resolveDockWidth` could return different answers for the same input
+    // depending on which bound it applied first.
+    for (const w of VIEWPORTS) {
+      const { min, max } = dockWidthBounds(w)
+      expect(max, `max >= min at viewport ${w}`).toBeGreaterThanOrEqual(min)
+    }
+    expect(dockWidthBounds(600)).toEqual({ min: 280, max: 280 }) // 40% = 240 < min
+  })
+
+  it('treats a non-finite or negative viewport as zero rather than propagating NaN', () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1000]) {
+      const { min, max } = dockWidthBounds(bad as number)
+      expect(Number.isFinite(max), `finite max for ${String(bad)}`).toBe(true)
+      expect(min).toBe(DOCK_MIN_WIDTH)
+      expect(max).toBe(DOCK_MIN_WIDTH)
+    }
+  })
+})
+
+describe('responsiveDockWidth — the width when the user has NEVER dragged', () => {
+  it('is proportional to the viewport below the historic ceiling', () => {
+    // 1280 is the measured laptop case: 0.26 * 1280 = 332.8 -> 333, which is
+    // what returns canvas to the graph. Bound to the exact viewport, so a
+    // change to the ratio reds here by name rather than silently drifting.
+    expect(responsiveDockWidth(1280)).toBe(333)
+    expect(responsiveDockWidth(1024)).toBe(SAFE_MIN(Math.round(1024 * DOCK_VIEWPORT_RATIO)))
+  })
+
+  it('never exceeds the historic fixed width, so wide screens are unchanged', () => {
+    // The whole change is a laptop-size REDUCTION, not a redesign. If this
+    // ever exceeds 416 a wide screen would get a dock bigger than it had
+    // before the refactor — a regression this spec exists to forbid.
+    for (const w of VIEWPORTS) {
+      expect(responsiveDockWidth(w), `viewport ${w}`).toBeLessThanOrEqual(DOCK_RESPONSIVE_MAX_WIDTH)
+    }
+    expect(responsiveDockWidth(1600)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // 0.26*1600 = 416 exactly
+    expect(responsiveDockWidth(2560)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // proportional 666, capped
+    expect(responsiveDockWidth(3840)).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+  })
+
+  it('never drops below the usable minimum, however narrow the viewport', () => {
+    for (const w of VIEWPORTS) {
+      expect(responsiveDockWidth(w), `viewport ${w}`).toBeGreaterThanOrEqual(DOCK_MIN_WIDTH)
+    }
+    expect(responsiveDockWidth(600)).toBe(DOCK_MIN_WIDTH) // proportional 156, floored
+  })
+
+  it('always lands inside dockWidthBounds for every viewport', () => {
+    // The spec-level invariant: the responsive default is a point INSIDE the
+    // drag range, never outside it. Written against the contract rather than
+    // against the 1280 case that motivated the module.
+    for (const w of VIEWPORTS) {
+      const { min, max } = dockWidthBounds(w)
+      const v = responsiveDockWidth(w)
+      expect(v, `>= min at ${w}`).toBeGreaterThanOrEqual(min)
+      expect(v, `<= max at ${w}`).toBeLessThanOrEqual(max)
+    }
+  })
+})
+
+describe('resolveDockWidth — explicit user width wins, re-clamped to bounds', () => {
+  it('falls back to the responsive default when there is no stored width', () => {
+    expect(resolveDockWidth(1280, null)).toBe(responsiveDockWidth(1280))
+    expect(resolveDockWidth(1280, null)).toBe(333)
+  })
+
+  it('honours an explicit width that is inside the bounds', () => {
+    // An explicit drag is a user decision; the responsive default must not
+    // override it. 480 is legal at 1280 (max 480) and must survive exactly.
+    expect(resolveDockWidth(1280, 480)).toBe(480)
+    expect(resolveDockWidth(1280, 416)).toBe(416)
+    expect(resolveDockWidth(1280, 300)).toBe(300)
+  })
+
+  it('re-clamps a width persisted at a WIDER viewport — the carried-over-width fix', () => {
+    // Previously a width persisted on a wide screen was applied unclamped in a
+    // narrow window. 480 persisted, then opened at 900px, where the bound says
+    // 360: the dock used to stay 480 (53% of the window).
+    expect(dockWidthBounds(900).max).toBe(360)
+    expect(resolveDockWidth(900, 480)).toBe(360)
+    expect(resolveDockWidth(600, 480)).toBe(280)
+  })
+
+  it('re-clamps a stored width below the usable minimum', () => {
+    expect(resolveDockWidth(1280, 100)).toBe(DOCK_MIN_WIDTH)
+    expect(resolveDockWidth(1280, 0)).toBe(DOCK_MIN_WIDTH)
+    expect(resolveDockWidth(1280, -50)).toBe(DOCK_MIN_WIDTH)
+  })
+
+  it('treats an unparseable stored width as "no preference", not as a number', () => {
+    // `null` — not 0, not NaN — is the signal for "never dragged". Anything
+    // unparseable must take the responsive default rather than silently
+    // becoming a number and pinning the dock at the minimum.
+    expect(resolveDockWidth(1280, Number.NaN)).toBe(responsiveDockWidth(1280))
+    expect(resolveDockWidth(1280, Number.POSITIVE_INFINITY)).toBe(responsiveDockWidth(1280))
+  })
+
+  it('always returns a width inside dockWidthBounds, for every viewport and every stored value', () => {
+    // The load-bearing invariant, swept over the whole admissible domain
+    // including values the contract admits but a laptop-shaped bug would
+    // never suggest (negative, zero, absurdly large).
+    const stored = [null, Number.NaN, -1000, 0, 1, 279, 280, 333, 416, 480, 481, 10_000]
+    for (const w of VIEWPORTS) {
+      const { min, max } = dockWidthBounds(w)
+      for (const s of stored) {
+        const v = resolveDockWidth(w, s)
+        expect(Number.isFinite(v), `finite at viewport ${w}, stored ${String(s)}`).toBe(true)
+        expect(v, `>= min at viewport ${w}, stored ${String(s)}`).toBeGreaterThanOrEqual(min)
+        expect(v, `<= max at viewport ${w}, stored ${String(s)}`).toBeLessThanOrEqual(max)
+      }
+    }
+  })
+
+  it('returns an integer — a fractional CSS pixel width causes subpixel seams', () => {
+    expect(resolveDockWidth(1280, 333.7)).toBe(334)
+    expect(Number.isInteger(responsiveDockWidth(1366))).toBe(true)
+  })
+})
+
+describe('parseStoredDockWidth — localStorage string to number | null', () => {
+  it('maps absent / empty / unparseable to null (the "never dragged" signal)', () => {
+    expect(parseStoredDockWidth(null)).toBeNull()
+    expect(parseStoredDockWidth(undefined)).toBeNull()
+    expect(parseStoredDockWidth('')).toBeNull()
+    expect(parseStoredDockWidth('not-a-number')).toBeNull()
+  })
+
+  it('parses a stored numeric string', () => {
+    expect(parseStoredDockWidth('416')).toBe(416)
+    expect(parseStoredDockWidth('333.5')).toBe(333.5)
+  })
+
+  it('round-trips through resolveDockWidth: a stored 480 at 900px yields the clamped 360', () => {
+    // Binds the parse step to the resolve step, so a parse that returned 0
+    // instead of null (the defect the null-signal exists to prevent) is
+    // visible here as a width of 280 rather than the responsive default.
+    expect(resolveDockWidth(900, parseStoredDockWidth('480'))).toBe(360)
+    expect(resolveDockWidth(1280, parseStoredDockWidth(null))).toBe(333)
+    expect(resolveDockWidth(1280, parseStoredDockWidth('garbage'))).toBe(333)
+  })
+})
+
+/** Clamp helper mirroring the module's floor, used only to express an expectation. */
+function SAFE_MIN(n: number): number {
+  return Math.max(DOCK_MIN_WIDTH, n)
+}

--- a/src/canvas/components/dockWidth.ts
+++ b/src/canvas/components/dockWidth.ts
@@ -1,0 +1,84 @@
+/**
+ * Responsive width for the right-hand OutputsDock.
+ *
+ * Why this module exists: the dock's expanded width was a single fixed
+ * `--dock-right-expanded: 26rem` (416px) applied at every viewport. At a
+ * 1280px laptop that is 32.5% of the screen, and because `computeFitPadding`
+ * reserves whatever the dock occludes, it also removes 444px from the graph's
+ * fitting box — measured 15 Aug 2026 at 1280x800: fit box 730px of 1280, the
+ * post-draft `fitView` hit its `minZoom` legibility floor and the graph
+ * overflowed the visible canvas.
+ *
+ * The rules, in one place so the mount path, the resize path and the drag
+ * path cannot drift apart (they were three separate copies of the bounds):
+ *
+ *  - `dockWidthBounds` — the HARD bounds a user drag may reach. Unchanged
+ *    from the previous inline copies (`280` .. `min(480, 40% of viewport)`),
+ *    so an existing persisted width keeps behaving exactly as before.
+ *  - `responsiveDockWidth` — what the dock is when the user has NEVER dragged
+ *    it. Proportional to the viewport, capped at the historic 416px so wide
+ *    screens are unchanged, floored at 280px so it stays usable.
+ *  - `resolveDockWidth` — the width to apply right now. An explicit user
+ *    width always wins over the responsive default; it is only re-clamped to
+ *    the hard bounds, which is itself a fix (previously a width persisted at
+ *    a wide viewport stayed 480px in a 900px window, where the clamp says 360).
+ *
+ * All three are pure so they can be unit-tested without a DOM.
+ */
+
+/** Narrowest usable dock. Never derived away — below this the panel content wraps unusably. */
+export const DOCK_MIN_WIDTH = 280
+
+/**
+ * Ceiling for the RESPONSIVE default: the historic fixed width. Screens wide
+ * enough to reach it get exactly the previous behaviour, so this change is a
+ * laptop-size reduction and not a redesign.
+ */
+export const DOCK_RESPONSIVE_MAX_WIDTH = 416
+
+/**
+ * Share of the viewport the dock takes before the ceiling bites. 0.26 puts a
+ * 1280px laptop at 333px (83px back to the canvas) and a 1600px screen back
+ * at the historic 416px.
+ */
+export const DOCK_VIEWPORT_RATIO = 0.26
+
+/** Hard bounds a user drag may reach — the pre-existing rule, now stated once. */
+export function dockWidthBounds(viewportWidth: number): { min: number; max: number } {
+  const usable = Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : 0
+  return {
+    min: DOCK_MIN_WIDTH,
+    // `max(min, …)` so a pathologically narrow viewport can never produce
+    // max < min, which would make the clamp order-dependent.
+    max: Math.max(DOCK_MIN_WIDTH, Math.min(480, Math.floor(usable * 0.4))),
+  }
+}
+
+/** The dock's width when the user has never resized it. */
+export function responsiveDockWidth(viewportWidth: number): number {
+  const { min, max } = dockWidthBounds(viewportWidth)
+  const proportional = Math.round((Number.isFinite(viewportWidth) ? viewportWidth : 0) * DOCK_VIEWPORT_RATIO)
+  const ceiling = Math.min(DOCK_RESPONSIVE_MAX_WIDTH, max)
+  return Math.max(min, Math.min(ceiling, proportional))
+}
+
+/**
+ * The width to apply now.
+ *
+ * @param storedWidth the user's persisted explicit width, or `null` when they
+ *   have never dragged the dock. `null` — not `0`, not `NaN` — is the signal
+ *   that the responsive default applies; anything unparseable is treated the
+ *   same way rather than silently becoming a number.
+ */
+export function resolveDockWidth(viewportWidth: number, storedWidth: number | null): number {
+  const { min, max } = dockWidthBounds(viewportWidth)
+  if (storedWidth == null || !Number.isFinite(storedWidth)) return responsiveDockWidth(viewportWidth)
+  return Math.max(min, Math.min(max, Math.round(storedWidth)))
+}
+
+/** Parse the persisted value into the `number | null` `resolveDockWidth` expects. */
+export function parseStoredDockWidth(raw: string | null | undefined): number | null {
+  if (raw == null || raw === '') return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
+++ b/src/canvas/hooks/__tests__/useFocusCamera.spec.tsx
@@ -68,8 +68,14 @@ const DOCK = 'aside[aria-label="Outputs dock"]'
 const PANE = { width: 1440, height: 900, left: 0, right: 1440, top: 0, bottom: 900 }
 /** An EXPANDED dock: overlaps the pane's right 428px, so it occludes. */
 const EXPANDED_DOCK = { width: 416, height: 900, left: 1012, right: 1428 }
-/** Base margin with nothing occluding: floor((1440 - 1440/1.2) * 0.5) = 120. */
-const BASE_X = 120
+/**
+ * Base margin with nothing occluding: floor((1440 - 1440/1.08) * 0.5) = 53.
+ * ⚠ Was 120 while `computeFitPadding`'s BASE_RATIO was 0.2; the ratio moved to
+ * 0.08 on 15 Aug 2026 to return fitting box to the graph at laptop widths.
+ * This constant tracks that one, so it is DERIVED here in the comment rather
+ * than being a second independent opinion about the same number.
+ */
+const BASE_X = 53
 
 function stubCanvas(opts: { dock?: boolean; pane?: Partial<DOMRect> | null } = {}) {
   const map: Record<string, HTMLElement | null> = {}

--- a/src/canvas/utils/__tests__/cameraComfort.spec.ts
+++ b/src/canvas/utils/__tests__/cameraComfort.spec.ts
@@ -239,8 +239,11 @@ describe('readFocusCamera — the live camera measurement bridge', () => {
     // overlap = flowRect.right - dock.left = 428, plus the 16px gap.
     expect(camera?.insets.right).toBe(444)
     expect(camera?.padding.right).toBe('444px')
-    // Base margin is untouched on the unoccluded left: floor((1440 - 1440/1.2) * 0.5).
-    expect(camera?.insets.left).toBe(120)
+    // Base margin is untouched on the unoccluded left: floor((1440 - 1440/1.08) * 0.5).
+    // ⚠ Was 120 under BASE_RATIO 0.2; the ratio moved to 0.08 on 15 Aug 2026.
+    // The point of this assertion is that an occluded side and an unoccluded
+    // side are treated DIFFERENTLY — that still holds, at a smaller base.
+    expect(camera?.insets.left).toBe(53)
   })
 
   it('a node under the expanded dock is NOT comfortable through the real bridge (F2/F4 end to end)', () => {

--- a/src/canvas/utils/computeFitPadding.ts
+++ b/src/canvas/utils/computeFitPadding.ts
@@ -17,14 +17,15 @@
  *
  * Margin model — each side gets `max(baseMargin, occluderOverlap + GAP)`, then a
  * defensive clamp:
- *  - `baseMargin` reproduces the prior `padding: 0.2` framing *exactly* (same
- *    formula), so when nothing meaningfully occludes a side the result is
- *    pixel-identical to the previous behaviour. At typical laptop widths the
- *    collapsed dock rail (~40px + 12px right gap) and the thin left sidebar
- *    (~52px) are smaller than `baseMargin`, so they are inert and closed-dock
- *    framing is unchanged. At *very narrow* widths `baseMargin` shrinks, so a
- *    rail/sidebar may legitimately reserve a little more than the base — that is
- *    still correct (it clears the panel), just not "inert".
+ *  - `baseMargin` is the breathing room when nothing occludes a side. It uses
+ *    xyflow's own bare-number formula so it is expressed in the same units the
+ *    rest of the codebase reasons about. See `BASE_RATIO` for why it was
+ *    lowered from `0.2` on 15 Aug 2026 and what that changes.
+ *  - Because the base is now smaller than the collapsed rail (~40px + 12px
+ *    right gap) and the left sidebar (~52px) at laptop widths, those panels
+ *    reserve their own overlap rather than hiding inside a larger base. That
+ *    is the intended behaviour of this function — it clears the panel — it is
+ *    simply no longer a no-op at those sizes.
  *  - Only an *expanded* panel (e.g. the ~416px OutputsDock) meaningfully exceeds
  *    `baseMargin` and pushes that side in, framing the graph clear of the panel.
  *  - A final clamp caps total per-axis padding at `MAX_PADDING_FRACTION` of the
@@ -42,8 +43,28 @@
  * pass its element explicitly.
  */
 
-/** Matches the prior `fitView({ padding: 0.2 })` contract so the no-occluder case is identical. */
-const BASE_RATIO = 0.2
+/**
+ * Breathing margin around the graph, expressed in xyflow's bare-number padding
+ * units (see the header note: `r` resolves to ~`r/(2(1+r))` of the dimension,
+ * so `0.08` ≈ 3.7% per side, not 8%).
+ *
+ * ⚠ WAS `0.2` (≈8.33% per side). Measured 15 Aug 2026 at 1280x800 with the
+ * committed CEE draft capture (17 nodes / 37 edges): `0.2` reserved 106px per
+ * side horizontally and 66px vertically, leaving a 730x668 fitting box out of
+ * a 1280x800 pane — 43% of the width gone before the dock's own reservation
+ * was even counted. The drafted graph rendered at the `minZoom` legibility
+ * floor with its left edge clipped under the floating Olumi panel.
+ *
+ * `0.08` keeps a genuine margin (47px horizontally / 29px vertically at
+ * 1280x800) while returning ~170px of fitting box. It does NOT change how an
+ * occluding panel is handled — each side is still
+ * `max(baseMargin, occluderOverlap + GAP)`, so the dock and sidebar reserve
+ * exactly what they occlude. The visible consequence of the lower base is that
+ * the collapsed rail and the left sidebar now EXCEED it and reserve their own
+ * overlap (68px for a 52px sidebar) instead of hiding inside a larger base —
+ * which is the correct behaviour, just no longer "inert".
+ */
+const BASE_RATIO = 0.08
 /** Breathing gap between the graph and an occluding panel edge. */
 const GAP = 16
 /** Never let combined per-axis padding exceed this fraction of the pane (keeps a fitting area). */


### PR DESCRIPTION
## PX-A (workspace shell) — one width authority for the OutputsDock, and honest fitView padding

**⚠ Lead finding: the acceptance condition this lane was given is NOT met, and cannot be met by
width work alone.** That is measured in a browser, not inferred. Please read "What this does NOT
fix" before approving — the headline numbers improve while what the user sees does not.

### The measured defect

At 1280×800 the dock's expanded width was a single fixed `--dock-right-expanded: 26rem` (416px) at
every viewport — 32.5% of a laptop screen. Because `computeFitPadding` reserves whatever the dock
occludes, that also removed 444px from the graph's fitting box.

### What changed

**1. `src/canvas/components/dockWidth.ts` (new) — the single width authority.**
The bounds existed as THREE hand-copied inline literals: the mount path, the resize path and the
drag path each carried their own `280` / `min(480, 40vw)`. They agreed when written and nothing
would have gone red when they stopped.

- `dockWidthBounds` — the HARD bounds a user drag may reach. **Unchanged** (`280 .. min(480, 40vw)`),
  so an existing persisted width behaves exactly as before.
- `responsiveDockWidth` — the width when the user has NEVER dragged. Proportional to the viewport
  (0.26), **capped at the historic 416px** so wide screens are unchanged, floored at 280px.
- `resolveDockWidth` — an explicit user width always wins, re-clamped to the bounds. That re-clamp
  is itself a fix: a width persisted at a wide viewport used to survive unclamped into a narrow
  window (480px in a 900px window, where the bound says 360).

The mount effect now re-runs on `resize` (rAF-coalesced) instead of once on mount, and a throwing
`localStorage` is treated as "no preference" rather than skipping the responsive default.

**2. `src/canvas/utils/computeFitPadding.ts` — `BASE_RATIO` 0.2 → 0.08.**
The old base reserved 106px per side horizontally at 1280×800 before the dock's own reservation was
counted. ⚠ **This INVERTS two claims the existing spec made**: the collapsed dock rail and the thin
left sidebar were previously "inert" at typical widths only because the base margin was larger than
what they occlude. They now reserve their own overlap — the documented intent of the function — but
it is a behaviour change at **every viewport**, so it is a separate commit and can be rejected
independently of commit 1.

### Measurements (1280×800, real CEE draft capture: 17 nodes / 37 edges)

| | before | after |
|---|---|---|
| dock width | 416px | **333px** |
| fitView right padding | 444px | **361px** |
| fitting box width | 730px | **843px** |
| final zoom | 0.5 | **0.5** |
| graph bbox width | 1008px | **1008px** |

### ⚠ What this does NOT fix

**The rendered graph is identical before and after.** Both clamp at the `LABEL_LEGIBLE_ZOOM` floor
(0.5), so the user sees the same thing. The change returns 83px of canvas and lifts the graph's
right edge clear of the dock (bbox `x1` 917 vs dock left 935; it previously ran 65px underneath),
but it does not change the framing.

Why it cannot: the drafted graph measures **2016 flow-units** wide, so at the 0.5 floor it needs
**1008px** of fitting box.

| dock width | fitting box | zoom | |
|---|---|---|---|
| 416 (pre-fix) | 760px | 0.377 | clamped |
| **333 (this PR)** | **843px** | **0.418** | **clamped** |
| 280 (hard minimum) | 896px | 0.444 | clamped |
| collapsed rail | 1136px | **0.563** | **clears the floor** |

**No dock width clears the floor** — even the 280px hard minimum leaves a 112px deficit.

There is also an occluder `computeFitPadding` does not reserve at all: the floating conversation
panel, 400px wide at x=52. With it and an expanded dock both open, the genuinely unoccluded canvas
band at 1280×800 is **483px** — that graph would need zoom 0.24 to fit inside it.

Driving the real controls in the browser (predicted 0.563, measured 0.563):

| state | zoom | above floor | bbox in pane | bbox in unoccluded band |
|---|---|---|---|---|
| default (dock 333, panel open) | 0.500 | ✗ | ✗ | ✗ |
| dock collapsed, panel open | 0.563 | ✓ | ✓ | ✗ |
| dock collapsed + panel closed | 0.563 | ✓ | ✓ | ✓ |

**The acceptance is reachable only when both panels are out of the way** — i.e. whether the dock
should auto-expand after a draft. That is a product behaviour change, not a padding constant, so it
is reported rather than shipped here.

### Gates

- **typecheck**: PASSED — 618 files / 2485 errors, **exactly the baseline, zero drift**. Baseline
  NOT regenerated.
- **lint**: PASSED — 0 errors; rules-of-hooks ratchet exactly at baseline (232 known, no new).
- **tests**: 104 passed across the 9 canvas fit/camera/dock spec files.
  - `dockWidth.spec.ts` — **new, 17 tests**; the module had none.
  - `computeFitPadding.spec.ts` — 11 tests.
  - Two further specs pinned the old base margin (`useFocusCamera` `BASE_X`, `cameraComfort`
    `insets.left`). Both were **green at the pristine base and red at this branch**, verified in an
    isolated worktree — so this change is the cause and they are the only two. Updated with their
    derivations, not just their numbers.
- **mutation kit** on `dockWidth.ts` (isolated detached worktree, restore from a pristine archive,
  applied-check scoped to `src/`): **7/7 mutants bitten**, including dropping the re-clamp (4 tests
  red). A comment-only equivalent mutant **survived**, proving the kit is not always-red. Leading
  and trailing controls both read exactly 0 changed lines with 17/17 collected.

**Pre-existing failures, not introduced here:** `OutputsDock.analysis-run.spec.tsx` fails 7 tests and
`OutputsDock.conversationSingleton.spec.tsx` is timing-flaky. Measured at the pristine base
`a3c71513` in an isolated worktree: the same 7 analysis-run failures, and 6 (not 2)
conversationSingleton failures. None are caused by this branch.

### Merge-order note — a brief premise, corrected

PX-A was briefed that `cutover/682-plus-retirement` also edits `OutputsDock.tsx` (deleting the
silent `/v2/run` fallback at ~:1078-1085) and that this PR would need to rebase onto it.
**Measured at that branch's head `0b13ecba`: it does not touch the file at all.** The blob hash is
identical to this PR's base (`360ad43d`), and `runV2Analysis()` is still live there at line 1084.
Verified with a positive control (the same command reports netlify.toml's 34 changed lines). **There
is no collision on this file.**

### Two things deliberately NOT in this PR

**1. The PX-C `altview` retirement patch.** Handed to PX-A because PX-A owns `OutputsDock.tsx`.
Applied and measured, then reverted: it **fails the gate**. `ResultsBody.v7Retired.spec.tsx` breaks
(it asserts the `altview` tab is registered), and the patch orphans `V7ComparisonTabBody`, which
**7 spec files still import**. Completing it means retiring a tab Paul asked for on 12 Aug and
deleting a component with its own test estate — PX-C's product decision, not one to make inside a
dock-width PR. The patch applies cleanly; it just needs its other 5 files.

**2. 16 files of unrelated canvas polish** from the salvaged branch, preserved and pushed as
`px-a/canvas-polish-salvage` (5 labelled commits, nothing lost). An independent review found:
- **node click/tap popovers — a user-visible defect on the exact path it was written to fix.**
  `NodePopover` renders through `createPortal` to `document.body`, so the outside-dismiss
  containment check does not contain it: a pointerdown *inside* a pinned popover unpins it, and on
  touch the popover unmounts before a chip click lands. Portal events also bubble the React tree and
  re-toggle the pin. The hook has no tests.
- **Olumi tab fronting — breaks 2 existing specs** (4 identity assertions in
  `guidanceStore.registrationOwnership.spec.ts`; a `vi.mock` factory in `sparkIntentContract.spec.ts`),
  and `run_analysis` dispatched through `_dispatchAction` now fronts Olumi — exactly the harm the
  deliberate `_runAnalysis` exclusion was written to avoid.
- evidence-lens classifier ships 3 exports with zero callers and a union still hand-duplicated in
  two files.

They are a different theme from dock width and belong in their own reviewed PRs.
