### PR TITLE
feat(versions): model version capture, one canonical diff, What Changed panel

### DIFF
--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -12,6 +12,7 @@
  */
 
 import { useCanvasStore } from '../store'
+import { captureBeforeIngest } from '../versions/autoCapture'
 import { DEFAULT_EDGE_DATA, readValidationMetadata } from '../domain/edges'
 import { edgeValueSourcePatch } from '../domain/edgeValueProvenance'
 import { saveAutosave } from '../store/scenarios'
@@ -212,7 +213,15 @@ export function applyDraftResult(
 
   // --- Apply to store ---
   const store = useCanvasStore.getState()
-  if (!opts.skipHistory) store.pushHistory()
+  if (!opts.skipHistory) {
+    // Versioned workspace: keep a named, comparable copy of the model the user
+    // is about to lose. Gated on the SAME condition as pushHistory because
+    // this function runs twice per streamed turn (preview, then terminal with
+    // skipHistory) and the user's own graph only still exists at the first
+    // call. Fully guarded — it can never fail the ingest.
+    captureBeforeIngest(store.nodes, store.edges)
+    store.pushHistory()
+  }
   useCanvasStore.setState({
     nodes,
     edges,

--- a/src/canvas/versions/DESIGN.md
+++ b/src/canvas/versions/DESIGN.md
@@ -1,0 +1,245 @@
+# Versioned workspace — design notes
+
+Scope of this document: what was BUILT in the first slice, what was deliberately
+DESIGNED-NOT-BUILT, and the precise asks that unblock the rest. British English
+throughout.
+
+Status rung of every claim below is stated explicitly. "Built" means code exists
+and is tested; it does not mean deployed, mounted or user-witnessed.
+
+---
+
+## What is built
+
+| Piece | File | Status |
+|---|---|---|
+| Shared types | `types.ts` | built + tested |
+| **The one diff authority** | `diffModelVersions.ts` | built + tested (28 cases) |
+| Capture projection | `captureModelVersion.ts` | built + tested (25 cases) |
+| Storage (localStorage, guest-working) | `versionStorage.ts` | built + tested (18 cases) |
+| Plain-language captions | `describeChange.ts` | built + tested (24 cases) |
+| Pre-ingest auto-capture | `autoCapture.ts` | built + tested (9 cases) |
+| What Changed panel | `WhatChangedPanel.tsx` | built + tested (13 cases, jsdom) |
+| Mount host | `VersionsPanelHost.tsx` | built |
+
+Mounted at `src/routes/CanvasMVP.tsx` (one lazy import, one JSX element), which
+serves both `/canvas` and `/scenario/:id`. No feature flag: the surface ships on,
+per programme doctrine.
+
+⚠ jsdom proves presence and text, never visibility. Nothing here is
+journey-witnessed. A browser witness on staging is still owed.
+
+---
+
+## One diff — the rule this namespace exists to hold
+
+`diffModelVersions` is the ONLY implementation of model comparison in this
+namespace, and every surface consumes the `ModelChangeset` it returns:
+What Changed today; restore and variants when they land.
+
+This matters because the estate already pays for the opposite pattern. There are
+two same-named `generateGraphHash` functions — one seed-bearing
+(`store/runHistory.ts:72`), one seedless (`canvas/utils/graphHash.ts:19`) —
+producing mutually incomparable values, and a third `computeGraphHash` in
+`hooks/useAutosave.ts:133`. Do not add a second diff. If a surface needs a
+different VIEW of a change, add a projection over `ModelChangeset`, not another
+comparison.
+
+Known adjacent implementations, deliberately not built on:
+
+- `compare-tab/graphChangeDiff.ts` — inside the Compare tab, which is
+  mid-retirement by the cutover train. Out of bounds.
+- `snapshots/VisualDiff.tsx` + `snapshots/useVisualDiff.ts` — part of the
+  unwired Snapshots v2 module (see below).
+
+---
+
+## Why a new namespace rather than wiring Snapshots v2
+
+`src/canvas/snapshots/` already implements named, timestamped, localStorage,
+FIFO-bounded snapshots with save/restore/delete, behind `VITE_FEATURE_SNAPSHOTS_V2`
+(default OFF). It has zero importers outside its own directory. On the face of it
+that is this feature, already built and dark.
+
+It was not used, and the reason is substantive rather than territorial: its stored
+shape is **lossy in exactly the dimension this feature needs**
+(`snapshots/snapshots.ts:26-39`):
+
+```ts
+nodes: Array<{ id; label; x; y; type? }>
+edges: Array<{ from; to; label?; weight? }>
+```
+
+No values, no observed state, no belief or direction, no provenance. A field-level
+diff over that can only ever report renames and positions — it structurally cannot
+answer "what did I change about my reasoning?". Capturing into it would have meant
+either flattening user data away or widening its schema, and widening the schema of
+a flag-off module with a `VisualDiff` of its own would have produced a second diff
+authority by the back door.
+
+**Recommendation for the estate:** retire `src/canvas/snapshots/` and its flag once
+this surface is witnessed, or explicitly re-scope it to visual/layout snapshots so
+the two are not competing answers to one question. Not actioned here — out of lane.
+
+---
+
+## Why versions are NOT sourced from run history
+
+`store/runHistory.ts:1-8` carries an explicit prohibition:
+
+> this local run history (client graph hashes + graph snapshots "for computing
+> deltas") must NEVER back a "What changed" surface or any freshness signal —
+> versioned comparison is producer-owned and absent from every contract today.
+> [...] Do not wire this in.
+
+Honoured in full. Nothing in this namespace imports run history, and nothing
+computes a graph hash.
+
+The distinction that makes this feature legitimate rather than a workaround: the
+prohibition is about ANALYSIS comparison — claims about what the engine now thinks,
+which are producer-owned. This feature compares **two snapshots the user authored
+themselves** and answers "what did I change?". It renders no freshness claim, no
+"your analysis is out of date", and no statement about analysis at all.
+
+If that distinction is ever judged too fine, the correct response is to withdraw
+the surface, not to soften the prohibition.
+
+---
+
+## Storage: localStorage-first, and the honest consequence
+
+Versions are stored in `localStorage` under `olumi-canvas-model-versions-v1`, for
+every session class, with **no identity check anywhere in the module**.
+
+That is deliberate. The nearest comparable surface hydrates through
+`compare-tab/useCompareHistoryHydration.ts:79`:
+
+```ts
+const { userId } = await getSessionIdentity()
+if (cancelled || !userId) return
+```
+
+Staging serves sessions as guest, so that surface is permanently empty for the
+people actually testing the product. The server alternative cannot fix it either:
+`v5_handler_facts` is RLS-scoped to `auth.uid()`, so guest rows are invisible by
+construction (`services/analysisRunHistoryService.ts:33-38` records that 643 of 773
+live run facts are guest rows invisible to that query).
+
+**What the user is told, on screen, in the panel:** versions are stored in this
+browser only, are not shared with collaborators, and are lost if site data is
+cleared. Stated rather than hidden.
+
+**Bounds:** 20 versions, newest-first, FIFO. On a quota error the store sheds
+oldest-first and reports what it kept; if even one version will not fit it fails
+loudly rather than reporting a save that did not happen.
+
+### Migration path to durable storage
+
+1. Keep `ModelVersion` and the `VersionedPayload` envelope exactly as they are —
+   the payload is already schema-versioned (`canvas.versions.v1`), so a server
+   table can adopt the same shape without a translation layer.
+2. Add a server-backed implementation behind the SAME module interface
+   (`loadVersions` / `appendVersion` / `deleteVersion`), selected at the storage
+   boundary, never at the surface.
+3. **Do not gate the local path off when the server path lands.** Guests must keep
+   working. The correct end state is local-first with server sync for signed-in
+   users, not server-only — otherwise the guest-blind defect returns wearing a
+   different hat.
+4. On first sign-in, offer to import local versions (precedent:
+   `lib/loginDraftImport.ts`).
+
+---
+
+## Designed, not built
+
+### Restore — blocked on the canonical transaction API
+
+Restoring a version is a WRITE to the canvas graph, and it is exactly the class of
+write that must go through Codex's canonical transaction API rather than a bare
+`setState`. Same gating as the model editor. Not built here.
+
+**The precise ask, stated so it can be actioned without this context:**
+
+> Restore needs a single transactional entry point that accepts a complete target
+> graph (`nodes`, `edges`) and applies it as ONE atomic, undoable, history-pushing
+> mutation, with the same external-mutation fencing that
+> `beginExternalGraphMutation` / `endExternalGraphMutation` provide — so a restore
+> cannot interleave with a streamed draft apply or an applied-edit reconcile.
+>
+> Signature shape wanted:
+> `applyGraphTransaction({ nodes, edges }, { label: string, source: 'version_restore' }): Result`
+>
+> Why a bare `setState` is not acceptable: `applyDraftResult` fires twice per
+> streamed turn and `reconcileAppliedGraph` can delete elements. A restore that
+> lands between them would be silently overwritten, and the user would be told
+> their model was restored when it was not — a false claim about their own data,
+> which is the worst failure this feature could have.
+
+Until that exists, the panel deliberately offers **no restore button**. An
+affordance that cannot keep its promise is worse than its absence.
+
+### Variants
+
+A variant is a version that is deliberately kept live as an alternative rather
+than as history — "what if we assumed demand held flat?". The data model already
+supports it: `VersionOrigin` is a union, and a `'variant'` member plus an optional
+`parentVersionId` would carry the branch relationship. What is NOT designed is the
+canvas affordance for switching between variants, which needs the same transaction
+API as restore and a decision about whether variants are comparable across
+branches (they are, using the same one diff — the changeset does not care whether
+two versions are sequential).
+
+Deferred until restore lands. Building variant capture without variant switching
+would be capability that reaches no user.
+
+### Analysis difference via `graph_hash`
+
+`ModelVersion.graphHash` exists on the type and `CaptureOptions.graphHash` is
+accepted, but **nothing supplies it today and nothing renders it**. This is stated
+plainly because a field that looks wired but is not is exactly how a dark
+capability gets recorded as shipped.
+
+Why it is unwired: there is no `graphHash` field on `useCanvasStore` at all. The
+two places a hash is actually held are both unavailable — the compare-tab snapshot
+store (mid-retirement) and local run history (prohibited above). Computing one here
+would mean choosing between the seeded and seedless twins, which produce mutually
+incomparable values; picking either would bake in a hash regime by accident.
+
+**The ask that unblocks it:** a single canonical, seedless model hash exposed on the
+canvas store and stamped onto analysis facts by the producer, so a version can
+record "this is the model the engine actually analysed". With that, a future
+surface could honestly say *"the model has changed since this analysis ran"* —
+which remains a producer-owned claim and must arrive with producer backing, not be
+derived client-side.
+
+### Known gaps in the capture projection
+
+Captured fields are DERIVED (every own scalar, minus a presentation denylist), so
+new domain fields appear automatically. Not captured, deliberately:
+
+- `interventions`, `functionParams`, `causal_claims`, `validation`, and the object
+  form of `prior` — nested structures that cannot be compared or captioned honestly
+  at field level yet. A nested diff is a real piece of work, not a one-line
+  extension, and half-doing it would produce confident wrong captions.
+- Node POSITION. Moving a node is not a change to the reasoning.
+
+The trade-off of a denylist over an allowlist: a newly added presentation field
+nobody denylists will surface as a visible "change" row. That failure direction is
+chosen on purpose — a visible wrong row gets fixed; a silently omitted user edit
+does not.
+
+---
+
+## Invariants any future change must preserve
+
+1. **One diff.** No second comparison implementation. Projections over
+   `ModelChangeset`, never a parallel diff.
+2. **Pair by identity.** Nodes and edges pair by `id` only. Never by label, never
+   by a value predicate — two nodes routinely share a label.
+3. **Never fabricate, never re-stamp.** Capture applies no defaults. The four edge
+   `*Source` markers mean "absent ⇒ defaulted"; stamping one launders a UI default
+   into a claim about the user.
+4. **Encode before caption.** Sentences come only from `describeChange.ts`, only
+   from the changeset. No summaries, scores or judgements.
+5. **Guests work.** No identity check in the storage path, ever.
+6. **Auto-capture cannot break ingest.** Every failure swallowed with a warning.

--- a/src/canvas/versions/VersionsPanelHost.tsx
+++ b/src/canvas/versions/VersionsPanelHost.tsx
@@ -1,0 +1,35 @@
+/**
+ * Mount host for the versions surface: the trigger and the panel together.
+ * British English: visualisation, colour, initialise.
+ *
+ * WHY A HOST. It owns its own open/closed state, so mounting the whole feature
+ * costs the canvas route exactly one line and touches no shared store. That
+ * keeps the integration surface with other lanes to a single JSX element, and
+ * makes the feature trivially removable if it is not wanted.
+ */
+
+import { useState } from 'react'
+import { GitCompare } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import { WhatChangedPanel } from './WhatChangedPanel'
+
+export function VersionsPanelHost() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      {!isOpen && (
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          data-testid="versions-panel-trigger"
+          className={`${typography.panelBody} absolute top-3 right-3 z-[1500] inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-panel border border-panel-border text-text-body shadow-panel hover:bg-panel-hover`}
+        >
+          <GitCompare className="w-3.5 h-3.5" />
+          Versions
+        </button>
+      )}
+      <WhatChangedPanel isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  )
+}

--- a/src/canvas/versions/WhatChangedPanel.tsx
+++ b/src/canvas/versions/WhatChangedPanel.tsx
@@ -1,0 +1,242 @@
+/**
+ * What Changed — the versions surface.
+ * British English: visualisation, colour, initialise.
+ *
+ * RENDERS THE CHANGESET AND NOTHING ELSE. Every line on screen comes from
+ * `describeChangeset`, which comes from `diffModelVersions`. There is no copy
+ * here that interprets, scores or summarises a change, because none of that is
+ * in the changeset and the product has not earned the right to claim it.
+ *
+ * EXCEPTIONS LOUD, NORMAL QUIET: a failed save says so, in place, with the real
+ * reason. A successful save says nothing — the new version simply appears.
+ */
+
+import { useCallback, useState } from 'react'
+import { GitCompare, Save, Trash2 } from 'lucide-react'
+import { PanelShell } from '../panels/_shared/PanelShell'
+import { PanelSection } from '../panels/_shared/PanelSection'
+import { typography } from '../../styles/typography'
+import { buildVersionLabelIndex, describeChangeset } from './describeChange'
+import { useModelVersions } from './useModelVersions'
+import type { ChangeLine } from './describeChange'
+
+export interface WhatChangedPanelProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function formatTimestamp(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return new Date(ms).toISOString()
+  }
+}
+
+/** Neutral markers — the change KIND, never a judgement about it. */
+const KIND_MARKER: Readonly<Record<ChangeLine['kind'], string>> = {
+  added: '+',
+  removed: '−',
+  modified: '~',
+}
+
+const KIND_CLASS: Readonly<Record<ChangeLine['kind'], string>> = {
+  added: 'text-success',
+  removed: 'text-danger',
+  modified: 'text-info',
+}
+
+export function WhatChangedPanel({ isOpen, onClose }: WhatChangedPanelProps) {
+  const {
+    versions,
+    fromId,
+    toId,
+    setFromId,
+    setToId,
+    changeset,
+    from,
+    to,
+    saveVersion,
+    removeVersion,
+  } = useModelVersions()
+
+  const [draftName, setDraftName] = useState('')
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const handleSave = useCallback(() => {
+    const name = draftName.trim() || `Version ${new Date().toLocaleString('en-GB')}`
+    const outcome = saveVersion(name)
+    if (outcome.ok) {
+      setDraftName('')
+      setSaveError(null)
+      return
+    }
+    setSaveError(outcome.message ?? 'This version could not be saved.')
+  }, [draftName, saveVersion])
+
+  if (!isOpen) return null
+
+  const lines =
+    changeset && from && to ? describeChangeset(changeset, buildVersionLabelIndex(from, to)) : []
+
+  return (
+    <div
+      className="fixed right-0 z-[2000]"
+      style={{ top: 'var(--topbar-h)', bottom: 'var(--bottombar-h)' }}
+      data-testid="what-changed-panel"
+    >
+      <PanelShell
+        icon={<GitCompare className="w-5 h-5" />}
+        title="Versions"
+        onClose={onClose}
+        width="420px"
+      >
+        <PanelSection title="Save a version">
+          <div className="flex items-center gap-2">
+            <label htmlFor="version-name" className="sr-only">
+              Version name
+            </label>
+            <input
+              id="version-name"
+              type="text"
+              value={draftName}
+              onChange={(event) => setDraftName(event.target.value)}
+              placeholder="Name this version"
+              className={`${typography.panelBody} flex-1 min-w-0 px-2 py-1.5 rounded-md border border-panel-border bg-panel text-text-body placeholder:text-text-light`}
+            />
+            <button
+              type="button"
+              onClick={handleSave}
+              className={`${typography.panelBody} shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color`}
+            >
+              <Save className="w-3.5 h-3.5" />
+              Save version
+            </button>
+          </div>
+          {saveError && (
+            <p className={`${typography.panelBody} text-danger`} role="alert">
+              {saveError}
+            </p>
+          )}
+          <p className={`${typography.panelMeta} text-text-light`}>
+            Versions are stored in this browser only. They are not shared with collaborators and are
+            lost if you clear site data.
+          </p>
+        </PanelSection>
+
+        {versions.length === 0 && (
+          <p className={`${typography.panelBody} text-text-light`}>
+            No versions saved yet. Save one to start tracking how your model changes.
+          </p>
+        )}
+
+        {versions.length > 0 && (
+          <PanelSection title="Compare">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="version-from"
+                  className={`${typography.panelMeta} text-text-light w-10 shrink-0`}
+                >
+                  From
+                </label>
+                <select
+                  id="version-from"
+                  value={fromId ?? ''}
+                  onChange={(event) => setFromId(event.target.value)}
+                  className={`${typography.panelBody} flex-1 min-w-0 px-2 py-1.5 rounded-md border border-panel-border bg-panel text-text-body`}
+                >
+                  {versions.map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.name} · {formatTimestamp(version.createdAt)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="version-to"
+                  className={`${typography.panelMeta} text-text-light w-10 shrink-0`}
+                >
+                  To
+                </label>
+                <select
+                  id="version-to"
+                  value={toId ?? ''}
+                  onChange={(event) => setToId(event.target.value)}
+                  className={`${typography.panelBody} flex-1 min-w-0 px-2 py-1.5 rounded-md border border-panel-border bg-panel text-text-body`}
+                >
+                  {versions.map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.name} · {formatTimestamp(version.createdAt)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </PanelSection>
+        )}
+
+        {versions.length === 1 && (
+          <p className={`${typography.panelBody} text-text-light`}>
+            Save a second version to see what changed between them.
+          </p>
+        )}
+
+        {changeset && (
+          <PanelSection title="What changed">
+            {changeset.isEmpty ? (
+              <p className={`${typography.panelBody} text-text-light`}>
+                No differences between these two versions.
+              </p>
+            ) : (
+              <ul className="space-y-1.5" data-testid="what-changed-list">
+                {lines.map((line) => (
+                  <li key={line.key} className="flex items-start gap-2">
+                    <span
+                      aria-hidden="true"
+                      className={`${typography.panelBody} ${KIND_CLASS[line.kind]} shrink-0 w-3`}
+                    >
+                      {KIND_MARKER[line.kind]}
+                    </span>
+                    <span className={`${typography.panelBody} text-text-body`}>{line.text}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </PanelSection>
+        )}
+
+        {versions.length > 0 && (
+          <PanelSection title="Saved versions">
+            <ul className="space-y-1">
+              {versions.map((version) => (
+                <li key={version.id} className="flex items-center justify-between gap-2">
+                  <span className={`${typography.panelBody} text-text-body truncate`}>
+                    {version.name}
+                    <span className={`${typography.panelMeta} text-text-light ml-2`}>
+                      {formatTimestamp(version.createdAt)}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    aria-label={`Delete version ${version.name}`}
+                    onClick={() => removeVersion(version.id)}
+                    className="shrink-0 p-1 rounded-md text-text-light hover:text-danger hover:bg-panel-hover"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </PanelSection>
+        )}
+      </PanelShell>
+    </div>
+  )
+}

--- a/src/canvas/versions/__tests__/WhatChangedPanel.spec.tsx
+++ b/src/canvas/versions/__tests__/WhatChangedPanel.spec.tsx
@@ -1,0 +1,166 @@
+/**
+ * What Changed panel — mounted behaviour pinned.
+ *
+ * ⚠ SCOPE, stated precisely (CLAUDE.md trap #16): jsdom proves PRESENCE and
+ * text, never visibility or layout. These tests assert that the panel mounts,
+ * that a save round-trips, and that the rendered lines derive from the diff.
+ * They are NOT evidence that the panel is visible on a real deployed canvas —
+ * that needs a browser witness.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import type { Edge, Node } from '@xyflow/react'
+import { WhatChangedPanel } from '../WhatChangedPanel'
+import { useCanvasStore } from '../../store'
+import type { EdgeData } from '../../domain/edges'
+
+function rfNode(id: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label, ...data } } as Node
+}
+
+function setGraph(nodes: Node[], edges: Edge<EdgeData>[] = []): void {
+  useCanvasStore.setState({ nodes, edges })
+}
+
+function saveVersionNamed(name: string): void {
+  fireEvent.change(screen.getByLabelText('Version name'), { target: { value: name } })
+  fireEvent.click(screen.getByRole('button', { name: /save version/i }))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  setGraph([])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+describe('WhatChangedPanel', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(<WhatChangedPanel isOpen={false} onClose={() => {}} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('mounts when open', () => {
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    expect(screen.getByTestId('what-changed-panel')).toBeInTheDocument()
+  })
+
+  it('invites a first save when no versions exist', () => {
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    expect(screen.getByText(/no versions saved yet/i)).toBeInTheDocument()
+  })
+
+  it('states the local-only storage limitation on screen', () => {
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    expect(screen.getByText(/stored in this browser only/i)).toBeInTheDocument()
+  })
+
+  it('saves a named version from the current canvas', () => {
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    saveVersionNamed('Baseline')
+
+    expect(screen.getByText('Baseline')).toBeInTheDocument()
+  })
+
+  it('asks for a second version before it will compare', () => {
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    saveVersionNamed('Baseline')
+
+    expect(screen.getByText(/save a second version/i)).toBeInTheDocument()
+  })
+
+  it('renders the changed field between two saved versions', () => {
+    setGraph([rfNode('n1', 'Price', { observedState: { value: 0.5 } })])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+    saveVersionNamed('Baseline')
+
+    setGraph([rfNode('n1', 'Price', { observedState: { value: 0.8 } })])
+    saveVersionNamed('After review')
+
+    const list = screen.getByTestId('what-changed-list')
+    expect(within(list).getByText('Factor "Price" value 0.5 → 0.8')).toBeInTheDocument()
+  })
+
+  it('reports an added node in plain language', () => {
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+    saveVersionNamed('Baseline')
+
+    setGraph([rfNode('n1', 'Price'), rfNode('n2', 'Volume')])
+    saveVersionNamed('With volume')
+
+    const list = screen.getByTestId('what-changed-list')
+    expect(within(list).getByText('Factor "Volume" added')).toBeInTheDocument()
+  })
+
+  it('says so plainly when two versions are identical', () => {
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+    saveVersionNamed('One')
+    saveVersionNamed('Two')
+
+    expect(screen.getByText(/no differences between these two versions/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('what-changed-list')).not.toBeInTheDocument()
+  })
+
+  it('deletes a version on request', () => {
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+    saveVersionNamed('Disposable')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete version Disposable' }))
+
+    expect(screen.queryByText('Disposable')).not.toBeInTheDocument()
+    expect(screen.getByText(/no versions saved yet/i)).toBeInTheDocument()
+  })
+
+  it('surfaces a real save failure instead of pretending it worked', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      const error = new Error('quota')
+      error.name = 'QuotaExceededError'
+      throw error
+    })
+    setGraph([rfNode('n1', 'Price')])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+
+    saveVersionNamed('Doomed')
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/too large to save/i)
+    expect(screen.queryByText('Doomed')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose from the panel close control', () => {
+    const onClose = vi.fn()
+    render(<WhatChangedPanel isOpen onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /close panel/i }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders no summary or judgement copy anywhere', () => {
+    setGraph([rfNode('n1', 'Price', { observedState: { value: 0.5 } })])
+    render(<WhatChangedPanel isOpen onClose={() => {}} />)
+    saveVersionNamed('Baseline')
+    setGraph([rfNode('n1', 'Price', { observedState: { value: 0.8 } })])
+    saveVersionNamed('After')
+
+    const text = screen.getByTestId('what-changed-panel').textContent?.toLowerCase() ?? ''
+    for (const forbidden of ['significant', 'major change', 'improved', 'weakened', 'stronger model']) {
+      expect(text).not.toContain(forbidden)
+    }
+  })
+})

--- a/src/canvas/versions/__tests__/autoCapture.spec.ts
+++ b/src/canvas/versions/__tests__/autoCapture.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Pre-ingest auto-capture — behaviour pinned.
+ *
+ * The governing requirement is that this NEVER breaks the ingest it guards.
+ * A version is a safety net; a net that can take down the canvas is worse than
+ * no net at all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import { captureBeforeIngest } from '../autoCapture'
+import { loadVersions } from '../versionStorage'
+
+function rfNode(id: string, label: string): Node {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label } } as Node
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+describe('captureBeforeIngest', () => {
+  it('stores a version of the graph it was given', () => {
+    captureBeforeIngest([rfNode('n1', 'Price'), rfNode('n2', 'Revenue')], [])
+
+    const stored = loadVersions()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]!.nodes.map((n) => n.id)).toEqual(['n1', 'n2'])
+  })
+
+  it('marks the version as pre-ingest, distinguishing it from a manual save', () => {
+    captureBeforeIngest([rfNode('n1', 'Price')], [])
+
+    expect(loadVersions()[0]!.origin).toBe('pre-ingest')
+  })
+
+  it('names the version after what happened, claiming nothing about quality', () => {
+    captureBeforeIngest([rfNode('n1', 'Price')], [])
+
+    const name = loadVersions()[0]!.name.toLowerCase()
+    expect(name).toContain('redraft')
+    for (const forbidden of ['better', 'worse', 'improved', 'lost']) {
+      expect(name).not.toContain(forbidden)
+    }
+  })
+
+  it('does NOT capture an empty canvas — replacing nothing is not a loss', () => {
+    captureBeforeIngest([], [])
+
+    expect(loadVersions()).toEqual([])
+  })
+
+  it('captures edges alongside nodes', () => {
+    const edges = [{ id: 'e1', source: 'n1', target: 'n2', data: { weight: 0.7 } } as Edge]
+
+    captureBeforeIngest([rfNode('n1', 'Price'), rfNode('n2', 'Revenue')], edges)
+
+    expect(loadVersions()[0]!.edges[0]).toMatchObject({ id: 'e1', from: 'n1', to: 'n2' })
+    expect(loadVersions()[0]!.edges[0]!.fields.weight).toBe(0.7)
+  })
+
+  it('never throws when storage rejects the write', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      const error = new Error('quota')
+      error.name = 'QuotaExceededError'
+      throw error
+    })
+
+    expect(() => captureBeforeIngest([rfNode('n1', 'Price')], [])).not.toThrow()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('never throws when storage reads throw outright', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+
+    expect(() => captureBeforeIngest([rfNode('n1', 'Price')], [])).not.toThrow()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('never throws on a malformed node', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const broken = { id: 'n1' } as Node
+
+    expect(() => captureBeforeIngest([broken], [])).not.toThrow()
+  })
+
+  it('keeps successive captures as separate versions', () => {
+    captureBeforeIngest([rfNode('n1', 'First')], [])
+    captureBeforeIngest([rfNode('n1', 'Second')], [])
+
+    expect(loadVersions()).toHaveLength(2)
+  })
+})

--- a/src/canvas/versions/__tests__/captureModelVersion.spec.ts
+++ b/src/canvas/versions/__tests__/captureModelVersion.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * Capture projection — behaviour pinned.
+ *
+ * The load-bearing assertions here are the NEGATIVE ones: that capture never
+ * invents a default and never re-stamps a provenance marker. An absent
+ * `weightSource` means "nobody set the weight"; a capture that filled it in
+ * would launder a UI default into a claim about the user.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import { captureEdge, captureModelVersion, captureNode } from '../captureModelVersion'
+
+function rfNode(id: string, data: Record<string, unknown>, type = 'factor'): Node {
+  return { id, type, position: { x: 0, y: 0 }, data } as Node
+}
+
+function rfEdge(id: string, source: string, target: string, data: Record<string, unknown> = {}): Edge {
+  return { id, source, target, data } as Edge
+}
+
+describe('captureNode', () => {
+  it('carries node identity, kind and label', () => {
+    const node = rfNode('n1', { label: 'Price', kind: 'factor' })
+
+    expect(captureNode(node)).toMatchObject({ id: 'n1', kind: 'factor', label: 'Price' })
+  })
+
+  it('prefers data.kind over the React Flow type', () => {
+    const node = rfNode('n1', { label: 'Price', kind: 'outcome' }, 'factor')
+
+    expect(captureNode(node).kind).toBe('outcome')
+  })
+
+  it('falls back to the React Flow type when data.kind is absent', () => {
+    const node = rfNode('n1', { label: 'Price' }, 'risk')
+
+    expect(captureNode(node).kind).toBe('risk')
+  })
+
+  it('captures scalar domain fields from the open data bag', () => {
+    const node = rfNode('n1', {
+      label: 'Price',
+      description: 'unit price',
+      utility: 0.4,
+      provenance: 'user_set',
+    })
+
+    const captured = captureNode(node)
+
+    expect(captured.fields.description).toBe('unit price')
+    expect(captured.fields.utility).toBe(0.4)
+    expect(captured.fields.provenance).toBe('user_set')
+  })
+
+  it('captures undeclared-but-live renderer fields (no schema parse strips them)', () => {
+    // These are read by GoalNode but declared by no node schema. A capture that
+    // parsed through AnyNodeDataSchema would silently destroy them.
+    const node = rfNode('n1', {
+      label: 'Revenue',
+      success_threshold: 500000,
+      goal_threshold_unit: '£',
+      threshold_source: 'user',
+    })
+
+    const captured = captureNode(node)
+
+    expect(captured.fields.success_threshold).toBe(500000)
+    expect(captured.fields.goal_threshold_unit).toBe('£')
+    expect(captured.fields.threshold_source).toBe('user')
+  })
+
+  it('flattens observedState one level with dotted keys', () => {
+    const node = rfNode('n1', {
+      label: 'Price',
+      observedState: { value: 0.5, unit: '£', raw_value: '26000', display_value: null },
+    })
+
+    const captured = captureNode(node)
+
+    expect(captured.fields['observedState.value']).toBe(0.5)
+    expect(captured.fields['observedState.unit']).toBe('£')
+    expect(captured.fields['observedState.raw_value']).toBe('26000')
+    expect(captured.fields['observedState.display_value']).toBeNull()
+  })
+
+  it('does NOT invent fields that are absent', () => {
+    const node = rfNode('n1', { label: 'Price' })
+
+    const captured = captureNode(node)
+
+    expect(Object.keys(captured.fields)).toEqual([])
+    expect('utility' in captured.fields).toBe(false)
+    expect('provenance' in captured.fields).toBe(false)
+  })
+
+  it('preserves a falsy value rather than dropping it', () => {
+    const node = rfNode('n1', { label: 'Price', utility: 0, is_baseline: false, body: '' })
+
+    const captured = captureNode(node)
+
+    expect(captured.fields.utility).toBe(0)
+    expect(captured.fields.is_baseline).toBe(false)
+    expect(captured.fields.body).toBe('')
+  })
+
+  it('excludes presentation and React Flow interaction state', () => {
+    const node = rfNode('n1', {
+      label: 'Price',
+      selected: true,
+      zIndex: 5,
+      width: 200,
+      schemaVersion: 4,
+      templateId: 'tpl-1',
+    })
+
+    const captured = captureNode(node)
+
+    for (const excluded of ['selected', 'zIndex', 'width', 'schemaVersion', 'templateId']) {
+      expect(captured.fields[excluded]).toBeUndefined()
+    }
+  })
+
+  it('does not capture nested structures it cannot compare honestly', () => {
+    const node = rfNode('n1', {
+      label: 'Choice',
+      interventions: { price: 3 },
+      prior: { distribution: 'normal', range_min: 1, range_max: 5 },
+    })
+
+    const captured = captureNode(node)
+
+    expect(captured.fields.interventions).toBeUndefined()
+    expect(captured.fields.prior).toBeUndefined()
+  })
+
+  it('captures a scalar prior, which IS comparable', () => {
+    const node = rfNode('n1', { label: 'Choice', prior: 0.7 })
+
+    expect(captureNode(node).fields.prior).toBe(0.7)
+  })
+
+  it('falls back to the node id when the label is missing or empty', () => {
+    expect(captureNode(rfNode('n1', {})).label).toBe('n1')
+    expect(captureNode(rfNode('n2', { label: '' })).label).toBe('n2')
+  })
+
+  it('tolerates a node with no data bag at all', () => {
+    const node = { id: 'n1', type: 'factor', position: { x: 0, y: 0 } } as Node
+
+    expect(() => captureNode(node)).not.toThrow()
+    expect(captureNode(node)).toMatchObject({ id: 'n1', label: 'n1' })
+  })
+})
+
+describe('captureEdge', () => {
+  it('carries edge identity and endpoints from source/target', () => {
+    expect(captureEdge(rfEdge('e1', 'n1', 'n2'))).toMatchObject({ id: 'e1', from: 'n1', to: 'n2' })
+  })
+
+  it('captures strength, belief and direction fields', () => {
+    const edge = rfEdge('e1', 'n1', 'n2', {
+      weight: 0.8,
+      beliefExists: 0.9,
+      beliefStrength: 0.6,
+      direction: 'positive',
+      strength_mean: -0.4,
+    })
+
+    const captured = captureEdge(edge)
+
+    expect(captured.fields.weight).toBe(0.8)
+    expect(captured.fields.beliefExists).toBe(0.9)
+    expect(captured.fields.beliefStrength).toBe(0.6)
+    expect(captured.fields.direction).toBe('positive')
+    expect(captured.fields.strength_mean).toBe(-0.4)
+  })
+
+  it('copies a provenance marker that IS present', () => {
+    const edge = rfEdge('e1', 'n1', 'n2', { weight: 0.8, weightSource: 'user' })
+
+    expect(captureEdge(edge).fields.weightSource).toBe('user')
+  })
+
+  it('NEVER stamps an absent provenance marker — absent means defaulted', () => {
+    // A user-drawn edge carries weight 0.5 by UI default with NO weightSource.
+    // Stamping one here would claim the user set it.
+    const edge = rfEdge('e1', 'n1', 'n2', { weight: 0.5, direction: 'positive' })
+
+    const captured = captureEdge(edge)
+
+    expect('weightSource' in captured.fields).toBe(false)
+    expect('directionSource' in captured.fields).toBe(false)
+    expect('beliefExistsSource' in captured.fields).toBe(false)
+    expect('strengthStdSource' in captured.fields).toBe(false)
+  })
+
+  it('NEVER applies an edge default for an absent value', () => {
+    const captured = captureEdge(rfEdge('e1', 'n1', 'n2', {}))
+
+    expect('weight' in captured.fields).toBe(false)
+    expect('direction' in captured.fields).toBe(false)
+    expect(captured.fields).toEqual({})
+  })
+
+  it('excludes edge presentation fields', () => {
+    const edge = rfEdge('e1', 'n1', 'n2', {
+      weight: 0.5,
+      style: 'dashed',
+      curvature: 0.2,
+      pathType: 'bezier',
+    })
+
+    const captured = captureEdge(edge)
+
+    expect(captured.fields.weight).toBe(0.5)
+    expect(captured.fields.style).toBeUndefined()
+    expect(captured.fields.curvature).toBeUndefined()
+    expect(captured.fields.pathType).toBeUndefined()
+  })
+
+  it('carries a string label and omits a non-string one', () => {
+    expect(captureEdge(rfEdge('e1', 'n1', 'n2', { label: 'drives' })).label).toBe('drives')
+    expect(captureEdge(rfEdge('e2', 'n1', 'n2', { label: 42 })).label).toBeUndefined()
+  })
+})
+
+describe('captureModelVersion', () => {
+  const nodes = [rfNode('n1', { label: 'Price' }), rfNode('n2', { label: 'Revenue' })]
+  const edges = [rfEdge('e1', 'n1', 'n2', { weight: 0.5 })]
+
+  it('carries the supplied metadata verbatim', () => {
+    const version = captureModelVersion(nodes, edges, {
+      id: 'v1',
+      name: 'Before board review',
+      origin: 'manual',
+      createdAt: 1234,
+    })
+
+    expect(version).toMatchObject({
+      id: 'v1',
+      name: 'Before board review',
+      origin: 'manual',
+      createdAt: 1234,
+    })
+    expect(version.nodes.map((n) => n.id)).toEqual(['n1', 'n2'])
+    expect(version.edges.map((e) => e.id)).toEqual(['e1'])
+  })
+
+  it('omits graphHash entirely when none was supplied', () => {
+    const version = captureModelVersion(nodes, edges, {
+      id: 'v1',
+      name: 'v',
+      origin: 'manual',
+      createdAt: 1,
+    })
+
+    expect('graphHash' in version).toBe(false)
+  })
+
+  it('copies a supplied graphHash verbatim and never derives one', () => {
+    const version = captureModelVersion(nodes, edges, {
+      id: 'v1',
+      name: 'v',
+      origin: 'manual',
+      createdAt: 1,
+      graphHash: 'abc123',
+    })
+
+    expect(version.graphHash).toBe('abc123')
+  })
+
+  it('captures an empty canvas without throwing', () => {
+    const version = captureModelVersion([], [], {
+      id: 'v1',
+      name: 'empty',
+      origin: 'pre-ingest',
+      createdAt: 1,
+    })
+
+    expect(version.nodes).toEqual([])
+    expect(version.edges).toEqual([])
+  })
+
+  it('produces a version that diffs clean against itself', () => {
+    const version = captureModelVersion(nodes, edges, {
+      id: 'v1',
+      name: 'v',
+      origin: 'manual',
+      createdAt: 1,
+    })
+
+    expect(JSON.parse(JSON.stringify(version))).toEqual(version)
+  })
+})

--- a/src/canvas/versions/__tests__/describeChange.spec.ts
+++ b/src/canvas/versions/__tests__/describeChange.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Caption layer — behaviour pinned.
+ *
+ * The governing property: every line traces to a field in the changeset. There
+ * is no line this module can emit that the diff did not find, and the
+ * "fabricates nothing" tests below are what keep that true.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildVersionLabelIndex, describeChangeset, formatFieldValue } from '../describeChange'
+import { diffModelVersions } from '../diffModelVersions'
+import type { ModelVersion, VersionedEdge, VersionedNode } from '../types'
+
+function node(
+  id: string,
+  label: string,
+  fields: Record<string, string | number | boolean | null> = {},
+  kind = 'factor',
+): VersionedNode {
+  return { id, kind, label, fields }
+}
+
+function edge(
+  id: string,
+  from: string,
+  to: string,
+  fields: Record<string, string | number | boolean | null> = {},
+): VersionedEdge {
+  return { id, from, to, fields }
+}
+
+function version(id: string, nodes: VersionedNode[], edges: VersionedEdge[]): ModelVersion {
+  return { id, name: `version ${id}`, createdAt: 1, origin: 'manual', nodes, edges }
+}
+
+/** Captions the way the panel does it: with a complete label index. */
+function textOf(before: ModelVersion, after: ModelVersion): string[] {
+  return describeChangeset(
+    diffModelVersions(before, after),
+    buildVersionLabelIndex(before, after),
+  ).map((l) => l.text)
+}
+
+describe('formatFieldValue', () => {
+  it('renders absence as "not set", never as a substituted value', () => {
+    expect(formatFieldValue(null)).toBe('not set')
+  })
+
+  it('renders zero as zero, not as absence', () => {
+    expect(formatFieldValue(0)).toBe('0')
+  })
+
+  it('renders an empty string distinctly from absence', () => {
+    expect(formatFieldValue('')).toBe('empty')
+  })
+
+  it('renders booleans in plain words', () => {
+    expect(formatFieldValue(true)).toBe('yes')
+    expect(formatFieldValue(false)).toBe('no')
+  })
+
+  it('trims binary floating-point noise without changing the value', () => {
+    expect(formatFieldValue(0.1 + 0.2)).toBe('0.3')
+    expect(formatFieldValue(0.8)).toBe('0.8')
+  })
+
+  it('quotes strings so an empty-looking value is unambiguous', () => {
+    expect(formatFieldValue('user_set')).toBe('"user_set"')
+  })
+})
+
+describe('describeChangeset', () => {
+  it('produces no lines at all for an empty changeset', () => {
+    const v = version('a', [node('n1', 'Price')], [])
+
+    expect(describeChangeset(diffModelVersions(v, v))).toEqual([])
+  })
+
+  it('describes an added node by kind and name', () => {
+    const a = version('a', [], [])
+    const b = version('b', [node('n1', 'Price', {}, 'factor')], [])
+
+    expect(textOf(a, b)).toEqual(['Factor "Price" added'])
+  })
+
+  it('describes a removed node', () => {
+    const a = version('a', [node('n1', 'Price', {}, 'risk')], [])
+    const b = version('b', [], [])
+
+    expect(textOf(a, b)).toEqual(['Risk "Price" removed'])
+  })
+
+  it('describes a value change with both the before and after values', () => {
+    const a = version('a', [node('n1', 'Price', { 'observedState.value': 0.5 })], [])
+    const b = version('b', [node('n1', 'Price', { 'observedState.value': 0.8 })], [])
+
+    expect(textOf(a, b)).toEqual(['Factor "Price" value 0.5 → 0.8'])
+  })
+
+  it('describes a rename using the field word "name"', () => {
+    const a = version('a', [node('n1', 'Price')], [])
+    const b = version('b', [node('n1', 'Unit price')], [])
+
+    expect(textOf(a, b)).toEqual(['Factor "Unit price" name "Price" → "Unit price"'])
+  })
+
+  it('names edges by their endpoint labels, not raw ids', () => {
+    const nodes = [node('n1', 'Price'), node('n2', 'Revenue')]
+    const a = version('a', nodes, [])
+    const b = version('b', nodes, [edge('e1', 'n1', 'n2')])
+
+    expect(textOf(a, b)).toEqual(['Link Price → Revenue added'])
+  })
+
+  it('resolves a removed edge label from the earlier version', () => {
+    const nodes = [node('n1', 'Price'), node('n2', 'Revenue')]
+    const a = version('a', nodes, [edge('e1', 'n1', 'n2')])
+    const b = version('b', nodes, [])
+
+    expect(textOf(a, b)).toEqual(['Link Price → Revenue removed'])
+  })
+
+  it('falls back to the raw id when an endpoint cannot be resolved', () => {
+    const a = version('a', [], [])
+    const b = version('b', [], [edge('e1', 'ghost1', 'ghost2')])
+
+    expect(textOf(a, b)).toEqual(['Link ghost1 → ghost2 added'])
+  })
+
+  it('resolves an unchanged endpoint only when given a complete index', () => {
+    // The changeset alone cannot name a node that did not change, so the
+    // changeset-only default degrades to raw ids rather than inventing a name.
+    const nodes = [node('n1', 'Price'), node('n2', 'Revenue')]
+    const a = version('a', nodes, [edge('e1', 'n1', 'n2', { weight: 0.5 })])
+    const b = version('b', nodes, [edge('e1', 'n1', 'n2', { weight: 0.9 })])
+    const changeset = diffModelVersions(a, b)
+
+    expect(describeChangeset(changeset).map((l) => l.text)).toEqual([
+      'Link n1 → n2 strength 0.5 → 0.9',
+    ])
+    expect(
+      describeChangeset(changeset, buildVersionLabelIndex(a, b)).map((l) => l.text),
+    ).toEqual(['Link Price → Revenue strength 0.5 → 0.9'])
+  })
+
+  it('prefers the later label when a node was renamed', () => {
+    const a = version('a', [node('n1', 'Price'), node('n2', 'Revenue')], [])
+    const b = version('b', [node('n1', 'Unit price'), node('n2', 'Revenue')], [])
+
+    expect(buildVersionLabelIndex(a, b).get('n1')).toBe('Unit price')
+  })
+
+  it('describes an edge strength change using the user-facing word', () => {
+    const nodes = [node('n1', 'Price'), node('n2', 'Revenue')]
+    const a = version('a', nodes, [edge('e1', 'n1', 'n2', { weight: 0.5 })])
+    const b = version('b', nodes, [edge('e1', 'n1', 'n2', { weight: 0.9 })])
+
+    expect(textOf(a, b)).toEqual(['Link Price → Revenue strength 0.5 → 0.9'])
+  })
+
+  it('renders an unmapped field under its raw name rather than hiding it', () => {
+    const a = version('a', [node('n1', 'Price', { some_new_field: 1 })], [])
+    const b = version('b', [node('n1', 'Price', { some_new_field: 2 })], [])
+
+    expect(textOf(a, b)).toEqual(['Factor "Price" some_new_field 1 → 2'])
+  })
+
+  it('renders a newly-set field as coming from "not set"', () => {
+    const a = version('a', [node('n1', 'Price', {})], [])
+    const b = version('b', [node('n1', 'Price', { utility: 0.4 })], [])
+
+    expect(textOf(a, b)).toEqual(['Factor "Price" payoff not set → 0.4'])
+  })
+
+  it('orders structure before detail: additions, removals, then modifications', () => {
+    const a = version('a', [node('n1', 'Price', { utility: 1 }), node('n2', 'Gone')], [])
+    const b = version('b', [node('n1', 'Price', { utility: 2 }), node('n3', 'New')], [])
+
+    expect(textOf(a, b)).toEqual([
+      'Factor "New" added',
+      'Factor "Gone" removed',
+      'Factor "Price" payoff 1 → 2',
+    ])
+  })
+
+  it('emits one line per changed field, each separately keyed', () => {
+    const a = version('a', [node('n1', 'Price', { utility: 1, body: 'a' })], [])
+    const b = version('b', [node('n1', 'Price', { utility: 2, body: 'c' })], [])
+
+    const lines = describeChangeset(diffModelVersions(a, b))
+
+    expect(lines).toHaveLength(2)
+    expect(new Set(lines.map((l) => l.key)).size).toBe(2)
+  })
+
+  it('tags every line with its scope and kind for rendering', () => {
+    const nodes = [node('n1', 'Price'), node('n2', 'Revenue')]
+    const a = version('a', nodes, [])
+    const b = version('b', [...nodes, node('n3', 'Cost')], [edge('e1', 'n1', 'n2')])
+
+    const lines = describeChangeset(diffModelVersions(a, b))
+
+    expect(lines.find((l) => l.text.includes('Cost'))).toMatchObject({
+      scope: 'node',
+      kind: 'added',
+    })
+    expect(lines.find((l) => l.text.startsWith('Link'))).toMatchObject({
+      scope: 'edge',
+      kind: 'added',
+    })
+  })
+
+  it('fabricates no summary, judgement or count line', () => {
+    const a = version('a', [node('n1', 'Price', { utility: 1 })], [])
+    const b = version('b', [node('n1', 'Price', { utility: 2 }), node('n2', 'Cost')], [])
+
+    const joined = textOf(a, b).join(' | ').toLowerCase()
+
+    for (const forbidden of ['major', 'significant', 'improved', 'weakened', 'you made', 'changes in total']) {
+      expect(joined).not.toContain(forbidden)
+    }
+  })
+
+  it('emits exactly as many lines as the changeset has recorded changes', () => {
+    const a = version('a', [node('n1', 'A', { x: 1 }), node('n2', 'B')], [edge('e1', 'n1', 'n2')])
+    const b = version('b', [node('n1', 'A', { x: 2 }), node('n3', 'C')], [])
+
+    const changeset = diffModelVersions(a, b)
+    const expected =
+      changeset.addedNodes.length +
+      changeset.removedNodes.length +
+      changeset.addedEdges.length +
+      changeset.removedEdges.length +
+      changeset.modifiedNodes.reduce((n, c) => n + c.fields.length, 0) +
+      changeset.modifiedEdges.reduce((n, c) => n + c.fields.length, 0)
+
+    expect(describeChangeset(changeset)).toHaveLength(expected)
+  })
+})

--- a/src/canvas/versions/__tests__/diffModelVersions.spec.ts
+++ b/src/canvas/versions/__tests__/diffModelVersions.spec.ts
@@ -1,0 +1,351 @@
+/**
+ * The canonical diff authority — behaviour pinned.
+ *
+ * BINDING ASSERTION STYLE (CLAUDE.md trap #19): every assertion binds to its
+ * object by IDENTITY (node/edge id, field name), never by a value predicate
+ * another object could satisfy. Fixtures therefore deliberately contain
+ * SEVERAL elements sharing a label and several sharing a value, so a diff that
+ * paired by label or by value would resolve the wrong object and RED here.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { diffModelVersions } from '../diffModelVersions'
+import type { ModelVersion, VersionedNode, VersionedEdge } from '../types'
+
+function node(
+  id: string,
+  label: string,
+  fields: Record<string, string | number | boolean | null> = {},
+  kind = 'factor',
+): VersionedNode {
+  return { id, kind, label, fields }
+}
+
+function edge(
+  id: string,
+  from: string,
+  to: string,
+  fields: Record<string, string | number | boolean | null> = {},
+  label?: string,
+): VersionedEdge {
+  return { id, from, to, label, fields }
+}
+
+function version(
+  id: string,
+  nodes: VersionedNode[],
+  edges: VersionedEdge[],
+  createdAt = 1_000,
+): ModelVersion {
+  return { id, name: `version ${id}`, createdAt, origin: 'manual', nodes, edges }
+}
+
+describe('diffModelVersions', () => {
+  it('reports no changes between a version and itself', () => {
+    const v = version('a', [node('n1', 'Price', { value: 0.5 })], [edge('e1', 'n1', 'n2')])
+
+    const cs = diffModelVersions(v, v)
+
+    expect(cs.isEmpty).toBe(true)
+    expect(cs.addedNodes).toHaveLength(0)
+    expect(cs.removedNodes).toHaveLength(0)
+    expect(cs.modifiedNodes).toHaveLength(0)
+    expect(cs.addedEdges).toHaveLength(0)
+    expect(cs.removedEdges).toHaveLength(0)
+    expect(cs.modifiedEdges).toHaveLength(0)
+  })
+
+  it('carries both version refs so a caption can name what was compared', () => {
+    const a: ModelVersion = {
+      id: 'va',
+      name: 'Before the board review',
+      createdAt: 111,
+      origin: 'manual',
+      nodes: [],
+      edges: [],
+    }
+    const b: ModelVersion = {
+      id: 'vb',
+      name: 'After the board review',
+      createdAt: 222,
+      origin: 'manual',
+      nodes: [],
+      edges: [],
+    }
+
+    const cs = diffModelVersions(a, b)
+
+    expect(cs.from).toEqual({ id: 'va', name: 'Before the board review', createdAt: 111 })
+    expect(cs.to).toEqual({ id: 'vb', name: 'After the board review', createdAt: 222 })
+  })
+
+  describe('node identity', () => {
+    it('pairs nodes by id, not by label — a renamed node is MODIFIED, not add+remove', () => {
+      const a = version('a', [node('n1', 'Price')], [])
+      const b = version('b', [node('n1', 'Unit price')], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.addedNodes).toHaveLength(0)
+      expect(cs.removedNodes).toHaveLength(0)
+      expect(cs.modifiedNodes).toHaveLength(1)
+      expect(cs.modifiedNodes[0]!.id).toBe('n1')
+      expect(cs.modifiedNodes[0]!.fields).toEqual([
+        { field: 'label', before: 'Price', after: 'Unit price' },
+      ])
+    })
+
+    it('does NOT pair two distinct nodes that share a label', () => {
+      // n1 and n2 both read "Cost" — a label-keyed diff would pair them and
+      // report zero changes. Identity keeps them separate.
+      const a = version('a', [node('n1', 'Cost', { value: 1 }), node('n2', 'Cost', { value: 2 })], [])
+      const b = version('b', [node('n1', 'Cost', { value: 9 }), node('n2', 'Cost', { value: 2 })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes.map((n) => n.id)).toEqual(['n1'])
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: 1, after: 9 }])
+    })
+
+    it('reports an added node by id', () => {
+      const a = version('a', [node('n1', 'Price')], [])
+      const b = version('b', [node('n1', 'Price'), node('n2', 'Volume')], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.addedNodes.map((n) => n.id)).toEqual(['n2'])
+      expect(cs.removedNodes).toHaveLength(0)
+      expect(cs.modifiedNodes).toHaveLength(0)
+    })
+
+    it('reports a removed node by id', () => {
+      const a = version('a', [node('n1', 'Price'), node('n2', 'Volume')], [])
+      const b = version('b', [node('n1', 'Price')], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.removedNodes.map((n) => n.id)).toEqual(['n2'])
+      expect(cs.addedNodes).toHaveLength(0)
+    })
+
+    it('uses the LATER label and kind on a modified node', () => {
+      const a = version('a', [node('n1', 'Price', { value: 1 }, 'factor')], [])
+      const b = version('b', [node('n1', 'Unit price', { value: 2 }, 'outcome')], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.label).toBe('Unit price')
+      expect(cs.modifiedNodes[0]!.kind).toBe('outcome')
+    })
+  })
+
+  describe('field-level node changes', () => {
+    it('reports only the fields that actually differ', () => {
+      const a = version('a', [node('n1', 'Price', { value: 0.5, unit: '£', utility: 1 })], [])
+      const b = version('b', [node('n1', 'Price', { value: 0.8, unit: '£', utility: 1 })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: 0.5, after: 0.8 }])
+    })
+
+    it('treats a field appearing as a change from null', () => {
+      const a = version('a', [node('n1', 'Price', {})], [])
+      const b = version('b', [node('n1', 'Price', { value: 0.8 })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: null, after: 0.8 }])
+    })
+
+    it('treats a field disappearing as a change to null', () => {
+      const a = version('a', [node('n1', 'Price', { value: 0.8 })], [])
+      const b = version('b', [node('n1', 'Price', {})], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: 0.8, after: null }])
+    })
+
+    it('does not confuse the number 0 with an absent field', () => {
+      // 0 is falsy; a truthiness-based presence check would call this "absent"
+      // and report no change at all.
+      const a = version('a', [node('n1', 'Price', { value: 0 })], [])
+      const b = version('b', [node('n1', 'Price', {})], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: 0, after: null }])
+    })
+
+    it('does not confuse the empty string with an absent field', () => {
+      const a = version('a', [node('n1', 'Price', { unit: '' })], [])
+      const b = version('b', [node('n1', 'Price', {})], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'unit', before: '', after: null }])
+    })
+
+    it('does not confuse false with an absent field', () => {
+      const a = version('a', [node('n1', 'Price', { pinned: false })], [])
+      const b = version('b', [node('n1', 'Price', {})], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'pinned', before: false, after: null }])
+    })
+
+    it('does not report a node whose fields are unchanged but reordered', () => {
+      const a = version('a', [node('n1', 'Price', { value: 1, unit: '£' })], [])
+      const b = version('b', [node('n1', 'Price', { unit: '£', value: 1 })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.isEmpty).toBe(true)
+    })
+
+    it('orders field changes deterministically by field name', () => {
+      const a = version('a', [node('n1', 'Price', { zeta: 1, alpha: 1, mid: 1 })], [])
+      const b = version('b', [node('n1', 'Price', { zeta: 2, alpha: 2, mid: 2 })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields.map((f) => f.field)).toEqual(['alpha', 'mid', 'zeta'])
+    })
+
+    it('distinguishes the number 1 from the string "1"', () => {
+      const a = version('a', [node('n1', 'Price', { value: 1 })], [])
+      const b = version('b', [node('n1', 'Price', { value: '1' })], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedNodes[0]!.fields).toEqual([{ field: 'value', before: 1, after: '1' }])
+    })
+  })
+
+  describe('edge identity', () => {
+    it('pairs edges by id and reports a re-pointed edge as modified', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2')])
+      const b = version('b', [], [edge('e1', 'n1', 'n3')])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.addedEdges).toHaveLength(0)
+      expect(cs.removedEdges).toHaveLength(0)
+      expect(cs.modifiedEdges).toHaveLength(1)
+      expect(cs.modifiedEdges[0]!.id).toBe('e1')
+      expect(cs.modifiedEdges[0]!.fields).toEqual([{ field: 'to', before: 'n2', after: 'n3' }])
+    })
+
+    it('reports an added edge by id', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2')])
+      const b = version('b', [], [edge('e1', 'n1', 'n2'), edge('e2', 'n2', 'n3')])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.addedEdges.map((e) => e.id)).toEqual(['e2'])
+    })
+
+    it('reports a removed edge by id', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2'), edge('e2', 'n2', 'n3')])
+      const b = version('b', [], [edge('e1', 'n1', 'n2')])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.removedEdges.map((e) => e.id)).toEqual(['e2'])
+    })
+
+    it('does NOT pair two distinct edges that share the same endpoints', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2', { weight: 1 }), edge('e2', 'n1', 'n2', { weight: 2 })])
+      const b = version('b', [], [edge('e1', 'n1', 'n2', { weight: 5 }), edge('e2', 'n1', 'n2', { weight: 2 })])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedEdges.map((e) => e.id)).toEqual(['e1'])
+      expect(cs.modifiedEdges[0]!.fields).toEqual([{ field: 'weight', before: 1, after: 5 }])
+    })
+
+    it('reports an edge strength change field-level', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2', { weight: 0.5, beliefExists: 0.8 })])
+      const b = version('b', [], [edge('e1', 'n1', 'n2', { weight: 0.9, beliefExists: 0.8 })])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedEdges[0]!.fields).toEqual([{ field: 'weight', before: 0.5, after: 0.9 }])
+    })
+
+    it('reports an edge label change and carries the later endpoints', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2', {}, 'drives')])
+      const b = version('b', [], [edge('e1', 'n1', 'n2', {}, 'strongly drives')])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.modifiedEdges[0]!.label).toBe('strongly drives')
+      expect(cs.modifiedEdges[0]!.from).toBe('n1')
+      expect(cs.modifiedEdges[0]!.to).toBe('n2')
+      expect(cs.modifiedEdges[0]!.fields).toEqual([
+        { field: 'label', before: 'drives', after: 'strongly drives' },
+      ])
+    })
+  })
+
+  describe('determinism and ordering', () => {
+    it('orders added/removed/modified collections by id', () => {
+      const a = version('a', [node('n3', 'C'), node('n1', 'A')], [])
+      const b = version('b', [node('n2', 'B'), node('n4', 'D'), node('n1', 'A')], [])
+
+      const cs = diffModelVersions(a, b)
+
+      expect(cs.addedNodes.map((n) => n.id)).toEqual(['n2', 'n4'])
+      expect(cs.removedNodes.map((n) => n.id)).toEqual(['n3'])
+    })
+
+    it('is asymmetric — swapping the arguments swaps added and removed', () => {
+      const a = version('a', [node('n1', 'Price')], [])
+      const b = version('b', [node('n1', 'Price'), node('n2', 'Volume')], [])
+
+      const forward = diffModelVersions(a, b)
+      const backward = diffModelVersions(b, a)
+
+      expect(forward.addedNodes.map((n) => n.id)).toEqual(['n2'])
+      expect(backward.removedNodes.map((n) => n.id)).toEqual(['n2'])
+      expect(backward.addedNodes).toHaveLength(0)
+    })
+
+    it('does not mutate either input version', () => {
+      const a = version('a', [node('n1', 'Price', { value: 1 })], [edge('e1', 'n1', 'n2')])
+      const b = version('b', [node('n1', 'Price', { value: 2 })], [])
+      const snapshotA = JSON.stringify(a)
+      const snapshotB = JSON.stringify(b)
+
+      diffModelVersions(a, b)
+
+      expect(JSON.stringify(a)).toBe(snapshotA)
+      expect(JSON.stringify(b)).toBe(snapshotB)
+    })
+  })
+
+  describe('isEmpty', () => {
+    it('is false when only an edge changed', () => {
+      const a = version('a', [], [edge('e1', 'n1', 'n2', { weight: 1 })])
+      const b = version('b', [], [edge('e1', 'n1', 'n2', { weight: 2 })])
+
+      expect(diffModelVersions(a, b).isEmpty).toBe(false)
+    })
+
+    it('is false when only a node was added', () => {
+      const a = version('a', [], [])
+      const b = version('b', [node('n1', 'Price')], [])
+
+      expect(diffModelVersions(a, b).isEmpty).toBe(false)
+    })
+
+    it('is true for two structurally identical but distinct versions', () => {
+      const a = version('a', [node('n1', 'Price', { value: 1 })], [edge('e1', 'n1', 'n2')])
+      const b = version('b', [node('n1', 'Price', { value: 1 })], [edge('e1', 'n1', 'n2')], 9_999)
+
+      expect(diffModelVersions(a, b).isEmpty).toBe(true)
+    })
+  })
+})

--- a/src/canvas/versions/__tests__/versionStorage.spec.ts
+++ b/src/canvas/versions/__tests__/versionStorage.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * Version persistence — behaviour pinned.
+ *
+ * The guest assertion is the one that matters: nothing in this module consults
+ * an identity, so a signed-out session gets a fully working feature. That is
+ * the defect at `compare-tab/useCompareHistoryHydration.ts:79` NOT repeated.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  MAX_VERSIONS,
+  VERSIONS_STORAGE_KEY,
+  appendVersion,
+  clearVersions,
+  deleteVersion,
+  loadVersions,
+  saveVersions,
+} from '../versionStorage'
+import type { ModelVersion } from '../types'
+
+function version(id: string, createdAt: number, name = `v-${id}`): ModelVersion {
+  return {
+    id,
+    name,
+    createdAt,
+    origin: 'manual',
+    nodes: [{ id: 'n1', kind: 'factor', label: 'Price', fields: { value: 1 } }],
+    edges: [],
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+describe('versionStorage', () => {
+  it('returns an empty list when nothing is stored', () => {
+    expect(loadVersions()).toEqual([])
+  })
+
+  it('round-trips a saved version', () => {
+    const saved = saveVersions([version('a', 100)])
+
+    expect(saved.success).toBe(true)
+    expect(loadVersions().map((v) => v.id)).toEqual(['a'])
+  })
+
+  it('works with NO user identity present — guests get a working feature', () => {
+    // There is no auth stub anywhere in this file. If this module ever grew a
+    // userId guard, this test would be the one that reds.
+    appendVersion(version('guest-save', 1))
+
+    expect(loadVersions().map((v) => v.id)).toEqual(['guest-save'])
+  })
+
+  it('returns versions newest first regardless of insertion order', () => {
+    saveVersions([version('old', 100), version('new', 300), version('mid', 200)])
+
+    expect(loadVersions().map((v) => v.id)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('appends to the front and keeps existing versions', () => {
+    appendVersion(version('first', 100))
+    appendVersion(version('second', 200))
+
+    expect(loadVersions().map((v) => v.id)).toEqual(['second', 'first'])
+  })
+
+  it('prunes to MAX_VERSIONS, dropping the oldest', () => {
+    const many = Array.from({ length: MAX_VERSIONS + 5 }, (_, i) => version(`v${i}`, i))
+
+    const result = saveVersions(many)
+
+    expect(result.success).toBe(true)
+    const stored = loadVersions()
+    expect(stored).toHaveLength(MAX_VERSIONS)
+    // Newest kept, oldest dropped.
+    expect(stored[0]!.id).toBe(`v${MAX_VERSIONS + 4}`)
+    expect(stored.map((v) => v.id)).not.toContain('v0')
+  })
+
+  it('deletes one version by id and leaves the rest', () => {
+    saveVersions([version('a', 100), version('b', 200), version('c', 300)])
+
+    deleteVersion('b')
+
+    expect(loadVersions().map((v) => v.id)).toEqual(['c', 'a'])
+  })
+
+  it('deletes the LAST remaining version', () => {
+    // Regression: the shedding loop stops at 1, so an empty write once fell
+    // through to a false QUOTA_EXCEEDED and the delete silently did nothing.
+    saveVersions([version('only', 100)])
+
+    const result = deleteVersion('only')
+
+    expect(result.success).toBe(true)
+    expect(loadVersions()).toEqual([])
+  })
+
+  it('saving an empty list succeeds and clears the store', () => {
+    saveVersions([version('a', 100)])
+
+    const result = saveVersions([])
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual([])
+    expect(loadVersions()).toEqual([])
+  })
+
+  it('deleting an unknown id is a no-op, not an error', () => {
+    saveVersions([version('a', 100)])
+
+    const result = deleteVersion('does-not-exist')
+
+    expect(result.success).toBe(true)
+    expect(loadVersions().map((v) => v.id)).toEqual(['a'])
+  })
+
+  it('clears every version', () => {
+    saveVersions([version('a', 100), version('b', 200)])
+
+    clearVersions()
+
+    expect(loadVersions()).toEqual([])
+  })
+
+  it('preserves the captured graph contents through a round trip', () => {
+    const original = version('a', 100)
+    original.nodes[0]!.fields = { value: 0, unit: '', flagged: false }
+
+    saveVersions([original])
+
+    expect(loadVersions()[0]!.nodes[0]!.fields).toEqual({ value: 0, unit: '', flagged: false })
+  })
+
+  describe('corrupt or hostile stored data', () => {
+    it('treats unparseable JSON as empty and warns', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem(VERSIONS_STORAGE_KEY, '{not json')
+
+      expect(loadVersions()).toEqual([])
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('treats a payload whose data is not an array as empty', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem(
+        VERSIONS_STORAGE_KEY,
+        JSON.stringify({ schema: 'x', version: '1', timestamp: 1, data: { nope: true } }),
+      )
+
+      expect(loadVersions()).toEqual([])
+    })
+
+    it('drops individually malformed entries but keeps the valid ones', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem(
+        VERSIONS_STORAGE_KEY,
+        JSON.stringify({
+          schema: 'x',
+          version: '1',
+          timestamp: 1,
+          data: [version('good', 100), { id: 'bad' }, null],
+        }),
+      )
+
+      expect(loadVersions().map((v) => v.id)).toEqual(['good'])
+      expect(warn).toHaveBeenCalled()
+    })
+  })
+
+  describe('quota exhaustion', () => {
+    it('sheds the oldest versions and reports success with what it kept', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let calls = 0
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        calls += 1
+        // Reject the first two attempts (3 versions, then 2); accept the third.
+        if (calls < 3) {
+          const error = new Error('quota')
+          error.name = 'QuotaExceededError'
+          throw error
+        }
+      })
+
+      const result = saveVersions([version('a', 300), version('b', 200), version('c', 100)])
+
+      expect(result.success).toBe(true)
+      // Newest survives, oldest two shed.
+      expect(result.success && result.data.map((v) => v.id)).toEqual(['a'])
+      expect(calls).toBe(3)
+    })
+
+    it('reports a real failure when even one version will not fit', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        const error = new Error('quota')
+        error.name = 'QuotaExceededError'
+        throw error
+      })
+
+      const result = saveVersions([version('a', 100)])
+
+      expect(result.success).toBe(false)
+      expect(result.success === false && result.error.type).toBe('QUOTA_EXCEEDED')
+    })
+
+    it('reports a non-quota write failure rather than swallowing it', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('security error')
+      })
+
+      const result = saveVersions([version('a', 100)])
+
+      expect(result.success).toBe(false)
+      expect(result.success === false && result.error.type).toBe('UNKNOWN')
+    })
+  })
+})

--- a/src/canvas/versions/autoCapture.ts
+++ b/src/canvas/versions/autoCapture.ts
@@ -1,0 +1,59 @@
+/**
+ * Automatic capture immediately before a destructive ingest.
+ * British English: visualisation, colour, initialise.
+ *
+ * WHY THIS EXISTS. `applyDraftResult` replaces the whole graph wholesale. A
+ * user who has spent an hour shaping a model and then asks a follow-up question
+ * can have that model replaced by a draft. Undo covers one step; a named
+ * version they can read and compare is what makes the loss recoverable and
+ * VISIBLE.
+ *
+ * WHERE IT FIRES, AND WHY EXACTLY THERE. `applyDraftResult` runs TWICE for one
+ * streamed turn — a GRAPH_READY preview at ~36 s and the terminal payload at
+ * ~61 s — and `opts.skipHistory` is `true` on the second. The pre-draft canvas
+ * therefore only exists at the FIRST call; by the second, the store already
+ * holds the preview graph. So this fires on exactly the same condition as
+ * `store.pushHistory()` — capture the user's model, once, while it is still
+ * there. Keying off anything else would snapshot the preview and call it the
+ * user's work.
+ *
+ * IT MUST NEVER BREAK THE INGEST. Every failure is swallowed with a warning.
+ * A version is a safety net; a safety net that can take down the canvas is
+ * worse than no net. This is the one place in the namespace where an exception
+ * is deliberately quiet, and the reason is that the user's actual request —
+ * "draft me a graph" — must still succeed.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import { captureModelVersion } from './captureModelVersion'
+import { appendVersion } from './versionStorage'
+
+/**
+ * Capture the current graph as an automatic version, if there is anything
+ * worth keeping.
+ *
+ * No-ops on an empty canvas: replacing nothing is not a loss, and a list
+ * cluttered with empty auto-saves would bury the versions the user named.
+ */
+export function captureBeforeIngest(nodes: readonly Node[], edges: readonly Edge[]): void {
+  try {
+    if (nodes.length === 0) return
+
+    const createdAt = Date.now()
+    const version = captureModelVersion(nodes, edges, {
+      id: `ver_auto_${createdAt}_${Math.random().toString(36).slice(2, 11)}`,
+      // Names what happened, in the user's terms. No claim about the draft's
+      // quality or about what changed — that is the changeset's job.
+      name: 'Before Olumi redrafted the model',
+      origin: 'pre-ingest',
+      createdAt,
+    })
+
+    const result = appendVersion(version)
+    if (!result.success) {
+      console.warn('[versions] Could not capture a version before redraft:', result.error.message)
+    }
+  } catch (error) {
+    console.warn('[versions] Version capture before redraft failed; ingest continues', error)
+  }
+}

--- a/src/canvas/versions/captureModelVersion.ts
+++ b/src/canvas/versions/captureModelVersion.ts
@@ -1,0 +1,208 @@
+/**
+ * Projection: live canvas graph -> a comparable `ModelVersion`.
+ * British English: visualisation, colour, initialise.
+ *
+ * DERIVED, NOT MIRRORED (CLAUDE.md trap #12)
+ * ------------------------------------------
+ * The set of captured fields is DERIVED from whatever the node/edge data bag
+ * actually carries — every own scalar field is captured — minus a small,
+ * explicit denylist of PRESENTATION and EPHEMERAL keys. It is deliberately not
+ * a hand-listed allowlist of domain fields.
+ *
+ * Why: `EdgeDataSchema` alone carries ~30 fields and grows; an allowlist would
+ * be a list somebody must remember to update, it would drift silently, and the
+ * drift would read as green — a version that simply stopped recording a field
+ * the user edits, with nothing anywhere going red. That is the estate's
+ * dominant defect class.
+ *
+ * THE TRADE-OFF, STATED HONESTLY: with a denylist, a newly-added PRESENTATION
+ * field that nobody denylists will surface as a visible "change" in the What
+ * Changed panel. That is the failure direction we want — a visible, obviously
+ * wrong row that gets fixed, rather than a silently omitted user edit. Prefer
+ * visible failure over confident wrongness.
+ *
+ * NEVER FABRICATE, NEVER RE-STAMP
+ * -------------------------------
+ * Absent stays absent. This module applies NO defaults: not `weight = 0.5`,
+ * not `direction = 'positive'`, not a provenance marker. The four edge
+ * `*Source` markers (`weightSource`, `beliefExistsSource`, `strengthStdSource`,
+ * `directionSource`) are load-bearing honesty markers whose ABSENCE MEANS
+ * DEFAULTED (`domain/edgeValueProvenance.ts`); stamping one here would launder
+ * a UI default into a claim that somebody set the value. They are copied when
+ * present and never invented.
+ *
+ * NO SCHEMA PARSE ON THE WAY IN. `AnyNodeDataSchema` is a strict discriminated
+ * union that STRIPS undeclared keys, and several live renderer fields
+ * (`success_threshold`, `goal_threshold_raw`, `goal_threshold_unit`,
+ * `threshold_source`, `flagged_as_assumption`) are undeclared. Parsing here
+ * would silently destroy user data (`domain/nodes.ts:325-366` documents this;
+ * the passthrough variant is `AnyNodeDataImportSchema`). The data bag is read
+ * as the open bag it is.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import type { FieldValue, ModelVersion, VersionOrigin, VersionedEdge, VersionedNode } from './types'
+
+/**
+ * Presentation, layout and ephemeral keys. Excluded because a change to one is
+ * not a change to the user's REASONING — the thing a version records.
+ *
+ * Scoped to genuine presentation concerns only. When in doubt, leave a field
+ * IN: an over-reported change is visible and correctable, an omitted one is
+ * silent.
+ */
+const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
+  // Identity / structure, carried explicitly on the version element instead.
+  'id',
+  'label',
+  'type',
+  'kind',
+  // Edge geometry and styling.
+  'style',
+  'curvature',
+  'pathType',
+  'animated',
+  'markerEnd',
+  'markerStart',
+  'sourceHandle',
+  'targetHandle',
+  // React Flow interaction state.
+  'selected',
+  'dragging',
+  'hidden',
+  'zIndex',
+  'width',
+  'height',
+  'position',
+  'positionAbsolute',
+  // Bookkeeping that is not user reasoning.
+  'schemaVersion',
+  'templateId',
+])
+
+function isFieldValue(value: unknown): value is FieldValue {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+/**
+ * Collect every own scalar field from a data bag, minus the denylist.
+ *
+ * `observedState` is the one nested object flattened (one level, dotted keys
+ * such as `observedState.value`), because it is the primary carrier of factor
+ * VALUES — precisely what a user edits and expects a version to record.
+ * Other nested structures (`interventions`, `functionParams`, `causal_claims`,
+ * `validation`, the `prior` distribution object) are NOT flattened and NOT
+ * captured: they cannot be compared or captioned honestly at field level in
+ * this slice, and inventing a rendering for them would be a fabricated claim.
+ * DESIGN.md records this as a known, deliberate gap.
+ */
+function collectFields(bag: Readonly<Record<string, unknown>>): Record<string, FieldValue> {
+  const fields: Record<string, FieldValue> = {}
+
+  for (const [key, value] of Object.entries(bag)) {
+    if (EXCLUDED_FIELDS.has(key)) continue
+
+    if (isFieldValue(value)) {
+      fields[key] = value
+      continue
+    }
+
+    if (key === 'observedState' && value && typeof value === 'object' && !Array.isArray(value)) {
+      for (const [innerKey, innerValue] of Object.entries(value as Record<string, unknown>)) {
+        if (isFieldValue(innerValue)) fields[`observedState.${innerKey}`] = innerValue
+      }
+    }
+  }
+
+  return fields
+}
+
+function labelOf(bag: Readonly<Record<string, unknown>>, fallback: string): string {
+  const label = bag.label
+  return typeof label === 'string' && label.length > 0 ? label : fallback
+}
+
+/**
+ * Project a live canvas node into its versioned form.
+ *
+ * `kind` prefers the node's data `kind` (the backend classification) and falls
+ * back to the React Flow `type`, matching how the canvas itself resolves a
+ * node's taxonomy on ingest (`applyDraftResult.mapDraftNodeToCanvas`).
+ */
+export function captureNode(node: Node): VersionedNode {
+  const bag = (node.data ?? {}) as Record<string, unknown>
+  const kind = typeof bag.kind === 'string' ? bag.kind : (node.type ?? 'unknown')
+
+  return {
+    id: node.id,
+    kind,
+    label: labelOf(bag, node.id),
+    fields: collectFields(bag),
+  }
+}
+
+/** Project a live canvas edge into its versioned form. */
+export function captureEdge(edge: Edge): VersionedEdge {
+  const bag = (edge.data ?? {}) as Record<string, unknown>
+  const label = bag.label
+
+  return {
+    id: edge.id,
+    from: edge.source,
+    to: edge.target,
+    label: typeof label === 'string' ? label : undefined,
+    fields: collectFields(bag),
+  }
+}
+
+export interface CaptureOptions {
+  name: string
+  origin: VersionOrigin
+  /** Unix ms. Injected so capture stays pure and testable. */
+  createdAt: number
+  /** Version id. Injected for the same reason. */
+  id: string
+  /**
+   * Opaque analysis graph hash, ONLY when the caller already holds one from an
+   * analysis fact.
+   *
+   * ⚠ NOT WIRED IN THIS SLICE, deliberately. There is no `graphHash` field on
+   * `useCanvasStore`, and the two places a hash is actually held are both
+   * unavailable to this lane: the compare-tab snapshot store (mid-retirement,
+   * out of bounds) and local run history (whose header forbids backing a "what
+   * changed" surface off it). Rather than compute one — which would mean
+   * choosing between two same-named `generateGraphHash` twins, seeded and
+   * seedless, that produce mutually incomparable values — the parameter is
+   * accepted and left unsupplied. A version simply carries no hash today.
+   * DESIGN.md states the precise ask that would make this stampable.
+   */
+  graphHash?: string
+}
+
+/**
+ * Capture the current canvas graph as a `ModelVersion`.
+ *
+ * Pure: takes the graph and the metadata, returns a value. It does not read
+ * the store, generate ids, or read the clock — callers supply those, so this
+ * is fully testable and cannot drift with ambient state.
+ */
+export function captureModelVersion(
+  nodes: readonly Node[],
+  edges: readonly Edge[],
+  options: CaptureOptions,
+): ModelVersion {
+  return {
+    id: options.id,
+    name: options.name,
+    createdAt: options.createdAt,
+    origin: options.origin,
+    ...(options.graphHash === undefined ? {} : { graphHash: options.graphHash }),
+    nodes: nodes.map(captureNode),
+    edges: edges.map(captureEdge),
+  }
+}

--- a/src/canvas/versions/describeChange.ts
+++ b/src/canvas/versions/describeChange.ts
@@ -1,0 +1,224 @@
+/**
+ * Changeset -> plain-language lines.
+ * British English: visualisation, colour, initialise.
+ *
+ * ENCODE BEFORE CAPTION. This module is the ONLY place a sentence is produced,
+ * and it produces sentences from nothing but the typed `ModelChangeset`. It
+ * cannot say anything the diff did not find: there is no store access, no
+ * summarisation, no ranking, no "this looks significant". If a line appears on
+ * screen, a field in the changeset produced it.
+ *
+ * NO FABRICATED SUMMARIES. There is deliberately no "you made 3 major changes"
+ * or "this weakened your model" line anywhere. Those are judgements the product
+ * has not earned and the changeset cannot support.
+ *
+ * FIELD NAMING IS DISPLAY-ONLY. `FIELD_LABELS` maps a few storage field names
+ * to the words the UI already uses for them elsewhere. It is display naming,
+ * not a semantic transform: no value is altered, and ANY unmapped field falls
+ * through to its raw name, so a newly added field is rendered honestly (if
+ * awkwardly) rather than silently hidden.
+ */
+
+import type {
+  EdgeChange,
+  FieldChange,
+  FieldValue,
+  ModelChangeset,
+  ModelVersion,
+  NodeChange,
+} from './types'
+
+export interface ChangeLine {
+  /** Stable React key — element id plus field, unique within a changeset. */
+  key: string
+  scope: 'node' | 'edge'
+  kind: 'added' | 'removed' | 'modified'
+  text: string
+}
+
+/**
+ * Display names for storage fields, using the vocabulary the rest of the
+ * canvas already shows the user. Unmapped fields fall back to the raw name.
+ */
+const FIELD_LABELS: Readonly<Record<string, string>> = {
+  label: 'name',
+  weight: 'strength',
+  beliefExists: 'confidence it exists',
+  beliefStrength: 'effect size',
+  strengthStd: 'uncertainty',
+  strength_mean: 'signed strength',
+  exists_probability: 'probability it exists',
+  direction: 'direction',
+  confidence: 'branch probability',
+  utility: 'payoff',
+  prior: 'prior probability',
+  probability: 'likelihood',
+  provenance: 'source',
+  provenanceDisplay: 'source',
+  description: 'description',
+  body: 'notes',
+  kind: 'type',
+  from: 'start',
+  to: 'end',
+  'observedState.value': 'value',
+  'observedState.raw_value': 'value as entered',
+  'observedState.unit': 'unit',
+  'observedState.baseline': 'baseline',
+  'observedState.display_value': 'displayed value',
+}
+
+function fieldLabel(field: string): string {
+  return FIELD_LABELS[field] ?? field
+}
+
+/**
+ * Render a stored value for reading.
+ *
+ * `null` becomes "not set" — a faithful rendering of absence, not a
+ * substituted value. Numbers are printed as-is apart from trimming binary
+ * floating-point noise, which is presentation, not rounding for effect.
+ */
+export function formatFieldValue(value: FieldValue): string {
+  if (value === null) return 'not set'
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return String(value)
+    return String(Number.parseFloat(value.toFixed(6)))
+  }
+  return value.length === 0 ? 'empty' : `"${value}"`
+}
+
+/** Sentence-case a node kind for reading ("factor" -> "Factor"). */
+function kindLabel(kind: string): string {
+  if (kind.length === 0) return 'Element'
+  return kind.charAt(0).toUpperCase() + kind.slice(1)
+}
+
+function describeField(change: FieldChange): string {
+  return `${fieldLabel(change.field)} ${formatFieldValue(change.before)} → ${formatFieldValue(change.after)}`
+}
+
+/**
+ * Resolve a node id to a readable label.
+ *
+ * Falls back to the raw id when the node is unknown, which is honest: the id
+ * is what we have, and inventing a friendly name for an element we cannot
+ * resolve would be a fabrication.
+ */
+function resolveLabel(labels: ReadonlyMap<string, string>, id: string): string {
+  return labels.get(id) ?? id
+}
+
+function edgeTitle(labels: ReadonlyMap<string, string>, from: string, to: string): string {
+  return `${resolveLabel(labels, from)} → ${resolveLabel(labels, to)}`
+}
+
+/**
+ * Build a label lookup from the changeset alone.
+ *
+ * ⚠ NECESSARILY INCOMPLETE, and that is why `describeChangeset` accepts a
+ * better index. A changeset only mentions elements that CHANGED, so an edge
+ * whose endpoints were untouched has no label available here and renders by
+ * raw id. Callers holding the two versions should pass
+ * `buildVersionLabelIndex(before, after)` instead. Rendering an id is the
+ * honest degradation; inventing a name for an unresolvable node would not be.
+ */
+export function buildLabelIndex(changeset: ModelChangeset): Map<string, string> {
+  const labels = new Map<string, string>()
+  for (const node of changeset.removedNodes) labels.set(node.id, node.label)
+  for (const node of changeset.addedNodes) labels.set(node.id, node.label)
+  for (const node of changeset.modifiedNodes) labels.set(node.id, node.label)
+  return labels
+}
+
+/**
+ * Build a complete label lookup from whole versions.
+ *
+ * Pass the EARLIER version first and the LATER one second: later entries
+ * overwrite earlier ones, so a renamed node reads by its current name while a
+ * node that exists only in the earlier version (deleted) still resolves.
+ */
+export function buildVersionLabelIndex(...versions: readonly ModelVersion[]): Map<string, string> {
+  const labels = new Map<string, string>()
+  for (const version of versions) {
+    for (const node of version.nodes) labels.set(node.id, node.label)
+  }
+  return labels
+}
+
+function describeNode(change: NodeChange): ChangeLine[] {
+  return change.fields.map((field) => ({
+    key: `node:${change.id}:${field.field}`,
+    scope: 'node' as const,
+    kind: 'modified' as const,
+    text: `${kindLabel(change.kind)} "${change.label}" ${describeField(field)}`,
+  }))
+}
+
+function describeEdge(change: EdgeChange, labels: ReadonlyMap<string, string>): ChangeLine[] {
+  return change.fields.map((field) => ({
+    key: `edge:${change.id}:${field.field}`,
+    scope: 'edge' as const,
+    kind: 'modified' as const,
+    text: `Link ${edgeTitle(labels, change.from, change.to)} ${describeField(field)}`,
+  }))
+}
+
+/**
+ * Turn a changeset into ordered, readable lines.
+ *
+ * Order is additions, then removals, then modifications, nodes before edges —
+ * structure before detail, which is how a person reads a model change. Within
+ * each group the changeset's own deterministic id ordering is preserved.
+ *
+ * @param labels optional complete node-label index. Defaults to what the
+ * changeset alone can supply, which cannot name unchanged endpoints — pass
+ * `buildVersionLabelIndex(before, after)` when the versions are to hand.
+ */
+export function describeChangeset(
+  changeset: ModelChangeset,
+  labels: ReadonlyMap<string, string> = buildLabelIndex(changeset),
+): ChangeLine[] {
+  const lines: ChangeLine[] = []
+
+  for (const node of changeset.addedNodes) {
+    lines.push({
+      key: `node-added:${node.id}`,
+      scope: 'node',
+      kind: 'added',
+      text: `${kindLabel(node.kind)} "${node.label}" added`,
+    })
+  }
+
+  for (const edge of changeset.addedEdges) {
+    lines.push({
+      key: `edge-added:${edge.id}`,
+      scope: 'edge',
+      kind: 'added',
+      text: `Link ${edgeTitle(labels, edge.from, edge.to)} added`,
+    })
+  }
+
+  for (const node of changeset.removedNodes) {
+    lines.push({
+      key: `node-removed:${node.id}`,
+      scope: 'node',
+      kind: 'removed',
+      text: `${kindLabel(node.kind)} "${node.label}" removed`,
+    })
+  }
+
+  for (const edge of changeset.removedEdges) {
+    lines.push({
+      key: `edge-removed:${edge.id}`,
+      scope: 'edge',
+      kind: 'removed',
+      text: `Link ${edgeTitle(labels, edge.from, edge.to)} removed`,
+    })
+  }
+
+  for (const node of changeset.modifiedNodes) lines.push(...describeNode(node))
+  for (const edge of changeset.modifiedEdges) lines.push(...describeEdge(edge, labels))
+
+  return lines
+}

--- a/src/canvas/versions/diffModelVersions.ts
+++ b/src/canvas/versions/diffModelVersions.ts
@@ -1,0 +1,201 @@
+/**
+ * THE canonical diff authority for model versions.
+ * British English: visualisation, colour, initialise.
+ *
+ * ONE DIFF, ONE PLACE. Every surface that reports what changed between two
+ * versions of the user's model consumes `diffModelVersions` and the
+ * `ModelChangeset` it returns. Restore and variants, when they land, consume
+ * the same function. Do not add a second implementation — the estate already
+ * carries the cost of that pattern elsewhere (two same-named `generateGraphHash`
+ * twins, CLAUDE.md trap #10; a separate `VisualDiff` in the unwired
+ * `canvas/snapshots/` module).
+ *
+ * PURE BY CONSTRUCTION. No store reads, no storage, no clock, no React. Given
+ * the same two versions it returns the same changeset, and it never mutates
+ * either argument. This is what makes it testable without a canvas mount and
+ * reusable from any surface.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ * --------------------------------
+ * It does not interpret, rank, summarise or explain. It reports the fields
+ * that differ and nothing else — captions are built from the changeset by
+ * `describeChange.ts` (encode before caption). A changeset never contains a
+ * sentence, and no renderer may state a change that is not present here.
+ */
+
+import type {
+  EdgeChange,
+  FieldChange,
+  FieldValue,
+  ModelChangeset,
+  ModelVersion,
+  NodeChange,
+  VersionRef,
+  VersionedEdge,
+  VersionedNode,
+} from './types'
+
+/**
+ * Read a field, mapping BOTH "absent" and "explicitly undefined" to `null`.
+ *
+ * ⚠ Deliberately not a truthiness check. `0`, `''` and `false` are legitimate
+ * user-set values; a `value ? ... : null` here would report an edit from 0 to
+ * absent as no change at all, silently swallowing a real edit. Pinned by three
+ * separate cases in the spec.
+ */
+function readField(fields: Readonly<Record<string, FieldValue>>, key: string): FieldValue {
+  const value = fields[key]
+  return value === undefined ? null : value
+}
+
+/**
+ * Compare two field bags and return only what differs, ordered by field name
+ * so a rendered list is stable between runs.
+ *
+ * Comparison is strict equality over scalars, so `1` and `'1'` are a change —
+ * a type flip on a value field is exactly the kind of thing a user needs to
+ * see, not something to normalise away.
+ */
+function diffFields(
+  before: Readonly<Record<string, FieldValue>>,
+  after: Readonly<Record<string, FieldValue>>,
+): FieldChange[] {
+  const keys = new Set<string>([...Object.keys(before), ...Object.keys(after)])
+  const changes: FieldChange[] = []
+
+  for (const field of [...keys].sort()) {
+    const from = readField(before, field)
+    const to = readField(after, field)
+    if (from !== to) changes.push({ field, before: from, after: to })
+  }
+
+  return changes
+}
+
+function byId<T extends { id: string }>(items: readonly T[]): Map<string, T> {
+  const map = new Map<string, T>()
+  for (const item of items) map.set(item.id, item)
+  return map
+}
+
+function sortedById<T extends { id: string }>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}
+
+function refOf(version: ModelVersion): VersionRef {
+  return { id: version.id, name: version.name, createdAt: version.createdAt }
+}
+
+/**
+ * Node fields participating in the comparison: the explicit `fields` bag plus
+ * the two identity-adjacent attributes a user reads as content.
+ *
+ * `label` and `kind` are folded in here rather than special-cased so that a
+ * rename and a value edit are reported through ONE mechanism and render
+ * identically. `id` is never a field — it is the pairing key.
+ */
+function nodeComparable(node: VersionedNode): Record<string, FieldValue> {
+  return { ...node.fields, label: node.label, kind: node.kind }
+}
+
+/**
+ * Edge fields participating in the comparison.
+ *
+ * `from`/`to` are included so a re-pointed edge reports as a modification of a
+ * surviving edge rather than a delete plus an add — the user moved one arrow,
+ * and that is what they should read.
+ */
+function edgeComparable(edge: VersionedEdge): Record<string, FieldValue> {
+  const comparable: Record<string, FieldValue> = { ...edge.fields, from: edge.from, to: edge.to }
+  if (edge.label !== undefined) comparable.label = edge.label
+  return comparable
+}
+
+/**
+ * Compare two model versions and return the typed changeset between them.
+ *
+ * Elements are paired BY ID and only by id. Never by label and never by a
+ * value predicate: two nodes routinely share a label ("Cost", "Revenue"), and
+ * pairing on one would resolve the wrong object and report a confident, wrong
+ * change — CLAUDE.md trap #19 at the level of the product rather than a test.
+ *
+ * @param before the earlier version
+ * @param after  the later version
+ */
+export function diffModelVersions(before: ModelVersion, after: ModelVersion): ModelChangeset {
+  const beforeNodes = byId(before.nodes)
+  const afterNodes = byId(after.nodes)
+  const beforeEdges = byId(before.edges)
+  const afterEdges = byId(after.edges)
+
+  const addedNodes: VersionedNode[] = []
+  const removedNodes: VersionedNode[] = []
+  const modifiedNodes: NodeChange[] = []
+
+  for (const [id, afterNode] of afterNodes) {
+    const beforeNode = beforeNodes.get(id)
+    if (!beforeNode) {
+      addedNodes.push(afterNode)
+      continue
+    }
+    const fields = diffFields(nodeComparable(beforeNode), nodeComparable(afterNode))
+    if (fields.length > 0) {
+      // Label and kind are taken from the LATER version: the user is looking
+      // at what the element is called now, not what it used to be called.
+      modifiedNodes.push({ id, label: afterNode.label, kind: afterNode.kind, fields })
+    }
+  }
+
+  for (const [id, beforeNode] of beforeNodes) {
+    if (!afterNodes.has(id)) removedNodes.push(beforeNode)
+  }
+
+  const addedEdges: VersionedEdge[] = []
+  const removedEdges: VersionedEdge[] = []
+  const modifiedEdges: EdgeChange[] = []
+
+  for (const [id, afterEdge] of afterEdges) {
+    const beforeEdge = beforeEdges.get(id)
+    if (!beforeEdge) {
+      addedEdges.push(afterEdge)
+      continue
+    }
+    const fields = diffFields(edgeComparable(beforeEdge), edgeComparable(afterEdge))
+    if (fields.length > 0) {
+      modifiedEdges.push({
+        id,
+        from: afterEdge.from,
+        to: afterEdge.to,
+        label: afterEdge.label,
+        fields,
+      })
+    }
+  }
+
+  for (const [id, beforeEdge] of beforeEdges) {
+    if (!afterEdges.has(id)) removedEdges.push(beforeEdge)
+  }
+
+  const changeset: Omit<ModelChangeset, 'isEmpty'> = {
+    from: refOf(before),
+    to: refOf(after),
+    addedNodes: sortedById(addedNodes),
+    removedNodes: sortedById(removedNodes),
+    modifiedNodes: sortedById(modifiedNodes),
+    addedEdges: sortedById(addedEdges),
+    removedEdges: sortedById(removedEdges),
+    modifiedEdges: sortedById(modifiedEdges),
+  }
+
+  return {
+    ...changeset,
+    // Derived, never set by hand, so it cannot disagree with the collections.
+    isEmpty:
+      changeset.addedNodes.length === 0 &&
+      changeset.removedNodes.length === 0 &&
+      changeset.modifiedNodes.length === 0 &&
+      changeset.addedEdges.length === 0 &&
+      changeset.removedEdges.length === 0 &&
+      changeset.modifiedEdges.length === 0,
+  }
+}

--- a/src/canvas/versions/types.ts
+++ b/src/canvas/versions/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Versioned workspace — shared types.
+ * British English: visualisation, colour, initialise.
+ *
+ * WHAT A VERSION IS, AND WHAT IT IS NOT
+ * -------------------------------------
+ * A `ModelVersion` is a snapshot of THE USER'S OWN MODEL — the nodes, edges,
+ * labels, values and provenance fields a user can see and author on the canvas.
+ * It is a record of authorship, not of analysis.
+ *
+ * ⚠ IT IS DELIBERATELY NOT SOURCED FROM RUN HISTORY. `store/runHistory.ts:1-8`
+ * carries an explicit prohibition: that module's client graph hashes and graph
+ * snapshots "must NEVER back a 'What changed' surface or any freshness signal —
+ * versioned comparison is producer-owned and absent from every contract today."
+ * That prohibition is honoured here in full and is the reason this namespace
+ * exists rather than a wiring of `loadRuns()`:
+ *   - nothing in `src/canvas/versions/**` imports run history;
+ *   - nothing here computes a graph hash (`generateGraphHash` is not called —
+ *     note it is also one of the two same-named twins CLAUDE.md trap #10 warns
+ *     about, the seed-bearing one);
+ *   - `graphHash` below is only ever COPIED from an analysis fact that already
+ *     carried one, as an opaque bridge for a future producer-owned
+ *     analysis-difference feature. Nothing in this slice renders it, and no
+ *     freshness or "your analysis is out of date" claim is derived from it.
+ * The distinction that makes this feature legitimate: the user authored both
+ * sides of this comparison. It answers "what did I change?", never "what does
+ * the engine now think?".
+ *
+ * STORAGE CLASS, STATED HONESTLY
+ * ------------------------------
+ * localStorage only, for every session class — guest AND signed-in. That is a
+ * deliberate PoC choice, not an oversight:
+ *   - it makes the feature work for GUESTS, which staging serves by default;
+ *   - it avoids repeating the defect at
+ *     `compare-tab/useCompareHistoryHydration.ts:79`, where hydration
+ *     early-returns on a missing `userId` so guests see a permanently empty
+ *     surface;
+ *   - the server-side alternative (`v5_handler_facts`) is RLS-scoped to
+ *     `auth.uid()`, so it is structurally incapable of serving guests.
+ * CONSEQUENCE THE USER MUST BE TOLD: versions live in ONE browser on ONE
+ * device, are not shared, and are lost when site data is cleared. The panel
+ * says so on screen. See DESIGN.md for the durable-storage migration path.
+ */
+
+/**
+ * A scalar field value that can be compared and rendered without
+ * interpretation. Anything richer (nested CEE objects, arrays, validation
+ * metadata) is deliberately EXCLUDED from the comparable projection rather
+ * than flattened — see `captureModelVersion.ts`. A field we cannot compare
+ * honestly is a field we do not claim to compare.
+ */
+export type FieldValue = string | number | boolean | null
+
+/**
+ * A node as captured for versioning: stable identity plus the comparable
+ * user-visible fields.
+ *
+ * `id` is the canvas node id and is the ONLY thing used to pair nodes across
+ * versions. Never pair by label or by value — two distinct nodes routinely
+ * share a label, and pairing by a value predicate is exactly the defect
+ * CLAUDE.md trap #19 names (a test, or a diff, that resolves the wrong object).
+ */
+export interface VersionedNode {
+  id: string
+  /** Node taxonomy member (goal | decision | option | factor | risk | ...). */
+  kind: string
+  label: string
+  fields: Readonly<Record<string, FieldValue>>
+}
+
+/**
+ * An edge as captured for versioning.
+ *
+ * `id` is the canvas edge id. `from`/`to` are carried for RENDERING a readable
+ * caption ("Price → Revenue"); they are NOT the pairing key, because an edge
+ * can be re-pointed while keeping its identity.
+ */
+export interface VersionedEdge {
+  id: string
+  from: string
+  to: string
+  label?: string
+  fields: Readonly<Record<string, FieldValue>>
+}
+
+/** How a version came to be captured. */
+export type VersionOrigin = 'manual' | 'pre-ingest'
+
+export interface ModelVersion {
+  id: string
+  /** User-supplied name for a manual save; a generated description otherwise. */
+  name: string
+  /** Unix ms. */
+  createdAt: number
+  origin: VersionOrigin
+  /**
+   * Opaque analysis graph hash, COPIED from an analysis fact when one was
+   * present at capture time. Never computed here, never rendered, never used
+   * to derive a freshness claim. See the header note.
+   */
+  graphHash?: string
+  nodes: VersionedNode[]
+  edges: VersionedEdge[]
+}
+
+/** Identity of a version, as carried on a changeset. */
+export interface VersionRef {
+  id: string
+  name: string
+  createdAt: number
+}
+
+/** One field that differs between two versions of the same element. */
+export interface FieldChange {
+  field: string
+  before: FieldValue
+  after: FieldValue
+}
+
+/** A node present in both versions whose comparable fields differ. */
+export interface NodeChange {
+  id: string
+  /** Label in the LATER version — what the user would look for now. */
+  label: string
+  kind: string
+  fields: FieldChange[]
+}
+
+/** An edge present in both versions whose comparable fields differ. */
+export interface EdgeChange {
+  id: string
+  from: string
+  to: string
+  /** Label in the LATER version. */
+  label?: string
+  fields: FieldChange[]
+}
+
+/**
+ * The typed result of comparing two model versions.
+ *
+ * THE SINGLE CANONICAL CHANGESET. Every surface that wants to say what
+ * changed — the What Changed panel today, restore/variants later — consumes
+ * this shape and no other. There is deliberately no second diff in this
+ * namespace and none should be added elsewhere (see DESIGN.md §"One diff").
+ */
+export interface ModelChangeset {
+  from: VersionRef
+  to: VersionRef
+  addedNodes: VersionedNode[]
+  removedNodes: VersionedNode[]
+  modifiedNodes: NodeChange[]
+  addedEdges: VersionedEdge[]
+  removedEdges: VersionedEdge[]
+  modifiedEdges: EdgeChange[]
+  /** True when every collection above is empty. Derived, never set by hand. */
+  isEmpty: boolean
+}

--- a/src/canvas/versions/useModelVersions.ts
+++ b/src/canvas/versions/useModelVersions.ts
@@ -1,0 +1,113 @@
+/**
+ * React binding for versions: list, save, delete, and the selected comparison.
+ * British English: visualisation, colour, initialise.
+ *
+ * Holds NO diff logic and NO storage logic — it composes `versionStorage` and
+ * `diffModelVersions`. The diff authority stays the single one.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import { useCanvasStore } from '../store'
+import { captureModelVersion } from './captureModelVersion'
+import { diffModelVersions } from './diffModelVersions'
+import type { ModelChangeset, ModelVersion, VersionOrigin } from './types'
+import { appendVersion, deleteVersion as deleteStoredVersion, loadVersions } from './versionStorage'
+
+/** Result of a save attempt, for surfacing an honest message. */
+export interface SaveOutcome {
+  ok: boolean
+  message?: string
+}
+
+function newVersionId(): string {
+  const globalCrypto = typeof globalThis === 'undefined' ? undefined : globalThis.crypto
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return `ver_${globalCrypto.randomUUID()}`
+  }
+  return `ver_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
+}
+
+export interface UseModelVersions {
+  versions: ModelVersion[]
+  /** Id of the earlier side of the comparison. */
+  fromId: string | null
+  /** Id of the later side of the comparison. */
+  toId: string | null
+  setFromId: (id: string) => void
+  setToId: (id: string) => void
+  /** The changeset for the current selection, or null when one is not selectable. */
+  changeset: ModelChangeset | null
+  from: ModelVersion | null
+  to: ModelVersion | null
+  saveVersion: (name: string, origin?: VersionOrigin) => SaveOutcome
+  removeVersion: (id: string) => void
+}
+
+/**
+ * Manage the stored version list and the pair currently being compared.
+ *
+ * Default selection is "latest vs previous" — the question a user actually
+ * arrives with. It is computed from the list rather than stored, so it stays
+ * correct after a save or a delete without a second piece of state to keep in
+ * step.
+ */
+export function useModelVersions(): UseModelVersions {
+  const [versions, setVersions] = useState<ModelVersion[]>(() => loadVersions())
+  const [selectedFromId, setSelectedFromId] = useState<string | null>(null)
+  const [selectedToId, setSelectedToId] = useState<string | null>(null)
+
+  // Versions are newest-first, so [1] is the previous one.
+  const defaultToId = versions[0]?.id ?? null
+  const defaultFromId = versions[1]?.id ?? null
+
+  const toId = selectedToId && versions.some((v) => v.id === selectedToId) ? selectedToId : defaultToId
+  const fromId =
+    selectedFromId && versions.some((v) => v.id === selectedFromId) ? selectedFromId : defaultFromId
+
+  const from = useMemo(() => versions.find((v) => v.id === fromId) ?? null, [versions, fromId])
+  const to = useMemo(() => versions.find((v) => v.id === toId) ?? null, [versions, toId])
+
+  const changeset = useMemo(() => {
+    if (!from || !to || from.id === to.id) return null
+    return diffModelVersions(from, to)
+  }, [from, to])
+
+  const saveVersion = useCallback((name: string, origin: VersionOrigin = 'manual'): SaveOutcome => {
+    const { nodes, edges } = useCanvasStore.getState()
+    const version = captureModelVersion(nodes, edges, {
+      id: newVersionId(),
+      name,
+      origin,
+      createdAt: Date.now(),
+    })
+
+    const result = appendVersion(version)
+    if (!result.success) {
+      // Exceptions loud: the user asked for a save and did not get one.
+      return { ok: false, message: result.error.message }
+    }
+
+    setVersions(result.data)
+    setSelectedToId(version.id)
+    setSelectedFromId(result.data[1]?.id ?? null)
+    return { ok: true }
+  }, [])
+
+  const removeVersion = useCallback((id: string) => {
+    const result = deleteStoredVersion(id)
+    if (result.success) setVersions(result.data)
+  }, [])
+
+  return {
+    versions,
+    fromId,
+    toId,
+    setFromId: setSelectedFromId,
+    setToId: setSelectedToId,
+    changeset,
+    from,
+    to,
+    saveVersion,
+    removeVersion,
+  }
+}

--- a/src/canvas/versions/versionStorage.ts
+++ b/src/canvas/versions/versionStorage.ts
@@ -1,0 +1,206 @@
+/**
+ * Version persistence — localStorage, guest-working, size-bounded.
+ * British English: visualisation, colour, initialise.
+ *
+ * WORKS FOR GUESTS BY CONSTRUCTION
+ * --------------------------------
+ * There is no identity check anywhere in this module, and that is the point.
+ * The nearest comparable surface — the compare tab's history — hydrates through
+ * `compare-tab/useCompareHistoryHydration.ts:79`, which early-returns on a
+ * missing `userId`; staging serves sessions as guest, so that surface is
+ * permanently empty for the people actually testing the product. The server
+ * alternative cannot help: `v5_handler_facts` is RLS-scoped to `auth.uid()`, so
+ * guest rows are invisible to it by construction.
+ *
+ * So versions are local for EVERY session class. The honest consequence, which
+ * the panel states on screen rather than hiding: versions live in one browser
+ * on one device, are not shared with collaborators, and are lost if site data
+ * is cleared. DESIGN.md carries the migration path to durable storage.
+ *
+ * REUSES THE REPO'S EXISTING CONVENTIONS rather than inventing new ones:
+ * `VersionedPayload` / `StorageResult` / `StorageErrorType` from
+ * `../persist/types`, and the `olumi-canvas-*` key convention with a `-v1`
+ * suffix. The payload is versioned from day one so a future shape change has a
+ * migration seam instead of a silent data loss.
+ */
+
+import type { StorageResult, VersionedPayload } from '../persist/types'
+import { StorageErrorType } from '../persist/types'
+import type { ModelVersion } from './types'
+
+export const VERSIONS_STORAGE_KEY = 'olumi-canvas-model-versions-v1'
+export const VERSIONS_SCHEMA = 'canvas.versions.v1'
+export const VERSIONS_SCHEMA_VERSION = '1.0.0'
+
+/**
+ * Retention bound. A version holds a whole graph, and localStorage is a ~5 MB
+ * shared budget, so this is deliberately modest — the PoC question is "can I
+ * see what changed", not "can I keep a year of history".
+ */
+export const MAX_VERSIONS = 20
+
+function isLocalStorageAvailable(): boolean {
+  try {
+    return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+  } catch {
+    return false
+  }
+}
+
+/** Newest first — the order every surface wants, applied in ONE place. */
+function newestFirst(versions: readonly ModelVersion[]): ModelVersion[] {
+  return [...versions].sort((a, b) => b.createdAt - a.createdAt)
+}
+
+function isModelVersion(value: unknown): value is ModelVersion {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<ModelVersion>
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.createdAt === 'number' &&
+    Array.isArray(candidate.nodes) &&
+    Array.isArray(candidate.edges)
+  )
+}
+
+/**
+ * Load every stored version, newest first.
+ *
+ * Never throws and never returns a partial lie: a corrupt or unreadable store
+ * yields an EMPTY list plus a console warning, because the honest answer to
+ * "which versions do I have" when the record is unreadable is "none I can
+ * show you", not a silently truncated subset presented as complete.
+ * Individually malformed entries are dropped and counted in the warning.
+ */
+export function loadVersions(): ModelVersion[] {
+  if (!isLocalStorageAvailable()) return []
+
+  try {
+    const stored = localStorage.getItem(VERSIONS_STORAGE_KEY)
+    if (!stored) return []
+
+    const payload = JSON.parse(stored) as VersionedPayload<unknown>
+    if (!payload || typeof payload !== 'object' || !Array.isArray(payload.data)) {
+      console.warn('[versions] Stored payload is not a version list; ignoring')
+      return []
+    }
+
+    const entries = payload.data as unknown[]
+    const valid = entries.filter(isModelVersion)
+    if (valid.length !== entries.length) {
+      console.warn(`[versions] Dropped ${entries.length - valid.length} malformed version(s)`)
+    }
+
+    return newestFirst(valid)
+  } catch (error) {
+    console.warn('[versions] Failed to read versions; treating as empty', error)
+    return []
+  }
+}
+
+function writePayload(versions: readonly ModelVersion[]): void {
+  const payload: VersionedPayload<ModelVersion[]> = {
+    schema: VERSIONS_SCHEMA,
+    version: VERSIONS_SCHEMA_VERSION,
+    timestamp: Date.now(),
+    data: [...versions],
+  }
+  localStorage.setItem(VERSIONS_STORAGE_KEY, JSON.stringify(payload))
+}
+
+function isQuotaError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED')
+  )
+}
+
+/**
+ * Persist a version list, pruned to `MAX_VERSIONS` newest-first.
+ *
+ * On a quota error it retries with progressively fewer versions rather than
+ * failing outright — losing the oldest version is a far better outcome for the
+ * user than losing the save they just asked for. If even a single version will
+ * not fit, that is reported as a real failure, loudly, and never as success.
+ */
+export function saveVersions(versions: readonly ModelVersion[]): StorageResult<ModelVersion[]> {
+  if (!isLocalStorageAvailable()) {
+    return {
+      success: false,
+      error: { type: StorageErrorType.UNAVAILABLE, message: 'localStorage is not available' },
+    }
+  }
+
+  const pruned = newestFirst(versions).slice(0, MAX_VERSIONS)
+
+  // Writing an EMPTY list is a legitimate operation — it is what deleting the
+  // last version means. The shedding loop below starts at `pruned.length` and
+  // stops at 1, so without this an empty write would fall straight through to
+  // the quota failure and the delete would silently not happen.
+  if (pruned.length === 0) {
+    try {
+      writePayload([])
+      return { success: true, data: [] }
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          type: StorageErrorType.UNKNOWN,
+          message: error instanceof Error ? error.message : 'Failed to clear versions',
+          original: error instanceof Error ? error : undefined,
+        },
+      }
+    }
+  }
+
+  for (let keep = pruned.length; keep >= 1; keep--) {
+    const attempt = pruned.slice(0, keep)
+    try {
+      writePayload(attempt)
+      if (keep < pruned.length) {
+        console.warn(`[versions] Storage full — kept the ${keep} most recent version(s)`)
+      }
+      return { success: true, data: attempt }
+    } catch (error) {
+      if (!isQuotaError(error)) {
+        return {
+          success: false,
+          error: {
+            type: StorageErrorType.UNKNOWN,
+            message: error instanceof Error ? error.message : 'Failed to save versions',
+            original: error instanceof Error ? error : undefined,
+          },
+        }
+      }
+    }
+  }
+
+  return {
+    success: false,
+    error: {
+      type: StorageErrorType.QUOTA_EXCEEDED,
+      message: 'This model is too large to save a version in this browser.',
+    },
+  }
+}
+
+/** Append a version and persist. Returns the stored list, newest first. */
+export function appendVersion(version: ModelVersion): StorageResult<ModelVersion[]> {
+  return saveVersions([version, ...loadVersions()])
+}
+
+/** Remove one version by id and persist. */
+export function deleteVersion(id: string): StorageResult<ModelVersion[]> {
+  return saveVersions(loadVersions().filter((version) => version.id !== id))
+}
+
+/** Remove every stored version. */
+export function clearVersions(): void {
+  if (!isLocalStorageAvailable()) return
+  try {
+    localStorage.removeItem(VERSIONS_STORAGE_KEY)
+  } catch (error) {
+    console.warn('[versions] Failed to clear versions', error)
+  }
+}

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -21,6 +21,7 @@ import { useServerGraphHydration } from '../canvas/hooks/useServerGraphHydration
 import { useImportRegistration } from '../canvas/registration/useImportRegistration'
 
 const TemplatesPanel = lazy(() => import('../canvas/panels/TemplatesPanel').then(m => ({ default: m.TemplatesPanel })))
+const VersionsPanelHost = lazy(() => import('../canvas/versions/VersionsPanelHost').then(m => ({ default: m.VersionsPanelHost })))
 
 export default function CanvasMVP() {
   // Brief 37 Task 3: Render counter to detect if parent is causing re-renders
@@ -297,6 +298,13 @@ export default function CanvasMVP() {
             onPinToCanvas={handlePinToCanvas}
             insertionError={insertionError}
           />
+        </Suspense>
+
+        {/* Versioned workspace: "Versions" trigger + What Changed panel.
+            Self-contained — owns its own open state and touches no shared
+            store, so this mount is the feature's entire integration surface. */}
+        <Suspense fallback={null}>
+          <VersionsPanelHost />
         </Suspense>
 
         {/* Phase 1A.5: Debug Tray (hidden by default, Shift+D to toggle) */}


### PR DESCRIPTION
Versioned workspace, first slice. **Capture → one diff authority → a What Changed surface.** Restore and variants are designed, not built.

Branched off `origin/staging` at `a3c71513`.

## What a user can now do

Open **Versions** on the canvas, name and save a version of their model, and read in plain language what changed between any two — "Factor "Price" value 0.5 → 0.8", "Link Price → Revenue removed". A version is also captured automatically just before a draft ingest replaces the model.

Works for **guests**, which is the tier staging actually serves.

## Derivation that shaped the design

- **`store/runHistory.ts:1-8` explicitly forbids** backing a "What changed" surface off local run history ("Do not wire this in"). Honoured in full: nothing here imports run history and nothing computes a graph hash. The prohibition targets *analysis* comparison, which is producer-owned; this feature compares two snapshots **the user authored themselves**, renders no freshness claim, and says nothing about analysis.
- **`compare-tab/useCompareHistoryHydration.ts:79`** early-returns on a missing `userId`, so that surface is permanently empty for guests. Not repeated: the storage path contains **no identity check anywhere**, and a test asserts that.
- **`snapshots/snapshots.ts:26-39`** already implements named localStorage snapshots — but stores a **lossy** flattened model (no values, belief, direction or provenance), so it structurally cannot support a field-level diff. It also ships its own `VisualDiff`. Superseded rather than extended; DESIGN.md recommends retiring it.
- **`domain/nodes.ts:325-366`**: the strict node union **strips undeclared keys**, and several live renderer fields are undeclared. Capture therefore does **no schema parse** — a parse here would silently destroy user data.
- **`domain/edgeValueProvenance.ts`**: the four edge `*Source` markers mean *absent ⇒ defaulted*. Capture **never stamps one**, or it would launder a UI default into a claim the user set the value.

## Design commitments

- **One diff.** `diffModelVersions` is the only comparison implementation; What Changed consumes it and so will restore/variants. Elements pair **by id only** — two nodes routinely share a label.
- **Encode before caption.** Sentences come only from `describeChange.ts`, only from the changeset. No summaries, scores or judgements — tests assert that copy is absent.
- **Exceptions loud, normal quiet.** A failed save says so with the real reason; a successful one just appears. The auto-capture is the deliberate exception: it can never fail the ingest it guards.
- **No new feature flag.** Ships on.
- **`graphHash` is accepted but deliberately unsupplied and unrendered** — there is no `graphHash` on the canvas store, and the two places one is held are the retiring compare-tab and the prohibited run history. Computing one would mean picking blind between the seeded/seedless twins. Stated in DESIGN.md rather than left looking wired.

**Restore ships no affordance**, because it is a write that needs the canonical transaction API. DESIGN.md states the precise ask, including why a bare `setState` is unsafe (`applyDraftResult` fires twice per streamed turn; `reconcileAppliedGraph` can delete elements — a restore landing between them would be silently overwritten while telling the user their model was restored).

## Integration surface

Two lines in two shared files: a guarded capture call in `applyDraftResult.ts`, and a lazy mount in `routes/CanvasMVP.tsx` (covers `/canvas` and `/scenario/:id`). No shared store touched. **No banned lane path touched** — asserted against `components/results/`, `canvas/conversation/`, `model-tab-v2/`, `OutputsDock`, `canvas/compare*`, `useScenarioComparison`.

## Evidence

| Check | Result |
|---|---|
| Versions suite | **117 passed / 6 specs**, each collecting non-zero by name |
| Regression (shared files) | 57 passed / 3 specs |
| Lint | 0 errors (warnings pre-existing in `CanvasMVP.tsx`) |
| Typecheck gate | **PASSED at baseline 2485, zero drift, no `--update-baseline`** |
| Guards | zustand · starters · vendor · schemas-version all green |

**Two real defects were found by the tests, not by inspection:**
1. `saveVersions([])` never wrote and falsely reported `QUOTA_EXCEEDED`, so deleting the **last** version silently did nothing. Fixed, with a regression test pinned at the storage layer.
2. The caption layer could not name edge endpoints whose nodes were unchanged, because a changeset only mentions what changed. Fixed by adding `buildVersionLabelIndex`; the changeset-only default degrades to raw ids rather than inventing a name, and a test pins both branches.

### Mutation testing

Worktree **outside** the repo, isolation proven by a **sentinel write** (source sha unchanged) plus distinct inodes — not by a path check. Restores from a **pristine archive**, never `git checkout --`. Applied-check per mutant scoped to `src/`; leading and trailing controls both read exactly 0.

**Discriminating pair** on node identity (5 tests in the scoped group, positive-control non-zero):

| Mutant | Object | Node-identity group |
|---|---|---|
| A — pair nodes by label | same | **RED** |
| B — pair edges by endpoints | different | **GREEN** (and RED on the edge group, so the mutation is real, not inert) |

A first attempt at this pair was **wrong and is worth flagging**: it ran the whole spec file, so mutant B reddened the edge tests and could never come back green. That measured sensitivity, not binding. Re-scoped with `-t` to a named group.

Five further sensitivity mutants all bit: drop-a-change (16 failed), truthiness-presence (3), loose equality (1), `isEmpty` hardcoded (3), earlier-label (1).

## Scope limits, stated plainly

- jsdom proves presence and text, **never visibility**. Nothing here is journey-witnessed; a browser witness on staging is still owed.
- Nested structures (`interventions`, `functionParams`, `causal_claims`, the object form of `prior`) are **not** captured — they cannot be compared or captioned honestly at field level yet, and half-doing it would produce confident wrong captions.
- Captured fields are **derived** (every own scalar minus a presentation denylist), so new domain fields appear automatically. The trade-off: a new presentation field nobody denylists surfaces as a visible row. Chosen deliberately — a visible wrong row gets fixed, a silently omitted user edit does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)