### PR TITLE
feat(readiness): forward option interventions on the readiness request graph

### DIFF
--- a/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
@@ -32,7 +32,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import type { Node, Edge } from 'reactflow'
+import type { Node, Edge } from '@xyflow/react'
 import { buildReadinessPayload } from '../readinessStore'
 
 type WireNode = Record<string, unknown>

--- a/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * readinessStore — the readiness request must be able to EXPRESS a configured
+ * option.
+ *
+ * THE MECHANISM (derived at CEE `c4476269` and at this tip):
+ *
+ * CEE's canonical readiness assessor (`assessCanonicalAnalysisReadiness`, the
+ * turn path's sole whole-model authority) decides whether an option is
+ * configured by reading that option's INTERVENTIONS off the graph. The
+ * readiness route's request projection has never sent them: it emitted
+ * `{id, type, kind, label}`, plus `data.value` when numeric, plus
+ * `observed_state` for factors — and nothing else.
+ *
+ * So a model the user has fully configured on the canvas arrived at CEE
+ * WIRE-INDISTINGUISHABLE from an empty one. Measured on the CEE side with a
+ * contrast control: the identical model read `can_run_analysis: false` with a
+ * `MISSING_OPTION_VALUE` blocker on EVERY option, and read `ready` the moment
+ * the graph carried interventions. Nothing else differed.
+ *
+ * That gap is why the readiness route cannot yet be re-pointed at the one
+ * canonical assessor (CEE #991). This closes it.
+ *
+ * ⚠ WHY TOP-LEVEL `node.interventions` AND NOT `node.data.interventions`:
+ * CEE's request `Graph` schema types option `data` as `OptionData`, whose
+ * `interventions` is `z.record(z.string(), z.number())` — STRICTLY NUMERIC. The
+ * canvas stores rich `{ value, source, target_match }` entries, so writing
+ * those under `data` risks failing `NodeData`'s union and returning HTTP 400.
+ * The top-level field is the safe carrier and the canonical one: `Node` is
+ * `.passthrough()` (so it survives the request parse) and CEE's `NodeV3`
+ * DECLARES `interventions: z.record(z.string(), z.any())`. The top-level
+ * numeric shape is the one verified end-to-end against the canonical assessor.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from 'reactflow'
+import { buildReadinessPayload } from '../readinessStore'
+
+type WireNode = Record<string, unknown>
+
+function optionNode(id: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label, ...data } } as Node
+}
+
+function factorNode(id: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label, ...data } } as Node
+}
+
+function wireNodes(nodes: Node[], edges: Edge[] = []): WireNode[] {
+  const payload = JSON.parse(
+    buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null }),
+  )
+  return payload.graph.nodes as WireNode[]
+}
+
+const byId = (nodes: WireNode[], id: string): WireNode => {
+  const found = nodes.find((n) => n.id === id)
+  if (!found) throw new Error(`no wire node with id ${id}`)
+  return found
+}
+
+describe('buildReadinessPayload — option interventions reach the wire', () => {
+  it('forwards a configured option\'s interventions, bound to THAT option and THAT factor', () => {
+    const nodes = wireNodes([
+      factorNode('fac_price', 'Price'),
+      optionNode('opt_a', 'Premium', { interventions: { fac_price: 0.9 } }),
+      optionNode('opt_c', 'Value', { interventions: { fac_price: 0.4 } }),
+    ])
+
+    // Bind by IDENTITY: this option, this factor, this value — not "some node
+    // has interventions", which a wrong-object match would also satisfy.
+    expect(byId(nodes, 'opt_a').interventions).toEqual({ fac_price: 0.9 })
+    expect(byId(nodes, 'opt_c').interventions).toEqual({ fac_price: 0.4 })
+  })
+
+  it('normalises rich CEEInterventionV3 entries to their numeric value', () => {
+    // The canvas stores either a bare number or a full
+    // `{ value, source, target_match }` object (applyPatch.ts:594-605).
+    const nodes = wireNodes([
+      factorNode('fac_price', 'Price'),
+      optionNode('opt_a', 'Premium', {
+        interventions: {
+          fac_price: {
+            value: 0.75,
+            source: 'cee_hypothesis',
+            target_match: { node_id: 'fac_price', match_type: 'exact_id', confidence: 'high' },
+          },
+        },
+      }),
+    ])
+
+    expect(byId(nodes, 'opt_a').interventions).toEqual({ fac_price: 0.75 })
+  })
+
+  // ==========================================================================
+  // NEGATIVE ARM — the forwarding must be narrow.
+  // ==========================================================================
+
+  it('omits the field entirely for an UNCONFIGURED option', () => {
+    const nodes = wireNodes([
+      factorNode('fac_price', 'Price'),
+      optionNode('opt_b', 'Unconfigured'),
+    ])
+
+    // Absent, not `{}` — an empty map is a configured-with-nothing claim.
+    expect('interventions' in byId(nodes, 'opt_b')).toBe(false)
+  })
+
+  it('leaves NON-OPTION nodes untouched', () => {
+    const nodes = wireNodes([
+      factorNode('fac_price', 'Price', { interventions: { fac_other: 0.5 } }),
+      optionNode('opt_a', 'Premium', { interventions: { fac_price: 0.9 } }),
+    ])
+
+    // A factor never carries interventions on the wire, even if the canvas
+    // somehow holds them — only option nodes are configured objects.
+    expect('interventions' in byId(nodes, 'fac_price')).toBe(false)
+    // ...and the option still does. This is the discrimination half: a change
+    // that forwarded interventions for EVERY node would pass the assertion
+    // above's twin but fail here.
+    expect(byId(nodes, 'opt_a').interventions).toEqual({ fac_price: 0.9 })
+  })
+
+  it('drops malformed entries rather than sending a non-numeric value', () => {
+    const nodes = wireNodes([
+      factorNode('fac_price', 'Price'),
+      factorNode('fac_time', 'Time'),
+      optionNode('opt_a', 'Premium', {
+        interventions: {
+          fac_price: 0.9,
+          fac_time: 'soon', // categorical, not yet encoded
+        },
+      }),
+    ])
+
+    // Only the numeric entry survives; the categorical one is not invented into
+    // a number, and does not poison the whole map.
+    expect(byId(nodes, 'opt_a').interventions).toEqual({ fac_price: 0.9 })
+  })
+
+  it('omits the field when every entry is malformed', () => {
+    const nodes = wireNodes([
+      optionNode('opt_a', 'Premium', { interventions: { fac_time: 'soon' } }),
+    ])
+
+    expect('interventions' in byId(nodes, 'opt_a')).toBe(false)
+  })
+
+  // ==========================================================================
+  // ADDITIVE ONLY — the rest of the payload must not move.
+  // ==========================================================================
+
+  it('changes nothing else about the projection', () => {
+    const nodes: Node[] = [
+      factorNode('fac_price', 'Price', { value: 0.5, observedState: { value: 0.5, raw_value: 20 } }),
+      optionNode('opt_a', 'Premium', { interventions: { fac_price: 0.9 } }),
+    ]
+    const edges: Edge[] = [
+      { id: 'e1', source: 'opt_a', target: 'fac_price', data: { weight: 0.3 } } as Edge,
+    ]
+
+    const payload = JSON.parse(
+      buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null }),
+    )
+
+    // Factor projection intact, field for field.
+    expect(byId(payload.graph.nodes, 'fac_price')).toEqual({
+      id: 'fac_price',
+      type: 'factor',
+      kind: 'factor',
+      label: 'Price',
+      data: { value: 0.5 },
+      observed_state: { value: 0.5, raw_value: 20 },
+    })
+
+    // Option projection is the OLD shape plus exactly one key.
+    expect(byId(payload.graph.nodes, 'opt_a')).toEqual({
+      id: 'opt_a',
+      type: 'option',
+      kind: 'option',
+      label: 'Premium',
+      interventions: { fac_price: 0.9 },
+    })
+
+    // Edge projection untouched.
+    expect(payload.graph.edges).toEqual([
+      { id: 'e1', from: 'opt_a', to: 'fac_price', weight: 0.3, belief: 0.8, effect_direction: 'positive' },
+    ])
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -304,6 +304,48 @@ export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
               : {}),
           }
         }
+        // ── Option interventions: what makes a CONFIGURED option legible ──
+        //
+        // CEE's canonical readiness assessor decides whether an option is
+        // configured by reading its interventions off the GRAPH. Until this
+        // existed, the projection sent none, so a fully-configured canvas model
+        // arrived wire-indistinguishable from an empty one and every option came
+        // back `MISSING_OPTION_VALUE` (measured CEE-side with a contrast
+        // control). That gap is what blocks re-pointing `/graph-readiness` at
+        // the single canonical assessor — see CEE #991.
+        //
+        // TOP-LEVEL, not under `data`, and this is load-bearing: CEE types
+        // option `data` as `OptionData`, whose `interventions` is
+        // `z.record(z.string(), z.number())` — strictly numeric — so writing the
+        // canvas's rich `{ value, source, target_match }` entries there risks
+        // failing the `NodeData` union and returning HTTP 400. The top-level
+        // field survives CEE's `.passthrough()` request parse and is DECLARED by
+        // its `NodeV3` as `z.record(z.string(), z.any())`.
+        //
+        // Numeric-only by construction: CEE's `extractNumericIntervention`
+        // accepts a bare number or `{ value: number }`, and a categorical value
+        // awaiting encoding is not a configured effect — it is dropped rather
+        // than invented into a number. An option with no resolvable value omits
+        // the field entirely, because an empty map would assert
+        // "configured with nothing".
+        if (nodeKind === 'option') {
+          const raw = data?.interventions
+          if (raw != null && typeof raw === 'object' && !Array.isArray(raw)) {
+            const interventions: Record<string, number> = {}
+            for (const [factorId, entry] of Object.entries(raw as Record<string, unknown>)) {
+              const value =
+                typeof entry === 'number'
+                  ? entry
+                  : entry != null &&
+                      typeof entry === 'object' &&
+                      typeof (entry as { value?: unknown }).value === 'number'
+                    ? (entry as { value: number }).value
+                    : undefined
+              if (value !== undefined && Number.isFinite(value)) interventions[factorId] = value
+            }
+            if (Object.keys(interventions).length > 0) node.interventions = interventions
+          }
+        }
         return node
       }),
       /**


### PR DESCRIPTION
## The enabling change for the readiness-route unification

CEE's canonical readiness assessor (`assessCanonicalAnalysisReadiness`, the turn path's sole
whole-model authority) decides whether an option is configured by reading its **interventions off
the graph**. This projection never sent them.

`buildReadinessPayload` emitted `{id, type, kind, label}`, plus `data.value` when numeric, plus
`observed_state` for factors — and nothing else. So a model the user had **fully configured on the
canvas** arrived at CEE wire-indistinguishable from an empty one.

Measured CEE-side with a contrast control (the only variable between rows 2 and 3 is the interventions):

| Probe | Verdict |
|---|---|
| Raw deployed-UI payload | `SCHEMA_INVALID` |
| Edge-normalised UI payload | `false` — `MISSING_OPTION_VALUE` on **every** option |
| Same model **+ interventions on the graph** | `true`, `ready`, no blockers |

That gap is precisely what blocked re-pointing `/assist/v1/graph-readiness` at the single canonical
assessor ([CEE #991](https://github.com/Talchain/olumi-assistants-service/pull/991), merged as prep).
This closes it.

## The change

One additive block in `buildReadinessPayload`. Option nodes now carry their `interventions`.

**Top-level `node.interventions`, not `node.data.interventions` — this is load-bearing.** CEE types
option `data` as `OptionData`, whose `interventions` is `z.record(z.string(), z.number())` —
*strictly numeric*. The canvas stores rich `{ value, source, target_match }` entries
(`applyPatch.ts:594-605`), so writing those under `data` risks failing the `NodeData` union and
returning **HTTP 400**. The top-level field survives CEE's `.passthrough()` request parse and is
DECLARED by its `NodeV3` as `z.record(z.string(), z.any())`. The top-level numeric shape is the one
verified end-to-end against the canonical assessor.

Deliberately narrow:

* **Option nodes only.** A factor never carries interventions on the wire.
* **Numeric values only.** CEE's `extractNumericIntervention` accepts a bare number or
  `{ value: number }`; both are handled. A categorical value awaiting encoding is **dropped, not
  invented into a number**, and does not poison the rest of the map.
* **Field omitted entirely when nothing resolves** — an empty map would assert "configured with
  nothing", which is a different and false claim.
* `is_baseline` was considered and **not** forwarded: it appears only in starter draft JSON, not in
  the canvas node model, so sending it would be speculative.

Everything else about the payload is byte-identical — pinned by a field-for-field assertion on the
factor projection, the option projection and the edge projection.

## Note for the CEE cutover follow-up

`buildReadinessPayload` is also the change-detector hash (ROADMAP 2.332 — "the payload hash cannot
drift from the payload because it IS the payload"). Adding this field means **editing an option's
interventions now correctly invalidates the cached verdict and triggers a refetch**, which it did
not before. That is a fix, not a side effect, but it is a behaviour change worth knowing at cutover.

## Verification

* **RED-first at pristine: 5 of 7 failed**, every one `expected undefined to deeply equal {...}` —
  the missing field. The 2 that passed are the absence arms, which are correct before *and* after.
* **Now 7/7.** Spec collects **7** tests, asserted by name, not inferred from a suite total.
* **Siblings unaffected:** all 28 files under `src/canvas/stores/__tests__` green (341 tests).
* **Typecheck ratchet: PASSED at exactly baseline** (571 files / 2325 errors, +0). It initially
  caught a `reactflow` import that should have been `@xyflow/react` — fixed at source; the baseline
  was **not** regenerated.
* **Lint clean**; rules-of-hooks ratchet exactly at baseline (231 known violations, no new).
* **Mutation kit** — throwaway worktree outside the repo root, HEAD-relative restore, applied-check
  scoped to `src/` (=1 per mutant), clean-tree assertion before and after, and isolation proven by
  writing a sentinel and confirming the source hash was unchanged (distinct inodes):

| Mutant | Expected | Result |
|---|---|---|
| M1 strip the forwarding entirely | RED | **RED** (5 failed) |
| M2 drop the option-kind guard (forward for every node) | RED | **RED** |
| M3 emit the empty map instead of omitting | RED | **RED** |
| M4 accept non-numeric values | RED | **RED** |

Trailing control on the unmutated tree: green, tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
