### PR TITLE
fix(routing): the guest gate's first click shows the canvas loading, not the gate

### DIFF
--- a/src/poc/AppPoC.tsx
+++ b/src/poc/AppPoC.tsx
@@ -27,6 +27,36 @@ const PlotWorkspace = lazy(() => import('../routes/PlotWorkspace'))
 const PlcLab = lazy(() => import('../routes/PlcLab'))
 const DecisionTemplates = lazy(() => import('../routes/templates/DecisionTemplates').then(m => ({ default: m.DecisionTemplates })))
 
+/**
+ * A Suspense boundary that belongs to the ROUTE, not to the app shell.
+ *
+ * `<HashRouter future={{ v7_startTransition: true }}>` wraps every navigation
+ * state update in `React.startTransition`, and React will not replace
+ * already-revealed content with a fallback during a transition. The single
+ * `<Suspense>` above `<Routes>` has committed content from the moment the first
+ * route renders, so on every later navigation into a lazy route it shows
+ * nothing and React simply holds the PREVIOUS page on screen until the new
+ * chunk arrives.
+ *
+ * That is what made the fresh guest's first click look dead: "Continue without
+ * an account" (pages/ScenarioListPage.tsx) moved the hash to `#/canvas`
+ * instantly and then left the sign-in gate on screen for the whole ~2 MB canvas
+ * download (CanvasMVP + ReactFlowGraph), with no spinner and no disabled
+ * button. Nothing was broken — there was simply no way to tell.
+ *
+ * A boundary mounted BY the transition has no revealed content to preserve, so
+ * it shows its fallback immediately. Wrapping the routed element therefore
+ * restores the loading state without a reload and without a flag.
+ *
+ * The shell boundary above `<Routes>` stays: it still covers the very first
+ * paint, and it remains the fallback for every route that does not carry its
+ * own. `guestGateCanvasTransition.spec.tsx` pins the gate → canvas transition
+ * against this, so removing the wrapper fails loud.
+ */
+function RouteContent({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<RouteLoadingFallback />}>{children}</Suspense>
+}
+
 // PR #156 follow-up — staging-only debug-export UI.
 // `<DebugPanel />` is the visibility / sizing shell that delegates the
 // actual debug content to `<DebugPanelV2 />`. It is the entry point for
@@ -919,12 +949,12 @@ export default function AppPoC() {
                 <Route element={<AuthGuard />}>
                   <Route path="/" element={<ScenarioListPage />} />
                   <Route path="/scenarios" element={<ScenarioListPage />} />
-                  <Route path="/scenario/:id" element={<CanvasMVP />} />
+                  <Route path="/scenario/:id" element={<RouteContent><CanvasMVP /></RouteContent>} />
                   {/* COLLAB — the owner's side. INSIDE AuthGuard: minting a
                       round pins a version of the owner's model and names real
                       people, so it requires a verified session. */}
                   <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
-                  <Route path="/canvas" element={<CanvasMVP />} />
+                  <Route path="/canvas" element={<RouteContent><CanvasMVP /></RouteContent>} />
                   <Route path="/profile" element={<ProfileSettingsPage />} />
                   <Route path="/templates" element={<DecisionTemplates />} />
                 </Route>

--- a/src/poc/__tests__/guestGateCanvasTransition.spec.tsx
+++ b/src/poc/__tests__/guestGateCanvasTransition.spec.tsx
@@ -1,0 +1,124 @@
+// src/poc/__tests__/guestGateCanvasTransition.spec.tsx
+//
+// THE FRESH GUEST'S FIRST CLICK. On the landing gate ("Sign in to save and
+// manage your decisions"), "Continue without an account" calls
+// `navigate('/canvas')` (src/pages/ScenarioListPage.tsx:387). The hash changes
+// immediately — and, before this spec, the GATE STAYED ON SCREEN for the whole
+// time the canvas chunk was downloading, with no spinner and no disabled
+// button. A fresh guest's first click appeared to do nothing.
+//
+// MECHANISM. `<HashRouter future={{ v7_startTransition: true }}>`
+// (AppPoC.tsx:895) wraps every navigation state update in
+// `React.startTransition`. React's transition rule is that it will NOT replace
+// already-revealed content with a fallback — so the single `<Suspense>` ABOVE
+// `<Routes>` (AppPoC.tsx:903), which has long since committed the gate, shows
+// nothing at all and React simply holds the old UI until the new tree is ready.
+// `/canvas` is `lazy` (AppPoC.tsx:23) and pulls ~2.06 MB on staging
+// (CanvasMVP 64 KB + ReactFlowGraph 1.94 MB + CSS), fetched as a waterfall.
+// The fix gives the routed element its own boundary: a Suspense boundary that
+// is NEWLY MOUNTED by the transition has no revealed content to preserve, so it
+// shows its fallback at once.
+//
+// WHY THE LAZY IMPORT IS HELD OPEN HERE. The defect only exists while the chunk
+// is in flight, so the test must be able to stand in that window. The CanvasMVP
+// mock is a promise this spec resolves by hand — until it does, the route is
+// exactly where a real guest on a cold cache spends those seconds.
+//
+// POSITIVE CONTROL (trap 13): the first case asserts the gate IS on screen
+// before the click, so "the gate is gone" afterwards is an absence this spec
+// can actually see rather than a query that never matched anything.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { createElement } from 'react'
+
+// The canvas chunk, held in flight until the test resolves it by hand.
+const canvasChunk = vi.hoisted(() => {
+  let resolve!: (mod: unknown) => void
+  const promise = new Promise<unknown>(r => { resolve = r })
+  return { promise, resolve }
+})
+
+vi.mock('../../lib/monitoring', () => ({ initMonitoring: () => {} }))
+vi.mock('../../lib/posthog', () => ({ trackEvent: () => {} }))
+
+// A guest: ready immediately, counts as authenticated so every route stays
+// reachable (contexts/AuthContext.tsx:475), and persistence is off — which is
+// the exact condition ScenarioListPage renders the gate under.
+vi.mock('../../contexts/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: unknown }) => children,
+  useAuth: () => ({ loading: false, authenticated: true, user: { id: 'guest', email: 'guest@poc' } }),
+}))
+vi.mock('../../hooks/useScenario', () => ({
+  useScenario: () => ({
+    createScenario: async () => {},
+    deleteScenario: async () => {},
+    isPersistenceActive: false,
+  }),
+}))
+vi.mock('../../services/scenarioService', () => ({
+  listScenarios: async () => [],
+  duplicateScenario: async () => {},
+  updateScenario: async () => {},
+  deleteScenario: async () => {},
+  createScenario: async () => {},
+}))
+vi.mock('../../components/auth/GuestDraftImportBanner', () => ({
+  GuestDraftImportBanner: () => null,
+}))
+
+vi.mock('../../routes/CanvasMVP', () => canvasChunk.promise as Promise<{ default: () => unknown }>)
+
+vi.mock('../components/SandboxHeader', () => ({
+  default: () => createElement('div', { 'data-testid': 'poc-sandbox' }),
+  __esModule: true,
+}))
+
+import AppPoC from '../AppPoC'
+
+const GATE_BUTTON = 'Continue without an account'
+
+async function renderGateAndClick() {
+  window.location.hash = '#/'
+  render(createElement(AppPoC))
+  const button = await screen.findByRole('button', { name: GATE_BUTTON }, { timeout: 5000 })
+  // POSITIVE CONTROL: the gate is genuinely on screen before the click.
+  expect(button).toBeInTheDocument()
+  fireEvent.click(button)
+  return button
+}
+
+describe('guest gate → canvas: the first click transitions without a reload', () => {
+  beforeEach(() => { localStorage.clear(); window.location.hash = '' })
+  afterEach(() => { localStorage.clear(); window.location.hash = '' })
+
+  it('unmounts the gate and shows the canvas loading state while the chunk is still in flight', async () => {
+    await renderGateAndClick()
+
+    // The hash moves synchronously — this was never the broken half.
+    expect(window.location.hash).toBe('#/canvas')
+
+    // THE PIN. While the chunk is in flight the user must be shown the route's
+    // own loading state, NOT the gate they just left. Bound by identity: the
+    // fallback's accessible name is derived from the pathname
+    // (RouteLoadingFallback.tsx:37), so this can only match the CANVAS route's
+    // loading state — not some other spinner that happens to be on screen.
+    await waitFor(
+      () => expect(screen.getByRole('status', { name: 'Loading Canvas' })).toBeInTheDocument(),
+      { timeout: 3000 },
+    )
+    expect(screen.queryByRole('button', { name: GATE_BUTTON })).not.toBeInTheDocument()
+  })
+
+  it('mounts the canvas when the chunk resolves — no page reload involved', async () => {
+    await renderGateAndClick()
+
+    canvasChunk.resolve({
+      default: () => createElement('div', { 'data-testid': 'route-canvas' }, 'canvas'),
+    })
+
+    await waitFor(() => expect(screen.getByTestId('route-canvas')).toBeInTheDocument(), { timeout: 3000 })
+    expect(screen.queryByRole('button', { name: GATE_BUTTON })).not.toBeInTheDocument()
+    expect(window.location.hash).toBe('#/canvas')
+  })
+})


### PR DESCRIPTION
## The defect

A fresh guest lands on the gate ("Sign in to save and manage your decisions"), clicks **Continue without an account**, and the hash moves to `#/canvas` immediately — while the **gate stays on screen** for the whole canvas download, with no spinner and no disabled button. The click reads as dead.

Witnessed on deployed staging `6bfe40f7`, cleared storage, 1280x800.

## Mechanism (derived, not assumed)

- `<HashRouter future={{ v7_startTransition: true }}>` — `AppPoC.tsx:895` — wraps every navigation state update in `React.startTransition`.
- React will **not** replace already-revealed content with a fallback during a transition.
- The only `<Suspense fallback={<RouteLoadingFallback />}>` sits **above** `<Routes>` (`AppPoC.tsx:903`) and has committed content from the first route onwards. So on navigation into a lazy route it shows nothing, and React holds the **previous page** until the chunk lands.
- `/canvas` is `lazy` (`AppPoC.tsx:23`) and pulls **~2.06 MB** on staging — `CanvasMVP` 64 KB + `ReactFlowGraph` 1.94 MB + CSS — as a waterfall (measured with `fetch(..., {cache:'reload'})` against the deployed chunks).
- A hard load of `#/canvas` works because that boundary has nothing to preserve yet, so it shows `RouteLoadingFallback` and commits.

Reproduced in jsdom as a discriminating pair: with the current structure the gate is still on screen after the click and no fallback exists anywhere; with a per-route boundary the gate unmounts and the fallback appears.

## Corrected premise

**The workspace never needed a reload.** It mounts on its own once the chunk arrives — measured **437 ms** warm on deployed staging, and witnessed mounting on a cold load too. The brief's "only mounts after a full page reload" is a long *entirely unindicated* wait misread as a dead end. That misread is the defect: on a cold cache — i.e. exactly the fresh guest standing at this gate — 2 MB of waterfall is seconds of a screen that says nothing happened.

## The fix

Give the two `CanvasMVP` routes their own Suspense boundary (`RouteContent`). A boundary **mounted by** the transition has no revealed content to preserve, so it reveals its fallback at once.

No flag, no forced reload, no change to the shell boundary (still covers first paint and every route without its own).

## Tests

`src/poc/__tests__/guestGateCanvasTransition.spec.tsx` — 2 tests, mounting the **real** `AppPoC` with the canvas chunk held in flight by hand:

1. gate unmounts + canvas loading state shown while the chunk is in flight — **RED at pristine**
2. canvas mounts on resolve, no reload

Bound by identity: the loading state is matched by its accessible name `Loading Canvas`, derived from the pathname (`RouteLoadingFallback.tsx:37`), so it can only match the canvas route's own loading state. Positive control: the gate is asserted present *before* the click.

### Mutants (throwaway worktree outside the repo root; isolation proven by writing a sentinel; applied-check scoped to `src/`, control exactly 0)

| Mutant | Expected | Result |
|---|---|---|
| control (no mutation) | green | 2/2 green, applied=0 |
| M1 — drop the wrapper on `/canvas` | RED | RED |
| M2 — drop the wrapper on `/scenario/:id` **only** | GREEN | GREEN |
| M3 — `RouteContent` fallback becomes `null` | RED | RED |
| trailing control | green | 2/2 green, applied=0 |

M1/M2 are the discriminating pair: the pin binds to the `/canvas` route it names, not to "a wrapper somewhere". M3 proves it pins the loading *state*, not merely the gate unmounting.

## Gates

- **lint** — 0 errors (1268 pre-existing warnings); rules-of-hooks ratchet exactly at baseline (232 across 15 files)
- **typecheck** — PASSED, `618 files / 2485 errors`, exactly the baseline; coverage 3472/3512
- **tests** — `src/poc src/routes src/pages`: 29 files / 300 tests passed, exit 0; the new spec asserted collecting **2 tests by name** in the combined run

## Scope

`src/poc/AppPoC.tsx` (routing seam) + one new spec. Touches none of tonight's other lanes' files.

Follow-up, deliberately **not** done here to keep this surgical: the same one-line wrapper applies to the remaining lazy routes (`/login`, `/profile`, `/templates`, ...). Those chunks are small enough that the wait is imperceptible; the 2 MB canvas routes are where it bites.

Do not merge — handing back for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)