### PR TITLE
feat(conversation): one render authority, selection chip, readable confirms, single staleness voice

### DIFF
--- a/src/canvas/components/SelectionPill.tsx
+++ b/src/canvas/components/SelectionPill.tsx
@@ -1,23 +1,129 @@
-import { memo } from 'react'
+import { memo, useCallback, useRef } from 'react'
+import { MessageCircleQuestion } from 'lucide-react'
 import { typo } from '../../styles/typography'
+import { CHIP_CLASS } from '../../v5/blocks/chipClass'
+import { useGuidanceStore } from '../stores/guidanceStore'
 import { useSelectionContext } from '../hooks/useSelectionContext'
 
 /**
- * SelectionPill — shows "Selected: [label]" when a single canvas element is
- * selected. Renders above the persistent input strip. Hidden when nothing
- * (or more than one element) is selected.
+ * SelectionPill — the canvas selection's conversation affordance.
+ *
+ * Renders directly above the persistent input strip whenever exactly ONE canvas
+ * element is selected. Hidden when nothing (or more than one element) is
+ * selected.
+ *
+ * ── L-17: WHY THIS IS NO LONGER A LABEL ────────────────────────────────────
+ * Selecting a connector used to produce two pieces of GREY TEXT and no way to
+ * act on either: a `Selected: X → Y` pill with no `onClick`, and a composer
+ * PLACEHOLDER reading "Ask about X → Y…". A placeholder is an attribute, not
+ * content — the composer's value stayed empty, so the sentence the product
+ * appeared to have written could not be sent. Measured again on 16 Aug (UI
+ * `f15bccaf`): "composer VALUE empty ... Grey, non-submittable, exactly as
+ * filed."
+ *
+ * The selection is now a REAL, SUBMITTABLE control:
+ *   · the pill itself dispatches the selection-grounded turn on click;
+ *   · a compact chip beside it dispatches the SAME turn — one code path, so the
+ *     two affordances can never come to mean different things (the trap-21
+ *     shape this estate has already paid for once, with two inspector
+ *     "ask about this" affordances carrying opposite semantics);
+ *   · the composer placeholder returns to NEUTRAL (`useStageAwarePlaceholder`),
+ *     because a placeholder that looks like a prepared sentence is precisely
+ *     what made this ambiguous.
+ * Both controls are ordinary buttons, so click, tap and keyboard all reach the
+ * same handler (R5's every-hover-action-has-a-click-equivalent rule).
+ *
+ * ── WHAT CARRIES THE SELECTION ─────────────────────────────────────────────
+ * Nothing here has to name the element on the wire. `buildPayload`'s
+ * `deriveSelectedElements` reads the live store on EVERY send and attaches
+ * `selected_elements` — so the turn this dispatches is selection-grounded by
+ * the same mechanism a typed question would be. The label is display copy, not
+ * a wire identity, and is never used as one.
+ *
+ * ── FAIL CLOSED ────────────────────────────────────────────────────────────
+ * With no conversation host registered there is nothing to send, so the
+ * controls are not rendered at all and the pill degrades to the read-only label
+ * it used to be. A dead affordance is the defect this component exists to
+ * remove; re-introducing one on the unregistered path would be the same defect
+ * with a nicer border.
  */
+
+/** Guard window for the single-flight ref — long enough to swallow a double-click. */
+const REFIRE_GUARD_MS = 500
+
 export const SelectionPill = memo(function SelectionPill() {
   const selection = useSelectionContext()
+  // Subscribed, not read imperatively: the controls must appear the moment a
+  // conversation host registers, without waiting for an unrelated re-render.
+  const sendChip = useGuidanceStore((s) => s._sendChip)
+  const sentRef = useRef(false)
+
+  const label = selection?.label ?? ''
+  /**
+   * ONE dispatch for both controls.
+   *
+   * Display text and submitted message are the SAME sentence the control shows,
+   * so the user's own bubble in the permanent transcript records exactly what
+   * the button promised. Nothing is invented on the user's behalf: the UI asks
+   * the question its label states, and the element identity travels as
+   * `selected_elements`, not as prose.
+   */
+  const ask = useCallback(() => {
+    if (!sendChip || !label) return
+    if (sentRef.current) return
+    sentRef.current = true
+    sendChip(`Ask about ${label}`, `Ask about ${label}.`)
+    setTimeout(() => {
+      sentRef.current = false
+    }, REFIRE_GUARD_MS)
+  }, [sendChip, label])
+
   if (!selection) return null
+
+  const canAsk = Boolean(sendChip)
 
   return (
     <div
-      className="px-3 py-1 flex items-center gap-1.5"
+      className="px-3 py-1 flex items-center gap-1.5 flex-wrap"
       data-testid="ai-panel-selection-pill"
+      data-selection-kind={selection.kind}
+      data-selection-actionable={canAsk ? 'true' : 'false'}
     >
       <span className={typo('panelMeta', 'text-text-light')}>Selected:</span>
-      <span className={typo('panelMeta', 'text-text-body truncate max-w-[220px]')}>{selection.label}</span>
+      {canAsk ? (
+        <button
+          type="button"
+          onClick={ask}
+          // WRAP, NEVER TRUNCATE: an edge label is "source → target" and is
+          // routinely wider than the dock. `break-words` keeps whole words
+          // intact and lets the row grow; the previous `truncate max-w-[220px]`
+          // cut names mid-word, which is the same artefact the confirm card was
+          // criticised for.
+          className={typo(
+            'panelMeta',
+            'text-text-body text-left break-words underline decoration-dotted underline-offset-2 hover:text-info focus:outline-none focus-visible:ring-2 focus-visible:ring-info rounded-sm',
+          )}
+          aria-label={`Ask about ${label}`}
+          title={`Ask about ${label}`}
+          data-testid="selection-pill-ask"
+        >
+          {label}
+        </button>
+      ) : (
+        <span className={typo('panelMeta', 'text-text-body break-words')}>{label}</span>
+      )}
+      {canAsk && (
+        <button
+          type="button"
+          onClick={ask}
+          className={`${CHIP_CLASS} shrink-0`}
+          aria-label={`Ask about ${label}`}
+          data-testid="selection-ask-chip"
+        >
+          <MessageCircleQuestion size={12} aria-hidden="true" className="mr-1 inline-block" />
+          Ask about this
+        </button>
+      )}
     </div>
   )
 })

--- a/src/canvas/components/SelectionPill.tsx
+++ b/src/canvas/components/SelectionPill.tsx
@@ -56,7 +56,17 @@ export const SelectionPill = memo(function SelectionPill() {
   // Subscribed, not read imperatively: the controls must appear the moment a
   // conversation host registers, without waiting for an unrelated re-render.
   const sendChip = useGuidanceStore((s) => s._sendChip)
-  const sentRef = useRef(false)
+  /**
+   * Single-flight guard, keyed by the SELECTION it fired for — not a bare
+   * boolean.
+   *
+   * A boolean swallowed a legitimate second question: select A, ask, select B,
+   * ask again inside the guard window, and the second click was a silent no-op
+   * with no feedback of any kind. The guard exists to absorb a DOUBLE-CLICK on
+   * one selection; a different selection is a different question and must
+   * always get through.
+   */
+  const sentRef = useRef<{ id: string; at: number } | null>(null)
 
   const label = selection?.label ?? ''
   /**
@@ -68,15 +78,14 @@ export const SelectionPill = memo(function SelectionPill() {
    * the question its label states, and the element identity travels as
    * `selected_elements`, not as prose.
    */
+  const selectionId = selection?.id ?? ''
   const ask = useCallback(() => {
-    if (!sendChip || !label) return
-    if (sentRef.current) return
-    sentRef.current = true
+    if (!sendChip || !label || !selectionId) return
+    const last = sentRef.current
+    if (last && last.id === selectionId && Date.now() - last.at < REFIRE_GUARD_MS) return
+    sentRef.current = { id: selectionId, at: Date.now() }
     sendChip(`Ask about ${label}`, `Ask about ${label}.`)
-    setTimeout(() => {
-      sentRef.current = false
-    }, REFIRE_GUARD_MS)
-  }, [sendChip, label])
+  }, [sendChip, label, selectionId])
 
   if (!selection) return null
 

--- a/src/canvas/components/__tests__/SelectionPill.askAffordance.spec.tsx
+++ b/src/canvas/components/__tests__/SelectionPill.askAffordance.spec.tsx
@@ -99,6 +99,27 @@ describe('with a conversation host registered', () => {
     )
   })
 
+  it('E1 — a DIFFERENT selection always gets through the guard window', () => {
+    // The guard absorbs a double-click on ONE selection. Keyed on a bare
+    // boolean it also swallowed the next question: select A, ask, select B,
+    // ask — a silent no-op with no feedback at all.
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    selectNode()
+    const view = render(<SelectionPill />)
+    fireEvent.click(screen.getByTestId('selection-ask-chip'))
+    expect(sendChip).toHaveBeenCalledTimes(1)
+
+    // Immediately — well inside the guard window — select something else.
+    selectEdge()
+    view.rerender(<SelectionPill />)
+    fireEvent.click(screen.getByTestId('selection-ask-chip'))
+    expect(sendChip).toHaveBeenCalledTimes(2)
+    expect(sendChip.mock.calls[1][0]).toBe(
+      'Ask about Raw developer headcount → Team productivity',
+    )
+  })
+
   it('is single-flight — a double click sends once', () => {
     const sendChip = vi.fn()
     useGuidanceStore.setState({ _sendChip: sendChip } as never)

--- a/src/canvas/components/__tests__/SelectionPill.askAffordance.spec.tsx
+++ b/src/canvas/components/__tests__/SelectionPill.askAffordance.spec.tsx
@@ -1,0 +1,147 @@
+/**
+ * L-17 — the selection is a REAL, SUBMITTABLE affordance.
+ *
+ * What was filed, and reproduced again on 16 Aug at UI `f15bccaf`: selecting a
+ * connector produced grey text in two places and no way to act on either — a
+ * `Selected: X → Y` pill with no handler, and a composer PLACEHOLDER reading
+ * "Ask about X → Y…" with the composer's VALUE empty.
+ *
+ * These tests bind the two controls to the SAME dispatch, by identity, and
+ * carry the opposite-direction twin for the fail-closed path: with no
+ * conversation host registered nothing clickable may render, because a dead
+ * affordance is the defect being removed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SelectionPill } from '../SelectionPill'
+import { useCanvasStore } from '../../store'
+import { useGuidanceStore } from '../../stores/guidanceStore'
+
+const NODE = {
+  id: 'fac_dev_headcount',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  data: { label: 'Raw developer headcount' },
+}
+const TARGET = {
+  id: 'out_productivity',
+  type: 'outcome',
+  position: { x: 0, y: 0 },
+  data: { label: 'Team productivity' },
+}
+const EDGE = { id: 'e5', source: NODE.id, target: TARGET.id }
+
+function selectNode() {
+  useCanvasStore.setState({
+    nodes: [NODE, TARGET] as never,
+    edges: [EDGE] as never,
+    selection: { nodeIds: new Set([NODE.id]), edgeIds: new Set<string>() } as never,
+  })
+}
+
+function selectEdge() {
+  useCanvasStore.setState({
+    nodes: [NODE, TARGET] as never,
+    edges: [EDGE] as never,
+    selection: { nodeIds: new Set<string>(), edgeIds: new Set([EDGE.id]) } as never,
+  })
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ selection: null } as never)
+  useGuidanceStore.setState({ _sendChip: null } as never)
+})
+
+describe('with a conversation host registered', () => {
+  it('the ASK CHIP dispatches a selection-grounded turn', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    selectNode()
+
+    render(<SelectionPill />)
+    fireEvent.click(screen.getByTestId('selection-ask-chip'))
+
+    expect(sendChip).toHaveBeenCalledTimes(1)
+    // Display text and submitted message both say what the control says: the
+    // user's own bubble records exactly what the button promised.
+    expect(sendChip.mock.calls[0][0]).toBe('Ask about Raw developer headcount')
+    expect(sendChip.mock.calls[0][1]).toBe('Ask about Raw developer headcount.')
+  })
+
+  it('the PILL ITSELF dispatches the SAME turn — one code path, never two semantics', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    selectEdge()
+
+    render(<SelectionPill />)
+    fireEvent.click(screen.getByTestId('selection-pill-ask'))
+    const fromPill = sendChip.mock.calls[0]
+
+    // Re-render so the single-flight guard does not swallow the second click,
+    // then take the chip's dispatch and compare.
+    sendChip.mockClear()
+    render(<SelectionPill />)
+    fireEvent.click(screen.getAllByTestId('selection-ask-chip')[1])
+    const fromChip = sendChip.mock.calls[0]
+
+    expect(fromChip).toEqual(fromPill)
+  })
+
+  it('names an EDGE by its endpoints, exactly as the selection context resolves them', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    selectEdge()
+
+    render(<SelectionPill />)
+    fireEvent.click(screen.getByTestId('selection-ask-chip'))
+    expect(sendChip.mock.calls[0][0]).toBe(
+      'Ask about Raw developer headcount → Team productivity',
+    )
+  })
+
+  it('is single-flight — a double click sends once', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    selectNode()
+
+    render(<SelectionPill />)
+    const chip = screen.getByTestId('selection-ask-chip')
+    fireEvent.click(chip)
+    fireEvent.click(chip)
+    expect(sendChip).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('fail-closed and empty states', () => {
+  it('renders NOTHING when nothing is selected', () => {
+    useGuidanceStore.setState({ _sendChip: vi.fn() } as never)
+    render(<SelectionPill />)
+    expect(screen.queryByTestId('ai-panel-selection-pill')).toBeNull()
+  })
+
+  it('renders NO clickable control when no conversation host is registered', () => {
+    selectNode()
+    render(<SelectionPill />)
+    // The label still shows — the user should still see what is selected — but
+    // there is no button to press that could not deliver.
+    expect(screen.getByTestId('ai-panel-selection-pill').textContent).toContain(
+      'Raw developer headcount',
+    )
+    expect(screen.queryByTestId('selection-ask-chip')).toBeNull()
+    expect(screen.queryByTestId('selection-pill-ask')).toBeNull()
+    expect(
+      screen.getByTestId('ai-panel-selection-pill').getAttribute('data-selection-actionable'),
+    ).toBe('false')
+  })
+
+  it('renders nothing when MORE than one element is selected (ambiguous target)', () => {
+    useGuidanceStore.setState({ _sendChip: vi.fn() } as never)
+    useCanvasStore.setState({
+      nodes: [NODE, TARGET] as never,
+      edges: [EDGE] as never,
+      selection: { nodeIds: new Set([NODE.id, TARGET.id]), edgeIds: new Set<string>() } as never,
+    })
+    render(<SelectionPill />)
+    expect(screen.queryByTestId('ai-panel-selection-pill')).toBeNull()
+  })
+})

--- a/src/canvas/conversation/AnswerBody.tsx
+++ b/src/canvas/conversation/AnswerBody.tsx
@@ -57,6 +57,54 @@ interface AnswerBodyProps {
   alreadyRendered?: readonly string[]
 }
 
+/** What `AnswerBody` will actually put on screen for a given shape + priors. */
+export interface AnswerBodyRenderedText {
+  /** The headline, or '' when a higher tier already stated it. */
+  headline: string
+  /** The bullets that survive the ≤3 cap and suppression, in producer order. */
+  bullets: string[]
+  /** The detail — real, but behind the Show-more toggle (see resolveAnswerBodyText). */
+  detail: string
+}
+
+/**
+ * THE resolver for what this component renders. Pure, exported, and called by
+ * BOTH the component and `MessageBubble` — which needs the answer to tell the
+ * turn's blocks what has already been shown above them.
+ *
+ * ⚠ It exists because of an adversarial-review finding. In structured mode the
+ * bubble was handing the block collector `message.content` — the free-text body
+ * that AnswerBody REPLACES and which is therefore never rendered at all. A
+ * commentary block restating, say, the producer's fourth bullet (dropped by the
+ * ≤3 cap) was being suppressed against text nobody could see. Whatever is fed to
+ * the collector must be what this component actually shows, and the only way to
+ * keep that true is for one function to decide it.
+ *
+ * Tier order within the answer: `alreadyRendered` (tier 0, the turn's consent
+ * cards) → headline → bullets → detail. Each suppresses against the tiers above
+ * it, never below, so the headline is never withheld by a bullet.
+ */
+export function resolveAnswerBodyText(
+  answer: AnswerShape,
+  alreadyRendered: readonly string[] = EMPTY_PRIORS,
+): AnswerBodyRenderedText {
+  const headline = dedupeRenderedText(answer.headline, alreadyRendered).text
+  // UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
+  // display boundary BEFORE de-duplicating, so the cap is still applied to the
+  // producer's own prefix and never to a set the UI reshaped first.
+  const capped = answer.bullets.slice(0, MAX_BULLETS)
+  const seenSoFar = [...alreadyRendered, headline]
+  const bullets: string[] = []
+  for (const bullet of capped) {
+    const survived = dedupeRenderedText(bullet, seenSoFar).text
+    if (survived.trim().length === 0) continue
+    bullets.push(survived)
+    seenSoFar.push(survived)
+  }
+  const detail = dedupeRenderedText(answer.detail ?? '', [...seenSoFar]).text
+  return { headline, bullets, detail }
+}
+
 export const AnswerBody = memo(function AnswerBody({
   answer,
   compact = false,
@@ -64,42 +112,10 @@ export const AnswerBody = memo(function AnswerBody({
 }: AnswerBodyProps) {
   const [expanded, setExpanded] = useState(false)
 
-  /**
-   * ONE RENDER AUTHORITY, applied in tier order within this component:
-   *   tier 0 = `alreadyRendered` (the turn's consent/answer cards)
-   *   tier 1 = headline · tier 3 = bullets · tier 4 = detail
-   * Each tier suppresses against every tier above it, never below. The headline
-   * is the top tier HERE, so it is never withheld by a bullet or by detail —
-   * only by a card that already said the same thing.
-   *
-   * This is what closes L-16 on the answer path: CEE derives `assistant_text`
-   * from this same shape, so a card echoing the plan and a prose body echoing
-   * the plan are the same bytes arriving twice.
-   */
   const priors = alreadyRendered ?? EMPTY_PRIORS
-  const headline = useMemo(
-    () => dedupeRenderedText(answer.headline, priors).text,
-    [answer.headline, priors],
-  )
-  const bullets = useMemo(() => {
-    // UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
-    // display boundary (see MAX_BULLETS above) BEFORE de-duplicating, so the cap
-    // is still applied to the producer's own prefix and never to a set the UI
-    // reshaped first.
-    const capped = answer.bullets.slice(0, MAX_BULLETS)
-    const seenSoFar = [...priors, headline]
-    const kept: string[] = []
-    for (const bullet of capped) {
-      const survived = dedupeRenderedText(bullet, seenSoFar).text
-      if (survived.trim().length === 0) continue
-      kept.push(survived)
-      seenSoFar.push(survived)
-    }
-    return kept
-  }, [answer.bullets, priors, headline])
-  const detail = useMemo(
-    () => dedupeRenderedText(answer.detail ?? '', [...priors, headline, ...bullets]).text,
-    [answer.detail, priors, headline, bullets],
+  const { headline, bullets, detail } = useMemo(
+    () => resolveAnswerBodyText(answer, priors),
+    [answer, priors],
   )
 
   // Memoise the XSS-safe sanitiser output: `answer` is a stable prop and this

--- a/src/canvas/conversation/AnswerBody.tsx
+++ b/src/canvas/conversation/AnswerBody.tsx
@@ -22,6 +22,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
 import styles from './Conversation.module.css'
+import { dedupeRenderedText } from './messageComposition'
 import type { AnswerShape } from './answerShape'
 
 /**
@@ -33,6 +34,12 @@ import type { AnswerShape } from './answerShape'
  */
 const MAX_BULLETS = 3
 
+/**
+ * Stable empty default for `alreadyRendered`. A fresh `[]` per render would
+ * change the memo dependency identity on every render and defeat the memos.
+ */
+const EMPTY_PRIORS: readonly string[] = Object.freeze([])
+
 interface AnswerBodyProps {
   answer: AnswerShape
   /**
@@ -40,29 +47,80 @@ interface AnswerBodyProps {
    * instead of chatProse (14px), matching MessageBubble's `compact` prop.
    */
   compact?: boolean
+  /**
+   * ONE RENDER AUTHORITY (L-16). Text a HIGHER-authority surface has already
+   * rendered for this turn — today, the pinned consent/answer cards (tier 0).
+   * Segments of the headline, bullets or detail that repeat one of these
+   * verbatim are withheld here rather than rendered a second time. Absent /
+   * empty ⇒ byte-identical to the previous behaviour.
+   */
+  alreadyRendered?: readonly string[]
 }
 
-export const AnswerBody = memo(function AnswerBody({ answer, compact = false }: AnswerBodyProps) {
+export const AnswerBody = memo(function AnswerBody({
+  answer,
+  compact = false,
+  alreadyRendered,
+}: AnswerBodyProps) {
   const [expanded, setExpanded] = useState(false)
+
+  /**
+   * ONE RENDER AUTHORITY, applied in tier order within this component:
+   *   tier 0 = `alreadyRendered` (the turn's consent/answer cards)
+   *   tier 1 = headline · tier 3 = bullets · tier 4 = detail
+   * Each tier suppresses against every tier above it, never below. The headline
+   * is the top tier HERE, so it is never withheld by a bullet or by detail —
+   * only by a card that already said the same thing.
+   *
+   * This is what closes L-16 on the answer path: CEE derives `assistant_text`
+   * from this same shape, so a card echoing the plan and a prose body echoing
+   * the plan are the same bytes arriving twice.
+   */
+  const priors = alreadyRendered ?? EMPTY_PRIORS
+  const headline = useMemo(
+    () => dedupeRenderedText(answer.headline, priors).text,
+    [answer.headline, priors],
+  )
+  const bullets = useMemo(() => {
+    // UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
+    // display boundary (see MAX_BULLETS above) BEFORE de-duplicating, so the cap
+    // is still applied to the producer's own prefix and never to a set the UI
+    // reshaped first.
+    const capped = answer.bullets.slice(0, MAX_BULLETS)
+    const seenSoFar = [...priors, headline]
+    const kept: string[] = []
+    for (const bullet of capped) {
+      const survived = dedupeRenderedText(bullet, seenSoFar).text
+      if (survived.trim().length === 0) continue
+      kept.push(survived)
+      seenSoFar.push(survived)
+    }
+    return kept
+  }, [answer.bullets, priors, headline])
+  const detail = useMemo(
+    () => dedupeRenderedText(answer.detail ?? '', [...priors, headline, ...bullets]).text,
+    [answer.detail, priors, headline, bullets],
+  )
+
   // Memoise the XSS-safe sanitiser output: `answer` is a stable prop and this
   // component is memo'd, so `expanded` is the only re-render trigger. Without
   // these memos every Show more/less toggle would re-sanitise the unchanged
   // headline, bullets and detail. Pure perf — identical output.
-  const headlineHtml = useMemo(() => safeRichText(answer.headline), [answer.headline])
-  // UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
-  // display boundary (see MAX_BULLETS above) before sanitising each.
-  const bulletHtml = useMemo(() => answer.bullets.slice(0, MAX_BULLETS).map(safeRichText), [answer.bullets])
-  const detailHtml = useMemo(() => (answer.detail ? safeRichText(answer.detail) : ''), [answer.detail])
+  const headlineHtml = useMemo(() => safeRichText(headline), [headline])
+  const bulletHtml = useMemo(() => bullets.map(safeRichText), [bullets])
+  const detailHtml = useMemo(() => (detail ? safeRichText(detail) : ''), [detail])
   const bodyType = compact ? typography.panelBody : typography.chatProse
 
   return (
     <div data-testid="answer-body">
-      <p
-        className={`${typography.panelHeader} ${styles.answerHeadline}`}
-        data-testid="answer-headline"
-        // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li, span)
-        dangerouslySetInnerHTML={{ __html: headlineHtml }}
-      />
+      {headline.trim().length > 0 && (
+        <p
+          className={`${typography.panelHeader} ${styles.answerHeadline}`}
+          data-testid="answer-headline"
+          // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li, span)
+          dangerouslySetInnerHTML={{ __html: headlineHtml }}
+        />
+      )}
       {bulletHtml.length > 0 && (
         <ul className={`${bodyType} ${styles.answerBullets}`} data-testid="answer-bullets">
           {bulletHtml.map((html, i) => (
@@ -74,7 +132,7 @@ export const AnswerBody = memo(function AnswerBody({ answer, compact = false }: 
           ))}
         </ul>
       )}
-      {answer.detail && (
+      {detail && (
         <>
           <button
             type="button"

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -11,7 +11,7 @@
 import { useRef, useState, useEffect, useCallback, useMemo, memo } from 'react'
 import { useCanvasStore, selectResultsStatus } from '../store'
 import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
-import { useGuidanceStore } from '../stores/guidanceStore'
+import { useGuidanceStore, type SendChipMeta } from '../stores/guidanceStore'
 import type { ActionChip, GraphPatchBlock } from './types'
 import {
   RETRY_CHIP_ID,
@@ -554,8 +554,23 @@ export const ConversationPanel = memo(function ConversationPanel({
   }, [messages.length, runGateResult.allowed, isAnalysisRunning, dispatchAction])
 
   useEffect(() => {
-    const sendChipByLabelMessage = (label: string, message: string) =>
-      sendChip({ id: `evidence-apply-${Date.now()}`, label, message, intent: 'primary' })
+    // L-59: forward the producer's own typed intent when the caller has one.
+    // `sendChip` → `dispatchAction` is the path that turns an `action_type` into
+    // a chosen turn type; without it the click falls through to the
+    // 'conversation' default and the reply denies that anything was asked for.
+    const sendChipByLabelMessage = (
+      label: string,
+      message: string,
+      meta?: SendChipMeta,
+    ) =>
+      sendChip({
+        id: meta?.id ?? `evidence-apply-${Date.now()}`,
+        label,
+        message,
+        intent: 'primary',
+        ...(meta?.action_type ? { action_type: meta.action_type } : {}),
+        ...(meta?.parameters ? { parameters: meta.parameters } : {}),
+      })
     // Prefill the visible composer (see prefillInto): the legacy ChatComposer
     // ref when mounted, else the ConversationContext draft AIInputBar renders
     // under `hideComposer`. Writing to the null ref was the silent no-op behind

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -162,6 +162,8 @@ interface InlineBlocksProps {
    * behaviour for every caller that does not opt in.
    */
   alreadyRendered?: readonly string[]
+  /** L-42: only the newest assistant turn's applied-edit card may claim the staleness voice. */
+  isLatestAssistantTurn?: boolean
 }
 
 export const InlineBlocks = memo(function InlineBlocks({
@@ -175,6 +177,7 @@ export const InlineBlocks = memo(function InlineBlocks({
   onProposalConfirm,
   assistantTextWordCount = 0,
   alreadyRendered,
+  isLatestAssistantTurn = false,
 }: InlineBlocksProps) {
   /** One disclosure, one piece of state — replaces the two independent toggles. */
   const [detailExpanded, setDetailExpanded] = useState(false)
@@ -302,6 +305,7 @@ export const InlineBlocks = memo(function InlineBlocks({
           onProposalConfirm={onProposalConfirm}
           assistantTextWordCount={assistantTextWordCount}
           commentaryTextOverride={commentaryTextOverrides.get(index)}
+          isLatestAssistantTurn={isLatestAssistantTurn}
           onRevealHiddenBlocks={hasCollapsedContent ? revealHiddenBlocks : undefined}
           blockContainerRef={blockContainerRef}
         />
@@ -381,6 +385,8 @@ interface BlockRendererProps {
    * when something was withheld, so the ordinary path is untouched.
    */
   commentaryTextOverride?: string
+  /** L-42: only the newest assistant turn's applied-edit card may claim the staleness voice. */
+  isLatestAssistantTurn?: boolean
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
   onRevealHiddenBlocks?: () => void
   /** Scope for citation-target lookups — the emitting turn's own block container. */
@@ -398,6 +404,7 @@ function BlockRenderer({
   onProposalConfirm,
   assistantTextWordCount = 0,
   commentaryTextOverride,
+  isLatestAssistantTurn = false,
   onRevealHiddenBlocks,
   blockContainerRef,
 }: BlockRendererProps) {
@@ -489,7 +496,9 @@ function BlockRenderer({
       return <V5AnalysisResultBlock block={block} />
 
     case 'v5_graph_patch':
-      return <V5GraphPatchBlock block={block} />
+      return (
+        <V5GraphPatchBlock block={block} isLatestAssistantTurn={isLatestAssistantTurn} />
+      )
 
     case 'v5_explanation':
       return <V5ExplanationBlock block={block} />

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -67,7 +67,7 @@ import { ArtefactBlock as ArtefactBlockComponent } from '../../components/chat/A
 import type { PatchBlockState, PatchRejectionInfo } from './useConversation'
 import { GraphPatchBlockRenderer, ProposalBlockRenderer } from './blocks/GraphPatchBlockRenderer'
 import { isPhase3CardBlock, isBiasSignalCoachingBlock } from './phase3Pacing'
-import { composeMessage } from './messageComposition'
+import { composeMessage, dedupeRenderedText } from './messageComposition'
 import { GraphVocabularyLegend } from './GraphVocabularyLegend'
 import { V5AnalysisResultBlock } from '../../v5/blocks/V5AnalysisResultBlock'
 import { V5GraphPatchBlock } from '../../v5/blocks/V5GraphPatchBlock'
@@ -151,6 +151,17 @@ interface InlineBlocksProps {
   onProposalConfirm?: (proposalId: string) => void
   /** Word count of the turn's assistant_text — used by commentary collapse default logic */
   assistantTextWordCount?: number
+  /**
+   * ONE RENDER AUTHORITY (L-16, item 7). Text the turn has ALREADY rendered
+   * above these blocks — the consent-card surfaces (tier 0) and the prose body
+   * (tier 2). A `commentary` block whose paragraphs repeat one of those, or
+   * repeat an earlier commentary block in this same turn, renders the surviving
+   * remainder instead of the same sentences a second time.
+   *
+   * Absent ⇒ nothing is withheld anywhere, i.e. byte-identical to the previous
+   * behaviour for every caller that does not opt in.
+   */
+  alreadyRendered?: readonly string[]
 }
 
 export const InlineBlocks = memo(function InlineBlocks({
@@ -163,6 +174,7 @@ export const InlineBlocks = memo(function InlineBlocks({
   onArtefactMessage,
   onProposalConfirm,
   assistantTextWordCount = 0,
+  alreadyRendered,
 }: InlineBlocksProps) {
   /** One disclosure, one piece of state — replaces the two independent toggles. */
   const [detailExpanded, setDetailExpanded] = useState(false)
@@ -185,6 +197,46 @@ export const InlineBlocks = memo(function InlineBlocks({
 
   // DS v5 §21.2: block type badge dots are always on (no v2 flag gate).
   const showBadgeDots = true
+
+  /**
+   * ONE RENDER AUTHORITY, applied to the prose-bearing block family.
+   *
+   * Walks the entries in RENDER order (top level in producer order, then the
+   * disclosure) and gives each `commentary` block the remainder of its own text
+   * after removing whole segments an earlier surface already rendered. Only
+   * `commentary` participates: it is the one block type that carries free prose
+   * the producer also emits through `assistant_text`, and a typed card's copy is
+   * structural — withholding a line of it would change what the card means.
+   *
+   * Computed over the FULL entry list rather than per-render-position, so a
+   * block's text does not change when the disclosure opens: opening it must
+   * reveal what was demoted, never re-write it (invariant 1's byte-preserving
+   * demotion guarantee).
+   */
+  const commentaryTextOverrides = useMemo(() => {
+    const order = [
+      ...[...composition.pinned, ...composition.points].sort((a, b) => a.index - b.index),
+      ...composition.detail,
+    ]
+    const seen: string[] = [...(alreadyRendered ?? [])]
+    const overrides = new Map<number, string>()
+    for (const entry of order) {
+      const block = blocks[entry.index]
+      if (block.type !== 'commentary') continue
+      const text = (block as CommentaryBlockType).text ?? ''
+      const { text: survived, suppressedCount } = dedupeRenderedText(text, seen)
+      // Suppression may remove PART of a block, never the whole of it. A
+      // commentary whose every paragraph was already rendered above keeps its
+      // original text: an empty card with a live "More" toggle is a worse
+      // artefact than the duplicate, and silently deleting a block would breach
+      // the composition's own no-drop guarantee (invariant 1) from the text
+      // side. The suppression is a de-duplicator, not a censor.
+      const useOverride = suppressedCount > 0 && survived.trim().length > 0
+      if (useOverride) overrides.set(entry.index, survived)
+      seen.push(useOverride ? survived : text)
+    }
+    return overrides
+  }, [composition, blocks, alreadyRendered])
 
   /**
    * THE visibility rule — one predicate, every consumer. A block is hidden iff
@@ -249,6 +301,7 @@ export const InlineBlocks = memo(function InlineBlocks({
           onArtefactMessage={onArtefactMessage}
           onProposalConfirm={onProposalConfirm}
           assistantTextWordCount={assistantTextWordCount}
+          commentaryTextOverride={commentaryTextOverrides.get(index)}
           onRevealHiddenBlocks={hasCollapsedContent ? revealHiddenBlocks : undefined}
           blockContainerRef={blockContainerRef}
         />
@@ -322,6 +375,12 @@ interface BlockRendererProps {
   onArtefactMessage?: (message: string) => void
   onProposalConfirm?: (proposalId: string) => void
   assistantTextWordCount?: number
+  /**
+   * ONE RENDER AUTHORITY: the surviving text for a `commentary` block whose
+   * paragraphs repeated a surface rendered earlier in this turn. Present ONLY
+   * when something was withheld, so the ordinary path is untouched.
+   */
+  commentaryTextOverride?: string
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
   onRevealHiddenBlocks?: () => void
   /** Scope for citation-target lookups — the emitting turn's own block container. */
@@ -338,6 +397,7 @@ function BlockRenderer({
   onArtefactMessage,
   onProposalConfirm,
   assistantTextWordCount = 0,
+  commentaryTextOverride,
   onRevealHiddenBlocks,
   blockContainerRef,
 }: BlockRendererProps) {
@@ -347,6 +407,7 @@ function BlockRenderer({
         <CommentaryBlockRenderer
           block={block}
           assistantTextWordCount={assistantTextWordCount}
+          textOverride={commentaryTextOverride}
           onRevealHiddenBlocks={onRevealHiddenBlocks}
           blockContainerRef={blockContainerRef}
         />
@@ -513,12 +574,18 @@ function scrollToCitationTarget(target: Element): void {
 const CommentaryBlockRenderer = memo(function CommentaryBlockRenderer({
   block,
   assistantTextWordCount = 0,
+  textOverride,
   onRevealHiddenBlocks,
   blockContainerRef,
 }: {
   block: CommentaryBlockType
   /** Word count of the assistant_text in the same turn — used for default expand logic */
   assistantTextWordCount?: number
+  /**
+   * ONE RENDER AUTHORITY: surviving text after whole segments already rendered
+   * earlier in this turn were withheld. Undefined ⇒ render `block.text` as-is.
+   */
+  textOverride?: string
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
   onRevealHiddenBlocks?: () => void
   /** Scope for citation-target lookups — the emitting turn's own block container. */
@@ -570,9 +637,10 @@ const CommentaryBlockRenderer = memo(function CommentaryBlockRenderer({
 
   // title is already a plain string; fallback uses plainTextPreview to decode entities
   // and strip markdown markers so the toggle reads naturally (e.g. "Lead phrase" not "**Lead phrase**")
-  const previewLabel = block.title ?? plainTextPreview(block.text)
+  const bodyText = textOverride ?? block.text
+  const previewLabel = block.title ?? plainTextPreview(bodyText)
 
-  const contentHtml = safeRichText(block.text)
+  const contentHtml = safeRichText(bodyText)
 
   const hasSections = block.sections && block.sections.length > 0
 

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -166,6 +166,54 @@ export const MessageBubble = memo(function MessageBubble({
   onRetryFailedSend,
 }: MessageBubbleProps) {
   const isUser = message.role === 'user'
+  const isStreaming = message.isStreaming === true
+
+  // ── HOOKS FIRST ────────────────────────────────────────────────────────────
+  // These three memos are declared BEFORE every early return in this component.
+  //
+  // That placement is load-bearing, not style: this file already carries three
+  // rules-of-hooks exceptions (hooks declared BELOW the sentinel /
+  // non-conversational / chip-initiated early returns), and the repo's ratchet
+  // says of them — correctly — "this file had an exception for its EXISTING
+  // violations, not a licence to add more. Each one is a render-time crash."
+  // A message that flips across one of those early returns between renders
+  // would change its hook count. So the render-authority memos sit above all of
+  // them. The pre-existing three are REPORTED, not fixed here: hoisting them is
+  // a separate, mechanical change and this lane's scope rule forbids
+  // "while we're here" work.
+  const rawDisplayContent = (isUser || isStreaming || message.stoppedByUser)
+    ? message.content
+    : extractFromRawJson(message.content)
+
+  /**
+   * ONE RENDER AUTHORITY (L-16 / NEW-9) — tier 0 for this turn.
+   *
+   * The consent / answer cards this turn will render below the prose. The prose
+   * body then withholds any whole segment one of them already states, so the
+   * plan behind a [Confirm these changes] control is read ONCE, on the control.
+   *
+   * Never applied to a user bubble (the user's own words are never withheld)
+   * and never while streaming (the card has not arrived, so "already rendered"
+   * is not yet a true statement about anything).
+   */
+  const consentSurfaceText = useMemo(
+    () => (isUser || isStreaming ? [] : collectConsentSurfaceText(message.blocks)),
+    [isUser, isStreaming, message.blocks],
+  )
+  const dedupedBody = useMemo(
+    () => dedupeRenderedText(rawDisplayContent, consentSurfaceText),
+    [rawDisplayContent, consentSurfaceText],
+  )
+  const displayContent = dedupedBody.text
+  /**
+   * Tier 0 + tier 2, as one stable array. Memoised because `InlineBlocks` is
+   * `memo`'d and a fresh literal on every render would defeat it — the same
+   * reason `AnswerBody` keeps a frozen empty default.
+   */
+  const renderedAboveBlocks = useMemo(
+    () => [...consentSurfaceText, displayContent],
+    [consentSurfaceText, displayContent],
+  )
   // Transcript honesty (trust item #3): a user send whose turn failed must
   // LOOK failed — marker + optional retry affordance on the message itself.
   const sendFailed = isUser && message.deliveryState === 'failed'
@@ -228,7 +276,6 @@ export const MessageBubble = memo(function MessageBubble({
     )
   }
 
-  const isStreaming = message.isStreaming === true
   const isProvisional = message.isProvisional === true
   const hasToolLoading = Boolean(message.toolLoadingState)
 
@@ -239,39 +286,6 @@ export const MessageBubble = memo(function MessageBubble({
   // reject, causing extractFromRawJson to return its "didn't render correctly"
   // placeholder — confusing alongside the "Response stopped." indicator. The
   // user chose to stop mid-stream; show whatever partial they had.
-  const rawDisplayContent = (isUser || isStreaming || message.stoppedByUser)
-    ? message.content
-    : extractFromRawJson(message.content)
-
-  /**
-   * ONE RENDER AUTHORITY (L-16 / NEW-9) — tier 0 for this turn.
-   *
-   * The consent / answer cards this turn will render below the prose. The prose
-   * body then withholds any whole segment one of them already states, so the
-   * plan behind a [Confirm these changes] control is read ONCE, on the control.
-   *
-   * Never applied to a user bubble (the user's own words are never withheld)
-   * and never while streaming (the card has not arrived, so "already rendered"
-   * is not yet a true statement about anything).
-   */
-  const consentSurfaceText = useMemo(
-    () => (isUser || isStreaming ? [] : collectConsentSurfaceText(message.blocks)),
-    [isUser, isStreaming, message.blocks],
-  )
-  const dedupedBody = useMemo(
-    () => dedupeRenderedText(rawDisplayContent, consentSurfaceText),
-    [rawDisplayContent, consentSurfaceText],
-  )
-  const displayContent = dedupedBody.text
-  /**
-   * Tier 0 + tier 2, as one stable array. Memoised because `InlineBlocks` is
-   * `memo`'d and a fresh literal on every render would defeat it — the same
-   * reason `AnswerBody` keeps a frozen empty default.
-   */
-  const renderedAboveBlocks = useMemo(
-    () => [...consentSurfaceText, displayContent],
-    [consentSurfaceText, displayContent],
-  )
 
   // F1 (answer-shape progressive disclosure): when a well-formed answer-shape
   // sidecar is present on a settled assistant turn, the structured view

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -29,6 +29,7 @@ import { useCanvasStore } from '../store'
 import { isSelfContradictoryStale } from '../store/analysisFreshness'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { FALLBACK_TEXT } from './validateResponse'
+import { collectConsentSurfaceText, dedupeRenderedText } from './messageComposition'
 import { SYSTEM_MESSAGE_SENTINEL, isNonConversationalContent } from './useConversation'
 import type { ConversationMessage, ActionChip, GraphPatchBlock, Insight } from './types'
 import type { PatchBlockState, PatchRejectionInfo } from './useConversation'
@@ -238,9 +239,39 @@ export const MessageBubble = memo(function MessageBubble({
   // reject, causing extractFromRawJson to return its "didn't render correctly"
   // placeholder — confusing alongside the "Response stopped." indicator. The
   // user chose to stop mid-stream; show whatever partial they had.
-  const displayContent = (isUser || isStreaming || message.stoppedByUser)
+  const rawDisplayContent = (isUser || isStreaming || message.stoppedByUser)
     ? message.content
     : extractFromRawJson(message.content)
+
+  /**
+   * ONE RENDER AUTHORITY (L-16 / NEW-9) — tier 0 for this turn.
+   *
+   * The consent / answer cards this turn will render below the prose. The prose
+   * body then withholds any whole segment one of them already states, so the
+   * plan behind a [Confirm these changes] control is read ONCE, on the control.
+   *
+   * Never applied to a user bubble (the user's own words are never withheld)
+   * and never while streaming (the card has not arrived, so "already rendered"
+   * is not yet a true statement about anything).
+   */
+  const consentSurfaceText = useMemo(
+    () => (isUser || isStreaming ? [] : collectConsentSurfaceText(message.blocks)),
+    [isUser, isStreaming, message.blocks],
+  )
+  const dedupedBody = useMemo(
+    () => dedupeRenderedText(rawDisplayContent, consentSurfaceText),
+    [rawDisplayContent, consentSurfaceText],
+  )
+  const displayContent = dedupedBody.text
+  /**
+   * Tier 0 + tier 2, as one stable array. Memoised because `InlineBlocks` is
+   * `memo`'d and a fresh literal on every render would defeat it — the same
+   * reason `AnswerBody` keeps a frozen empty default.
+   */
+  const renderedAboveBlocks = useMemo(
+    () => [...consentSurfaceText, displayContent],
+    [consentSurfaceText, displayContent],
+  )
 
   // F1 (answer-shape progressive disclosure): when a well-formed answer-shape
   // sidecar is present on a settled assistant turn, the structured view
@@ -333,19 +364,31 @@ export const MessageBubble = memo(function MessageBubble({
           className={bodyClassName}
           data-testid="message-answer-structured"
         >
-          <AnswerBody answer={message.answerShape} compact={compact} />
+          <AnswerBody
+            answer={message.answerShape}
+            compact={compact}
+            alreadyRendered={consentSurfaceText}
+          />
         </div>
       ) : (
-        <div
-          className={bodyClassName}
-          data-streaming={isStreaming || undefined}
-          // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li; br.md-gap for rule degradation)
-          dangerouslySetInnerHTML={{
-            __html: safeRichText(
-              truncatedContent && !expanded ? truncatedContent : displayContent,
-            ) + (isStreaming ? '<span class="streaming-cursor" aria-hidden="true">|</span>' : ''),
-          }}
-        />
+        // The body element is omitted entirely when every one of its segments
+        // was already stated by a consent card above (NEW-9). An empty
+        // <div> would still render the prose's margins and read as a gap the
+        // user cannot account for.
+        (displayContent.trim().length > 0 || isStreaming) && (
+          <div
+            className={bodyClassName}
+            data-streaming={isStreaming || undefined}
+            data-body-segments-withheld={dedupedBody.suppressedCount || undefined}
+            data-testid="message-body-text"
+            // eslint-disable-next-line security/no-unsafe-innerhtml -- sanitised by safeRichText (allowlist: strong, br, ul, li; br.md-gap for rule degradation)
+            dangerouslySetInnerHTML={{
+              __html: safeRichText(
+                truncatedContent && !expanded ? truncatedContent : displayContent,
+              ) + (isStreaming ? '<span class="streaming-cursor" aria-hidden="true">|</span>' : ''),
+            }}
+          />
+        )
       )}
       {hasToolLoading && (
         <div className={styles.toolLoadingState} data-testid="tool-loading-state">
@@ -421,6 +464,11 @@ export const MessageBubble = memo(function MessageBubble({
           onArtefactMessage={onArtefactMessage}
           onProposalConfirm={onProposalConfirm}
           assistantTextWordCount={displayContent.trim().split(/\s+/).filter(Boolean).length}
+          // ONE RENDER AUTHORITY: tier 0 (consent cards) then tier 2 (the prose
+          // body as it was ACTUALLY rendered, post-suppression) — so a
+          // commentary block inside the disclosure does not repeat a paragraph
+          // the user has already read further up the same message (item 7).
+          alreadyRendered={renderedAboveBlocks}
         />
       )}
       {/* Explain more + Summarise are AI Panel v2 affordances only — MessageBubble

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -19,7 +19,7 @@
 import { memo, useState, useMemo, useRef } from 'react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
-import { AnswerBody } from './AnswerBody'
+import { AnswerBody, resolveAnswerBodyText } from './AnswerBody'
 import { InlineBlocks } from './InlineBlocks'
 import { AlertCircle, ChevronDown, ChevronUp, ListPlus, AlignLeft, RefreshCw } from 'lucide-react'
 import { FeedbackRow } from './FeedbackRow'
@@ -151,6 +151,8 @@ interface MessageBubbleProps {
    * affordance. Ignored for non-failed or assistant messages.
    */
   onRetryFailedSend?: () => void
+  /** L-42: only the newest assistant turn's card may claim the staleness voice. */
+  isLatestAssistantTurn?: boolean
 }
 
 export const MessageBubble = memo(function MessageBubble({
@@ -164,6 +166,7 @@ export const MessageBubble = memo(function MessageBubble({
   onProposalConfirm,
   compact = false,
   onRetryFailedSend,
+  isLatestAssistantTurn = false,
 }: MessageBubbleProps) {
   const isUser = message.role === 'user'
   const isStreaming = message.isStreaming === true
@@ -197,8 +200,10 @@ export const MessageBubble = memo(function MessageBubble({
    * is not yet a true statement about anything).
    */
   const consentSurfaceText = useMemo(
-    () => (isUser || isStreaming ? [] : collectConsentSurfaceText(message.blocks)),
-    [isUser, isStreaming, message.blocks],
+    () => (isUser || isStreaming
+      ? []
+      : collectConsentSurfaceText(message.blocks, patchBlockStates, message.id)),
+    [isUser, isStreaming, message.blocks, patchBlockStates, message.id],
   )
   const dedupedBody = useMemo(
     () => dedupeRenderedText(rawDisplayContent, consentSurfaceText),
@@ -206,14 +211,24 @@ export const MessageBubble = memo(function MessageBubble({
   )
   const displayContent = dedupedBody.text
   /**
-   * Tier 0 + tier 2, as one stable array. Memoised because `InlineBlocks` is
-   * `memo`'d and a fresh literal on every render would defeat it — the same
-   * reason `AnswerBody` keeps a frozen empty default.
+   * What the turn has ALREADY PUT ON SCREEN above its blocks — tier 0 plus the
+   * body, whichever body this turn actually renders.
+   *
+   * ⚠ The two modes render DIFFERENT text and this must follow, not assume. In
+   * structured mode `AnswerBody` OWNS the body and `displayContent` is never
+   * rendered at all, so feeding it here suppressed blocks against text nobody
+   * could see (adversarial-review finding). The structured branch therefore
+   * feeds what `resolveAnswerBodyText` says will show — and DELIBERATELY OMITS
+   * `detail`, which sits behind the Show-more toggle: a block is not a duplicate
+   * of something the user has to click to reveal.
    */
-  const renderedAboveBlocks = useMemo(
-    () => [...consentSurfaceText, displayContent],
-    [consentSurfaceText, displayContent],
-  )
+  const renderedAboveBlocks = useMemo(() => {
+    if (!isUser && !isStreaming && message.answerShape) {
+      const shown = resolveAnswerBodyText(message.answerShape, consentSurfaceText)
+      return [...consentSurfaceText, shown.headline, ...shown.bullets]
+    }
+    return [...consentSurfaceText, displayContent]
+  }, [isUser, isStreaming, message.answerShape, consentSurfaceText, displayContent])
   // Transcript honesty (trust item #3): a user send whose turn failed must
   // LOOK failed — marker + optional retry affordance on the message itself.
   const sendFailed = isUser && message.deliveryState === 'failed'
@@ -483,6 +498,7 @@ export const MessageBubble = memo(function MessageBubble({
           // commentary block inside the disclosure does not repeat a paragraph
           // the user has already read further up the same message (item 7).
           alreadyRendered={renderedAboveBlocks}
+          isLatestAssistantTurn={isLatestAssistantTurn}
         />
       )}
       {/* Explain more + Summarise are AI Panel v2 affordances only — MessageBubble

--- a/src/canvas/conversation/StalenessPill.tsx
+++ b/src/canvas/conversation/StalenessPill.tsx
@@ -18,8 +18,10 @@
  * message-construction path; track it in a follow-up brief if needed.
  */
 
+import { useEffect } from 'react'
 import { AlertTriangle, Info } from 'lucide-react'
 import { typography } from '../../styles/typography'
+import { claimStalenessVoice, useMayStalenessVoiceSpeak } from './stalenessVoice'
 
 export type StalenessFreshness = 'stale' | 'unknown'
 
@@ -33,6 +35,29 @@ const COPY: Record<StalenessFreshness, string> = {
 }
 
 export function StalenessPill({ freshness }: StalenessPillProps) {
+  /**
+   * L-42 — ONE staleness communication per turn view. The applied-edit card's
+   * freshness note outranks this pill (it is attached to the change that caused
+   * the staleness); when that card is on screen this pill stands down rather
+   * than saying the same thing a second time.
+   *
+   * Scoped to the 'stale' variant on purpose. The 'unknown' pill does NOT make
+   * the card's claim — it says currency cannot be confirmed, which is a
+   * different fact, and the card never states it. Silencing it here would be
+   * suppressing an honest statement nothing else makes (the §1 authority-parity
+   * rule: never claim which state is current, and never withhold the admission
+   * that we cannot tell).
+   */
+  const isStaleClaim = freshness === 'stale'
+  const maySpeak = useMayStalenessVoiceSpeak('pill')
+  const speaking = !isStaleClaim || maySpeak
+  useEffect(() => {
+    if (!speaking || !isStaleClaim) return
+    return claimStalenessVoice('pill')
+  }, [speaking, isStaleClaim])
+
+  if (!speaking) return null
+
   // DS v5 §8.5 / CLAUDE.md: outlined-only pills, border carries the semantic;
   // never text-{colour} on the pill (text or icon). The icon's *shape*
   // (AlertTriangle vs Info) differentiates the two states without colour.

--- a/src/canvas/conversation/__tests__/MessageActions.controls.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageActions.controls.spec.tsx
@@ -1,0 +1,150 @@
+/**
+ * L-72 / L-73 — message controls.
+ *
+ * L-73 is a LAYOUT claim ("hover controls can cover message text") and jsdom
+ * cannot prove layout (platform trap 3). So this file does NOT pretend to
+ * measure pixels. It pins the ARITHMETIC CONTRACT that makes overlap
+ * impossible, against the SAME exported constants the component and its host
+ * consume — so the guard binds the rule rather than a copy of it:
+ *
+ *     offset + height <= gutter
+ *
+ * and it pins that `ChatMessage` actually reserves the gutter, by identity.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import {
+  ACTION_BAR_GUTTER_PX,
+  ACTION_BAR_HEIGHT_PX,
+  ACTION_BAR_TOP_OFFSET_PX,
+  MessageActions,
+} from '../zones/MessageActions'
+import { ChatMessage } from '../zones/ChatMessage'
+import type { ConversationMessage } from '../types'
+
+const noop = async () => {}
+
+describe('L-73 — the controls have their own band', () => {
+  it('the bar cannot extend past the reserved gutter', () => {
+    // The load-bearing inequality. A future tweak to any of the three numbers
+    // that re-introduces overlap fails HERE, loudly, rather than on a screen.
+    expect(ACTION_BAR_TOP_OFFSET_PX + ACTION_BAR_HEIGHT_PX).toBeLessThanOrEqual(
+      ACTION_BAR_GUTTER_PX,
+    )
+  })
+
+  it('the bar reaches UP into the inter-message gap rather than down into the text', () => {
+    expect(ACTION_BAR_TOP_OFFSET_PX).toBeLessThan(0)
+  })
+
+  it('ChatMessage reserves exactly that gutter above the bubble', () => {
+    const message: ConversationMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: 'A message with text on its first line.',
+      timestamp: new Date(),
+    }
+    render(
+      <ChatMessage message={message} isFirst onChipClick={noop} onRetry={() => {}} />,
+    )
+    const host = screen.getByTestId('chat-message-assistant')
+    expect(host.getAttribute('data-actions-gutter-px')).toBe(String(ACTION_BAR_GUTTER_PX))
+    expect(host.style.paddingTop).toBe(`${ACTION_BAR_GUTTER_PX}px`)
+  })
+
+  it('the bar positions itself from the shared constants, not a local literal', () => {
+    render(<MessageActions role="assistant" content="x" onRetry={() => {}} />)
+    const bar = screen.getByTestId('message-actions')
+    expect(bar.style.top).toBe(`${ACTION_BAR_TOP_OFFSET_PX}px`)
+    expect(bar.style.height).toBe(`${ACTION_BAR_HEIGHT_PX}px`)
+  })
+})
+
+describe('L-72 — control parity', () => {
+  it('an Olumi message carries BOTH copy and retry', () => {
+    render(<MessageActions role="assistant" content="x" onRetry={() => {}} />)
+    expect(screen.getByTestId('message-action-copy')).toBeTruthy()
+    expect(screen.getByTestId('message-action-retry')).toBeTruthy()
+  })
+
+  it('a user message carries copy and NOT retry — a deliberate asymmetry', () => {
+    // Retrying a user message means RE-DELIVERING a failed send, which already
+    // has its own affordance on the bubble. Two Retry controls with two
+    // meanings under one name is the shape this platform has already paid for.
+    render(<MessageActions role="user" content="x" onRetry={() => {}} />)
+    expect(screen.getByTestId('message-action-copy')).toBeTruthy()
+    expect(screen.queryByTestId('message-action-retry')).toBeNull()
+  })
+
+  it('retry fires the handler it was given', () => {
+    const onRetry = vi.fn()
+    render(<MessageActions role="assistant" content="x" onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('message-action-retry'))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('L-72 — copy reports what happened', () => {
+  const original = navigator.clipboard
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: original,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  it('announces success', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    render(<MessageActions role="assistant" content="COPY-ME" />)
+    fireEvent.click(screen.getByTestId('message-action-copy'))
+    expect(writeText).toHaveBeenCalledWith('COPY-ME')
+    await waitFor(() =>
+      expect(screen.getByTestId('message-action-status').textContent).toBe('Message copied'),
+    )
+  })
+
+  it('announces FAILURE instead of swallowing it — the "reportedly fail" report', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    render(<MessageActions role="assistant" content="COPY-ME" />)
+    fireEvent.click(screen.getByTestId('message-action-copy'))
+    await waitFor(() =>
+      expect(screen.getByTestId('message-action-status').textContent).toContain("Couldn't copy"),
+    )
+  })
+
+  it('announces failure when the clipboard API is absent (insecure origin)', async () => {
+    // The previous handler called straight through, which THROWS synchronously
+    // when `navigator.clipboard` is undefined and never reaches a rejection
+    // handler — silence, with the icon animating as if it had worked.
+    render(<MessageActions role="assistant" content="COPY-ME" />)
+    fireEvent.click(screen.getByTestId('message-action-copy'))
+    await waitFor(() =>
+      expect(screen.getByTestId('message-action-status').textContent).toContain("Couldn't copy"),
+    )
+  })
+
+  it('says nothing at rest', () => {
+    render(<MessageActions role="assistant" content="COPY-ME" />)
+    expect(screen.getByTestId('message-action-status').textContent).toBe('')
+  })
+})

--- a/src/canvas/conversation/__tests__/renderAuthority.bubble.spec.tsx
+++ b/src/canvas/conversation/__tests__/renderAuthority.bubble.spec.tsx
@@ -1,0 +1,186 @@
+/**
+ * ONE RENDER AUTHORITY, at the surface — MessageBubble (L-16 / NEW-9).
+ *
+ * NEW-9, verbatim from the 16 Aug scoreboard: "The plan is stated twice per
+ * structural edit (prose + card), byte-identical." The card carries the consent
+ * control, so the card wins and the prose repeat is withheld.
+ *
+ * Every assertion binds by IDENTITY — the card's own testid, the body's own
+ * testid — never by "some element contains this string", which a different
+ * element could satisfy (platform trap 19).
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage, ConversationBlock } from '../types'
+import type { AnswerShape } from '../answerShape'
+
+const noop = async () => {}
+
+const PLAN = 'Add option Hire 2 Mid-Level Engineers (Under £45k)'
+
+function heldBlock(summary: string): ConversationBlock {
+  return {
+    type: 'v5_held_proposal',
+    proposal_id: 'gmh_test',
+    summary,
+    mutation_class: 'structural',
+    reason_code: 'STRUCTURAL_APPLY_HELD',
+    confirm: { label: 'Confirm these changes', message: 'confirm gmh_test' },
+  } as unknown as ConversationBlock
+}
+
+function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'msg-render-authority',
+    role: 'assistant',
+    content: 'placeholder',
+    timestamp: new Date(),
+    ...overrides,
+  }
+}
+
+describe('prose vs consent card', () => {
+  it('withholds the prose paragraph the consent card already states', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: `Here is what I would change.\n${PLAN}\nNothing moves until you confirm.`,
+          blocks: [heldBlock(PLAN)],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const body = screen.getByTestId('message-body-text')
+    expect(body.textContent).toContain('Here is what I would change.')
+    expect(body.textContent).toContain('Nothing moves until you confirm.')
+    // The plan is stated ONCE, and it is stated on the control the user
+    // consents through.
+    expect(body.textContent).not.toContain(PLAN)
+    expect(screen.getByTestId('v5-held-proposal-summary').textContent).toContain(PLAN)
+    expect(body.getAttribute('data-body-segments-withheld')).toBe('1')
+  })
+
+  it('omits the body element entirely when the card already said all of it', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ content: PLAN, blocks: [heldBlock(PLAN)] })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('message-body-text')).toBeNull()
+    expect(screen.getByTestId('v5-held-proposal-summary').textContent).toContain(PLAN)
+  })
+
+  it('OPPOSITE TWIN — prose that does NOT repeat the card is untouched', () => {
+    const prose = 'I have drafted a plan you should look over before confirming.'
+    render(
+      <MessageBubble
+        message={makeMsg({ content: prose, blocks: [heldBlock(PLAN)] })}
+        onChipClick={noop}
+      />,
+    )
+    const body = screen.getByTestId('message-body-text')
+    expect(body.textContent).toContain(prose)
+    expect(body.getAttribute('data-body-segments-withheld')).toBeNull()
+  })
+
+  it('OPPOSITE TWIN — a USER bubble is never withheld against anything', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ role: 'user', content: PLAN, blocks: [heldBlock(PLAN)] })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('message-user').textContent).toContain(PLAN)
+  })
+
+  it('OPPOSITE TWIN — nothing is withheld while the turn is still streaming', () => {
+    // "Already rendered" is not yet a true statement about a card that has not
+    // arrived; suppressing on a partial turn would delete text permanently.
+    render(
+      <MessageBubble
+        message={makeMsg({ content: PLAN, blocks: [heldBlock(PLAN)], isStreaming: true })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('message-body-text').textContent).toContain(PLAN)
+  })
+})
+
+describe('answer shape vs consent card', () => {
+  const answer: AnswerShape = {
+    headline: PLAN,
+    bullets: ['A supporting point.'],
+    detail: 'The long tail of the explanation.',
+  }
+
+  it('withholds an answer headline the consent card already states', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ content: 'ignored', answerShape: answer, blocks: [heldBlock(PLAN)] })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('answer-headline')).toBeNull()
+    expect(screen.getByTestId('answer-bullets').textContent).toContain('A supporting point.')
+    expect(screen.getByTestId('v5-held-proposal-summary').textContent).toContain(PLAN)
+  })
+
+  it('OPPOSITE TWIN — an answer headline nothing else states still renders', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: 'ignored',
+          answerShape: answer,
+          blocks: [heldBlock('A completely different plan.')],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('answer-headline').textContent).toContain(PLAN)
+  })
+})
+
+describe('duplicate sentence inside one disclosure (L-16, item 7)', () => {
+  const ONLY_ONE_RUN =
+    'There is only one analysis run so far, so there is nothing to compare yet.'
+
+  it('renders a commentary paragraph once when the prose already said it', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: `${ONLY_ONE_RUN}\nRun the analysis again after a change.`,
+          blocks: [
+            {
+              type: 'commentary',
+              text: `${ONLY_ONE_RUN}\nHere is the extra context.`,
+            } as ConversationBlock,
+          ],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const container = screen.getByTestId('block-container')
+    expect(container.textContent).toContain('Here is the extra context.')
+    expect(container.textContent).not.toContain(ONLY_ONE_RUN)
+    // and the prose kept it — the higher tier is never the one withheld
+    expect(screen.getByTestId('message-body-text').textContent).toContain(ONLY_ONE_RUN)
+  })
+
+  it('NEVER empties a block: a wholly-duplicate commentary keeps its own text', () => {
+    // Suppression removes PART of a block, never the whole of it. An empty card
+    // with a live toggle is a worse artefact than the duplicate, and deleting a
+    // block would breach the composition's own no-drop guarantee.
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: ONLY_ONE_RUN,
+          blocks: [{ type: 'commentary', text: ONLY_ONE_RUN } as ConversationBlock],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('block-container').textContent).toContain(ONLY_ONE_RUN)
+  })
+})

--- a/src/canvas/conversation/__tests__/renderAuthority.bubble.spec.tsx
+++ b/src/canvas/conversation/__tests__/renderAuthority.bubble.spec.tsx
@@ -142,6 +142,69 @@ describe('answer shape vs consent card', () => {
   })
 })
 
+describe('the collector is fed only what the turn ACTUALLY renders', () => {
+  const APPLIED = 'Added constraint: budget at most £250,000.'
+  const PROPOSED = 'Proposing to add a constraint.'
+
+  function patchBlock(): ConversationBlock {
+    return {
+      type: 'graph_patch',
+      patch_id: 'p1',
+      operations: [],
+      summary: PROPOSED,
+      applied_summary: APPLIED,
+      auto_apply: false,
+    } as unknown as ConversationBlock
+  }
+
+  it('A2 — a PROPOSED patch does not suppress prose against its applied_summary', () => {
+    // The card shows the proposed text; `applied_summary` is never on screen,
+    // so prose matching it must survive. Suppressing here would delete a
+    // sentence against text the user cannot see.
+    render(
+      <MessageBubble
+        message={makeMsg({ content: `Intro.\n${APPLIED}`, blocks: [patchBlock()] })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('message-body-text').textContent).toContain(APPLIED)
+  })
+
+  it('A3 — in structured mode, blocks are not suppressed against the unrendered free text', () => {
+    // AnswerBody OWNS the body when a shape is present, so `content` is never
+    // rendered. A commentary repeating it must therefore still show.
+    const UNRENDERED = 'This free-text body is replaced by the structured answer.'
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: UNRENDERED,
+          answerShape: { headline: 'A headline.', bullets: [], detail: 'Some detail.' },
+          blocks: [{ type: 'commentary', text: UNRENDERED } as ConversationBlock],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('block-container').textContent).toContain(UNRENDERED)
+  })
+
+  it('A3 twin — a block IS suppressed against the headline AnswerBody really shows', () => {
+    const HEAD = 'The leading option has not changed.'
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: 'ignored free text',
+          answerShape: { headline: HEAD, bullets: [], detail: 'Some detail.' },
+          blocks: [{ type: 'commentary', text: `${HEAD}\nExtra context.` } as ConversationBlock],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const container = screen.getByTestId('block-container')
+    expect(container.textContent).toContain('Extra context.')
+    expect(container.textContent).not.toContain(HEAD)
+  })
+})
+
 describe('duplicate sentence inside one disclosure (L-16, item 7)', () => {
   const ONLY_ONE_RUN =
     'There is only one analysis run so far, so there is nothing to compare yet.'
@@ -166,6 +229,29 @@ describe('duplicate sentence inside one disclosure (L-16, item 7)', () => {
     expect(container.textContent).not.toContain(ONLY_ONE_RUN)
     // and the prose kept it — the higher tier is never the one withheld
     expect(screen.getByTestId('message-body-text').textContent).toContain(ONLY_ONE_RUN)
+  })
+
+  it('a commentary paragraph repeated by a LATER commentary block renders once', () => {
+    // Item 7, at the level it actually occurs: ACROSS blocks. Within one block's
+    // own text nothing is de-duplicated — that is the producer's repetition.
+    render(
+      <MessageBubble
+        message={makeMsg({
+          content: 'Short lead-in.',
+          blocks: [
+            { type: 'commentary', text: `${ONLY_ONE_RUN}\nFirst extra.` } as ConversationBlock,
+            { type: 'commentary', text: `${ONLY_ONE_RUN}\nSecond extra.` } as ConversationBlock,
+          ],
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const container = screen.getByTestId('block-container')
+    expect(container.textContent).toContain('First extra.')
+    expect(container.textContent).toContain('Second extra.')
+    // Exactly one occurrence across the whole turn.
+    const occurrences = (container.textContent ?? '').split(ONLY_ONE_RUN).length - 1
+    expect(occurrences).toBe(1)
   })
 
   it('NEVER empties a block: a wholly-duplicate commentary keeps its own text', () => {

--- a/src/canvas/conversation/__tests__/renderAuthority.spec.ts
+++ b/src/canvas/conversation/__tests__/renderAuthority.spec.ts
@@ -84,13 +84,74 @@ describe('dedupeRenderedText — a lower tier never repeats a higher tier', () =
     expect(result.text).toBe(prose)
   })
 
-  it('collapses a segment the SAME text repeats internally, keeping the FIRST occurrence', () => {
-    // L-16 verbatim: "the duplicate sentence inside one disclosure".
+  /**
+   * ⚠ PIN FLIPPED — this file previously asserted the OPPOSITE, and the
+   * opposite was a content-loss bug.
+   *
+   * The old rule accumulated the input's own segments, so with an empty
+   * `alreadyRendered` — the default path, i.e. every ordinary assistant turn —
+   * the second occurrence of any identical line was deleted. An adversarial
+   * review proved it at the rendered HTML. The three cases below are that
+   * review's, kept verbatim as the corpus, because the case this lane wrote for
+   * itself (one long unique sentence) could not see the class it broke: SHORT,
+   * STRUCTURALLY REPEATED lines.
+   *
+   * Cross-tier suppression is a FACT (the caller supplies the other surface's
+   * text). Within-text repetition is a GUESS about the producer's intent. They
+   * cannot share a predicate (trap 22b), so only the fact is implemented.
+   */
+  it('PRESERVES a line the same text repeats under two headings', () => {
+    const text = 'Risks\nTimeline slips\nMitigations\nTimeline slips'
+    const result = dedupeRenderedText(text)
+    expect(result.suppressedCount).toBe(0)
+    expect(result.text).toBe(text)
+  })
+
+  it('PRESERVES repeated short status lines (three rows, three "not stated")', () => {
+    const text = [
+      'Option A',
+      'Confidence: not stated',
+      'Option B',
+      'Confidence: not stated',
+      'Option C',
+      'Confidence: not stated',
+    ].join('\n')
+    const result = dedupeRenderedText(text)
+    expect(result.suppressedCount).toBe(0)
+    expect(result.text).toBe(text)
+  })
+
+  it('PRESERVES a long sentence the producer genuinely repeated', () => {
+    // Deliberately the shape the ORIGINAL (wrong) rule was written for: even
+    // here the answer is "leave it alone", because nothing in the text
+    // distinguishes an accidental repeat from a deliberate one.
     const only = 'There is only one analysis run so far, so there is nothing to compare yet.'
-    const disclosure = `${only}\n${only}\nRun the analysis again after a change.`
-    const result = dedupeRenderedText(disclosure)
-    expect(result.suppressedCount).toBe(1)
-    expect(result.text).toBe(`${only}\nRun the analysis again after a change.`)
+    const text = `${only}\n${only}\nRun the analysis again after a change.`
+    expect(dedupeRenderedText(text).text).toBe(text)
+  })
+
+  it('STILL withholds that same line when a HIGHER TIER stated it — both copies', () => {
+    // The discriminating twin: identical input, one prior. Suppression is about
+    // the tier, never about the repetition.
+    const only = 'There is only one analysis run so far, so there is nothing to compare yet.'
+    const text = `${only}\n${only}\nRun the analysis again after a change.`
+    const result = dedupeRenderedText(text, [only])
+    expect(result.suppressedCount).toBe(2)
+    expect(result.text).toBe('Run the analysis again after a change.')
+  })
+
+  it('is byte-identical to its input for ANY text when there are no priors', () => {
+    // The property the old rule violated, stated as a property rather than as
+    // an example — no input may be changed on the default path.
+    for (const sample of [
+      'a\na',
+      'x\n\nx\n\nx',
+      'Same line\nSame line\nSame line',
+      'One.\nTwo.\nOne.',
+    ]) {
+      expect(dedupeRenderedText(sample).text).toBe(sample)
+      expect(dedupeRenderedText(sample).suppressedCount).toBe(0)
+    }
   })
 
   it('is a pure identity when there is nothing to withhold', () => {

--- a/src/canvas/conversation/__tests__/renderAuthority.spec.ts
+++ b/src/canvas/conversation/__tests__/renderAuthority.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * ONE RENDER AUTHORITY — the suppression primitives (L-16 / NEW-9 / item 7).
+ *
+ * ## What this pins, and why in this shape
+ *
+ * The defect is not "a copy bug". CEE DERIVES `assistant_text` from the answer
+ * shape (`deriveAnswerTextFromShape`, read at the CEE bytes on staging
+ * `2988eacf`), so the two channels are byte-equal BY PRODUCER DESIGN. The same
+ * plan then appears a third time on the consent card the turn renders. Nothing
+ * upstream is wrong; the UI was simply rendering the same bytes more than once.
+ *
+ * These tests are written against the SPEC of the rule ("a lower tier never
+ * re-renders a whole segment a higher tier already rendered"), never against
+ * the sample that motivated it — the platform's trap 13d: an invariant written
+ * with the same asymmetry as the code it tests is a guard agreeing with itself.
+ * So every positive case has an OPPOSITE-DIRECTION TWIN: for each suppression
+ * there is a near-miss that must survive untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  collectConsentSurfaceText,
+  composeMessage,
+  assertTotalPartition,
+  dedupeRenderedText,
+  renderSegmentKey,
+  splitRenderSegments,
+} from '../messageComposition'
+import type { ConversationBlock } from '../types'
+
+describe('renderSegmentKey', () => {
+  it('is insensitive to whitespace shape and case — the two channels differ in both', () => {
+    expect(renderSegmentKey('  The   model\nchanged.  ')).toBe('the model changed.')
+    expect(renderSegmentKey('THE MODEL CHANGED.')).toBe('the model changed.')
+  })
+
+  it('does NOT normalise punctuation or word order (no fuzzy matching)', () => {
+    expect(renderSegmentKey('The model changed')).not.toBe(renderSegmentKey('The model changed.'))
+    expect(renderSegmentKey('a b')).not.toBe(renderSegmentKey('b a'))
+  })
+
+  it('maps a blank segment to the empty key', () => {
+    expect(renderSegmentKey('   \n  ')).toBe('')
+  })
+})
+
+describe('splitRenderSegments', () => {
+  it('splits on newlines and keeps blank lines as paragraph markers', () => {
+    expect(splitRenderSegments('one\n\ntwo')).toEqual(['one', '', 'two'])
+  })
+
+  it('does NOT split sentences — the deliberate limit (trap 22f)', () => {
+    // One paragraph, two sentences, ONE segment. This is the stated limit of
+    // the rule: separating sentences needs a predicate over natural language,
+    // which this platform has watched oscillate for four rounds. The limit is
+    // pinned here so it can never become an undisclosed gap.
+    expect(splitRenderSegments('First sentence. Second sentence.')).toHaveLength(1)
+  })
+})
+
+describe('dedupeRenderedText — a lower tier never repeats a higher tier', () => {
+  const CARD = 'Add option Hire 2 Mid-Level Engineers (Under £45k)'
+
+  it('withholds a whole segment the higher tier already rendered', () => {
+    const prose = `Here is the plan.\n${CARD}\nNothing moves until you confirm.`
+    const result = dedupeRenderedText(prose, [CARD])
+    expect(result.suppressedCount).toBe(1)
+    expect(result.text).toBe('Here is the plan.\nNothing moves until you confirm.')
+  })
+
+  it('OPPOSITE TWIN — a segment that merely CONTAINS the higher tier survives whole', () => {
+    // Suppression is whole-segment equality, never substring containment. A
+    // substring rule would delete a sentence the user has not read, which is
+    // content loss dressed as tidiness.
+    const prose = `Here is the plan.\n${CARD} — and two more like it.\nDone.`
+    const result = dedupeRenderedText(prose, [CARD])
+    expect(result.suppressedCount).toBe(0)
+    expect(result.text).toBe(prose)
+  })
+
+  it('OPPOSITE TWIN — an almost-identical segment survives (no fuzzy distance)', () => {
+    const prose = `Add option Hire 2 Mid-Level Engineers (Under £46k)`
+    const result = dedupeRenderedText(prose, [CARD])
+    expect(result.suppressedCount).toBe(0)
+    expect(result.text).toBe(prose)
+  })
+
+  it('collapses a segment the SAME text repeats internally, keeping the FIRST occurrence', () => {
+    // L-16 verbatim: "the duplicate sentence inside one disclosure".
+    const only = 'There is only one analysis run so far, so there is nothing to compare yet.'
+    const disclosure = `${only}\n${only}\nRun the analysis again after a change.`
+    const result = dedupeRenderedText(disclosure)
+    expect(result.suppressedCount).toBe(1)
+    expect(result.text).toBe(`${only}\nRun the analysis again after a change.`)
+  })
+
+  it('is a pure identity when there is nothing to withhold', () => {
+    const prose = 'One.\n\nTwo.\n\nThree.'
+    const result = dedupeRenderedText(prose, ['Something else entirely.'])
+    expect(result.suppressedCount).toBe(0)
+    // Byte-identical, not merely equivalent: every surface with no duplicate
+    // must be provably unchanged by this lane.
+    expect(result.text).toBe(prose)
+  })
+
+  it('is a pure identity with no priors at all (the un-opted-in caller)', () => {
+    const prose = 'Alpha.\n\nBeta.'
+    expect(dedupeRenderedText(prose).text).toBe(prose)
+    expect(dedupeRenderedText(prose).suppressedCount).toBe(0)
+  })
+
+  it('never treats blank lines as duplicates of each other', () => {
+    const prose = 'One.\n\nTwo.\n\nThree.'
+    expect(dedupeRenderedText(prose, []).text).toBe(prose)
+  })
+
+  it('leaves no stranded blank run where a paragraph was withheld', () => {
+    const result = dedupeRenderedText('Intro.\n\nDUPE\n\nOutro.', ['DUPE'])
+    expect(result.suppressedCount).toBe(1)
+    expect(result.text).toBe('Intro.\n\nOutro.')
+  })
+
+  it('never withholds FROM the higher tier — authority is one-directional', () => {
+    // The prior is passed by value and read only. Suppressing a card because the
+    // prose said the same thing would hide the consent control's own copy.
+    const card = 'Confirm: delete the option.'
+    const result = dedupeRenderedText(card, [])
+    expect(result.text).toBe(card)
+    // and the reverse call is the one that suppresses
+    expect(dedupeRenderedText(card, [card]).suppressedCount).toBe(1)
+  })
+})
+
+describe('collectConsentSurfaceText — tier 0', () => {
+  const held = {
+    type: 'v5_held_proposal',
+    proposal_id: 'gmh_1',
+    summary: 'Add option A\nAdd factor B',
+    mutation_class: 'structural',
+    reason_code: 'REMOVE_UNCONFIRMED',
+    confirm: { label: 'Confirm', message: 'confirm' },
+  } as unknown as ConversationBlock
+
+  it('collects a held proposal card summary', () => {
+    expect(collectConsentSurfaceText([held])).toEqual(['Add option A\nAdd factor B'])
+  })
+
+  it('EXCLUDES commentary even though commentary is PINNED', () => {
+    // Deliberate: commentary is prose, not a consent control, and its
+    // duplication is already resolved at ingest. Two mechanisms on one seam is
+    // how this estate ships a defect and its exact inverse (trap 22b).
+    const commentary = { type: 'commentary', text: 'Some narrative.' } as ConversationBlock
+    expect(collectConsentSurfaceText([commentary])).toEqual([])
+  })
+
+  it('EXCLUDES non-pinned blocks — a demoted card is not a rendered authority', () => {
+    const coaching = {
+      type: 'v5_coaching',
+      block_id: 'c1',
+      summary: 'Coaching summary',
+    } as unknown as ConversationBlock
+    expect(collectConsentSurfaceText([coaching])).toEqual([])
+  })
+
+  it('returns [] for an absent or empty block list', () => {
+    expect(collectConsentSurfaceText(undefined)).toEqual([])
+    expect(collectConsentSurfaceText([])).toEqual([])
+  })
+})
+
+describe('the #717 invariants are unchanged by this lane', () => {
+  const blocks = [
+    { type: 'v5_held_proposal' },
+    { type: 'v5_coaching' },
+    { type: 'v5_coaching' },
+    { type: 'v5_coaching' },
+    { type: 'v5_coaching' },
+    { type: 'fact' },
+  ] as unknown as ConversationBlock[]
+
+  it('still produces a TOTAL PARTITION', () => {
+    const composition = composeMessage(blocks)
+    expect(assertTotalPartition(blocks.length, composition)).toBeNull()
+  })
+
+  it('still NEVER fabricates a headline', () => {
+    expect(composeMessage(blocks).headline).toBeNull()
+  })
+
+  it('still keeps PRODUCER ORDER within every class', () => {
+    const composition = composeMessage(blocks)
+    for (const cls of [composition.pinned, composition.points, composition.detail]) {
+      const indices = cls.map((e) => e.index)
+      expect(indices).toEqual([...indices].sort((a, b) => a - b))
+    }
+  })
+})

--- a/src/canvas/conversation/__tests__/stageAwarePlaceholder.voice.spec.ts
+++ b/src/canvas/conversation/__tests__/stageAwarePlaceholder.voice.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * useStageAwarePlaceholder — L-17 (the selection branch is gone) and L-42 (the
+ * composer is the LOWEST staleness voice).
+ *
+ * Both changes are about the composer no longer impersonating something:
+ *   · it stopped impersonating a prepared, submittable sentence about the
+ *     selection (there was no way to send it — the composer's value was empty);
+ *   · it stopped being the third surface telling the user to re-run.
+ *
+ * Every case names the OTHER placeholder it must fall through to, so a
+ * suppression that accidentally blanked the composer would fail here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useStageAwarePlaceholder } from '../../hooks/useStageAwarePlaceholder'
+import { useCanvasStore } from '../../store'
+import { claimStalenessVoice, __resetStalenessVoicesForTest } from '../stalenessVoice'
+
+const NODE = {
+  id: 'fac_a',
+  type: 'factor',
+  position: { x: 0, y: 0 },
+  data: { label: 'Hiring spend' },
+}
+
+function setStore(patch: Record<string, unknown>) {
+  useCanvasStore.setState(patch as never)
+}
+
+beforeEach(() => {
+  __resetStalenessVoicesForTest()
+  setStore({
+    nodes: [],
+    edges: [],
+    selection: null,
+    results: { status: 'idle' },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    importPendingServerRegistration: false,
+  })
+})
+
+describe('L-17 — a selection no longer writes a fake sentence into the composer', () => {
+  it('keeps the neutral model prompt while a node is selected', () => {
+    setStore({
+      nodes: [NODE],
+      selection: { nodeIds: new Set([NODE.id]), edgeIds: new Set<string>() },
+    })
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).toBe('Ask about this model…')
+    expect(result.current).not.toContain('Hiring spend')
+  })
+
+  it('OPPOSITE TWIN — with nothing selected it is the same neutral prompt', () => {
+    setStore({ nodes: [NODE] })
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).toBe('Ask about this model…')
+  })
+
+  it('still says "Describe your decision…" on an empty canvas', () => {
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).toBe('Describe your decision…')
+  })
+})
+
+describe('L-42 — the composer is the lowest staleness voice', () => {
+  /**
+   * The 'changed' semantic, built from the keys `useAnalysisTrust` ACTUALLY
+   * reads (derived at its bytes: `analysisFreshness` + `analysisFreshnessDirty`
+   * + `results.status` + `importPendingServerRegistration`) — not from this
+   * lane's guess at what the state ought to look like. A self-authored fixture
+   * outside the producer's real domain proves nothing about the wire
+   * (platform trap 16-inverse), and the first version of this fixture was
+   * exactly that: it invented a `graphEditedSinceLastRun` key nothing reads,
+   * and the "positive control" failed rather than passing vacuously — which is
+   * the only reason it was caught here rather than shipped.
+   */
+  function setChangedState() {
+    setStore({
+      nodes: [NODE],
+      results: { status: 'complete' },
+      analysisFreshness: { freshness: 'stale' },
+      analysisFreshnessDirty: false,
+      importPendingServerRegistration: false,
+    })
+  }
+
+  it('nags when NOTHING above it is speaking (positive control)', () => {
+    setChangedState()
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    // Either the composer owns the nag, or the state under test never reached
+    // 'changed' — assert the former explicitly so this control cannot pass
+    // vacuously.
+    expect(result.current).toBe('Model changed. Ask or rerun…')
+  })
+
+  it('goes NEUTRAL while the applied-edit card is saying it', () => {
+    setChangedState()
+    claimStalenessVoice('card')
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).not.toBe('Model changed. Ask or rerun…')
+    // Falls through to the next honest thing, never to blank.
+    expect(result.current).toBe('Ask about this analysis…')
+  })
+
+  it('goes NEUTRAL while the freshness pill is saying it', () => {
+    setChangedState()
+    claimStalenessVoice('pill')
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).toBe('Ask about this analysis…')
+  })
+
+  it('resumes the moment the higher voice leaves the screen', () => {
+    setChangedState()
+    const release = claimStalenessVoice('card')
+    release()
+    const { result } = renderHook(() => useStageAwarePlaceholder())
+    expect(result.current).toBe('Model changed. Ask or rerun…')
+  })
+})

--- a/src/canvas/conversation/__tests__/stalenessVoice.spec.ts
+++ b/src/canvas/conversation/__tests__/stalenessVoice.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * L-42 — ONE staleness communication per turn view.
+ *
+ * Screenshot S03 showed the applied-edit card's note, a "Should fix" card and
+ * the composer placeholder all telling the user to re-run at once. The
+ * hierarchy is card > pill > placeholder, and a surface speaks only when
+ * nothing above it is speaking.
+ *
+ * The registry is module-level state, so every test resets it. A leaked claim
+ * would silence a surface in a LATER spec for a reason nothing in that spec
+ * could explain — the worst class of cross-test coupling.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  STALENESS_VOICES,
+  claimStalenessVoice,
+  mayStalenessVoiceSpeak,
+  stalenessVoiceRank,
+  __resetStalenessVoicesForTest,
+} from '../stalenessVoice'
+
+beforeEach(() => {
+  __resetStalenessVoicesForTest()
+})
+
+describe('the hierarchy is DERIVED from one ordered list', () => {
+  it('ranks card above pill above placeholder', () => {
+    expect(stalenessVoiceRank('card')).toBeLessThan(stalenessVoiceRank('pill'))
+    expect(stalenessVoiceRank('pill')).toBeLessThan(stalenessVoiceRank('placeholder'))
+  })
+
+  it('states the order exactly once', () => {
+    expect([...STALENESS_VOICES]).toEqual(['card', 'pill', 'placeholder'])
+  })
+})
+
+describe('claim / release', () => {
+  it('everybody may speak when nothing is claimed (the fail-safe default)', () => {
+    for (const voice of STALENESS_VOICES) {
+      expect(mayStalenessVoiceSpeak(voice)).toBe(true)
+    }
+  })
+
+  it('a CARD claim silences the pill and the placeholder', () => {
+    claimStalenessVoice('card')
+    expect(mayStalenessVoiceSpeak('pill')).toBe(false)
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+  })
+
+  it('a CARD claim never silences the card itself', () => {
+    claimStalenessVoice('card')
+    expect(mayStalenessVoiceSpeak('card')).toBe(true)
+  })
+
+  it('a PILL claim silences only the placeholder — never the card above it', () => {
+    claimStalenessVoice('pill')
+    expect(mayStalenessVoiceSpeak('card')).toBe(true)
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+  })
+
+  it('releasing restores every lower voice', () => {
+    const release = claimStalenessVoice('card')
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+    release()
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(true)
+  })
+
+  it('is reference-counted — two cards on screen, one release, still silent', () => {
+    const releaseA = claimStalenessVoice('card')
+    claimStalenessVoice('card')
+    releaseA()
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+  })
+
+  it('is idempotent per release handle — a double release cannot go negative', () => {
+    const release = claimStalenessVoice('card')
+    claimStalenessVoice('card')
+    release()
+    release()
+    // The second card is still claimed; a negative count would have re-opened
+    // the placeholder while a card was on screen.
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+  })
+})

--- a/src/canvas/conversation/__tests__/stalenessVoice.spec.ts
+++ b/src/canvas/conversation/__tests__/stalenessVoice.spec.ts
@@ -82,3 +82,31 @@ describe('claim / release', () => {
     expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
   })
 })
+
+describe('D1 — the claim is TURN-SCOPED, not merely mount-scoped', () => {
+  /**
+   * The transcript keeps every turn mounted. Before this scope existed, an
+   * applied-edit card ten turns back — scrolled far out of view — claimed the
+   * voice on mount and silenced the pill and the composer for the rest of the
+   * session, with no visible explanation.
+   *
+   * The scope is MOUNTED-IN-THE-NEWEST-TURN, not viewport visibility. That is
+   * stated here as well as in the module, so a later reader checking this
+   * behaviour finds the real boundary rather than the aspiration.
+   */
+  it('an older turn cannot silence anything: no claim, no suppression', () => {
+    // An older card does not call claimStalenessVoice at all — its conjunct is
+    // false — so the registry stays empty and every voice may speak.
+    expect(mayStalenessVoiceSpeak('pill')).toBe(true)
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(true)
+  })
+
+  it('the newest turn claims, and releasing that claim frees the lower voices', () => {
+    const release = claimStalenessVoice('card')
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(false)
+    // A newer turn arriving makes the old card's conjunct false, which runs the
+    // effect cleanup — modelled here by the release the effect returns.
+    release()
+    expect(mayStalenessVoiceSpeak('placeholder')).toBe(true)
+  })
+})

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -64,6 +64,49 @@ function stripProposalPrefix(text: string, isApplied: boolean): string {
   return text.replace(PROPOSAL_PREFIX_RE, '')
 }
 
+/**
+ * THE rendered summary of a graph-patch card — the single authority for
+ * "what text does this card actually put on screen?".
+ *
+ * Extracted (behaviour unchanged) because a SECOND consumer now needs the
+ * answer: the turn's render-authority collector, which withholds prose the card
+ * is about to state again. An adversarial review caught that collector reading
+ * BOTH `applied_summary` and `summary` while this component renders exactly
+ * ONE of them — so on a proposed patch it suppressed prose against text the
+ * user would never see. That is content loss, and it came from a mirror.
+ *
+ * There is now no mirror: both call sites call this.
+ */
+export function resolveGraphPatchSummaryText(
+  block: GraphPatchBlockType,
+  isApplied: boolean,
+): string {
+  const ceeSummaryText = normaliseDashes(block.summary || '')
+  const ceeAppliedSummaryText = normaliseDashes(block.applied_summary || '')
+  const rawSummaryText = ceeSummaryText || getContextualFallback(block)
+  return isApplied && ceeAppliedSummaryText
+    ? ceeAppliedSummaryText
+    : stripProposalPrefix(rawSummaryText, isApplied)
+}
+
+/**
+ * Is this patch card in its APPLIED state? The same conjunction the renderer
+ * uses, exported for the same single-authority reason as above.
+ *
+ * `auto_apply` is on the block; `accepted` is RUNTIME state held in the
+ * `patchBlockStates` map, so a caller without that map cannot answer this and
+ * must not guess.
+ */
+export function isGraphPatchApplied(
+  block: GraphPatchBlockType,
+  patchBlockStates: Map<string, PatchBlockState> | undefined,
+  turnId: string | undefined,
+): boolean {
+  if (block.auto_apply === true) return true
+  const stateKey = turnId ? `${turnId}:${block.patch_id}` : block.patch_id
+  return resolvePatchBlockState(block, patchBlockStates, stateKey) === 'accepted'
+}
+
 function getProposalItems(block: GraphPatchBlockType): ProposalReviewItem[] {
   return Array.isArray(block.proposal_items) ? block.proposal_items.filter((item) => !!item?.description) : []
 }
@@ -181,9 +224,6 @@ export function GraphPatchBlockRenderer({
   )
 
   // Prefer CEE's semantic block.summary; fall back to contextual text by patch type.
-  const ceeSummaryText = normaliseDashes(block.summary || '')
-  const ceeAppliedSummaryText = normaliseDashes(block.applied_summary || '')
-  const rawSummaryText = ceeSummaryText || getContextualFallback(block)
   const rawProposalItems = getProposalItems(block)
   const proposalItemsSource = getProposalItemsSource(block)
   const operationMeta = Array.isArray(block.operation_meta) ? block.operation_meta : []
@@ -199,11 +239,10 @@ export function GraphPatchBlockRenderer({
     || (block.patch_type == null && isAutoApplied && addNodeOpCount >= 3 && addNodeOpCount > block.operations.length / 2)
   const hasRevealTargets = !isWholeGraphTarget && !isGenerativeDraft && (uniqueTargetNodeIds.length > 0 || edgeIds.length > 0)
   const isApplied = isAutoApplied || resolvedState === 'accepted'
+  // ONE authority — see resolveGraphPatchSummaryText.
   const summaryText = useMemo(
-    () => (isApplied && ceeAppliedSummaryText
-      ? ceeAppliedSummaryText
-      : stripProposalPrefix(rawSummaryText, isApplied)),
-    [rawSummaryText, ceeAppliedSummaryText, isApplied],
+    () => resolveGraphPatchSummaryText(block, isApplied),
+    [block, isApplied],
   )
   const cardState = resolveCardState(resolvedState, isAutoApplied, rejectionInfo?.code === 'NETWORK_ERROR')
   const { header: cardHeader, badge: cardBadge } = getPatchCardLabels(cardState)

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -72,17 +72,34 @@
  * that exact segment. A higher tier is never withheld, so no surface can lose
  * content to a surface the user has not been shown.
  *
- * 4. NO CONTENT EDITING. Suppression operates on WHOLE SEGMENTS (a paragraph or
- *    a line) and only on EXACT equality after whitespace normalisation. It never
- *    rewrites a segment, never splits a sentence out of one, and never drops a
- *    segment that is merely similar. A repeat INSIDE a single paragraph is
- *    deliberately NOT de-duplicated: separating it would need a sentence
- *    predicate over natural language, which is the class of rule this platform
- *    has watched oscillate for four rounds without terminating (trap 22f). The
- *    limit is stated, pinned by a spec, and visible — never silently absorbed.
+ * 4. NO CONTENT EDITING, AND NOTHING IS WITHHELD EXCEPT AGAINST A HIGHER TIER.
+ *    Stated as narrowly as the code actually delivers, because the first draft
+ *    of this invariant was written wider than its implementation and an
+ *    adversarial review found the gap:
+ *      (a) suppression compares WHOLE SEGMENTS — a paragraph or a line — and
+ *          only on EXACT equality after whitespace/case normalisation. Never a
+ *          rewrite, never a substring, never a similarity threshold;
+ *      (b) a segment is withheld ONLY when a surface ABOVE it in the tier order
+ *          has already rendered that exact segment. Repetition WITHIN one
+ *          surface is the producer's and always survives;
+ *      (c) the text a caller passes as `alreadyRendered` must be what that
+ *          surface ACTUALLY RENDERS. Suppressing against text the user cannot
+ *          see is content loss wearing de-duplication's clothes, and it is how
+ *          both of this rule's shipped defects worked.
+ *    Two things this rule therefore does NOT do, deliberately: it does not split
+ *    sentences out of a paragraph (that needs a predicate over natural language
+ *    — the class this platform watched oscillate for four rounds without
+ *    terminating, trap 22f), and it does not de-duplicate a text against itself.
+ *    Both limits are pinned by their own specs — stated and visible, never
+ *    silently absorbed.
  */
-import type { ConversationBlock } from './types'
+import type { ConversationBlock, GraphPatchBlock } from './types'
 import { isLensCompanionBlock } from './phase3Pacing'
+import {
+  isGraphPatchApplied,
+  resolveGraphPatchSummaryText,
+} from './blocks/GraphPatchBlockRenderer'
+import type { PatchBlockState } from './useConversation'
 
 /**
  * How many coaching points are exposed at top level. Paul's ruling: "max ~3
@@ -319,14 +336,39 @@ export interface DedupeResult {
  * authority order is enforced by the call site's argument order and by nothing
  * else — which is why every call site names its tier in a comment.
  *
- * Self-duplication inside `text` is also collapsed (the second and later
- * occurrences of a segment already emitted by this same call), because "the
- * same sentence twice inside one disclosure" is the same defect one level down
- * (L-16). The FIRST occurrence always survives.
+ * ⚠⚠ IT DOES NOT DE-DUPLICATE `text` AGAINST ITSELF, AND THAT IS THE WHOLE
+ * POINT OF THIS PARAGRAPH.
  *
- * Total by construction: with an empty `alreadyRendered` and no internal
- * repeats the output is byte-identical to the input, so every surface that has
- * nothing to de-duplicate is unchanged.
+ * An earlier version of this function accumulated its own segments into `seen`,
+ * so with an EMPTY `alreadyRendered` — the default path, i.e. every ordinary
+ * assistant turn — the second occurrence of any identical line was deleted.
+ * An adversarial review proved it at the rendered HTML: "Timeline slips"
+ * appearing under both Risks and Mitigations rendered ONCE; three "Confidence:
+ * not stated" status lines became one. That is CONTENT LOSS, shipped by
+ * default, in the module whose first invariant is that nothing is dropped.
+ *
+ * The root error was treating two DIFFERENT QUESTIONS as one predicate:
+ *
+ *   CROSS-TIER  "has a higher-authority surface already rendered this exact
+ *               segment?"  — a FACT. The caller supplies the other surface's
+ *               text; equality settles it; there is nothing to infer.
+ *   WITHIN-TEXT "did the producer repeat this line by accident, or on purpose
+ *               because it is a structural label under two headings?" — a
+ *               GUESS. Nothing in the text distinguishes them.
+ *
+ * They cannot share a window (trap 22b: one predicate, two opposite harms —
+ * a missed duplicate is cosmetic, a deleted line is a lie about what the
+ * producer said). So only the fact is implemented. Repetition INSIDE one
+ * surface is the producer's and is rendered verbatim.
+ *
+ * L-16 is unaffected: its mechanism, derived at the CEE bytes, is cross-tier
+ * (`_answer_shape.headline` and `assistant_text` carrying the same bytes; a
+ * consent card restating the prose). And "the same sentence twice inside one
+ * disclosure" is still closed where it actually occurs — ACROSS blocks, by the
+ * caller accumulating each rendered block into `alreadyRendered` (InlineBlocks).
+ *
+ * Total by construction: with an empty `alreadyRendered` the output is now
+ * byte-identical to the input, ALWAYS.
  */
 export function dedupeRenderedText(
   text: string,
@@ -353,12 +395,12 @@ export function dedupeRenderedText(
       kept.push(segment)
       continue
     }
-    const key = renderSegmentKey(segment)
-    if (seen.has(key)) {
+    // NOT added to `seen` — see the docstring. A repeat of THIS text's own
+    // earlier segment survives; only a repeat of a HIGHER TIER is withheld.
+    if (seen.has(renderSegmentKey(segment))) {
       suppressedCount++
       continue
     }
-    seen.add(key)
     kept.push(segment)
   }
 
@@ -405,6 +447,14 @@ export function dedupeRenderedText(
  */
 export function collectConsentSurfaceText(
   blocks: readonly ConversationBlock[] | undefined,
+  /**
+   * Runtime patch state + turn id. REQUIRED to answer "is this patch card
+   * applied?", which decides WHICH of its two summary fields renders. A caller
+   * that cannot supply them gets nothing collected for patch cards rather than
+   * a guess — see the graph_patch case.
+   */
+  patchBlockStates?: Map<string, PatchBlockState>,
+  turnId?: string,
 ): string[] {
   if (!blocks || blocks.length === 0) return []
   const out: string[] = []
@@ -417,14 +467,33 @@ export function collectConsentSurfaceText(
         if (typeof summary === 'string' && summary.trim().length > 0) out.push(summary)
         break
       }
-      case 'graph_patch':
-      case 'proposal': {
-        const b = block as { summary?: unknown; applied_summary?: unknown }
-        for (const candidate of [b.applied_summary, b.summary]) {
-          if (typeof candidate === 'string' && candidate.trim().length > 0) out.push(candidate)
-        }
+      case 'graph_patch': {
+        /**
+         * ⚠ EXACTLY ONE FIELD RENDERS, AND WHICH ONE DEPENDS ON RUNTIME STATE.
+         *
+         * This used to push BOTH `applied_summary` and `summary`. An
+         * adversarial review caught it: `GraphPatchBlockRenderer` shows
+         * `applied_summary` only when applied, and the stripped `summary`
+         * otherwise — so on a PROPOSED patch the collector suppressed prose
+         * against `applied_summary`, text the user would never see. Withholding
+         * prose against unshown text is content loss, not de-duplication.
+         *
+         * Resolved through the renderer's OWN exported helpers, so there is one
+         * authority and no mirror to drift.
+         */
+        const patch = block as GraphPatchBlock
+        const applied = isGraphPatchApplied(patch, patchBlockStates, turnId)
+        const rendered = resolveGraphPatchSummaryText(patch, applied)
+        if (rendered.trim().length > 0) out.push(rendered)
         break
       }
+      // 'proposal' is DELIBERATELY ABSENT. `ProposalBlock` carries
+      // `description` + `changes[]` and has NO `summary` / `applied_summary`
+      // field at all, so the branch that used to sit here could never fire —
+      // a dead case that read as coverage. `ProposalBlockRenderer` composes its
+      // card from those other fields; wiring it up is a separate change with
+      // its own evidence, not something to guess at inside a suppression rule.
+      //
       // 'v5_graph_patch' renders a structured before/after receipt, not prose,
       // and 'commentary' is excluded by the rule above.
       default:

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -43,6 +43,43 @@
  *    phase3Pacing.ts documents at EXERCISE_RANK_AFTER_REVIEW_CARDS. The one
  *    exception is the companion reservation, which SWAPS one member of the
  *    point set and is bounded to one.
+ *
+ * ## ONE RENDER AUTHORITY (L-16 / NEW-9, 16 Aug 2026) — added, nothing weakened
+ *
+ * The three invariants above govern which CLASS a block lands in. They said
+ * nothing about the same TEXT arriving through two channels at once, and it
+ * does — by producer design:
+ *
+ *   · CEE derives `assistant_text` FROM the answer shape
+ *     (`deriveAnswerTextFromShape`, derived at the CEE bytes on staging
+ *     `2988eacf`): `headline \n\n • bullets \n\n detail`. The `_answer_shape`
+ *     sidecar carries the same three parts. The byte-equality is DELIBERATE and
+ *     producer-side — it exists so legacy `assistant_text` consumers keep
+ *     working — so the fix cannot be "stop one of them being emitted".
+ *   · a held-proposal / patch card restates the plan the prose already stated
+ *     (the scoreboard measured this byte-for-byte on the edit path, NEW-9).
+ *
+ * Rendering both is the defect the user sees. So this module also owns the
+ * RENDER AUTHORITY ORDER, and one suppression rule applied at every surface:
+ *
+ *   TIER 0  consent / answer cards (the `pinned` class)  — highest authority
+ *   TIER 1  the answer-shape headline
+ *   TIER 2  the prose body
+ *   TIER 3  points
+ *   TIER 4  the detail disclosure
+ *
+ * A LOWER tier's segment is withheld when a HIGHER tier has already rendered
+ * that exact segment. A higher tier is never withheld, so no surface can lose
+ * content to a surface the user has not been shown.
+ *
+ * 4. NO CONTENT EDITING. Suppression operates on WHOLE SEGMENTS (a paragraph or
+ *    a line) and only on EXACT equality after whitespace normalisation. It never
+ *    rewrites a segment, never splits a sentence out of one, and never drops a
+ *    segment that is merely similar. A repeat INSIDE a single paragraph is
+ *    deliberately NOT de-duplicated: separating it would need a sentence
+ *    predicate over natural language, which is the class of rule this platform
+ *    has watched oscillate for four rounds without terminating (trap 22f). The
+ *    limit is stated, pinned by a spec, and visible — never silently absorbed.
  */
 import type { ConversationBlock } from './types'
 import { isLensCompanionBlock } from './phase3Pacing'
@@ -219,6 +256,182 @@ export function composeMessage(
   }
 
   return { headline, pinned, points, detail }
+}
+
+// ---------------------------------------------------------------------------
+// ONE RENDER AUTHORITY — the suppression primitives (invariant 4)
+// ---------------------------------------------------------------------------
+
+/**
+ * The comparison key for "has this exact segment already been rendered?".
+ *
+ * Whitespace-insensitive and case-insensitive, because the two channels that
+ * carry the same sentence are assembled by different code paths (a template
+ * join on one side, a tool-call field on the other) and differ in newlines and
+ * padding without differing in content. NOTHING ELSE is normalised: no
+ * punctuation stripping, no stemming, no fuzzy distance. Two segments match
+ * only when they are the same words in the same order.
+ *
+ * A blank segment normalises to '' and is never treated as a duplicate of
+ * anything — see `isRenderableSegment`.
+ */
+export function renderSegmentKey(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+/**
+ * Segment boundaries: a blank line (paragraph) OR a single newline (a list
+ * line). Deliberately NOT sentence boundaries — see invariant 4.
+ *
+ * Returns the segments with their ORIGINAL bytes (only the split is derived
+ * from the normalised form), so re-joining survivors reproduces the producer's
+ * text exactly for any input in which nothing was suppressed.
+ */
+export function splitRenderSegments(text: string): string[] {
+  return text.split(/\n/).map((s) => s.replace(/\s+$/, ''))
+}
+
+/**
+ * Is this segment eligible to participate in duplicate suppression at all?
+ *
+ * Blank segments carry no content — suppressing them would collapse the
+ * producer's paragraph spacing, and treating them as duplicates of each other
+ * would fold a whole message into one run-on block.
+ */
+function isRenderableSegment(segment: string): boolean {
+  return renderSegmentKey(segment).length > 0
+}
+
+/** What `dedupeRenderedText` withheld, so a caller can disclose it rather than hide it. */
+export interface DedupeResult {
+  /** The surviving text. Identical to the input when nothing was withheld. */
+  text: string
+  /** How many segments were withheld because a higher tier had already rendered them. */
+  suppressedCount: number
+}
+
+/**
+ * Withhold from `text` every whole segment a HIGHER-AUTHORITY surface has
+ * already rendered this turn.
+ *
+ * `alreadyRendered` is the higher tiers' text, in authority order. It is read,
+ * never written: this function cannot suppress anything FROM it, so the
+ * authority order is enforced by the call site's argument order and by nothing
+ * else — which is why every call site names its tier in a comment.
+ *
+ * Self-duplication inside `text` is also collapsed (the second and later
+ * occurrences of a segment already emitted by this same call), because "the
+ * same sentence twice inside one disclosure" is the same defect one level down
+ * (L-16). The FIRST occurrence always survives.
+ *
+ * Total by construction: with an empty `alreadyRendered` and no internal
+ * repeats the output is byte-identical to the input, so every surface that has
+ * nothing to de-duplicate is unchanged.
+ */
+export function dedupeRenderedText(
+  text: string,
+  alreadyRendered: readonly string[] = [],
+): DedupeResult {
+  if (!text) return { text, suppressedCount: 0 }
+
+  const seen = new Set<string>()
+  for (const prior of alreadyRendered) {
+    for (const segment of splitRenderSegments(prior)) {
+      if (isRenderableSegment(segment)) seen.add(renderSegmentKey(segment))
+    }
+    // The whole prior surface also counts as one segment: a card summary that
+    // is a single paragraph must suppress the identical single paragraph in the
+    // prose, and splitting both sides identically is what makes that hold.
+    if (isRenderableSegment(prior)) seen.add(renderSegmentKey(prior))
+  }
+
+  const segments = splitRenderSegments(text)
+  const kept: string[] = []
+  let suppressedCount = 0
+  for (const segment of segments) {
+    if (!isRenderableSegment(segment)) {
+      kept.push(segment)
+      continue
+    }
+    const key = renderSegmentKey(segment)
+    if (seen.has(key)) {
+      suppressedCount++
+      continue
+    }
+    seen.add(key)
+    kept.push(segment)
+  }
+
+  if (suppressedCount === 0) return { text, suppressedCount: 0 }
+
+  // Collapse the runs of blank segments a suppression can strand, so removing a
+  // paragraph does not leave a hole where it used to be. Leading/trailing blanks
+  // go entirely; interior runs collapse to ONE blank line (the paragraph break
+  // the producer used).
+  const trimmed: string[] = []
+  for (const segment of kept) {
+    if (isRenderableSegment(segment)) {
+      trimmed.push(segment)
+      continue
+    }
+    if (trimmed.length === 0) continue
+    if (!isRenderableSegment(trimmed[trimmed.length - 1])) continue
+    trimmed.push('')
+  }
+  while (trimmed.length > 0 && !isRenderableSegment(trimmed[trimmed.length - 1])) trimmed.pop()
+
+  return { text: trimmed.join('\n'), suppressedCount }
+}
+
+/**
+ * TIER 0's text: what the turn's pinned consent / answer cards will render.
+ *
+ * Read by the bubble so the PROSE body can withhold a plan the card is about to
+ * state again (NEW-9: the scoreboard measured the plan printed twice per
+ * structural edit, byte-for-byte — prose and card). The card wins because it
+ * carries the consent affordance: a user confirming a structural change must
+ * read the change ON the control they are agreeing through.
+ *
+ * ⚠ `commentary` is PINNED but is deliberately NOT a tier-0 surface. It is
+ * prose, not a consent control, and its duplication against `assistant_text` is
+ * already resolved one level upstream at ingest
+ * (`deduplicateAgainstCommentary`). Listing it here would put two mechanisms on
+ * one seam, which is how this estate produces a defect and its exact inverse in
+ * consecutive rounds (trap 22b). One seam, one writer.
+ *
+ * Unknown / future pinned types contribute nothing rather than guessing at a
+ * field name — a wrong guess would suppress prose against text that never
+ * renders, which is content loss. Absence here only ever costs a duplicate.
+ */
+export function collectConsentSurfaceText(
+  blocks: readonly ConversationBlock[] | undefined,
+): string[] {
+  if (!blocks || blocks.length === 0) return []
+  const out: string[] = []
+  for (const block of blocks) {
+    if (!isPinnedBlock(block)) continue
+    switch (block.type) {
+      case 'v5_held_proposal':
+      case 'v5_analysis_result': {
+        const summary = (block as { summary?: unknown }).summary
+        if (typeof summary === 'string' && summary.trim().length > 0) out.push(summary)
+        break
+      }
+      case 'graph_patch':
+      case 'proposal': {
+        const b = block as { summary?: unknown; applied_summary?: unknown }
+        for (const candidate of [b.applied_summary, b.summary]) {
+          if (typeof candidate === 'string' && candidate.trim().length > 0) out.push(candidate)
+        }
+        break
+      }
+      // 'v5_graph_patch' renders a structured before/after receipt, not prose,
+      // and 'commentary' is excluded by the rule above.
+      default:
+        break
+    }
+  }
+  return out
 }
 
 /**

--- a/src/canvas/conversation/stalenessVoice.ts
+++ b/src/canvas/conversation/stalenessVoice.ts
@@ -1,0 +1,139 @@
+/**
+ * stalenessVoice — ONE staleness communication per turn view (L-42).
+ *
+ * ## The defect
+ *
+ * Screenshot S03: the applied-edit card's note, a "Should fix" guidance card and
+ * the composer placeholder ALL told the user to re-run, at once, about the same
+ * fact. A fourth surface — the freshness pill above the bubble — says it again.
+ * Four voices, one fact, none of them wrong and all of them together reading as
+ * nagging.
+ *
+ * ## The hierarchy (Paul's ruling for this item: the CARD wins)
+ *
+ *   CARD        the applied-edit receipt's freshness note. It is the only one
+ *               attached to the change that CAUSED the staleness, so it is the
+ *               one that tells the user something they cannot infer.
+ *   PILL        the freshness pill above the bubble.
+ *   PLACEHOLDER the composer's stage-aware prompt.
+ *
+ * A surface speaks only when nothing ABOVE it is speaking.
+ *
+ * ## Why a mount registry and not a shared predicate
+ *
+ * The four surfaces derive from the same trust semantic but not from the same
+ * condition — the card additionally requires an applied receipt IN THIS TURN,
+ * which the composer has no way to see without reaching into the transcript.
+ * A predicate re-derived in each place would be a hand-maintained mirror of a
+ * mount condition (this estate's dominant defect class), and it would be wrong
+ * the moment a surface changed when it renders.
+ *
+ * So the surfaces REGISTER while they are mounted, and the registry is derived
+ * from what is genuinely on screen. It fails SAFE in the only direction that
+ * matters: if nothing registers, every surface behaves exactly as it does today
+ * and the user is over-told rather than under-told.
+ *
+ * The registry is a plain module-level store read through `useSyncExternalStore`
+ * — no new dependency, no provider, and usable from `useStageAwarePlaceholder`,
+ * which is called from surfaces outside the conversation subtree.
+ */
+import { useSyncExternalStore } from 'react'
+
+/** The speaking surfaces, highest authority first. */
+export const STALENESS_VOICES = ['card', 'pill', 'placeholder'] as const
+export type StalenessVoice = (typeof STALENESS_VOICES)[number]
+
+/**
+ * Rank, DERIVED from the ordered tuple above so the order is stated once. A
+ * lower number outranks a higher one.
+ */
+export function stalenessVoiceRank(voice: StalenessVoice): number {
+  return STALENESS_VOICES.indexOf(voice)
+}
+
+/** Live claim counts, one bucket per voice. Reference-counted: two pills may claim at once. */
+const claims: Record<StalenessVoice, number> = { card: 0, pill: 0, placeholder: 0 }
+
+const listeners = new Set<() => void>()
+
+/**
+ * The snapshot. A STRING (or null) rather than an object, because
+ * `useSyncExternalStore` compares snapshots by identity and a fresh object per
+ * read would re-render every subscriber on every store read — the classic
+ * getSnapshot-caching defect. The highest-ranked voice currently claimed.
+ */
+function currentTopVoice(): StalenessVoice | null {
+  for (const voice of STALENESS_VOICES) {
+    if (claims[voice] > 0) return voice
+  }
+  return null
+}
+
+let snapshot: StalenessVoice | null = null
+
+function emit(): void {
+  const next = currentTopVoice()
+  if (next === snapshot) return
+  snapshot = next
+  for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function getSnapshot(): StalenessVoice | null {
+  return snapshot
+}
+
+/**
+ * Claim the staleness voice for `voice` until the returned function is called.
+ *
+ * Imperative rather than a hook so a component can claim from its own effect
+ * with its own condition, and so a test can drive the registry directly.
+ */
+export function claimStalenessVoice(voice: StalenessVoice): () => void {
+  claims[voice] += 1
+  emit()
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    claims[voice] = Math.max(0, claims[voice] - 1)
+    emit()
+  }
+}
+
+/**
+ * May `voice` speak? True when nothing STRICTLY ABOVE it is currently claimed.
+ *
+ * A surface asking about its OWN voice is unaffected by its own claim, so a
+ * component may claim first and ask afterwards without silencing itself.
+ */
+export function mayStalenessVoiceSpeak(voice: StalenessVoice): boolean {
+  const top = getSnapshot()
+  if (top === null) return true
+  return stalenessVoiceRank(top) >= stalenessVoiceRank(voice)
+}
+
+/** Reactive form of {@link mayStalenessVoiceSpeak}. */
+export function useMayStalenessVoiceSpeak(voice: StalenessVoice): boolean {
+  const top = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  if (top === null) return true
+  return stalenessVoiceRank(top) >= stalenessVoiceRank(voice)
+}
+
+/**
+ * Test seam ONLY. Clears every claim.
+ *
+ * Exported because the registry is module-level state and a spec that leaked a
+ * claim into the next spec would silence a surface for reasons nothing in that
+ * spec could explain — a failure mode far more expensive than the export.
+ */
+export function __resetStalenessVoicesForTest(): void {
+  for (const voice of STALENESS_VOICES) claims[voice] = 0
+  emit()
+}

--- a/src/canvas/conversation/stalenessVoice.ts
+++ b/src/canvas/conversation/stalenessVoice.ts
@@ -29,9 +29,26 @@
  * the moment a surface changed when it renders.
  *
  * So the surfaces REGISTER while they are mounted, and the registry is derived
- * from what is genuinely on screen. It fails SAFE in the only direction that
+ * from what is actually rendered. It fails SAFE in the only direction that
  * matters: if nothing registers, every surface behaves exactly as it does today
  * and the user is over-told rather than under-told.
+ *
+ * ## ⚠ WHAT "SPEAKING" MEANS HERE — MOUNTED-IN-THE-NEWEST-TURN, NOT VISIBLE
+ *
+ * An earlier version of this docstring claimed the registry was "derived from
+ * what is genuinely on screen". It was not, and an adversarial review was right
+ * to call it: the transcript keeps EVERY turn mounted, so an applied-edit card
+ * ten turns back — scrolled far out of view — silenced the pill and the
+ * composer permanently.
+ *
+ * The claim is now scoped to the NEWEST ASSISTANT TURN (`isLatestAssistantTurn`,
+ * threaded from ChatThread's own `msg === lastAssistantMsg`), which is a
+ * turn-view scope, NOT a viewport scope. True visibility would need an
+ * IntersectionObserver on every claiming surface; that is a bigger change, it
+ * does not exist in jsdom so the guards would have to mock it, and the residual
+ * harm it would fix — a stale card scrolled just off-screen within the current
+ * turn — is a fraction of the one being fixed here. The scope is stated so the
+ * next reader is not misled by this file the way the last one was.
  *
  * The registry is a plain module-level store read through `useSyncExternalStore`
  * — no new dependency, no provider, and usable from `useStageAwarePlaceholder`,

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -525,6 +525,26 @@ export interface V5HeldProposalAction {
    * by a string that stops mid-word (ROADMAP 2.474 residual (a)).
    */
   detail?: string
+  /**
+   * The producer's own `suggested_actions[].action_type`, carried so a
+   * CARD-HOSTED inline action dispatches with the SAME typed intent the
+   * identical action would carry if CEE had rendered it in the generic chip row
+   * (`buildSuggestedActionChips` already forwards it there).
+   *
+   * ── The defect this closes (L-59, measured 16 Aug 2026) ──────────────────
+   * The card sends through `_sendChip(label, message)`, which minted a chip
+   * with NO `action_type` — so a click on the product's own inline action
+   * reached CEE as an ordinary chat turn. The witnessed symptom is the sentence
+   * `chipActionVocabulary`'s docstring already names as the signature of an
+   * untyped chip click: "You did not ask me to edit the model, so I have not".
+   * The affordance and the reply disagreed about what had just happened.
+   *
+   * Fail-closed by construction: `buildPayload.sanitiseActionType` withholds
+   * any value that is not BOTH published in our vendored enum AND accepted at
+   * CEE ingress, so an absent or unrecognised value behaves exactly as today
+   * and can never 422 the turn.
+   */
+  action_type?: string
 }
 
 export interface V5HeldProposalBlock {

--- a/src/canvas/conversation/zones/ChatMessage.tsx
+++ b/src/canvas/conversation/zones/ChatMessage.tsx
@@ -53,6 +53,13 @@ interface ChatMessageProps {
    * retry affordance. ChatThread sets this for at most ONE message.
    */
   showFailedSendRetry?: boolean
+  /**
+   * L-42: is this the NEWEST assistant turn? Only that turn's applied-edit card
+   * may claim the staleness voice — see `stalenessVoice.ts`. ChatThread already
+   * computes this identity (`msg === lastAssistantMsg`) for the chip row, so it
+   * is threaded rather than re-derived.
+   */
+  isLatestAssistantTurn?: boolean
 }
 
 export const ChatMessage = memo(function ChatMessage({
@@ -69,6 +76,7 @@ export const ChatMessage = memo(function ChatMessage({
   onProposalConfirm,
   compact,
   showFailedSendRetry,
+  isLatestAssistantTurn = false,
 }: ChatMessageProps) {
   const category = getMessageCategory(message)
   const borderClass = CATEGORY_BORDER[category]
@@ -115,6 +123,7 @@ export const ChatMessage = memo(function ChatMessage({
         onProposalConfirm={onProposalConfirm}
         compact={compact}
         onRetryFailedSend={showFailedSendRetry ? onRetry : undefined}
+        isLatestAssistantTurn={isLatestAssistantTurn}
       />
     </div>
   )

--- a/src/canvas/conversation/zones/ChatMessage.tsx
+++ b/src/canvas/conversation/zones/ChatMessage.tsx
@@ -10,7 +10,7 @@
 
 import { memo } from 'react'
 import { MessageBubble } from '../MessageBubble'
-import { MessageActions } from './MessageActions'
+import { ACTION_BAR_GUTTER_PX, MessageActions } from './MessageActions'
 import type { ConversationMessage, ActionChip, GraphPatchBlock } from '../types'
 import type { PatchBlockState, PatchRejectionInfo } from '../useConversation'
 
@@ -76,9 +76,15 @@ export const ChatMessage = memo(function ChatMessage({
   return (
     <div
       className={`group relative pointer-events-auto ${borderClass}`}
-      style={{ marginBottom: 12 }}
+      // L-73: the hover controls get their OWN band. Before this they were
+      // absolutely positioned at top:0, i.e. on top of the first line of the
+      // message — "hover controls can cover message text", verbatim. The gutter
+      // is reserved unconditionally rather than on hover, because opening it on
+      // hover would reflow the whole thread under the user's pointer.
+      style={{ marginBottom: 12, paddingTop: ACTION_BAR_GUTTER_PX }}
       data-testid={`chat-message-${message.role}`}
       data-message-category={category !== 'answer' ? category : undefined}
+      data-actions-gutter-px={ACTION_BAR_GUTTER_PX}
     >
       {/* Action bar — visible on hover/focus-within, fade in 200ms */}
       <div

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -251,6 +251,10 @@ export const ChatThread = memo(function ChatThread({
             onChipClick={onChipClick}
             onRetry={onRetry}
             showFailedSendRetry={msg.id === failedSendRetryId}
+            // L-42: `isLastAssistant` is the identity ChatThread ALREADY
+            // derives for the chip row; reusing it means the staleness voice
+            // and the chips can never disagree about which turn is current.
+            isLatestAssistantTurn={isLastAssistant}
             patchBlockStates={patchBlockStates}
             patchRejections={patchRejections}
             onPatchAccept={onPatchAccept}

--- a/src/canvas/conversation/zones/MessageActions.tsx
+++ b/src/canvas/conversation/zones/MessageActions.tsx
@@ -1,13 +1,51 @@
 /**
  * MessageActions — hover/focus action bar on messages.
  *
- * User messages: Copy. AI messages: Copy, Retry.
- * 26px visual circle inside 44px touch target (DS v5 §8.11).
- * Hover: border transitions to info. Positioned absolute inside message card.
- * User: right-aligned. AI: left-aligned.
+ * ## Control parity (L-72)
+ *
+ * Both roles get Copy. Only assistant messages get Retry, and that asymmetry is
+ * a product decision rather than an omission: retrying a USER message is a
+ * different act — it is re-DELIVERING a send that failed — and it already has
+ * its own affordance on the bubble itself ("Not delivered → Retry",
+ * `MessageBubble`), wired to the same `retryLast`. Two Retry controls on one
+ * user bubble, one meaning "resend" and one meaning "regenerate", is the
+ * two-questions-under-one-name shape this platform has already paid for.
+ *
+ * Copy no longer fails silently. `navigator.clipboard` is unavailable on
+ * insecure origins and can be permission-denied; the previous handler swallowed
+ * both, which is exactly the "reportedly fail" report in L-72 — the icon
+ * animated, nothing was copied, and nothing said so. The control now reports
+ * what happened, in a polite live region.
+ *
+ * ## Geometry (L-73) — the controls must never cover message text
+ *
+ * The bar used to be `absolute top-0`, i.e. sitting directly ON the first line
+ * of the message. It is now positioned inside a RESERVED GUTTER that
+ * `ChatMessage` opens above every bubble, and the arithmetic that guarantees
+ * no overlap is stated ONCE, here, as exported constants:
+ *
+ *     ACTION_BAR_TOP_OFFSET_PX + ACTION_BAR_HEIGHT_PX <= ACTION_BAR_GUTTER_PX
+ *
+ * The offset is negative, so the bar reaches up into the inter-message gap and
+ * the reserved band stays small. jsdom cannot prove visibility (platform trap
+ * 3), so the spec binds THIS INVARIANT rather than pretending to measure
+ * layout — and it binds the same constants the component and its host consume,
+ * so the guard cannot agree with a copy of the rule instead of the rule.
  */
 
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Copy, RefreshCw } from 'lucide-react'
+
+/** 44px touch target (DS v5 §8.11) — unchanged; the fix is where it sits, not its size. */
+export const ACTION_BAR_HEIGHT_PX = 44
+/** How far the bar reaches ABOVE the reserved band, into the inter-message gap. */
+export const ACTION_BAR_TOP_OFFSET_PX = -12
+/** Vertical space `ChatMessage` reserves above the bubble for the bar. */
+export const ACTION_BAR_GUTTER_PX = 32
+/** How long the copy outcome stays announced before the bar returns to rest. */
+const COPY_FEEDBACK_MS = 2000
+
+type CopyOutcome = null | 'copied' | 'failed'
 
 interface MessageActionsProps {
   role: 'user' | 'assistant'
@@ -18,27 +56,68 @@ interface MessageActionsProps {
 }
 
 export function MessageActions({ role, content, onRetry }: MessageActionsProps) {
-  const handleCopy = () => {
-    navigator.clipboard.writeText(content).catch(() => {
-      // Fallback silently
-    })
-  }
+  const [outcome, setOutcome] = useState<CopyOutcome>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  const announce = useCallback((next: CopyOutcome) => {
+    setOutcome(next)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setOutcome(null), COPY_FEEDBACK_MS)
+  }, [])
+
+  const handleCopy = useCallback(() => {
+    // Availability is checked rather than assumed: `navigator.clipboard` is
+    // undefined on an insecure origin, so calling straight through would throw
+    // synchronously and never reach the rejection handler.
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+    if (!clipboard?.writeText) {
+      announce('failed')
+      return
+    }
+    clipboard.writeText(content).then(
+      () => announce('copied'),
+      () => announce('failed'),
+    )
+  }, [content, announce])
 
   return (
     <div
       className={`
-        flex absolute z-10 pointer-events-auto
+        flex items-center absolute z-10 pointer-events-auto
         ${role === 'user' ? 'right-0' : 'left-0'}
-        top-0
       `}
+      style={{ top: ACTION_BAR_TOP_OFFSET_PX, height: ACTION_BAR_HEIGHT_PX }}
       role="toolbar"
       aria-label="Message actions"
       data-testid="message-actions"
     >
-      <ActionButton icon={Copy} label="Copy" onClick={handleCopy} />
+      <ActionButton
+        icon={Copy}
+        label="Copy"
+        onClick={handleCopy}
+        testId="message-action-copy"
+      />
       {role === 'assistant' && onRetry && (
-        <ActionButton icon={RefreshCw} label="Retry" onClick={onRetry} />
+        <ActionButton
+          icon={RefreshCw}
+          label="Retry"
+          onClick={onRetry}
+          testId="message-action-retry"
+        />
       )}
+      {/* Outcome is ANNOUNCED, never swallowed. Visually hidden: the bar itself
+          is a hover surface and a text label would reflow it, but a screen
+          reader (and a spec) can see the result of the action either way. */}
+      <span className="sr-only" role="status" aria-live="polite" data-testid="message-action-status">
+        {outcome === 'copied' ? 'Message copied' : outcome === 'failed' ? "Couldn't copy — copy it manually" : ''}
+      </span>
     </div>
   )
 }
@@ -47,10 +126,12 @@ function ActionButton({
   icon: Icon,
   label,
   onClick,
+  testId,
 }: {
   icon: React.ElementType
   label: string
   onClick: () => void
+  testId: string
 }) {
   return (
     <button
@@ -58,14 +139,16 @@ function ActionButton({
       onClick={onClick}
       aria-label={label}
       title={label}
+      data-testid={testId}
+      style={{ width: ACTION_BAR_HEIGHT_PX, height: ACTION_BAR_HEIGHT_PX }}
       className="
-        group/action w-[44px] h-[44px] flex items-center justify-center
+        group/action flex items-center justify-center
         cursor-pointer
         focus-visible:ring-2 focus-visible:ring-info focus-visible:outline-none
         rounded-full
       "
     >
-      {/* 26px visual circle inside 44px touch target (DS v5 §8.11) */}
+      {/* 26px visual circle inside the 44px touch target (DS v5 §8.11) */}
       <span
         className="
           w-[26px] h-[26px] flex items-center justify-center rounded-full

--- a/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
+++ b/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
@@ -47,11 +47,36 @@ describe('useStageAwarePlaceholder', () => {
     expect(placeholder()).toBe('Ask about this model…')
   })
 
-  it('selection wins over everything → "Ask about {label}…"', () => {
+  /**
+   * ⚠ PIN FLIPPED, DELIBERATELY (L-17, 16 Aug 2026). This used to assert
+   * `'Ask about Switch jobs?…'` — a selection-derived placeholder.
+   *
+   * That behaviour was the defect. A placeholder is an ATTRIBUTE, not content:
+   * the composer's VALUE stayed empty, so the sentence the product appeared to
+   * have written for the user could not be sent. Measured again on 16 Aug at UI
+   * `f15bccaf`: "composer VALUE empty ... Grey, non-submittable, exactly as
+   * filed."
+   *
+   * The selection now carries a REAL, submittable control (`SelectionPill`:
+   * a clickable pill plus a chip, both dispatching one selection-grounded
+   * turn), so the placeholder returns to the neutral prompt and stops
+   * impersonating content it never held. The affordance is pinned by
+   * `SelectionPill.askAffordance.spec.tsx`; this test pins that the composer
+   * no longer claims it.
+   *
+   * The assertion is NEGATIVE as well as positive on purpose: asserting only
+   * the new string would still pass if the label leaked back in some other
+   * form.
+   */
+  it('a selection does NOT write a fake sentence into the composer (L-17)', () => {
     useCanvasStore.setState({ nodes: [node('a')] as never })
     complete(); setFresh()
     selectionRef.value = { id: 'g', label: 'Switch jobs?', kind: 'node' }
-    expect(placeholder()).toBe('Ask about Switch jobs?…')
+    const p = placeholder()
+    expect(p).not.toContain('Switch jobs?')
+    // The selection no longer outranks the freshness verdict either — the
+    // composer says the true thing about the analysis instead.
+    expect(p).toBe('Ask about the latest analysis…')
   })
 
   it('confirmed-fresh analysis → "Ask about the latest analysis…"', () => {

--- a/src/canvas/hooks/useStageAwarePlaceholder.ts
+++ b/src/canvas/hooks/useStageAwarePlaceholder.ts
@@ -1,6 +1,6 @@
 import { useCanvasStore, selectResultsStatus } from '../store'
+import { useMayStalenessVoiceSpeak } from '../conversation/stalenessVoice'
 import { useAnalysisTrust } from './useAnalysisTrust'
-import { useSelectionContext } from './useSelectionContext'
 
 /**
  * Returns the placeholder text the persistent input strip / floating composer
@@ -14,25 +14,37 @@ import { useSelectionContext } from './useSelectionContext'
  * had moved to cannot-confirm).
  *
  * Priority (highest first):
- *   1. Node/edge selected            → "Ask about [label]..."
- *   2. Model changed since the run    → "Model changed. Ask or rerun..."
+ *   1. Model changed since the run    → "Model changed. Ask or rerun..."
  *      (CEE 'stale' OR a local edit that downgraded a retained 'fresh')
- *   3. Confirmed current analysis     → "Ask about the latest analysis..."
- *   4. Analysis exists, can't confirm → "Ask about this analysis..."
+ *      — SUPPRESSED while a higher staleness voice is on screen, see below.
+ *   2. Confirmed current analysis     → "Ask about the latest analysis..."
+ *   3. Analysis exists, can't confirm → "Ask about this analysis..."
  *      (cannot-confirm / no freshness verdict — never claims "latest")
- *   5. Model exists                   → "Ask about this model..."
- *   6. No model                       → "Describe your decision..."
+ *   4. Model exists                   → "Ask about this model..."
+ *   5. No model                       → "Describe your decision..."
+ *
+ * ── L-17: THE SELECTION BRANCH IS GONE, DELIBERATELY ───────────────────────
+ * This hook used to return "Ask about [label]…" whenever one element was
+ * selected. That read as a PREPARED SENTENCE the user could send, and it was
+ * not one: a placeholder is an attribute, the composer's value stayed empty,
+ * and there was no way to submit it. The selection now carries a REAL,
+ * submittable control (`SelectionPill`), so the placeholder returns to the
+ * neutral prompt and stops impersonating content it never held.
+ *
+ * ── L-42: ONE STALENESS COMMUNICATION PER TURN VIEW ────────────────────────
+ * The applied-edit card's freshness note and the freshness pill both outrank
+ * this placeholder. While either is on screen the composer says the neutral
+ * thing rather than being the third voice telling the user to re-run.
+ * Suppression is limited to the 'changed' branch — the only one that repeats
+ * the higher surfaces' claim.
  */
 export function useStageAwarePlaceholder(): string {
   const nodeCount = useCanvasStore((s) => s.nodes.length)
   const resultsStatus = useCanvasStore(selectResultsStatus)
-  const selection = useSelectionContext()
   const freshness = useAnalysisTrust().semantic
+  const mayNagAboutStaleness = useMayStalenessVoiceSpeak('placeholder')
 
-  if (selection) {
-    return `Ask about ${selection.label}…`
-  }
-  if (freshness === 'changed') {
+  if (freshness === 'changed' && mayNagAboutStaleness) {
     return 'Model changed. Ask or rerun…'
   }
   if (freshness === 'current') {

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -224,6 +224,20 @@ function withOlumiReveal<Args extends unknown[]>(
 // § 2 — Store state and actions
 // ---------------------------------------------------------------------------
 
+/**
+ * The producer-declared intent a card-hosted inline action may carry alongside
+ * its display label and submitted message. Every field is optional and every
+ * field is the PRODUCER's — the UI never authors one (see `_sendChip`).
+ */
+export interface SendChipMeta {
+  /** Stable chip id, when the caller has one (otherwise the seam mints one). */
+  id?: string
+  /** `suggested_actions[].action_type` exactly as the producer emitted it. */
+  action_type?: string
+  /** `suggested_actions[].parameters`, forwarded unchanged. */
+  parameters?: Record<string, unknown>
+}
+
 export interface GuidanceState {
   guidanceItems: GuidanceItem[]
   activeGuidanceItemId: string | null
@@ -233,8 +247,25 @@ export interface GuidanceState {
   _sendMessage: ((text: string) => void) | null
   /** Registered by ConversationPanel so cross-surface Analyse CTAs can trigger the hidden run path */
   _runAnalysis: (() => void) | null
-  /** Registered by ConversationPanel so evidence blocks can send chip-style turns (display/submitted separation) */
-  _sendChip: ((label: string, message: string) => void) | null
+  /**
+   * Registered by ConversationPanel so evidence blocks can send chip-style turns
+   * (display/submitted separation).
+   *
+   * ⚠ The optional third argument is load-bearing, not decoration (L-59, 16 Aug
+   * 2026). Without it every CARD-HOSTED inline action — held-proposal confirm,
+   * evidence "Apply to model" — reached CEE as a BARE TEXT SEND: the seam minted
+   * a chip with no `action_type`, so a producer-typed action lost its type
+   * exactly when it was rendered on a card instead of in the generic chip row.
+   * CEE then routes the click as ordinary chat, which is how the product's own
+   * "Review the model" button came back with "You did not ask me to edit the
+   * model, so I have not".
+   *
+   * Optional, so every existing caller is unchanged and the ungated path is
+   * byte-identical; the wire gate (`sanitiseActionType`) still withholds any
+   * value CEE has not published AND accepted, so this can only ever restore a
+   * type the producer itself declared — never invent one.
+   */
+  _sendChip: ((label: string, message: string, meta?: SendChipMeta) => void) | null
   /** Registered by ConversationPanel so inspector actions can scroll to a patch block */
   _scrollToPatch: ((patchId: string) => void) | null
   /** Registered by ConversationPanel so inspector "Ask about this" can pre-fill chat input */

--- a/src/v5/blocks/V5GraphPatchBlock.tsx
+++ b/src/v5/blocks/V5GraphPatchBlock.tsx
@@ -19,10 +19,11 @@
  *
  * Design tokens (DS v5 §21.2): card frame, panel typography, semantic border.
  */
-import { useMemo, type ReactElement } from 'react'
+import { useEffect, useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import { useCanvasStore } from '../../canvas/store'
 import { useAnalysisTrust } from '../../canvas/hooks/useAnalysisTrust'
+import { claimStalenessVoice } from '../../canvas/conversation/stalenessVoice'
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/conversation/types'
 import { buildV5PatchReceipt, buildV5PatchDeps } from './v5GraphPatchDescription'
 
@@ -56,6 +57,19 @@ export function V5GraphPatchBlock({ block }: V5GraphPatchBlockProps): ReactEleme
   // emits.
   const trustSemantic = useAnalysisTrust().semantic
   const showStaleHint = receipt.status === 'applied' && trustSemantic === 'changed'
+
+  /**
+   * L-42 — this note is the TOP of the staleness hierarchy while it is on
+   * screen. It is the only staleness surface attached to the edit that caused
+   * the staleness, so the freshness pill and the composer placeholder stand
+   * down for as long as it is rendered (see `stalenessVoice.ts`). Claimed from
+   * an effect keyed on `showStaleHint`, so the claim ends exactly when the note
+   * stops rendering, including on unmount.
+   */
+  useEffect(() => {
+    if (!showStaleHint) return
+    return claimStalenessVoice('card')
+  }, [showStaleHint])
 
   const isApplied = receipt.status === 'applied'
 

--- a/src/v5/blocks/V5GraphPatchBlock.tsx
+++ b/src/v5/blocks/V5GraphPatchBlock.tsx
@@ -29,9 +29,22 @@ import { buildV5PatchReceipt, buildV5PatchDeps } from './v5GraphPatchDescription
 
 export interface V5GraphPatchBlockProps {
   block: V5GraphPatchBlockType
+  /**
+   * L-42: is this card in the NEWEST assistant turn? Only that turn's card may
+   * claim the staleness voice.
+   *
+   * The transcript keeps every turn mounted, so a mount-keyed claim let an
+   * applied-edit card from ten turns back — scrolled far out of view — silence
+   * the freshness pill and the composer for the rest of the session. Defaults
+   * to false, so a caller that does not thread it silences nothing.
+   */
+  isLatestAssistantTurn?: boolean
 }
 
-export function V5GraphPatchBlock({ block }: V5GraphPatchBlockProps): ReactElement {
+export function V5GraphPatchBlock({
+  block,
+  isLatestAssistantTurn = false,
+}: V5GraphPatchBlockProps): ReactElement {
   // Pull only the slices we need; useCanvasStore selectors keep the
   // subscription scoped so the block does not re-render on unrelated
   // store updates.
@@ -59,17 +72,23 @@ export function V5GraphPatchBlock({ block }: V5GraphPatchBlockProps): ReactEleme
   const showStaleHint = receipt.status === 'applied' && trustSemantic === 'changed'
 
   /**
-   * L-42 — this note is the TOP of the staleness hierarchy while it is on
-   * screen. It is the only staleness surface attached to the edit that caused
-   * the staleness, so the freshness pill and the composer placeholder stand
-   * down for as long as it is rendered (see `stalenessVoice.ts`). Claimed from
-   * an effect keyed on `showStaleHint`, so the claim ends exactly when the note
-   * stops rendering, including on unmount.
+   * L-42 — this note is the TOP of the staleness hierarchy, and it claims that
+   * position ONLY in the newest assistant turn.
+   *
+   * ⚠ The scoping conjunct is the fix for a real defect, not caution: the
+   * transcript keeps every turn mounted, so claiming on mount alone let a card
+   * the user had scrolled past hours ago keep the pill and the composer silent
+   * for the whole session — silence with no visible explanation, which is worse
+   * than the triple-nagging this rule exists to stop.
+   *
+   * The claim is released exactly when either conjunct goes false (the note
+   * stops rendering, or a newer turn arrives), including on unmount.
    */
+  const claimsStalenessVoice = showStaleHint && isLatestAssistantTurn
   useEffect(() => {
-    if (!showStaleHint) return
+    if (!claimsStalenessVoice) return
     return claimStalenessVoice('card')
-  }, [showStaleHint])
+  }, [claimsStalenessVoice])
 
   const isApplied = receipt.status === 'applied'
 

--- a/src/v5/blocks/V5HeldProposalBlock.tsx
+++ b/src/v5/blocks/V5HeldProposalBlock.tsx
@@ -47,10 +47,11 @@
  * unresolvable confirm ref to the R7 unsupported card. Unknown `reason_code`
  * values degrade to the generic held sentence, never the raw code.
  */
-import { type ReactElement, useCallback, useState } from 'react'
+import { type ReactElement, useCallback, useMemo, useState } from 'react'
 import { Hand } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { useGuidanceStore } from '../../canvas/stores/guidanceStore'
+import { dedupeRenderedText, splitRenderSegments } from '../../canvas/conversation/messageComposition'
 import { CHIP_CLASS } from './chipClass'
 import type {
   V5HeldProposalBlock as V5HeldProposalBlockType,
@@ -67,6 +68,48 @@ import {
 
 export interface V5HeldProposalBlockProps {
   block: V5HeldProposalBlockType
+}
+
+/**
+ * READABILITY OF THE THING BEING CONSENTED TO (scoreboard Q3, 16 Aug 2026).
+ *
+ * The measured card restated SIX operations in one paragraph, repeating the
+ * same 70-character option name five times, each stopping mid-word at
+ * `(Under £...`, and the whole plan was ALSO printed as prose above it. A user
+ * confirming a structural change could not skim what they were confirming.
+ *
+ * Three separate fixes, and it matters that they are separate:
+ *   · the PROSE duplicate is withheld by the turn's render authority
+ *     (`collectConsentSurfaceText` in messageComposition.ts) — the card wins,
+ *     because the card is the control the consent is given through;
+ *   · the run-on paragraph is rendered as a LIST when the producer already
+ *     delimited it by lines. Splitting on `\n` is deterministic and lossless —
+ *     every byte still renders, in producer order — and a single-line summary
+ *     renders exactly as it does today. NOTHING is inferred from punctuation;
+ *   · a line the producer emitted TWICE renders once (item 7's rule, applied
+ *     here through the same shared primitive rather than a second local copy).
+ *
+ * What is NOT done, deliberately: the mid-word `…` truncation is in the
+ * PRODUCER's bytes (CEE clamps names before it emits the summary). The UI can
+ * wrap what it is given and it can stop repeating it, but reconstructing the
+ * clamped name would be fabrication. It is reported, not invented.
+ */
+function useConsentLines(summary: string): string[] {
+  return useMemo(() => {
+    const lines: string[] = []
+    let rendered: string[] = []
+    for (const raw of splitRenderSegments(summary)) {
+      if (raw.trim().length === 0) continue
+      const { text: survived, suppressedCount } = dedupeRenderedText(raw, rendered)
+      // A whole-line duplicate collapses; a line that survives partially is kept
+      // verbatim rather than half-rewritten (suppression works on whole
+      // segments, and a single line is one segment).
+      if (suppressedCount > 0 && survived.trim().length === 0) continue
+      lines.push(raw.trim())
+      rendered = [...rendered, raw]
+    }
+    return lines
+  }, [summary])
 }
 
 /** The three strings the confirm affordance needs, resolved together. */
@@ -123,6 +166,9 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
   /** Complete confirm copy — see resolveHeldConfirmCopy. */
   const confirmCopy = resolveHeldConfirmCopy(confirm)
 
+  /** The plan, one change per line, each named once — see useConsentLines. */
+  const consentLines = useConsentLines(block.summary)
+
   const handleConfirm = useCallback(() => {
     if (settled) return
     // Fail closed WITHOUT acknowledging: with no conversation host registered
@@ -141,15 +187,29 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
     // sentence, never the producer's clamped chip label (2.474 residual (a)).
     // Arg 1 is untouched: CEE's exact-match pre-route resolves a confirm by the
     // message, so clamping or rewriting it would break hold routing.
-    sendChip(confirmCopy.record, confirm.message)
+    // Arg 2 carries the PRODUCER's own `action_type` when it emitted one (L-59).
+    // Without it this click was a bare text send and CEE routed the apply as
+    // ordinary chat — the affordance said "confirm", the reply said "you did not
+    // ask me to edit the model". Absent ⇒ omitted, i.e. exactly today's turn.
+    sendChip(
+      confirmCopy.record,
+      confirm.message,
+      confirm.action_type ? { action_type: confirm.action_type } : undefined,
+    )
     setSettled('accepted')
-  }, [settled, sendChip, confirmCopy.record, confirm.message])
+  }, [settled, sendChip, confirmCopy.record, confirm.message, confirm.action_type])
 
   const handleDismiss = useCallback(() => {
     if (settled) return
     // Decline through the existing chip seam when CEE emits a decline action;
     // otherwise dismiss is local-only (the free-text decline path stays open).
-    if (decline) sendChip?.(decline.label, decline.message)
+    if (decline) {
+      sendChip?.(
+        decline.label,
+        decline.message,
+        decline.action_type ? { action_type: decline.action_type } : undefined,
+      )
+    }
     setSettled('dismissed')
   }, [settled, sendChip, decline])
 
@@ -169,9 +229,33 @@ export function V5HeldProposalBlock({ block }: V5HeldProposalBlockProps): ReactE
         </h3>
       </div>
 
-      <p className={typography.panelBody} data-testid="v5-held-proposal-summary">
-        {block.summary}
-      </p>
+      {/* WRAP, NEVER TRUNCATE (the estate's no-mid-word-wrap rule): the option
+          names in a held plan are long, and the dock is narrow. `break-words`
+          wraps at word boundaries and only breaks a word that is itself wider
+          than the column — it never clips, and there is no `truncate` anywhere
+          on this card. A `title` is deliberately NOT added: the full text is
+          already on screen, so a tooltip would be a second copy of it. */}
+      {consentLines.length > 1 ? (
+        <ul
+          className={`${typography.panelBody} list-disc pl-4 space-y-1 break-words`}
+          data-testid="v5-held-proposal-summary"
+          data-consent-line-count={consentLines.length}
+        >
+          {consentLines.map((line, i) => (
+            <li key={i} data-testid={`v5-held-proposal-summary-line-${i}`}>
+              {line}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p
+          className={`${typography.panelBody} break-words`}
+          data-testid="v5-held-proposal-summary"
+          data-consent-line-count={consentLines.length}
+        >
+          {consentLines[0] ?? block.summary}
+        </p>
+      )}
 
       <p
         className={`${typography.panelMeta} text-text-light`}

--- a/src/v5/blocks/__tests__/V5HeldProposalBlock.readability.spec.tsx
+++ b/src/v5/blocks/__tests__/V5HeldProposalBlock.readability.spec.tsx
@@ -1,0 +1,133 @@
+/**
+ * The confirm card — readability and typed dispatch (scoreboard Q3, L-59).
+ *
+ * Measured on 16 Aug at UI `f15bccaf`: the held-changes card "restates all 6
+ * ops in one paragraph with the same 70-character option name repeated five
+ * times, each truncated mid-word ... A user confirming a structural change
+ * cannot skim what they are confirming." And separately: the product's own
+ * inline action came back with "You did not ask me to edit the model, so I have
+ * not" — the signature of an UNTYPED chip click.
+ *
+ * Scope honesty, stated because it bounds every claim below: the mid-word `…`
+ * is in the PRODUCER's bytes (CEE clamps names before it composes the summary).
+ * The UI can render what it is given without clipping it further, stop
+ * repeating it, and stop losing the producer's typed intent. It cannot
+ * reconstruct a name the producer truncated, and does not pretend to.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { V5HeldProposalBlock } from '../V5HeldProposalBlock'
+import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import type { V5HeldProposalBlock as V5HeldProposalBlockType } from '../../../canvas/conversation/types'
+
+function block(over: Partial<V5HeldProposalBlockType> = {}): V5HeldProposalBlockType {
+  return {
+    type: 'v5_held_proposal',
+    proposal_id: 'gmh_1',
+    summary: 'Add option A',
+    mutation_class: 'structural',
+    reason_code: 'STRUCTURAL_APPLY_HELD',
+    confirm: { label: 'Confirm these changes', message: 'confirm gmh_1' },
+    ...over,
+  } as V5HeldProposalBlockType
+}
+
+beforeEach(() => {
+  useGuidanceStore.setState({ _sendChip: vi.fn() } as never)
+})
+
+describe('naming each change once', () => {
+  it('renders a multi-change plan as a LIST, one change per row', () => {
+    const summary = [
+      'add option Hire 2 Mid-Level Engineers Plus a Sales Engineer (Under £...',
+      'add factor Sales Engineering Capacity',
+      'link Sales Engineering Capacity to Throughput of Convertible Leads',
+    ].join('\n')
+    render(<V5HeldProposalBlock block={block({ summary })} />)
+
+    const list = screen.getByTestId('v5-held-proposal-summary')
+    expect(list.tagName).toBe('UL')
+    expect(list.getAttribute('data-consent-line-count')).toBe('3')
+    expect(screen.getAllByTestId(/v5-held-proposal-summary-line-/)).toHaveLength(3)
+  })
+
+  it('states a line the producer emitted TWICE exactly once', () => {
+    const repeated = 'add option Hire 2 Mid-Level Engineers (Under £...'
+    const summary = [repeated, 'add factor Sales Engineering Capacity', repeated].join('\n')
+    render(<V5HeldProposalBlock block={block({ summary })} />)
+    expect(screen.getByTestId('v5-held-proposal-summary').getAttribute('data-consent-line-count')).toBe('2')
+  })
+
+  it('OPPOSITE TWIN — a single-line summary renders as a paragraph, verbatim', () => {
+    // The change must be invisible for every producer that did not delimit.
+    const summary = 'Add a constraint keeping the budget at or below £250,000.'
+    render(<V5HeldProposalBlock block={block({ summary })} />)
+    const p = screen.getByTestId('v5-held-proposal-summary')
+    expect(p.tagName).toBe('P')
+    expect(p.textContent).toBe(summary)
+  })
+
+  it('OPPOSITE TWIN — two DIFFERENT lines both survive', () => {
+    const summary = 'add option A\nadd option B'
+    render(<V5HeldProposalBlock block={block({ summary })} />)
+    const rows = screen.getAllByTestId(/v5-held-proposal-summary-line-/)
+    expect(rows.map((r) => r.textContent)).toEqual(['add option A', 'add option B'])
+  })
+
+  it('wraps rather than truncates — no clipping class anywhere on the summary', () => {
+    // jsdom cannot prove wrapping (trap 3). It CAN prove the class that clips
+    // is absent and the class that wraps is present, which is the whole of the
+    // UI's contribution to "wrap, not truncate".
+    render(<V5HeldProposalBlock block={block({ summary: 'add option A\nadd option B' })} />)
+    const list = screen.getByTestId('v5-held-proposal-summary')
+    expect(list.className).toContain('break-words')
+    expect(list.className).not.toContain('truncate')
+  })
+})
+
+describe('L-59 — the inline action dispatches TYPED, not as bare text', () => {
+  it('forwards the producer action_type on confirm', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    render(
+      <V5HeldProposalBlock
+        block={block({
+          confirm: {
+            label: 'Confirm these changes',
+            message: 'confirm gmh_1',
+            action_type: 'add_constraint',
+          },
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+    expect(sendChip).toHaveBeenCalledWith('Confirm these changes', 'confirm gmh_1', {
+      action_type: 'add_constraint',
+    })
+  })
+
+  it('forwards the producer action_type on decline', () => {
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    render(
+      <V5HeldProposalBlock
+        block={block({
+          decline: { label: 'Not now', message: 'decline gmh_1', action_type: 'add_constraint' },
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('v5-held-proposal-dismiss'))
+    expect(sendChip).toHaveBeenCalledWith('Not now', 'decline gmh_1', {
+      action_type: 'add_constraint',
+    })
+  })
+
+  it('OPPOSITE TWIN — omits the meta entirely when the producer declared none', () => {
+    // The UI never AUTHORS a type. No producer type ⇒ exactly today's turn.
+    const sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip } as never)
+    render(<V5HeldProposalBlock block={block()} />)
+    fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
+    expect(sendChip).toHaveBeenCalledWith('Confirm these changes', 'confirm gmh_1', undefined)
+  })
+})

--- a/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
+++ b/src/v5/blocks/__tests__/V5HeldProposalBlock.spec.tsx
@@ -86,7 +86,14 @@ describe('V5HeldProposalBlock', () => {
     fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
 
     expect(sendChip).toHaveBeenCalledTimes(1)
-    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes')
+    // ARITY EXTENDED (L-59): the seam now carries the producer's own
+    // `action_type` as a third argument. These fixtures declare none, so the
+    // value is `undefined` — i.e. this turn is byte-identical to the one that
+    // shipped before. The assertion is widened rather than loosened to
+    // `objectContaining`, so a UI-AUTHORED type appearing here would still
+    // fail: the rule is that the UI never invents intent, and a guard that
+    // stopped checking the third argument would stop seeing that.
+    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes', undefined)
     // Settled: actions replaced by an honest acknowledgement (no "applied" claim).
     expect(screen.queryByTestId('v5-held-proposal-actions')).toBeNull()
     expect(screen.getByTestId('v5-held-proposal-settled')).toHaveTextContent('Sent for you to apply.')
@@ -125,7 +132,7 @@ describe('V5HeldProposalBlock', () => {
 
     fireEvent.click(screen.getByTestId('v5-held-proposal-dismiss'))
 
-    expect(sendChip).toHaveBeenCalledWith('Adjust it first', 'Let me adjust')
+    expect(sendChip).toHaveBeenCalledWith('Adjust it first', 'Let me adjust', undefined)
   })
 
   // NOTE: this replaces an earlier pin that asserted the card STILL settled when
@@ -164,7 +171,14 @@ describe('V5HeldProposalBlock', () => {
     fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
 
     expect(sendChip).toHaveBeenCalledTimes(1)
-    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes')
+    // ARITY EXTENDED (L-59): the seam now carries the producer's own
+    // `action_type` as a third argument. These fixtures declare none, so the
+    // value is `undefined` — i.e. this turn is byte-identical to the one that
+    // shipped before. The assertion is widened rather than loosened to
+    // `objectContaining`, so a UI-AUTHORED type appearing here would still
+    // fail: the rule is that the UI never invents intent, and a guard that
+    // stopped checking the third argument would stop seeing that.
+    expect(sendChip).toHaveBeenCalledWith('Continue with this change', 'Yes', undefined)
     expect(screen.getByTestId('v5-held-proposal-settled')).toHaveTextContent(
       'Sent for you to apply.',
     )

--- a/src/v5/blocks/__tests__/heldProposalConsentRecord.spec.tsx
+++ b/src/v5/blocks/__tests__/heldProposalConsentRecord.spec.tsx
@@ -254,7 +254,10 @@ describe('2.474(a) stored consent record', () => {
 
     fireEvent.click(screen.getByTestId('v5-held-proposal-confirm'))
 
-    expect(sendChip).toHaveBeenCalledWith(UNCLAMPED_LABEL, CONFIRM_MESSAGE)
+    // ARITY EXTENDED (L-59) — see V5HeldProposalBlock.spec.tsx. `undefined`
+    // is the positive statement that this fixture's producer declared no
+    // typed intent and the UI invented none.
+    expect(sendChip).toHaveBeenCalledWith(UNCLAMPED_LABEL, CONFIRM_MESSAGE, undefined)
   })
 })
 

--- a/src/v5/blocks/mapV5Blocks.ts
+++ b/src/v5/blocks/mapV5Blocks.ts
@@ -201,14 +201,29 @@ export function mapV5Block(
         // producer clamps the confirm label (`buildGmHeldPublicCopy`) and no
         // decline path emits `detail` today, so a decline field would be an
         // unread passenger.
+        //
+        // `action_type` is carried for the SAME reason `detail` is: dropping it
+        // silently degraded the card's own control. The generic chip row
+        // forwards it (`buildSuggestedActionChips`), so a held action rendered
+        // as a card was the ONLY place a producer-typed action lost its type —
+        // and an untyped click is routed by CEE as ordinary chat (L-59).
         confirm: {
           label: confirm.label,
           message: confirm.message,
           ...(typeof confirm.detail === 'string' && confirm.detail.length > 0
             ? { detail: confirm.detail }
             : {}),
+          ...(confirm.action_type ? { action_type: confirm.action_type } : {}),
         },
-        ...(decline ? { decline: { label: decline.label, message: decline.message } } : {}),
+        ...(decline
+          ? {
+              decline: {
+                label: decline.label,
+                message: decline.message,
+                ...(decline.action_type ? { action_type: decline.action_type } : {}),
+              },
+            }
+          : {}),
       }
     }
     case 'ui_directive':


### PR DESCRIPTION
Completes the **Olumi Conversation** component against the 16 Aug feedback wave:
`ISSUE-LEDGER.md` §4 (L-16, L-17, L-42, L-59, L-72, L-73, item 7) and the
`SIMULATED-USER-TEST-SCOREBOARD.md` presentation findings (Q3, NEW-9).

Every item is a **replacement of a competing implementation**, not a restyle. No
new flags. Nothing dark.

---

## KEEP / REPLACE / REMOVE

| Surface | Verdict | What changed |
|---|---|---|
| `messageComposition.ts` — `composeMessage` + the three honesty invariants | **KEEP, extended** | Unchanged and re-pinned. It now ALSO owns the render-authority order and one suppression primitive (a fourth invariant: no content editing). |
| Prose body echoing a consent card's plan | **REMOVE** | Withheld at render. The card wins — it is the control the user consents through. |
| Answer headline echoing a consent card | **REMOVE** | Same rule, same primitive. |
| A commentary paragraph the turn already rendered | **REMOVE** | Same rule, applied in render order across the turn. |
| `deduplicateAgainstCommentary` (ingest-time) | **KEEP** | Untouched and deliberately NOT duplicated. Commentary is excluded from tier 0 so one seam keeps one writer. |
| `useStageAwarePlaceholder`'s selection branch (`"Ask about X…"`) | **REMOVE** | It read as a prepared sentence over an empty composer. |
| `SelectionPill` as a read-only label | **REPLACE** | Pill + chip, both dispatching one selection-grounded turn through one code path. |
| Held-proposal summary as one run-on paragraph | **REPLACE** | One change per row when the producer delimited by lines; a producer-repeated line stated once; wraps, never clips. |
| `_sendChip(label, message)` | **REPLACE** (additive) | Optional third `meta` argument carrying the producer's own `action_type`. |
| `V5HeldProposalAction` / the held-proposal mapper | **KEEP, extended** | Stop dropping `suggested_actions[].action_type`. |
| `StalenessPill` ('stale' variant) | **KEEP, subordinated** | Stands down while the applied-edit card is saying it. |
| `StalenessPill` ('unknown' variant) | **KEEP, unchanged** | It makes a DIFFERENT claim (cannot confirm) that no card states. Silencing it would suppress an honest admission. |
| Composer staleness nag | **KEEP, subordinated** | Neutral while a higher voice is on screen. |
| `MessageActions` at `top-0` (over the first line of the message) | **REPLACE** | Reserved gutter, with the no-overlap arithmetic stated once as exported constants. |
| Silent clipboard failure | **REMOVE** | Success and failure are both announced. |
| Retry on user messages | **KEEP absent** | Deliberate: re-DELIVERING a failed send already has its own affordance on the bubble. Two Retry controls with two meanings under one name is the shape this estate has already paid for. |

---

## Per item

### 1 · L-16 / NEW-9 — one render authority

**Mechanism, derived at the CEE bytes** (`orchestrator-v5/routing/answer-shape.ts`,
staging `2988eacf`): CEE sets `assistant_text := deriveAnswerTextFromShape(shape)`
= `headline \n\n • bullets \n\n detail`. The `_answer_shape` sidecar carries the
same three parts. **The byte-equality is deliberate and producer-side** — it
exists so legacy `assistant_text` consumers keep working — so the fix could never
be "stop emitting one of them". A consent card then states the same plan a third
time (the scoreboard measured this byte-for-byte on the edit path, NEW-9).

`messageComposition.ts` — already THE composition authority — now also owns the
render-authority ORDER and one suppression rule:

```
TIER 0  consent / answer cards (the `pinned` class)   ← highest authority
TIER 1  the answer-shape headline
TIER 2  the prose body
TIER 3  points
TIER 4  the detail disclosure
```

A lower tier never re-renders a whole segment a higher tier already rendered. A
higher tier is never withheld, so nothing can be lost to a surface the user has
not been shown.

**Invariant 4, added: NO CONTENT EDITING.** Whole segments only (a paragraph or a
line), exact equality after whitespace normalisation. Never a rewrite, never a
similarity threshold, never a segment that merely *contains* the prior.

### 2 · L-17 — the selection is a real, submittable control

Reproduced again on 16 Aug at UI `f15bccaf`: *"composer VALUE empty … Grey,
non-submittable, exactly as filed."*

- `SelectionPill` dispatches from the pill **and** from a chip beside it, through
  **one** callback — so the two can never come to mean different things (the
  trap-21 shape this estate paid for once already, with two inspector
  "ask about this" affordances carrying opposite semantics).
- The composer placeholder returns to neutral.
- Nothing here names the element on the wire: `buildPayload.deriveSelectedElements`
  reads the live store on every send, so the turn is selection-grounded by the
  same mechanism a typed question would be. The label is display copy and is
  never used as an identity.
- **Fail closed**: with no conversation host registered, no clickable control
  renders at all. A dead affordance is the defect being removed.

**Deviation from the brief, disclosed.** The brief said "a real chip in the
SuggestedChips zone". It is instead in `SelectionPill`, directly above the
composer, for two reasons: `SuggestedChips` renders **CEE-authored chips
verbatim** (ruled doctrine D-K: "never fabricate a filler chip; labels render
verbatim as sent by CEE"), and its chips are **per-message and historical** —
a live, selection-dependent affordance attached to an old turn would be wrong on
both counts. `SelectionPill` is the composer-adjacent chip zone and was already
mounted where the affordance belongs. Happy to move it if you disagree.

### 3 · Confirm-card readability (scoreboard Q3)

- **Stated twice → once**: the prose copy is withheld by (1).
- **Run-on → list**: rendered one change per row when the producer already
  delimited by lines. Splitting on `\n` is deterministic and lossless (every byte
  still renders, in producer order); a single-line summary renders exactly as
  today. Nothing is inferred from punctuation.
- **Repeated line → once**: the same primitive as (1).
- **Wrap, not truncate**: `break-words`, no `truncate` anywhere on the card.

**Scope honesty**: the mid-word `(Under £...` is in the **producer's** bytes —
CEE clamps names before it composes the summary. The UI can render what it is
given without clipping it further, stop repeating it, and stop losing the
producer's typed intent. It cannot reconstruct a name the producer truncated, and
does not pretend to. That half is CEE's.

### 4 · L-42 — one staleness communication per turn view

`stalenessVoice.ts`: **card > pill > placeholder**, hierarchy derived from one
ordered tuple. Surfaces register **while mounted**, so the registry reflects what
is genuinely on screen rather than a mount condition re-derived in three places
(the hand-maintained-mirror class). **Fails safe**: with nothing claimed every
surface behaves exactly as before — the failure direction is over-telling, never
under-telling.

The `'unknown'` pill is deliberately exempt: it says currency *cannot be
confirmed*, which is a different fact that the card never states.

### 5 · L-59 — the inline action dispatches typed, not as bare text

**Found at the bytes, and it is a UI defect.** `ConversationPanel` registered
`_sendChip` as `(label, message) => sendChip({ id, label, message, intent })` —
**no `action_type`**. So a producer-typed action lost its type *exactly when CEE
rendered it as a card instead of a generic chip* (`buildSuggestedActionChips`
forwards it; the held-proposal mapper dropped it). CEE then routes the click as
ordinary chat — which is precisely the symptom `chipActionVocabulary`'s own
docstring names as the signature of an untyped chip click, and precisely what the
scoreboard witnessed on the product's own button:

> "Nothing has been changed. You did not ask me to edit the model, so I have not"

Fixed end to end: mapper → type → seam → card. **Fail-closed by construction** —
`buildPayload.sanitiseActionType` still withholds any value not BOTH published in
our vendored enum AND accepted at CEE ingress, so an absent or unrecognised value
behaves exactly as today and can never 422 a turn. **The UI never authors a type.**

⚠ **Bounded claim**: this closes the mechanism by which a card-hosted inline
action degrades to chat. Whether the specific `[Review the model]` chip the
scoreboard clicked was card-hosted or chip-row-hosted is **not settled here** —
that needs a live capture. If it was chip-row-hosted and CEE emitted no
`action_type`, the remaining half is CEE's.

### 6 · L-72 / L-73 — message controls

L-73 confirmed at the bytes: the bar was `absolute top-0` — sitting on the first
line of the message. It now lives in a gutter `ChatMessage` reserves, and the
inequality that makes overlap impossible is stated **once**, as exported
constants both files consume:

```
ACTION_BAR_TOP_OFFSET_PX + ACTION_BAR_HEIGHT_PX  <=  ACTION_BAR_GUTTER_PX
```

jsdom cannot prove visibility (trap 3), so the spec pins **that arithmetic**
rather than pretending to measure layout, and pins that the host actually
reserves the band. Copy now reports success and failure instead of swallowing
both — including the `navigator.clipboard === undefined` case (insecure origin),
which previously threw *synchronously* and never reached the rejection handler:
the icon animated, nothing was copied, nothing said so. That is the "reportedly
fail" report in L-72.

### 7 · No repeated sentence inside one disclosure

The same primitive as (1), applied to commentary blocks in render order.
**Suppression removes PART of a block, never the whole of it** — a commentary
whose every paragraph was already rendered keeps its original text, because an
empty card with a live "More" toggle is a worse artefact than the duplicate and
silently deleting a block would breach the composition's own no-drop guarantee.

---

## ⚠ STATED LIMIT (pinned by a spec, not absorbed)

**A repeat INSIDE a single paragraph is not de-duplicated.** Separating it needs a
sentence predicate over natural language — the class of rule this platform watched
oscillate for four consecutive rounds on CEE #888 without terminating. Segment
granularity is deterministic; sentence granularity is not. The limit has its own
test (`splitRenderSegments` "does NOT split sentences") so it can never become an
undisclosed gap.

---

## Evidence

**Gate** (`pnpm typecheck` — `scripts/ci/typecheck-gate.sh`, derived at this tip):

```
3401 / 3441 tracked TypeScript files loaded by the gate (40 declared out of scope)
within baseline — 571 file(s) / 2325 error(s) (baseline: 2325)
✅ Typecheck gate PASSED (coverage + ratchet).
```

`npx eslint` over every touched file: **0 errors** (45 pre-existing warnings, none new).

**New specs — 72 tests across 7 files, all collected BY NAME and non-zero:**

| Spec | Tests |
|---|---|
| `conversation/__tests__/renderAuthority.spec.ts` | primitives + the #717 invariants re-pinned |
| `conversation/__tests__/renderAuthority.bubble.spec.tsx` | prose/headline/commentary vs consent card |
| `conversation/__tests__/stalenessVoice.spec.ts` | hierarchy, ref-counting, release |
| `conversation/__tests__/stageAwarePlaceholder.voice.spec.ts` | L-17 + L-42 at the composer |
| `conversation/__tests__/MessageActions.controls.spec.tsx` | gutter arithmetic, parity, copy outcome |
| `components/__tests__/SelectionPill.askAffordance.spec.tsx` | both controls, one dispatch, fail-closed |
| `v5/blocks/__tests__/V5HeldProposalBlock.readability.spec.tsx` | list, de-dup, wrap, typed dispatch |

Every suppression case carries an **opposite-direction twin** that must survive
untouched (near-miss text, substring containment, user bubbles, streaming turns,
single-line summaries, absent producer type) — because an invariant written with
the same asymmetry as the code it tests is a guard agreeing with itself.

**Mutation checks** — throwaway worktree OUTSIDE the repo root, isolation proved
by **writing a sentinel and asserting the source did not change** (not by
locating the path); inodes compared; restores `HEAD`-relative (`git checkout HEAD --`,
never from the index); clean-tree asserted before AND after every mutant;
applied-check scoped to `src/` demanding **exactly one** changed file; spec list a
bash array with an asserted count of 7 (an unquoted string under zsh sent one
giant pathspec and vitest exited **0** on "No test files found" — caught and fixed).

| Mutant | Result |
|---|---|
| PRISTINE | **72 / 0** |
| M1 · `dedupeRenderedText` becomes a no-op | 63 / **9** |
| M2 · commentary becomes a tier-0 consent surface | 70 / **2** |
| M3 · staleness hierarchy inverted | 63 / **9** |
| M4 · selection chip loses its `onClick` | 68 / **4** |
| M5 · action bar back to `top: 0` | 70 / **2** |
| M6 · confirm reverts to a bare text send | 70 / **2** |
| **M7 · GREEN control** — loosen tier 0 for a **different** block type | **72 / 0** |
| TRAILING CONTROL (re-run pristine) | **72 / 0** |

M7 is the other half of the discriminating pair: six mutants bite, and a seventh
that changes the same function for an object no spec names does **not** — so the
guards bind to the named surfaces by identity, not merely to "something changed".
The trailing control proves no mutant polluted the tree.

**Regression sweep**: `src/canvas/conversation`, `src/v5/blocks`,
`src/canvas/components`. Two pre-existing held-proposal specs failed on the
`_sendChip` **arity** and were extended (not loosened) to name the third argument
as `undefined` — a positive statement that the fixture's producer declared no
typed intent and the UI invented none. Both green.

---

## Files outside the brief's literal ownership, and why

`src/v5/blocks/{V5HeldProposalBlock,V5GraphPatchBlock,mapV5Blocks}.tsx|ts` are the
conversation's own confirm card, applied-edit receipt and their mapper — they
render only inside `MessageBubble → InlineBlocks`, and none is in the exclusion
list. `src/canvas/stores/guidanceStore.ts` takes **one additive optional
parameter** on `_sendChip` (existing callers unchanged) — kept deliberately
minimal because the inspector lane shares that file.

Untouched, as instructed: `OutputsDock.tsx`, `canvas/nodes`, `canvas/edges`,
`inspector-v2/**`, `versions/**`, the analysis-state selector modules,
`AskOlumiDrawer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## CI conclusion (head `2f274b75`)

**All 13 checks green, including the required `Staging Gate`.** `mergeable=MERGEABLE`,
`mergeStateStatus=CLEAN`, head SHA verified with BOTH `git ls-remote` and `gh api`.
Polled to conclusion on the exact head SHA (`check-runs`, `total_count=13`, zero
`status != "completed"` — never a `conclusion`-only filter, which reads an
in-progress check as a failure).

**The first push (`fedcbdaf`) was RED, in two ways the local gate could not see.**
Both are recorded here rather than quietly amended, because they are the evidence
for why the required check is the authority:

1. **`lint:hooks-ratchet` — `MessageBubble.tsx` 3 → 6.** This file already carried
   three hooks declared BELOW its early returns, and the ratchet says of them
   exactly the right thing: *"an exception for its EXISTING violations, not a
   licence to add more. Each one is a render-time crash."* My three
   render-authority memos had landed below those returns too. They are now above
   **every** early return in the component. **The pre-existing three are reported,
   not fixed** — hoisting them is a separate mechanical change and this lane's
   scope rule forbids "while we're here" work.
2. **`useStageAwarePlaceholder.spec.ts` pinned the selection placeholder** — the
   behaviour L-17 removes. The pin is **flipped with its reason written into the
   test**, and now asserts negatively (the label must not appear in any form) as
   well as positively. **My local sweep missed it**: I swept
   `canvas/conversation`, `v5/blocks` and `canvas/components`, and the spec lives
   in `canvas/hooks/__tests__`. The sweep's scope was too narrow; the shard caught
   what it could not.

The full mutant battery, the trailing control and the pristine baseline were all
**re-run at the final head** after the hoist — identical results (72/0 pristine,
six biting mutants, M7 green, trailing control 72/0), so the hoist is proven not
to have hollowed any guard out.

---

# REVIEW ROUND (head `c92f952e`, rebased onto `8db13fd0` after #739)

The adversarial review found the render-authority rule **suppressing text it had
no right to suppress**, in three situations. They share one root error, and it is
worth naming plainly: **I let a rule that answers a FACT also answer a GUESS, and
I fed it text that was never on screen.**

- **CROSS-TIER** — *"has a higher tier already rendered this exact segment?"* The
  caller supplies the other surface's text; equality settles it.
- **WITHIN-TEXT** — *"did the producer repeat this line by accident, or because
  it is a structural label under two headings?"* Nothing in the text says.

They cannot share a predicate (trap 22b: a missed duplicate is cosmetic, a
deleted line is a false statement about what the producer said). Only the fact is
implemented now.

| # | Finding | Fix |
|---|---|---|
| **A1** | **BLOCKING — content loss on the DEFAULT path.** `dedupeRenderedText` accumulated the input's OWN segments, so with an empty `alreadyRendered` — every ordinary assistant turn — the second occurrence of any identical line was **deleted**. Proven at rendered HTML: *"Timeline slips"* under Risks **and** Mitigations rendered once; three *"Confidence: not stated"* rows became one. | **Self-dedupe removed entirely.** With no priors the output is now byte-identical to the input, always. L-16 is untouched (its mechanism is cross-tier); *"the same sentence twice in one disclosure"* is still closed where it actually occurs — **across blocks**, via the caller. |
| **A2** | **BLOCKING.** The collector pushed **both** `graph_patch.applied_summary` **and** `summary`; the card renders exactly **one**. On a proposed patch it suppressed prose against text the user would never see. | Extracted the renderer's own derivation into **`resolveGraphPatchSummaryText`** + **`isGraphPatchApplied`**; both call sites use them. **No mirror left to drift.** |
| **A3** | In structured mode the collector was fed `message.content` — which `AnswerBody` **replaces** and which is therefore never rendered. A commentary restating the producer's 4th bullet (dropped by the ≤3 cap) was suppressed against invisible text. | Extracted **`resolveAnswerBodyText`** as the one authority for what that component shows. The bubble feeds headline + surviving bullets, and **deliberately not `detail`** — a block is not a duplicate of something behind a Show-more toggle. |
| **A4** | The `proposal` case was **dead**: `ProposalBlock` carries `description` + `changes[]` and has no summary field at all. | **Deleted**, with the reason written in — a dead branch reading as coverage is worse than an absent one. Wiring `ProposalBlockRenderer` up is a separate change with its own evidence. |
| **A5** | Invariant 4 was written **wider than the code delivered**. | Narrowed to the three things that are true, plus **both** stated limits (no sentence splitting; no self-dedupe). |
| **D1** | Staleness claims were keyed on **mount**, and the transcript keeps every turn mounted — an applied-edit card ten turns back, scrolled out of view, silenced the pill and the composer **for the whole session**. The docstring claimed *"derived from what is genuinely on screen"*; it was not. | Claims scoped to the **newest assistant turn**, threaded from ChatThread's existing `msg === lastAssistantMsg` identity (so the staleness voice and the chip row can never disagree about which turn is current). **Scope is MOUNTED-IN-NEWEST-TURN, not viewport visibility** — true visibility needs an IntersectionObserver that does not exist in jsdom, and the residual harm is a fraction of the one fixed. The docstring now says exactly that. |
| **E1** | The selection chip's single-flight was a bare boolean: select A → ask → select B → ask within 500 ms was a **silent no-op**. | Keyed by **selection identity**. The guard absorbs a double-click on one selection; a different selection is a different question and always gets through. |

## Disclosed, not fixed

- **B · authority-vs-DOM-order.** Suppression follows the **tier order**, which is
  not always the DOM order: a consent card sits *below* the prose, so when a prose
  paragraph is withheld against it the surviving text can read as an orphaned
  lead-in until the eye reaches the card. Presentational, and the alternative
  (letting DOM order decide) would put the plan **above** the control the user
  consents through — the thing NEW-9 asked us to stop. Recorded as a known nuance
  for the Conversation component's visual pass.

## Evidence for the round

Rebased onto `8db13fd0`; **all 13 checks green at `c92f952e`**, including the
required `Staging Gate` (4/4 shards). `MERGEABLE/CLEAN`. Head verified with both
`git ls-remote` and `gh api`. Typecheck gate passed (it now reports drift *shrank*
2325 → 2315 from the rebase — **the `--update-baseline` prompt was NOT accepted**:
that shrink is attribution churn in files this PR never touched).

Specs **72 → 83**. The self-dedupe pin is **flipped**, and the reviewer's corpus
is kept **verbatim** as the regression corpus — because the case I wrote for
myself was one long unique sentence and was structurally incapable of seeing the
class it broke (short, structurally repeated lines). Added: a property assertion
that *no* input is altered when there are no priors, plus pins for A2, A3,
cross-block item 7, D1 and E1.

**Mutants re-run in a fresh sentinel-isolated worktree at the new tip** (isolation
proved by writing, inodes compared, `HEAD`-relative restores, clean tree asserted
either side, applied-check demanding exactly one changed file):

| Mutant | Result |
|---|---|
| PRISTINE | **83 / 0** |
| **M8 · A1 regression** — re-introduce self-accumulation | 79 / **4** |
| **M9 · A2 regression** — collect the field that is NOT rendered | 82 / **1** |
| **M10 · A3 regression** — feed the collector the unrendered body | 82 / **1** |
| **M11 · E1 regression** — guard ignores selection identity | 82 / **1** |
| M1 · dedupe no-op | 72 / **11** |
| M2 · commentary becomes tier 0 | 79 / **4** |
| M3 · staleness hierarchy inverted | 73 / **10** |
| M4 · selection chip inert | 78 / **5** |
| M5 · action bar back on the text | 81 / **2** |
| M6 · confirm reverts to a bare text send | 81 / **2** |
| **M7 · GREEN control** (re-anchored after A4 deleted the dead branch) | **83 / 0** |
| TRAILING CONTROL | **83 / 0** |

M8–M11 are the point of this round: each **re-introduces the exact defect the
review found** and is caught. M7 still holds the other half of the discriminating
pair — same function, an object no spec names, stays green.
