### PR TITLE
A2: give the drafted model the canvas, and make every send visible

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -338,6 +338,46 @@ function StoreConfirmDialog() {
   )
 }
 
+/**
+ * Pointer tolerances for select/grab reliability (16 Aug 2026).
+ *
+ * All three were previously UNSET, so xyflow's own defaults applied — and those
+ * defaults are strict to the pixel. Derived at the bytes in
+ * `@xyflow/react/dist/esm/index.js`: `nodeClickDistance = 0` and
+ * `paneClickDistance = 1` (:3598), `nodeDragThreshold = 1` (:3184).
+ *
+ * `nodeClickDistance = 0` is the sharp one: a node click registers ONLY if the
+ * pointer travelled zero pixels between press and release, and a 1px drag
+ * threshold promotes a wobble into a drag, which suppresses the click outright.
+ * On a trackpad that makes click-to-select a coin toss — the user presses a
+ * node, the pointer jitters by a pixel, and the selection silently does not
+ * happen, with nothing to distinguish it from a dead zone. That is precisely
+ * the "grab miss" this lane was sent to find.
+ *
+ * A few pixels is what real pointer hardware delivers, and it costs nothing
+ * else: a deliberate drag passes 2px immediately, so dragging is unaffected.
+ *
+ * Module scope, not component scope: they are constants, and
+ * `SELECT_MODE_PAN_BUTTONS` in particular must keep a STABLE IDENTITY across
+ * renders (a fresh array each render re-triggers xyflow's pane wiring). It was
+ * briefly a `useMemo`, which the rules-of-hooks ratchet correctly rejected —
+ * this file is at its exception limit and a new hook here is a render-time
+ * crash risk. A module constant needs no hook at all.
+ */
+const NODE_CLICK_DISTANCE = 4
+const PANE_CLICK_DISTANCE = 4
+const NODE_DRAG_THRESHOLD = 2
+
+/**
+ * Which mouse buttons pan in SELECT mode (xyflow numbering: 0 left, 1 middle,
+ * 2 right). This was `[1, 2]`, which made right-drag a pan trigger while
+ * `onPaneContextMenu` / `onNodeContextMenu` / `onEdgeContextMenu` were all
+ * bound — so a right-press that moved a pixel panned the canvas AND opened the
+ * context menu on release. Button 2 belongs to the menu; middle-drag keeps
+ * panning. Hand mode is unchanged (`panOnDrag={true}` — every button pans).
+ */
+const SELECT_MODE_PAN_BUTTONS = [1]
+
 // Brief 37: Wrap in memo to prevent parent-triggered re-renders from ReactFlowProvider
 const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBus, onCanvasInteraction, enableGhostSuggestions = false }: ReactFlowGraphProps) {
   // React #185 FIX: Use INDIVIDUAL selectors - NOT object + shallow
@@ -627,6 +667,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   // Interaction mode: 'select' for normal selection/drag, 'hand' for pan mode (like Figma V/H)
   // Default to 'hand' mode for easier canvas navigation on load
   const [interactionMode, setInteractionMode] = useState<'select' | 'hand'>('hand')
+
 
   // Spacebar hold-to-pan: temporarily switches to hand mode while held (like Figma)
   const [spaceHeld, setSpaceHeld] = useState(false)
@@ -2109,8 +2150,11 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
             selectionOnDrag={canDragSelect}
             selectionMode={SelectionMode.Partial}
             multiSelectionKeyCode={['Meta', 'Control']}
-            panOnDrag={effectiveMode === 'hand' ? true : [1, 2]}
+            panOnDrag={effectiveMode === 'hand' ? true : SELECT_MODE_PAN_BUTTONS}
             nodesDraggable={effectiveMode === 'select'}
+            nodeClickDistance={NODE_CLICK_DISTANCE}
+            paneClickDistance={PANE_CLICK_DISTANCE}
+            nodeDragThreshold={NODE_DRAG_THRESHOLD}
             fitView
             minZoom={0.1}
             maxZoom={4}

--- a/src/canvas/__tests__/computeFitPadding.spec.ts
+++ b/src/canvas/__tests__/computeFitPadding.spec.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { computeFitPadding } from '../utils/computeFitPadding'
+import { computeFitPadding, cheapestReservation } from '../utils/computeFitPadding'
 
 function fakeEl(rect: Partial<DOMRect>): HTMLElement {
   const full: DOMRect = {
@@ -217,5 +217,209 @@ describe('computeFitPadding', () => {
     const GRAPH_FLOW_WIDTH = 2016
     const LEGIBILITY_FLOOR = 0.5
     expect(fitBoxWidth).toBeLessThan(GRAPH_FLOW_WIDTH * LEGIBILITY_FLOOR)
+  })
+})
+
+/**
+ * A2 (16 Aug 2026) — the FLOATING conversation panel's reservation.
+ *
+ * The dock and the sidebar are edge-anchored, so "what do they occlude" has one
+ * answer. The floating Olumi panel is free-floating, so it does not: these tests
+ * are written against the STATED CONTRACT — "the graph must not be framed
+ * underneath the panel, at the least cost to the fitting box" — and not against
+ * the 1280x800 case that motivated the work. A reservation is correct when the
+ * chosen side EXCLUDES the occluder from the fitting box; that postcondition is
+ * asserted directly below rather than by pinning the side a particular geometry
+ * happens to pick.
+ */
+describe('computeFitPadding — floating Olumi panel', () => {
+  const PANEL = '[data-testid="floating-olumi-panel"]'
+  const SIDE_TAB = '[data-testid="floating-olumi-panel-side-tab"]'
+  const PILL = '[aria-label="Restore Olumi"]'
+  const FLOW = { left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }
+
+  /** The fitting box the returned padding implies, in viewport coordinates. */
+  function fitBoxOf(p: { top: string; right: string; bottom: string; left: string }) {
+    return {
+      left: FLOW.left + parseInt(p.left, 10),
+      right: FLOW.right - parseInt(p.right, 10),
+      top: FLOW.top + parseInt(p.top, 10),
+      bottom: FLOW.bottom - parseInt(p.bottom, 10),
+    }
+  }
+
+  function overlaps(a: { left: number; right: number; top: number; bottom: number }, b: typeof a) {
+    return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+  }
+
+  it('excludes the panel from the fitting box at every EDGE-RESTING position', () => {
+    // The POSTCONDITION, swept over the positions the panel actually rests at in
+    // the product: the bottom-right anchor `FirstUseComposer` slides to on the
+    // 0→N draft, the left clamp floor (x = DEFAULT_MARGIN + SIDE_TAB_WIDTH = 52,
+    // where `clampPositionToViewport` parks it), and the top-left corner. If any
+    // of these framed the graph under the panel the reservation would be
+    // decorative. The CENTRED case is excluded here on purpose and gets its own
+    // test below — it cannot satisfy this postcondition, and pretending
+    // otherwise by widening the sweep until it passed would hide that.
+    const positions = [
+      { name: 'bottom-right anchor', left: 812, top: 234 },
+      { name: 'left clamp floor', left: 52, top: 73 },
+      { name: 'top-left', left: 52, top: 16 },
+    ]
+    for (const pos of positions) {
+      const panel = { left: pos.left, right: pos.left + 400, top: pos.top, bottom: pos.top + 550 }
+      stubSelectors({
+        [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
+        [SIDE_TAB]: fakeEl({ left: panel.left - 36, right: panel.left, top: pos.top, bottom: pos.top + 120, width: 36, height: 120 }),
+      })
+      const p = computeFitPadding(fakeEl(FLOW))
+      const box = fitBoxOf(p)
+      const panelWithTab = { ...panel, left: panel.left - 36 }
+      // PIN THE PRECONDITION (else this passes for the wrong reason): assert the
+      // MAX_PADDING_FRACTION clamp is NOT binding on either axis, so the
+      // exclusion below is the reservation's doing and not an accident of a
+      // capped padding that happened to land clear.
+      const hSum = parseInt(p.left, 10) + parseInt(p.right, 10)
+      const vSum = parseInt(p.top, 10) + parseInt(p.bottom, 10)
+      expect(hSum, `${pos.name}: horizontal clamp bound`).toBeLessThanOrEqual(1024)
+      expect(vSum, `${pos.name}: vertical clamp bound`).toBeLessThanOrEqual(640)
+      expect(overlaps(box, panelWithTab), `${pos.name}: fitting box still overlaps the panel`).toBe(false)
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('CANNOT clear a centred panel — the fitting-area clamp binds first', () => {
+    // An honest limit, not a pass. A 400x550 panel resting mid-pane needs a
+    // 691px reservation on its cheapest side; MAX_PADDING_FRACTION caps the
+    // vertical pair at 640px, so the clamp scales the reservation DOWN and the
+    // fitting box still overlaps the panel. Recorded rather than papered over:
+    // it is the strongest statement of why the hero MINIMISES after the draft
+    // (FirstUseComposer) instead of the product trying to fit around it.
+    const panel = { left: 440, right: 840, top: 125, bottom: 675 }
+    stubSelectors({
+      [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
+      [SIDE_TAB]: fakeEl({ left: 404, right: 440, top: 125, bottom: 245, width: 36, height: 120 }),
+    })
+    const p = computeFitPadding(fakeEl(FLOW))
+    const box = fitBoxOf(p)
+    // 639, not 640: `capPair` floors each side after scaling (29→25, 691→614),
+    // so the pair lands one below the 0.8 cap. Pinned at the value the code
+    // actually produces rather than the value the cap suggests.
+    expect(parseInt(p.top, 10) + parseInt(p.bottom, 10)).toBe(639)
+    expect(overlaps(box, { ...panel, left: 404 })).toBe(true) // and so it is NOT cleared
+  })
+
+  it('unions the side tab, which sits OUTSIDE the panel rect at left:-36', () => {
+    // Identity-bound, and deliberately measured on a RIGHT-side reservation.
+    // The side tab extends the panel's LEFT edge, and a left-side reservation is
+    // `occ.right - flow.left` — which does not read occ.left at all, so the tab
+    // is invisible there. Only `right` (= flow.right - occ.left) can observe it.
+    // The first draft of this test asserted the difference on a left-resting
+    // panel and measured 0: a spec written from the assumption rather than from
+    // the formula would have "proved" the union works while testing nothing.
+    const panel = { left: 812, right: 1212, top: 234, bottom: 784 }
+    stubSelectors({
+      [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
+      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
+    })
+    const withTab = parseInt(computeFitPadding(fakeEl(FLOW)).right, 10)
+    vi.restoreAllMocks()
+
+    stubSelectors({ [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }) })
+    const withoutTab = parseInt(computeFitPadding(fakeEl(FLOW)).right, 10)
+
+    expect(withTab - withoutTab).toBe(36)
+    expect(withTab).toBe(520) // 1280 - 776 + 16 gap
+  })
+
+  it('takes the CHEAPEST side, not a fixed one — a bottom-resting panel costs bottom, not width', () => {
+    // A wide, short panel hugging the bottom edge: reserving width would cost
+    // far more than reserving height. This is the discriminating case — a
+    // right-only implementation passes the first test and fails this one.
+    stubSelectors({
+      [PANEL]: fakeEl({ left: 300, right: 1000, top: 700, bottom: 790, width: 700, height: 90 }),
+    })
+    const p = computeFitPadding(fakeEl(FLOW))
+    expect(p.bottom).toBe('116px') // 800 - 700 + 16
+    expect(p.left).toBe('47px') // untouched base margin
+    expect(p.right).toBe('47px')
+  })
+
+  it('reserves nothing when the panel does not overlap the flow rect', () => {
+    // Positive control for the absence claim: the SAME stub shape that produces
+    // a reservation above must produce none here, so a no-op implementation
+    // cannot pass both this and the tests above.
+    stubSelectors({
+      [PANEL]: fakeEl({ left: 1400, right: 1800, top: 73, bottom: 623, width: 400, height: 550 }),
+    })
+    const p = computeFitPadding(fakeEl(FLOW))
+    expect(p.left).toBe('47px')
+    expect(p.right).toBe('47px')
+    expect(p.top).toBe('29px')
+    expect(p.bottom).toBe('29px')
+  })
+
+  it('does NOT reserve the minimised pill — the measured reason it is excluded', () => {
+    // Deliberate product judgement, pinned so a later tidy-up cannot "restore
+    // consistency" by adding the pill selector back without re-reading why.
+    // Measured 16 Aug 2026: reserving an 84x28 pill resting mid-pane took 416px
+    // of bottom padding, collapsing the vertical fitting box to 355px for a
+    // graph needing 524px — clamping the entire first view of the model to
+    // avoid a node grazing a draggable affordance.
+    stubSelectors({ [PILL]: fakeEl({ left: 640, right: 708, top: 400, bottom: 425, width: 68, height: 25 }) })
+    const p = computeFitPadding(fakeEl(FLOW))
+    expect(p.bottom).toBe('29px')
+    expect(p.top).toBe('29px')
+    expect(p.left).toBe('47px')
+    expect(p.right).toBe('47px')
+  })
+
+  it('reserves the panel ALONGSIDE the dock, taking the larger on a shared side', () => {
+    // Both occlude the right at 1280x800 with the dock collapsed: the rail
+    // reserves 68, the bottom-right panel 504. The side must carry the larger,
+    // never the last one written.
+    stubSelectors({
+      [DOCK]: fakeEl({ left: 1228, right: 1268, width: 40, top: 12, bottom: 784, height: 772 }),
+      [PANEL]: fakeEl({ left: 812, right: 1212, top: 234, bottom: 784, width: 400, height: 550 }),
+      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
+    })
+    const p = computeFitPadding(fakeEl(FLOW))
+    expect(p.right).toBe('520px') // 1280 - 776 + 16, beating the rail's 68
+  })
+})
+
+describe('cheapestReservation', () => {
+  const FLOW = { left: 0, top: 0, right: 1280, bottom: 800 }
+
+  it('returns null when the boxes do not intersect', () => {
+    expect(cheapestReservation(FLOW, { left: 1400, top: 0, right: 1800, bottom: 550 })).toBeNull()
+    expect(cheapestReservation(FLOW, { left: 100, top: 900, right: 500, bottom: 1200 })).toBeNull()
+  })
+
+  it('picks the minimum of the four clearing distances', () => {
+    // Bottom-right anchored panel: right (504) < bottom (566) < left (1212).
+    expect(cheapestReservation(FLOW, { left: 776, top: 234, right: 1212, bottom: 784 })).toEqual({
+      side: 'right',
+      amount: 504,
+    })
+    // Same panel moved to hug the top edge: top (262) is now cheapest.
+    expect(cheapestReservation(FLOW, { left: 776, top: 0, right: 1212, bottom: 262 })).toEqual({
+      side: 'top',
+      amount: 262,
+    })
+  })
+
+  it('never returns a negative amount', () => {
+    // Spec-level invariant (not a case): a padding is a non-negative length,
+    // whatever pathological rect arrives.
+    const boxes = [
+      { left: -500, top: -500, right: 2000, bottom: 2000 },
+      { left: 0, top: 0, right: 1280, bottom: 800 },
+      { left: 1279, top: 799, right: 1281, bottom: 801 },
+    ]
+    for (const b of boxes) {
+      const r = cheapestReservation(FLOW, b)
+      if (r) expect(r.amount).toBeGreaterThanOrEqual(0)
+    }
   })
 })

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -226,6 +226,29 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick, blu
       // dependency change (e.g. another node-count tick during the 450ms
       // clear window).
       performAutoReposition(anchor, { reducedMotion: prefersReducedMotion })
+
+      // …then step out of the model's way. Measured 16 Aug 2026 at 1280x800
+      // with the committed CEE draft capture: with the dock collapsed to its
+      // rail, an OPEN floating panel leaves an 796px fitting box for a graph
+      // that needs 1008px at the legibility floor, so the user's first view of
+      // their own model is clamped and overflowing. Closed or minimised, the
+      // same measurement gives 1136px and fits at 0.563. No dock width and no
+      // padding rule can recover that: a 400x550 panel plus its side tab is a
+      // third of a laptop viewport, so while it is open the fit CANNOT clear
+      // the floor — the only honest options are to occlude the graph or to
+      // clamp it, and this chooses neither.
+      //
+      // Scope is deliberately the narrowest that achieves it: this runs only
+      // under `canAutoDock` (source === 'system-first-use' && !userRepositioned)
+      // and only on the 0→N draft transition, i.e. the TRANSCRIPT-LESS hero
+      // that the user has never moved. A panel the user opened or dragged is
+      // never touched, and neither is one showing a transcript — so this cannot
+      // hide an assistant reply the user could otherwise read. (The hero has no
+      // transcript by construction; that is precisely why
+      // `shouldAutoExpandDockForResponse` treats it as showing nothing.)
+      // Coaching stays one click away on the restore pill, and every dispatch
+      // path that sends work to Olumi reveals the surface again.
+      useFloatingPanelState.getState().minimise()
     }
     if (prefersReducedMotion) {
       performReposition()

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -252,6 +252,84 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
 // enforced by `handleTabClick` + the close-floating-on-olumi-active
 // effect (see OutputsDockBody below).
 
+/**
+ * Whether the dock renders as its collapsed 40px rail rather than its full
+ * body — the "first use" state.
+ *
+ * ⚠ THE INPUT CHANGED ON 16 Aug 2026 and that IS the behaviour change: this
+ * used to be driven by `!hasGraphContent`, so a DRAFTED GRAPH ended first use
+ * and the dock expanded to its full width the instant the model appeared —
+ * showing a pre-run Analysis tab with no analysis in it. An outputs dock with
+ * no outputs has no claim to that width, and the canvas pays for it: measured
+ * at 1280x800 with the committed CEE draft capture, the expanded dock reserved
+ * 361px of `computeFitPadding`, leaving an 843px fitting box for a graph
+ * needing 1008px at the legibility floor — so the product's own first view of
+ * the user's model was clamped and overflowing. Collapsed: 1136px, fits at
+ * 0.563.
+ *
+ * Pure and exported so the rule is mutation-testable without mounting the dock.
+ *
+ * @param hasAnalysisResult `hasCompletedFirstRun` — at least one successful or
+ *   restored run exists in this session, i.e. the dock has something to show.
+ * @param analysisActive a run is IN FLIGHT (results status is anything but
+ *   `idle`/`cancelled`). Outputs are not here yet but they are coming, and the
+ *   run's own progress narration lives in the dock body.
+ *
+ *   ⚠ This is NOT redundant with the run-start effect's override, and the
+ *   difference is reachable: that effect fires on the `idle → active`
+ *   TRANSITION, so it never fires for a run that is ALREADY active when the
+ *   dock mounts — a page reload mid-analysis, or a resumed session. Without
+ *   this input the user would watch their running analysis from behind a 40px
+ *   rail. The override still earns its place for the other direction: once a
+ *   run has opened the dock it STAYS open, so a cancelled run does not collapse
+ *   the dock out from under the user.
+ * @param userExplicitlyOpened the session-scoped override raised by the rail's
+ *   own chevron, by a started run, and by the collapsed-response signal. Once
+ *   raised it wins outright: an explicit expand is never undone by this rule.
+ */
+export function shouldRenderFirstUseRail(input: {
+  aiPanelV2On: boolean
+  hasAnalysisResult: boolean
+  analysisActive: boolean
+  userExplicitlyOpened: boolean
+}): boolean {
+  return (
+    input.aiPanelV2On &&
+    !input.hasAnalysisResult &&
+    !input.analysisActive &&
+    !input.userExplicitlyOpened
+  )
+}
+
+/**
+ * Whether a programmatic tab activation is entitled to END the first-use rail.
+ *
+ * Only a forced activation of the OLUMI tab is — that is `revealOlumiSurface()`,
+ * and revealing a thread the user cannot see is meaningless behind a 40px rail.
+ *
+ * ⚠ THE 'olumi' CLAUSE IS THE WHOLE POINT, AND ITS ABSENCE WAS A MEASURED
+ * REGRESSION (16 Aug 2026). Without it, ANY forced activation cleared the rail —
+ * which looks equivalent, since all of them are "programmatic navigation that
+ * has decided to front the dock". But `FirstUseComposer` forces `'results'` on
+ * the 0→N draft transition, so the DRAFT ITSELF cleared the rail: the dock
+ * re-claimed its full width with no analysis in it and the post-draft fit went
+ * straight back to the clamped 843px this lane exists to remove. One change
+ * silently undoing the other, on the single journey both were written for.
+ *
+ * The full test suite was GREEN with that defect present — it is a two-effect
+ * interaction, invisible to every unit test — and it was caught only by
+ * re-running the browser measurement on the final tip. Hence this pure helper:
+ * so the rule has somewhere to be tested, and a mutant has something to bite.
+ *
+ * Two different questions under one mechanism (trap 21): "reveal the Olumi
+ * thread" legitimately claims the dock; "the draft landed, front Analysis" does
+ * not. A started run ends the rail through its own effect, so no other tab
+ * needs this.
+ */
+export function forcedActivationEndsRail(versionChanged: boolean, resolvedTab: string): boolean {
+  return versionChanged && resolvedTab === 'olumi'
+}
+
 /** Dynamic accessor: re-evaluates feature flags on every call. Exported so
  *  parity tests can verify tab gating without remounting OutputsDock. The
  *  component computes its own OUTPUT_TABS via useMemo at render time, so a
@@ -368,6 +446,19 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // floatingPanelIsOpen subscriber is declared — keeps Rules of Hooks
   // happy with the deps array.)
 
+  /**
+   * Session-scoped override that ends the first-use rail (see
+   * `shouldRenderFirstUseRail`). Raised by the rail's own chevron
+   * (`toggleOpen`), by a started run, by the collapsed-response signal, and by
+   * a forced tab activation. Never persisted, so a returning user with no
+   * analysis still gets the rail.
+   *
+   * Declared HERE, above the E1 sync effect, because that effect raises it —
+   * keeping the declaration below its first use would rely on closure timing to
+   * stay legal.
+   */
+  const userExplicitlyOpenedRailRef = useRef(false)
+
   // E1: Sync external tab changes from Zustand store (programmatic navigation).
   // Also watches activeOutputTabVersion so `forceActivateOutputTab` triggers
   // the sync even when the tab value itself didn't change — e.g. auto-dock
@@ -409,6 +500,34 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       || (externalTab === 'olumi' && !isAiPanelV2Enabled())
       ? 'results'
       : externalTab
+    // A forced activation OF THE OLUMI TAB must also clear the FIRST-USE RAIL,
+    // for the same reason `versionChanged` clears an overlay panel above. Since
+    // 16 Aug the rail persists until an analysis result exists, and
+    // `effectiveIsOpen` is `isFirstUse ? false : state.isOpen` — so the
+    // `isOpen: true` below is overridden by the rail, and `revealOlumiSurface()`
+    // would "open" a dock that stays 40px wide. That is ROADMAP 2.639's defect
+    // (the turn reports success and nothing on screen moves) reachable again
+    // through a different override, so it gets 2.639's answer. This is what
+    // makes the class-8 guarantee true.
+    //
+    // ⚠ SCOPED TO 'olumi' DELIBERATELY, and the wider version cost a measured
+    // regression. Clearing the rail on ANY forced activation looks equivalent —
+    // both are "programmatic navigation that has decided to front the dock" —
+    // but `FirstUseComposer` calls `forceActivateOutputTab('results')` on the
+    // 0→N draft transition, which bumps the same counter. The rail was
+    // therefore cleared by the draft itself, the dock re-claimed its full width
+    // with no analysis in it, and the post-draft fit went straight back to the
+    // clamped 843px this lane exists to fix — the class-8 change silently
+    // undoing the coexistence change, on the one journey both were written for.
+    // Caught only by re-running the browser measurement on the final tip.
+    //
+    // The two are different questions (trap 21): "reveal the Olumi thread"
+    // legitimately claims the dock; "the draft landed, front Analysis" does not.
+    // A run start clears the rail through its own effect, so nothing else needs
+    // this.
+    if (forcedActivationEndsRail(versionChanged, resolvedTab)) {
+      userExplicitlyOpenedRailRef.current = true
+    }
     setState(prev => {
       if (prev.activeTab === resolvedTab && prev.isOpen) return prev
       return { ...prev, isOpen: true, activeTab: resolvedTab as OutputsDockTab }
@@ -499,16 +618,41 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // The collapse is NOT persisted — derived per render so returning users
   // with an empty canvas only see the rail until they explicitly engage.
   const aiPanelV2On = isAiPanelV2Enabled()
+  // Read here (not at the later `resultsStatus` site) because the rail
+  // derivation below needs it and runs first. Same selector, so no extra
+  // subscription cost beyond the one hook call.
+  const railResultsStatus = useCanvasStore(selectResultsStatus)
+  // "A run is in flight." Mirrors the auto-switch effect's own `isNowActive`
+  // notion — anything that is not idle/cancelled — so the two cannot drift into
+  // disagreeing about what an active run is.
+  const analysisActive = railResultsStatus !== 'idle' && railResultsStatus !== 'cancelled'
   const conversationCtxForFirstUse = useOptionalConversationContext()
   const realMessageCount = conversationCtxForFirstUse
     ? conversationCtxForFirstUse.messages.filter((m) => !m.synthetic).length
     : 0
-  // First-use ends only when graph content exists OR the user explicitly
-  // expands the dock (via the rail's chevron). We do NOT use realMessageCount
-  // here — the brief is explicit that the empty Analysis tab should not flash
-  // after a user message but before the graph builds.
-  const userExplicitlyOpenedRailRef = useRef(false)
-  const isFirstUse = aiPanelV2On && !hasGraphContent && !userExplicitlyOpenedRailRef.current
+  // First-use ends when the dock has OUTPUTS TO SHOW — i.e. an analysis result
+  // exists (`hasCompletedFirstRun`: at least one successful or restored run this
+  // session) — OR the user explicitly expands the dock (the rail's chevron), OR
+  // a run starts (see the auto-switch effect, which drops the lock so a running
+  // analysis is visible). We do NOT use realMessageCount here — the brief is
+  // explicit that the empty Analysis tab should not flash after a user message
+  // but before the graph builds.
+  //
+  // ⚠ THIS WAS `!hasGraphContent` UNTIL 16 Aug 2026, and that is the defect.
+  // A drafted graph ended first-use, so the dock expanded to its full width the
+  // moment the model appeared — showing a pre-run Analysis tab with no analysis
+  // in it. An outputs dock with no outputs has no claim to that width, and the
+  // cost is paid by the canvas: measured at 1280x800 with the committed CEE
+  // draft capture, the expanded dock reserved 361px of `computeFitPadding`,
+  // leaving a 843px fitting box for a graph needing 1008px at the legibility
+  // floor — so the product's own first view of the user's model was clamped and
+  // overflowing. Collapsed, the same measurement gives a 1136px fitting box.
+  const isFirstUse = shouldRenderFirstUseRail({
+    aiPanelV2On,
+    hasAnalysisResult: hasCompletedFirstRun,
+    analysisActive,
+    userExplicitlyOpened: userExplicitlyOpenedRailRef.current,
+  })
   // realMessageCount kept for downstream consumers (Olumi tab empty-state
   // logic); intentionally does NOT participate in isFirstUse.
   void realMessageCount
@@ -1509,6 +1653,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       userInteractedSinceRunRef.current = false
       runAutoSwitchedToAnalysisRef.current = activeTabRef.current !== 'results'
     }
+
+    // Drop the first-use rail lock. Since 16 Aug the rail persists until an
+    // analysis result EXISTS (`hasCompletedFirstRun`), which is only set when a
+    // run COMPLETES — so without this, the dock would stay collapsed for the
+    // whole duration of the first run and the user would watch their analysis
+    // run behind a 40px rail. `isOpen: true` below is not enough on its own:
+    // `effectiveIsOpen` is `isFirstUse ? false : state.isOpen`, so the rail
+    // overrides it. A started run is exactly the "outputs are coming" signal the
+    // dock should open for; this is the same one-line override the user's own
+    // chevron-expand and the collapsed-response signal already use.
+    userExplicitlyOpenedRailRef.current = true
 
     // Task F: Auto-open results — close overlay panels so OutputsDock becomes visible
     useUIStore.getState().openRightPanel('results')

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -23,6 +23,34 @@ function renderOutputsDock() {
   )
 }
 
+/**
+ * Expand the dock from its collapsed rail, the way a user does, and return the
+ * Run control the caller is about to click.
+ *
+ * ⚠ WHY THIS EXISTS (16 Aug 2026). This suite's `beforeEach` seeds
+ * `hasCompletedFirstRun: false` with a graph present — a DRAFTED, NOT YET
+ * ANALYSED session. `shouldRenderFirstUseRail` was re-based from "does a graph
+ * exist" onto "does an analysis RESULT exist", so that state now renders the
+ * 40px rail, and the dock's own Run control lives inside the body the rail
+ * hides. (The user is not stranded: the drafted decision node carries its own
+ * "Run analysis" chip, and this chevron is one click.)
+ *
+ * The tests below are about the Run control's DISPATCH behaviour — V2 vs the
+ * conversation callback vs the canonical chip — not about its visibility, so
+ * they open the dock first. This is a REACHABLE state, not a test-only
+ * convenience: `toggleOpen` raises the same session override that a started run
+ * and the collapsed-response signal raise.
+ *
+ * Bound to the chevron's aria-label rather than a testid so a rename fails
+ * loudly, and it ASSERTS THE CHEVRON WAS THERE — an expand that silently no-ops
+ * would otherwise resurface as the original "unable to find outputs-run-button"
+ * error one line later, which is exactly the confusion this helper removes.
+ */
+function expandDockFromRail() {
+  fireEvent.click(screen.getByLabelText('Expand outputs dock'))
+  return screen.getByTestId('outputs-run-button')
+}
+
 const {
   mockIsOrchestratorV2Enabled,
   mockIsLegacyDirectRunEnabled,
@@ -205,7 +233,7 @@ describe('OutputsDock analyse convergence', () => {
 
     renderOutputsDock()
 
-    fireEvent.click(screen.getByTestId('outputs-run-button'))
+    fireEvent.click(expandDockFromRail())
 
     // The run now awaits the pre-dispatch save flush (F1 barrier) before
     // reaching the V2/dispatch path, so the spy resolves on a later microtask.
@@ -219,7 +247,7 @@ describe('OutputsDock analyse convergence', () => {
 
     renderOutputsDock()
 
-    fireEvent.click(screen.getByTestId('outputs-run-button'))
+    fireEvent.click(expandDockFromRail())
 
     await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
     expect(mockShowToast).not.toHaveBeenCalled()
@@ -247,7 +275,7 @@ describe('OutputsDock analyse convergence', () => {
       useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
 
       renderOutputsDock()
-      fireEvent.click(screen.getByTestId('outputs-run-button'))
+      fireEvent.click(expandDockFromRail())
 
       // Correction 8: exact chip/action payload shape — action_type
       // 'run_analysis', source 'chip', no free-text LLM route.
@@ -275,7 +303,7 @@ describe('OutputsDock analyse convergence', () => {
       useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
 
       renderOutputsDock()
-      fireEvent.click(screen.getByTestId('outputs-run-button'))
+      fireEvent.click(expandDockFromRail())
 
       await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
       expect(dispatchAction).not.toHaveBeenCalled()
@@ -291,7 +319,7 @@ describe('OutputsDock analyse convergence', () => {
       useGuidanceStore.setState({ _dispatchAction: dispatchAction } as any)
 
       renderOutputsDock()
-      fireEvent.click(screen.getByTestId('outputs-run-button'))
+      fireEvent.click(expandDockFromRail())
 
       await waitFor(() => expect(runV2Analysis).toHaveBeenCalledTimes(1))
       expect(dispatchAction).not.toHaveBeenCalled()
@@ -322,6 +350,12 @@ describe('OutputsDock analyse convergence', () => {
       // POSITIVE CONTROL: bind to the runner the dock actually registered, so a
       // null here fails loudly instead of the assertions below passing against
       // a dock that never mounted.
+      //
+      // Conflict resolution (A2 rebase onto #723): staging replaced this case's
+      // DOM click with the registered runner, so the dock no longer has to be
+      // expanded for it — the A2 side's `expandDockFromRail()` is obsolete HERE
+      // and is dropped. It is kept in the cases below that still click the
+      // dock's own Run control, which the first-use rail does hide.
       expect(runner).not.toBeNull()
 
       const outcome = await runner!({ source: 'test' })

--- a/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.conversationSingleton.spec.tsx
@@ -197,6 +197,9 @@ describe('Olumi tab click while floating is open', () => {
     // order-dependent on a leaked canvas state.
     useCanvasStore.getState().resetCanvas()
     useCanvasStore.getState().addNode(undefined, 'decision')
+    // Since 16 Aug 2026 the first-use rail ends on an analysis RESULT, not on
+    // graph content, so the node alone no longer expands the dock.
+    useCanvasStore.setState({ hasCompletedFirstRun: true } as any)
 
     // Pre-state: Analysis tab is active in the global store, and the
     // floating panel is open.
@@ -240,6 +243,9 @@ describe('Olumi tab click while floating is open', () => {
 
     useCanvasStore.getState().resetCanvas()
     useCanvasStore.getState().addNode(undefined, 'decision') // populated → dock can host Olumi
+    // …and an analysis result, which is what actually ends the rail since
+    // 16 Aug 2026. "Populated" alone leaves the dock at 40px and unable to host.
+    useCanvasStore.setState({ hasCompletedFirstRun: true } as any)
     try {
       sessionStorage.setItem(
         'canvas.outputsDock.v1',
@@ -372,6 +378,11 @@ describe('Olumi tab click while floating is open', () => {
     // is on the Olumi tab, no floating open.
     useCanvasStore.setState({
       nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+      // Since 16 Aug 2026 the first-use rail ends on an analysis RESULT, not on
+      // graph content, so the graph alone no longer expands the dock. These
+      // cases are about tab/floating-panel behaviour in an EXPANDED dock, so a
+      // session that has produced an analysis is the accurate fixture.
+      hasCompletedFirstRun: true,
     } as any)
     useUIStore.setState({ activeOutputTab: 'olumi', activeOutputTabVersion: 0 })
     useFloatingPanelState.getState().reset()
@@ -412,7 +423,10 @@ describe('Olumi tab click while floating is open', () => {
     expect(persisted).not.toBe('olumi')
 
     // Cleanup: leave the canvas store empty for the next test.
-    useCanvasStore.setState({ nodes: [] } as any)
+    // Symmetric teardown: these tests now also seed `hasCompletedFirstRun`, and
+    // clearing only `nodes` would leak an analysis result into the next test —
+    // which is precisely what made a later rail-path case render expanded.
+    useCanvasStore.setState({ nodes: [], hasCompletedFirstRun: false } as any)
   })
 
   it('persisted activeTab=olumi + global=results + floating open → floating yields on first render (round-5 race guard)', async () => {
@@ -445,6 +459,11 @@ describe('Olumi tab click while floating is open', () => {
     // Need a graph so the panel doesn't yield via yieldToFirstUse.
     useCanvasStore.setState({
       nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+      // Since 16 Aug 2026 the first-use rail ends on an analysis RESULT, not on
+      // graph content, so the graph alone no longer expands the dock. These
+      // cases are about tab/floating-panel behaviour in an EXPANDED dock, so a
+      // session that has produced an analysis is the accurate fixture.
+      hasCompletedFirstRun: true,
     } as any)
 
     const { container } = render(
@@ -459,7 +478,10 @@ describe('Olumi tab click while floating is open', () => {
 
     // Cleanup: clear the persisted state so subsequent tests don't inherit it.
     try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
-    useCanvasStore.setState({ nodes: [] } as any)
+    // Symmetric teardown: these tests now also seed `hasCompletedFirstRun`, and
+    // clearing only `nodes` would leak an analysis result into the next test —
+    // which is precisely what made a later rail-path case render expanded.
+    useCanvasStore.setState({ nodes: [], hasCompletedFirstRun: false } as any)
   })
 
   it('docked Olumi float-out returns the user to the LAST non-Olumi tab (round-5 UX)', async () => {
@@ -477,6 +499,11 @@ describe('Olumi tab click while floating is open', () => {
     // (internally 'diagnostics'), then switched to Olumi.
     useCanvasStore.setState({
       nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+      // Since 16 Aug 2026 the first-use rail ends on an analysis RESULT, not on
+      // graph content, so the graph alone no longer expands the dock. These
+      // cases are about tab/floating-panel behaviour in an EXPANDED dock, so a
+      // session that has produced an analysis is the accurate fixture.
+      hasCompletedFirstRun: true,
     } as any)
     useUIStore.setState({ activeOutputTab: 'diagnostics', activeOutputTabVersion: 0 })
     useFloatingPanelState.getState().reset()
@@ -511,7 +538,10 @@ describe('Olumi tab click while floating is open', () => {
 
     // Cleanup.
     try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
-    useCanvasStore.setState({ nodes: [] } as any)
+    // Symmetric teardown: these tests now also seed `hasCompletedFirstRun`, and
+    // clearing only `nodes` would leak an analysis result into the next test —
+    // which is precisely what made a later rail-path case render expanded.
+    useCanvasStore.setState({ nodes: [], hasCompletedFirstRun: false } as any)
   })
 
   it('persistent strip chevron from Olumi tab opens floating panel (round-14 regression)', async () => {
@@ -542,6 +572,11 @@ describe('Olumi tab click while floating is open', () => {
     // floating closed.
     useCanvasStore.setState({
       nodes: [{ id: 'n1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'd', kind: 'decision' } }],
+      // Since 16 Aug 2026 the first-use rail ends on an analysis RESULT, not on
+      // graph content, so the graph alone no longer expands the dock. These
+      // cases are about tab/floating-panel behaviour in an EXPANDED dock, so a
+      // session that has produced an analysis is the accurate fixture.
+      hasCompletedFirstRun: true,
     } as any)
     useUIStore.setState({ activeOutputTab: 'olumi', activeOutputTabVersion: 0 })
     useFloatingPanelState.getState().reset()
@@ -576,7 +611,10 @@ describe('Olumi tab click while floating is open', () => {
 
     // Cleanup.
     try { sessionStorage.removeItem('canvas.outputsDock.v1') } catch {}
-    useCanvasStore.setState({ nodes: [] } as any)
+    // Symmetric teardown: these tests now also seed `hasCompletedFirstRun`, and
+    // clearing only `nodes` would leak an analysis result into the next test —
+    // which is precisely what made a later rail-path case render expanded.
+    useCanvasStore.setState({ nodes: [], hasCompletedFirstRun: false } as any)
   })
 
   it('falls through to normal tab activation when floating is CLOSED', async () => {

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -145,7 +145,21 @@ function resetDockEnvironment() {
       results: PRISTINE_RESULTS,
       currentScenarioFraming: null,
       currentScenarioLastResultHash: null,
-      hasCompletedFirstRun: false,
+      // ⚠ WAS `false` UNTIL 16 Aug 2026 — the same "wrong fixture" the comment
+      // above describes, one rule further on. `shouldRenderFirstUseRail` was
+      // re-based from "does a graph exist" onto "does an analysis RESULT
+      // exist", so seeding nodes is no longer enough to put the dock into its
+      // body: a drafted-but-unanalysed session renders the 40px rail, and the
+      // tests below assert on tab-strip and dock-body chrome (ARIA sections,
+      // the Model verify badge, persisted tab state, ?tab= handling, the
+      // Journey flag) which only exist once the body is showing.
+      //
+      // Seeding a session that HAS an analysis result is the accurate fixture
+      // for those assertions, not a relaxation of them — every assertion is
+      // untouched. Tests that genuinely exercise the PRE-RUN dock or the rail
+      // itself set `hasCompletedFirstRun: false` explicitly for themselves, and
+      // still do.
+      hasCompletedFirstRun: true,
     } as any)
   useGuidanceStore.setState({
     guidanceItems: [],
@@ -1047,6 +1061,13 @@ describe('I.2a: Secondary action button interaction', () => {
         { id: 'seed-decision', type: 'decision', data: { label: 'Seed Decision' }, position: { x: 100, y: 100 } },
       ],
       edges: [{ id: 'seed-e1', source: 'seed-decision', target: 'seed-goal' }],
+      // The comment above predicted this exact failure and its symptom — "icon
+      // buttons with no text" — it just predicted it one rule early. Since
+      // 16 Aug the rail ends on an analysis RESULT, not on graph content, so
+      // seeding nodes alone leaves the fresh store on the rail and the assertion
+      // below reads six empty strings instead of the tab labels. Mirrors the
+      // `beforeEach` fixture; the assertion is untouched.
+      hasCompletedFirstRun: true,
     } as any)
     render(
       <FreshToastProvider>

--- a/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
+++ b/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * `shouldRenderFirstUseRail` — the rule deciding whether the OutputsDock renders
+ * as its 40px rail or claims its full width.
+ *
+ * Written against the STATED RULE ("the dock is a rail until it has outputs to
+ * show, unless something has explicitly opened it"), not against the 1280x800
+ * measurement that motivated the change — the measurement is evidence for the
+ * rule, and a spec pinned to the measurement would go stale the moment the
+ * viewport or the graph changed while the rule stayed correct.
+ *
+ * The behaviour change this pins: the input used to be "does a graph exist",
+ * so a drafted model expanded the dock to show an Analysis tab containing no
+ * analysis. It is now "does an analysis RESULT exist".
+ */
+
+import { describe, it, expect } from 'vitest'
+import { shouldRenderFirstUseRail, forcedActivationEndsRail } from '../OutputsDock'
+
+describe('shouldRenderFirstUseRail', () => {
+  const base = {
+    aiPanelV2On: true,
+    hasAnalysisResult: false,
+    analysisActive: false,
+    userExplicitlyOpened: false,
+  }
+
+  it('rails when there is no analysis result yet', () => {
+    expect(shouldRenderFirstUseRail(base)).toBe(true)
+  })
+
+  it('releases the rail once an analysis result exists', () => {
+    expect(shouldRenderFirstUseRail({ ...base, hasAnalysisResult: true })).toBe(false)
+  })
+
+  it('releases the rail on an explicit open, result or not', () => {
+    // The override is unconditional by design: the rail's chevron, a started
+    // run, and the collapsed-response signal all raise it, and none of them
+    // should be second-guessed by this rule.
+    expect(shouldRenderFirstUseRail({ ...base, userExplicitlyOpened: true })).toBe(false)
+    expect(
+      shouldRenderFirstUseRail({ ...base, hasAnalysisResult: true, userExplicitlyOpened: true }),
+    ).toBe(false)
+  })
+
+  it('releases the rail while a run is IN FLIGHT, before any result exists', () => {
+    // The reachable case this input exists for: a run that is ALREADY active
+    // when the dock mounts (page reload mid-analysis, resumed session) never
+    // fires the idle→active transition the run-start override rides, so without
+    // this the user would watch their running analysis from behind the rail.
+    expect(shouldRenderFirstUseRail({ ...base, analysisActive: true })).toBe(false)
+  })
+
+  it('never rails when aiPanelV2 is off', () => {
+    // The rail is a floating-first-UX affordance; with the flag off the legacy
+    // dock owns its own open state and this rule must be inert. Swept over
+    // every combination of the other two inputs so the claim is about the flag,
+    // not about the one combination that happened to be tried.
+    for (const hasAnalysisResult of [true, false]) {
+      for (const analysisActive of [true, false]) {
+        for (const userExplicitlyOpened of [true, false]) {
+          expect(
+            shouldRenderFirstUseRail({
+              aiPanelV2On: false,
+              hasAnalysisResult,
+              analysisActive,
+              userExplicitlyOpened,
+            }),
+            `aiPanelV2Off/${hasAnalysisResult}/${analysisActive}/${userExplicitlyOpened}`,
+          ).toBe(false)
+        }
+      }
+    }
+  })
+
+  it('is NOT a function of graph content — the defect this replaced', () => {
+    // A DISCRIMINATING assertion, not a restatement: the old rule released the
+    // rail as soon as nodes existed. The signature no longer admits graph
+    // content at all, so the only way to observe the difference is that a
+    // drafted-but-unanalysed session — every input the old rule would have
+    // flipped on — still rails. If someone reintroduces a node-count input,
+    // this is the test that has to be deleted to do it.
+    const draftedButNotAnalysed = {
+      aiPanelV2On: true,
+      hasAnalysisResult: false,
+      analysisActive: false,
+      userExplicitlyOpened: false,
+    }
+    expect(shouldRenderFirstUseRail(draftedButNotAnalysed)).toBe(true)
+    expect(Object.keys(draftedButNotAnalysed)).not.toContain('hasGraphContent')
+  })
+})
+
+describe('forcedActivationEndsRail', () => {
+  it('ends the rail for a forced OLUMI activation — the class-8 reveal', () => {
+    // Revealing a thread the user cannot see is meaningless behind a 40px rail.
+    expect(forcedActivationEndsRail(true, 'olumi')).toBe(true)
+  })
+
+  it('does NOT end the rail for a forced RESULTS activation — the measured regression', () => {
+    // THE DISCRIMINATING CASE. `FirstUseComposer` forces 'results' on the 0→N
+    // draft transition, so a rule that fired on any forced tab let the DRAFT
+    // clear the rail: the dock re-claimed its full width with no analysis in it
+    // and the post-draft fit returned to the clamped 843px this lane removes.
+    // The full suite was green with that defect present — it is a two-effect
+    // interaction no unit test saw — so this case is the pin.
+    expect(forcedActivationEndsRail(true, 'results')).toBe(false)
+  })
+
+  it('ends the rail for no other tab', () => {
+    // Swept rather than sampled: 'results' is the one that actually bit, but the
+    // claim is about every non-Olumi tab, and a future forced activation of any
+    // of these must not silently re-open the dock either.
+    for (const tab of ['results', 'altview', 'compare', 'diagnostics', 'journey']) {
+      expect(forcedActivationEndsRail(true, tab), tab).toBe(false)
+    }
+  })
+
+  it('requires the version counter to have changed', () => {
+    // A plain `setActiveOutputTab` does not bump the counter, and must leave a
+    // dock the user collapsed for themselves exactly where they put it.
+    expect(forcedActivationEndsRail(false, 'olumi')).toBe(false)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
@@ -274,10 +274,19 @@ describe('ROADMAP 2.204 — the run returns the user to the surface it produced'
     try { localStorage.clear() } catch { /* private mode */ }
     useFloatingPanelState.getState().reset()
     useCanvasStore.getState().resetCanvas()
-    // A populated canvas: without it the dock is forced to its 40px first-use
-    // rail and hosts no tabs at all.
+    // A populated canvas AND a session that has already produced an analysis:
+    // without both, the dock is forced to its 40px first-use rail and hosts no
+    // tabs at all.
+    //
+    // ⚠ The graph alone was enough until 16 Aug 2026, when the rail was re-based
+    // from "does a graph exist" onto "does an analysis RESULT exist". These
+    // tests are about where a COMPLETED run returns the user, so a session that
+    // has run is the accurate fixture — and `status: 'idle'` beside it is not a
+    // contradiction: `resultsSettle` lands a finished run back on idle while
+    // `hasCompletedFirstRun` stays true, which is exactly the post-run state
+    // these cases exercise.
     useCanvasStore.getState().addNode(undefined, 'decision')
-    useCanvasStore.setState({ results: { status: 'idle', progress: 0 } })
+    useCanvasStore.setState({ results: { status: 'idle', progress: 0 }, hasCompletedFirstRun: true } as any)
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
 
@@ -555,7 +564,10 @@ describe('ROADMAP 2.204-R3 — the return lands on the arriving card', () => {
     useFloatingPanelState.getState().reset()
     useCanvasStore.getState().resetCanvas()
     useCanvasStore.getState().addNode(undefined, 'decision')
-    useCanvasStore.setState({ results: { status: 'idle', progress: 0 } })
+    // Mirrors the sibling describe's fixture: since 16 Aug 2026 the first-use
+    // rail ends on an analysis RESULT, not on graph content, so the node alone
+    // leaves the dock at 40px with no Olumi tab to scroll within.
+    useCanvasStore.setState({ results: { status: 'idle', progress: 0 }, hasCompletedFirstRun: true } as any)
     useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
   })
 

--- a/src/canvas/stores/__tests__/guidanceStore.olumiReveal.spec.ts
+++ b/src/canvas/stores/__tests__/guidanceStore.olumiReveal.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Class-8 guarantee: an action that sends work to Olumi visibly reveals Olumi.
+ *
+ * The guarantee is enforced at the REGISTRATION SEAM (`withOlumiReveal` in
+ * guidanceStore.ts) rather than at each call site, because a per-call-site
+ * reveal is a hand-maintained list that is correct the day it is written and
+ * silently short the first time someone adds a send. These tests are therefore
+ * written against the SEAM's contract — "a dispatched conversation callback
+ * reveals" — and not against the ~25 individual surfaces that ride it, which is
+ * what makes them stable when a new surface is added.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const revealSpy = vi.fn()
+vi.mock('../../conversation/revealOlumi', () => ({
+  revealOlumiSurface: () => revealSpy(),
+}))
+
+import { useGuidanceStore } from '../guidanceStore'
+
+const makeCallbacks = () => ({
+  sendMessage: vi.fn((_text: string) => {}),
+  scrollToPatch: vi.fn((_id: string) => {}),
+  sendChip: vi.fn((_label: string, _message: string) => {}),
+  runAnalysis: vi.fn(() => {}),
+  prefillChat: vi.fn((_text: string) => {}),
+  dispatchAction: vi.fn((_opts: { label: string; message: string; source: string }) => {}),
+})
+
+const register = (cb: ReturnType<typeof makeCallbacks>) =>
+  useGuidanceStore
+    .getState()
+    .registerConversationCallbacks(
+      cb.sendMessage,
+      cb.scrollToPatch,
+      cb.sendChip,
+      cb.runAnalysis,
+      cb.prefillChat,
+      cb.dispatchAction,
+    )
+
+describe('guidanceStore — Olumi reveal on dispatch', () => {
+  beforeEach(() => {
+    revealSpy.mockClear()
+    useGuidanceStore.setState({
+      _sendMessage: null,
+      _runAnalysis: null,
+      _sendChip: null,
+      _scrollToPatch: null,
+      _prefillChat: null,
+      _dispatchAction: null,
+      _registrationToken: null,
+    })
+  })
+
+  it('reveals on every SENDING callback, and delivers the message', () => {
+    // Swept over all four sending callbacks rather than the one a given surface
+    // happens to use — a per-callback test would pass while a sibling stayed
+    // silent, which is the exact shape of the defect being fixed.
+    const cb = makeCallbacks()
+    register(cb)
+    const s = useGuidanceStore.getState()
+
+    s._sendMessage?.('ask about this factor')
+    expect(cb.sendMessage).toHaveBeenCalledWith('ask about this factor')
+    expect(revealSpy).toHaveBeenCalledTimes(1)
+
+    s._sendChip?.('Gather evidence', 'How can I gather better evidence?')
+    expect(cb.sendChip).toHaveBeenCalledTimes(1)
+    expect(revealSpy).toHaveBeenCalledTimes(2)
+
+    s._prefillChat?.('draft text')
+    expect(cb.prefillChat).toHaveBeenCalledTimes(1)
+    expect(revealSpy).toHaveBeenCalledTimes(3)
+
+    s._dispatchAction?.({ label: 'Explain', message: 'explain this', source: 'chip' })
+    expect(cb.dispatchAction).toHaveBeenCalledTimes(1)
+    expect(revealSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('does NOT reveal on the non-sending callbacks', () => {
+    // The negative half, and the reason it exists: `_runAnalysis` navigates the
+    // dock to Analysis and has its own return-to-Olumi signal once the run
+    // produces review content, so fronting Olumi at run START would fight it;
+    // `_scrollToPatch` moves within an already-visible thread. Without this
+    // test, "wrap everything" would pass the test above and quietly break both.
+    const cb = makeCallbacks()
+    register(cb)
+    const s = useGuidanceStore.getState()
+
+    s._runAnalysis?.()
+    s._scrollToPatch?.('patch-1')
+
+    expect(cb.runAnalysis).toHaveBeenCalledTimes(1)
+    expect(cb.scrollToPatch).toHaveBeenCalledWith('patch-1')
+    expect(revealSpy).not.toHaveBeenCalled()
+  })
+
+  it('delivers the message even when the reveal throws', () => {
+    // The reveal is best-effort and must never convert a delivered message into
+    // a thrown error at the call site. Ordering is asserted too: the send has
+    // already happened by the time the reveal runs.
+    const cb = makeCallbacks()
+    register(cb)
+    revealSpy.mockImplementationOnce(() => {
+      throw new Error('no surface mounted')
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => useGuidanceStore.getState()._sendMessage?.('still lands')).not.toThrow()
+    expect(cb.sendMessage).toHaveBeenCalledWith('still lands')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('does not reveal when nothing is registered', () => {
+    // Positive control for the absence claim: the same probe that reveals four
+    // times above must reveal zero times here, so a wrapper that revealed
+    // unconditionally could not pass both.
+    const s = useGuidanceStore.getState()
+    expect(s._sendMessage).toBeNull()
+    expect(s._dispatchAction).toBeNull()
+    expect(revealSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/stores/__tests__/guidanceStore.registrationOwnership.spec.ts
+++ b/src/canvas/stores/__tests__/guidanceStore.registrationOwnership.spec.ts
@@ -8,16 +8,20 @@
  * "Try Again" and every other cross-surface run/ask CTA until a chat panel
  * was reopened.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useGuidanceStore } from '../guidanceStore'
 
+// Spies rather than bare stubs: since the store wraps callbacks (see the note
+// above `expectDelegatesTo`), ownership is asserted by WHICH callback runs, and
+// that needs a call record. Each `makeCallbacks()` returns fresh spies so two
+// hosts are distinguishable.
 const makeCallbacks = () => ({
-  sendMessage: (_text: string) => {},
-  scrollToPatch: (_id: string) => {},
-  sendChip: (_label: string, _message: string) => {},
-  runAnalysis: () => {},
-  prefillChat: (_text: string) => {},
-  dispatchAction: (_opts: { label: string; message: string; source: string }) => {},
+  sendMessage: vi.fn((_text: string) => {}),
+  scrollToPatch: vi.fn((_id: string) => {}),
+  sendChip: vi.fn((_label: string, _message: string) => {}),
+  runAnalysis: vi.fn(() => {}),
+  prefillChat: vi.fn((_text: string) => {}),
+  dispatchAction: vi.fn((_opts: { label: string; message: string; source: string }) => {}),
 })
 
 const register = (cb: ReturnType<typeof makeCallbacks>) =>
@@ -31,6 +35,31 @@ const register = (cb: ReturnType<typeof makeCallbacks>) =>
       cb.prefillChat,
       cb.dispatchAction,
     )
+
+/**
+ * ⚠ IDENTITY vs DELEGATION (16 Aug 2026). `registerConversationCallbacks` now
+ * stores `withOlumiReveal(cb)` — a wrapper that invokes the registered callback
+ * and then reveals the Olumi surface (the class-8 guarantee: an action that
+ * sends work to Olumi must visibly reveal Olumi). The stored value is therefore
+ * a NEW function object, and `toBe(cb.dispatchAction)` can no longer hold.
+ *
+ * These assertions were rewritten to test what they were always ABOUT — which
+ * host's registration is active — via DELEGATION rather than object identity.
+ * That is also the more honest test: this suite's own subject is that ownership
+ * is decided by `_registrationToken`, precisely BECAUSE callback identity
+ * cannot discriminate hosts (both hosts share the singleton conversation's
+ * function objects). An identity assertion was the one thing the file argues
+ * against everywhere else.
+ */
+function expectDelegatesTo(
+  stored: unknown,
+  spy: { mockClear: () => void; mock: { calls: unknown[][] } },
+) {
+  expect(stored).toBeTypeOf('function')
+  spy.mockClear()
+  ;(stored as (arg: unknown) => void)({ probe: true })
+  expect(spy.mock.calls).toEqual([[{ probe: true }]])
+}
 
 describe('guidanceStore registration ownership', () => {
   beforeEach(() => {
@@ -48,7 +77,7 @@ describe('guidanceStore registration ownership', () => {
   it('registers all callbacks and returns an unregister function', () => {
     const cb = makeCallbacks()
     const unregister = register(cb)
-    expect(useGuidanceStore.getState()._dispatchAction).toBe(cb.dispatchAction)
+    expectDelegatesTo(useGuidanceStore.getState()._dispatchAction, cb.dispatchAction)
     expect(typeof unregister).toBe('function')
   })
 
@@ -70,7 +99,7 @@ describe('guidanceStore registration ownership', () => {
     register(shared) // second host, identical callback identities
     unregisterFirst() // first host unmounts AFTER the second registered
     // The second host's registration must survive.
-    expect(useGuidanceStore.getState()._dispatchAction).toBe(shared.dispatchAction)
+    expectDelegatesTo(useGuidanceStore.getState()._dispatchAction, shared.dispatchAction)
     expect(useGuidanceStore.getState()._registrationToken).not.toBeNull()
   })
 
@@ -90,8 +119,15 @@ describe('guidanceStore registration ownership', () => {
     // registered (e.g. dock tab unmounts while the floating panel stays up).
     unregisterFirst()
     const s = useGuidanceStore.getState()
-    expect(s._dispatchAction).toBe(second.dispatchAction)
-    expect(s._sendMessage).toBe(second.sendMessage)
+    // Discriminating: the SECOND host's spies must fire and the FIRST host's
+    // must not — which is the claim, and one that survives the wrapper.
+    expectDelegatesTo(s._dispatchAction, second.dispatchAction)
+    expect(first.dispatchAction).not.toHaveBeenCalled()
+    expectDelegatesTo(s._sendMessage, second.sendMessage)
+    expect(first.sendMessage).not.toHaveBeenCalled()
+    // `_runAnalysis` is stored UNWRAPPED by design (a run navigates to Analysis
+    // and has its own return-to-Olumi signal), so identity still holds here —
+    // and asserting it pins that deliberate asymmetry.
     expect(s._runAnalysis).toBe(second.runAnalysis)
   })
 })

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -6,6 +6,7 @@
  */
 import { create } from 'zustand'
 import { AlertTriangle, Lightbulb, type LucideIcon } from 'lucide-react'
+import { revealOlumiSurface } from '../conversation/revealOlumi'
 
 // ---------------------------------------------------------------------------
 // § 1 — CEE contract types
@@ -171,6 +172,51 @@ export function deriveGuidanceDskProvenance(
     (GUIDANCE_EVIDENCE_STRENGTHS as readonly string[]).includes(strength)
       ? { strength }
       : {}),
+  }
+}
+
+/**
+ * Wrap a conversation callback so invoking it also REVEALS the Olumi surface.
+ *
+ * Class-8 guarantee (16 Aug 2026): *every action that sends work to Olumi
+ * visibly reveals Olumi with the in-flight turn.* A swept census found ~25
+ * dispatch sites that sent silently — node chips and coaching markers
+ * (`nodes/NodeChip`, `FactorNode`, `RiskNode`, `GoalNode`, `DecisionNode`,
+ * `OutcomeNode`, `GhostOptionNode`, `shared/ScienceIcon`), the Ask-Olumi drawer
+ * and its ~15 result-surface callers, and the `onSendMessage` prop chain — all
+ * firing while the thread sat on a hidden dock tab or behind a minimised panel.
+ * The user pressed a button and, as far as the screen was concerned, nothing
+ * happened.
+ *
+ * ⭐ WRAPPED AT THE REGISTRATION SEAM, ON PURPOSE. The obvious alternative is a
+ * `revealOlumiSurface()` call next to each send — which is a hand-maintained
+ * list of call sites, the defect class this codebase pays for most often: it is
+ * correct the day it is written and silently short the first time someone adds
+ * a send. Wrapping here means a callback cannot be dispatched WITHOUT the
+ * reveal, and it covers surfaces this lane must not edit (the Ask-Olumi drawer
+ * and the result-surface callers belong to another lane) without touching one
+ * line of them.
+ *
+ * The reveal runs AFTER the send so a throwing callback cannot be masked, and
+ * the reveal itself is best-effort: it must never turn a delivered message into
+ * a thrown error, so it is caught and logged.
+ *
+ * Not every callback is wrapped — see the notes at each field in
+ * `registerConversationCallbacks`. Identity: the wrapper is a new function
+ * object, so ownership must be compared by `_registrationToken` (which it
+ * already is, deliberately, for the singleton-host reason documented there).
+ */
+function withOlumiReveal<Args extends unknown[]>(
+  fn: ((...args: Args) => void) | null,
+): ((...args: Args) => void) | null {
+  if (!fn) return null
+  return (...args: Args) => {
+    fn(...args)
+    try {
+      revealOlumiSurface()
+    } catch (err) {
+      console.warn('[guidanceStore] Olumi reveal failed after dispatch:', err)
+    }
   }
 }
 
@@ -543,12 +589,18 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
   registerConversationCallbacks: (sendMessage, scrollToPatch, sendChip, runAnalysis, prefillChat, dispatchAction) => {
     const token = {}
     set({
-      _sendMessage: sendMessage,
+      _sendMessage: withOlumiReveal(sendMessage),
+      // `_runAnalysis` is deliberately NOT wrapped: a run navigates the dock to
+      // Analysis and has its own return-to-Olumi signal once the run produces
+      // review content (`runReturnSignal.ts`). Fronting Olumi at run START would
+      // fight that, and would yank the user off the surface the run is filling.
       _runAnalysis: runAnalysis ?? null,
+      // `_scrollToPatch` moves within an ALREADY-visible thread; revealing on it
+      // would be motion without a message.
       _scrollToPatch: scrollToPatch,
-      _sendChip: sendChip ?? null,
-      _prefillChat: prefillChat ?? null,
-      _dispatchAction: dispatchAction ?? null,
+      _sendChip: withOlumiReveal(sendChip ?? null),
+      _prefillChat: withOlumiReveal(prefillChat ?? null),
+      _dispatchAction: withOlumiReveal(dispatchAction ?? null),
       _registrationToken: token,
     })
     return () => {

--- a/src/canvas/utils/computeFitPadding.ts
+++ b/src/canvas/utils/computeFitPadding.ts
@@ -73,6 +73,80 @@ const MAX_PADDING_FRACTION = 0.8
 /** A pixel padding string, e.g. `'120px'` — matches xyflow's `PaddingWithUnit`. */
 type PxString = `${number}px`
 
+/** The four sides a reservation can be taken from. */
+export type ReservationSide = 'left' | 'right' | 'top' | 'bottom'
+
+/** A rectangle in viewport coordinates — the shape `getBoundingClientRect` returns. */
+export interface Box {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+/**
+ * The cheapest way to push the graph clear of a FREE-FLOATING occluder.
+ *
+ * The dock and the sidebar are edge-anchored, so "how much do they occlude"
+ * has exactly one answer and the caller reserves it on that side. The floating
+ * Olumi panel is not: it can rest anywhere, and after the 0→N draft transition
+ * it slides to a bottom-right anchor (`FirstUseComposer`), while a minimised
+ * pill is a small box wherever the panel last was. There is no single "its
+ * side" to reserve.
+ *
+ * `fitView` padding is rectangular, so the only way to guarantee the graph is
+ * not drawn underneath a box is to keep the graph entirely to one side of it.
+ * Four reservations achieve that; this returns the SMALLEST, i.e. the direction
+ * that costs the fitting box least:
+ *
+ *   right  → `flow.right - occ.left`     (graph sits left of the occluder)
+ *   left   → `occ.right - flow.left`     (graph sits right of it)
+ *   bottom → `flow.bottom - occ.top`     (graph sits above it)
+ *   top    → `occ.bottom - flow.top`     (graph sits below it)
+ *
+ * This is what makes a minimised pill cheap: a 28px-tall pill resting near the
+ * bottom edge costs ~44px of BOTTOM padding, where reserving the whole right
+ * band from its left edge would have cost ~468px of width.
+ *
+ * Returns `null` when the occluder does not overlap the flow rect at all —
+ * nothing to reserve. Ties resolve in `right, left, bottom, top` order, which
+ * only matters for exactly-square overlaps and never changes the amount.
+ */
+export function cheapestReservation(flow: Box, occ: Box): { side: ReservationSide; amount: number } | null {
+  const overlapsX = occ.left < flow.right && occ.right > flow.left
+  const overlapsY = occ.top < flow.bottom && occ.bottom > flow.top
+  if (!overlapsX || !overlapsY) return null
+
+  const candidates: Array<{ side: ReservationSide; amount: number }> = [
+    { side: 'right', amount: flow.right - occ.left },
+    { side: 'left', amount: occ.right - flow.left },
+    { side: 'bottom', amount: flow.bottom - occ.top },
+    { side: 'top', amount: occ.bottom - flow.top },
+  ]
+  let best = candidates[0]
+  for (const c of candidates) {
+    if (c.amount < best.amount) best = c
+  }
+  return { side: best.side, amount: Math.max(0, best.amount) }
+}
+
+/**
+ * Union of a set of rects, or `null` when none are present. Used to treat the
+ * floating panel and its side tab (which is positioned OUTSIDE the panel's left
+ * edge at `left: -36`, so it is absent from the panel's own
+ * `getBoundingClientRect`) as the single opaque box the user actually sees.
+ */
+function unionOf(boxes: Array<DOMRect | null>): Box | null {
+  const present = boxes.filter((b): b is DOMRect => b != null)
+  if (present.length === 0) return null
+  return {
+    left: Math.min(...present.map((b) => b.left)),
+    top: Math.min(...present.map((b) => b.top)),
+    right: Math.max(...present.map((b) => b.right)),
+    bottom: Math.max(...present.map((b) => b.bottom)),
+  }
+}
+
 export interface FitPadding {
   top: PxString
   right: PxString
@@ -143,6 +217,42 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
     if (sidebar) {
       const overlap = Math.max(0, sidebar.right - flowRect.left)
       if (overlap > 0) left = Math.max(left, overlap + GAP)
+    }
+
+    // The floating Olumi conversation panel — a FREE-FLOATING occluder, so it
+    // reserves in whichever direction costs the fitting box least (see
+    // `cheapestReservation`). Measured 16 Aug 2026 at 1280x800: with the panel
+    // open, 10 of the 18 nodes in the committed CEE draft capture rendered
+    // UNDERNEATH it, because this function reserved nothing for it at all.
+    //
+    // The side tab is a sibling positioned at `left: -36` with the panel
+    // `overflow: visible`, so it is NOT part of the panel's own rect — union
+    // the two or the reservation is 36px short of what the user sees.
+    //
+    // ⚠ THE MINIMISED PILL IS DELIBERATELY NOT RESERVED, and this is a judgement
+    // with a measurement behind it rather than an oversight. Reserving it was
+    // tried first: an 84x28 pill resting mid-pane took a 416px BOTTOM
+    // reservation (the cheapest of its four directions), which collapsed the
+    // vertical fitting box to 355px for a graph needing 524px and clamped the
+    // whole first view at the legibility floor. The harm avoided was one node
+    // partially behind a 28px-tall affordance; the harm caused was an
+    // unreadable model. The pill's entire contract is "I am out of the way" —
+    // it is small, semi-transparent and draggable — whereas the open panel is a
+    // 400x550 opaque surface the user is reading. Reserve the surface, not the
+    // affordance.
+    const floating = unionOf([
+      rectOf('[data-testid="floating-olumi-panel"]'),
+      rectOf('[data-testid="floating-olumi-panel-side-tab"]'),
+    ])
+    if (floating) {
+      const reservation = cheapestReservation(flowRect, floating)
+      if (reservation && reservation.amount > 0) {
+        const value = reservation.amount + GAP
+        if (reservation.side === 'right') right = Math.max(right, value)
+        else if (reservation.side === 'left') left = Math.max(left, value)
+        else if (reservation.side === 'top') top = Math.max(top, value)
+        else bottom = Math.max(bottom, value)
+      }
     }
   }
 


### PR DESCRIPTION
## A2 — workspace attention & input

Base `6bfe40f7` (PX-A's merge). Everything below is measured at **1280×800** in a real browser
against the committed CEE draft capture (18 nodes rendered); jsdom cannot prove visibility, so every
layout claim here comes from the browser harness, and every rule claim from a unit spec.

---

### 1. The coexistence ruling — measured, then shipped

The legibility floor is `LABEL_LEGIBLE_ZOOM = 0.5`; the drafted graph is 2016 flow-units, so it needs
a **1008px** fitting box to render unclamped.

| scenario | scale | clamped? | fit box | occlusion |
|---|---|---|---|---|
| **BEFORE** — post-draft, panel open | 0.5 | **yes** | 843px | **10 of 18 nodes drawn UNDER the panel** |
| BEFORE — panel closed | 0.5 | **yes** | 843px | none |
| AFTER (a+b) — panel open | 0.5 | **yes** | 796px | none (now honest, still clamped) |
| AFTER (a+b+c) — panel closed | 0.563 | no | 1136px | none |
| **AFTER (a+b+c) — REAL first-use journey** | **0.563** | **no** | **1136px** | 1 node grazes the restore pill |

The last row drives the actual send through the hero composer, so the product's own 0→N transition
effect fires — a fixture-injected draft does not exercise it, and would not have been evidence about
the journey.

**Which set cleared the floor, and why each part is needed:**

- **(a) The dock rails until an analysis result exists.** `shouldRenderFirstUseRail` was re-based from
  *"does a graph exist"* onto *"does an analysis RESULT exist"*. Alone this takes the fit box
  843 → 1136 and clears the floor whenever the panel is not open. An outputs dock with no outputs was
  claiming 333px and charging the canvas 361px of `computeFitPadding` for it.
- **(b) `computeFitPadding` reserves the floating panel honestly.** This does **not** clear the floor
  — it converts a *silent occlusion* (10 nodes drawn underneath the panel) into a *visible clamp*
  (796px). It is necessary for truthfulness, not sufficient for legibility.
- **(c) The transcript-less hero minimises once the draft renders.** **Required, and the measurement
  is why:** with the panel open the honest fit box is 796px against a 1008px requirement, and no dock
  width or padding rule can close that gap — a 400×550 panel plus its 36px side tab is a third of a
  1280px viewport. The only honest alternatives were to occlude the graph or to clamp it; this
  chooses neither.

Two findings worth a reviewer's attention:

- **A centred panel cannot be cleared at all.** It needs a 691px reservation on its cheapest side;
  `MAX_PADDING_FRACTION` caps the vertical pair at 640, so the clamp scales the reservation *down*
  and the panel is still overlapped. Pinned as an explicit test (`CANNOT clear a centred panel`)
  rather than papered over — it is the strongest argument for (c).
- **The minimised pill is deliberately NOT reserved.** Reserving it cost **416px** of bottom padding
  (vertical fit box 355px against 524px needed) and clamped the entire first view — to avoid a node
  grazing a 28px draggable affordance. The open panel is a surface the user is reading; the pill's
  whole contract is being out of the way.

Scope of (c) is the narrowest that achieves it: it runs only under the existing
`canAutoDock` guard (`source === 'system-first-use' && !userRepositioned`) on the 0→N transition, so
a panel the user opened or dragged is never touched, and it cannot hide a reply the user could
otherwise read — the hero has no transcript by construction, which is exactly why
`shouldAutoExpandDockForResponse` already treats it as showing nothing.

**Known residual (not fixed):** in the real journey one node grazes the 68×25 restore pill, which
inherits the panel's top-left (812,234) instead of parking in a corner. Parking it churns restore
semantics and an existing spec for a minor graze; panel occlusion itself went 10 → 0.

**Behaviour change reviewers should weigh:** pre-first-run the dock's own Run control is now behind
the rail. The user is not stranded — the drafted decision node carries its own "Run analysis" chip
(visible in the screenshot evidence), and the rail chevron is one click — but it is a real change,
and it is what the 6 updated assertions in `OutputsDock.analysis-run.spec.tsx` encode.

### 2. Class 3 — select/grab reliability

Three xyflow props were **unset**, so its defaults applied, and they are strict to the pixel
(derived at the bytes in `@xyflow/react/dist/esm/index.js`): `nodeClickDistance = 0` (:3598),
`paneClickDistance = 1`, `nodeDragThreshold = 1` (:3184). `nodeClickDistance = 0` means a node click
registers **only if the pointer travelled zero pixels** — on a trackpad, click-to-select is a coin
toss, and a lost click is indistinguishable from a dead zone. Now 4/4/2.

Also `panOnDrag` in select mode was `[1, 2]`, making right-drag a pan trigger while all three
context-menu handlers were bound — a right-press that moved a pixel panned the canvas *and* opened
the menu. Button 2 now belongs to the menu.

*Verified at pristine first, as briefed:* `OutputsDock.analysis-run.spec.tsx` is **18/18 GREEN at
`6bfe40f7`** — the failures the brief flagged at `a3c71513` do not reproduce at this base, so nothing
was absorbed.

### 3. Class 8 — every send reveals Olumi

A census found ~25 dispatch sites sending silently while the thread sat on a hidden dock tab or
behind a minimised panel. **Wrapped at the registration seam** (`withOlumiReveal` in
`guidanceStore`), not at each call site: a per-site reveal is a hand-maintained list that is correct
the day it is written and silently short the first time someone adds a send. The seam also covers
surfaces this lane must not edit (the Ask-Olumi drawer and its ~15 result-surface callers) without
touching one line of them.

`_runAnalysis` and `_scrollToPatch` are deliberately **not** wrapped, with a negative test pinning
that: a run navigates to Analysis and has its own return-to-Olumi signal, so fronting Olumi at run
start would fight it.

This also required the dock to honour a forced activation by clearing the rail — otherwise
`revealOlumiSurface()` would "open" a dock that stays 40px wide. That is ROADMAP 2.639's exact defect
(the turn reports success, nothing on screen moves) made reachable again through a different
override, so it gets 2.639's answer.

### Late catch: the class-8 fix was silently undoing the coexistence fix

Re-running the browser measurement on the FINAL rebased tip (rather than trusting the earlier one)
showed the real-journey row back at **843px, clamped** — the dock expanded to 333px again. Cause: the
class-8 rail-clear fired on ANY forced tab activation, and `FirstUseComposer` forces `'results'` on
the 0→N draft transition. **The draft itself was clearing the rail**, on the one journey both changes
were written for.

The full suite was green with that defect present — it is a two-effect interaction no unit test sees.
It is now scoped to `'olumi'` (`forcedActivationEndsRail`), pinned by four tests and a mutant, and
the real-journey row is back to **0.563 / 1136px / unclamped**.

### Gates

`lint` → 0 errors, rules-of-hooks ratchet **exactly at baseline 232** · `typecheck` → **PASSED at the
ratchet baseline 2485/618**, fixed at source, baseline never regenerated · full `vitest` suite → see
the comment below. 10-mutant kit on the fit/collapse/reveal logic, run in a worktree outside the repo
with a **sentinel-write isolation proof** and a trailing control.
