### PR TITLE
P0: the Versions trigger occludes the OutputsDock's expand control — make the trigger yield

### DIFF
--- a/src/canvas/versions/VersionsPanelHost.tsx
+++ b/src/canvas/versions/VersionsPanelHost.tsx
@@ -13,8 +13,8 @@ import { GitCompare } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { WhatChangedPanel } from './WhatChangedPanel'
 import {
+  VERSIONS_TRIGGER_RIGHT_INSET_CSS,
   VERSIONS_TRIGGER_TOP_PX,
-  versionsTriggerRightOffsetCss,
 } from './versionsTriggerPosition'
 
 export function VersionsPanelHost() {
@@ -34,7 +34,7 @@ export function VersionsPanelHost() {
           // asserted against what this component actually renders rather than
           // against a class name that a build step still has to honour.
           style={{
-            right: versionsTriggerRightOffsetCss(),
+            right: VERSIONS_TRIGGER_RIGHT_INSET_CSS,
             top: VERSIONS_TRIGGER_TOP_PX,
           }}
           className={`${typography.panelBody} absolute z-[1500] inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-panel border border-panel-border text-text-body shadow-panel hover:bg-panel-hover`}

--- a/src/canvas/versions/VersionsPanelHost.tsx
+++ b/src/canvas/versions/VersionsPanelHost.tsx
@@ -12,6 +12,10 @@ import { useState } from 'react'
 import { GitCompare } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { WhatChangedPanel } from './WhatChangedPanel'
+import {
+  VERSIONS_TRIGGER_TOP_PX,
+  versionsTriggerRightOffsetCss,
+} from './versionsTriggerPosition'
 
 export function VersionsPanelHost() {
   const [isOpen, setIsOpen] = useState(false)
@@ -23,7 +27,17 @@ export function VersionsPanelHost() {
           type="button"
           onClick={() => setIsOpen(true)}
           data-testid="versions-panel-trigger"
-          className={`${typography.panelBody} absolute top-3 right-3 z-[1500] inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-panel border border-panel-border text-text-body shadow-panel hover:bg-panel-hover`}
+          // The inset is INLINE, not a Tailwind class, for two reasons: it is
+          // a `calc()` over the dock's own custom property (see
+          // versionsTriggerPosition.ts for why it must be), and an inline
+          // value is readable in jsdom, so the no-overlap guarantee can be
+          // asserted against what this component actually renders rather than
+          // against a class name that a build step still has to honour.
+          style={{
+            right: versionsTriggerRightOffsetCss(),
+            top: VERSIONS_TRIGGER_TOP_PX,
+          }}
+          className={`${typography.panelBody} absolute z-[1500] inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-panel border border-panel-border text-text-body shadow-panel hover:bg-panel-hover`}
         >
           <GitCompare className="w-3.5 h-3.5" />
           Versions

--- a/src/canvas/versions/__tests__/versionsTriggerPosition.spec.tsx
+++ b/src/canvas/versions/__tests__/versionsTriggerPosition.spec.tsx
@@ -1,0 +1,263 @@
+/**
+ * P0 — the "Versions" trigger must never occlude the OutputsDock's chrome.
+ *
+ * ── WHAT THIS FILE CAN AND CANNOT PROVE (trap 3) ─────────────────────────────
+ * jsdom has no layout engine: `getBoundingClientRect()` returns zeros here, so
+ * a hit-test in this environment would be theatre. What jsdom CAN prove is
+ * that the component renders the DERIVED offset, and arithmetic can prove that
+ * offset clears the dock across the whole supported viewport x dock-width
+ * matrix. The remaining claim — that a real browser returns the dock's own
+ * control from `elementFromPoint()` at its centre — is a browser witness and
+ * is banked separately at 1280x800 in both dock states. Neither half is
+ * claimed by the other.
+ *
+ * ── WHY THE MATRIX IS DERIVED (trap 12d) ─────────────────────────────────────
+ * The dock widths below are not a hand-written list; they are generated from
+ * `dockWidth.ts`, the dock's own width authority. A hand-written list would
+ * agree with itself forever while the dock moved underneath it. The rail width
+ * and the expanded fallback are additionally pinned against OutputsDock's
+ * SOURCE, so a change to either file REDs here rather than silently
+ * re-opening the defect.
+ */
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { VersionsPanelHost } from '../VersionsPanelHost'
+import {
+  DOCK_EXPANDED_WIDTH_FALLBACK,
+  DOCK_EXPANDED_WIDTH_VAR,
+  DOCK_VIEWPORT_GUTTER_PX,
+  VERSIONS_TRIGGER_TOP_PX,
+  triggerDockHorizontalOverlapPx,
+  versionsTriggerRightOffsetCss,
+  versionsTriggerRightOffsetPx,
+} from '../versionsTriggerPosition'
+import {
+  DOCK_MIN_WIDTH,
+  dockWidthBounds,
+  responsiveDockWidth,
+} from '../../components/dockWidth'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const OUTPUTS_DOCK_SRC = resolve(HERE, '../../components/OutputsDock.tsx')
+const dockSource = readFileSync(OUTPUTS_DOCK_SRC, 'utf8')
+
+/** The rail the dock collapses to — `var(--dock-right-collapsed, 2.5rem)`. */
+const DOCK_RAIL_WIDTH_PX = 40
+
+/**
+ * Every laptop-and-up viewport the product supports. 1280 is the narrowest
+ * the charter names; the upper end covers external and retina desktops.
+ */
+const SUPPORTED_VIEWPORTS = [1280, 1366, 1440, 1512, 1600, 1728, 1920, 2560]
+
+/** The measured width of the rendered trigger on the deployed build. */
+const OBSERVED_TRIGGER_WIDTH = 95
+
+/**
+ * Every EXPANDED width the dock can hold at a given viewport — the responsive
+ * default plus both ends of the hard drag bounds. Derived from the dock's own
+ * rules, so a change there regenerates this matrix automatically.
+ */
+function reachableExpandedWidths(viewportWidth: number): number[] {
+  const { min, max } = dockWidthBounds(viewportWidth)
+  return [...new Set([min, responsiveDockWidth(viewportWidth), max])]
+}
+
+/**
+ * The two dock states, for one expanded width.
+ *
+ * ⚠ The pairing here is the whole point, and getting it wrong is how this file
+ * first went green-then-red on itself: `--dock-right-expanded` holds the
+ * expanded width in BOTH states — collapsing the dock swaps which variable
+ * `asideStyle.width` reads, it does not rewrite the expanded one. So the
+ * trigger's offset is a function of the EXPANDED width in both rows, while the
+ * dock's rendered width is 40px in one of them. Feeding the offset a width the
+ * dock does not currently have would be testing a configuration the product
+ * cannot reach (trap 16-inverse).
+ */
+function dockStates(expandedWidth: number): Array<{ label: string; dockWidth: number }> {
+  return [
+    { label: `expanded to ${expandedWidth}px`, dockWidth: expandedWidth },
+    { label: `collapsed to the rail (expanded var still ${expandedWidth}px)`, dockWidth: DOCK_RAIL_WIDTH_PX },
+  ]
+}
+
+function renderTrigger(): HTMLElement {
+  render(<VersionsPanelHost />)
+  return screen.getByTestId('versions-panel-trigger')
+}
+
+/**
+ * The exact shape the trigger's `right` inset must have. Anchored, and it
+ * captures the two numbers, so a change to either the fallback or the constant
+ * is measured rather than waved through by a substring match.
+ */
+const RIGHT_INSET_SHAPE = /^calc\(var\(--dock-right-expanded,\s*([\d.]+)rem\)\s*\+\s*([\d.]+)px\)$/
+
+/**
+ * Resolve what the RENDERED component's `right` inset comes to, in px, for a
+ * given dock expanded width.
+ *
+ * ⚠ THIS IS THE LOAD-BEARING BINDING (trap 19). Every clearance assertion
+ * below runs on the number this returns, so it is measuring the COMPONENT, not
+ * this file's own arithmetic. Reverting the component to `right-3` makes the
+ * regex fail and takes the entire matrix red — which is the proof obligation:
+ * delete the fix, and the guarantee tests must go with it. Reading the offset
+ * from `versionsTriggerRightOffsetPx()` instead would leave the matrix green
+ * over a product that had gone back to occluding the dock.
+ */
+function resolveRenderedRightOffsetPx(dockExpandedWidthPx: number): number {
+  const trigger = renderTrigger()
+  const rightInset = trigger.style.right
+  const className = trigger.className
+  // Render-and-release, so this is safe to call repeatedly inside one test
+  // without a second mount making `getByTestId` ambiguous.
+  cleanup()
+  const match = RIGHT_INSET_SHAPE.exec(rightInset)
+  if (!match) {
+    throw new Error(
+      `the trigger's right inset does not read the dock's width variable: got ${JSON.stringify(rightInset)} ` +
+        `(className: ${className})`,
+    )
+  }
+  const [, fallbackRem, constantPx] = match
+  // First paint, before anything has set the custom property, must ALSO clear
+  // the dock — so the fallback has to be at least the dock's minimum width.
+  expect(Number(fallbackRem) * 16).toBeGreaterThanOrEqual(DOCK_MIN_WIDTH)
+  return dockExpandedWidthPx + Number(constantPx)
+}
+
+afterEach(cleanup)
+
+describe('the Versions trigger clears the OutputsDock', () => {
+  // ── Preconditions, pinned in-test (trap 13b) ───────────────────────────────
+  // Every assertion below is about HORIZONTAL separation. That is only the
+  // whole guarantee if the two elements genuinely share a vertical band — if
+  // they did not, the horizontal arithmetic would be passing for a reason
+  // that has nothing to do with the fix.
+  it('PRECONDITION: the trigger and the dock share a vertical band, so horizontal clearance is the whole guarantee', () => {
+    // The dock's own top inset, read from its source rather than restated.
+    expect(dockSource).toContain('top: 12,')
+    expect(VERSIONS_TRIGGER_TOP_PX).toBe(12)
+    // Same top edge, both ~34px and ~24px tall: they overlap vertically in
+    // every state. Nothing about the vertical axis separates them.
+  })
+
+  it('PRECONDITION: the dock anchors to the same viewport edge at the same inset', () => {
+    expect(dockSource).toContain('right: 12,')
+    expect(DOCK_VIEWPORT_GUTTER_PX).toBe(12)
+  })
+
+  // ── The cross-file pins. These are what stop the derivation drifting. ──────
+  it('the offset reads the dock’s OWN width variable, with the dock’s OWN fallback', () => {
+    // If OutputsDock renames the property or changes the fallback, this REDs
+    // here instead of silently re-opening the overlap at first paint.
+    expect(dockSource).toContain(`var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK})`)
+    expect(versionsTriggerRightOffsetCss()).toContain(
+      `var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK})`,
+    )
+  })
+
+  it('the rail width this matrix uses is the width the dock actually collapses to', () => {
+    expect(dockSource).toContain('var(--dock-right-collapsed, 2.5rem)')
+    expect(DOCK_RAIL_WIDTH_PX).toBe(2.5 * 16)
+  })
+
+  // ── The binding to the component (trap 19: bind by IDENTITY) ───────────────
+  it('the rendered trigger carries the derived offset — bound by testid AND accessible name', () => {
+    const trigger = renderTrigger()
+    // Two independent identity handles, so this cannot pass on some other
+    // button that happens to be positioned correctly.
+    expect(trigger).toHaveAccessibleName(/versions/i)
+    expect(trigger.tagName).toBe('BUTTON')
+
+    expect(trigger.style.right).toBe(versionsTriggerRightOffsetCss())
+    expect(trigger.style.top).toBe(`${VERSIONS_TRIGGER_TOP_PX}px`)
+  })
+
+  it('the trigger no longer pins itself to the viewport edge', () => {
+    const trigger = renderTrigger()
+    // The defect in one line: `right-3` put the trigger at the dock's own
+    // inset. Any return to an edge-pinned inset REDs here.
+    expect(trigger.className).not.toMatch(/(^|\s)right-3(\s|$)/)
+    expect(trigger.style.right).not.toBe('12px')
+    expect(trigger.style.right).not.toBe('0.75rem')
+  })
+
+  // ── The guarantee itself, across the derived matrix ────────────────────────
+  describe.each(SUPPORTED_VIEWPORTS)('at %ipx wide', (viewportWidth) => {
+    const cases = reachableExpandedWidths(viewportWidth).flatMap((expandedWidth) =>
+      dockStates(expandedWidth).map((state) => ({ expandedWidth, ...state })),
+    )
+
+    it.each(cases)('clears the dock $label', ({ expandedWidth, dockWidth }) => {
+      const overlap = triggerDockHorizontalOverlapPx({
+        triggerWidth: OBSERVED_TRIGGER_WIDTH,
+        // Read off the rendered component, not off this file's arithmetic.
+        triggerRightOffset: resolveRenderedRightOffsetPx(expandedWidth),
+        dockWidth,
+      })
+      expect(overlap).toBe(0)
+    })
+  })
+
+  it('the clearance does not depend on the trigger’s width — it extends away from the dock', () => {
+    // A longer label (localisation, a count badge) must not reintroduce the
+    // overlap. This is why the rule is stated as an offset and not as a
+    // measured gap.
+    for (const triggerWidth of [95, 160, 400, 900]) {
+      expect(
+        triggerDockHorizontalOverlapPx({
+          triggerWidth,
+          triggerRightOffset: resolveRenderedRightOffsetPx(DOCK_MIN_WIDTH),
+          dockWidth: DOCK_MIN_WIDTH,
+        }),
+      ).toBe(0)
+    }
+  })
+
+  it('the numeric and CSS forms of the offset agree — one rule, two spellings', () => {
+    // The component renders the CSS form; the arithmetic above uses the
+    // numeric one. If they ever diverge, every clearance number in this file
+    // would be about a position the product does not render.
+    for (const expandedWidth of [DOCK_MIN_WIDTH, 333, 416, 480]) {
+      expect(resolveRenderedRightOffsetPx(expandedWidth)).toBe(
+        versionsTriggerRightOffsetPx(expandedWidth),
+      )
+    }
+  })
+
+  // ── The positive control (trap 13): prove the metric can SEE an overlap ────
+  // Without this, `toBe(0)` above is satisfied by a calculator that returns 0
+  // for everything, and the whole file would be vacuous.
+  it('POSITIVE CONTROL: the shipped defect’s offset is measured as a large overlap, not as zero', () => {
+    const shippedOffset = 12 // `right-3`, the offset that shipped in #720
+    const overlap = triggerDockHorizontalOverlapPx({
+      triggerWidth: OBSERVED_TRIGGER_WIDTH,
+      triggerRightOffset: shippedOffset,
+      dockWidth: DOCK_RAIL_WIDTH_PX,
+    })
+    // The rail spans [12, 52] from the right edge; the shipped trigger spanned
+    // [12, 107]. The trigger swallowed the rail WHOLE — all 40px of it — which
+    // is why `elementFromPoint` at the expand control's own centre returned
+    // the trigger on the deployed build.
+    expect(overlap).toBe(DOCK_RAIL_WIDTH_PX)
+    expect(overlap).toBeGreaterThan(0)
+  })
+
+  it('POSITIVE CONTROL: the shipped offset also overlaps the EXPANDED dock at every supported viewport', () => {
+    for (const viewportWidth of SUPPORTED_VIEWPORTS) {
+      const overlap = triggerDockHorizontalOverlapPx({
+        triggerWidth: OBSERVED_TRIGGER_WIDTH,
+        triggerRightOffset: 12,
+        dockWidth: responsiveDockWidth(viewportWidth),
+      })
+      expect(overlap).toBe(OBSERVED_TRIGGER_WIDTH)
+    }
+  })
+})

--- a/src/canvas/versions/__tests__/versionsTriggerPosition.spec.tsx
+++ b/src/canvas/versions/__tests__/versionsTriggerPosition.spec.tsx
@@ -31,9 +31,9 @@ import {
   DOCK_EXPANDED_WIDTH_FALLBACK,
   DOCK_EXPANDED_WIDTH_VAR,
   DOCK_VIEWPORT_GUTTER_PX,
+  VERSIONS_TRIGGER_RIGHT_INSET_CSS,
   VERSIONS_TRIGGER_TOP_PX,
   triggerDockHorizontalOverlapPx,
-  versionsTriggerRightOffsetCss,
   versionsTriggerRightOffsetPx,
 } from '../versionsTriggerPosition'
 import {
@@ -155,12 +155,22 @@ describe('the Versions trigger clears the OutputsDock', () => {
 
   // ── The cross-file pins. These are what stop the derivation drifting. ──────
   it('the offset reads the dock’s OWN width variable, with the dock’s OWN fallback', () => {
-    // If OutputsDock renames the property or changes the fallback, this REDs
-    // here instead of silently re-opening the overlap at first paint.
-    expect(dockSource).toContain(`var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK})`)
-    expect(versionsTriggerRightOffsetCss()).toContain(
-      `var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK})`,
+    // Extracted from the shipped literal rather than composed here. Composing
+    // it would spell `var(--${…})` in this file, which registers a DYNAMIC
+    // var() site with the estate's css-var census and makes the fallback
+    // unresolvable to it (`@@1@@`) — the guard would go blind on the very
+    // reference this test exists to pin.
+    const varRef = VERSIONS_TRIGGER_RIGHT_INSET_CSS.slice(
+      VERSIONS_TRIGGER_RIGHT_INSET_CSS.indexOf('var('),
+      VERSIONS_TRIGGER_RIGHT_INSET_CSS.indexOf(')') + 1,
     )
+    // Still derived: the extracted reference must name the constants.
+    expect(varRef).toContain(DOCK_EXPANDED_WIDTH_VAR)
+    expect(varRef).toContain(DOCK_EXPANDED_WIDTH_FALLBACK)
+    // The cross-file pin. If OutputsDock renames the property or changes the
+    // fallback, the trigger stops matching it VERBATIM and this REDs — rather
+    // than silently re-opening the overlap at first paint.
+    expect(dockSource).toContain(varRef)
   })
 
   it('the rail width this matrix uses is the width the dock actually collapses to', () => {
@@ -176,7 +186,7 @@ describe('the Versions trigger clears the OutputsDock', () => {
     expect(trigger).toHaveAccessibleName(/versions/i)
     expect(trigger.tagName).toBe('BUTTON')
 
-    expect(trigger.style.right).toBe(versionsTriggerRightOffsetCss())
+    expect(trigger.style.right).toBe(VERSIONS_TRIGGER_RIGHT_INSET_CSS)
     expect(trigger.style.top).toBe(`${VERSIONS_TRIGGER_TOP_PX}px`)
   })
 

--- a/src/canvas/versions/versionsTriggerPosition.ts
+++ b/src/canvas/versions/versionsTriggerPosition.ts
@@ -1,0 +1,114 @@
+/**
+ * Where the "Versions" trigger sits, relative to the OutputsDock.
+ *
+ * ── THE DEFECT THIS EXISTS TO MAKE IMPOSSIBLE ────────────────────────────────
+ * The trigger shipped as `absolute top-3 right-3` (#720). The OutputsDock is
+ * `position: fixed; right: 12; top: 12` (OutputsDock.tsx `asideStyle`). Both
+ * anchor to the SAME viewport edge at the SAME inset, so the trigger landed
+ * exactly on the dock's top-right chrome — and it carries `z-[1500]` against
+ * the dock's `zIndex: 900`, so it won the stack.
+ *
+ * Measured on the deployed build `8e6f7629` at 1280x800, dock expanded:
+ * `Collapse outputs dock` at x=1235 w=24 h=24; trigger at x=1173 w=95 h=33.5;
+ * overlap 540px2 = 93.8% of the control, and
+ * `document.elementFromPoint()` at the control's own centre returned the
+ * TRIGGER. The dock's expand/collapse control could not be clicked at all —
+ * Playwright reported "versions-panel-trigger intercepts pointer events".
+ * The same measurement held 8/8 across four laptop viewports x both dock
+ * states, so it is not a corner case.
+ *
+ * ── WHY THE OFFSET IS DERIVED, NOT A CONSTANT (trap 12) ──────────────────────
+ * The obvious repair — "nudge the trigger left by 350px" — is a hand-copy of
+ * the dock's width into a second file, and it goes stale silently the first
+ * time the dock's width rule changes. It already would have: the dock's width
+ * moved from a fixed 26rem to a viewport-proportional 280..480px band
+ * (dockWidth.ts) three days before the trigger shipped.
+ *
+ * So the offset is expressed against the dock's OWN width authority, the
+ * `--dock-right-expanded` custom property that `asideStyle` itself consumes,
+ * with the SAME `24rem` fallback the dock declares. Producer and consumer read
+ * one value; there is no second copy to drift.
+ *
+ * ── WHY THE *EXPANDED* WIDTH, IN BOTH DOCK STATES ────────────────────────────
+ * The dock is narrow (a 40px rail) when collapsed and 280..480px when open,
+ * and the trigger cannot see which — it owns no shared state, deliberately
+ * (see VersionsPanelHost's header). Positioning against the EXPANDED width
+ * unconditionally makes the clearance hold in BOTH states without the trigger
+ * knowing anything about the dock: the expanded width is always the larger of
+ * the two, so clearing it clears the rail as well. The trigger keeps ONE
+ * resting place instead of jumping when the dock toggles.
+ */
+
+/**
+ * The dock's own inset from the viewport edge — `asideStyle.right`. Not a
+ * choice this module makes; it is where the dock is.
+ */
+export const DOCK_VIEWPORT_GUTTER_PX = 12
+
+/** Visual breathing room between the trigger's right edge and the dock's left edge. */
+export const TRIGGER_DOCK_GAP_PX = 12
+
+/** The custom property `asideStyle.width` reads when the dock is open. */
+export const DOCK_EXPANDED_WIDTH_VAR = '--dock-right-expanded'
+
+/**
+ * The fallback `asideStyle.width` declares for that property. It MUST equal
+ * the dock's, or the two disagree in exactly the window where nothing has set
+ * the variable yet — which is first paint, i.e. the state every fresh user
+ * loads. Pinned by spec against OutputsDock's own source.
+ */
+export const DOCK_EXPANDED_WIDTH_FALLBACK = '24rem'
+
+/**
+ * The trigger's `right` inset, in px, given the dock's expanded width.
+ *
+ * The dock occupies `[gutter, gutter + dockWidth]` measured from the right
+ * edge; the trigger begins where that ends, plus a gap.
+ */
+export function versionsTriggerRightOffsetPx(dockExpandedWidthPx: number): number {
+  return DOCK_VIEWPORT_GUTTER_PX + dockExpandedWidthPx + TRIGGER_DOCK_GAP_PX
+}
+
+/**
+ * The same rule as a CSS value, for the element that cannot know the dock's
+ * pixel width at render time. Built from the constants above so the numeric
+ * and CSS forms cannot drift.
+ */
+export function versionsTriggerRightOffsetCss(): string {
+  const constant = DOCK_VIEWPORT_GUTTER_PX + TRIGGER_DOCK_GAP_PX
+  return `calc(var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK}) + ${constant}px)`
+}
+
+/** The trigger's `top` inset — level with the dock's own top edge. */
+export const VERSIONS_TRIGGER_TOP_PX = DOCK_VIEWPORT_GUTTER_PX
+
+export interface OverlapInput {
+  /** Rendered width of the trigger button. */
+  triggerWidth: number
+  /** The trigger's `right` inset in px. */
+  triggerRightOffset: number
+  /** The dock's rendered width in px — 40 when collapsed to the rail. */
+  dockWidth: number
+}
+
+/**
+ * Horizontal overlap, in px, between the trigger and the dock.
+ *
+ * Both elements are anchored to the RIGHT edge, so the viewport width cancels
+ * out of the arithmetic entirely — which is precisely why the guarantee holds
+ * at every supported viewport rather than at the four that were measured. The
+ * spec asserts that property directly rather than trusting this comment.
+ */
+export function triggerDockHorizontalOverlapPx({
+  triggerWidth,
+  triggerRightOffset,
+  dockWidth,
+}: OverlapInput): number {
+  // Distances from the viewport's right edge, near edge first.
+  const dockNear = DOCK_VIEWPORT_GUTTER_PX
+  const dockFar = DOCK_VIEWPORT_GUTTER_PX + dockWidth
+  const triggerNear = triggerRightOffset
+  const triggerFar = triggerRightOffset + triggerWidth
+
+  return Math.max(0, Math.min(dockFar, triggerFar) - Math.max(dockNear, triggerNear))
+}

--- a/src/canvas/versions/versionsTriggerPosition.ts
+++ b/src/canvas/versions/versionsTriggerPosition.ts
@@ -71,13 +71,23 @@ export function versionsTriggerRightOffsetPx(dockExpandedWidthPx: number): numbe
 
 /**
  * The same rule as a CSS value, for the element that cannot know the dock's
- * pixel width at render time. Built from the constants above so the numeric
- * and CSS forms cannot drift.
+ * pixel width at render time.
+ *
+ * ⚠ WRITTEN AS A LITERAL, DELIBERATELY — do not "improve" this into a template
+ * built from the constants above. The estate's css-var census
+ * (`tests/ci-guards/css-var-resolution.spec.ts`) statically resolves every
+ * `var()` site so a reference to a token that does not exist, or a hardcoded
+ * fallback that disagrees with the token it shadows, is caught before it
+ * ships. An interpolated fallback resolves to the placeholder `@@1@@`, which
+ * the census cannot check — so a template here would make this site OPAQUE to
+ * the guard, and register two new dynamic-var sites into the bargain. A
+ * literal keeps it legible to static analysis.
+ *
+ * Drift is prevented at test time instead: the spec parses this string and
+ * asserts it composes exactly to `versionsTriggerRightOffsetPx`, and that its
+ * `var()` reference appears VERBATIM in OutputsDock.tsx.
  */
-export function versionsTriggerRightOffsetCss(): string {
-  const constant = DOCK_VIEWPORT_GUTTER_PX + TRIGGER_DOCK_GAP_PX
-  return `calc(var(${DOCK_EXPANDED_WIDTH_VAR}, ${DOCK_EXPANDED_WIDTH_FALLBACK}) + ${constant}px)`
-}
+export const VERSIONS_TRIGGER_RIGHT_INSET_CSS = 'calc(var(--dock-right-expanded, 24rem) + 24px)'
 
 /** The trigger's `top` inset — level with the dock's own top edge. */
 export const VERSIONS_TRIGGER_TOP_PX = DOCK_VIEWPORT_GUTTER_PX


### PR DESCRIPTION
## The defect

**The outputs dock cannot be opened by hand at any laptop size.** #720's Versions
trigger (`absolute top-3 right-3`, `z-[1500]`) and the OutputsDock
(`position: fixed; right: 12; top: 12`, `zIndex: 900`) anchor to the **same
viewport edge at the same inset**, so the trigger lands on the dock's top-right
chrome and wins the stack.

Found by the Regression Shield's browser probe, not by any spec
(`olumi-docs/regression-shield-2026-08-16/07-FINDING-R3-dock-expand-blocked.md`).

**Measured on deployed `8e6f7629`:**

| state | measurement |
|---|---|
| collapsed (shield, 4 viewports x 2 states, 8/8) | **528 px2 = 100%** of `Expand outputs dock` covered |
| expanded, 1280x800 (this lane) | **540 px2 = 93.8%** of `Collapse outputs dock` covered |

`document.elementFromPoint()` at the control's own centre returns the **trigger**
in both. Playwright: 29 retries, *"versions-panel-trigger intercepts pointer
events"* — the click never lands. `Minimise` and `Dock to panel` are covered by
the same element.

## The fix

The trigger is the newcomer, so **the trigger yields**; the dock's controls do not move.

Its `right` inset is now **derived from the dock's own width authority** — the
`--dock-right-expanded` custom property that `asideStyle` itself consumes, with
the dock's own `24rem` fallback — instead of a copied constant. A "nudge it left
by 350px" fix would be a second copy of the dock's width in a second file, and it
would go stale: the dock's width rule moved from a fixed `26rem` to a
viewport-proportional 280..480px band three days before the trigger shipped.

It positions against the **expanded** width in *both* dock states, so the
clearance holds without the trigger needing to know the dock's open state — which
it deliberately cannot see (`VersionsPanelHost` owns no shared state by design).

## Two commits — and why the second exists

`ec1d3be2` built the CSS with a **template literal**. CI shard 2/4 failed: the
estate's css-var census (`tests/ci-guards/css-var-resolution.spec.ts`) resolves
every `var()` site statically, an interpolated fallback resolves to `@@1@@`, and
the two new files tripped an exact pin on files carrying a dynamic `var(--${…})`.
Shard 2/4 is **green on the base commit**, so the red was this PR's.

`3f6a9598` makes the site legible rather than widening the guard. That guard
exists to catch a reference to a token that does not exist, or a hardcoded
fallback that disagrees with the token it shadows; widening its pins would have
bought a green tick by blinding it to a brand-new reference. The CSS is a plain
literal now, and the anti-drift pin moved to test time — the spec extracts the
`var()` reference **from the shipped literal** and asserts it appears **verbatim**
in `OutputsDock.tsx`. Same guarantee, enforced one layer later.

## Evidence

**RED-first:** 52 of 58 tests red at pristine, the failure naming the defect
verbatim (`absolute top-3 right-3`).

**The guarantee binds to the COMPONENT, not to the new module's arithmetic:** the
spec parses the *rendered* `right` inset and feeds that number to the overlap
calculator, so reverting the component takes all 48 clearance assertions red. The
matrix is generated from `dockWidth.ts` (the dock's own rules), and the rail
width, the dock's inset and the expanded fallback are pinned against
`OutputsDock.tsx`'s **source**.

**Mutants — 13/13 behaved as required** (kit re-derived at the second head; the
M1 anchor had moved). Worktree outside the repo root, isolation proven by
*writing* a sentinel, restores from a pristine archive, applied-check exactly 1
per mutant and exactly 0 at both controls:

| mutant | result |
|---|---|
| M1 revert trigger to `right-3` | RED (52 failed) — the proof obligation |
| M2 gap 12 -> -1 | RED |
| M3 dock gutter 12 -> 0 | RED |
| M4 constant fallback `24rem` -> `1rem` | RED |
| M4b **shipped literal** fallback -> `1rem` | RED (51 failed) |
| M4c shipped literal `+ 24px` -> `+ 11px` | RED (26 failed) |
| M4d shipped literal `+ 24px` -> `+ 12px` (exactly flush) | RED — caught by the numeric/CSS agreement test, not an equivalent survivor |
| M5 **dock** `right: 12` -> `16` | RED — the cross-file pin bites |
| M6 **dock** width fallback -> `26rem` | RED |
| M7 drop the `versions-panel-trigger` testid | RED |
| M8 trigger `top` 12 -> 100 | RED |
| M9 overlap calculator always returns 0 | RED — the positive controls catch it |
| M10 perturb a **different** component | **GREEN (survives, as required)** |

M1/M10 are the discriminating pair (trap 19): sensitive to *this* element, not to
the feature at large.

**Browser witness** (jsdom cannot prove layout — trap 3), banked at
`olumi-docs/regression-shield-2026-08-16/R3-FIX-BROWSER-WITNESS.md`:

- 1280x800 **collapsed**: gap 314px, overlap **0**, `elementFromPoint()` at the
  expand control's centre returns **the expand control**.
- **A real click on the expand control LANDED** — dock `w=40` -> `w=333`. That
  click could not be delivered at all on the deployed build.
- 1280x800 **expanded**: gap **exactly 12px**, overlap with the control **0**,
  overlap with the whole dock **0**, collapse control topmost.
- Sweep 1280 / 1440 / 1920: gap `12 / 12 / 12`, overlap `0 / 0 / 0`, control
  topmost at all three — constant because the trigger *tracks* the dock's
  variable rather than agreeing with it by luck.

**Gates at `3f6a9598`:** `lint` 0 errors + hooks ratchet exactly at baseline
(231/14) · `typecheck` PASSED, ratchet **exactly at baseline (2348)**, coverage
3401/3441 · css-var census 12/12 · **shard 2/4 (the one that failed): 411 files /
5415 passed** · `src/canvas/versions` 7 files / 175 tests ·
`src/canvas/components/__tests__` + `src/routes` 145 files / 1630 passed.

## Scope, stated honestly

- The browser witness is a **fresh guest, first-use canvas, local dev build**.
  Deploy-verify on staging is owed after merge.
- A user-dragged dock at the 480px hard maximum is covered by the derived matrix,
  not by the browser sweep.
- **Pre-existing drift found, deliberately not fixed:** `index.css` defines
  `--dock-right-expanded: 26rem` while `OutputsDock.tsx` declares a `24rem`
  fallback. Already pinned in `KNOWN_FALLBACK_DRIFT`, and unreachable because
  `index.css` always defines the property. The trigger inherits the dock's value
  rather than inventing a third one. That drift is the dock's to resolve.
- **#720 is not the only thing on that corner.** The shield also reported `Redo`
  and `Help me set a target` blocked by something else; a survey found
  `InfluenceExplainer` (`ReactFlowGraph.tsx:2220`, `right: 1rem`, z-1200) also
  sits over the dock band when it renders, and `computeFitPadding` reserves
  nothing for the fixed TopBar on a false premise stated in its own comment
  (`computeFitPadding.ts:200-202`). **Not fixed here** — this PR is scoped to the
  P0 the shield attributed to #720.
- Residual, narrow: at 1280 with a user-dragged maximum dock, the trigger's band
  can meet the top-centre transient-banner lane (`top-4`). Those banners are
  z-3000/z-50 and transient; no control is occluded either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)