### PR TITLE
feat(inspector): honest states, real rename, one ask semantic, user-language evidence

### DIFF
--- a/src/canvas/components/pre-analysis/DiscussWithAiButton.tsx
+++ b/src/canvas/components/pre-analysis/DiscussWithAiButton.tsx
@@ -18,7 +18,7 @@ import { memo, useCallback } from 'react'
 import { Sparkles } from 'lucide-react'
 import Tooltip from '@/components/Tooltip'
 import { useGuidanceStore } from '@/canvas/stores/guidanceStore'
-import { openAskOlumi } from '@/components/results/coaching/askOlumiStore'
+import { requestAsk } from '@/canvas/ui/inspector-v2/askSemantic'
 import { buildAiDiscussPrompt, type AiDiscussElement } from './buildAiDiscussPrompt'
 
 interface DiscussWithAiButtonProps {
@@ -63,15 +63,20 @@ function DiscussWithAiButtonImpl({ element, onSend, ariaLabel, className, varian
       onSend(text)
       return
     }
-    // Parity P7a: open the Work-through-it-with-Olumi drawer with the prompt
-    // PREFILLED and EDITABLE instead of auto-sending into a conversation on
-    // another tab — the invisible auto-send read as "the button does
-    // nothing" (audit dead-button class). The drawer dispatches on Send and
-    // degrades honestly when no conversation callback is registered.
-    openAskOlumi({
-      context: 'Discuss this part of the model with Olumi.',
-      draft: text,
+    // ONE ASK SEMANTIC (ledger L-18). This control has always been
+    // prefill-and-confirm — it was `InspectorCoaching` that auto-sent — but the
+    // two implemented it independently, which is how the pair diverged. Both
+    // now route through the single definition in `askSemantic.ts`.
+    //
+    // The routing change that follows: when a chat composer is registered, the
+    // draft goes THERE and the composer is revealed, instead of floating the
+    // Ask-Olumi drawer as a third surface. The drawer remains the fallback when
+    // no composer is available, and the carrier for asks with typed dispatch
+    // parameters (this one has none).
+    requestAsk({
+      text,
       label: 'Discuss with Olumi',
+      context: 'Discuss this part of the model with Olumi.',
       source: 'chip',
     })
   }, [element, onSend])

--- a/src/canvas/ui/inspector-v2/InspectorRouter.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorRouter.tsx
@@ -3,7 +3,7 @@
  * inside an InspectorShell.
  */
 
-import { memo, useMemo, useCallback } from 'react'
+import { memo, useMemo, useCallback, type ComponentType } from 'react'
 import { useCanvasStore } from '../../store'
 import type { NodeType, FactorCategory } from '../../domain/nodes'
 import { InspectorShell } from './InspectorShell'
@@ -47,6 +47,24 @@ const PILL_COLORS: Record<string, string> = {
   factor:     'var(--factor)',
   outcome:    'var(--success)',
   risk:       'var(--danger)',
+}
+
+/**
+ * Every NODE panel type → its panel. TOTAL by construction: `Record` over the
+ * union minus 'edge' (early-returned) and null (guarded), so adding a panel
+ * type without an arm here fails the typecheck instead of silently rendering
+ * nothing.
+ */
+const NODE_PANELS: Record<Exclude<NonNullable<PanelType>, 'edge'>, ComponentType<import('./types').InspectorPanelProps>> = {
+  'goal':                 GoalPanel,
+  'decision':             DecisionPanel,
+  'option':               OptionPanel,
+  'factor-controllable':  FactorControllablePanel,
+  'factor-observable':    FactorObservablePanel,
+  'factor-external':      FactorExternalPanel,
+  'outcome':              OutcomePanel,
+  'risk':                 RiskPanel,
+  'generic':              GenericNodePanel,
 }
 
 interface InspectorRouterProps {
@@ -248,17 +266,14 @@ export const InspectorRouter = memo(function InspectorRouter({
     onNavigate: handleNavigate,
   }
 
-  const PanelComponent = {
-    'goal':                 GoalPanel,
-    'decision':             DecisionPanel,
-    'option':               OptionPanel,
-    'factor-controllable':  FactorControllablePanel,
-    'factor-observable':    FactorObservablePanel,
-    'factor-external':      FactorExternalPanel,
-    'outcome':              OutcomePanel,
-    'risk':                 RiskPanel,
-    'generic':              GenericNodePanel,
-  }[panelType]
+  // Typed as a TOTAL map over every NODE panel type (edge is handled by the
+  // early return above, null by the guard at the top). Before this it was an
+  // untyped object literal indexed by the full union, so `panelType` could be
+  // 'edge' at the lookup and TypeScript reported TS2339 on the missing key —
+  // a real hole, not noise: a panel type added to the union but forgotten here
+  // would have resolved to `undefined` and rendered nothing, which is exactly
+  // the L-24 defect this PR is closing. Now a missing arm is a TYPE ERROR.
+  const PanelComponent = panelType === 'edge' ? null : NODE_PANELS[panelType]
 
   if (!PanelComponent) return null
 

--- a/src/canvas/ui/inspector-v2/InspectorRouter.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorRouter.tsx
@@ -25,6 +25,8 @@ import { FactorObservablePanel } from './panels/FactorObservablePanel'
 import { FactorExternalPanel } from './panels/FactorExternalPanel'
 import { OutcomePanel } from './panels/OutcomePanel'
 import { RiskPanel } from './panels/RiskPanel'
+import { GenericNodePanel } from './panels/GenericNodePanel'
+import { InspectorQuickActions } from './shared/InspectorQuickActions'
 
 // Entity colour map — used as fallback for inspector header entity colour
 const TOP_BAR_COLORS: Record<string, string> = {
@@ -64,6 +66,13 @@ type PanelType =
   | 'factor-external'
   | 'outcome'
   | 'risk'
+  /**
+   * L-24 — the real fallback. This used to be `null` for `action`,
+   * `constraint`, `ghost-option` and anything a future producer emits, and the
+   * router then rendered NOTHING: the user selected an element and the
+   * inspector silently refused to appear.
+   */
+  | 'generic'
   | null
 
 function resolvePanelType(
@@ -95,9 +104,16 @@ function resolvePanelType(
     case 'option':     return 'option'
     case 'outcome':    return 'outcome'
     case 'risk':       return 'risk'
-    default:           return null
+    // L-24 — every OTHER resolvable node gets a panel. `null` above is
+    // reserved for "there is no node", which is the only honest silence.
+    default:           return 'generic'
   }
 }
+
+/** Node kinds NodeShapeIndicator has a shape for. */
+const SHAPED_KINDS = new Set<string>([
+  'goal', 'decision', 'option', 'factor', 'risk', 'outcome', 'action', 'constraint',
+])
 
 export const InspectorRouter = memo(function InspectorRouter({
   nodeId,
@@ -166,6 +182,14 @@ export const InspectorRouter = memo(function InspectorRouter({
         onTechToggleChange={setTechMode}
         onClose={onClose}
         dragHandlers={dragHandlers}
+        quickActions={
+          <InspectorQuickActions
+            elementId={edgeId}
+            elementLabel={edgeLabel}
+            panelType="edge"
+            labelContext={{ sourceLabel, targetLabel }}
+          />
+        }
       >
         <EdgePanel
           edgeId={edgeId}
@@ -233,6 +257,7 @@ export const InspectorRouter = memo(function InspectorRouter({
     'factor-external':      FactorExternalPanel,
     'outcome':              OutcomePanel,
     'risk':                 RiskPanel,
+    'generic':              GenericNodePanel,
   }[panelType]
 
   if (!PanelComponent) return null
@@ -240,7 +265,9 @@ export const InspectorRouter = memo(function InspectorRouter({
   return (
     <InspectorShell
       topBarColor={topColor}
-      nodeKind={nodeType}
+      /* A kind with no shape (e.g. `ghost-option`) falls through to the shell's
+         generic icon rather than rendering a shape that means something else. */
+      nodeKind={SHAPED_KINDS.has(nodeType) ? nodeType : undefined}
       nodeId={nodeId}
       label={label}
       onLabelChange={nodeMutations.setLabel}
@@ -252,6 +279,13 @@ export const InspectorRouter = memo(function InspectorRouter({
       onTechToggleChange={setTechMode}
       onClose={onClose}
       dragHandlers={dragHandlers}
+      quickActions={
+        <InspectorQuickActions
+          elementId={nodeId}
+          elementLabel={label}
+          panelType={panelType}
+        />
+      }
     >
       {/* Full raw label in disclosure only when truncated */}
       {rawLabel !== label && (

--- a/src/canvas/ui/inspector-v2/InspectorShell.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorShell.tsx
@@ -37,16 +37,33 @@ export const InspectorShell = memo(function InspectorShell({
   const [showRationale, setShowRationale] = useState(false)
 
   // L-04 — a pending rename intent for THIS element opens the title in editing
-  // state, then is consumed. One-shot by design: leaving it set would reopen
-  // the editor on every unrelated re-render.
+  // state, then is consumed.
+  //
+  // ⚠ THIS WAS A BOOLEAN AND IT LEAKED (adversarial review D1). The live
+  // inspector does NOT remount per selection: `InspectorModal` keeps ONE shell
+  // mounted and changes `nodeId`. A boolean `autoEdit` therefore stayed true
+  // across a retarget, so selecting node B after arming node A opened B's
+  // editor — holding A's text, because the editor's own draft also survived —
+  // and the blur-save wrote "Option A" onto node B. A silent, wrong, persisted
+  // rename, and every test in the first round rendered FRESH, which is exactly
+  // why none of them could see it.
+  //
+  // The intent is now carried AS AN ID at every hop and is only honoured when
+  // it matches the node the shell is currently mounted for. Consumption clears
+  // it, so returning to A does not reopen the editor under a user who has
+  // moved on.
   const renameNodeId = useRenameIntentStore((s) => s.renameNodeId)
-  const [autoEditLabel, setAutoEditLabel] = useState(false)
+  const [armedForNodeId, setArmedForNodeId] = useState<string | null>(null)
   useEffect(() => {
     if (nodeId && renameNodeId === nodeId) {
-      setAutoEditLabel(true)
+      setArmedForNodeId(nodeId)
       clearNodeRename()
     }
   }, [nodeId, renameNodeId])
+  // The comparison — not a boolean — is what makes a retarget disarm.
+  const autoEditLabel = armedForNodeId !== null && armedForNodeId === nodeId
+  // One-shot: once the editor has opened, the intent is spent.
+  const handleAutoEditConsumed = useCallback(() => setArmedForNodeId(null), [])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -106,11 +123,20 @@ export const InspectorShell = memo(function InspectorShell({
         <div className="flex items-start justify-between gap-1.5">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1">
+              {/* `key` is load-bearing, not cosmetic (D1): it remounts the
+                  editor whenever the shell is retargeted, so an open editor
+                  and a half-typed draft CANNOT survive onto the next element.
+                  Without it a retarget mid-rename carries the previous
+                  element's text into this one's save. An abandoned edit is
+                  discarded, which is the honest outcome — the user navigated
+                  away from it. */}
               <EditableLabel
+                key={nodeId ?? 'inspector-label'}
                 value={label}
                 onSave={onLabelChange}
                 maxLength={NODE_LABEL_MAX_LENGTH}
                 autoEdit={autoEditLabel}
+                onAutoEditConsumed={handleAutoEditConsumed}
                 className={`${typography.panelHeader} text-text-header`}
               />
               {rationale && (

--- a/src/canvas/ui/inspector-v2/InspectorShell.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorShell.tsx
@@ -5,7 +5,7 @@
  * Header is the drag surface when dragHandlers are provided.
  */
 
-import { memo, useState, useCallback, type KeyboardEvent } from 'react'
+import { memo, useState, useCallback, useEffect, type KeyboardEvent } from 'react'
 import { X, Code2, Spline, HelpCircle, ArrowLeft } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { NodeShapeIndicator } from '../../nodes/NodeShapeIndicator'
@@ -13,6 +13,8 @@ import { useCanvasStore } from '../../store'
 import { isAiPanelV2Enabled } from '../../../flags'
 import type { InspectorShellProps } from './types'
 import { EditableLabel } from './shared/EditableLabel'
+import { NODE_LABEL_MAX_LENGTH } from './useInspectorMutations'
+import { useRenameIntentStore, clearNodeRename } from './renameIntent'
 
 export const InspectorShell = memo(function InspectorShell({
   topBarColor,
@@ -28,10 +30,23 @@ export const InspectorShell = memo(function InspectorShell({
   onTechToggleChange,
   onClose,
   dragHandlers,
+  quickActions,
   children,
 }: InspectorShellProps) {
   const rationale = useCanvasStore((s) => nodeId ? s.nodeRationales?.[nodeId] : undefined)
   const [showRationale, setShowRationale] = useState(false)
+
+  // L-04 — a pending rename intent for THIS element opens the title in editing
+  // state, then is consumed. One-shot by design: leaving it set would reopen
+  // the editor on every unrelated re-render.
+  const renameNodeId = useRenameIntentStore((s) => s.renameNodeId)
+  const [autoEditLabel, setAutoEditLabel] = useState(false)
+  useEffect(() => {
+    if (nodeId && renameNodeId === nodeId) {
+      setAutoEditLabel(true)
+      clearNodeRename()
+    }
+  }, [nodeId, renameNodeId])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -94,7 +109,8 @@ export const InspectorShell = memo(function InspectorShell({
               <EditableLabel
                 value={label}
                 onSave={onLabelChange}
-                maxLength={500}
+                maxLength={NODE_LABEL_MAX_LENGTH}
+                autoEdit={autoEditLabel}
                 className={`${typography.panelHeader} text-text-header`}
               />
               {rationale && (
@@ -160,8 +176,12 @@ export const InspectorShell = memo(function InspectorShell({
         </div>
       </div>
 
-      {/* Body — scrollable when content exceeds panel max height */}
+      {/* Body — scrollable when content exceeds panel max height.
+          R5: quick actions sit at the TOP of the body, above every panel
+          group, so the two power functions (ask Olumi about this element,
+          open its analysis) are never buried behind a scroll. */}
       <div className="px-4 pb-4 overflow-y-auto" style={{ maxHeight: 560 }}>
+        {quickActions}
         {children}
       </div>
     </div>

--- a/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InspectorCoaching.spec.tsx
@@ -5,7 +5,7 @@
  * - Orchestrator GuidanceItems render through CoachingCard visual
  * - Guidance filtered to selected element only
  * - Static coaching is fallback when no guidance exists
- * - "Ask about this" SENDS via _sendMessage (falls back to _prefillChat)
+ * - "Ask about this" PREFILLS an editable draft and waits (never auto-sends)
  * - Button hidden when _prefillChat and _sendMessage are both null
  */
 
@@ -95,7 +95,23 @@ describe('InspectorCoaching', () => {
     expect(screen.queryByText(/Low priority/)).toBeNull()
   })
 
-  it('"Ask about this" SENDS the question via _sendMessage (not _prefillChat)', () => {
+  /**
+   * ⚠ THIS TEST'S EXPECTATION WAS INVERTED, DELIBERATELY (ledger L-18).
+   *
+   * It previously read: '"Ask about this" SENDS the question via _sendMessage
+   * (not _prefillChat)' — and it was a correct pin on the behaviour that
+   * shipped. That behaviour is the defect. This component auto-sent while the
+   * inspector's OTHER ask affordance (DiscussWithAiButton) prefilled and
+   * waited: same intent, opposite semantics, one panel (a trap-21 pair). The
+   * auto-send half is the one that lies, because the question lands in a
+   * surface the user may not be looking at.
+   *
+   * The ruling is prefill-and-confirm everywhere (`askSemantic.ts`). This is
+   * not a fixture being tidied to match new code — it is a semantic that was
+   * ruled against, and the old expectation is recorded above rather than
+   * deleted so the reversal is legible.
+   */
+  it('"Ask about this" PREFILLS the question and does NOT auto-send', () => {
     const prefill = vi.fn()
     const send = vi.fn()
     useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: send })
@@ -104,12 +120,12 @@ describe('InspectorCoaching', () => {
     const button = screen.getByText('Ask about this')
     fireEvent.click(button)
 
-    expect(send).toHaveBeenCalledTimes(1)
-    expect(send).toHaveBeenCalledWith('How important is Marketing Budget to the outcome?')
-    expect(prefill).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+    expect(prefill).toHaveBeenCalledTimes(1)
+    expect(prefill).toHaveBeenCalledWith('How important is Marketing Budget to the outcome?')
   })
 
-  it('falls back to _prefillChat when _sendMessage is unavailable', () => {
+  it('still lands the draft when only _prefillChat is registered', () => {
     const prefill = vi.fn()
     useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: null })
     render(<InspectorCoaching {...defaultProps} />)

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
@@ -1,0 +1,305 @@
+/**
+ * Inspector completion — ONE ASK SEMANTIC (the ledger's trap-21 pair) + R5
+ * quick actions.
+ *
+ * THE PAIR, and the two questions it conflated:
+ *
+ *   `InspectorCoaching`  — "Ask about this" AUTO-SENT via `_sendMessage`.
+ *   `DiscussWithAiButton` — PREFILLED an editable draft and waited.
+ *
+ * Same user intent ("ask Olumi about this element"), opposite semantics, one
+ * inspector. Auto-send is the one that lies: the message vanishes into a
+ * surface the user may not be looking at, so the button reads as dead.
+ *
+ * RULING APPLIED: prefill-and-confirm, everywhere. An ask affordance NEVER
+ * dispatches. It lands the question as an EDITABLE DRAFT in a visible surface
+ * with a single obvious Send, which the user presses.
+ *
+ * The two questions are now named apart (trap 21):
+ *   Q1 "how does an ask get CONFIRMED?"  → one answer: the user sends it.
+ *   Q2 "which CARRIER does it travel on?" → per call site, unchanged.
+ * Q2 is deliberately NOT unified: the analysis-tab asks ride a typed dispatch
+ * that carries chip_metadata, and a bare composer prefill would drop it.
+ *
+ * `run_exercise` stays a direct command: its button IS the confirmation, and a
+ * prefilled '/exercise …' would sit in the composer as literal text.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { InspectorCoaching } from '../shared/InspectorCoaching'
+import { InspectorRouter } from '../InspectorRouter'
+import { DiscussWithAiButton } from '../../../components/pre-analysis/DiscussWithAiButton'
+import { requestAsk, ASK_SEMANTIC } from '../askSemantic'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore, type GuidanceItem } from '../../../stores/guidanceStore'
+import { useAskOlumiStore } from '../../../../components/results/coaching/askOlumiStore'
+
+vi.mock('@xyflow/react', () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+vi.mock('../../../conversation/revealOlumi', () => ({
+  revealOlumiSurface: vi.fn(),
+}))
+
+import { revealOlumiSurface } from '../../../conversation/revealOlumi'
+const mockReveal = revealOlumiSurface as ReturnType<typeof vi.fn>
+
+const coachingProps = {
+  elementId: 'node-1',
+  panelType: 'factor-controllable',
+  fallbackText: 'Static coaching fallback text',
+  labelContext: { label: 'Marketing Budget' },
+}
+
+const EXPECTED_QUESTION = 'How important is Marketing Budget to the outcome?'
+
+function makeGuidanceItem(overrides: Partial<GuidanceItem> = {}): GuidanceItem {
+  return {
+    item_id: 'g1',
+    signal_code: 'evidence_gap',
+    category: 'should_fix',
+    source: 'analysis',
+    title: 'Orchestrator guidance title',
+    detail: 'with detail',
+    primary_action: { type: 'discuss', prompt: 'Tell me more about this' },
+    target_object: { type: 'node', id: 'node-1', label: 'Test Factor' },
+    priority: 80,
+    ...overrides,
+  } as GuidanceItem
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useAskOlumiStore.getState().close()
+  useAskOlumiStore.setState({ draft: '', context: '', label: '' } as never)
+  useGuidanceStore.setState({
+    guidanceItems: [],
+    activeGuidanceItemId: null,
+    inspectorDeepLinkField: null,
+    _sendMessage: null,
+    _runAnalysis: null,
+    _sendChip: null,
+    _scrollToPatch: null,
+    _prefillChat: null,
+    _dispatchAction: null,
+  } as never)
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// The semantic itself
+// ─────────────────────────────────────────────────────────────────────
+
+describe('one ask semantic · the module declares it and never dispatches', () => {
+  it('declares prefill-and-confirm as the semantic', () => {
+    expect(ASK_SEMANTIC).toBe('prefill-and-confirm')
+  })
+
+  it('prefills the composer and reveals it — it does NOT send', () => {
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: send } as never)
+
+    requestAsk({ text: 'Why does this matter?', label: 'Ask', context: 'ctx' })
+
+    expect(prefill).toHaveBeenCalledWith('Why does this matter?')
+    expect(send).not.toHaveBeenCalled()
+    expect(mockReveal).toHaveBeenCalled()
+    // No third floating surface when a simple prefill suffices.
+    expect(useAskOlumiStore.getState().isOpen).toBe(false)
+  })
+
+  it('falls back to the drawer — still unsent — when no composer is registered', () => {
+    const send = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: null, _sendMessage: send } as never)
+
+    requestAsk({ text: 'Why does this matter?', label: 'Ask', context: 'ctx' })
+
+    expect(send).not.toHaveBeenCalled()
+    const drawer = useAskOlumiStore.getState()
+    expect(drawer.isOpen).toBe(true)
+    expect(drawer.draft).toBe('Why does this matter?')
+  })
+
+  it('uses the drawer when the ask carries a typed-dispatch payload', () => {
+    // Q2: chip_metadata survives ONLY on the typed turn, so an ask carrying
+    // parameters must not be flattened into a bare composer prefill.
+    const prefill = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: prefill } as never)
+
+    requestAsk({
+      text: 'Run the outside view on this',
+      label: 'Outside view',
+      context: 'ctx',
+      parameters: { method_id: 'outside_view' },
+    })
+
+    expect(prefill).not.toHaveBeenCalled()
+    expect(useAskOlumiStore.getState().isOpen).toBe(true)
+  })
+
+  it('does nothing at all when there is no surface to receive the draft', () => {
+    requestAsk({ text: 'Why does this matter?', label: 'Ask', context: 'ctx' })
+    expect(useAskOlumiStore.getState().isOpen).toBe(false)
+    expect(mockReveal).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Half one of the pair — InspectorCoaching stops auto-sending
+// ─────────────────────────────────────────────────────────────────────
+
+describe('one ask semantic · InspectorCoaching no longer auto-sends', () => {
+  it('"Ask about this" prefills and does NOT call _sendMessage', () => {
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: send } as never)
+
+    render(<InspectorCoaching {...coachingProps} />)
+    fireEvent.click(screen.getByText('Ask about this'))
+
+    expect(send).not.toHaveBeenCalled()
+    expect(prefill).toHaveBeenCalledWith(EXPECTED_QUESTION)
+  })
+
+  it('a "discuss" guidance action also prefills rather than sending', () => {
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({
+      guidanceItems: [makeGuidanceItem()],
+      _prefillChat: prefill,
+      _sendMessage: send,
+    } as never)
+
+    render(<InspectorCoaching {...coachingProps} />)
+    fireEvent.click(screen.getByText('Discuss'))
+
+    expect(send).not.toHaveBeenCalled()
+    expect(prefill).toHaveBeenCalledWith('Tell me more about this')
+  })
+
+  it('still routes a slash-command exercise as a direct command', () => {
+    // Discriminating twin: proves the change is scoped to ASKS. A prefilled
+    // '/exercise …' would sit in the composer as literal text, so its button
+    // remains the confirmation. If this ever goes green-by-accident the
+    // distinction has been flattened.
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({
+      guidanceItems: [
+        makeGuidanceItem({
+          primary_action: { type: 'run_exercise', exercise: 'premortem' } as GuidanceItem['primary_action'],
+        }),
+      ],
+      _prefillChat: prefill,
+      _sendMessage: send,
+    } as never)
+
+    render(<InspectorCoaching {...coachingProps} />)
+    fireEvent.click(screen.getByText('Ask about this'))
+
+    expect(send).toHaveBeenCalledWith('/exercise premortem')
+    expect(prefill).not.toHaveBeenCalled()
+  })
+
+  it('hides the action when no surface can receive it', () => {
+    useGuidanceStore.setState({ _prefillChat: null, _sendMessage: null } as never)
+    render(<InspectorCoaching {...coachingProps} />)
+    expect(screen.queryByText('Ask about this')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Half two of the pair — DiscussWithAiButton runs the same semantic
+// ─────────────────────────────────────────────────────────────────────
+
+describe('one ask semantic · DiscussWithAiButton runs the same routing', () => {
+  it('prefills the composer instead of floating a drawer when one is registered', () => {
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: send } as never)
+
+    render(<DiscussWithAiButton element={{ kind: 'factor', label: 'Team size' }} />)
+    fireEvent.click(screen.getByTestId('discuss-with-ai'))
+
+    expect(send).not.toHaveBeenCalled()
+    expect(prefill).toHaveBeenCalledTimes(1)
+    expect(useAskOlumiStore.getState().isOpen).toBe(false)
+  })
+
+  it('honours an explicit onSend override unchanged', () => {
+    // The override is the caller managing its own handler; it must not be
+    // re-routed underneath the caller.
+    const onSend = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: vi.fn() } as never)
+    render(<DiscussWithAiButton element={{ kind: 'factor', label: 'Team size' }} onSend={onSend} />)
+    fireEvent.click(screen.getByTestId('discuss-with-ai'))
+    expect(onSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the drawer when no composer is registered', () => {
+    useGuidanceStore.setState({ _prefillChat: null, _sendMessage: vi.fn() } as never)
+    render(<DiscussWithAiButton element={{ kind: 'factor', label: 'Team size' }} />)
+    fireEvent.click(screen.getByTestId('discuss-with-ai'))
+    expect(useAskOlumiStore.getState().isOpen).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// R5 — quick actions at the TOP of the inspector
+// ─────────────────────────────────────────────────────────────────────
+
+describe('R5 · quick actions sit at the top of the inspector', () => {
+  function setNodeStore() {
+    useCanvasStore.setState({
+      ...useCanvasStore.getState(),
+      nodes: [
+        { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Marketing Budget', kind: 'factor', category: 'controllable' } },
+      ],
+      edges: [],
+      results: { status: 'none', report: null },
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    } as never)
+  }
+
+  it('renders both ruled quick actions', () => {
+    useGuidanceStore.setState({ _prefillChat: vi.fn() } as never)
+    setNodeStore()
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    expect(screen.getByTestId('inspector-quick-ask')).toBeTruthy()
+    expect(screen.getByTestId('inspector-quick-analysis')).toBeTruthy()
+  })
+
+  it('places them ABOVE the panel body — nothing buried', () => {
+    useGuidanceStore.setState({ _prefillChat: vi.fn() } as never)
+    setNodeStore()
+    const { container } = render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    const quick = screen.getByTestId('inspector-quick-actions')
+    const firstGroup = container.querySelector('[data-panel-group]')
+    expect(firstGroup).not.toBeNull()
+    // DOCUMENT_POSITION_FOLLOWING === 4: the first panel group follows the
+    // quick-action row in document order.
+    expect(quick.compareDocumentPosition(firstGroup as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('the quick ask runs the ONE semantic — prefill, never send', () => {
+    const prefill = vi.fn()
+    const send = vi.fn()
+    useGuidanceStore.setState({ _prefillChat: prefill, _sendMessage: send } as never)
+    setNodeStore()
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('inspector-quick-ask'))
+    expect(send).not.toHaveBeenCalled()
+    expect(prefill).toHaveBeenCalledTimes(1)
+    expect(String(prefill.mock.calls[0][0])).toContain('Marketing Budget')
+  })
+
+  it('hides the quick ask when no conversation surface exists — no dead button', () => {
+    useGuidanceStore.setState({ _prefillChat: null, _sendMessage: null } as never)
+    setNodeStore()
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('inspector-quick-ask')).toBeNull()
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
@@ -201,7 +201,10 @@ describe('one ask semantic · InspectorCoaching no longer auto-sends', () => {
     } as never)
 
     render(<InspectorCoaching {...coachingProps} />)
-    fireEvent.click(screen.getByText('Ask about this'))
+    // Labelled 'Try it', not 'Ask about this' — an auto-sending control must
+    // not wear an ask's label (review item 4). Clicking it still sends.
+    expect(screen.queryByText('Ask about this')).toBeNull()
+    fireEvent.click(screen.getByText('Try it'))
 
     expect(send).toHaveBeenCalledWith('/exercise pre_mortem')
     expect(prefill).not.toHaveBeenCalled()

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.askSemantic.spec.tsx
@@ -190,7 +190,10 @@ describe('one ask semantic · InspectorCoaching no longer auto-sends', () => {
     useGuidanceStore.setState({
       guidanceItems: [
         makeGuidanceItem({
-          primary_action: { type: 'run_exercise', exercise: 'premortem' } as GuidanceItem['primary_action'],
+          // The producer's own enum — 'pre_mortem', not 'premortem'. Derived
+          // from GuidanceAction in guidanceStore.ts rather than guessed, and
+          // asserted without a cast so the compiler keeps checking it.
+          primary_action: { type: 'run_exercise', exercise: 'pre_mortem' },
         }),
       ],
       _prefillChat: prefill,
@@ -200,7 +203,7 @@ describe('one ask semantic · InspectorCoaching no longer auto-sends', () => {
     render(<InspectorCoaching {...coachingProps} />)
     fireEvent.click(screen.getByText('Ask about this'))
 
-    expect(send).toHaveBeenCalledWith('/exercise premortem')
+    expect(send).toHaveBeenCalledWith('/exercise pre_mortem')
     expect(prefill).not.toHaveBeenCalled()
   })
 

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.honestStates.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.honestStates.spec.tsx
@@ -1,0 +1,319 @@
+/**
+ * Inspector completion — L-40 (self-contradictions) + L-24 (add-path divergence).
+ *
+ * RED-first. Each case is bound to its object by IDENTITY (panel-group testids,
+ * node ids, string-table constants), never by a value predicate another element
+ * could satisfy.
+ *
+ * L-40 half A (S02): "This option doesn't change any factors yet" rendered
+ * DIRECTLY ABOVE a populated Connections list. The empty-state was derived from
+ * `data.interventions` while the connections list was derived from `edges` —
+ * two different data sources answering the same user-facing question. The fix
+ * derives the empty state from the SAME edge data the connections list reads.
+ *
+ * L-40 half B (S04): the Decision inspector said "No connections yet." while
+ * the canvas showed its edges. `otherConnections` EXCLUDES option edges by
+ * design (options live in the Input group), so a decision whose only edges are
+ * its options rendered a flat denial of edges the user can see. The fix counts
+ * what the user sees, or names the concept honestly.
+ *
+ * L-24: the Impact group was gated on GLOBAL results mode. An option added
+ * after the last run therefore rendered the same "unavailable for this analysis
+ * run" copy as an option the run genuinely returned nothing for — two different
+ * situations under one sentence. The fix derives the state PER NODE.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { OptionPanel } from '../panels/OptionPanel'
+import { DecisionPanel } from '../panels/DecisionPanel'
+import { InspectorRouter } from '../InspectorRouter'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { EMPTY_STATES, OPTION_STRINGS, DECISION_STRINGS } from '../inspectorStrings'
+
+vi.mock('@xyflow/react', () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+vi.mock('../../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(),
+}))
+
+import { useNodeDisplayMetadata } from '../../../hooks/useNodeDisplayMetadata'
+const mockDisplayMetadata = useNodeDisplayMetadata as ReturnType<typeof vi.fn>
+
+const baseMetadata = {
+  sensitivityRank: null,
+  influence: null,
+  confidence: null,
+  valueOfInformation: null,
+  inSensitivityAnalysis: false,
+  winRate: null,
+}
+
+const optionProps = {
+  nodeId: 'optA',
+  techMode: false,
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+}
+
+const decisionProps = {
+  nodeId: 'dec1',
+  techMode: false,
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+}
+
+function setStore(patch: Record<string, unknown>) {
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    results: { status: 'none', report: null },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    ...patch,
+  } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDisplayMetadata.mockReturnValue(baseMetadata)
+  useGuidanceStore.setState({
+    guidanceItems: [],
+    _sendMessage: null,
+    _prefillChat: null,
+    _dispatchAction: null,
+  } as never)
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// L-40 half A — the option empty-state must agree with the connections list
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-40 · OptionPanel does not deny factor links it is simultaneously listing', () => {
+  /**
+   * The exact S02 shape: an add-path option with NO `interventions` map but
+   * three real outbound edges to factors. The Connections group renders three
+   * rows from `edges`; the Input group must not deny them.
+   */
+  function setContradictionStore() {
+    setStore({
+      nodes: [
+        { id: 'optA', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Hire aggressively', description: '' } },
+        { id: 'fac1', type: 'factor', position: { x: 1, y: 0 }, data: { label: 'Team productivity', category: 'controllable' } },
+        { id: 'fac2', type: 'factor', position: { x: 2, y: 0 }, data: { label: 'Hiring spend', category: 'controllable' } },
+        { id: 'fac3', type: 'factor', position: { x: 3, y: 0 }, data: { label: 'Onboarding load', category: 'controllable' } },
+      ],
+      edges: [
+        { id: 'e1', source: 'optA', target: 'fac1', data: {} },
+        { id: 'e2', source: 'optA', target: 'fac2', data: {} },
+        { id: 'e3', source: 'optA', target: 'fac3', data: {} },
+      ],
+    })
+  }
+
+  it('renders the three factor connections (fixture precondition — pinned in-test)', () => {
+    setContradictionStore()
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const connections = container.querySelector('[data-panel-group="connections"]')
+    expect(connections).not.toBeNull()
+    // Pin the precondition: this fixture DOES render a populated list. Without
+    // this the absence assertion below could pass on an empty panel.
+    expect(connections?.textContent).toContain('Team productivity')
+    expect(connections?.textContent).toContain('Hiring spend')
+    expect(connections?.textContent).toContain('Onboarding load')
+    expect(connections?.textContent).not.toContain(EMPTY_STATES.noInterventions)
+  })
+
+  it('does NOT render the "changes no factors" denial while those connections are on screen', () => {
+    setContradictionStore()
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const input = container.querySelector('[data-panel-group="input"]')
+    expect(input).not.toBeNull()
+    expect(input?.textContent).not.toContain(EMPTY_STATES.noInterventions)
+  })
+
+  it('names the unset-values state honestly, counting the same edges the list reads', () => {
+    setContradictionStore()
+    render(<OptionPanel {...optionProps} />)
+    expect(screen.getByTestId('option-links-without-values')).toBeTruthy()
+    expect(screen.getByTestId('option-links-without-values').textContent).toContain('3')
+  })
+
+  it('still shows the true empty state when there are no factor links at all', () => {
+    setStore({
+      nodes: [
+        { id: 'optA', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Do nothing', description: '' } },
+        { id: 'dec1', type: 'decision', position: { x: 1, y: 0 }, data: { label: 'The decision' } },
+      ],
+      // Only the organisational decision→option edge exists.
+      edges: [{ id: 'e0', source: 'dec1', target: 'optA', data: {} }],
+    })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const input = container.querySelector('[data-panel-group="input"]')
+    expect(input?.textContent).toContain(EMPTY_STATES.noInterventions)
+    expect(screen.queryByTestId('option-links-without-values')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// L-40 half B — the Decision inspector must not deny edges the canvas draws
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-40 · DecisionPanel does not claim "no connections" while its options are edges', () => {
+  function setDecisionStore() {
+    setStore({
+      nodes: [
+        { id: 'dec1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Launch strategy', description: '' } },
+        { id: 'optA', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Option A', interventions: {} } },
+        { id: 'optB', type: 'option', position: { x: 2, y: 0 }, data: { label: 'Option B', interventions: {} } },
+      ],
+      edges: [
+        { id: 'e1', source: 'dec1', target: 'optA', data: {} },
+        { id: 'e2', source: 'dec1', target: 'optB', data: {} },
+      ],
+    })
+  }
+
+  it('lists both options (fixture precondition — pinned in-test)', () => {
+    setDecisionStore()
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const input = container.querySelector('[data-panel-group="input"]')
+    expect(input?.textContent).toContain('Option A')
+    expect(input?.textContent).toContain('Option B')
+  })
+
+  it('does NOT render the flat "No connections yet." denial', () => {
+    setDecisionStore()
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const connections = container.querySelector('[data-panel-group="connections"]')
+    expect(connections).not.toBeNull()
+    expect(connections?.textContent).not.toContain(EMPTY_STATES.noConnectionsFlat)
+  })
+
+  it('names where those connections are, counting the option edges the canvas draws', () => {
+    setDecisionStore()
+    render(<DecisionPanel {...decisionProps} />)
+    const el = screen.getByTestId('decision-connections-are-options')
+    expect(el.textContent).toContain('2')
+  })
+
+  it('still shows the plain empty state for a decision with genuinely no edges', () => {
+    setStore({
+      nodes: [{ id: 'dec1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Untouched decision' } }],
+      edges: [],
+    })
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const connections = container.querySelector('[data-panel-group="connections"]')
+    expect(connections?.textContent).toContain(EMPTY_STATES.noConnectionsFlat)
+    expect(screen.queryByTestId('decision-connections-are-options')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// L-24 — per-node Impact gating + a real router fallback
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-24 · OptionPanel Impact group is derived per node, not from global results mode', () => {
+  const analysedReport = {
+    option_comparison: [
+      { option_id: 'optOld', win_probability: 0.62, label: 'Existing option' },
+    ],
+  }
+
+  function setAddPathStore() {
+    setStore({
+      nodes: [
+        { id: 'optA', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Newly added option' } },
+        { id: 'optOld', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Existing option' } },
+      ],
+      edges: [],
+      results: { status: 'complete', report: analysedReport },
+    })
+  }
+
+  it('tells a node added since the last run WHY it has no impact, not "unavailable"', () => {
+    setAddPathStore()
+    mockDisplayMetadata.mockReturnValue({ ...baseMetadata, winRate: null })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const impact = container.querySelector('[data-panel-group="impact"]')
+    expect(impact).not.toBeNull()
+    expect(screen.getByTestId('option-impact-not-in-run')).toBeTruthy()
+    // The generic sentence must NOT be what an add-path node gets: it conflates
+    // "the run did not cover you" with "the run returned nothing for you".
+    expect(impact?.textContent).not.toContain(OPTION_STRINGS.impactUnavailable)
+  })
+
+  it('keeps the honest generic fallback for a node the run DID cover but returned nothing for', () => {
+    setStore({
+      nodes: [
+        { id: 'optA', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Covered option' } },
+      ],
+      edges: [],
+      // optA IS in the comparison, but with no win_probability.
+      results: { status: 'complete', report: { option_comparison: [{ option_id: 'optA', label: 'Covered option' }] } },
+    })
+    mockDisplayMetadata.mockReturnValue({ ...baseMetadata, winRate: null })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const impact = container.querySelector('[data-panel-group="impact"]')
+    expect(impact?.textContent).toContain(OPTION_STRINGS.impactUnavailable)
+    expect(screen.queryByTestId('option-impact-not-in-run')).toBeNull()
+  })
+
+  it('renders no Impact group at all before any analysis has run', () => {
+    setStore({
+      nodes: [{ id: 'optA', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Fresh option' } }],
+      edges: [],
+      results: { status: 'none', report: null },
+    })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    expect(container.querySelector('[data-panel-group="impact"]')).toBeNull()
+  })
+})
+
+describe('L-24 · InspectorRouter never renders NOTHING for a selected node', () => {
+  it.each([
+    ['action', { id: 'n1', type: 'action', data: { label: 'Draft the brief', kind: 'action' }, position: { x: 0, y: 0 } }],
+    ['constraint', { id: 'n1', type: 'constraint', data: { label: 'Budget cap', kind: 'constraint' }, position: { x: 0, y: 0 } }],
+    ['ghost-option', { id: 'n1', type: 'ghost-option', data: { label: 'Suggested option', kind: 'ghost-option' }, position: { x: 0, y: 0 } }],
+  ])('renders a fallback panel for a %s node', (_kind, node) => {
+    setStore({ nodes: [node], edges: [] })
+    const { container } = render(
+      <InspectorRouter nodeId="n1" edgeId={null} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).not.toBe('')
+    expect(screen.getByTestId('inspector-generic-panel')).toBeTruthy()
+    // The element's own name must be on screen — the fallback is a panel, not a
+    // placeholder that loses the user's selection.
+    expect(container.textContent).toContain(String((node as { data: { label: string } }).data.label))
+  })
+
+  it('still renders nothing when the selection resolves to no node at all', () => {
+    setStore({ nodes: [], edges: [] })
+    const { container } = render(
+      <InspectorRouter nodeId="missing" edgeId={null} onClose={vi.fn()} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+})
+
+describe('string table — the honest-state copy exists and is user language', () => {
+  it('exposes the constants the panels bind to', () => {
+    expect(typeof EMPTY_STATES.noConnectionsFlat).toBe('string')
+    expect(typeof OPTION_STRINGS.impactNotInLastRun).toBe('string')
+    expect(typeof OPTION_STRINGS.linksWithoutValues).toBe('string')
+    expect(typeof DECISION_STRINGS.connectionsAreOptions).toBe('string')
+  })
+
+  it('carries no raw enum or engineering tokens', () => {
+    const copy = [
+      EMPTY_STATES.noConnectionsFlat,
+      OPTION_STRINGS.impactNotInLastRun,
+      OPTION_STRINGS.linksWithoutValues,
+      DECISION_STRINGS.connectionsAreOptions,
+    ].join(' ')
+    expect(copy).not.toMatch(/_[a-z]+_/)
+    expect(copy).not.toMatch(/\b(null|undefined|winRate|option_comparison)\b/)
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.rename.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.rename.spec.tsx
@@ -1,0 +1,214 @@
+/**
+ * Inspector completion — L-04 (node title editing very difficult).
+ *
+ * RED-first. Three separate defects, three separate pins:
+ *
+ * 1. NO VISIBLE AFFORDANCE. The rename control was a bare `<button>` carrying
+ *    only `cursor-text` — nothing on screen said "you can rename this".
+ *
+ * 2. THE DRAG HANDLE SWALLOWED IT. The control sits inside the panel header,
+ *    which is the drag surface; a pointerdown on the label started a panel drag.
+ *
+ * 3. SILENT TRUNCATION. The input allowed 500 characters; the store setter
+ *    sliced to 100 and told nobody. One honest limit — the store's — surfaced
+ *    to the user.
+ *
+ * Plus the EXPORTED ENTRY the workspace lane consumes: `requestNodeRename(id)`
+ * mounts the label in editing state so a canvas double-click lands the user in
+ * the field.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { EditableLabel } from '../shared/EditableLabel'
+import { InspectorShell } from '../InspectorShell'
+import {
+  requestNodeRename,
+  clearNodeRename,
+  useRenameIntentStore,
+} from '../renameIntent'
+import { NODE_LABEL_MAX_LENGTH } from '../useInspectorMutations'
+
+vi.mock('@xyflow/react', () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+const shellProps = {
+  topBarColor: 'var(--option)',
+  nodeKind: 'option' as const,
+  nodeId: 'optA',
+  typePill: 'Option',
+  techMode: false,
+  onTechToggleChange: vi.fn(),
+  onClose: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearNodeRename()
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// 1 · A real, visible affordance
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-04 · the rename control is a visible affordance', () => {
+  it('exposes an identified rename trigger with an accessible name', () => {
+    render(<EditableLabel value="Team productivity" onSave={vi.fn()} />)
+    const trigger = screen.getByTestId('inspector-rename-trigger')
+    expect(trigger.getAttribute('aria-label')).toMatch(/rename/i)
+    expect(trigger.getAttribute('title')).toMatch(/rename/i)
+  })
+
+  it('renders a visible edit cue alongside the text, not a bare button', () => {
+    render(<EditableLabel value="Team productivity" onSave={vi.fn()} />)
+    expect(screen.getByTestId('inspector-rename-cue')).toBeTruthy()
+  })
+
+  it('renders no trigger at all in read-only mode (no onSave)', () => {
+    render(<EditableLabel value="Team productivity" />)
+    expect(screen.queryByTestId('inspector-rename-trigger')).toBeNull()
+    expect(screen.queryByTestId('inspector-rename-cue')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// 2 · The header drag handler must not swallow the rename press
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-04 · the panel drag handle does not swallow the rename control', () => {
+  function renderShell() {
+    const onPointerDown = vi.fn()
+    const dragHandlers = {
+      onPointerDown,
+      onPointerMove: vi.fn(),
+      onPointerUp: vi.fn(),
+      onPointerCancel: vi.fn(),
+      isDragging: false,
+    }
+    render(
+      <InspectorShell {...shellProps} label="Team productivity" onLabelChange={vi.fn()} dragHandlers={dragHandlers}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    return { onPointerDown }
+  }
+
+  it('does not start a panel drag when the press lands on the rename trigger', () => {
+    const { onPointerDown } = renderShell()
+    fireEvent.pointerDown(screen.getByTestId('inspector-rename-trigger'), { bubbles: true })
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+
+  it('STILL starts a panel drag when the press lands on the header elsewhere', () => {
+    // Discriminating twin: proves the fix is scoped to the rename control and
+    // has not simply disabled dragging.
+    const { onPointerDown } = renderShell()
+    fireEvent.pointerDown(screen.getByText('Option'), { bubbles: true })
+    expect(onPointerDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('enters editing state when the trigger is clicked', () => {
+    renderShell()
+    fireEvent.click(screen.getByTestId('inspector-rename-trigger'))
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// 3 · One honest limit — the store's — surfaced, never silently applied
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-04 · one honest length limit, surfaced', () => {
+  it('the store setter exports its own limit as the single source of truth', () => {
+    expect(NODE_LABEL_MAX_LENGTH).toBe(100)
+  })
+
+  it('the input enforces the STORE limit, not a larger UI one', () => {
+    render(
+      <InspectorShell {...shellProps} label="Team productivity" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    fireEvent.click(screen.getByTestId('inspector-rename-trigger'))
+    const input = screen.getByTestId('inspector-rename-input') as HTMLInputElement
+    expect(input.maxLength).toBe(NODE_LABEL_MAX_LENGTH)
+  })
+
+  it('surfaces remaining characters once the user approaches the limit', () => {
+    const onSave = vi.fn()
+    render(<EditableLabel value="short" onSave={onSave} />)
+    fireEvent.click(screen.getByTestId('inspector-rename-trigger'))
+    const input = screen.getByTestId('inspector-rename-input') as HTMLInputElement
+
+    // Below the warning threshold: no counter (no permanent chrome).
+    expect(screen.queryByTestId('inspector-rename-counter')).toBeNull()
+
+    fireEvent.change(input, { target: { value: 'x'.repeat(NODE_LABEL_MAX_LENGTH - 5) } })
+    const counter = screen.getByTestId('inspector-rename-counter')
+    expect(counter.textContent).toContain(String(NODE_LABEL_MAX_LENGTH))
+  })
+
+  it('saves what the user can see — no silent slice on commit', () => {
+    const onSave = vi.fn()
+    render(<EditableLabel value="short" onSave={onSave} />)
+    fireEvent.click(screen.getByTestId('inspector-rename-trigger'))
+    const input = screen.getByTestId('inspector-rename-input') as HTMLInputElement
+    const atLimit = 'y'.repeat(NODE_LABEL_MAX_LENGTH)
+    fireEvent.change(input, { target: { value: atLimit } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSave).toHaveBeenCalledWith(atLimit)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// 4 · The exported entry the workspace lane consumes
+// ─────────────────────────────────────────────────────────────────────
+
+describe('L-04 · requestNodeRename mounts the label in editing state', () => {
+  it('records the intent against the requested node id', () => {
+    requestNodeRename('optA')
+    expect(useRenameIntentStore.getState().renameNodeId).toBe('optA')
+  })
+
+  it('mounts the shell label in editing state for the REQUESTED node', () => {
+    requestNodeRename('optA')
+    render(
+      <InspectorShell {...shellProps} nodeId="optA" label="Team productivity" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+  })
+
+  it('does NOT mount another node in editing state', () => {
+    // Discriminating twin: the intent is bound to an id, not a global "edit now".
+    requestNodeRename('someOtherNode')
+    render(
+      <InspectorShell {...shellProps} nodeId="optA" label="Team productivity" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+    expect(screen.getByTestId('inspector-rename-trigger')).toBeTruthy()
+  })
+
+  it('consumes the intent so a later re-render does not reopen the editor', () => {
+    requestNodeRename('optA')
+    const { unmount } = render(
+      <InspectorShell {...shellProps} nodeId="optA" label="Team productivity" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(useRenameIntentStore.getState().renameNodeId).toBeNull()
+    unmount()
+
+    render(
+      <InspectorShell {...shellProps} nodeId="optA" label="Team productivity" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.reviewFixes.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.reviewFixes.spec.tsx
@@ -1,0 +1,508 @@
+/**
+ * Adversarial-review round — D1, D2, D3 and the promoted advisory.
+ *
+ * Every case here exists because the FIRST round's corpus could not see the
+ * defect. That is the finding worth keeping: each original test was correct
+ * about the case it named and blind to the case beside it.
+ *
+ *   D1  the rename kit only ever tested FRESH MOUNTS, so it could not observe
+ *       a shell that is RETARGETED from one node to another — which is what
+ *       the live inspector actually does.
+ *   D2  the impact fixture used a ONE-option comparison, the only shape in
+ *       which the new copy fires. A real run has two or more.
+ *   D3  the decision fixture was OUTBOUND-ONLY, and the canvas permits an
+ *       inbound `option → decision` edge.
+ *
+ * That is trap 22 three times over: a corpus drawn from the author's head
+ * cannot see the class the author did not imagine.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { InspectorShell } from '../InspectorShell'
+import { OptionPanel } from '../panels/OptionPanel'
+import { DecisionPanel } from '../panels/DecisionPanel'
+import { InspectorCoaching } from '../shared/InspectorCoaching'
+import { requestNodeRename, clearNodeRename } from '../renameIntent'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore, type GuidanceItem } from '../../../stores/guidanceStore'
+import { EMPTY_STATES, OPTION_STRINGS, DECISION_STRINGS } from '../inspectorStrings'
+
+vi.mock('@xyflow/react', () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+vi.mock('../../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(),
+}))
+
+import { useNodeDisplayMetadata } from '../../../hooks/useNodeDisplayMetadata'
+const mockDisplayMetadata = useNodeDisplayMetadata as ReturnType<typeof vi.fn>
+
+const baseMetadata = {
+  sensitivityRank: null,
+  influence: null,
+  confidence: null,
+  valueOfInformation: null,
+  inSensitivityAnalysis: false,
+  winRate: null,
+}
+
+function setStore(patch: Record<string, unknown>) {
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    results: { status: 'none', report: null },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    ...patch,
+  } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearNodeRename()
+  mockDisplayMetadata.mockReturnValue(baseMetadata)
+  useGuidanceStore.setState({
+    guidanceItems: [],
+    _sendMessage: null,
+    _prefillChat: null,
+    _dispatchAction: null,
+  } as never)
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// D1 · the rename intent must not leak onto the next selected node
+// ─────────────────────────────────────────────────────────────────────
+
+describe('D1 · a rename intent is bound to its node across a RETARGET, not just a fresh mount', () => {
+  const shellBase = {
+    topBarColor: 'var(--option)',
+    nodeKind: 'option' as const,
+    typePill: 'Option',
+    techMode: false,
+    onTechToggleChange: vi.fn(),
+    onClose: vi.fn(),
+  }
+
+  /**
+   * The live inspector does NOT remount per selection — `InspectorModal` keeps
+   * one `InspectorRouter`/`InspectorShell` mounted and changes `nodeId`. The
+   * first round's tests all rendered fresh, which is exactly why they stayed
+   * green while this was live.
+   */
+  it('does not open node B in editing state when the intent was for node A', () => {
+    requestNodeRename('optA')
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    // Precondition pinned in-test: A really did arm. Without this the
+    // assertion below could pass on a shell that never armed at all.
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+    expect(screen.getByTestId('inspector-rename-trigger')).toBeTruthy()
+  })
+
+  /**
+   * THE MEASURED HARM, and the reason this is P0-class: an editor left open
+   * across a retarget still holds the PREVIOUS element's text, so the blur-save
+   * writes node A's label onto node B. A silent, wrong, persisted rename.
+   */
+  it('never writes node A’s label onto node B', () => {
+    const saveA = vi.fn()
+    const saveB = vi.fn()
+    requestNodeRename('optA')
+
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={saveA}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={saveB}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    // Whatever the panel now shows, it must not be a live editor carrying A's
+    // text, and nothing may be saved onto B.
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+    expect(saveB).not.toHaveBeenCalled()
+    expect(saveB).not.toHaveBeenCalledWith('Option A')
+  })
+
+  it('discards an in-flight edit when the shell is retargeted mid-rename', () => {
+    // No intent at all — the user opened the editor by hand, typed, then
+    // clicked a different node on the canvas. The draft must not follow.
+    const saveA = vi.fn()
+    const saveB = vi.fn()
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={saveA}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    fireEvent.click(screen.getByTestId('inspector-rename-trigger'))
+    fireEvent.change(screen.getByTestId('inspector-rename-input'), {
+      target: { value: 'Half-typed new name' },
+    })
+
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={saveB}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+    expect(saveB).not.toHaveBeenCalled()
+    expect(screen.getByTestId('inspector-rename-trigger').textContent).toContain('Option B')
+  })
+
+  it('does not re-arm when the user navigates BACK to the renamed node', () => {
+    // The intent is one-shot. Returning to A must not reopen the editor under
+    // a user who has moved on.
+    requestNodeRename('optA')
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+  })
+
+  /**
+   * ─── Paul's required cases (D1 refinement, 16 Aug) ───────────────
+   *
+   * The mechanism, end to end: `autoEditLabel` was a boolean that never reset;
+   * `EditableLabel`'s effect deps include `onSave`, whose identity is rebuilt
+   * per `[nodeId, updateNode, getNode]` by `useInspectorMutations`; and the
+   * chain InspectorRouter → InspectorShell (InspectorModal:174,
+   * ReactFlowGraph:2232-2238) is UNKEYED with `showFullInspector` persisting
+   * across selections — so the shell re-renders in place on node→node.
+   *
+   * `setLabel`'s own `trimmed !== node.data?.label` guard cannot save you:
+   * "Option A" !== "Option B", so the cross-node write sails straight through.
+   *
+   * These pass a NEW onLabelChange identity on the retarget, because that
+   * identity change is half the trigger.
+   */
+  it('POSITIVE CONTROL · node A’s editor does open with the intent', () => {
+    // Without this the two absence assertions below could both pass on a
+    // shell that never armed at all (trap 13).
+    requestNodeRename('optA')
+    render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+  })
+
+  it('A→B on a MOUNTED shell with a NEW onLabelChange identity never opens or saves on B', () => {
+    requestNodeRename('optA')
+    const saveA = vi.fn()
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={saveA}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+
+    // A DIFFERENT function object, exactly as useInspectorMutations produces
+    // when nodeId changes.
+    const saveB = vi.fn()
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={saveB}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+    expect(saveB).not.toHaveBeenCalled()
+  })
+
+  it('an editor closed with Escape STAYS closed when onLabelChange identity changes', () => {
+    requestNodeRename('optA')
+    const save1 = vi.fn()
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={save1}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    const input = screen.getByTestId('inspector-rename-input')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+
+    // Same node, new callback identity — an ordinary re-render. The editor
+    // must not spring back open under the user.
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+  })
+
+  it('STILL arms the requested node on a retarget INTO it', () => {
+    // Discriminating twin: the fix must not be "never arm on a retarget",
+    // which would break the workspace lane's double-click on any node other
+    // than the one already selected.
+    const { rerender } = render(
+      <InspectorShell {...shellBase} nodeId="optA" label="Option A" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+    expect(screen.queryByTestId('inspector-rename-input')).toBeNull()
+
+    requestNodeRename('optB')
+    rerender(
+      <InspectorShell {...shellBase} nodeId="optB" label="Option B" onLabelChange={vi.fn()}>
+        <div>body</div>
+      </InspectorShell>,
+    )
+
+    expect(screen.getByTestId('inspector-rename-input')).toBeTruthy()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// D2 · the add-path impact copy must fire on a REAL (multi-option) run
+// ─────────────────────────────────────────────────────────────────────
+
+describe('D2 · an option added after a multi-option run gets the honest copy', () => {
+  const optionProps = { nodeId: 'optNew', techMode: false, onClose: vi.fn(), onNavigate: vi.fn() }
+
+  /**
+   * The mainline shape, and the one the first round missed: a run that
+   * compared TWO options, then the user adds a third. `hasImpactContent`'s
+   * third disjunct was RUN-level, so the new option rendered the other two
+   * options' bars — foreign data under its own name — and never reached the
+   * "added after the last analysis" branch.
+   */
+  function setPostRunAddStore() {
+    setStore({
+      nodes: [
+        { id: 'optNew', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Newly added option' } },
+        { id: 'optA', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Existing A' } },
+        { id: 'optB', type: 'option', position: { x: 2, y: 0 }, data: { label: 'Existing B' } },
+      ],
+      edges: [],
+      results: {
+        status: 'complete',
+        report: {
+          option_comparison: [
+            { option_id: 'optA', win_probability: 0.62, label: 'Existing A' },
+            { option_id: 'optB', win_probability: 0.38, label: 'Existing B' },
+          ],
+        },
+      },
+    })
+  }
+
+  it('says it was added after the last run, on a TWO-option comparison', () => {
+    setPostRunAddStore()
+    mockDisplayMetadata.mockReturnValue({ ...baseMetadata, winRate: null })
+    render(<OptionPanel {...optionProps} />)
+    expect(screen.getByTestId('option-impact-not-in-run')).toBeTruthy()
+  })
+
+  it('shows NO foreign option rows under this option’s own Impact heading', () => {
+    setPostRunAddStore()
+    mockDisplayMetadata.mockReturnValue({ ...baseMetadata, winRate: null })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const impact = container.querySelector('[data-panel-group="impact"]')
+    expect(impact).not.toBeNull()
+    // The other options' names and numbers belong to THEM, not to this node.
+    expect(impact?.textContent).not.toContain('Existing A')
+    expect(impact?.textContent).not.toContain('Existing B')
+    expect(impact?.textContent).not.toContain('62%')
+    expect(impact?.textContent).not.toContain(OPTION_STRINGS.impactUnavailable)
+  })
+
+  it('STILL shows the comparison to an option the run DID cover', () => {
+    // Discriminating twin: the fix must suppress foreign data for a node the
+    // run never saw, not delete the comparison for nodes it did.
+    setStore({
+      nodes: [
+        { id: 'optNew', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Covered option' } },
+        { id: 'optA', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Existing A' } },
+      ],
+      edges: [],
+      results: {
+        status: 'complete',
+        report: {
+          option_comparison: [
+            { option_id: 'optNew', win_probability: 0.55, label: 'Covered option' },
+            { option_id: 'optA', win_probability: 0.45, label: 'Existing A' },
+          ],
+        },
+      },
+    })
+    mockDisplayMetadata.mockReturnValue({ ...baseMetadata, winRate: 0.55 })
+    const { container } = render(<OptionPanel {...optionProps} />)
+    const impact = container.querySelector('[data-panel-group="impact"]')
+    expect(impact?.textContent).toContain('Existing A')
+    expect(screen.queryByTestId('option-impact-not-in-run')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// D3 · the decision must count edges in BOTH directions
+// ─────────────────────────────────────────────────────────────────────
+
+describe('D3 · an inbound option → decision edge is not invisible', () => {
+  const decisionProps = { nodeId: 'dec1', techMode: false, onClose: vi.fn(), onNavigate: vi.fn() }
+
+  /**
+   * `connectedOptions` filtered on `source === nodeId` and `otherConnections`
+   * dropped option-kind nodes, so an `option → decision` edge — which the
+   * canvas's own `isValidConnection` permits a user to draw — fell through
+   * BOTH lists and the panel reported "No connections yet." while the canvas
+   * drew two edges.
+   */
+  function setInboundStore() {
+    setStore({
+      nodes: [
+        { id: 'dec1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Launch strategy' } },
+        { id: 'optA', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Option A', interventions: {} } },
+        { id: 'optB', type: 'option', position: { x: 2, y: 0 }, data: { label: 'Option B', interventions: {} } },
+      ],
+      // Both drawn INTO the decision — the direction the first corpus omitted.
+      edges: [
+        { id: 'e1', source: 'optA', target: 'dec1', data: {} },
+        { id: 'e2', source: 'optB', target: 'dec1', data: {} },
+      ],
+    })
+  }
+
+  it('lists inbound options in the Input group', () => {
+    setInboundStore()
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const input = container.querySelector('[data-panel-group="input"]')
+    expect(input?.textContent).toContain('Option A')
+    expect(input?.textContent).toContain('Option B')
+  })
+
+  it('does NOT claim "No connections yet." while two edges are on the canvas', () => {
+    setInboundStore()
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const connections = container.querySelector('[data-panel-group="connections"]')
+    expect(connections?.textContent).not.toContain(EMPTY_STATES.noConnectionsFlat)
+    expect(screen.getByTestId('decision-connections-are-options').textContent).toContain('2')
+  })
+
+  it('counts an option connected in BOTH directions exactly once', () => {
+    setStore({
+      nodes: [
+        { id: 'dec1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Launch strategy' } },
+        { id: 'optA', type: 'option', position: { x: 1, y: 0 }, data: { label: 'Option A', interventions: {} } },
+      ],
+      edges: [
+        { id: 'e1', source: 'dec1', target: 'optA', data: {} },
+        { id: 'e2', source: 'optA', target: 'dec1', data: {} },
+      ],
+    })
+    render(<DecisionPanel {...decisionProps} />)
+    expect(screen.getByTestId('decision-connections-are-options').textContent).toContain('1')
+    expect(screen.getAllByText('Option A')).toHaveLength(1)
+  })
+
+  it('STILL reports a genuinely unconnected decision honestly', () => {
+    // Discriminating twin: widening the filter must not make every decision
+    // claim connections it does not have.
+    setStore({
+      nodes: [{ id: 'dec1', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Untouched' } }],
+      edges: [],
+    })
+    const { container } = render(<DecisionPanel {...decisionProps} />)
+    const connections = container.querySelector('[data-panel-group="connections"]')
+    expect(connections?.textContent).toContain(EMPTY_STATES.noConnectionsFlat)
+    expect(screen.queryByTestId('decision-connections-are-options')).toBeNull()
+  })
+
+  it('exposes the count copy for both directions from ONE constant', () => {
+    expect(DECISION_STRINGS.connectionsAreOptions).toContain('{count}')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// 4 · no auto-sending control may be labelled as an ask
+// ─────────────────────────────────────────────────────────────────────
+
+describe('4 · a run_exercise action is labelled for what it does', () => {
+  const coachingProps = {
+    elementId: 'node-1',
+    panelType: 'factor-controllable',
+    fallbackText: 'Static coaching fallback text',
+    labelContext: { label: 'Marketing Budget' },
+  }
+
+  function exerciseItem(): GuidanceItem {
+    return {
+      item_id: 'g1',
+      signal_code: 'evidence_gap',
+      category: 'should_fix',
+      source: 'analysis',
+      title: 'Try a pre-mortem on this',
+      detail: '',
+      primary_action: { type: 'run_exercise', exercise: 'pre_mortem' },
+      target_object: { type: 'node', id: 'node-1', label: 'Test Factor' },
+      priority: 80,
+    } as GuidanceItem
+  }
+
+  it('labels it "Try it" — the estate’s existing label for this action class', () => {
+    useGuidanceStore.setState({
+      guidanceItems: [exerciseItem()],
+      _sendMessage: vi.fn(),
+      _prefillChat: vi.fn(),
+    } as never)
+    render(<InspectorCoaching {...coachingProps} />)
+    expect(screen.getByText('Try it')).toBeTruthy()
+    // The defect: an AUTO-SENDING control wearing the ask label, which is the
+    // exact semantic this PR unified.
+    expect(screen.queryByText('Ask about this')).toBeNull()
+  })
+
+  it('still sends the command when that label is clicked', () => {
+    const send = vi.fn()
+    useGuidanceStore.setState({
+      guidanceItems: [exerciseItem()],
+      _sendMessage: send,
+      _prefillChat: vi.fn(),
+    } as never)
+    render(<InspectorCoaching {...coachingProps} />)
+    fireEvent.click(screen.getByText('Try it'))
+    expect(send).toHaveBeenCalledWith('/exercise pre_mortem')
+  })
+
+  it('leaves the genuine ask labelled as an ask', () => {
+    // Discriminating twin: only the command class is relabelled.
+    useGuidanceStore.setState({ _prefillChat: vi.fn() } as never)
+    render(<InspectorCoaching {...coachingProps} />)
+    expect(screen.getByText('Ask about this')).toBeTruthy()
+    expect(screen.queryByText('Try it')).toBeNull()
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.userLanguage.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorCompletion.userLanguage.spec.tsx
@@ -1,0 +1,182 @@
+/**
+ * Inspector completion — L-38 (internal/engineering vocabulary), inspector half.
+ *
+ * RED-first. Three instances on the S01 relationship inspector:
+ *
+ *   a. `contested_reasons` rendered as RAW ENUM TOKENS
+ *      ("existence_boundary_crossing") via a bare `.join(', ')`.
+ *   b. `pass2.basis` rendered as a RAW ENUM TOKEN ("domain_prior").
+ *   c. "Pass 1 (current) / Pass 2 (review)" stat blocks — Strength / Std /
+ *      Exists — presented at rest as the primary explanation.
+ *
+ * The estate already owns the translation and the good copy precedent (S18):
+ * `getContestedReasonLabel` / `getBasisLabel` in model-tab/strengthBands.ts.
+ * The inspector must consume THOSE, not re-mint a second vocabulary — a
+ * hand-copied twin is how the same enum came to have two labels before.
+ *
+ * Acceptance: no raw enum tokens AT REST. The numbers survive, behind a
+ * progressive-disclosure detail, in user language.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { EdgePanel } from '../panels/EdgePanel'
+import { useCanvasStore } from '../../../store'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import {
+  getContestedReasonLabel,
+  getBasisLabel,
+} from '../../../components/model-tab/strengthBands'
+
+const panelProps = {
+  edgeId: 'e1',
+  techMode: false,
+  onClose: vi.fn(),
+  onNavigate: vi.fn(),
+}
+
+const contestedValidation = {
+  status: 'contested',
+  contested_reasons: ['existence_boundary_crossing', 'sign_flip'],
+  pass1: { strength_mean: 0.35, strength_std: 0.15, exists_probability: 0.82 },
+  pass2: {
+    strength_mean: 0.62,
+    strength_std: 0.2,
+    exists_probability: 0.7,
+    reasoning: 'Second pass read the brief as a stronger link.',
+    basis: 'domain_prior',
+    needs_user_input: true,
+  },
+  max_divergence: 0.27,
+  distance_to_goal: 1,
+  evoi_rank: null,
+  evoi_impact: null,
+  surfaced: true,
+  was_shown: false,
+  user_action: 'pending',
+  resolved_value: null,
+  resolved_by: 'default',
+}
+
+function setContestedStore(overrides: Record<string, unknown> = {}) {
+  useCanvasStore.setState({
+    ...useCanvasStore.getState(),
+    nodes: [
+      { id: 'fac1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Marketing budget' } },
+      { id: 'out1', type: 'outcome', position: { x: 100, y: 0 }, data: { label: 'Revenue' } },
+    ],
+    edges: [
+      {
+        id: 'e1',
+        source: 'fac1',
+        target: 'out1',
+        data: {
+          weight: 0.35,
+          direction: 'positive',
+          beliefExists: 0.82,
+          strengthStd: 0.15,
+          validation: contestedValidation,
+        },
+      },
+    ],
+    results: { status: 'none', report: null },
+    ...overrides,
+  } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useGuidanceStore.setState({
+    guidanceItems: [],
+    _prefillChat: null,
+    _sendMessage: null,
+    _dispatchAction: null,
+  } as never)
+})
+
+describe('L-38 · the contested-edge surface renders no raw enum tokens at rest', () => {
+  it('renders the Evidence group for this fixture (precondition — pinned in-test)', () => {
+    // Without this the absence assertions below could pass on a panel that
+    // never rendered the surface under test at all.
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    expect(container.querySelector('[data-panel-group="evidence"]')).not.toBeNull()
+  })
+
+  it('does not print the raw contested-reason tokens', () => {
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    expect(container.textContent).not.toContain('existence_boundary_crossing')
+    expect(container.textContent).not.toContain('sign_flip')
+  })
+
+  it('does not print the raw basis token', () => {
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    expect(container.textContent).not.toContain('domain_prior')
+  })
+
+  it('does not print the "Pass 1 / Pass 2" engineering headings at rest', () => {
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    expect(container.textContent).not.toContain('Pass 1 (current)')
+    expect(container.textContent).not.toContain('Pass 2 (review)')
+    expect(container.textContent).not.toContain('Std:')
+  })
+})
+
+describe('L-38 · it says the same thing in the S18 vocabulary instead', () => {
+  it('uses the SHARED translator for every reason (not a second hand-written map)', () => {
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    for (const reason of ['existence_boundary_crossing', 'sign_flip'] as const) {
+      expect(container.textContent).toContain(getContestedReasonLabel(reason))
+    }
+  })
+
+  it('uses the SHARED translator for the basis', () => {
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} />)
+    expect(container.textContent).toContain(getBasisLabel('domain_prior'))
+  })
+
+  it('keeps the reviewer reasoning quote, which was already user language', () => {
+    setContestedStore()
+    render(<EdgePanel {...panelProps} />)
+    expect(screen.getByText(/Second pass read the brief as a stronger link/)).toBeTruthy()
+  })
+})
+
+describe('L-38 · the numbers survive behind progressive disclosure, in user language', () => {
+  it('offers a detail control rather than deleting the comparison', () => {
+    setContestedStore()
+    render(<EdgePanel {...panelProps} />)
+    expect(screen.getByTestId('edge-review-detail')).toBeTruthy()
+  })
+
+  it('reveals both estimates under user-language headings when opened', () => {
+    setContestedStore()
+    render(<EdgePanel {...panelProps} />)
+    fireEvent.click(screen.getByTestId('edge-review-detail-toggle'))
+    const detail = screen.getByTestId('edge-review-detail')
+    // Both numbers, both named for what they mean to the reader.
+    expect(detail.textContent).toContain('0.35')
+    expect(detail.textContent).toContain('0.62')
+    expect(detail.textContent).toMatch(/currently uses/i)
+    expect(detail.textContent).toMatch(/review suggested/i)
+    // Still no engineering tokens once opened.
+    expect(detail.textContent).not.toContain('Std:')
+    expect(detail.textContent).not.toContain('pass1')
+    expect(detail.textContent).not.toContain('pass2')
+  })
+
+  it('keeps the raw tokens available to expert mode only', () => {
+    // Discriminating twin: the tokens are not deleted from the product, they
+    // are moved behind the technical disclosure. Proves the at-rest absence
+    // above is a placement fix, not a data loss.
+    setContestedStore()
+    const { container } = render(<EdgePanel {...panelProps} techMode={true} />)
+    expect(container.textContent).toContain('existence_boundary_crossing')
+  })
+})

--- a/src/canvas/ui/inspector-v2/askSemantic.ts
+++ b/src/canvas/ui/inspector-v2/askSemantic.ts
@@ -1,0 +1,113 @@
+/**
+ * askSemantic — ONE semantic for every "ask Olumi about this" affordance.
+ *
+ * The defect this closes (ledger L-18, a trap-21 pair): the inspector carried
+ * TWO ask affordances with OPPOSITE semantics. `InspectorCoaching` AUTO-SENT
+ * via `_sendMessage`; `DiscussWithAiButton` PREFILLED an editable draft and
+ * waited. Same user intent, opposite behaviour, one panel — and the auto-send
+ * is the one that lies, because the message lands in a surface the user may not
+ * be looking at, so the control reads as dead.
+ *
+ * ─── THE TWO QUESTIONS, NAMED APART ──────────────────────────────────
+ *
+ * Q1 · "How does an ask get CONFIRMED?"
+ *      ONE answer, everywhere: it does not dispatch. It becomes an editable
+ *      draft in a visible surface with a single obvious Send, which the user
+ *      presses. That is `ASK_SEMANTIC`.
+ *
+ * Q2 · "Which CARRIER does the confirmed ask travel on?"
+ *      Per call site, and deliberately NOT unified. An ask carrying dispatch
+ *      `parameters` rides the conversation-typed turn, because chip_metadata —
+ *      the contextual-session carrier — survives ONLY on that turn type.
+ *      Flattening those into a bare composer prefill would silently drop it.
+ *
+ * Conflating Q1 and Q2 is what produced the pair in the first place. They are
+ * answered separately here, on purpose.
+ *
+ * ─── ROUTING ─────────────────────────────────────────────────────────
+ *
+ *   plain ask + composer registered  → prefill the composer, reveal it.
+ *                                      No third floating surface: a simple
+ *                                      prefill suffices.
+ *   ask with dispatch parameters     → the Ask-Olumi drawer (typed dispatch).
+ *   no composer registered           → the Ask-Olumi drawer (the fallback
+ *                                      confirm surface — the ask is never lost
+ *                                      and never auto-sent).
+ *   no surface at all                → nothing. The affordance should not have
+ *                                      rendered; it must not pretend.
+ *
+ * NOT an ask, and therefore not routed here: a slash command such as
+ * `/exercise premortem`. Its button IS the confirmation, and a prefilled slash
+ * command would sit in the composer as literal text instead of executing.
+ */
+
+import { useGuidanceStore } from '../../stores/guidanceStore'
+import { revealOlumiSurface } from '../../conversation/revealOlumi'
+import { openAskOlumi } from '../../../components/results/coaching/askOlumiStore'
+
+/**
+ * The one semantic. Exported so a guard can pin it: if this string ever
+ * changes, every surface that claims to implement it must be re-read.
+ */
+export const ASK_SEMANTIC = 'prefill-and-confirm' as const
+
+export interface AskRequest {
+  /** The question, as the user will see it in the editable draft. */
+  text: string
+  /** Short label describing the ask (drawer heading / dispatch label). */
+  label: string
+  /** Optional context line for the drawer. */
+  context?: string
+  /** Optional model target enabling the drawer's "Focus on canvas". */
+  targetId?: string
+  /**
+   * Dispatch parameters. PRESENCE OF THIS FIELD IS THE CARRIER DECISION (Q2):
+   * an ask that carries parameters must ride the typed dispatch, so it routes
+   * to the drawer even when a composer is available.
+   */
+  parameters?: Record<string, unknown>
+  /** Dispatch source tag (defaults to 'chip'). */
+  source?: string
+}
+
+/**
+ * Route an ask under the one semantic. NEVER dispatches; returns the surface
+ * that received the draft so callers can assert on it.
+ */
+export function requestAsk(req: AskRequest): 'composer' | 'drawer' | 'none' {
+  const text = req.text.trim()
+  if (!text) return 'none'
+
+  const state = useGuidanceStore.getState()
+  const needsTypedDispatch = req.parameters !== undefined
+
+  if (!needsTypedDispatch && state._prefillChat) {
+    state._prefillChat(text)
+    revealOlumiSurface()
+    return 'composer'
+  }
+
+  // Any registered conversation wire means the drawer's Send can land.
+  if (state._prefillChat || state._sendMessage || state._dispatchAction) {
+    openAskOlumi({
+      context: req.context ?? '',
+      draft: text,
+      label: req.label,
+      targetId: req.targetId,
+      parameters: req.parameters,
+      source: req.source ?? 'chip',
+    })
+    return 'drawer'
+  }
+
+  return 'none'
+}
+
+/** True when any surface can receive an ask. Use to gate the affordance. */
+export function canReceiveAsk(state: {
+  _prefillChat: unknown
+  _sendMessage: unknown
+  _dispatchAction: unknown
+}): boolean {
+  return state._prefillChat !== null || state._sendMessage !== null || state._dispatchAction !== null
+}

--- a/src/canvas/ui/inspector-v2/index.ts
+++ b/src/canvas/ui/inspector-v2/index.ts
@@ -1,5 +1,22 @@
 export { InspectorRouter } from './InspectorRouter'
 export { InspectorShell } from './InspectorShell'
 export { useTechToggle } from './useTechToggle'
-export { useNodeMutations, useEdgeMutations } from './useInspectorMutations'
+export { useNodeMutations, useEdgeMutations, NODE_LABEL_MAX_LENGTH } from './useInspectorMutations'
 export type { InspectorPanelProps, InspectorShellProps, AnalysisState } from './types'
+
+/**
+ * L-04 — the rename capability, EXPORTED for the workspace lane.
+ *
+ * The inspector owns the rename affordance; the canvas owns the gesture. The
+ * workspace lane's double-click handler selects the node and then calls
+ * `requestNodeRename(nodeId)`; the inspector mounts its title in editing state
+ * and consumes the intent. Neither lane reaches into the other's components.
+ */
+export { requestNodeRename, clearNodeRename, useRenameIntentStore } from './renameIntent'
+
+/**
+ * The ONE ask semantic (ledger L-18, trap-21 pair). Any surface offering
+ * "ask Olumi about this" routes here: prefill-and-confirm, never auto-send.
+ */
+export { requestAsk, canReceiveAsk, ASK_SEMANTIC } from './askSemantic'
+export type { AskRequest } from './askSemantic'

--- a/src/canvas/ui/inspector-v2/inspectorStrings.ts
+++ b/src/canvas/ui/inspector-v2/inspectorStrings.ts
@@ -236,6 +236,13 @@ export const EMPTY_STATES = {
   noEvidence:       'No calibration or external data. Providing evidence would improve trust in this connection.',
   noInboundConnections: 'No inbound connections yet.',
   noPrediction:     'No prediction available',
+  /**
+   * L-40 — the flat denial. Previously typed out three times as a literal, and
+   * rendered by panels that were simultaneously showing connections the user
+   * could see on the canvas. Now one constant, and every panel that shows it
+   * must first prove there is genuinely nothing to show.
+   */
+  noConnectionsFlat: 'No connections yet.',
 } as const
 
 // ─── Group labels (v6.2 three-group layout) ───────────────────────
@@ -387,6 +394,20 @@ export const GOAL_STRINGS = {
 export const OPTION_STRINGS = {
   impactUnavailable: 'Option impact data unavailable for this analysis run.',
   /**
+   * L-24 — an option ADDED SINCE the last run is not the same situation as an
+   * option the run covered and returned nothing for, and it must not inherit
+   * the same sentence. Derived per node from whether this option appears in the
+   * run's own comparison, not from global results mode.
+   */
+  impactNotInLastRun: 'This option was added after the last analysis, so it has no results yet. Re-run the analysis to include it.',
+  /**
+   * L-40 — the honest replacement for the contradiction. The option HAS factor
+   * links (the Connections list below is rendering them from the same edges);
+   * what it lacks is a value for each. Saying it "changes no factors" while
+   * three of them are on screen is the product disagreeing with itself.
+   */
+  linksWithoutValues: 'Linked to {count} factor{s} below, but no change values are set yet — set one to give this option an effect in the analysis.',
+  /**
    * ROADMAP 2.1204 — attribution for the drafter's rephrase-absorption note.
    *
    * The note's SENTENCE comes from the wire and is rendered verbatim; this is
@@ -427,4 +448,47 @@ export const GOAL_CONSTRAINT_COPY = {
   // they never see this. Owned here; pinned as a raw literal in specs.
   guestConstraintsNotInAnalysis:
     "In guest mode, constraints added here aren't included in the analysis. Add them in chat instead.",
+} as const
+
+// ─── Decision panel strings ──────────────────────────────────────
+export const DECISION_STRINGS = {
+  /**
+   * L-40 — the Decision inspector said "No connections yet." while the canvas
+   * plainly drew its edges. `otherConnections` EXCLUDES option edges by design
+   * (options belong in the Input group above), so a decision whose only edges
+   * are its options hit a flat denial of edges the user could see.
+   *
+   * Derived from the SAME edge data the options list reads, and it names where
+   * those connections went rather than pretending they do not exist.
+   */
+  connectionsAreOptions: 'Its {count} option{s} above are its only connections. Nothing else links to this decision yet.',
+} as const
+
+// ─── Generic fallback panel strings ──────────────────────────────
+export const GENERIC_STRINGS = {
+  /**
+   * L-24 — the router used to render NOTHING for element types without a
+   * bespoke panel. An honest, modest panel beats a silent refusal: the user
+   * clicked something and must get a response.
+   */
+  noSpecialisedEditor: 'This element has no detailed editor yet. You can rename it, describe it, and follow its connections.',
+} as const
+
+// ─── Contested-edge review copy (L-38) ───────────────────────────
+//
+// The relationship inspector printed `contested_reasons` and `pass2.basis` as
+// RAW ENUM TOKENS ("existence_boundary_crossing", "domain_prior") and headed
+// the comparison "Pass 1 (current) / Pass 2 (review)" with Strength / Std /
+// Exists rows. The estate already owns the user-facing translations and the
+// good copy precedent (S18) in `model-tab/strengthBands.ts` — the inspector
+// CONSUMES those rather than minting a second vocabulary for the same enum.
+export const EDGE_REVIEW_COPY = {
+  heading:          'Our two reviews disagree here',
+  currentEstimate:  'What the model currently uses',
+  reviewEstimate:   'What the review suggested',
+  strength:         'Effect strength',
+  uncertainty:      'How uncertain that is',
+  existence:        'Confidence the link is real',
+  showDetail:       'See both estimates',
+  hideDetail:       'Hide both estimates',
 } as const

--- a/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
@@ -16,6 +16,8 @@ import { formatWinProbability } from '../../../utils/labelUtils'
 import {
   GROUP_LABELS,
   DESCRIPTION_PLACEHOLDERS,
+  DECISION_STRINGS,
+  EMPTY_STATES,
 } from '../inspectorStrings'
 import { PanelGroup } from '../shared/PanelGroup'
 import { PrimaryControlCard } from '../shared/PrimaryControlCard'
@@ -234,8 +236,25 @@ export const DecisionPanel = memo(function DecisionPanel({
             onClick={() => onNavigate(conn.nodeId)}
           />
         ))}
+        {/* L-40 — `otherConnections` EXCLUDES option edges by design (options
+            live in the Input group above), so a decision whose only edges are
+            its options used to render a flat "No connections yet." while the
+            canvas drew every one of them. The empty state is now derived from
+            the SAME edge data the options list reads, and names where those
+            connections went instead of denying them. */}
         {otherConnections.length === 0 && (
-          <p className={`${typography.panelMeta} text-text-light`}>No connections yet.</p>
+          connectedOptions.length > 0 ? (
+            <p
+              data-testid="decision-connections-are-options"
+              className={`${typography.panelMeta} text-text-light`}
+            >
+              {DECISION_STRINGS.connectionsAreOptions
+                .replace('{count}', String(connectedOptions.length))
+                .replace('{s}', connectedOptions.length === 1 ? '' : 's')}
+            </p>
+          ) : (
+            <p className={`${typography.panelMeta} text-text-light`}>{EMPTY_STATES.noConnectionsFlat}</p>
+          )
         )}
       </PanelGroup>
 

--- a/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
@@ -62,31 +62,45 @@ export const DecisionPanel = memo(function DecisionPanel({
   const [description, setDescription] = useState(String(node?.data?.description ?? ''))
   const [isEditingDescription, setIsEditingDescription] = useState(false)
 
-  // Connected options — stored with raw winProb for formatWinProbability()
+  // Connected options — stored with raw winProb for formatWinProbability().
+  //
+  // ⚠ BOTH DIRECTIONS, and it was outbound-only (review D3). The canvas's
+  // `isValidConnection` lets a user draw `option → decision`, and such an edge
+  // fell through BOTH lists: excluded here by `source === nodeId`, and
+  // excluded from `otherConnections` below by its option kind. The panel then
+  // reported "No connections yet." while the canvas plainly drew the edges —
+  // the very L-40 contradiction this file was changed to close, surviving in
+  // the direction the first corpus never drew.
   const connectedOptions = useMemo(() => {
+    const seen = new Set<string>()
     return edges
-      .filter(e => e.source === nodeId)
+      .filter(e => e.source === nodeId || e.target === nodeId)
       .map(e => {
-        const optNode = nodes.find(n => n.id === e.target)
+        const otherId = e.source === nodeId ? e.target : e.source
+        const optNode = nodes.find(n => n.id === otherId)
         if (!optNode) return null
         const kind = (optNode.type || optNode.data?.kind) as string
         if (kind !== 'option') return null
+        // An option joined in BOTH directions is ONE connection to the user,
+        // not two. Dedupe by the option's node id, not by edge id.
+        if (seen.has(otherId)) return null
+        seen.add(otherId)
         // Cast to `unknown` (not `number`) — interventions may be V3 objects
         // ({ value, source, ... }) or plain numbers. Only the key count is read
         // here, but the type should not lie about the value shape.
         const ivs = (optNode.data as Record<string, unknown>)?.interventions as Record<string, unknown> | undefined
         const ivCount = ivs ? Object.keys(ivs).length : 0
-        const label = String(optNode.data?.label ?? e.target)
+        const label = String(optNode.data?.label ?? otherId)
         // Explicit `is_baseline` wins; regex fallback only fires when the flag is
         // absent — mirrors OptionNode.tsx / OptionPanel.tsx.
         const explicitIsBaseline = (optNode.data as { is_baseline?: boolean | null })?.is_baseline
         const isBaseline = explicitIsBaseline ?? detectBaseline(label).isBaseline
         // Raw win probability — formatted via formatWinProbability() at render.
         const rawWinProb = optionComparison && Array.isArray(optionComparison)
-          ? (optionComparison as Array<{ option_id: string; win_probability?: number }>).find(o => o.option_id === e.target)?.win_probability
+          ? (optionComparison as Array<{ option_id: string; win_probability?: number }>).find(o => o.option_id === otherId)?.win_probability
           : undefined
         return {
-          nodeId: e.target,
+          nodeId: otherId,
           label,
           ivCount,
           isBaseline,

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -45,6 +45,7 @@ import {
 import { useEditImpactPreview } from '../../../hooks/useEditImpactPreview'
 import { StrengthBandButtons } from '../shared/StrengthBandButtons'
 import { EdgeAdvancedEditor } from '../editors/EdgeAdvancedEditor'
+import { EdgeReviewDisagreement } from '../shared/EdgeReviewDisagreement'
 
 // ─── Slider component for confidence and uncertainty ───────────────
 function InspectorSlider({
@@ -451,41 +452,12 @@ export const EdgePanel = memo(function EdgePanel({
             if (!validation || validation.status !== 'contested') return null
             return (
               <PanelGroup kind="evidence" label={GROUP_LABELS.evidence}>
-                <div className="bg-panel border border-warning/30 rounded-lg p-2.5">
-                  <div className={`${typography.panelBody} font-medium text-warning flex items-center gap-1`}>
-                    <AlertTriangle size={13} className="text-warning" />
-                    {EDGE_COPY.needsYourJudgement}
-                  </div>
-                  {validation.contested_reasons?.length > 0 && (
-                    <p className={`${typography.panelMeta} text-text-light mt-1`}>
-                      {validation.contested_reasons.join(', ')}
-                    </p>
-                  )}
-                  <div className="mt-2 grid grid-cols-2 gap-2">
-                    <div className="bg-panel border border-panel-border rounded p-2">
-                      <div className={`${typography.panelMeta} text-text-light mb-1`}>Pass 1 (current)</div>
-                      <div className={typography.panelMeta}>Strength: {validation.pass1.strength_mean.toFixed(2)}</div>
-                      <div className={typography.panelMeta}>Std: {validation.pass1.strength_std.toFixed(2)}</div>
-                      <div className={typography.panelMeta}>Exists: {Math.round(validation.pass1.exists_probability * 100)}%</div>
-                    </div>
-                    <div className="bg-panel border border-panel-border rounded p-2">
-                      <div className={`${typography.panelMeta} text-text-light mb-1`}>Pass 2 (review)</div>
-                      <div className={typography.panelMeta}>Strength: {validation.pass2.strength_mean.toFixed(2)}</div>
-                      <div className={typography.panelMeta}>Std: {validation.pass2.strength_std.toFixed(2)}</div>
-                      <div className={typography.panelMeta}>Exists: {Math.round(validation.pass2.exists_probability * 100)}%</div>
-                    </div>
-                  </div>
-                  {validation.pass2.reasoning && (
-                    <p className={`${typography.panelMeta} text-text-light mt-2 italic`}>
-                      &ldquo;{validation.pass2.reasoning}&rdquo;
-                    </p>
-                  )}
-                  {validation.pass2.basis && (
-                    <span className={`${typography.panelMeta} inline-block mt-1 px-1.5 py-0.5 rounded-full bg-transparent border border-info/30 text-text-body`}>
-                      {validation.pass2.basis}
-                    </span>
-                  )}
-                </div>
+                {/* L-38 — this block used to print raw enum tokens
+                    (`contested_reasons.join(', ')`, `pass2.basis`) and the
+                    internal "Pass 1 (current) / Pass 2 (review)" stat grid.
+                    The user-language surface, and the progressive disclosure
+                    that keeps the numbers, live in EdgeReviewDisagreement. */}
+                <EdgeReviewDisagreement validation={validation} techMode={techMode} />
               </PanelGroup>
             )
           })()}

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -23,6 +23,7 @@ import { factorDisplayText } from '../../../../utils/formatFactorDisplayValue'
 import {
   GROUP_LABELS,
   DESCRIPTION_PLACEHOLDERS,
+  EMPTY_STATES,
   getExtractionLabel,
   getProvenanceLabel,
 } from '../inspectorStrings'
@@ -624,7 +625,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
           </>
         )}
         {setByOptions.length === 0 && influences.length === 0 && (
-          <p className={`${typography.panelMeta} text-text-light`}>No connections yet.</p>
+          <p className={`${typography.panelMeta} text-text-light`}>{EMPTY_STATES.noConnectionsFlat}</p>
         )}
       </PanelGroup>
 

--- a/src/canvas/ui/inspector-v2/panels/GenericNodePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GenericNodePanel.tsx
@@ -1,0 +1,123 @@
+/**
+ * GenericNodePanel — the InspectorRouter's real fallback (L-24).
+ *
+ * `resolvePanelType` returned `null` for any node type without a bespoke panel
+ * — `action`, `constraint`, `ghost-option`, and anything a future producer
+ * emits. The router then rendered NOTHING: the user selected an element on the
+ * canvas and the inspector silently refused to appear, which is
+ * indistinguishable from a broken click.
+ *
+ * This panel is deliberately modest. It shows what every node has — its
+ * description and its connections — and says plainly that this element type has
+ * no specialised editor yet. Selecting an element always produces a panel; a
+ * panel that admits its own limits beats a panel that does not exist.
+ */
+
+import { memo, useMemo, useState } from 'react'
+
+import { useCanvasStore } from '../../../store'
+import type { NodeType } from '../../../domain/nodes'
+import { typography } from '../../../../styles/typography'
+import { useNodeMutations } from '../useInspectorMutations'
+import { GROUP_LABELS, EMPTY_STATES, DESCRIPTION_PLACEHOLDERS, GENERIC_STRINGS } from '../inspectorStrings'
+import { PanelGroup } from '../shared/PanelGroup'
+import { ConnectionRow } from '../shared/ConnectionRow'
+import { EmptyDescriptionPrompt } from '../shared/EmptyDescriptionPrompt'
+import { TechnicalDisclosure } from '../shared/TechnicalDisclosure'
+import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
+import type { InspectorPanelProps } from '../types'
+
+export const GenericNodePanel = memo(function GenericNodePanel({
+  nodeId,
+  techMode,
+  onNavigate,
+}: InspectorPanelProps) {
+  const nodes = useCanvasStore(s => s.nodes)
+  const edges = useCanvasStore(s => s.edges)
+  const node = nodeId ? nodes.find(n => n.id === nodeId) : undefined
+  const mutations = useNodeMutations(nodeId ?? '')
+
+  const [description, setDescription] = useState(String(node?.data?.description ?? ''))
+  const [isEditingDescription, setIsEditingDescription] = useState(false)
+
+  const connections = useMemo(() => {
+    return edges
+      .filter(e => e.source === nodeId || e.target === nodeId)
+      .map(e => {
+        const otherId = e.source === nodeId ? e.target : e.source
+        const other = nodes.find(n => n.id === otherId)
+        if (!other) return null
+        return {
+          edgeId: e.id,
+          nodeId: otherId,
+          nodeKind: (other.type || other.data?.kind || 'factor') as NodeType,
+          label: String(other.data?.label ?? otherId),
+          strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
+        }
+      })
+      .filter(Boolean) as Array<{
+        edgeId: string
+        nodeId: string
+        nodeKind: NodeType
+        label: string
+        strength: EdgeValueDisplay
+      }>
+  }, [edges, nodes, nodeId])
+
+  if (!nodeId || !node) return null
+
+  const rawKind = String(node.type || node.data?.kind || 'unknown')
+
+  return (
+    <div data-testid="inspector-generic-panel">
+      <PanelGroup kind="context" label={GROUP_LABELS.context}>
+        {description || isEditingDescription ? (
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            onBlur={() => {
+              mutations.setDescription(description)
+              if (!description.trim()) setIsEditingDescription(false)
+            }}
+            autoFocus={isEditingDescription && !description}
+            placeholder={DESCRIPTION_PLACEHOLDERS.decision}
+            rows={2}
+            maxLength={500}
+            className={`${typography.panelBody} w-full border border-panel-border rounded-lg px-2.5 py-1.5 bg-panel resize-none`}
+          />
+        ) : (
+          <EmptyDescriptionPrompt
+            placeholder={DESCRIPTION_PLACEHOLDERS.decision}
+            onStartEditing={() => setIsEditingDescription(true)}
+          />
+        )}
+
+        <p className={`${typography.panelMeta} text-text-light mt-2`} data-testid="inspector-generic-note">
+          {GENERIC_STRINGS.noSpecialisedEditor}
+        </p>
+      </PanelGroup>
+
+      <PanelGroup kind="connections" label={GROUP_LABELS.connections}>
+        {connections.map(conn => (
+          <ConnectionRow
+            key={conn.edgeId}
+            nodeKind={conn.nodeKind}
+            label={conn.label}
+            strength={conn.strength}
+            fullLabel
+            techMode={techMode}
+            onClick={() => onNavigate(conn.nodeId)}
+          />
+        ))}
+        {connections.length === 0 && (
+          <p className={`${typography.panelMeta} text-text-light`}>{EMPTY_STATES.noConnectionsFlat}</p>
+        )}
+      </PanelGroup>
+
+      <TechnicalDisclosure visible={techMode}>
+        <div>System: node type: {rawKind}</div>
+      </TechnicalDisclosure>
+    </div>
+  )
+})

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -281,9 +281,27 @@ export const OptionPanel = memo(function OptionPanel({
       <PanelGroup kind="input" label={GROUP_LABELS.whatThisChanges}>
         <PrimaryControlCard>
           {interventions.length === 0 ? (
-            <p className={`${typography.panelMeta} text-text-light py-2 text-center`}>
-              {EMPTY_STATES.noInterventions}
-            </p>
+            /* L-40 — the empty state is derived from THE SAME edge data the
+               Connections group below reads (`outboundConnections`), not from
+               `data.interventions` alone. An add-path option carries real
+               factor edges and no intervention map, so the old copy denied
+               three "Very strong +" connections that were on screen inches
+               below it. Two data sources, one user-facing question, is how a
+               panel comes to contradict itself. */
+            outboundConnections.length > 0 ? (
+              <p
+                data-testid="option-links-without-values"
+                className={`${typography.panelMeta} text-text-light py-2 text-center`}
+              >
+                {OPTION_STRINGS.linksWithoutValues
+                  .replace('{count}', String(outboundConnections.length))
+                  .replace('{s}', outboundConnections.length === 1 ? '' : 's')}
+              </p>
+            ) : (
+              <p className={`${typography.panelMeta} text-text-light py-2 text-center`}>
+                {EMPTY_STATES.noInterventions}
+              </p>
+            )
           ) : (
             interventions.map(iv => (
               <InterventionRow
@@ -364,10 +382,21 @@ export const OptionPanel = memo(function OptionPanel({
           fallback message rather than showing an empty bordered section —
           mirrors GoalPanel Task 1 pattern. */}
       {isResultsMode && (() => {
+        // L-24 — every branch below is derived PER NODE. Previously the only
+        // per-node signal was `hasImpactContent`; the fallback sentence was
+        // shared, so an option ADDED SINCE the run and an option the run
+        // covered-and-returned-nothing-for read identically. They are
+        // different situations and only one of them is the user's to fix.
         const hasImpactContent =
           displayMetadata.winRate !== null
           || !!headline
           || (allOptions.length > 1 && allOptions.some(o => o.winPct != null))
+        // Was THIS node in the run's own comparison? `allOptions` is built
+        // from `option_comparison`, i.e. the run's own record of what it
+        // analysed — not from the canvas, and not from global mode.
+        const runCoveredSomething = allOptions.length > 0
+        const nodeWasInRun = allOptions.some(o => o.isCurrent)
+        const addedSinceRun = runCoveredSomething && !nodeWasInRun
         return (
         <PanelGroup kind="impact" label={GROUP_LABELS.impact}>
           <StaleGuardBanner hasResults={isResultsMode}>
@@ -463,6 +492,13 @@ export const OptionPanel = memo(function OptionPanel({
                 </div>
               )}
             </div>
+            ) : addedSinceRun ? (
+              <p
+                data-testid="option-impact-not-in-run"
+                className={`${typography.panelMeta} text-text-light`}
+              >
+                {OPTION_STRINGS.impactNotInLastRun}
+              </p>
             ) : (
               <p className={`${typography.panelMeta} text-text-light`}>{OPTION_STRINGS.impactUnavailable}</p>
             )}
@@ -485,7 +521,7 @@ export const OptionPanel = memo(function OptionPanel({
           />
         ))}
         {outboundConnections.length === 0 && (
-          <p className={`${typography.panelMeta} text-text-light`}>No connections yet.</p>
+          <p className={`${typography.panelMeta} text-text-light`}>{EMPTY_STATES.noConnectionsFlat}</p>
         )}
       </PanelGroup>
 

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -387,16 +387,25 @@ export const OptionPanel = memo(function OptionPanel({
         // shared, so an option ADDED SINCE the run and an option the run
         // covered-and-returned-nothing-for read identically. They are
         // different situations and only one of them is the user's to fix.
-        const hasImpactContent =
-          displayMetadata.winRate !== null
-          || !!headline
-          || (allOptions.length > 1 && allOptions.some(o => o.winPct != null))
         // Was THIS node in the run's own comparison? `allOptions` is built
         // from `option_comparison`, i.e. the run's own record of what it
         // analysed — not from the canvas, and not from global mode.
         const runCoveredSomething = allOptions.length > 0
         const nodeWasInRun = allOptions.some(o => o.isCurrent)
         const addedSinceRun = runCoveredSomething && !nodeWasInRun
+        // ⚠ THE THIRD DISJUNCT WAS RUN-LEVEL, NOT PER-NODE (review D2), so the
+        // fix above never fired on the mainline shape. A run compares two or
+        // more options; the user then adds a third. `allOptions.length > 1 &&
+        // some(winPct != null)` is true of THE RUN, so the new option scored
+        // as having impact content and rendered the OTHER options' bars —
+        // foreign data under its own heading — instead of saying it was added
+        // afterwards. The first round's fixture used a ONE-option comparison,
+        // the single shape in which the old predicate happened to be false.
+        // Gating on `nodeWasInRun` makes the whole predicate per-node.
+        const hasImpactContent =
+          displayMetadata.winRate !== null
+          || !!headline
+          || (nodeWasInRun && allOptions.length > 1 && allOptions.some(o => o.winPct != null))
         return (
         <PanelGroup kind="impact" label={GROUP_LABELS.impact}>
           <StaleGuardBanner hasResults={isResultsMode}>

--- a/src/canvas/ui/inspector-v2/renameIntent.ts
+++ b/src/canvas/ui/inspector-v2/renameIntent.ts
@@ -1,0 +1,46 @@
+/**
+ * renameIntent — the inspector's EXPORTED rename entry point (L-04).
+ *
+ * The inspector owns the rename affordance; the workspace owns the gesture that
+ * asks for it. This store is the seam between them, so neither lane has to
+ * reach into the other's components.
+ *
+ * The workspace lane's canvas double-click handler calls `requestNodeRename(id)`
+ * (after selecting the node, so the inspector mounts for it). The inspector
+ * shell consumes the intent on mount and opens its label in editing state, then
+ * CLEARS it — a rename intent is a one-shot event, not a mode. Leaving it set
+ * would reopen the editor on every unrelated re-render.
+ *
+ * Bound by node id, never a global "edit now" flag: two inspectors can be
+ * mounted (panel + modal) and only the requested element may enter editing.
+ */
+
+import { create } from 'zustand'
+
+interface RenameIntentState {
+  /** The node whose label should open in editing state, or null. */
+  renameNodeId: string | null
+  request: (nodeId: string) => void
+  clear: () => void
+}
+
+export const useRenameIntentStore = create<RenameIntentState>((set) => ({
+  renameNodeId: null,
+  request: (nodeId) => set({ renameNodeId: nodeId }),
+  clear: () => set({ renameNodeId: null }),
+}))
+
+/**
+ * Ask the inspector to open `nodeId`'s title in editing state.
+ *
+ * Caller contract: the node must be (or be about to become) the inspector's
+ * current selection — this sets the intent, it does not open the inspector.
+ */
+export function requestNodeRename(nodeId: string): void {
+  useRenameIntentStore.getState().request(nodeId)
+}
+
+/** Drop any pending rename intent (consumed by the shell; also used in tests). */
+export function clearNodeRename(): void {
+  useRenameIntentStore.getState().clear()
+}

--- a/src/canvas/ui/inspector-v2/shared/EdgeReviewDisagreement.tsx
+++ b/src/canvas/ui/inspector-v2/shared/EdgeReviewDisagreement.tsx
@@ -1,0 +1,159 @@
+/**
+ * EdgeReviewDisagreement — the contested-edge surface, in user language (L-38).
+ *
+ * WHAT IT REPLACED, and why each part was wrong:
+ *
+ *   `validation.contested_reasons.join(', ')`
+ *       printed RAW ENUM TOKENS at rest — "existence_boundary_crossing",
+ *       "sign_flip" — to a user who has never seen the wire contract.
+ *
+ *   `{validation.pass2.basis}`
+ *       same defect, one line down: "domain_prior".
+ *
+ *   "Pass 1 (current)" / "Pass 2 (review)" + Strength / Std / Exists
+ *       the internal name for the two-pass validation pipeline, presented as
+ *       the PRIMARY explanation of a disagreement the user is being asked to
+ *       settle. "Std" is not a word in this product's vocabulary.
+ *
+ * The translations are IMPORTED from `model-tab/strengthBands.ts`, which
+ * already owns them and already ships the good S18 copy ("Our reviews disagree
+ * on whether this effect is positive or negative"). Re-typing them here would
+ * create a second label for the same enum — the hand-maintained-mirror defect
+ * that gave this estate two `generateGraphHash` twins.
+ *
+ * The numbers are not deleted; they move behind a progressive-disclosure
+ * control, named for what they mean rather than for the field they came from.
+ * Raw tokens remain available to expert mode only.
+ */
+
+import { useState } from 'react'
+import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+
+import { typography } from '../../../../styles/typography'
+import type { ValidationMetadata, ContestedReason, EstimateBasis } from '../../../domain/validation'
+import {
+  getContestedReasonLabel,
+  getBasisLabel,
+} from '../../../components/model-tab/strengthBands'
+import { EDGE_COPY, EDGE_REVIEW_COPY } from '../inspectorStrings'
+
+interface EdgeReviewDisagreementProps {
+  validation: ValidationMetadata
+  techMode: boolean
+}
+
+/**
+ * Translate one reason. An UNKNOWN token (a producer adding a reason we have
+ * no copy for) degrades to the honest generic sentence — never to the token
+ * itself. A raw enum leaking through a fallback is exactly how this defect
+ * shipped in the first place.
+ */
+function reasonSentence(reason: string): string {
+  const known = getContestedReasonLabel(reason as ContestedReason)
+  return known ?? EDGE_REVIEW_COPY.heading
+}
+
+function basisSentence(basis: string | undefined): string | null {
+  if (!basis) return null
+  return getBasisLabel(basis as EstimateBasis) ?? null
+}
+
+export function EdgeReviewDisagreement({ validation, techMode }: EdgeReviewDisagreementProps) {
+  const [showNumbers, setShowNumbers] = useState(false)
+
+  const reasons = Array.from(
+    new Set((validation.contested_reasons ?? []).map(reasonSentence)),
+  )
+  const basisLabel = basisSentence(validation.pass2?.basis)
+
+  return (
+    <div className="bg-panel border border-warning/30 rounded-lg p-2.5">
+      <div className={`${typography.panelBody} font-medium text-warning flex items-center gap-1`}>
+        <AlertTriangle size={13} className="text-warning" />
+        {EDGE_COPY.needsYourJudgement}
+      </div>
+
+      {reasons.length > 0 && (
+        <ul className={`${typography.panelMeta} text-text-light mt-1 space-y-0.5`}>
+          {reasons.map(sentence => (
+            <li key={sentence}>{sentence}</li>
+          ))}
+        </ul>
+      )}
+
+      {validation.pass2?.reasoning && (
+        <p className={`${typography.panelMeta} text-text-light mt-2 italic`}>
+          &ldquo;{validation.pass2.reasoning}&rdquo;
+        </p>
+      )}
+
+      {basisLabel && (
+        <span className={`${typography.panelMeta} inline-block mt-1 px-1.5 py-0.5 rounded-full bg-transparent border border-info/30 text-text-body`}>
+          {basisLabel}
+        </span>
+      )}
+
+      {/* Progressive disclosure: the two estimates, named for what they mean. */}
+      <div className="mt-2" data-testid="edge-review-detail">
+        <button
+          type="button"
+          data-testid="edge-review-detail-toggle"
+          onClick={() => setShowNumbers(v => !v)}
+          aria-expanded={showNumbers}
+          className={`${typography.panelMeta} bg-transparent border-none cursor-pointer text-info flex items-center gap-1 p-0 hover:underline`}
+        >
+          {showNumbers
+            ? <ChevronDown size={12} className="text-info" aria-hidden="true" />
+            : <ChevronRight size={12} className="text-info" aria-hidden="true" />}
+          {showNumbers ? EDGE_REVIEW_COPY.hideDetail : EDGE_REVIEW_COPY.showDetail}
+        </button>
+
+        {showNumbers && (
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <div className="bg-panel border border-panel-border rounded p-2">
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>
+                {EDGE_REVIEW_COPY.currentEstimate}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.strength}: {validation.pass1.strength_mean.toFixed(2)}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.uncertainty}: {validation.pass1.strength_std.toFixed(2)}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.existence}: {Math.round(validation.pass1.exists_probability * 100)}%
+              </div>
+            </div>
+            <div className="bg-panel border border-panel-border rounded p-2">
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>
+                {EDGE_REVIEW_COPY.reviewEstimate}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.strength}: {validation.pass2.strength_mean.toFixed(2)}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.uncertainty}: {validation.pass2.strength_std.toFixed(2)}
+              </div>
+              <div className={typography.panelMeta}>
+                {EDGE_REVIEW_COPY.existence}: {Math.round(validation.pass2.exists_probability * 100)}%
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Expert mode only: the wire's own tokens, for anyone debugging a
+          producer. Moved here rather than deleted — the placement was the
+          defect, not the data. */}
+      {techMode && (
+        <div
+          data-testid="edge-review-raw"
+          className={`${typography.panelMeta} text-text-light mt-2 space-y-0.5`}
+        >
+          <div>System: contested_reasons: {(validation.contested_reasons ?? []).join(', ')}</div>
+          {validation.pass2?.basis && <div>System: basis: {validation.pass2.basis}</div>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
+++ b/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
@@ -1,9 +1,34 @@
 /**
- * EditableLabel — inline text editing with blur-save
+ * EditableLabel — inline title editing with blur-save.
  * Enter saves and blurs. Escape reverts and blurs.
+ *
+ * L-04 — three defects closed here:
+ *
+ * 1. NO VISIBLE AFFORDANCE. This was a bare `<button>` whose only hint was
+ *    `cursor-text`, so nothing on screen said the title could be renamed.
+ *    It now carries a persistent pencil cue, a dotted underline, and a real
+ *    accessible name ("Rename …").
+ *
+ * 2. THE DRAG HANDLE SWALLOWED IT. The control lives inside the inspector
+ *    header, which is the panel's drag surface. `onPointerDown` is stopped
+ *    here so a press on the title starts an edit, not a drag. Scoped to this
+ *    control only — the rest of the header still drags.
+ *
+ * 3. SILENT TRUNCATION. The input allowed 500 characters while the store
+ *    setter sliced to 100 and told nobody. There is now ONE limit — the
+ *    store's, imported from the setter that enforces it, not re-typed — the
+ *    input stops at it, and a counter appears as the user approaches it.
+ *
+ * `autoEdit` mounts the field already in editing state. That is what makes a
+ * canvas double-click land the user in the input (see `renameIntent.ts`).
  */
 
 import { useState, useCallback, useRef, useEffect, type KeyboardEvent } from 'react'
+import { Pencil } from 'lucide-react'
+import { NODE_LABEL_MAX_LENGTH } from '../useInspectorMutations'
+
+/** Characters remaining at which the counter appears. */
+const COUNTER_REVEAL_MARGIN = 20
 
 interface EditableLabelProps {
   value: string
@@ -11,14 +36,17 @@ interface EditableLabelProps {
   maxLength?: number
   className?: string
   placeholder?: string
+  /** Mount directly in editing state (canvas double-click → rename). */
+  autoEdit?: boolean
 }
 
 export function EditableLabel({
   value,
   onSave,
-  maxLength = 100,
+  maxLength = NODE_LABEL_MAX_LENGTH,
   className = '',
   placeholder = 'Untitled',
+  autoEdit = false,
 }: EditableLabelProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(value)
@@ -29,7 +57,19 @@ export function EditableLabel({
     if (!isEditing) setDraft(value)
   }, [value, isEditing])
 
+  // Rename intent: open the editor when asked. Only reacts to the transition
+  // INTO true, so clearing the intent does not slam the editor shut under the
+  // user's cursor.
+  useEffect(() => {
+    if (autoEdit && onSave) {
+      setIsEditing(true)
+      requestAnimationFrame(() => inputRef.current?.focus())
+    }
+  }, [autoEdit, onSave])
+
   const save = useCallback(() => {
+    // The input already caps at `maxLength`; the slice is defensive only, and
+    // can no longer discard text the user was allowed to type.
     const trimmed = draft.trim().slice(0, maxLength)
     if (trimmed && trimmed !== value && onSave) {
       onSave(trimmed)
@@ -55,7 +95,7 @@ export function EditableLabel({
   }, [save, revert])
 
   if (!onSave) {
-    // Read-only mode
+    // Read-only mode — no rename affordance, because there is no rename.
     return (
       <span className={className} title={value}>
         {value || placeholder}
@@ -67,30 +107,57 @@ export function EditableLabel({
     return (
       <button
         type="button"
-        className={`${className} cursor-text text-left truncate block w-full hover:bg-panel-hover rounded px-0.5 -mx-0.5 transition-colors`}
+        data-testid="inspector-rename-trigger"
+        className={`${className} group cursor-text text-left flex items-center gap-1 w-full min-w-0 hover:bg-panel-hover rounded px-0.5 -mx-0.5 transition-colors`}
+        // The header above is the drag surface. Without this, pressing the
+        // title starts a panel drag instead of an edit.
+        onPointerDown={e => e.stopPropagation()}
         onClick={() => {
           setIsEditing(true)
-          // Focus after render
           requestAnimationFrame(() => inputRef.current?.focus())
         }}
-        title={value}
+        title={`Rename — ${value || placeholder}`}
+        aria-label={`Rename ${value || placeholder}`}
       >
-        {value || placeholder}
+        <span className="truncate border-b border-dashed border-panel-border group-hover:border-info">
+          {value || placeholder}
+        </span>
+        <Pencil
+          size={12}
+          data-testid="inspector-rename-cue"
+          aria-hidden="true"
+          className="shrink-0 text-text-light group-hover:text-info transition-colors"
+        />
       </button>
     )
   }
 
+  const remaining = maxLength - draft.length
+
   return (
-    <input
-      ref={inputRef}
-      type="text"
-      value={draft}
-      onChange={e => setDraft(e.target.value)}
-      onBlur={save}
-      onKeyDown={handleKeyDown}
-      maxLength={maxLength}
-      className={`${className} w-full bg-transparent border-b border-info outline-none px-0.5 -mx-0.5`}
-      autoFocus
-    />
+    <div className="w-full">
+      <input
+        ref={inputRef}
+        type="text"
+        data-testid="inspector-rename-input"
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        onPointerDown={e => e.stopPropagation()}
+        onBlur={save}
+        onKeyDown={handleKeyDown}
+        maxLength={maxLength}
+        aria-label="Element name"
+        className={`${className} w-full bg-transparent border-b border-info outline-none px-0.5 -mx-0.5`}
+        autoFocus
+      />
+      {remaining <= COUNTER_REVEAL_MARGIN && (
+        <span
+          data-testid="inspector-rename-counter"
+          className="block text-[11px] leading-snug text-text-light mt-0.5"
+        >
+          {draft.length}/{maxLength} characters
+        </span>
+      )}
+    </div>
   )
 }

--- a/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
+++ b/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
@@ -38,6 +38,12 @@ interface EditableLabelProps {
   placeholder?: string
   /** Mount directly in editing state (canvas double-click → rename). */
   autoEdit?: boolean
+  /**
+   * Called once the auto-edit intent has actually opened the editor, so the
+   * owner can clear it. A rename intent is a ONE-SHOT EVENT: left set, it
+   * reopens the editor on every later re-render and follows the user around.
+   */
+  onAutoEditConsumed?: () => void
 }
 
 export function EditableLabel({
@@ -47,6 +53,7 @@ export function EditableLabel({
   className = '',
   placeholder = 'Untitled',
   autoEdit = false,
+  onAutoEditConsumed,
 }: EditableLabelProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState(value)
@@ -57,15 +64,33 @@ export function EditableLabel({
     if (!isEditing) setDraft(value)
   }, [value, isEditing])
 
-  // Rename intent: open the editor when asked. Only reacts to the transition
-  // INTO true, so clearing the intent does not slam the editor shut under the
-  // user's cursor.
+  // Rename intent: open the editor when asked, then report the intent spent so
+  // the owner can clear it.
+  //
+  // ⚠ The comment that stood here claimed this "only reacts to the transition
+  // INTO true". That was FALSE and it mattered: nothing in this component was
+  // keyed by element, so when the owner retargeted the shell to a different
+  // node this component kept `isEditing` AND kept `draft` — the previous
+  // element's text — and the next blur saved it onto the new element. The
+  // owner now remounts this component per element (`key`), so editing state
+  // and draft cannot cross an element boundary at all. Opening remains
+  // one-directional: clearing the intent never slams the editor shut under
+  // the user's cursor.
+  //
+  // The deps include `onSave`, whose IDENTITY changes: `useInspectorMutations`
+  // rebuilds `setLabel` per `[nodeId, updateNode, getNode]`. So the effect
+  // re-ran on ordinary re-renders while `autoEdit` was still true and REOPENED
+  // an editor the user had already closed. `prevAutoEdit` makes the trigger a
+  // genuine false→true TRANSITION, which is what the comment always claimed.
+  const prevAutoEdit = useRef(false)
   useEffect(() => {
-    if (autoEdit && onSave) {
-      setIsEditing(true)
-      requestAnimationFrame(() => inputRef.current?.focus())
-    }
-  }, [autoEdit, onSave])
+    const wasArmed = prevAutoEdit.current
+    prevAutoEdit.current = autoEdit
+    if (!autoEdit || wasArmed || !onSave) return
+    setIsEditing(true)
+    requestAnimationFrame(() => inputRef.current?.focus())
+    onAutoEditConsumed?.()
+  }, [autoEdit, onSave, onAutoEditConsumed])
 
   const save = useCallback(() => {
     // The input already caps at `maxLength`; the slice is defensive only, and

--- a/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
@@ -131,8 +131,14 @@ export function InspectorCoaching({
     ? `${topGuidanceItem.title}${topGuidanceItem.detail ? ` ${topGuidanceItem.detail}` : ''}`
     : fallbackText
 
+  // ⚠ A `run_exercise` item kept the ASK label ("Ask about this") while
+  // AUTO-SENDING a slash command — a control labelled as one semantic doing
+  // the other, inside the very component this PR unified. Labelled for what it
+  // does, using the estate's EXISTING word for this action class
+  // (`GuidanceStrip.tsx` / `InspectorGuidanceSection.tsx` both say 'Try it')
+  // rather than minting a third vocabulary for the same enum.
   const guidanceActionLabel = topGuidanceItem
-    ? (topGuidanceItem.primary_action.type === 'discuss' ? 'Discuss' : actionLabel)
+    ? guidanceActionLabelFor(topGuidanceItem.primary_action.type, actionLabel)
     : actionLabel
 
   const action = canInteract
@@ -143,4 +149,17 @@ export function InspectorCoaching({
     : undefined
 
   return <CoachingCard text={text} action={action} />
+}
+
+/**
+ * Label for a guidance action. `discuss` and the default are ASKS and keep the
+ * ask wording; `run_exercise` is a COMMAND and must not wear an ask's label.
+ * Kept in step with the shared table in `GuidanceStrip` / `InspectorGuidanceSection`.
+ */
+function guidanceActionLabelFor(type: string, askLabel: string): string {
+  switch (type) {
+    case 'discuss':      return 'Discuss'
+    case 'run_exercise': return 'Try it'
+    default:             return askLabel
+  }
 }

--- a/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InspectorCoaching.tsx
@@ -3,10 +3,21 @@
  *
  * Priority: orchestrator GuidanceItems > static coaching text.
  * Maximum ONE coaching card visible. If a GuidanceItem exists for this element,
- * it renders instead of the static fallback. "Ask about this" SENDS the question
- * to Olumi immediately (via the guidance store's registered _sendMessage) and
- * reveals the chat. Falls back to prefilling the composer only if the send wire is
- * unavailable.
+ * it renders instead of the static fallback.
+ *
+ * ⚠ THIS COMPONENT USED TO AUTO-SEND (ledger L-18, a trap-21 pair). "Ask about
+ * this" dispatched via `_sendMessage` immediately, while the inspector's OTHER
+ * ask affordance (DiscussWithAiButton) prefilled an editable draft and waited.
+ * Same user intent, opposite semantics, one panel. Auto-send is the half that
+ * lies: the question lands in a surface the user may not be looking at, so the
+ * control reads as dead.
+ *
+ * Both now run the ONE semantic in `askSemantic.ts` — prefill-and-confirm.
+ * The ask never dispatches; the user presses Send.
+ *
+ * ONE deliberate exception, and it is not an ask: `run_exercise` is a slash
+ * COMMAND whose button IS the confirmation. A prefilled '/exercise …' would sit
+ * in the composer as literal text instead of executing.
  *
  * Replaces the separate CoachingCard + InspectorGuidanceSection pattern.
  */
@@ -16,6 +27,7 @@ import { useGuidanceStore, compareGuidanceDisplayOrder } from '../../../stores/g
 import { revealOlumiSurface } from '../../../conversation/revealOlumi'
 import { CoachingCard } from './CoachingCard'
 import { resolveAskTemplate } from '../inspectorStrings'
+import { requestAsk } from '../askSemantic'
 
 interface InspectorCoachingProps {
   /** Node or edge ID for guidance filtering */
@@ -68,26 +80,32 @@ export function InspectorCoaching({
     [panelType, labelContext],
   )
 
-  // Send the text to Olumi immediately (auto-send) and reveal the chat. Prose falls
-  // back to prefilling the composer when the send wire is unavailable; slash
-  // commands pass allowPrefillFallback:false because a prefilled '/exercise …'
-  // would sit in the composer as literal text instead of executing.
-  const sendToChat = useCallback((text: string, opts?: { allowPrefillFallback?: boolean }) => {
+  // ASK — the one semantic. Lands an editable draft the user sends; never
+  // dispatches. Routing (composer vs drawer) is askSemantic's decision.
+  const ask = useCallback((text: string) => {
+    requestAsk({
+      text,
+      label: 'Ask about this',
+      context: '',
+      targetId: elementId,
+    })
+  }, [elementId])
+
+  // COMMAND — not an ask. The button is the confirmation, and a prefilled
+  // slash command would sit in the composer as literal text.
+  const runCommand = useCallback((text: string) => {
     const state = useGuidanceStore.getState()
     if (state._sendMessage) {
       state._sendMessage(text)
       revealOlumiSurface()
-    } else if (opts?.allowPrefillFallback !== false && state._prefillChat) {
-      state._prefillChat(text)
-      revealOlumiSurface()
     }
   }, [])
 
-  // Handle "Ask about this" — send the contextual question to Olumi
+  // Handle "Ask about this" — prefill the contextual question for the user
   const handleAsk = useCallback(() => {
     if (!questionText) return
-    sendToChat(questionText)
-  }, [questionText, sendToChat])
+    ask(questionText)
+  }, [questionText, ask])
 
   // Handle guidance item action
   const handleGuidanceAction = useCallback(() => {
@@ -96,17 +114,17 @@ export function InspectorCoaching({
 
     switch (action.type) {
       case 'discuss':
-        sendToChat(action.prompt)
+        ask(action.prompt)
         break
       case 'run_exercise':
-        // Slash command: send-only (no prefill fallback — see sendToChat).
-        sendToChat(`/exercise ${action.exercise}`, { allowPrefillFallback: false })
+        // Slash command: a COMMAND, not an ask — see the header note.
+        runCommand(`/exercise ${action.exercise}`)
         break
       default:
         // For other action types, fall back to "Ask about this"
-        if (questionText) sendToChat(questionText)
+        if (questionText) ask(questionText)
     }
-  }, [topGuidanceItem, questionText, sendToChat])
+  }, [topGuidanceItem, questionText, ask, runCommand])
 
   // Determine text and action
   const text = topGuidanceItem?.title

--- a/src/canvas/ui/inspector-v2/shared/InspectorQuickActions.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InspectorQuickActions.tsx
@@ -1,0 +1,104 @@
+/**
+ * InspectorQuickActions — R5, Paul's own formulation (16 Aug 2026).
+ *
+ * "Full functionality stays in the inspector and may be DUPLICATED there
+ *  (quick actions at the top of the inspector). Efficiency principle: minimise
+ *  clicks to power functionality; nothing buried."
+ *
+ * Two actions, both one click from any selected element:
+ *   · ask Olumi about THIS element
+ *   · open the analysis for THIS element
+ *
+ * The ask runs the ONE ask semantic (`askSemantic.ts`): it never dispatches, it
+ * lands an editable draft the user sends. It is HIDDEN — not disabled, not
+ * silently inert — when no conversation surface is registered, because a
+ * control that looks live and does nothing is the dead-button class this
+ * estate keeps shipping.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { MessageCircleQuestion, BarChart3 } from 'lucide-react'
+
+import { typography } from '../../../../styles/typography'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { useUIStore, type OutputTab } from '../../../../stores/uiStore'
+import { requestAsk } from '../askSemantic'
+import { resolveAskTemplate } from '../inspectorStrings'
+
+interface InspectorQuickActionsProps {
+  /** Node or edge id — the ask's model target. */
+  elementId: string
+  /** User-facing name of the element, used in the question and the labels. */
+  elementLabel: string
+  /** Panel type, for the shared ask-question template table. */
+  panelType: string
+  /** Extra label context for edge templates. */
+  labelContext?: { sourceLabel?: string; targetLabel?: string }
+  /** Which results surface this element's analysis lives on. */
+  analysisTab?: OutputTab
+}
+
+export function InspectorQuickActions({
+  elementId,
+  elementLabel,
+  panelType,
+  labelContext,
+  analysisTab = 'results',
+}: InspectorQuickActionsProps) {
+  const canAsk = useGuidanceStore(
+    (s) => s._prefillChat !== null || s._sendMessage !== null || s._dispatchAction !== null,
+  )
+
+  const question = useMemo(() => {
+    const templated = resolveAskTemplate(panelType, { label: elementLabel, ...labelContext })
+    // Fallback keeps the action live for element types with no template rather
+    // than silently dropping the affordance for exactly the unusual nodes a
+    // user is most likely to have questions about.
+    return templated ?? `Tell me about ${elementLabel} in this model.`
+  }, [panelType, elementLabel, labelContext])
+
+  const handleAsk = useCallback(() => {
+    requestAsk({
+      text: question,
+      label: `Ask about ${elementLabel}`,
+      context: '',
+      targetId: elementId,
+    })
+  }, [question, elementLabel, elementId])
+
+  const handleAnalysis = useCallback(() => {
+    useUIStore.getState().setActiveOutputTab(analysisTab)
+  }, [analysisTab])
+
+  return (
+    <div
+      data-testid="inspector-quick-actions"
+      className="flex items-center gap-1.5 pt-2 pb-0.5"
+    >
+      {canAsk && (
+        <button
+          type="button"
+          data-testid="inspector-quick-ask"
+          onClick={handleAsk}
+          title={`Ask Olumi about ${elementLabel}`}
+          aria-label={`Ask Olumi about ${elementLabel}`}
+          className={`${typography.panelMeta} inline-flex items-center gap-1 rounded-full border border-panel-border px-2 py-1 text-text-body hover:bg-panel-hover hover:text-info focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/40 transition-colors`}
+        >
+          <MessageCircleQuestion size={12} aria-hidden="true" />
+          Ask Olumi
+        </button>
+      )}
+      <button
+        type="button"
+        data-testid="inspector-quick-analysis"
+        onClick={handleAnalysis}
+        title={`Open the analysis for ${elementLabel}`}
+        aria-label={`Open the analysis for ${elementLabel}`}
+        className={`${typography.panelMeta} inline-flex items-center gap-1 rounded-full border border-panel-border px-2 py-1 text-text-body hover:bg-panel-hover hover:text-info focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/40 transition-colors`}
+      >
+        <BarChart3 size={12} aria-hidden="true" />
+        Its analysis
+      </button>
+    </div>
+  )
+}

--- a/src/canvas/ui/inspector-v2/types.ts
+++ b/src/canvas/ui/inspector-v2/types.ts
@@ -67,6 +67,11 @@ export interface InspectorShellProps {
   onClose: () => void
   /** Drag handlers from InspectorModal — makes the header draggable */
   dragHandlers?: DragHandlers
+  /**
+   * R5 quick actions, rendered at the TOP of the panel body above every group.
+   * Supplied by InspectorRouter, which knows the element's identity.
+   */
+  quickActions?: ReactNode
   children: ReactNode
 }
 

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -31,6 +31,17 @@ import { useOptionalConversationContext } from '../../conversation/ConversationC
 // action, the baseline toggle, the model-action apply path) are NOT listed here
 // — they are named in the registry guard's residual list with their write sites.
 
+/**
+ * The node-label length limit, OWNED BY THE SETTER THAT ENFORCES IT (L-04).
+ *
+ * The inspector input previously allowed 500 characters while this setter
+ * sliced to 100 and reported nothing — a silent truncation the user could not
+ * see coming. The input now imports this constant rather than re-typing a
+ * number, so the two cannot drift apart again: there is one limit, and it is
+ * this one.
+ */
+export const NODE_LABEL_MAX_LENGTH = 100
+
 /** node setter name → the top-level `data` field(s) that setter writes. */
 export const NODE_SETTER_FIELDS = {
   setLabel: ['label'],
@@ -98,7 +109,7 @@ export function useNodeMutations(nodeId: string) {
   const setLabel = useCallback((value: string) => {
     const node = getNode()
     if (!node) return
-    const trimmed = value.trim().slice(0, 100)
+    const trimmed = value.trim().slice(0, NODE_LABEL_MAX_LENGTH)
     if (trimmed && trimmed !== node.data?.label) {
       updateNode(nodeId, { data: { ...node.data, label: trimmed } })
     }


### PR DESCRIPTION
Inspector component completion. Six items from the 16 Aug issue ledger: L-04 (rename), L-40 (self-contradictions), L-24 (add-path divergence), L-38 inspector half (internal vocabulary), the L-18 trap-21 ask pair, and ruling R5 (quick actions).

Scope is `src/canvas/ui/inspector-v2/**` plus `DiscussWithAiButton` and `useInspectorMutations`. `ReactFlowGraph.tsx`, `OutputsDock.tsx`, `conversation/**`, `versions/**` and the analysis-state selectors are untouched — this PR **exports** the rename capability; the workspace lane wires the double-click.

---

## KEEP / REPLACE / REMOVE

| Disposition | Component / behaviour | What happened, and why |
|---|---|---|
| **REPLACE** | `EditableLabel` | Bare `<button>` with `cursor-text` → real affordance: pencil cue, dashed underline, `Rename …` accessible name, `onPointerDown` guard against the header drag surface, store-owned length limit with a counter. |
| **REPLACE** | Node-label limit | UI `maxLength={500}` vs store `slice(0, 100)` → one limit, `NODE_LABEL_MAX_LENGTH`, **owned by the setter that enforces it** and imported by the input. Not re-typed — the two cannot drift again. |
| **REPLACE** | Option "changes no factors" empty state | Derived from `data.interventions` alone while the Connections list read `edges` → both now derive from `outboundConnections`. Same data, same answer. |
| **REPLACE** | Decision "No connections yet." | Flat denial of edges the canvas draws → names where those connections went, counting the same option edges the Input group lists. |
| **REPLACE** | Option Impact fallback | One sentence covered two situations → an option **added since the run** gets its own honest copy, derived per node from the run's own `option_comparison`. |
| **REPLACE** | Contested-edge evidence block | Raw enums (`existence_boundary_crossing`, `domain_prior`) + "Pass 1 (current) / Pass 2 (review)" stat grid → `EdgeReviewDisagreement`, consuming the **existing** S18 translators. |
| **REPLACE** | `InspectorCoaching` ask | Auto-send via `_sendMessage` → prefill-and-confirm through the shared `askSemantic`. |
| **REPLACE** | `DiscussWithAiButton` routing | Hard-coded `openAskOlumi` → the same shared `askSemantic`. **One behaviour change, flagged below.** |
| **ADD** | `renameIntent.ts` | The exported seam the workspace lane consumes. |
| **ADD** | `askSemantic.ts` | The single definition of what an "ask" does. |
| **ADD** | `GenericNodePanel` | The router's real fallback. |
| **ADD** | `InspectorQuickActions` | R5. |
| **REMOVE** | Nothing user-visible | The Pass 1/Pass 2 numbers and the raw enum tokens are **moved**, not deleted: numbers behind a progressive-disclosure control in user language, tokens into expert mode. No visible surface is withdrawn, so R12's archive rule is not engaged. |

---

## 1 · L-04 · Rename is a real affordance

Three separate defects, three separate fixes:

- **No visible cue.** The control was a bare `<button>` whose only hint was `cursor-text`. It now carries a persistent pencil, a dashed underline, `title="Rename — …"` and `aria-label="Rename …"`.
- **The drag handle swallowed it.** The control sits inside the panel header, which is the drag surface, so a press started a panel drag. `onPointerDown` is now stopped **on the control only** — the rest of the header still drags, and there is a discriminating test for each direction.
- **Silent truncation.** The input allowed 500 characters; `setLabel` sliced to 100 and told nobody. There is now **one** limit — the store's — exported from the setter, imported by the input, with a counter appearing at 20 characters remaining.

### Interface exported for the workspace lane

```ts
import { requestNodeRename } from '@/canvas/ui/inspector-v2'

// In the canvas double-click handler, AFTER selecting the node:
requestNodeRename(nodeId)
```

**Contract.** `requestNodeRename(nodeId: string): void` sets a one-shot intent. It does **not** open the inspector — the caller selects the node so the inspector mounts for it. The shell consumes the intent on mount, opens the title in editing state, and clears it (a rename is an event, not a mode; leaving it set would reopen the editor on every unrelated re-render). The intent is bound **by node id**, so with two inspectors mounted only the requested element enters editing. `clearNodeRename()` and `useRenameIntentStore` are exported for cancellation and for tests.

---

## 2 · L-40 · The panel stops contradicting itself

**S02 — option.** "This option doesn't change any factors yet" rendered directly above three populated "Very strong +" connections. Cause: the empty state read `data.interventions`, the connections list read `edges`. Two data sources, one user-facing question. Both now derive from `outboundConnections`; when links exist but values do not, the copy says so and counts them.

**S04 — decision.** "No connections yet." while the canvas drew the decision's edges. Cause: `otherConnections` excludes option edges by design (options live in the Input group above). The empty state now derives from the same edge data the options list reads and names where those connections are, rather than denying them. `EMPTY_STATES.noConnectionsFlat` replaces three separate literals so there is one definition.

---

## 3 · L-24 · Add-path divergence

**Impact group, per node.** The group was gated on **global** `results.status === 'complete'`, so an option added *after* a run and an option the run *covered and returned nothing for* got the same sentence. Every branch is now derived per node from the run's own `option_comparison`: `addedSinceRun` gets its own honest copy ("added after the last analysis … re-run to include it"), the genuine no-data case keeps `impactUnavailable`, and nothing renders before any run.

> **Deliberate refinement of the brief, flagged for review.** The brief said to gate the group on `displayMetadata.winRate !== null`. Dropping the group entirely for a data-less node makes an add-path option's panel shape diverge *more* from its siblings — the exact L-24 complaint. So the **content** is derived per node (including `winRate`) and the group survives to explain itself. If the reviewer prefers the literal gate, it is a two-line change.

**Router fallback.** `resolvePanelType` returned `null` for `action`, `constraint`, `ghost-option` and anything a future producer emits, and the router rendered **nothing** — a click indistinguishable from a broken one. `default` now returns `'generic'`, and `GenericNodePanel` shows description, connections and an honest note. `null` is reserved for "there is no node", the only honest silence.

---

## 4 · L-38 · User language, no raw enum tokens at rest

Three instances on S01, all in the contested-edge block:

| Was | Now |
|---|---|
| `contested_reasons.join(', ')` → `existence_boundary_crossing` | `getContestedReasonLabel` → "Our reviews disagree on whether this relationship is reliable" |
| `pass2.basis` → `domain_prior` | `getBasisLabel` → "Based on general domain knowledge" |
| "Pass 1 (current) / Pass 2 (review)", `Strength / Std / Exists` | "What the model currently uses" / "What the review suggested", behind a **progressive-disclosure** toggle |

The translators are **imported** from `model-tab/strengthBands.ts`, which already owns them and already ships the S18 copy. Re-typing them here would create a second label for the same enum — the hand-maintained-mirror defect. An unknown reason token degrades to the honest generic sentence, never to the token. Raw tokens remain available under expert mode: the placement was the defect, not the data.

---

## 5 · One ask semantic (the trap-21 pair)

The inspector carried two ask affordances with **opposite** semantics: `InspectorCoaching` auto-sent via `_sendMessage`; `DiscussWithAiButton` prefilled an editable draft and waited. Same intent, one panel. Auto-send is the half that lies — the question lands in a surface the user may not be looking at, so the control reads as dead.

**Both now route through `askSemantic.ts`.** Per trap 21, the two questions are named apart rather than merged:

- **Q1 — how does an ask get CONFIRMED?** One answer everywhere: it never dispatches. It becomes an editable draft in a visible surface with a single obvious Send, which the user presses. `ASK_SEMANTIC = 'prefill-and-confirm'`.
- **Q2 — which CARRIER does it travel on?** Per call site, and deliberately **not** unified. An ask carrying dispatch `parameters` rides the conversation-typed turn, because chip_metadata survives only on that turn type. Flattening those into a bare composer prefill would silently drop it.

Routing: plain ask + composer registered → prefill the composer and reveal it (no third floating surface — a simple prefill suffices); ask with parameters → the drawer; no composer → the drawer as the confirm fallback; no surface at all → nothing, and the affordance is hidden rather than dead.

`run_exercise` stays a direct command and is **not** routed here: its button is the confirmation, and a prefilled `/exercise …` would sit in the composer as literal text. There is a discriminating test pinning that distinction so it cannot be flattened by a later tidy-up.

### ⚠ The one cross-surface behaviour change, for the reviewer

`DiscussWithAiButton` is used on results surfaces outside this lane (`ResultsBody`, `DriversSection`, `ConfidenceSection`, `FragileEdgeGroupCard`, `TriageCard`, `MissingKnowledgePrompt`, `OlumiTabBody`, and four pre-analysis cards). Its **confirm semantic is unchanged** — it never auto-sent and still never does. What changes is the **surface**: where a chat composer is registered, the draft now lands there with the composer revealed instead of floating the Ask-Olumi drawer. The drawer remains the fallback and remains the carrier for parameterised asks. This is the "AskOlumiDrawer stops being a third floating surface where a simple prefill suffices" half of the item, and it is the change most worth a second opinion.

---

## 6 · R5 · Quick actions at the top of the inspector

Paul's ruling: *"Full functionality stays in the inspector and may be DUPLICATED there (quick actions at the top of the inspector) … minimise clicks to power functionality; nothing buried."*

`InspectorQuickActions` renders in the shell body **above every panel group**, on node and edge panels alike: **Ask Olumi** (runs the one semantic) and **Its analysis**. The ask is hidden — not disabled, not inert — when no conversation surface is registered, because a control that looks live and does nothing is the dead-button class. A test asserts the document-order placement, so a later layout change cannot quietly bury them.

---

## Evidence

RED-first per item, at the pristine tip, with counts asserted by name (never inferred from a suite total):

| Spec | Pristine | After |
|---|---|---|
| `inspectorCompletion.honestStates.spec.tsx` | 17 collected · **10 failed** / 7 passed | 17 / 17 |
| `inspectorCompletion.userLanguage.spec.tsx` | 10 collected · **7 failed** / 3 passed | 10 / 10 |
| `inspectorCompletion.rename.spec.tsx` | collect-level RED (new modules absent) | 14 / 14 |
| `inspectorCompletion.askSemantic.spec.tsx` | collect-level RED (new modules absent) | 16 / 16 |

The seven and three that passed at pristine are the **preconditions pinned in-test** — the fixture really does render three connections, the Evidence group really does mount — so the absence assertions cannot pass on an empty panel (trap 13). The two collect-level REDs are honestly weaker; their behavioural sensitivity is carried by the mutant kit instead.

Assertions bind by **identity** — `data-testid`, `data-panel-group`, node ids, string-table constants — never by a value predicate another element could satisfy.

**Discriminating pairs**, not single mutants: rename-drag (control guarded / header still drags), rename-intent (requested node opens / another node does not), ask-carrier (plain ask prefills / parameterised ask uses the drawer), ask-vs-command (asks prefill / `/exercise` still sends), option empty-state (fires on real links / does not fire without them).

Mutation kit: external worktree at a unique absolute `/private/tmp` path, isolation **proven by writing a sentinel** and asserting the source clone's hash is unchanged plus an inode comparison (trap 9g — `cp -R` can preserve APFS hard links and inspection cannot see it), restore from a pristine archive outside both trees (trap 9h), per-mutation applied-check scoped to `src/` with the control asserting exactly zero, and a trailing green control.

### Mutation kit — 13/13 bitten

Isolation proved **by writing**: a sentinel appended in the worktree left the source clone's
SHA-256 unchanged, and the inodes differ (640331009 vs 640721668). Leading control
applied-count **0**; every mutation asserted exactly **1** changed file under `src/`; restore
from a pristine archive outside both trees.

| # | Mutation | Spec | Result |
|---|---|---|---|
| M1 | Option empty state reverts to the single data source | honestStates | **RED** (2 failed / 15) |
| M2 | Option empty state counts the wrong edges — *twin* | honestStates | **RED** (1 failed / 16) |
| M3 | Decision reverts to the flat denial | honestStates | **RED** (2 failed / 15) |
| M4 | Router default returns `null` again | honestStates | **RED** (3 failed / 14) |
| M5 | Add-path impact branch removed | honestStates | **RED** (1 failed / 16) |
| M6 | Reason translator leaks the raw token | userLanguage | **RED** (2 failed / 8) |
| M7 | Estimate headings revert to "Pass 1 (current)" | userLanguage | **RED** (1 failed / 9) |
| M8 | `requestAsk` auto-sends again | askSemantic | **RED** (7 failed / 9) |
| M9 | `requestAsk` drops the typed-dispatch carrier rule — *twin* | askSemantic | **RED** (1 failed / 15) |
| M10 | Rename trigger stops guarding the drag handle | rename | **RED** (1 failed / 13) |
| M11 | Shell re-imposes the 500-char UI limit | rename | **RED** (1 failed / 13) |
| M12 | Rename intent stops binding to the node id — *twin* | rename | **RED** (1 failed / 13) |
| M13 | R5 quick actions moved below the panel body | askSemantic | **RED** (1 failed / 15) |

**Trailing control: applied-count 0, all four specs 57/57 GREEN.**

The twins discriminate as intended — each failed exactly the ONE test that names the property it
breaks, leaving its partner green. M10 in particular reds "does not start a panel drag" while
"STILL starts a panel drag elsewhere in the header" stays green, so the guard is proven scoped
rather than proven present.


## Gates

| Gate | Result |
|---|---|
| Full `inspector-v2` suite (43 files) | **454 tests · 1 failure**, and that failure was the old `InspectorCoaching.spec.tsx` pin on the auto-send semantic — inverted in its own commit, with the previous expectation recorded in a comment so the reversal stays legible. Now 14/14. |
| Consumer surfaces (`DiscussWithAiButton` call sites, TriageCard, MissingKnowledgePrompt, SharpenYourThinking, WorthInvestigating, AskOlumiDrawer ×2, ctaPrefillNeverAutosend, OlumiTabBody) | **100/100 pass** — no fallout from the routing change in any existing spec |
| `TypeScript + Lint` (CI, the authority) | **green** at `07267b28` |
| `Production Build` | green · `Security Audit` green · `CEE Contract Validation` green · `Flag Deployment Drift` green |

### CI at `b23deac4` — 13/13 green, polled to conclusion

`Staging Gate` (the required check) · `Full Test Suite` shards 1–4 + Summary · `TypeScript + Lint`
· `Typecheck Gate Self-Test` · `Production Build` · `Security Audit` · `CEE Contract Validation`
· `Flag Deployment Drift` · `Install & Cache`. Zero running, zero failed, `mergeStateStatus:
CLEAN`, head verified with both `gh api` and `git ls-remote`.

**⚠ CI caught TWO real errors my local run did not, and both were mine.** `pnpm run typecheck` exceeded a ten-minute
local window twice and never returned; I pushed rather than report a gate I had not seen finish.
CI's ratchet then failed on TS2352 in my own new spec: it asserted `exercise: 'premortem'`
**behind a cast**, and the producer's enum is `'pre_mortem' | 'devil_advocate' |
'disconfirmation'`. The cast is what let a wrong literal through. Fixed at source with the cast
removed, so the compiler keeps checking the value — **the baseline was NOT regenerated**.

**Second, the `Typecheck Gate Self-Test` failed while the gate itself passed** — a distinction
worth stating, because it is the self-test doing exactly its job. The gate's identity baseline is
keyed on file + TS code + **message**, and adding `'generic'` to the panel lookup changed an
existing TS2339's message, so one diagnostic "appeared" and one "disappeared". Counts still fit,
so the gate exited 0 and printed a notice; the self-test asserts a clean tree adds nothing.

I did not regenerate the baseline. The TS2339 was a **real hole**: an untyped object literal
indexed by the full union, so `'edge'` had no key and any panel type added to the union without
an arm would resolve to `undefined` and render nothing — precisely the L-24 defect this PR
exists to close, waiting to happen again. `NODE_PANELS` is now a `Record` over the union minus
`'edge'` (early-returned) and `null` (guarded), so a missing arm is a compile error. The
diagnostic is gone rather than rebaselined and the file's baseline count drops 2 → 1.

**Baseline confirmed on `staging` first**: `f15bccaf` (this PR's base) passes the self-test, so
the red was established as mine rather than inherited before I touched anything.

---

# Adversarial-review round — four fixes at `9ccc7d39`

All four were invisible to the first round's corpus, **and in the same way**: each original test
was correct about the case it named and blind to the case beside it. That is trap 22 four times
in one PR, and it is the finding worth keeping from this round.

## D1 (P0-class, latent) — the rename intent leaked onto the next node and silently renamed it

The mechanism, end to end:

- `autoEditLabel` was a **boolean that never reset**;
- `EditableLabel`'s effect deps include `onSave`, whose **identity** `useInspectorMutations`
  rebuilds per `[nodeId, updateNode, getNode]` — so the effect re-fired on ordinary re-renders and
  the comment claiming it "only reacts to the transition INTO true" was simply **false**;
- the chain `InspectorRouter → InspectorShell` (`InspectorModal:174`, `ReactFlowGraph:2232-2238`)
  is **unkeyed**, with `showFullInspector` persisting across selections, so node→node re-renders
  **in place**.

`setLabel`'s own `trimmed !== node.data?.label` guard cannot save you: `"Option A" !== "Option B"`,
so the cross-node write sails straight through. Navigate A→B with an armed intent and B's editor
opens holding **A's label**; blur persists it onto B.

**Both halves fixed.** (a) The intent is carried **as an id** at every hop —
`armedForNodeId === nodeId`, a comparison rather than a boolean — so a retarget disarms by
construction, and consumption clears it so returning to A does not reopen the editor under a user
who has moved on. (b) `EditableLabel` tracks the previous `autoEdit` in a **ref** and fires only on
a genuine `false→true` transition, so an `onSave` identity change cannot reopen a closed editor.
Belt and braces: the label is **keyed by node id**, so an open editor and a half-typed draft cannot
cross an element boundary at all.

*I keyed `EditableLabel`, not `InspectorShell`* — the leak is editor-local, and keying the whole
shell would discard unrelated panel state (rationale disclosure, scroll position) on every
selection change.

## D2 — the L-24 fix never fired on the mainline path

The third disjunct of `hasImpactContent` was **run-level**
(`allOptions.length > 1 && some(winPct != null)`). A real run compares two or more options; the
user then adds a third. That predicate is true of **the run**, so the new option scored as having
impact content and rendered the *other* options' bars — foreign data under its own heading — and
never reached `addedSinceRun`. My first fixture used a **one-option** comparison, the single shape
in which the old predicate happened to be false. Now gated on `nodeWasInRun`.

## D3 — the L-40 decision fix was direction-partial

`connectedOptions` filtered `source === nodeId` only, and `otherConnections` drops option-kind, so
an `option → decision` edge — which the canvas's own `isValidConnection` permits a user to draw —
fell through **both** lists and the panel said "No connections yet." while the canvas drew the
edges. Now bidirectional, deduped by option node id so an option joined both ways counts once.

## 4 — no auto-sending control wears an ask's label

A `run_exercise` guidance item kept "Ask about this" while **auto-sending**, inside the very
component this PR unified. Relabelled **"Try it"** — the estate's existing word for that action
class (`GuidanceStrip.tsx:66`, `InspectorGuidanceSection.tsx:37`) — rather than minting a third
vocabulary for the same enum.

## Evidence

**RED-first**: `inspectorCompletion.reviewFixes.spec.tsx` — **19 collected by name, 10 failed at
pristine**. The 6 that passed were the discriminating twins and the pinned preconditions, so the
absence assertions cannot pass vacuously. Twins included: still arms on a retarget *into* the
requested node; still shows the comparison to an option the run *did* cover; still reports a
genuinely unconnected decision honestly; genuine asks keep the ask label.

| Gate | Result |
|---|---|
| `pnpm typecheck` (local, the named gate) | **PASSED** — `1 diagnostic fixed since the identity baseline, none added`; app 1996 + tooling 540, total 2324 vs baseline 2325. Baseline **not** regenerated. |
| `pnpm lint` (local) | **0 errors**, 1203 warnings — unchanged from the pre-change CI run; rules-of-hooks ratchet exactly at baseline (231 across 14 files), so the new `useRef` added no conditional hook |
| Named spec | 19/19, collected count asserted `>= 19` **by name** |
| `inspector-v2` suite | **486/486** across 45 files |
| Consumer surfaces | **143/143** across 13 files |
| CI at `9ccc7d39` | **13/13 green**, zero running, `mergeStateStatus: CLEAN` |

Untouched as instructed: `guidanceStore`, `ConversationPanel` (#736), `ReactFlowGraph` (#738).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
